### PR TITLE
Fix: Improve robustness of E2E tests

### DIFF
--- a/cypress_shared/pages/manage/premisesShow.ts
+++ b/cypress_shared/pages/manage/premisesShow.ts
@@ -27,7 +27,7 @@ export default class PremisesShowPage extends Page {
   }
 
   selectBooking() {
-    cy.get('#arriving-today > .govuk-table > .govuk-table__body > :nth-child(1) > :nth-child(3) > a').click()
+    cy.get('#current-residents > .govuk-table > .govuk-table__body > :nth-child(1) > :nth-child(3) > a').click()
   }
 
   shouldShowPremisesDetail(): void {

--- a/server/@types/shared/models/NewPremises.ts
+++ b/server/@types/shared/models/NewPremises.ts
@@ -6,7 +6,6 @@ export type NewPremises = {
     name?: string;
     addressLine1: string;
     postcode: string;
-    service: string;
     notes?: string;
     localAuthorityAreaId: string;
 };

--- a/server/@types/shared/models/NewRoom.ts
+++ b/server/@types/shared/models/NewRoom.ts
@@ -5,5 +5,6 @@
 export type NewRoom = {
     name: string;
     notes?: string;
+    characteristics: Array<string>;
 };
 

--- a/server/@types/shared/models/Room.ts
+++ b/server/@types/shared/models/Room.ts
@@ -3,11 +3,13 @@
 /* eslint-disable */
 
 import type { Bed } from './Bed';
+import type { Characteristic } from './Characteristic';
 
 export type Room = {
     id: string;
     name: string;
     notes?: string;
     beds?: Array<Bed>;
+    characteristics: Array<Characteristic>;
 };
 

--- a/server/views/premises/show.njk
+++ b/server/views/premises/show.njk
@@ -85,6 +85,7 @@
   <h2>Current residents</h2>
 
   {{ govukTable({
+    id:"current-residents",
     caption: "Current residents",
     captionClasses: "govuk-visually-hidden",
     firstCellIsHeader: true,


### PR DESCRIPTION
We have been seeing some flakiness with the E2E tests around Booking Extensions.
Previously we used the ‘Arriving Today’ table when selecting a booking to extend which could be empty if no residents were arriving on that day.
Now we use the 'Current Residents' table which should always be populated.