### PR TITLE
(637) - Apply - Rehabilitative interventions

### DIFF
--- a/cypress_shared/pages/apply/rehabilitativeInterventions.ts
+++ b/cypress_shared/pages/apply/rehabilitativeInterventions.ts
@@ -1,0 +1,20 @@
+import Page from '../page'
+
+export default class RehabilitativeInterventions extends Page {
+  constructor() {
+    super("Which rehabilitative interventions will support the person's Approved Premises (AP) placement?")
+  }
+
+  completeForm(): void {
+    this.checkCheckboxByNameAndValue('rehabilitativeInterventions', 'accomodation')
+    this.checkCheckboxByNameAndValue('rehabilitativeInterventions', 'drugsAndAlcohol')
+    this.checkCheckboxByNameAndValue('rehabilitativeInterventions', 'childrenAndFamilies')
+    this.checkCheckboxByNameAndValue('rehabilitativeInterventions', 'health')
+    this.checkCheckboxByNameAndValue('rehabilitativeInterventions', 'educationTrainingAndEmployment')
+    this.checkCheckboxByNameAndValue('rehabilitativeInterventions', 'financeBenefitsAndDebt')
+    this.checkCheckboxByNameAndValue('rehabilitativeInterventions', 'attitudesAndBehaviour')
+    this.checkCheckboxByNameAndValue('rehabilitativeInterventions', 'abuse')
+    this.checkCheckboxByNameAndValue('rehabilitativeInterventions', 'other')
+    this.getTextInputByIdAndEnterDetails('otherIntervention', 'another one')
+  }
+}

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -12,6 +12,7 @@ import {
 import ConvictedOffences from '../../../cypress_shared/pages/apply/convictedOffences'
 import DateOfOffence from '../../../cypress_shared/pages/apply/dateOfOffence'
 import PlacementPurposePage from '../../../cypress_shared/pages/apply/placementPurpose'
+import RehabilitativeInterventions from '../../../cypress_shared/pages/apply/rehabilitativeInterventions'
 import RiskManagementFeatures from '../../../cypress_shared/pages/apply/riskManagementFeatures'
 import TypeOfConvictedOffence from '../../../cypress_shared/pages/apply/typeOfConvictedOffence'
 
@@ -203,6 +204,10 @@ context('Apply', () => {
     const dateOfOffencePage = new DateOfOffence()
     dateOfOffencePage.completeForm()
     dateOfOffencePage.clickSubmit()
+
+    const rehabilitativeInterventionsPage = new RehabilitativeInterventions()
+    rehabilitativeInterventionsPage.completeForm()
+    rehabilitativeInterventionsPage.clickSubmit()
 
     // Then I should be taken back to the task list
     // And the risk management task should show a completed status

--- a/server/@types/shared/index.d.ts
+++ b/server/@types/shared/index.d.ts
@@ -8,6 +8,7 @@ export type { Application } from './models/Application';
 export type { ApprovedPremises } from './models/ApprovedPremises';
 export type { Arrival } from './models/Arrival';
 export type { Assessment } from './models/Assessment';
+export type { AssessmentDecision } from './models/AssessmentDecision';
 export type { Bed } from './models/Bed';
 export type { Booking } from './models/Booking';
 export type { BookingBody } from './models/BookingBody';

--- a/server/@types/shared/models/Assessment.ts
+++ b/server/@types/shared/models/Assessment.ts
@@ -4,6 +4,7 @@
 
 import type { AnyValue } from './AnyValue';
 import type { Application } from './Application';
+import type { AssessmentDecision } from './AssessmentDecision';
 import type { ClarificationNote } from './ClarificationNote';
 
 export type Assessment = {
@@ -15,6 +16,7 @@ export type Assessment = {
     createdAt: string;
     allocatedAt: string;
     submittedAt?: string;
+    decision?: AssessmentDecision;
     data: AnyValue;
     clarificationNotes: Array<ClarificationNote>;
 };

--- a/server/@types/shared/models/AssessmentDecision.ts
+++ b/server/@types/shared/models/AssessmentDecision.ts
@@ -1,0 +1,5 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type AssessmentDecision = 'accepted' | 'rejected';

--- a/server/@types/shared/models/NewRoom.ts
+++ b/server/@types/shared/models/NewRoom.ts
@@ -5,6 +5,6 @@
 export type NewRoom = {
     name: string;
     notes?: string;
-    characteristics: Array<string>;
+    characteristicIds: Array<string>;
 };
 

--- a/server/form-pages/apply/basic-information/oralHearing.test.ts
+++ b/server/form-pages/apply/basic-information/oralHearing.test.ts
@@ -5,13 +5,11 @@ import applicationFactory from '../../../testutils/factories/application'
 import personFactory from '../../../testutils/factories/person'
 
 describe('OralHearing', () => {
-  let application = applicationFactory.build()
+  const person = personFactory.build({ name: 'John Wayne' })
+  const application = applicationFactory.build({ person })
 
   describe('title', () => {
     it('shold add the name of the person', () => {
-      const person = personFactory.build({ name: 'John Wayne' })
-      application = applicationFactory.build({ person })
-
       const page = new OralHearing({}, application)
 
       expect(page.title).toEqual('Do you know John Wayne’s oral hearing date?')

--- a/server/form-pages/apply/basic-information/releaseDate.test.ts
+++ b/server/form-pages/apply/basic-information/releaseDate.test.ts
@@ -5,13 +5,11 @@ import applicationFactory from '../../../testutils/factories/application'
 import personFactory from '../../../testutils/factories/person'
 
 describe('ReleaseDate', () => {
-  let application = applicationFactory.build()
+  const person = personFactory.build({ name: 'John Wayne' })
+  const application = applicationFactory.build({ person })
 
   describe('title', () => {
     it('shold add the name of the person', () => {
-      const person = personFactory.build({ name: 'John Wayne' })
-      application = applicationFactory.build({ person })
-
       const page = new ReleaseDate({}, application, 'previousPage')
 
       expect(page.title).toEqual('Do you know John Wayne’s release date?')

--- a/server/form-pages/apply/basic-information/situation.test.ts
+++ b/server/form-pages/apply/basic-information/situation.test.ts
@@ -4,13 +4,8 @@ import applicationFactory from '../../../testutils/factories/application'
 import Situation from './situation'
 
 describe('Situation', () => {
-  let application = applicationFactory.build({
+  const application = applicationFactory.build({
     data: { 'basic-information': { 'sentence-type': { sentenceType: 'communityOrder' } } },
-  })
-  beforeEach(() => {
-    application = applicationFactory.build({
-      data: { 'basic-information': { 'sentence-type': { sentenceType: 'communityOrder' } } },
-    })
   })
 
   describe('body', () => {

--- a/server/form-pages/apply/risk-management-features/convictedOffences.test.ts
+++ b/server/form-pages/apply/risk-management-features/convictedOffences.test.ts
@@ -26,7 +26,7 @@ describe('ConvictedOffences', () => {
   })
 
   describe('if the response is no', () => {
-    itShouldHaveNextValue(new ConvictedOffences({ response: 'no' }, application), '')
+    itShouldHaveNextValue(new ConvictedOffences({ response: 'no' }, application), 'rehabilitative-interventions')
   })
 
   describe('errors', () => {

--- a/server/form-pages/apply/risk-management-features/convictedOffences.ts
+++ b/server/form-pages/apply/risk-management-features/convictedOffences.ts
@@ -31,7 +31,7 @@ export default class ConvictedOffences implements TasklistPage {
   }
 
   next() {
-    return this.body.response === 'yes' ? 'type-of-convicted-offence' : ''
+    return this.body.response === 'yes' ? 'type-of-convicted-offence' : 'rehabilitative-interventions'
   }
 
   response() {

--- a/server/form-pages/apply/risk-management-features/dateOfOffence.test.ts
+++ b/server/form-pages/apply/risk-management-features/dateOfOffence.test.ts
@@ -22,9 +22,9 @@ describe('DateOfOffence', () => {
     })
   })
 
-  itShouldHavePreviousValue(new DateOfOffence({}), 'convicted-offences')
+  itShouldHavePreviousValue(new DateOfOffence({}), 'type-of-convicted-offence')
 
-  itShouldHaveNextValue(new DateOfOffence({}), '')
+  itShouldHaveNextValue(new DateOfOffence({}), 'rehabilitative-interventions')
 
   describe('errors', () => {
     it('should return an empty object if the time period for one offence is present', () => {

--- a/server/form-pages/apply/risk-management-features/dateOfOffence.ts
+++ b/server/form-pages/apply/risk-management-features/dateOfOffence.ts
@@ -37,11 +37,11 @@ export default class DateOfOffence implements TasklistPage {
   }
 
   previous() {
-    return 'convicted-offences'
+    return 'type-of-convicted-offence'
   }
 
   next() {
-    return ''
+    return 'rehabilitative-interventions'
   }
 
   response() {

--- a/server/form-pages/apply/risk-management-features/index.ts
+++ b/server/form-pages/apply/risk-management-features/index.ts
@@ -1,13 +1,13 @@
 import RiskManagementFeatures from './riskManagementFeatures'
-import DateOfOffence from './dateOfOffence'
 import ConvictedOffences from './convictedOffences'
+import DateOfOffence from './dateOfOffence'
 import TypeOfConvictedOffence from './typeOfConvictedOffence'
 import RehabilitativeInterventions from './rehabilitativeInterventions'
 
 export default {
   'risk-management-features': RiskManagementFeatures,
-  'date-of-offence': DateOfOffence,
   'convicted-offences': ConvictedOffences,
   'type-of-convicted-offence': TypeOfConvictedOffence,
+  'date-of-offence': DateOfOffence,
   'rehabilitative-interventions': RehabilitativeInterventions,
 }

--- a/server/form-pages/apply/risk-management-features/index.ts
+++ b/server/form-pages/apply/risk-management-features/index.ts
@@ -2,10 +2,12 @@ import RiskManagementFeatures from './riskManagementFeatures'
 import DateOfOffence from './dateOfOffence'
 import ConvictedOffences from './convictedOffences'
 import TypeOfConvictedOffence from './typeOfConvictedOffence'
+import RehabilitativeInterventions from './rehabilitativeInterventions'
 
 export default {
   'risk-management-features': RiskManagementFeatures,
   'date-of-offence': DateOfOffence,
   'convicted-offences': ConvictedOffences,
   'type-of-convicted-offence': TypeOfConvictedOffence,
+  'rehabilitative-interventions': RehabilitativeInterventions,
 }

--- a/server/form-pages/apply/risk-management-features/rehabilitativeInterventions.test.ts
+++ b/server/form-pages/apply/risk-management-features/rehabilitativeInterventions.test.ts
@@ -30,6 +30,32 @@ describe('RehabilitativeInterventions', () => {
 
   itShouldHaveNextValue(new RehabilitativeInterventions({}, application, previousPage), '')
 
+  describe('errors', () => {
+    it("should return an empty object if 'interventions' isn't populated", () => {
+      const page = new RehabilitativeInterventions({}, application, previousPage)
+      expect(page.errors()).toEqual({})
+    })
+
+    it('should return an empty object if "interventions" is populated with an array of interventions', () => {
+      const page = new RehabilitativeInterventions({ interventions: ['accomodation'] }, application, previousPage)
+      expect(page.errors()).toEqual({})
+    })
+
+    it('should return an error if "interventions" includes "other" and no other intervention is supplied', () => {
+      expect(
+        new RehabilitativeInterventions(
+          { interventions: ['other', 'accomodation'] },
+          application,
+          previousPage,
+        ).errors(),
+      ).toEqual({ otherIntervention: 'You must specify the other intervention' })
+
+      expect(new RehabilitativeInterventions({ interventions: 'other' }, application, previousPage).errors()).toEqual({
+        otherIntervention: 'You must specify the other intervention',
+      })
+    })
+  })
+
   describe('response', () => {
     describe('should return a translated version of the response', () => {
       it('When there are multiple interventions', () => {

--- a/server/form-pages/apply/risk-management-features/rehabilitativeInterventions.test.ts
+++ b/server/form-pages/apply/risk-management-features/rehabilitativeInterventions.test.ts
@@ -1,0 +1,78 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+
+import applicationFactory from '../../../testutils/factories/application'
+import personFactory from '../../../testutils/factories/person'
+import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
+import RehabilitativeInterventions, { interventionsTranslations } from './rehabilitativeInterventions'
+
+jest.mock('../../../utils/formUtils')
+
+describe('RehabilitativeInterventions', () => {
+  const person = personFactory.build({ name: 'John Wayne' })
+  const application = applicationFactory.build({ person })
+  const previousPage = 'previousPage'
+
+  describe('body', () => {
+    it('should strip unknown attributes from the body', () => {
+      const page = new RehabilitativeInterventions(
+        { interventions: 'accomodation', something: 'else' },
+        application,
+        previousPage,
+      )
+
+      expect(page.body).toEqual({ interventions: ['accomodation'] })
+    })
+  })
+
+  describe('it should return the value passed in for the previous page ', () => {
+    itShouldHavePreviousValue(new RehabilitativeInterventions({}, application, previousPage), previousPage)
+  })
+
+  itShouldHaveNextValue(new RehabilitativeInterventions({}, application, previousPage), '')
+
+  describe('response', () => {
+    describe('should return a translated version of the response', () => {
+      it('When there are multiple interventions', () => {
+        const page = new RehabilitativeInterventions(
+          {
+            interventions: [
+              'accomodation',
+              'drugsAndAlcohol',
+              'childrenAndFamilies',
+              'health',
+              'educationTrainingAndEmployment',
+              'financeBenefitsAndDebt',
+              'attitudesAndBehaviour',
+              'abuse',
+              'other',
+            ],
+            otherIntervention: 'Some intervention',
+          },
+          application,
+          previousPage,
+        )
+
+        expect(page.response()).toEqual({
+          "Which rehabilitative interventions will support the person's Approved Premises (AP) placement?":
+            'Accomodation, Drugs and alcohol, Children and families, Health, Education, training and employment, Finance, benefits and debt, Attitudes, thinking and behaviour, Abuse, Other',
+          'Other intervention': 'Some intervention',
+        })
+      })
+
+      it('When there is a single intervention', () => {
+        const page = new RehabilitativeInterventions({ interventions: 'health' }, application, previousPage)
+
+        expect(page.response()).toEqual({
+          "Which rehabilitative interventions will support the person's Approved Premises (AP) placement?": 'Health',
+        })
+      })
+    })
+  })
+  describe('items', () => {
+    it('calls convertKeyValuePairToCheckBoxItems with the correct arguments', () => {
+      const { other, ...interventionsForCheckboxes } = interventionsTranslations
+      new RehabilitativeInterventions({ interventions: 'health' }, application, previousPage).items()
+      expect(convertKeyValuePairToCheckBoxItems).toHaveBeenCalledWith(interventionsForCheckboxes, ['health'])
+    })
+  })
+})

--- a/server/form-pages/apply/risk-management-features/rehabilitativeInterventions.ts
+++ b/server/form-pages/apply/risk-management-features/rehabilitativeInterventions.ts
@@ -62,6 +62,14 @@ export default class RehabilitativeInterventions implements TasklistPage {
     return { ...response, 'Other intervention': this.body.otherIntervention }
   }
 
+  errors() {
+    const errors: TaskListErrors<this> = {}
+    if (this.otherInterventionDetailIsNeeded(this.body.interventions) && !this.body.otherIntervention) {
+      errors.otherIntervention = 'You must specify the other intervention'
+    }
+    return errors
+  }
+
   items() {
     const { other, ...uiInterventions } = interventionsTranslations
     return convertKeyValuePairToCheckBoxItems(uiInterventions, this.body.interventions)

--- a/server/form-pages/apply/risk-management-features/rehabilitativeInterventions.ts
+++ b/server/form-pages/apply/risk-management-features/rehabilitativeInterventions.ts
@@ -1,0 +1,73 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+import { Application } from '../../../@types/shared'
+import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
+
+import TasklistPage from '../../tasklistPage'
+
+export const interventionsTranslations = {
+  accomodation: 'Accomodation',
+  drugsAndAlcohol: 'Drugs and alcohol',
+  childrenAndFamilies: 'Children and families',
+  health: 'Health',
+  educationTrainingAndEmployment: 'Education, training and employment',
+  financeBenefitsAndDebt: 'Finance, benefits and debt',
+  attitudesAndBehaviour: 'Attitudes, thinking and behaviour',
+  abuse: 'Abuse',
+  other: 'Other',
+} as const
+
+type Interventions = Array<keyof typeof interventionsTranslations>
+
+export default class RehabilitativeInterventions implements TasklistPage {
+  name = 'rehabilitative-interventions'
+
+  title = `Which rehabilitative interventions will support the person's Approved Premises (AP) placement?`
+
+  body: { interventions: Interventions; otherIntervention?: string }
+
+  constructor(
+    body: Record<string, unknown>,
+    private readonly _application: Application,
+    private readonly previousPage: string,
+  ) {
+    const interventions = [body.interventions].flat() as Interventions
+
+    this.body = { interventions }
+
+    if (this.otherInterventionDetailIsNeeded(interventions)) {
+      this.body = {
+        interventions,
+        otherIntervention: body.otherIntervention as string,
+      }
+    }
+  }
+
+  previous() {
+    return this.previousPage
+  }
+
+  next() {
+    return ''
+  }
+
+  response() {
+    const response = {
+      [this.title]: this.body.interventions.map(intervention => interventionsTranslations[intervention]).join(', '),
+    }
+
+    if (!this.otherInterventionDetailIsNeeded(this.body.interventions)) {
+      return response
+    }
+
+    return { ...response, 'Other intervention': this.body.otherIntervention }
+  }
+
+  items() {
+    const { other, ...uiInterventions } = interventionsTranslations
+    return convertKeyValuePairToCheckBoxItems(uiInterventions, this.body.interventions)
+  }
+
+  private otherInterventionDetailIsNeeded(interventions: Interventions) {
+    return interventions.find(element => element === 'other')
+  }
+}

--- a/server/form-pages/apply/risk-management-features/riskManagementFeatures.test.ts
+++ b/server/form-pages/apply/risk-management-features/riskManagementFeatures.test.ts
@@ -7,9 +7,8 @@ import personFactory from '../../../testutils/factories/person'
 jest.mock('../../../utils/formUtils')
 
 describe('RiskManagementFeatures', () => {
-  let application = applicationFactory.build()
   const person = personFactory.build({ name: 'John Wayne' })
-  application = applicationFactory.build({ person })
+  const application = applicationFactory.build({ person })
 
   describe('body', () => {
     it('should strip unknown attributes from the body', () => {

--- a/server/form-pages/apply/risk-management-features/typeOfConvictedOffence.test.ts
+++ b/server/form-pages/apply/risk-management-features/typeOfConvictedOffence.test.ts
@@ -47,7 +47,7 @@ describe('TypeOfConvictedOffence', () => {
 
         expect(page.response()).toEqual({
           'What type of offending has John Wayne been convicted of?': {
-            Offences: 'Arson, Sexual Offence, Hate Crimes, Non-sexual offences against children',
+            Offences: 'Arson offences, Sexual offences, Hate crimes, Non-sexual offences against children',
           },
         })
       })
@@ -56,7 +56,7 @@ describe('TypeOfConvictedOffence', () => {
 
         expect(page.response()).toEqual({
           'What type of offending has John Wayne been convicted of?': {
-            Offences: 'Arson',
+            Offences: 'Arson offences',
           },
         })
       })

--- a/server/form-pages/apply/risk-management-features/typeOfConvictedOffence.ts
+++ b/server/form-pages/apply/risk-management-features/typeOfConvictedOffence.ts
@@ -5,9 +5,9 @@ import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
 import TasklistPage from '../../tasklistPage'
 
 export const offences = {
-  arson: 'Arson',
-  sexualOffence: 'Sexual Offence',
-  hateCrimes: 'Hate Crimes',
+  arson: 'Arson offences',
+  sexualOffence: 'Sexual offences',
+  hateCrimes: 'Hate crimes',
   childNonSexualOffence: 'Non-sexual offences against children',
 } as const
 

--- a/server/form-pages/apply/type-of-ap/apType.test.ts
+++ b/server/form-pages/apply/type-of-ap/apType.test.ts
@@ -8,13 +8,11 @@ import personFactory from '../../../testutils/factories/person'
 jest.mock('../../../utils/formUtils')
 
 describe('ApType', () => {
-  let application = applicationFactory.build()
+  const person = personFactory.build({ name: 'John Wayne' })
+  const application = applicationFactory.build({ person })
 
   describe('title', () => {
     it('shold add the name of the person', () => {
-      const person = personFactory.build({ name: 'John Wayne' })
-      application = applicationFactory.build({ person })
-
       const page = new ApType({}, application)
 
       expect(page.title).toEqual('Which type of AP does John Wayne require?')

--- a/server/form-pages/apply/type-of-ap/esapPlacementScreening.test.ts
+++ b/server/form-pages/apply/type-of-ap/esapPlacementScreening.test.ts
@@ -8,13 +8,11 @@ import personFactory from '../../../testutils/factories/person'
 jest.mock('../../../utils/formUtils')
 
 describe('EsapPlacementScreening', () => {
-  let application = applicationFactory.build()
+  const person = personFactory.build({ name: 'John Wayne' })
+  const application = applicationFactory.build({ person })
 
   describe('title', () => {
     it('shold add the name of the person', () => {
-      const person = personFactory.build({ name: 'John Wayne' })
-      application = applicationFactory.build({ person })
-
       const page = new EsapPlacementScreening({}, application)
 
       expect(page.title).toEqual('Why does John Wayne require an enhanced security placement?')

--- a/server/form-pages/apply/type-of-ap/pipeReferral.test.ts
+++ b/server/form-pages/apply/type-of-ap/pipeReferral.test.ts
@@ -5,13 +5,11 @@ import applicationFactory from '../../../testutils/factories/application'
 import personFactory from '../../../testutils/factories/person'
 
 describe('PipeReferral', () => {
-  let application = applicationFactory.build()
+  const person = personFactory.build({ name: 'John Wayne' })
+  const application = applicationFactory.build({ person })
 
   describe('title', () => {
     it('shold add the name of the person', () => {
-      const person = personFactory.build({ name: 'John Wayne' })
-      application = applicationFactory.build({ person })
-
       const page = new PipeReferral({}, application)
 
       expect(page.title).toEqual('Has John Wayne been screened into the OPD pathway?')

--- a/server/views/applications/pages/risk-management-features/rehabilitative-interventions.njk
+++ b/server/views/applications/pages/risk-management-features/rehabilitative-interventions.njk
@@ -1,0 +1,43 @@
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+
+{% extends "../layout.njk" %}
+
+{% set interventions = page.items() %}
+
+{% block questions %}
+
+    <h1 class="govuk-heading-l">{{page.title}}</h1>
+
+    <p class="govuk-body">Formerly known as purposeful activities.</p>
+    <p class="govuk-body">Select any additional needs the person has that an AP could help meet. For example, support getting qualifications or finding work.</p>
+
+    {% set otherIntervention %}
+    {{ govukInput({
+                id: "otherIntervention",
+                name: "otherIntervention",
+                type: "text",
+                autocomplete: "text",
+                spellcheck: false,
+                classes: "govuk-!-width-two-thirds",
+                label: {
+                    text: "Please specify"
+                }
+                }) }}
+    {% endset %}
+
+    {{ govukCheckboxes({
+        idPrefix: "rehabilitativeInterventions",
+        name: "rehabilitativeInterventions",
+        hint: {
+          text: "You can select more than one option"
+        },
+        items: (interventions.push({
+    value: "other",
+    text: "Other",
+    conditional: {
+        html: otherIntervention
+    }
+}), interventions) 
+      }) }}
+
+{% endblock %}

--- a/server/views/applications/pages/risk-management-features/type-of-convicted-offence.njk
+++ b/server/views/applications/pages/risk-management-features/type-of-convicted-offence.njk
@@ -6,7 +6,7 @@
 
   <h1 class="govuk-heading-l">{{page.title}}</h1>
 
-  <p class="govuk-body">This information will be used to match the person to a bed in an Approved Premises</p>
+  <p class="govuk-body">This information will be used to match them to a bed in an Approved Premises</p>
 
   {{ govukCheckboxes({
         id: "offenceConvictions",


### PR DESCRIPTION
# Context
This PR adds a page to the Apply form for Rehabilitative Interventions. 
This is one of the more interesting Apply pages for a couple of reasons.
[Trello ticket](https://trello.com/c/edxP0Guq/637-purposeful-activities-now-called-rehabilitative-intervention-screen)

# Changes in this PR
1. I believe this is the final page of the 'Risk Management Features' task. It is the point at which the paths that split at the 'ConvictedOffences' page rejoin. All users will see this page but the previous page will be different depending on the different paths that have been followed. For this reason I have taken some time to correct the user flows through this task.
2. Removing 'Other' from `interventions`: We want to keep as much of the copy as possible in the rehabilitativeInterventions.ts file so it can be unit tested in order for changes to break tests so that we remember to update copy when things change. However the ‘other’ checkbox needs to trigger a textbox to show which means it needs to use a variable which can only be in nunjucks land. We need the translation to be in TS though as that’s where our translations live so I have opted to have 'Other' in the object on line 7 of `rehabilitativeInterventions.ts` so we can use it for the Interventions type and responses translations but we need to remove it in the `items` method. It’s not ideal but hopefully it’s clear enough what’s going on. 
An alternative option is to add in 'Other' when doing the translation - let me know if this would be preferable.
3. Error handling: This page is notable as we currently believe the user does not have to select any intervention to be able to proceed so the `errors` method simply returns an empty object if no interventions are selected. However we do want to check that an ‘other’ intervention is specified if the user chooses that option so we have to test whether the input is ‘other’ or is an array including ‘other’.

## Screenshots of UI changes
![Apply -- shows a tasklist](https://user-images.githubusercontent.com/44123869/199290816-4fc9b4f4-76bd-4af1-b797-91dacfc5e4a9.png)

