### PR TITLE
Generate types and open a PR when API specification changes

### DIFF
--- a/.github/workflows/generate-types.yml
+++ b/.github/workflows/generate-types.yml
@@ -9,9 +9,18 @@ env:
   API_CLIENT_SECRET: clientsecret
 
 jobs:
-  test:
+  generate-types:
     runs-on: ubuntu-latest
-
     steps:
-      - name: TODO
-        run: echo "TODO - Generate types and open a PR"
+      - name: Generate Types
+        run: ./script/generate-types
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.OPEN_PR_ACCESS_TOKEN }}
+          title: 'API model updates'
+          commit-message: 'Updating hmpps-approved-premises-api models from OpenAPI specification'
+          body: 'Updating hmpps-approved-premises-api models from OpenAPI specification.  This PR was created automatically from the generate-types.yml Workflow'
+          delete-branch: true
+          branch-suffix: timestamp
+          branch: update-api-types

--- a/doc/how-to/replace_type_generation_pr_token.md
+++ b/doc/how-to/replace_type_generation_pr_token.md
@@ -1,0 +1,24 @@
+# Replace Type Generation PR Token
+
+The `Generate Types` Workflow is triggered by `hmpps-approved-premises-api` whenever its OpenAPI specification file changes.
+
+The default `GITHUB_TOKEN` token that Actions run with cannot create pull requests that run subsequent 
+Workflows (i.e. tests will not run on PRs created with it.)  We therefore need to provide a GitHub Personal Access Token (PAT)
+as a repository secret.  These expire so need to be changed every 90 days.
+
+1. Go to https://github.com/settings/personal-access-tokens/new
+2. Name the token, e.g. `Open PR for updated OpenAPI types`
+3. Set 90 day expiration
+4. Select `ministryofjustice` as the Resource Owner
+5. Enter the following as the justification:
+   ```
+   To create a Pull Request where the test suite will run against updated TS models when the OpenAPI specification changes in `hmpps-approved-premises-api`
+   ```
+6. For Repository Access, select `Only select repositories`, then select `hmpps-approved-premises-ui` as the repository
+7. Under Permissions->Repository Permissions, select `Access: Read and Write` on the `Contents` and `Pull Requests` options
+8. Click `Generate token and request access`
+9. Copy the token
+10. Go to `https://github.com/ministryofjustice/hmpps-approved-premises-api/settings/secrets/actions`
+11. Under the Repository secrets section, click the edit pencil next to `OPEN_PR_ACCESS_TOKEN`
+12. Paste the PAT and click `Update Secret`
+13. An Administrator for the ministryofjustice GitHub Organisation will need to approve the token before it starts to work (you will receive an email from GitHub once this has been done.)


### PR DESCRIPTION
From the `generate-types.yml` Action Workflow, run `./script/generate-types` to update the TS models for the API then open a new pull request.