### PR TITLE
Add a clickBack helper method to our base Page class

### DIFF
--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -69,7 +69,11 @@ export default abstract class Page {
     cy.get(`#${prefix}-year`).type(parsedDate.getFullYear().toString())
   }
 
-  public clickSubmit(): void {
+  clickSubmit(): void {
     cy.get('button').click()
+  }
+
+  clickBack(): void {
+    cy.get('a').contains('Back').click()
   }
 }


### PR DESCRIPTION
A back link is used in many of our templates, so worth including a helper in our base Page class