### PR TITLE
Change user-facing application name from "Approved Premises Ui" to "Approved Premises"

### DIFF
--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -22,7 +22,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   app.set('view engine', 'njk')
 
   app.locals.asset_path = '/assets/'
-  app.locals.applicationName = 'Approved Premises Ui'
+  app.locals.applicationName = 'Approved Premises'
 
   // Cachebusting version string
   if (production) {


### PR DESCRIPTION
End user doesn't need to see/care about the UI/backend distinction, so change user-facing app name

In response to feedback from @pezholio on https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/236, I'm submitting this as a PR to go into the main branch