### PR TITLE
Remove matching the @types/node package in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,6 @@
   "packageRules": [
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["@types/node"],
       "matchUpdateTypes": ["minor"]
     },
     {


### PR DESCRIPTION
We want to recieve updates for all our packages not just this specific one