### PR TITLE
Add generator for form pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
       "<rootDir>/(server|job)/**/?(*.)(cy|test).{ts,js,jsx,mjs}",
       "<rootDir>/wiremock/?(*.)(cy|test).{ts,js,jsx,mjs}"
     ],
+    "testPathIgnorePatterns": [
+      "<rootDir>/server/form-pages/utils/templates/test.ts"
+    ],
     "testEnvironment": "node",
     "reporters": [
       "default",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "api-stubs:create": "npx ts-node --transpile-only ./wiremock/stubApis.ts",
     "api-stubs:reset": "npx ts-node --transpile-only ./wiremock/resetStubs.ts",
     "start-test-wiremock": "docker-compose -f docker-compose-test.yml up -d",
-    "generate-types": "script/generate-types"
+    "generate-types": "script/generate-types",
+    "form-page:generate": "npx ts-node --transpile-only ./server/form-pages/utils/generator.ts"
   },
   "engines": {
     "node": "^18",

--- a/server/form-pages/utils/generator.ts
+++ b/server/form-pages/utils/generator.ts
@@ -1,0 +1,127 @@
+/* istanbul ignore file */
+/* eslint-disable no-console */
+
+import fs from 'fs'
+import path from 'path'
+
+import { pascalCase, camelCase } from '../../utils/utils'
+
+import pageTemplate from './templates/page'
+import testTemplate from './templates/test'
+import indexTemplate from './templates/index'
+import viewTemplate from './templates/view'
+import pageObjectTemplate from './templates/pageObject'
+
+const args = process.argv.slice(2)
+const pagePath = args[0]
+
+if (!pagePath) {
+  console.error('You must specify a path for a page (i.e apply/basic-information/page)')
+  process.exit(1)
+}
+
+const [formName, sectionName, pageName] = pagePath.split('/')
+
+const dirName = pagePath.replace(pageName, '')
+
+let newSection = false
+
+if (!pageName) {
+  console.error('You must specify a path for a page (i.e apply/basic-information/page)')
+  process.exit(1)
+}
+
+// Create the class directory if it doesn't exist
+if (!fs.existsSync(path.resolve(__dirname, '..', dirName))) {
+  fs.mkdirSync(`${__dirname}/../${dirName}`)
+  newSection = true
+}
+
+// Create Page Definition
+const pageClassName = pascalCase(pageName)
+const pageClassPath = path.resolve(__dirname, `../${pagePath}.ts`)
+const pageClassTestPath = path.resolve(__dirname, `../${pagePath}.test.ts`)
+
+fs.writeFileSync(pageClassPath, pageTemplate(pageClassName, pageName), {
+  flag: 'w+',
+})
+
+// Create test file for Page Definition
+fs.writeFileSync(pageClassTestPath, testTemplate(pageClassName, pageName), {
+  flag: 'w+',
+})
+
+const indexPath = path.resolve(__dirname, `../${dirName}/index.ts`)
+
+// Add Page Definition to index file
+if (!newSection) {
+  const indexFile = fs.readFileSync(indexPath, 'utf8')
+
+  const importLine = `import ${pageClassName} from './${pageName}'`
+  const pageDefLine = `  '${pageName}': ${pageClassName},`
+
+  if (!indexFile.includes(importLine) || !indexFile.includes(pageDefLine)) {
+    const lines = indexFile.split(/\r?\n/)
+    let importAdded = false
+
+    for (let i = 0; i < lines.length; i += 1) {
+      const line = lines[i]
+
+      if (!importAdded && line.startsWith('import') && !lines[i + 1].startsWith('import')) {
+        lines.splice(i + 1, 0, importLine)
+        importAdded = true
+      }
+
+      if (line.startsWith('}')) {
+        lines.splice(i, 0, pageDefLine)
+        break
+      }
+    }
+
+    fs.writeFileSync(indexPath, lines.join('\n'), {
+      flag: 'w+',
+    })
+  }
+} else {
+  fs.writeFileSync(indexPath, indexTemplate(pageClassName, pageName), {
+    flag: 'w+',
+  })
+
+  const formIndexPath = path.resolve(__dirname, `../${dirName}/../index.ts`)
+  let formIndexFileContent = fs.readFileSync(formIndexPath, 'utf8')
+
+  const toDoComment = `// TODO: Add reference to ${sectionName} section`
+
+  formIndexFileContent = `${toDoComment}\r\n${formIndexFileContent}`
+
+  fs.writeFileSync(formIndexPath, formIndexFileContent, {
+    flag: 'w+',
+  })
+}
+
+// Create template file
+const viewDir = path.resolve(__dirname, `../../views/applications/pages/${sectionName}`)
+
+if (!fs.existsSync(viewDir)) {
+  fs.mkdirSync(viewDir)
+}
+
+const viewPath = `${viewDir}/${pageName}.njk`
+
+fs.writeFileSync(viewPath, viewTemplate(), {
+  flag: 'w+',
+})
+
+// Create Page Object file
+const pageObjectPath = path.resolve(__dirname, `../../../cypress_shared/pages/${formName}/${camelCase(pageName)}.ts`)
+
+fs.writeFileSync(pageObjectPath, pageObjectTemplate(pageName), {
+  flag: 'w+',
+})
+
+console.log('Form page files successfully generated:')
+
+console.log(pageClassPath)
+console.log(pageClassTestPath)
+console.log(viewPath)
+console.log(pageObjectPath)

--- a/server/form-pages/utils/templates/index.ts
+++ b/server/form-pages/utils/templates/index.ts
@@ -1,0 +1,14 @@
+/* istanbul ignore file */
+
+const indexTemplate = (pageClassName: string, pageFileName: string) => `/* istanbul ignore file */
+
+import ${pageClassName} from './${pageFileName}'
+
+const pages = {
+  '${pageFileName}': ${pageClassName},
+}
+
+export default pages
+`
+
+export default indexTemplate

--- a/server/form-pages/utils/templates/page.ts
+++ b/server/form-pages/utils/templates/page.ts
@@ -1,0 +1,43 @@
+/* istanbul ignore file */
+
+const pageTemplate = (
+  pageClassName: string,
+  pageName: string,
+) => `import type { TaskListErrors } from '@approved-premises/ui'
+
+import TasklistPage from '../../tasklistPage'
+
+export default class ${pageClassName} implements TasklistPage {
+  name = '${pageName}'
+
+  // TODO: Add title of page
+  title = ''
+
+  body: {}
+
+  // TODO: Add the body params to the constructor
+  constructor(body: Record<string, unknown>) {}
+
+  // TODO: Set the previous page (if applicable)
+  previous() {
+    return ''
+  }
+
+  // TODO: Set the next page (if applicable)
+  next() {
+    return ''
+  }
+
+  // TODO: Add logic to translate the response (if applicable)
+  response() {}
+
+  // TODO: Add logic for error handling
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    return errors
+  }
+}
+`
+
+export default pageTemplate

--- a/server/form-pages/utils/templates/pageObject.ts
+++ b/server/form-pages/utils/templates/pageObject.ts
@@ -1,0 +1,14 @@
+/* istanbul ignore file */
+
+const pageObjectTemplate = (pageName: string) => `import Page from '../page'
+
+export default class ${pageName}Page extends Page {
+  constructor() {
+    // TODO: Add title of page
+    super('')
+  }
+
+  // TODO: Add form completion methods
+}
+`
+export default pageObjectTemplate

--- a/server/form-pages/utils/templates/test.ts
+++ b/server/form-pages/utils/templates/test.ts
@@ -1,0 +1,32 @@
+/* istanbul ignore file */
+
+const testTemplate = (
+  pageClassName: string,
+  pageFileName: string,
+) => `import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+
+import ${pageClassName} from './${pageFileName}'
+
+describe('${pageClassName}', () => {
+
+  // TODO: Add title tests (if applicable)
+  describe('title', () => {})
+
+  // TODO: Add body tests (if applicable)
+  describe('body', () => {
+    it('should strip unknown attributes from the body', () => {})
+  })
+
+  // TODO: Update next and previous values and add logic tests (if applicable)
+  itShouldHaveNextValue(new ${pageClassName}({}), '')
+  itShouldHavePreviousValue(new ${pageClassName}({}), '')
+
+  // TODO: Add error tests (if applicable)
+  describe('errors', () => {})
+
+  // TODO: Add response tests
+  describe('response', () => {})
+})
+`
+
+export default testTemplate

--- a/server/form-pages/utils/templates/view.ts
+++ b/server/form-pages/utils/templates/view.ts
@@ -1,0 +1,13 @@
+/* istanbul ignore file */
+
+const viewTemplate = () => `
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  // TODO: Add questions here
+
+{% endblock %}
+`
+
+export default viewTemplate

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -7,6 +7,8 @@ import {
   retrieveQuestionResponseFromApplication,
   removeBlankSummaryListItems,
   mapApiPersonRisksForUi,
+  pascalCase,
+  camelCase,
 } from './utils'
 import risksFactory from '../testutils/factories/risks'
 import { DateFormats } from './dateUtils'
@@ -24,6 +26,18 @@ describe('convert to title case', () => {
     ['Hyphenated', 'Robert-John SmiTH-jONes-WILSON', 'Robert-John Smith-Jones-Wilson'],
   ])('%s convertToTitleCase(%s, %s)', (_: string, a: string, expected: string) => {
     expect(convertToTitleCase(a)).toEqual(expected)
+  })
+})
+
+describe('pascalCase', () => {
+  it('converts a string to Pascal Case', () => {
+    expect(pascalCase('my-string')).toEqual('MyString')
+  })
+})
+
+describe('camelCase', () => {
+  it('converts a string to camel Case', () => {
+    expect(camelCase('my-string')).toEqual('myString')
   })
 })
 

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -44,6 +44,25 @@ const kebabCase = (string: string) =>
     .toLowerCase()
 
 /**
+ * Converts a string from any case to camelCase
+ * @param string string to be converted.
+ * @returns name converted to camelCase.
+ */
+export const camelCase = (string: string) =>
+  string
+    .toLowerCase()
+    .replace(/[-_]+/g, ' ')
+    .replace(/[^\w\s]/g, '')
+    .replace(/\s+(.)(\w*)/g, (_$1, $2, $3) => `${$2.toUpperCase() + $3}`)
+
+/**
+ * Converts a string from any case to PascalCase
+ * @param string string to be converted.
+ * @returns name converted to PascalCase.
+ */
+export const pascalCase = (string: string) => camelCase(string).replace(/\w/, s => s.toUpperCase())
+
+/**
  * Converts a string from any case to Sentence case
  * @param string string to be converted.
  * @returns name converted to sentence case.


### PR DESCRIPTION
This add a generator task that will allow us to generate all the necessary scaffolding for creating a new form page for Apply. It can be run like so:

```bash
npm run form-page:generate apply/basic-information/page
```

It's very scrappy and procedural, but will do the job for us. It generates a skeleton page class, a test file, a view, and a page object for use in Cypress and adds `TODO` comments for all the things that need adding.

The only thing it doesn’t do is add a new section to the imports, but this requires manual work anyway. It does add a `TODO` as a reminder to do it manually.