### PR TITLE
(737) Contract tests for creating a lost bed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           name: E2E Check - << parameters.environment >>
           command: |
             npm run test:e2e --\
-              --env "username=${CYPRESS_USERNAME_<< parameters.environment >>},password=${CYPRESS_PASSWORD_<< parameters.environment >>},offender_crn=${OFFENDER_CRN_<< parameters.environment >>},offender_name=${OFFENDER_NAME_<< parameters.environment >>},keyworker_name=${KEYWORKER_NAME_<< parameters.environment >>}"  \
+              --env "username=${CYPRESS_USERNAME_<< parameters.environment >>},password=${CYPRESS_PASSWORD_<< parameters.environment >>},offender_crn=${OFFENDER_CRN_<< parameters.environment >>},offender_name=${OFFENDER_NAME_<< parameters.environment >>},keyworker_name=${KEYWORKER_NAME_<< parameters.environment >>},lost_bed_reason_id=${LOST_BED_REASON_ID_<< parameters.environment >>}"  \
               --config baseUrl=https://approved-premises-<< parameters.environment >>.hmpps.service.justice.gov.uk
       - store_artifacts:
           path: e2e/screenshots

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ integration_tests/screenshots/
 **/Chart.lock
 /e2e/screenshots
 /e2e/videos
+/e2e.env

--- a/cypress_shared/pages/manage/premisesShow.ts
+++ b/cypress_shared/pages/manage/premisesShow.ts
@@ -14,6 +14,18 @@ export default class PremisesShowPage extends Page {
     return new PremisesShowPage(premises)
   }
 
+  clickLostBedsOption() {
+    cy.get('.moj-button-menu__toggle-button')
+      .click()
+      .then(() => cy.get('a').contains('Record a lost bed').click())
+  }
+
+  clickCreateBookingOption() {
+    cy.get('.moj-button-menu__toggle-button')
+      .click()
+      .then(() => cy.get('a').contains('Create a booking').click())
+  }
+
   shouldShowPremisesDetail(): void {
     cy.get('.govuk-summary-list__key')
       .contains('Code')

--- a/e2e/tests/manage.feature
+++ b/e2e/tests/manage.feature
@@ -12,5 +12,13 @@ Feature: Manage an Approved Premises
         Scenario: Creating a lost bed
                 When I access the premises homepage
                 And I choose a premises
+                And I navigate to the lost beds create page
                 And I create a lost bed
                 Then I should see a notification that the lost bed has been created
+
+        Scenario: Showing lost bed errors
+                When I access the premises homepage
+                And I choose a premises
+                And I navigate to the lost beds create page
+                And I attempt to create a lost bed without the necessary information
+                Then I should see a list of the problems encountered creating the lost bed

--- a/e2e/tests/manage.feature
+++ b/e2e/tests/manage.feature
@@ -1,7 +1,16 @@
 Feature: Manage an Approved Premises
-        Scenario: Creating a booking
+        Background:
                 Given I am logged in
+
+        Scenario: Creating a booking
+                When I access the premises homepage
                 And I see a list of premises
                 And I choose a premises
                 And I create a booking
-                Then I should see a confirmation screen
+                Then I should see a confirmation screen for my booking
+
+        Scenario: Creating a lost bed
+                When I access the premises homepage
+                And I choose a premises
+                And I create a lost bed
+                Then I should see a notification that the lost bed has been created

--- a/e2e/tests/manage.feature
+++ b/e2e/tests/manage.feature
@@ -3,22 +3,16 @@ Feature: Manage an Approved Premises
                 Given I am logged in
 
         Scenario: Creating a booking
-                When I access the premises homepage
-                And I see a list of premises
-                And I choose a premises
+                Given I'm managing a premises
                 And I create a booking
                 Then I should see a confirmation screen for my booking
 
         Scenario: Creating a lost bed
-                When I access the premises homepage
-                And I choose a premises
-                And I navigate to the lost beds create page
+                Given I'm managing a premises
                 And I create a lost bed
                 Then I should see a notification that the lost bed has been created
 
         Scenario: Showing lost bed errors
-                When I access the premises homepage
-                And I choose a premises
-                And I navigate to the lost beds create page
+                Given I'm managing a premises
                 And I attempt to create a lost bed without the necessary information
                 Then I should see a list of the problems encountered creating the lost bed

--- a/e2e/tests/stepDefinitions/booking.ts
+++ b/e2e/tests/stepDefinitions/booking.ts
@@ -1,6 +1,11 @@
 import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
 
-import { BookingNewPage, BookingConfirmationPage, BookingFindPage } from '../../../cypress_shared/pages/manage'
+import {
+  BookingNewPage,
+  BookingConfirmationPage,
+  BookingFindPage,
+  PremisesShowPage,
+} from '../../../cypress_shared/pages/manage'
 
 import bookingFactory from '../../../server/testutils/factories/booking'
 import personFactory from '../../../server/testutils/factories/person'
@@ -11,9 +16,9 @@ const person = personFactory.build({ name: Cypress.env('offender_name'), crn: Cy
 const booking = bookingFactory.build({ keyWorker, person })
 
 Given('I create a booking', () => {
-  cy.get('.moj-button-menu__toggle-button')
-    .click()
-    .then(() => cy.get('a').contains('Create a booking').click())
+  cy.get('@premisesShowPage').then((premisesShowPage: PremisesShowPage) => {
+    premisesShowPage.clickCreateBookingOption()
+  })
 
   const bookingNewPage = new BookingFindPage()
   bookingNewPage.enterCrn(person.crn)

--- a/e2e/tests/stepDefinitions/booking.ts
+++ b/e2e/tests/stepDefinitions/booking.ts
@@ -1,0 +1,33 @@
+import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
+
+import { BookingNewPage, BookingConfirmationPage, BookingFindPage } from '../../../cypress_shared/pages/manage'
+
+import bookingFactory from '../../../server/testutils/factories/booking'
+import personFactory from '../../../server/testutils/factories/person'
+import keyWorkerFactory from '../../../server/testutils/factories/keyWorker'
+
+const keyWorker = keyWorkerFactory.build({ name: Cypress.env('keyworker_name') })
+const person = personFactory.build({ name: Cypress.env('offender_name'), crn: Cypress.env('offender_crn') })
+const booking = bookingFactory.build({ keyWorker, person })
+
+Given('I create a booking', () => {
+  cy.get('.moj-button-menu__toggle-button')
+    .click()
+    .then(() => cy.get('a').contains('Create a booking').click())
+
+  const bookingNewPage = new BookingFindPage()
+  bookingNewPage.enterCrn(person.crn)
+  bookingNewPage.clickSubmit()
+
+  const form = new BookingNewPage()
+
+  form.verifyPersonIsVisible(person)
+  form.completeForm(booking)
+  form.clickSubmit()
+})
+
+Then('I should see a confirmation screen for my booking', () => {
+  const page = new BookingConfirmationPage()
+
+  page.verifyBookingIsVisible(booking)
+})

--- a/e2e/tests/stepDefinitions/lostBeds.ts
+++ b/e2e/tests/stepDefinitions/lostBeds.ts
@@ -4,6 +4,12 @@ import { LostBedCreatePage } from '../../../cypress_shared/pages/manage'
 import lostBedFactory from '../../../server/testutils/factories/lostBed'
 import referenceDataFactory from '../../../server/testutils/factories/referenceData'
 
+Given('I navigate to the lost beds create page', () => {
+  cy.get('.moj-button-menu__toggle-button')
+    .click()
+    .then(() => cy.get('a').contains('Record a lost bed').click())
+})
+
 Given('I create a lost bed', () => {
   const lostBed = lostBedFactory.build({
     startDate: new Date(2022, 1, 11, 0, 0).toISOString(),
@@ -11,16 +17,22 @@ Given('I create a lost bed', () => {
     reason: referenceDataFactory.build({ id: Cypress.env('lost_bed_reason_id') }),
   })
 
-  cy.get('.moj-button-menu__toggle-button')
-    .click()
-    .then(() => cy.get('a').contains('Record a lost bed').click())
-
-  const lostBedCreatePage = new LostBedCreatePage(lostBed)
+  const lostBedCreatePage = new LostBedCreatePage()
 
   lostBedCreatePage.completeForm(lostBed)
   lostBedCreatePage.clickSubmit()
 })
 
+Given('I attempt to create a lost bed without the necessary information', () => {
+  const lostBedCreatePage = new LostBedCreatePage()
+  lostBedCreatePage.clickSubmit()
+})
+
 Then('I should see a notification that the lost bed has been created', () => {
   cy.get('.govuk-notification-banner').should('contain', 'Lost bed logged')
+})
+
+Then('I should see a list of the problems encountered creating the lost bed', () => {
+  const lostBedCreatePage = new LostBedCreatePage()
+  lostBedCreatePage.shouldShowErrorMessagesForFields(['startDate', 'endDate', 'numberOfBeds', 'reason'])
 })

--- a/e2e/tests/stepDefinitions/lostBeds.ts
+++ b/e2e/tests/stepDefinitions/lostBeds.ts
@@ -1,38 +1,45 @@
 import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
 
-import { LostBedCreatePage } from '../../../cypress_shared/pages/manage'
+import { PremisesShowPage, LostBedCreatePage } from '../../../cypress_shared/pages/manage'
 import lostBedFactory from '../../../server/testutils/factories/lostBed'
 import referenceDataFactory from '../../../server/testutils/factories/referenceData'
 
-Given('I navigate to the lost beds create page', () => {
-  cy.get('.moj-button-menu__toggle-button')
-    .click()
-    .then(() => cy.get('a').contains('Record a lost bed').click())
-})
-
 Given('I create a lost bed', () => {
+  cy.get('@premisesShowPage').then((premisesShowPage: PremisesShowPage) => {
+    premisesShowPage.clickLostBedsOption()
+  })
+
+  const lostBedCreatePage = new LostBedCreatePage()
+
   const lostBed = lostBedFactory.build({
     startDate: new Date(2022, 1, 11, 0, 0).toISOString(),
     endDate: new Date(2022, 2, 11, 0, 0).toISOString(),
     reason: referenceDataFactory.build({ id: Cypress.env('lost_bed_reason_id') }),
   })
 
-  const lostBedCreatePage = new LostBedCreatePage()
-
   lostBedCreatePage.completeForm(lostBed)
   lostBedCreatePage.clickSubmit()
 })
 
 Given('I attempt to create a lost bed without the necessary information', () => {
+  cy.get('@premisesShowPage').then((premisesShowPage: PremisesShowPage) => {
+    premisesShowPage.clickLostBedsOption()
+  })
+
   const lostBedCreatePage = new LostBedCreatePage()
+  cy.wrap(lostBedCreatePage).as('lostBedCreatePage')
+
   lostBedCreatePage.clickSubmit()
 })
 
 Then('I should see a notification that the lost bed has been created', () => {
-  cy.get('.govuk-notification-banner').should('contain', 'Lost bed logged')
+  cy.get('@premisesShowPage').then((premisesShowPage: PremisesShowPage) => {
+    premisesShowPage.shouldShowBanner('Lost bed logged')
+  })
 })
 
 Then('I should see a list of the problems encountered creating the lost bed', () => {
-  const lostBedCreatePage = new LostBedCreatePage()
-  lostBedCreatePage.shouldShowErrorMessagesForFields(['startDate', 'endDate', 'numberOfBeds', 'reason'])
+  cy.get('@lostBedCreatePage').then((lostBedCreatePage: LostBedCreatePage) => {
+    lostBedCreatePage.shouldShowErrorMessagesForFields(['startDate', 'endDate', 'numberOfBeds', 'reason'])
+  })
 })

--- a/e2e/tests/stepDefinitions/lostBeds.ts
+++ b/e2e/tests/stepDefinitions/lostBeds.ts
@@ -1,0 +1,26 @@
+import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
+
+import { LostBedCreatePage } from '../../../cypress_shared/pages/manage'
+import lostBedFactory from '../../../server/testutils/factories/lostBed'
+import referenceDataFactory from '../../../server/testutils/factories/referenceData'
+
+Given('I create a lost bed', () => {
+  const lostBed = lostBedFactory.build({
+    startDate: new Date(2022, 1, 11, 0, 0).toISOString(),
+    endDate: new Date(2022, 2, 11, 0, 0).toISOString(),
+    reason: referenceDataFactory.build({ id: Cypress.env('lost_bed_reason_id') }),
+  })
+
+  cy.get('.moj-button-menu__toggle-button')
+    .click()
+    .then(() => cy.get('a').contains('Record a lost bed').click())
+
+  const lostBedCreatePage = new LostBedCreatePage(lostBed)
+
+  lostBedCreatePage.completeForm(lostBed)
+  lostBedCreatePage.clickSubmit()
+})
+
+Then('I should see a notification that the lost bed has been created', () => {
+  cy.get('.govuk-notification-banner').should('contain', 'Lost bed logged')
+})

--- a/e2e/tests/stepDefinitions/manage.ts
+++ b/e2e/tests/stepDefinitions/manage.ts
@@ -1,14 +1,4 @@
-import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
-
-import { BookingNewPage, BookingConfirmationPage, BookingFindPage } from '../../../cypress_shared/pages/manage'
-
-import bookingFactory from '../../../server/testutils/factories/booking'
-import personFactory from '../../../server/testutils/factories/person'
-import keyWorkerFactory from '../../../server/testutils/factories/keyWorker'
-
-const keyWorker = keyWorkerFactory.build({ name: Cypress.env('keyworker_name') })
-const person = personFactory.build({ name: Cypress.env('offender_name'), crn: Cypress.env('offender_crn') })
-const booking = bookingFactory.build({ keyWorker, person })
+import { Given } from '@badeball/cypress-cucumber-preprocessor'
 
 Given('I am logged in', () => {
   cy.visit('/')
@@ -18,6 +8,10 @@ Given('I am logged in', () => {
   cy.get('.govuk-button').contains('Sign in').click()
 })
 
+Given('I access the premises homepage', () => {
+  cy.visit('/premises')
+})
+
 Given('I see a list of premises', () => {
   cy.get('h1').should('contain', 'Approved Premises')
   cy.get('.govuk-table tbody tr').its('length').should('be.gt', 0)
@@ -25,26 +19,4 @@ Given('I see a list of premises', () => {
 
 Given('I choose a premises', () => {
   cy.get('.govuk-table tbody tr a').first().click()
-})
-
-Given('I create a booking', () => {
-  cy.get('.moj-button-menu__toggle-button')
-    .click()
-    .then(() => cy.get('a').contains('Create a booking').click())
-
-  const bookingNewPage = new BookingFindPage()
-  bookingNewPage.enterCrn(person.crn)
-  bookingNewPage.clickSubmit()
-
-  const form = new BookingNewPage()
-
-  form.verifyPersonIsVisible(person)
-  form.completeForm(booking)
-  form.clickSubmit()
-})
-
-Then('I should see a confirmation screen', () => {
-  const page = new BookingConfirmationPage()
-
-  page.verifyBookingIsVisible(booking)
 })

--- a/e2e/tests/stepDefinitions/manage.ts
+++ b/e2e/tests/stepDefinitions/manage.ts
@@ -1,4 +1,6 @@
 import { Given } from '@badeball/cypress-cucumber-preprocessor'
+import premisesFactory from '../../../server/testutils/factories/premises'
+import { PremisesShowPage } from '../../../cypress_shared/pages/manage'
 
 Given('I am logged in', () => {
   cy.visit('/')
@@ -8,15 +10,18 @@ Given('I am logged in', () => {
   cy.get('.govuk-button').contains('Sign in').click()
 })
 
-Given('I access the premises homepage', () => {
+Given("I'm managing a premises", () => {
   cy.visit('/premises')
-})
+  cy.get('.govuk-table tbody tr')
+    .first()
+    .within($row => {
+      cy.wrap($row).get('th').first().invoke('text').as('premisesName')
+      cy.wrap($row).get('a').click()
+    })
 
-Given('I see a list of premises', () => {
-  cy.get('h1').should('contain', 'Approved Premises')
-  cy.get('.govuk-table tbody tr').its('length').should('be.gt', 0)
-})
-
-Given('I choose a premises', () => {
-  cy.get('.govuk-table tbody tr a').first().click()
+  cy.get('@premisesName').then(premisesName => {
+    const premises = premisesFactory.build({ name: premisesName })
+    const premisesShowPage = new PremisesShowPage(premises)
+    cy.wrap(premisesShowPage).as('premisesShowPage')
+  })
 })

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "typecheck": "tsc && tsc -p integration_tests",
     "test": "jest",
     "test:e2e": "cypress run -C cypress.config.e2e.ts",
+    "test:e2e:ui": "set -a && source e2e.env && set +a && cypress open -C cypress.config.e2e.ts --config baseUrl=https://approved-premises-dev.hmpps.service.justice.gov.uk",
     "test:integration": "start-server-and-test start-feature http://localhost:3007/ping int-test",
     "test:integration:ui": "npm run start-test-wiremock && start-server-and-test start-feature:dev http://localhost:3007/ping int-test-ui",
     "security_audit": "npx audit-ci --config audit-ci.json",


### PR DESCRIPTION
This adds a contract test for creating a lost bed, as well as the unhappy path for any errors. I've also refactored the specs a bit to make them more lightweight and lean on the page objects a bit more.