### PR TITLE
Fix - Apply - bug squashing

### DIFF
--- a/server/form-pages/apply/basic-information/placementDate.test.ts
+++ b/server/form-pages/apply/basic-information/placementDate.test.ts
@@ -34,7 +34,7 @@ describe('PlacementDate', () => {
   })
 
   itShouldHaveNextValue(new PlacementDate({}, application), 'placement-purpose')
-  itShouldHavePreviousValue(new PlacementDate({}, application), 'oral-hearing')
+  itShouldHavePreviousValue(new PlacementDate({}, application), 'release-date')
 
   describe('errors', () => {
     it('should return an empty object if the release date is the same as the start date', () => {

--- a/server/form-pages/apply/basic-information/placementDate.ts
+++ b/server/form-pages/apply/basic-information/placementDate.ts
@@ -35,7 +35,7 @@ export default class PlacementDate implements TasklistPage {
   }
 
   previous() {
-    return 'oral-hearing'
+    return 'release-date'
   }
 
   response() {

--- a/server/form-pages/apply/basic-information/placementPurpose.ts
+++ b/server/form-pages/apply/basic-information/placementPurpose.ts
@@ -27,7 +27,10 @@ export default class PlacementPurpose implements TasklistPage {
   previousPage: string
 
   constructor(body: Record<string, unknown>, private readonly _application: Application, previousPage: string) {
-    const placementPurposesResponse = [body.placementPurposes].flat() as Array<PlacementPurposeT>
+    const placementPurposesResponse = body?.placementPurposes
+      ? ([body.placementPurposes].flat() as Array<PlacementPurposeT>)
+      : []
+
     if (this.responseNeedsFreeTextReason(body)) {
       this.body = {
         placementPurposes: placementPurposesResponse,
@@ -63,7 +66,7 @@ export default class PlacementPurpose implements TasklistPage {
   }
 
   private responseContainsReasons(body: Record<string, unknown>): body is { placementPurposes: Array<unknown> } {
-    if (body?.placementPurposes && Array.isArray(body.placementPurposes)) {
+    if (body?.placementPurposes && Array.isArray(body.placementPurposes) && body.placementPurposes.length) {
       return true
     }
     return false
@@ -79,7 +82,7 @@ export default class PlacementPurpose implements TasklistPage {
   }
 
   items() {
-    return convertKeyValuePairToCheckBoxItems(placementPurposes, this.body.placementPurposes)
+    return convertKeyValuePairToCheckBoxItems(placementPurposes, this.body?.placementPurposes)
   }
 
   response() {

--- a/server/form-pages/apply/basic-information/placementPurpose.ts
+++ b/server/form-pages/apply/basic-information/placementPurpose.ts
@@ -27,13 +27,14 @@ export default class PlacementPurpose implements TasklistPage {
   previousPage: string
 
   constructor(body: Record<string, unknown>, private readonly _application: Application, previousPage: string) {
+    const placementPurposesResponse = [body.placementPurposes].flat() as Array<PlacementPurposeT>
     if (this.responseNeedsFreeTextReason(body)) {
       this.body = {
-        placementPurposes: body.placementPurposes as Array<PlacementPurposeT>,
+        placementPurposes: placementPurposesResponse,
         otherReason: body.otherReason as string,
       }
     } else {
-      this.body = { placementPurposes: body.placementPurposes as Array<PlacementPurposeT> }
+      this.body = { placementPurposes: placementPurposesResponse }
     }
 
     this.previousPage = previousPage

--- a/server/form-pages/apply/basic-information/sentenceType.ts
+++ b/server/form-pages/apply/basic-information/sentenceType.ts
@@ -47,6 +47,8 @@ export default class SentenceType implements TasklistPage {
         return 'release-type'
       case 'ipp':
         return 'release-type'
+      case 'nonStatutory':
+        return 'release-type'
       case 'life':
         return 'release-type'
       default:

--- a/server/form-pages/apply/risk-management-features/rehabilitativeInterventions.ts
+++ b/server/form-pages/apply/risk-management-features/rehabilitativeInterventions.ts
@@ -30,7 +30,7 @@ export default class RehabilitativeInterventions implements TasklistPage {
     private readonly _application: Application,
     private readonly previousPage: string,
   ) {
-    const interventions = [body.interventions].flat() as Interventions
+    const interventions = body.interventions ? ([body.interventions].flat() as Interventions) : []
 
     this.body = { interventions }
 
@@ -64,7 +64,7 @@ export default class RehabilitativeInterventions implements TasklistPage {
 
   errors() {
     const errors: TaskListErrors<this> = {}
-    if (this.otherInterventionDetailIsNeeded(this.body.interventions) && !this.body.otherIntervention) {
+    if (this.otherInterventionDetailIsNeeded(this.body?.interventions) && !this.body?.otherIntervention) {
       errors.otherIntervention = 'You must specify the other intervention'
     }
     return errors
@@ -72,7 +72,7 @@ export default class RehabilitativeInterventions implements TasklistPage {
 
   items() {
     const { other, ...uiInterventions } = interventionsTranslations
-    return convertKeyValuePairToCheckBoxItems(uiInterventions, this.body.interventions)
+    return convertKeyValuePairToCheckBoxItems(uiInterventions, this.body?.interventions)
   }
 
   private otherInterventionDetailIsNeeded(interventions: Interventions) {

--- a/server/views/applications/pages/layout.njk
+++ b/server/views/applications/pages/layout.njk
@@ -14,7 +14,7 @@
 
 {% block content %}
 
-  {% if page.previous %}
+  {% if page.previous() %}
     {{ govukBackLink({
       text: "Back",
       href: paths.applications.pages.show({ id: applicationId, task: task, page: page.previous() })

--- a/server/views/arrivals/new.njk
+++ b/server/views/arrivals/new.njk
@@ -65,7 +65,7 @@
           id: "keyWorkerStaffId",
           name: "arrival[keyWorkerStaffId]",
           items: convertObjectsToSelectOptions(staffMembers, 'Select a keyworker', 'name', 'id', 'keyWorkerStaffId'),
-          errorMessage: errors.keyWorkerStaffId
+          errorMessage: errors.keyWorkerStaffId.empty
         }) }}
 
         {{ govukTextarea({


### PR DESCRIPTION
Here's an asortment of small bugs I've found whilst using Apply in the last 24 hours. 
There all too minor to justify their own PRs so I've collected them here.

- [Add case for nonStatutory sentence type](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/309/commits/f161568185907a3e40d9705356e8aa4a2a515ad3)
[f161568](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/309/commits/f161568185907a3e40d9705356e8aa4a2a515ad3)
- [Invoke page.previous function in evaluation in layout.njk](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/309/commits/810fd6d725232875340173c95b4c8be24a11b402)
[810fd6d](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/309/commits/810fd6d725232875340173c95b4c8be24a11b402)
- [Add translation for errors.keyWorkerStaffId.empty](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/309/commits/22c92452943cea9a75634a4f734dca726d9d1d21)
[22c9245](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/309/commits/22c92452943cea9a75634a4f734dca726d9d1d21)
- [Correct previous path for placementDate](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/309/commits/3ae11a46d67e8efe1fc6e7ad64023c61e62ff309)
[3ae11a4](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/309/commits/3ae11a46d67e8efe1fc6e7ad64023c61e62ff309)
- [Ensure placementPurpose answer is always an array](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/309/commits/6f39522ae6687f964c1923f67bbbf260eccc5dff)
[6f39522](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/309/commits/6f39522ae6687f964c1923f67bbbf260eccc5dff)
- [Correct assignments from user response for placementPurpose and rehab…](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/309/commits/1a664b07e9efb5b0d3baf028dd47f85cbd04abf9)