### PR TITLE
(750) Frontend for risk widgets

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -6,6 +6,7 @@ $path: "/assets/images/"
 
 @import './components/header-bar'
 @import './components/task-list'
+@import './components/risk-widgets'
 @import './local'
 
 @import './pages/premises/show'

--- a/assets/sass/components/_risk-widgets.scss
+++ b/assets/sass/components/_risk-widgets.scss
@@ -1,0 +1,132 @@
+$low-score-colour: #485b10;
+$low-score-border-colour: #85994b;
+$medium-score-colour: #a34e00;
+$medium-score-border-colour: #f47738;
+$high-score-colour: #942514;
+$high-score-border-colour: #d4351c;
+$very-high-score-colour: #711a0d;
+$very-high-score-border-colour: #942514;
+$mappa-colour: #4c2c92;
+
+.rosh-widget {
+  border: 2px solid govuk-colour('black');
+  padding: govuk-spacing(4);
+  margin-bottom: govuk-spacing(4);
+
+  & h3 {
+    margin-bottom: govuk-spacing(1);
+    font-weight: 400;
+  }
+
+  & :nth-child(2) {
+    margin-bottom: govuk-spacing(2);
+  }
+  & :nth-child(3) {
+    margin-bottom: govuk-spacing(1);
+  }
+}
+
+.rosh-widget--low {
+  border: 2px solid $low-score-border-colour;
+
+  & h3 {
+    color: $low-score-colour;
+  }
+}
+
+.rosh-widget--medium {
+  border: 2px solid $medium-score-border-colour;
+
+  & h3 {
+    color: $medium-score-colour;
+  }
+}
+
+.rosh-widget--high {
+  border: 2px solid $high-score-border-colour;
+
+  & h3 {
+    color: $high-score-colour;
+  }
+}
+
+.rosh-widget--very-high {
+  border: 2px solid $very-high-score-border-colour;
+
+  & h3 {
+    color: $very-high-score-colour;
+  }
+}
+
+.rosh-widget__table {
+  text-align: left;
+  margin: 0;
+
+  & tbody {
+    & th {
+      font-weight: 400;
+    }
+
+    & td {
+      font-weight: bold;
+    }
+  }
+}
+
+.rosh-widget__risk--low {
+  color: $low-score-colour;
+}
+
+.rosh-widget__risk--medium {
+  color: $medium-score-colour;
+}
+
+.rosh-widget__risk--high {
+  color: $high-score-colour;
+}
+
+.rosh-widget__risk--very-high {
+  color: $very-high-score-colour;
+}
+
+.mappa-widget {
+  border: 2px solid $mappa-colour;
+  padding: govuk-spacing(4);
+  margin-bottom: govuk-spacing(4);
+
+  & h3 {
+    color: $mappa-colour;
+    margin-bottom: 0;
+    font-weight: 400;
+  }
+
+  & p {
+    margin-bottom: govuk-spacing(1);
+  }
+  & :last-child {
+    margin-bottom: 0;
+  }
+}
+
+.risk-flag-widget {
+  border: 2px solid #93afc3;
+  background-color: #ebf7ff;
+  padding: govuk-spacing(4);
+  margin-bottom: govuk-spacing(4);
+}
+
+.tier-widget {
+  color: govuk-colour('turquoise');
+  border: 2px solid govuk-colour('turquoise');
+  padding: govuk-spacing(3);
+  margin-bottom: govuk-spacing(4);
+
+  & h3 {
+    color: govuk-colour('turquoise');
+    margin-bottom: 0;
+    font-weight: 400;
+  }
+  & :last-child {
+    margin-bottom: 0;
+  }
+}

--- a/cypress_shared/pages/apply/taskListPage.ts
+++ b/cypress_shared/pages/apply/taskListPage.ts
@@ -1,3 +1,5 @@
+import type { PersonRisksUI } from 'approved-premises'
+
 import Page from '../page'
 
 export default class TaskListPage extends Page {
@@ -7,5 +9,43 @@ export default class TaskListPage extends Page {
 
   shouldShowTaskStatus = (task: string, status: string): void => {
     cy.get(`#${task}-status`).should('contain', status)
+  }
+
+  shouldShowMappa = (): void => {
+    cy.get('h3').contains('MAPPA')
+    cy.get('h3').contains('CAT 2 / LEVEL 1')
+  }
+
+  shouldShowRosh = (risks: PersonRisksUI['roshRisks']): void => {
+    cy.get('h3').contains(`${risks.overallRisk.toLocaleUpperCase()} RoSH`)
+    cy.get('p').contains(`Last updated: ${risks.lastUpdated}`)
+
+    cy.get('.rosh-widget__table').within($row => {
+      cy.wrap($row).get('th').contains('Children').get('td').contains(risks.riskToChildren, { matchCase: false })
+      cy.wrap($row).get('th').contains('Public').get('td').contains(risks.riskToPublic, { matchCase: false })
+      cy.wrap($row).get('th').contains('Known adult').get('td').contains(risks.riskToKnownAdult, { matchCase: false })
+      cy.wrap($row).get('th').contains('Staff').get('td').contains(risks.riskToStaff, { matchCase: false })
+    })
+  }
+
+  shouldShowTier = (tier: PersonRisksUI['tier']): void => {
+    cy.get('h3').contains(`TIER ${tier.level}`)
+    cy.get('p').contains(`Last updated: ${tier.lastUpdated}`)
+  }
+
+  shouldShowDeliusRiskFlags = (flags: string[]): void => {
+    cy.get('h3').contains(`Delius risk flags (registers)`)
+    cy.get('.risk-flag-widget > ul').within($item => {
+      flags.forEach(flag => {
+        cy.wrap($item).get('li').should('contain', flag)
+      })
+    })
+  }
+
+  shouldShowRiskWidgets(risks: PersonRisksUI): void {
+    this.shouldShowMappa()
+    this.shouldShowRosh(risks.roshRisks)
+    this.shouldShowTier(risks.tier)
+    this.shouldShowDeliusRiskFlags(risks.flags)
   }
 }

--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -1,6 +1,6 @@
 import { SuperAgentRequest } from 'superagent'
 
-import type { Person } from 'approved-premises'
+import type { Person, PersonRisks } from 'approved-premises'
 
 import { stubFor, getMatchingRequests } from '../../wiremock'
 
@@ -25,6 +25,18 @@ export default {
       },
       response: {
         status: 404,
+      },
+    }),
+  stubPersonRisks: (args: { person: Person; risks: PersonRisks }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/applications/people/${args.person.crn}/risks`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.risks,
       },
     }),
   verifyFindPerson: async (args: { person: Person }) =>

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -15,6 +15,8 @@ declare module 'approved-premises' {
   export type ApplicationSummary = schemas['ApplicationSummary']
   export type Application = schemas['Application']
   export type StaffMember = schemas['StaffMember']
+  export type PersonRisks = schemas['PersonRisks']
+  export type PersonRisksUI = schemas['PersonRisksUI']
 
   // A utility type that allows us to define an object with a date attribute split into
   // date, month, year (and optionally, time) attributes. Designed for use with the GOV.UK
@@ -150,6 +152,13 @@ declare module 'approved-premises' {
 
   export type PersonStatus = 'InCustody' | 'InCommunity'
 
+  export type RiskLevel = 'Low' | 'Medium' | 'High' | 'Very High'
+
+  export type RiskEnvelopeStatus = 'retrieved' | 'not_found' | 'error'
+
+  export type TierNumber = '1' | '2' | '3' | '4'
+  export type TierLetter = 'A' | 'B' | 'C' | 'D'
+  export type RiskTierLevel = `${TierLetter}${TierNumber}`
   export interface schemas {
     Premises: {
       id: string
@@ -243,7 +252,7 @@ declare module 'approved-premises' {
       availableBeds: number
     }
     RiskTier: {
-      level: string
+      level: RiskTierLevel
       lastUpdated: string
     }
     ApplicationSummary: {
@@ -267,6 +276,47 @@ declare module 'approved-premises' {
     StaffMember: {
       id: string
       name: string
+    }
+    PersonRisks: {
+      crn: string
+      roshRisks: schemas['RoshRisksEnvelope']
+      tier: schemas['RiskTierEnvelope']
+      flags: schemas['FlagsEnvelope']
+      mappa: schemas['MappaEnvelope']
+    }
+    PersonRisksUI: {
+      roshRisks: schemas['RoshRisks']
+      tier: schemas['RiskTier']
+      flags: schemas['FlagsEnvelope']['value']
+      mappa: schemas['Mappa']
+    }
+    RoshRisksEnvelope: {
+      status: RiskEnvelopeStatus
+      value: schemas['RoshRisks']
+    }
+    RoshRisks: {
+      overallRisk: RiskLevel
+      riskToChildren: RiskLevel
+      riskToPublic: RiskLevel
+      riskToKnownAdult: RiskLevel
+      riskToStaff: RiskLevel
+      lastUpdated: string
+    }
+    MappaEnvelope: {
+      status: RiskEnvelopeStatus
+      value: schemas['Mappa']
+    }
+    Mappa: {
+      level: string
+      lastUpdated: string
+    }
+    RiskTierEnvelope: {
+      status: RiskEnvelopeStatus
+      value: schemas['RiskTier']
+    }
+    FlagsEnvelope: {
+      status: RiskEnvelopeStatus
+      value: Array<string>
     }
   }
 }

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -27,14 +27,16 @@ export default class ApplicationsController {
   }
 
   show(): RequestHandler {
-    return (req: Request, res: Response, next: NextFunction) => {
+    return async (req: Request, res: Response, next: NextFunction) => {
       const { application } = req.session
 
-      if (!application) {
+      if (application) {
+        const risks = await this.personService.getPersonRisks(req.user.token, application.person.crn)
+
+        res.render('applications/show', { application, risks })
+      } else {
         next(createError(404, 'Not found'))
       }
-
-      res.render('applications/show', { application })
     }
   }
 

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -2,7 +2,9 @@ import nock from 'nock'
 
 import PersonClient from './personClient'
 import config from '../config'
+import riskFactory from '../testutils/factories/risks'
 import personFactory from '../testutils/factories/person'
+import paths from '../paths/api'
 
 describe('PersonClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
@@ -35,6 +37,23 @@ describe('PersonClient', () => {
         .reply(201, person)
 
       const result = await personClient.search('crn')
+
+      expect(result).toEqual(person)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+
+  describe('risks', () => {
+    it('should return the risks for a person', async () => {
+      const crn = 'crn'
+      const person = riskFactory.build()
+
+      fakeApprovedPremisesApi
+        .get(paths.applications.personRisks({ crn }))
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(201, person)
+
+      const result = await personClient.risks(crn)
 
       expect(result).toEqual(person)
       expect(nock.isDone()).toBeTruthy()

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -1,6 +1,7 @@
-import type { Person } from 'approved-premises'
+import type { Person, PersonRisks } from 'approved-premises'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
+import paths from '../paths/api'
 
 export default class PersonClient {
   restClient: RestClient
@@ -15,5 +16,13 @@ export default class PersonClient {
     })
 
     return response as Person
+  }
+
+  async risks(crn: string): Promise<PersonRisks> {
+    const response = await this.restClient.get({
+      path: paths.applications.personRisks({ crn }),
+    })
+
+    return response as PersonRisks
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -24,6 +24,7 @@ const applyPaths = {
     create: applicationsPath,
     index: applicationsPath,
     update: singleApplicationPath,
+    personRisks: applicationsPath.path('people').path(':crn').path('risks'),
   },
 }
 
@@ -44,5 +45,6 @@ export default {
     index: applyPaths.applications.index,
     update: applyPaths.applications.update,
     new: applyPaths.applications.create,
+    personRisks: applyPaths.applications.personRisks,
   },
 }

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -3,6 +3,8 @@ import type { Person } from 'approved-premises'
 import PersonService from './personService'
 import PersonClient from '../data/personClient'
 import PersonFactory from '../testutils/factories/person'
+import risksFactory from '../testutils/factories/risks'
+import { mapApiPersonRisksForUi } from '../utils/utils'
 
 jest.mock('../data/personClient.ts')
 
@@ -30,6 +32,21 @@ describe('PersonService', () => {
 
       expect(personClientFactory).toHaveBeenCalledWith(token)
       expect(personClient.search).toHaveBeenCalledWith('crn')
+    })
+  })
+
+  describe('getPersonRisks', () => {
+    it("on success returns the person's risks given their CRN", async () => {
+      const apiRisks = risksFactory.build()
+      const uiRisks = mapApiPersonRisksForUi(apiRisks)
+      personClient.risks.mockResolvedValue(apiRisks)
+
+      const postedPerson = await service.getPersonRisks(token, 'crn')
+
+      expect(postedPerson).toEqual(uiRisks)
+
+      expect(personClientFactory).toHaveBeenCalledWith(token)
+      expect(personClient.risks).toHaveBeenCalledWith('crn')
     })
   })
 })

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -1,5 +1,7 @@
-import type { Person } from 'approved-premises'
+import type { Person, PersonRisksUI } from 'approved-premises'
 import type { RestClientBuilder, PersonClient } from '../data'
+
+import { mapApiPersonRisksForUi } from '../utils/utils'
 
 export default class PersonService {
   constructor(private readonly personClientFactory: RestClientBuilder<PersonClient>) {}
@@ -9,5 +11,13 @@ export default class PersonService {
 
     const person = await personClient.search(crn)
     return person
+  }
+
+  async getPersonRisks(token: string, crn: string): Promise<PersonRisksUI> {
+    const personClient = this.personClientFactory(token)
+
+    const risks = await personClient.risks(crn)
+
+    return mapApiPersonRisksForUi(risks)
   }
 }

--- a/server/testutils/factories/applicationSummary.ts
+++ b/server/testutils/factories/applicationSummary.ts
@@ -3,19 +3,14 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 
 import type { ApplicationSummary } from 'approved-premises'
 import personFactory from './person'
+import { riskTierLevel } from './risks'
 
 export default Factory.define<ApplicationSummary>(() => ({
   id: faker.datatype.uuid(),
   person: personFactory.build(),
   arrivalDate: faker.date.future().toISOString(),
   tier: {
-    level: faker.helpers.arrayElement(
-      ['A', 'B', 'C', 'D']
-        .map(letter => {
-          return [0, 1, 2, 3].map(number => `${letter}${number}`)
-        })
-        .flat(),
-    ),
+    level: riskTierLevel,
     lastUpdated: faker.date.recent().toISOString(),
   },
   currentLocation: faker.address.county(),

--- a/server/testutils/factories/risks.ts
+++ b/server/testutils/factories/risks.ts
@@ -1,0 +1,69 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type {
+  PersonRisks,
+  RiskLevel,
+  RiskEnvelopeStatus,
+  TierLetter,
+  TierNumber,
+  RiskTierLevel,
+} from 'approved-premises'
+import { DateFormats } from '../../utils/dateUtils'
+
+const riskLevels: RiskLevel[] = ['Low', 'Medium', 'High', 'Very High']
+const riskEnvelopeStatuses: RiskEnvelopeStatus[] = ['retrieved', 'not_found', 'error']
+
+export default Factory.define<PersonRisks>(() => ({
+  crn: `C${faker.datatype.number({ min: 100000, max: 999999 })}`,
+  roshRisks: roshRisksFactory.build(),
+  mappa: mappaFactory.build(),
+  flags: flagsFactory.build(),
+  tier: tierEnvelopeFactory.build(),
+}))
+
+const roshRisksFactory = Factory.define<PersonRisks['roshRisks']>(() => ({
+  status: faker.helpers.arrayElement(riskEnvelopeStatuses),
+  value: {
+    overallRisk: faker.helpers.arrayElement(riskLevels),
+    riskToChildren: faker.helpers.arrayElement(riskLevels),
+    riskToPublic: faker.helpers.arrayElement(riskLevels),
+    riskToKnownAdult: faker.helpers.arrayElement(riskLevels),
+    riskToStaff: faker.helpers.arrayElement(riskLevels),
+    lastUpdated: DateFormats.formatApiDate(faker.date.past()),
+  },
+}))
+
+const mappaFactory = Factory.define<PersonRisks['mappa']>(() => ({
+  status: faker.helpers.arrayElement(riskEnvelopeStatuses),
+  value: { level: 'CAT 2 / LEVEL 1', lastUpdated: DateFormats.formatApiDate(faker.date.past()) },
+}))
+
+const flagsFactory = Factory.define<PersonRisks['flags']>(() => {
+  return {
+    status: faker.helpers.arrayElement(riskEnvelopeStatuses),
+    value: faker.helpers.arrayElements([
+      'Registered Sex Offender',
+      'Hate Crime',
+      'Non Registered Sex Offender',
+      'Not MAPPA Eligible',
+      'Sexual Harm Prevention Order/Sexual Risk Order',
+      'Street Gangs',
+      'Suicide/Self Harm',
+      'Weapons',
+    ]),
+  }
+})
+
+const lettersFactory: () => TierLetter = () => faker.helpers.arrayElement<TierLetter>(['A', 'B', 'C', 'D'])
+const numbersFactory: () => TierNumber = () => faker.helpers.arrayElement<TierNumber>(['1', '2', '3', '4'])
+
+export const riskTierLevel: RiskTierLevel = `${lettersFactory()}${numbersFactory()}`
+
+const tierEnvelopeFactory = Factory.define<PersonRisks['tier']>(() => ({
+  status: faker.helpers.arrayElement(riskEnvelopeStatuses),
+  value: {
+    level: riskTierLevel,
+    lastUpdated: DateFormats.formatApiDate(faker.date.past()),
+  },
+}))

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -6,7 +6,10 @@ import {
   initialiseName,
   retrieveQuestionResponseFromApplication,
   removeBlankSummaryListItems,
+  mapApiPersonRisksForUi,
 } from './utils'
+import risksFactory from '../testutils/factories/risks'
+import { DateFormats } from './dateUtils'
 
 describe('convert to title case', () => {
   it.each([
@@ -132,5 +135,32 @@ describe('removeBlankSummaryListItems', () => {
         },
       },
     ])
+  })
+})
+
+describe('mapApiPersonRiskForUI', () => {
+  it('maps the PersonRisks from the API into a shape thats useful for the UI', () => {
+    const risks = risksFactory.build()
+    const actual = mapApiPersonRisksForUi(risks)
+    expect(actual).toEqual({
+      crn: risks.crn,
+      flags: risks.flags.value,
+      mappa: {
+        lastUpdated: DateFormats.isoDateToUIDate(risks.mappa.value.lastUpdated),
+        level: 'CAT 2 / LEVEL 1',
+      },
+      roshRisks: {
+        lastUpdated: DateFormats.isoDateToUIDate(risks.roshRisks.value.lastUpdated),
+        overallRisk: risks.roshRisks.value.overallRisk,
+        riskToChildren: risks.roshRisks.value.riskToChildren,
+        riskToKnownAdult: risks.roshRisks.value.riskToKnownAdult,
+        riskToPublic: risks.roshRisks.value.riskToPublic,
+        riskToStaff: risks.roshRisks.value.riskToStaff,
+      },
+      tier: {
+        lastUpdated: DateFormats.isoDateToUIDate(risks.tier.value.lastUpdated),
+        level: risks.tier.value.level,
+      },
+    })
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,4 +1,5 @@
-import type { SummaryListItem, Application } from 'approved-premises'
+import type { SummaryListItem, Application, PersonRisksUI, PersonRisks } from 'approved-premises'
+import { DateFormats } from './dateUtils'
 import { SessionDataError } from './errors'
 
 /* istanbul ignore next */
@@ -71,4 +72,23 @@ export const removeBlankSummaryListItems = (items: Array<SummaryListItem>): Arra
     }
     return false
   })
+}
+
+export const mapApiPersonRisksForUi = (risks: PersonRisks): PersonRisksUI => {
+  return {
+    ...risks,
+    roshRisks: {
+      ...risks.roshRisks.value,
+      lastUpdated: DateFormats.isoDateToUIDate(risks.roshRisks.value.lastUpdated),
+    },
+    mappa: {
+      ...risks.mappa.value,
+      lastUpdated: DateFormats.isoDateToUIDate(risks.mappa.value.lastUpdated),
+    },
+    tier: {
+      ...risks.tier.value,
+      lastUpdated: DateFormats.isoDateToUIDate(risks.tier.value.lastUpdated),
+    },
+    flags: risks.flags.value,
+  }
 }

--- a/server/views/applications/components/riskWidgets/macro.njk
+++ b/server/views/applications/components/riskWidgets/macro.njk
@@ -1,0 +1,3 @@
+{% macro widgets(params) %}
+    {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/applications/components/riskWidgets/mappa-widget/macro.njk
+++ b/server/views/applications/components/riskWidgets/mappa-widget/macro.njk
@@ -1,0 +1,3 @@
+{% macro mappaWidget(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/applications/components/riskWidgets/mappa-widget/template.njk
+++ b/server/views/applications/components/riskWidgets/mappa-widget/template.njk
@@ -1,0 +1,5 @@
+<div class="mappa-widget">
+    <h3 class="govuk-heading-m"><strong>{{ params.level | default("NO", true) }}</strong> MAPPA</h3>
+    <p class="govuk-body-m">Multi-agency public protection arrangements</p>
+    {% if params.level %}<p class="govuk-hint govuk-body-m">Last updated: {{ params.lastUpdated | default("Not known") }}</p>{% endif %}
+</div>

--- a/server/views/applications/components/riskWidgets/risk-flag-widget/macro.njk
+++ b/server/views/applications/components/riskWidgets/risk-flag-widget/macro.njk
@@ -1,0 +1,3 @@
+{% macro riskFlagWidget(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/applications/components/riskWidgets/risk-flag-widget/template.njk
+++ b/server/views/applications/components/riskWidgets/risk-flag-widget/template.njk
@@ -1,0 +1,13 @@
+<div class="risk-flag-widget">
+    <h3 class="govuk-heading-m">Delius risk flags (registers)</h3>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    {% if params %}
+        <ul class="govuk-list">
+            {% for risk in params %}
+                <li>{{ risk }}</li>
+            {% endfor %}
+        </ul>
+    {% else %}
+        <p>No risks</p>
+    {% endif %}
+</div>

--- a/server/views/applications/components/riskWidgets/rosh-widget/macro.njk
+++ b/server/views/applications/components/riskWidgets/rosh-widget/macro.njk
@@ -1,0 +1,3 @@
+{% macro roshWidget(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/applications/components/riskWidgets/rosh-widget/template.njk
+++ b/server/views/applications/components/riskWidgets/rosh-widget/template.njk
@@ -1,0 +1,78 @@
+{% macro getOverallRiskLevelClass(level) %}
+    {% if level == 'Very High' %}
+rosh-widget--very-high
+{% elif level == 'High' %}
+rosh-widget--high
+{% elif level == 'Medium' %}
+rosh-widget--medium
+{% elif level == 'Low' %}
+rosh-widget--low
+{% endif %}
+{% endmacro %}
+
+{% macro getRiskLevelText(level) %}
+    {% if level == 'Very High' %}
+Very high
+{% elif level == 'High' %}
+High
+{% elif level == 'Medium' %}
+Medium
+{% elif level == 'Low' %}
+Low
+{% endif %}
+{% endmacro %}
+
+{% macro getRiskLevelClass(level) %}
+    {% if level == 'Very High' %}
+rosh-widget__risk--very-high
+{% elif level == 'High' %}
+rosh-widget__risk--high
+{% elif level == 'Medium' %}
+rosh-widget__risk--medium
+{% elif level == 'Low' %}
+rosh-widget__risk--low
+{% endif %}
+{% endmacro %}
+
+{% if params and params.overallRisk %}
+    <div class="rosh-widget {{ getOverallRiskLevelClass(params.overallRisk) }}">
+        <h3 class="govuk-heading-m">
+            <strong>{{ getRiskLevelText(params.overallRisk) | upper }}</strong> RoSH</h3>
+        <p class="govuk-body-m">Risk of serious harm</p>
+        <p class="govuk-hint govuk-body-m">Last updated: {{ params.lastUpdated | default("Not known") }}</p>
+
+        <table class="govuk-table rosh-widget__table">
+            <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                    <th class="govuk-table__header">Risk to</th>
+                    <th class="govuk-table__header">Community</th>
+                </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+                <tr class="govuk-table__row">
+                    <th class="govuk-table__header">Children</th>
+                    <td class="govuk-table__cell {{ getRiskLevelClass(params.riskToChildren) }}">{{ getRiskLevelText(params.riskToChildren) | default("No data") }}</td>
+                </tr>
+                <tr>
+                    <th class="govuk-table__header">Public</th>
+                    <td class="govuk-table__cell {{ getRiskLevelClass(params.riskToPublic) }}">{{ getRiskLevelText(params.riskToPublic) | default("No data") }}</td>
+                </tr>
+                <tr>
+                    <th class="govuk-table__header">Known adult</th>
+                    <td class="govuk-table__cell {{ getRiskLevelClass(params.riskToKnownAdult) }}">{{ getRiskLevelText(params.riskToKnownAdult) | default("No data") }}</td>
+                </tr>
+                <tr>
+                    <th class="govuk-table__header">Staff</th>
+                    <td class="govuk-table__cell {{ getRiskLevelClass(params.riskToStaff) }}">{{ getRiskLevelText(params.riskToStaff) | default("No data") }}</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+{% else %}
+    <div class="rosh-widget {{ roshWidgetClass }}">
+        <h3 class="govuk-heading-m">
+            <strong>NO</strong> RoSH</h3>
+        <p class="govuk-body-m">Risk of serious harm</p>
+        <p class="govuk-hint govuk-body-m">A RoSH has not been completed for this individual.</p>
+    </div>
+{% endif %}

--- a/server/views/applications/components/riskWidgets/template.njk
+++ b/server/views/applications/components/riskWidgets/template.njk
@@ -1,0 +1,9 @@
+{% from "./rosh-widget/macro.njk" import roshWidget %}
+{% from "./mappa-widget/macro.njk" import mappaWidget %}
+{% from "./tier-widget/macro.njk" import tierWidget %}
+{% from "./risk-flag-widget/macro.njk" import riskFlagWidget %}
+
+{{ roshWidget(params.roshRisks) }}
+{{ mappaWidget(params.mappa) }}
+{{ tierWidget(params.tier)}}
+{{ riskFlagWidget(params.flags)}}

--- a/server/views/applications/components/riskWidgets/tier-widget/macro.njk
+++ b/server/views/applications/components/riskWidgets/tier-widget/macro.njk
@@ -1,0 +1,3 @@
+{% macro tierWidget(params) %}
+    {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/applications/components/riskWidgets/tier-widget/template.njk
+++ b/server/views/applications/components/riskWidgets/tier-widget/template.njk
@@ -1,0 +1,8 @@
+<div class="tier-widget">
+    <h3 class="govuk-heading-m">
+        <strong>TIER {{ params.level }}</strong>
+    </h3>
+    {% if params.level %}
+        <p class="govuk-hint govuk-body-m">Last updated: {{ params.lastUpdated | default("Not known") }}</p>
+    {% endif %}
+</div>

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -3,6 +3,8 @@
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
+{% from "./components/riskWidgets/macro.njk" import widgets %}
+
 {% extends "../partials/layout.njk" %}
 
 {% block pageTitle %}
@@ -11,13 +13,16 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-width-container">
       <h1 class="govuk-heading-xl">
         Apply for an approved premises (AP) placement
       </h1>
 
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Application incomplete</h2>
       <p class="govuk-body govuk-!-margin-bottom-7">You have completed 3 of 8 sections.</p>
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
 
       <ol class="app-task-list">
         <li>
@@ -189,6 +194,9 @@
 
     </div>
 
+    <div class="govuk-grid-column-one-third">
+      {{ widgets(risks) }}
+    </div>
     <div class="risk-information">
       <div class="govuk-grid-column-one-third"></div>
     </div>

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -164,8 +164,8 @@
           </h2>
 
           {{ govukCheckboxes({
-            idPrefix: "waste",
-            name: "waste",
+            idPrefix: "confirmation",
+            name: "confirmation",
             items: [
               {
                 value: "submit",


### PR DESCRIPTION
# Context
Applicants need to be able to see the risk widgets on the page
[Trello ticket](https://trello.com/c/2QdcWtlh/750-frontend-for-risk-widgets)

Helpfully these widgets already exist and we just have to pull them in with minor tweaks: https://github.com/ministryofjustice/hmpps-risk-ui-elements/

## Changes in this PR

As the risks relate to a Person we use the Person service and client to make the call to the API from the Applications controller.

## Screenshots of UI changes

### Before
![image](https://user-images.githubusercontent.com/44123869/195632963-6acd4442-2d8f-4afc-ad99-938553e12bd4.png)

### After
![image](https://user-images.githubusercontent.com/44123869/195635064-d455d00c-e148-4165-bd6c-3410c54dd742.png)
