### PR TITLE
Update RestClient query type to allow a Record<string, string>

### DIFF
--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -12,7 +12,7 @@ import { restClientMetricsMiddleware } from './restClientMetricsMiddleware'
 
 interface GetRequest {
   path?: string
-  query?: string
+  query?: string | Record<string, string>
   headers?: Record<string, string>
   responseType?: string
   raw?: boolean


### PR DESCRIPTION
This allows us to do:
```
restClient.get({ path: somePath, query: { foo: 'bar' } })
```

rather than:
```
restClient.get({ path: somePath, query: 'foo:bar' })
```
