### PR TITLE
(649) Apply: Move on - Move on date

### DIFF
--- a/cypress_shared/pages/apply/index.ts
+++ b/cypress_shared/pages/apply/index.ts
@@ -15,6 +15,7 @@ import PreviousPlacements from './previousPlacements'
 import ComplexCaseBoard from './complexCaseBoard'
 import CateringPage from './catering'
 import ArsonPage from './arson'
+import PlacementDurationPage from './placementDuration'
 
 export {
   ConfirmDetailsPage,
@@ -34,4 +35,5 @@ export {
   ComplexCaseBoard,
   CateringPage,
   ArsonPage,
+  PlacementDurationPage,
 }

--- a/cypress_shared/pages/apply/placementDuration.ts
+++ b/cypress_shared/pages/apply/placementDuration.ts
@@ -1,0 +1,19 @@
+import { add } from 'date-fns'
+import { DateFormats } from '../../../server/utils/dateUtils'
+import Page from '../page'
+
+export default class PlacementDurationPage extends Page {
+  constructor() {
+    super('Placement duration and move on')
+  }
+
+  completeForm() {
+    this.getTextInputByIdAndEnterDetails('duration', '10')
+    this.completeTextArea('durationDetail', 'Some more information')
+  }
+
+  expectedDepartureDateShouldBeCompleted(releaseDate: string) {
+    const departureDate = DateFormats.dateObjtoUIDate(add(DateFormats.convertIsoToDateObj(releaseDate), { weeks: 10 }))
+    cy.get('span[data-departure-date]').contains(departureDate)
+  }
+}

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -15,6 +15,7 @@ import {
   ComplexCaseBoard,
   CateringPage,
   ArsonPage,
+  PlacementDurationPage,
 } from '../../../cypress_shared/pages/apply'
 import ConvictedOffences from '../../../cypress_shared/pages/apply/convictedOffences'
 import DateOfOffence from '../../../cypress_shared/pages/apply/dateOfOffence'
@@ -299,5 +300,17 @@ context('Apply', () => {
     // Then I should be taken back to the task list
     // And the further considerations task should show a completed status
     tasklistPage.shouldShowTaskStatus('further-considerations', 'Completed')
+
+    // Given I click the 'Add move on information' task
+    cy.get('[data-cy-task-name="move-on"]').click()
+
+    const placementDurationPage = new PlacementDurationPage()
+    placementDurationPage.completeForm()
+    placementDurationPage.expectedDepartureDateShouldBeCompleted(releaseDate)
+    placementDurationPage.clickSubmit()
+
+    // Then I should be taken back to the task list
+    // And the move on information task should show a completed status
+    tasklistPage.shouldShowTaskStatus('move-on', 'Completed')
   })
 })

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -23,6 +23,7 @@ export type TaskNames =
   | 'location-factors'
   | 'access-and-healthcare'
   | 'further-considerations'
+  | 'move-on'
 
 export type YesOrNoWithDetail<T extends string> = {
   [K in T]: YesOrNo

--- a/server/form-pages/apply/index.ts
+++ b/server/form-pages/apply/index.ts
@@ -7,6 +7,7 @@ import riskAndNeedPages from './risk-management-features'
 import locationFactorPages from './location-factors'
 import accessAndHealthcarePages from './access-and-healthcare'
 import furtherConsiderationsPages from './further-considerations'
+import moveOnPages from './move-on'
 
 const pages: {
   [key in TaskNames]: Record<string, unknown>
@@ -17,6 +18,7 @@ const pages: {
   'location-factors': locationFactorPages,
   'access-and-healthcare': accessAndHealthcarePages,
   'further-considerations': furtherConsiderationsPages,
+  'move-on': moveOnPages,
 }
 
 const sections: FormSections = [
@@ -57,6 +59,16 @@ const sections: FormSections = [
         id: 'further-considerations',
         title: 'Detail further considerations for placement',
         pages: furtherConsiderationsPages,
+      },
+    ],
+  },
+  {
+    title: 'Considerations for when the placement ends',
+    tasks: [
+      {
+        id: 'move-on',
+        title: 'Add move on information',
+        pages: moveOnPages,
       },
     ],
   },

--- a/server/form-pages/apply/move-on/index.ts
+++ b/server/form-pages/apply/move-on/index.ts
@@ -1,0 +1,8 @@
+/* istanbul ignore file */
+
+import PlacementDuration from './placementDuration'
+
+const pages = {
+}
+
+export default pages

--- a/server/form-pages/apply/move-on/index.ts
+++ b/server/form-pages/apply/move-on/index.ts
@@ -3,6 +3,7 @@
 import PlacementDuration from './placementDuration'
 
 const pages = {
+  'placement-duration': PlacementDuration,
 }
 
 export default pages

--- a/server/form-pages/apply/move-on/placementDuration.test.ts
+++ b/server/form-pages/apply/move-on/placementDuration.test.ts
@@ -1,23 +1,121 @@
+import { Application } from '@approved-premises/api'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+import { SessionDataError } from '../../../utils/errors'
 
 import PlacementDuration from './placementDuration'
+import applicationFactory from '../../../testutils/factories/application'
 
 describe('PlacementDuration', () => {
+  let data: Record<string, unknown>
+  let application: Application
+
+  beforeEach(() => {
+    data = {
+      'basic-information': {
+        'placement-date': {
+          startDateSameAsReleaseDate: 'no',
+          startDate: '2022-11-11',
+        },
+      },
+    }
+    application = applicationFactory.build({ data })
+  })
+
   describe('body', () => {
     it('should strip unknown attributes from the body', () => {
       const body = { duration: 4, durationDetail: 'Some detail' }
-      const page = new PlacementDuration({ ...body, something: 'else' })
+      const page = new PlacementDuration({ ...body, something: 'else' }, application)
 
       expect(page.body).toEqual(body)
     })
   })
 
-  itShouldHaveNextValue(new PlacementDuration({}), '')
-  itShouldHavePreviousValue(new PlacementDuration({}), '')
+  describe('arrivalDate', () => {
+    it('returns the placement date if the start date is not the same as the release date', () => {
+      data = {
+        'basic-information': {
+          'placement-date': {
+            startDateSameAsReleaseDate: 'no',
+            startDate: '2022-11-11',
+          },
+        },
+      }
+      application = applicationFactory.build({ data })
+
+      const page = new PlacementDuration({}, application)
+
+      expect(page.arrivalDate).toEqual(new Date(2022, 10, 11))
+    })
+
+    it('returns the release date if the start date is the same as the release date', () => {
+      data = {
+        'basic-information': {
+          'placement-date': {
+            startDateSameAsReleaseDate: 'yes',
+          },
+          'release-date': {
+            releaseDate: '2022-12-11',
+          },
+        },
+      }
+      application = applicationFactory.build({ data })
+
+      const page = new PlacementDuration({}, application)
+
+      expect(page.arrivalDate).toEqual(new Date(2022, 11, 11))
+    })
+
+    it('throws an error if the "basic-information" object is not present', () => {
+      application = applicationFactory.build({ data: {} })
+
+      expect(() => new PlacementDuration({}, application)).toThrow(
+        new SessionDataError('Move on information placement duration error: Error: No basic information'),
+      )
+    })
+
+    it('throws an error if the "placement-date" object is not present', () => {
+      application = applicationFactory.build({ data: { 'basic-information': {} } })
+
+      expect(() => new PlacementDuration({}, application)).toThrow(
+        new SessionDataError('Move on information placement duration error: Error: No placement date'),
+      )
+    })
+
+    it('throws an error if the start date is the same as the release date and the "release-date" object is not present', () => {
+      application = applicationFactory.build({
+        data: {
+          'basic-information': {
+            'placement-date': {
+              startDateSameAsReleaseDate: 'yes',
+            },
+          },
+        },
+      })
+
+      expect(() => new PlacementDuration({}, application)).toThrow(
+        new SessionDataError('Move on information placement duration error: Error: No release date'),
+      )
+    })
+  })
+
+  describe('the previous and next page are correct', () => {
+    data = {
+      'basic-information': {
+        'placement-date': {
+          startDateSameAsReleaseDate: 'no',
+          startDate: '2022-11-11',
+        },
+      },
+    }
+    application = applicationFactory.build({ data })
+
+    itShouldHaveNextValue(new PlacementDuration({}, application), '')
+    itShouldHavePreviousValue(new PlacementDuration({}, application), '')
+  })
 
   describe('errors', () => {
     it('returns an error if the duration is blank', () => {
-      const page = new PlacementDuration({})
+      const page = new PlacementDuration({}, application)
 
       expect(page.errors()).toEqual({ duration: 'You must specify the duration of the placement' })
     })
@@ -25,7 +123,7 @@ describe('PlacementDuration', () => {
 
   describe('response', () => {
     it('should return a translated version of the response', () => {
-      const page = new PlacementDuration({ duration: 4, durationDetail: 'Some detail' })
+      const page = new PlacementDuration({ duration: 4, durationDetail: 'Some detail' }, application)
 
       expect(page.response()).toEqual({
         'What duration of placement do you recommend?': '4 weeks',
@@ -34,7 +132,7 @@ describe('PlacementDuration', () => {
     })
 
     it("should not include the detail if it's blank", () => {
-      const page = new PlacementDuration({ duration: 4, durationDetail: '' })
+      const page = new PlacementDuration({ duration: 4, durationDetail: '' }, application)
 
       expect(page.response()).toEqual({ 'What duration of placement do you recommend?': '4 weeks' })
     })

--- a/server/form-pages/apply/move-on/placementDuration.test.ts
+++ b/server/form-pages/apply/move-on/placementDuration.test.ts
@@ -1,0 +1,42 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+
+import PlacementDuration from './placementDuration'
+
+describe('PlacementDuration', () => {
+  describe('body', () => {
+    it('should strip unknown attributes from the body', () => {
+      const body = { duration: 4, durationDetail: 'Some detail' }
+      const page = new PlacementDuration({ ...body, something: 'else' })
+
+      expect(page.body).toEqual(body)
+    })
+  })
+
+  itShouldHaveNextValue(new PlacementDuration({}), '')
+  itShouldHavePreviousValue(new PlacementDuration({}), '')
+
+  describe('errors', () => {
+    it('returns an error if the duration is blank', () => {
+      const page = new PlacementDuration({})
+
+      expect(page.errors()).toEqual({ duration: 'You must specify the duration of the placement' })
+    })
+  })
+
+  describe('response', () => {
+    it('should return a translated version of the response', () => {
+      const page = new PlacementDuration({ duration: 4, durationDetail: 'Some detail' })
+
+      expect(page.response()).toEqual({
+        'What duration of placement do you recommend?': '4 weeks',
+        'Provide any additional information': 'Some detail',
+      })
+    })
+
+    it("should not include the detail if it's blank", () => {
+      const page = new PlacementDuration({ duration: 4, durationDetail: '' })
+
+      expect(page.response()).toEqual({ 'What duration of placement do you recommend?': '4 weeks' })
+    })
+  })
+})

--- a/server/form-pages/apply/move-on/placementDuration.ts
+++ b/server/form-pages/apply/move-on/placementDuration.ts
@@ -1,0 +1,56 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+
+import TasklistPage from '../../tasklistPage'
+
+export default class PlacementDuration implements TasklistPage {
+  name = 'placement-duration'
+
+  title = 'Placement duration and move on'
+
+  body: {
+    duration: number
+    durationDetail: string
+  }
+
+  questions = {
+    duration: 'What duration of placement do you recommend?',
+    durationDetail: 'Provide any additional information',
+  }
+
+  constructor(body: Record<string, unknown>) {
+    this.body = {
+      duration: body.duration as number,
+      durationDetail: body.durationDetail as string,
+    }
+  }
+
+  previous() {
+    return ''
+  }
+
+  next() {
+    return ''
+  }
+
+  response() {
+    const response = {
+      [this.questions.duration]: `${this.body.duration} weeks`,
+    }
+
+    if (this.body.durationDetail) {
+      response[this.questions.durationDetail] = this.body.durationDetail
+    }
+
+    return response
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.duration) {
+      errors.duration = 'You must specify the duration of the placement'
+    }
+
+    return errors
+  }
+}

--- a/server/views/applications/pages/move-on/placement-duration.njk
+++ b/server/views/applications/pages/move-on/placement-duration.njk
@@ -1,0 +1,91 @@
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  <h1 class="govuk-heading-l">{{ page.title }}</h2>
+
+  <h3 class="govuk-heading-m">{{ page.questions.duration }}</h3>
+  <p>We'll use this to calculate the date the person will be expected to leave the AP, if they're accepted. </p>
+
+  {{ govukDetails({
+      summaryText: "How to decide the duration of an AP placement",
+      text: "Standard AP placements usually last up to 12 weeks but can sometimes be longer. PIPE placements usually last up to 26 weeks. Consider the level of support and risk management you expect the AP to provide and how long it will take to be effective. When is the person most likely to resettle successfully in the community?"
+    }) }}
+
+  {{
+    applyInput(
+      {
+        label: {
+          text: "Duration in weeks"
+        },
+        classes: "govuk-input--width-2",
+        fieldName: "duration"
+      },
+      fetchContext()
+    )
+  }}
+
+  <div
+    id="durationWrapper"
+    class="govuk-visually-hidden"
+    data-expected-dates
+    data-arrivalDate="{{ page.arrivalDate.toISOString() }}"
+    aria-live="polite"
+    aria-atomic="true"
+  >
+    <h3 class="govuk-heading-m">Expected dates of stay in Approved Premises:</h3>
+    <p>
+      <b>Arrival date:</b>
+      {{ formatDate(page.arrivalDate.toISOString()) }}</p>
+    <p>
+      <b>Departure date:</b>
+      <span data-departure-date></span></p>
+  </div>
+
+  <br>
+
+  {{
+    applyTextarea(
+      {
+        fieldName: "durationDetail",
+        label: {
+          text: page.questions.durationDetail,
+          classes: "govuk-label--m"
+        },
+        hint: {
+          text: "If the duration of placement is not a standard length (12 weeks) provide reason as to why it is not."
+        }
+      },
+      fetchContext()
+    )
+  }}
+
+{% endblock %}
+
+{% block extraScripts %}
+  <script type="text/javascript" nonce="{{ cspNonce }}">
+    var duration = document.querySelector('#duration')
+    var expectedDatesContainer = document.querySelector('div[data-expected-dates]')
+
+    duration.addEventListener('input', function (e) {
+      var numWeeks = duration.value
+      var arrivalDate = new Date(expectedDatesContainer.dataset.arrivaldate)
+      var departureDate = arrivalDate.setDate(arrivalDate.getDate() + numWeeks * 7)
+      var departureDateContainer = document.querySelector('[data-departure-date]')
+
+      departureDateContainer.innerHTML = new Date(departureDate)
+        .toLocaleString('en-GB', {
+          weekday: 'long',
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric'
+        })
+        .replace(',', '')
+      expectedDatesContainer.setAttribute('class', '')
+
+      e.preventDefault()
+    })
+  </script>
+{% endblock %}


### PR DESCRIPTION
This adds the Move On Date page, task and section to Apply. There's also a bit of frontend JS that autopopulates the move on date. This is not essential to the flow, and functions just fine without JS added.

## Screenshot

![image](https://user-images.githubusercontent.com/109774/201093208-6ea54ddf-dcb2-4d4d-97c8-6fd6d8176ff3.png)
