### PR TITLE
Fix: Change key worker ID to key worker code

### DIFF
--- a/cypress_shared/pages/manage/arrivalCreate.ts
+++ b/cypress_shared/pages/manage/arrivalCreate.ts
@@ -13,7 +13,7 @@ export default class ArrivalCreatePage extends Page {
     return new ArrivalCreatePage(premisesId, bookingId)
   }
 
-  public completeArrivalForm(arrival: Arrival, staffMemberId: string): void {
+  public completeArrivalForm(arrival: Arrival, staffMemberCode: string): void {
     const arrivalDate = new Date(Date.parse(arrival.arrivalDate))
     const expectedDeparture = new Date(Date.parse(arrival.expectedDepartureDate))
 
@@ -26,7 +26,7 @@ export default class ArrivalCreatePage extends Page {
     cy.get('input[name="expectedDepartureDate-year"]').type(String(expectedDeparture.getFullYear()))
 
     this.getLabel('Key Worker')
-    this.getSelectInputByIdAndSelectAnEntry('keyWorkerStaffId', staffMemberId)
+    this.getSelectInputByIdAndSelectAnEntry('keyWorkerStaffCode', staffMemberCode)
 
     cy.get('[name="arrival[notes]"]').type(arrival.notes)
 

--- a/integration_tests/tests/manage/arrivals.cy.ts
+++ b/integration_tests/tests/manage/arrivals.cy.ts
@@ -36,7 +36,7 @@ context('Arrivals', () => {
 
     // When I mark the booking as having arrived
     const page = ArrivalCreatePage.visit(premises.id, bookingId)
-    page.completeArrivalForm(arrival, staff[0].id.toString())
+    page.completeArrivalForm(arrival, staff[0].code)
 
     // Then an arrival should be created in the API
     cy.task('verifyArrivalCreate', { premisesId: premises.id, bookingId }).then(requests => {
@@ -47,7 +47,7 @@ context('Arrivals', () => {
 
       expect(requestBody.notes).equal(arrival.notes)
       expect(requestBody.arrivalDate).equal(arrivalDate)
-      expect(requestBody.keyWorkerStaffId).equal(staff[0].id.toString())
+      expect(requestBody.keyWorkerStaffCode).equal(staff[0].code)
       expect(requestBody.expectedDepartureDate).equal(expectedDepartureDate)
     })
 
@@ -74,7 +74,7 @@ context('Arrivals', () => {
     cy.task('stubArrivalErrors', {
       premisesId: premises.id,
       bookingId,
-      params: ['date', 'expectedDepartureDate', 'keyWorkerStaffId'],
+      params: ['date', 'expectedDepartureDate', 'keyWorkerStaffCode'],
     })
     page.submitArrivalFormWithoutFields()
 

--- a/integration_tests/tests/manage/arrivals.cy.ts
+++ b/integration_tests/tests/manage/arrivals.cy.ts
@@ -5,7 +5,7 @@ import { ArrivalCreatePage, PremisesShowPage } from '../../../cypress_shared/pag
 import dateCapacityFactory from '../../../server/testutils/factories/dateCapacity'
 import staffMemberFactory from '../../../server/testutils/factories/staffMember'
 
-const staff = staffMemberFactory.buildList(5)
+const staff = staffMemberFactory.buildList(5, { keyWorker: true })
 
 context('Arrivals', () => {
   beforeEach(() => {

--- a/server/@types/shared/models/NewArrival.ts
+++ b/server/@types/shared/models/NewArrival.ts
@@ -6,6 +6,6 @@ export type NewArrival = {
     arrivalDate: string;
     expectedDepartureDate: string;
     notes?: string;
-    keyWorkerStaffId: number;
+    keyWorkerStaffCode: string;
 };
 

--- a/server/@types/shared/models/PrisonCaseNote.ts
+++ b/server/@types/shared/models/PrisonCaseNote.ts
@@ -3,7 +3,8 @@
 /* eslint-disable */
 
 export type PrisonCaseNote = {
-    id: number;
+    id: string;
+    sensitive: boolean;
     createdAt: string;
     occurredAt: string;
     authorName: string;

--- a/server/@types/shared/models/StaffMember.ts
+++ b/server/@types/shared/models/StaffMember.ts
@@ -3,7 +3,8 @@
 /* eslint-disable */
 
 export type StaffMember = {
-    id: number;
+    code: string;
+    keyWorker: boolean;
     name: string;
 };
 

--- a/server/controllers/manage/arrivalsController.test.ts
+++ b/server/controllers/manage/arrivalsController.test.ts
@@ -33,6 +33,11 @@ describe('ArrivalsController', () => {
     it('renders the form', async () => {
       const requestHandler = arrivalsController.new()
       ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [], userInput: {} })
+      const staffMember1 = staffMemberFactory.build({ keyWorker: false })
+      const staffMember2 = staffMemberFactory.build({ keyWorker: true })
+      const staffMember3 = staffMemberFactory.build({ keyWorker: false })
+
+      premisesService.getStaffMembers.mockResolvedValue([staffMember1, staffMember2, staffMember3])
 
       request.params = {
         bookingId: 'bookingId',
@@ -47,12 +52,16 @@ describe('ArrivalsController', () => {
         pageHeading: 'Mark the person as arrived',
         errors: {},
         errorSummary: [],
-        staffMembers,
+        staffMembers: [staffMember2],
       })
     })
 
     it('renders the form with errors and user input if an error has been sent to the flash', async () => {
       const requestHandler = arrivalsController.new()
+      const staffMember1 = staffMemberFactory.build({ keyWorker: true })
+      const staffMember2 = staffMemberFactory.build({ keyWorker: false })
+
+      premisesService.getStaffMembers.mockResolvedValue([staffMember1, staffMember2])
 
       request.params = {
         bookingId: 'bookingId',
@@ -71,7 +80,7 @@ describe('ArrivalsController', () => {
         pageHeading: 'Mark the person as arrived',
         errors: errorsAndUserInput.errors,
         errorSummary: errorsAndUserInput.errorSummary,
-        staffMembers,
+        staffMembers: [staffMember1],
         ...errorsAndUserInput.userInput,
       })
     })

--- a/server/controllers/manage/arrivalsController.test.ts
+++ b/server/controllers/manage/arrivalsController.test.ts
@@ -95,7 +95,7 @@ describe('ArrivalsController', () => {
         'expectedDepartureDate-day': 12,
         arrival: {
           notes: 'Some notes',
-          keyWorkerStaffId: 'some-staff-id',
+          keyWorkerStaffCode: 'some-staff-id',
         },
       }
 
@@ -103,7 +103,7 @@ describe('ArrivalsController', () => {
 
       const expectedArrival = {
         notes: request.body.arrival.notes,
-        keyWorkerStaffId: request.body.arrival.keyWorkerStaffId,
+        keyWorkerStaffCode: request.body.arrival.keyWorkerStaffCode,
         arrivalDate: '2022-12-11',
         expectedDepartureDate: '2022-11-12',
       }

--- a/server/controllers/manage/arrivalsController.ts
+++ b/server/controllers/manage/arrivalsController.ts
@@ -40,7 +40,7 @@ export default class ArrivalsController {
       const { expectedDepartureDate } = DateFormats.convertDateAndTimeInputsToIsoString(body, 'expectedDepartureDate')
 
       const arrival: NewArrival = {
-        keyWorkerStaffId: body.arrival.keyWorkerStaffId,
+        keyWorkerStaffCode: body.arrival.keyWorkerStaffCode,
         notes: body.arrival.notes,
         arrivalDate,
         expectedDepartureDate,

--- a/server/controllers/manage/arrivalsController.ts
+++ b/server/controllers/manage/arrivalsController.ts
@@ -24,7 +24,7 @@ export default class ArrivalsController {
         bookingId,
         errors,
         errorSummary,
-        staffMembers,
+        staffMembers: staffMembers.filter(staffMember => staffMember.keyWorker),
         pageHeading: 'Mark the person as arrived',
         ...userInput,
       })

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -34,7 +34,7 @@
     "invalid": "The expected departure date is an invalid date",
     "beforeBookingArrivalDate": "The departure date cannot be before the arrival date"
   },
-  "keyWorkerStaffId": {
+  "keyWorkerStaffCode": {
     "empty": "You must choose a keyworker"
   },
   "dateTime": {

--- a/server/testutils/factories/newArrival.ts
+++ b/server/testutils/factories/newArrival.ts
@@ -8,5 +8,5 @@ export default Factory.define<NewArrival>(() => ({
   arrivalDate: DateFormats.formatApiDate(faker.date.soon()),
   expectedDepartureDate: DateFormats.formatApiDate(faker.date.future()),
   notes: faker.lorem.sentence(),
-  keyWorkerStaffId: faker.datatype.number(),
+  keyWorkerStaffCode: faker.datatype.uuid(),
 }))

--- a/server/testutils/factories/staffMember.ts
+++ b/server/testutils/factories/staffMember.ts
@@ -6,4 +6,6 @@ import type { StaffMember } from '@approved-premises/api'
 export default Factory.define<StaffMember>(() => ({
   id: faker.datatype.number(),
   name: faker.name.fullName(),
+  code: faker.datatype.uuid(),
+  keyWorker: faker.datatype.boolean(),
 }))

--- a/server/views/arrivals/new.njk
+++ b/server/views/arrivals/new.njk
@@ -62,10 +62,10 @@
               classes: "govuk-label--m"
           },
           classes: "govuk-input--width-20",
-          id: "keyWorkerStaffId",
-          name: "arrival[keyWorkerStaffId]",
-          items: convertObjectsToSelectOptions(staffMembers, 'Select a keyworker', 'name', 'id', 'keyWorkerStaffId'),
-          errorMessage: errors.keyWorkerStaffId.empty
+          id: "keyWorkerStaffCode",
+          name: "arrival[keyWorkerStaffCode]",
+          items: convertObjectsToSelectOptions(staffMembers, 'Select a keyworker', 'name', 'code', 'keyWorkerStaffCode'),
+          errorMessage: errors.keyWorkerStaffCode.empty
         }) }}
 
         {{ govukTextarea({


### PR DESCRIPTION
Some changes in the API repo have meant we need to change references to keyWorkerId to keyWorkerCode and update our factories.