### PR TITLE
Use new input macros in location factors screen

### DIFF
--- a/server/views/applications/pages/location-factors/describe-location-factors.njk
+++ b/server/views/applications/pages/location-factors/describe-location-factors.njk
@@ -4,72 +4,79 @@
 
   <h1 class="govuk-heading-l">{{page.title}}</h1>
 
-  {{ govukInput({
-    label: {
-      text: page.questions.postcodeArea,
-      classes: "govuk-label--m"
-    },
-    hint: {
-      text: "Please provide a postcode area - for example: SW1"
-    },
-    id: "postcodeArea",
-    name: "postcodeArea",
-    value: postcodeArea,
-    errorMessage: errors.postcodeArea
-  }) }}
-
-  {{ govukTextarea({
-    name: "positiveFactors",
-    id: "positiveFactors",
-    errorMessage: errors.positiveFactors,
-    value: positiveFactors,
-    label: {
-      text: page.questions.positiveFactors
-    }
-  }) }}
-
-  {% set placementRestrictions %}
-  {{ govukTextarea({
-      id: "restrictionDetail",
-      name: "restrictionDetail",
-      spellcheck: false,
-      errorMessage: errors.restrictionDetail,
-      value: restrictionDetail,
-      label: {
-        text: page.questions.restrictionDetail
-      }
-    }) }}
-  {% endset -%}
-
-  {{ govukRadios({
-    idPrefix: "restrictions",
-    name: "restrictions",
-    errorMessage: errors.restrictions,
-    fieldset: {
-      legend: {
-        text: page.questions.restrictions,
-        classes: "govuk-fieldset__legend--m"
-      }
-    },
-    hint: {
-      text: "Where there's a risk to a known person, exclusion zones or limits on movements."
-    },
-    items: [
+  {{
+    applyInput(
       {
-        value: "yes",
-        text: "Yes",
-        checked: restrictions == 'yes',
-        conditional: {
-          html: placementRestrictions
+        label: {
+          text: page.questions.postcodeArea,
+          classes: "govuk-label--m"
+        },
+        hint: {
+          text: "Please provide a postcode area - for example: SW1"
+        },
+        fieldName: "postcodeArea"
+      },
+      fetchContext()
+    )
+  }}
+
+  {{
+    applyTextarea(
+      {
+        fieldName: "positiveFactors",
+        label: {
+          text: page.questions.positiveFactors
         }
       },
+      fetchContext()
+    )
+  }}
+
+  {% set placementRestrictions %}
+  {{
+    applyTextarea(
       {
-        value: "no",
-        checked: restrictions == 'no',
-        text: "No"
-      }
-    ]
-  }) }}
+        fieldName: "restrictionDetail",
+        spellcheck: false,
+        label: {
+          text: page.questions.restrictionDetail
+        }
+      },
+      fetchContext()
+    )
+  }}
+  {% endset -%}
+
+  {{
+    applyRadios(
+      {
+        fieldName: "restrictions",
+        fieldset: {
+          legend: {
+            text: page.questions.restrictions,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        hint: {
+          text: "Where there's a risk to a known person, exclusion zones or limits on movements."
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes",
+            conditional: {
+              html: placementRestrictions
+            }
+          },
+          {
+            value: "no",
+            text: "No"
+          }
+        ]
+      },
+      fetchContext()
+    )
+  }}
 
   {% set alternativeRadiusSelect %}
   {{ govukSelect({
@@ -83,55 +90,57 @@
   }) }}
   {% endset -%}
 
-  {{ govukRadios({
-    idPrefix: "alternativeRadiusAccepted",
-    name: "alternativeRadiusAccepted",
-    errorMessage: errors.alternativeRadiusAccepted,
-    fieldset: {
-      legend: {
-        text: page.questions.alternativeRadiusAccepted,
-        classes: "govuk-fieldset__legend--m"
-      }
-    },
-    items: [
+  {{
+    applyRadios(
       {
-        value: "yes",
-        text: "Yes",
-        checked: alternativeRadiusAccepted == 'yes',
-        conditional: {
-          html: alternativeRadiusSelect
-        }
+        fieldName: "alternativeRadiusAccepted",
+        fieldset: {
+          legend: {
+            text: page.questions.alternativeRadiusAccepted,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes",
+            conditional: {
+              html: alternativeRadiusSelect
+            }
+          },
+          {
+            value: "no",
+            text: "No"
+          }
+        ]
       },
-      {
-        value: "no",
-        checked: alternativeRadiusAccepted == 'no',
-        text: "No"
-      }
-    ]
-  }) }}
+      fetchContext()
+    )
+  }}
 
-  {{ govukRadios({
-    idPrefix: "differentPDU",
-    name: "differentPDU",
-    errorMessage: errors.differentPDU,
-    fieldset: {
-      legend: {
-        text: page.questions.differentPDU,
-        classes: "govuk-fieldset__legend--m"
-      }
-    },
-    items: [
+  {{
+    applyRadios(
       {
-        value: "yes",
-        text: "Yes",
-        checked: differentPDU == 'yes'
+        fieldName: "differentPDU",
+        fieldset: {
+          legend: {
+            text: page.questions.differentPDU,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes"
+          },
+          {
+            value: "no",
+            text: "No"
+          }
+        ]
       },
-      {
-        value: "no",
-        checked: differentPDU == 'no',
-        text: "No"
-      }
-    ]
-  }) }}
+      fetchContext()
+    )
+  }}
 
 {% endblock %}


### PR DESCRIPTION
Just realised these were missed, so adding them for consistency. I haven't added a new macro for the select input type, as we're only using it once in Apply so far. If we end up using it more, then we can add one. GDS guidelines are to [avoid them if at all possible](https://design-system.service.gov.uk/components/select/#when-not-to-use-this-component), so we shouldn't have too many