### PR TITLE
(630) Add Purpose of placement application page

### DIFF
--- a/cypress_shared/pages/apply/placementPurpose.ts
+++ b/cypress_shared/pages/apply/placementPurpose.ts
@@ -1,0 +1,13 @@
+import Page from '../page'
+
+export default class PlacementPurposePage extends Page {
+  constructor() {
+    super('What is the purpose of the Approved Premises (AP) placement?')
+  }
+
+  completeForm() {
+    this.checkCheckboxByNameAndValue('placementPurpose', 'drugAlcoholSupport')
+    this.checkCheckboxByNameAndValue('placementPurpose', 'otherReason')
+    this.getTextInputByIdAndEnterDetails('otherReason', 'Another reason')
+  }
+}

--- a/cypress_shared/pages/apply/placementStart.ts
+++ b/cypress_shared/pages/apply/placementStart.ts
@@ -3,6 +3,6 @@ import { DateFormats } from '../../../server/utils/dateUtils'
 
 export default class PlacementStartPage extends Page {
   constructor(releaseDate: string) {
-    super(`Is ${DateFormats.isoDateToUIDate(releaseDate)} the date you want the placement to start? `)
+    super(`Is ${DateFormats.isoDateToUIDate(releaseDate)} the date you want the placement to start?`)
   }
 }

--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -58,6 +58,10 @@ export default abstract class Page {
     cy.get(`input[name="${name}"][value="${option}"]`).check()
   }
 
+  checkCheckboxByNameAndValue(name: string, option: string): void {
+    cy.get(`input[name="${name}"][value="${option}"]`).check()
+  }
+
   completeTextArea(name: string, value: string): void {
     cy.get(`textarea[name="${name}"]`).type(value)
   }

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -9,6 +9,7 @@ import {
   TaskListPage,
   TypeOfApPage,
 } from '../../../cypress_shared/pages/apply'
+import PlacementPurposePage from '../../../cypress_shared/pages/apply/placementPurpose'
 
 import Page from '../../../cypress_shared/pages/page'
 import applicationFactory from '../../../server/testutils/factories/application'
@@ -146,6 +147,10 @@ context('Apply', () => {
     const placementStartPage = new PlacementStartPage(releaseDate)
     placementStartPage.checkRadioByNameAndValue('startDateSameAsReleaseDate', 'yes')
     placementStartPage.clickSubmit()
+
+    const placementPurposePage = new PlacementPurposePage()
+    placementPurposePage.completeForm()
+    placementPurposePage.clickSubmit()
 
     // Then I should be redirected to the task list
     const tasklistPage = Page.verifyOnPage(TaskListPage)

--- a/server/form-pages/apply/basic-information/index.ts
+++ b/server/form-pages/apply/basic-information/index.ts
@@ -6,6 +6,7 @@ import Situation from './situation'
 import ReleaseDate from './releaseDate'
 import OralHearing from './oralHearing'
 import PlacementDate from './placementDate'
+import PlacementPurpose from './placementPurpose'
 
 const pages = {
   'sentence-type': SentenceType,
@@ -14,6 +15,7 @@ const pages = {
   'release-date': ReleaseDate,
   'oral-hearing': OralHearing,
   'placement-date': PlacementDate,
+  'placement-purpose': PlacementPurpose,
 }
 
 export default pages

--- a/server/form-pages/apply/basic-information/placementDate.test.ts
+++ b/server/form-pages/apply/basic-information/placementDate.test.ts
@@ -33,7 +33,7 @@ describe('PlacementDate', () => {
     })
   })
 
-  itShouldHaveNextValue(new PlacementDate({}, application), '')
+  itShouldHaveNextValue(new PlacementDate({}, application), 'placement-purpose')
   itShouldHavePreviousValue(new PlacementDate({}, application), 'oral-hearing')
 
   describe('errors', () => {

--- a/server/form-pages/apply/basic-information/placementDate.ts
+++ b/server/form-pages/apply/basic-information/placementDate.ts
@@ -31,7 +31,7 @@ export default class PlacementDate implements TasklistPage {
   }
 
   next() {
-    return ''
+    return 'placement-purpose'
   }
 
   previous() {

--- a/server/form-pages/apply/basic-information/placementPurpose.test.ts
+++ b/server/form-pages/apply/basic-information/placementPurpose.test.ts
@@ -1,0 +1,113 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+
+import applicationFactory from '../../../testutils/factories/application'
+
+import PlacementPurpose, { placementPurposes } from './placementPurpose'
+import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
+
+jest.mock('../../../utils/formUtils')
+
+describe('PlacementPurpose', () => {
+  const application = applicationFactory.build()
+
+  describe('body', () => {
+    it('should strip unknown attributes from the body', () => {
+      const page = new PlacementPurpose(
+        {
+          placementPurposes: ['publicProtection', 'readjust'],
+          something: 'else',
+        },
+        application,
+        'previousPage',
+      )
+
+      expect(page.body).toEqual({
+        placementPurposes: ['publicProtection', 'readjust'],
+      })
+    })
+
+    it('should strip otherReason unless the placement purpose is "Other reason"', () => {
+      const pageWithOtherReason = new PlacementPurpose(
+        {
+          placementPurposes: ['publicProtection', 'otherReason'],
+          otherReason: 'Another reason',
+        },
+        application,
+        'previousPage',
+      )
+
+      expect(pageWithOtherReason.body).toEqual({
+        placementPurposes: ['publicProtection', 'otherReason'],
+        otherReason: 'Another reason',
+      })
+
+      const pageWithoutOtherReason = new PlacementPurpose(
+        {
+          placementPurposes: ['publicProtection'],
+          otherReason: 'Another reason',
+        },
+        application,
+        'previousPage',
+      )
+
+      expect(pageWithoutOtherReason.body).toEqual({
+        placementPurposes: ['publicProtection'],
+      })
+    })
+  })
+
+  describe('when knowReleaseDate is set to yes', () => {
+    itShouldHaveNextValue(
+      new PlacementPurpose({ placementPurposes: ['publicProtection'] }, application, 'somePage'),
+      '',
+    )
+  })
+
+  describe("previous returns the value passed into the previousPage parameter of the object's constructor", () => {
+    itShouldHavePreviousValue(new PlacementPurpose({}, application, 'previousPage'), 'previousPage')
+  })
+
+  describe('errors', () => {
+    it('should return an empty object if the placement purpose is specified as a reason other than "Other reason"', () => {
+      const page = new PlacementPurpose({ placementPurposes: ['publicProtection'] }, application, 'somePage')
+      expect(page.errors()).toEqual({})
+    })
+
+    it('should return an error if the placementPurpose is "Other reason" and the reason is note given', () => {
+      const page = new PlacementPurpose({ placementPurposes: ['otherReason'] }, application, 'somePage')
+      expect(page.errors()).toEqual({ placementPurposes: 'You must explain the reason' })
+    })
+  })
+
+  describe('calls convertKeyValuePairToCheckBoxItems', () => {
+    it('should return an empty object if the placement purpose is specified as a reason other than "Other reason"', () => {
+      const page = new PlacementPurpose({ placementPurposes: ['publicProtection'] }, application, 'somePage')
+      page.items()
+      expect(convertKeyValuePairToCheckBoxItems).toHaveBeenCalledWith(placementPurposes, ['publicProtection'])
+    })
+  })
+
+  it('should return an error if the reason is not populated', () => {
+    const page = new PlacementPurpose({}, application, 'somePage')
+    expect(page.errors()).toEqual({ placementPurposes: 'You must choose at least one placement purpose' })
+  })
+
+  describe('response', () => {
+    it('should return a translated version of the response when the user does not know the release date', () => {
+      const page = new PlacementPurpose({ placementPurposes: ['drugAlcoholMonitoring'] }, application, 'somePage')
+
+      expect(page.response()).toEqual({
+        [page.title]: 'Provide drug or alcohol monitoring',
+      })
+    })
+  })
+
+  describe('items', () => {
+    it('it calls convertKeyValuePairToRadioItems', () => {
+      const page = new PlacementPurpose({}, application, 'somePage')
+      page.items()
+
+      expect(convertKeyValuePairToCheckBoxItems).toHaveBeenCalled()
+    })
+  })
+})

--- a/server/form-pages/apply/basic-information/placementPurpose.ts
+++ b/server/form-pages/apply/basic-information/placementPurpose.ts
@@ -1,0 +1,87 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+import type { Application } from '@approved-premises/api'
+
+import TasklistPage from '../../tasklistPage'
+import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
+
+export const placementPurposes = {
+  publicProtection: 'Public protection',
+  preventContact: 'Prevent Contact',
+  readjust: 'Help individual readjust to life outside custody',
+  drugAlcoholMonitoring: 'Provide drug or alcohol monitoring',
+  preventSelfHalf: 'Prevent self harm or suicide',
+  otherReason: 'Other (please specify)',
+} as const
+
+type PlacementPurposeT = keyof typeof placementPurposes
+
+export default class PlacementPurpose implements TasklistPage {
+  name = 'placement-purpose'
+
+  title = `What is the purpose of the AP placement?`
+
+  body: { placementPurposes: Array<PlacementPurposeT>; otherReason?: string } | Record<string, never>
+
+  purposes = placementPurposes
+
+  previousPage: string
+
+  constructor(body: Record<string, unknown>, private readonly _application: Application, previousPage: string) {
+    if (this.responseNeedsFreeTextReason(body)) {
+      this.body = {
+        placementPurposes: body.placementPurposes as Array<PlacementPurposeT>,
+        otherReason: body.otherReason as string,
+      }
+    } else {
+      this.body = { placementPurposes: body.placementPurposes as Array<PlacementPurposeT> }
+    }
+
+    this.previousPage = previousPage
+  }
+
+  next() {
+    return ''
+  }
+
+  previous() {
+    return this.previousPage
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.responseContainsReasons(this.body)) {
+      errors.placementPurposes = 'You must choose at least one placement purpose'
+    }
+
+    if (this.responseNeedsFreeTextReason(this.body)) {
+      errors.placementPurposes = 'You must explain the reason'
+    }
+
+    return errors
+  }
+
+  private responseContainsReasons(body: Record<string, unknown>): body is { placementPurposes: Array<unknown> } {
+    if (body?.placementPurposes && Array.isArray(body.placementPurposes)) {
+      return true
+    }
+    return false
+  }
+
+  private responseNeedsFreeTextReason(body: Record<string, unknown>) {
+    if (this.responseContainsReasons(body)) {
+      if (body.placementPurposes.find(element => element === 'otherReason')) {
+        return true
+      }
+    }
+    return false
+  }
+
+  items() {
+    return convertKeyValuePairToCheckBoxItems(placementPurposes, this.body.placementPurposes)
+  }
+
+  response() {
+    return { [this.title]: this.body.placementPurposes.map(purpose => placementPurposes[purpose]).join(', ') }
+  }
+}

--- a/server/views/applications/pages/basic-information/placement-purpose.njk
+++ b/server/views/applications/pages/basic-information/placement-purpose.njk
@@ -1,0 +1,61 @@
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  <h1 class="govuk-heading-l">What is the purpose of the Approved Premises (AP) placement?</h1>
+
+  {% set otherReason %}
+  {{ govukInput({
+      id: "otherReason",
+      name: "otherReason",
+      type: "text",
+      label: {
+        text: "Please specify"
+      }
+    }) }}
+  {% endset %}
+
+  {{ govukCheckboxes({
+      idPrefix: "placementPurpose",
+      name: "placementPurpose",
+      fieldset: {
+      },
+      hint: {
+        text: "Select all that apply."
+      },
+      items: [
+        {
+          value: "publicProtection",
+          text: "Public protection"
+        },
+        {
+          value: "resettlement",
+          text: "Support resettlement into the community"
+        },
+        {
+          value: "drugAlcoholSupport",
+          text: "Enhanced drug or alcohol support"
+        },
+        {
+          value: "risktoSelff",
+          text: "Support the management of risk to self"
+        },
+        {
+          divider: "or"
+        },
+        {
+          value: "otherReason",
+          text: "Please specify other purpose",
+          conditional: {
+            html: otherReason
+          }
+        }
+      ]
+    }) }}
+
+{% endblock %}

--- a/server/views/applications/pages/basic-information/placement-purpose.njk
+++ b/server/views/applications/pages/basic-information/placement-purpose.njk
@@ -50,7 +50,7 @@
         },
         {
           value: "otherReason",
-          text: "Please specify other purpose",
+          text: "Other",
           conditional: {
             html: otherReason
           }


### PR DESCRIPTION
# Context
This adds a 'Purpose of AP placement' screen to the Apply form in the pattern establish in #142 

[Trello card](https://trello.com/c/ketHjqUU/630-purpose-of-ap-placement)
# Changes in this PR

## Screenshots of UI changes

### Before
N/A
### After
![image](https://user-images.githubusercontent.com/44123869/197741225-0f9166ef-18ce-4cc9-aa59-73d5ba946274.png)
