### PR TITLE
Increase E2E tests timeout to 70000

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     configFile: 'reporter-config.json',
   },
   videoUploadOnPasses: false,
-  taskTimeout: 60000,
+  taskTimeout: 70000,
   e2e: {
     setupNodeEvents(on) {
       on('task', {


### PR DESCRIPTION
There have been some failures in the pipeline recently but the tests seem to pass locally.
Hopefully this will fix it - lets see

