### PR TITLE
Decouple API paths from user-facing paths

### DIFF
--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -1,5 +1,31 @@
-import managePaths from './manage'
-import applyPaths from './apply'
+import { path } from 'static-path'
+
+const premisesPath = path('/premises')
+const singlePremisesPath = premisesPath.path(':premisesId')
+
+const lostBedsPath = singlePremisesPath.path('lost-beds')
+
+const managePaths = {
+  premises: {
+    index: premisesPath,
+    show: singlePremisesPath,
+  },
+  lostBeds: {
+    create: lostBedsPath,
+  },
+}
+
+const applicationsPath = path('/applications')
+const singleApplicationPath = applicationsPath.path(':id')
+
+const applyPaths = {
+  applications: {
+    show: singleApplicationPath,
+    create: applicationsPath,
+    index: applicationsPath,
+    update: singleApplicationPath,
+  },
+}
 
 export default {
   premises: {


### PR DESCRIPTION
We shouldn't necessarily expect user-facing paths to match API endpoints, so it makes sense to decouple these

In response to feedback from @pezholio on #236, I'm submitting this as a PR to go into the main branch