### PR TITLE
(791) Add translations for apply questions/answers

### DIFF
--- a/doc/architecture/decisions/0005-persist-submitted-documents-in-translated-json.md
+++ b/doc/architecture/decisions/0005-persist-submitted-documents-in-translated-json.md
@@ -1,0 +1,51 @@
+# 5. Persist Submitted Documents in Translated JSON
+
+Date: 2022-10-17
+
+## Status
+
+Accepted
+
+## Context
+
+We need to ensure that submitted and assessed Applications are
+reliably persisted as permanent read-only artefacts. We know that they will
+have an enduring role as a snapshot of an individual's AP-related risks and
+needs at a point in time. The application, along with the content added during
+the assessment stage will be an important reference document at every stage
+in the lifecycle of person's relationship with the probation service.
+
+Throughout the lifecycle of the product, it is expected that the questions will
+change, so it is important that we ensure that any changes made to the questions
+still mean that older Applications are still readable with the questions as
+they were when the application was completed.
+
+## Decision
+
+At the moment, an application has a `data` field that contains the application
+in a machine-readable format (i.e with questions and things like radio and
+checkbox answers as as single-character keys). In addition to this, we also
+propose  that a "translated" JSON version of the "check your answers" review stage may be a good solution. Our questionnaire hierarchy of:
+
+```text
+Sections
+  > Tasks
+    > Pages
+      > Questions
+```
+
+can be represented in JSON hierarchy, and be "re-hydrated" back into a summary
+screen consisting of nested questions and answers similar to the long "check
+your answers" pages planned for the Apply and Assess stages. These JSON
+documents would be marshalled by the Node app when the Application and the
+Assessment are complete and "submitted". The API would persist them in a
+dedicated field e.g. Application#document - distinct from the working data at
+Application#data.
+
+## Consequences
+
+This will ensure that we have a clear record of the answers that were given at
+the time, without having to maintain a list of translations for older versions
+of the questionnaire. This will also make playing back the answers at the
+"Check your answers" and assessment stages easier, as we will already have the
+translated questionnaire persisted.

--- a/server/form-pages/apply/basic-information/oralHearing.test.ts
+++ b/server/form-pages/apply/basic-information/oralHearing.test.ts
@@ -112,4 +112,34 @@ describe('OralHearing', () => {
       ])
     })
   })
+
+  describe('response', () => {
+    it('should return a translated version of the response when the user does not know the oral hearing date', () => {
+      const page = new OralHearing(
+        {
+          knowOralHearingDate: 'no',
+        },
+        application,
+      )
+
+      expect(page.response()).toEqual({
+        [page.title]: 'No',
+      })
+    })
+
+    it('should return a translated version of the response when the start date is not the same as the release date', () => {
+      const page = new OralHearing(
+        {
+          knowOralHearingDate: 'yes',
+          oralHearingDate: '2022-11-11T00:00:00.000Z',
+        },
+        application,
+      )
+
+      expect(page.response()).toEqual({
+        [page.title]: 'Yes',
+        'Oral Hearing Date': 'Friday 11 November 2022',
+      })
+    })
+  })
 })

--- a/server/form-pages/apply/basic-information/oralHearing.ts
+++ b/server/form-pages/apply/basic-information/oralHearing.ts
@@ -1,7 +1,8 @@
 import type { ObjectWithDateParts, YesOrNo, Application } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
-import { dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../utils/dateUtils'
+import { dateAndTimeInputsAreValidDates, dateIsBlank, DateFormats } from '../../../utils/dateUtils'
+import { convertToTitleCase } from '../../../utils/utils'
 
 export default class OralHearing implements TasklistPage {
   name = 'oral-hearing'
@@ -17,6 +18,7 @@ export default class OralHearing implements TasklistPage {
       'oralHearingDate-year': body['oralHearingDate-year'] as string,
       'oralHearingDate-month': body['oralHearingDate-month'] as string,
       'oralHearingDate-day': body['oralHearingDate-day'] as string,
+      oralHearingDate: body.oralHearingDate as string,
       knowOralHearingDate: body.knowOralHearingDate as YesOrNo,
     }
   }
@@ -27,6 +29,18 @@ export default class OralHearing implements TasklistPage {
 
   previous() {
     return 'release-date'
+  }
+
+  response() {
+    const response = {
+      [this.title]: convertToTitleCase(this.body.knowOralHearingDate),
+    } as Record<string, string>
+
+    if (this.body.knowOralHearingDate === 'yes') {
+      response['Oral Hearing Date'] = DateFormats.isoDateToUIDate(this.body.oralHearingDate)
+    }
+
+    return response
   }
 
   errors() {

--- a/server/form-pages/apply/basic-information/placementDate.test.ts
+++ b/server/form-pages/apply/basic-information/placementDate.test.ts
@@ -105,4 +105,34 @@ describe('PlacementDate', () => {
       ])
     })
   })
+
+  describe('response', () => {
+    it('should return a translated version of the response when the start date is the same as the release date', () => {
+      const page = new PlacementDate(
+        {
+          startDateSameAsReleaseDate: 'yes',
+        },
+        application,
+      )
+
+      expect(page.response()).toEqual({
+        [page.title]: 'Yes',
+      })
+    })
+
+    it('should return a translated version of the response when the start date is not the same as the release date', () => {
+      const page = new PlacementDate(
+        {
+          startDateSameAsReleaseDate: 'no',
+          startDate: '2022-11-11T00:00:00.000Z',
+        },
+        application,
+      )
+
+      expect(page.response()).toEqual({
+        [page.title]: 'No',
+        'Placement Start Date': 'Friday 11 November 2022',
+      })
+    })
+  })
 })

--- a/server/form-pages/apply/basic-information/placementDate.ts
+++ b/server/form-pages/apply/basic-information/placementDate.ts
@@ -1,7 +1,7 @@
 import type { ObjectWithDateParts, YesOrNo, Application } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
-import { retrieveQuestionResponseFromApplication } from '../../../utils/utils'
+import { retrieveQuestionResponseFromApplication, convertToTitleCase } from '../../../utils/utils'
 import { dateIsBlank, dateAndTimeInputsAreValidDates, DateFormats } from '../../../utils/dateUtils'
 
 export default class PlacementDate implements TasklistPage {
@@ -18,6 +18,7 @@ export default class PlacementDate implements TasklistPage {
       'startDate-year': body['startDate-year'] as string,
       'startDate-month': body['startDate-month'] as string,
       'startDate-day': body['startDate-day'] as string,
+      startDate: body.startDate as string,
       startDateSameAsReleaseDate: body.startDateSameAsReleaseDate as YesOrNo,
     }
 
@@ -34,6 +35,18 @@ export default class PlacementDate implements TasklistPage {
 
   previous() {
     return 'oral-hearing'
+  }
+
+  response() {
+    const response = {
+      [this.title]: convertToTitleCase(this.body.startDateSameAsReleaseDate),
+    } as Record<string, string>
+
+    if (this.body.startDateSameAsReleaseDate === 'no') {
+      response['Placement Start Date'] = DateFormats.isoDateToUIDate(this.body.startDate)
+    }
+
+    return response
   }
 
   errors() {

--- a/server/form-pages/apply/basic-information/releaseDate.test.ts
+++ b/server/form-pages/apply/basic-information/releaseDate.test.ts
@@ -126,4 +126,36 @@ describe('ReleaseDate', () => {
       ])
     })
   })
+
+  describe('response', () => {
+    it('should return a translated version of the response when the user does not know the release date', () => {
+      const page = new ReleaseDate(
+        {
+          knowReleaseDate: 'no',
+        },
+        application,
+        'somePage',
+      )
+
+      expect(page.response()).toEqual({
+        [page.title]: 'No',
+      })
+    })
+
+    it('should return a translated version of the response when the user knows the release date', () => {
+      const page = new ReleaseDate(
+        {
+          knowReleaseDate: 'yes',
+          releaseDate: '2022-11-11T00:00:00.000Z',
+        },
+        application,
+        'somePage',
+      )
+
+      expect(page.response()).toEqual({
+        [page.title]: 'Yes',
+        'Release Date': 'Friday 11 November 2022',
+      })
+    })
+  })
 })

--- a/server/form-pages/apply/basic-information/releaseDate.ts
+++ b/server/form-pages/apply/basic-information/releaseDate.ts
@@ -1,7 +1,8 @@
 import type { ObjectWithDateParts, YesOrNo, Application } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
-import { dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../utils/dateUtils'
+import { dateAndTimeInputsAreValidDates, dateIsBlank, DateFormats } from '../../../utils/dateUtils'
+import { convertToTitleCase } from '../../../utils/utils'
 
 export default class ReleaseDate implements TasklistPage {
   name = 'release-date'
@@ -19,6 +20,7 @@ export default class ReleaseDate implements TasklistPage {
       'releaseDate-year': body['releaseDate-year'] as string,
       'releaseDate-month': body['releaseDate-month'] as string,
       'releaseDate-day': body['releaseDate-day'] as string,
+      releaseDate: body.releaseDate as string,
       knowReleaseDate: body.knowReleaseDate as YesOrNo,
     }
 
@@ -31,6 +33,18 @@ export default class ReleaseDate implements TasklistPage {
 
   previous() {
     return this.previousPage
+  }
+
+  response() {
+    const response = {
+      [this.title]: convertToTitleCase(this.body.knowReleaseDate),
+    } as Record<string, string>
+
+    if (this.body.knowReleaseDate === 'yes') {
+      response['Release Date'] = DateFormats.isoDateToUIDate(this.body.releaseDate)
+    }
+
+    return response
   }
 
   errors() {

--- a/server/form-pages/apply/basic-information/releaseType.test.ts
+++ b/server/form-pages/apply/basic-information/releaseType.test.ts
@@ -110,4 +110,14 @@ describe('ReleaseType', () => {
       expect(selectedOptions.length).toEqual(0)
     })
   })
+
+  describe('response', () => {
+    it('should return a translated version of the response', () => {
+      const page = new ReleaseType({ releaseType: 'rotl' }, application)
+
+      expect(page.response()).toEqual({
+        [page.title]: 'Release on Temporary License (ROTL)',
+      })
+    })
+  })
 })

--- a/server/form-pages/apply/basic-information/releaseType.ts
+++ b/server/form-pages/apply/basic-information/releaseType.ts
@@ -20,7 +20,7 @@ type SentenceType = Extract<SentenceTypesT, 'standardDeterminate' | 'extendedDet
 export default class ReleaseType implements TasklistPage {
   name = 'release-type'
 
-  title = 'What type of release will the application support'
+  title = 'What type of release will the application support?'
 
   body: { releaseType: keyof (AllReleaseTypes | ReducedReleaseTypes) }
 
@@ -46,6 +46,10 @@ export default class ReleaseType implements TasklistPage {
 
   previous() {
     return 'sentence-type'
+  }
+
+  response() {
+    return { [this.title]: allReleaseTypes[this.body.releaseType] }
   }
 
   errors() {

--- a/server/form-pages/apply/basic-information/sentenceType.test.ts
+++ b/server/form-pages/apply/basic-information/sentenceType.test.ts
@@ -82,4 +82,12 @@ describe('SentenceType', () => {
       expect(selectedOptions.length).toEqual(0)
     })
   })
+
+  describe('response', () => {
+    it('should return a translated version of the response', () => {
+      const page = new SentenceType({ sentenceType: 'life' })
+
+      expect(page.response()).toEqual({ [page.title]: 'Life sentence' })
+    })
+  })
 })

--- a/server/form-pages/apply/basic-information/sentenceType.ts
+++ b/server/form-pages/apply/basic-information/sentenceType.ts
@@ -25,6 +25,10 @@ export default class SentenceType implements TasklistPage {
     }
   }
 
+  response() {
+    return { [this.title]: sentenceTypes[this.body.sentenceType] }
+  }
+
   next() {
     switch (this.body.sentenceType) {
       case 'standardDeterminate':

--- a/server/form-pages/apply/basic-information/situation.test.ts
+++ b/server/form-pages/apply/basic-information/situation.test.ts
@@ -91,4 +91,14 @@ describe('Situation', () => {
       expect(selectedOptions.length).toEqual(0)
     })
   })
+
+  describe('response', () => {
+    it('should return a translated version of the response', () => {
+      const page = new Situation({ situation: 'riskManagement' }, application)
+
+      expect(page.response()).toEqual({
+        [page.title]: 'Referral for risk management',
+      })
+    })
+  })
 })

--- a/server/form-pages/apply/basic-information/situation.ts
+++ b/server/form-pages/apply/basic-information/situation.ts
@@ -47,6 +47,10 @@ export default class Situation implements TasklistPage {
     return 'sentence-type'
   }
 
+  response() {
+    return { [`${this.title}`]: situations[this.body.situation] }
+  }
+
   errors() {
     const errors = []
 

--- a/server/form-pages/apply/type-of-ap/apType.test.ts
+++ b/server/form-pages/apply/type-of-ap/apType.test.ts
@@ -66,4 +66,14 @@ describe('ApType', () => {
       expect(convertKeyValuePairToRadioItems).toHaveBeenCalled()
     })
   })
+
+  describe('response', () => {
+    it('should return a translated version of the response', () => {
+      const page = new ApType({ type: 'pipe' }, application)
+
+      expect(page.response()).toEqual({
+        [page.title]: 'PIPE (physcologically informed planned environment)',
+      })
+    })
+  })
 })

--- a/server/form-pages/apply/type-of-ap/apType.ts
+++ b/server/form-pages/apply/type-of-ap/apType.ts
@@ -35,6 +35,10 @@ export default class ApType implements TasklistPage {
     return null
   }
 
+  response() {
+    return { [`${this.title}`]: apTypes[this.body.type] }
+  }
+
   errors() {
     const errors = []
 

--- a/server/form-pages/apply/type-of-ap/pipeOpdScreening.test.ts
+++ b/server/form-pages/apply/type-of-ap/pipeOpdScreening.test.ts
@@ -1,36 +1,72 @@
 import { itShouldHavePreviousValue } from '../../shared-examples'
 
 import PipeOpdScreening from './pipeOpdScreening'
+import applicationFactory from '../../../testutils/factories/application'
 
 describe('PipeOpdScreening', () => {
+  const application = applicationFactory.build()
+
   describe('body', () => {
     it('should strip unknown attributes from the body', () => {
-      const page = new PipeOpdScreening({
-        pipeReferral: 'yes',
-        pipeReferralMoreDetail: 'More detail',
-        something: 'else',
-      })
+      const page = new PipeOpdScreening(
+        {
+          pipeReferral: 'yes',
+          pipeReferralMoreDetail: 'More detail',
+          something: 'else',
+        },
+        application,
+      )
 
       expect(page.body).toEqual({ pipeReferral: 'yes', pipeReferralMoreDetail: 'More detail' })
     })
   })
 
-  itShouldHavePreviousValue(new PipeOpdScreening({}), 'pipe-referral')
+  itShouldHavePreviousValue(new PipeOpdScreening({}, application), 'pipe-referral')
 
   describe('errors', () => {
     it('should return an empty array if the pipeReferral is populated', () => {
-      const page = new PipeOpdScreening({ pipeReferral: 'yes' })
+      const page = new PipeOpdScreening({ pipeReferral: 'yes' }, application)
       expect(page.errors()).toEqual([])
     })
 
     it('should return an errors if the pipeReferral is not populated', () => {
-      const page = new PipeOpdScreening({ pipeReferral: '' })
+      const page = new PipeOpdScreening({ pipeReferral: '' }, application)
       expect(page.errors()).toEqual([
         {
           propertyName: '$.pipeReferral',
           errorType: 'empty',
         },
       ])
+    })
+  })
+
+  describe('response', () => {
+    it('should return a translated version of the response when the user has answered "no" to the `pipeReferral` question', () => {
+      const page = new PipeOpdScreening(
+        {
+          pipeReferral: 'no',
+        },
+        application,
+      )
+
+      expect(page.response()).toEqual({
+        [page.title]: 'No',
+      })
+    })
+
+    it('should return a translated version of the response when the user has answered "yes" to the `pipeReferral` question', () => {
+      const page = new PipeOpdScreening(
+        {
+          pipeReferral: 'yes',
+          pipeReferralMoreDetail: 'Some Text',
+        },
+        application,
+      )
+
+      expect(page.response()).toEqual({
+        [page.title]: 'Yes',
+        [`Additional detail about why ${application.person.name} needs a PIPE placement.`]: 'Some Text',
+      })
     })
   })
 })

--- a/server/form-pages/apply/type-of-ap/pipeOpdScreening.ts
+++ b/server/form-pages/apply/type-of-ap/pipeOpdScreening.ts
@@ -1,6 +1,7 @@
-import type { YesOrNo } from 'approved-premises'
+import type { Application, YesOrNo } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
+import { convertToTitleCase } from '../../../utils/utils'
 
 export default class PipeOpdReferral implements TasklistPage {
   name = 'pipe-opd-screening'
@@ -9,7 +10,7 @@ export default class PipeOpdReferral implements TasklistPage {
 
   body: { pipeReferral: YesOrNo; pipeReferralMoreDetail: string }
 
-  constructor(body: Record<string, unknown>) {
+  constructor(body: Record<string, unknown>, private readonly application: Application) {
     this.body = {
       pipeReferral: body.pipeReferral as YesOrNo,
       pipeReferralMoreDetail: body.pipeReferralMoreDetail as string,
@@ -18,6 +19,19 @@ export default class PipeOpdReferral implements TasklistPage {
 
   previous() {
     return 'pipe-referral'
+  }
+
+  response() {
+    const response = {
+      [this.title]: convertToTitleCase(this.body.pipeReferral),
+    } as Record<string, string>
+
+    if (this.body.pipeReferral === 'yes') {
+      response[`Additional detail about why ${this.application.person.name} needs a PIPE placement.`] =
+        this.body.pipeReferralMoreDetail
+    }
+
+    return response
   }
 
   errors() {

--- a/server/form-pages/apply/type-of-ap/pipeReferral.test.ts
+++ b/server/form-pages/apply/type-of-ap/pipeReferral.test.ts
@@ -113,4 +113,34 @@ describe('PipeReferral', () => {
       ])
     })
   })
+
+  describe('response', () => {
+    it('should return a translated version of the response when opdPathway is "no"', () => {
+      const page = new PipeReferral(
+        {
+          opdPathway: 'no',
+        },
+        application,
+      )
+
+      expect(page.response()).toEqual({
+        [page.title]: 'No',
+      })
+    })
+
+    it('should return a translated version of the response when opdPathway is "yes"', () => {
+      const page = new PipeReferral(
+        {
+          opdPathway: 'yes',
+          opdPathwayDate: '2022-11-11T00:00:00.000Z',
+        },
+        application,
+      )
+
+      expect(page.response()).toEqual({
+        [page.title]: 'Yes',
+        'OPD Pathway Screening Date': 'Friday 11 November 2022',
+      })
+    })
+  })
 })

--- a/server/form-pages/apply/type-of-ap/pipeReferral.ts
+++ b/server/form-pages/apply/type-of-ap/pipeReferral.ts
@@ -1,7 +1,8 @@
 import type { YesOrNo, ObjectWithDateParts, Application } from 'approved-premises'
 
 import TasklistPage from '../../tasklistPage'
-import { dateIsBlank, dateAndTimeInputsAreValidDates } from '../../../utils/dateUtils'
+import { convertToTitleCase } from '../../../utils/utils'
+import { dateIsBlank, dateAndTimeInputsAreValidDates, DateFormats } from '../../../utils/dateUtils'
 
 export default class PipeReferral implements TasklistPage {
   name = 'pipe-referral'
@@ -15,6 +16,7 @@ export default class PipeReferral implements TasklistPage {
       'opdPathwayDate-year': body['opdPathwayDate-year'] as string,
       'opdPathwayDate-month': body['opdPathwayDate-month'] as string,
       'opdPathwayDate-day': body['opdPathwayDate-day'] as string,
+      opdPathwayDate: body.opdPathwayDate as string,
       opdPathway: body.opdPathway as YesOrNo,
     }
   }
@@ -25,6 +27,18 @@ export default class PipeReferral implements TasklistPage {
 
   previous() {
     return 'ap-type'
+  }
+
+  response() {
+    const response = {
+      [this.title]: convertToTitleCase(this.body.opdPathway),
+    } as Record<string, string>
+
+    if (this.body.opdPathway === 'yes') {
+      response['OPD Pathway Screening Date'] = DateFormats.isoDateToUIDate(this.body.opdPathwayDate)
+    }
+
+    return response
   }
 
   errors() {

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -313,4 +313,25 @@ describe('ApplicationService', () => {
       })
     })
   })
+
+  describe('getResponses', () => {
+    it('returns the responses from all answered questions', () => {
+      FirstPage.mockReturnValue({
+        response: () => {
+          return { foo: 'bar' }
+        },
+      })
+
+      SecondPage.mockReturnValue({
+        response: () => {
+          return { bar: 'foo' }
+        },
+      })
+
+      const application = applicationFactory.build()
+      application.data = { 'my-task': { first: '', second: '' } }
+
+      expect(service.getResponses(application)).toEqual({ 'my-task': [{ foo: 'bar' }, { bar: 'foo' }] })
+    })
+  })
 })


### PR DESCRIPTION
This adds a new `response` method to each page to get an English translation in a key/value format of each response to each question. We can then build this up by mapping the question data, initialising the Page object, and calling our `response` method. This will result in something like this:

```json
{
    "basic-information": {
        "sentence-type": {
            "sentenceType": "bailPlacement"
        },
        "situation": {
            "situation": "bailAssessment"
        },
        "release-date": {
            "releaseDate-year": "2022",
            "releaseDate-month": "11",
            "releaseDate-day": "11",
            "releaseDate": "2022-11-11T00:00:00.000Z",
            "knowReleaseDate": "yes"
        },
        "placement-date": {
            "startDate-year": "2022",
            "startDate-month": "3",
            "startDate-day": "27",
            "startDate": "2022-03-27T00:00:00.000Z",
            "startDateSameAsReleaseDate": "no"
        }
    },
    "type-of-ap": {
        "ap-type": {
            "type": "pipe"
        },
        "pipe-referral": {
            "opdPathwayDate-year": "2022",
            "opdPathwayDate-month": "11",
            "opdPathwayDate-day": "11",
            "opdPathwayDate": "2022-11-11T00:00:00.000Z",
            "opdPathway": "yes"
        },
        "pipe-opd-screening": {
            "pipeReferral": "yes",
            "pipeReferralMoreDetail": "sdfsdfsdfsd"
        }
    }
}
```

Becoming something like this:

```json
{
	"basic-information": [{
			"Which of the following best describes the sentence type?": "Bail placement"
		},
		{
			"Which of the following options best describes the situation?": "Bail assessment for community penalty"
		},
		{
			"Do you know Aadland Bertrand’s release date?": "Yes",
			"Release Date": "Friday 11 November 2022"
		},
		{
			"Is Friday 11 November 2022 the date you want the placement to start?": "No",
			"Placement Start Date": "Sunday 27 March 2022"
		}
	],
	"type-of-ap": [{
			"Which type of AP does Aadland Bertrand require?": "PIPE (physcologically informed planned environment)"
		},
		{
			"Has Aadland Bertrand been screened into the OPD pathway?": "Yes",
			"OPD Pathway Screening Date": "Friday 11 November 2022"
		},
		{
			"Has a referral for PIPE placement been recommended in the OPD pathway plan?": "Yes",
			"Additional detail about why Aadland Bertrand needs a PIPE placement.": "sdfsdfsdfsd"
		}
	]
}
```

This isn't currently used anywhere, but we'll use it at the end of the application process, as well as in the Check Your Answers page