### PR TITLE
(640) - Apply - Access needs screen

### DIFF
--- a/cypress_shared/pages/apply/accessNeeds.ts
+++ b/cypress_shared/pages/apply/accessNeeds.ts
@@ -1,0 +1,33 @@
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import Page from '../page'
+
+export default class AccessNeedsPage extends Page {
+  constructor() {
+    super('Access needs')
+  }
+
+  checkAdditionalNeedsBoxes() {
+    this.checkCheckboxByNameAndValue('additionalNeeds', 'mobility')
+    this.checkCheckboxByNameAndValue('additionalNeeds', 'learningDisability')
+    this.checkCheckboxByNameAndValue('additionalNeeds', 'neurodivergentConditions')
+    this.checkCheckboxByNameAndValue('additionalNeeds', 'none')
+  }
+
+  completeReligiousAndCulturalNeedsSection() {
+    this.checkRadioByNameAndValue('religiousOrCulturalNeeds', 'yes')
+    this.getTextInputByIdAndEnterDetails('religiousOrCulturalNeedsDetails', faker.lorem.words())
+  }
+
+  completeNeedsInterpreterSection() {
+    this.checkRadioByNameAndValue('needsInterpreter', 'yes')
+    this.getTextInputByIdAndEnterDetails('interpreterLanguage', faker.lorem.words())
+  }
+
+  completeForm() {
+    this.checkAdditionalNeedsBoxes()
+    this.completeReligiousAndCulturalNeedsSection()
+    this.completeNeedsInterpreterSection()
+    this.checkRadioByNameAndValue('careActAssessmentCompleted', 'yes')
+  }
+}

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -23,6 +23,7 @@ import applicationFactory from '../../../server/testutils/factories/application'
 import personFactory from '../../../server/testutils/factories/person'
 import risksFactory from '../../../server/testutils/factories/risks'
 import { mapApiPersonRisksForUi } from '../../../server/utils/utils'
+import AccessNeedsPage from '../../../cypress_shared/pages/apply/accessNeeds'
 
 context('Apply', () => {
   beforeEach(() => {
@@ -230,5 +231,15 @@ context('Apply', () => {
     // Then I should be taken back to the task list
     // And the location factors task should show a completed status
     tasklistPage.shouldShowTaskStatus('location-factors', 'Completed')
+
+    // Given I click the 'Provide access and healthcare information' task
+    cy.get('[data-cy-task-name="access-and-healthcare"]').click()
+
+    // When I complete the form
+    const accessNeedsPage = new AccessNeedsPage()
+    accessNeedsPage.completeForm()
+    accessNeedsPage.clickSubmit()
+
+    Page.verifyOnPage(TaskListPage)
   })
 })

--- a/server/@types/shared/index.d.ts
+++ b/server/@types/shared/index.d.ts
@@ -66,6 +66,7 @@ export type { SupervisingTeam } from './models/SupervisingTeam';
 export type { TemporaryAccommodationPremises } from './models/TemporaryAccommodationPremises';
 export type { UpdateApplication } from './models/UpdateApplication';
 export type { UpdateAssessment } from './models/UpdateAssessment';
+export type { UpdateRoom } from './models/UpdateRoom';
 export type { User } from './models/User';
 export type { UserQualification } from './models/UserQualification';
 export type { UserRole } from './models/UserRole';

--- a/server/@types/shared/models/UpdateRoom.ts
+++ b/server/@types/shared/models/UpdateRoom.ts
@@ -1,0 +1,9 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type UpdateRoom = {
+    notes?: string;
+    characteristicIds: Array<string>;
+};
+

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -16,7 +16,12 @@ export type ObjectWithDateParts<K extends string | number> = { [P in `${K}-${'ye
 
 export type BookingStatus = 'arrived' | 'awaiting-arrival' | 'not-arrived' | 'departed' | 'cancelled'
 
-export type TaskNames = 'basic-information' | 'type-of-ap' | 'risk-management-features' | 'location-factors'
+export type TaskNames =
+  | 'basic-information'
+  | 'type-of-ap'
+  | 'risk-management-features'
+  | 'location-factors'
+  | 'access-and-healthcare'
 
 export type Task = {
   id: string
@@ -125,6 +130,7 @@ export interface ErrorsAndUserInput {
 export type TaskListErrors<K extends TasklistPage> = Partial<Record<keyof K['body'], string>>
 
 export type YesOrNo = 'yes' | 'no'
+export type YesNoOrIDK = YesOrNo | 'dontKnow'
 
 export type PersonStatus = 'InCustody' | 'InCommunity'
 

--- a/server/form-pages/apply/access-and-healthcare/accessNeeds.test.ts
+++ b/server/form-pages/apply/access-and-healthcare/accessNeeds.test.ts
@@ -1,0 +1,96 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+
+import AccessNeeds, { additionalNeeds } from './accessNeeds'
+
+import applicationFactory from '../../../testutils/factories/application'
+import personFactory from '../../../testutils/factories/person'
+import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
+
+jest.mock('../../../utils/formUtils')
+
+describe('AccessNeeds', () => {
+  const person = personFactory.build({ name: 'John Wayne' })
+  const application = applicationFactory.build({ person })
+
+  describe('title', () => {
+    expect(new AccessNeeds({}, application).title).toBe('Access needs')
+  })
+
+  describe('body', () => {
+    it('should strip unknown attributes from the body', () => {
+      const page = new AccessNeeds(
+        {
+          additionalNeeds: 'mobility',
+          careActAssessmentCompleted: 'yes',
+          interpreterLanguage: 'french',
+          needsInterpreter: 'no',
+          anotherThing: 'here',
+          religiousOrCulturalNeeds: 'Yes',
+          religiousOrCulturalNeedsDetails: 'Some details',
+        },
+        application,
+      )
+      expect(page.body).toEqual({
+        additionalNeeds: ['mobility'],
+        careActAssessmentCompleted: 'yes',
+        interpreterLanguage: 'french',
+        needsInterpreter: 'no',
+        religiousOrCulturalNeeds: 'Yes',
+        religiousOrCulturalNeedsDetails: 'Some details',
+      })
+    })
+  })
+
+  itShouldHaveNextValue(new AccessNeeds({}, application), '')
+  itShouldHavePreviousValue(new AccessNeeds({}, application), '')
+
+  describe('errors', () => {
+    const page = new AccessNeeds({}, application)
+
+    expect(page.errors()).toEqual({
+      careActAssessmentCompleted: 'You must confirm whether a care act assessment has been completed',
+      needsInterpreter: 'You must confirm the need for an interpreter',
+      religiousOrCulturalNeeds: 'You must confirm whether John Wayne has any religious or cultural needs',
+      additionalNeeds: 'You must confirm whether John Wayne has any additional needs',
+    })
+  })
+
+  describe('response', () => {
+    it('returns the correct plain english responses for the questions', () => {
+      const page = new AccessNeeds(
+        {
+          additionalNeeds: ['mobility', 'visualImpairment'],
+          needsInterpreter: 'yes',
+          interpreterLanguage: 'French',
+          anotherThing: 'here',
+          religiousOrCulturalNeeds: 'Yes',
+          religiousOrCulturalNeedsDetails: 'Some details',
+          careActAssessmentCompleted: 'yes',
+        },
+        application,
+      )
+
+      expect(page.response()).toEqual({
+        'Access needs': {
+          'Does John Wayne have any of the following needs?': 'Mobility needs, visual impairment',
+          'Does John Wayne need an interpreter?': 'Yes',
+          'Which language is an interpreter needed for?': 'French',
+          'Does John Wayne have any religious or cultural needs?': 'Yes',
+          'Details of religious or cultural needs': 'Some details',
+          'Has a care act assessment been completed?': 'Yes',
+        },
+      })
+    })
+  })
+
+  describe('needsCheckboxes', () => {
+    it('calls convertKeyValuePairToCheckBoxItems with the correct arguments', () => {
+      new AccessNeeds({ additionalNeeds: ['mobility', 'neurodivergentConditions'] }, application).needsCheckboxes()
+
+      expect(convertKeyValuePairToCheckBoxItems).toHaveBeenCalledWith(additionalNeeds, [
+        'mobility',
+        'neurodivergentConditions',
+      ])
+    })
+  })
+})

--- a/server/form-pages/apply/access-and-healthcare/accessNeeds.ts
+++ b/server/form-pages/apply/access-and-healthcare/accessNeeds.ts
@@ -1,0 +1,126 @@
+import type { TaskListErrors, YesNoOrIDK, YesOrNo } from '@approved-premises/ui'
+import { Application } from '../../../@types/shared'
+import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
+import { pascalCase, sentenceCase } from '../../../utils/utils'
+
+import TasklistPage from '../../tasklistPage'
+
+export const additionalNeeds = {
+  mobility: 'Mobility needs',
+  visualImpairment: 'Visual impairment',
+  learningDisability: 'Learning disability',
+  hearingImpairment: 'Hearing impairment',
+  neurodivergentConditions: 'Neurodivergent conditions',
+  other: 'Other',
+  none: 'None of the above',
+}
+
+type AdditionalNeed = keyof typeof additionalNeeds
+
+export default class AccessNeeds implements TasklistPage {
+  name = 'access-needs'
+
+  title = 'Access needs'
+
+  questions = {
+    needs: {
+      question: `Does ${this.application.person.name} have any of the following needs?`,
+      hint: `For example, if ${this.application.person.name} has a visual impairment, uses a hearing aid or has a learning difficulty.`,
+    },
+    religiousAndCulturalNeeds: {
+      question: `Does ${this.application.person.name} have any religious or cultural needs?`,
+      furtherDetails: `Details of religious or cultural needs`,
+    },
+    interpreter: {
+      question: `Does ${this.application.person.name} need an interpreter?`,
+      language: 'Which language is an interpreter needed for?',
+    },
+    careActAssessmentCompleted: 'Has a care act assessment been completed?',
+  }
+
+  body: {
+    additionalNeeds: AdditionalNeed[]
+    religiousOrCulturalNeeds: YesOrNo
+    religiousOrCulturalNeedsDetails: string
+    careActAssessmentCompleted: YesNoOrIDK
+    needsInterpreter: YesOrNo
+    interpreterLanguage: string
+  }
+
+  constructor(body: Record<string, unknown>, private readonly application: Application) {
+    this.body = {
+      additionalNeeds: body.additionalNeeds ? ([body.additionalNeeds].flat() as Array<AdditionalNeed>) : [],
+      religiousOrCulturalNeeds: body.religiousOrCulturalNeeds as YesOrNo,
+      religiousOrCulturalNeedsDetails: (body.religiousOrCulturalNeedsDetails as string) || '',
+      needsInterpreter: body.needsInterpreter as YesOrNo,
+      interpreterLanguage: body.interpreterLanguage as string,
+      careActAssessmentCompleted: body.careActAssessmentCompleted as YesNoOrIDK,
+    }
+  }
+
+  previous() {
+    return ''
+  }
+
+  next() {
+    return ''
+  }
+
+  response() {
+    const response = {
+      [this.title]: {
+        [this.questions.needs.question]: this.body.additionalNeeds
+          .map((need, i) => (i < 1 ? additionalNeeds[need] : additionalNeeds[need].toLowerCase()))
+          .join(', '),
+        [this.questions.religiousAndCulturalNeeds.question]: sentenceCase(this.body.religiousOrCulturalNeeds),
+        [this.questions.religiousAndCulturalNeeds.furtherDetails]: this.body.religiousOrCulturalNeedsDetails,
+        [this.questions.interpreter.question]: sentenceCase(this.body.needsInterpreter),
+        [this.questions.careActAssessmentCompleted]:
+          this.body.careActAssessmentCompleted === 'yes' || this.body.careActAssessmentCompleted === 'no'
+            ? pascalCase(this.body.careActAssessmentCompleted)
+            : "I don't know",
+      },
+    }
+    if (this.body.needsInterpreter === 'yes') {
+      return {
+        [this.title]: {
+          ...response[this.title],
+          [this.questions.interpreter.language]: this.body.interpreterLanguage,
+        },
+      }
+    }
+    if (this.body.religiousOrCulturalNeeds === 'yes') {
+      return {
+        [this.title]: {
+          ...response[this.title],
+          religiousOrCulturalNeedsDetails: this.body.religiousOrCulturalNeedsDetails,
+        },
+      }
+    }
+
+    return response
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.additionalNeeds.length) {
+      errors.additionalNeeds = `You must confirm whether ${this.application.person.name} has any additional needs`
+    }
+    if (!this.body.religiousOrCulturalNeeds) {
+      errors.religiousOrCulturalNeeds = `You must confirm whether ${this.application.person.name} has any religious or cultural needs`
+    }
+    if (!this.body.needsInterpreter) {
+      errors.needsInterpreter = 'You must confirm the need for an interpreter'
+    }
+    if (!this.body.careActAssessmentCompleted) {
+      errors.careActAssessmentCompleted = 'You must confirm whether a care act assessment has been completed'
+    }
+
+    return errors
+  }
+
+  needsCheckboxes() {
+    return convertKeyValuePairToCheckBoxItems(additionalNeeds, this.body.additionalNeeds)
+  }
+}

--- a/server/form-pages/apply/access-and-healthcare/index.ts
+++ b/server/form-pages/apply/access-and-healthcare/index.ts
@@ -1,0 +1,5 @@
+import AccessNeeds from './accessNeeds'
+
+export default {
+  'access-needs': AccessNeeds,
+}

--- a/server/form-pages/apply/index.ts
+++ b/server/form-pages/apply/index.ts
@@ -5,6 +5,7 @@ import basicInfomationPages from './basic-information'
 import typeOfApPages from './type-of-ap'
 import riskAndNeedPages from './risk-management-features'
 import locationFactorPages from './location-factors'
+import accessAndHealthcarePages from './access-and-healthcare'
 
 const pages: {
   [key in TaskNames]: Record<string, unknown>
@@ -13,6 +14,7 @@ const pages: {
   'type-of-ap': typeOfApPages,
   'risk-management-features': riskAndNeedPages,
   'location-factors': locationFactorPages,
+  'access-and-healthcare': accessAndHealthcarePages,
 }
 
 const sections: FormSections = [
@@ -43,6 +45,11 @@ const sections: FormSections = [
         id: 'location-factors',
         title: 'Describe location factors',
         pages: locationFactorPages,
+      },
+      {
+        id: 'access-and-healthcare',
+        title: 'Provide access and healthcare information',
+        pages: accessAndHealthcarePages,
       },
     ],
   },

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -48,12 +48,7 @@ const kebabCase = (string: string) =>
  * @param string string to be converted.
  * @returns name converted to camelCase.
  */
-export const camelCase = (string: string) =>
-  string
-    .toLowerCase()
-    .replace(/[-_]+/g, ' ')
-    .replace(/[^\w\s]/g, '')
-    .replace(/\s+(.)(\w*)/g, (_$1, $2, $3) => `${$2.toUpperCase() + $3}`)
+export const camelCase = (string: string) => Case.camel(string)
 
 /**
  * Converts a string from any case to PascalCase

--- a/server/views/applications/pages/access-and-healthcare/access-needs.njk
+++ b/server/views/applications/pages/access-and-healthcare/access-needs.njk
@@ -1,0 +1,110 @@
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  <h1 class="govuk-heading-l">{{page.title}}</h1>
+
+  {{ applyCheckboxes({
+      fieldName: "additionalNeeds",
+      hint: {
+        text: page.questions.needs.hint
+      },
+      fieldset: {
+        legend: {
+          text: page.questions.needs.question,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: page.needsCheckboxes()
+    }, fetchContext()) }}
+
+  {% set culturalNeeds %}
+  {{ applyTextarea({
+      fieldName: 'religiousOrCulturalNeedsDetails',
+      spellcheck: false,
+      label: {
+        text: "Provide details"
+      }
+    },fetchContext()) }}
+  {% endset %}
+
+  {{ applyRadios({
+      fieldName: "religiousOrCulturalNeeds",
+      fieldset: {
+        legend: {
+          text: page.questions.religiousOrCulturalNeeds.question,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: [
+        {
+          value: "yes",
+          text: "Yes",
+          conditional: {
+            html: culturalNeeds
+          }
+        },
+        {
+          value: "no",
+          text: "No"
+        }
+      ]
+    },fetchContext()) }}
+
+  {% set needInterpreter %}
+  {{ applyInput({
+        fieldName: "interpreterLanguage",
+        label: {
+          text: "Which language?"
+        }
+      },fetchContext()) }}
+  {% endset -%}
+
+  {{ applyRadios({
+        fieldName: "needsInterpreter",
+        fieldset: {
+          legend: {
+            text: page.questions.interpreter.language,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes",
+            conditional: {
+              html: needInterpreter
+            }
+          },
+          {
+            value: "no",
+            text: "No"
+          }
+        ]
+      },fetchContext()) }}
+
+  {{ applyRadios({
+        fieldName: "careActAssessmentCompleted",
+        fieldset: {
+          legend: {
+            text: page.questions.careActAssessmentCompleted,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes"
+          },
+          {
+            value: "no",
+            text: "No"
+          },
+          {
+            value: "dontKnow",
+            text: "I don't know"
+          }
+        ]
+      },fetchContext()) }}
+
+{% endblock %}


### PR DESCRIPTION
This PR adds an Apply questionaire page for the 'Access needs' screen in the pattern established in #142.

The eagle eyed reviewer may notice that this question asks questions unrelated to the PoP's access needs. I have raised this with our content and design team, they are working on it and the title can be updated once I've heard back.

[Trello ticket](https://trello.com/c/l14emuWP/640-access-needs-screen)

## Screenshots of UI changes
![Apply -- allows completion of the form](https://user-images.githubusercontent.com/44123869/200590941-da09826b-5c40-41b3-914c-76449248b905.png)
