### PR TITLE
(761) Correct Arrival/Non-arrival page titles

### DIFF
--- a/cypress_shared/pages/manage/arrivalCreate.ts
+++ b/cypress_shared/pages/manage/arrivalCreate.ts
@@ -5,7 +5,7 @@ import paths from '../../../server/paths/manage'
 
 export default class ArrivalCreatePage extends Page {
   constructor(private readonly premisesId: string, private readonly bookingId: string) {
-    super('Mark the resident as arrived')
+    super('Record an arrival')
   }
 
   static visit(premisesId: string, bookingId: string): ArrivalCreatePage {

--- a/cypress_shared/pages/manage/nonarrivalCreate.ts
+++ b/cypress_shared/pages/manage/nonarrivalCreate.ts
@@ -5,7 +5,7 @@ import paths from '../../../server/paths/manage'
 
 export default class NonarrivalCreatePage extends Page {
   constructor(private readonly premisesId: string, private readonly bookingId: string) {
-    super('Mark the resident as not arrived')
+    super('Record a non-arrival')
   }
 
   static visit(premisesId: string, bookingId: string): NonarrivalCreatePage {

--- a/server/@types/shared/models/UserQualification.ts
+++ b/server/@types/shared/models/UserQualification.ts
@@ -2,4 +2,4 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type UserQualification = 'WOMENS' | 'PIPE';
+export type UserQualification = 'womens' | 'pipe';

--- a/server/@types/shared/models/UserRole.ts
+++ b/server/@types/shared/models/UserRole.ts
@@ -2,4 +2,4 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type UserRole = 'ASSESSOR' | 'MATCHER' | 'MANAGER' | 'WORKFLOW_MANAGER' | 'APPLICANT' | 'ROLE_ADMIN';
+export type UserRole = 'assessor' | 'matcher' | 'manager' | 'workflow_manager' | 'applicant' | 'admin';

--- a/server/controllers/manage/arrivalsController.test.ts
+++ b/server/controllers/manage/arrivalsController.test.ts
@@ -44,7 +44,7 @@ describe('ArrivalsController', () => {
       expect(response.render).toHaveBeenCalledWith('arrivals/new', {
         premisesId: 'premisesId',
         bookingId: 'bookingId',
-        pageHeading: 'Mark the resident as arrived',
+        pageHeading: 'Record an arrival',
         errors: {},
         errorSummary: [],
         staffMembers,
@@ -68,7 +68,7 @@ describe('ArrivalsController', () => {
       expect(response.render).toHaveBeenCalledWith('arrivals/new', {
         premisesId: 'premisesId',
         bookingId: 'bookingId',
-        pageHeading: 'Mark the resident as arrived',
+        pageHeading: 'Record an arrival',
         errors: errorsAndUserInput.errors,
         errorSummary: errorsAndUserInput.errorSummary,
         staffMembers,

--- a/server/controllers/manage/arrivalsController.ts
+++ b/server/controllers/manage/arrivalsController.ts
@@ -25,7 +25,7 @@ export default class ArrivalsController {
         errors,
         errorSummary,
         staffMembers,
-        pageHeading: 'Mark the resident as arrived',
+        pageHeading: 'Record an arrival',
         ...userInput,
       })
     }

--- a/server/controllers/manage/nonArrivalsController.test.ts
+++ b/server/controllers/manage/nonArrivalsController.test.ts
@@ -34,7 +34,7 @@ describe('NonArrivalsController', () => {
       expect(response.render).toHaveBeenCalledWith('nonarrivals/new', {
         premisesId: 'premisesId',
         bookingId: 'bookingId',
-        pageHeading: 'Mark the resident as not arrived',
+        pageHeading: 'Record a non-arrival',
         errors: {},
         errorSummary: [],
       })
@@ -57,7 +57,7 @@ describe('NonArrivalsController', () => {
       expect(response.render).toHaveBeenCalledWith('nonarrivals/new', {
         premisesId: 'premisesId',
         bookingId: 'bookingId',
-        pageHeading: 'Mark the resident as not arrived',
+        pageHeading: 'Record a non-arrival',
         errors: errorsAndUserInput.errors,
         errorSummary: errorsAndUserInput.errorSummary,
         ...errorsAndUserInput.userInput,

--- a/server/controllers/manage/nonArrivalsController.ts
+++ b/server/controllers/manage/nonArrivalsController.ts
@@ -20,7 +20,7 @@ export default class NonArrivalsController {
         bookingId,
         errors,
         errorSummary,
-        pageHeading: 'Mark the resident as not arrived',
+        pageHeading: 'Record a non-arrival',
         ...userInput,
       })
     }


### PR DESCRIPTION
This PR updates the page titles for when a user records an arrival or non-arrival as advised by our content designer.
[Trello card](https://trello.com/c/EFliHTlR/761-update-arrivals-page-radio-buttons) 


## Screenshots
### Before
![image](https://user-images.githubusercontent.com/44123869/196918457-91761c9b-6ba1-4434-8056-7d094e08bef1.png)
![image](https://user-images.githubusercontent.com/44123869/196918495-e96fb3ac-bf57-4f60-aab3-19ecf07aa05f.png)
### After
![image](https://user-images.githubusercontent.com/44123869/196918942-e7d4b7c7-290b-4e86-8443-ff84e007dabf.png)
![image](https://user-images.githubusercontent.com/44123869/196918976-d1fcac15-3854-40c3-a4d9-8eb3c3452b96.png)
