### PR TITLE
Consolidate date formats

### DIFF
--- a/cypress_shared/pages/apply/list.ts
+++ b/cypress_shared/pages/apply/list.ts
@@ -1,7 +1,7 @@
 import type { ApplicationSummary } from 'approved-premises'
 import Page from '../page'
 import paths from '../../../server/paths/apply'
-import { formatDateString } from '../../../server/utils/utils'
+import { DateFormats } from '../../../server/utils/dateUtils'
 
 export default class ListPage extends Page {
   constructor() {
@@ -23,7 +23,7 @@ export default class ListPage extends Page {
         .within(() => {
           cy.get('td').eq(0).contains(summary.person.crn)
           cy.get('td').eq(1).contains(summary.tier.level)
-          cy.get('td').eq(2).contains(formatDateString(summary.arrivalDate))
+          cy.get('td').eq(2).contains(DateFormats.isoDateToUIDate(summary.arrivalDate))
           cy.get('td').eq(3).contains(summary.status)
         })
     })

--- a/cypress_shared/pages/apply/placementStart.ts
+++ b/cypress_shared/pages/apply/placementStart.ts
@@ -1,8 +1,8 @@
 import Page from '../page'
-import { formatDateString } from '../../../server/utils/utils'
+import { DateFormats } from '../../../server/utils/dateUtils'
 
 export default class PlacementStartPage extends Page {
   constructor(releaseDate: string) {
-    super(`Is ${formatDateString(releaseDate)} the date you want the placement to start? `)
+    super(`Is ${DateFormats.isoDateToUIDate(releaseDate)} the date you want the placement to start? `)
   }
 }

--- a/cypress_shared/pages/manage/booking/confirmation.ts
+++ b/cypress_shared/pages/manage/booking/confirmation.ts
@@ -1,10 +1,8 @@
-import parseISO from 'date-fns/parseISO'
-
 import type { Booking } from 'approved-premises'
 
 import Page from '../../page'
-import { formatDate, formatDateString } from '../../../../server/utils/utils'
 import paths from '../../../../server/paths/manage'
+import { DateFormats } from '../../../../server/utils/dateUtils'
 
 type OvercapacityPeriod = {
   start: string
@@ -25,8 +23,8 @@ export default class BookingConfirmationPage extends Page {
     cy.get('dl').within(() => {
       this.assertDefinition('Name', booking.person.name)
       this.assertDefinition('CRN', booking.person.crn)
-      this.assertDefinition('Expected arrival date', formatDate(parseISO(booking.arrivalDate)))
-      this.assertDefinition('Expected departure date', formatDate(parseISO(booking.departureDate)))
+      this.assertDefinition('Expected arrival date', DateFormats.isoDateToUIDate(booking.arrivalDate))
+      this.assertDefinition('Expected departure date', DateFormats.isoDateToUIDate(booking.departureDate))
       this.assertDefinition('Key worker', booking.keyWorker.name)
     })
   }
@@ -37,10 +35,14 @@ export default class BookingConfirmationPage extends Page {
   ) {
     this.shouldShowBanner(`The premises is over capacity for the periods:`)
     cy.get('.govuk-list > :nth-child(1)').contains(
-      `${formatDateString(firstOvercapacityPeriod.start)} to ${formatDateString(firstOvercapacityPeriod.end)}`,
+      `${DateFormats.isoDateToUIDate(firstOvercapacityPeriod.start)} to ${DateFormats.isoDateToUIDate(
+        firstOvercapacityPeriod.end,
+      )}`,
     )
     cy.get('.govuk-list > :nth-child(2)').contains(
-      `${formatDateString(secondOvercapacityPeriod.start)} to ${formatDateString(secondOvercapacityPeriod.end)}`,
+      `${DateFormats.isoDateToUIDate(secondOvercapacityPeriod.start)} to ${DateFormats.isoDateToUIDate(
+        secondOvercapacityPeriod.end,
+      )}`,
     )
   }
 }

--- a/cypress_shared/pages/manage/booking/extension/confirmation.ts
+++ b/cypress_shared/pages/manage/booking/extension/confirmation.ts
@@ -1,8 +1,8 @@
-import parseISO from 'date-fns/parseISO'
 import type { Booking } from 'approved-premises'
-import { formatDate } from '../../../../../server/utils/utils'
+
 import Page from '../../../page'
 import paths from '../../../../../server/paths/manage'
+import { DateFormats } from '../../../../../server/utils/dateUtils'
 
 export default class BookingExtensionConfirmationPage extends Page {
   constructor() {
@@ -18,8 +18,8 @@ export default class BookingExtensionConfirmationPage extends Page {
     cy.get('dl').within(() => {
       this.assertDefinition('Name', booking.person.name)
       this.assertDefinition('CRN', booking.person.crn)
-      this.assertDefinition('Expected arrival date', formatDate(parseISO(booking.arrivalDate)))
-      this.assertDefinition('New expected departure date', formatDate(parseISO(booking.departureDate)))
+      this.assertDefinition('Expected arrival date', DateFormats.isoDateToUIDate(booking.arrivalDate))
+      this.assertDefinition('New expected departure date', DateFormats.isoDateToUIDate(booking.departureDate))
       this.assertDefinition('Key worker', booking.keyWorker.name)
     })
   }

--- a/cypress_shared/pages/manage/booking/show.ts
+++ b/cypress_shared/pages/manage/booking/show.ts
@@ -1,8 +1,8 @@
 import type { Booking } from 'approved-premises'
 
 import Page from '../../page'
-import { formatDateString } from '../../../../server/utils/utils'
 import paths from '../../../../server/paths/manage'
+import { DateFormats } from '../../../../server/utils/dateUtils'
 
 export default class BookingShowPage extends Page {
   constructor() {
@@ -16,19 +16,19 @@ export default class BookingShowPage extends Page {
 
   shouldShowBookingDetails(booking: Booking): void {
     cy.get('dl[data-cy-dates]').within(() => {
-      this.assertDefinition('Arrival date', formatDateString(booking.arrivalDate))
-      this.assertDefinition('Departure date', formatDateString(booking.departureDate))
+      this.assertDefinition('Arrival date', DateFormats.isoDateToUIDate(booking.arrivalDate))
+      this.assertDefinition('Departure date', DateFormats.isoDateToUIDate(booking.departureDate))
       this.assertDefinition('Key worker', booking.keyWorker.name)
     })
 
     cy.get('dl[data-cy-arrival-information]').within(() => {
-      this.assertDefinition('Arrival date', formatDateString(booking.arrival.date))
-      this.assertDefinition('Departure date', formatDateString(booking.arrival.expectedDepartureDate))
+      this.assertDefinition('Arrival date', DateFormats.isoDateToUIDate(booking.arrival.date))
+      this.assertDefinition('Departure date', DateFormats.isoDateToUIDate(booking.arrival.expectedDepartureDate))
       this.assertDefinition('Notes', booking.arrival.notes)
     })
 
     cy.get('dl[data-cy-departure-information]').within(() => {
-      this.assertDefinition('Actual departure date', formatDateString(booking.departure.dateTime))
+      this.assertDefinition('Actual departure date', DateFormats.isoDateToUIDate(booking.departure.dateTime))
       this.assertDefinition('Reason', booking.departure.reason.name)
       this.assertDefinition('Notes', booking.departure.notes)
     })

--- a/cypress_shared/pages/manage/cancellationConfirmation.ts
+++ b/cypress_shared/pages/manage/cancellationConfirmation.ts
@@ -1,6 +1,5 @@
-import parseISO from 'date-fns/parseISO'
 import type { Cancellation, Booking } from 'approved-premises'
-import { formatDate } from '../../../server/utils/utils'
+import { DateFormats } from '../../../server/utils/dateUtils'
 import Page from '../page'
 
 export default class CancellationConfirmPage extends Page {
@@ -12,9 +11,9 @@ export default class CancellationConfirmPage extends Page {
     cy.get('dl').within(() => {
       this.assertDefinition('Name', booking.person.name)
       this.assertDefinition('CRN', booking.person.crn)
-      this.assertDefinition('Arrival date', formatDate(parseISO(booking.arrivalDate)))
-      this.assertDefinition('Expected departure date', formatDate(parseISO(booking.departureDate)))
-      this.assertDefinition('Date of cancellation', formatDate(parseISO(cancellation.date)))
+      this.assertDefinition('Arrival date', DateFormats.isoDateToUIDate(booking.arrivalDate))
+      this.assertDefinition('Expected departure date', DateFormats.isoDateToUIDate(booking.departureDate))
+      this.assertDefinition('Date of cancellation', DateFormats.isoDateToUIDate(cancellation.date))
       this.assertDefinition('Notes', cancellation.notes)
     })
   }

--- a/cypress_shared/pages/manage/departureConfirmation.ts
+++ b/cypress_shared/pages/manage/departureConfirmation.ts
@@ -1,7 +1,7 @@
-import parseISO from 'date-fns/parseISO'
 import type { Departure, Booking } from 'approved-premises'
 import Page from '../page'
 import paths from '../../../server/paths/manage'
+import { DateFormats } from '../../../server/utils/dateUtils'
 
 export default class DepartureConfirmation extends Page {
   constructor() {
@@ -18,7 +18,7 @@ export default class DepartureConfirmation extends Page {
     cy.get('dl').within(() => {
       this.assertDefinition('Name', booking.person.name)
       this.assertDefinition('CRN', booking.person.crn)
-      this.assertDefinition('Departure date', parseISO(departure.dateTime).toLocaleDateString('en-GB'))
+      this.assertDefinition('Departure date', DateFormats.isoDateToUIDate(departure.dateTime))
       this.assertDefinition('Reason', departure.reason.name)
       this.assertDefinition('Destination approved premises', departure.destinationAp.name)
       this.assertDefinition('Destination provider', departure.destinationProvider.name)

--- a/cypress_shared/pages/manage/premisesShow.ts
+++ b/cypress_shared/pages/manage/premisesShow.ts
@@ -1,10 +1,8 @@
-import { parseISO } from 'date-fns'
-
 import type { Premises, Booking } from 'approved-premises'
 
 import Page from '../page'
-import { formatDateString, formatDate } from '../../../server/utils/utils'
 import paths from '../../../server/paths/manage'
+import { DateFormats } from '../../../server/utils/dateUtils'
 
 export default class PremisesShowPage extends Page {
   constructor(private readonly premises: Premises) {
@@ -75,11 +73,11 @@ export default class PremisesShowPage extends Page {
 
   private tableShouldContainBookings(bookings: Array<Booking>, type: 'arrival' | 'departure') {
     bookings.forEach((item: Booking) => {
-      const date = type === 'arrival' ? parseISO(item.arrivalDate) : parseISO(item.departureDate)
+      const date = type === 'arrival' ? item.arrivalDate : item.departureDate
       cy.contains(item.person.crn)
         .parent()
         .within(() => {
-          cy.get('td').eq(0).contains(formatDate(date))
+          cy.get('td').eq(0).contains(DateFormats.isoDateToUIDate(date))
           cy.get('td')
             .eq(1)
             .contains('Manage')
@@ -94,9 +92,7 @@ export default class PremisesShowPage extends Page {
       cy.contains(item.person.crn)
         .parent()
         .within(() => {
-          cy.get('td')
-            .eq(0)
-            .contains(formatDate(parseISO(item.departureDate)))
+          cy.get('td').eq(0).contains(DateFormats.isoDateToUIDate(item.departureDate))
           cy.get('td')
             .eq(1)
             .contains('Manage')
@@ -107,9 +103,9 @@ export default class PremisesShowPage extends Page {
 
   shouldShowOvercapacityMessage(overcapacityStartDate: string, overcapacityEndDate: string) {
     this.shouldShowBanner(
-      `The premises is over capacity for the period ${formatDateString(overcapacityStartDate)} to ${formatDateString(
-        overcapacityEndDate,
-      )}`,
+      `The premises is over capacity for the period ${DateFormats.isoDateToUIDate(
+        overcapacityStartDate,
+      )} to ${DateFormats.isoDateToUIDate(overcapacityEndDate)}`,
     )
   }
 }

--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -1,5 +1,5 @@
 import errorLookups from '../../server/i18n/en/errors.json'
-import { convertDateString } from '../../server/utils/utils'
+import { DateFormats } from '../../server/utils/dateUtils'
 
 export type PageElement = Cypress.Chainable<JQuery>
 
@@ -63,8 +63,7 @@ export default abstract class Page {
   }
 
   completeDateInputs(prefix: string, date: string): void {
-    const parsedDate = convertDateString(date)
-
+    const parsedDate = DateFormats.convertIsoToDateObj(date)
     cy.get(`#${prefix}-day`).type(parsedDate.getDate().toString())
     cy.get(`#${prefix}-month`).type(`${parsedDate.getMonth() + 1}`)
     cy.get(`#${prefix}-year`).type(parsedDate.getFullYear().toString())

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -10,7 +10,7 @@ import personFactory from '../../testutils/factories/person'
 import applicationFactory from '../../testutils/factories/application'
 
 import paths from '../../paths/apply'
-import { formatDateString } from '../../utils/utils'
+import { DateFormats } from '../../utils/dateUtils'
 
 jest.mock('../../utils/validation')
 
@@ -115,7 +115,7 @@ describe('applicationsController', () => {
         expect(response.render).toHaveBeenCalledWith('applications/confirm', {
           pageHeading: `Confirm ${person.name}'s details`,
           ...person,
-          dateOfBirth: formatDateString(person.dateOfBirth),
+          dateOfBirth: DateFormats.isoDateToUIDate(person.dateOfBirth),
           errors: {},
           errorSummary: [],
         })
@@ -135,7 +135,7 @@ describe('applicationsController', () => {
         expect(response.render).toHaveBeenCalledWith('applications/confirm', {
           pageHeading: `Confirm ${person.name}'s details`,
           ...person,
-          dateOfBirth: formatDateString(person.dateOfBirth),
+          dateOfBirth: DateFormats.isoDateToUIDate(person.dateOfBirth),
           errors: errorsAndUserInput.errors,
           errorSummary: errorsAndUserInput.errorSummary,
           ...errorsAndUserInput.userInput,

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -5,7 +5,7 @@ import ApplicationService from '../../services/applicationService'
 import { PersonService } from '../../services'
 import { fetchErrorsAndUserInput } from '../../utils/validation'
 import paths from '../../paths/apply'
-import { formatDateString } from '../../utils/utils'
+import { DateFormats } from '../../utils/dateUtils'
 
 export default class ApplicationsController {
   constructor(private readonly applicationService: ApplicationService, private readonly personService: PersonService) {}
@@ -50,7 +50,7 @@ export default class ApplicationsController {
         return res.render(`applications/confirm`, {
           pageHeading: `Confirm ${person.name}'s details`,
           ...person,
-          dateOfBirth: formatDateString(person.dateOfBirth),
+          dateOfBirth: DateFormats.isoDateToUIDate(person.dateOfBirth),
           errors,
           errorSummary,
           ...userInput,

--- a/server/controllers/manage/arrivalsController.ts
+++ b/server/controllers/manage/arrivalsController.ts
@@ -1,7 +1,7 @@
 import type { Response, Request, RequestHandler } from 'express'
 import type { Arrival, NewArrival } from 'approved-premises'
 
-import { convertDateAndTimeInputsToIsoString } from '../../utils/utils'
+import { DateFormats } from '../../utils/dateUtils'
 import ArrivalService from '../../services/arrivalService'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
 import paths from '../../paths/manage'
@@ -30,8 +30,8 @@ export default class ArrivalsController {
       const { premisesId, bookingId } = req.params
       const body = req.body as NewArrival
 
-      const { date } = convertDateAndTimeInputsToIsoString(body, 'date')
-      const { expectedDepartureDate } = convertDateAndTimeInputsToIsoString(body, 'expectedDepartureDate')
+      const { date } = DateFormats.convertDateAndTimeInputsToIsoString(body, 'date')
+      const { expectedDepartureDate } = DateFormats.convertDateAndTimeInputsToIsoString(body, 'expectedDepartureDate')
 
       const arrival: Omit<Arrival, 'id' | 'bookingId'> = {
         ...body.arrival,

--- a/server/controllers/manage/bookingExtensionsController.ts
+++ b/server/controllers/manage/bookingExtensionsController.ts
@@ -3,7 +3,8 @@ import type { Request, Response, RequestHandler } from 'express'
 import type { BookingExtension } from 'approved-premises'
 import BookingService from '../../services/bookingService'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
-import { convertDateAndTimeInputsToIsoString } from '../../utils/utils'
+import { DateFormats } from '../../utils/dateUtils'
+
 import paths from '../../paths/manage'
 
 export default class BookingExtensionsController {
@@ -26,7 +27,7 @@ export default class BookingExtensionsController {
 
       const bookingExtension: BookingExtension = {
         ...req.body,
-        ...convertDateAndTimeInputsToIsoString(req.body, 'newDepartureDate'),
+        ...DateFormats.convertDateAndTimeInputsToIsoString(req.body, 'newDepartureDate'),
       }
 
       try {

--- a/server/controllers/manage/bookingsController.ts
+++ b/server/controllers/manage/bookingsController.ts
@@ -3,7 +3,8 @@ import type { Request, Response, RequestHandler } from 'express'
 
 import { BookingService, PremisesService, PersonService } from '../../services'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
-import { convertDateAndTimeInputsToIsoString } from '../../utils/utils'
+import { DateFormats } from '../../utils/dateUtils'
+
 import paths from '../../paths/manage'
 
 export default class BookingsController {
@@ -61,8 +62,8 @@ export default class BookingsController {
 
       const booking: NewBooking = {
         ...req.body,
-        ...convertDateAndTimeInputsToIsoString(req.body, 'arrivalDate'),
-        ...convertDateAndTimeInputsToIsoString(req.body, 'departureDate'),
+        ...DateFormats.convertDateAndTimeInputsToIsoString(req.body, 'arrivalDate'),
+        ...DateFormats.convertDateAndTimeInputsToIsoString(req.body, 'departureDate'),
       }
 
       try {

--- a/server/controllers/manage/cancellationsController.ts
+++ b/server/controllers/manage/cancellationsController.ts
@@ -4,7 +4,8 @@ import type { NewCancellation } from 'approved-premises'
 
 import { CancellationService, BookingService } from '../../services'
 import { fetchErrorsAndUserInput, catchValidationErrorOrPropogate } from '../../utils/validation'
-import { convertDateAndTimeInputsToIsoString } from '../../utils/utils'
+import { DateFormats } from '../../utils/dateUtils'
+
 import paths from '../../paths/manage'
 
 export default class CancellationsController {
@@ -37,7 +38,7 @@ export default class CancellationsController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, bookingId } = req.params
-      const { date } = convertDateAndTimeInputsToIsoString(req.body, 'date')
+      const { date } = DateFormats.convertDateAndTimeInputsToIsoString(req.body, 'date')
 
       const cancellation = {
         ...req.body.cancellation,

--- a/server/controllers/manage/departuresController.ts
+++ b/server/controllers/manage/departuresController.ts
@@ -1,7 +1,7 @@
 import type { Response, Request, RequestHandler } from 'express'
 import type { NewDeparture } from 'approved-premises'
 
-import { convertDateAndTimeInputsToIsoString } from '../../utils/utils'
+import { DateFormats } from '../../utils/dateUtils'
 import DepartureService from '../../services/departureService'
 import PremisesService from '../../services/premisesService'
 import BookingService from '../../services/bookingService'
@@ -40,7 +40,7 @@ export default class DeparturesController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, bookingId } = req.params
-      const { dateTime } = convertDateAndTimeInputsToIsoString(req.body, 'dateTime')
+      const { dateTime } = DateFormats.convertDateAndTimeInputsToIsoString(req.body, 'dateTime')
 
       const departure = {
         ...req.body.departure,

--- a/server/controllers/manage/lostBedsController.ts
+++ b/server/controllers/manage/lostBedsController.ts
@@ -3,8 +3,8 @@ import type { Response, Request, RequestHandler } from 'express'
 import type { NewLostBed } from 'approved-premises'
 import LostBedService from '../../services/lostBedService'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
-import { convertDateAndTimeInputsToIsoString } from '../../utils/utils'
 import paths from '../../paths/manage'
+import { DateFormats } from '../../utils/dateUtils'
 
 export default class LostBedsController {
   constructor(private readonly lostBedService: LostBedService) {}
@@ -30,8 +30,8 @@ export default class LostBedsController {
     return async (req: Request, res: Response) => {
       const { premisesId } = req.params
 
-      const { startDate } = convertDateAndTimeInputsToIsoString(req.body, 'startDate')
-      const { endDate } = convertDateAndTimeInputsToIsoString(req.body, 'endDate')
+      const { startDate } = DateFormats.convertDateAndTimeInputsToIsoString(req.body, 'startDate')
+      const { endDate } = DateFormats.convertDateAndTimeInputsToIsoString(req.body, 'endDate')
 
       const lostBed: NewLostBed = { ...req.body.lostBed, startDate, endDate }
 

--- a/server/controllers/manage/nonArrivalsController.ts
+++ b/server/controllers/manage/nonArrivalsController.ts
@@ -1,6 +1,6 @@
 import { Response, Request, RequestHandler } from 'express'
 import type { NonArrival, NewNonArrival } from 'approved-premises'
-import { convertDateAndTimeInputsToIsoString } from '../../utils/utils'
+import { DateFormats } from '../../utils/dateUtils'
 import NonArrivalService from '../../services/nonArrivalService'
 import { catchValidationErrorOrPropogate } from '../../utils/validation'
 import paths from '../../paths/manage'
@@ -12,7 +12,7 @@ export default class NonArrivalsController {
     return async (req: Request, res: Response) => {
       const { premisesId, bookingId } = req.params
       const body = req.body as NewNonArrival
-      const { nonArrivalDate } = convertDateAndTimeInputsToIsoString(body, 'nonArrivalDate')
+      const { nonArrivalDate } = DateFormats.convertDateAndTimeInputsToIsoString(body, 'nonArrivalDate')
 
       const nonArrival: Omit<NonArrival, 'id' | 'bookingId'> = {
         ...body.nonArrival,

--- a/server/form-pages/apply/basic-information/oralHearing.ts
+++ b/server/form-pages/apply/basic-information/oralHearing.ts
@@ -1,8 +1,7 @@
 import type { ObjectWithDateParts, YesOrNo } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
-import { dateIsBlank } from '../../../utils/utils'
-import { dateAndTimeInputsAreValidDates } from '../../../utils/dateUtils'
+import { dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../utils/dateUtils'
 
 export default class OralHearing implements TasklistPage {
   name = 'oral-hearing'

--- a/server/form-pages/apply/basic-information/oralHearing.ts
+++ b/server/form-pages/apply/basic-information/oralHearing.ts
@@ -1,7 +1,8 @@
 import type { ObjectWithDateParts, YesOrNo } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
-import { dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../utils/utils'
+import { dateIsBlank } from '../../../utils/utils'
+import { dateAndTimeInputsAreValidDates } from '../../../utils/dateUtils'
 
 export default class OralHearing implements TasklistPage {
   name = 'oral-hearing'

--- a/server/form-pages/apply/basic-information/placementDate.test.ts
+++ b/server/form-pages/apply/basic-information/placementDate.test.ts
@@ -1,7 +1,7 @@
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
-import { formatDateString } from '../../../utils/utils'
 
 import PlacementDate from './placementDate'
+import { DateFormats } from '../../../utils/dateUtils'
 
 describe('PlacementDate', () => {
   const releaseDate = new Date().toISOString()
@@ -26,7 +26,9 @@ describe('PlacementDate', () => {
         'startDate-month': 12,
         'startDate-day': 1,
       })
-      expect(page.title).toEqual(`Is ${formatDateString(releaseDate)} the date you want the placement to start?`)
+      expect(page.title).toEqual(
+        `Is ${DateFormats.isoDateToUIDate(releaseDate)} the date you want the placement to start?`,
+      )
     })
   })
 

--- a/server/form-pages/apply/basic-information/placementDate.ts
+++ b/server/form-pages/apply/basic-information/placementDate.ts
@@ -1,8 +1,8 @@
 import type { ObjectWithDateParts, YesOrNo } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
-import { dateIsBlank, retrieveQuestionResponseFromSession } from '../../../utils/utils'
-import { dateAndTimeInputsAreValidDates, DateFormats } from '../../../utils/dateUtils'
+import { retrieveQuestionResponseFromSession } from '../../../utils/utils'
+import { dateIsBlank, dateAndTimeInputsAreValidDates, DateFormats } from '../../../utils/dateUtils'
 
 export default class PlacementDate implements TasklistPage {
   name = 'placement-date'

--- a/server/form-pages/apply/basic-information/placementDate.ts
+++ b/server/form-pages/apply/basic-information/placementDate.ts
@@ -1,8 +1,8 @@
 import type { ObjectWithDateParts, YesOrNo } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
-import { dateAndTimeInputsAreValidDates, dateIsBlank, retrieveQuestionResponseFromSession } from '../../../utils/utils'
-import { DateFormats } from '../../../utils/dateUtils'
+import { dateIsBlank, retrieveQuestionResponseFromSession } from '../../../utils/utils'
+import { dateAndTimeInputsAreValidDates, DateFormats } from '../../../utils/dateUtils'
 
 export default class PlacementDate implements TasklistPage {
   name = 'placement-date'

--- a/server/form-pages/apply/basic-information/placementDate.ts
+++ b/server/form-pages/apply/basic-information/placementDate.ts
@@ -1,12 +1,8 @@
 import type { ObjectWithDateParts, YesOrNo } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
-import {
-  dateAndTimeInputsAreValidDates,
-  dateIsBlank,
-  formatDateString,
-  retrieveQuestionResponseFromSession,
-} from '../../../utils/utils'
+import { dateAndTimeInputsAreValidDates, dateIsBlank, retrieveQuestionResponseFromSession } from '../../../utils/utils'
+import { DateFormats } from '../../../utils/dateUtils'
 
 export default class PlacementDate implements TasklistPage {
   name = 'placement-date'
@@ -25,7 +21,9 @@ export default class PlacementDate implements TasklistPage {
       startDateSameAsReleaseDate: body.startDateSameAsReleaseDate as YesOrNo,
     }
 
-    const formattedReleaseDate = formatDateString(retrieveQuestionResponseFromSession(session, 'releaseDate'))
+    const formattedReleaseDate = DateFormats.isoDateToUIDate(
+      retrieveQuestionResponseFromSession(session, 'releaseDate'),
+    )
 
     this.title = `Is ${formattedReleaseDate} the date you want the placement to start?`
   }

--- a/server/form-pages/apply/basic-information/releaseDate.ts
+++ b/server/form-pages/apply/basic-information/releaseDate.ts
@@ -1,7 +1,8 @@
 import type { ObjectWithDateParts, YesOrNo } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
-import { dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../utils/utils'
+import { dateIsBlank } from '../../../utils/utils'
+import { dateAndTimeInputsAreValidDates } from '../../../utils/dateUtils'
 
 export default class ReleaseDate implements TasklistPage {
   name = 'release-date'

--- a/server/form-pages/apply/basic-information/releaseDate.ts
+++ b/server/form-pages/apply/basic-information/releaseDate.ts
@@ -1,8 +1,7 @@
 import type { ObjectWithDateParts, YesOrNo } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
-import { dateIsBlank } from '../../../utils/utils'
-import { dateAndTimeInputsAreValidDates } from '../../../utils/dateUtils'
+import { dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../utils/dateUtils'
 
 export default class ReleaseDate implements TasklistPage {
   name = 'release-date'

--- a/server/form-pages/apply/type-of-ap/pipeReferral.ts
+++ b/server/form-pages/apply/type-of-ap/pipeReferral.ts
@@ -1,8 +1,7 @@
 import type { YesOrNo, ObjectWithDateParts } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
-import { dateIsBlank } from '../../../utils/utils'
-import { dateAndTimeInputsAreValidDates } from '../../../utils/dateUtils'
+import { dateIsBlank, dateAndTimeInputsAreValidDates } from '../../../utils/dateUtils'
 
 export default class PipeReferral implements TasklistPage {
   name = 'pipe-referral'

--- a/server/form-pages/apply/type-of-ap/pipeReferral.ts
+++ b/server/form-pages/apply/type-of-ap/pipeReferral.ts
@@ -1,7 +1,8 @@
 import type { YesOrNo, ObjectWithDateParts } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
-import { dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../utils/utils'
+import { dateIsBlank } from '../../../utils/utils'
+import { dateAndTimeInputsAreValidDates } from '../../../utils/dateUtils'
 
 export default class PipeReferral implements TasklistPage {
   name = 'pipe-referral'

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -10,8 +10,8 @@ import ApplicationClient from '../data/applicationClient'
 
 import pages from '../form-pages/apply'
 import paths from '../paths/apply'
-import { formatDateString } from '../utils/utils'
 import applicationFactory from '../testutils/factories/application'
+import { DateFormats } from '../utils/dateUtils'
 
 const FirstPage = jest.fn()
 const SecondPage = jest.fn()
@@ -82,7 +82,7 @@ describe('ApplicationService', () => {
             html: `<span class="moj-badge moj-badge--red">${applicationSummaryA.tier.level}</span>`,
           },
           {
-            text: formatDateString(applicationSummaryA.arrivalDate),
+            text: DateFormats.isoDateToUIDate(applicationSummaryA.arrivalDate),
           },
           {
             html: `<strong class="govuk-tag govuk-tag--blue">${applicationSummaryA.status}</strong>`,
@@ -101,7 +101,7 @@ describe('ApplicationService', () => {
             html: `<span class="moj-badge moj-badge--purple">${applicationSummaryB.tier.level}</span>`,
           },
           {
-            text: formatDateString(applicationSummaryB.arrivalDate),
+            text: DateFormats.isoDateToUIDate(applicationSummaryB.arrivalDate),
           },
           {
             html: `<strong class="govuk-tag govuk-tag--yellow">${applicationSummaryB.status}</strong>`,

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -8,8 +8,8 @@ import { UnknownPageError, ValidationError } from '../utils/errors'
 import type { PersonService } from './index'
 
 import pages from '../form-pages/apply'
-import { formatDateString } from '../utils/utils'
 import paths from '../paths/apply'
+import { DateFormats } from '../utils/dateUtils'
 
 export type DataServices = {
   personService: PersonService
@@ -117,7 +117,7 @@ export default class ApplicationService {
         this.createNameAnchorElement(application.person.name, application.id),
         this.textValue(application.person.crn),
         this.createTierBadge(application.tier.level),
-        this.textValue(formatDateString(application.arrivalDate)),
+        this.textValue(DateFormats.isoDateToUIDate(application.arrivalDate)),
         this.createStatusTag(application.status),
       ]
     })

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -6,8 +6,8 @@ import newBookingFactory from '../testutils/factories/newBooking'
 import bookingFactory from '../testutils/factories/booking'
 import referenceDataFactory from '../testutils/factories/referenceData'
 
-import { formatDate } from '../utils/utils'
 import paths from '../paths/manage'
+import { DateFormats } from '../utils/dateUtils'
 
 jest.mock('../data/bookingClient.ts')
 jest.mock('../data/referenceDataClient.ts')
@@ -173,13 +173,13 @@ describe('BookingService', () => {
       const results = service.bookingsToTableRows(bookings, premisesId, 'arrival')
 
       expect(results[0][0]).toEqual({ text: bookings[0].person.crn })
-      expect(results[0][1]).toEqual({ text: formatDate(booking1Date) })
+      expect(results[0][1]).toEqual({ text: DateFormats.dateObjtoUIDate(booking1Date) })
       expect(results[0][2]).toEqual({
         html: expect.stringMatching(paths.bookings.show({ premisesId, bookingId: bookings[0].id })),
       })
 
       expect(results[1][0]).toEqual({ text: bookings[1].person.crn })
-      expect(results[1][1]).toEqual({ text: formatDate(booking2Date) })
+      expect(results[1][1]).toEqual({ text: DateFormats.dateObjtoUIDate(booking2Date) })
       expect(results[1][2]).toEqual({
         html: expect.stringMatching(paths.bookings.show({ premisesId, bookingId: bookings[1].id })),
       })
@@ -199,13 +199,13 @@ describe('BookingService', () => {
       const results = service.bookingsToTableRows(bookings, premisesId, 'departure')
 
       expect(results[0][0]).toEqual({ text: bookings[0].person.crn })
-      expect(results[0][1]).toEqual({ text: formatDate(booking1Date) })
+      expect(results[0][1]).toEqual({ text: DateFormats.dateObjtoUIDate(booking1Date) })
       expect(results[0][2]).toEqual({
         html: expect.stringMatching(paths.bookings.show({ premisesId, bookingId: bookings[0].id })),
       })
 
       expect(results[1][0]).toEqual({ text: bookings[1].person.crn })
-      expect(results[1][1]).toEqual({ text: formatDate(booking2Date) })
+      expect(results[1][1]).toEqual({ text: DateFormats.dateObjtoUIDate(booking2Date) })
       expect(results[1][2]).toEqual({
         html: expect.stringMatching(paths.bookings.show({ premisesId, bookingId: bookings[1].id })),
       })

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -11,8 +11,8 @@ import type {
 
 import type { RestClientBuilder, ReferenceDataClient } from '../data'
 import BookingClient from '../data/bookingClient'
-import { convertDateString, formatDate } from '../utils/utils'
 import paths from '../paths/manage'
+import { DateFormats } from '../utils/dateUtils'
 
 export default class BookingService {
   UPCOMING_WINDOW_IN_DAYS = 5
@@ -87,7 +87,7 @@ export default class BookingService {
         text: booking.person.crn,
       },
       {
-        text: formatDate(convertDateString(type === 'arrival' ? booking.arrivalDate : booking.departureDate)),
+        text: DateFormats.isoDateToUIDate(type === 'arrival' ? booking.arrivalDate : booking.departureDate),
       },
       {
         html: `<a href="${paths.bookings.show({ premisesId, bookingId: booking.id })}">
@@ -115,7 +115,7 @@ export default class BookingService {
         text: booking.person.crn,
       },
       {
-        text: formatDate(convertDateString(booking.departureDate)),
+        text: DateFormats.isoDateToUIDate(booking.departureDate),
       },
       {
         html: `<a href="${paths.bookings.show({ premisesId, bookingId: booking.id })}">

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -130,12 +130,14 @@ export default class BookingService {
 
   private bookingsArrivingToday(bookings: Array<Booking>, today: Date): Array<Booking> {
     return this.bookingsAwaitingArrival(bookings).filter(booking =>
-      isSameDay(convertDateString(booking.arrivalDate), today),
+      isSameDay(DateFormats.convertIsoToDateObj(booking.arrivalDate), today),
     )
   }
 
   private bookingsDepartingToday(bookings: Array<Booking>, today: Date): Array<Booking> {
-    return this.arrivedBookings(bookings).filter(booking => isSameDay(convertDateString(booking.departureDate), today))
+    return this.arrivedBookings(bookings).filter(booking =>
+      isSameDay(DateFormats.convertIsoToDateObj(booking.departureDate), today),
+    )
   }
 
   private upcomingArrivals(bookings: Array<Booking>, today: Date): Array<Booking> {
@@ -155,7 +157,7 @@ export default class BookingService {
   }
 
   private isUpcoming(date: string, today: Date) {
-    return isWithinInterval(convertDateString(date), {
+    return isWithinInterval(DateFormats.convertIsoToDateObj(date), {
       start: addDays(today, 1),
       end: addDays(today, this.UPCOMING_WINDOW_IN_DAYS + 1),
     })

--- a/server/services/departureService.test.ts
+++ b/server/services/departureService.test.ts
@@ -1,5 +1,4 @@
 import type { Departure } from 'approved-premises'
-import { parseISO } from 'date-fns'
 
 import DepartureService from './departureService'
 import BookingClient from '../data/bookingClient'
@@ -8,6 +7,7 @@ import ReferenceDataClient from '../data/referenceDataClient'
 import departureFactory from '../testutils/factories/departure'
 import referenceDataFactory from '../testutils/factories/referenceData'
 import newDepartureFactory from '../testutils/factories/newDeparture'
+import { DateFormats } from '../utils/dateUtils'
 
 jest.mock('../data/bookingClient.ts')
 jest.mock('../data/referenceDataClient.ts')
@@ -53,7 +53,7 @@ describe('DepartureService', () => {
 
       expect(requestedDeparture).toEqual({
         ...departure,
-        dateTime: parseISO(departure.dateTime).toLocaleDateString('en-GB'),
+        dateTime: DateFormats.isoDateToUIDate(departure.dateTime),
       })
 
       expect(DepartureClientFactory).toHaveBeenCalledWith(token)

--- a/server/services/departureService.ts
+++ b/server/services/departureService.ts
@@ -1,7 +1,6 @@
-import { parseISO } from 'date-fns'
-
 import type { Departure, ReferenceData, NewDeparture } from 'approved-premises'
 import type { RestClientBuilder, BookingClient, ReferenceDataClient } from '../data'
+import { DateFormats } from '../utils/dateUtils'
 
 export type DepartureReferenceData = {
   departureReasons: Array<ReferenceData>
@@ -33,7 +32,7 @@ export default class DepartureService {
 
     const departure = await departureClient.findDeparture(premisesId, bookingId, departureId)
 
-    return { ...departure, dateTime: parseISO(departure.dateTime).toLocaleDateString('en-GB') }
+    return { ...departure, dateTime: DateFormats.isoDateToUIDate(departure.dateTime) }
   }
 
   async getReferenceData(token: string): Promise<DepartureReferenceData> {

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -1,7 +1,7 @@
 import type { Premises, TableRow, SummaryList } from 'approved-premises'
 import type { RestClientBuilder, PremisesClient } from '../data'
 
-import { formatDateString } from '../utils/utils'
+import { DateFormats } from '../utils/dateUtils'
 import getDateRangesWithNegativeBeds, { NegativeDateRange } from '../utils/premisesUtils'
 
 export default class PremisesService {
@@ -47,21 +47,23 @@ export default class PremisesService {
   private generateOvercapacityMessage(overcapacityDateRanges: NegativeDateRange[]) {
     if (overcapacityDateRanges.length === 1) {
       if (!overcapacityDateRanges[0].end) {
-        return `<h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity on ${formatDateString(
+        return `<h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity on ${DateFormats.isoDateToUIDate(
           overcapacityDateRanges[0].start,
         )}</h4>`
       }
-      return `<h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity for the period ${formatDateString(
+      return `<h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity for the period ${DateFormats.isoDateToUIDate(
         overcapacityDateRanges[0].start,
-      )} to ${formatDateString(overcapacityDateRanges[0].end)}</h4>`
+      )} to ${DateFormats.isoDateToUIDate(overcapacityDateRanges[0].end)}</h4>`
     }
 
     if (overcapacityDateRanges.length > 1) {
       const dateRanges = overcapacityDateRanges
         .map((dateRange: NegativeDateRange) =>
           !dateRange.end
-            ? `<li>${formatDateString(dateRange.start)}</li>`
-            : `<li>${formatDateString(dateRange.start)} to ${formatDateString(dateRange.end)}</li>`,
+            ? `<li>${DateFormats.isoDateToUIDate(dateRange.start)}</li>`
+            : `<li>${DateFormats.isoDateToUIDate(dateRange.start)} to ${DateFormats.isoDateToUIDate(
+                dateRange.end,
+              )}</li>`,
         )
         .join('')
       return `<h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity for the periods:</h4>

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 
 import type { Application } from 'approved-premises'
 import personFactory from './person'
-import { DateFormats } from '../../utils/dateFormats'
+import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<Application>(() => ({
   id: faker.datatype.uuid(),

--- a/server/testutils/factories/arrival.ts
+++ b/server/testutils/factories/arrival.ts
@@ -2,7 +2,7 @@ import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
 
 import type { Arrival } from 'approved-premises'
-import { DateFormats } from '../../utils/dateFormats'
+import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<Arrival>(() => ({
   id: faker.datatype.uuid(),

--- a/server/testutils/factories/booking.ts
+++ b/server/testutils/factories/booking.ts
@@ -7,7 +7,7 @@ import arrivalFactory from './arrival'
 import departureFactory from './departure'
 import keyWorkerFactory from './keyWorker'
 import personFactory from './person'
-import { DateFormats } from '../../utils/dateFormats'
+import { DateFormats } from '../../utils/dateUtils'
 
 const today = DateFormats.formatApiDate(startOfToday())
 const soon = () => DateFormats.formatApiDate(faker.date.soon(5, addDays(new Date(new Date().setHours(0, 0, 0, 0)), 1)))

--- a/server/testutils/factories/cancellation.ts
+++ b/server/testutils/factories/cancellation.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 
 import type { Cancellation } from 'approved-premises'
 import referenceDataFactory from './referenceData'
-import { DateFormats } from '../../utils/dateFormats'
+import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<Cancellation>(() => ({
   id: faker.datatype.uuid(),

--- a/server/testutils/factories/departure.ts
+++ b/server/testutils/factories/departure.ts
@@ -4,7 +4,7 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 import type { Departure } from 'approved-premises'
 import referenceDataFactory from './referenceData'
 import premisesFactory from './premises'
-import { DateFormats } from '../../utils/dateFormats'
+import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<Departure>(() => ({
   id: faker.datatype.uuid(),

--- a/server/testutils/factories/departure.ts
+++ b/server/testutils/factories/departure.ts
@@ -8,7 +8,7 @@ import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<Departure>(() => ({
   id: faker.datatype.uuid(),
-  dateTime: DateFormats.formatApiDate(faker.date.soon()),
+  dateTime: DateFormats.formatApiDateTime(faker.date.soon()),
   bookingId: faker.datatype.uuid(),
   reason: referenceDataFactory.departureReasons().build(),
   notes: faker.lorem.sentence(),

--- a/server/testutils/factories/lostBed.ts
+++ b/server/testutils/factories/lostBed.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 
 import type { LostBed } from 'approved-premises'
 import referenceDataFactory from './referenceData'
-import { DateFormats } from '../../utils/dateFormats'
+import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<LostBed>(() => ({
   id: faker.datatype.uuid(),

--- a/server/testutils/factories/newBooking.ts
+++ b/server/testutils/factories/newBooking.ts
@@ -5,7 +5,7 @@ import type { NewBooking } from 'approved-premises'
 
 import keyWorkerFactory from './keyWorker'
 import personFactory from './person'
-import { DateFormats } from '../../utils/dateFormats'
+import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<NewBooking>(() => {
   const arrivalDate = faker.date.soon()

--- a/server/testutils/factories/newCancellation.ts
+++ b/server/testutils/factories/newCancellation.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 
 import type { NewCancellation } from 'approved-premises'
 import referenceDataFactory from './referenceData'
-import { DateFormats } from '../../utils/dateFormats'
+import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<NewCancellation>(() => {
   const date = faker.date.soon()

--- a/server/testutils/factories/newDeparture.ts
+++ b/server/testutils/factories/newDeparture.ts
@@ -4,7 +4,7 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 import type { NewDeparture } from 'approved-premises'
 import referenceDataFactory from './referenceData'
 import premisesFactory from './premises'
-import { DateFormats } from '../../utils/dateFormats'
+import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<NewDeparture>(() => {
   const date = faker.date.soon()

--- a/server/testutils/factories/newDeparture.ts
+++ b/server/testutils/factories/newDeparture.ts
@@ -9,7 +9,7 @@ import { DateFormats } from '../../utils/dateUtils'
 export default Factory.define<NewDeparture>(() => {
   const date = faker.date.soon()
   return {
-    dateTime: DateFormats.formatApiDate(date),
+    dateTime: DateFormats.formatApiDateTime(date),
     'dateTime-day': date.getDate().toString(),
     'dateTime-month': date.getMonth().toString(),
     'dateTime-year': date.getFullYear().toString(),

--- a/server/testutils/factories/newLostBed.ts
+++ b/server/testutils/factories/newLostBed.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 
 import type { NewLostBed } from 'approved-premises'
 import referenceDataFactory from './referenceData'
-import { DateFormats } from '../../utils/dateFormats'
+import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<NewLostBed>(() => {
   const startDate = faker.date.soon()

--- a/server/testutils/factories/nonArrival.ts
+++ b/server/testutils/factories/nonArrival.ts
@@ -2,7 +2,7 @@ import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
 
 import type { NonArrival } from 'approved-premises'
-import { DateFormats } from '../../utils/dateFormats'
+import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<NonArrival>(() => ({
   id: faker.datatype.uuid(),

--- a/server/testutils/factories/person.ts
+++ b/server/testutils/factories/person.ts
@@ -2,7 +2,7 @@ import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
 
 import type { Person } from 'approved-premises'
-import { DateFormats } from '../../utils/dateFormats'
+import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<Person>(() => ({
   crn: `C${faker.datatype.number({ min: 100000, max: 999999 })}`,

--- a/server/testutils/factories/premisesCapacityItem.ts
+++ b/server/testutils/factories/premisesCapacityItem.ts
@@ -2,7 +2,7 @@ import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
 
 import type { PremisesCapacityItem } from 'approved-premises'
-import { DateFormats } from '../../utils/dateFormats'
+import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<PremisesCapacityItem>(() => ({
   availableBeds: faker.datatype.number({ min: -1, max: 2 }),

--- a/server/utils/dateFormats.ts
+++ b/server/utils/dateFormats.ts
@@ -1,8 +1,0 @@
-import formatISO from 'date-fns/formatISO'
-
-// eslint-disable-next-line
-export class DateFormats {
-  static formatApiDate(date: Date) {
-    return formatISO(date, { representation: 'date' })
-  }
-}

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -1,6 +1,26 @@
 import { DateFormats, InvalidDateStringError, dateAndTimeInputsAreValidDates } from './dateUtils'
 
 describe('DateFormats', () => {
+  describe('convertIsoToDateObj', () => {
+    it('converts a ISO8601 date string', () => {
+      const date = '2022-11-11T00:00:00.000Z'
+
+      expect(DateFormats.convertIsoToDateObj(date)).toEqual(new Date(2022, 10, 11))
+    })
+
+    it('raises an error if the date is not a valid ISO8601 date string', () => {
+      const date = '23/11/2022'
+
+      expect(() => DateFormats.convertIsoToDateObj(date)).toThrow(new InvalidDateStringError(`Invalid Date: ${date}`))
+    })
+
+    it('raises an error if the date is not a date string', () => {
+      const date = 'NOT A DATE'
+
+      expect(() => DateFormats.convertIsoToDateObj(date)).toThrow(new InvalidDateStringError(`Invalid Date: ${date}`))
+    })
+  })
+
   describe('isoDateToUIDate', () => {
     it('converts a ISO8601 date string to a GOV.UK formatted date', () => {
       const date = '2022-11-11T00:00:00.000Z'

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -40,4 +40,67 @@ describe('DateFormats', () => {
       expect(() => DateFormats.isoDateToUIDate(date)).toThrow(new InvalidDateStringError(`Invalid Date: ${date}`))
     })
   })
+
+  describe('convertDateAndTimeInputsToIsoString', () => {
+    it('converts a date object', () => {
+      const obj: ObjectWithDateParts<'date'> = {
+        'date-year': '2022',
+        'date-month': '12',
+        'date-day': '11',
+      }
+
+      const result = DateFormats.convertDateAndTimeInputsToIsoString(obj, 'date')
+
+      expect(result.date).toEqual(new Date(2022, 11, 11).toISOString())
+    })
+
+    it('pads the months and days', () => {
+      const obj: ObjectWithDateParts<'date'> = {
+        'date-year': '2022',
+        'date-month': '1',
+        'date-day': '1',
+      }
+
+      const result = DateFormats.convertDateAndTimeInputsToIsoString(obj, 'date')
+
+      expect(result.date).toEqual(new Date(2022, 0, 1).toISOString())
+    })
+
+    it('returns the date with a time if passed one', () => {
+      const obj: ObjectWithDateParts<'date'> = {
+        'date-year': '2022',
+        'date-month': '1',
+        'date-day': '1',
+        'date-time': '12:35',
+      }
+
+      const result = DateFormats.convertDateAndTimeInputsToIsoString(obj, 'date')
+
+      expect(result.date).toEqual(new Date(2022, 0, 1, 12, 35).toISOString())
+    })
+
+    it('returns an empty string when given empty strings as input', () => {
+      const obj: ObjectWithDateParts<'date'> = {
+        'date-year': '',
+        'date-month': '',
+        'date-day': '',
+      }
+
+      const result = DateFormats.convertDateAndTimeInputsToIsoString(obj, 'date')
+
+      expect(result.date).toEqual('')
+    })
+
+    it('returns an invalid ISO string when given invalid strings as input', () => {
+      const obj: ObjectWithDateParts<'date'> = {
+        'date-year': 'twothousandtwentytwo',
+        'date-month': '20',
+        'date-day': 'foo',
+      }
+
+      const result = DateFormats.convertDateAndTimeInputsToIsoString(obj, 'date')
+
+      expect(result.date.toString()).toEqual('twothousandtwentytwo-20-ooT00:00:00.000Z')
+    })
+  })
 })

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -1,3 +1,4 @@
+import type { ObjectWithDateParts } from 'approved-premises'
 import { DateFormats, InvalidDateStringError, dateAndTimeInputsAreValidDates } from './dateUtils'
 
 describe('DateFormats', () => {
@@ -102,5 +103,53 @@ describe('DateFormats', () => {
 
       expect(result.date.toString()).toEqual('twothousandtwentytwo-20-ooT00:00:00.000Z')
     })
+  })
+})
+
+describe('dateAndTimeInputsAreValidDates', () => {
+  it('returns true when the date is valid', () => {
+    const obj: ObjectWithDateParts<'date'> = {
+      'date-year': '2022',
+      'date-month': '12',
+      'date-day': '11',
+    }
+
+    const result = dateAndTimeInputsAreValidDates(obj, 'date')
+
+    expect(result).toEqual(true)
+  })
+
+  it('returns false when the date is invalid', () => {
+    const obj: ObjectWithDateParts<'date'> = {
+      'date-year': '99',
+      'date-month': '99',
+      'date-day': '99',
+    }
+
+    const result = dateAndTimeInputsAreValidDates(obj, 'date')
+
+    expect(result).toEqual(false)
+  })
+})
+
+describe('dateIsBlank', () => {
+  it('returns false if the date is not blank', () => {
+    const date: ObjectWithDateParts<'field'> = {
+      'field-day': '12',
+      'field-month': '1',
+      'field-year': '2022',
+    }
+
+    expect(dateIsBlank(date)).toEqual(false)
+  })
+
+  it('returns true if the date is blank', () => {
+    const date: ObjectWithDateParts<'field'> = {
+      'field-day': '',
+      'field-month': '',
+      'field-year': '',
+    }
+
+    expect(dateIsBlank(date)).toEqual(true)
   })
 })

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -1,5 +1,5 @@
 import type { ObjectWithDateParts } from 'approved-premises'
-import { DateFormats, InvalidDateStringError, dateAndTimeInputsAreValidDates } from './dateUtils'
+import { DateFormats, InvalidDateStringError, dateAndTimeInputsAreValidDates, dateIsBlank } from './dateUtils'
 
 describe('DateFormats', () => {
   describe('convertIsoToDateObj', () => {

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -1,0 +1,23 @@
+import { DateFormats, InvalidDateStringError, dateAndTimeInputsAreValidDates } from './dateUtils'
+
+describe('DateFormats', () => {
+  describe('isoDateToUIDate', () => {
+    it('converts a ISO8601 date string to a GOV.UK formatted date', () => {
+      const date = '2022-11-11T00:00:00.000Z'
+
+      expect(DateFormats.isoDateToUIDate(date)).toEqual('Friday 11 November 2022')
+    })
+
+    it('raises an error if the date is not a valid ISO8601 date string', () => {
+      const date = '23/11/2022'
+
+      expect(() => DateFormats.isoDateToUIDate(date)).toThrow(new InvalidDateStringError(`Invalid Date: ${date}`))
+    })
+
+    it('raises an error if the date is not a date string', () => {
+      const date = 'NOT A DATE'
+
+      expect(() => DateFormats.isoDateToUIDate(date)).toThrow(new InvalidDateStringError(`Invalid Date: ${date}`))
+    })
+  })
+})

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,0 +1,17 @@
+/* eslint-disable */
+import formatISO from 'date-fns/formatISO'
+import parseISO from 'date-fns/parseISO'
+import format from 'date-fns/format'
+import { ObjectWithDateParts } from 'approved-premises'
+
+export class DateFormats {
+  /**
+   * @param date JS Date object.
+   * @returns the date in the format '2019-09-18'.
+   */
+  static formatApiDate(date: Date) {
+    return formatISO(date, { representation: 'date' })
+  }
+
+}
+

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -29,6 +29,22 @@ export class DateFormats {
   }
 
   /**
+   * Converts an ISO8601 datetime string into a Javascript Date object.
+   * @param date An ISO8601 datetime string
+   * @returns A Date object
+   * @throws {InvalidDateStringError} If the string is not a valid ISO8601 datetime string
+   */
+  static convertIsoToDateObj(date: string) {
+    const parsedDate = parseISO(date)
+
+    if (Number.isNaN(parsedDate.getTime())) {
+      throw new InvalidDateStringError(`Invalid Date: ${date}`)
+    }
+
+    return parsedDate
+  }
+
+  /**
    * @param isoDate an ISO date string.
    * @returns the date in the to be shown in the UI: "Thursday, 20 December 2012".
    */
@@ -36,3 +52,5 @@ export class DateFormats {
     return DateFormats.dateObjtoUIDate(DateFormats.convertIsoToDateObj(isoDate))
   }
 }
+
+export class InvalidDateStringError extends Error {}

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -97,4 +97,9 @@ export const dateAndTimeInputsAreValidDates = <K extends string | number>(
   return true
 }
 
+export const dateIsBlank = <T = ObjectWithDateParts<string | number>>(body: T): boolean => {
+  const fields = Object.keys(body).filter(key => key.match(/-[year|month|day]/))
+  return fields.every(field => !body[field])
+}
+
 export class InvalidDateStringError extends Error {}

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import formatISO from 'date-fns/formatISO'
+import parseISO from 'date-fns/parseISO'
 import format from 'date-fns/format'
 
 export class DateFormats {
@@ -25,5 +26,13 @@ export class DateFormats {
    */
   static dateObjtoUIDate(date: Date) {
     return format(date, 'cccc d MMMM y')
+  }
+
+  /**
+   * @param isoDate an ISO date string.
+   * @returns the date in the to be shown in the UI: "Thursday, 20 December 2012".
+   */
+  static isoDateToUIDate(isoDate: string) {
+    return DateFormats.dateObjtoUIDate(DateFormats.convertIsoToDateObj(isoDate))
   }
 }

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,8 +1,5 @@
 /* eslint-disable */
 import formatISO from 'date-fns/formatISO'
-import parseISO from 'date-fns/parseISO'
-import format from 'date-fns/format'
-import { ObjectWithDateParts } from 'approved-premises'
 
 export class DateFormats {
   /**
@@ -13,5 +10,11 @@ export class DateFormats {
     return formatISO(date, { representation: 'date' })
   }
 
+  /**
+   * @param date JS Date object.
+   * @returns the date in the format '2019-09-18T19:00:52Z'.
+   */
+  static formatApiDateTime(date: Date) {
+    return formatISO(date)
+  }
 }
-

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import formatISO from 'date-fns/formatISO'
+import format from 'date-fns/format'
 
 export class DateFormats {
   /**
@@ -16,5 +17,13 @@ export class DateFormats {
    */
   static formatApiDateTime(date: Date) {
     return formatISO(date)
+  }
+
+  /**
+   * @param date JS Date object.
+   * @returns the date in the to be shown in the UI: "Thursday, 20 December 2012".
+   */
+  static dateObjtoUIDate(date: Date) {
+    return format(date, 'cccc d MMMM y')
   }
 }

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -51,6 +51,31 @@ export class DateFormats {
   static isoDateToUIDate(isoDate: string) {
     return DateFormats.dateObjtoUIDate(DateFormats.convertIsoToDateObj(isoDate))
   }
+
+  /**
+   * Converts input for a GDS date input https://design-system.service.gov.uk/components/date-input/
+   * into an ISO8601 date string
+   * @param dateInputObj an object with date parts (i.e. `-month` `-day` `-year`), which come from a `govukDateInput`.
+   * @param key the key that prefixes each item in the dateInputObj, also the name of the property which the date object will be returned in the return value.
+   * @returns an ISO8601 date string.
+   */
+  static convertDateAndTimeInputsToIsoString<K extends string | number>(dateInputObj: ObjectWithDateParts<K>, key: K) {
+    const day = `0${dateInputObj[`${key}-day`]}`.slice(-2)
+    const month = `0${dateInputObj[`${key}-month`]}`.slice(-2)
+    const year = dateInputObj[`${key}-year`]
+    const time = dateInputObj[`${key}-time`]
+
+    const timeSegment = time || '00:00'
+
+    const o: { [P in K]?: string } = dateInputObj
+    if (day && month && year) {
+      o[key] = `${year}-${month}-${day}T${timeSegment}:00.000Z`
+    } else {
+      o[key] = ''
+    }
+
+    return dateInputObj
+  }
 }
 
 export class InvalidDateStringError extends Error {}

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,4 +1,6 @@
 /* eslint-disable */
+import type { ObjectWithDateParts } from 'approved-premises'
+
 import formatISO from 'date-fns/formatISO'
 import parseISO from 'date-fns/parseISO'
 import format from 'date-fns/format'
@@ -76,6 +78,23 @@ export class DateFormats {
 
     return dateInputObj
   }
+}
+
+export const dateAndTimeInputsAreValidDates = <K extends string | number>(
+  dateInputObj: ObjectWithDateParts<K>,
+  key: K,
+): boolean => {
+  const dateString = DateFormats.convertDateAndTimeInputsToIsoString(dateInputObj, key)
+
+  try {
+    DateFormats.convertIsoToDateObj(dateString[key])
+  } catch (err) {
+    if (err instanceof InvalidDateStringError) {
+      return false
+    }
+  }
+
+  return true
 }
 
 export class InvalidDateStringError extends Error {}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -6,10 +6,11 @@ import express from 'express'
 import * as pathModule from 'path'
 
 import type { ErrorMessages, ApplicationData, TaskNames } from 'approved-premises'
-import { initialiseName, formatDateString } from './utils'
+import { initialiseName } from './utils'
 import { dateFieldValues, convertObjectsToRadioItems, convertObjectsToSelectOptions } from './formUtils'
 import { getTaskStatus, taskLink } from './applicationUtils'
 import bookingActions from './bookingUtils'
+import { DateFormats } from './dateUtils'
 
 import managePaths from '../paths/manage'
 import applyPaths from '../paths/apply'
@@ -55,7 +56,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
 
   njkEnv.addFilter('initialiseName', initialiseName)
   njkEnv.addGlobal('dateFieldValues', dateFieldValues)
-  njkEnv.addGlobal('formatDate', formatDateString)
+  njkEnv.addGlobal('formatDate', DateFormats.isoDateToUIDate)
 
   njkEnv.addGlobal('dateFieldValues', function sendContextToDateFieldValues(fieldName: string, errors: ErrorMessages) {
     return dateFieldValues(fieldName, this.ctx, errors)

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -3,7 +3,6 @@ import { SessionDataError } from './errors'
 import {
   convertToTitleCase,
   initialiseName,
-  convertDateAndTimeInputsToIsoString,
   dateAndTimeInputsAreValidDates,
   retrieveQuestionResponseFromSession,
   dateIsBlank,
@@ -35,69 +34,6 @@ describe('initialise name', () => {
     ['Double barrelled', 'Robert-John Smith-Jones-Wilson', 'R. Smith-Jones-Wilson'],
   ])('%s initialiseName(%s, %s)', (_: string, a: string, expected: string) => {
     expect(initialiseName(a)).toEqual(expected)
-  })
-})
-
-describe('convertDateInputsToDateObj', () => {
-  it('converts a date object', () => {
-    const obj: ObjectWithDateParts<'date'> = {
-      'date-year': '2022',
-      'date-month': '12',
-      'date-day': '11',
-    }
-
-    const result = convertDateAndTimeInputsToIsoString(obj, 'date')
-
-    expect(result.date).toEqual(new Date(2022, 11, 11).toISOString())
-  })
-
-  it('pads the months and days', () => {
-    const obj: ObjectWithDateParts<'date'> = {
-      'date-year': '2022',
-      'date-month': '1',
-      'date-day': '1',
-    }
-
-    const result = convertDateAndTimeInputsToIsoString(obj, 'date')
-
-    expect(result.date).toEqual(new Date(2022, 0, 1).toISOString())
-  })
-
-  it('returns the date with a time if passed one', () => {
-    const obj: ObjectWithDateParts<'date'> = {
-      'date-year': '2022',
-      'date-month': '1',
-      'date-day': '1',
-      'date-time': '12:35',
-    }
-
-    const result = convertDateAndTimeInputsToIsoString(obj, 'date')
-
-    expect(result.date).toEqual(new Date(2022, 0, 1, 12, 35).toISOString())
-  })
-
-  it('returns an empty string when given empty strings as input', () => {
-    const obj: ObjectWithDateParts<'date'> = {
-      'date-year': '',
-      'date-month': '',
-      'date-day': '',
-    }
-
-    const result = convertDateAndTimeInputsToIsoString(obj, 'date')
-
-    expect(result.date).toEqual('')
-  })
-
-  it('returns an invalid ISO string when given invalid strings as input', () => {
-    const obj: ObjectWithDateParts<'date'> = {
-      'date-year': 'twothousandtwentytwo',
-      'date-month': '20',
-      'date-day': 'foo',
-    }
-
-    const result = convertDateAndTimeInputsToIsoString(obj, 'date')
-
-    expect(result.date.toString()).toEqual('twothousandtwentytwo-20-ooT00:00:00.000Z')
   })
 })
 

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,12 +1,6 @@
 import type { ObjectWithDateParts } from 'approved-premises'
 import { SessionDataError } from './errors'
-import {
-  convertToTitleCase,
-  initialiseName,
-  dateAndTimeInputsAreValidDates,
-  retrieveQuestionResponseFromSession,
-  dateIsBlank,
-} from './utils'
+import { convertToTitleCase, initialiseName, retrieveQuestionResponseFromSession, dateIsBlank } from './utils'
 
 describe('convert to title case', () => {
   it.each([
@@ -34,32 +28,6 @@ describe('initialise name', () => {
     ['Double barrelled', 'Robert-John Smith-Jones-Wilson', 'R. Smith-Jones-Wilson'],
   ])('%s initialiseName(%s, %s)', (_: string, a: string, expected: string) => {
     expect(initialiseName(a)).toEqual(expected)
-  })
-})
-
-describe('dateAndTimeInputsAreValidDates', () => {
-  it('returns true when the date is valid', () => {
-    const obj: ObjectWithDateParts<'date'> = {
-      'date-year': '2022',
-      'date-month': '12',
-      'date-day': '11',
-    }
-
-    const result = dateAndTimeInputsAreValidDates(obj, 'date')
-
-    expect(result).toEqual(true)
-  })
-
-  it('returns false when the date is invalid', () => {
-    const obj: ObjectWithDateParts<'date'> = {
-      'date-year': '99',
-      'date-month': '99',
-      'date-day': '99',
-    }
-
-    const result = dateAndTimeInputsAreValidDates(obj, 'date')
-
-    expect(result).toEqual(false)
   })
 })
 

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,6 +1,5 @@
-import type { ObjectWithDateParts } from 'approved-premises'
 import { SessionDataError } from './errors'
-import { convertToTitleCase, initialiseName, retrieveQuestionResponseFromSession, dateIsBlank } from './utils'
+import { convertToTitleCase, initialiseName, retrieveQuestionResponseFromSession } from './utils'
 
 describe('convert to title case', () => {
   it.each([
@@ -44,27 +43,5 @@ describe('retrieveQuestionResponseFromSession', () => {
       'questionResponse',
     )
     expect(questionResponse).toBe('no')
-  })
-})
-
-describe('dateIsBlank', () => {
-  it('returns false if the date is not blank', () => {
-    const date: ObjectWithDateParts<'field'> = {
-      'field-day': '12',
-      'field-month': '1',
-      'field-year': '2022',
-    }
-
-    expect(dateIsBlank(date)).toEqual(false)
-  })
-
-  it('returns true if the date is blank', () => {
-    const date: ObjectWithDateParts<'field'> = {
-      'field-day': '',
-      'field-month': '',
-      'field-year': '',
-    }
-
-    expect(dateIsBlank(date)).toEqual(true)
   })
 })

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,13 +1,9 @@
 import type { ObjectWithDateParts } from 'approved-premises'
 import { SessionDataError } from './errors'
 import {
-  convertDateString,
   convertToTitleCase,
   initialiseName,
   convertDateAndTimeInputsToIsoString,
-  InvalidDateStringError,
-  formatDate,
-  formatDateString,
   dateAndTimeInputsAreValidDates,
   retrieveQuestionResponseFromSession,
   dateIsBlank,
@@ -39,36 +35,6 @@ describe('initialise name', () => {
     ['Double barrelled', 'Robert-John Smith-Jones-Wilson', 'R. Smith-Jones-Wilson'],
   ])('%s initialiseName(%s, %s)', (_: string, a: string, expected: string) => {
     expect(initialiseName(a)).toEqual(expected)
-  })
-})
-
-describe('formatDate', () => {
-  it('converts a date to a GOV.UK formatted date', () => {
-    const date1 = new Date(2022, 7, 1)
-    const date2 = new Date(2022, 8, 16)
-
-    expect(formatDate(date1)).toEqual('Monday 1 August 2022')
-    expect(formatDate(date2)).toEqual('Friday 16 September 2022')
-  })
-})
-
-describe('formatDateString', () => {
-  it('converts a ISO8601 date string to a GOV.UK formatted date', () => {
-    const date = '2022-11-11T00:00:00.000Z'
-
-    expect(formatDateString(date)).toEqual('Friday 11 November 2022')
-  })
-
-  it('raises an error if the date is not a valid ISO8601 date string', () => {
-    const date = '23/11/2022'
-
-    expect(() => formatDateString(date)).toThrow(new InvalidDateStringError(`Invalid Date: ${date}`))
-  })
-
-  it('raises an error if the date is not a date string', () => {
-    const date = 'NOT A DATE'
-
-    expect(() => formatDateString(date)).toThrow(new InvalidDateStringError(`Invalid Date: ${date}`))
   })
 })
 
@@ -132,26 +98,6 @@ describe('convertDateInputsToDateObj', () => {
     const result = convertDateAndTimeInputsToIsoString(obj, 'date')
 
     expect(result.date.toString()).toEqual('twothousandtwentytwo-20-ooT00:00:00.000Z')
-  })
-})
-
-describe('convertDateString', () => {
-  it('converts a ISO8601 date string', () => {
-    const date = '2022-11-11T00:00:00.000Z'
-
-    expect(convertDateString(date)).toEqual(new Date(2022, 10, 11))
-  })
-
-  it('raises an error if the date is not a valid ISO8601 date string', () => {
-    const date = '23/11/2022'
-
-    expect(() => convertDateString(date)).toThrow(new InvalidDateStringError(`Invalid Date: ${date}`))
-  })
-
-  it('raises an error if the date is not a date string', () => {
-    const date = 'NOT A DATE'
-
-    expect(() => convertDateString(date)).toThrow(new InvalidDateStringError(`Invalid Date: ${date}`))
   })
 })
 

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,6 +1,5 @@
 import type { ObjectWithDateParts } from 'approved-premises'
 import { SessionDataError } from './errors'
-import { DateFormats, InvalidDateStringError } from './dateUtils'
 
 /* istanbul ignore next */
 const properCase = (word: string): string =>

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,6 +1,7 @@
-import { parseISO, format } from 'date-fns'
+import { format } from 'date-fns'
 import type { ObjectWithDateParts } from 'approved-premises'
 import { SessionDataError } from './errors'
+import { DateFormats, InvalidDateStringError } from './dateFormats'
 
 /* istanbul ignore next */
 const properCase = (word: string): string =>
@@ -39,7 +40,6 @@ const kebabCase = (string: string) =>
     .replace(/[\s_]+/g, '-')
     .toLowerCase()
 
-export const formatDateString = (date: string): string => format(convertDateString(date), 'cccc d MMMM y')
 
 export class InvalidDateStringError extends Error {}
 /**
@@ -93,7 +93,7 @@ export const dateAndTimeInputsAreValidDates = <K extends string | number>(
   const dateString = convertDateAndTimeInputsToIsoString(dateInputObj, key)
 
   try {
-    convertDateString(dateString[key])
+    DateFormats.convertIsoToDateObj(dateString[key])
   } catch (err) {
     if (err instanceof InvalidDateStringError) {
       return false

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,4 +1,3 @@
-import type { ObjectWithDateParts } from 'approved-premises'
 import { SessionDataError } from './errors'
 
 /* istanbul ignore next */
@@ -50,9 +49,4 @@ export const retrieveQuestionResponseFromSession = <T>(sessionData: Record<strin
   } catch (e) {
     throw new SessionDataError(`Question ${question} was not found in the session`)
   }
-}
-
-export const dateIsBlank = <T = ObjectWithDateParts<string | number>>(body: T): boolean => {
-  const fields = Object.keys(body).filter(key => key.match(/-[year|month|day]/))
-  return fields.every(field => !body[field])
 }

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -40,51 +40,6 @@ const kebabCase = (string: string) =>
     .toLowerCase()
 
 /**
- * Converts input for a GDS date input https://design-system.service.gov.uk/components/date-input/
- * into an ISO8601 date string
- * @param dateInputObj an object with date parts (i.e. `-month` `-day` `-year`), which come from a `govukDateInput`.
- * @param key the key that prefixes each item in the dateInputObj, also the name of the property which the date object will be returned in the return value.
- * @returns an ISO8601 date string.
- */
-export const convertDateAndTimeInputsToIsoString = <K extends string | number>(
-  dateInputObj: ObjectWithDateParts<K>,
-  key: K,
-) => {
-  const day = `0${dateInputObj[`${key}-day`]}`.slice(-2)
-  const month = `0${dateInputObj[`${key}-month`]}`.slice(-2)
-  const year = dateInputObj[`${key}-year`]
-  const time = dateInputObj[`${key}-time`]
-
-  const timeSegment = time || '00:00'
-
-  const o: { [P in K]?: string } = dateInputObj
-  if (day && month && year) {
-    o[key] = `${year}-${month}-${day}T${timeSegment}:00.000Z`
-  } else {
-    o[key] = ''
-  }
-
-  return dateInputObj
-}
-
-export const dateAndTimeInputsAreValidDates = <K extends string | number>(
-  dateInputObj: ObjectWithDateParts<K>,
-  key: K,
-): boolean => {
-  const dateString = convertDateAndTimeInputsToIsoString(dateInputObj, key)
-
-  try {
-    DateFormats.convertIsoToDateObj(dateString[key])
-  } catch (err) {
-    if (err instanceof InvalidDateStringError) {
-      return false
-    }
-  }
-
-  return true
-}
-
-/**
  * Retrieves response for a given question from the session object.
  * @param sessionData the session data for an application.
  * @param question the question that we need the response for in camelCase.

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -39,9 +39,6 @@ const kebabCase = (string: string) =>
     .replace(/[\s_]+/g, '-')
     .toLowerCase()
 
-// returns a date like 'Tuesday 6 September 2022'
-export const formatDate = (date: Date): string => format(date, 'cccc d MMMM y')
-
 export const formatDateString = (date: string): string => format(convertDateString(date), 'cccc d MMMM y')
 
 export class InvalidDateStringError extends Error {}

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,7 +1,6 @@
-import { format } from 'date-fns'
 import type { ObjectWithDateParts } from 'approved-premises'
 import { SessionDataError } from './errors'
-import { DateFormats, InvalidDateStringError } from './dateFormats'
+import { DateFormats, InvalidDateStringError } from './dateUtils'
 
 /* istanbul ignore next */
 const properCase = (word: string): string =>
@@ -39,24 +38,6 @@ const kebabCase = (string: string) =>
     .replace(/([a-z])([A-Z])/g, '$1-$2')
     .replace(/[\s_]+/g, '-')
     .toLowerCase()
-
-
-export class InvalidDateStringError extends Error {}
-/**
- * Converts an ISO8601 datetime string into a Javascript Date object.
- * @param date An ISO8601 datetime string
- * @returns A Date object
- * @throws {InvalidDateStringError} If the string is not a valid ISO8601 datetime string
- */
-export const convertDateString = (date: string): Date => {
-  const parsedDate = parseISO(date)
-
-  if (Number.isNaN(parsedDate.getTime())) {
-    throw new InvalidDateStringError(`Invalid Date: ${date}`)
-  }
-
-  return parsedDate
-}
 
 /**
  * Converts input for a GDS date input https://design-system.service.gov.uk/components/date-input/


### PR DESCRIPTION
This branches from #185 where this work was started but is not  yet merged.

I think it makes sense to consolidate our date formatting functions and date helpers into one file. We were using a number of different methods to achieve the same goal and any changes to the formatting meant to combing through the codebase and changing every function call. 

The majority of the functions now live as static functions within the class `DateFormats`. Once all our date formatting functions were moved over, it made sense (to me at least) to move our other date utilities (`convertDateAndTimeInputsToIsoString`, `dateAndTimeInputsAreValidDates`, `dateIsBlank`) to the same file too. The difference between these functions and those of `DateFormats` is that they deal with the date objects created from GOV.UK inputs and not JS Date objects/strings. 

There are still a few instances of us calling `.toISO` on some JS dates in our test files which it would be good to eventually move over to these classes but I can't see us touching them regularly so I haven't do it for now.