### PR TITLE
E2E tests: ensure presence of env vars and hide sensitive vars

### DIFF
--- a/e2e/tests/stepDefinitions/booking.ts
+++ b/e2e/tests/stepDefinitions/booking.ts
@@ -1,6 +1,6 @@
 import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
 
-import throwMissingError from './utils'
+import throwMissingCypressEnvError from './utils'
 
 import {
   BookingNewPage,
@@ -13,9 +13,9 @@ import bookingFactory from '../../../server/testutils/factories/booking'
 import personFactory from '../../../server/testutils/factories/person'
 import keyWorkerFactory from '../../../server/testutils/factories/keyWorker'
 
-const keyWorkerName = Cypress.env('keyworker_name') || throwMissingError('keyworker_name')
-const offenderName = Cypress.env('offender_name') || throwMissingError('offender_name')
-const offenderCrn = Cypress.env('offender_crn') || throwMissingError('offender_crn')
+const keyWorkerName = Cypress.env('keyworker_name') || throwMissingCypressEnvError('keyworker_name')
+const offenderName = Cypress.env('offender_name') || throwMissingCypressEnvError('offender_name')
+const offenderCrn = Cypress.env('offender_crn') || throwMissingCypressEnvError('offender_crn')
 
 const keyWorker = keyWorkerFactory.build({ name: keyWorkerName })
 const person = personFactory.build({ name: offenderName, crn: offenderCrn })

--- a/e2e/tests/stepDefinitions/booking.ts
+++ b/e2e/tests/stepDefinitions/booking.ts
@@ -1,5 +1,7 @@
 import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
 
+import throwMissingError from './utils'
+
 import {
   BookingNewPage,
   BookingConfirmationPage,
@@ -11,8 +13,12 @@ import bookingFactory from '../../../server/testutils/factories/booking'
 import personFactory from '../../../server/testutils/factories/person'
 import keyWorkerFactory from '../../../server/testutils/factories/keyWorker'
 
-const keyWorker = keyWorkerFactory.build({ name: Cypress.env('keyworker_name') })
-const person = personFactory.build({ name: Cypress.env('offender_name'), crn: Cypress.env('offender_crn') })
+const keyWorkerName = Cypress.env('keyworker_name') || throwMissingError('keyworker_name')
+const offenderName = Cypress.env('offender_name') || throwMissingError('offender_name')
+const offenderCrn = Cypress.env('offender_crn') || throwMissingError('offender_crn')
+
+const keyWorker = keyWorkerFactory.build({ name: keyWorkerName })
+const person = personFactory.build({ name: offenderName, crn: offenderCrn })
 const booking = bookingFactory.build({ keyWorker, person })
 
 Given('I create a booking', () => {

--- a/e2e/tests/stepDefinitions/lostBeds.ts
+++ b/e2e/tests/stepDefinitions/lostBeds.ts
@@ -3,8 +3,11 @@ import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
 import { PremisesShowPage, LostBedCreatePage } from '../../../cypress_shared/pages/manage'
 import lostBedFactory from '../../../server/testutils/factories/lostBed'
 import referenceDataFactory from '../../../server/testutils/factories/referenceData'
+import throwMissingError from './utils'
 
 Given('I create a lost bed', () => {
+  const lostBedReasonId = Cypress.env('lost_bed_reason_id') || throwMissingError('lost_bed_reason_id')
+
   cy.get('@premisesShowPage').then((premisesShowPage: PremisesShowPage) => {
     premisesShowPage.clickLostBedsOption()
   })
@@ -14,7 +17,7 @@ Given('I create a lost bed', () => {
   const lostBed = lostBedFactory.build({
     startDate: new Date(2022, 1, 11, 0, 0).toISOString(),
     endDate: new Date(2022, 2, 11, 0, 0).toISOString(),
-    reason: referenceDataFactory.build({ id: Cypress.env('lost_bed_reason_id') }),
+    reason: referenceDataFactory.build({ id: lostBedReasonId }),
   })
 
   lostBedCreatePage.completeForm(lostBed)

--- a/e2e/tests/stepDefinitions/lostBeds.ts
+++ b/e2e/tests/stepDefinitions/lostBeds.ts
@@ -3,10 +3,10 @@ import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
 import { PremisesShowPage, LostBedCreatePage } from '../../../cypress_shared/pages/manage'
 import lostBedFactory from '../../../server/testutils/factories/lostBed'
 import referenceDataFactory from '../../../server/testutils/factories/referenceData'
-import throwMissingError from './utils'
+import throwMissingCypressEnvError from './utils'
 
 Given('I create a lost bed', () => {
-  const lostBedReasonId = Cypress.env('lost_bed_reason_id') || throwMissingError('lost_bed_reason_id')
+  const lostBedReasonId = Cypress.env('lost_bed_reason_id') || throwMissingCypressEnvError('lost_bed_reason_id')
 
   cy.get('@premisesShowPage').then((premisesShowPage: PremisesShowPage) => {
     premisesShowPage.clickLostBedsOption()

--- a/e2e/tests/stepDefinitions/manage.ts
+++ b/e2e/tests/stepDefinitions/manage.ts
@@ -1,10 +1,7 @@
 import { Given } from '@badeball/cypress-cucumber-preprocessor'
+import throwMissingError from './utils'
 import premisesFactory from '../../../server/testutils/factories/premises'
 import { PremisesShowPage } from '../../../cypress_shared/pages/manage'
-
-const throwMissingError = (field: string) => {
-  throw new Error(`Missing Cypress env variable for '${field}'`)
-}
 
 Given('I am logged in', () => {
   const username = Cypress.env('username') || throwMissingError('username')

--- a/e2e/tests/stepDefinitions/manage.ts
+++ b/e2e/tests/stepDefinitions/manage.ts
@@ -1,11 +1,11 @@
 import { Given } from '@badeball/cypress-cucumber-preprocessor'
-import throwMissingError from './utils'
+import throwMissingCypressEnvError from './utils'
 import premisesFactory from '../../../server/testutils/factories/premises'
 import { PremisesShowPage } from '../../../cypress_shared/pages/manage'
 
 Given('I am logged in', () => {
-  const username = Cypress.env('username') || throwMissingError('username')
-  const password = Cypress.env('password') || throwMissingError('password')
+  const username = Cypress.env('username') || throwMissingCypressEnvError('username')
+  const password = Cypress.env('password') || throwMissingCypressEnvError('password')
 
   cy.visit('/')
   cy.get('input[name="username"]').type(username)

--- a/e2e/tests/stepDefinitions/manage.ts
+++ b/e2e/tests/stepDefinitions/manage.ts
@@ -2,10 +2,17 @@ import { Given } from '@badeball/cypress-cucumber-preprocessor'
 import premisesFactory from '../../../server/testutils/factories/premises'
 import { PremisesShowPage } from '../../../cypress_shared/pages/manage'
 
+const throwMissingError = (field: string) => {
+  throw new Error(`Missing Cypress env variable for '${field}'`)
+}
+
 Given('I am logged in', () => {
+  const username = Cypress.env('username') || throwMissingError('username')
+  const password = Cypress.env('password') || throwMissingError('password')
+
   cy.visit('/')
-  cy.get('input[name="username"]').type(Cypress.env('username'))
-  cy.get('input[name="password"]').type(Cypress.env('password'))
+  cy.get('input[name="username"]').type(username)
+  cy.get('input[name="password"]').type(password, { log: false })
 
   cy.get('.govuk-button').contains('Sign in').click()
 })

--- a/e2e/tests/stepDefinitions/utils.ts
+++ b/e2e/tests/stepDefinitions/utils.ts
@@ -1,0 +1,5 @@
+const throwMissingError = (field: string) => {
+  throw new Error(`Missing Cypress env variable for '${field}'`)
+}
+
+export default throwMissingError

--- a/e2e/tests/stepDefinitions/utils.ts
+++ b/e2e/tests/stepDefinitions/utils.ts
@@ -1,5 +1,5 @@
-const throwMissingError = (field: string) => {
+const throwMissingCypressEnvError = (field: string) => {
   throw new Error(`Missing Cypress env variable for '${field}'`)
 }
 
-export default throwMissingError
+export default throwMissingCypressEnvError


### PR DESCRIPTION
This is related to my review of [(737) Contract tests for creating a lost bed](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/203/)

It attempts two things:

### 1. ensure that missing environment variable fail clearly

Uses a utility function to throw an informative error:

```ts
const throwMissingError = (field: string) => {
  throw new Error(`Missing Cypress env variable for '${field}'`)
}
```

e.g.

```ts
const username = Cypress.env('username') || throwMissingError('username')
```

### 2. hide sensitive env vars from Cypress videos and logs

Set `log: false`

when filling in sensitive fields, eg.

```ts
cy.get('input[name="password"]').type(password, { log: false })
```

I followed guidance on:

https://glebbahmutov.com/blog/keep-passwords-secret-in-e2e-tests/

### NB: Continuous integration
I haven't checked the CircleCI setup properly but it doesn't look like
we are using the [security context](https://circleci.com/docs/2.0/contexts/)
system the above article suggests. Quite likely we have it covered in
some other way?