### PR TITLE
Move to shared namespace

### DIFF
--- a/helm_deploy/hmpps-approved-premises-ui/values.yaml
+++ b/helm_deploy/hmpps-approved-premises-ui/values.yaml
@@ -42,7 +42,7 @@ generic-service:
   #     [name of environment variable as seen by app]: [key of kubernetes secret to load]
 
   namespace_secrets:
-    approved-premises-ui:
+    hmpps-approved-premises-ui:
       APPINSIGHTS_INSTRUMENTATIONKEY: 'APPINSIGHTS_INSTRUMENTATIONKEY'
       API_CLIENT_ID: 'API_CLIENT_ID'
       API_CLIENT_SECRET: 'API_CLIENT_SECRET'

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -6,14 +6,14 @@ generic-service:
 
   ingress:
     hosts:
-      - approved-premises-dev.hmpps.service.justice.gov.uk
+      - cas-approved-premises-dev.hmpps.service.justice.gov.uk
     contextColour: green
     tlsSecretName: hmpps-approved-premises-dev-cert
 
   env:
     ENVIRONMENT: dev
-    APPROVED_PREMISES_API_URL: 'https://approved-premises-api-dev.hmpps.service.justice.gov.uk'
-    INGRESS_URL: 'https://approved-premises-dev.hmpps.service.justice.gov.uk'
+    APPROVED_PREMISES_API_URL: 'https://cas-approved-premises-api-dev.hmpps.service.justice.gov.uk'
+    INGRESS_URL: 'https://cas-approved-premises-dev.hmpps.service.justice.gov.uk'
     HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
     COMMUNITY_ACCOMMODATION_API_SERVICE_NAME: approved-premises


### PR DESCRIPTION
This puts in the groundwork for moving AP over to the shared `hmpps-community-accommodation-dev` namespace. We'll need to do the following before this is ready to go:

- [x] Wait for CAS3 to move to the new namespace and confirm it's working
- [x] Change our namespace in https://github.com/ministryofjustice/dps-project-bootstrap