### PR TITLE
Filter out blank strings in PUT and POST requests

### DIFF
--- a/integration_tests/mockApis/arrival.ts
+++ b/integration_tests/mockApis/arrival.ts
@@ -19,12 +19,7 @@ export default {
       },
     }),
   stubArrivalErrors: (args: { premisesId: string; bookingId: string; params: Array<string> }): SuperAgentRequest =>
-    stubFor(
-      errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/arrivals`, [
-        'date',
-        'expectedDepartureDate',
-      ]),
-    ),
+    stubFor(errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/arrivals`)),
   verifyArrivalCreate: async (args: { premisesId: string; bookingId: string }) =>
     (
       await getMatchingRequests({

--- a/integration_tests/mockApis/booking.ts
+++ b/integration_tests/mockApis/booking.ts
@@ -35,7 +35,7 @@ export default {
       },
     }),
   stubBookingErrors: (args: { premisesId: string; params: Array<string> }) =>
-    stubFor(errorStub(args.params, `/premises/${args.premisesId}/bookings`, ['arrivalDate', 'departureDate'])),
+    stubFor(errorStub(args.params, `/premises/${args.premisesId}/bookings`)),
   stubBookingGet: (args: { premisesId: string; booking: Booking }) =>
     stubFor({
       request: {

--- a/integration_tests/mockApis/bookingExtension.ts
+++ b/integration_tests/mockApis/bookingExtension.ts
@@ -23,11 +23,7 @@ export default {
     bookingId: string
     params: Array<string>
   }): SuperAgentRequest =>
-    stubFor(
-      errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/extensions`, [
-        'newDepartureDate',
-      ]),
-    ),
+    stubFor(errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/extensions`)),
   verifyBookingExtensionCreate: async (args: { premisesId: string; bookingId: string }) =>
     (
       await getMatchingRequests({

--- a/integration_tests/mockApis/cancellation.ts
+++ b/integration_tests/mockApis/cancellation.ts
@@ -39,12 +39,7 @@ export default {
       },
     }),
   stubCancellationErrors: (args: { premisesId: string; bookingId: string; params: Array<string> }) =>
-    stubFor(
-      errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/cancellations`, [
-        'reason',
-        'date',
-      ]),
-    ),
+    stubFor(errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/cancellations`)),
   verifyCancellationCreate: async (args: { premisesId: string; bookingId: string; cancellation: Cancellation }) =>
     (
       await getMatchingRequests({

--- a/integration_tests/mockApis/departure.ts
+++ b/integration_tests/mockApis/departure.ts
@@ -32,15 +32,7 @@ export default {
       },
     }),
   stubDepartureErrors: (args: { premisesId: string; bookingId: string; params: Array<string> }) =>
-    stubFor(
-      errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/departures`, [
-        'notes',
-        'destinationProvider',
-        'moveOnCategory',
-        'reason',
-        'dateTime',
-      ]),
-    ),
+    stubFor(errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/departures`)),
   stubDepartureReferenceData: (): Promise<[Response, Response, Response]> =>
     Promise.all([stubFor(departureReasons), stubFor(moveOnCategories), stubFor(destinationProviders)]),
   verifyDepartureCreate: async (args: { premisesId: string; bookingId: string }) =>

--- a/integration_tests/mockApis/lostBed.ts
+++ b/integration_tests/mockApis/lostBed.ts
@@ -21,9 +21,7 @@ export default {
     }),
 
   stubLostBedErrors: (args: { premisesId: string; params: Array<string> }): SuperAgentRequest =>
-    stubFor(
-      errorStub(args.params, `/premises/${args.premisesId}/lost-beds`, ['notes', 'reason', 'startDate', 'endDate']),
-    ),
+    stubFor(errorStub(args.params, `/premises/${args.premisesId}/lost-beds`)),
 
   stubLostBedReferenceData: (): Promise<Response> => stubFor(lostBedReasons),
 

--- a/integration_tests/mockApis/nonArrival.ts
+++ b/integration_tests/mockApis/nonArrival.ts
@@ -19,12 +19,7 @@ export default {
       },
     }),
   stubNonArrivalErrors: (args: { premisesId: string; bookingId: string; params: Array<string> }): SuperAgentRequest =>
-    stubFor(
-      errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/non-arrivals`, [
-        'reason',
-        'date',
-      ]),
-    ),
+    stubFor(errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/non-arrivals`)),
   verifyNonArrivalCreate: async (args: { premisesId: string; bookingId: string }) =>
     (
       await getMatchingRequests({

--- a/server/data/restClient.test.ts
+++ b/server/data/restClient.test.ts
@@ -1,0 +1,60 @@
+import nock from 'nock'
+
+import config, { ApiConfig } from '../config'
+import RestClient from './restClient'
+
+describe('restClient', () => {
+  let fakeApprovedPremisesApi: nock.Scope
+  let restClient: RestClient
+
+  const token = 'token-1'
+
+  beforeEach(() => {
+    config.apis.approvedPremises.url = 'http://localhost:8080'
+    fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
+    restClient = new RestClient('premisesClient', config.apis.approvedPremises as ApiConfig, token)
+  })
+
+  afterEach(() => {
+    if (!nock.isDone()) {
+      nock.cleanAll()
+      throw new Error('Not all nock interceptors were used!')
+    }
+    nock.abortPendingRequests()
+    nock.cleanAll()
+  })
+
+  describe('post', () => {
+    it('should filter out blank values', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const data = { some: 'data', empty: '', undefinedItem: undefined, nullItem: null } as any
+
+      fakeApprovedPremisesApi
+        .post(`/some/path`, { some: 'data' })
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(201, { some: 'data' })
+
+      const result = await restClient.post({ path: '/some/path', data })
+
+      expect(result).toEqual({ some: 'data' })
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+
+  describe('put', () => {
+    it('should filter out blank values', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const data = { some: 'data', empty: '', undefinedItem: undefined, nullItem: null } as any
+
+      fakeApprovedPremisesApi
+        .put(`/some/path`, { some: 'data' })
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(201, { some: 'data' })
+
+      const result = await restClient.put({ path: '/some/path', data })
+
+      expect(result).toEqual({ some: 'data' })
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+})

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -122,7 +122,7 @@ export default class RestClient {
         method === 'post' ? superagent.post(`${this.apiUrl()}${path}`) : superagent.put(`${this.apiUrl()}${path}`)
 
       const result = await request
-        .send(data)
+        .send(this.filterBlanksFromData(data))
         .agent(this.agent)
         .use(restClientMetricsMiddleware)
         .retry(2, (err, res) => {
@@ -140,5 +140,11 @@ export default class RestClient {
       logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: 'PUT'`)
       throw sanitisedError
     }
+  }
+
+  private filterBlanksFromData(data: Record<string, unknown>): Record<string, unknown> {
+    Object.keys(data).forEach(k => !data[k] && delete data[k])
+
+    return data
   }
 }

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -74,66 +74,12 @@ export default class RestClient {
     }
   }
 
-  async post({
-    path = null,
-    headers = {},
-    responseType = '',
-    data = {},
-    raw = false,
-  }: PostRequest = {}): Promise<unknown> {
-    logger.info(`Post using user credentials: calling ${this.name}: ${path}`)
-    try {
-      const result = await superagent
-        .post(`${this.apiUrl()}${path}`)
-        .send(data)
-        .agent(this.agent)
-        .use(restClientMetricsMiddleware)
-        .retry(2, (err, res) => {
-          if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
-          return undefined // retry handler only for logging retries, not to influence retry logic
-        })
-        .auth(this.token, { type: 'bearer' })
-        .set(headers)
-        .responseType(responseType)
-        .timeout(this.timeoutConfig())
-
-      return raw ? result : result.body
-    } catch (error) {
-      const sanitisedError = sanitiseError(error)
-      logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: 'POST'`)
-      throw sanitisedError
-    }
+  async post(request: PostRequest = {}): Promise<unknown> {
+    return this.postOrPut('post', request)
   }
 
-  async put({
-    path = null,
-    headers = {},
-    responseType = '',
-    data = {},
-    raw = false,
-  }: PutRequest = {}): Promise<unknown> {
-    logger.info(`Put using user credentials: calling ${this.name}: ${path}`)
-    try {
-      const result = await superagent
-        .put(`${this.apiUrl()}${path}`)
-        .send(data)
-        .agent(this.agent)
-        .use(restClientMetricsMiddleware)
-        .retry(2, (err, res) => {
-          if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
-          return undefined // retry handler only for logging retries, not to influence retry logic
-        })
-        .auth(this.token, { type: 'bearer' })
-        .set(headers)
-        .responseType(responseType)
-        .timeout(this.timeoutConfig())
-
-      return raw ? result : result.body
-    } catch (error) {
-      const sanitisedError = sanitiseError(error)
-      logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: 'PUT'`)
-      throw sanitisedError
-    }
+  async put(request: PutRequest = {}): Promise<unknown> {
+    return this.postOrPut('put', request)
   }
 
   async stream({ path = null, headers = {} }: StreamRequest = {}): Promise<unknown> {
@@ -164,5 +110,35 @@ export default class RestClient {
           }
         })
     })
+  }
+
+  private async postOrPut(
+    method: 'post' | 'put',
+    { path = null, headers = {}, responseType = '', data = {}, raw = false }: PutRequest | PostRequest = {},
+  ): Promise<unknown> {
+    logger.info(`${method} using user credentials: calling ${this.name}: ${path}`)
+    try {
+      const request =
+        method === 'post' ? superagent.post(`${this.apiUrl()}${path}`) : superagent.put(`${this.apiUrl()}${path}`)
+
+      const result = await request
+        .send(data)
+        .agent(this.agent)
+        .use(restClientMetricsMiddleware)
+        .retry(2, (err, res) => {
+          if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
+          return undefined // retry handler only for logging retries, not to influence retry logic
+        })
+        .auth(this.token, { type: 'bearer' })
+        .set(headers)
+        .responseType(responseType)
+        .timeout(this.timeoutConfig())
+
+      return raw ? result : result.body
+    } catch (error) {
+      const sanitisedError = sanitiseError(error)
+      logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: 'PUT'`)
+      throw sanitisedError
+    }
   }
 }

--- a/wiremock/cancellationStubs.ts
+++ b/wiremock/cancellationStubs.ts
@@ -37,7 +37,7 @@ cancellationStubs.push(
 const requiredFields = getCombinations(['date', 'reason'])
 
 requiredFields.forEach((fields: Array<string>) => {
-  cancellationStubs.push(errorStub(fields, `/premises/${guidRegex}/bookings/${guidRegex}/cancellations`, ['reason']))
+  cancellationStubs.push(errorStub(fields, `/premises/${guidRegex}/bookings/${guidRegex}/cancellations`))
 })
 
 export default cancellationStubs

--- a/wiremock/departuresStubs.ts
+++ b/wiremock/departuresStubs.ts
@@ -37,13 +37,7 @@ departureStubs.push(
 const requiredFields = getCombinations(['dateTime', 'destinationProvider', 'moveOnCategory', 'reason'])
 
 requiredFields.forEach((fields: Array<string>) => {
-  departureStubs.push(
-    errorStub(fields, `/premises/${guidRegex}/bookings/${guidRegex}/departures`, [
-      'destinationProvider',
-      'moveOnCategory',
-      'reason',
-    ]),
-  )
+  departureStubs.push(errorStub(fields, `/premises/${guidRegex}/bookings/${guidRegex}/departures`))
 })
 
 export default departureStubs

--- a/wiremock/lostBedStubs.ts
+++ b/wiremock/lostBedStubs.ts
@@ -21,7 +21,7 @@ lostBeds.push({
 const requiredFields = getCombinations(['startDate', 'endDate', 'numberOfBeds', 'reason', 'referenceNumber'])
 
 requiredFields.forEach((fields: Array<string>) => {
-  lostBeds.push(errorStub(fields, `/premises/${guidRegex}/lost-beds`, ['notes', 'reason']))
+  lostBeds.push(errorStub(fields, `/premises/${guidRegex}/lost-beds`))
 })
 
 export default lostBeds

--- a/wiremock/nonArrivalStubs.ts
+++ b/wiremock/nonArrivalStubs.ts
@@ -30,7 +30,7 @@ nonArrivalStubs.push({
 const requiredFields = getCombinations(['date', 'reason'])
 
 requiredFields.forEach((fields: Array<string>) => {
-  nonArrivalStubs.push(errorStub(fields, `/premises/${guidRegex}/bookings/${guidRegex}/non-arrivals`, ['reason']))
+  nonArrivalStubs.push(errorStub(fields, `/premises/${guidRegex}/bookings/${guidRegex}/non-arrivals`))
 })
 
 export default nonArrivalStubs

--- a/wiremock/utils.ts
+++ b/wiremock/utils.ts
@@ -11,18 +11,13 @@ const getCombinations = (arr: Array<string>) => {
   return result.sort((a, b) => b.length - a.length)
 }
 
-const errorStub = (fields: Array<string>, pattern: string, nullifiedFields: Array<string> = []) => {
+const errorStub = (fields: Array<string>, pattern: string) => {
   const bodyPatterns = fields.map(field => {
-    if (nullifiedFields.includes(field)) {
-      return {
-        matchesJsonPath: {
-          expression: `$.${field}`,
-          absent: '(absent)',
-        },
-      }
-    }
     return {
-      matchesJsonPath: `$.[?(@.${field} === '')]`,
+      matchesJsonPath: {
+        expression: `$.${field}`,
+        absent: '(absent)',
+      },
     }
   })
 


### PR DESCRIPTION
We will very rarely want to send literal blank strings to the API, and sending blank strings can result in confusing error messages (for example if the API expects a number but gets an empty string, the error will be that the value should be a number), so it’s better to filter these out before sending them to the API.