### PR TITLE
[TA] (423,445) A user can view a list of TA properties

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/premisesList.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesList.ts
@@ -1,0 +1,34 @@
+import type { Premises } from 'approved-premises'
+
+import Page from '../../page'
+import paths from '../../../../server/paths/temporary-accommodation/manage'
+
+export default class PremisesListPage extends Page {
+  constructor() {
+    super('Properties')
+  }
+
+  static visit(): PremisesListPage {
+    cy.visit(paths.premises.index({}))
+    return new PremisesListPage()
+  }
+
+  shouldShowPremises(premises: Array<Premises>): void {
+    premises.forEach((item: Premises) => {
+      cy.contains(item.name)
+        .parent()
+        .within(() => {
+          cy.get('td').eq(0).contains(item.apCode)
+          cy.get('td').eq(1).contains(item.bedCount)
+          cy.get('td')
+            .eq(2)
+            .contains('View')
+            .should('have.attr', 'href', paths.premises.show({ premisesId: item.id }))
+        })
+    })
+  }
+
+  clickAddPremisesButton() {
+    cy.get('a').contains('Add a new property').click()
+  }
+}

--- a/integration_tests/mockApis/premises.ts
+++ b/integration_tests/mockApis/premises.ts
@@ -1,22 +1,27 @@
 import type { Response, SuperAgentRequest } from 'superagent'
 
-import type { Premises, Booking, PremisesCapacity, StaffMember } from 'approved-premises'
+import type { Premises, Booking, PremisesCapacity, StaffMember, Service } from 'approved-premises'
 
 import { getMatchingRequests, stubFor } from '../../wiremock'
 import bookingStubs from './booking'
 
-const stubPremises = (premises: Array<Premises>) =>
+const stubPremises = (args: { premises: Array<Premises>; service: Service }) =>
   stubFor({
     request: {
       method: 'GET',
-      urlPattern: '/premises',
+      urlPath: '/premises',
+      queryParameters: {
+        service: {
+          equalTo: args.service,
+        },
+      },
     },
     response: {
       status: 200,
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
       },
-      jsonBody: premises,
+      jsonBody: args.premises,
     },
   })
 

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -1,5 +1,5 @@
 Cypress.Commands.add('signIn', (options = { failOnStatusCode: true }) => {
-  cy.task('stubPremises', [])
+  cy.task('stubPremises', { premises: [], service: 'approved-premises' })
   cy.request('/')
   return cy.task('getSignInUrl').then((url: string) => cy.visit(url, options))
 })

--- a/integration_tests/tests/manage/departure.cy.ts
+++ b/integration_tests/tests/manage/departure.cy.ts
@@ -33,7 +33,7 @@ context('Departures', () => {
       destinationProvider,
     })
 
-    cy.task('stubPremises', premises)
+    cy.task('stubPremises', { premises, service: 'approved-premises' })
     cy.task('stubBookingGet', { premisesId: premises[0].id, booking })
     cy.task('stubDepartureCreate', { premisesId: premises[0].id, bookingId: booking.id, departure })
     cy.task('stubDepartureGet', { premisesId: premises[0].id, bookingId: booking.id, departure })
@@ -75,7 +75,7 @@ context('Departures', () => {
     })
 
     // Given I am signed in
-    cy.task('stubPremises', premises)
+    cy.task('stubPremises', { premises, service: 'approved-premises' })
     cy.task('stubBookingGet', { premisesId: premises[0].id, booking })
     cy.task('stubDepartureGet', { premisesId: premises[0].id, bookingId: booking.id, departure })
     cy.signIn()

--- a/integration_tests/tests/manage/premises.cy.ts
+++ b/integration_tests/tests/manage/premises.cy.ts
@@ -17,7 +17,7 @@ context('Premises', () => {
 
     // And there are premises in the database
     const premises = premisesFactory.buildList(5)
-    cy.task('stubPremises', premises)
+    cy.task('stubPremises', { premises, service: 'approved-premises' })
 
     // When I visit the premises page
     const page = PremisesListPage.visit()

--- a/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
@@ -79,4 +79,22 @@ context('Premises', () => {
     const premisesNewPage = PremisesNewPage.verifyOnPage(PremisesNewPage)
     premisesNewPage.shouldShowBanner('Property created')
   })
+
+  it('should navigate back to the premises list page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are premises in the database
+    const premises = premisesFactory.buildList(5)
+    cy.task('stubPremises', { premises, service: 'temporary-accommodation' })
+
+    // When I visit the new premises page
+    const page = PremisesNewPage.visit()
+
+    // Add I click back
+    page.clickBack()
+
+    // Then I navigate to the premises list page
+    Page.verifyOnPage(PremisesListPage)
+  })
 })

--- a/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
@@ -1,12 +1,47 @@
 import premisesFactory from '../../../../server/testutils/factories/premises'
 import newPremisesFactory from '../../../../server/testutils/factories/newPremises'
 import PremisesNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesNew'
+import PremisesListPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesList'
+import Page from '../../../../cypress_shared/pages/page'
 
 context('Premises', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+  })
+
+  it('should list all premises', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are premises in the database
+    const premises = premisesFactory.buildList(5)
+    cy.task('stubPremises', { premises, service: 'temporary-accommodation' })
+
+    // When I visit the premises page
+    const page = PremisesListPage.visit()
+
+    // Then I should see all of the premises listed
+    page.shouldShowPremises(premises)
+  })
+
+  it('should navigate to the new premises page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are premises in the database
+    const premises = premisesFactory.buildList(5)
+    cy.task('stubPremises', { premises, service: 'temporary-accommodation' })
+
+    // When I visit the premises page
+    const page = PremisesListPage.visit()
+
+    // Add I click the add a premises button
+    page.clickAddPremisesButton()
+
+    // Then I navigate to the new premises page
+    Page.verifyOnPage(PremisesNewPage)
   })
 
   it('should allow me to create a premises', () => {

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -154,6 +154,8 @@ declare module 'approved-premises' {
 
   export type PersonStatus = 'InCustody' | 'InCommunity'
 
+  export type Service = 'approved-premises' | 'temporary-accommodation'
+
   export interface schemas {
     Premises: {
       id: string

--- a/server/controllers/applicationController.ts
+++ b/server/controllers/applicationController.ts
@@ -11,7 +11,7 @@ export default class ApplicationController {
       if (service === 'approved-premises') {
         res.redirect(apManagePaths.premises.index({}))
       } else {
-        res.redirect(taManagePaths.premises.new({}))
+        res.redirect(taManagePaths.premises.index({}))
       }
     }
   }

--- a/server/controllers/manage/premisesController.test.ts
+++ b/server/controllers/manage/premisesController.test.ts
@@ -26,7 +26,7 @@ describe('PremisesController', () => {
 
       expect(response.render).toHaveBeenCalledWith('premises/index', { tableRows: [] })
 
-      expect(premisesService.tableRows).toHaveBeenCalledWith(token)
+      expect(premisesService.tableRows).toHaveBeenCalledWith(token, 'approved-premises')
     })
   })
 

--- a/server/controllers/manage/premisesController.ts
+++ b/server/controllers/manage/premisesController.ts
@@ -8,7 +8,7 @@ export default class PremisesController {
 
   index(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const tableRows = await this.premisesService.tableRows(req.user.token)
+      const tableRows = await this.premisesService.tableRows(req.user.token, 'approved-premises')
       return res.render('premises/index', { tableRows })
     }
   }

--- a/server/controllers/temporary-accommodation/manage/premisesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.test.ts
@@ -19,6 +19,19 @@ describe('PremisesController', () => {
   const premisesService = createMock<PremisesService>({})
   const premisesController = new PremisesController(premisesService)
 
+  describe('index', () => {
+    it('should return the table rows to the template', async () => {
+      premisesService.tableRows.mockResolvedValue([])
+
+      const requestHandler = premisesController.index()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/premises/index', { tableRows: [] })
+
+      expect(premisesService.tableRows).toHaveBeenCalledWith(token, 'temporary-accommodation')
+    })
+  })
+
   describe('new', () => {
     it('show render the form', async () => {
       const requestHandler = premisesController.new()

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -8,6 +8,13 @@ import { catchValidationErrorOrPropogate } from '../../../utils/validation'
 export default class PremisesController {
   constructor(private readonly premisesService: PremisesService) {}
 
+  index(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const tableRows = await this.premisesService.tableRows(req.user.token, 'temporary-accommodation')
+      return res.render('temporary-accommodation/premises/index', { tableRows })
+    }
+  }
+
   new(): RequestHandler {
     return async (_req: Request, res: Response) => {
       return res.render('temporary-accommodation/premises/new')

--- a/server/data/premisesClient.test.ts
+++ b/server/data/premisesClient.test.ts
@@ -32,13 +32,14 @@ describe('PremisesClient', () => {
   describe('all', () => {
     const premises = premisesFactory.buildList(5)
 
-    it('should get all premises', async () => {
+    it('should get all premises for the given service', async () => {
       fakeApprovedPremisesApi
         .get(paths.premises.index({}))
         .matchHeader('authorization', `Bearer ${token}`)
+        .query({ service: 'approved-premises' })
         .reply(200, premises)
 
-      const output = await premisesClient.all()
+      const output = await premisesClient.all('approved-premises')
       expect(output).toEqual(premises)
     })
   })

--- a/server/data/premisesClient.ts
+++ b/server/data/premisesClient.ts
@@ -1,4 +1,4 @@
-import type { Premises, NewPremises, PremisesCapacityItem, StaffMember } from 'approved-premises'
+import type { Premises, NewPremises, PremisesCapacityItem, StaffMember, Service } from 'approved-premises'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -10,8 +10,8 @@ export default class PremisesClient {
     this.restClient = new RestClient('premisesClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
-  async all(): Promise<Array<Premises>> {
-    return (await this.restClient.get({ path: paths.premises.index({}) })) as Array<Premises>
+  async all(service: Service): Promise<Array<Premises>> {
+    return (await this.restClient.get({ path: paths.premises.index({}), query: { service } })) as Array<Premises>
   }
 
   async find(id: string): Promise<Premises> {

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -5,6 +5,7 @@ const singlePremisesPath = premisesPath.path(':premisesId')
 
 const paths = {
   premises: {
+    index: premisesPath,
     show: singlePremisesPath,
     new: premisesPath.path('new'),
     create: premisesPath,

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -1,9 +1,11 @@
 import { temporaryAccommodationPath } from '../service'
 
 const premisesPath = temporaryAccommodationPath.path('properties')
+const singlePremisesPath = premisesPath.path(':premisesId')
 
 const paths = {
   premises: {
+    show: singlePremisesPath,
     new: premisesPath.path('new'),
     create: premisesPath,
   },

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -12,6 +12,7 @@ export default function routes(controllers: Controllers, router: Router): Router
 
   const { premisesController } = controllers.temporaryAccommodation
 
+  get(paths.premises.index.pattern, premisesController.index())
   get(paths.premises.new.pattern, premisesController.new())
   post(paths.premises.create.pattern, premisesController.create())
 

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -1,3 +1,4 @@
+import type { Service } from 'approved-premises'
 import PremisesService from './premisesService'
 import PremisesClient from '../data/premisesClient'
 import premisesFactory from '../testutils/factories/premises'
@@ -5,7 +6,8 @@ import premisesCapacityItemFactory from '../testutils/factories/premisesCapacity
 import staffMemberFactory from '../testutils/factories/staffMember'
 import newPremisesFactory from '../testutils/factories/newPremises'
 import getDateRangesWithNegativeBeds from '../utils/premisesUtils'
-import paths from '../paths/manage'
+import apPaths from '../paths/manage'
+import taPaths from '../paths/temporary-accommodation/manage'
 
 jest.mock('../data/premisesClient')
 jest.mock('../utils/premisesUtils')
@@ -39,69 +41,74 @@ describe('PremisesService', () => {
   })
 
   describe('tableRows', () => {
-    it('returns a table view of the premises', async () => {
-      const premises1 = premisesFactory.build({ name: 'XYZ' })
-      const premises2 = premisesFactory.build({ name: 'ABC' })
-      const premises3 = premisesFactory.build({ name: 'GHI' })
+    describe.each([
+      ['approved-premises' as Service, apPaths.premises.show],
+      ['temporary-accommodation' as Service, taPaths.premises.show],
+    ])('when the given service is %p', (serviceName, showPath) => {
+      it(`returns a table view of the premises for ${serviceName}`, async () => {
+        const premises1 = premisesFactory.build({ name: 'XYZ' })
+        const premises2 = premisesFactory.build({ name: 'ABC' })
+        const premises3 = premisesFactory.build({ name: 'GHI' })
 
-      const premises = [premises1, premises2, premises3]
-      premisesClient.all.mockResolvedValue(premises)
+        const premises = [premises1, premises2, premises3]
+        premisesClient.all.mockResolvedValue(premises)
 
-      const rows = await service.tableRows(token)
+        const rows = await service.tableRows(token, serviceName)
 
-      expect(rows).toEqual([
-        [
-          {
-            text: premises2.name,
-          },
-          {
-            text: premises2.apCode,
-          },
-          {
-            text: premises2.bedCount.toString(),
-          },
-          {
-            html: `<a href="${paths.premises.show({
-              premisesId: premises2.id,
-            })}">View<span class="govuk-visually-hidden">about ${premises2.name}</span></a>`,
-          },
-        ],
-        [
-          {
-            text: premises3.name,
-          },
-          {
-            text: premises3.apCode,
-          },
-          {
-            text: premises3.bedCount.toString(),
-          },
-          {
-            html: `<a href="${paths.premises.show({
-              premisesId: premises3.id,
-            })}">View<span class="govuk-visually-hidden">about ${premises3.name}</span></a>`,
-          },
-        ],
-        [
-          {
-            text: premises1.name,
-          },
-          {
-            text: premises1.apCode,
-          },
-          {
-            text: premises1.bedCount.toString(),
-          },
-          {
-            html: `<a href="${paths.premises.show({
-              premisesId: premises1.id,
-            })}">View<span class="govuk-visually-hidden">about ${premises1.name}</span></a>`,
-          },
-        ],
-      ])
+        expect(rows).toEqual([
+          [
+            {
+              text: premises2.name,
+            },
+            {
+              text: premises2.apCode,
+            },
+            {
+              text: premises2.bedCount.toString(),
+            },
+            {
+              html: `<a href="${showPath({
+                premisesId: premises2.id,
+              })}">View<span class="govuk-visually-hidden">about ${premises2.name}</span></a>`,
+            },
+          ],
+          [
+            {
+              text: premises3.name,
+            },
+            {
+              text: premises3.apCode,
+            },
+            {
+              text: premises3.bedCount.toString(),
+            },
+            {
+              html: `<a href="${showPath({
+                premisesId: premises3.id,
+              })}">View<span class="govuk-visually-hidden">about ${premises3.name}</span></a>`,
+            },
+          ],
+          [
+            {
+              text: premises1.name,
+            },
+            {
+              text: premises1.apCode,
+            },
+            {
+              text: premises1.bedCount.toString(),
+            },
+            {
+              html: `<a href="${showPath({
+                premisesId: premises1.id,
+              })}">View<span class="govuk-visually-hidden">about ${premises1.name}</span></a>`,
+            },
+          ],
+        ])
 
-      expect(premisesClientFactory).toHaveBeenCalledWith(token)
-      expect(premisesClient.all).toHaveBeenCalled()
+        expect(premisesClientFactory).toHaveBeenCalledWith(token)
+        expect(premisesClient.all).toHaveBeenCalledWith(serviceName)
+      })
     })
   })
 

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -18,7 +18,7 @@ export default class PremisesService {
 
   async tableRows(token: string): Promise<Array<TableRow>> {
     const premisesClient = this.premisesClientFactory(token)
-    const premises = await premisesClient.all()
+    const premises = await premisesClient.all('approved-premises')
 
     return premises
       .sort((a, b) => a.name.localeCompare(b.name))
@@ -57,7 +57,7 @@ export default class PremisesService {
 
   async getPremisesSelectList(token: string): Promise<Array<{ text: string; value: string }>> {
     const premisesClient = this.premisesClientFactory(token)
-    const premises = await premisesClient.all()
+    const premises = await premisesClient.all('approved-premises')
 
     return premises
       .map(singlePremises => {

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -1,6 +1,7 @@
-import type { Premises, NewPremises, TableRow, SummaryList, StaffMember } from 'approved-premises'
+import type { Premises, NewPremises, TableRow, SummaryList, StaffMember, Service } from 'approved-premises'
 import type { RestClientBuilder, PremisesClient } from '../data'
-import paths from '../paths/manage'
+import apPaths from '../paths/manage'
+import taPaths from '../paths/temporary-accommodation/manage'
 
 import { DateFormats } from '../utils/dateUtils'
 import getDateRangesWithNegativeBeds, { NegativeDateRange } from '../utils/premisesUtils'
@@ -16,9 +17,11 @@ export default class PremisesService {
     return staffMembers
   }
 
-  async tableRows(token: string): Promise<Array<TableRow>> {
+  async tableRows(token: string, service: Service): Promise<Array<TableRow>> {
     const premisesClient = this.premisesClientFactory(token)
-    const premises = await premisesClient.all('approved-premises')
+    const premises = await premisesClient.all(service)
+
+    const showPath = service === 'approved-premises' ? apPaths.premises.show : taPaths.premises.show
 
     return premises
       .sort((a, b) => a.name.localeCompare(b.name))
@@ -28,7 +31,7 @@ export default class PremisesService {
           this.textValue(p.apCode),
           this.textValue(p.bedCount.toString()),
           this.htmlValue(
-            `<a href="${paths.premises.show({ premisesId: p.id })}">View<span class="govuk-visually-hidden">about ${
+            `<a href="${showPath({ premisesId: p.id })}">View<span class="govuk-visually-hidden">about ${
               p.name
             }</span></a>`,
           ),

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -1,4 +1,4 @@
-import type { Application, TaskNames } from 'approved-premises'
+import type { Application, Service, TaskNames } from 'approved-premises'
 import { Request } from 'express'
 import config from '../config'
 import pages from '../form-pages/apply'
@@ -22,7 +22,7 @@ const taskLink = (task: TaskNames, id: string): string => {
   })}" aria-describedby="eligibility-${task}" data-cy-task-name="${task}">${taskLookup[task]}</a>`
 }
 
-const getService = (req: Request): 'approved-premises' | 'temporary-accommodation' => {
+const getService = (req: Request): Service => {
   if (config.serviceSignifier === 'approved-premises-only') {
     return 'approved-premises'
   }

--- a/server/views/temporary-accommodation/premises/index.njk
+++ b/server/views/temporary-accommodation/premises/index.njk
@@ -1,0 +1,39 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - Properties" %}
+
+{% block content %}
+  {% include "../../_messages.njk" %}
+  
+  <main class="app-container govuk-body">
+    <h1>Properties</h1>
+
+    {{ govukButton({
+      text: "Add a new property",
+      href: paths.premises.new()
+    }) }}
+
+    {{ govukTable({
+      captionClasses: "govuk-table__caption--m",
+      firstCellIsHeader: true,
+        head: [
+        {
+          text: "Name"
+        },
+        {
+          text: "Code"
+        },
+        {
+          text: "Bed Count"
+        },
+        {
+          html: '<span class="govuk-visually-hidden">Actions</span>'
+        }
+      ],
+      rows: tableRows
+    }) }}
+  </main>
+
+{% endblock %}

--- a/server/views/temporary-accommodation/premises/new.njk
+++ b/server/views/temporary-accommodation/premises/new.njk
@@ -1,3 +1,4 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% extends "../../partials/layout.njk" %}
@@ -7,11 +8,16 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
+  {{ govukBackLink({
+    text: "Back",
+    href: paths.premises.index()
+  }) }}
+
   {% include "../../_messages.njk" %}
   
-	<h1>Add a new property</h1>
+  <h1>Add a new property</h1>
 
-	<div class="govuk-grid-row">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form action="{{ paths.premises.create() }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -26,17 +26,44 @@ const stubs = []
 
 const premises = premisesJson.map(item => premisesFactory.build(item as DeepPartial<Premises>))
 
+const apPremises = premises.slice(0, Math.floor(premises.length / 2))
+const taPremises = premises.slice(Math.floor(premises.length / 2), premises.length)
+
 stubs.push({
   request: {
     method: 'GET',
-    url: '/premises',
+    urlPath: '/premises',
+    queryParameters: {
+      service: {
+        equalTo: 'approved-premises',
+      },
+    },
   },
   response: {
     status: 200,
     headers: {
       'Content-Type': 'application/json;charset=UTF-8',
     },
-    jsonBody: premises,
+    jsonBody: apPremises,
+  },
+})
+
+stubs.push({
+  request: {
+    method: 'GET',
+    urlPath: '/premises',
+    queryParameters: {
+      service: {
+        equalTo: 'temporary-accommodation',
+      },
+    },
+  },
+  response: {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json;charset=UTF-8',
+    },
+    jsonBody: taPremises,
   },
 })
 


### PR DESCRIPTION
# Context

Trello [#423](https://trello.com/c/P6TEGW6m/423-a-user-can-view-a-list-of-properties)/[#445](https://trello.com/c/7gUPFXcB/445-cas1-properties-are-not-viewable-in-view-list-of-properties)

# Changes in this PR

* PremisesClient sends a "service" parameter
* TA service start page is now a list of TA premises
* A user can return back to the premises listing from the "new premises" screen

Final design to be refined later based on wireframes from Chanelle

## Screenshots of UI changes

![localhost_3000_temporary-accommodation_properties](https://user-images.githubusercontent.com/94137563/195589029-714ce5c2-b6ad-4657-9589-799cec53a8be.png)

