### PR TITLE
(776) Add 'Planned FM works required' option

### DIFF
--- a/wiremock/stubs/lost-bed-reasons.json
+++ b/wiremock/stubs/lost-bed-reasons.json
@@ -18,5 +18,10 @@
     "id": "7f3eb6cd-b3fc-4a8d-b9ce-5959918ffbe8",
     "name": "Staff shortage",
     "isActive": true
+  },
+  {
+    "id": "1f2eb6cd-b3fc-4a8d-b9ce-5959918ffbe8",
+    "name": "Planned FM works required",
+    "isActive": true
   }
 ]


### PR DESCRIPTION
We need to add an radio option for **Planned FM works required** on the lost bed radio list
[Trello card](https://trello.com/c/4fGUP8HV/776-add-an-extra-radio-button-to-the-lost-bed-radio-list)
This change is made in the DB with [this PR](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/164)
