### PR TITLE
Add Renovate config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'daily'
-    open-pull-requests-limit: 5

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,24 @@
+{
+  "extends": ["config:base", ":disableDependencyDashboard", ":preserveSemverRanges"],
+  "assigneesFromCodeOwners": true,
+  "timezone": "Europe/London",
+  "schedule": ["after 9am every weekday", "before 5pm every weekday"],
+  "enabledManagers": ["npm", "nvm", "dockerfile", "docker-compose", "helmv3", "helm-values", "circleci"],
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@types/node"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "matchDatasources": ["docker"],
+      "allowedVersions": "18.10.0-bullseye-slim"
+    },
+    {
+      "matchDatasources": ["docker-compose"],
+      "matchPackageNames": ["bitnami/redis"],
+      "allowedVersions": "5.0"
+    }
+  ]
+}


### PR DESCRIPTION
We currently use Dependabot for managing updates, but it seems that a lot of teams are migrating to Renovate now, so I thought we’d give it a go. We get a lot more control over what dependencies we can update, and can be a lot smarter about rebasing etc.