### PR TITLE
(652) Apply: Move on - type of accomodation

### DIFF
--- a/cypress_shared/pages/apply/typeOfAccommodation.ts
+++ b/cypress_shared/pages/apply/typeOfAccommodation.ts
@@ -1,0 +1,13 @@
+import { Person } from '../../../server/@types/shared'
+import Page from '../page'
+
+export default class TypeOfAccomodationPage extends Page {
+  constructor(person: Person) {
+    super('Placement duration and move on')
+    cy.get('.govuk-form-group').contains(`What type of accommodation will ${person.name} have when they leave the AP?`)
+  }
+
+  completeForm() {
+    this.checkRadioByNameAndValue('accommodationType', 'privateRented')
+  }
+}

--- a/cypress_shared/pages/apply/typeOfAccommodation.ts
+++ b/cypress_shared/pages/apply/typeOfAccommodation.ts
@@ -8,6 +8,7 @@ export default class TypeOfAccomodationPage extends Page {
   }
 
   completeForm() {
-    this.checkRadioByNameAndValue('accommodationType', 'privateRented')
+    this.checkRadioByNameAndValue('accommodationType', 'other')
+    this.getTextInputByIdAndEnterDetails('otherAccommodationType', 'Another type')
   }
 }

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -36,6 +36,7 @@ import CovidPage from '../../../cypress_shared/pages/apply/covid'
 import AccessNeedsAdditionalAdjustmentsPage from '../../../cypress_shared/pages/apply/accessNeedsAdditionalAdjustments'
 import RelocationRegionPage from '../../../cypress_shared/pages/apply/relocationRegion'
 import PlansInPlacePage from '../../../cypress_shared/pages/apply/plansInPlace'
+import TypeOfAccomodationPage from '../../../cypress_shared/pages/apply/typeOfAccommodation'
 
 context('Apply', () => {
   beforeEach(() => {
@@ -318,6 +319,10 @@ context('Apply', () => {
     const plansInPlacePage = new PlansInPlacePage()
     plansInPlacePage.completeForm()
     plansInPlacePage.clickSubmit()
+
+    const typeOfAccommodationPage = new TypeOfAccomodationPage(person)
+    typeOfAccommodationPage.completeForm()
+    typeOfAccommodationPage.clickSubmit()
 
     // Then I should be taken back to the task list
     // And the move on information task should show a completed status

--- a/server/@types/shared/index.d.ts
+++ b/server/@types/shared/index.d.ts
@@ -52,6 +52,7 @@ export type { Premises } from './models/Premises';
 export type { PrisonCaseNote } from './models/PrisonCaseNote';
 export type { ProbationRegion } from './models/ProbationRegion';
 export type { Problem } from './models/Problem';
+export type { PropertyStatus } from './models/PropertyStatus';
 export type { Reallocation } from './models/Reallocation';
 export type { RiskEnvelopeStatus } from './models/RiskEnvelopeStatus';
 export type { RiskTier } from './models/RiskTier';

--- a/server/@types/shared/models/NewPremises.ts
+++ b/server/@types/shared/models/NewPremises.ts
@@ -2,6 +2,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import type { PropertyStatus } from './PropertyStatus';
+
 export type NewPremises = {
     name: string;
     addressLine1: string;
@@ -9,5 +11,6 @@ export type NewPremises = {
     notes?: string;
     localAuthorityAreaId: string;
     characteristicIds: Array<string>;
+    status: PropertyStatus;
 };
 

--- a/server/@types/shared/models/Premises.ts
+++ b/server/@types/shared/models/Premises.ts
@@ -6,6 +6,7 @@ import type { ApArea } from './ApArea';
 import type { Characteristic } from './Characteristic';
 import type { LocalAuthorityArea } from './LocalAuthorityArea';
 import type { ProbationRegion } from './ProbationRegion';
+import type { PropertyStatus } from './PropertyStatus';
 
 export type Premises = {
     id: string;
@@ -20,5 +21,6 @@ export type Premises = {
     apArea: ApArea;
     localAuthorityArea: LocalAuthorityArea;
     characteristics?: Array<Characteristic>;
+    status: PropertyStatus;
 };
 

--- a/server/@types/shared/models/PropertyStatus.ts
+++ b/server/@types/shared/models/PropertyStatus.ts
@@ -1,0 +1,5 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type PropertyStatus = 'pending' | 'active' | 'archived';

--- a/server/@types/shared/models/UpdatePremises.ts
+++ b/server/@types/shared/models/UpdatePremises.ts
@@ -2,11 +2,14 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import type { PropertyStatus } from './PropertyStatus';
+
 export type UpdatePremises = {
     addressLine1: string;
     postcode: string;
     notes?: string;
     localAuthorityAreaId: string;
     characteristicIds: Array<string>;
+    status: PropertyStatus;
 };
 

--- a/server/form-pages/apply/move-on/index.ts
+++ b/server/form-pages/apply/move-on/index.ts
@@ -3,11 +3,13 @@
 import RelocationRegion from './relocationRegion'
 import PlacementDuration from './placementDuration'
 import PlansInPlace from './plansInPlace'
+import TypeOfAccommodation from './typeOfAccommodation'
 
 const pages = {
   'placement-duration': PlacementDuration,
   'relocation-region': RelocationRegion,
   'plans-in-place': PlansInPlace,
+  'type-of-accommodation': TypeOfAccommodation,
 }
 
 export default pages

--- a/server/form-pages/apply/move-on/plansInPlace.test.ts
+++ b/server/form-pages/apply/move-on/plansInPlace.test.ts
@@ -14,7 +14,7 @@ describe('PlansInPlace', () => {
     })
   })
 
-  itShouldHaveNextValue(new PlansInPlace({}), '')
+  itShouldHaveNextValue(new PlansInPlace({}), 'type-of-accommodation')
   itShouldHavePreviousValue(new PlansInPlace({}), 'pdu-region')
 
   describe('errors', () => {

--- a/server/form-pages/apply/move-on/plansInPlace.ts
+++ b/server/form-pages/apply/move-on/plansInPlace.ts
@@ -23,7 +23,7 @@ export default class PlansInPlace implements TasklistPage {
   }
 
   next() {
-    return ''
+    return 'type-of-accommodation'
   }
 
   response() {

--- a/server/form-pages/apply/move-on/typeOfAccommodation.test.ts
+++ b/server/form-pages/apply/move-on/typeOfAccommodation.test.ts
@@ -1,0 +1,80 @@
+import { convertKeyValuePairToRadioItems } from '../../../utils/formUtils'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+
+import TypeOfAccommodation, { accommodationType } from './typeOfAccommodation'
+
+import applicationFactory from '../../../testutils/factories/application'
+import personFactory from '../../../testutils/factories/person'
+
+jest.mock('../../../utils/formUtils', () => ({
+  convertKeyValuePairToRadioItems: jest
+    .fn()
+    .mockImplementation(() => [{ value: 'other' }, { value: 'anotherTypeofAccommodation' }]),
+}))
+
+describe('TypeOfAccomodation', () => {
+  const person = personFactory.build({ name: 'John Wayne' })
+  const application = applicationFactory.build({ person })
+  describe('title', () => {
+    expect(new TypeOfAccommodation({}, application).title).toBe('Placement duration and move on')
+  })
+
+  describe('body', () => {
+    it('should strip unknown attributes from the body', () => {
+      const page = new TypeOfAccommodation(
+        {
+          accommodationType: 'other',
+          otherAccommodationType: 'hotel',
+          something: 'else',
+        },
+        application,
+      )
+
+      expect(page.body).toEqual({
+        accommodationType: 'other',
+        otherAccommodationType: 'hotel',
+      })
+    })
+  })
+
+  itShouldHaveNextValue(new TypeOfAccommodation({}, application), '')
+  itShouldHavePreviousValue(new TypeOfAccommodation({}, application), 'plans-in-place')
+
+  describe('errors', () => {
+    it('returns an error if no accomodation type is selected', () => {
+      const page = new TypeOfAccommodation({}, application)
+
+      expect(page.errors()).toEqual({ accommodationType: 'You must specify a type of accommodation' })
+    })
+
+    it('returns an error if the accommodation is "other" but no other type is specified', () => {
+      const page = new TypeOfAccommodation({ accommodationType: 'other' }, application)
+
+      expect(page.errors()).toEqual({ otherAccommodationType: 'You must specify the type of accommodation' })
+    })
+  })
+
+  describe('response', () => {
+    const page = new TypeOfAccommodation(
+      {
+        accommodationType: 'other',
+        otherAccommodationType: 'Some other accommodation',
+      },
+      application,
+    )
+
+    expect(page.response()).toEqual({
+      'What type of accommodation will John Wayne have when they leave the AP?': 'Other, please specify',
+      'Other, please specify': 'Some other accommodation',
+    })
+  })
+
+  describe('items', () => {
+    it('calls convertKeyValuePairToRadioItems with the correct items', () => {
+      const items = new TypeOfAccommodation({ accommodationType: 'privateRented' }, application).items()
+
+      expect(convertKeyValuePairToRadioItems).toHaveBeenCalledWith(accommodationType, 'privateRented')
+      expect(items).not.toContain('other')
+    })
+  })
+})

--- a/server/form-pages/apply/move-on/typeOfAccommodation.ts
+++ b/server/form-pages/apply/move-on/typeOfAccommodation.ts
@@ -1,0 +1,79 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+import { Application } from '../../../@types/shared'
+import { convertKeyValuePairToRadioItems } from '../../../utils/formUtils'
+
+import TasklistPage from '../../tasklistPage'
+
+export const accommodationType = {
+  ownAccomodation: 'Own accommodation',
+  livingWithPartnerFamilyOrFriends: 'Living with partner, family or friends',
+  rentedThroughLocalAuthority: 'Rented through local authority',
+  rentedThroughHousingAssociation: 'Rented through housing association',
+  privateRented: 'Private rented',
+  supportedAccommodation: 'Supported accommodation',
+  supportedHousing: 'Supported housing',
+  cas3: 'CAS3 (Community Accommodation Service) provided',
+  homeOffice: 'Accommodation provided through Home Office section 10 for foreign national',
+  other: 'Other, please specify',
+}
+
+type AccommodationType = keyof typeof accommodationType & 'other'
+
+export default class TypeOfAccommodation implements TasklistPage {
+  name = 'type-of-accommodation'
+
+  title = 'Placement duration and move on'
+
+  question = `What type of accommodation will ${this.application.person.name} have when they leave the AP?`
+
+  otherQuestion = accommodationType.other
+
+  body: {
+    accommodationType: AccommodationType
+    otherAccommodationType: string
+  }
+
+  constructor(body: Record<string, unknown>, private readonly application: Application) {
+    this.body = {
+      accommodationType: body.accommodationType as AccommodationType,
+      otherAccommodationType: body.otherAccommodationType as string,
+    }
+  }
+
+  previous() {
+    return 'plans-in-place'
+  }
+
+  next() {
+    return ''
+  }
+
+  response() {
+    const response = { [this.question]: accommodationType[this.body.accommodationType] }
+
+    if (this.body.accommodationType === 'other')
+      return { ...response, [accommodationType.other]: this.body.otherAccommodationType }
+
+    return response
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.accommodationType) {
+      errors.accommodationType = 'You must specify a type of accommodation'
+    }
+
+    if (this.body.accommodationType === 'other' && !this.body.otherAccommodationType) {
+      errors.otherAccommodationType = 'You must specify the type of accommodation'
+    }
+
+    return errors
+  }
+
+  items() {
+    return convertKeyValuePairToRadioItems(accommodationType, this.body.accommodationType).filter(
+      type => type.value !== 'other',
+    )
+  }
+}

--- a/server/testutils/factories/premises.ts
+++ b/server/testutils/factories/premises.ts
@@ -6,6 +6,7 @@ import type { ApArea, ApprovedPremises, ProbationRegion, LocalAuthorityArea } fr
 export default Factory.define<ApprovedPremises>(() => ({
   id: faker.datatype.uuid(),
   name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
+  status: faker.helpers.arrayElement(['pending', 'active', 'archived']),
   apCode: faker.random.alphaNumeric(5, { casing: 'upper' }),
   postcode: faker.address.zipCode(),
   bedCount: 50,

--- a/server/views/applications/pages/move-on/type-of-accommodation.njk
+++ b/server/views/applications/pages/move-on/type-of-accommodation.njk
@@ -1,0 +1,41 @@
+{% extends "../layout.njk" %}
+
+{% set accommodationTypes = page.items() %}
+
+{% block questions %}
+  <h1 class="govuk-heading-l">
+    {{page.title}}
+  </h1>
+
+  {% set otherAccommodationType %}
+  {{ applyInput({
+        fieldName: 'otherAccommodationType',
+        classes: "govuk-!-width-two-thirds",
+        label: {
+          text: "Other accommodation type"
+        }
+      }, fetchContext()) }}
+  {% endset %}
+
+  {{ applyRadios({
+      fieldName: "accommodationType",
+      hint: {
+        text: page.question
+      },
+      fieldset: {
+        legend: {
+          text: page.questions.needs.question,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: (accommodationTypes.push({
+              value: "other",
+              text: page.otherQuestion,
+              checked: page.body.accommodationType === 'other',
+              conditional: {
+                  html: otherAccommodationType
+              }
+          }), accommodationTypes
+        )
+    }, fetchContext()) }}
+{% endblock %}

--- a/server/views/applications/start.njk
+++ b/server/views/applications/start.njk
@@ -1,7 +1,4 @@
-{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 


### PR DESCRIPTION
This adds a 'Type of Accommodation' screen to the 'Move on' section of Apply in the pattern established in #142 

[Trello Card](https://trello.com/c/jMuPeBVr/652-move-on-type-of-accommodation)



## Screenshots of UI changes

![Apply -- allows completion of the form (2)](https://user-images.githubusercontent.com/44123869/201316811-013feadf-792d-4a61-aa61-acbf047cbeca.png)

