### PR TITLE
[TA] Remove "service" from premises creation and listing API calls

### DIFF
--- a/integration_tests/mockApis/premises.ts
+++ b/integration_tests/mockApis/premises.ts
@@ -1,29 +1,23 @@
 import type { Response, SuperAgentRequest } from 'superagent'
 
 import type { Premises, Booking, DateCapacity, StaffMember } from '@approved-premises/api'
-import { Service } from '@approved-premises/ui'
 
 import { getMatchingRequests, stubFor } from '../../wiremock'
 import bookingStubs from './booking'
 import { errorStub } from '../../wiremock/utils'
 
-const stubPremises = (args: { premises: Array<Premises>; service: Service }) =>
+const stubPremises = (premises: Array<Premises>) =>
   stubFor({
     request: {
       method: 'GET',
       urlPath: '/premises',
-      queryParameters: {
-        service: {
-          equalTo: args.service,
-        },
-      },
     },
     response: {
       status: 200,
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
       },
-      jsonBody: args.premises,
+      jsonBody: premises,
     },
   })
 

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -1,5 +1,5 @@
 Cypress.Commands.add('signIn', (options = { failOnStatusCode: true }) => {
-  cy.task('stubPremises', { premises: [], service: 'approved-premises' })
+  cy.task('stubPremises', [])
   cy.request('/')
   return cy.task('getSignInUrl').then((url: string) => cy.visit(url, options))
 })

--- a/integration_tests/tests/manage/departure.cy.ts
+++ b/integration_tests/tests/manage/departure.cy.ts
@@ -30,7 +30,7 @@ context('Departures', () => {
       moveOnCategory,
     })
 
-    cy.task('stubPremises', { premises, service: 'approved-premises' })
+    cy.task('stubPremises', premises)
     cy.task('stubBookingGet', { premisesId: premises[0].id, booking })
     cy.task('stubDepartureCreate', { premisesId: premises[0].id, bookingId: booking.id, departure })
     cy.task('stubDepartureGet', { premisesId: premises[0].id, bookingId: booking.id, departure })
@@ -70,7 +70,7 @@ context('Departures', () => {
     })
 
     // Given I am signed in
-    cy.task('stubPremises', { premises, service: 'approved-premises' })
+    cy.task('stubPremises', premises)
     cy.task('stubBookingGet', { premisesId: premises[0].id, booking })
     cy.task('stubDepartureGet', { premisesId: premises[0].id, bookingId: booking.id, departure })
     cy.signIn()

--- a/integration_tests/tests/manage/premises.cy.ts
+++ b/integration_tests/tests/manage/premises.cy.ts
@@ -17,7 +17,7 @@ context('Premises', () => {
 
     // And there are premises in the database
     const premises = premisesFactory.buildList(5)
-    cy.task('stubPremises', { premises, service: 'approved-premises' })
+    cy.task('stubPremises', premises)
 
     // When I visit the premises page
     const page = PremisesListPage.visit()

--- a/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
@@ -19,7 +19,7 @@ context('Premises', () => {
 
     // And there are premises in the database
     const premises = premisesFactory.buildList(5)
-    cy.task('stubPremises', { premises, service: 'temporary-accommodation' })
+    cy.task('stubPremises', premises)
 
     // When I visit the premises page
     const page = PremisesListPage.visit()
@@ -34,7 +34,7 @@ context('Premises', () => {
 
     // And there are premises in the database
     const premises = premisesFactory.buildList(5)
-    cy.task('stubPremises', { premises, service: 'temporary-accommodation' })
+    cy.task('stubPremises', premises)
 
     // And there are local authorities in the database
     const localAuthorities = localAuthorityFactory.buildList(5)
@@ -56,7 +56,7 @@ context('Premises', () => {
 
     // And there are premises in the database
     const premises = premisesFactory.buildList(5)
-    cy.task('stubPremises', { premises, service: 'temporary-accommodation' })
+    cy.task('stubPremises', premises)
     cy.task('stubSinglePremises', premises[0])
 
     // When I visit the premises page
@@ -136,7 +136,7 @@ context('Premises', () => {
 
     // And there are premises in the database
     const premises = premisesFactory.buildList(5)
-    cy.task('stubPremises', { premises, service: 'temporary-accommodation' })
+    cy.task('stubPremises', premises)
 
     // And there are local authorities in the database
     const localAuthorities = localAuthorityFactory.buildList(5)
@@ -173,7 +173,7 @@ context('Premises', () => {
 
     // And there are premises in the database
     const premises = premisesFactory.buildList(5)
-    cy.task('stubPremises', { premises, service: 'temporary-accommodation' })
+    cy.task('stubPremises', premises)
     cy.task('stubSinglePremises', premises[0])
 
     // When I visit the show premises page

--- a/server/controllers/temporary-accommodation/manage/premisesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.test.ts
@@ -95,7 +95,6 @@ describe('PremisesController', () => {
       expect(premisesService.create).toHaveBeenCalledWith(token, {
         name: premises.name,
         postcode: premises.postcode,
-        service: 'temporary-accommodation',
       })
 
       expect(request.flash).toHaveBeenCalledWith('success', 'Property created')

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -38,7 +38,6 @@ export default class PremisesController {
     return async (req: Request, res: Response) => {
       const newPremises: NewPremises = {
         ...req.body,
-        service: 'temporary-accommodation',
       }
 
       try {

--- a/server/data/premisesClient.test.ts
+++ b/server/data/premisesClient.test.ts
@@ -36,10 +36,9 @@ describe('PremisesClient', () => {
       fakeApprovedPremisesApi
         .get(paths.premises.index({}))
         .matchHeader('authorization', `Bearer ${token}`)
-        .query({ service: 'approved-premises' })
         .reply(200, premises)
 
-      const output = await premisesClient.all('approved-premises')
+      const output = await premisesClient.all()
       expect(output).toEqual(premises)
     })
   })

--- a/server/data/premisesClient.ts
+++ b/server/data/premisesClient.ts
@@ -1,5 +1,4 @@
 import type { DateCapacity, NewPremises, Premises, StaffMember } from '@approved-premises/api'
-import type { Service } from '@approved-premises/ui'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -11,8 +10,8 @@ export default class PremisesClient {
     this.restClient = new RestClient('premisesClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
-  async all(service: Service): Promise<Array<Premises>> {
-    return (await this.restClient.get({ path: paths.premises.index({}), query: { service } })) as Array<Premises>
+  async all(): Promise<Array<Premises>> {
+    return (await this.restClient.get({ path: paths.premises.index({}) })) as Array<Premises>
   }
 
   async find(id: string): Promise<Premises> {

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -105,7 +105,7 @@ describe('PremisesService', () => {
       ])
 
       expect(premisesClientFactory).toHaveBeenCalledWith(token)
-      expect(premisesClient.all).toHaveBeenCalledWith('approved-premises')
+      expect(premisesClient.all).toHaveBeenCalled()
     })
   })
 
@@ -201,7 +201,7 @@ describe('PremisesService', () => {
       ])
 
       expect(premisesClientFactory).toHaveBeenCalledWith(token)
-      expect(premisesClient.all).toHaveBeenCalledWith('temporary-accommodation')
+      expect(premisesClient.all).toHaveBeenCalled()
     })
   })
 

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -21,7 +21,7 @@ export default class PremisesService {
 
   async approvedPremisesTableRows(token: string): Promise<Array<TableRow>> {
     const premisesClient = this.premisesClientFactory(token)
-    const premises = await premisesClient.all('approved-premises')
+    const premises = await premisesClient.all()
 
     return premises
       .sort((a, b) => a.name.localeCompare(b.name))
@@ -41,7 +41,7 @@ export default class PremisesService {
 
   async temporaryAccommodationTableRows(token: string): Promise<Array<TableRow>> {
     const premisesClient = this.premisesClientFactory(token)
-    const premises = await premisesClient.all('temporary-accommodation')
+    const premises = await premisesClient.all()
 
     return premises
       .map(p => ({ premises: p, shortAddress: `${p.addressLine1}, ${p.postcode}` }))
@@ -96,7 +96,7 @@ export default class PremisesService {
 
   async getPremisesSelectList(token: string): Promise<Array<{ text: string; value: string }>> {
     const premisesClient = this.premisesClientFactory(token)
-    const premises = await premisesClient.all('approved-premises')
+    const premises = await premisesClient.all()
 
     return premises
       .map(singlePremises => {

--- a/server/testutils/factories/newPremises.ts
+++ b/server/testutils/factories/newPremises.ts
@@ -8,5 +8,5 @@ export default Factory.define<NewPremises>(() => ({
   postcode: faker.address.zipCode(),
   localAuthorityAreaId: faker.datatype.uuid(),
   notes: faker.lorem.lines(),
-  service: 'temporary-accommodation',
+  service: undefined,
 }))

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -31,44 +31,17 @@ const premises = premisesJson.map(item => {
   return premisesFactory.build({ ...(item as DeepPartial<Premises>), localAuthorityArea: localAuthority })
 })
 
-const apPremises = premises.slice(0, Math.floor(premises.length / 2))
-const taPremises = premises.slice(Math.floor(premises.length / 2), premises.length)
-
 stubs.push({
   request: {
     method: 'GET',
     urlPath: '/premises',
-    queryParameters: {
-      service: {
-        equalTo: 'approved-premises',
-      },
-    },
   },
   response: {
     status: 200,
     headers: {
       'Content-Type': 'application/json;charset=UTF-8',
     },
-    jsonBody: apPremises,
-  },
-})
-
-stubs.push({
-  request: {
-    method: 'GET',
-    urlPath: '/premises',
-    queryParameters: {
-      service: {
-        equalTo: 'temporary-accommodation',
-      },
-    },
-  },
-  response: {
-    status: 200,
-    headers: {
-      'Content-Type': 'application/json;charset=UTF-8',
-    },
-    jsonBody: taPremises,
+    jsonBody: premises,
   },
 })
 


### PR DESCRIPTION
# Context

See #285 

As we will be sending the service name as part of the header once #285 is merged in, we no longer need to send the `service` field as part of premises creation or the `service` query parameter when getting the list of premises

This PR is opened as a draft, to be finalised when #285 is merged in, and `service` is removed from the `NewPremises` type. This will allow us to remove `service: undefined` from the `NewPremises` factory in `newPremises.ts`, which is something of a bodge

Note this PR does not remove `SERVICE_SIGNIFIER` etc. configuration, which can safely be removed once TA is in its own fork and running in its own environment