### PR TITLE
(763) Improve application session handling

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -14,6 +14,7 @@ services:
     - hmpps_int
     container_name: wiremock_test
     restart: always
+    command: --local-response-templating
     ports:
       - "9091:8080"
 

--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -36,9 +36,20 @@ export default {
         url: `/applications/${args.application.id}`,
       },
       response: {
-        status: 200,
+        status: 201,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: args.application,
+        body: `
+        {
+          "id": "{{request.pathSegments.[1]}}",
+          "person": ${JSON.stringify(args.application.person)},
+          "createdByProbationOfficerId": "${args.application.createdByProbationOfficerId}",
+          "schemaVersion": "${args.application.schemaVersion}",
+          "createdAt": "${args.application.createdAt}",
+          "submittedAt": "${args.application.submittedAt}",
+          "data": {{{jsonPath request.body '$.data'}}}
+        }
+        `,
+        transformers: ['response-template'],
       },
     }),
   verifyApplicationUpdate: async (applicationId: string) =>

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -258,7 +258,7 @@ declare module 'approved-premises' {
     }
     Application: {
       id: string
-      crn: string
+      person: Person
       createdByProbationOfficerId: string
       schemaVersion: string
       createdAt: string

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -60,8 +60,6 @@ declare module 'approved-premises' {
 
   export type TaskNames = 'basic-information' | 'type-of-ap'
 
-  export type ApplicationData = Record<TaskNames, unknown>
-
   export interface HtmlAttributes {
     [key: string]: string
   }

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,4 +1,4 @@
-import type { ErrorMessages } from 'approved-premises'
+import type { ErrorMessages, Application } from 'approved-premises'
 
 export default {}
 
@@ -7,7 +7,7 @@ declare module 'express-session' {
   interface SessionData {
     returnTo: string
     nowInMinutes: number
-    application: Record<string, unknown>
+    application: Application
     previousPage: string
   }
 }

--- a/server/controllers/apply/applications/pagesController.ts
+++ b/server/controllers/apply/applications/pagesController.ts
@@ -44,7 +44,7 @@ export default class PagesController {
       const page = await this.applicationService.getCurrentPage(req, this.dataServices)
 
       try {
-        this.applicationService.save(page, req)
+        await this.applicationService.save(page, req)
         const next = page.next()
         if (next) {
           res.redirect(paths.applications.pages.show({ id: req.params.id, task: req.params.task, page: page.next() }))

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -189,6 +189,7 @@ describe('applicationsController', () => {
 
   describe('create', () => {
     let application: Application
+
     beforeEach(() => {
       request = createMock<Request>({
         user: { token },
@@ -196,6 +197,7 @@ describe('applicationsController', () => {
       request.body.crn = 'some-crn'
       application = applicationFactory.build()
     })
+
     it('creates an application and redirects to the first page of the first step', async () => {
       applicationService.createApplication.mockResolvedValue(application)
 
@@ -207,6 +209,16 @@ describe('applicationsController', () => {
       expect(response.redirect).toHaveBeenCalledWith(
         paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'sentence-type' }),
       )
+    })
+
+    it('saves the application to the session', async () => {
+      applicationService.createApplication.mockResolvedValue(application)
+
+      const requestHandler = applicationsController.create()
+
+      await requestHandler(request, response, next)
+
+      expect(request.session.application).toEqual(application)
     })
   })
 })

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -64,16 +64,15 @@ describe('applicationsController', () => {
       const requestHandler = applicationsController.show()
 
       const application = createMock<Application>()
-      const id = 'some-uuid'
 
       request = createMock<Request>({
-        params: { id },
-        session: { application: { [id]: application } },
+        params: { id: application.id },
+        session: { application },
       })
 
       requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('applications/show', { application, id })
+      expect(response.render).toHaveBeenCalledWith('applications/show', { application })
     })
 
     it('404s if the application is not present in the session', () => {

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -28,13 +28,13 @@ export default class ApplicationsController {
 
   show(): RequestHandler {
     return (req: Request, res: Response, next: NextFunction) => {
-      const application = req.session?.application?.[req.params.id]
+      const { application } = req.session
 
       if (!application) {
         next(createError(404, 'Not found'))
       }
 
-      res.render('applications/show', { application, id: req.params.id })
+      res.render('applications/show', { application })
     }
   }
 

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -70,6 +70,7 @@ export default class ApplicationsController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const application = await this.applicationService.createApplication(req.user.token, req.body.crn)
+      req.session.application = application
 
       res.redirect(
         paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'sentence-type' }),

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -43,6 +43,22 @@ describe('ApplicationClient', () => {
     })
   })
 
+  describe('find', () => {
+    it('should return an application', async () => {
+      const application = applicationFactory.build()
+
+      fakeApprovedPremisesApi
+        .get(paths.applications.show({ id: application.id }))
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, application)
+
+      const result = await applicationClient.find(application.id)
+
+      expect(result).toEqual(application)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+
   describe('update', () => {
     it('should return an application when a PUT request is made', async () => {
       const application = applicationFactory.build()

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -68,7 +68,7 @@ describe('ApplicationClient', () => {
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, application)
 
-      const result = await applicationClient.update(application, application.id)
+      const result = await applicationClient.update(application)
 
       expect(result).toEqual(application)
       expect(nock.isDone()).toBeTruthy()

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -36,7 +36,7 @@ describe('ApplicationClient', () => {
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(201, application)
 
-      const result = await applicationClient.create(application.crn)
+      const result = await applicationClient.create(application.person.crn)
 
       expect(result).toEqual(application)
       expect(nock.isDone()).toBeTruthy()

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -64,7 +64,7 @@ describe('ApplicationClient', () => {
       const application = applicationFactory.build()
 
       fakeApprovedPremisesApi
-        .put(paths.applications.update({ id: application.id }))
+        .put(paths.applications.update({ id: application.id }), JSON.stringify({ data: application.data }))
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, application)
 

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -22,7 +22,7 @@ export default class ApplicationClient {
   async update(application: Application, applicationId: string): Promise<Application> {
     return (await this.restClient.put({
       path: paths.applications.update({ id: applicationId }),
-      data: { data: application },
+      data: { data: application.data },
     })) as Application
   }
 

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -19,9 +19,9 @@ export default class ApplicationClient {
     return (await this.restClient.post({ path: paths.applications.new.pattern, data: { crn } })) as Application
   }
 
-  async update(application: Application, applicationId: string): Promise<Application> {
+  async update(application: Application): Promise<Application> {
     return (await this.restClient.put({
-      path: paths.applications.update({ id: applicationId }),
+      path: paths.applications.update({ id: application.id }),
       data: { data: application.data },
     })) as Application
   }

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -11,6 +11,10 @@ export default class ApplicationClient {
     this.restClient = new RestClient('applicationClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
+  async find(applicationId: string): Promise<Application> {
+    return (await this.restClient.get({ path: paths.applications.show({ id: applicationId }) })) as Application
+  }
+
   async create(crn: string): Promise<Application> {
     return (await this.restClient.post({ path: paths.applications.new.pattern, data: { crn } })) as Application
   }

--- a/server/form-pages/apply/basic-information/placementDate.test.ts
+++ b/server/form-pages/apply/basic-information/placementDate.test.ts
@@ -2,10 +2,11 @@ import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-e
 
 import PlacementDate from './placementDate'
 import { DateFormats } from '../../../utils/dateUtils'
+import applicationFactory from '../../../testutils/factories/application'
 
 describe('PlacementDate', () => {
   const releaseDate = new Date().toISOString()
-  const session = { 'basic-information': { 'release-date': { releaseDate } } }
+  const application = applicationFactory.build({ data: { 'basic-information': { 'release-date': { releaseDate } } } })
 
   describe('title and body', () => {
     it('should strip unknown attributes from the body', () => {
@@ -17,7 +18,7 @@ describe('PlacementDate', () => {
           'startDate-day': 1,
           something: 'else',
         },
-        session,
+        application,
       )
 
       expect(page.body).toEqual({
@@ -32,8 +33,8 @@ describe('PlacementDate', () => {
     })
   })
 
-  itShouldHaveNextValue(new PlacementDate({}, session), '')
-  itShouldHavePreviousValue(new PlacementDate({}, session), 'oral-hearing')
+  itShouldHaveNextValue(new PlacementDate({}, application), '')
+  itShouldHavePreviousValue(new PlacementDate({}, application), 'oral-hearing')
 
   describe('errors', () => {
     it('should return an empty array if the release date is the same as the start date', () => {
@@ -41,7 +42,7 @@ describe('PlacementDate', () => {
         {
           startDateSameAsReleaseDate: 'yes',
         },
-        session,
+        application,
       )
       expect(page.errors()).toEqual([])
     })
@@ -55,7 +56,7 @@ describe('PlacementDate', () => {
             'startDate-month': 12,
             'startDate-day': 1,
           },
-          session,
+          application,
         )
         expect(page.errors()).toEqual([])
       })
@@ -65,7 +66,7 @@ describe('PlacementDate', () => {
           {
             startDateSameAsReleaseDate: 'no',
           },
-          session,
+          application,
         )
         expect(page.errors()).toEqual([
           {
@@ -83,7 +84,7 @@ describe('PlacementDate', () => {
             'startDate-month': 99999,
             'startDate-day': 9999,
           },
-          session,
+          application,
         )
         expect(page.errors()).toEqual([
           {
@@ -95,7 +96,7 @@ describe('PlacementDate', () => {
     })
 
     it('should return an error if the startDateSameAsReleaseDate field is not populated', () => {
-      const page = new PlacementDate({}, session)
+      const page = new PlacementDate({}, application)
       expect(page.errors()).toEqual([
         {
           propertyName: '$.startDateSameAsReleaseDate',

--- a/server/form-pages/apply/basic-information/placementDate.ts
+++ b/server/form-pages/apply/basic-information/placementDate.ts
@@ -1,7 +1,7 @@
-import type { ObjectWithDateParts, YesOrNo } from 'approved-premises'
+import type { ObjectWithDateParts, YesOrNo, Application } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
-import { retrieveQuestionResponseFromSession } from '../../../utils/utils'
+import { retrieveQuestionResponseFromApplication } from '../../../utils/utils'
 import { dateIsBlank, dateAndTimeInputsAreValidDates, DateFormats } from '../../../utils/dateUtils'
 
 export default class PlacementDate implements TasklistPage {
@@ -13,7 +13,7 @@ export default class PlacementDate implements TasklistPage {
     startDateSameAsReleaseDate: YesOrNo
   }
 
-  constructor(body: Record<string, unknown>, session: Record<string, unknown>) {
+  constructor(body: Record<string, unknown>, application: Application) {
     this.body = {
       'startDate-year': body['startDate-year'] as string,
       'startDate-month': body['startDate-month'] as string,
@@ -22,7 +22,7 @@ export default class PlacementDate implements TasklistPage {
     }
 
     const formattedReleaseDate = DateFormats.isoDateToUIDate(
-      retrieveQuestionResponseFromSession(session, 'releaseDate'),
+      retrieveQuestionResponseFromApplication(application, 'releaseDate'),
     )
 
     this.title = `Is ${formattedReleaseDate} the date you want the placement to start?`

--- a/server/form-pages/apply/basic-information/releaseDate.test.ts
+++ b/server/form-pages/apply/basic-information/releaseDate.test.ts
@@ -1,8 +1,11 @@
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
 
 import ReleaseDate from './releaseDate'
+import applicationFactory from '../../../testutils/factories/application'
 
 describe('ReleaseDate', () => {
+  const application = applicationFactory.build()
+
   describe('body', () => {
     it('should strip unknown attributes from the body', () => {
       const page = new ReleaseDate(
@@ -13,7 +16,7 @@ describe('ReleaseDate', () => {
           'releaseDate-day': 3,
           something: 'else',
         },
-        {},
+        application,
         'previousPage',
       )
 
@@ -27,15 +30,15 @@ describe('ReleaseDate', () => {
   })
 
   describe('when knowReleaseDate is set to yes', () => {
-    itShouldHaveNextValue(new ReleaseDate({ knowReleaseDate: 'yes' }, {}, 'somePage'), 'placement-date')
+    itShouldHaveNextValue(new ReleaseDate({ knowReleaseDate: 'yes' }, application, 'somePage'), 'placement-date')
   })
 
   describe('when knowReleaseDate is set to no', () => {
-    itShouldHaveNextValue(new ReleaseDate({ knowReleaseDate: 'no' }, {}, 'somePage'), 'oral-hearing')
+    itShouldHaveNextValue(new ReleaseDate({ knowReleaseDate: 'no' }, application, 'somePage'), 'oral-hearing')
   })
 
   describe("previous returns the value passed into the previousPage parameter of the object's constructor", () => {
-    itShouldHavePreviousValue(new ReleaseDate({}, {}, 'previousPage'), 'previousPage')
+    itShouldHavePreviousValue(new ReleaseDate({}, application, 'previousPage'), 'previousPage')
   })
 
   describe('errors', () => {
@@ -48,7 +51,7 @@ describe('ReleaseDate', () => {
             'releaseDate-month': 3,
             'releaseDate-day': 3,
           },
-          {},
+          application,
           'somePage',
         )
         expect(page.errors()).toEqual([])
@@ -59,7 +62,7 @@ describe('ReleaseDate', () => {
           {
             knowReleaseDate: 'yes',
           },
-          {},
+          application,
           'somePage',
         )
         expect(page.errors()).toEqual([
@@ -78,7 +81,7 @@ describe('ReleaseDate', () => {
             'releaseDate-month': 99,
             'releaseDate-day': 99,
           },
-          {},
+          application,
           'somePage',
         )
         expect(page.errors()).toEqual([
@@ -95,14 +98,14 @@ describe('ReleaseDate', () => {
         {
           knowReleaseDate: 'no',
         },
-        {},
+        application,
         'somePage',
       )
       expect(page.errors()).toEqual([])
     })
 
     it('should return an error if the knowReleaseDate field is not populated', () => {
-      const page = new ReleaseDate({}, {}, 'somePage')
+      const page = new ReleaseDate({}, application, 'somePage')
       expect(page.errors()).toEqual([
         {
           propertyName: '$.knowReleaseDate',

--- a/server/form-pages/apply/basic-information/releaseDate.ts
+++ b/server/form-pages/apply/basic-information/releaseDate.ts
@@ -1,4 +1,4 @@
-import type { ObjectWithDateParts, YesOrNo } from 'approved-premises'
+import type { ObjectWithDateParts, YesOrNo, Application } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
 import { dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../utils/dateUtils'
@@ -14,7 +14,7 @@ export default class ReleaseDate implements TasklistPage {
 
   previousPage: string
 
-  constructor(body: Record<string, unknown>, _session: Record<string, unknown>, previousPage: string) {
+  constructor(body: Record<string, unknown>, _application: Application, previousPage: string) {
     this.body = {
       'releaseDate-year': body['releaseDate-year'] as string,
       'releaseDate-month': body['releaseDate-month'] as string,

--- a/server/form-pages/apply/basic-information/releaseType.test.ts
+++ b/server/form-pages/apply/basic-information/releaseType.test.ts
@@ -1,29 +1,32 @@
 import { itShouldHavePreviousValue, itShouldHaveNextValue } from '../../shared-examples'
+import applicationFactory from '../../../testutils/factories/application'
 
 import ReleaseType from './releaseType'
 
 describe('ReleaseType', () => {
-  const session = { 'basic-information': { 'sentence-type': { sentenceType: 'standardDeterminate' } } }
+  const application = applicationFactory.build({
+    data: { 'basic-information': { 'sentence-type': { sentenceType: 'standardDeterminate' } } },
+  })
 
   describe('body', () => {
     it('should strip unknown attributes from the body', () => {
-      const page = new ReleaseType({ releaseType: 'rotl', something: 'else' }, session)
+      const page = new ReleaseType({ releaseType: 'rotl', something: 'else' }, application)
 
       expect(page.body).toEqual({ releaseType: 'rotl' })
     })
   })
 
-  itShouldHavePreviousValue(new ReleaseType({}, session), 'sentence-type')
-  itShouldHaveNextValue(new ReleaseType({}, session), 'release-date')
+  itShouldHavePreviousValue(new ReleaseType({}, application), 'sentence-type')
+  itShouldHaveNextValue(new ReleaseType({}, application), 'release-date')
 
   describe('errors', () => {
     it('should return an empty array if the release type is populated', () => {
-      const page = new ReleaseType({ releaseType: 'rotl' }, session)
+      const page = new ReleaseType({ releaseType: 'rotl' }, application)
       expect(page.errors()).toEqual([])
     })
 
     it('should return an errors if the release type is not populated', () => {
-      const page = new ReleaseType({ releaseType: '' }, session)
+      const page = new ReleaseType({ releaseType: '' }, application)
       expect(page.errors()).toEqual([
         {
           propertyName: '$.releaseType',
@@ -38,7 +41,9 @@ describe('ReleaseType', () => {
       it('if the release type is "standardDeterminate" then all the items should be shown', () => {
         const items = new ReleaseType(
           { releaseType: 'standardDeterminate' },
-          { 'basic-information': { 'sentence-type': { sentenceType: 'standardDeterminate' } } },
+          applicationFactory.build({
+            data: { 'basic-information': { 'sentence-type': { sentenceType: 'standardDeterminate' } } },
+          }),
         ).items()
 
         expect(items.length).toEqual(5)
@@ -52,7 +57,9 @@ describe('ReleaseType', () => {
       it('if the release type is "extendedDeterminate" then the reduced list of items should be shown', () => {
         const items = new ReleaseType(
           { releaseType: 'extendedDeterminate' },
-          { 'basic-information': { 'sentence-type': { sentenceType: 'extendedDeterminate' } } },
+          applicationFactory.build({
+            data: { 'basic-information': { 'sentence-type': { sentenceType: 'extendedDeterminate' } } },
+          }),
         ).items()
 
         expect(items.length).toEqual(3)
@@ -64,7 +71,7 @@ describe('ReleaseType', () => {
       it('if the release type is "ipp" then the reduced list of items should be shown', () => {
         const items = new ReleaseType(
           { releaseType: 'ipp' },
-          { 'basic-information': { 'sentence-type': { sentenceType: 'ipp' } } },
+          applicationFactory.build({ data: { 'basic-information': { 'sentence-type': { sentenceType: 'ipp' } } } }),
         ).items()
 
         expect(items.length).toEqual(3)
@@ -76,7 +83,7 @@ describe('ReleaseType', () => {
       it('if the release type is "life" then the reduced list of items should be shown', () => {
         const items = new ReleaseType(
           { releaseType: 'life' },
-          { 'basic-information': { 'sentence-type': { sentenceType: 'life' } } },
+          applicationFactory.build({ data: { 'basic-information': { 'sentence-type': { sentenceType: 'life' } } } }),
         ).items()
 
         expect(items.length).toEqual(3)
@@ -87,7 +94,7 @@ describe('ReleaseType', () => {
     })
 
     it('marks an option as selected when the releaseType is set', () => {
-      const page = new ReleaseType({ releaseType: 'rotl' }, session)
+      const page = new ReleaseType({ releaseType: 'rotl' }, application)
 
       const selectedOptions = page.items().filter(item => item.checked)
 
@@ -96,7 +103,7 @@ describe('ReleaseType', () => {
     })
 
     it('marks no options as selected when the releaseType is not set', () => {
-      const page = new ReleaseType({}, session)
+      const page = new ReleaseType({}, application)
 
       const selectedOptions = page.items().filter(item => item.checked)
 

--- a/server/form-pages/apply/basic-information/releaseType.ts
+++ b/server/form-pages/apply/basic-information/releaseType.ts
@@ -1,5 +1,7 @@
+import type { Application } from 'approved-premises'
+
 import { SessionDataError } from '../../../utils/errors'
-import { retrieveQuestionResponseFromSession } from '../../../utils/utils'
+import { retrieveQuestionResponseFromApplication } from '../../../utils/utils'
 import TasklistPage from '../../tasklistPage'
 import { SentenceTypesT } from './sentenceType'
 
@@ -24,8 +26,8 @@ export default class ReleaseType implements TasklistPage {
 
   releaseTypes: AllReleaseTypes | ReducedReleaseTypes
 
-  constructor(body: Record<string, unknown>, session: Record<string, unknown>) {
-    const sessionSentenceType = retrieveQuestionResponseFromSession<SentenceType>(session, 'sentenceType')
+  constructor(body: Record<string, unknown>, application: Application) {
+    const sessionSentenceType = retrieveQuestionResponseFromApplication<SentenceType>(application, 'sentenceType')
 
     this.releaseTypes = this.getReleaseTypes(sessionSentenceType)
 

--- a/server/form-pages/apply/basic-information/situation.test.ts
+++ b/server/form-pages/apply/basic-information/situation.test.ts
@@ -1,32 +1,37 @@
 import { itShouldHavePreviousValue, itShouldHaveNextValue } from '../../shared-examples'
+import applicationFactory from '../../../testutils/factories/application'
 
 import Situation from './situation'
 
 describe('Situation', () => {
-  let session = { 'basic-information': { 'sentence-type': { sentenceType: 'communityOrder' } } }
+  let application = applicationFactory.build({
+    data: { 'basic-information': { 'sentence-type': { sentenceType: 'communityOrder' } } },
+  })
   beforeEach(() => {
-    session = { 'basic-information': { 'sentence-type': { sentenceType: 'communityOrder' } } }
+    application = applicationFactory.build({
+      data: { 'basic-information': { 'sentence-type': { sentenceType: 'communityOrder' } } },
+    })
   })
 
   describe('body', () => {
     it('should strip unknown attributes from the body', () => {
-      const page = new Situation({ situation: 'riskManagement', something: 'else' }, session)
+      const page = new Situation({ situation: 'riskManagement', something: 'else' }, application)
 
       expect(page.body).toEqual({ situation: 'riskManagement' })
     })
   })
 
-  itShouldHavePreviousValue(new Situation({}, session), 'sentence-type')
-  itShouldHaveNextValue(new Situation({}, session), 'release-date')
+  itShouldHavePreviousValue(new Situation({}, application), 'sentence-type')
+  itShouldHaveNextValue(new Situation({}, application), 'release-date')
 
   describe('errors', () => {
     it('should return an empty array if the situation is populated', () => {
-      const page = new Situation({ situation: 'riskManagement' }, session)
+      const page = new Situation({ situation: 'riskManagement' }, application)
       expect(page.errors()).toEqual([])
     })
 
     it('should return an errors if the situation is not populated', () => {
-      const page = new Situation({ situation: '' }, session)
+      const page = new Situation({ situation: '' }, application)
       expect(page.errors()).toEqual([
         {
           propertyName: '$.situation',
@@ -41,7 +46,9 @@ describe('Situation', () => {
       it('if the sentence type is "communityOrder" then the items should be correct', () => {
         const items = new Situation(
           { situation: 'riskManagement' },
-          { 'basic-information': { 'sentence-type': { sentenceType: 'communityOrder' } } },
+          applicationFactory.build({
+            data: { 'basic-information': { 'sentence-type': { sentenceType: 'communityOrder' } } },
+          }),
         ).items()
 
         expect(items.length).toEqual(2)
@@ -52,7 +59,9 @@ describe('Situation', () => {
       it('if the sentence type is "bailPlacement" then the items should be correct', () => {
         const items = new Situation(
           { situation: 'bailAssessment' },
-          { 'basic-information': { 'sentence-type': { sentenceType: 'bailPlacement' } } },
+          applicationFactory.build({
+            data: { 'basic-information': { 'sentence-type': { sentenceType: 'bailPlacement' } } },
+          }),
         ).items()
 
         expect(items.length).toEqual(2)
@@ -66,7 +75,7 @@ describe('Situation', () => {
     })
 
     it('marks an option as selected when the releaseType is set', () => {
-      const page = new Situation({ situation: 'riskManagement' }, session)
+      const page = new Situation({ situation: 'riskManagement' }, application)
 
       const selectedOptions = page.items().filter(item => item.checked)
 
@@ -75,7 +84,7 @@ describe('Situation', () => {
     })
 
     it('marks no options as selected when the releaseType is not set', () => {
-      const page = new Situation({}, session)
+      const page = new Situation({}, application)
 
       const selectedOptions = page.items().filter(item => item.checked)
 

--- a/server/form-pages/apply/basic-information/situation.ts
+++ b/server/form-pages/apply/basic-information/situation.ts
@@ -1,5 +1,7 @@
+import type { Application } from 'approved-premises'
+
 import { SessionDataError } from '../../../utils/errors'
-import { retrieveQuestionResponseFromSession } from '../../../utils/utils'
+import { retrieveQuestionResponseFromApplication } from '../../../utils/utils'
 import TasklistPage from '../../tasklistPage'
 import { SentenceTypesT } from './sentenceType'
 
@@ -23,8 +25,8 @@ export default class Situation implements TasklistPage {
 
   situations: CommunityOrderSituations | BailPlacementSituations
 
-  constructor(body: Record<string, unknown>, session: Record<string, unknown>) {
-    const sessionSentenceType = retrieveQuestionResponseFromSession<SentenceType>(session, 'sentenceType')
+  constructor(body: Record<string, unknown>, application: Application) {
+    const sessionSentenceType = retrieveQuestionResponseFromApplication<SentenceType>(application, 'sentenceType')
 
     this.situations = this.getSituationsForSentenceType(sessionSentenceType)
 

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -11,6 +11,7 @@ export default {
     },
   },
   applications: {
+    show: applyPaths.applications.show,
     index: applyPaths.applications.index,
     update: applyPaths.applications.update,
     new: applyPaths.applications.create,

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -121,12 +121,12 @@ describe('ApplicationService', () => {
 
       applicationClient.create.mockResolvedValue(application)
 
-      const result = await service.createApplication(token, application.crn)
+      const result = await service.createApplication(token, application.person.crn)
 
       expect(result).toEqual(application)
 
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
-      expect(applicationClient.create).toHaveBeenCalledWith(application.crn)
+      expect(applicationClient.create).toHaveBeenCalledWith(application.person.crn)
     })
   })
 

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -238,9 +238,11 @@ describe('ApplicationService', () => {
 
   describe('save', () => {
     const application = applicationFactory.build()
+    const token = 'some-token'
     const request = createMock<Request>({
       params: { id: application.id, task: 'some-task', page: 'some-page' },
       session: { application },
+      user: { token },
     })
 
     describe('when there are no validation errors', () => {
@@ -265,6 +267,13 @@ describe('ApplicationService', () => {
 
         expect(request.session.application).toEqual(application)
         expect(request.session.application.data).toEqual({ 'some-task': { 'some-page': { foo: 'bar' } } })
+      })
+
+      it('saves data to the api', async () => {
+        await service.save(page, request)
+
+        expect(applicationClientFactory).toHaveBeenCalledWith(token)
+        expect(applicationClient.update).toHaveBeenCalledWith(application)
       })
     })
 

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -115,7 +115,7 @@ describe('ApplicationService', () => {
   })
 
   describe('createApplication', () => {
-    it('calls the create method and returns a uuid', async () => {
+    it('calls the create method and returns an application', async () => {
       const application = applicationFactory.build()
       const token = 'SOME_TOKEN'
 
@@ -127,6 +127,22 @@ describe('ApplicationService', () => {
 
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
       expect(applicationClient.create).toHaveBeenCalledWith(application.person.crn)
+    })
+  })
+
+  describe('findApplication', () => {
+    it('calls the find method and returns an application', async () => {
+      const application = applicationFactory.build()
+      const token = 'SOME_TOKEN'
+
+      applicationClient.find.mockResolvedValue(application)
+
+      const result = await service.findApplication(token, application.id)
+
+      expect(result).toEqual(application)
+
+      expect(applicationClientFactory).toHaveBeenCalledWith(token)
+      expect(applicationClient.find).toHaveBeenCalledWith(application.id)
     })
   })
 

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -149,20 +149,26 @@ describe('ApplicationService', () => {
   describe('getCurrentPage', () => {
     let request: DeepMocked<Request>
     const dataServices = createMock<DataServices>({}) as DataServices
+    const application = applicationFactory.build()
 
     beforeEach(() => {
       request = createMock<Request>({
-        params: { id: 'some-uuid', task: 'my-task' },
-        session: { previousPage: '' },
+        params: { id: application.id, task: 'my-task' },
+        session: { application, previousPage: '' },
+        user: { token: 'some-token' },
       })
     })
 
-    it('should return the session and first page if the page is not defined', async () => {
+    it('should fetch the application from the API if it is not in the session', async () => {
+      request.session.application = undefined
+      applicationClient.find.mockResolvedValue(application)
+
       const result = await service.getCurrentPage(request, dataServices)
 
       expect(result).toBeInstanceOf(FirstPage)
 
-      expect(FirstPage).toHaveBeenCalledWith(request.body, { 'my-task': {} }, '')
+      expect(FirstPage).toHaveBeenCalledWith(request.body, application, '')
+      expect(applicationClient.find).toHaveBeenCalledWith(request.params.id)
     })
 
     it('should return the session and a page from a page list', async () => {
@@ -172,7 +178,7 @@ describe('ApplicationService', () => {
 
       expect(result).toBeInstanceOf(SecondPage)
 
-      expect(SecondPage).toHaveBeenCalledWith(request.body, { 'my-task': {} }, '')
+      expect(SecondPage).toHaveBeenCalledWith(request.body, application, '')
     })
 
     it('should initialize the page with the session and the userInput if specified', async () => {
@@ -181,18 +187,18 @@ describe('ApplicationService', () => {
 
       expect(result).toBeInstanceOf(FirstPage)
 
-      expect(FirstPage).toHaveBeenCalledWith(userInput, { 'my-task': {} }, '')
+      expect(FirstPage).toHaveBeenCalledWith(userInput, application, '')
     })
 
     it('should load from the session if the body and userInput are blank', async () => {
       request.body = {}
-      request.session.application = { 'some-uuid': { 'my-task': { first: { foo: 'bar' } } } }
+      request.session.application.data = { 'my-task': { first: { foo: 'bar' } } }
 
       const result = await service.getCurrentPage(request, dataServices)
 
       expect(result).toBeInstanceOf(FirstPage)
 
-      expect(FirstPage).toHaveBeenCalledWith({ foo: 'bar' }, { 'my-task': { first: { foo: 'bar' } } }, '')
+      expect(FirstPage).toHaveBeenCalledWith({ foo: 'bar' }, application, '')
     })
 
     it("should call a service's setup method if it exists", async () => {
@@ -210,7 +216,7 @@ describe('ApplicationService', () => {
       request.session.previousPage = 'previous-page-name'
       await service.getCurrentPage(request, dataServices)
 
-      expect(FirstPage).toHaveBeenCalledWith(request.body, { 'my-task': {} }, 'previous-page-name')
+      expect(FirstPage).toHaveBeenCalledWith(request.body, application, 'previous-page-name')
     })
 
     it('should raise an error if the page is not found', async () => {
@@ -231,12 +237,17 @@ describe('ApplicationService', () => {
   })
 
   describe('save', () => {
-    const request = createMock<Request>({ params: { id: 'some-uuid', task: 'some-task', page: 'some-page' } })
+    const application = applicationFactory.build()
+    const request = createMock<Request>({
+      params: { id: application.id, task: 'some-task', page: 'some-page' },
+      session: { application },
+    })
 
     describe('when there are no validation errors', () => {
       let page: DeepMocked<TasklistPage>
 
       beforeEach(() => {
+        application.data = {}
         page = createMock<TasklistPage>({
           errors: () => [] as TaskListErrors,
           body: { foo: 'bar' },
@@ -252,7 +263,8 @@ describe('ApplicationService', () => {
       it('saves data to the session', async () => {
         await service.save(page, request)
 
-        expect(request.session.application).toEqual({ 'some-uuid': { 'some-task': { 'some-page': { foo: 'bar' } } } })
+        expect(request.session.application).toEqual(application)
+        expect(request.session.application.data).toEqual({ 'some-task': { 'some-page': { foo: 'bar' } } })
       })
     })
 

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -79,11 +79,11 @@ export default class ApplicationService {
     }
   }
 
-  private getApplicationFromSessionOrAPI(request: Request): Promise<Application> {
+  private getApplicationFromSessionOrAPI(request: Request): Promise<Application> | Application {
     const { application } = request.session
 
     if (application && application.id === request.params.id) {
-      return application as unknown as Promise<Application>
+      return application
     }
     return this.findApplication(request.user.token, request.params.id)
   }

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -26,6 +26,14 @@ export default class ApplicationService {
     return application
   }
 
+  async findApplication(token: string, id: string): Promise<Application> {
+    const applicationClient = this.applicationClientFactory(token)
+
+    const application = await applicationClient.find(id)
+
+    return application
+  }
+
   async getCurrentPage(
     request: Request,
     dataServices: DataServices,

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -7,7 +7,7 @@ import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<Application>(() => ({
   id: faker.datatype.uuid(),
-  crn: personFactory.build().crn,
+  person: personFactory.build(),
   createdByProbationOfficerId: faker.datatype.uuid(),
   schemaVersion: faker.datatype.uuid(),
   createdAt: DateFormats.formatApiDate(faker.date.past()),

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -1,10 +1,10 @@
-import type { ApplicationData } from 'approved-premises'
+import applicationFactory from '../testutils/factories/application'
 import { taskLink, getTaskStatus } from './applicationUtils'
 
 describe('applicationUtils', () => {
   describe('getTaskStatus', () => {
     it('returns a not started tag when the task is incomplete', () => {
-      const application = {} as ApplicationData
+      const application = applicationFactory.build()
 
       expect(getTaskStatus('basic-information', application)).toEqual(
         '<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="basic-information-status">Not started</strong>',
@@ -12,7 +12,7 @@ describe('applicationUtils', () => {
     })
 
     it('returns a completed tag when the task is complete', () => {
-      const application = { 'basic-information': { foo: 'bar' } } as ApplicationData
+      const application = applicationFactory.build({ data: { 'basic-information': { foo: 'bar' } } })
 
       expect(getTaskStatus('basic-information', application)).toEqual(
         '<strong class="govuk-tag app-task-list__tag" id="basic-information-status">Completed</strong>',

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -1,9 +1,9 @@
-import type { ApplicationData, TaskNames } from 'approved-premises'
+import type { Application, TaskNames } from 'approved-premises'
 import pages from '../form-pages/apply'
 import taskLookup from '../i18n/en/tasks.json'
 
-const getTaskStatus = (task: TaskNames, application: ApplicationData): string => {
-  if (!application[task]) {
+const getTaskStatus = (task: TaskNames, application: Application): string => {
+  if (!application.data[task]) {
     return `<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="${task}-status">Not started</strong>`
   }
   return `<strong class="govuk-tag app-task-list__tag" id="${task}-status">Completed</strong>`

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -5,7 +5,7 @@ import nunjucks from 'nunjucks'
 import express from 'express'
 import * as pathModule from 'path'
 
-import type { ErrorMessages, ApplicationData, TaskNames, PersonStatus } from 'approved-premises'
+import type { ErrorMessages, Application, TaskNames, PersonStatus } from 'approved-premises'
 import { initialiseName, removeBlankSummaryListItems } from './utils'
 import { dateFieldValues, convertObjectsToRadioItems, convertObjectsToSelectOptions } from './formUtils'
 import { getTaskStatus, taskLink } from './applicationUtils'
@@ -91,7 +91,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
 
   njkEnv.addGlobal('paths', { ...managePaths, ...applyPaths })
 
-  njkEnv.addGlobal('getTaskStatus', (task: TaskNames, application: ApplicationData) =>
+  njkEnv.addGlobal('getTaskStatus', (task: TaskNames, application: Application) =>
     markAsSafe(getTaskStatus(task, application)),
   )
 

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,9 +1,10 @@
 import type { SummaryListItem } from 'approved-premises'
 import { SessionDataError } from './errors'
+import applicationFactory from '../testutils/factories/application'
 import {
   convertToTitleCase,
   initialiseName,
-  retrieveQuestionResponseFromSession,
+  retrieveQuestionResponseFromApplication,
   removeBlankSummaryListItems,
 } from './utils'
 
@@ -36,18 +37,20 @@ describe('initialise name', () => {
   })
 })
 
-describe('retrieveQuestionResponseFromSession', () => {
+describe('retrieveQuestionResponseFromApplication', () => {
   it("throws a SessionDataError if the property doesn't exist", () => {
-    expect(() => retrieveQuestionResponseFromSession({}, '')).toThrow(SessionDataError)
+    const application = applicationFactory.build()
+    expect(() => retrieveQuestionResponseFromApplication(application, '')).toThrow(SessionDataError)
   })
 
   it('returns the property if it does existion', () => {
-    const questionResponse = retrieveQuestionResponseFromSession(
-      {
+    const application = applicationFactory.build({
+      data: {
         'basic-information': { 'question-response': { questionResponse: 'no' } },
       },
-      'questionResponse',
-    )
+    })
+
+    const questionResponse = retrieveQuestionResponseFromApplication(application, 'questionResponse')
     expect(questionResponse).toBe('no')
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,4 +1,4 @@
-import type { SummaryListItem } from 'approved-premises'
+import type { SummaryListItem, Application } from 'approved-premises'
 import { SessionDataError } from './errors'
 
 /* istanbul ignore next */
@@ -39,14 +39,14 @@ const kebabCase = (string: string) =>
     .toLowerCase()
 
 /**
- * Retrieves response for a given question from the session object.
- * @param sessionData the session data for an application.
+ * Retrieves response for a given question from the application object.
+ * @param application the application to fetch the response from.
  * @param question the question that we need the response for in camelCase.
  * @returns name converted to proper case.
  */
-export const retrieveQuestionResponseFromSession = <T>(sessionData: Record<string, unknown>, question: string) => {
+export const retrieveQuestionResponseFromApplication = <T>(application: Application, question: string) => {
   try {
-    return sessionData['basic-information'][kebabCase(question)][question] as T
+    return application.data['basic-information'][kebabCase(question)][question] as T
   } catch (e) {
     throw new SessionDataError(`Question ${question} was not found in the session`)
   }

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -27,13 +27,13 @@
           <ul class="app-task-list__items">
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                {{ taskLink('basic-information', id)  }}
+                {{ taskLink('basic-information', application.id)  }}
               </span>
               {{ getTaskStatus('basic-information', application) }}
             </li>
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                {{ taskLink('type-of-ap', id) }}
+                {{ taskLink('type-of-ap', application.id) }}
               </span>
               {{ getTaskStatus('type-of-ap', application) }}
             </li>

--- a/wiremock/applicationStubs.ts
+++ b/wiremock/applicationStubs.ts
@@ -1,3 +1,5 @@
+import { guidRegex } from './index'
+
 import applicationSummaryFactory from '../server/testutils/factories/applicationSummary'
 import applicationFactory from '../server/testutils/factories/application'
 
@@ -11,6 +13,17 @@ export default [
       status: 200,
       headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       jsonBody: applicationSummaryFactory.buildList(20),
+    },
+  },
+  {
+    request: {
+      method: 'GET',
+      url: `/applications/${guidRegex}`,
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: applicationFactory.build(),
     },
   },
   {

--- a/wiremock/applicationStubs.ts
+++ b/wiremock/applicationStubs.ts
@@ -1,4 +1,5 @@
 import applicationSummaryFactory from '../server/testutils/factories/applicationSummary'
+import applicationFactory from '../server/testutils/factories/application'
 
 export default [
   {
@@ -10,6 +11,17 @@ export default [
       status: 200,
       headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       jsonBody: applicationSummaryFactory.buildList(20),
+    },
+  },
+  {
+    request: {
+      method: 'POST',
+      url: `/applications`,
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: applicationFactory.build(),
     },
   },
 ]


### PR DESCRIPTION
This started out as an attempt to add person details to an application, but as the work progressed, I realised there was a bunch of groundwork that needed to be put in first. This changes the flow of Apply to now add an Application object to the session, this touches a whole bunch of parts of the code, so there was a fair bit to do! 

I could have added the person details to this PR, but I thought it was better to get the groundwork in place so a) I don't block any more work and b) the PR doesn't get too big!

Hopefully it's easy enough to understand - let me know if there's anything I can do to make it more digestable!

## Caveats / things to note

At the moment, running Apply locally is a bit broken, because it's tricky to maintain state using Wiremock. I'm not entirely sure how to handle this, apart from running the whole stack locally. Thoughts welcome!