### PR TITLE
Allow convertObjectsToSelectOptions to take a prompt string

### DIFF
--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -186,7 +186,7 @@ describe('formUtils', () => {
     ]
 
     it('converts objects to an array of select options', () => {
-      const result = convertObjectsToSelectOptions(objects, 'name', 'id', 'field', {})
+      const result = convertObjectsToSelectOptions(objects, 'Select a keyworker', 'name', 'id', 'field', {})
 
       expect(result).toEqual([
         {
@@ -208,7 +208,9 @@ describe('formUtils', () => {
     })
 
     it('marks the object that is in the context as selected', () => {
-      const result = convertObjectsToSelectOptions(objects, 'name', 'id', 'field', { field: '123' })
+      const result = convertObjectsToSelectOptions(objects, 'Select a keyworker', 'name', 'id', 'field', {
+        field: '123',
+      })
 
       expect(result).toEqual([
         {

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -39,6 +39,7 @@ export const convertObjectsToRadioItems = (
 
 export const convertObjectsToSelectOptions = (
   items: Array<Record<string, string>>,
+  prompt: string,
   textKey: string,
   valueKey: string,
   fieldName: string,
@@ -47,7 +48,7 @@ export const convertObjectsToSelectOptions = (
   const options = [
     {
       value: '',
-      text: 'Select a keyworker',
+      text: prompt,
       selected: !context[fieldName] || context[fieldName] === '',
     },
   ]

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -79,11 +79,12 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
     'convertObjectsToSelectOptions',
     function sendContextConvertObjectsToSelectOptions(
       items: Array<Record<string, string>>,
+      prompt: string,
       textKey: string,
       valueKey: string,
       fieldName: string,
     ) {
-      return convertObjectsToSelectOptions(items, textKey, valueKey, fieldName, this.ctx)
+      return convertObjectsToSelectOptions(items, prompt, textKey, valueKey, fieldName, this.ctx)
     },
   )
 

--- a/server/views/arrivals/_arrival_form.njk
+++ b/server/views/arrivals/_arrival_form.njk
@@ -42,7 +42,7 @@
       classes: "govuk-input--width-20",
       id: "keyWorkerStaffId",
       name: "arrival[keyWorkerStaffId]",
-      items: convertObjectsToSelectOptions(staffMembers, 'name', 'id', 'keyWorkerStaffId'),
+      items: convertObjectsToSelectOptions(staffMembers, 'Select a keyworker', 'name', 'id', 'keyWorkerStaffId'),
       errorMessage: errors.keyWorkerStaffId
   }) }}
 


### PR DESCRIPTION
Previously this was hardcoded to 'Select a keyworker', but we want to use this function in other contexts, so allow this string to be specified by the caller