### PR TITLE
Fix arrival types

### DIFF
--- a/cypress_shared/pages/manage/arrivalCreate.ts
+++ b/cypress_shared/pages/manage/arrivalCreate.ts
@@ -18,12 +18,12 @@ export default class ArrivalCreatePage extends Page {
 
     cy.log('arrival', arrival)
 
-    const date = new Date(Date.parse(arrival.date))
+    const arrivalDate = new Date(Date.parse(arrival.arrivalDate))
     const expectedDeparture = new Date(Date.parse(arrival.expectedDepartureDate))
 
-    cy.get('input[name="date-day"]').type(String(date.getDate()))
-    cy.get('input[name="date-month"]').type(String(date.getMonth() + 1))
-    cy.get('input[name="date-year"]').type(String(date.getFullYear()))
+    cy.get('input[name="arrivalDate-day"]').type(String(arrivalDate.getDate()))
+    cy.get('input[name="arrivalDate-month"]').type(String(arrivalDate.getMonth() + 1))
+    cy.get('input[name="arrivalDate-year"]').type(String(arrivalDate.getFullYear()))
 
     cy.get('input[name="expectedDepartureDate-day"]').type(String(expectedDeparture.getDate()))
     cy.get('input[name="expectedDepartureDate-month"]').type(String(expectedDeparture.getMonth() + 1))

--- a/cypress_shared/pages/manage/booking/show.ts
+++ b/cypress_shared/pages/manage/booking/show.ts
@@ -27,7 +27,7 @@ export default class BookingShowPage extends Page {
     })
 
     cy.get('dl[data-cy-arrival-information]').within(() => {
-      this.assertDefinition('Arrival date', DateFormats.isoDateToUIDate(booking.arrival.date))
+      this.assertDefinition('Arrival date', DateFormats.isoDateToUIDate(booking.arrival.arrivalDate))
       this.assertDefinition('Departure date', DateFormats.isoDateToUIDate(booking.arrival.expectedDepartureDate))
       this.assertDefinition('Notes', booking.arrival.notes)
     })

--- a/integration_tests/tests/manage/arrivals.cy.ts
+++ b/integration_tests/tests/manage/arrivals.cy.ts
@@ -23,7 +23,7 @@ context('Arrivals', () => {
     const premises = premisesFactory.build()
     const bookingId = 'some-uuid'
     const arrival = arrivalFactory.build({
-      date: new Date(2022, 1, 11).toISOString(),
+      arrivalDate: new Date(2022, 1, 11).toISOString(),
       expectedDepartureDate: new Date(2022, 11, 11).toISOString(),
     })
 
@@ -44,10 +44,10 @@ context('Arrivals', () => {
       expect(requests).to.have.length(1)
       const requestBody = JSON.parse(requests[0].body)
 
-      const { date, expectedDepartureDate } = arrival
+      const { arrivalDate, expectedDepartureDate } = arrival
 
       expect(requestBody.notes).equal(arrival.notes)
-      expect(requestBody.date).equal(date)
+      expect(requestBody.arrivalDate).equal(arrivalDate)
       expect(requestBody.keyWorkerStaffId).equal(staff[0].id)
       expect(requestBody.expectedDepartureDate).equal(expectedDepartureDate)
     })

--- a/integration_tests/tests/manage/arrivals.cy.ts
+++ b/integration_tests/tests/manage/arrivals.cy.ts
@@ -23,8 +23,8 @@ context('Arrivals', () => {
     const premises = premisesFactory.build()
     const bookingId = 'some-uuid'
     const arrival = arrivalFactory.build({
-      arrivalDate: new Date(2022, 1, 11).toISOString(),
-      expectedDepartureDate: new Date(2022, 11, 11).toISOString(),
+      arrivalDate: '2022-11-11',
+      expectedDepartureDate: '2022-12-11',
     })
 
     cy.task('stubPremisesStaff', { premisesId: premises.id, staff })
@@ -91,7 +91,7 @@ context('Arrivals', () => {
     const premises = premisesFactory.build()
     const bookingId = 'some-uuid'
     const nonArrival = nonArrivalFactory.build({
-      date: new Date(2022, 1, 11).toISOString(),
+      date: '2021-11-01',
       reason: 'recalled',
     })
 

--- a/integration_tests/tests/manage/booking.cy.ts
+++ b/integration_tests/tests/manage/booking.cy.ts
@@ -19,8 +19,8 @@ context('Booking', () => {
     const person = personFactory.build()
     const booking = bookingFactory.build({
       person,
-      arrivalDate: new Date(Date.UTC(2022, 5, 1, 0, 0, 0)).toISOString(),
-      departureDate: new Date(Date.UTC(2022, 5, 3, 0, 0, 0)).toISOString(),
+      arrivalDate: '2022-06-01',
+      departureDate: '2022-06-01',
     })
     const firstOvercapacityPeriodStartDate = premisesCapacityItemFactory.build({
       date: new Date(2023, 0, 1).toISOString(),

--- a/integration_tests/tests/manage/bookingExtension.cy.ts
+++ b/integration_tests/tests/manage/bookingExtension.cy.ts
@@ -12,9 +12,9 @@ context('BookingExtension', () => {
 
   it('should show booking extension form', () => {
     const booking = bookingFactory.build({
-      departureDate: new Date(Date.UTC(2022, 5, 3, 0, 0, 0)).toISOString(),
+      departureDate: '2022-06-03',
     })
-    const newDepartureDate = new Date(Date.UTC(2022, 6, 3, 0, 0, 0)).toISOString()
+    const newDepartureDate = '2022-07-03'
     const premises = premisesFactory.build()
 
     cy.task('stubBookingExtensionCreate', { premisesId: premises.id, booking })

--- a/integration_tests/tests/manage/cancellation.cy.ts
+++ b/integration_tests/tests/manage/cancellation.cy.ts
@@ -22,7 +22,7 @@ context('Cancellation', () => {
     cy.task('stubBookingGet', { premisesId: premises.id, booking })
 
     // When I navigate to the booking's cancellation page
-    const cancellation = cancellationFactory.build({ date: new Date(Date.UTC(2022, 5, 1, 0, 0, 0)).toISOString() })
+    const cancellation = cancellationFactory.build({ date: '2022-06-01' })
     cy.task('stubCancellationCreate', { premisesId: premises.id, bookingId: booking.id, cancellation })
     cy.task('stubCancellationGet', { premisesId: premises.id, bookingId: booking.id, cancellation })
 

--- a/integration_tests/tests/manage/lostBed.cy.ts
+++ b/integration_tests/tests/manage/lostBed.cy.ts
@@ -22,8 +22,8 @@ context('LostBed', () => {
 
     // When I navigate to the lost bed form
     const lostBed = lostBedFactory.build({
-      startDate: new Date(2022, 1, 11, 0, 0).toISOString(),
-      endDate: new Date(2022, 2, 11, 0, 0).toISOString(),
+      startDate: '2022-02-11',
+      endDate: '2022-03-11',
     })
     cy.task('stubLostBedCreate', { premisesId: premises.id, lostBed })
     cy.task('stubPremisesCapacity', {

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -27,10 +27,7 @@ declare module 'approved-premises' {
 
   export type NewBooking = ObjectWithDateParts<'arrivalDate'> & ObjectWithDateParts<'departureDate'> & { crn: string }
 
-  export type NewArrival = ObjectWithDateParts<'date'> &
-    ObjectWithDateParts<'expectedDepartureDate'> & { arrival: Omit<Arrival, 'id' | 'bookingId'> } & {
-      keyWorkerStaffId: string
-    }
+  export type NewArrival = Omit<Arrival, 'id' | 'bookingId'> & { keyWorkerStaffId: string }
 
   export type NewNonArrival = ObjectWithDateParts<'nonArrivalDate'> & {
     nonArrival: Omit<NonArrival, 'id' | 'bookingId'>
@@ -181,11 +178,9 @@ declare module 'approved-premises' {
     Arrival: {
       id: string
       bookingId: string
-      date: string
+      arrivalDate: string
       expectedDepartureDate: string
       notes: string
-      name: string
-      crn: string
     }
     NonArrival: {
       id: string

--- a/server/controllers/manage/arrivalsController.test.ts
+++ b/server/controllers/manage/arrivalsController.test.ts
@@ -87,20 +87,24 @@ describe('ArrivalsController', () => {
       }
 
       request.body = {
-        'date-year': 2022,
-        'date-month': 12,
-        'date-day': 11,
+        'arrivalDate-year': 2022,
+        'arrivalDate-month': 12,
+        'arrivalDate-day': 11,
         'expectedDepartureDate-year': 2022,
         'expectedDepartureDate-month': 11,
         'expectedDepartureDate-day': 12,
-        notes: 'Some notes',
+        arrival: {
+          notes: 'Some notes',
+          keyWorkerStaffId: 'some-staff-id',
+        },
       }
 
       await requestHandler(request, response, next)
 
       const expectedArrival = {
-        ...request.body.arrival,
-        date: new Date(2022, 11, 11).toISOString(),
+        notes: request.body.arrival.notes,
+        keyWorkerStaffId: request.body.arrival.keyWorkerStaffId,
+        arrivalDate: new Date(2022, 11, 11).toISOString(),
         expectedDepartureDate: new Date(2022, 10, 12).toISOString(),
       }
 

--- a/server/controllers/manage/arrivalsController.test.ts
+++ b/server/controllers/manage/arrivalsController.test.ts
@@ -104,8 +104,8 @@ describe('ArrivalsController', () => {
       const expectedArrival = {
         notes: request.body.arrival.notes,
         keyWorkerStaffId: request.body.arrival.keyWorkerStaffId,
-        arrivalDate: new Date(2022, 11, 11).toISOString(),
-        expectedDepartureDate: new Date(2022, 10, 12).toISOString(),
+        arrivalDate: '2022-12-11',
+        expectedDepartureDate: '2022-11-12',
       }
 
       expect(arrivalService.createArrival).toHaveBeenCalledWith(

--- a/server/controllers/manage/arrivalsController.ts
+++ b/server/controllers/manage/arrivalsController.ts
@@ -1,5 +1,5 @@
 import type { Response, Request, RequestHandler } from 'express'
-import type { Arrival, NewArrival } from 'approved-premises'
+import type { NewArrival } from 'approved-premises'
 
 import { DateFormats } from '../../utils/dateUtils'
 import ArrivalService from '../../services/arrivalService'
@@ -33,14 +33,15 @@ export default class ArrivalsController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, bookingId } = req.params
-      const body = req.body as NewArrival
+      const { body } = req
 
-      const { date } = DateFormats.convertDateAndTimeInputsToIsoString(body, 'date')
+      const { arrivalDate } = DateFormats.convertDateAndTimeInputsToIsoString(body, 'arrivalDate')
       const { expectedDepartureDate } = DateFormats.convertDateAndTimeInputsToIsoString(body, 'expectedDepartureDate')
 
-      const arrival: Omit<Arrival, 'id' | 'bookingId'> = {
-        ...body.arrival,
-        date,
+      const arrival: NewArrival = {
+        keyWorkerStaffId: body.arrival.keyWorkerStaffId,
+        notes: body.arrival.notes,
+        arrivalDate,
         expectedDepartureDate,
       }
 

--- a/server/controllers/manage/bookingExtensionsController.test.ts
+++ b/server/controllers/manage/bookingExtensionsController.test.ts
@@ -88,7 +88,7 @@ describe('bookingExtensionsController', () => {
 
       expect(bookingService.extendBooking).toHaveBeenCalledWith(token, premisesId, bookingExtension.bookingId, {
         ...request.body,
-        newDepartureDate: '2022-02-01T00:00:00.000Z',
+        newDepartureDate: '2022-02-01',
       })
 
       expect(response.redirect).toHaveBeenCalledWith(

--- a/server/controllers/manage/cancellationsController.test.ts
+++ b/server/controllers/manage/cancellationsController.test.ts
@@ -111,7 +111,7 @@ describe('cancellationsController', () => {
 
       const expectedCancellation = {
         ...request.body.cancellation,
-        date: new Date(2022, 11, 11).toISOString(),
+        date: '2022-12-11',
       }
 
       expect(cancellationService.createCancellation).toHaveBeenCalledWith(

--- a/server/controllers/manage/lostBedsController.test.ts
+++ b/server/controllers/manage/lostBedsController.test.ts
@@ -98,8 +98,8 @@ describe('LostBedsController', () => {
 
       expect(lostBedService.createLostBed).toHaveBeenCalledWith(token, request.params.premisesId, {
         ...request.body.lostBed,
-        startDate: '2022-08-22T00:00:00.000Z',
-        endDate: '2022-09-22T00:00:00.000Z',
+        startDate: '2022-08-22',
+        endDate: '2022-09-22',
       })
       expect(request.flash).toHaveBeenCalledWith('success', 'Lost bed logged')
       expect(response.redirect).toHaveBeenCalledWith(paths.premises.show({ premisesId: request.params.premisesId }))

--- a/server/controllers/manage/nonArrivalsController.test.ts
+++ b/server/controllers/manage/nonArrivalsController.test.ts
@@ -38,7 +38,7 @@ describe('NonArrivalsController', () => {
 
       const expectedNonArrival = {
         ...request.body.nonArrival,
-        date: new Date(2022, 11, 11).toISOString(),
+        date: '2022-12-11',
       }
 
       expect(response.redirect).toHaveBeenCalledWith(paths.premises.show({ premisesId: request.params.premisesId }))

--- a/server/data/bookingClient.test.ts
+++ b/server/data/bookingClient.test.ts
@@ -10,6 +10,7 @@ import newCancellationFactory from '../testutils/factories/newCancellation'
 import departureFactory from '../testutils/factories/departure'
 import newDepartureFactory from '../testutils/factories/newDeparture'
 import nonArrivalFactory from '../testutils/factories/nonArrival'
+import newArrivalFactory from '../testutils/factories/newArrival'
 
 import config from '../config'
 
@@ -113,13 +114,11 @@ describe('BookingClient', () => {
   describe('markAsArrived', () => {
     it('should create an arrival', async () => {
       const arrival = arrivalFactory.build()
-      const payload = {
-        date: arrival.date.toString(),
+      const payload = newArrivalFactory.build({
+        arrivalDate: arrival.arrivalDate.toString(),
         expectedDepartureDate: arrival.expectedDepartureDate.toString(),
         notes: arrival.notes,
-        name: arrival.name,
-        crn: arrival.crn,
-      }
+      })
 
       fakeApprovedPremisesApi
         .post(`/premises/premisesId/bookings/bookingId/arrivals`, payload)
@@ -130,7 +129,7 @@ describe('BookingClient', () => {
 
       expect(result).toEqual({
         ...arrival,
-        date: arrival.date,
+        arrivalDate: arrival.arrivalDate,
         expectedDepartureDate: arrival.expectedDepartureDate,
       })
       expect(nock.isDone()).toBeTruthy()

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -9,6 +9,7 @@ import type {
   Departure,
   NonArrival,
   NewBookingExtension,
+  NewArrival,
 } from 'approved-premises'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
@@ -43,11 +44,7 @@ export default class BookingClient {
     })) as BookingExtension
   }
 
-  async markAsArrived(
-    premisesId: string,
-    bookingId: string,
-    arrival: Omit<Arrival, 'id' | 'bookingId'>,
-  ): Promise<Arrival> {
+  async markAsArrived(premisesId: string, bookingId: string, arrival: NewArrival): Promise<Arrival> {
     const response = await this.restClient.post({
       path: `${this.bookingPath(premisesId, bookingId)}/arrivals`,
       data: arrival,

--- a/server/services/arrivalService.test.ts
+++ b/server/services/arrivalService.test.ts
@@ -1,8 +1,7 @@
-import type { Arrival } from 'approved-premises'
-
 import ArrivalService from './arrivalService'
 import BookingClient from '../data/bookingClient'
-import ArrivalFactory from '../testutils/factories/arrival'
+import arrivalFactory from '../testutils/factories/arrival'
+import newArrivalFactory from '../testutils/factories/newArrival'
 
 jest.mock('../data/bookingClient.ts')
 
@@ -19,15 +18,18 @@ describe('ArrivalService', () => {
 
   describe('createArrival', () => {
     it('on success returns the arrival that has been posted', async () => {
-      const arrival: Arrival = ArrivalFactory.build()
+      const arrival = arrivalFactory.build()
+      const payload = newArrivalFactory.build()
+
       const token = 'SOME_TOKEN'
+
       bookingClient.markAsArrived.mockResolvedValue(arrival)
 
-      const postedArrival = await service.createArrival(token, 'premisesID', 'bookingId', arrival)
+      const postedArrival = await service.createArrival(token, 'premisesID', 'bookingId', payload)
       expect(postedArrival).toEqual(arrival)
 
       expect(bookingClientFactory).toHaveBeenCalledWith(token)
-      expect(bookingClient.markAsArrived).toHaveBeenCalledWith('premisesID', 'bookingId', arrival)
+      expect(bookingClient.markAsArrived).toHaveBeenCalledWith('premisesID', 'bookingId', payload)
     })
   })
 })

--- a/server/services/arrivalService.ts
+++ b/server/services/arrivalService.ts
@@ -1,15 +1,10 @@
-import type { Arrival } from 'approved-premises'
+import type { Arrival, NewArrival } from 'approved-premises'
 import type { RestClientBuilder, BookingClient } from '../data'
 
 export default class ArrivalService {
   constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
 
-  async createArrival(
-    token: string,
-    premisesId: string,
-    bookingId: string,
-    arrival: Omit<Arrival, 'id' | 'bookingId'>,
-  ): Promise<Arrival> {
+  async createArrival(token: string, premisesId: string, bookingId: string, arrival: NewArrival): Promise<Arrival> {
     const bookingClient = this.bookingClientFactory(token)
 
     const confirmedArrival = await bookingClient.markAsArrived(premisesId, bookingId, arrival)

--- a/server/testutils/factories/newArrival.ts
+++ b/server/testutils/factories/newArrival.ts
@@ -1,15 +1,12 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
 
-import type { Arrival } from 'approved-premises'
+import type { NewArrival } from 'approved-premises'
 import { DateFormats } from '../../utils/dateUtils'
 
-export default Factory.define<Arrival>(() => ({
-  id: faker.datatype.uuid(),
+export default Factory.define<NewArrival>(() => ({
   arrivalDate: DateFormats.formatApiDate(faker.date.soon()),
-  bookingId: faker.datatype.uuid(),
   expectedDepartureDate: DateFormats.formatApiDate(faker.date.future()),
   notes: faker.lorem.sentence(),
-  name: `${faker.name.firstName()} ${faker.name.lastName()}`,
-  crn: faker.datatype.uuid(),
+  keyWorkerStaffId: faker.datatype.uuid(),
 }))

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -58,7 +58,7 @@ describe('DateFormats', () => {
 
       const result = DateFormats.convertDateAndTimeInputsToIsoString(obj, 'date')
 
-      expect(result.date).toEqual(new Date(2022, 11, 11).toISOString())
+      expect(result.date).toEqual('2022-12-11')
     })
 
     it('pads the months and days', () => {
@@ -70,7 +70,7 @@ describe('DateFormats', () => {
 
       const result = DateFormats.convertDateAndTimeInputsToIsoString(obj, 'date')
 
-      expect(result.date).toEqual(new Date(2022, 0, 1).toISOString())
+      expect(result.date).toEqual('2022-01-01')
     })
 
     it('returns the date with a time if passed one', () => {
@@ -83,7 +83,7 @@ describe('DateFormats', () => {
 
       const result = DateFormats.convertDateAndTimeInputsToIsoString(obj, 'date')
 
-      expect(result.date).toEqual(new Date(2022, 0, 1, 12, 35).toISOString())
+      expect(result.date).toEqual('2022-01-01T12:35:00.000Z')
     })
 
     it('returns an empty string when given empty strings as input', () => {
@@ -107,7 +107,7 @@ describe('DateFormats', () => {
 
       const result = DateFormats.convertDateAndTimeInputsToIsoString(obj, 'date')
 
-      expect(result.date.toString()).toEqual('twothousandtwentytwo-20-ooT00:00:00.000Z')
+      expect(result.date.toString()).toEqual('twothousandtwentytwo-20-oo')
     })
   })
 })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -71,11 +71,13 @@ export class DateFormats {
     const year = dateInputObj[`${key}-year`]
     const time = dateInputObj[`${key}-time`]
 
-    const timeSegment = time || '00:00'
-
     const o: { [P in K]?: string } = dateInputObj
     if (day && month && year) {
-      o[key] = `${year}-${month}-${day}T${timeSegment}:00.000Z`
+      if (time) {
+        o[key] = `${year}-${month}-${day}T${time}:00.000Z`
+      } else {
+        o[key] = `${year}-${month}-${day}`
+      }
     } else {
       o[key] = undefined
     }

--- a/server/views/arrivals/_arrival_form.njk
+++ b/server/views/arrivals/_arrival_form.njk
@@ -3,15 +3,15 @@
 <form action="{{ paths.bookings.arrivals.create({ premisesId: premisesId, bookingId: bookingId }) }}" method="post">
   <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
   {{ govukDateInput({
-    id: "arrival[date]",
-    namePrefix: "date",
+    id: "arrival[arrivalDate]",
+    namePrefix: "arrivalDate",
     fieldset: {
     legend: {
         text: "What is the arrival date?",
         classes: "govuk-fieldset__legend--m"
         }
     },
-    items: dateFieldValues('date', errors),
+    items: dateFieldValues('arrivalDate', errors),
     errorMessage: errors.date,
     hint: {
         text: "For example, 27 3 2007"

--- a/server/views/bookings/show.njk
+++ b/server/views/bookings/show.njk
@@ -70,7 +70,7 @@
                   text: "Arrival date"
                 },
                 value: {
-                  text: formatDate(booking.arrival.date)
+                  text: formatDate(booking.arrival.arrivalDate)
                 }
               },
               {


### PR DESCRIPTION
This updates the Arrival form to send the expected values, before the `arrivalDate` was `date`  and the `keyWorkerStaffId` was not present. I've also updated the DateTime converter to only include the timestamp if a time is provided, The API only accepts dates in `YYYY-MM-DD` format, except for in the case of departures.