### PR TITLE
(629) Type of AP required screen: ESAP

### DIFF
--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -98,13 +98,19 @@ declare module 'approved-premises' {
     rows: Array<SummaryListItem>
   }
 
-  export interface RadioItems {
+  export interface RadioItem {
     text: string
     value: string
     checked?: boolean
   }
 
-  export interface SelectOptions {
+  export interface CheckBoxItem {
+    text: string
+    value: string
+    checked?: boolean
+  }
+
+  export interface SelectOption {
     text: string
     value: string
     selected?: boolean

--- a/server/form-pages/apply/type-of-ap/esapPlacementCCTV.test.ts
+++ b/server/form-pages/apply/type-of-ap/esapPlacementCCTV.test.ts
@@ -1,0 +1,154 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
+
+import EsapPlacementCCTV, { cctvHistory } from './esapPlacementCCTV'
+import applicationFactory from '../../../testutils/factories/application'
+import personFactory from '../../../testutils/factories/person'
+
+jest.mock('../../../utils/formUtils')
+
+describe('EsapPlacementCCTV', () => {
+  const application = applicationFactory.build()
+
+  describe('body', () => {
+    it('should strip unknown attributes from the body', () => {
+      const page = new EsapPlacementCCTV(
+        {
+          cctvHistory: ['prisonerAssualt'],
+          cctvIntelligence: 'yes',
+          cctvNotes: 'notes',
+          something: 'else',
+        },
+        application,
+      )
+
+      expect(page.body).toEqual({
+        cctvHistory: ['prisonerAssualt'],
+        cctvIntelligence: 'yes',
+        cctvNotes: 'notes',
+      })
+    })
+  })
+
+  itShouldHaveNextValue(new EsapPlacementCCTV({}, application), '')
+
+  describe('previous', () => {
+    describe('when the application has a previous response that includes `secreting`', () => {
+      beforeEach(() => {
+        application.data = {
+          'type-of-ap': {
+            'esap-placement-screening': {
+              esapReasons: ['cctv', 'secreting'],
+            },
+          },
+        }
+      })
+
+      itShouldHavePreviousValue(new EsapPlacementCCTV({}, application), 'esap-placement-secreting')
+    })
+
+    describe('when the application has a previous response does not include `secreting`', () => {
+      beforeEach(() => {
+        application.data = {
+          'type-of-ap': {
+            'esap-placement-screening': {
+              esapReasons: ['cctv'],
+            },
+          },
+        }
+      })
+
+      itShouldHavePreviousValue(new EsapPlacementCCTV({}, application), 'esap-placement-screening')
+    })
+  })
+
+  describe('response', () => {
+    it('should translate the response correctly', () => {
+      const person = personFactory.build({ name: 'John Wayne' })
+      const page = new EsapPlacementCCTV(
+        {
+          cctvHistory: ['prisonerAssualt'],
+          cctvIntelligence: 'yes',
+          cctvIntelligenceDetails: 'Some detail',
+          cctvNotes: 'notes',
+        },
+        applicationFactory.build({ person }),
+      )
+
+      expect(page.response()).toEqual({
+        'Which behaviours has John Wayne demonstrated that require enhanced CCTV provision to monitor?': [
+          'Physically assaulted other people in prison',
+        ],
+        'Have partnership agencies requested the sharing of intelligence captured via enhanced CCTV?': 'Yes',
+        'Provide details': 'Some detail',
+        'Provide any supporting information about why John Wayne requires enhanced CCTV provision': 'notes',
+      })
+    })
+  })
+
+  describe('errors', () => {
+    it('should return an empty array when `cctvHistory` and `cctvIntelligence` are defined', () => {
+      const page = new EsapPlacementCCTV(
+        {
+          cctvHistory: ['prisonerAssualt'],
+          cctvIntelligence: 'yes',
+          cctvIntelligenceDetails: 'Some detail',
+          cctvNotes: 'notes',
+        },
+        application,
+      )
+      expect(page.errors()).toEqual([])
+    })
+
+    it('should return error messages when `cctvHistory` and `cctvIntelligence` are undefined', () => {
+      const page = new EsapPlacementCCTV({}, application)
+      expect(page.errors()).toEqual([
+        {
+          propertyName: '$.cctvHistory',
+          errorType: 'empty',
+        },
+        {
+          propertyName: '$.cctvIntelligence',
+          errorType: 'empty',
+        },
+      ])
+    })
+
+    it('should return an error message when `cctvHistory` is empty', () => {
+      const page = new EsapPlacementCCTV({ cctvHistory: [], cctvIntelligence: 'no' }, application)
+      expect(page.errors()).toEqual([
+        {
+          propertyName: '$.cctvHistory',
+          errorType: 'empty',
+        },
+      ])
+    })
+
+    it('should return an empty array when `cctvIntelligence` is yes and no details are given', () => {
+      const page = new EsapPlacementCCTV(
+        {
+          cctvHistory: ['prisonerAssualt'],
+          cctvIntelligence: 'yes',
+          cctvIntelligenceDetails: '',
+          cctvNotes: 'notes',
+        },
+        application,
+      )
+      expect(page.errors()).toEqual([
+        {
+          propertyName: '$.cctvIntelligenceDetails',
+          errorType: 'empty',
+        },
+      ])
+    })
+  })
+
+  describe('cctvHistoryItems', () => {
+    it('it calls convertKeyValuePairToCheckBoxItems with the correct values', () => {
+      const page = new EsapPlacementCCTV({ cctvHistory: ['prisonerAssualt'] }, application)
+      page.cctvHistoryItems()
+
+      expect(convertKeyValuePairToCheckBoxItems).toHaveBeenCalledWith(cctvHistory, page.body.cctvHistory)
+    })
+  })
+})

--- a/server/form-pages/apply/type-of-ap/esapPlacementCCTV.ts
+++ b/server/form-pages/apply/type-of-ap/esapPlacementCCTV.ts
@@ -1,0 +1,106 @@
+import type { Application, YesOrNo } from 'approved-premises'
+
+import TasklistPage from '../../tasklistPage'
+import { convertToTitleCase, retrieveQuestionResponseFromApplication } from '../../../utils/utils'
+import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
+import { EsapReasons } from './esapPlacementScreening'
+
+export const cctvHistory = {
+  appearance: 'Changed their appearance or clothing to offend',
+  networks: 'Built networks within offender groups',
+  staffAssualt: 'Physically assaulted staff',
+  prisonerAssualt: 'Physically assaulted other people in prison',
+  threatsToLife: 'Received credible threats to life',
+  communityThreats:
+    'Experienced threats from the local community or media intrusion that poses a risk to the individual, other residents or staff ',
+} as const
+
+type CCTVHistory = typeof cctvHistory
+
+export default class EsapPlacementCCTV implements TasklistPage {
+  name = 'esap-placement-cctv'
+
+  title = 'Enhanced CCTV Provision'
+
+  body: {
+    cctvHistory: Array<keyof CCTVHistory>
+    cctvIntelligence: YesOrNo
+    cctvIntelligenceDetails: string
+    cctvNotes: string
+  }
+
+  questions = {
+    cctvHistory: `Which behaviours has ${this.application.person.name} demonstrated that require enhanced CCTV provision to monitor?`,
+    cctvIntelligence: 'Have partnership agencies requested the sharing of intelligence captured via enhanced CCTV?',
+    cctvIntelligenceDetails: 'Provide details',
+    cctvNotes: `Provide any supporting information about why ${this.application.person.name} requires enhanced CCTV provision`,
+  }
+
+  constructor(body: Record<string, unknown>, private readonly application: Application) {
+    this.body = {
+      cctvHistory: body.cctvHistory as Array<keyof CCTVHistory>,
+      cctvIntelligence: body.cctvIntelligence as YesOrNo,
+      cctvIntelligenceDetails: body.cctvIntelligenceDetails as string,
+      cctvNotes: body.cctvNotes as string,
+    }
+  }
+
+  previous() {
+    const esapReasons = retrieveQuestionResponseFromApplication(
+      this.application,
+      'type-of-ap',
+      'esap-placement-screening',
+      'esapReasons',
+    ) as Array<keyof EsapReasons>
+
+    if (esapReasons.includes('secreting')) {
+      return 'esap-placement-secreting'
+    }
+
+    return 'esap-placement-screening'
+  }
+
+  next() {
+    return ''
+  }
+
+  response() {
+    return {
+      [this.questions.cctvHistory]: this.body.cctvHistory.map(response => cctvHistory[response]),
+      [this.questions.cctvIntelligence]: convertToTitleCase(this.body.cctvIntelligence),
+      [this.questions.cctvIntelligenceDetails]: this.body.cctvIntelligenceDetails,
+      [this.questions.cctvNotes]: this.body.cctvNotes,
+    }
+  }
+
+  errors() {
+    const errors = []
+
+    if (!this.body.cctvHistory || !this.body.cctvHistory.length) {
+      errors.push({
+        propertyName: '$.cctvHistory',
+        errorType: 'empty',
+      })
+    }
+
+    if (!this.body.cctvIntelligence) {
+      errors.push({
+        propertyName: '$.cctvIntelligence',
+        errorType: 'empty',
+      })
+    }
+
+    if (this.body.cctvIntelligence === 'yes' && !this.body.cctvIntelligenceDetails) {
+      errors.push({
+        propertyName: '$.cctvIntelligenceDetails',
+        errorType: 'empty',
+      })
+    }
+
+    return errors
+  }
+
+  cctvHistoryItems() {
+    return convertKeyValuePairToCheckBoxItems(cctvHistory, this.body.cctvHistory)
+  }
+}

--- a/server/form-pages/apply/type-of-ap/esapPlacementScreening.test.ts
+++ b/server/form-pages/apply/type-of-ap/esapPlacementScreening.test.ts
@@ -1,0 +1,138 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
+
+import EsapPlacementScreening, { esapReasons, esapFactors } from './esapPlacementScreening'
+import applicationFactory from '../../../testutils/factories/application'
+import personFactory from '../../../testutils/factories/person'
+
+jest.mock('../../../utils/formUtils')
+
+describe('EsapPlacementScreening', () => {
+  let application = applicationFactory.build()
+
+  describe('title', () => {
+    it('shold add the name of the person', () => {
+      const person = personFactory.build({ name: 'John Wayne' })
+      application = applicationFactory.build({ person })
+
+      const page = new EsapPlacementScreening({}, application)
+
+      expect(page.title).toEqual('Why does John Wayne require an enhanced security placement?')
+    })
+  })
+
+  describe('body', () => {
+    it('should strip unknown attributes from the body', () => {
+      const page = new EsapPlacementScreening(
+        { esapReasons: ['secreting'], esapFactors: ['neurodiverse'], something: 'else' },
+        application,
+      )
+
+      expect(page.body).toEqual({ esapReasons: ['secreting'], esapFactors: ['neurodiverse'] })
+    })
+  })
+
+  itShouldHavePreviousValue(new EsapPlacementScreening({}, application), 'ap-type')
+
+  describe('next', () => {
+    describe('when esapReasons includes `secreting`', () => {
+      itShouldHaveNextValue(
+        new EsapPlacementScreening({ esapReasons: ['secreting'] }, application),
+        'esap-placement-secreting',
+      )
+    })
+
+    describe('when esapReasons includes `cctv`', () => {
+      itShouldHaveNextValue(new EsapPlacementScreening({ esapReasons: ['cctv'] }, application), 'esap-placement-cctv')
+    })
+
+    describe('when esapReasons includes `cctv` and `secreting`', () => {
+      itShouldHaveNextValue(
+        new EsapPlacementScreening({ esapReasons: ['secreting', 'cctv'] }, application),
+        'esap-placement-secreting',
+      )
+    })
+  })
+
+  describe('response', () => {
+    it('should translate the response correctly', () => {
+      const page = new EsapPlacementScreening(
+        { esapReasons: ['secreting', 'cctv'], esapFactors: ['neurodiverse', 'complexPersonality'], something: 'else' },
+        application,
+      )
+
+      expect(page.response()).toEqual({
+        'Why does John Wayne require an enhanced security placement?': [
+          'History of secreting items relevant to risk and re-offending in their room - requires enhanced room search through the use of body worn technology',
+          'History of engaging in behaviours which are most effectively monitored via enhanced CCTV technology - requires enhanced CCTV provision',
+        ],
+        'Do any of the following factors also apply?': [
+          'A diagnosis of autism or neurodiverse traits',
+          'A complex personality presentation which has created challenges in the prison and where an AP PIPE is deemed unsuitable',
+        ],
+      })
+    })
+
+    it('should cope with missing factors', () => {
+      const page = new EsapPlacementScreening({ esapReasons: ['secreting', 'cctv'] }, application)
+
+      expect(page.response()).toEqual({
+        'Why does John Wayne require an enhanced security placement?': [
+          'History of secreting items relevant to risk and re-offending in their room - requires enhanced room search through the use of body worn technology',
+          'History of engaging in behaviours which are most effectively monitored via enhanced CCTV technology - requires enhanced CCTV provision',
+        ],
+      })
+    })
+  })
+
+  describe('errors', () => {
+    it('should return an empty array when `esapReasons` is defined', () => {
+      const page = new EsapPlacementScreening({ esapReasons: ['secreting', 'cctv'] }, application)
+      expect(page.errors()).toEqual([])
+    })
+
+    it('should return an error message when `esapReasons` is undefined', () => {
+      const page = new EsapPlacementScreening({}, application)
+      expect(page.errors()).toEqual([
+        {
+          propertyName: '$.esapReasons',
+          errorType: 'empty',
+        },
+      ])
+    })
+
+    it('should return an error message when `esapReasons` is empty', () => {
+      const page = new EsapPlacementScreening({ esapReasons: [] }, application)
+      expect(page.errors()).toEqual([
+        {
+          propertyName: '$.esapReasons',
+          errorType: 'empty',
+        },
+      ])
+    })
+  })
+
+  describe('reasons', () => {
+    it('it calls convertKeyValuePairToCheckBoxItems with the correct values', () => {
+      const page = new EsapPlacementScreening(
+        { esapReasons: ['secreting', 'cctv'], esapFactors: ['neurodiverse', 'complexPersonality'] },
+        application,
+      )
+      page.reasons()
+
+      expect(convertKeyValuePairToCheckBoxItems).toHaveBeenCalledWith(esapReasons, page.body.esapReasons)
+    })
+  })
+
+  describe('factors', () => {
+    it('it calls convertKeyValuePairToCheckBoxItems with the correct values', () => {
+      const page = new EsapPlacementScreening(
+        { esapReasons: ['secreting', 'cctv'], esapFactors: ['neurodiverse', 'complexPersonality'] },
+        application,
+      )
+      page.factors()
+
+      expect(convertKeyValuePairToCheckBoxItems).toHaveBeenCalledWith(esapFactors, page.body.esapFactors)
+    })
+  })
+})

--- a/server/form-pages/apply/type-of-ap/esapPlacementScreening.ts
+++ b/server/form-pages/apply/type-of-ap/esapPlacementScreening.ts
@@ -1,0 +1,84 @@
+import type { Application } from 'approved-premises'
+
+import TasklistPage from '../../tasklistPage'
+import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
+
+export const esapReasons = {
+  secreting:
+    'History of secreting items relevant to risk and re-offending in their room - requires enhanced room search through the use of body worn technology',
+  cctv: 'History of engaging in behaviours which are most effectively monitored via enhanced CCTV technology - requires enhanced CCTV provision',
+} as const
+
+export const esapFactors = {
+  neurodiverse: 'A diagnosis of autism or neurodiverse traits',
+  complexPersonality:
+    'A complex personality presentation which has created challenges in the prison and where an AP PIPE is deemed unsuitable',
+  nonNsd:
+    'A non-NSD case where enhanced national standards are required to manage the risks posed and thought to be beneficial to risk reduction',
+  careAndSeperation: 'Individual has spent time in a Care and Separation Unit in the last 24 months',
+  unlock: 'Individual has required a 2/3 prison officer unlock in the last 12 months.',
+  corrupter: 'Individual has been identified as a known/suspected corrupter of staff',
+}
+
+type EsapReasons = typeof esapReasons
+type EsapFactors = typeof esapFactors
+
+export default class EsapPlacementScreening implements TasklistPage {
+  name = 'esap-placement-screening'
+
+  title = `Why does ${this.application.person.name} require an enhanced security placement?`
+
+  questions = {
+    esapReasons: this.title,
+    esapFactors: 'Do any of the following factors also apply?',
+  }
+
+  body: { esapReasons: Array<keyof EsapReasons>; esapFactors: Array<keyof EsapFactors> }
+
+  constructor(body: Record<string, unknown>, private readonly application: Application) {
+    this.body = {
+      esapReasons: body.esapReasons as Array<keyof EsapReasons>,
+      esapFactors: body.esapFactors as Array<keyof EsapFactors>,
+    }
+  }
+
+  previous() {
+    return 'ap-type'
+  }
+
+  next() {
+    if (this.body.esapReasons.includes('secreting')) {
+      return 'esap-placement-secreting'
+    }
+
+    return 'esap-placement-cctv'
+  }
+
+  response() {
+    return {
+      [`${this.questions.esapReasons}`]: this.body.esapReasons.map(reason => esapReasons[reason]),
+      [`${this.questions.esapFactors}`]: this.body.esapFactors?.map(factor => esapFactors[factor]),
+    }
+  }
+
+  errors() {
+    const errors = []
+
+    if (!this.body.esapReasons || !this.body.esapReasons.length) {
+      errors.push({
+        propertyName: '$.esapReasons',
+        errorType: 'empty',
+      })
+    }
+
+    return errors
+  }
+
+  reasons() {
+    return convertKeyValuePairToCheckBoxItems(esapReasons, this.body.esapReasons)
+  }
+
+  factors() {
+    return convertKeyValuePairToCheckBoxItems(esapFactors, this.body.esapFactors)
+  }
+}

--- a/server/form-pages/apply/type-of-ap/esapPlacementScreening.ts
+++ b/server/form-pages/apply/type-of-ap/esapPlacementScreening.ts
@@ -20,8 +20,8 @@ export const esapFactors = {
   corrupter: 'Individual has been identified as a known/suspected corrupter of staff',
 }
 
-type EsapReasons = typeof esapReasons
-type EsapFactors = typeof esapFactors
+export type EsapReasons = typeof esapReasons
+export type EsapFactors = typeof esapFactors
 
 export default class EsapPlacementScreening implements TasklistPage {
   name = 'esap-placement-screening'

--- a/server/form-pages/apply/type-of-ap/esapPlacementSecreting.test.ts
+++ b/server/form-pages/apply/type-of-ap/esapPlacementSecreting.test.ts
@@ -1,0 +1,154 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
+
+import EsapPlacementSecreting, { secretingHistory } from './esapPlacementSecreting'
+import applicationFactory from '../../../testutils/factories/application'
+import personFactory from '../../../testutils/factories/person'
+
+jest.mock('../../../utils/formUtils')
+
+describe('EsapPlacementSecreting', () => {
+  const application = applicationFactory.build()
+
+  describe('body', () => {
+    it('should strip unknown attributes from the body', () => {
+      const page = new EsapPlacementSecreting(
+        {
+          secretingHistory: ['radicalisationLiterature'],
+          secretingIntelligence: 'yes',
+          secretingNotes: 'notes',
+          something: 'else',
+        },
+        application,
+      )
+
+      expect(page.body).toEqual({
+        secretingHistory: ['radicalisationLiterature'],
+        secretingIntelligence: 'yes',
+        secretingNotes: 'notes',
+      })
+    })
+  })
+
+  itShouldHavePreviousValue(new EsapPlacementSecreting({}, application), 'esap-placement-screening')
+
+  describe('next', () => {
+    describe('when the application has a previous response that includes `cctv`', () => {
+      beforeEach(() => {
+        application.data = {
+          'type-of-ap': {
+            'esap-placement-screening': {
+              esapReasons: ['cctv', 'secreting'],
+            },
+          },
+        }
+      })
+
+      itShouldHaveNextValue(new EsapPlacementSecreting({}, application), 'esap-placement-cctv')
+    })
+
+    describe('when the application has a previous response does not include `cctv`', () => {
+      beforeEach(() => {
+        application.data = {
+          'type-of-ap': {
+            'esap-placement-screening': {
+              esapReasons: ['secreting'],
+            },
+          },
+        }
+      })
+
+      itShouldHaveNextValue(new EsapPlacementSecreting({}, application), '')
+    })
+  })
+
+  describe('response', () => {
+    it('should translate the response correctly', () => {
+      const person = personFactory.build({ name: 'John Wayne' })
+      const page = new EsapPlacementSecreting(
+        {
+          secretingHistory: ['radicalisationLiterature'],
+          secretingIntelligence: 'yes',
+          secretingIntelligenceDetails: 'Some detail',
+          secretingNotes: 'notes',
+        },
+        applicationFactory.build({ person }),
+      )
+
+      expect(page.response()).toEqual({
+        'Which items does John Wayne have a history of secreting?': [
+          'Literature and materials supporting radicalisation ideals',
+        ],
+        'Have partnership agencies requested the sharing of intelligence captured via body worn technology?': 'Yes',
+        'Provide details': 'Some detail',
+        'Provide any supporting information about why John Wayne requires enhanced room searches': 'notes',
+      })
+    })
+  })
+
+  describe('errors', () => {
+    it('should return an empty array when `secretingHistory` and `secretingIntelligence` are defined', () => {
+      const page = new EsapPlacementSecreting(
+        {
+          secretingHistory: ['radicalisationLiterature'],
+          secretingIntelligence: 'yes',
+          secretingIntelligenceDetails: 'Some detail',
+          secretingNotes: 'notes',
+        },
+        application,
+      )
+      expect(page.errors()).toEqual([])
+    })
+
+    it('should return error messages when `secretingHistory` and `secretingIntelligence` are undefined', () => {
+      const page = new EsapPlacementSecreting({}, application)
+      expect(page.errors()).toEqual([
+        {
+          propertyName: '$.secretingHistory',
+          errorType: 'empty',
+        },
+        {
+          propertyName: '$.secretingIntelligence',
+          errorType: 'empty',
+        },
+      ])
+    })
+
+    it('should return an error message when `secretingHistory` is empty', () => {
+      const page = new EsapPlacementSecreting({ secretingHistory: [], secretingIntelligence: 'no' }, application)
+      expect(page.errors()).toEqual([
+        {
+          propertyName: '$.secretingHistory',
+          errorType: 'empty',
+        },
+      ])
+    })
+  })
+
+  describe('secretingHistoryItems', () => {
+    it('it calls convertKeyValuePairToCheckBoxItems with the correct values', () => {
+      const page = new EsapPlacementSecreting({ secretingHistory: ['radicalisationLiterature'] }, application)
+      page.secretingHistoryItems()
+
+      expect(convertKeyValuePairToCheckBoxItems).toHaveBeenCalledWith(secretingHistory, page.body.secretingHistory)
+    })
+  })
+
+  it('should return an empty array when `secretingIntelligence` is yes and no details are given', () => {
+    const page = new EsapPlacementSecreting(
+      {
+        secretingHistory: ['radicalisationLiterature'],
+        secretingIntelligence: 'yes',
+        secretingIntelligenceDetails: '',
+        secretingNotes: 'notes',
+      },
+      application,
+    )
+    expect(page.errors()).toEqual([
+      {
+        propertyName: '$.secretingIntelligenceDetails',
+        errorType: 'empty',
+      },
+    ])
+  })
+})

--- a/server/form-pages/apply/type-of-ap/esapPlacementSecreting.ts
+++ b/server/form-pages/apply/type-of-ap/esapPlacementSecreting.ts
@@ -1,0 +1,107 @@
+import type { Application, YesOrNo } from 'approved-premises'
+
+import TasklistPage from '../../tasklistPage'
+import { convertToTitleCase, retrieveQuestionResponseFromApplication } from '../../../utils/utils'
+import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
+import { EsapReasons } from './esapPlacementScreening'
+
+export const secretingHistory = {
+  radicalisationLiterature: 'Literature and materials supporting radicalisation ideals',
+  hateCrimeLiterature: 'Offence related literature indicative of hate crimes or beliefs',
+  csaLiterature: 'Literature and/or items of relevance to child sexual abuse or exploitation',
+  drugs: 'Drugs and drug paraphernalia indicative of dealing drugs',
+  weapons: 'Weapons, actual or makeshift',
+  fire: 'Fire-setting or explosive materials',
+  electronicItems: 'Electronic items of significance to the individuals offending profile',
+} as const
+
+type SecretingHistory = typeof secretingHistory
+
+export default class EsapPlacementSecreting implements TasklistPage {
+  name = 'esap-placement-secreting'
+
+  title = 'Enhanced room searches using body worn technology'
+
+  body: {
+    secretingHistory: Array<keyof SecretingHistory>
+    secretingIntelligence: YesOrNo
+    secretingIntelligenceDetails: string
+    secretingNotes: string
+  }
+
+  questions = {
+    secretingHistory: `Which items does ${this.application.person.name} have a history of secreting?`,
+    secretingIntelligence:
+      'Have partnership agencies requested the sharing of intelligence captured via body worn technology?',
+    secretingIntelligenceDetails: 'Provide details',
+    secretingNotes: `Provide any supporting information about why ${this.application.person.name} requires enhanced room searches`,
+  }
+
+  constructor(body: Record<string, unknown>, private readonly application: Application) {
+    this.body = {
+      secretingHistory: body.secretingHistory as Array<keyof SecretingHistory>,
+      secretingIntelligence: body.secretingIntelligence as YesOrNo,
+      secretingIntelligenceDetails: body.secretingIntelligenceDetails as string,
+      secretingNotes: body.secretingNotes as string,
+    }
+  }
+
+  previous() {
+    return 'esap-placement-screening'
+  }
+
+  next() {
+    const esapReasons = retrieveQuestionResponseFromApplication(
+      this.application,
+      'type-of-ap',
+      'esap-placement-screening',
+      'esapReasons',
+    ) as Array<keyof EsapReasons>
+
+    if (esapReasons.includes('cctv')) {
+      return 'esap-placement-cctv'
+    }
+
+    return ''
+  }
+
+  response() {
+    return {
+      [this.questions.secretingHistory]: this.body.secretingHistory.map(response => secretingHistory[response]),
+      [this.questions.secretingIntelligence]: convertToTitleCase(this.body.secretingIntelligence),
+      [this.questions.secretingIntelligenceDetails]: this.body.secretingIntelligenceDetails,
+      [this.questions.secretingNotes]: this.body.secretingNotes,
+    }
+  }
+
+  errors() {
+    const errors = []
+
+    if (!this.body.secretingHistory || !this.body.secretingHistory.length) {
+      errors.push({
+        propertyName: '$.secretingHistory',
+        errorType: 'empty',
+      })
+    }
+
+    if (!this.body.secretingIntelligence) {
+      errors.push({
+        propertyName: '$.secretingIntelligence',
+        errorType: 'empty',
+      })
+    }
+
+    if (this.body.secretingIntelligence === 'yes' && !this.body.secretingIntelligenceDetails) {
+      errors.push({
+        propertyName: '$.secretingIntelligenceDetails',
+        errorType: 'empty',
+      })
+    }
+
+    return errors
+  }
+
+  secretingHistoryItems() {
+    return convertKeyValuePairToCheckBoxItems(secretingHistory, this.body.secretingHistory)
+  }
+}

--- a/server/form-pages/apply/type-of-ap/index.ts
+++ b/server/form-pages/apply/type-of-ap/index.ts
@@ -3,11 +3,13 @@
 import ApType from './apType'
 import PipeReferral from './pipeReferral'
 import PipeOpdScreening from './pipeOpdScreening'
+import EsapPlacementScreening from './esapPlacementScreening'
 
 const pages = {
   'ap-type': ApType,
   'pipe-referral': PipeReferral,
   'pipe-opd-screening': PipeOpdScreening,
+  'esap-placement-screening': EsapPlacementScreening,
 }
 
 export default pages

--- a/server/form-pages/apply/type-of-ap/index.ts
+++ b/server/form-pages/apply/type-of-ap/index.ts
@@ -4,12 +4,14 @@ import ApType from './apType'
 import PipeReferral from './pipeReferral'
 import PipeOpdScreening from './pipeOpdScreening'
 import EsapPlacementScreening from './esapPlacementScreening'
+import EsapPlacementSecreting from './esapPlacementSecreting'
 
 const pages = {
   'ap-type': ApType,
   'pipe-referral': PipeReferral,
   'pipe-opd-screening': PipeOpdScreening,
   'esap-placement-screening': EsapPlacementScreening,
+  'esap-placement-secreting': EsapPlacementSecreting,
 }
 
 export default pages

--- a/server/form-pages/apply/type-of-ap/index.ts
+++ b/server/form-pages/apply/type-of-ap/index.ts
@@ -5,6 +5,7 @@ import PipeReferral from './pipeReferral'
 import PipeOpdScreening from './pipeOpdScreening'
 import EsapPlacementScreening from './esapPlacementScreening'
 import EsapPlacementSecreting from './esapPlacementSecreting'
+import EsapPlacementCCTV from './esapPlacementCCTV'
 
 const pages = {
   'ap-type': ApType,
@@ -12,6 +13,7 @@ const pages = {
   'pipe-opd-screening': PipeOpdScreening,
   'esap-placement-screening': EsapPlacementScreening,
   'esap-placement-secreting': EsapPlacementSecreting,
+  'esap-placement-cctv': EsapPlacementCCTV,
 }
 
 export default pages

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -73,6 +73,7 @@
   "startDateSameAsReleaseDate": { "empty": "You must specify if the start date is the same as the release date" },
   "type": { "empty": "You must specify an AP type" },
   "opdPathway": { "empty": "You must specify if xxxx has been screened into the OPD pathway" },
+  "esapReasons": { "empty": "You must specify why xxxx requires an enhanced security placement" },
   "opdPathwayDate": {
     "empty": "You must enter an OPD Pathway date",
     "invalid": "The OPD Pathway date is an invalid date"

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -74,6 +74,13 @@
   "type": { "empty": "You must specify an AP type" },
   "opdPathway": { "empty": "You must specify if xxxx has been screened into the OPD pathway" },
   "esapReasons": { "empty": "You must specify why xxxx requires an enhanced security placement" },
+  "secretingHistory": { "empty": "You must specify what items xxx has a history of secreting" },
+  "secretingIntelligence": {
+    "empty": "You must specify if partnership agencies requested the sharing of intelligence captured via body worn technology"
+  },
+  "secretingIntelligenceDetails": {
+    "empty": "You must specify the details if partnership agencies have requested the sharing of intelligence captured via body worn technology"
+  },
   "opdPathwayDate": {
     "empty": "You must enter an OPD Pathway date",
     "invalid": "The OPD Pathway date is an invalid date"

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -81,6 +81,15 @@
   "secretingIntelligenceDetails": {
     "empty": "You must specify the details if partnership agencies have requested the sharing of intelligence captured via body worn technology"
   },
+  "cctvHistory": {
+    "empty": "You must specify which behaviours xxx has demonstrated that require enhanced CCTV provision to monitor"
+  },
+  "cctvIntelligence": {
+    "empty": "You must specify if partnership agencies requested the sharing of intelligence captured via enhanced CCTV"
+  },
+  "cctvIntelligenceDetails": {
+    "empty": "You must specify the details if partnership agencies have requested the sharing of intelligence captured via enhanced CCTV"
+  },
   "opdPathwayDate": {
     "empty": "You must enter an OPD Pathway date",
     "invalid": "The OPD Pathway date is an invalid date"

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -6,6 +6,7 @@ import {
   convertObjectsToRadioItems,
   convertKeyValuePairToRadioItems,
   convertObjectsToSelectOptions,
+  convertKeyValuePairToCheckBoxItems,
 } from './formUtils'
 
 describe('formUtils', () => {
@@ -118,6 +119,84 @@ describe('formUtils', () => {
           text: 'def',
           value: '345',
           checked: false,
+        },
+      ])
+    })
+  })
+
+  describe('convertKeyValuePairToCheckBoxItems', () => {
+    const obj = {
+      foo: 'Foo',
+      bar: 'Bar',
+    }
+
+    it('should convert a key value pair to checkbox items', () => {
+      expect(convertKeyValuePairToCheckBoxItems(obj, [])).toEqual([
+        {
+          value: 'foo',
+          text: 'Foo',
+          checked: false,
+        },
+        {
+          value: 'bar',
+          text: 'Bar',
+          checked: false,
+        },
+      ])
+    })
+
+    it('should handle an undefined checkedItems value', () => {
+      expect(convertKeyValuePairToCheckBoxItems(obj, undefined)).toEqual([
+        {
+          value: 'foo',
+          text: 'Foo',
+          checked: false,
+        },
+        {
+          value: 'bar',
+          text: 'Bar',
+          checked: false,
+        },
+      ])
+    })
+
+    it('should check the checked item', () => {
+      expect(convertKeyValuePairToCheckBoxItems(obj, ['foo'])).toEqual([
+        {
+          value: 'foo',
+          text: 'Foo',
+          checked: true,
+        },
+        {
+          value: 'bar',
+          text: 'Bar',
+          checked: false,
+        },
+      ])
+
+      expect(convertKeyValuePairToCheckBoxItems(obj, ['bar'])).toEqual([
+        {
+          value: 'foo',
+          text: 'Foo',
+          checked: false,
+        },
+        {
+          value: 'bar',
+          text: 'Bar',
+          checked: true,
+        },
+      ])
+
+      expect(convertKeyValuePairToCheckBoxItems(obj, ['foo', 'bar'])).toEqual([
+        {
+          value: 'foo',
+          text: 'Foo',
+          checked: true,
+        },
+        {
+          value: 'bar',
+          text: 'Bar',
+          checked: true,
         },
       ])
     })

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -1,4 +1,4 @@
-import type { ErrorMessages, RadioItems, SelectOptions } from 'approved-premises'
+import type { ErrorMessages, RadioItem, SelectOption, CheckBoxItem } from 'approved-premises'
 
 export const dateFieldValues = (fieldName: string, context: Record<string, unknown>, errors: ErrorMessages = {}) => {
   const errorClass = errors[fieldName] ? 'govuk-input--error' : ''
@@ -27,7 +27,7 @@ export const convertObjectsToRadioItems = (
   valueKey: string,
   fieldName: string,
   context: Record<string, unknown>,
-): Array<RadioItems> => {
+): Array<RadioItem> => {
   return items.map(item => {
     return {
       text: item[textKey],
@@ -44,7 +44,7 @@ export const convertObjectsToSelectOptions = (
   valueKey: string,
   fieldName: string,
   context: Record<string, unknown>,
-): Array<SelectOptions> => {
+): Array<SelectOption> => {
   const options = [
     {
       value: '',
@@ -64,12 +64,25 @@ export const convertObjectsToSelectOptions = (
   return options
 }
 
-export function convertKeyValuePairToRadioItems<T>(object: T, checkedItem: string): Array<RadioItems> {
+export function convertKeyValuePairToRadioItems<T>(object: T, checkedItem: string): Array<RadioItem> {
   return Object.keys(object).map(key => {
     return {
       value: key,
       text: object[key],
       checked: checkedItem === key,
+    }
+  })
+}
+
+export function convertKeyValuePairToCheckBoxItems<T>(
+  object: T,
+  checkedItems: Array<string> = [],
+): Array<CheckBoxItem> {
+  return Object.keys(object).map(key => {
+    return {
+      value: key,
+      text: object[key],
+      checked: checkedItems.includes(key),
     }
   })
 }

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -48,16 +48,28 @@ describe('retrieveQuestionResponseFromApplication', () => {
     )
   })
 
-  it('returns the property if it does existion', () => {
+  it('returns the property if it does exist and a question is not provided', () => {
     const application = applicationFactory.build({
       data: {
-        'basic-information': { 'question-response': { questionResponse: 'no' } },
+        'basic-information': { 'my-page': { myPage: 'no' } },
+      },
+    })
+
+    const questionResponse = retrieveQuestionResponseFromApplication(application, 'basic-information', 'myPage')
+    expect(questionResponse).toBe('no')
+  })
+
+  it('returns the property if it does exist and a question is provided', () => {
+    const application = applicationFactory.build({
+      data: {
+        'basic-information': { 'my-page': { questionResponse: 'no' } },
       },
     })
 
     const questionResponse = retrieveQuestionResponseFromApplication(
       application,
       'basic-information',
+      'myPage',
       'questionResponse',
     )
     expect(questionResponse).toBe('no')

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -42,16 +42,19 @@ const kebabCase = (string: string) =>
 /**
  * Retrieves response for a given question from the application object.
  * @param application the application to fetch the response from.
- * @param question the question that we need the response for in camelCase.
- * @returns name converted to proper case.
+ * @param task the task to retrieve the response for.
+ * @param page the page that we need the response for in camelCase.
+ * @param {string} question [question=page] the page that we need the response for. Defaults to the value of `page`.
+ * @returns the response for the given task/page/question.
  */
 export const retrieveQuestionResponseFromApplication = <T>(
   application: Application,
   task: string,
-  question: string,
+  page: string,
+  question?: string,
 ) => {
   try {
-    return application.data[task][kebabCase(question)][question] as T
+    return application.data[task][kebabCase(page)][question || page] as T
   } catch (e) {
     throw new SessionDataError(`Question ${question} was not found in the session`)
   }

--- a/server/views/applications/pages/type-of-ap/esap-placement-cctv.njk
+++ b/server/views/applications/pages/type-of-ap/esap-placement-cctv.njk
@@ -1,0 +1,75 @@
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
+  {{ govukCheckboxes({
+      name: "cctvHistory",
+      errorMessage: errors.cctvHistory,
+      fieldset: {
+        legend: {
+          text: page.questions.cctvHistory,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: page.cctvHistoryItems()
+    }) }}
+
+  {% set yesDetails %}
+  {{ govukTextarea({
+    id: "cctvIntelligenceDetails",
+    name: "cctvIntelligenceDetails",
+    type: "textarea",
+    spellcheck: false,
+    errorMessage: errors.cctvIntelligenceDetails,
+    label: {
+      text: page.questions.cctvIntelligenceDetails
+    },
+    value: cctvIntelligenceDetails
+  }) }}
+  {% endset -%}
+
+  {{ govukRadios({
+    idPrefix: "cctvIntelligence",
+    name: "cctvIntelligence",
+    errorMessage: errors.cctvIntelligence,
+    hint: {
+      text: "For example, DOS, JEXU or NSD."
+    },
+    fieldset: {
+      legend: {
+        text: page.questions.cctvIntelligence,
+        classes: "govuk-fieldset__legend--m"
+      }
+    },
+    items: [
+      {
+        value: "yes",
+        text: "Yes",
+        checked: cctvIntelligence == 'yes',
+        conditional: {
+          html: yesDetails
+        }
+      },
+      {
+        text: "No",
+        value: "no",
+        checked: cctvIntelligence == 'no'
+      }
+    ]
+    }) }}
+
+  <h2 class="govuk-heading-s">{{ page.questions.cctvNotes }}</h2>
+
+  {{ govukTextarea({
+      name: "cctvNotes",
+      id: "cctvNotes",
+      value: cctvNotes
+  }) }}
+
+{% endblock %}

--- a/server/views/applications/pages/type-of-ap/esap-placement-screening.njk
+++ b/server/views/applications/pages/type-of-ap/esap-placement-screening.njk
@@ -1,0 +1,33 @@
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
+  {{ govukCheckboxes({
+      name: "esapReasons",
+      errorMessage: errors.esapReasons,
+      fieldset: {
+        legend: {
+          text: "Select at least one of the following reasons.",
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: page.reasons()
+    }) }}
+
+  {{ govukCheckboxes({
+      name: "esapFactors",
+      errorMessage: errors.esapFactors,
+      fieldset: {
+        legend: {
+          text: page.questions.esapFactors,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: page.factors()
+    }) }}
+
+{% endblock %}

--- a/server/views/applications/pages/type-of-ap/esap-placement-secreting.njk
+++ b/server/views/applications/pages/type-of-ap/esap-placement-secreting.njk
@@ -1,0 +1,75 @@
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
+  {{ govukCheckboxes({
+      name: "secretingHistory",
+      errorMessage: errors.secretingHistory,
+      fieldset: {
+        legend: {
+          text: page.questions.secretingHistory,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: page.secretingHistoryItems()
+    }) }}
+
+  {% set yesDetails %}
+  {{ govukTextarea({
+    id: "secretingIntelligenceDetails",
+    name: "secretingIntelligenceDetails",
+    type: "textarea",
+    spellcheck: false,
+    errorMessage: errors.secretingIntelligenceDetails,
+    label: {
+      text: page.questions.secretingIntelligenceDetails
+    },
+    value: secretingIntelligenceDetails
+  }) }}
+  {% endset -%}
+
+  {{ govukRadios({
+    idPrefix: "secretingIntelligence",
+    name: "secretingIntelligence",
+    errorMessage: errors.secretingIntelligence,
+    hint: {
+      text: "For example, DOS, JEXU or NSD."
+    },
+    fieldset: {
+      legend: {
+        text: page.questions.secretingIntelligence,
+        classes: "govuk-fieldset__legend--m"
+      }
+    },
+    items: [
+      {
+        value: "yes",
+        text: "Yes",
+        checked: secretingIntelligence == 'yes',
+        conditional: {
+          html: yesDetails
+        }
+      },
+      {
+        text: "No",
+        value: "no",
+        checked: secretingIntelligence == 'no'
+      }
+    ]
+    }) }}
+
+  <h2 class="govuk-heading-s">{{ page.questions.secretingNotes }}</h2>
+
+  {{ govukTextarea({
+      name: "secretingNotes",
+      id: "secretingNotes",
+      value: secretingNotes
+  }) }}
+
+{% endblock %}


### PR DESCRIPTION
This adds various screens for if a user chooses an ESAP AP. A couple of things have come to light here, including the fact that these are the first multi-question pages, so I've added a `questions` attribute to make sure there is one source of truth for question names. This is also the first time we're using the answers to previous questions for branching, so I've made an improvement to the `retrieveQuestionResponseFromApplication` function.

## Screenshots

![image](https://user-images.githubusercontent.com/109774/196404270-ced125b2-60f2-4a63-95d7-08ac8b3ac0b8.png)
![image](https://user-images.githubusercontent.com/109774/196404331-3d1dd4fe-0fca-47cd-9153-e9bc2e7a9f66.png)
![image](https://user-images.githubusercontent.com/109774/196404386-ef4feed1-c88d-4dd5-a04b-3d7e769fd088.png)
