### PR TITLE
Fix/docker container errors in dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     image: 'bitnami/redis:5.0'
     networks:
       - hmpps
-    container_name: redis
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
     ports:
@@ -15,7 +14,6 @@ services:
     image: quay.io/hmpps/hmpps-auth:latest
     networks:
       - hmpps
-    container_name: hmpps-auth
     ports:
       - "9090:8080"
     healthcheck:
@@ -34,7 +32,6 @@ services:
     image: wiremock/wiremock
     networks:
       - hmpps
-    container_name: wiremock
     restart: always
     ports:
       - "9092:8080"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -15,8 +15,3 @@ nodenv install --skip-existing
 npm install
 
 script/utils/start-backing-services.sh
-
-echo "==> Stubbing API endpoints"
-
-npm run api-stubs:reset > /dev/null
-npm run api-stubs:create > /dev/null

--- a/script/server
+++ b/script/server
@@ -7,6 +7,12 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+cleanup() {
+  echo "==> Tearing down any old containers..."
+  docker-compose down
+}
+trap cleanup EXIT
+
 script/utils/launch-docker.sh
 
 script/utils/start-backing-services.sh

--- a/script/utils/start-backing-services.sh
+++ b/script/utils/start-backing-services.sh
@@ -3,3 +3,8 @@
 echo "==> Starting the backing services in Docker..."
 
 docker-compose up --scale=app=0 -d
+
+echo "==> Stubbing API endpoints"
+
+npm run api-stubs:reset > /dev/null
+npm run api-stubs:create > /dev/null


### PR DESCRIPTION
# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

These changes are the ones I found were needed to get both apps running using docker-compose. This is a proposal that goes in tandem with a similar [pull request in the API](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/142).

We've got:

- removing container names when not needed to remove name clashes with the frontend
- an addition to the script/server to shut any old containers down when starting up. The script can leave things hanging when we term the process. We found maing changes to the docker-compose and restarting the server was clashing with existing containers running without this

With these changes and a similar set on the frontend both apps work together when running script/server which is nice. I'm aware you're experimenting with Tilt right now however I think these changes are still useful.