### PR TITLE
Change all instances of Premises to ApprovedPremises

### DIFF
--- a/cypress_shared/pages/manage/premisesList.ts
+++ b/cypress_shared/pages/manage/premisesList.ts
@@ -1,4 +1,4 @@
-import type { Premises } from '@approved-premises/api'
+import type { ApprovedPremises } from '@approved-premises/api'
 
 import Page from '../page'
 import paths from '../../../server/paths/manage'
@@ -13,8 +13,8 @@ export default class PremisesListPage extends Page {
     return new PremisesListPage()
   }
 
-  shouldShowPremises(premises: Array<Premises>): void {
-    premises.forEach((item: Premises) => {
+  shouldShowPremises(premises: Array<ApprovedPremises>): void {
+    premises.forEach((item: ApprovedPremises) => {
       cy.contains(item.name)
         .parent()
         .within(() => {

--- a/cypress_shared/pages/manage/premisesShow.ts
+++ b/cypress_shared/pages/manage/premisesShow.ts
@@ -1,15 +1,15 @@
-import type { Premises, Booking } from '@approved-premises/api'
+import type { ApprovedPremises, Booking } from '@approved-premises/api'
 
 import Page from '../page'
 import paths from '../../../server/paths/manage'
 import { DateFormats } from '../../../server/utils/dateUtils'
 
 export default class PremisesShowPage extends Page {
-  constructor(private readonly premises: Premises) {
+  constructor(private readonly premises: ApprovedPremises) {
     super(premises.name)
   }
 
-  static visit(premises: Premises): PremisesShowPage {
+  static visit(premises: ApprovedPremises): PremisesShowPage {
     cy.visit(paths.premises.show({ premisesId: premises.id }))
     return new PremisesShowPage(premises)
   }

--- a/server/@types/shared/index.d.ts
+++ b/server/@types/shared/index.d.ts
@@ -5,6 +5,7 @@
 export type { AnyValue } from './models/AnyValue';
 export type { ApArea } from './models/ApArea';
 export type { Application } from './models/Application';
+export type { ApprovedPremises } from './models/ApprovedPremises';
 export type { Arrival } from './models/Arrival';
 export type { Assessment } from './models/Assessment';
 export type { Booking } from './models/Booking';
@@ -57,6 +58,7 @@ export type { StaffMember } from './models/StaffMember';
 export type { SupervisingOfficer } from './models/SupervisingOfficer';
 export type { SupervisingProvider } from './models/SupervisingProvider';
 export type { SupervisingTeam } from './models/SupervisingTeam';
+export type { TemporaryAccommodationPremises } from './models/TemporaryAccommodationPremises';
 export type { UpdateApplication } from './models/UpdateApplication';
 export type { UpdateAssessment } from './models/UpdateAssessment';
 export type { User } from './models/User';

--- a/server/@types/shared/models/ApprovedPremises.ts
+++ b/server/@types/shared/models/ApprovedPremises.ts
@@ -1,0 +1,12 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { Premises } from './Premises';
+
+export type ApprovedPremises = (Premises & {
+    apCode?: string;
+} & {
+    apCode: string;
+});
+

--- a/server/@types/shared/models/Premises.ts
+++ b/server/@types/shared/models/Premises.ts
@@ -10,7 +10,6 @@ import type { ProbationRegion } from './ProbationRegion';
 export type Premises = {
     id: string;
     name: string;
-    apCode: string;
     addressLine1: string;
     postcode: string;
     bedCount: number;

--- a/server/@types/shared/models/TemporaryAccommodationPremises.ts
+++ b/server/@types/shared/models/TemporaryAccommodationPremises.ts
@@ -1,0 +1,8 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { Premises } from './Premises';
+
+export type TemporaryAccommodationPremises = Premises;
+

--- a/server/data/premisesClient.ts
+++ b/server/data/premisesClient.ts
@@ -1,4 +1,4 @@
-import type { Premises, DateCapacity, StaffMember } from '@approved-premises/api'
+import type { ApprovedPremises, DateCapacity, StaffMember } from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -10,12 +10,12 @@ export default class PremisesClient {
     this.restClient = new RestClient('premisesClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
-  async all(): Promise<Array<Premises>> {
-    return (await this.restClient.get({ path: paths.premises.index({}) })) as Array<Premises>
+  async all(): Promise<Array<ApprovedPremises>> {
+    return (await this.restClient.get({ path: paths.premises.index({}) })) as Array<ApprovedPremises>
   }
 
-  async find(id: string): Promise<Premises> {
-    return (await this.restClient.get({ path: paths.premises.show({ premisesId: id }) })) as Premises
+  async find(id: string): Promise<ApprovedPremises> {
+    return (await this.restClient.get({ path: paths.premises.show({ premisesId: id }) })) as ApprovedPremises
   }
 
   async capacity(id: string): Promise<DateCapacity[]> {

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -1,5 +1,5 @@
 import type { TableRow, SummaryList } from '@approved-premises/ui'
-import type { Premises, StaffMember } from '@approved-premises/api'
+import type { ApprovedPremises, StaffMember } from '@approved-premises/api'
 import type { RestClientBuilder, PremisesClient } from '../data'
 import paths from '../paths/manage'
 
@@ -23,7 +23,7 @@ export default class PremisesService {
 
     return premises
       .sort((a, b) => a.name.localeCompare(b.name))
-      .map((p: Premises) => {
+      .map((p: ApprovedPremises) => {
         return [
           this.textValue(p.name),
           this.textValue(p.apCode),
@@ -103,7 +103,7 @@ export default class PremisesService {
       })
   }
 
-  async summaryListForPremises(premises: Premises): Promise<SummaryList> {
+  async summaryListForPremises(premises: ApprovedPremises): Promise<SummaryList> {
     return {
       rows: [
         {

--- a/server/testutils/factories/premises.ts
+++ b/server/testutils/factories/premises.ts
@@ -1,9 +1,9 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
 
-import type { ApArea, Premises, ProbationRegion, LocalAuthorityArea } from '@approved-premises/api'
+import type { ApArea, ApprovedPremises, ProbationRegion, LocalAuthorityArea } from '@approved-premises/api'
 
-export default Factory.define<Premises>(() => ({
+export default Factory.define<ApprovedPremises>(() => ({
   id: faker.datatype.uuid(),
   name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
   apCode: faker.random.alphaNumeric(5, { casing: 'upper' }),

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { DeepPartial } from 'fishery'
 
-import type { Premises } from '@approved-premises/api'
+import type { ApprovedPremises } from '@approved-premises/api'
 import { bulkStub } from './index'
 
 import premisesJson from './stubs/premises.json'
@@ -24,7 +24,7 @@ import staffMemberFactory from '../server/testutils/factories/staffMember'
 
 const stubs = []
 
-const premises = premisesJson.map(item => premisesFactory.build(item as DeepPartial<Premises>))
+const premises = premisesJson.map(item => premisesFactory.build(item as DeepPartial<ApprovedPremises>))
 
 stubs.push({
   request: {


### PR DESCRIPTION
As of [this PR](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/183) The API splits the Premises response body for AP/TA into two different types. This means what we previously referred to as ‘Premises’ are now ‘ApprovedPremises’ (this enables TA to use ‘TemporaryAccomodationPremises’)

I have pointed the type generator to the PR version of the api.spec so this PR is a draft for now. I will revert the change to the typegen script before merging.