### PR TITLE
(656) Check your answers screen

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -8,5 +8,6 @@ $path: "/assets/images/"
 @import './components/identity-bar'
 @import './components/task-list'
 @import './components/risk-widgets'
+@import './components/box'
 @import './local'
 

--- a/assets/sass/components/_box.scss
+++ b/assets/sass/components/_box.scss
@@ -1,0 +1,14 @@
+.main-box{
+  border:2px solid #e5e5e5;
+  margin-bottom: 30px;
+}
+
+.box-title{
+  background-color:#E5E5E5;
+  padding: 10px;
+}
+
+.box-content{
+  padding-left:20px;
+  padding-right:10px;
+}

--- a/cypress_shared/pages/apply/accessNeeds.ts
+++ b/cypress_shared/pages/apply/accessNeeds.ts
@@ -1,16 +1,14 @@
-import { faker } from '@faker-js/faker/locale/en_GB'
+import { Application } from '@approved-premises/api'
 
-import Page from '../page'
+import ApplyPage from './applyPage'
 
-export default class AccessNeedsPage extends Page {
-  constructor() {
-    super('Access needs')
+export default class AccessNeedsPage extends ApplyPage {
+  constructor(application: Application) {
+    super('Access needs', application, 'access-and-healthcare', 'access-needs')
   }
 
   checkAdditionalNeedsBoxes() {
-    this.checkCheckboxByNameAndValue('additionalNeeds', 'mobility')
-    this.checkCheckboxByNameAndValue('additionalNeeds', 'learningDisability')
-    this.checkCheckboxByNameAndValue('additionalNeeds', 'neurodivergentConditions')
+    this.checkCheckboxesFromPageBody('additionalNeeds')
   }
 
   checkingAdditionalNeedsOtherDisablesOtherCheckBoxes() {
@@ -24,13 +22,13 @@ export default class AccessNeedsPage extends Page {
   }
 
   completeReligiousOrCulturalNeedsSection() {
-    this.checkRadioByNameAndValue('religiousOrCulturalNeeds', 'yes')
-    this.getTextInputByIdAndEnterDetails('religiousOrCulturalNeedsDetails', faker.lorem.words())
+    this.checkRadioButtonFromPageBody('religiousOrCulturalNeeds')
+    this.completeTextInputFromPageBody('religiousOrCulturalNeedsDetails')
   }
 
   completeNeedsInterpreterSection() {
     this.checkRadioByNameAndValue('needsInterpreter', 'yes')
-    this.getTextInputByIdAndEnterDetails('interpreterLanguage', faker.lorem.words())
+    this.completeTextInputFromPageBody('interpreterLanguage')
   }
 
   completeForm() {

--- a/cypress_shared/pages/apply/accessNeedsAdditionalAdjustments.ts
+++ b/cypress_shared/pages/apply/accessNeedsAdditionalAdjustments.ts
@@ -1,15 +1,17 @@
-import Page from '../page'
+import { Application } from '@approved-premises/api'
 
-export default class AccessNeedsAdditionalAdjustmentsPage extends Page {
-  constructor() {
-    super('Access needs')
+import ApplyPage from './applyPage'
+
+export default class AccessNeedsAdditionalAdjustmentsPage extends ApplyPage {
+  constructor(application: Application) {
+    super('Access needs', application, 'access-and-healthcare', 'access-needs-additional-adjustments')
     cy.get('legend').contains(
       /Does the placement require adjustments for the mobility, learning disability and neurodivergent conditions needs you selected?/,
     )
   }
 
   completeForm() {
-    this.checkRadioByNameAndValue('adjustments', 'yes')
-    this.completeTextArea('adjustmentsDetail', 'Some details here')
+    this.checkRadioButtonFromPageBody('adjustments')
+    this.completeTextInputFromPageBody('adjustmentsDetail')
   }
 }

--- a/cypress_shared/pages/apply/accessNeedsMobility.ts
+++ b/cypress_shared/pages/apply/accessNeedsMobility.ts
@@ -1,17 +1,16 @@
-import { faker } from '@faker-js/faker/locale/en_GB'
-import { Person } from '../../../server/@types/shared'
+import { Application } from '@approved-premises/api'
 
-import Page from '../page'
+import ApplyPage from './applyPage'
 
-export default class AccessNeedsMobilityPage extends Page {
-  constructor(person: Person) {
-    super('Access needs')
-    cy.get('.govuk-form-group').contains(`Does ${person.name} require use of a wheelchair?`)
+export default class AccessNeedsMobilityPage extends ApplyPage {
+  constructor(application: Application) {
+    super('Access needs', application, 'access-and-healthcare', 'access-needs-mobility')
+    cy.get('.govuk-form-group').contains(`Does ${application.person.name} require use of a wheelchair?`)
   }
 
   completeForm() {
-    this.checkRadioByNameAndValue('needsWheelchair', 'yes')
-    this.getTextInputByIdAndEnterDetails('mobilityNeeds', faker.lorem.word())
-    this.getTextInputByIdAndEnterDetails('visualImpairment', faker.lorem.word())
+    this.checkRadioButtonFromPageBody('needsWheelchair')
+    this.completeTextInputFromPageBody('mobilityNeeds')
+    this.completeTextInputFromPageBody('visualImpairment')
   }
 }

--- a/cypress_shared/pages/apply/applyPage.ts
+++ b/cypress_shared/pages/apply/applyPage.ts
@@ -1,0 +1,41 @@
+import Page from '../page'
+import TasklistPage from '../../../server/form-pages/tasklistPage'
+import { Application } from '../../../server/@types/shared/models/Application'
+
+import { pages } from '../../../server/form-pages/apply'
+
+export default class ApplyPage extends Page {
+  tasklistPage: TasklistPage
+
+  constructor(title: string, application: Application, taskName: string, pageName: string) {
+    super(title)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const Class = pages[taskName][pageName] as any
+
+    this.tasklistPage = new Class(application.data?.[taskName]?.[pageName], application)
+  }
+
+  checkRadioButtonFromPageBody(fieldName: string) {
+    this.checkRadioByNameAndValue(fieldName, this.tasklistPage.body[fieldName] as string)
+  }
+
+  completeTextInputFromPageBody(fieldName: string) {
+    this.getTextInputByIdAndEnterDetails(fieldName, this.tasklistPage.body[fieldName] as string)
+  }
+
+  checkCheckboxesFromPageBody(fieldName: string) {
+    ;(this.tasklistPage.body[fieldName] as Array<string>).forEach(need => {
+      this.checkCheckboxByNameAndValue(fieldName, need)
+    })
+  }
+
+  completeDateInputsFromPageBody(fieldName: string) {
+    const date = this.tasklistPage.body[fieldName] as string
+    this.completeDateInputs(fieldName, date)
+  }
+
+  selectSelectOptionFromPageBody(fieldName: string) {
+    this.getSelectInputByIdAndSelectAnEntry(fieldName, this.tasklistPage.body[fieldName] as string)
+  }
+}

--- a/cypress_shared/pages/apply/arson.ts
+++ b/cypress_shared/pages/apply/arson.ts
@@ -1,14 +1,15 @@
-import Page from '../page'
-import { Person } from '../../../server/@types/shared'
+import { Application } from '@approved-premises/api'
 
-export default class ArsonPage extends Page {
-  constructor(person: Person) {
-    super('Arson')
-    cy.get('.govuk-form-group').contains(`Does ${person.name} need a specialist arson room?`)
+import ApplyPage from './applyPage'
+
+export default class ArsonPage extends ApplyPage {
+  constructor(application: Application) {
+    super('Arson', application, 'further-considerations', 'arson')
+    cy.get('.govuk-form-group').contains(`Does ${application.person.name} need a specialist arson room?`)
   }
 
   completeForm(): void {
-    this.checkRadioByNameAndValue('arson', 'yes')
-    this.completeTextArea('arsonDetail', 'Some details here')
+    this.checkRadioButtonFromPageBody('arson')
+    this.completeTextInputFromPageBody('arsonDetail')
   }
 }

--- a/cypress_shared/pages/apply/catering.ts
+++ b/cypress_shared/pages/apply/catering.ts
@@ -1,14 +1,17 @@
-import Page from '../page'
-import { Person } from '../../../server/@types/shared'
+import { Application } from '@approved-premises/api'
 
-export default class CateringPage extends Page {
-  constructor(person: Person) {
-    super('Catering requirements')
-    cy.get('.govuk-form-group').contains(`Do you have any concerns about ${person.name} catering for themselves?`)
+import ApplyPage from './applyPage'
+
+export default class CateringPage extends ApplyPage {
+  constructor(application: Application) {
+    super('Catering requirements', application, 'further-considerations', 'catering')
+    cy.get('.govuk-form-group').contains(
+      `Do you have any concerns about ${application.person.name} catering for themselves?`,
+    )
   }
 
   completeForm(): void {
-    this.checkRadioByNameAndValue('catering', 'yes')
-    this.completeTextArea('cateringDetail', 'Some details here')
+    this.checkRadioButtonFromPageBody('catering')
+    this.completeTextInputFromPageBody('cateringDetail')
   }
 }

--- a/cypress_shared/pages/apply/checkYourAnswersPage.ts
+++ b/cypress_shared/pages/apply/checkYourAnswersPage.ts
@@ -1,0 +1,65 @@
+import type { Person } from '@approved-premises/api'
+import { DateFormats } from '../../../server/utils/dateUtils'
+import ApplyPage from './applyPage'
+
+import Page from '../page'
+
+export default class CheckYourAnswersPage extends Page {
+  constructor() {
+    super('Check your answers')
+  }
+
+  shouldShowPersonInformation(person: Person) {
+    cy.get('[data-cy-check-your-answers-section="person-details"]').within(() => {
+      this.assertDefinition('Name', person.name)
+      this.assertDefinition('CRN', person.crn)
+      this.assertDefinition('Date of Birth', DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }))
+      this.assertDefinition('NOMS Number', person.nomsNumber)
+      this.assertDefinition('Nationality', person.nationality)
+      this.assertDefinition('Religion or Belief', person.religionOrBelief)
+      this.assertDefinition('Sex', person.sex)
+
+      cy.get(`[data-cy-status]`).should('have.attr', 'data-cy-status').and('equal', person.status)
+      this.assertDefinition('Prison', person.prisonName)
+    })
+  }
+
+  shouldShowBasicInformationAnswers(pages: Array<ApplyPage>) {
+    this.shouldShowAnswersForTask('basic-information', pages)
+  }
+
+  shouldShowTypeOfApAnswers(pages: Array<ApplyPage>) {
+    this.shouldShowAnswersForTask('type-of-ap', pages)
+  }
+
+  shouldShowRiskManagementAnswers(pages: Array<ApplyPage>) {
+    this.shouldShowAnswersForTask('risk-management-features', pages)
+  }
+
+  shouldShowAccessAndHealthcareAnswers(pages: Array<ApplyPage>) {
+    this.shouldShowAnswersForTask('access-and-healthcare', pages)
+  }
+
+  shouldShowLocationFactorsAnswers(pages: Array<ApplyPage>) {
+    this.shouldShowAnswersForTask('location-factors', pages)
+  }
+
+  shouldShowFurtherConsiderationsAnswers(pages: Array<ApplyPage>) {
+    this.shouldShowAnswersForTask('further-considerations', pages)
+  }
+
+  shouldShowMoveOnAnswers(pages: Array<ApplyPage>) {
+    this.shouldShowAnswersForTask('move-on', pages)
+  }
+
+  private shouldShowAnswersForTask(taskName: string, pages: Array<ApplyPage>) {
+    cy.get(`[data-cy-check-your-answers-section="${taskName}"]`).within(() => {
+      pages.forEach(page => {
+        const responses = page.tasklistPage.response()
+        Object.keys(responses).forEach(key => {
+          this.assertDefinition(key, responses[key] as string)
+        })
+      })
+    })
+  }
+}

--- a/cypress_shared/pages/apply/complexCaseBoard.ts
+++ b/cypress_shared/pages/apply/complexCaseBoard.ts
@@ -1,16 +1,17 @@
-import Page from '../page'
-import { Person } from '../../../server/@types/shared'
+import { Application } from '@approved-premises/api'
 
-export default class ComplexCaseBoardPage extends Page {
-  constructor(person: Person) {
-    super('Complex case board')
+import ApplyPage from './applyPage'
+
+export default class ComplexCaseBoardPage extends ApplyPage {
+  constructor(application: Application) {
+    super('Complex case board', application, 'further-considerations', 'complex-case-board')
     cy.get('.govuk-form-group').contains(
-      `Does ${person.name}'s gender identity require a complex case board to review their application? `,
+      `Does ${application.person.name}'s gender identity require a complex case board to review their application? `,
     )
   }
 
   completeForm(): void {
-    this.checkRadioByNameAndValue('complexCaseBoard', 'yes')
-    this.completeTextArea('complexCaseBoardDetail', 'Some details here')
+    this.checkRadioButtonFromPageBody('complexCaseBoard')
+    this.completeTextInputFromPageBody('complexCaseBoardDetail')
   }
 }

--- a/cypress_shared/pages/apply/convictedOffences.ts
+++ b/cypress_shared/pages/apply/convictedOffences.ts
@@ -1,12 +1,18 @@
-import Page from '../page'
-import { Person } from '../../../server/@types/shared'
+import { Application } from '@approved-premises/api'
 
-export default class ConvictedOffences extends Page {
-  constructor(person: Person) {
-    super(`Has ${person.name} ever been convicted of the following offences?`)
+import ApplyPage from './applyPage'
+
+export default class ConvictedOffences extends ApplyPage {
+  constructor(application: Application) {
+    super(
+      `Has ${application.person.name} ever been convicted of the following offences?`,
+      application,
+      'risk-management-features',
+      'convicted-offences',
+    )
   }
 
   completeForm(): void {
-    this.checkRadioByNameAndValue('response', 'yes')
+    this.checkRadioButtonFromPageBody('response')
   }
 }

--- a/cypress_shared/pages/apply/covid.ts
+++ b/cypress_shared/pages/apply/covid.ts
@@ -1,13 +1,15 @@
-import Page from '../page'
+import { Application } from '@approved-premises/api'
 
-export default class CovidPage extends Page {
-  constructor() {
-    super('Healthcare information')
+import ApplyPage from './applyPage'
+
+export default class CovidPage extends ApplyPage {
+  constructor(application: Application) {
+    super('Healthcare information', application, 'access-and-healthcare', 'covid')
   }
 
   completeForm() {
-    this.checkRadioByNameAndValue('fullyVaccinated', 'yes')
-    this.checkRadioByNameAndValue('highRisk', 'yes')
-    this.getTextInputByIdAndEnterDetails('additionalCovidInfo', 'additional info')
+    this.checkRadioButtonFromPageBody('fullyVaccinated')
+    this.checkRadioButtonFromPageBody('highRisk')
+    this.completeTextInputFromPageBody('additionalCovidInfo')
   }
 }

--- a/cypress_shared/pages/apply/dateOfOffence.ts
+++ b/cypress_shared/pages/apply/dateOfOffence.ts
@@ -1,14 +1,15 @@
-import Page from '../page'
+import { Application } from '@approved-premises/api'
 
-export default class DateOfOffence extends Page {
-  constructor() {
-    super('Convicted offences')
+import ApplyPage from './applyPage'
+
+export default class DateOfOffence extends ApplyPage {
+  constructor(application: Application) {
+    super('Convicted offences', application, 'risk-management-features', 'date-of-offence')
   }
 
   completeForm(): void {
-    this.checkCheckboxByNameAndValue('arsonOffence', 'current')
-    this.checkCheckboxByNameAndValue('hateCrime', 'previous')
-    this.checkCheckboxByNameAndValue('inPersonSexualOffence', 'previous')
-    this.checkCheckboxByNameAndValue('inPersonSexualOffence', 'current')
+    this.checkCheckboxesFromPageBody('arsonOffence')
+    this.checkCheckboxesFromPageBody('hateCrime')
+    this.checkCheckboxesFromPageBody('inPersonSexualOffence')
   }
 }

--- a/cypress_shared/pages/apply/describeLocationFactors.ts
+++ b/cypress_shared/pages/apply/describeLocationFactors.ts
@@ -1,17 +1,19 @@
-import Page from '../page'
+import { Application } from '@approved-premises/api'
 
-export default class DescribeLocationFactors extends Page {
-  constructor() {
-    super('Location factors')
+import ApplyPage from './applyPage'
+
+export default class DescribeLocationFactors extends ApplyPage {
+  constructor(application: Application) {
+    super('Location factors', application, 'location-factors', 'describe-location-factors')
   }
 
   completeForm(): void {
-    this.getTextInputByIdAndEnterDetails('postcodeArea', 'SW1')
-    this.getTextInputByIdAndEnterDetails('positiveFactors', 'Some positive factors')
-    this.checkRadioByNameAndValue('restrictions', 'yes')
-    this.getTextInputByIdAndEnterDetails('restrictionDetail', 'Restrictions go here')
-    this.checkRadioByNameAndValue('alternativeRadiusAccepted', 'yes')
-    this.getSelectInputByIdAndSelectAnEntry('alternativeRadius', '70')
-    this.checkRadioByNameAndValue('differentPDU', 'no')
+    this.completeTextInputFromPageBody('postcodeArea')
+    this.completeTextInputFromPageBody('positiveFactors')
+    this.checkRadioButtonFromPageBody('restrictions')
+    this.completeTextInputFromPageBody('restrictionDetail')
+    this.checkRadioButtonFromPageBody('alternativeRadiusAccepted')
+    this.selectSelectOptionFromPageBody('alternativeRadius')
+    this.checkRadioButtonFromPageBody('differentPDU')
   }
 }

--- a/cypress_shared/pages/apply/foreignNational.ts
+++ b/cypress_shared/pages/apply/foreignNational.ts
@@ -1,12 +1,14 @@
-import Page from '../page'
+import { Application } from '@approved-premises/api'
 
-export default class ForeignNationalPage extends Page {
-  constructor() {
-    super('Placement duration and move on')
+import ApplyPage from './applyPage'
+
+export default class ForeignNationalPage extends ApplyPage {
+  constructor(application: Application) {
+    super('Placement duration and move on', application, 'move-on', 'foreign-national')
   }
 
   completeForm() {
-    this.checkRadioByNameAndValue('response', 'yes')
-    this.completeDateInputs('date', new Date().toISOString())
+    this.checkRadioButtonFromPageBody('response')
+    this.completeDateInputsFromPageBody('date')
   }
 }

--- a/cypress_shared/pages/apply/index.ts
+++ b/cypress_shared/pages/apply/index.ts
@@ -17,6 +17,7 @@ import CateringPage from './catering'
 import ArsonPage from './arson'
 import PlacementDurationPage from './placementDuration'
 import ForeignNationalPage from './foreignNational'
+import CheckYourAnswersPage from './checkYourAnswersPage'
 
 export {
   ConfirmDetailsPage,
@@ -38,4 +39,5 @@ export {
   ArsonPage,
   PlacementDurationPage,
   ForeignNationalPage,
+  CheckYourAnswersPage,
 }

--- a/cypress_shared/pages/apply/index.ts
+++ b/cypress_shared/pages/apply/index.ts
@@ -16,6 +16,7 @@ import ComplexCaseBoard from './complexCaseBoard'
 import CateringPage from './catering'
 import ArsonPage from './arson'
 import PlacementDurationPage from './placementDuration'
+import ForeignNationalPage from './foreignNational'
 
 export {
   ConfirmDetailsPage,
@@ -36,4 +37,5 @@ export {
   CateringPage,
   ArsonPage,
   PlacementDurationPage,
+  ForeignNationalPage,
 }

--- a/cypress_shared/pages/apply/pduTransfer.ts
+++ b/cypress_shared/pages/apply/pduTransfer.ts
@@ -1,13 +1,19 @@
-import { Person } from '../../../server/@types/shared'
-import Page from '../page'
+import { Application } from '@approved-premises/api'
 
-export default class PduTransferPage extends Page {
-  constructor(person: Person) {
-    super(`Have you agreed ${person.name}'s transfer/supervision with the receiving PDU?`)
+import ApplyPage from './applyPage'
+
+export default class PduTransferPage extends ApplyPage {
+  constructor(application: Application) {
+    super(
+      `Have you agreed ${application.person.name}'s transfer/supervision with the receiving PDU?`,
+      application,
+      'location-factors',
+      'pdu-transfer',
+    )
   }
 
   completeForm() {
-    this.checkRadioByNameAndValue('transferStatus', 'yes')
-    this.getTextInputByIdAndEnterDetails('probationPractitioner', 'Probation Practicioner')
+    this.checkRadioButtonFromPageBody('transferStatus')
+    this.completeTextInputFromPageBody('probationPractitioner')
   }
 }

--- a/cypress_shared/pages/apply/placementDuration.ts
+++ b/cypress_shared/pages/apply/placementDuration.ts
@@ -1,15 +1,22 @@
 import { add } from 'date-fns'
+import { Application } from '@approved-premises/api'
 import { DateFormats } from '../../../server/utils/dateUtils'
-import Page from '../page'
 
-export default class PlacementDurationPage extends Page {
-  constructor() {
-    super('Placement duration and move on')
+import ApplyPage from './applyPage'
+
+export default class PlacementDurationPage extends ApplyPage {
+  application: Application
+
+  constructor(application: Application) {
+    super('Placement duration and move on', application, 'move-on', 'placement-duration')
+    this.application = application
   }
 
   completeForm() {
-    this.getTextInputByIdAndEnterDetails('duration', '10')
-    this.completeTextArea('durationDetail', 'Some more information')
+    this.completeTextInputFromPageBody('duration')
+    this.completeTextInputFromPageBody('durationDetail')
+
+    this.expectedDepartureDateShouldBeCompleted(this.application.data['basic-information']['release-date'].releaseDate)
   }
 
   expectedDepartureDateShouldBeCompleted(releaseDate: string) {

--- a/cypress_shared/pages/apply/placementPurpose.ts
+++ b/cypress_shared/pages/apply/placementPurpose.ts
@@ -1,13 +1,19 @@
-import Page from '../page'
+import { Application } from '@approved-premises/api'
 
-export default class PlacementPurposePage extends Page {
-  constructor() {
-    super('What is the purpose of the Approved Premises (AP) placement?')
+import ApplyPage from './applyPage'
+
+export default class PlacementPurposePage extends ApplyPage {
+  constructor(application: Application) {
+    super(
+      'What is the purpose of the Approved Premises (AP) placement?',
+      application,
+      'basic-information',
+      'placement-purpose',
+    )
   }
 
   completeForm() {
-    this.checkCheckboxByNameAndValue('placementPurposes', 'drugAlcoholSupport')
-    this.checkCheckboxByNameAndValue('placementPurposes', 'otherReason')
-    this.getTextInputByIdAndEnterDetails('otherReason', 'Reason')
+    this.checkCheckboxesFromPageBody('placementPurposes')
+    this.completeTextInputFromPageBody('otherReason')
   }
 }

--- a/cypress_shared/pages/apply/placementStart.ts
+++ b/cypress_shared/pages/apply/placementStart.ts
@@ -1,8 +1,20 @@
-import Page from '../page'
+import { Application } from '@approved-premises/api'
+import ApplyPage from './applyPage'
 import { DateFormats } from '../../../server/utils/dateUtils'
 
-export default class PlacementStartPage extends Page {
-  constructor(releaseDate: string) {
-    super(`Is ${DateFormats.isoDateToUIDate(releaseDate)} the date you want the placement to start?`)
+export default class PlacementStartPage extends ApplyPage {
+  constructor(application: Application) {
+    const { releaseDate } = application.data['basic-information']['release-date']
+
+    super(
+      `Is ${DateFormats.isoDateToUIDate(releaseDate)} the date you want the placement to start?`,
+      application,
+      'basic-information',
+      'placement-date',
+    )
+  }
+
+  completeForm() {
+    this.checkRadioButtonFromPageBody('startDateSameAsReleaseDate')
   }
 }

--- a/cypress_shared/pages/apply/plansInPlace.ts
+++ b/cypress_shared/pages/apply/plansInPlace.ts
@@ -1,11 +1,13 @@
-import Page from '../page'
+import { Application } from '@approved-premises/api'
 
-export default class PlansInPlacePage extends Page {
-  constructor() {
-    super('Placement duration and move on')
+import ApplyPage from './applyPage'
+
+export default class PlansInPlacePage extends ApplyPage {
+  constructor(application: Application) {
+    super('Placement duration and move on', application, 'move-on', 'plans-in-place')
   }
 
   completeForm() {
-    this.checkCheckboxByNameAndValue('arePlansInPlace', 'yes')
+    this.checkRadioButtonFromPageBody('arePlansInPlace')
   }
 }

--- a/cypress_shared/pages/apply/previousPlacements.ts
+++ b/cypress_shared/pages/apply/previousPlacements.ts
@@ -1,14 +1,17 @@
-import Page from '../page'
-import { Person } from '../../../server/@types/shared'
+import { Application } from '@approved-premises/api'
 
-export default class PreviousPlacementsPage extends Page {
-  constructor(person: Person) {
-    super('Previous placements')
-    cy.get('.govuk-form-group').contains(`Has ${person.name} stayed or been offered a placement in an AP before?`)
+import ApplyPage from './applyPage'
+
+export default class PreviousPlacementsPage extends ApplyPage {
+  constructor(application: Application) {
+    super('Previous placements', application, 'further-considerations', 'previous-placements')
+    cy.get('.govuk-form-group').contains(
+      `Has ${application.person.name} stayed or been offered a placement in an AP before?`,
+    )
   }
 
   completeForm(): void {
-    this.checkRadioByNameAndValue('previousPlacement', 'yes')
-    this.completeTextArea('previousPlacementDetail', 'Some details here')
+    this.checkRadioButtonFromPageBody('previousPlacement')
+    this.completeTextInputFromPageBody('previousPlacementDetail')
   }
 }

--- a/cypress_shared/pages/apply/rehabilitativeInterventions.ts
+++ b/cypress_shared/pages/apply/rehabilitativeInterventions.ts
@@ -1,20 +1,19 @@
-import Page from '../page'
+import { Application } from '@approved-premises/api'
 
-export default class RehabilitativeInterventions extends Page {
-  constructor() {
-    super("Which rehabilitative interventions will support the person's Approved Premises (AP) placement?")
+import ApplyPage from './applyPage'
+
+export default class RehabilitativeInterventions extends ApplyPage {
+  constructor(application: Application) {
+    super(
+      "Which rehabilitative interventions will support the person's Approved Premises (AP) placement?",
+      application,
+      'risk-management-features',
+      'rehabilitative-interventions',
+    )
   }
 
   completeForm(): void {
-    this.checkCheckboxByNameAndValue('rehabilitativeInterventions', 'accomodation')
-    this.checkCheckboxByNameAndValue('rehabilitativeInterventions', 'drugsAndAlcohol')
-    this.checkCheckboxByNameAndValue('rehabilitativeInterventions', 'childrenAndFamilies')
-    this.checkCheckboxByNameAndValue('rehabilitativeInterventions', 'health')
-    this.checkCheckboxByNameAndValue('rehabilitativeInterventions', 'educationTrainingAndEmployment')
-    this.checkCheckboxByNameAndValue('rehabilitativeInterventions', 'financeBenefitsAndDebt')
-    this.checkCheckboxByNameAndValue('rehabilitativeInterventions', 'attitudesAndBehaviour')
-    this.checkCheckboxByNameAndValue('rehabilitativeInterventions', 'abuse')
-    this.checkCheckboxByNameAndValue('rehabilitativeInterventions', 'other')
-    this.getTextInputByIdAndEnterDetails('otherIntervention', 'Another')
+    this.checkCheckboxesFromPageBody('rehabilitativeInterventions')
+    this.completeTextInputFromPageBody('otherIntervention')
   }
 }

--- a/cypress_shared/pages/apply/releaseDate.ts
+++ b/cypress_shared/pages/apply/releaseDate.ts
@@ -1,8 +1,14 @@
-import type { Person } from '@approved-premises/api'
-import Page from '../page'
+import type { Application } from '@approved-premises/api'
 
-export default class ReleaseDatePage extends Page {
-  constructor(person: Person) {
-    super(`Do you know ${person.name}’s release date?`)
+import ApplyPage from './applyPage'
+
+export default class ReleaseDatePage extends ApplyPage {
+  constructor(application: Application) {
+    super(`Do you know ${application.person.name}’s release date?`, application, 'basic-information', 'release-date')
+  }
+
+  completeForm() {
+    this.checkRadioButtonFromPageBody('knowReleaseDate')
+    this.completeDateInputsFromPageBody('releaseDate')
   }
 }

--- a/cypress_shared/pages/apply/relocationRegion.ts
+++ b/cypress_shared/pages/apply/relocationRegion.ts
@@ -1,13 +1,16 @@
-import { Person } from '../../../server/@types/shared'
-import Page from '../page'
+import { Application } from '@approved-premises/api'
 
-export default class RelocationRegionPage extends Page {
-  constructor(person: Person) {
-    super('Placement duration and move on')
-    cy.get('.govuk-form-group').contains(`Where is ${person.name} most likely to live when they move on from the AP?`)
+import ApplyPage from './applyPage'
+
+export default class RelocationRegionPage extends ApplyPage {
+  constructor(application: Application) {
+    super('Placement duration and move on', application, 'move-on', 'relocation-region')
+    cy.get('.govuk-form-group').contains(
+      `Where is ${application.person.name} most likely to live when they move on from the AP?`,
+    )
   }
 
   completeForm() {
-    this.getTextInputByIdAndEnterDetails('postcodeArea', 'XX1')
+    this.completeTextInputFromPageBody('postcodeArea')
   }
 }

--- a/cypress_shared/pages/apply/riskManagementFeatures.ts
+++ b/cypress_shared/pages/apply/riskManagementFeatures.ts
@@ -1,18 +1,23 @@
-import { faker } from '@faker-js/faker'
+import { Application } from '@approved-premises/api'
 
-import Page from '../page'
+import ApplyPage from './applyPage'
 
-export default class RiskManagementFeatures extends Page {
-  constructor() {
-    super('What features of AP will support the management of risk?')
+export default class RiskManagementFeatures extends ApplyPage {
+  constructor(application: Application) {
+    super(
+      'What features of AP will support the management of risk?',
+      application,
+      'risk-management-features',
+      'risk-management-features',
+    )
   }
 
   enterRiskManagementDetails() {
-    this.getTextInputByIdAndEnterDetails('manageRiskDetails', faker.lorem.words())
+    this.completeTextInputFromPageBody('manageRiskDetails')
   }
 
   enterAdditionalFeaturesDetails() {
-    this.getTextInputByIdAndEnterDetails('additionalFeaturesDetails', faker.lorem.words())
+    this.completeTextInputFromPageBody('additionalFeaturesDetails')
   }
 
   completeForm() {

--- a/cypress_shared/pages/apply/roomSharing.ts
+++ b/cypress_shared/pages/apply/roomSharing.ts
@@ -1,16 +1,18 @@
-import Page from '../page'
+import { Application } from '@approved-premises/api'
 
-export default class RoomSharingPage extends Page {
-  constructor() {
-    super('Room sharing')
+import ApplyPage from './applyPage'
+
+export default class RoomSharingPage extends ApplyPage {
+  constructor(application: Application) {
+    super('Room sharing', application, 'further-considerations', 'room-sharing')
   }
 
   completeForm(): void {
-    this.checkRadioByNameAndValue('riskToStaff', 'no')
-    this.checkRadioByNameAndValue('riskToOthers', 'no')
-    this.checkRadioByNameAndValue('sharingConcerns', 'yes')
-    this.completeTextArea('sharingConcernsDetail', 'Some details here')
-    this.checkRadioByNameAndValue('traumaConcerns', 'no')
-    this.checkRadioByNameAndValue('sharingBenefits', 'no')
+    this.checkRadioButtonFromPageBody('riskToStaff')
+    this.checkRadioButtonFromPageBody('riskToOthers')
+    this.checkRadioButtonFromPageBody('sharingConcerns')
+    this.completeTextInputFromPageBody('sharingConcernsDetail')
+    this.checkRadioButtonFromPageBody('traumaConcerns')
+    this.checkRadioButtonFromPageBody('sharingBenefits')
   }
 }

--- a/cypress_shared/pages/apply/sentenceType.ts
+++ b/cypress_shared/pages/apply/sentenceType.ts
@@ -1,7 +1,13 @@
-import Page from '../page'
+import type { Application } from '@approved-premises/api'
 
-export default class SentenceTypePage extends Page {
-  constructor() {
-    super('Which of the following best describes the sentence type?')
+import ApplyPage from './applyPage'
+
+export default class SentenceTypePage extends ApplyPage {
+  constructor(application: Application) {
+    super('Which of the following best describes the sentence type?', application, 'basic-information', 'sentence-type')
+  }
+
+  completeForm() {
+    this.checkRadioButtonFromPageBody('sentenceType')
   }
 }

--- a/cypress_shared/pages/apply/situationPage.ts
+++ b/cypress_shared/pages/apply/situationPage.ts
@@ -1,7 +1,13 @@
-import Page from '../page'
+import type { Application } from '@approved-premises/api'
 
-export default class SituationPage extends Page {
-  constructor() {
-    super('Which of the following options best describes the situation?')
+import ApplyPage from './applyPage'
+
+export default class SituationPage extends ApplyPage {
+  constructor(application: Application) {
+    super('Which of the following options best describes the situation?', application, 'basic-information', 'situation')
+  }
+
+  completeForm() {
+    this.checkRadioButtonFromPageBody('situation')
   }
 }

--- a/cypress_shared/pages/apply/typeOfAccommodation.ts
+++ b/cypress_shared/pages/apply/typeOfAccommodation.ts
@@ -1,13 +1,16 @@
-import { Person } from '../../../server/@types/shared'
-import Page from '../page'
+import { Application } from '@approved-premises/api'
 
-export default class TypeOfAccomodationPage extends Page {
-  constructor(person: Person) {
-    super('Placement duration and move on')
-    cy.get('.govuk-form-group').contains(`What type of accommodation will ${person.name} have when they leave the AP?`)
+import ApplyPage from './applyPage'
+
+export default class TypeOfAccomodationPage extends ApplyPage {
+  constructor(application: Application) {
+    super('Placement duration and move on', application, 'move-on', 'type-of-accommodation')
+    cy.get('.govuk-form-group').contains(
+      `What type of accommodation will ${application.person.name} have when they leave the AP?`,
+    )
   }
 
   completeForm() {
-    this.checkRadioByNameAndValue('accommodationType', 'foreignNational')
+    this.checkRadioButtonFromPageBody('accommodationType')
   }
 }

--- a/cypress_shared/pages/apply/typeOfAp.ts
+++ b/cypress_shared/pages/apply/typeOfAp.ts
@@ -1,12 +1,12 @@
-import { Person } from '../../../server/@types/shared'
-import Page from '../page'
+import { Application } from '../../../server/@types/shared'
+import ApplyPage from './applyPage'
 
-export default class TypeOfApPage extends Page {
-  constructor(person: Person) {
-    super(`Which type of AP does ${person.name} require?`)
+export default class TypeOfApPage extends ApplyPage {
+  constructor(application: Application) {
+    super(`Which type of AP does ${application.person.name} require?`, application, 'type-of-ap', 'ap-type')
   }
 
   completeForm() {
-    this.checkRadioByNameAndValue('type', 'standard')
+    this.checkRadioButtonFromPageBody('type')
   }
 }

--- a/cypress_shared/pages/apply/typeOfConvictedOffence.ts
+++ b/cypress_shared/pages/apply/typeOfConvictedOffence.ts
@@ -1,15 +1,18 @@
-import Page from '../page'
-import { Person } from '../../../server/@types/shared'
+import { Application } from '@approved-premises/api'
 
-export default class TypeOfConvictedOffence extends Page {
-  constructor(person: Person) {
-    super(`What type of offending has ${person.name} been convicted of?`)
+import ApplyPage from './applyPage'
+
+export default class TypeOfConvictedOffence extends ApplyPage {
+  constructor(application: Application) {
+    super(
+      `What type of offending has ${application.person.name} been convicted of?`,
+      application,
+      'risk-management-features',
+      'type-of-convicted-offence',
+    )
   }
 
   completeForm(): void {
-    this.checkCheckboxByNameAndValue('offenceConvictions', 'arson')
-    this.checkCheckboxByNameAndValue('offenceConvictions', 'sexualOffence')
-    this.checkCheckboxByNameAndValue('offenceConvictions', 'hateCrimes')
-    this.checkCheckboxByNameAndValue('offenceConvictions', 'childNonSexualOffence')
+    this.checkCheckboxesFromPageBody('offenceConvictions')
   }
 }

--- a/cypress_shared/pages/apply/vulnerability.ts
+++ b/cypress_shared/pages/apply/vulnerability.ts
@@ -1,18 +1,21 @@
-import Page from '../page'
-import { Person } from '../../../server/@types/shared'
+import { Application } from '@approved-premises/api'
 
-export default class VulnerabilityPage extends Page {
-  constructor(person: Person) {
-    super('Vulnerability')
-    cy.get('.govuk-form-group').contains(`Are you aware that ${person.name} is vulnerable to exploitation from others?`)
+import ApplyPage from './applyPage'
+
+export default class VulnerabilityPage extends ApplyPage {
+  constructor(application: Application) {
+    super('Vulnerability', application, 'further-considerations', 'vulnerability')
     cy.get('.govuk-form-group').contains(
-      `Is there any evidence or expectation that ${person.name} may groom, radicalise or exploit others?`,
+      `Are you aware that ${application.person.name} is vulnerable to exploitation from others?`,
+    )
+    cy.get('.govuk-form-group').contains(
+      `Is there any evidence or expectation that ${application.person.name} may groom, radicalise or exploit others?`,
     )
   }
 
   completeForm(): void {
-    this.checkRadioByNameAndValue('exploitable', 'no')
-    this.checkRadioByNameAndValue('exploitOthers', 'yes')
-    this.completeTextArea('exploitOthersDetail', 'Some details here')
+    this.checkRadioButtonFromPageBody('exploitable')
+    this.checkRadioButtonFromPageBody('exploitOthers')
+    this.completeTextInputFromPageBody('exploitOthersDetail')
   }
 }

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -1,0 +1,116 @@
+{
+  "basic-information": {
+    "sentence-type": { "sentenceType": "bailPlacement" },
+    "situation": { "situation": "bailSentence" },
+    "release-date": {
+      "releaseDate-year": "2022",
+      "releaseDate-month": "11",
+      "releaseDate-day": "14",
+      "releaseDate": "2022-11-14",
+      "knowReleaseDate": "yes"
+    },
+    "placement-date": {
+      "startDate-year": "",
+      "startDate-month": "",
+      "startDate-day": "",
+      "startDateSameAsReleaseDate": "yes"
+    },
+    "placement-purpose": { "placementPurposes": ["drugAlcoholSupport", "otherReason"], "otherReason": "Reason" }
+  },
+  "type-of-ap": { "ap-type": { "type": "standard" } },
+  "risk-management-features": {
+    "risk-management-features": {
+      "manageRiskDetails": "est vero nesciunt",
+      "additionalFeaturesDetails": "deleniti enim necessitatibus"
+    },
+    "convicted-offences": { "response": "yes" },
+    "type-of-convicted-offence": {
+      "offenceConvictions": ["arson", "sexualOffence", "hateCrimes", "childNonSexualOffence"]
+    },
+    "date-of-offence": {
+      "arsonOffence": ["current"],
+      "hateCrime": ["previous"],
+      "inPersonSexualOffence": ["current", "previous"]
+    },
+    "rehabilitative-interventions": {
+      "rehabilitativeInterventions": [
+        "accomodation",
+        "drugsAndAlcohol",
+        "childrenAndFamilies",
+        "health",
+        "educationTrainingAndEmployment",
+        "financeBenefitsAndDebt",
+        "attitudesAndBehaviour",
+        "abuse",
+        "other"
+      ],
+      "otherIntervention": "Another"
+    }
+  },
+  "location-factors": {
+    "describe-location-factors": {
+      "postcodeArea": "SW1",
+      "positiveFactors": "Some positive factors",
+      "restrictions": "yes",
+      "restrictionDetail": "Restrictions go here",
+      "alternativeRadiusAccepted": "yes",
+      "alternativeRadius": "70",
+      "differentPDU": "no"
+    },
+    "pdu-transfer": { "transferStatus": "yes", "probationPractitioner": "Probation Practicioner" }
+  },
+  "access-and-healthcare": {
+    "access-needs": {
+      "additionalNeeds": ["mobility", "learningDisability", "neurodivergentConditions"],
+      "religiousOrCulturalNeeds": "yes",
+      "religiousOrCulturalNeedsDetails": "sunt at minus",
+      "needsInterpreter": "yes",
+      "interpreterLanguage": "beatae eligendi explicabo",
+      "careActAssessmentCompleted": "yes"
+    },
+    "access-needs-mobility": {
+      "needsWheelchair": "yes",
+      "mobilityNeeds": "laboriosam",
+      "visualImpairment": "exercitationem"
+    },
+    "access-needs-additional-adjustments": { "adjustments": "yes", "adjustmentsDetail": "Some details here" },
+    "covid": { "fullyVaccinated": "yes", "highRisk": "yes", "additionalCovidInfo": "additional info" }
+  },
+  "further-considerations": {
+    "room-sharing": {
+      "riskToStaff": "no",
+      "riskToStaffDetail": "",
+      "riskToOthers": "no",
+      "riskToOthersDetail": "",
+      "sharingConcerns": "yes",
+      "sharingConcernsDetail": "Some details here",
+      "traumaConcerns": "no",
+      "traumaConcernsDetail": "",
+      "sharingBenefits": "no",
+      "sharingBenefitsDetail": ""
+    },
+    "vulnerability": {
+      "exploitable": "no",
+      "exploitableDetail": "",
+      "exploitOthers": "yes",
+      "exploitOthersDetail": "Some details here"
+    },
+    "previous-placements": { "previousPlacement": "yes", "previousPlacementDetail": "Some details here" },
+    "complex-case-board": { "complexCaseBoard": "yes", "complexCaseBoardDetail": "Some details here" },
+    "catering": { "catering": "yes", "cateringDetail": "Some details here" },
+    "arson": { "arson": "yes", "arsonDetail": "Some details here" }
+  },
+  "move-on": {
+    "placement-duration": { "duration": "10", "durationDetail": "Some more information" },
+    "relocation-region": { "postcodeArea": "XX1" },
+    "plans-in-place": { "arePlansInPlace": "yes" },
+    "type-of-accommodation": { "accommodationType": "foreignNational" },
+    "foreign-national": {
+      "response": "yes",
+      "date": "2015-01-01",
+      "date-year": "2015",
+      "date-month": "01",
+      "date-day": "01"
+    }
+  }
+}

--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -53,6 +53,18 @@ export default {
         transformers: ['response-template'],
       },
     }),
+  stubApplicationGet: (args: { application: Application }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/applications/${args.application.id}`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.application,
+      },
+    }),
   verifyApplicationUpdate: async (applicationId: string) =>
     (
       await getMatchingRequests({

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -16,6 +16,7 @@ import {
   CateringPage,
   ArsonPage,
   PlacementDurationPage,
+  ForeignNationalPage,
 } from '../../../cypress_shared/pages/apply'
 import ConvictedOffences from '../../../cypress_shared/pages/apply/convictedOffences'
 import DateOfOffence from '../../../cypress_shared/pages/apply/dateOfOffence'
@@ -37,7 +38,6 @@ import AccessNeedsAdditionalAdjustmentsPage from '../../../cypress_shared/pages/
 import RelocationRegionPage from '../../../cypress_shared/pages/apply/relocationRegion'
 import PlansInPlacePage from '../../../cypress_shared/pages/apply/plansInPlace'
 import TypeOfAccomodationPage from '../../../cypress_shared/pages/apply/typeOfAccommodation'
-import ForeignNationalPage from '../../../cypress_shared/pages/apply/foreignNational'
 
 context('Apply', () => {
   beforeEach(() => {
@@ -47,10 +47,6 @@ context('Apply', () => {
   })
 
   it('shows the details of a person from their CRN', () => {
-    const application = applicationFactory.build()
-    cy.task('stubApplicationCreate', { application })
-    cy.task('stubApplicationUpdate', { application })
-
     // Given I am logged in
     cy.signIn()
 
@@ -59,47 +55,52 @@ context('Apply', () => {
     cy.task('stubFindPerson', { person })
 
     // And I have started an application
-    const startPage = StartPage.visit()
-    startPage.startApplication()
+    cy.fixture('applicationData.json').then(applicationData => {
+      const application = applicationFactory.build({ person, data: applicationData })
+      cy.task('stubApplicationCreate', { application })
+      cy.task('stubApplicationUpdate', { application })
+      const startPage = StartPage.visit()
+      startPage.startApplication()
 
-    // When I enter a CRN
-    const crnPage = new EnterCRNPage()
-    crnPage.enterCrn(person.crn)
-    crnPage.clickSubmit()
+      // When I enter a CRN
+      const crnPage = new EnterCRNPage()
+      crnPage.enterCrn(person.crn)
+      crnPage.clickSubmit()
 
-    // Then I should see the person's detail
-    const confirmDetailsPage = new ConfirmDetailsPage(person)
-    confirmDetailsPage.verifyPersonIsVisible()
+      // Then I should see the person's detail
+      const confirmDetailsPage = new ConfirmDetailsPage(person)
+      confirmDetailsPage.verifyPersonIsVisible()
 
-    // When I click submit
-    confirmDetailsPage.clickSubmit()
+      // When I click submit
+      confirmDetailsPage.clickSubmit()
 
-    // Then I should be on the Sentence Type page
-    const sentenceTypePage = new SentenceTypePage()
+      // Then I should be on the Sentence Type page
+      const sentenceTypePage = new SentenceTypePage(application)
 
-    // When I select 'Bail Placement'
-    sentenceTypePage.checkRadioByNameAndValue('sentenceType', 'bailPlacement')
-    sentenceTypePage.clickSubmit()
+      // When I select 'Bail Placement'
+      sentenceTypePage.checkRadioByNameAndValue('sentenceType', 'bailPlacement')
+      sentenceTypePage.clickSubmit()
 
-    // Then I should be on the Situation Page
-    const situationPage = new SituationPage()
+      // Then I should be on the Situation Page
+      const situationPage = new SituationPage(application)
 
-    // When I select 'Bail Sentence'
-    situationPage.checkRadioByNameAndValue('situation', 'bailSentence')
-    situationPage.clickSubmit()
+      // When I select 'Bail Sentence'
+      situationPage.checkRadioByNameAndValue('situation', 'bailSentence')
+      situationPage.clickSubmit()
 
-    // Then I should be asked if I know the release date
-    Page.verifyOnPage(ReleaseDatePage, application.person)
+      // Then I should be asked if I know the release date
+      Page.verifyOnPage(ReleaseDatePage, application)
 
-    // And the API should have recieved the updated application
-    cy.task('verifyApplicationUpdate', application.id).then(requests => {
-      expect(requests).to.have.length(2)
+      // And the API should have recieved the updated application
+      cy.task('verifyApplicationUpdate', application.id).then(requests => {
+        expect(requests).to.have.length(2)
 
-      const firstRequestData = JSON.parse(requests[0].body).data
-      const secondRequestData = JSON.parse(requests[1].body).data
+        const firstRequestData = JSON.parse(requests[0].body).data
+        const secondRequestData = JSON.parse(requests[1].body).data
 
-      expect(firstRequestData['basic-information']['sentence-type'].sentenceType).equal('bailPlacement')
-      expect(secondRequestData['basic-information'].situation.situation).equal('bailSentence')
+        expect(firstRequestData['basic-information']['sentence-type'].sentenceType).equal('bailPlacement')
+        expect(secondRequestData['basic-information'].situation.situation).equal('bailSentence')
+      })
     })
   })
 
@@ -126,12 +127,8 @@ context('Apply', () => {
 
   it('allows completion of the form', () => {
     const person = personFactory.build()
-    const application = applicationFactory.build({ person })
     const apiRisks = risksFactory.build({ crn: person.crn })
     const uiRisks = mapApiPersonRisksForUi(apiRisks)
-
-    cy.task('stubApplicationCreate', { application })
-    cy.task('stubApplicationUpdate', { application })
 
     // Given I am logged in
     cy.signIn()
@@ -141,196 +138,210 @@ context('Apply', () => {
     cy.task('stubFindPerson', { person })
 
     // And I have started an application
-    const startPage = StartPage.visit()
-    startPage.startApplication()
+    cy.fixture('applicationData.json').then(applicationData => {
+      const application = applicationFactory.build({ person, data: applicationData })
 
-    // And I complete the first step
-    const crnPage = new EnterCRNPage()
-    crnPage.enterCrn(person.crn)
-    crnPage.clickSubmit()
+      cy.task('stubApplicationCreate', { application })
+      cy.task('stubApplicationUpdate', { application })
 
-    const confirmDetailsPage = new ConfirmDetailsPage(person)
-    confirmDetailsPage.clickSubmit()
+      const startPage = StartPage.visit()
+      startPage.startApplication()
 
-    const sentenceTypePage = new SentenceTypePage()
-    sentenceTypePage.checkRadioByNameAndValue('sentenceType', 'bailPlacement')
-    sentenceTypePage.clickSubmit()
+      // And I complete the first step
+      const crnPage = new EnterCRNPage()
+      crnPage.enterCrn(person.crn)
+      crnPage.clickSubmit()
 
-    const situationPage = new SituationPage()
-    situationPage.checkRadioByNameAndValue('situation', 'bailSentence')
-    situationPage.clickSubmit()
+      const confirmDetailsPage = new ConfirmDetailsPage(person)
+      confirmDetailsPage.clickSubmit()
 
-    const releaseDate = new Date().toISOString()
-    const releaseDatePage = new ReleaseDatePage(application.person)
-    releaseDatePage.checkRadioByNameAndValue('knowReleaseDate', 'yes')
-    releaseDatePage.completeDateInputs('releaseDate', releaseDate)
-    situationPage.clickSubmit()
+      const sentenceTypePage = new SentenceTypePage(application)
+      sentenceTypePage.completeForm()
+      sentenceTypePage.clickSubmit()
 
-    const placementStartPage = new PlacementStartPage(releaseDate)
-    placementStartPage.checkRadioByNameAndValue('startDateSameAsReleaseDate', 'yes')
-    placementStartPage.clickSubmit()
+      const situationPage = new SituationPage(application)
+      situationPage.completeForm()
+      situationPage.clickSubmit()
 
-    const placementPurposePage = new PlacementPurposePage()
-    placementPurposePage.completeForm()
-    placementPurposePage.clickSubmit()
+      const releaseDatePage = new ReleaseDatePage(application)
+      releaseDatePage.completeForm()
+      releaseDatePage.clickSubmit()
 
-    // Then I should be redirected to the task list
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+      const placementStartPage = new PlacementStartPage(application)
+      placementStartPage.completeForm()
+      placementStartPage.clickSubmit()
 
-    // And the task should be marked as completed
-    tasklistPage.shouldShowTaskStatus('basic-information', 'Completed')
+      const placementPurposePage = new PlacementPurposePage(application)
+      placementPurposePage.completeForm()
+      placementPurposePage.clickSubmit()
 
-    // And the next task should be marked as not started
-    tasklistPage.shouldShowTaskStatus('type-of-ap', 'Not started')
 
-    // And the risk widgets should be visible
-    tasklistPage.shouldShowRiskWidgets(uiRisks)
+      // Then I should be redirected to the task list
+      const tasklistPage = Page.verifyOnPage(TaskListPage)
 
-    // And I should be able to start the next task
-    cy.get('[data-cy-task-name="type-of-ap"]').click()
-    Page.verifyOnPage(TypeOfApPage, application.person)
+      // And the task should be marked as completed
+      tasklistPage.shouldShowTaskStatus('basic-information', 'Completed')
 
-    // Given I am on the Type of AP Page
-    const typeOfApPage = new TypeOfApPage(person)
+      // And the next task should be marked as not started
+      tasklistPage.shouldShowTaskStatus('type-of-ap', 'Not started')
 
-    // When I complete the form and click submit
-    typeOfApPage.completeForm()
-    typeOfApPage.clickSubmit()
+      // And the risk widgets should be visible
+      tasklistPage.shouldShowRiskWidgets(uiRisks)
 
-    // Then the Type of AP task should show as completed
-    tasklistPage.shouldShowTaskStatus('type-of-ap', 'Completed')
-    // And the Risk Management Features task should show as not started
-    tasklistPage.shouldShowTaskStatus('risk-management-features', 'Not started')
+      // And I should be able to start the next task
+      cy.get('[data-cy-task-name="type-of-ap"]').click()
+      Page.verifyOnPage(TypeOfApPage, application)
 
-    // Given I click the 'Add detail about managing risks and needs' task
-    cy.get('[data-cy-task-name="risk-management-features"]').click()
+      // Given I am on the Type of AP Page
+      const typeOfApPage = new TypeOfApPage(application)
 
-    // When I complete the form
-    const riskManagementFeaturesPage = new RiskManagementFeatures()
-    riskManagementFeaturesPage.completeForm()
-    riskManagementFeaturesPage.clickSubmit()
+      // When I complete the form and click submit
+      typeOfApPage.completeForm()
+      typeOfApPage.clickSubmit()
 
-    const convictedOffencesPage = new ConvictedOffences(person)
-    convictedOffencesPage.completeForm()
-    convictedOffencesPage.clickSubmit()
+      // Then the Type of AP task should show as completed
+      tasklistPage.shouldShowTaskStatus('type-of-ap', 'Completed')
+      // And the Risk Management Features task should show as not started
+      tasklistPage.shouldShowTaskStatus('risk-management-features', 'Not started')
 
-    const typeOfConvictedOffencePage = new TypeOfConvictedOffence(person)
-    typeOfConvictedOffencePage.completeForm()
-    typeOfConvictedOffencePage.clickSubmit()
+      // Given I click the 'Add detail about managing risks and needs' task
+      cy.get('[data-cy-task-name="risk-management-features"]').click()
 
-    const dateOfOffencePage = new DateOfOffence()
-    dateOfOffencePage.completeForm()
-    dateOfOffencePage.clickSubmit()
+      const typeOfApPages = [typeOfApPage]
 
-    const rehabilitativeInterventionsPage = new RehabilitativeInterventions()
-    rehabilitativeInterventionsPage.completeForm()
-    rehabilitativeInterventionsPage.clickSubmit()
+      // When I complete the form
+      const riskManagementFeaturesPage = new RiskManagementFeatures(application)
+      riskManagementFeaturesPage.completeForm()
+      riskManagementFeaturesPage.clickSubmit()
 
-    // Then I should be taken back to the task list
-    // And the risk management task should show a completed status
-    tasklistPage.shouldShowTaskStatus('risk-management-features', 'Completed')
+      const convictedOffencesPage = new ConvictedOffences(application)
+      convictedOffencesPage.completeForm()
+      convictedOffencesPage.clickSubmit()
 
-    // Given I click the 'Describe location factors' task
-    cy.get('[data-cy-task-name="location-factors"]').click()
+      const typeOfConvictedOffencePage = new TypeOfConvictedOffence(application)
+      typeOfConvictedOffencePage.completeForm()
+      typeOfConvictedOffencePage.clickSubmit()
 
-    // When I complete the form
-    const describeLocationFactorsPage = new DescribeLocationFactors()
-    describeLocationFactorsPage.completeForm()
-    describeLocationFactorsPage.clickSubmit()
+      const dateOfOffencePage = new DateOfOffence(application)
+      dateOfOffencePage.completeForm()
+      dateOfOffencePage.clickSubmit()
 
-    const pduTransferPage = new PduTransferPage(person)
-    pduTransferPage.completeForm()
-    pduTransferPage.clickSubmit()
+      const rehabilitativeInterventionsPage = new RehabilitativeInterventions(application)
+      rehabilitativeInterventionsPage.completeForm()
+      rehabilitativeInterventionsPage.clickSubmit()
 
-    // Then I should be taken back to the task list
-    // And the location factors task should show a completed status
-    tasklistPage.shouldShowTaskStatus('location-factors', 'Completed')
 
-    // Given I click the 'Provide access and healthcare information' task
-    cy.get('[data-cy-task-name="access-and-healthcare"]').click()
+      // Then I should be taken back to the task list
+      // And the risk management task should show a completed status
+      tasklistPage.shouldShowTaskStatus('risk-management-features', 'Completed')
 
-    // When I complete the form
-    const accessNeedsPage = new AccessNeedsPage()
-    accessNeedsPage.completeForm()
-    accessNeedsPage.clickSubmit()
+      // Given I click the 'Describe location factors' task
+      cy.get('[data-cy-task-name="location-factors"]').click()
 
-    const accessNeedsMobilityPage = new AccessNeedsMobilityPage(person)
-    accessNeedsMobilityPage.completeForm()
-    accessNeedsMobilityPage.clickSubmit()
+      // When I complete the form
+      const describeLocationFactorsPage = new DescribeLocationFactors(application)
+      describeLocationFactorsPage.completeForm()
+      describeLocationFactorsPage.clickSubmit()
 
-    const accessNeedsAdditionalAdjustmentsPage = new AccessNeedsAdditionalAdjustmentsPage()
-    accessNeedsAdditionalAdjustmentsPage.completeForm()
-    accessNeedsAdditionalAdjustmentsPage.clickSubmit()
+      const pduTransferPage = new PduTransferPage(application)
+      pduTransferPage.completeForm()
+      pduTransferPage.clickSubmit()
 
-    const covidPage = new CovidPage()
-    covidPage.completeForm()
-    covidPage.clickSubmit()
+      const locationFactorsPages = [describeLocationFactorsPage, pduTransferPage]
 
-    Page.verifyOnPage(TaskListPage)
+      // Then I should be taken back to the task list
+      // And the location factors task should show a completed status
+      tasklistPage.shouldShowTaskStatus('location-factors', 'Completed')
 
-    // Given I click the 'Detail further considerations for placement' task
-    cy.get('[data-cy-task-name="further-considerations"]').click()
+      // Given I click the 'Provide access and healthcare information' task
+      cy.get('[data-cy-task-name="access-and-healthcare"]').click()
 
-    // And I complete the Room Sharing page
-    const roomSharingPage = new RoomSharingPage()
-    roomSharingPage.completeForm()
-    roomSharingPage.clickSubmit()
+      // When I complete the form
+      const accessNeedsPage = new AccessNeedsPage(application)
+      accessNeedsPage.completeForm()
+      accessNeedsPage.clickSubmit()
 
-    // And I complete the Vulnerability page
-    const vulnerabilityPage = new VulnerabilityPage(person)
-    vulnerabilityPage.completeForm()
-    vulnerabilityPage.clickSubmit()
+      const accessNeedsMobilityPage = new AccessNeedsMobilityPage(application)
+      accessNeedsMobilityPage.completeForm()
+      accessNeedsMobilityPage.clickSubmit()
 
-    // And I complete the Previous Placements page
-    const previousPlacementsPage = new PreviousPlacements(person)
-    previousPlacementsPage.completeForm()
-    previousPlacementsPage.clickSubmit()
+      const accessNeedsAdditionalAdjustmentsPage = new AccessNeedsAdditionalAdjustmentsPage(application)
+      accessNeedsAdditionalAdjustmentsPage.completeForm()
+      accessNeedsAdditionalAdjustmentsPage.clickSubmit()
 
-    // And I complete the Complex Case Board page
-    const complexCaseBoardPage = new ComplexCaseBoard(person)
-    complexCaseBoardPage.completeForm()
-    complexCaseBoardPage.clickSubmit()
+      const covidPage = new CovidPage(application)
+      covidPage.completeForm()
+      covidPage.clickSubmit()
 
-    // And I complete the Catering page
-    const cateringPage = new CateringPage(person)
-    cateringPage.completeForm()
-    cateringPage.clickSubmit()
+      Page.verifyOnPage(TaskListPage)
 
-    // And I complete the Arson page
-    const arsonPage = new ArsonPage(person)
-    arsonPage.completeForm()
-    arsonPage.clickSubmit()
+      // Given I click the 'Detail further considerations for placement' task
+      cy.get('[data-cy-task-name="further-considerations"]').click()
 
-    // Then I should be taken back to the task list
-    // And the further considerations task should show a completed status
-    tasklistPage.shouldShowTaskStatus('further-considerations', 'Completed')
+      // And I complete the Room Sharing page
+      const roomSharingPage = new RoomSharingPage(application)
+      roomSharingPage.completeForm()
+      roomSharingPage.clickSubmit()
 
-    // Given I click the 'Add move on information' task
-    cy.get('[data-cy-task-name="move-on"]').click()
+      // And I complete the Vulnerability page
+      const vulnerabilityPage = new VulnerabilityPage(application)
+      vulnerabilityPage.completeForm()
+      vulnerabilityPage.clickSubmit()
 
-    const placementDurationPage = new PlacementDurationPage()
-    placementDurationPage.completeForm()
-    placementDurationPage.expectedDepartureDateShouldBeCompleted(releaseDate)
-    placementDurationPage.clickSubmit()
+      // And I complete the Previous Placements page
+      const previousPlacementsPage = new PreviousPlacements(application)
+      previousPlacementsPage.completeForm()
+      previousPlacementsPage.clickSubmit()
 
-    const relocationRegion = new RelocationRegionPage(person)
-    relocationRegion.completeForm()
-    relocationRegion.clickSubmit()
+      // And I complete the Complex Case Board page
+      const complexCaseBoardPage = new ComplexCaseBoard(application)
+      complexCaseBoardPage.completeForm()
+      complexCaseBoardPage.clickSubmit()
 
-    const plansInPlacePage = new PlansInPlacePage()
-    plansInPlacePage.completeForm()
-    plansInPlacePage.clickSubmit()
+      // And I complete the Catering page
+      const cateringPage = new CateringPage(application)
+      cateringPage.completeForm()
+      cateringPage.clickSubmit()
 
-    const typeOfAccommodationPage = new TypeOfAccomodationPage(person)
-    typeOfAccommodationPage.completeForm()
-    typeOfAccommodationPage.clickSubmit()
+      // And I complete the Arson page
+      const arsonPage = new ArsonPage(application)
+      arsonPage.completeForm()
+      arsonPage.clickSubmit()
 
-    const foreignNationalPage = new ForeignNationalPage()
-    foreignNationalPage.completeForm()
-    foreignNationalPage.clickSubmit()
+      // Then I should be taken back to the task list
+      // And the further considerations task should show a completed status
+      tasklistPage.shouldShowTaskStatus('further-considerations', 'Completed')
 
-    // Then I should be taken back to the task list
-    // And the move on information task should show a completed status
-    tasklistPage.shouldShowTaskStatus('move-on', 'Completed')
+      // Given I click the 'Add move on information' task
+      cy.get('[data-cy-task-name="move-on"]').click()
+
+      // And I complete the Placement Duration page
+      const placementDurationPage = new PlacementDurationPage(application)
+      placementDurationPage.completeForm()
+      placementDurationPage.clickSubmit()
+
+      // And I complete the relocation region page
+      const relocationRegion = new RelocationRegionPage(application)
+      relocationRegion.completeForm()
+      relocationRegion.clickSubmit()
+
+      // And I complete the plans in place page
+      const plansInPlacePage = new PlansInPlacePage(application)
+      plansInPlacePage.completeForm()
+      plansInPlacePage.clickSubmit()
+
+      // And I complete the type of accommodation page
+      const typeOfAccommodationPage = new TypeOfAccomodationPage(application)
+      typeOfAccommodationPage.completeForm()
+      typeOfAccommodationPage.clickSubmit()
+
+      const foreignNationalPage = new ForeignNationalPage(application)
+      foreignNationalPage.completeForm()
+      foreignNationalPage.clickSubmit()
+
+      // Then I should be taken back to the task list
+      // And the move on information task should show a completed status
+      tasklistPage.shouldShowTaskStatus('move-on', 'Completed')
+    })
   })
 })

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -17,6 +17,7 @@ import {
   ArsonPage,
   PlacementDurationPage,
   ForeignNationalPage,
+  CheckYourAnswersPage,
 } from '../../../cypress_shared/pages/apply'
 import ConvictedOffences from '../../../cypress_shared/pages/apply/convictedOffences'
 import DateOfOffence from '../../../cypress_shared/pages/apply/dateOfOffence'
@@ -143,6 +144,7 @@ context('Apply', () => {
 
       cy.task('stubApplicationCreate', { application })
       cy.task('stubApplicationUpdate', { application })
+      cy.task('stubApplicationGet', { application })
 
       const startPage = StartPage.visit()
       startPage.startApplication()
@@ -175,6 +177,7 @@ context('Apply', () => {
       placementPurposePage.completeForm()
       placementPurposePage.clickSubmit()
 
+      const basicInformationPages = [sentenceTypePage, releaseDatePage, placementStartPage, placementPurposePage]
 
       // Then I should be redirected to the task list
       const tasklistPage = Page.verifyOnPage(TaskListPage)
@@ -230,6 +233,13 @@ context('Apply', () => {
       rehabilitativeInterventionsPage.completeForm()
       rehabilitativeInterventionsPage.clickSubmit()
 
+      const riskManagementPages = [
+        riskManagementFeaturesPage,
+        convictedOffencesPage,
+        typeOfConvictedOffencePage,
+        dateOfOffencePage,
+        rehabilitativeInterventionsPage,
+      ]
 
       // Then I should be taken back to the task list
       // And the risk management task should show a completed status
@@ -273,6 +283,13 @@ context('Apply', () => {
       covidPage.completeForm()
       covidPage.clickSubmit()
 
+      const accessAndHealthcarePages = [
+        accessNeedsPage,
+        accessNeedsMobilityPage,
+        accessNeedsAdditionalAdjustmentsPage,
+        covidPage,
+      ]
+
       Page.verifyOnPage(TaskListPage)
 
       // Given I click the 'Detail further considerations for placement' task
@@ -308,6 +325,15 @@ context('Apply', () => {
       arsonPage.completeForm()
       arsonPage.clickSubmit()
 
+      const furtherConsiderationsPages = [
+        roomSharingPage,
+        vulnerabilityPage,
+        previousPlacementsPage,
+        complexCaseBoardPage,
+        cateringPage,
+        arsonPage,
+      ]
+
       // Then I should be taken back to the task list
       // And the further considerations task should show a completed status
       tasklistPage.shouldShowTaskStatus('further-considerations', 'Completed')
@@ -339,9 +365,33 @@ context('Apply', () => {
       foreignNationalPage.completeForm()
       foreignNationalPage.clickSubmit()
 
+      const moveOnPages = [
+        placementDurationPage,
+        relocationRegion,
+        plansInPlacePage,
+        typeOfAccommodationPage,
+        foreignNationalPage,
+      ]
+
       // Then I should be taken back to the task list
       // And the move on information task should show a completed status
       tasklistPage.shouldShowTaskStatus('move-on', 'Completed')
+
+      // Given I click the check your answers task
+      cy.get('[data-cy-task-name="check-your-answers"]').click()
+
+      // Then I should be on the check your answers page
+      const checkYourAnswersPage = new CheckYourAnswersPage()
+
+      // And the page should be populated with my answers
+      checkYourAnswersPage.shouldShowPersonInformation(person)
+      checkYourAnswersPage.shouldShowBasicInformationAnswers(basicInformationPages)
+      checkYourAnswersPage.shouldShowTypeOfApAnswers(typeOfApPages)
+      checkYourAnswersPage.shouldShowRiskManagementAnswers(riskManagementPages)
+      checkYourAnswersPage.shouldShowLocationFactorsAnswers(locationFactorsPages)
+      checkYourAnswersPage.shouldShowAccessAndHealthcareAnswers(accessAndHealthcarePages)
+      checkYourAnswersPage.shouldShowFurtherConsiderationsAnswers(furtherConsiderationsPages)
+      checkYourAnswersPage.shouldShowMoveOnAnswers(moveOnPages)
     })
   })
 })

--- a/server/controllers/apply/applications/checkYourAnswersController.test.ts
+++ b/server/controllers/apply/applications/checkYourAnswersController.test.ts
@@ -1,0 +1,55 @@
+import type { Request, Response, NextFunction } from 'express'
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+import type { SummaryListItem } from '@approved-premises/ui'
+
+import CheckYourAnswersController from './checkYourAnswersController'
+import { ApplicationService } from '../../../services'
+import { sections } from '../../../form-pages/apply'
+
+import applicationFactory from '../../../testutils/factories/application'
+
+jest.mock('../../../utils/validation')
+
+describe('checkYourAnswersController', () => {
+  const request: DeepMocked<Request> = createMock<Request>({})
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = jest.fn()
+
+  const applicationService = createMock<ApplicationService>({})
+
+  let checkYourAnswersController: CheckYourAnswersController
+
+  beforeEach(() => {
+    checkYourAnswersController = new CheckYourAnswersController(applicationService)
+  })
+
+  describe('show', () => {
+    const application = applicationFactory.build({})
+    const summaryListItems = createMock<Record<string, Array<SummaryListItem>>>()
+
+    beforeEach(() => {
+      request.params = {
+        id: 'some-uuid',
+      }
+
+      applicationService.findApplication.mockResolvedValue(application)
+      applicationService.getResponsesAsSummaryListItems.mockReturnValue(summaryListItems)
+    })
+
+    it('renders the check your answers page with the responses', async () => {
+      const requestHandler = checkYourAnswersController.show()
+
+      await requestHandler(request, response, next)
+
+      expect(applicationService.findApplication).toHaveBeenCalledWith(request.user.token, 'some-uuid')
+      expect(applicationService.getResponsesAsSummaryListItems).toHaveBeenCalledWith(application)
+
+      expect(response.render).toHaveBeenCalledWith(`applications/check-your-answers`, {
+        pageHeading: 'Check your answers',
+        sections,
+        application,
+        summaryListItems,
+      })
+    })
+  })
+})

--- a/server/controllers/apply/applications/checkYourAnswersController.ts
+++ b/server/controllers/apply/applications/checkYourAnswersController.ts
@@ -1,0 +1,22 @@
+import type { Request, Response, RequestHandler } from 'express'
+
+import { ApplicationService } from '../../../services'
+import { sections } from '../../../form-pages/apply'
+
+export default class CheckYourAnswers {
+  constructor(private readonly applicationService: ApplicationService) {}
+
+  show(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const application = await this.applicationService.findApplication(req.user.token, req.params.id)
+      const responses = this.applicationService.getResponsesAsSummaryListItems(application)
+
+      res.render('applications/check-your-answers', {
+        pageHeading: 'Check your answers',
+        sections,
+        application,
+        responses,
+      })
+    }
+  }
+}

--- a/server/controllers/apply/index.ts
+++ b/server/controllers/apply/index.ts
@@ -2,6 +2,7 @@
 
 import ApplicationsController from './applicationsController'
 import PagesController from './applications/pagesController'
+import CheckYourAnswersController from './applications/checkYourAnswersController'
 
 import type { Services } from '../../services'
 
@@ -9,10 +10,12 @@ export const controllers = (services: Services) => {
   const { applicationService, personService } = services
   const applicationsController = new ApplicationsController(applicationService, personService)
   const pagesController = new PagesController(applicationService, { personService })
+  const checkYourAnswersController = new CheckYourAnswersController(applicationService)
 
   return {
     applicationsController,
     pagesController,
+    checkYourAnswersController,
   }
 }
 

--- a/server/paths/apply.ts
+++ b/server/paths/apply.ts
@@ -14,6 +14,7 @@ const paths = {
     index: applicationsPath,
     show: applicationPath,
     update: applicationPath,
+    checkYourAnswers: applicationPath.path('check-your-answers'),
     pages: {
       show: pagesPath,
       update: pagesPath,

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -9,12 +9,13 @@ import actions from './utils'
 
 export default function routes(controllers: Controllers, router: Router): Router {
   const { get, post, put } = actions(router)
-  const { applicationsController, pagesController, peopleController } = controllers
+  const { applicationsController, pagesController, peopleController, checkYourAnswersController } = controllers
 
   get(paths.applications.start.pattern, applicationsController.start())
   get(paths.applications.index.pattern, applicationsController.index())
   get(paths.applications.new.pattern, applicationsController.new())
   get(paths.applications.show.pattern, applicationsController.show())
+  get(paths.applications.checkYourAnswers.pattern, checkYourAnswersController.show())
   post(paths.applications.create.pattern, applicationsController.create())
   post(paths.applications.people.pattern, peopleController.find())
 

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -326,4 +326,54 @@ describe('ApplicationService', () => {
       expect(service.getResponses(application)).toEqual({ 'my-task': [{ foo: 'bar' }, { bar: 'foo' }] })
     })
   })
+
+  describe('getResponsesAsSummaryListItems', () => {
+    it('returns the responses from all answered questions as summaryList items', () => {
+      FirstPage.mockReturnValue({
+        response: () => {
+          return { foo: 'bar' }
+        },
+      })
+
+      SecondPage.mockReturnValue({
+        response: () => {
+          return { bar: 'foo' }
+        },
+      })
+
+      const application = applicationFactory.build()
+      application.data = { 'my-task': { first: '', second: '' } }
+
+      expect(service.getResponsesAsSummaryListItems(application)).toEqual({
+        'my-task': [
+          {
+            key: { text: 'foo' },
+            value: { text: 'bar' },
+            actions: {
+              items: [
+                {
+                  href: paths.applications.pages.show({ task: 'my-task', page: 'first', id: application.id }),
+                  text: 'Change',
+                  visuallyHiddenText: 'foo',
+                },
+              ],
+            },
+          },
+          {
+            key: { text: 'bar' },
+            value: { text: 'foo' },
+            actions: {
+              items: [
+                {
+                  href: paths.applications.pages.show({ task: 'my-task', page: 'second', id: application.id }),
+                  text: 'Change',
+                  visuallyHiddenText: 'bar',
+                },
+              ],
+            },
+          },
+        ],
+      })
+    })
+  })
 })

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -1,5 +1,5 @@
 import type { Request } from 'express'
-import type { HtmlItem, TextItem, DataServices } from '@approved-premises/ui'
+import type { HtmlItem, TextItem, DataServices, SummaryListItem } from '@approved-premises/ui'
 import type { Application } from '@approved-premises/api'
 
 import type TasklistPage from '../form-pages/tasklistPage'
@@ -61,6 +61,43 @@ export default class ApplicationService {
 
     Object.keys(application.data).forEach(taskName => {
       responses[taskName] = this.getResponsesForTask(application, taskName)
+    })
+
+    return responses
+  }
+
+  getResponsesAsSummaryListItems(application: Application): Record<string, Array<SummaryListItem>> {
+    const responses = {}
+
+    Object.keys(pages).forEach(taskName => {
+      const pageNames = Object.keys(application.data[taskName])
+      const items: Array<SummaryListItem> = []
+
+      pageNames.forEach(pageName => {
+        const response = this.getResponseForPage(application, taskName, pageName)
+
+        Object.keys(response).forEach(key => {
+          items.push({
+            key: {
+              text: key,
+            },
+            value: {
+              text: response[key],
+            },
+            actions: {
+              items: [
+                {
+                  href: paths.applications.pages.show({ task: taskName, page: pageName, id: application.id }),
+                  text: 'Change',
+                  visuallyHiddenText: key,
+                },
+              ],
+            },
+          })
+        })
+      })
+
+      responses[taskName] = items
     })
 
     return responses

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -58,7 +58,9 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
 
   njkEnv.addFilter('initialiseName', initialiseName)
   njkEnv.addGlobal('dateFieldValues', dateFieldValues)
-  njkEnv.addGlobal('formatDate', DateFormats.isoDateToUIDate)
+  njkEnv.addGlobal('formatDate', (date: string, options: { format: 'short' | 'long' } = { format: 'long' }) =>
+    DateFormats.isoDateToUIDate(date, options),
+  )
 
   njkEnv.addGlobal('dateFieldValues', function sendContextToDateFieldValues(fieldName: string, errors: ErrorMessages) {
     return dateFieldValues(fieldName, this.ctx, errors)

--- a/server/views/applications/check-your-answers.njk
+++ b/server/views/applications/check-your-answers.njk
@@ -1,0 +1,133 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+  {{ govukBackLink({
+      text: "Back",
+      href: paths.applications.show({ id: application.id })
+  }) }}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-width-container">
+      <h1 class="govuk-heading-xl">
+        {{ pageHeading }}
+      </h1>
+
+      <div class="main-box">
+        <div class="box-title govuk-heading-m">
+          Person Details
+        </div>
+        <div class="box-content" data-cy-check-your-answers-section="person-details">
+          {{ govukSummaryList({
+          rows: ([
+            {
+              key: {
+                text: "Names"
+              },
+              value: {
+                text: application.person.name
+              }
+            },
+            {
+              key: {
+                text: "CRN"
+              },
+              value: {
+                text: application.person.crn
+              }
+            },
+            {
+              key: {
+                text: "Date of Birth"
+              },
+              value: {
+                text: formatDate(application.person.dateOfBirth, { format: 'short' })
+              }
+            },
+            {
+              key: {
+                text: "NOMS Number"
+              },
+              value: {
+                text: application.person.nomsNumber
+              }
+            },
+            {
+              key: {
+                text: "Nationality"
+              },
+              value: {
+                text: application.person.nationality
+              }
+            },
+            {
+              key: {
+                text: "Religion or Belief"
+              },
+              value: {
+                text: application.person.religionOrBelief
+              }
+            },
+            {
+              key: {
+                text: "Sex"
+              },
+              value: {
+                text: application.person.sex
+              }
+            },
+            {
+              key: {
+                text: "Gender Identity"
+              },
+              value: {
+                text: application.person.genderIdentity
+              }
+            },
+            {
+              key: {
+                text: "Status"
+              },
+              value: {
+                html: statusTag(application.person.status)
+              }
+            },
+            {
+              key: {
+                text: "Prison"
+              },
+              value: {
+                text: application.person.prisonName
+              }
+            }
+          ])
+        }) }}
+        </div>
+      </div>
+
+      {% for section in sections %}
+        <h2 class="govuk-heading-l">{{ section.title }}</h2>
+        {% for task in section.tasks %}
+          <div class="main-box">
+            <div class="box-title govuk-heading-m">
+              {{ task.title }}
+            </div>
+            <div class="box-content" data-cy-check-your-answers-section="{{ task.id }}">
+              {{
+                govukSummaryList({
+                  rows: responses[task.id]
+                })
+              }}
+            </div>
+          </div>
+        {% endfor %}
+      {% endfor %}
+
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -48,6 +48,26 @@
             <span class="app-task-list__section-number">
               {{ (sections | length) + 1 }}.
             </span>
+            Check your answers
+          </h2>
+
+          <ul class="app-task-list__items">
+            <li class="app-task-list__item">
+              <span class="app-task-list__task-name">
+                <a href="{{ paths.applications.checkYourAnswers({id: application.id }) }}" data-cy-task-name="check-your-answers">
+                  Check your answers
+                </a>
+              </span>
+              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="submit-pay-status">Cannot start yet</strong>
+            </li>
+          </ul>
+        </li>
+
+        <li>
+          <h2 class="app-task-list__section">
+            <span class="app-task-list__section-number">
+              {{ (sections | length) + 2 }}.
+            </span>
             Submit your application
           </h2>
 


### PR DESCRIPTION
This adds a Check Your Answers Screen to the application and links to it from the task list. This has required a bit of jiggery pokery with the integration tests, so now each integration test Page object has a reference to the TasklistPage Class it's associated with (so, the `CateringPage` has a reference to the `Catering`). This allows us to keep a reference to all the questions that have been answered, as well as the translation, allowing us to assert that the Check Your Answers Page contains references to all the questions that have been answered.

The next jobs are to:

- Ensure that a user can't access CYA until they've answered all the questions
- Add a `Continue` button to the CYA page
- Only allow the form to be submitted when the CYA page has been completed

In the interests of keeping this PR (relatively) lightweight, this will come next

### Screenshots

![image](https://user-images.githubusercontent.com/109774/201903054-d0399ef7-e24a-4de8-be26-fb12f3b3ad97.png)

![image](https://user-images.githubusercontent.com/109774/201903109-a3160287-3d42-47bc-a72c-0553bd0b1fcb.png)
