### PR TITLE
Remove temporary `cas` prefix from domains

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -6,14 +6,14 @@ generic-service:
 
   ingress:
     hosts:
-      - cas-approved-premises-dev.hmpps.service.justice.gov.uk
+      - approved-premises-dev.hmpps.service.justice.gov.uk
     contextColour: green
     tlsSecretName: hmpps-approved-premises-dev-cert
 
   env:
     ENVIRONMENT: dev
-    APPROVED_PREMISES_API_URL: 'https://cas-approved-premises-api-dev.hmpps.service.justice.gov.uk'
-    INGRESS_URL: 'https://cas-approved-premises-dev.hmpps.service.justice.gov.uk'
+    APPROVED_PREMISES_API_URL: 'https://approved-premises-api-dev.hmpps.service.justice.gov.uk'
+    INGRESS_URL: 'https://approved-premises-dev.hmpps.service.justice.gov.uk'
     HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
     COMMUNITY_ACCOMMODATION_API_SERVICE_NAME: approved-premises


### PR DESCRIPTION
While we were setting up the new `hmpps-community-accommodation-dev` namespace, we had to temporarily change the domains. Now https://github.com/ministryofjustice/cloud-platform-environments/pull/9190 is in, we can safely switch back