### PR TITLE
[TA] (417) A user can view information about a property

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/premisesList.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesList.ts
@@ -31,4 +31,12 @@ export default class PremisesListPage extends Page {
   clickAddPremisesButton() {
     cy.get('a').contains('Add a new property').click()
   }
+
+  clickPremisesViewLink(premises: Premises) {
+    cy.contains(premises.name)
+      .parent()
+      .within(() => {
+        cy.get('td').eq(2).contains('View').click()
+      })
+  }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
@@ -1,0 +1,37 @@
+import type { Premises } from 'approved-premises'
+
+import Page from '../../page'
+import paths from '../../../../server/paths/temporary-accommodation/manage'
+
+export default class PremisesShowPage extends Page {
+  constructor(private readonly premises: Premises) {
+    super(premises.name)
+  }
+
+  static visit(premises: Premises): PremisesShowPage {
+    cy.visit(paths.premises.show({ premisesId: premises.id }))
+    return new PremisesShowPage(premises)
+  }
+
+  shouldShowPremisesDetail(): void {
+    cy.get('.govuk-summary-list__key')
+      .contains('Code')
+      .siblings('.govuk-summary-list__value')
+      .should('contain', this.premises.apCode)
+
+    cy.get('.govuk-summary-list__key')
+      .contains('Postcode')
+      .siblings('.govuk-summary-list__value')
+      .should('contain', this.premises.postcode)
+
+    cy.get('.govuk-summary-list__key')
+      .contains('Number of Beds')
+      .siblings('.govuk-summary-list__value')
+      .should('contain', this.premises.bedCount)
+
+    cy.get('.govuk-summary-list__key')
+      .contains('Available Beds')
+      .siblings('.govuk-summary-list__value')
+      .should('contain', this.premises.availableBedsForToday)
+  }
+}

--- a/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
@@ -3,6 +3,7 @@ import newPremisesFactory from '../../../../server/testutils/factories/newPremis
 import PremisesNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesNew'
 import PremisesListPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesList'
 import Page from '../../../../cypress_shared/pages/page'
+import PremisesShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesShow'
 
 context('Premises', () => {
   beforeEach(() => {
@@ -44,6 +45,25 @@ context('Premises', () => {
     Page.verifyOnPage(PremisesNewPage)
   })
 
+  it('should navigate to the show premises page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are premises in the database
+    const premises = premisesFactory.buildList(5)
+    cy.task('stubPremises', { premises, service: 'temporary-accommodation' })
+    cy.task('stubSinglePremises', premises[0])
+
+    // When I visit the premises page
+    const page = PremisesListPage.visit()
+
+    // Add I click the add a premises button
+    page.clickPremisesViewLink(premises[0])
+
+    // Then I navigate to the show premises page
+    Page.verifyOnPage(PremisesShowPage, premises[0])
+  })
+
   it('should allow me to create a premises', () => {
     // Given I am signed in
     cy.signIn()
@@ -80,7 +100,7 @@ context('Premises', () => {
     premisesNewPage.shouldShowBanner('Property created')
   })
 
-  it('should navigate back to the premises list page', () => {
+  it('should navigate back from the new premises page to the premises list page', () => {
     // Given I am signed in
     cy.signIn()
 
@@ -93,6 +113,40 @@ context('Premises', () => {
 
     // And I click the previous bread crumb
     page.clickBreadCrumbUp()
+
+    // Then I navigate to the premises list page
+    Page.verifyOnPage(PremisesListPage)
+  })
+
+  it('should show a single premises', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises in the database
+    const premises = premisesFactory.build()
+    cy.task('stubSinglePremises', premises)
+
+    // When I visit the show premises page
+    const page = PremisesShowPage.visit(premises)
+
+    // Then I should see the premises details shown
+    page.shouldShowPremisesDetail()
+  })
+
+  it('should navigate back from the show page to the premises list page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are premises in the database
+    const premises = premisesFactory.buildList(5)
+    cy.task('stubPremises', { premises, service: 'temporary-accommodation' })
+    cy.task('stubSinglePremises', premises[0])
+
+    // When I visit the show premises page
+    const page = PremisesShowPage.visit(premises[0])
+
+    // Add I click back
+    page.clickBack()
 
     // Then I navigate to the premises list page
     Page.verifyOnPage(PremisesListPage)

--- a/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
@@ -77,6 +77,7 @@ context('Premises', () => {
     })
 
     cy.task('stubPremisesCreate', premises)
+    cy.task('stubSinglePremises', premises)
 
     const page = PremisesNewPage.visit()
 
@@ -95,8 +96,8 @@ context('Premises', () => {
       expect(requestBody.notes.replaceAll('\r\n', '\n')).equal(newPremises.notes)
     })
 
-    // And I should be redirected to the new premises page
-    const premisesNewPage = PremisesNewPage.verifyOnPage(PremisesNewPage)
+    // And I should be redirected to the show premises page
+    const premisesNewPage = PremisesNewPage.verifyOnPage(PremisesShowPage, premises)
     premisesNewPage.shouldShowBanner('Property created')
   })
 

--- a/server/controllers/temporary-accommodation/manage/premisesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.test.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 
+import type { SummaryListItem } from 'approved-premises'
 import premisesFactory from '../../../testutils/factories/premises'
 import PremisesService from '../../../services/premisesService'
 import PremisesController from './premisesController'
@@ -103,6 +104,24 @@ describe('PremisesController', () => {
       await requestHandler(request, response, next)
 
       expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, paths.premises.new({}))
+    })
+  })
+
+  describe('show', () => {
+    it('should return the premises detail to the template', async () => {
+      const premises = { name: 'Some premises', summaryList: { rows: [] as Array<SummaryListItem> } }
+      premisesService.getPremisesDetails.mockResolvedValue(premises)
+
+      request.params.premisesId = 'some-uuid'
+
+      const requestHandler = premisesController.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/premises/show', {
+        premises,
+      })
+
+      expect(premisesService.getPremisesDetails).toHaveBeenCalledWith(token, 'some-uuid')
     })
   })
 })

--- a/server/controllers/temporary-accommodation/manage/premisesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.test.ts
@@ -63,7 +63,7 @@ describe('PremisesController', () => {
   })
 
   describe('create', () => {
-    it('creates a premises and redirects to the new premises page', async () => {
+    it('creates a premises and redirects to the show premises page', async () => {
       const requestHandler = premisesController.create()
 
       const premises = premisesFactory.build()
@@ -72,6 +72,8 @@ describe('PremisesController', () => {
         name: premises.name,
         postcode: premises.postcode,
       }
+
+      premisesService.create.mockResolvedValue(premises)
 
       await requestHandler(request, response, next)
 
@@ -82,7 +84,7 @@ describe('PremisesController', () => {
       })
 
       expect(request.flash).toHaveBeenCalledWith('success', 'Property created')
-      expect(response.redirect).toHaveBeenCalledWith(paths.premises.new({}))
+      expect(response.redirect).toHaveBeenCalledWith(paths.premises.show({ premisesId: premises.id }))
     })
 
     it('renders with errors if the API returns an error', async () => {

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -57,4 +57,14 @@ export default class PremisesController {
       }
     }
   }
+
+  show(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const premises = await this.premisesService.getPremisesDetails(req.user.token, req.params.premisesId)
+
+      return res.render('temporary-accommodation/premises/show', {
+        premises,
+      })
+    }
+  }
 }

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -48,10 +48,10 @@ export default class PremisesController {
       }
 
       try {
-        await this.premisesService.create(req.user.token, newPremises)
+        const { id: premisesId } = await this.premisesService.create(req.user.token, newPremises)
 
         req.flash('success', 'Property created')
-        res.redirect(paths.premises.new({}))
+        res.redirect(paths.premises.show({ premisesId }))
       } catch (err) {
         catchValidationErrorOrPropogate(req, res, err, paths.premises.new({}))
       }

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -6,9 +6,9 @@ const singlePremisesPath = premisesPath.path(':premisesId')
 const paths = {
   premises: {
     index: premisesPath,
-    show: singlePremisesPath,
     new: premisesPath.path('new'),
     create: premisesPath,
+    show: singlePremisesPath,
   },
 }
 

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -15,6 +15,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(paths.premises.index.pattern, premisesController.index())
   get(paths.premises.new.pattern, premisesController.new())
   post(paths.premises.create.pattern, premisesController.create())
+  get(paths.premises.show.pattern, premisesController.show())
 
   return router
 }

--- a/server/views/temporary-accommodation/premises/show.njk
+++ b/server/views/temporary-accommodation/premises/show.njk
@@ -1,0 +1,24 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + premises.name %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: paths.premises.index()
+  }) }}
+
+  {% include "../../_messages.njk" %}
+
+  <h1>{{ premises.name }}</h1>
+
+  {{
+    govukSummaryList(premises.summaryList)
+  }}
+
+{% endblock %}

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -77,7 +77,7 @@ stubs.push({
     headers: {
       'Content-Type': 'application/json;charset=UTF-8',
     },
-    jsonBody: premisesFactory.build(),
+    jsonBody: premises[0],
   },
 })
 


### PR DESCRIPTION
# Context

Trello [#417](https://trello.com/c/V3NEodde/417-a-user-can-view-information-about-a-property)

# Changes in this PR

* Adds a bare-bones premises information page, that can be reached from the premises listing, or by creating a new property

## Screenshots of UI changes

![localhost_3000_temporary-accommodation_properties_efd52239-f5cb-4b00-ab1a-9a4e3402fc58](https://user-images.githubusercontent.com/94137563/195644197-a10e7d75-31ee-4ac1-837e-76c9c909fdb1.png)

