### PR TITLE
Updating an application handles null data

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -26,7 +26,7 @@ export default {
       response: {
         status: 201,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: args.application,
+        jsonBody: { ...args.application, data: null },
       },
     }),
   stubApplicationUpdate: (args: { application: Application }): SuperAgentRequest =>

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -237,7 +237,7 @@ describe('ApplicationService', () => {
   })
 
   describe('save', () => {
-    const application = applicationFactory.build()
+    const application = applicationFactory.build({ data: null })
     const token = 'some-token'
     const request = createMock<Request>({
       params: { id: application.id, task: 'some-task', page: 'some-page' },
@@ -249,7 +249,6 @@ describe('ApplicationService', () => {
       let page: DeepMocked<TasklistPage>
 
       beforeEach(() => {
-        application.data = {}
         page = createMock<TasklistPage>({
           errors: () => [] as TaskListErrors,
           body: { foo: 'bar' },
@@ -274,6 +273,17 @@ describe('ApplicationService', () => {
 
         expect(applicationClientFactory).toHaveBeenCalledWith(token)
         expect(applicationClient.update).toHaveBeenCalledWith(application)
+      })
+
+      it('updates an in-progress application', async () => {
+        application.data = { 'some-task': { 'other-page': { question: 'answer' } } }
+
+        await service.save(page, request)
+
+        expect(request.session.application).toEqual(application)
+        expect(request.session.application.data).toEqual({
+          'some-task': { 'other-page': { question: 'answer' }, 'some-page': { foo: 'bar' } },
+        })
       })
     })
 

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -71,6 +71,7 @@ export default class ApplicationService {
     } else {
       const application = await this.getApplicationFromSessionOrAPI(request)
 
+      application.data = application.data || {}
       application.data[request.params.task] = application.data[request.params.task] || {}
       application.data[request.params.task][request.params.page] = page.body
 


### PR DESCRIPTION
When an application is first returned from the API, the `data` attribute is `null`, so we need to initialize `data` with an empty object. I’ve updated the tests to be more inline with reality and also added another unit test to make sure the session data gets updated correctly.