### PR TITLE
Allow e2e tests to be run locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,31 @@ See development seeding in [HMPPS-Auth](https://github.com/ministryofjustice/hmp
 
 ## Running the tests
 
-To run linting, unit and end-to-end tests, from the root directory, run:
+### Unit and Integration Tests
 
+There is a complete suite of unit and integration tests that run as part of CI.
+
+The integration tests are run using [Cypress](https://www.cypress.io/), and API
+calls are mocked using [Wiremock](https://wiremock.org/).
+
+To run linting, unit and integration tests, from the root directory, run:
+
+```bash
 script/test
+```
+
+### End to end tests
+
+As well as unit and integration tests, there are also a [smaller suite of
+end-to-end tests](https://github.com/ministryofjustice/hmpps-approved-premises-ui/tree/main/e2e/tests)
+that run in [Circle CI](https://circleci.com/) post-deploy to the `dev`
+environment.
+
+If you want to run these tests against a local version of the full stack, then
+you can run the End to End tests against Docker containers running the full stack with:
+
+```bash
+script/local_e2e
+```
+
+Note: This requires `ap-tools` to be installed (<https://github.com/ministryofjustice/hmpps-approved-premises-tools>)

--- a/e2e.local.env
+++ b/e2e.local.env
@@ -1,0 +1,6 @@
+CYPRESS_username=JimSnowLdap
+CYPRESS_password=secret
+CYPRESS_offender_crn=X320741
+CYPRESS_offender_name="Aadland Bertrand"
+CYPRESS_keyworker_name="Kelby Tabert"
+CYPRESS_lost_bed_reason_id=2f46e769-17a5-4b5c-b04a-a5a9a5b3f773

--- a/script/local_e2e
+++ b/script/local_e2e
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# script/bootstrap: Run the End to End tests against a local version of the stack
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if ! [ "$(command -v ap-tools)" ];then
+    echo "ap-tools not installed, please ensure you have the Approved Premises Toolkit installed (https://github.com/ministryofjustice/hmpps-approved-premises-tools)"
+    exit
+fi
+
+ap-tools server start --local-ui
+
+set -a
+
+# shellcheck source=/dev/null
+. ./e2e.local.env
+
+set +a
+
+npx cypress open -C cypress.config.e2e.ts --config '{"baseUrl":"http://localhost:3000","e2e":{"experimentalSessionAndOrigin": true}}'


### PR DESCRIPTION
This adds a script to run the e2e tests locally against the full stack of Docker containers, run using `ap-tools`. I've also added a bit of documentation to give context on the current state of play for testing.