### PR TITLE
Set up known state in e2e tests

### DIFF
--- a/cypress_shared/pages/manage/booking/confirmation.ts
+++ b/cypress_shared/pages/manage/booking/confirmation.ts
@@ -28,6 +28,10 @@ export default class BookingConfirmationPage extends Page {
     })
   }
 
+  clickToViewBooking(): void {
+    cy.get('a').contains('Back to dashboard').click()
+  }
+
   shouldShowOvercapacityMessage(
     firstOvercapacityPeriod: OvercapacityPeriod,
     secondOvercapacityPeriod: OvercapacityPeriod,

--- a/cypress_shared/pages/manage/premisesShow.ts
+++ b/cypress_shared/pages/manage/premisesShow.ts
@@ -26,10 +26,6 @@ export default class PremisesShowPage extends Page {
       .then(() => cy.get('a').contains('Create a placement').click())
   }
 
-  selectBooking() {
-    cy.get('#current-residents > .govuk-table > .govuk-table__body > :nth-child(1) > :nth-child(3) > a').click()
-  }
-
   shouldShowPremisesDetail(): void {
     cy.get('.govuk-summary-list__key')
       .contains('Code')

--- a/e2e/tests/manage.feature
+++ b/e2e/tests/manage.feature
@@ -19,10 +19,12 @@ Feature: Manage an Approved Premises
 
         Scenario: Extending a booking
                 Given I'm managing a premises
-                And I extend a booking
+                And I have created a booking
+                And I extend that booking
                 Then I should see a message on the booking page confirming the extension
 
         Scenario: Showing booking extension errors
                 Given I'm managing a premises
-                And I attempt to extend a booking without entering the date
+                And I have created a booking
+                And I attempt to extend that booking without entering the date
                 Then I should see an error

--- a/e2e/tests/stepDefinitions/booking.ts
+++ b/e2e/tests/stepDefinitions/booking.ts
@@ -18,7 +18,7 @@ const offenderCrn = Cypress.env('offender_crn') || throwMissingCypressEnvError('
 const person = personFactory.build({ name: offenderName, crn: offenderCrn })
 const booking = bookingFactory.build({ person })
 
-Given('I create a booking', () => {
+const createBooking = (): void => {
   cy.get('@premisesShowPage').then((premisesShowPage: PremisesShowPage) => {
     premisesShowPage.clickCreateBookingOption()
   })
@@ -32,10 +32,21 @@ Given('I create a booking', () => {
   form.verifyPersonIsVisible(person)
   form.completeForm(booking)
   form.clickSubmit()
+}
+
+Given('I create a booking', () => {
+  createBooking()
 })
 
 Then('I should see a confirmation screen for my booking', () => {
   const page = new BookingConfirmationPage()
 
   page.verifyBookingIsVisible(booking)
+})
+
+Given('I have created a booking', () => {
+  createBooking()
+
+  const page = new BookingConfirmationPage()
+  cy.wrap(page).as('bookingConfirmationPage')
 })

--- a/e2e/tests/stepDefinitions/bookingExtensions.ts
+++ b/e2e/tests/stepDefinitions/bookingExtensions.ts
@@ -1,8 +1,8 @@
 import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
 
 import {
-  PremisesShowPage,
   BookingShowPage,
+  BookingConfirmationPage,
   BookingExtensionCreatePage,
   BookingExtensionConfirmationPage,
 } from '../../../cypress_shared/pages/manage'
@@ -11,9 +11,9 @@ import { DateFormats } from '../../../server/utils/dateUtils'
 
 const extensionDate = DateFormats.formatApiDate(new Date(2050, 0, 1))
 
-Given('I extend a booking', () => {
-  cy.get('@premisesShowPage').then((premisesShowPage: PremisesShowPage) => {
-    premisesShowPage.selectBooking()
+Given('I extend that booking', () => {
+  cy.get('@bookingConfirmationPage').then((bookingConfirmationPage: BookingConfirmationPage) => {
+    bookingConfirmationPage.clickToViewBooking()
   })
 
   const bookingShowPage = new BookingShowPage()
@@ -30,9 +30,9 @@ Then('I should see a message on the booking page confirming the extension', () =
   bookingExtensionCreatePage.verifyNewExpectedDepartureDate(extensionDate)
 })
 
-Then('I attempt to extend a booking without entering the date', () => {
-  cy.get('@premisesShowPage').then((premisesShowPage: PremisesShowPage) => {
-    premisesShowPage.selectBooking()
+Then('I attempt to extend that booking without entering the date', () => {
+  cy.get('@bookingConfirmationPage').then((bookingConfirmationPage: BookingConfirmationPage) => {
+    bookingConfirmationPage.clickToViewBooking()
   })
 
   const bookingShowPage = new BookingShowPage()


### PR DESCRIPTION
After the attempt in #304 to fix the UI tests, it seems that the extension tests are still a bit flaky. The combat this, I thought it might be best to set up a known state in the application, rather than relying on a state that may or may not exist. Now we create a booking and then attempt to extend that exact booking. It will make the tests a tad slower, but hopefully more reliable!