### PR TITLE
Fix zero beds issue

### DIFF
--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -58,6 +58,6 @@
     "invalid": "The end date is an invalid date",
     "beforeStartDate": "The end date must be before the start date"
   },
-  "numberOfBeds": { "empty": "You must enter the number of beds lost" },
+  "numberOfBeds": { "empty": "You must enter the number of beds lost", "isZero": "Number of beds lost cannot be zero" },
   "referenceNumber": { "empty": "You must enter a reference number" }
 }

--- a/server/testutils/factories/lostBed.ts
+++ b/server/testutils/factories/lostBed.ts
@@ -10,7 +10,7 @@ export default Factory.define<LostBed>(() => ({
   notes: faker.lorem.sentence(),
   startDate: DateFormats.formatApiDate(faker.date.soon()),
   endDate: DateFormats.formatApiDate(faker.date.future()),
-  numberOfBeds: faker.datatype.number({ max: 10 }),
+  numberOfBeds: faker.datatype.number({ min: 1, max: 10 }),
   referenceNumber: faker.datatype.uuid(),
   reason: referenceDataFactory.lostBedReasons().build(),
 }))


### PR DESCRIPTION
We've had an issue with the e2e tests where sometimes the factory generates a `lostBed` object with a `numberOfBeds` of zero. This causes an error because we don't have a translation for this error. This adds the error, but also updates the factory to not generate a `lostBed` object with a `numberOfBeds` of zero.