### PR TITLE
Fix missing `lastUpdated`

### DIFF
--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -300,7 +300,7 @@ declare module 'approved-premises' {
       riskToPublic: RiskLevel
       riskToKnownAdult: RiskLevel
       riskToStaff: RiskLevel
-      lastUpdated: string
+      lastUpdated?: string
     }
     MappaEnvelope: {
       status: RiskEnvelopeStatus

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -163,4 +163,32 @@ describe('mapApiPersonRiskForUI', () => {
       },
     })
   })
+
+  it('handles the case where roshRisks lastUpdated is null', () => {
+    const risks = risksFactory.build()
+    risks.roshRisks.value.lastUpdated = null
+
+    const actual = mapApiPersonRisksForUi(risks)
+
+    expect(actual).toEqual({
+      crn: risks.crn,
+      flags: risks.flags.value,
+      mappa: {
+        lastUpdated: DateFormats.isoDateToUIDate(risks.mappa.value.lastUpdated),
+        level: 'CAT 2 / LEVEL 1',
+      },
+      roshRisks: {
+        lastUpdated: '',
+        overallRisk: risks.roshRisks.value.overallRisk,
+        riskToChildren: risks.roshRisks.value.riskToChildren,
+        riskToKnownAdult: risks.roshRisks.value.riskToKnownAdult,
+        riskToPublic: risks.roshRisks.value.riskToPublic,
+        riskToStaff: risks.roshRisks.value.riskToStaff,
+      },
+      tier: {
+        lastUpdated: DateFormats.isoDateToUIDate(risks.tier.value.lastUpdated),
+        level: risks.tier.value.level,
+      },
+    })
+  })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -79,7 +79,9 @@ export const mapApiPersonRisksForUi = (risks: PersonRisks): PersonRisksUI => {
     ...risks,
     roshRisks: {
       ...risks.roshRisks.value,
-      lastUpdated: DateFormats.isoDateToUIDate(risks.roshRisks.value.lastUpdated),
+      lastUpdated: risks.roshRisks.value.lastUpdated
+        ? DateFormats.isoDateToUIDate(risks.roshRisks.value.lastUpdated)
+        : '',
     },
     mappa: {
       ...risks.mappa.value,


### PR DESCRIPTION
The `lastUpdated` value that comes back for `roshRisks` is sometimes null, so we need to guard against it.