### PR TITLE
(634) - Apply - Type of offence

### DIFF
--- a/cypress_shared/pages/apply/typeOfConvictedOffence.ts
+++ b/cypress_shared/pages/apply/typeOfConvictedOffence.ts
@@ -1,0 +1,15 @@
+import Page from '../page'
+import { Person } from '../../../server/@types/shared'
+
+export default class TypeOfConvictedOffence extends Page {
+  constructor(person: Person) {
+    super(`What type of offending has ${person.name} been convicted of?`)
+  }
+
+  completeForm(): void {
+    this.checkCheckboxByNameAndValue('offenceConvictions', 'arson')
+    this.checkCheckboxByNameAndValue('offenceConvictions', 'sexualOffence')
+    this.checkCheckboxByNameAndValue('offenceConvictions', 'hateCrimes')
+    this.checkCheckboxByNameAndValue('offenceConvictions', 'childNonSexualOffence')
+  }
+}

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -13,6 +13,7 @@ import ConvictedOffences from '../../../cypress_shared/pages/apply/convictedOffe
 import DateOfOffence from '../../../cypress_shared/pages/apply/dateOfOffence'
 import PlacementPurposePage from '../../../cypress_shared/pages/apply/placementPurpose'
 import RiskManagementFeatures from '../../../cypress_shared/pages/apply/riskManagementFeatures'
+import TypeOfConvictedOffence from '../../../cypress_shared/pages/apply/typeOfConvictedOffence'
 
 import Page from '../../../cypress_shared/pages/page'
 import applicationFactory from '../../../server/testutils/factories/application'
@@ -194,6 +195,10 @@ context('Apply', () => {
     const convictedOffencesPage = new ConvictedOffences(person)
     convictedOffencesPage.completeForm()
     convictedOffencesPage.clickSubmit()
+
+    const typeOfConvictedOffencePage = new TypeOfConvictedOffence(person)
+    typeOfConvictedOffencePage.completeForm()
+    typeOfConvictedOffencePage.clickSubmit()
 
     const dateOfOffencePage = new DateOfOffence()
     dateOfOffencePage.completeForm()

--- a/server/form-pages/apply/risk-management-features/convictedOffences.test.ts
+++ b/server/form-pages/apply/risk-management-features/convictedOffences.test.ts
@@ -21,7 +21,13 @@ describe('ConvictedOffences', () => {
 
   itShouldHavePreviousValue(new ConvictedOffences({}, application), 'risk-management-features')
 
-  itShouldHaveNextValue(new ConvictedOffences({}, application), 'date-of-offence')
+  describe('if the response is yes', () => {
+    itShouldHaveNextValue(new ConvictedOffences({ response: 'yes' }, application), 'type-of-convicted-offence')
+  })
+
+  describe('if the response is no', () => {
+    itShouldHaveNextValue(new ConvictedOffences({ response: 'no' }, application), '')
+  })
 
   describe('errors', () => {
     it('should return an empty object if the response is populated', () => {

--- a/server/form-pages/apply/risk-management-features/convictedOffences.ts
+++ b/server/form-pages/apply/risk-management-features/convictedOffences.ts
@@ -31,7 +31,7 @@ export default class ConvictedOffences implements TasklistPage {
   }
 
   next() {
-    return 'date-of-offence'
+    return this.body.response === 'yes' ? 'type-of-convicted-offence' : ''
   }
 
   response() {

--- a/server/form-pages/apply/risk-management-features/index.ts
+++ b/server/form-pages/apply/risk-management-features/index.ts
@@ -1,9 +1,11 @@
 import RiskManagementFeatures from './riskManagementFeatures'
 import DateOfOffence from './dateOfOffence'
 import ConvictedOffences from './convictedOffences'
+import TypeOfConvictedOffence from './typeOfConvictedOffence'
 
 export default {
   'risk-management-features': RiskManagementFeatures,
   'date-of-offence': DateOfOffence,
   'convicted-offences': ConvictedOffences,
+  'type-of-convicted-offence': TypeOfConvictedOffence,
 }

--- a/server/form-pages/apply/risk-management-features/typeOfConvictedOffence.test.ts
+++ b/server/form-pages/apply/risk-management-features/typeOfConvictedOffence.test.ts
@@ -1,0 +1,71 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+
+import applicationFactory from '../../../testutils/factories/application'
+import personFactory from '../../../testutils/factories/person'
+import TypeOfConvictedOffence, { offences } from './typeOfConvictedOffence'
+import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
+
+jest.mock('../../../utils/formUtils')
+
+describe('TypeOfConvictedOffence', () => {
+  const person = personFactory.build({ name: 'John Wayne' })
+  const application = applicationFactory.build({ person })
+
+  describe('body', () => {
+    it('should strip unknown attributes from the body', () => {
+      const page = new TypeOfConvictedOffence({ offenceConvictions: 'some offence', something: 'else' }, application)
+
+      expect(page.body).toEqual({ offenceConvictions: 'some offence' })
+    })
+  })
+
+  itShouldHavePreviousValue(new TypeOfConvictedOffence({}, application), 'convicted-offences')
+
+  itShouldHaveNextValue(new TypeOfConvictedOffence({}, application), 'date-of-offence')
+
+  describe('errors', () => {
+    it('should return an empty object if the offenceConvictions are populated', () => {
+      const page = new TypeOfConvictedOffence({ offenceConvictions: 'some offence' }, application)
+      expect(page.errors()).toEqual({})
+    })
+
+    it('should return an error if the offenceConvictions are not populated', () => {
+      const page = new TypeOfConvictedOffence({}, application)
+      expect(page.errors()).toEqual({
+        offenceConvictions: 'You must specify at least one type of offence',
+      })
+    })
+  })
+
+  describe('response', () => {
+    describe('should return a translated version of the response', () => {
+      it('When there are multiple convictions', () => {
+        const page = new TypeOfConvictedOffence(
+          { offenceConvictions: ['arson', 'sexualOffence', 'hateCrimes', 'childNonSexualOffence'] },
+          application,
+        )
+
+        expect(page.response()).toEqual({
+          'What type of offending has John Wayne been convicted of?': {
+            Offences: 'Arson, Sexual Offence, Hate Crimes, Non-sexual offences against children',
+          },
+        })
+      })
+      it('When there is a single conviction', () => {
+        const page = new TypeOfConvictedOffence({ offenceConvictions: 'arson' }, application)
+
+        expect(page.response()).toEqual({
+          'What type of offending has John Wayne been convicted of?': {
+            Offences: 'Arson',
+          },
+        })
+      })
+    })
+  })
+  describe('items', () => {
+    it('calls convertKeyValuePairToCheckBoxItems with the correct arguments', () => {
+      new TypeOfConvictedOffence({ offenceConvictions: 'arson' }, application).items()
+      expect(convertKeyValuePairToCheckBoxItems).toHaveBeenCalledWith(offences, 'arson')
+    })
+  })
+})

--- a/server/form-pages/apply/risk-management-features/typeOfConvictedOffence.ts
+++ b/server/form-pages/apply/risk-management-features/typeOfConvictedOffence.ts
@@ -1,0 +1,60 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+import { Application } from '../../../@types/shared'
+import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
+
+import TasklistPage from '../../tasklistPage'
+
+export const offences = {
+  arson: 'Arson',
+  sexualOffence: 'Sexual Offence',
+  hateCrimes: 'Hate Crimes',
+  childNonSexualOffence: 'Non-sexual offences against children',
+} as const
+
+type Offences = Array<keyof typeof offences>
+
+export default class TypeOfConvictedOffence implements TasklistPage {
+  name = 'type-of-convicted-offence'
+
+  title = `What type of offending has ${this.application.person.name} been convicted of?`
+
+  body: { offenceConvictions: Offences }
+
+  constructor(body: Record<string, unknown>, private readonly application: Application) {
+    this.body = {
+      offenceConvictions: body.offenceConvictions as Offences,
+    }
+  }
+
+  previous() {
+    return 'convicted-offences'
+  }
+
+  next() {
+    return 'date-of-offence'
+  }
+
+  response() {
+    return {
+      [this.title]: {
+        Offences: Array.isArray(this.body.offenceConvictions)
+          ? this.body.offenceConvictions.map(offence => offences[offence]).join(', ')
+          : offences[this.body.offenceConvictions],
+      },
+    }
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.offenceConvictions) {
+      errors.offenceConvictions = `You must specify at least one type of offence`
+    }
+
+    return errors
+  }
+
+  items() {
+    return convertKeyValuePairToCheckBoxItems(offences, this.body.offenceConvictions)
+  }
+}

--- a/server/views/applications/pages/risk-management-features/type-of-convicted-offence.njk
+++ b/server/views/applications/pages/risk-management-features/type-of-convicted-offence.njk
@@ -1,0 +1,20 @@
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  <h1 class="govuk-heading-l">{{page.title}}</h1>
+
+  <p class="govuk-body">This information will be used to match the person to a bed in an Approved Premises</p>
+
+  {{ govukCheckboxes({
+        id: "offenceConvictions",
+        name: "offenceConvictions",
+        hint: {
+          text: "You can select more than one option"
+        },
+        items: page.items()
+      }) }}
+
+{% endblock %}


### PR DESCRIPTION
# Context
This PR adds a screen asking the user which of type of offences the PiP has been convicted of.
In the pattern established in https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/142
This PR builds on #301 
[Trello ticket](https://trello.com/c/kCBaTn3F/633-convicted-of-offences-screen)

## Screenshots of UI changes
![Apply -- shows a tasklist](https://user-images.githubusercontent.com/44123869/199192869-b9e188be-ae1a-48f0-ac88-9bd985593e4a.png)
