### PR TITLE
Update Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,8 +8,7 @@
     {
       "matchManagers": ["npm"],
       "matchPackageNames": ["@types/node"],
-      "matchUpdateTypes": ["major"],
-      "enabled": false
+      "matchUpdateTypes": ["minor"]
     },
     {
       "matchDatasources": ["docker"],


### PR DESCRIPTION
I was getting concerned that we haven't had any Renovate updates since we enabled it (and disabled dependabot #226) so I took a second look at the config. 
It seems like we want to *enable* the first rule in the rule set as we want `npm` updates.
Also I think we should be updating minor versions as this should give us less headaches when the time comes to update to major versions. 