### PR TITLE
(746) Generate task list automatically

### DIFF
--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -18,6 +18,19 @@ export type BookingStatus = 'arrived' | 'awaiting-arrival' | 'not-arrived' | 'de
 
 export type TaskNames = 'basic-information' | 'type-of-ap'
 
+export type Task = {
+  id: string
+  title: string
+  pages: Record<string, unknown>
+}
+
+export type FormSection = {
+  title: string
+  tasks: Array<Task>
+}
+
+export type FormSections = Array<FormSection>
+
 export interface HtmlAttributes {
   [key: string]: string
 }

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -10,6 +10,7 @@ import { fetchErrorsAndUserInput } from '../../utils/validation'
 import personFactory from '../../testutils/factories/person'
 import applicationFactory from '../../testutils/factories/application'
 import risksFactory from '../../testutils/factories/risks'
+import { sections } from '../../form-pages/apply'
 
 import paths from '../../paths/apply'
 import { DateFormats } from '../../utils/dateUtils'
@@ -81,7 +82,7 @@ describe('applicationsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('applications/show', { application, risks })
+      expect(response.render).toHaveBeenCalledWith('applications/show', { application, risks, sections })
       expect(personService.getPersonRisks).toHaveBeenCalledWith(token, 'some-crn')
     })
 

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -6,6 +6,7 @@ import { PersonService } from '../../services'
 import { fetchErrorsAndUserInput } from '../../utils/validation'
 import paths from '../../paths/apply'
 import { DateFormats } from '../../utils/dateUtils'
+import { sections } from '../../form-pages/apply'
 
 export default class ApplicationsController {
   constructor(private readonly applicationService: ApplicationService, private readonly personService: PersonService) {}
@@ -33,7 +34,7 @@ export default class ApplicationsController {
       if (application) {
         const risks = await this.personService.getPersonRisks(req.user.token, application.person.crn)
 
-        res.render('applications/show', { application, risks })
+        res.render('applications/show', { application, risks, sections })
       } else {
         next(createError(404, 'Not found'))
       }

--- a/server/form-pages/apply/index.ts
+++ b/server/form-pages/apply/index.ts
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
 
-import type { TaskNames } from '@approved-premises/ui'
+import type { TaskNames, FormSections } from '@approved-premises/ui'
 import basicInfomationPages from './basic-information'
 import typeOfApPages from './type-of-ap'
 
@@ -11,4 +11,22 @@ const pages: {
   'type-of-ap': typeOfApPages,
 }
 
-export default pages
+const sections: FormSections = [
+  {
+    title: 'Reasons for placement',
+    tasks: [
+      {
+        id: 'basic-information',
+        title: 'Basic Information',
+        pages: basicInfomationPages,
+      },
+      {
+        id: 'type-of-ap',
+        title: 'Type of Approved Premises required',
+        pages: typeOfApPages,
+      },
+    ],
+  },
+]
+
+export { pages, sections }

--- a/server/i18n/en/tasks.json
+++ b/server/i18n/en/tasks.json
@@ -1,4 +1,0 @@
-{
-  "basic-information": "Basic Information",
-  "type-of-ap": "Type of Approved Premises required"
-}

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -8,7 +8,7 @@ import { UnknownPageError, ValidationError } from '../utils/errors'
 import ApplicationService from './applicationService'
 import ApplicationClient from '../data/applicationClient'
 
-import pages from '../form-pages/apply'
+import { pages } from '../form-pages/apply'
 import paths from '../paths/apply'
 import applicationFactory from '../testutils/factories/application'
 import { DateFormats } from '../utils/dateUtils'
@@ -18,7 +18,7 @@ const SecondPage = jest.fn()
 
 jest.mock('../form-pages/apply', () => {
   return {
-    'my-task': {},
+    pages: { 'my-task': {} },
   }
 })
 

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -6,7 +6,7 @@ import type TasklistPage from '../form-pages/tasklistPage'
 import type { RestClientBuilder, ApplicationClient } from '../data'
 import { UnknownPageError, ValidationError } from '../utils/errors'
 
-import pages from '../form-pages/apply'
+import { pages } from '../form-pages/apply'
 import paths from '../paths/apply'
 import { DateFormats } from '../utils/dateUtils'
 

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -5,32 +5,31 @@ import paths from '../paths/apply'
 import { taskLink, getTaskStatus } from './applicationUtils'
 
 describe('applicationUtils', () => {
+  const task = {
+    id: 'type-of-ap',
+    title: 'Type of Approved Premises required',
+    pages: { foo: 'bar', bar: 'baz' },
+  } as Task
+
   describe('getTaskStatus', () => {
     it('returns a not started tag when the task is incomplete', () => {
       const application = applicationFactory.build()
-
-      expect(getTaskStatus('basic-information', application)).toEqual(
-        '<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="basic-information-status">Not started</strong>',
+      expect(getTaskStatus(task, application)).toEqual(
+        '<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="type-of-ap-status">Not started</strong>',
       )
     })
 
     it('returns a completed tag when the task is complete', () => {
-      const application = applicationFactory.build({ data: { 'basic-information': { foo: 'bar' } } })
+      const application = applicationFactory.build({ data: { 'type-of-ap': { foo: 'bar' } } })
 
-      expect(getTaskStatus('basic-information', application)).toEqual(
-        '<strong class="govuk-tag app-task-list__tag" id="basic-information-status">Completed</strong>',
+      expect(getTaskStatus(task, application)).toEqual(
+        '<strong class="govuk-tag app-task-list__tag" id="type-of-ap-status">Completed</strong>',
       )
     })
   })
 
   describe('taskLink', () => {
     it('should return a link to a task', () => {
-      const task = {
-        id: 'type-of-ap',
-        title: 'Type of Approved Premises required',
-        pages: { foo: 'bar', bar: 'baz' },
-      } as Task
-
       expect(taskLink(task, 'some-uuid')).toEqual(
         `<a href="${paths.applications.pages.show({
           id: 'some-uuid',

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -1,3 +1,5 @@
+import type { Task } from '@approved-premises/ui'
+
 import applicationFactory from '../testutils/factories/application'
 import paths from '../paths/apply'
 import { taskLink, getTaskStatus } from './applicationUtils'
@@ -23,11 +25,17 @@ describe('applicationUtils', () => {
 
   describe('taskLink', () => {
     it('should return a link to a task', () => {
-      expect(taskLink('type-of-ap', 'some-uuid')).toEqual(
+      const task = {
+        id: 'type-of-ap',
+        title: 'Type of Approved Premises required',
+        pages: { foo: 'bar', bar: 'baz' },
+      } as Task
+
+      expect(taskLink(task, 'some-uuid')).toEqual(
         `<a href="${paths.applications.pages.show({
           id: 'some-uuid',
           task: 'type-of-ap',
-          page: 'ap-type',
+          page: 'foo',
         })}" aria-describedby="eligibility-type-of-ap" data-cy-task-name="type-of-ap">Type of Approved Premises required</a>`,
       )
     })

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -2,7 +2,7 @@ import type { Task } from '@approved-premises/ui'
 
 import applicationFactory from '../testutils/factories/application'
 import paths from '../paths/apply'
-import { taskLink, getTaskStatus } from './applicationUtils'
+import { taskLink, getTaskStatus, getCompleteSectionCount } from './applicationUtils'
 
 describe('applicationUtils', () => {
   const task = {
@@ -37,6 +37,64 @@ describe('applicationUtils', () => {
           page: 'foo',
         })}" aria-describedby="eligibility-type-of-ap" data-cy-task-name="type-of-ap">Type of Approved Premises required</a>`,
       )
+    })
+  })
+
+  describe('getCompleteSectionCount', () => {
+    const sections = [
+      {
+        title: 'Section 1',
+        tasks: [
+          {
+            id: 'basic-information',
+            title: 'Basic Information',
+            pages: { foo: 'bar', bar: 'baz' },
+          },
+          task,
+        ],
+      },
+      {
+        title: 'Section 2',
+        tasks: [
+          {
+            id: 'something-else',
+            title: 'Something Else',
+            pages: { foo: 'bar', bar: 'baz' },
+          },
+        ],
+      },
+    ]
+
+    it('returns zero when no sections are completed', () => {
+      const application = applicationFactory.build()
+
+      expect(getCompleteSectionCount(sections, application)).toEqual(0)
+    })
+
+    it('returns zero when a section is part completed', () => {
+      const application = applicationFactory.build({ data: { 'type-of-ap': { foo: 'bar' } } })
+
+      expect(getCompleteSectionCount(sections, application)).toEqual(0)
+    })
+
+    it('returns 1 when a section is complete', () => {
+      const application = applicationFactory.build({
+        data: { 'type-of-ap': { foo: 'bar' }, 'basic-information': { foo: 'baz' } },
+      })
+
+      expect(getCompleteSectionCount(sections, application)).toEqual(1)
+    })
+
+    it('returns 2 when a both sections are complete', () => {
+      const application = applicationFactory.build({
+        data: {
+          'type-of-ap': { foo: 'bar' },
+          'basic-information': { foo: 'baz' },
+          'something-else': { foo: 'baz' },
+        },
+      })
+
+      expect(getCompleteSectionCount(sections, application)).toEqual(2)
     })
   })
 })

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -1,4 +1,4 @@
-import type { Task, TaskNames } from '@approved-premises/ui'
+import type { Task, FormSections, FormSection } from '@approved-premises/ui'
 import type { Application } from '@approved-premises/api'
 import paths from '../paths/apply'
 
@@ -12,6 +12,11 @@ const getTaskStatus = (task: Task, application: Application): string => {
   }
   return `<strong class="govuk-tag app-task-list__tag" id="${task.id}-status">Completed</strong>`
 }
+
+const getCompleteSectionCount = (sections: FormSections, application: Application): number => {
+  return sections.filter((section: FormSection) => {
+    return section.tasks.filter((task: Task) => taskIsComplete(task, application)).length === section.tasks.length
+  }).length
 }
 
 const taskLink = (task: Task, applicationId: string): string => {
@@ -24,4 +29,4 @@ const taskLink = (task: Task, applicationId: string): string => {
   })}" aria-describedby="eligibility-${task.id}" data-cy-task-name="${task.id}">${task.title}</a>`
 }
 
-export { getTaskStatus, taskLink }
+export { getTaskStatus, taskLink, getCompleteSectionCount }

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -2,11 +2,16 @@ import type { Task, TaskNames } from '@approved-premises/ui'
 import type { Application } from '@approved-premises/api'
 import paths from '../paths/apply'
 
-const getTaskStatus = (task: TaskNames, application: Application): string => {
-  if (!application.data[task]) {
-    return `<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="${task}-status">Not started</strong>`
+const taskIsComplete = (task: Task, application: Application): boolean => {
+  return application.data[task.id]
+}
+
+const getTaskStatus = (task: Task, application: Application): string => {
+  if (!taskIsComplete(task, application)) {
+    return `<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="${task.id}-status">Not started</strong>`
   }
-  return `<strong class="govuk-tag app-task-list__tag" id="${task}-status">Completed</strong>`
+  return `<strong class="govuk-tag app-task-list__tag" id="${task.id}-status">Completed</strong>`
+}
 }
 
 const taskLink = (task: Task, applicationId: string): string => {

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -1,7 +1,5 @@
-import type { TaskNames } from '@approved-premises/ui'
+import type { Task, TaskNames } from '@approved-premises/ui'
 import type { Application } from '@approved-premises/api'
-import { pages } from '../form-pages/apply'
-import taskLookup from '../i18n/en/tasks.json'
 import paths from '../paths/apply'
 
 const getTaskStatus = (task: TaskNames, application: Application): string => {
@@ -11,14 +9,14 @@ const getTaskStatus = (task: TaskNames, application: Application): string => {
   return `<strong class="govuk-tag app-task-list__tag" id="${task}-status">Completed</strong>`
 }
 
-const taskLink = (task: TaskNames, id: string): string => {
-  const firstPage = Object.keys(pages[task])[0]
+const taskLink = (task: Task, applicationId: string): string => {
+  const firstPage = Object.keys(task.pages)[0]
 
   return `<a href="${paths.applications.pages.show({
-    id,
-    task,
+    id: applicationId,
+    task: task.id,
     page: firstPage,
-  })}" aria-describedby="eligibility-${task}" data-cy-task-name="${task}">${taskLookup[task]}</a>`
+  })}" aria-describedby="eligibility-${task.id}" data-cy-task-name="${task.id}">${task.title}</a>`
 }
 
 export { getTaskStatus, taskLink }

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -1,6 +1,6 @@
 import type { TaskNames } from '@approved-premises/ui'
 import type { Application } from '@approved-premises/api'
-import pages from '../form-pages/apply'
+import { pages } from '../form-pages/apply'
 import taskLookup from '../i18n/en/tasks.json'
 import paths from '../paths/apply'
 

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -5,11 +5,11 @@ import nunjucks from 'nunjucks'
 import express from 'express'
 import * as pathModule from 'path'
 
-import type { ErrorMessages, TaskNames, PersonStatus, Task } from '@approved-premises/ui'
+import type { ErrorMessages, PersonStatus, Task } from '@approved-premises/ui'
 import type { Application } from '@approved-premises/api'
 import { initialiseName, removeBlankSummaryListItems } from './utils'
 import { dateFieldValues, convertObjectsToRadioItems, convertObjectsToSelectOptions } from './formUtils'
-import { getTaskStatus, taskLink } from './applicationUtils'
+import { getTaskStatus, taskLink, getCompleteSectionCount } from './applicationUtils'
 import { statusTag } from './personUtils'
 import bookingActions from './bookingUtils'
 import { DateFormats } from './dateUtils'
@@ -92,6 +92,8 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('bookingActions', bookingActions)
 
   njkEnv.addGlobal('paths', { ...managePaths, ...applyPaths })
+
+  njkEnv.addGlobal('getCompleteSectionCount', getCompleteSectionCount)
 
   njkEnv.addGlobal('getTaskStatus', (task: Task, application: Application) =>
     markAsSafe(getTaskStatus(task, application)),

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -5,7 +5,7 @@ import nunjucks from 'nunjucks'
 import express from 'express'
 import * as pathModule from 'path'
 
-import type { ErrorMessages, TaskNames, PersonStatus } from '@approved-premises/ui'
+import type { ErrorMessages, TaskNames, PersonStatus, Task } from '@approved-premises/ui'
 import type { Application } from '@approved-premises/api'
 import { initialiseName, removeBlankSummaryListItems } from './utils'
 import { dateFieldValues, convertObjectsToRadioItems, convertObjectsToSelectOptions } from './formUtils'
@@ -97,7 +97,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
     markAsSafe(getTaskStatus(task, application)),
   )
 
-  njkEnv.addGlobal('taskLink', (task: TaskNames, id: string) => markAsSafe(taskLink(task, id)))
+  njkEnv.addGlobal('taskLink', (task: Task, applicationId: string) => markAsSafe(taskLink(task, applicationId)))
 
   njkEnv.addGlobal('statusTag', (status: PersonStatus) => markAsSafe(statusTag(status)))
 

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -93,7 +93,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
 
   njkEnv.addGlobal('paths', { ...managePaths, ...applyPaths })
 
-  njkEnv.addGlobal('getTaskStatus', (task: TaskNames, application: Application) =>
+  njkEnv.addGlobal('getTaskStatus', (task: Task, application: Application) =>
     markAsSafe(getTaskStatus(task, application)),
   )
 

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -19,153 +19,36 @@
       </h1>
 
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Application incomplete</h2>
-      <p class="govuk-body govuk-!-margin-bottom-7">You have completed 3 of 8 sections.</p>
+      <p class="govuk-body govuk-!-margin-bottom-7">You have completed {{ getCompleteSectionCount(sections, application) }} of {{ (sections | length) }} sections.</p>
     </div>
 
     <div class="govuk-grid-column-two-thirds">
-
       <ol class="app-task-list">
-        <li>
-          <h2 class="app-task-list__section">
-            <span class="app-task-list__section-number">1. </span> Reasons for placement
-          </h2>
-          <ul class="app-task-list__items">
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
-                {{ taskLink('basic-information', application.id)  }}
-              </span>
-              {{ getTaskStatus('basic-information', application) }}
-            </li>
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
-                {{ taskLink('type-of-ap', application.id) }}
-              </span>
-              {{ getTaskStatus('type-of-ap', application) }}
-            </li>
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
-                <a href="release-date.html" aria-describedby="eligibility-status">
-                  Add information about dates of release
-                </a>
-              </span>
-              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="financial-evidence-status">Cannot start yet</strong>
-            </li>
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
-                <a href="purpose-of-placement.html" aria-describedby="read-declaration-status">
-                  Confirm the need for an AP
-                </a>
-              </span>
-              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="financial-evidence-status">Cannot start yet</strong>
-            </li>
-          </ul>
-        </li>
-
-        <!-- Section 2 -->
+        {% for section in sections %}
+          <li>
+            <h2 class="app-task-list__section">
+              <span class="app-task-list__section-number">{{loop.index}}. </span>
+              {{ section.title }}
+            </h2>
+            <ul class="app-task-list__items">
+              {% for task in section.tasks %}
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    {{ taskLink(task, application.id)  }}
+                  </span>
+                  {{ getTaskStatus(task, application) }}
+                </li>
+              {% endfor %}
+            </ul>
+          </li>
+        {% endfor %}
 
         <li>
           <h2 class="app-task-list__section">
-            <span class="app-task-list__section-number">2. </span> Risk and need factors
-          </h2>
-          <ul class="app-task-list__items">
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
-                <a href="import-oasys.html" aria-describedby="company-information-status">
-                  Choose sections of OASys to import
-                </a>
-              </span>
-              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="financial-evidence-status">Cannot start yet</strong>
-            </li>
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
-                <a href="useful-features-of-ap.html" aria-describedby="contact-details-status">
-                  Add detail about managing risks and needs
-                </a>
-              </span>
-              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="financial-evidence-status">Cannot start yet</strong>
-            </li>
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
-                <a href="prison-behaviours.html" aria-describedby="contact-details-status">
-                  Review prison information
-                </a>
-              </span>
-              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="financial-evidence-status">Cannot start yet</strong>
-            </li>
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
-                <a href="location-factors.html" aria-describedby="list-convictions-status">
-                  Describe location factors
-                </a>
-              </span>
-              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="financial-evidence-status">Cannot start yet</strong>
-            </li>
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
-                <a href="access-needs.html" aria-describedby="list-convictions-status">
-                  Provide access and healthcare information
-                </a>
-              </span>
-              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="financial-evidence-status">Cannot start yet</strong>
-            </li>
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
-                <a href="further-considerations-room-share.html" aria-describedby="list-convictions-status">
-                Detail further considerations for placement
-              </a>
-              </span>
-              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="medical-information-status">Cannot start yet</strong>
-            </li>
-          </ul>
-        </li>
-
-        <li>
-          <h2 class="app-task-list__section">
-            <span class="app-task-list__section-number">3. </span> Considerations for when the placement ends
-          </h2>
-          <ul class="app-task-list__items">
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
-                <a href="further-considerations-room-share.html" aria-describedby="list-convictions-status">
-                Add move on information
-                </a>
-              </span>
-              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="submit-pay-status">Cannot start yet</strong>
-            </li>
-          </ul>
-        </li>
-
-        <li>
-          <h2 class="app-task-list__section">
-            <span class="app-task-list__section-number">4. </span> Add documents
-          </h2>
-          <ul class="app-task-list__items">
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
-                Attach required documents
-              </span>
-              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="submit-pay-status">Cannot start yet</strong>
-            </li>
-          </ul>
-        </li>
-
-        <li>
-          <h2 class="app-task-list__section">
-            <span class="app-task-list__section-number">5. </span> Check your answers
-          </h2>
-          <ul class="app-task-list__items">
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
-                Check your answers
-              </span>
-              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="submit-pay-status">Cannot start yet</strong>
-            </li>
-          </ul>
-        </li>
-
-        <li>
-          <h2 class="app-task-list__section">
-            <span class="app-task-list__section-number">6. </span> Submit your application
+            <span class="app-task-list__section-number">
+              {{ (sections | length) + 1 }}.
+            </span>
+            Submit your application
           </h2>
 
           {{ govukCheckboxes({


### PR DESCRIPTION
# Context

At the moment, the task list has the layout copied from the prototype with the tasks we have added manually. As the project develops, we'll need to add more tasks and sections, and we need to make sure we can do this in a manageable way.

# Changes in this PR

This adds a `sections` object, which spells out what tasks are contained in what section, allowing us to check if a section is complete, as well as automatically output the section and tasks within in the Nunjucks template.

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/109774/196950651-fc32e593-7f38-4996-a89c-72e99f5c079c.png)

### After

![image](https://user-images.githubusercontent.com/109774/196950407-075a5790-5267-41a8-8302-cfe4dbb70ad4.png)