### PR TITLE
[TA] Use correct local authority endpoint

### DIFF
--- a/integration_tests/mockApis/localAuthority.ts
+++ b/integration_tests/mockApis/localAuthority.ts
@@ -1,10 +1,10 @@
 import type { SuperAgentRequest } from 'superagent'
+import type { LocalAuthorityArea } from '@approved-premises/api'
 
-import type { LocalAuthority } from '@approved-premises/ui'
 import { stubFor } from '../../wiremock'
 import paths from '../../server/paths/temporary-accommodation/api'
 
-const stubLocalAuthorities = (localAuthorities: LocalAuthority[]): SuperAgentRequest =>
+const stubLocalAuthorities = (localAuthorities: LocalAuthorityArea[]): SuperAgentRequest =>
   stubFor({
     request: {
       method: 'GET',

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -159,8 +159,3 @@ export type NewPremises = {
   notes: string
   service: Service
 }
-
-export type LocalAuthority = {
-  id: string
-  name: string
-}

--- a/server/data/temporary-accommodation/localAuthorityClient.ts
+++ b/server/data/temporary-accommodation/localAuthorityClient.ts
@@ -1,4 +1,4 @@
-import type { LocalAuthority } from '@approved-premises/ui'
+import type { LocalAuthorityArea } from '@approved-premises/api'
 import RestClient from '../restClient'
 import config, { ApiConfig } from '../../config'
 import paths from '../../paths/temporary-accommodation/api'
@@ -10,7 +10,7 @@ export default class LocalAuthorityClient {
     this.restClient = new RestClient('localAuthorityClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
-  async all(): Promise<Array<LocalAuthority>> {
-    return (await this.restClient.get({ path: paths.localAuthorities.index({}) })) as Array<LocalAuthority>
+  async all(): Promise<Array<LocalAuthorityArea>> {
+    return (await this.restClient.get({ path: paths.localAuthorities.index({}) })) as Array<LocalAuthorityArea>
   }
 }

--- a/server/paths/temporary-accommodation/api.ts
+++ b/server/paths/temporary-accommodation/api.ts
@@ -1,7 +1,7 @@
 import { path } from 'static-path'
 import paths from '../api'
 
-const localAuthoritiesPath = path('/local-authorities')
+const localAuthoritiesPath = path('/reference-data/local-authority-areas')
 
 const localAuthoritiesPaths = {
   index: localAuthoritiesPath,

--- a/server/services/temporary-accommodation/localAuthorityService.ts
+++ b/server/services/temporary-accommodation/localAuthorityService.ts
@@ -1,11 +1,11 @@
-import type { LocalAuthority } from '@approved-premises/ui'
+import type { LocalAuthorityArea } from '@approved-premises/api'
 import { RestClientBuilder } from '../../data'
 import LocalAuthorityClient from '../../data/temporary-accommodation/localAuthorityClient'
 
 export default class LocalAuthorityService {
   constructor(private readonly localAuthorityClientFactory: RestClientBuilder<LocalAuthorityClient>) {}
 
-  async getLocalAuthorities(token: string): Promise<Array<LocalAuthority>> {
+  async getLocalAuthorities(token: string): Promise<Array<LocalAuthorityArea>> {
     const localAuthorityClient = this.localAuthorityClientFactory(token)
 
     return [...(await localAuthorityClient.all())].sort((a, b) => a.name.localeCompare(b.name))

--- a/server/testutils/factories/localAuthority.ts
+++ b/server/testutils/factories/localAuthority.ts
@@ -1,9 +1,13 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
 
-import type { LocalAuthority } from '@approved-premises/ui'
+import type { LocalAuthorityArea } from '@approved-premises/api'
 
-export default Factory.define<LocalAuthority>(() => ({
-  id: faker.datatype.uuid(),
-  name: faker.address.county(),
-}))
+export default Factory.define<LocalAuthorityArea>(() => {
+  const name = faker.address.county()
+  return {
+    id: faker.datatype.uuid(),
+    identifier: name.toLocaleLowerCase(),
+    name,
+  }
+})


### PR DESCRIPTION
# Changes in this PR

* This updates the UI to use the correct endpoint for getting a list of local authorities, and to use the shared type rather than a UI only type
* This has been tested again latest main API, and the new premises screen will now show an API-provided list of local authorities