### PR TITLE
Use the new Cloud Platform namespace

### DIFF
--- a/helm_deploy/hmpps-approved-premises-ui/Chart.yaml
+++ b/helm_deploy/hmpps-approved-premises-ui/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: '1.0'
 description: A Helm chart for Kubernetes
-name: approved-premises-ui
+name: hmpps-approved-premises-ui
 version: 0.2.0
 dependencies:
   - name: generic-service

--- a/helm_deploy/hmpps-approved-premises-ui/values.yaml
+++ b/helm_deploy/hmpps-approved-premises-ui/values.yaml
@@ -1,11 +1,11 @@
 ---
 generic-service:
-  nameOverride: approved-premises-ui
+  nameOverride: hmpps-approved-premises-ui
 
   replicaCount: 4
 
   image:
-    repository: quay.io/hmpps/approved-premises-ui
+    repository: quay.io/hmpps/hmpps-approved-premises-ui
     tag: app_version # override at deployment time
     port: 3000
 
@@ -63,4 +63,4 @@ generic-service:
     cloudplatform-live1-3: '35.177.252.54/32'
 
 generic-prometheus-alerts:
-  targetApplication: approved-premises-ui
+  targetApplication: hmpps-approved-premises-ui

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -7,7 +7,7 @@ generic-service:
   ingress:
     host: approved-premises-dev.hmpps.service.justice.gov.uk
     contextColour: green
-    tlsSecretName: approved-premises-dev-cert
+    tlsSecretName: hmpps-approved-premises-dev-cert
 
   env:
     APPROVED_PREMISES_API_URL: 'https://approved-premises-api-dev.hmpps.service.justice.gov.uk'

--- a/script/tail-logs
+++ b/script/tail-logs
@@ -25,9 +25,9 @@ else
 fi
 
 if [ "$app" = "api" ]; then
-  stern -n "approved-premises-api-$environment" "approved-premises-dev" -t
+  stern -n "hmpps-approved-premises-$environment" "hmpps-approved-premises-api" -t
 elif [ "$app" = "ui" ]; then
-  stern -n "approved-premises-$environment" "approved-premises-ui" -t
+  stern -n "hmpps-approved-premises-$environment" "hmpps-approved-premises-ui" -t
 else
   echo "Unknown application $2"
   exit 1


### PR DESCRIPTION
Since we updated the repo name, the deploys have been failing, rather than put in a bunch of fixes that will hang around forever, I thought it best to create a whole new namespace that fits the naming conventions and allows us to host both services in the same namespace. I’ve copied the secrets over from our old namespace to the new one too.