### PR TITLE
(763) Add person details to an application

### DIFF
--- a/cypress_shared/pages/apply/releaseDate.ts
+++ b/cypress_shared/pages/apply/releaseDate.ts
@@ -1,7 +1,8 @@
+import type { Person } from 'approved-premises'
 import Page from '../page'
 
 export default class ReleaseDatePage extends Page {
-  constructor() {
-    super('Do you know Robert Brown’s release date?')
+  constructor(person: Person) {
+    super(`Do you know ${person.name}’s release date?`)
   }
 }

--- a/cypress_shared/pages/apply/typeOfAp.ts
+++ b/cypress_shared/pages/apply/typeOfAp.ts
@@ -1,7 +1,9 @@
+import type { Person } from 'approved-premises'
+
 import Page from '../page'
 
 export default class TypeOfApPage extends Page {
-  constructor() {
-    super('Which type of AP does xxxx require?')
+  constructor(person: Person) {
+    super(`Which type of AP does ${person.name} require?`)
   }
 }

--- a/integration_tests/e2e/apply/apply.cy.ts
+++ b/integration_tests/e2e/apply/apply.cy.ts
@@ -64,7 +64,7 @@ context('Apply', () => {
     situationPage.clickSubmit()
 
     // Then I should be asked if I know the release date
-    Page.verifyOnPage(ReleaseDatePage)
+    Page.verifyOnPage(ReleaseDatePage, application.person)
 
     // And the API should have recieved the updated application
     cy.task('verifyApplicationUpdate', application.id).then(requests => {
@@ -132,7 +132,7 @@ context('Apply', () => {
     situationPage.clickSubmit()
 
     const releaseDate = new Date().toISOString()
-    const releaseDatePage = new ReleaseDatePage()
+    const releaseDatePage = new ReleaseDatePage(application.person)
     releaseDatePage.checkRadioByNameAndValue('knowReleaseDate', 'yes')
     releaseDatePage.completeDateInputs('releaseDate', releaseDate)
     situationPage.clickSubmit()
@@ -152,6 +152,6 @@ context('Apply', () => {
 
     // And I should be able to start the next task
     cy.get('[data-cy-task-name="type-of-ap"]').click()
-    Page.verifyOnPage(TypeOfApPage)
+    Page.verifyOnPage(TypeOfApPage, application.person)
   })
 })

--- a/server/form-pages/apply/basic-information/oralHearing.test.ts
+++ b/server/form-pages/apply/basic-information/oralHearing.test.ts
@@ -1,17 +1,35 @@
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
 
 import OralHearing from './oralHearing'
+import applicationFactory from '../../../testutils/factories/application'
+import personFactory from '../../../testutils/factories/person'
 
 describe('OralHearing', () => {
+  let application = applicationFactory.build()
+
+  describe('title', () => {
+    it('shold add the name of the person', () => {
+      const person = personFactory.build({ name: 'John Wayne' })
+      application = applicationFactory.build({ person })
+
+      const page = new OralHearing({}, application)
+
+      expect(page.title).toEqual('Do you know John Wayne’s oral hearing date?')
+    })
+  })
+
   describe('body', () => {
     it('should strip unknown attributes from the body', () => {
-      const page = new OralHearing({
-        knowOralHearingDate: 'yes',
-        'oralHearingDate-year': 2022,
-        'oralHearingDate-month': 3,
-        'oralHearingDate-day': 3,
-        something: 'else',
-      })
+      const page = new OralHearing(
+        {
+          knowOralHearingDate: 'yes',
+          'oralHearingDate-year': 2022,
+          'oralHearingDate-month': 3,
+          'oralHearingDate-day': 3,
+          something: 'else',
+        },
+        application,
+      )
 
       expect(page.body).toEqual({
         knowOralHearingDate: 'yes',
@@ -22,25 +40,31 @@ describe('OralHearing', () => {
     })
   })
 
-  itShouldHaveNextValue(new OralHearing({}), 'placement-date')
-  itShouldHavePreviousValue(new OralHearing({}), 'release-date')
+  itShouldHaveNextValue(new OralHearing({}, application), 'placement-date')
+  itShouldHavePreviousValue(new OralHearing({}, application), 'release-date')
 
   describe('errors', () => {
     describe('if the user knows the oral hearing date', () => {
       it('should return an empty array if the user knows the release date and specifies the date', () => {
-        const page = new OralHearing({
-          knowOralHearingDate: 'yes',
-          'oralHearingDate-year': 2022,
-          'oralHearingDate-month': 3,
-          'oralHearingDate-day': 3,
-        })
+        const page = new OralHearing(
+          {
+            knowOralHearingDate: 'yes',
+            'oralHearingDate-year': 2022,
+            'oralHearingDate-month': 3,
+            'oralHearingDate-day': 3,
+          },
+          application,
+        )
         expect(page.errors()).toEqual([])
       })
 
       it('should return an error if the date is not populated', () => {
-        const page = new OralHearing({
-          knowOralHearingDate: 'yes',
-        })
+        const page = new OralHearing(
+          {
+            knowOralHearingDate: 'yes',
+          },
+          application,
+        )
         expect(page.errors()).toEqual([
           {
             propertyName: '$.oralHearingDate',
@@ -50,12 +74,15 @@ describe('OralHearing', () => {
       })
 
       it('should return an error if the date is invalid', () => {
-        const page = new OralHearing({
-          knowOralHearingDate: 'yes',
-          'oralHearingDate-year': 99,
-          'oralHearingDate-month': 99,
-          'oralHearingDate-day': 99,
-        })
+        const page = new OralHearing(
+          {
+            knowOralHearingDate: 'yes',
+            'oralHearingDate-year': 99,
+            'oralHearingDate-month': 99,
+            'oralHearingDate-day': 99,
+          },
+          application,
+        )
         expect(page.errors()).toEqual([
           {
             propertyName: '$.oralHearingDate',
@@ -66,14 +93,17 @@ describe('OralHearing', () => {
     })
 
     it('should return an empty array  if the user does not know the release date', () => {
-      const page = new OralHearing({
-        knowOralHearingDate: 'no',
-      })
+      const page = new OralHearing(
+        {
+          knowOralHearingDate: 'no',
+        },
+        application,
+      )
       expect(page.errors()).toEqual([])
     })
 
     it('should return an error if the knowOralHearingDate field is not populated', () => {
-      const page = new OralHearing({})
+      const page = new OralHearing({}, application)
       expect(page.errors()).toEqual([
         {
           propertyName: '$.knowOralHearingDate',

--- a/server/form-pages/apply/basic-information/oralHearing.ts
+++ b/server/form-pages/apply/basic-information/oralHearing.ts
@@ -1,4 +1,4 @@
-import type { ObjectWithDateParts, YesOrNo } from 'approved-premises'
+import type { ObjectWithDateParts, YesOrNo, Application } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
 import { dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../utils/dateUtils'
@@ -6,13 +6,13 @@ import { dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../utils/date
 export default class OralHearing implements TasklistPage {
   name = 'oral-hearing'
 
-  title = 'Do you know Robert Brown’s oral hearing date?'
+  title = `Do you know ${this.application.person.name}’s oral hearing date?`
 
   body: ObjectWithDateParts<'oralHearingDate'> & {
     knowOralHearingDate: YesOrNo
   }
 
-  constructor(body: Record<string, unknown>) {
+  constructor(body: Record<string, unknown>, private readonly application: Application) {
     this.body = {
       'oralHearingDate-year': body['oralHearingDate-year'] as string,
       'oralHearingDate-month': body['oralHearingDate-month'] as string,

--- a/server/form-pages/apply/basic-information/placementDate.ts
+++ b/server/form-pages/apply/basic-information/placementDate.ts
@@ -22,7 +22,7 @@ export default class PlacementDate implements TasklistPage {
     }
 
     const formattedReleaseDate = DateFormats.isoDateToUIDate(
-      retrieveQuestionResponseFromApplication(application, 'releaseDate'),
+      retrieveQuestionResponseFromApplication(application, 'basic-information', 'releaseDate'),
     )
 
     this.title = `Is ${formattedReleaseDate} the date you want the placement to start?`

--- a/server/form-pages/apply/basic-information/releaseDate.test.ts
+++ b/server/form-pages/apply/basic-information/releaseDate.test.ts
@@ -2,9 +2,21 @@ import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-e
 
 import ReleaseDate from './releaseDate'
 import applicationFactory from '../../../testutils/factories/application'
+import personFactory from '../../../testutils/factories/person'
 
 describe('ReleaseDate', () => {
-  const application = applicationFactory.build()
+  let application = applicationFactory.build()
+
+  describe('title', () => {
+    it('shold add the name of the person', () => {
+      const person = personFactory.build({ name: 'John Wayne' })
+      application = applicationFactory.build({ person })
+
+      const page = new ReleaseDate({}, application, 'previousPage')
+
+      expect(page.title).toEqual('Do you know John Wayne’s release date?')
+    })
+  })
 
   describe('body', () => {
     it('should strip unknown attributes from the body', () => {

--- a/server/form-pages/apply/basic-information/releaseDate.ts
+++ b/server/form-pages/apply/basic-information/releaseDate.ts
@@ -6,7 +6,7 @@ import { dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../utils/date
 export default class ReleaseDate implements TasklistPage {
   name = 'release-date'
 
-  title = 'Do you know Robert Brown’s release date?'
+  title = `Do you know ${this.application.person.name}’s release date?`
 
   body: ObjectWithDateParts<'releaseDate'> & {
     knowReleaseDate: YesOrNo
@@ -14,7 +14,7 @@ export default class ReleaseDate implements TasklistPage {
 
   previousPage: string
 
-  constructor(body: Record<string, unknown>, _application: Application, previousPage: string) {
+  constructor(body: Record<string, unknown>, private readonly application: Application, previousPage: string) {
     this.body = {
       'releaseDate-year': body['releaseDate-year'] as string,
       'releaseDate-month': body['releaseDate-month'] as string,

--- a/server/form-pages/apply/basic-information/releaseType.ts
+++ b/server/form-pages/apply/basic-information/releaseType.ts
@@ -27,7 +27,11 @@ export default class ReleaseType implements TasklistPage {
   releaseTypes: AllReleaseTypes | ReducedReleaseTypes
 
   constructor(body: Record<string, unknown>, application: Application) {
-    const sessionSentenceType = retrieveQuestionResponseFromApplication<SentenceType>(application, 'sentenceType')
+    const sessionSentenceType = retrieveQuestionResponseFromApplication<SentenceType>(
+      application,
+      'basic-information',
+      'sentenceType',
+    )
 
     this.releaseTypes = this.getReleaseTypes(sessionSentenceType)
 

--- a/server/form-pages/apply/basic-information/situation.ts
+++ b/server/form-pages/apply/basic-information/situation.ts
@@ -26,7 +26,11 @@ export default class Situation implements TasklistPage {
   situations: CommunityOrderSituations | BailPlacementSituations
 
   constructor(body: Record<string, unknown>, application: Application) {
-    const sessionSentenceType = retrieveQuestionResponseFromApplication<SentenceType>(application, 'sentenceType')
+    const sessionSentenceType = retrieveQuestionResponseFromApplication<SentenceType>(
+      application,
+      'basic-information',
+      'sentenceType',
+    )
 
     this.situations = this.getSituationsForSentenceType(sessionSentenceType)
 

--- a/server/form-pages/apply/type-of-ap/apType.test.ts
+++ b/server/form-pages/apply/type-of-ap/apType.test.ts
@@ -2,38 +2,53 @@ import { itShouldHaveNextValue } from '../../shared-examples'
 import { convertKeyValuePairToRadioItems } from '../../../utils/formUtils'
 
 import ApType from './apType'
+import applicationFactory from '../../../testutils/factories/application'
+import personFactory from '../../../testutils/factories/person'
 
 jest.mock('../../../utils/formUtils')
 
 describe('ApType', () => {
+  let application = applicationFactory.build()
+
+  describe('title', () => {
+    it('shold add the name of the person', () => {
+      const person = personFactory.build({ name: 'John Wayne' })
+      application = applicationFactory.build({ person })
+
+      const page = new ApType({}, application)
+
+      expect(page.title).toEqual('Which type of AP does John Wayne require?')
+    })
+  })
+
   describe('body', () => {
     it('should strip unknown attributes from the body', () => {
-      const page = new ApType({ type: 'standard', something: 'else' })
+      const page = new ApType({ type: 'standard', something: 'else' }, application)
 
       expect(page.body).toEqual({ type: 'standard' })
     })
   })
 
   describe('when type is set to pipe', () => {
-    itShouldHaveNextValue(new ApType({ type: 'pipe' }), 'pipe-referral')
+    itShouldHaveNextValue(new ApType({ type: 'pipe' }, application), 'pipe-referral')
   })
 
   describe('when type is set to esap', () => {
-    itShouldHaveNextValue(new ApType({ type: 'esap' }), 'esap-placement-screening')
+    itShouldHaveNextValue(new ApType({ type: 'esap' }, application), 'esap-placement-screening')
   })
 
   describe('when type is set to standard', () => {
-    itShouldHaveNextValue(new ApType({ type: 'standard' }), null)
+    itShouldHaveNextValue(new ApType({ type: 'standard' }, application), null)
   })
 
   describe('errors', () => {
     it('should return an empty array if the type is populated', () => {
-      const page = new ApType({ type: 'riskManagement' })
+      const page = new ApType({ type: 'riskManagement' }, application)
       expect(page.errors()).toEqual([])
     })
 
     it('should return an errors if the type is not populated', () => {
-      const page = new ApType({ type: '' })
+      const page = new ApType({ type: '' }, application)
       expect(page.errors()).toEqual([
         {
           propertyName: '$.type',
@@ -45,7 +60,7 @@ describe('ApType', () => {
 
   describe('items', () => {
     it('it calls convertKeyValuePairToRadioItems', () => {
-      const page = new ApType({ type: '' })
+      const page = new ApType({ type: '' }, application)
       page.items()
 
       expect(convertKeyValuePairToRadioItems).toHaveBeenCalled()

--- a/server/form-pages/apply/type-of-ap/apType.ts
+++ b/server/form-pages/apply/type-of-ap/apType.ts
@@ -1,3 +1,5 @@
+import type { Application } from 'approved-premises'
+
 import TasklistPage from '../../tasklistPage'
 import { convertKeyValuePairToRadioItems } from '../../../utils/formUtils'
 
@@ -12,11 +14,11 @@ type ApTypes = typeof apTypes
 export default class ApType implements TasklistPage {
   name = 'ap-type'
 
-  title = 'Which type of AP does xxxx require?'
+  title = `Which type of AP does ${this.application.person.name} require?`
 
   body: { type: keyof ApTypes }
 
-  constructor(body: Record<string, unknown>) {
+  constructor(body: Record<string, unknown>, private readonly application: Application) {
     this.body = {
       type: body.type as keyof ApTypes,
     }

--- a/server/form-pages/apply/type-of-ap/pipeReferral.test.ts
+++ b/server/form-pages/apply/type-of-ap/pipeReferral.test.ts
@@ -1,17 +1,35 @@
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
 
 import PipeReferral from './pipeReferral'
+import applicationFactory from '../../../testutils/factories/application'
+import personFactory from '../../../testutils/factories/person'
 
 describe('PipeReferral', () => {
+  let application = applicationFactory.build()
+
+  describe('title', () => {
+    it('shold add the name of the person', () => {
+      const person = personFactory.build({ name: 'John Wayne' })
+      application = applicationFactory.build({ person })
+
+      const page = new PipeReferral({}, application)
+
+      expect(page.title).toEqual('Has John Wayne been screened into the OPD pathway?')
+    })
+  })
+
   describe('body', () => {
     it('should strip unknown attributes from the body', () => {
-      const page = new PipeReferral({
-        opdPathway: 'yes',
-        'opdPathwayDate-year': 2022,
-        'opdPathwayDate-month': 3,
-        'opdPathwayDate-day': 3,
-        something: 'else',
-      })
+      const page = new PipeReferral(
+        {
+          opdPathway: 'yes',
+          'opdPathwayDate-year': 2022,
+          'opdPathwayDate-month': 3,
+          'opdPathwayDate-day': 3,
+          something: 'else',
+        },
+        application,
+      )
 
       expect(page.body).toEqual({
         opdPathway: 'yes',
@@ -22,26 +40,32 @@ describe('PipeReferral', () => {
     })
   })
 
-  itShouldHaveNextValue(new PipeReferral({}), 'pipe-opd-screening')
+  itShouldHaveNextValue(new PipeReferral({}, application), 'pipe-opd-screening')
 
-  itShouldHavePreviousValue(new PipeReferral({}), 'ap-type')
+  itShouldHavePreviousValue(new PipeReferral({}, application), 'ap-type')
 
   describe('errors', () => {
     describe('if opdPathway is yes', () => {
       it('should return an empty array if the date is specified', () => {
-        const page = new PipeReferral({
-          opdPathway: 'yes',
-          'opdPathwayDate-year': 2022,
-          'opdPathwayDate-month': 3,
-          'opdPathwayDate-day': 3,
-        })
+        const page = new PipeReferral(
+          {
+            opdPathway: 'yes',
+            'opdPathwayDate-year': 2022,
+            'opdPathwayDate-month': 3,
+            'opdPathwayDate-day': 3,
+          },
+          application,
+        )
         expect(page.errors()).toEqual([])
       })
 
       it('should return an error if  the date is not populated', () => {
-        const page = new PipeReferral({
-          opdPathway: 'yes',
-        })
+        const page = new PipeReferral(
+          {
+            opdPathway: 'yes',
+          },
+          application,
+        )
         expect(page.errors()).toEqual([
           {
             propertyName: '$.opdPathwayDate',
@@ -51,12 +75,15 @@ describe('PipeReferral', () => {
       })
 
       it('should return an error if the date is invalid', () => {
-        const page = new PipeReferral({
-          opdPathway: 'yes',
-          'opdPathwayDate-year': 99,
-          'opdPathwayDate-month': 99,
-          'opdPathwayDate-day': 99,
-        })
+        const page = new PipeReferral(
+          {
+            opdPathway: 'yes',
+            'opdPathwayDate-year': 99,
+            'opdPathwayDate-month': 99,
+            'opdPathwayDate-day': 99,
+          },
+          application,
+        )
         expect(page.errors()).toEqual([
           {
             propertyName: '$.opdPathwayDate',
@@ -67,14 +94,17 @@ describe('PipeReferral', () => {
     })
 
     it('should return an empty array if opdPathway in no', () => {
-      const page = new PipeReferral({
-        opdPathway: 'no',
-      })
+      const page = new PipeReferral(
+        {
+          opdPathway: 'no',
+        },
+        application,
+      )
       expect(page.errors()).toEqual([])
     })
 
     it('should return an error if the opdPathway field is not populated', () => {
-      const page = new PipeReferral({})
+      const page = new PipeReferral({}, application)
       expect(page.errors()).toEqual([
         {
           propertyName: '$.opdPathway',

--- a/server/form-pages/apply/type-of-ap/pipeReferral.ts
+++ b/server/form-pages/apply/type-of-ap/pipeReferral.ts
@@ -1,4 +1,4 @@
-import type { YesOrNo, ObjectWithDateParts } from 'approved-premises'
+import type { YesOrNo, ObjectWithDateParts, Application } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
 import { dateIsBlank, dateAndTimeInputsAreValidDates } from '../../../utils/dateUtils'
@@ -8,9 +8,9 @@ export default class PipeReferral implements TasklistPage {
 
   body: ObjectWithDateParts<'opdPathwayDate'> & { opdPathway: YesOrNo }
 
-  title = 'Has xxxx been screened into the OPD pathway?'
+  title = `Has ${this.application.person.name} been screened into the OPD pathway?`
 
-  constructor(body: Record<string, unknown>) {
+  constructor(body: Record<string, unknown>, private readonly application: Application) {
     this.body = {
       'opdPathwayDate-year': body['opdPathwayDate-year'] as string,
       'opdPathwayDate-month': body['opdPathwayDate-month'] as string,

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -40,7 +40,9 @@ describe('initialise name', () => {
 describe('retrieveQuestionResponseFromApplication', () => {
   it("throws a SessionDataError if the property doesn't exist", () => {
     const application = applicationFactory.build()
-    expect(() => retrieveQuestionResponseFromApplication(application, '')).toThrow(SessionDataError)
+    expect(() => retrieveQuestionResponseFromApplication(application, 'basic-information', '')).toThrow(
+      SessionDataError,
+    )
   })
 
   it('returns the property if it does existion', () => {
@@ -50,7 +52,11 @@ describe('retrieveQuestionResponseFromApplication', () => {
       },
     })
 
-    const questionResponse = retrieveQuestionResponseFromApplication(application, 'questionResponse')
+    const questionResponse = retrieveQuestionResponseFromApplication(
+      application,
+      'basic-information',
+      'questionResponse',
+    )
     expect(questionResponse).toBe('no')
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -44,9 +44,13 @@ const kebabCase = (string: string) =>
  * @param question the question that we need the response for in camelCase.
  * @returns name converted to proper case.
  */
-export const retrieveQuestionResponseFromApplication = <T>(application: Application, question: string) => {
+export const retrieveQuestionResponseFromApplication = <T>(
+  application: Application,
+  task: string,
+  question: string,
+) => {
   try {
-    return application.data['basic-information'][kebabCase(question)][question] as T
+    return application.data[task][kebabCase(question)][question] as T
   } catch (e) {
     throw new SessionDataError(`Question ${question} was not found in the session`)
   }


### PR DESCRIPTION
Now we have a full application object stored in the session and passed to our pages, we can use the name of the person we are applying for in the page titles.

## Screenshots

![Apply -- shows the details of a person from their CRN](https://user-images.githubusercontent.com/109774/193839696-947a8f09-3123-446e-8314-47c4f802e0bb.png)

![Apply -- shows a tasklist](https://user-images.githubusercontent.com/109774/193839784-b21fee1e-ed91-4035-af76-4e617bafd38c.png)

