### PR TITLE
[TA] (447) Creating a premises includes location data

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -12,6 +12,7 @@ import cancellation from './integration_tests/mockApis/cancellation'
 import lostBed from './integration_tests/mockApis/lostBed'
 import person from './integration_tests/mockApis/person'
 import applications from './integration_tests/mockApis/applications'
+import localAuthority from './integration_tests/mockApis/localAuthority'
 
 export default defineConfig({
   chromeWebSecurity: false,
@@ -40,6 +41,7 @@ export default defineConfig({
         ...lostBed,
         ...person,
         ...applications,
+        ...localAuthority,
       })
     },
     baseUrl: 'http://localhost:3007',

--- a/integration_tests/mockApis/localAuthority.ts
+++ b/integration_tests/mockApis/localAuthority.ts
@@ -1,0 +1,22 @@
+import type { SuperAgentRequest } from 'superagent'
+
+import type { LocalAuthority } from 'approved-premises'
+import { stubFor } from '../../wiremock'
+import paths from '../../server/paths/temporary-accommodation/api'
+
+const stubLocalAuthorities = (localAuthorities: LocalAuthority[]): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      url: paths.localAuthorities.index({}),
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: localAuthorities,
+    },
+  })
+
+export default {
+  stubLocalAuthorities,
+}

--- a/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
@@ -1,5 +1,6 @@
 import premisesFactory from '../../../../server/testutils/factories/premises'
 import newPremisesFactory from '../../../../server/testutils/factories/newPremises'
+import localAuthorityFactory from '../../../../server/testutils/factories/localAuthority'
 import PremisesNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesNew'
 import PremisesListPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesList'
 import Page from '../../../../cypress_shared/pages/page'
@@ -34,6 +35,10 @@ context('Premises', () => {
     const premises = premisesFactory.buildList(5)
     cy.task('stubPremises', { premises, service: 'temporary-accommodation' })
 
+    // And there are local authorities in the database
+    const localAuthorities = localAuthorityFactory.buildList(5)
+    cy.task('stubLocalAuthorities', localAuthorities)
+
     // When I visit the premises page
     const page = PremisesListPage.visit()
 
@@ -48,12 +53,17 @@ context('Premises', () => {
     // Given I am signed in
     cy.signIn()
 
+    // And there are local authorities in the database
+    const localAuthorities = localAuthorityFactory.buildList(5)
+    cy.task('stubLocalAuthorities', localAuthorities)
+
     // When I visit the new premises page
+    const localAuthority = localAuthorities[2]
     const premises = premisesFactory.build()
     const newPremises = newPremisesFactory.build({
       name: premises.name,
       postcode: premises.postcode,
-      localAuthorityId: 'c2892a98-dea6-4a80-9c3e-bf4e5c42ee0a',
+      localAuthorityId: localAuthority.id,
     })
 
     cy.task('stubPremisesCreate', premises)
@@ -87,6 +97,10 @@ context('Premises', () => {
     // And there are premises in the database
     const premises = premisesFactory.buildList(5)
     cy.task('stubPremises', { premises, service: 'temporary-accommodation' })
+
+    // And there are local authorities in the database
+    const localAuthorities = localAuthorityFactory.buildList(5)
+    cy.task('stubLocalAuthorities', localAuthorities)
 
     // When I visit the new premises page
     const page = PremisesNewPage.visit()

--- a/server/@types/approved-premises/index.d.ts
+++ b/server/@types/approved-premises/index.d.ts
@@ -18,6 +18,7 @@ declare module 'approved-premises' {
   export type StaffMember = schemas['StaffMember']
   export type PersonRisks = schemas['PersonRisks']
   export type PersonRisksUI = schemas['PersonRisksUI']
+  export type LocalAuthority = schemas['LocalAuthority']
 
   // A utility type that allows us to define an object with a date attribute split into
   // date, month, year (and optionally, time) attributes. Designed for use with the GOV.UK
@@ -335,6 +336,10 @@ declare module 'approved-premises' {
     FlagsEnvelope: {
       status: RiskEnvelopeStatus
       value: Array<string>
+    }
+    LocalAuthority: {
+      id: string
+      name: string
     }
   }
 }

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -4,7 +4,7 @@ import { Services } from '../../../services'
 import PremisesController from './premisesController'
 
 export const controllers = (services: Services) => {
-  const premisesController = new PremisesController(services.premisesService)
+  const premisesController = new PremisesController(services.premisesService, services.localAuthorityService)
 
   return {
     premisesController,

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -4,9 +4,13 @@ import type { NewPremises } from 'approved-premises'
 import paths from '../../../paths/temporary-accommodation/manage'
 import PremisesService from '../../../services/premisesService'
 import { catchValidationErrorOrPropogate } from '../../../utils/validation'
+import LocalAuthorityService from '../../../services/temporary-accommodation/localAuthorityService'
 
 export default class PremisesController {
-  constructor(private readonly premisesService: PremisesService) {}
+  constructor(
+    private readonly premisesService: PremisesService,
+    private readonly localAuthorityService: LocalAuthorityService,
+  ) {}
 
   index(): RequestHandler {
     return async (req: Request, res: Response) => {
@@ -16,26 +20,11 @@ export default class PremisesController {
   }
 
   new(): RequestHandler {
-    return async (_req: Request, res: Response) => {
+    return async (req: Request, res: Response) => {
+      const localAuthorities = await this.localAuthorityService.getLocalAuthorities(req.user.token)
+
       return res.render('temporary-accommodation/premises/new', {
-        localAuthorities: [
-          {
-            name: 'Aberdeen City',
-            id: '0fb03403-17e8-4b3a-b283-122a18ed8929',
-          },
-          {
-            name: 'Babergh',
-            id: 'c2892a98-dea6-4a80-9c3e-bf4e5c42ee0a',
-          },
-          {
-            name: 'Caerphilly',
-            id: '69fbc53a-a930-4d9f-b218-4c9c6bf3de7b',
-          },
-          {
-            name: 'Dacorum',
-            id: 'bed5ff2d-ee34-4423-967c-4dc50f12843e',
-          },
-        ],
+        localAuthorities,
       })
     }
   }

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -20,6 +20,7 @@ import { createRedisClient } from './redisClient'
 import TokenStore from './tokenStore'
 import LostBedClient from './lostBedClient'
 import ApplicationClient from './applicationClient'
+import LocalAuthorityClient from './temporary-accommodation/localAuthorityClient'
 
 type RestClientBuilder<T> = (token: string) => T
 
@@ -32,6 +33,8 @@ export const dataAccess = () => ({
   lostBedClientBuilder: ((token: string) => new LostBedClient(token)) as RestClientBuilder<LostBedClient>,
   personClient: ((token: string) => new PersonClient(token)) as RestClientBuilder<PersonClient>,
   applicationClientBuilder: ((token: string) => new ApplicationClient(token)) as RestClientBuilder<ApplicationClient>,
+  localAuthorityClientBuilder: ((token: string) =>
+    new LocalAuthorityClient(token)) as RestClientBuilder<LocalAuthorityClient>,
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>

--- a/server/data/temporary-accommodation/localAuthorityClient.test.ts
+++ b/server/data/temporary-accommodation/localAuthorityClient.test.ts
@@ -1,0 +1,43 @@
+import nock from 'nock'
+
+import config from '../../config'
+import localAuthorityFactory from '../../testutils/factories/localAuthority'
+import paths from '../../paths/temporary-accommodation/api'
+import LocalAuthorityClient from './localAuthorityClient'
+
+describe('LocalAuthorityClient', () => {
+  let fakeApi: nock.Scope
+  let localAuthorityClient: LocalAuthorityClient
+
+  const token = 'token-1'
+
+  beforeEach(() => {
+    config.apis.approvedPremises.url = 'http://localhost:8080'
+    fakeApi = nock(config.apis.approvedPremises.url)
+    localAuthorityClient = new LocalAuthorityClient(token)
+  })
+
+  afterEach(() => {
+    if (!nock.isDone()) {
+      nock.cleanAll()
+      throw new Error('Not all nock interceptors were used!')
+    }
+    nock.abortPendingRequests()
+    nock.cleanAll()
+  })
+
+  describe('all', () => {
+    it('should get all localAuthorities', async () => {
+      const localAuthorities = localAuthorityFactory.buildList(5)
+
+      fakeApi
+        .get(paths.localAuthorities.index.pattern)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, localAuthorities)
+
+      const result = await localAuthorityClient.all()
+
+      expect(result).toEqual(localAuthorities)
+    })
+  })
+})

--- a/server/data/temporary-accommodation/localAuthorityClient.ts
+++ b/server/data/temporary-accommodation/localAuthorityClient.ts
@@ -1,0 +1,16 @@
+import type { LocalAuthority } from 'approved-premises'
+import RestClient from '../restClient'
+import config, { ApiConfig } from '../../config'
+import paths from '../../paths/temporary-accommodation/api'
+
+export default class LocalAuthorityClient {
+  restClient: RestClient
+
+  constructor(token: string) {
+    this.restClient = new RestClient('localAuthorityClient', config.apis.approvedPremises as ApiConfig, token)
+  }
+
+  async all(): Promise<Array<LocalAuthority>> {
+    return (await this.restClient.get({ path: paths.localAuthorities.index({}) })) as Array<LocalAuthority>
+  }
+}

--- a/server/paths/temporary-accommodation/api.ts
+++ b/server/paths/temporary-accommodation/api.ts
@@ -1,5 +1,15 @@
+import { path } from 'static-path'
 import paths from '../api'
+
+const localAuthoritiesPath = path('/local-authorities')
+
+const localAuthoritiesPaths = {
+  index: localAuthoritiesPath,
+}
 
 export default {
   ...paths,
+  localAuthorities: {
+    index: localAuthoritiesPaths.index,
+  },
 }

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -12,6 +12,7 @@ import DepartureService from './departureService'
 import CancellationService from './cancellationService'
 import LostBedService from './lostBedService'
 import ApplicationService from './applicationService'
+import LocalAuthorityService from './temporary-accommodation/localAuthorityService'
 
 export const services = () => {
   const {
@@ -22,6 +23,7 @@ export const services = () => {
     lostBedClientBuilder,
     personClient,
     applicationClientBuilder,
+    localAuthorityClientBuilder,
   } = dataAccess()
 
   const userService = new UserService(hmppsAuthClient)
@@ -34,6 +36,7 @@ export const services = () => {
   const cancellationService = new CancellationService(bookingClientBuilder, referenceDataClientBuilder)
   const lostBedService = new LostBedService(lostBedClientBuilder, referenceDataClientBuilder)
   const applicationService = new ApplicationService(applicationClientBuilder)
+  const localAuthorityService = new LocalAuthorityService(localAuthorityClientBuilder)
 
   return {
     userService,
@@ -46,6 +49,7 @@ export const services = () => {
     cancellationService,
     lostBedService,
     applicationService,
+    localAuthorityService,
   }
 }
 
@@ -62,4 +66,5 @@ export {
   BookingService,
   LostBedService,
   ApplicationService,
+  LocalAuthorityService,
 }

--- a/server/services/temporary-accommodation/localAuthorityService.test.ts
+++ b/server/services/temporary-accommodation/localAuthorityService.test.ts
@@ -1,0 +1,43 @@
+import localAuthorityFactory from '../../testutils/factories/localAuthority'
+import LocalAuthorityClient from '../../data/temporary-accommodation/localAuthorityClient'
+import LocalAuthorityService from './localAuthorityService'
+
+jest.mock('../../data/temporary-accommodation/localAuthorityClient')
+
+describe('LocalAuthorityService', () => {
+  const localAuthorityClient = new LocalAuthorityClient(null) as jest.Mocked<LocalAuthorityClient>
+  const localAuthorityClientFactory = jest.fn()
+
+  const service = new LocalAuthorityService(localAuthorityClientFactory)
+
+  const token = 'SOME_TOKEN'
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    localAuthorityClientFactory.mockReturnValue(localAuthorityClient)
+  })
+
+  describe('getLocalAuthorities', () => {
+    it('calls the all method and returns a sorted list of local authorities', async () => {
+      const localAuthorities = [
+        localAuthorityFactory.build({
+          name: 'XYZ',
+        }),
+        localAuthorityFactory.build({
+          name: 'ABC',
+        }),
+        localAuthorityFactory.build({
+          name: 'RST',
+        }),
+      ]
+      localAuthorityClient.all.mockResolvedValue(localAuthorities)
+
+      const result = await service.getLocalAuthorities(token)
+
+      expect(result).toEqual([localAuthorities[1], localAuthorities[2], localAuthorities[0]])
+
+      expect(localAuthorityClientFactory).toHaveBeenCalledWith(token)
+      expect(localAuthorityClient.all).toHaveBeenCalled()
+    })
+  })
+})

--- a/server/services/temporary-accommodation/localAuthorityService.ts
+++ b/server/services/temporary-accommodation/localAuthorityService.ts
@@ -1,0 +1,13 @@
+import type { LocalAuthority } from 'approved-premises'
+import { RestClientBuilder } from '../../data'
+import LocalAuthorityClient from '../../data/temporary-accommodation/localAuthorityClient'
+
+export default class LocalAuthorityService {
+  constructor(private readonly localAuthorityClientFactory: RestClientBuilder<LocalAuthorityClient>) {}
+
+  async getLocalAuthorities(token: string): Promise<Array<LocalAuthority>> {
+    const localAuthorityClient = this.localAuthorityClientFactory(token)
+
+    return [...(await localAuthorityClient.all())].sort((a, b) => a.name.localeCompare(b.name))
+  }
+}

--- a/server/testutils/factories/localAuthority.ts
+++ b/server/testutils/factories/localAuthority.ts
@@ -1,0 +1,9 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { LocalAuthority } from 'approved-premises'
+
+export default Factory.define<LocalAuthority>(() => ({
+  id: faker.datatype.uuid(),
+  name: faker.address.county(),
+}))

--- a/wiremock/localAuthorityStubs.ts
+++ b/wiremock/localAuthorityStubs.ts
@@ -1,0 +1,16 @@
+import paths from '../server/paths/temporary-accommodation/api'
+import localAuthorityFactory from '../server/testutils/factories/localAuthority'
+
+export default [
+  {
+    request: {
+      method: 'GET',
+      url: paths.localAuthorities.index({}),
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: localAuthorityFactory.buildList(20),
+    },
+  },
+]

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -17,6 +17,7 @@ import cancellationStubs from './cancellationStubs'
 import lostBedStubs from './lostBedStubs'
 import personStubs from './personStubs'
 import applicationStubs from './applicationStubs'
+import localAuthorityStubs from './localAuthorityStubs'
 
 import * as referenceDataStubs from './referenceDataStubs'
 import premisesCapacityItemFactory from '../server/testutils/factories/premisesCapacityItem'
@@ -177,6 +178,7 @@ stubs.push(
   ...lostBedStubs,
   ...personStubs,
   ...applicationStubs,
+  ...localAuthorityStubs,
   ...Object.values(referenceDataStubs),
 )
 


### PR DESCRIPTION
# Changes in this PR

* Frontend now makes a call to a `local-authorities` endpoint, rather than using a hardcoded list of local authorities and database IDs