### PR TITLE
Use extension of ARN Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,22 +1,3 @@
 {
-  "extends": ["config:base", ":disableDependencyDashboard", ":preserveSemverRanges"],
-  "assigneesFromCodeOwners": true,
-  "timezone": "Europe/London",
-  "schedule": ["after 9am every weekday", "before 5pm every weekday"],
-  "enabledManagers": ["npm", "nvm", "dockerfile", "docker-compose", "helmv3", "helm-values", "circleci"],
-  "packageRules": [
-    {
-      "matchManagers": ["npm"],
-      "matchUpdateTypes": ["minor"]
-    },
-    {
-      "matchDatasources": ["docker"],
-      "allowedVersions": "16.15.0-bullseye-slim"
-    },
-    {
-      "matchDatasources": ["docker-compose"],
-      "matchPackageNames": ["bitnami/redis"],
-      "allowedVersions": "5.0"
-    }
-  ]
+  "extends": ["github>ministryofjustice/arn-renovate-config"]
 }


### PR DESCRIPTION
[Renovate](https://github.com/renovatebot/renovate) has yet to issue any updates in the ~3 weeks we've had this config in place.
Various tweaks (#234 #241) haven't seem to have any effect so instead I propose extending our colleagues in the ARNS team's config in order to get some PRs coming through. If there are too many (or too few) updates we can tweak our settings from there but this should get us moving for now. 
