### PR TITLE
Update Pipe questions to use a questions attribute

### DIFF
--- a/server/form-pages/apply/type-of-ap/pipeOpdScreening.test.ts
+++ b/server/form-pages/apply/type-of-ap/pipeOpdScreening.test.ts
@@ -1,4 +1,4 @@
-import { itShouldHavePreviousValue } from '../../shared-examples'
+import { itShouldHavePreviousValue, itShouldHaveNextValue } from '../../shared-examples'
 
 import PipeOpdScreening from './pipeOpdScreening'
 import applicationFactory from '../../../testutils/factories/application'
@@ -22,6 +22,7 @@ describe('PipeOpdScreening', () => {
   })
 
   itShouldHavePreviousValue(new PipeOpdScreening({}, application), 'pipe-referral')
+  itShouldHaveNextValue(new PipeOpdScreening({}, application), '')
 
   describe('errors', () => {
     it('should return an empty array if the pipeReferral is populated', () => {

--- a/server/form-pages/apply/type-of-ap/pipeOpdScreening.ts
+++ b/server/form-pages/apply/type-of-ap/pipeOpdScreening.ts
@@ -27,6 +27,10 @@ export default class PipeOpdReferral implements TasklistPage {
     return 'pipe-referral'
   }
 
+  next() {
+    return ''
+  }
+
   response() {
     const response = {
       [this.questions.pipeReferral]: convertToTitleCase(this.body.pipeReferral),

--- a/server/form-pages/apply/type-of-ap/pipeOpdScreening.ts
+++ b/server/form-pages/apply/type-of-ap/pipeOpdScreening.ts
@@ -11,6 +11,11 @@ export default class PipeOpdReferral implements TasklistPage {
 
   body: { pipeReferral: YesOrNo; pipeReferralMoreDetail: string }
 
+  questions = {
+    pipeReferral: this.title,
+    pipeReferralMoreDetail: `Additional detail about why ${this.application.person.name} needs a PIPE placement.`,
+  }
+
   constructor(body: Record<string, unknown>, private readonly application: Application) {
     this.body = {
       pipeReferral: body.pipeReferral as YesOrNo,
@@ -24,12 +29,11 @@ export default class PipeOpdReferral implements TasklistPage {
 
   response() {
     const response = {
-      [this.title]: convertToTitleCase(this.body.pipeReferral),
+      [this.questions.pipeReferral]: convertToTitleCase(this.body.pipeReferral),
     } as Record<string, string>
 
     if (this.body.pipeReferral === 'yes') {
-      response[`Additional detail about why ${this.application.person.name} needs a PIPE placement.`] =
-        this.body.pipeReferralMoreDetail
+      response[this.questions.pipeReferralMoreDetail] = this.body.pipeReferralMoreDetail
     }
 
     return response

--- a/server/form-pages/apply/type-of-ap/pipeReferral.test.ts
+++ b/server/form-pages/apply/type-of-ap/pipeReferral.test.ts
@@ -139,7 +139,7 @@ describe('PipeReferral', () => {
 
       expect(page.response()).toEqual({
         [page.title]: 'Yes',
-        'OPD Pathway Screening Date': 'Friday 11 November 2022',
+        "When was John Wayne's last consultation or formulation?": 'Friday 11 November 2022',
       })
     })
   })

--- a/server/form-pages/apply/type-of-ap/pipeReferral.ts
+++ b/server/form-pages/apply/type-of-ap/pipeReferral.ts
@@ -12,6 +12,11 @@ export default class PipeReferral implements TasklistPage {
 
   title = `Has ${this.application.person.name} been screened into the OPD pathway?`
 
+  questions = {
+    opdPathway: this.title,
+    opdPathwayDate: `When was ${this.application.person.name}'s last consultation or formulation?`,
+  }
+
   constructor(body: Record<string, unknown>, private readonly application: Application) {
     this.body = {
       'opdPathwayDate-year': body['opdPathwayDate-year'] as string,
@@ -32,11 +37,11 @@ export default class PipeReferral implements TasklistPage {
 
   response() {
     const response = {
-      [this.title]: convertToTitleCase(this.body.opdPathway),
+      [this.questions.opdPathway]: convertToTitleCase(this.body.opdPathway),
     } as Record<string, string>
 
     if (this.body.opdPathway === 'yes') {
-      response['OPD Pathway Screening Date'] = DateFormats.isoDateToUIDate(this.body.opdPathwayDate)
+      response[this.questions.opdPathwayDate] = DateFormats.isoDateToUIDate(this.body.opdPathwayDate)
     }
 
     return response

--- a/server/views/applications/pages/type-of-ap/pipe-opd-screening.njk
+++ b/server/views/applications/pages/type-of-ap/pipe-opd-screening.njk
@@ -35,7 +35,7 @@
       id: "pipeReferralMoreDetail",
       value: pipeReferralMoreDetail,
       label: {
-        text: "Provide any additional detail about why xxxx needs a PIPE placement."
+        text: page.questions.pipeReferralMoreDetail
       }
     }) }}
 

--- a/server/views/applications/pages/type-of-ap/pipe-referral.njk
+++ b/server/views/applications/pages/type-of-ap/pipe-referral.njk
@@ -13,7 +13,7 @@
       errorMessage: errors.opdPathwayDate,
       fieldset: {
         legend: {
-          text: "When was xxxx's last consultation or formulation?"
+          text: page.questions.opdPathwayDate
         }
       },
       hint: {


### PR DESCRIPTION
This builds on the work in #256 to add a questions attribute to the Pipe-related questions, so we can add a person's name to the question text, as well as keep all the question text in one place

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/109774/196409764-0025e467-5540-40d8-80fc-df6d2ecb41ee.png)
![image](https://user-images.githubusercontent.com/109774/196409782-3a63f1c3-a520-48ca-920d-e35df2251f01.png)

### After

![image](https://user-images.githubusercontent.com/109774/196409628-074652f2-940f-4493-8e16-fb19edb1164c.png)
![image](https://user-images.githubusercontent.com/109774/196409655-a0352c43-fa04-4912-b47f-ba1f1649326d.png)

