### PR TITLE
(639) - Apply - PDU Transfer screen

### DIFF
--- a/cypress_shared/pages/apply/pduTransfer.ts
+++ b/cypress_shared/pages/apply/pduTransfer.ts
@@ -1,0 +1,13 @@
+import { Person } from '../../../server/@types/shared'
+import Page from '../page'
+
+export default class PduTransferPage extends Page {
+  constructor(person: Person) {
+    super(`Have you agreed ${person.name}'s transfer/supervision with the receiving PDU?`)
+  }
+
+  completeForm() {
+    this.checkRadioByNameAndValue('transferStatus', 'yes')
+    this.getTextInputByIdAndEnterDetails('probationPractitioner', 'Probation Practicioner')
+  }
+}

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../cypress_shared/pages/apply'
 import ConvictedOffences from '../../../cypress_shared/pages/apply/convictedOffences'
 import DateOfOffence from '../../../cypress_shared/pages/apply/dateOfOffence'
+import PduTransferPage from '../../../cypress_shared/pages/apply/pduTransfer'
 import PlacementPurposePage from '../../../cypress_shared/pages/apply/placementPurpose'
 import RehabilitativeInterventions from '../../../cypress_shared/pages/apply/rehabilitativeInterventions'
 import RiskManagementFeatures from '../../../cypress_shared/pages/apply/riskManagementFeatures'
@@ -221,6 +222,10 @@ context('Apply', () => {
     const describeLocationFactorsPage = new DescribeLocationFactors()
     describeLocationFactorsPage.completeForm()
     describeLocationFactorsPage.clickSubmit()
+
+    const pduTransferPage = new PduTransferPage(person)
+    pduTransferPage.completeForm()
+    pduTransferPage.clickSubmit()
 
     // Then I should be taken back to the task list
     // And the location factors task should show a completed status

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -218,9 +218,9 @@ context('Apply', () => {
     cy.get('[data-cy-task-name="location-factors"]').click()
 
     // When I complete the form
-    const describeLocationFactors = new DescribeLocationFactors()
-    describeLocationFactors.completeForm()
-    describeLocationFactors.clickSubmit()
+    const describeLocationFactorsPage = new DescribeLocationFactors()
+    describeLocationFactorsPage.completeForm()
+    describeLocationFactorsPage.clickSubmit()
 
     // Then I should be taken back to the task list
     // And the location factors task should show a completed status

--- a/server/form-pages/apply/location-factors/describeLocationFactors.test.ts
+++ b/server/form-pages/apply/location-factors/describeLocationFactors.test.ts
@@ -12,6 +12,7 @@ describe('ConvictedOffences', () => {
   })
 
   itShouldHavePreviousValue(new DescribeLocationFactors({}), '')
+  itShouldHaveNextValue(new DescribeLocationFactors({ differentPDU: 'yes' }), 'pdu-transfer')
   itShouldHaveNextValue(new DescribeLocationFactors({}), '')
 
   describe('errors', () => {

--- a/server/form-pages/apply/location-factors/describeLocationFactors.ts
+++ b/server/form-pages/apply/location-factors/describeLocationFactors.ts
@@ -51,6 +51,9 @@ export default class DescribeLocationFactors implements TasklistPage {
   }
 
   next() {
+    if (this.body.differentPDU) {
+      return 'pdu-transfer'
+    }
     return ''
   }
 

--- a/server/form-pages/apply/location-factors/index.ts
+++ b/server/form-pages/apply/location-factors/index.ts
@@ -1,9 +1,11 @@
 /* istanbul ignore file */
 
 import DescribeLocationFactors from './describeLocationFactors'
+import PduTransfer from './pduTransfer'
 
 const pages = {
   'describe-location-factors': DescribeLocationFactors,
+  'pdu-transfer': PduTransfer,
 }
 
 export default pages

--- a/server/form-pages/apply/location-factors/pduTransfer.test.ts
+++ b/server/form-pages/apply/location-factors/pduTransfer.test.ts
@@ -1,0 +1,68 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+
+import PduTransfer from './pduTransfer'
+
+import applicationFactory from '../../../testutils/factories/application'
+import personFactory from '../../../testutils/factories/person'
+
+describe('PduTransfer', () => {
+  const person = personFactory.build({ name: 'John Wayne' })
+  const application = applicationFactory.build({ person })
+
+  describe('title', () => {
+    expect(new PduTransfer({ transferStatus: '' }, application).title).toBe(
+      "Have you agreed John Wayne's transfer/supervision with the receiving PDU?",
+    )
+  })
+
+  describe('body', () => {
+    it('should strip unknown attributes from the body', () => {
+      expect(
+        new PduTransfer({ transferStatus: 'yes', probationPractitioner: 'bob', someProperty: 'bye' }, application).body,
+      ).toEqual({ transferStatus: 'yes', probationPractitioner: 'bob' })
+    })
+  })
+
+  itShouldHaveNextValue(new PduTransfer({}, application), '')
+  itShouldHavePreviousValue(new PduTransfer({}, application), 'describe-location-factors')
+
+  describe('errors', () => {
+    it('should have an error if no response is submitted', () => {
+      expect(new PduTransfer({}, application).errors()).toEqual({
+        transferStatus: 'You must choose an answer',
+      })
+    })
+
+    it('should have an error if the answer is "yes" but no probation practitioner is named', () => {
+      expect(new PduTransfer({ transferStatus: 'yes' }, application).errors()).toEqual({
+        probationPractitioner: "You must give the probation practitioner's name",
+      })
+    })
+  })
+
+  describe('response', () => {
+    it('returns the full copy for the users response if they answer yes', () => {
+      const page = new PduTransfer({ transferStatus: 'yes', probationPractitioner: 'Alice' }, application)
+      expect(page.response()).toEqual({
+        "Have you agreed John Wayne's transfer/supervision with the receiving PDU?": 'Yes',
+        'Probation practitioner': 'Alice',
+      })
+    })
+
+    it('returns the full copy for the users response if they answer noNeedToMakeArrangements', () => {
+      const page = new PduTransfer({ transferStatus: 'noNeedToMakeArrangements' }, application)
+      expect(page.response()).toEqual({
+        "Have you agreed John Wayne's transfer/supervision with the receiving PDU?":
+          'No, I still need to make arrangements',
+      })
+    })
+
+    it('returns the full copy for the users response if they answer noProbationPractitioner', () => {
+      const page = new PduTransfer({ transferStatus: 'noProbationPractitioner' }, application)
+      expect(page.response()).toEqual({
+        "Have you agreed John Wayne's transfer/supervision with the receiving PDU?":
+          'No, management and supervision will be maintained by the existing probation practitioner',
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/location-factors/pduTransfer.ts
+++ b/server/form-pages/apply/location-factors/pduTransfer.ts
@@ -1,0 +1,56 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+import { Application } from '../../../@types/shared'
+
+import TasklistPage from '../../tasklistPage'
+
+const questions = {
+  yes: 'Yes',
+  noNeedToMakeArrangements: 'No, I still need to make arrangements',
+  noProbationPractitioner: 'No, management and supervision will be maintained by the existing probation practitioner',
+}
+
+type Response = keyof typeof questions
+
+export default class PduTransfer implements TasklistPage {
+  name = 'pdu-transfer'
+
+  title = `Have you agreed ${this.application.person.name}'s transfer/supervision with the receiving PDU?`
+
+  body: { transferStatus: Response; probationPractitioner?: string }
+
+  questions = questions
+
+  constructor(body: Record<string, unknown>, private readonly application: Application) {
+    this.body = { transferStatus: body.transferStatus as Response }
+    if (this.body.transferStatus === 'yes') {
+      this.body.probationPractitioner = body.probationPractitioner as string
+    }
+  }
+
+  previous() {
+    return 'describe-location-factors'
+  }
+
+  next() {
+    return ''
+  }
+
+  response() {
+    if (!this.body.probationPractitioner) return { [this.title]: questions[this.body.transferStatus] }
+    return {
+      [this.title]: questions[this.body.transferStatus],
+      'Probation practitioner': this.body.probationPractitioner,
+    }
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+    if (!this.body.transferStatus) {
+      errors.transferStatus = 'You must choose an answer'
+    }
+    if (this.body.transferStatus === 'yes' && !this.body.probationPractitioner) {
+      errors.probationPractitioner = "You must give the probation practitioner's name"
+    }
+    return errors
+  }
+}

--- a/server/form-pages/utils/generator.ts
+++ b/server/form-pages/utils/generator.ts
@@ -115,7 +115,7 @@ fs.writeFileSync(viewPath, viewTemplate(), {
 // Create Page Object file
 const pageObjectPath = path.resolve(__dirname, `../../../cypress_shared/pages/${formName}/${camelCase(pageName)}.ts`)
 
-fs.writeFileSync(pageObjectPath, pageObjectTemplate(pageName), {
+fs.writeFileSync(pageObjectPath, pageObjectTemplate(pascalCase(pageName)), {
   flag: 'w+',
 })
 

--- a/server/views/applications/pages/location-factors/describe-location-factors.njk
+++ b/server/views/applications/pages/location-factors/describe-location-factors.njk
@@ -34,6 +34,7 @@
       name: "restrictionDetail",
       spellcheck: false,
       errorMessage: errors.restrictionDetail,
+      value: restrictionDetail,
       label: {
         text: page.questions.restrictionDetail
       }

--- a/server/views/applications/pages/location-factors/pdu-transfer.njk
+++ b/server/views/applications/pages/location-factors/pdu-transfer.njk
@@ -1,0 +1,48 @@
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  {% set pduTransfer %}
+  {{ applyInput({
+        fieldName: "probationPractitioner",
+        autocomplete: "text",
+        spellcheck: false,
+        label: {
+          text: "Who have you agreed this with? Enter the probation practitioner's full name."
+        }
+      },
+      fetchContext()
+      ) }}
+  {% endset %}
+
+  {{ applyRadios({
+        fieldName: "transferStatus",
+        fieldset: {
+          legend: {
+            text: page.title,
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l"
+          }
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes",
+            conditional: {
+              html: pduTransfer
+            }
+          },
+          {
+            value: "noNeedToMakeArrangements",
+            text: page.questions.noNeedToMakeArrangements
+          },
+          {
+            value: "noProbationPractitioner",
+            text: page.questions.noProbationPractitioner
+          }
+        ]  
+      },
+      fetchContext()
+      ) }}
+
+{% endblock %}


### PR DESCRIPTION
This PR adds a screen asking the user whether a PDU transfer has been agreed. This only shows if the user submits yes to the 'different PDU' question on the Location Factors screen #310 
In the pattern established in https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/142
[Trello card](https://trello.com/b/ps9bUN4V/approved-premises-team-board)


## Screenshots of UI changes

![Apply -- shows a tasklist](https://user-images.githubusercontent.com/44123869/200331882-c8697f08-911d-4d16-b8d5-a706b0f286a0.png)
