### PR TITLE
Update the docker-compose ports for test

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -6,7 +6,7 @@ services:
     networks:
       - hmpps_int
     ports:
-      - '6379:6379'
+      - '6380:6379'
 
   wiremock:
     image: wiremock/wiremock
@@ -16,7 +16,7 @@ services:
     restart: always
     command: --local-response-templating
     ports:
-      - "9091:8080"
+      - "9999:8080"
 
 networks:
   hmpps_int:

--- a/feature.env
+++ b/feature.env
@@ -1,11 +1,12 @@
 PORT=3007
-HMPPS_AUTH_URL=http://localhost:9091/auth
-TOKEN_VERIFICATION_API_URL=http://localhost:9091/verification
+HMPPS_AUTH_URL=http://localhost:9999/auth
+TOKEN_VERIFICATION_API_URL=http://localhost:9999/verification
 TOKEN_VERIFICATION_ENABLED=true
 NODE_ENV=development
 API_CLIENT_ID=clientid
 API_CLIENT_SECRET=clientsecret
+REDIS_PORT=6380
 SYSTEM_CLIENT_ID=clientid
 SYSTEM_CLIENT_SECRET=clientsecret
-APPROVED_PREMISES_API_URL=http://localhost:9091
+APPROVED_PREMISES_API_URL=http://localhost:9999
 COMMUNITY_ACCOMMODATION_API_SERVICE_NAME=approved-premises

--- a/wiremock/index.ts
+++ b/wiremock/index.ts
@@ -1,6 +1,6 @@
 import superagent, { SuperAgentRequest, Response } from 'superagent'
 
-const wiremockEndpoint = process.env.CYPRESS ? 'http://localhost:9091' : 'http://localhost:9092'
+const wiremockEndpoint = process.env.CYPRESS ? 'http://localhost:9999' : 'http://localhost:9092'
 
 const url = `${wiremockEndpoint}/__admin`
 


### PR DESCRIPTION
This allows us to keep the dev application running and run the tests too without having to take any containers down