### PR TITLE
(800) Update error handling in Apply forms

### DIFF
--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -3,6 +3,7 @@ import { RoshRisks, RiskTier, FlagsEnvelope, Mappa } from '@approved-premises/ap
 interface TasklistPage {
   body: Record<string, unknown>
 }
+interface PersonService {}
 
 // A utility type that allows us to define an object with a date attribute split into
 // date, month, year (and optionally, time) attributes. Designed for use with the GOV.UK
@@ -129,4 +130,8 @@ export interface PersonRisksUI {
 
 export type GroupedListofBookings = {
   [K in 'arrivingToday' | 'departingToday' | 'upcomingArrivals' | 'upcomingDepartures']: Array<TableRow>
+}
+
+export type DataServices = {
+  personService: PersonService
 }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,5 +1,9 @@
 import { RoshRisks, RiskTier, FlagsEnvelope, Mappa } from '@approved-premises/api'
 
+interface TasklistPage {
+  body: Record<string, unknown>
+}
+
 // A utility type that allows us to define an object with a date attribute split into
 // date, month, year (and optionally, time) attributes. Designed for use with the GOV.UK
 // date input

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -104,7 +104,7 @@ export interface ErrorsAndUserInput {
   userInput: Record<string, unknown>
 }
 
-export type TaskListErrors = Array<{ propertyName: string; errorType: string }>
+export type TaskListErrors<K extends TasklistPage> = Partial<Record<keyof K['body'], string>>
 
 export type YesOrNo = 'yes' | 'no'
 

--- a/server/controllers/apply/applications/pagesController.test.ts
+++ b/server/controllers/apply/applications/pagesController.test.ts
@@ -2,10 +2,9 @@ import type { Request, Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 import createError from 'http-errors'
 
-import type { ErrorsAndUserInput } from '@approved-premises/ui'
+import type { ErrorsAndUserInput, DataServices } from '@approved-premises/ui'
 import PagesController from './pagesController'
 import { ApplicationService } from '../../../services'
-import type { DataServices } from '../../../services/applicationService'
 import TasklistPage from '../../../form-pages/tasklistPage'
 
 import {

--- a/server/controllers/apply/applications/pagesController.ts
+++ b/server/controllers/apply/applications/pagesController.ts
@@ -1,8 +1,8 @@
 import type { Request, Response, RequestHandler, NextFunction } from 'express'
 import createError from 'http-errors'
 
+import type { DataServices } from '@approved-premises/ui'
 import { ApplicationService } from '../../../services'
-import type { DataServices } from '../../../services/applicationService'
 
 import {
   catchValidationErrorOrPropogate,

--- a/server/form-pages/apply/basic-information/oralHearing.test.ts
+++ b/server/form-pages/apply/basic-information/oralHearing.test.ts
@@ -45,7 +45,7 @@ describe('OralHearing', () => {
 
   describe('errors', () => {
     describe('if the user knows the oral hearing date', () => {
-      it('should return an empty array if the user knows the release date and specifies the date', () => {
+      it('should return an empty object if the user knows the release date and specifies the date', () => {
         const page = new OralHearing(
           {
             knowOralHearingDate: 'yes',
@@ -55,7 +55,7 @@ describe('OralHearing', () => {
           },
           application,
         )
-        expect(page.errors()).toEqual([])
+        expect(page.errors()).toEqual({})
       })
 
       it('should return an error if the date is not populated', () => {
@@ -65,12 +65,7 @@ describe('OralHearing', () => {
           },
           application,
         )
-        expect(page.errors()).toEqual([
-          {
-            propertyName: '$.oralHearingDate',
-            errorType: 'empty',
-          },
-        ])
+        expect(page.errors()).toEqual({ oralHearingDate: 'You must specify the oral hearing date' })
       })
 
       it('should return an error if the date is invalid', () => {
@@ -83,33 +78,23 @@ describe('OralHearing', () => {
           },
           application,
         )
-        expect(page.errors()).toEqual([
-          {
-            propertyName: '$.oralHearingDate',
-            errorType: 'invalid',
-          },
-        ])
+        expect(page.errors()).toEqual({ oralHearingDate: 'The oral hearing date is an invalid date' })
       })
     })
 
-    it('should return an empty array  if the user does not know the release date', () => {
+    it('should return an empty object if the user does not know the release date', () => {
       const page = new OralHearing(
         {
           knowOralHearingDate: 'no',
         },
         application,
       )
-      expect(page.errors()).toEqual([])
+      expect(page.errors()).toEqual({})
     })
 
     it('should return an error if the knowOralHearingDate field is not populated', () => {
       const page = new OralHearing({}, application)
-      expect(page.errors()).toEqual([
-        {
-          propertyName: '$.knowOralHearingDate',
-          errorType: 'empty',
-        },
-      ])
+      expect(page.errors()).toEqual({ knowOralHearingDate: 'You must specify if you know the oral hearing date' })
     })
   })
 

--- a/server/form-pages/apply/basic-information/oralHearing.ts
+++ b/server/form-pages/apply/basic-information/oralHearing.ts
@@ -1,4 +1,4 @@
-import type { ObjectWithDateParts, YesOrNo } from '@approved-premises/ui'
+import type { ObjectWithDateParts, YesOrNo, TaskListErrors } from '@approved-premises/ui'
 import type { Application } from '@approved-premises/api'
 
 import TasklistPage from '../../tasklistPage'
@@ -45,26 +45,17 @@ export default class OralHearing implements TasklistPage {
   }
 
   errors() {
-    const errors = []
+    const errors: TaskListErrors<this> = {}
 
     if (!this.body.knowOralHearingDate) {
-      errors.push({
-        propertyName: '$.knowOralHearingDate',
-        errorType: 'empty',
-      })
+      errors.knowOralHearingDate = 'You must specify if you know the oral hearing date'
     }
 
     if (this.body.knowOralHearingDate === 'yes') {
       if (dateIsBlank(this.body)) {
-        errors.push({
-          propertyName: '$.oralHearingDate',
-          errorType: 'empty',
-        })
+        errors.oralHearingDate = 'You must specify the oral hearing date'
       } else if (!dateAndTimeInputsAreValidDates(this.body, 'oralHearingDate')) {
-        errors.push({
-          propertyName: '$.oralHearingDate',
-          errorType: 'invalid',
-        })
+        errors.oralHearingDate = 'The oral hearing date is an invalid date'
       }
     }
 

--- a/server/form-pages/apply/basic-information/placementDate.test.ts
+++ b/server/form-pages/apply/basic-information/placementDate.test.ts
@@ -37,18 +37,18 @@ describe('PlacementDate', () => {
   itShouldHavePreviousValue(new PlacementDate({}, application), 'oral-hearing')
 
   describe('errors', () => {
-    it('should return an empty array if the release date is the same as the start date', () => {
+    it('should return an empty object if the release date is the same as the start date', () => {
       const page = new PlacementDate(
         {
           startDateSameAsReleaseDate: 'yes',
         },
         application,
       )
-      expect(page.errors()).toEqual([])
+      expect(page.errors()).toEqual({})
     })
 
     describe('if the start date is not the same as the release date', () => {
-      it('should return an empty array if the date is specified', () => {
+      it('should return an empty object if the date is specified', () => {
         const page = new PlacementDate(
           {
             startDateSameAsReleaseDate: 'no',
@@ -58,7 +58,7 @@ describe('PlacementDate', () => {
           },
           application,
         )
-        expect(page.errors()).toEqual([])
+        expect(page.errors()).toEqual({})
       })
 
       it('should return an error if the date is not specified', () => {
@@ -68,12 +68,7 @@ describe('PlacementDate', () => {
           },
           application,
         )
-        expect(page.errors()).toEqual([
-          {
-            propertyName: '$.startDate',
-            errorType: 'empty',
-          },
-        ])
+        expect(page.errors()).toEqual({ startDate: 'You must enter a start date' })
       })
 
       it('should return an error if the date is invalid', () => {
@@ -86,23 +81,15 @@ describe('PlacementDate', () => {
           },
           application,
         )
-        expect(page.errors()).toEqual([
-          {
-            propertyName: '$.startDate',
-            errorType: 'invalid',
-          },
-        ])
+        expect(page.errors()).toEqual({ startDate: 'The start date is an invalid date' })
       })
     })
 
     it('should return an error if the startDateSameAsReleaseDate field is not populated', () => {
       const page = new PlacementDate({}, application)
-      expect(page.errors()).toEqual([
-        {
-          propertyName: '$.startDateSameAsReleaseDate',
-          errorType: 'empty',
-        },
-      ])
+      expect(page.errors()).toEqual({
+        startDateSameAsReleaseDate: 'You must specify if the start date is the same as the release date',
+      })
     })
   })
 

--- a/server/form-pages/apply/basic-information/placementDate.ts
+++ b/server/form-pages/apply/basic-information/placementDate.ts
@@ -1,4 +1,4 @@
-import type { ObjectWithDateParts, YesOrNo } from '@approved-premises/ui'
+import type { ObjectWithDateParts, YesOrNo, TaskListErrors } from '@approved-premises/ui'
 import type { Application } from '@approved-premises/api'
 
 import TasklistPage from '../../tasklistPage'
@@ -51,26 +51,17 @@ export default class PlacementDate implements TasklistPage {
   }
 
   errors() {
-    const errors = []
+    const errors: TaskListErrors<this> = {}
 
     if (!this.body.startDateSameAsReleaseDate) {
-      errors.push({
-        propertyName: '$.startDateSameAsReleaseDate',
-        errorType: 'empty',
-      })
+      errors.startDateSameAsReleaseDate = 'You must specify if the start date is the same as the release date'
     }
 
     if (this.body.startDateSameAsReleaseDate === 'no') {
       if (dateIsBlank(this.body)) {
-        errors.push({
-          propertyName: '$.startDate',
-          errorType: 'empty',
-        })
+        errors.startDate = 'You must enter a start date'
       } else if (!dateAndTimeInputsAreValidDates(this.body, 'startDate')) {
-        errors.push({
-          propertyName: '$.startDate',
-          errorType: 'invalid',
-        })
+        errors.startDate = 'The start date is an invalid date'
       }
     }
 

--- a/server/form-pages/apply/basic-information/releaseDate.test.ts
+++ b/server/form-pages/apply/basic-information/releaseDate.test.ts
@@ -55,7 +55,7 @@ describe('ReleaseDate', () => {
 
   describe('errors', () => {
     describe('if the user knows the release date', () => {
-      it('should return an empty array if the date is specified', () => {
+      it('should return an empty object if the date is specified', () => {
         const page = new ReleaseDate(
           {
             knowReleaseDate: 'yes',
@@ -66,10 +66,10 @@ describe('ReleaseDate', () => {
           application,
           'somePage',
         )
-        expect(page.errors()).toEqual([])
+        expect(page.errors()).toEqual({})
       })
 
-      it('should return an error if  the date is not populated', () => {
+      it('should return an error if the date is not populated', () => {
         const page = new ReleaseDate(
           {
             knowReleaseDate: 'yes',
@@ -77,12 +77,7 @@ describe('ReleaseDate', () => {
           application,
           'somePage',
         )
-        expect(page.errors()).toEqual([
-          {
-            propertyName: '$.releaseDate',
-            errorType: 'empty',
-          },
-        ])
+        expect(page.errors()).toEqual({ releaseDate: 'You must specify the release date' })
       })
 
       it('should return an error if the date is invalid', () => {
@@ -96,16 +91,11 @@ describe('ReleaseDate', () => {
           application,
           'somePage',
         )
-        expect(page.errors()).toEqual([
-          {
-            propertyName: '$.releaseDate',
-            errorType: 'invalid',
-          },
-        ])
+        expect(page.errors()).toEqual({ releaseDate: 'The release date is an invalid date' })
       })
     })
 
-    it('should return an empty array if the user does not know the release date', () => {
+    it('should return an empty object if the user does not know the release date', () => {
       const page = new ReleaseDate(
         {
           knowReleaseDate: 'no',
@@ -113,17 +103,12 @@ describe('ReleaseDate', () => {
         application,
         'somePage',
       )
-      expect(page.errors()).toEqual([])
+      expect(page.errors()).toEqual({})
     })
 
     it('should return an error if the knowReleaseDate field is not populated', () => {
       const page = new ReleaseDate({}, application, 'somePage')
-      expect(page.errors()).toEqual([
-        {
-          propertyName: '$.knowReleaseDate',
-          errorType: 'empty',
-        },
-      ])
+      expect(page.errors()).toEqual({ knowReleaseDate: 'You must specify if you know the release date' })
     })
   })
 

--- a/server/form-pages/apply/basic-information/releaseDate.ts
+++ b/server/form-pages/apply/basic-information/releaseDate.ts
@@ -1,4 +1,4 @@
-import type { ObjectWithDateParts, YesOrNo } from '@approved-premises/ui'
+import type { ObjectWithDateParts, YesOrNo, TaskListErrors } from '@approved-premises/ui'
 import type { Application } from '@approved-premises/api'
 
 import TasklistPage from '../../tasklistPage'
@@ -49,26 +49,17 @@ export default class ReleaseDate implements TasklistPage {
   }
 
   errors() {
-    const errors = []
+    const errors: TaskListErrors<this> = {}
 
     if (!this.body.knowReleaseDate) {
-      errors.push({
-        propertyName: '$.knowReleaseDate',
-        errorType: 'empty',
-      })
+      errors.knowReleaseDate = 'You must specify if you know the release date'
     }
 
     if (this.body.knowReleaseDate === 'yes') {
       if (dateIsBlank(this.body)) {
-        errors.push({
-          propertyName: '$.releaseDate',
-          errorType: 'empty',
-        })
+        errors.releaseDate = 'You must specify the release date'
       } else if (!dateAndTimeInputsAreValidDates(this.body, 'releaseDate')) {
-        errors.push({
-          propertyName: '$.releaseDate',
-          errorType: 'invalid',
-        })
+        errors.releaseDate = 'The release date is an invalid date'
       }
     }
 

--- a/server/form-pages/apply/basic-information/releaseType.test.ts
+++ b/server/form-pages/apply/basic-information/releaseType.test.ts
@@ -20,19 +20,14 @@ describe('ReleaseType', () => {
   itShouldHaveNextValue(new ReleaseType({}, application), 'release-date')
 
   describe('errors', () => {
-    it('should return an empty array if the release type is populated', () => {
+    it('should return an empty object if the release type is populated', () => {
       const page = new ReleaseType({ releaseType: 'rotl' }, application)
-      expect(page.errors()).toEqual([])
+      expect(page.errors()).toEqual({})
     })
 
     it('should return an errors if the release type is not populated', () => {
       const page = new ReleaseType({ releaseType: '' }, application)
-      expect(page.errors()).toEqual([
-        {
-          propertyName: '$.releaseType',
-          errorType: 'empty',
-        },
-      ])
+      expect(page.errors()).toEqual({ releaseType: 'You must choose a release type' })
     })
   })
 

--- a/server/form-pages/apply/basic-information/releaseType.ts
+++ b/server/form-pages/apply/basic-information/releaseType.ts
@@ -1,4 +1,5 @@
 import type { Application } from '@approved-premises/api'
+import type { TaskListErrors } from '@approved-premises/ui'
 
 import { SessionDataError } from '../../../utils/errors'
 import { retrieveQuestionResponseFromApplication } from '../../../utils/utils'
@@ -53,13 +54,10 @@ export default class ReleaseType implements TasklistPage {
   }
 
   errors() {
-    const errors = []
+    const errors: TaskListErrors<this> = {}
 
     if (!this.body.releaseType) {
-      errors.push({
-        propertyName: '$.releaseType',
-        errorType: 'empty',
-      })
+      errors.releaseType = 'You must choose a release type'
     }
 
     return errors

--- a/server/form-pages/apply/basic-information/sentenceType.test.ts
+++ b/server/form-pages/apply/basic-information/sentenceType.test.ts
@@ -1,3 +1,5 @@
+import { itShouldHavePreviousValue } from '../../shared-examples'
+
 import SentenceType from './sentenceType'
 
 describe('SentenceType', () => {
@@ -47,20 +49,17 @@ describe('SentenceType', () => {
     })
   })
 
+  itShouldHavePreviousValue(new SentenceType({}), '')
+
   describe('errors', () => {
-    it('should return an empty array if the sentence type is populated', () => {
+    it('should return an empty object if the sentence type is populated', () => {
       const page = new SentenceType({ sentenceType: 'life' })
-      expect(page.errors()).toEqual([])
+      expect(page.errors()).toEqual({})
     })
 
     it('should return an errors if the sentence type is not populated', () => {
       const page = new SentenceType({ sentenceType: '' })
-      expect(page.errors()).toEqual([
-        {
-          propertyName: '$.sentenceType',
-          errorType: 'empty',
-        },
-      ])
+      expect(page.errors()).toEqual({ sentenceType: 'You must choose a sentence type' })
     })
   })
 

--- a/server/form-pages/apply/basic-information/sentenceType.ts
+++ b/server/form-pages/apply/basic-information/sentenceType.ts
@@ -1,3 +1,5 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+
 import TasklistPage from '../../tasklistPage'
 
 export const sentenceTypes = {
@@ -29,6 +31,10 @@ export default class SentenceType implements TasklistPage {
     return { [this.title]: sentenceTypes[this.body.sentenceType] }
   }
 
+  previous() {
+    return ''
+  }
+
   next() {
     switch (this.body.sentenceType) {
       case 'standardDeterminate':
@@ -49,13 +55,10 @@ export default class SentenceType implements TasklistPage {
   }
 
   errors() {
-    const errors = []
+    const errors: TaskListErrors<this> = {}
 
     if (!this.body.sentenceType) {
-      errors.push({
-        propertyName: '$.sentenceType',
-        errorType: 'empty',
-      })
+      errors.sentenceType = 'You must choose a sentence type'
     }
 
     return errors

--- a/server/form-pages/apply/basic-information/situation.test.ts
+++ b/server/form-pages/apply/basic-information/situation.test.ts
@@ -25,19 +25,14 @@ describe('Situation', () => {
   itShouldHaveNextValue(new Situation({}, application), 'release-date')
 
   describe('errors', () => {
-    it('should return an empty array if the situation is populated', () => {
+    it('should return an empty object if the situation is populated', () => {
       const page = new Situation({ situation: 'riskManagement' }, application)
-      expect(page.errors()).toEqual([])
+      expect(page.errors()).toEqual({})
     })
 
     it('should return an errors if the situation is not populated', () => {
       const page = new Situation({ situation: '' }, application)
-      expect(page.errors()).toEqual([
-        {
-          propertyName: '$.situation',
-          errorType: 'empty',
-        },
-      ])
+      expect(page.errors()).toEqual({ situation: 'You must choose a situation' })
     })
   })
 

--- a/server/form-pages/apply/basic-information/situation.ts
+++ b/server/form-pages/apply/basic-information/situation.ts
@@ -1,4 +1,5 @@
 import type { Application } from '@approved-premises/api'
+import type { TaskListErrors } from '@approved-premises/ui'
 
 import { SessionDataError } from '../../../utils/errors'
 import { retrieveQuestionResponseFromApplication } from '../../../utils/utils'
@@ -52,13 +53,10 @@ export default class Situation implements TasklistPage {
   }
 
   errors() {
-    const errors = []
+    const errors: TaskListErrors<this> = {}
 
     if (!this.body.situation) {
-      errors.push({
-        propertyName: '$.situation',
-        errorType: 'empty',
-      })
+      errors.situation = 'You must choose a situation'
     }
 
     return errors

--- a/server/form-pages/apply/type-of-ap/apType.test.ts
+++ b/server/form-pages/apply/type-of-ap/apType.test.ts
@@ -1,4 +1,4 @@
-import { itShouldHaveNextValue } from '../../shared-examples'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
 import { convertKeyValuePairToRadioItems } from '../../../utils/formUtils'
 
 import ApType from './apType'
@@ -29,6 +29,8 @@ describe('ApType', () => {
     })
   })
 
+  itShouldHavePreviousValue(new ApType({}, application), '')
+
   describe('when type is set to pipe', () => {
     itShouldHaveNextValue(new ApType({ type: 'pipe' }, application), 'pipe-referral')
   })
@@ -42,19 +44,14 @@ describe('ApType', () => {
   })
 
   describe('errors', () => {
-    it('should return an empty array if the type is populated', () => {
+    it('should return an empty object if the type is populated', () => {
       const page = new ApType({ type: 'riskManagement' }, application)
-      expect(page.errors()).toEqual([])
+      expect(page.errors()).toEqual({})
     })
 
     it('should return an errors if the type is not populated', () => {
       const page = new ApType({ type: '' }, application)
-      expect(page.errors()).toEqual([
-        {
-          propertyName: '$.type',
-          errorType: 'empty',
-        },
-      ])
+      expect(page.errors()).toEqual({ type: 'You must specify an AP type' })
     })
   })
 

--- a/server/form-pages/apply/type-of-ap/apType.ts
+++ b/server/form-pages/apply/type-of-ap/apType.ts
@@ -1,4 +1,5 @@
 import type { Application } from '@approved-premises/api'
+import type { TaskListErrors } from '@approved-premises/ui'
 
 import TasklistPage from '../../tasklistPage'
 import { convertKeyValuePairToRadioItems } from '../../../utils/formUtils'
@@ -24,6 +25,10 @@ export default class ApType implements TasklistPage {
     }
   }
 
+  previous() {
+    return ''
+  }
+
   next() {
     if (this.body.type === 'pipe') {
       return 'pipe-referral'
@@ -40,13 +45,10 @@ export default class ApType implements TasklistPage {
   }
 
   errors() {
-    const errors = []
+    const errors: TaskListErrors<this> = {}
 
     if (!this.body.type) {
-      errors.push({
-        propertyName: '$.type',
-        errorType: 'empty',
-      })
+      errors.type = 'You must specify an AP type'
     }
 
     return errors

--- a/server/form-pages/apply/type-of-ap/esapPlacementCCTV.test.ts
+++ b/server/form-pages/apply/type-of-ap/esapPlacementCCTV.test.ts
@@ -87,7 +87,12 @@ describe('EsapPlacementCCTV', () => {
   })
 
   describe('errors', () => {
-    it('should return an empty array when `cctvHistory` and `cctvIntelligence` are defined', () => {
+    beforeEach(() => {
+      const person = personFactory.build({ name: 'John Wayne' })
+      application.person = person
+    })
+
+    it('should return an empty object when `cctvHistory` and `cctvIntelligence` are defined', () => {
       const page = new EsapPlacementCCTV(
         {
           cctvHistory: ['prisonerAssualt'],
@@ -97,31 +102,25 @@ describe('EsapPlacementCCTV', () => {
         },
         application,
       )
-      expect(page.errors()).toEqual([])
+      expect(page.errors()).toEqual({})
     })
 
     it('should return error messages when `cctvHistory` and `cctvIntelligence` are undefined', () => {
       const page = new EsapPlacementCCTV({}, application)
-      expect(page.errors()).toEqual([
-        {
-          propertyName: '$.cctvHistory',
-          errorType: 'empty',
-        },
-        {
-          propertyName: '$.cctvIntelligence',
-          errorType: 'empty',
-        },
-      ])
+      expect(page.errors()).toEqual({
+        cctvHistory:
+          'You must specify which behaviours John Wayne has demonstrated that require enhanced CCTV provision to monitor',
+        cctvIntelligence:
+          'You must specify if partnership agencies requested the sharing of intelligence captured via enhanced CCTV',
+      })
     })
 
     it('should return an error message when `cctvHistory` is empty', () => {
       const page = new EsapPlacementCCTV({ cctvHistory: [], cctvIntelligence: 'no' }, application)
-      expect(page.errors()).toEqual([
-        {
-          propertyName: '$.cctvHistory',
-          errorType: 'empty',
-        },
-      ])
+      expect(page.errors()).toEqual({
+        cctvHistory:
+          'You must specify which behaviours John Wayne has demonstrated that require enhanced CCTV provision to monitor',
+      })
     })
 
     it('should return an empty array when `cctvIntelligence` is yes and no details are given', () => {
@@ -134,12 +133,10 @@ describe('EsapPlacementCCTV', () => {
         },
         application,
       )
-      expect(page.errors()).toEqual([
-        {
-          propertyName: '$.cctvIntelligenceDetails',
-          errorType: 'empty',
-        },
-      ])
+      expect(page.errors()).toEqual({
+        cctvIntelligenceDetails:
+          'You must specify the details if partnership agencies have requested the sharing of intelligence captured via enhanced CCTV',
+      })
     })
   })
 

--- a/server/form-pages/apply/type-of-ap/esapPlacementCCTV.ts
+++ b/server/form-pages/apply/type-of-ap/esapPlacementCCTV.ts
@@ -1,4 +1,4 @@
-import type { YesOrNo } from '@approved-premises/ui'
+import type { YesOrNo, TaskListErrors } from '@approved-premises/ui'
 import type { Application } from '@approved-premises/api'
 
 import TasklistPage from '../../tasklistPage'
@@ -75,27 +75,20 @@ export default class EsapPlacementCCTV implements TasklistPage {
   }
 
   errors() {
-    const errors = []
+    const errors: TaskListErrors<this> = {}
 
     if (!this.body.cctvHistory || !this.body.cctvHistory.length) {
-      errors.push({
-        propertyName: '$.cctvHistory',
-        errorType: 'empty',
-      })
+      errors.cctvHistory = `You must specify which behaviours ${this.application.person.name} has demonstrated that require enhanced CCTV provision to monitor`
     }
 
     if (!this.body.cctvIntelligence) {
-      errors.push({
-        propertyName: '$.cctvIntelligence',
-        errorType: 'empty',
-      })
+      errors.cctvIntelligence =
+        'You must specify if partnership agencies requested the sharing of intelligence captured via enhanced CCTV'
     }
 
     if (this.body.cctvIntelligence === 'yes' && !this.body.cctvIntelligenceDetails) {
-      errors.push({
-        propertyName: '$.cctvIntelligenceDetails',
-        errorType: 'empty',
-      })
+      errors.cctvIntelligenceDetails =
+        'You must specify the details if partnership agencies have requested the sharing of intelligence captured via enhanced CCTV'
     }
 
     return errors

--- a/server/form-pages/apply/type-of-ap/esapPlacementScreening.test.ts
+++ b/server/form-pages/apply/type-of-ap/esapPlacementScreening.test.ts
@@ -86,29 +86,23 @@ describe('EsapPlacementScreening', () => {
   })
 
   describe('errors', () => {
-    it('should return an empty array when `esapReasons` is defined', () => {
+    it('should return an empty object when `esapReasons` is defined', () => {
       const page = new EsapPlacementScreening({ esapReasons: ['secreting', 'cctv'] }, application)
-      expect(page.errors()).toEqual([])
+      expect(page.errors()).toEqual({})
     })
 
     it('should return an error message when `esapReasons` is undefined', () => {
       const page = new EsapPlacementScreening({}, application)
-      expect(page.errors()).toEqual([
-        {
-          propertyName: '$.esapReasons',
-          errorType: 'empty',
-        },
-      ])
+      expect(page.errors()).toEqual({
+        esapReasons: 'You must specify why John Wayne requires an enhanced security placement',
+      })
     })
 
     it('should return an error message when `esapReasons` is empty', () => {
       const page = new EsapPlacementScreening({ esapReasons: [] }, application)
-      expect(page.errors()).toEqual([
-        {
-          propertyName: '$.esapReasons',
-          errorType: 'empty',
-        },
-      ])
+      expect(page.errors()).toEqual({
+        esapReasons: 'You must specify why John Wayne requires an enhanced security placement',
+      })
     })
   })
 

--- a/server/form-pages/apply/type-of-ap/esapPlacementScreening.ts
+++ b/server/form-pages/apply/type-of-ap/esapPlacementScreening.ts
@@ -1,4 +1,5 @@
 import type { Application } from '@approved-premises/api'
+import type { TaskListErrors } from '@approved-premises/ui'
 
 import TasklistPage from '../../tasklistPage'
 import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
@@ -62,13 +63,10 @@ export default class EsapPlacementScreening implements TasklistPage {
   }
 
   errors() {
-    const errors = []
+    const errors: TaskListErrors<this> = {}
 
     if (!this.body.esapReasons || !this.body.esapReasons.length) {
-      errors.push({
-        propertyName: '$.esapReasons',
-        errorType: 'empty',
-      })
+      errors.esapReasons = `You must specify why ${this.application.person.name} requires an enhanced security placement`
     }
 
     return errors

--- a/server/form-pages/apply/type-of-ap/esapPlacementSecreting.test.ts
+++ b/server/form-pages/apply/type-of-ap/esapPlacementSecreting.test.ts
@@ -87,7 +87,12 @@ describe('EsapPlacementSecreting', () => {
   })
 
   describe('errors', () => {
-    it('should return an empty array when `secretingHistory` and `secretingIntelligence` are defined', () => {
+    beforeEach(() => {
+      const person = personFactory.build({ name: 'John Wayne' })
+      application.person = person
+    })
+
+    it('should return an empty object when `secretingHistory` and `secretingIntelligence` are defined', () => {
       const page = new EsapPlacementSecreting(
         {
           secretingHistory: ['radicalisationLiterature'],
@@ -97,31 +102,39 @@ describe('EsapPlacementSecreting', () => {
         },
         application,
       )
-      expect(page.errors()).toEqual([])
+      expect(page.errors()).toEqual({})
     })
 
     it('should return error messages when `secretingHistory` and `secretingIntelligence` are undefined', () => {
       const page = new EsapPlacementSecreting({}, application)
-      expect(page.errors()).toEqual([
-        {
-          propertyName: '$.secretingHistory',
-          errorType: 'empty',
-        },
-        {
-          propertyName: '$.secretingIntelligence',
-          errorType: 'empty',
-        },
-      ])
+      expect(page.errors()).toEqual({
+        secretingHistory: 'You must specify what items John Wayne has a history of secreting',
+        secretingIntelligence:
+          'You must specify if partnership agencies requested the sharing of intelligence captured via body worn technology',
+      })
     })
 
     it('should return an error message when `secretingHistory` is empty', () => {
       const page = new EsapPlacementSecreting({ secretingHistory: [], secretingIntelligence: 'no' }, application)
-      expect(page.errors()).toEqual([
+      expect(page.errors()).toEqual({
+        secretingHistory: 'You must specify what items John Wayne has a history of secreting',
+      })
+    })
+
+    it('should return an error message when `secretingIntelligence` is yes and no details are given', () => {
+      const page = new EsapPlacementSecreting(
         {
-          propertyName: '$.secretingHistory',
-          errorType: 'empty',
+          secretingHistory: ['radicalisationLiterature'],
+          secretingIntelligence: 'yes',
+          secretingIntelligenceDetails: '',
+          secretingNotes: 'notes',
         },
-      ])
+        application,
+      )
+      expect(page.errors()).toEqual({
+        secretingIntelligenceDetails:
+          'You must specify the details if partnership agencies have requested the sharing of intelligence captured via body worn technology',
+      })
     })
   })
 
@@ -132,23 +145,5 @@ describe('EsapPlacementSecreting', () => {
 
       expect(convertKeyValuePairToCheckBoxItems).toHaveBeenCalledWith(secretingHistory, page.body.secretingHistory)
     })
-  })
-
-  it('should return an empty array when `secretingIntelligence` is yes and no details are given', () => {
-    const page = new EsapPlacementSecreting(
-      {
-        secretingHistory: ['radicalisationLiterature'],
-        secretingIntelligence: 'yes',
-        secretingIntelligenceDetails: '',
-        secretingNotes: 'notes',
-      },
-      application,
-    )
-    expect(page.errors()).toEqual([
-      {
-        propertyName: '$.secretingIntelligenceDetails',
-        errorType: 'empty',
-      },
-    ])
   })
 })

--- a/server/form-pages/apply/type-of-ap/esapPlacementSecreting.ts
+++ b/server/form-pages/apply/type-of-ap/esapPlacementSecreting.ts
@@ -1,5 +1,5 @@
 import type { Application } from '@approved-premises/api'
-import type { YesOrNo } from '@approved-premises/ui'
+import type { YesOrNo, TaskListErrors } from '@approved-premises/ui'
 
 import TasklistPage from '../../tasklistPage'
 import { convertToTitleCase, retrieveQuestionResponseFromApplication } from '../../../utils/utils'
@@ -76,27 +76,20 @@ export default class EsapPlacementSecreting implements TasklistPage {
   }
 
   errors() {
-    const errors = []
+    const errors: TaskListErrors<this> = {}
 
     if (!this.body.secretingHistory || !this.body.secretingHistory.length) {
-      errors.push({
-        propertyName: '$.secretingHistory',
-        errorType: 'empty',
-      })
+      errors.secretingHistory = `You must specify what items ${this.application.person.name} has a history of secreting`
     }
 
     if (!this.body.secretingIntelligence) {
-      errors.push({
-        propertyName: '$.secretingIntelligence',
-        errorType: 'empty',
-      })
+      errors.secretingIntelligence =
+        'You must specify if partnership agencies requested the sharing of intelligence captured via body worn technology'
     }
 
     if (this.body.secretingIntelligence === 'yes' && !this.body.secretingIntelligenceDetails) {
-      errors.push({
-        propertyName: '$.secretingIntelligenceDetails',
-        errorType: 'empty',
-      })
+      errors.secretingIntelligenceDetails =
+        'You must specify the details if partnership agencies have requested the sharing of intelligence captured via body worn technology'
     }
 
     return errors

--- a/server/form-pages/apply/type-of-ap/pipeOpdScreening.test.ts
+++ b/server/form-pages/apply/type-of-ap/pipeOpdScreening.test.ts
@@ -25,19 +25,16 @@ describe('PipeOpdScreening', () => {
   itShouldHaveNextValue(new PipeOpdScreening({}, application), '')
 
   describe('errors', () => {
-    it('should return an empty array if the pipeReferral is populated', () => {
+    it('should return an empty object if the pipeReferral is populated', () => {
       const page = new PipeOpdScreening({ pipeReferral: 'yes' }, application)
-      expect(page.errors()).toEqual([])
+      expect(page.errors()).toEqual({})
     })
 
     it('should return an errors if the pipeReferral is not populated', () => {
       const page = new PipeOpdScreening({ pipeReferral: '' }, application)
-      expect(page.errors()).toEqual([
-        {
-          propertyName: '$.pipeReferral',
-          errorType: 'empty',
-        },
-      ])
+      expect(page.errors()).toEqual({
+        pipeReferral: 'You must specify if  a referral for PIPE placement has been recommended in the OPD pathway plan',
+      })
     })
   })
 

--- a/server/form-pages/apply/type-of-ap/pipeOpdScreening.ts
+++ b/server/form-pages/apply/type-of-ap/pipeOpdScreening.ts
@@ -1,4 +1,4 @@
-import type { YesOrNo } from '@approved-premises/ui'
+import type { YesOrNo, TaskListErrors } from '@approved-premises/ui'
 import type { Application } from '@approved-premises/api'
 
 import TasklistPage from '../../tasklistPage'
@@ -23,12 +23,12 @@ export default class PipeOpdReferral implements TasklistPage {
     }
   }
 
-  previous() {
-    return 'pipe-referral'
-  }
-
   next() {
     return ''
+  }
+
+  previous() {
+    return 'pipe-referral'
   }
 
   response() {
@@ -44,13 +44,11 @@ export default class PipeOpdReferral implements TasklistPage {
   }
 
   errors() {
-    const errors = []
+    const errors: TaskListErrors<this> = {}
 
     if (!this.body.pipeReferral) {
-      errors.push({
-        propertyName: '$.pipeReferral',
-        errorType: 'empty',
-      })
+      errors.pipeReferral =
+        'You must specify if  a referral for PIPE placement has been recommended in the OPD pathway plan'
     }
 
     return errors

--- a/server/form-pages/apply/type-of-ap/pipeReferral.test.ts
+++ b/server/form-pages/apply/type-of-ap/pipeReferral.test.ts
@@ -46,7 +46,7 @@ describe('PipeReferral', () => {
 
   describe('errors', () => {
     describe('if opdPathway is yes', () => {
-      it('should return an empty array if the date is specified', () => {
+      it('should return an empty object if the date is specified', () => {
         const page = new PipeReferral(
           {
             opdPathway: 'yes',
@@ -56,7 +56,7 @@ describe('PipeReferral', () => {
           },
           application,
         )
-        expect(page.errors()).toEqual([])
+        expect(page.errors()).toEqual({})
       })
 
       it('should return an error if  the date is not populated', () => {
@@ -66,12 +66,7 @@ describe('PipeReferral', () => {
           },
           application,
         )
-        expect(page.errors()).toEqual([
-          {
-            propertyName: '$.opdPathwayDate',
-            errorType: 'empty',
-          },
-        ])
+        expect(page.errors()).toEqual({ opdPathwayDate: 'You must enter an OPD Pathway date' })
       })
 
       it('should return an error if the date is invalid', () => {
@@ -84,33 +79,25 @@ describe('PipeReferral', () => {
           },
           application,
         )
-        expect(page.errors()).toEqual([
-          {
-            propertyName: '$.opdPathwayDate',
-            errorType: 'invalid',
-          },
-        ])
+        expect(page.errors()).toEqual({ opdPathwayDate: 'The OPD Pathway date is an invalid date' })
       })
     })
 
-    it('should return an empty array if opdPathway in no', () => {
+    it('should return an empty object if opdPathway in no', () => {
       const page = new PipeReferral(
         {
           opdPathway: 'no',
         },
         application,
       )
-      expect(page.errors()).toEqual([])
+      expect(page.errors()).toEqual({})
     })
 
     it('should return an error if the opdPathway field is not populated', () => {
       const page = new PipeReferral({}, application)
-      expect(page.errors()).toEqual([
-        {
-          propertyName: '$.opdPathway',
-          errorType: 'empty',
-        },
-      ])
+      expect(page.errors()).toEqual({
+        opdPathway: 'You must specify if John Wayne has been screened into the OPD pathway',
+      })
     })
   })
 

--- a/server/form-pages/apply/type-of-ap/pipeReferral.ts
+++ b/server/form-pages/apply/type-of-ap/pipeReferral.ts
@@ -1,4 +1,4 @@
-import type { YesOrNo, ObjectWithDateParts } from '@approved-premises/ui'
+import type { YesOrNo, ObjectWithDateParts, TaskListErrors } from '@approved-premises/ui'
 import type { Application } from '@approved-premises/api'
 
 import TasklistPage from '../../tasklistPage'
@@ -48,26 +48,17 @@ export default class PipeReferral implements TasklistPage {
   }
 
   errors() {
-    const errors = []
+    const errors: TaskListErrors<this> = {}
 
     if (!this.body.opdPathway) {
-      errors.push({
-        propertyName: '$.opdPathway',
-        errorType: 'empty',
-      })
+      errors.opdPathway = `You must specify if ${this.application.person.name} has been screened into the OPD pathway`
     }
 
     if (this.body.opdPathway === 'yes') {
       if (dateIsBlank(this.body)) {
-        errors.push({
-          propertyName: '$.opdPathwayDate',
-          errorType: 'empty',
-        })
+        errors.opdPathwayDate = 'You must enter an OPD Pathway date'
       } else if (!dateAndTimeInputsAreValidDates(this.body, 'opdPathwayDate')) {
-        errors.push({
-          propertyName: '$.opdPathwayDate',
-          errorType: 'invalid',
-        })
+        errors.opdPathwayDate = 'The OPD Pathway date is an invalid date'
       }
     }
 

--- a/server/form-pages/tasklistPage.ts
+++ b/server/form-pages/tasklistPage.ts
@@ -1,7 +1,5 @@
 import type { Request } from 'express'
-import type { TaskListErrors } from '@approved-premises/ui'
-
-import type { DataServices } from '../services/applicationService'
+import type { TaskListErrors, DataServices } from '@approved-premises/ui'
 
 export default abstract class TasklistPage {
   abstract name: string

--- a/server/form-pages/tasklistPage.ts
+++ b/server/form-pages/tasklistPage.ts
@@ -1,6 +1,6 @@
 import type { Request } from 'express'
-
 import type { TaskListErrors } from '@approved-premises/ui'
+
 import type { DataServices } from '../services/applicationService'
 
 export default abstract class TasklistPage {
@@ -8,13 +8,13 @@ export default abstract class TasklistPage {
 
   abstract title: string
 
-  body?: Record<string, unknown>
+  abstract body: Record<string, unknown>
 
-  previous?(): string
+  abstract previous(): string
 
-  next?(): string
+  abstract next(): string
 
-  errors?(): TaskListErrors
+  abstract errors(): TaskListErrors<this>
 
   async setup?(request: Request, dataServices: DataServices): Promise<void>
 }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -61,7 +61,6 @@
   "numberOfBeds": { "empty": "You must enter the number of beds lost" },
   "referenceNumber": { "empty": "You must enter a reference number" },
   "opdPathway": { "empty": "You must specify if xxxx has been screened into the OPD pathway" },
-  "esapReasons": { "empty": "You must specify why xxxx requires an enhanced security placement" },
   "secretingHistory": { "empty": "You must specify what items xxx has a history of secreting" },
   "secretingIntelligence": {
     "empty": "You must specify if partnership agencies requested the sharing of intelligence captured via body worn technology"

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -60,7 +60,6 @@
   },
   "numberOfBeds": { "empty": "You must enter the number of beds lost" },
   "referenceNumber": { "empty": "You must enter a reference number" },
-  "type": { "empty": "You must specify an AP type" },
   "opdPathway": { "empty": "You must specify if xxxx has been screened into the OPD pathway" },
   "esapReasons": { "empty": "You must specify why xxxx requires an enhanced security placement" },
   "secretingHistory": { "empty": "You must specify what items xxx has a history of secreting" },

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -65,11 +65,6 @@
   "situation": { "empty": "You must choose a situation" },
   "knowReleaseDate": { "empty": "You must specify if you know the release date" },
   "releaseDate": { "empty": "You must specify the release date", "invalid": "The release date is an invalid date" },
-  "knowOralHearingDate": { "empty": "You must specify if you know the oral hearing date" },
-  "oralHearingDate": {
-    "empty": "You must specify the oral hearing date",
-    "invalid": "The oral hearing date is an invalid date"
-  },
   "startDateSameAsReleaseDate": { "empty": "You must specify if the start date is the same as the release date" },
   "type": { "empty": "You must specify an AP type" },
   "opdPathway": { "empty": "You must specify if xxxx has been screened into the OPD pathway" },

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -69,15 +69,6 @@
   "secretingIntelligenceDetails": {
     "empty": "You must specify the details if partnership agencies have requested the sharing of intelligence captured via body worn technology"
   },
-  "cctvHistory": {
-    "empty": "You must specify which behaviours xxx has demonstrated that require enhanced CCTV provision to monitor"
-  },
-  "cctvIntelligence": {
-    "empty": "You must specify if partnership agencies requested the sharing of intelligence captured via enhanced CCTV"
-  },
-  "cctvIntelligenceDetails": {
-    "empty": "You must specify the details if partnership agencies have requested the sharing of intelligence captured via enhanced CCTV"
-  },
   "opdPathwayDate": {
     "empty": "You must enter an OPD Pathway date",
     "invalid": "The OPD Pathway date is an invalid date"

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -63,8 +63,6 @@
   "sentenceType": { "empty": "You must choose a sentence type" },
   "releaseType": { "empty": "You must choose a release type" },
   "situation": { "empty": "You must choose a situation" },
-  "knowReleaseDate": { "empty": "You must specify if you know the release date" },
-  "releaseDate": { "empty": "You must specify the release date", "invalid": "The release date is an invalid date" },
   "type": { "empty": "You must specify an AP type" },
   "opdPathway": { "empty": "You must specify if xxxx has been screened into the OPD pathway" },
   "esapReasons": { "empty": "You must specify why xxxx requires an enhanced security placement" },

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -61,13 +61,6 @@
   "numberOfBeds": { "empty": "You must enter the number of beds lost" },
   "referenceNumber": { "empty": "You must enter a reference number" },
   "opdPathway": { "empty": "You must specify if xxxx has been screened into the OPD pathway" },
-  "secretingHistory": { "empty": "You must specify what items xxx has a history of secreting" },
-  "secretingIntelligence": {
-    "empty": "You must specify if partnership agencies requested the sharing of intelligence captured via body worn technology"
-  },
-  "secretingIntelligenceDetails": {
-    "empty": "You must specify the details if partnership agencies have requested the sharing of intelligence captured via body worn technology"
-  },
   "opdPathwayDate": {
     "empty": "You must enter an OPD Pathway date",
     "invalid": "The OPD Pathway date is an invalid date"

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -60,7 +60,6 @@
   },
   "numberOfBeds": { "empty": "You must enter the number of beds lost" },
   "referenceNumber": { "empty": "You must enter a reference number" },
-  "sentenceType": { "empty": "You must choose a sentence type" },
   "situation": { "empty": "You must choose a situation" },
   "type": { "empty": "You must specify an AP type" },
   "opdPathway": { "empty": "You must specify if xxxx has been screened into the OPD pathway" },

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -65,7 +65,6 @@
   "situation": { "empty": "You must choose a situation" },
   "knowReleaseDate": { "empty": "You must specify if you know the release date" },
   "releaseDate": { "empty": "You must specify the release date", "invalid": "The release date is an invalid date" },
-  "startDateSameAsReleaseDate": { "empty": "You must specify if the start date is the same as the release date" },
   "type": { "empty": "You must specify an AP type" },
   "opdPathway": { "empty": "You must specify if xxxx has been screened into the OPD pathway" },
   "esapReasons": { "empty": "You must specify why xxxx requires an enhanced security placement" },

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -60,7 +60,6 @@
   },
   "numberOfBeds": { "empty": "You must enter the number of beds lost" },
   "referenceNumber": { "empty": "You must enter a reference number" },
-  "situation": { "empty": "You must choose a situation" },
   "type": { "empty": "You must specify an AP type" },
   "opdPathway": { "empty": "You must specify if xxxx has been screened into the OPD pathway" },
   "esapReasons": { "empty": "You must specify why xxxx requires an enhanced security placement" },

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -61,7 +61,6 @@
   "numberOfBeds": { "empty": "You must enter the number of beds lost" },
   "referenceNumber": { "empty": "You must enter a reference number" },
   "sentenceType": { "empty": "You must choose a sentence type" },
-  "releaseType": { "empty": "You must choose a release type" },
   "situation": { "empty": "You must choose a situation" },
   "type": { "empty": "You must specify an AP type" },
   "opdPathway": { "empty": "You must specify if xxxx has been screened into the OPD pathway" },

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -64,8 +64,5 @@
   "opdPathwayDate": {
     "empty": "You must enter an OPD Pathway date",
     "invalid": "The OPD Pathway date is an invalid date"
-  },
-  "pipeReferral": {
-    "empty": "You must specify if  a referral for PIPE placement has been recommended in the OPD pathway plan"
   }
 }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -59,10 +59,5 @@
     "beforeStartDate": "The end date must be before the start date"
   },
   "numberOfBeds": { "empty": "You must enter the number of beds lost" },
-  "referenceNumber": { "empty": "You must enter a reference number" },
-  "opdPathway": { "empty": "You must specify if xxxx has been screened into the OPD pathway" },
-  "opdPathwayDate": {
-    "empty": "You must enter an OPD Pathway date",
-    "invalid": "The OPD Pathway date is an invalid date"
-  }
+  "referenceNumber": { "empty": "You must enter a reference number" }
 }

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -1,11 +1,11 @@
 import type { Request } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
-import type { TaskListErrors } from '@approved-premises/ui'
+import type { TaskListErrors, DataServices } from '@approved-premises/ui'
 
 import applicationSummaryFactory from '../testutils/factories/applicationSummary'
 import type TasklistPage from '../form-pages/tasklistPage'
 import { UnknownPageError, ValidationError } from '../utils/errors'
-import ApplicationService, { type DataServices } from './applicationService'
+import ApplicationService from './applicationService'
 import ApplicationClient from '../data/applicationClient'
 
 import pages from '../form-pages/apply'

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -250,7 +250,9 @@ describe('ApplicationService', () => {
 
       beforeEach(() => {
         page = createMock<TasklistPage>({
-          errors: () => [] as TaskListErrors,
+          errors: () => {
+            return {} as TaskListErrors<TasklistPage>
+          },
           body: { foo: 'bar' },
         })
       })
@@ -289,7 +291,7 @@ describe('ApplicationService', () => {
 
     describe('When there validation errors', () => {
       it('throws an error if there is a validation error', async () => {
-        const errors = createMock<TaskListErrors>([{ propertyName: 'foo', errorType: 'bar' }])
+        const errors = createMock<TaskListErrors<TasklistPage>>({ knowOralHearingDate: 'error' })
         const page = createMock<TasklistPage>({
           errors: () => errors,
         })
@@ -300,16 +302,6 @@ describe('ApplicationService', () => {
         } catch (e) {
           expect(e).toEqual(new ValidationError(errors))
         }
-      })
-
-      it('does not thow an error when the page has no errors method', () => {
-        const page = createMock<TasklistPage>({
-          errors: undefined,
-        })
-
-        expect(async () => {
-          await service.save(page, request)
-        }).not.toThrow(ValidationError)
       })
     })
   })

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -72,10 +72,10 @@ export default class ApplicationService {
   }
 
   async save(page: TasklistPage, request: Request) {
-    const errors = page.errors ? page.errors() : []
+    const errors = page.errors()
 
     if (errors.length) {
-      throw new ValidationError(errors)
+      throw new ValidationError<typeof page>(errors)
     } else {
       const application = await this.getApplicationFromSessionOrAPI(request)
 

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -1,19 +1,14 @@
 import type { Request } from 'express'
-import type { HtmlItem, TextItem } from '@approved-premises/ui'
+import type { HtmlItem, TextItem, DataServices } from '@approved-premises/ui'
 import type { Application } from '@approved-premises/api'
 
 import type TasklistPage from '../form-pages/tasklistPage'
 import type { RestClientBuilder, ApplicationClient } from '../data'
 import { UnknownPageError, ValidationError } from '../utils/errors'
-import type { PersonService } from './index'
 
 import pages from '../form-pages/apply'
 import paths from '../paths/apply'
 import { DateFormats } from '../utils/dateUtils'
-
-export type DataServices = {
-  personService: PersonService
-}
 
 type PageResponse = Record<string, string>
 type ApplicationResponse = Record<string, Array<PageResponse>>

--- a/server/utils/errors.ts
+++ b/server/utils/errors.ts
@@ -1,10 +1,11 @@
 /* eslint-disable max-classes-per-file */
 import type { TaskListErrors } from '@approved-premises/ui'
+import TaskListPage from '../form-pages/tasklistPage'
 
-export class ValidationError extends Error {
-  data: TaskListErrors
+export class ValidationError<T extends TaskListPage> extends Error {
+  data: TaskListErrors<T>
 
-  constructor(data: TaskListErrors) {
+  constructor(data: TaskListErrors<T>) {
     super('Validation error')
     this.data = data
   }

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -6,6 +6,7 @@ import { SanitisedError } from '../sanitisedError'
 import { catchValidationErrorOrPropogate, catchAPIErrorOrPropogate, fetchErrorsAndUserInput } from './validation'
 import errorLookups from '../i18n/en/errors.json'
 import { ValidationError, TasklistAPIError } from './errors'
+import type TaskListPage from '../form-pages/tasklistPage'
 
 jest.mock('../i18n/en/errors.json', () => {
   return {
@@ -67,17 +68,11 @@ describe('catchValidationErrorOrPropogate', () => {
   })
 
   it('gets errors from a ValidationError type', () => {
-    const error = createMock<ValidationError>({
-      data: [
-        {
-          propertyName: '$.crn',
-          errorType: 'empty',
-        },
-        {
-          propertyName: '$.arrivalDate',
-          errorType: 'empty',
-        },
-      ],
+    const error = createMock<ValidationError<TaskListPage>>({
+      data: {
+        crn: 'You must enter a valid crn',
+        error: 'You must enter a valid arrival date',
+      },
     })
 
     catchValidationErrorOrPropogate(request, response, error, 'some/url')
@@ -95,13 +90,15 @@ describe('catchValidationErrorOrPropogate', () => {
   })
 
   it('throws an error if the property is not found in the error lookup', () => {
-    const error = createMock<ValidationError>({
-      data: [
-        {
-          propertyName: '$.foo',
-          errorType: 'bar',
-        },
-      ],
+    const error = createMock<SanitisedError>({
+      data: {
+        'invalid-params': [
+          {
+            propertyName: '$.foo',
+            errorType: 'bar',
+          },
+        ],
+      },
     })
 
     expect(() => catchValidationErrorOrPropogate(request, response, error, 'some/url')).toThrowError(
@@ -110,13 +107,15 @@ describe('catchValidationErrorOrPropogate', () => {
   })
 
   it('throws an error if the error type is not found in the error lookup', () => {
-    const error = createMock<ValidationError>({
-      data: [
-        {
-          propertyName: '$.crn',
-          errorType: 'invalid',
-        },
-      ],
+    const error = createMock<SanitisedError>({
+      data: {
+        'invalid-params': [
+          {
+            propertyName: '$.crn',
+            errorType: 'invalid',
+          },
+        ],
+      },
     })
 
     expect(() => catchValidationErrorOrPropogate(request, response, error, 'some/url')).toThrowError(

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -18,9 +18,9 @@ export const catchValidationErrorOrPropogate = (
   redirectPath: string,
 ): void => {
   if ('data' in error) {
-    const invalidParams = error.data['invalid-params'] || error.data
-
-    const errors = generateErrors(invalidParams)
+    const errors = error.data['invalid-params']
+      ? generateErrors(error.data['invalid-params'])
+      : (error.data as Record<string, string>)
 
     const errorMessages = generateErrorMessages(errors)
     const errorSummary = generateErrorSummary(errors)


### PR DESCRIPTION
Currently, when we return errors from an Apply Page, we get them back in the same way we get them from an API call, in this format:

```
{
  propertyName: '$.secretingHistory',
  errorType: 'empty',
}
```

These then refer to a translation in the errors.json file, i.e

```
{
...
  "secretingHistory": { "empty": "Some error"},
...
}
```

This causes us two problems:

- We can't inject information about the application (at the moment there are placeholders like `You must specify why xxxx requires an enhanced security placement`
- This breaks our rule of the page classes knowing everything about the question / answer text

This updates the Apply page errors so they're simple key/value records with the text defined in the classes themselves. This allows us to inject information about the application directly into the errors, as well as keep information about the question(s) in one place.

There are a lot of commits, but most of them are updating the error types to the correct format. We also encountered some errors where types were being pulled in alongside other code by the integration tests, so the typechecks were failing, so I've addressed that too!