### PR TITLE
[TA] Creating a premises shows errors when required fields are missing

### DIFF
--- a/integration_tests/mockApis/premises.ts
+++ b/integration_tests/mockApis/premises.ts
@@ -5,6 +5,7 @@ import { Service } from '@approved-premises/ui'
 
 import { getMatchingRequests, stubFor } from '../../wiremock'
 import bookingStubs from './booking'
+import { errorStub } from '../../wiremock/utils'
 
 const stubPremises = (args: { premises: Array<Premises>; service: Service }) =>
   stubFor({
@@ -93,6 +94,7 @@ export default {
         jsonBody: premises,
       },
     }),
+  stubPremisesCreateErrors: (params: Array<string>): SuperAgentRequest => stubFor(errorStub(params, '/premises')),
   verifyPremisesCreate: async () =>
     (
       await getMatchingRequests({

--- a/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
@@ -90,6 +90,25 @@ context('Premises', () => {
     premisesNewPage.shouldShowBanner('Property created')
   })
 
+  it('should show errors when the API returns an error', () => {
+    // Given I am logged in
+    cy.signIn()
+
+    // And there are local authorities in the database
+    const localAuthorities = localAuthorityFactory.buildList(5)
+    cy.task('stubLocalAuthorities', localAuthorities)
+
+    // When I visit the new premises page
+    const page = PremisesNewPage.visit()
+
+    // And I miss required fields
+    cy.task('stubPremisesCreateErrors', ['address', 'postcode', 'localAuthorityId'])
+    page.clickSubmit()
+
+    // Then I should see error messages relating to those fields
+    page.shouldShowErrorMessagesForFields(['address', 'postcode', 'localAuthorityId'])
+  })
+
   it('should navigate back to the premises list page', () => {
     // Given I am signed in
     cy.signIn()

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -3,7 +3,7 @@ import type { Request, Response, RequestHandler } from 'express'
 import type { NewPremises } from '@approved-premises/ui'
 import paths from '../../../paths/temporary-accommodation/manage'
 import PremisesService from '../../../services/premisesService'
-import { catchValidationErrorOrPropogate } from '../../../utils/validation'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import LocalAuthorityService from '../../../services/temporary-accommodation/localAuthorityService'
 
 export default class PremisesController {
@@ -21,10 +21,15 @@ export default class PremisesController {
 
   new(): RequestHandler {
     return async (req: Request, res: Response) => {
+      const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
+
       const localAuthorities = await this.localAuthorityService.getLocalAuthorities(req.user.token)
 
       return res.render('temporary-accommodation/premises/new', {
         localAuthorities,
+        errors,
+        errorSummary,
+        ...userInput,
       })
     }
   }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -59,5 +59,14 @@
     "beforeStartDate": "The end date must be before the start date"
   },
   "numberOfBeds": { "empty": "You must enter the number of beds lost" },
-  "referenceNumber": { "empty": "You must enter a reference number" }
+  "referenceNumber": { "empty": "You must enter a reference number" },
+  "address": {
+    "empty": "You must enter an address"
+  },
+  "postcode": {
+    "empty": "You must enter a postcode"
+  },
+  "localAuthorityId": {
+    "empty": "You must choose a local authority"
+  }
 }

--- a/server/views/temporary-accommodation/premises/new.njk
+++ b/server/views/temporary-accommodation/premises/new.njk
@@ -58,6 +58,7 @@
           id: "address",
           name: "address",
           autocomplete: "address-line1",
+          value: address,
           errorMessage: errors.address
         }) }}
 
@@ -84,7 +85,7 @@
           hint: {
             text: "Local authority"
           },
-          items: convertObjectsToSelectOptions(localAuthorities, 'Select a local authority', 'name', 'id', ''),
+          items: convertObjectsToSelectOptions(localAuthorities, 'Select a local authority', 'name', 'id', 'localAuthorityId'),
           id: "localAuthorityId",
           name: "localAuthorityId",
           errorMessage: errors.localAuthorityId
@@ -100,6 +101,7 @@
           },
           id: "notes",
           name: "notes",
+          value: notes,
           errorMessage: errors.notes
         }) }}
 

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -22,6 +22,7 @@ import localAuthorityStubs from './localAuthorityStubs'
 import * as referenceDataStubs from './referenceDataStubs'
 import dateCapacityFactory from '../server/testutils/factories/dateCapacity'
 import staffMemberFactory from '../server/testutils/factories/staffMember'
+import { errorStub, getCombinations } from './utils'
 
 const stubs = []
 
@@ -66,6 +67,12 @@ stubs.push({
     },
     jsonBody: taPremises,
   },
+})
+
+const requiredFields = getCombinations(['address', 'postcode', 'localAuthorityId'])
+
+requiredFields.forEach((fields: Array<string>) => {
+  stubs.push(errorStub(fields, `/premises`))
 })
 
 stubs.push({


### PR DESCRIPTION
# Changes in this PR

* Per-field validation errors are shown to the user

## Screenshots of UI changes

### Before
![localhost_3000_temporary-accommodation_properties (1)](https://user-images.githubusercontent.com/94137563/196482421-1c9503fe-2429-4b53-b171-4b1d3a20515b.png)

### After
![localhost_3000_temporary-accommodation_properties_new (3)](https://user-images.githubusercontent.com/94137563/196482237-5e1e024e-f629-479e-a7ac-29ff11605b0b.png)
