### PR TITLE
(767) Move key worker selection from booking to arrival form

### DIFF
--- a/cypress_shared/pages/manage/arrivalCreate.ts
+++ b/cypress_shared/pages/manage/arrivalCreate.ts
@@ -13,7 +13,7 @@ export default class ArrivalCreatePage extends Page {
     return new ArrivalCreatePage(premisesId, bookingId)
   }
 
-  public completeArrivalForm(arrival: Arrival): void {
+  public completeArrivalForm(arrival: Arrival, staffMemberId: string): void {
     cy.get('input[name="arrived"][value="Yes"]').check()
 
     cy.log('arrival', arrival)
@@ -28,6 +28,9 @@ export default class ArrivalCreatePage extends Page {
     cy.get('input[name="expectedDepartureDate-day"]').type(String(expectedDeparture.getDate()))
     cy.get('input[name="expectedDepartureDate-month"]').type(String(expectedDeparture.getMonth() + 1))
     cy.get('input[name="expectedDepartureDate-year"]').type(String(expectedDeparture.getFullYear()))
+
+    this.getLabel('Key Worker')
+    this.getSelectInputByIdAndSelectAnEntry('keyWorkerStaffId', staffMemberId)
 
     cy.get('[name="arrival[notes]"]').type(arrival.notes)
 

--- a/cypress_shared/pages/manage/booking/confirmation.ts
+++ b/cypress_shared/pages/manage/booking/confirmation.ts
@@ -25,7 +25,6 @@ export default class BookingConfirmationPage extends Page {
       this.assertDefinition('CRN', booking.person.crn)
       this.assertDefinition('Expected arrival date', DateFormats.isoDateToUIDate(booking.arrivalDate))
       this.assertDefinition('Expected departure date', DateFormats.isoDateToUIDate(booking.departureDate))
-      this.assertDefinition('Key worker', booking.keyWorker.name)
     })
   }
 

--- a/cypress_shared/pages/manage/booking/extension/confirmation.ts
+++ b/cypress_shared/pages/manage/booking/extension/confirmation.ts
@@ -20,7 +20,6 @@ export default class BookingExtensionConfirmationPage extends Page {
       this.assertDefinition('CRN', booking.person.crn)
       this.assertDefinition('Expected arrival date', DateFormats.isoDateToUIDate(booking.arrivalDate))
       this.assertDefinition('New expected departure date', DateFormats.isoDateToUIDate(booking.departureDate))
-      this.assertDefinition('Key worker', booking.keyWorker.name)
     })
   }
 }

--- a/cypress_shared/pages/manage/booking/new.ts
+++ b/cypress_shared/pages/manage/booking/new.ts
@@ -60,8 +60,5 @@ export default class BookingNewPage extends Page {
     this.expectedDepartureDay().type(departureDate.getDate().toString())
     this.expectedDepartureMonth().type(`${departureDate.getMonth() + 1}`)
     this.expectedDepartureYear().type(departureDate.getFullYear().toString())
-
-    this.getLabel('Key Worker')
-    this.getSelectInputByIdAndSelectAnEntry('keyWorkerId', booking.keyWorker.name)
   }
 }

--- a/cypress_shared/pages/manage/booking/show.ts
+++ b/cypress_shared/pages/manage/booking/show.ts
@@ -18,7 +18,6 @@ export default class BookingShowPage extends Page {
     cy.get('dl[data-cy-dates]').within(() => {
       this.assertDefinition('Arrival date', DateFormats.isoDateToUIDate(booking.arrivalDate))
       this.assertDefinition('Departure date', DateFormats.isoDateToUIDate(booking.departureDate))
-      this.assertDefinition('Key worker', booking.keyWorker.name)
     })
 
     cy.get('dl[data-cy-arrival-information]').within(() => {

--- a/e2e/tests/stepDefinitions/booking.ts
+++ b/e2e/tests/stepDefinitions/booking.ts
@@ -11,15 +11,12 @@ import {
 
 import bookingFactory from '../../../server/testutils/factories/booking'
 import personFactory from '../../../server/testutils/factories/person'
-import keyWorkerFactory from '../../../server/testutils/factories/keyWorker'
 
-const keyWorkerName = Cypress.env('keyworker_name') || throwMissingCypressEnvError('keyworker_name')
 const offenderName = Cypress.env('offender_name') || throwMissingCypressEnvError('offender_name')
 const offenderCrn = Cypress.env('offender_crn') || throwMissingCypressEnvError('offender_crn')
 
-const keyWorker = keyWorkerFactory.build({ name: keyWorkerName })
 const person = personFactory.build({ name: offenderName, crn: offenderCrn })
-const booking = bookingFactory.build({ keyWorker, person })
+const booking = bookingFactory.build({ person })
 
 Given('I create a booking', () => {
   cy.get('@premisesShowPage').then((premisesShowPage: PremisesShowPage) => {

--- a/integration_tests/e2e/manage/arrivals.cy.ts
+++ b/integration_tests/e2e/manage/arrivals.cy.ts
@@ -37,7 +37,7 @@ context('Arrivals', () => {
 
     // When I mark the booking as having arrived
     const page = ArrivalCreatePage.visit(premises.id, bookingId)
-    page.completeArrivalForm(arrival)
+    page.completeArrivalForm(arrival, staff[0].id)
 
     // Then an arrival should be created in the API
     cy.task('verifyArrivalCreate', { premisesId: premises.id, bookingId }).then(requests => {
@@ -48,6 +48,7 @@ context('Arrivals', () => {
 
       expect(requestBody.notes).equal(arrival.notes)
       expect(requestBody.date).equal(date)
+      expect(requestBody.keyWorkerStaffId).equal(staff[0].id)
       expect(requestBody.expectedDepartureDate).equal(expectedDepartureDate)
     })
 
@@ -74,7 +75,7 @@ context('Arrivals', () => {
     cy.task('stubArrivalErrors', {
       premisesId: premises.id,
       bookingId,
-      params: ['date', 'expectedDepartureDate'],
+      params: ['date', 'expectedDepartureDate', 'keyWorkerStaffId'],
     })
     page.submitArrivalFormWithoutFields()
 

--- a/integration_tests/e2e/manage/arrivals.cy.ts
+++ b/integration_tests/e2e/manage/arrivals.cy.ts
@@ -4,6 +4,9 @@ import nonArrivalFactory from '../../../server/testutils/factories/nonArrival'
 
 import { ArrivalCreatePage, PremisesShowPage } from '../../../cypress_shared/pages/manage'
 import premisesCapacityItemFactory from '../../../server/testutils/factories/premisesCapacityItem'
+import staffMemberFactory from '../../../server/testutils/factories/staffMember'
+
+const staff = staffMemberFactory.buildList(5)
 
 context('Arrivals', () => {
   beforeEach(() => {
@@ -24,6 +27,7 @@ context('Arrivals', () => {
       expectedDepartureDate: new Date(2022, 11, 11).toISOString(),
     })
 
+    cy.task('stubPremisesStaff', { premisesId: premises.id, staff })
     cy.task('stubSinglePremises', premises)
     cy.task('stubArrivalCreate', { premisesId: premises.id, bookingId, arrival })
     cy.task('stubPremisesCapacity', {
@@ -61,6 +65,7 @@ context('Arrivals', () => {
     const bookingId = 'some-uuid'
 
     cy.task('stubSinglePremises', premises)
+    cy.task('stubPremisesStaff', { premisesId: premises.id, staff })
 
     // When I visit the arrivals page
     const page = ArrivalCreatePage.visit(premises.id, bookingId)
@@ -89,6 +94,7 @@ context('Arrivals', () => {
       reason: 'recalled',
     })
 
+    cy.task('stubPremisesStaff', { premisesId: premises.id, staff })
     cy.task('stubSinglePremises', premises)
     cy.task('stubNonArrivalCreate', { premisesId: premises.id, bookingId, nonArrival })
     cy.task('stubPremisesCapacity', {
@@ -124,6 +130,7 @@ context('Arrivals', () => {
     const bookingId = 'some-uuid'
 
     cy.task('stubSinglePremises', premises)
+    cy.task('stubPremisesStaff', { premisesId: premises.id, staff })
 
     // When I visit the arrivals page
     const page = ArrivalCreatePage.visit(premises.id, bookingId)

--- a/integration_tests/e2e/manage/booking.cy.ts
+++ b/integration_tests/e2e/manage/booking.cy.ts
@@ -1,6 +1,5 @@
 import premisesFactory from '../../../server/testutils/factories/premises'
 import bookingFactory from '../../../server/testutils/factories/booking'
-import keyWorkerFactory from '../../../server/testutils/factories/keyWorker'
 import premisesCapacityItemFactory from '../../../server/testutils/factories/premisesCapacityItem'
 
 import { BookingFindPage, BookingNewPage, BookingShowPage } from '../../../cypress_shared/pages/manage'
@@ -9,14 +8,11 @@ import Page from '../../../cypress_shared/pages/page'
 import BookingConfirmation from '../../../cypress_shared/pages/manage/booking/confirmation'
 import personFactory from '../../../server/testutils/factories/person'
 
-const keyWorkers = keyWorkerFactory.buildList(5)
-
 context('Booking', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubKeyWorkers', { keyWorkers })
   })
 
   it('should show the CRN form followed by the booking form', () => {
@@ -25,7 +21,6 @@ context('Booking', () => {
       person,
       arrivalDate: new Date(Date.UTC(2022, 5, 1, 0, 0, 0)).toISOString(),
       departureDate: new Date(Date.UTC(2022, 5, 3, 0, 0, 0)).toISOString(),
-      keyWorker: keyWorkers[1],
     })
     const firstOvercapacityPeriodStartDate = premisesCapacityItemFactory.build({
       date: new Date(2023, 0, 1).toISOString(),
@@ -105,7 +100,6 @@ context('Booking', () => {
 
       expect(requestBody.arrivalDate).equal(booking.arrivalDate)
       expect(requestBody.departureDate).equal(booking.departureDate)
-      expect(requestBody.keyWorkerId).equal(booking.keyWorker.id)
     })
   })
 
@@ -140,12 +134,12 @@ context('Booking', () => {
     // And I miss the required fields
     cy.task('stubBookingErrors', {
       premisesId: premises.id,
-      params: ['arrivalDate', 'departureDate', 'keyWorkerId'],
+      params: ['arrivalDate', 'departureDate'],
     })
     bookingCreatePage.clickSubmit()
 
     // Then I should see error messages relating to those fields
-    page.shouldShowErrorMessagesForFields(['arrivalDate', 'departureDate', 'keyWorkerId'])
+    page.shouldShowErrorMessagesForFields(['arrivalDate', 'departureDate'])
   })
 
   it('should allow me to see a booking', () => {

--- a/integration_tests/mockApis/booking.ts
+++ b/integration_tests/mockApis/booking.ts
@@ -1,25 +1,9 @@
-import type { Booking, KeyWorker } from 'approved-premises'
+import type { Booking } from 'approved-premises'
 
 import { getMatchingRequests, stubFor } from '../../wiremock'
 import { errorStub } from '../../wiremock/utils'
 
 export default {
-  stubKeyWorkers: (args: { keyWorkers: Array<KeyWorker> }) =>
-    stubFor({
-      request: {
-        method: 'GET',
-        url: '/reference-data/key-workers',
-      },
-      response: {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json;charset=UTF-8',
-        },
-        jsonBody: args.keyWorkers.map(keyWorker => {
-          return { ...keyWorker, isActive: true }
-        }),
-      },
-    }),
   stubBookingCreate: (args: { premisesId: string; booking: Booking }) =>
     stubFor({
       request: {

--- a/integration_tests/mockApis/premises.ts
+++ b/integration_tests/mockApis/premises.ts
@@ -1,6 +1,6 @@
-import type { Response } from 'superagent'
+import type { Response, SuperAgentRequest } from 'superagent'
 
-import type { Premises, Booking, PremisesCapacity } from 'approved-premises'
+import type { Premises, Booking, PremisesCapacity, StaffMember } from 'approved-premises'
 
 import { stubFor } from '../../wiremock'
 import bookingStubs from './booking'
@@ -63,4 +63,16 @@ export default {
       bookingStubs.stubBookingsForPremisesId({ premisesId: args.premises.id, bookings: args.bookings }),
     ]),
   stubPremisesCapacity,
+  stubPremisesStaff: (args: { premisesId: string; staff: Array<StaffMember> }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/premises/${args.premisesId}/staff`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.staff,
+      },
+    }),
 }

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -24,8 +24,7 @@ declare module 'approved-premises' {
     [P in K]?: string
   }
 
-  export type NewBooking = ObjectWithDateParts<'arrivalDate'> &
-    ObjectWithDateParts<'departureDate'> & { crn: string; keyWorkerId: string }
+  export type NewBooking = ObjectWithDateParts<'arrivalDate'> & ObjectWithDateParts<'departureDate'> & { crn: string }
 
   export type NewArrival = ObjectWithDateParts<'date'> &
     ObjectWithDateParts<'expectedDepartureDate'> & { arrival: Omit<Arrival, 'id' | 'bookingId'> }
@@ -164,7 +163,6 @@ declare module 'approved-premises' {
       person: Person
       arrivalDate: string
       departureDate: string
-      keyWorker: KeyWorker
       status: BookingStatus
       arrival?: Arrival
       departure?: Departure

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -28,7 +28,9 @@ declare module 'approved-premises' {
   export type NewBooking = ObjectWithDateParts<'arrivalDate'> & ObjectWithDateParts<'departureDate'> & { crn: string }
 
   export type NewArrival = ObjectWithDateParts<'date'> &
-    ObjectWithDateParts<'expectedDepartureDate'> & { arrival: Omit<Arrival, 'id' | 'bookingId'> }
+    ObjectWithDateParts<'expectedDepartureDate'> & { arrival: Omit<Arrival, 'id' | 'bookingId'> } & {
+      keyWorkerStaffId: string
+    }
 
   export type NewNonArrival = ObjectWithDateParts<'nonArrivalDate'> & {
     nonArrival: Omit<NonArrival, 'id' | 'bookingId'>

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -14,6 +14,7 @@ declare module 'approved-premises' {
   export type PremisesCapacity = Array<PremisesCapacityItem>
   export type ApplicationSummary = schemas['ApplicationSummary']
   export type Application = schemas['Application']
+  export type StaffMember = schemas['StaffMember']
 
   // A utility type that allows us to define an object with a date attribute split into
   // date, month, year (and optionally, time) attributes. Designed for use with the GOV.UK
@@ -260,6 +261,10 @@ declare module 'approved-premises' {
       createdAt: string
       submittedAt?: string
       data: Record<string, unknown>
+    }
+    StaffMember: {
+      id: string
+      name: string
     }
   }
 }

--- a/server/controllers/manage/arrivalsController.ts
+++ b/server/controllers/manage/arrivalsController.ts
@@ -3,22 +3,27 @@ import type { Arrival, NewArrival } from 'approved-premises'
 
 import { DateFormats } from '../../utils/dateUtils'
 import ArrivalService from '../../services/arrivalService'
+import PremisesService from '../../services/premisesService'
+
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
 import paths from '../../paths/manage'
 
 export default class ArrivalsController {
-  constructor(private readonly arrivalService: ArrivalService) {}
+  constructor(private readonly arrivalService: ArrivalService, private readonly premisesService: PremisesService) {}
 
   new(): RequestHandler {
-    return (req: Request, res: Response) => {
+    return async (req: Request, res: Response) => {
       const { premisesId, bookingId } = req.params
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
+
+      const staffMembers = await this.premisesService.getStaffMembers(req.user.token, premisesId)
 
       res.render('arrivals/new', {
         premisesId,
         bookingId,
         errors,
         errorSummary,
+        staffMembers,
         pageHeading: 'Did the resident arrive?',
         ...userInput,
       })

--- a/server/controllers/manage/bookingsController.test.ts
+++ b/server/controllers/manage/bookingsController.test.ts
@@ -10,7 +10,6 @@ import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../
 import bookingFactory from '../../testutils/factories/booking'
 import newBookingFactory from '../../testutils/factories/newBooking'
 import personFactory from '../../testutils/factories/person'
-import referenceDataFactory from '../../testutils/factories/referenceData'
 import paths from '../../paths/manage'
 
 jest.mock('../../utils/validation')
@@ -54,7 +53,6 @@ describe('bookingsController', () => {
   describe('new', () => {
     describe('If there is a CRN in the flash', () => {
       const person = personFactory.build()
-      const keyWorkers = referenceDataFactory.buildList(5)
 
       beforeEach(() => {
         request = createMock<Request>({
@@ -64,7 +62,6 @@ describe('bookingsController', () => {
         })
 
         personService.findByCrn.mockResolvedValue(person)
-        bookingService.getKeyWorkers.mockResolvedValue(keyWorkers)
       })
 
       it('it should render the new booking form', async () => {
@@ -78,7 +75,6 @@ describe('bookingsController', () => {
 
         expect(response.render).toHaveBeenCalledWith('bookings/new', {
           premisesId,
-          keyWorkers,
           pageHeading: 'Make a booking',
           ...person,
           errors: {},
@@ -98,7 +94,6 @@ describe('bookingsController', () => {
 
         expect(response.render).toHaveBeenCalledWith('bookings/new', {
           premisesId,
-          keyWorkers,
           pageHeading: 'Make a booking',
           ...person,
           errors: errorsAndUserInput.errors,

--- a/server/controllers/manage/bookingsController.ts
+++ b/server/controllers/manage/bookingsController.ts
@@ -32,13 +32,11 @@ export default class BookingsController {
       const crnArr = req.flash('crn')
 
       if (crnArr.length) {
-        const keyWorkers = await this.bookingService.getKeyWorkers(req.user.token)
         const person = await this.personService.findByCrn(req.user.token, crnArr[0])
 
         return res.render(`bookings/new`, {
           pageHeading: 'Make a booking',
           premisesId,
-          keyWorkers,
           ...person,
           errors,
           errorSummary,

--- a/server/controllers/manage/index.ts
+++ b/server/controllers/manage/index.ts
@@ -20,7 +20,7 @@ export const controllers = (services: Services) => {
     services.personService,
   )
   const bookingExtensionsController = new BookingExtensionsController(services.bookingService)
-  const arrivalsController = new ArrivalsController(services.arrivalService)
+  const arrivalsController = new ArrivalsController(services.arrivalService, services.premisesService)
   const nonArrivalsController = new NonArrivalsController(services.nonArrivalService)
   const departuresController = new DeparturesController(
     services.departureService,

--- a/server/data/bookingClient.test.ts
+++ b/server/data/bookingClient.test.ts
@@ -41,7 +41,6 @@ describe('BookingClient', () => {
         arrivalDate: booking.arrivalDate,
         departureDate: booking.departureDate,
         crn: booking.person.crn,
-        keyWorkerId: booking.keyWorker.id,
       })
 
       fakeApprovedPremisesApi

--- a/server/data/premisesClient.test.ts
+++ b/server/data/premisesClient.test.ts
@@ -5,6 +5,7 @@ import PremisesClient from './premisesClient'
 import config from '../config'
 import paths from '../paths/api'
 import premisesCapacityItemFactory from '../testutils/factories/premisesCapacityItem'
+import staffMemberFactory from '../testutils/factories/staffMember'
 
 describe('PremisesClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
@@ -67,6 +68,21 @@ describe('PremisesClient', () => {
 
       const output = await premisesClient.capacity(premisesId)
       expect(output).toEqual(premisesCapacityItem)
+    })
+  })
+
+  describe('getStaffMembers', () => {
+    const premises = premisesFactory.build()
+    const staffMembers = staffMemberFactory.buildList(5)
+
+    it('should return a list of staff members', async () => {
+      fakeApprovedPremisesApi
+        .get(paths.premises.staffMembers.index({ premisesId: premises.id }))
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, staffMembers)
+
+      const output = await premisesClient.getStaffMembers(premises.id)
+      expect(output).toEqual(staffMembers)
     })
   })
 })

--- a/server/data/premisesClient.ts
+++ b/server/data/premisesClient.ts
@@ -1,4 +1,4 @@
-import type { Premises, PremisesCapacityItem } from 'approved-premises'
+import type { Premises, PremisesCapacityItem, StaffMember } from 'approved-premises'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -20,5 +20,11 @@ export default class PremisesClient {
 
   async capacity(id: string): Promise<PremisesCapacityItem[]> {
     return (await this.restClient.get({ path: paths.premises.capacity({ premisesId: id }) })) as PremisesCapacityItem[]
+  }
+
+  async getStaffMembers(premisesId: string): Promise<Array<StaffMember>> {
+    return (await this.restClient.get({
+      path: paths.premises.staffMembers.index({ premisesId }),
+    })) as StaffMember[]
   }
 }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -34,7 +34,7 @@
     "invalid": "The expected departure date is an invalid date",
     "beforeBookingArrivalDate": "The departure date cannot be before the arrival date"
   },
-  "keyWorkerId": {
+  "keyWorkerStaffId": {
     "empty": "You must choose a keyworker"
   },
   "dateTime": {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -9,6 +9,9 @@ export default {
     lostBeds: {
       create: managePaths.lostBeds.create,
     },
+    staffMembers: {
+      index: managePaths.premises.show.path('staff'),
+    },
   },
   applications: {
     show: applyPaths.applications.show,

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -4,7 +4,6 @@ import ReferenceDataClient from '../data/referenceDataClient'
 
 import newBookingFactory from '../testutils/factories/newBooking'
 import bookingFactory from '../testutils/factories/booking'
-import referenceDataFactory from '../testutils/factories/referenceData'
 
 import paths from '../paths/manage'
 import { DateFormats } from '../utils/dateUtils'
@@ -77,20 +76,6 @@ describe('BookingService', () => {
 
       expect(bookingClientFactory).toHaveBeenCalledWith(token)
       expect(bookingClient.allBookingsForPremisesId).toHaveBeenCalledWith(premisesId)
-    })
-  })
-
-  describe('getKeyWorkers', () => {
-    it('should return the keyworker data needed', async () => {
-      const keyWorkers = referenceDataFactory.buildList(2)
-
-      referenceDataClient.getReferenceData.mockResolvedValue(keyWorkers)
-
-      const result = await service.getKeyWorkers(token)
-
-      expect(result).toEqual(keyWorkers)
-      expect(referenceDataClientFactory).toHaveBeenCalledWith(token)
-      expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('key-workers')
     })
   })
 

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -1,13 +1,6 @@
 import { isSameDay, isWithinInterval, addDays } from 'date-fns'
 
-import type {
-  Booking,
-  NewBooking,
-  TableRow,
-  GroupedListofBookings,
-  BookingExtension,
-  ReferenceData,
-} from 'approved-premises'
+import type { Booking, NewBooking, TableRow, GroupedListofBookings, BookingExtension } from 'approved-premises'
 
 import type { RestClientBuilder, ReferenceDataClient } from '../data'
 import BookingClient from '../data/bookingClient'
@@ -36,14 +29,6 @@ export default class BookingService {
     const booking = await bookingClient.find(premisesId, bookingId)
 
     return booking
-  }
-
-  async getKeyWorkers(token: string): Promise<Array<ReferenceData>> {
-    const referenceDataClient = this.referenceDataClientFactory(token)
-
-    const keyWorkers = await referenceDataClient.getReferenceData('key-workers')
-
-    return keyWorkers
   }
 
   async listOfBookingsForPremisesId(token: string, premisesId: string): Promise<Array<TableRow>> {

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -2,6 +2,7 @@ import PremisesService from './premisesService'
 import PremisesClient from '../data/premisesClient'
 import premisesFactory from '../testutils/factories/premises'
 import premisesCapacityItemFactory from '../testutils/factories/premisesCapacityItem'
+import staffMemberFactory from '../testutils/factories/staffMember'
 import getDateRangesWithNegativeBeds from '../utils/premisesUtils'
 import paths from '../paths/manage'
 
@@ -20,6 +21,20 @@ describe('PremisesService', () => {
   beforeEach(() => {
     jest.resetAllMocks()
     premisesClientFactory.mockReturnValue(premisesClient)
+  })
+
+  describe('getStaffMembers', () => {
+    it('on success returns the person given their CRN', async () => {
+      const staffMembers = staffMemberFactory.buildList(5)
+      premisesClient.getStaffMembers.mockResolvedValue(staffMembers)
+
+      const result = await service.getStaffMembers(token, premisesId)
+
+      expect(result).toEqual(staffMembers)
+
+      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClient.getStaffMembers).toHaveBeenCalledWith(premisesId)
+    })
   })
 
   describe('tableRows', () => {

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -1,4 +1,4 @@
-import type { Premises, TableRow, SummaryList } from 'approved-premises'
+import type { Premises, TableRow, SummaryList, StaffMember } from 'approved-premises'
 import type { RestClientBuilder, PremisesClient } from '../data'
 import paths from '../paths/manage'
 
@@ -7,6 +7,14 @@ import getDateRangesWithNegativeBeds, { NegativeDateRange } from '../utils/premi
 
 export default class PremisesService {
   constructor(private readonly premisesClientFactory: RestClientBuilder<PremisesClient>) {}
+
+  async getStaffMembers(token: string, premisesId: string): Promise<Array<StaffMember>> {
+    const premisesClient = this.premisesClientFactory(token)
+
+    const staffMembers = await premisesClient.getStaffMembers(premisesId)
+
+    return staffMembers
+  }
 
   async tableRows(token: string): Promise<Array<TableRow>> {
     const premisesClient = this.premisesClientFactory(token)

--- a/server/testutils/factories/booking.ts
+++ b/server/testutils/factories/booking.ts
@@ -5,7 +5,6 @@ import { addDays, startOfToday } from 'date-fns'
 import type { Booking } from 'approved-premises'
 import arrivalFactory from './arrival'
 import departureFactory from './departure'
-import keyWorkerFactory from './keyWorker'
 import personFactory from './person'
 import { DateFormats } from '../../utils/dateUtils'
 
@@ -89,7 +88,6 @@ export default BookingFactory.define(() => ({
   person: personFactory.build(),
   arrivalDate: DateFormats.formatApiDate(faker.date.soon()),
   departureDate: DateFormats.formatApiDate(faker.date.future()),
-  keyWorker: keyWorkerFactory.build(),
   name: `${faker.name.firstName()} ${faker.name.lastName()}`,
   id: faker.datatype.uuid(),
   status: 'awaiting-arrival' as const,

--- a/server/testutils/factories/keyWorker.ts
+++ b/server/testutils/factories/keyWorker.ts
@@ -1,9 +1,0 @@
-import { Factory } from 'fishery'
-import { faker } from '@faker-js/faker/locale/en_GB'
-
-import type { KeyWorker } from 'approved-premises'
-
-export default Factory.define<KeyWorker>(() => ({
-  id: faker.datatype.uuid(),
-  name: `${faker.name.firstName()} ${faker.name.lastName()}`,
-}))

--- a/server/testutils/factories/newBooking.ts
+++ b/server/testutils/factories/newBooking.ts
@@ -3,7 +3,6 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 
 import type { NewBooking } from 'approved-premises'
 
-import keyWorkerFactory from './keyWorker'
 import personFactory from './person'
 import { DateFormats } from '../../utils/dateUtils'
 
@@ -13,7 +12,6 @@ export default Factory.define<NewBooking>(() => {
 
   return {
     crn: personFactory.build().crn,
-    keyWorkerId: keyWorkerFactory.build().id,
     arrivalDate: DateFormats.formatApiDate(arrivalDate),
     'arrivalDate-day': arrivalDate.getDate().toString(),
     'arrivalDate-month': arrivalDate.getMonth().toString(),

--- a/server/testutils/factories/staffMember.ts
+++ b/server/testutils/factories/staffMember.ts
@@ -1,0 +1,9 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { StaffMember } from 'approved-premises'
+
+export default Factory.define<StaffMember>(() => ({
+  id: faker.datatype.uuid(),
+  name: faker.name.fullName(),
+}))

--- a/server/views/arrivals/_arrival_form.njk
+++ b/server/views/arrivals/_arrival_form.njk
@@ -1,3 +1,5 @@
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+
 <form action="{{ paths.bookings.arrivals.create({ premisesId: premisesId, bookingId: bookingId }) }}" method="post">
   <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
   {{ govukDateInput({
@@ -30,6 +32,18 @@
     hint: {
       text: "For example, 27 3 2007"
     }
+  }) }}
+
+  {{ govukSelect({
+      label: {
+          text: "Key Worker",
+          classes: "govuk-label--m"
+      },
+      classes: "govuk-input--width-20",
+      id: "arrival_keyWorkerStaffId",
+      name: "arrival[keyWorkerStaffId]",
+      items: convertObjectsToSelectOptions(staffMembers, 'name', 'id', 'keyWorkerStaffId'),
+      errorMessage: errors.keyWorkerStaffId
   }) }}
 
   {{ govukTextarea({

--- a/server/views/arrivals/_arrival_form.njk
+++ b/server/views/arrivals/_arrival_form.njk
@@ -40,7 +40,7 @@
           classes: "govuk-label--m"
       },
       classes: "govuk-input--width-20",
-      id: "arrival_keyWorkerStaffId",
+      id: "keyWorkerStaffId",
       name: "arrival[keyWorkerStaffId]",
       items: convertObjectsToSelectOptions(staffMembers, 'name', 'id', 'keyWorkerStaffId'),
       errorMessage: errors.keyWorkerStaffId

--- a/server/views/bookings/confirm.njk
+++ b/server/views/bookings/confirm.njk
@@ -47,14 +47,6 @@
                     value: {
                         text: formatDate(departureDate)
                     }
-                    },
-                    {
-                    key: {
-                        text: "Key worker"
-                    },
-                    value: {
-                        text: keyWorker.name
-                    }
                     }
                 ]
             }) }}

--- a/server/views/bookings/extensions/confirm.njk
+++ b/server/views/bookings/extensions/confirm.njk
@@ -45,14 +45,6 @@
                     value: {
                         text: formatDate(departureDate)
                     }
-                    },
-                    {
-                    key: {
-                        text: "Key worker"
-                    },
-                    value: {
-                        text: keyWorker.name
-                    }
                     }
                 ]
             }) }}

--- a/server/views/bookings/extensions/new.njk
+++ b/server/views/bookings/extensions/new.njk
@@ -54,14 +54,6 @@
                     value: {
                         text: formatDate(booking.departureDate)
                     }
-                    },
-                    {
-                    key: {
-                        text: "Key worker"
-                    },
-                    value: {
-                        text: booking.keyWorker.name
-                    }
                     }
                 ]
             }) }}

--- a/server/views/bookings/new.njk
+++ b/server/views/bookings/new.njk
@@ -81,18 +81,6 @@
                     errorMessage: errors.departureDate
                 }) }}
 
-                {{ govukSelect({
-                    label: {
-                        text: "Key Worker",
-                        classes: "govuk-label--m"
-                    },
-                    classes: "govuk-input--width-20",
-                    id: "keyWorkerId",
-                    name: "keyWorkerId",
-                    items: convertObjectsToSelectOptions(keyWorkers, 'name', 'id', 'keyWorkerId'),
-                    errorMessage: errors.keyWorkerId
-                }) }}
-
                 {{ govukButton({
                     text: "Submit"
                 }) }}

--- a/server/views/bookings/show.njk
+++ b/server/views/bookings/show.njk
@@ -50,14 +50,6 @@
               value: {
                 text: formatDate(booking.departureDate)
               }
-            },
-            {
-              key: {
-                text: "Key worker"
-              },
-              value: {
-                text: booking.keyWorker.name
-              }
             }
           ]
         })

--- a/wiremock/bookingStubs.ts
+++ b/wiremock/bookingStubs.ts
@@ -14,10 +14,10 @@ bookingStubs.push({
         matchesJsonPath: "$.[?(@.crn != '')]",
       },
       {
-        matchesJsonPath: "$.[?(@.expectedArrivalDate != '')]",
+        matchesJsonPath: "$.[?(@.arrivalDate != '')]",
       },
       {
-        matchesJsonPath: "$.[?(@.expectedDepartureDate != '')]",
+        matchesJsonPath: "$.[?(@.departureDate != '')]",
       },
       {
         matchesJsonPath: "$.[?(@.keyWorkerId != '')]",
@@ -48,7 +48,7 @@ bookingStubs.push({
   },
 })
 
-const requiredFields = getCombinations(['crn', 'name', 'expectedArrivalDate', 'expectedDepartureDate', 'keyWorkerId'])
+const requiredFields = getCombinations(['crn', 'arrivalDate', 'departureDate'])
 
 requiredFields.forEach((fields: Array<string>) => {
   bookingStubs.push(errorStub(fields, `/premises/${guidRegex}/bookings`))

--- a/wiremock/bookingStubs.ts
+++ b/wiremock/bookingStubs.ts
@@ -19,9 +19,6 @@ bookingStubs.push({
       {
         matchesJsonPath: "$.[?(@.departureDate != '')]",
       },
-      {
-        matchesJsonPath: "$.[?(@.keyWorkerId != '')]",
-      },
     ],
   },
   response: {

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -20,6 +20,7 @@ import applicationStubs from './applicationStubs'
 
 import * as referenceDataStubs from './referenceDataStubs'
 import premisesCapacityItemFactory from '../server/testutils/factories/premisesCapacityItem'
+import staffMemberFactory from '../server/testutils/factories/staffMember'
 
 const stubs = []
 
@@ -65,6 +66,20 @@ premises.forEach(item => {
         'Content-Type': 'application/json;charset=UTF-8',
       },
       jsonBody: premisesCapacityItemFactory.buildList(20),
+    },
+  })
+
+  stubs.push({
+    request: {
+      method: 'GET',
+      url: `/premises/${item.id}/staff`,
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: staffMemberFactory.buildList(10),
     },
   })
 


### PR DESCRIPTION
The selection of a keyworker currently takes place on the booking form. In Delius this is done on the Arrival form, so in mini-manage we ought to be replicating this behaviour. The API has already changed this behaviour, so the contract tests are currently broken. We also now fetch the key workers from the appropriate endpoint, which returns staff for a specific premises.

## Screenshots

![image](https://user-images.githubusercontent.com/109774/194081541-a3aa07ce-59c5-4b3d-9346-97c3896407de.png)

![image](https://user-images.githubusercontent.com/109774/194081477-465edc52-3210-424f-ab4d-70245ef2c20e.png)
