### PR TITLE
Disable other access fields when none selected

### DIFF
--- a/cypress_shared/pages/apply/accessNeeds.ts
+++ b/cypress_shared/pages/apply/accessNeeds.ts
@@ -13,6 +13,16 @@ export default class AccessNeedsPage extends Page {
     this.checkCheckboxByNameAndValue('additionalNeeds', 'neurodivergentConditions')
   }
 
+  checkingAdditionalNeedsOtherDisablesOtherCheckBoxes() {
+    this.checkAdditionalNeedsBoxes()
+
+    this.checkCheckboxByNameAndValue('additionalNeeds', 'none')
+
+    cy.get('input[name="additionalNeeds"]:not([value="none"])').should('be.disabled')
+
+    this.uncheckCheckboxbyNameAndValue('additionalNeeds', 'none')
+  }
+
   completeReligiousOrCulturalNeedsSection() {
     this.checkRadioByNameAndValue('religiousOrCulturalNeeds', 'yes')
     this.getTextInputByIdAndEnterDetails('religiousOrCulturalNeedsDetails', faker.lorem.words())
@@ -24,6 +34,7 @@ export default class AccessNeedsPage extends Page {
   }
 
   completeForm() {
+    this.checkingAdditionalNeedsOtherDisablesOtherCheckBoxes()
     this.checkAdditionalNeedsBoxes()
     this.completeReligiousOrCulturalNeedsSection()
     this.completeNeedsInterpreterSection()

--- a/cypress_shared/pages/apply/accessNeeds.ts
+++ b/cypress_shared/pages/apply/accessNeeds.ts
@@ -13,7 +13,7 @@ export default class AccessNeedsPage extends Page {
     this.checkCheckboxByNameAndValue('additionalNeeds', 'neurodivergentConditions')
   }
 
-  completeReligiousAndCulturalNeedsSection() {
+  completeReligiousOrCulturalNeedsSection() {
     this.checkRadioByNameAndValue('religiousOrCulturalNeeds', 'yes')
     this.getTextInputByIdAndEnterDetails('religiousOrCulturalNeedsDetails', faker.lorem.words())
   }
@@ -25,7 +25,7 @@ export default class AccessNeedsPage extends Page {
 
   completeForm() {
     this.checkAdditionalNeedsBoxes()
-    this.completeReligiousAndCulturalNeedsSection()
+    this.completeReligiousOrCulturalNeedsSection()
     this.completeNeedsInterpreterSection()
     this.checkRadioByNameAndValue('careActAssessmentCompleted', 'yes')
   }

--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -62,6 +62,10 @@ export default abstract class Page {
     cy.get(`input[name="${name}"][value="${option}"]`).check()
   }
 
+  uncheckCheckboxbyNameAndValue(name: string, option: string): void {
+    cy.get(`input[name="${name}"][value="${option}"]`).uncheck()
+  }
+
   completeTextArea(name: string, value: string): void {
     cy.get(`textarea[name="${name}"]`).type(value)
   }

--- a/server/form-pages/apply/access-and-healthcare/accessNeeds.ts
+++ b/server/form-pages/apply/access-and-healthcare/accessNeeds.ts
@@ -27,7 +27,7 @@ export default class AccessNeeds implements TasklistPage {
       question: `Does ${this.application.person.name} have any of the following needs?`,
       hint: `For example, if ${this.application.person.name} has a visual impairment, uses a hearing aid or has a learning difficulty.`,
     },
-    religiousAndCulturalNeeds: {
+    religiousOrCulturalNeeds: {
       question: `Does ${this.application.person.name} have any religious or cultural needs?`,
       furtherDetails: `Details of religious or cultural needs`,
     },
@@ -75,8 +75,8 @@ export default class AccessNeeds implements TasklistPage {
         [this.questions.needs.question]: this.body.additionalNeeds
           .map((need, i) => (i < 1 ? additionalNeeds[need] : additionalNeeds[need].toLowerCase()))
           .join(', '),
-        [this.questions.religiousAndCulturalNeeds.question]: sentenceCase(this.body.religiousOrCulturalNeeds),
-        [this.questions.religiousAndCulturalNeeds.furtherDetails]: this.body.religiousOrCulturalNeedsDetails,
+        [this.questions.religiousOrCulturalNeeds.question]: sentenceCase(this.body.religiousOrCulturalNeeds),
+        [this.questions.religiousOrCulturalNeeds.furtherDetails]: this.body.religiousOrCulturalNeedsDetails,
         [this.questions.interpreter.question]: sentenceCase(this.body.needsInterpreter),
         [this.questions.careActAssessmentCompleted]:
           this.body.careActAssessmentCompleted === 'yes' || this.body.careActAssessmentCompleted === 'no'

--- a/server/views/applications/pages/access-and-healthcare/access-needs.njk
+++ b/server/views/applications/pages/access-and-healthcare/access-needs.njk
@@ -108,3 +108,23 @@
       },fetchContext()) }}
 
 {% endblock %}
+
+{% block extraScripts %}
+  <script type="text/javascript" nonce="{{ cspNonce }}">
+    var none = document.querySelector('input[name="additionalNeeds"][value="none"]')
+    var checkBoxes = document.querySelectorAll('input[name="additionalNeeds"]:not([value="none"])')
+
+    none.addEventListener('change', function () {
+      if (this.checked) {
+        for (let i = 0; i < checkBoxes.length; i++) {
+          checkBoxes[i].checked = false
+          checkBoxes[i].setAttribute('disabled', true)
+        }
+      } else {
+        for (let i = 0; i < checkBoxes.length; i++) {
+          checkBoxes[i].removeAttribute('disabled')
+        }
+      }
+    });
+  </script>
+{% endblock %}


### PR DESCRIPTION
This follows on from #325 to disable and clear the access needs checkboxes when `none` is selected. We handle this in the backend, but I thought it would be good to add this for usablity (and I has my frontend JS hat on 😆 )

## Demo

![](http://g.recordit.co/PMJS0Bs4QK.gif)