### PR TITLE
(643) - Apply - COVID screen

### DIFF
--- a/cypress_shared/pages/apply/covid.ts
+++ b/cypress_shared/pages/apply/covid.ts
@@ -1,0 +1,13 @@
+import Page from '../page'
+
+export default class CovidPage extends Page {
+  constructor() {
+    super('Healthcare information')
+  }
+
+  completeForm() {
+    this.checkRadioByNameAndValue('fullyVaccinated', 'yes')
+    this.checkRadioByNameAndValue('highRisk', 'yes')
+    this.getTextInputByIdAndEnterDetails('additionalCovidInfo', 'additional info')
+  }
+}

--- a/cypress_shared/pages/apply/taskListPage.ts
+++ b/cypress_shared/pages/apply/taskListPage.ts
@@ -4,7 +4,7 @@ import Page from '../page'
 
 export default class TaskListPage extends Page {
   constructor() {
-    super('Apply for an approved premises (AP) placement')
+    super('Apply for an Approved Premises (AP) placement')
   }
 
   shouldShowTaskStatus = (task: string, status: string): void => {

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -27,6 +27,7 @@ import risksFactory from '../../../server/testutils/factories/risks'
 import { mapApiPersonRisksForUi } from '../../../server/utils/utils'
 import AccessNeedsPage from '../../../cypress_shared/pages/apply/accessNeeds'
 import AccessNeedsMobilityPage from '../../../cypress_shared/pages/apply/accessNeedsMobility'
+import CovidPage from '../../../cypress_shared/pages/apply/covid'
 
 context('Apply', () => {
   beforeEach(() => {
@@ -113,7 +114,7 @@ context('Apply', () => {
     crnPage.shouldShowErrorMessage(person)
   })
 
-  it('shows a tasklist', () => {
+  it('allows completion of the form', () => {
     const person = personFactory.build()
     const application = applicationFactory.build({ person })
     const apiRisks = risksFactory.build({ crn: person.crn })
@@ -163,7 +164,7 @@ context('Apply', () => {
     placementPurposePage.completeForm()
     placementPurposePage.clickSubmit()
 
-    // Then I should be redirected to the task list
+    // // Then I should be redirected to the task list
     const tasklistPage = Page.verifyOnPage(TaskListPage)
 
     // And the task should be marked as completed
@@ -246,6 +247,10 @@ context('Apply', () => {
     const accessNeedsMobilityPage = new AccessNeedsMobilityPage(person)
     accessNeedsMobilityPage.completeForm()
     accessNeedsMobilityPage.clickSubmit()
+
+    const covidPage = new CovidPage()
+    covidPage.completeForm()
+    covidPage.clickSubmit()
 
     Page.verifyOnPage(TaskListPage)
 

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -137,7 +137,7 @@ export interface ErrorsAndUserInput {
 export type TaskListErrors<K extends TasklistPage> = Partial<Record<keyof K['body'], string>>
 
 export type YesOrNo = 'yes' | 'no'
-export type YesNoOrIDK = YesOrNo | 'dontKnow'
+export type YesNoOrIDK = YesOrNo | 'iDontKnow'
 
 export type PersonStatus = 'InCustody' | 'InCommunity'
 

--- a/server/form-pages/apply/access-and-healthcare/accessNeeds.test.ts
+++ b/server/form-pages/apply/access-and-healthcare/accessNeeds.test.ts
@@ -41,7 +41,7 @@ describe('AccessNeeds', () => {
     })
   })
 
-  itShouldHaveNextValue(new AccessNeeds({}, application), '')
+  itShouldHaveNextValue(new AccessNeeds({}, application), 'covid')
   itShouldHaveNextValue(new AccessNeeds({ additionalNeeds: ['mobility'] }, application), 'access-needs-mobility')
   itShouldHavePreviousValue(new AccessNeeds({}, application), '')
 

--- a/server/form-pages/apply/access-and-healthcare/accessNeeds.ts
+++ b/server/form-pages/apply/access-and-healthcare/accessNeeds.ts
@@ -63,7 +63,7 @@ export default class AccessNeeds implements TasklistPage {
   }
 
   next() {
-    return this.body.additionalNeeds.includes('mobility') ? 'access-needs-mobility' : ''
+    return this.body.additionalNeeds.includes('mobility') ? 'access-needs-mobility' : 'covid'
   }
 
   response() {

--- a/server/form-pages/apply/access-and-healthcare/accessNeedsMobility.test.ts
+++ b/server/form-pages/apply/access-and-healthcare/accessNeedsMobility.test.ts
@@ -32,7 +32,7 @@ describe('AccessNeedsMobility', () => {
     })
   })
 
-  itShouldHaveNextValue(new AccessNeedsMobility({}, application), '')
+  itShouldHaveNextValue(new AccessNeedsMobility({}, application), 'covid')
   itShouldHavePreviousValue(new AccessNeedsMobility({}, application), 'access-needs')
 
   describe('errors', () => {

--- a/server/form-pages/apply/access-and-healthcare/accessNeedsMobility.ts
+++ b/server/form-pages/apply/access-and-healthcare/accessNeedsMobility.ts
@@ -34,7 +34,7 @@ export default class AccessNeedsMobility implements TasklistPage {
   }
 
   next() {
-    return ''
+    return 'covid'
   }
 
   response() {

--- a/server/form-pages/apply/access-and-healthcare/covid.test.ts
+++ b/server/form-pages/apply/access-and-healthcare/covid.test.ts
@@ -1,0 +1,65 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+
+import applicationFactory from '../../../testutils/factories/application'
+import personFactory from '../../../testutils/factories/person'
+
+import Covid from './covid'
+
+describe('Covid', () => {
+  const person = personFactory.build({ name: 'John Wayne' })
+  const application = applicationFactory.build({ person })
+  const previousPage = 'previousPage'
+
+  describe('title', () => {
+    expect(new Covid({}, application, '').title).toBe('Healthcare information')
+  })
+
+  describe('body', () => {
+    it('should strip unknown attributes from the body', () => {
+      const page = new Covid(
+        {
+          fullyVaccinated: 'yes',
+          highRisk: 'yes',
+          additionalCovidInfo: 'some info',
+          somethingElse: 'ok',
+        },
+        application,
+        previousPage,
+      )
+      expect(page.body).toEqual({
+        fullyVaccinated: 'yes',
+        highRisk: 'yes',
+        additionalCovidInfo: 'some info',
+      })
+    })
+  })
+
+  itShouldHaveNextValue(new Covid({}, application, previousPage), '')
+  itShouldHavePreviousValue(new Covid({}, application, previousPage), 'previousPage')
+
+  describe('errors', () => {
+    const page = new Covid({}, application, '')
+    expect(page.errors()).toEqual({
+      fullyVaccinated: 'You must confirm if John Wayne has been fully vaccinated',
+      highRisk: 'You must confirm if John Wayne is at high risk from COVID-19',
+    })
+  })
+
+  describe('response', () => {
+    const page = new Covid(
+      {
+        fullyVaccinated: 'yes',
+        highRisk: 'yes',
+        additionalCovidInfo: 'Some info',
+      },
+      application,
+      '',
+    )
+
+    expect(page.response()).toEqual({
+      'Has John Wayne been fully vaccinated for COVID-19?': 'Yes',
+      'Is the John Wayne at high risk from COVID-19?': 'Yes',
+      'Other considerations and comments on COVID-19': 'Some info',
+    })
+  })
+})

--- a/server/form-pages/apply/access-and-healthcare/covid.ts
+++ b/server/form-pages/apply/access-and-healthcare/covid.ts
@@ -1,0 +1,74 @@
+import type { TaskListErrors, YesNoOrIDK } from '@approved-premises/ui'
+import { Application } from '../../../@types/shared'
+import { sentenceCase } from '../../../utils/utils'
+
+import TasklistPage from '../../tasklistPage'
+
+export default class Covid implements TasklistPage {
+  name = 'covid'
+
+  title = 'Healthcare information'
+
+  body: {
+    fullyVaccinated: YesNoOrIDK
+    highRisk: YesNoOrIDK
+    additionalCovidInfo: string
+  }
+
+  questions = {
+    fullyVaccinated: {
+      question: `Has ${this.application.person.name} been fully vaccinated for COVID-19?`,
+      hint: `A person is considered fully vaccinated if they have had two doses and a booster of a COVID-19 vaccine.`,
+    },
+    highRisk: {
+      question: `Is the ${this.application.person.name} at high risk from COVID-19?`,
+      hint: `This includes autoimmune diseases and those eligible for nMAB treatment.`,
+    },
+    additionalCovidInfo: 'Other considerations and comments on COVID-19',
+  }
+
+  constructor(
+    body: Record<string, unknown>,
+    private readonly application: Application,
+    private readonly previousPage: string,
+  ) {
+    this.body = {
+      fullyVaccinated: body.fullyVaccinated as YesNoOrIDK,
+      highRisk: body.highRisk as YesNoOrIDK,
+      additionalCovidInfo: body.additionalCovidInfo as string,
+    }
+  }
+
+  previous() {
+    return this.previousPage
+  }
+
+  next() {
+    return ''
+  }
+
+  response() {
+    const response = {
+      [this.questions.fullyVaccinated.question]: sentenceCase(this.body.fullyVaccinated),
+      [this.questions.highRisk.question]: sentenceCase(this.body.highRisk),
+    }
+    if (this.body.additionalCovidInfo) {
+      return { ...response, [this.questions.additionalCovidInfo]: this.body.additionalCovidInfo }
+    }
+    return response
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.fullyVaccinated) {
+      errors.fullyVaccinated = `You must confirm if ${this.application.person.name} has been fully vaccinated`
+    }
+
+    if (!this.body.highRisk) {
+      errors.highRisk = `You must confirm if ${this.application.person.name} is at high risk from COVID-19`
+    }
+
+    return errors
+  }
+}

--- a/server/form-pages/apply/access-and-healthcare/index.ts
+++ b/server/form-pages/apply/access-and-healthcare/index.ts
@@ -1,7 +1,9 @@
 import AccessNeeds from './accessNeeds'
 import AccessNeedsMobility from './accessNeedsMobility'
+import Covid from './covid'
 
 export default {
   'access-needs': AccessNeeds,
   'access-needs-mobility': AccessNeedsMobility,
+  covid: Covid,
 }

--- a/server/form-pages/apply/index.ts
+++ b/server/form-pages/apply/index.ts
@@ -30,7 +30,7 @@ const sections: FormSections = [
       },
       {
         id: 'type-of-ap',
-        title: 'Type of Approved Premises required',
+        title: 'Type of AP required',
         pages: typeOfApPages,
       },
     ],

--- a/server/views/applications/pages/access-and-healthcare/access-needs.njk
+++ b/server/views/applications/pages/access-and-healthcare/access-needs.njk
@@ -101,7 +101,7 @@
             text: "No"
           },
           {
-            value: "dontKnow",
+            value: "iDontKnow",
             text: "I don't know"
           }
         ]

--- a/server/views/applications/pages/access-and-healthcare/covid.njk
+++ b/server/views/applications/pages/access-and-healthcare/covid.njk
@@ -1,0 +1,72 @@
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  <h1 class="govuk-heading-l">
+    {{page.title}}
+  </h1>
+  <p>This information will be used to help decide whether the person can room share.</p>
+
+  {{ applyRadios({
+      fieldName: "fullyVaccinated",
+      fieldset: {
+        legend: {
+          text: page.questions.fullyVaccinated.question,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      hint: {
+        text: page.questions.fullyVaccinated.hint
+      },
+      items: [
+        {
+          value: "yes",
+          text: "Yes"
+        },
+        {
+          value: "no",
+          text: "No"
+        },
+        {
+          value: "dontKnow",
+          text: "I don't know"
+        }
+      ]
+    }, fetchContext()) }}
+
+  {{ applyRadios({
+      fieldName: "highRisk",
+      fieldset: {
+        legend: {
+          text: page.questions.highRisk.question,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      hint: {
+        text: page.questions.highRisk.question
+      },
+      items: [
+        {
+          value: "yes",
+          text: "Yes"
+        },
+        {
+          value: "no",
+          text: "No"
+        },
+        {
+          value: "iDontKnow",
+          text: "I don't know"
+        }
+      ]
+    }, fetchContext()) }}
+
+  {{ applyTextarea({
+      fieldName: "additionalCovidInfo",
+      label: {
+        text: page.questions.additionalCovidInfo,
+        classes: "govuk-label--s"
+        }
+    }, fetchContext()) }}
+
+{% endblock %}

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -15,7 +15,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-width-container">
       <h1 class="govuk-heading-xl">
-        Apply for an approved premises (AP) placement
+        Apply for an Approved Premises (AP) placement
       </h1>
 
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Application incomplete</h2>


### PR DESCRIPTION
This PR adds a COVID question screen to the Apply questionaire in the pattern established in #142 

[Trello ticket](https://trello.com/c/ZJIRm97V/643-covid-screen)

## Screenshots of UI changes
![Apply -- allows completion of the form](https://user-images.githubusercontent.com/44123869/200814653-50d9c52f-b9a4-4860-96a2-238448b7fe38.png)
