### PR TITLE
Fix placement purpose

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -15,7 +15,7 @@
       "startDate-day": "",
       "startDateSameAsReleaseDate": "yes"
     },
-    "placement-purpose": { "placementPurposes": ["drugAlcoholSupport", "otherReason"], "otherReason": "Reason" }
+    "placement-purpose": { "placementPurposes": ["drugAlcoholMonitoring", "otherReason"], "otherReason": "Reason" }
   },
   "type-of-ap": { "ap-type": { "type": "standard" } },
   "risk-management-features": {

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -74,11 +74,15 @@ export interface RadioItem {
   checked?: boolean
 }
 
-export interface CheckBoxItem {
-  text: string
-  value: string
-  checked?: boolean
-}
+export type CheckBoxItem =
+  | {
+      text: string
+      value: string
+      checked?: boolean
+    }
+  | CheckBoxDivider
+
+export type CheckBoxDivider = { divider: string }
 
 export interface SelectOption {
   text: string

--- a/server/form-pages/apply/basic-information/placementPurpose.test.ts
+++ b/server/form-pages/apply/basic-information/placementPurpose.test.ts
@@ -2,10 +2,7 @@ import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-e
 
 import applicationFactory from '../../../testutils/factories/application'
 
-import PlacementPurpose, { placementPurposes } from './placementPurpose'
-import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
-
-jest.mock('../../../utils/formUtils')
+import PlacementPurpose from './placementPurpose'
 
 describe('PlacementPurpose', () => {
   const application = applicationFactory.build()
@@ -79,14 +76,6 @@ describe('PlacementPurpose', () => {
     })
   })
 
-  describe('calls convertKeyValuePairToCheckBoxItems', () => {
-    it('should return an empty object if the placement purpose is specified as a reason other than "Other reason"', () => {
-      const page = new PlacementPurpose({ placementPurposes: ['publicProtection'] }, application, 'somePage')
-      page.items()
-      expect(convertKeyValuePairToCheckBoxItems).toHaveBeenCalledWith(placementPurposes, ['publicProtection'])
-    })
-  })
-
   it('should return an error if the reason is not populated', () => {
     const page = new PlacementPurpose({}, application, 'somePage')
     expect(page.errors()).toEqual({ placementPurposes: 'You must choose at least one placement purpose' })
@@ -103,11 +92,24 @@ describe('PlacementPurpose', () => {
   })
 
   describe('items', () => {
-    it('it calls convertKeyValuePairToRadioItems', () => {
+    it('it returns radio buttons with a divider and conditional HTML for the `other` option', () => {
       const page = new PlacementPurpose({}, application, 'somePage')
-      page.items()
+      const items = page.items('<strong>Some HTML</strong>')
 
-      expect(convertKeyValuePairToCheckBoxItems).toHaveBeenCalled()
+      expect(items).toEqual([
+        { checked: false, text: 'Public protection', value: 'publicProtection' },
+        { checked: false, text: 'Prevent Contact', value: 'preventContact' },
+        { checked: false, text: 'Help individual readjust to life outside custody', value: 'readjust' },
+        { checked: false, text: 'Provide drug or alcohol monitoring', value: 'drugAlcoholMonitoring' },
+        { checked: false, text: 'Prevent self harm or suicide', value: 'preventSelfHarm' },
+        { divider: 'or' },
+        {
+          checked: false,
+          conditional: { html: '<strong>Some HTML</strong>' },
+          text: 'Other (please specify)',
+          value: 'otherReason',
+        },
+      ])
     })
   })
 })

--- a/server/form-pages/apply/basic-information/placementPurpose.test.ts
+++ b/server/form-pages/apply/basic-information/placementPurpose.test.ts
@@ -51,6 +51,22 @@ describe('PlacementPurpose', () => {
         placementPurposes: ['publicProtection'],
       })
     })
+
+    it('should apply `otherReason` to the body when `otherReason` is the only `placementPurposes` option', () => {
+      const page = new PlacementPurpose(
+        {
+          placementPurposes: 'otherReason',
+          otherReason: 'Another reason',
+        },
+        application,
+        'previousPage',
+      )
+
+      expect(page.body).toEqual({
+        placementPurposes: ['otherReason'],
+        otherReason: 'Another reason',
+      })
+    })
   })
 
   describe('when knowReleaseDate is set to yes', () => {

--- a/server/form-pages/apply/basic-information/placementPurpose.test.ts
+++ b/server/form-pages/apply/basic-information/placementPurpose.test.ts
@@ -98,11 +98,40 @@ describe('PlacementPurpose', () => {
   })
 
   describe('response', () => {
-    it('should return a translated version of the response when the user does not know the release date', () => {
-      const page = new PlacementPurpose({ placementPurposes: ['drugAlcoholMonitoring'] }, application, 'somePage')
+    it('should return a translated version of the placement purposes', () => {
+      const page = new PlacementPurpose(
+        {
+          placementPurposes: [
+            'publicProtection',
+            'preventContact',
+            'readjust',
+            'drugAlcoholMonitoring',
+            'preventSelfHarm',
+          ],
+        },
+        application,
+        'somePage',
+      )
 
       expect(page.response()).toEqual({
-        [page.title]: 'Provide drug or alcohol monitoring',
+        [page.title]:
+          'Public protection, Prevent Contact, Help individual readjust to life outside custody, Provide drug or alcohol monitoring, Prevent self harm or suicide',
+      })
+    })
+
+    it('should include an other reason if one is present', () => {
+      const page = new PlacementPurpose(
+        {
+          placementPurposes: ['drugAlcoholMonitoring', 'otherReason'],
+          otherReason: 'Another reason',
+        },
+        application,
+        'somePage',
+      )
+
+      expect(page.response()).toEqual({
+        [page.title]: 'Provide drug or alcohol monitoring, Other (please specify)',
+        'Other purpose for AP Placement': 'Another reason',
       })
     })
   })

--- a/server/form-pages/apply/basic-information/placementPurpose.ts
+++ b/server/form-pages/apply/basic-information/placementPurpose.ts
@@ -93,6 +93,12 @@ export default class PlacementPurpose implements TasklistPage {
   }
 
   response() {
-    return { [this.title]: this.body.placementPurposes.map(purpose => placementPurposes[purpose]).join(', ') }
+    const response = { [this.title]: this.body.placementPurposes.map(purpose => placementPurposes[purpose]).join(', ') }
+
+    if (this.body.otherReason) {
+      response['Other purpose for AP Placement'] = this.body.otherReason
+    }
+
+    return response
   }
 }

--- a/server/form-pages/apply/basic-information/placementPurpose.ts
+++ b/server/form-pages/apply/basic-information/placementPurpose.ts
@@ -14,30 +14,28 @@ export const placementPurposes = {
 } as const
 
 type PlacementPurposeT = keyof typeof placementPurposes
+type PlacementPurposeBody = { placementPurposes: Array<PlacementPurposeT>; otherReason?: string }
 
 export default class PlacementPurpose implements TasklistPage {
   name = 'placement-purpose'
 
   title = `What is the purpose of the AP placement?`
 
-  body: { placementPurposes: Array<PlacementPurposeT>; otherReason?: string } | Record<string, never>
+  body: PlacementPurposeBody
 
   purposes = placementPurposes
 
   previousPage: string
 
   constructor(body: Record<string, unknown>, private readonly _application: Application, previousPage: string) {
-    const placementPurposesResponse = body?.placementPurposes
+    this.body = {} as PlacementPurposeBody
+
+    this.body.placementPurposes = body?.placementPurposes
       ? ([body.placementPurposes].flat() as Array<PlacementPurposeT>)
       : []
 
-    if (this.responseNeedsFreeTextReason(body)) {
-      this.body = {
-        placementPurposes: placementPurposesResponse,
-        otherReason: body.otherReason as string,
-      }
-    } else {
-      this.body = { placementPurposes: placementPurposesResponse }
+    if (this.responseNeedsFreeTextReason(this.body)) {
+      this.body.otherReason = body.otherReason as string
     }
 
     this.previousPage = previousPage
@@ -65,7 +63,9 @@ export default class PlacementPurpose implements TasklistPage {
     return errors
   }
 
-  private responseContainsReasons(body: Record<string, unknown>): body is { placementPurposes: Array<unknown> } {
+  private responseContainsReasons(
+    body: Record<string, unknown>,
+  ): body is { placementPurposes: Array<PlacementPurposeT> } {
     if (body?.placementPurposes && Array.isArray(body.placementPurposes) && body.placementPurposes.length) {
       return true
     }

--- a/server/form-pages/apply/basic-information/placementPurpose.ts
+++ b/server/form-pages/apply/basic-information/placementPurpose.ts
@@ -9,7 +9,7 @@ export const placementPurposes = {
   preventContact: 'Prevent Contact',
   readjust: 'Help individual readjust to life outside custody',
   drugAlcoholMonitoring: 'Provide drug or alcohol monitoring',
-  preventSelfHalf: 'Prevent self harm or suicide',
+  preventSelfHarm: 'Prevent self harm or suicide',
   otherReason: 'Other (please specify)',
 } as const
 
@@ -81,8 +81,15 @@ export default class PlacementPurpose implements TasklistPage {
     return false
   }
 
-  items() {
-    return convertKeyValuePairToCheckBoxItems(placementPurposes, this.body?.placementPurposes)
+  items(conditionalHtml: string) {
+    const items = convertKeyValuePairToCheckBoxItems(placementPurposes, this.body?.placementPurposes)
+    const other = items.pop()
+
+    items.push({
+      divider: 'or',
+    })
+
+    return [...items, { ...other, conditional: { html: conditionalHtml } }]
   }
 
   response() {

--- a/server/views/applications/pages/basic-information/placement-purpose.njk
+++ b/server/views/applications/pages/basic-information/placement-purpose.njk
@@ -26,34 +26,7 @@
         hint: {
           text: "Select all that apply."
         },
-        items: [
-          {
-            value: "publicProtection",
-            text: "Public protection"
-          },
-          {
-            value: "resettlement",
-            text: "Support resettlement into the community"
-          },
-          {
-            value: "drugAlcoholSupport",
-            text: "Enhanced drug or alcohol support"
-          },
-          {
-            value: "risktoSelff",
-            text: "Support the management of risk to self"
-          },
-          {
-            divider: "or"
-          },
-          {
-            value: "otherReason",
-            text: "Other",
-            conditional: {
-              html: otherReason
-            }
-          }
-        ]
+        items: page.items(otherReason)
       },
       fetchContext()
     )


### PR DESCRIPTION
There were a couple of issues with the Placement Purpose screen with translations not returning properly, as well as errors showing when `other` was the only option provided.