### PR TITLE
(659) Apply - Prison behaviours

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -9,5 +9,6 @@ $path: "/assets/images/"
 @import './components/task-list'
 @import './components/risk-widgets'
 @import './components/box'
+@import './components/summary-list'
 @import './local'
 

--- a/assets/sass/components/_summary-list.scss
+++ b/assets/sass/components/_summary-list.scss
@@ -1,0 +1,23 @@
+.govuk-summary-list--embedded {
+  font-size: 0.9em;
+  padding-bottom: govuk-spacing(6);
+  border-bottom: 1px solid $govuk-border-colour;
+  border-collapse: separate;
+
+  &:last-child {
+    border: none
+  }
+}
+
+.govuk-summary-list__row--embedded {
+  border: 0;
+
+  @include govuk-media-query($from: tablet) {
+    .govuk-summary-list__key,
+    .govuk-summary-list__value,
+    .govuk-summary-list__actions {
+      padding-bottom: 0;
+    }
+  }
+}
+

--- a/cypress_shared/pages/apply/caseNotes.ts
+++ b/cypress_shared/pages/apply/caseNotes.ts
@@ -2,13 +2,13 @@ import { Application, PrisonCaseNote } from '@approved-premises/api'
 import { faker } from '@faker-js/faker'
 import { DateFormats } from '../../../server/utils/dateUtils'
 
-import ApplyPage from './applyPage'
+import Page from '../page'
 
-export default class CaseNotesPage extends ApplyPage {
+export default class CaseNotesPage extends Page {
   prisonCaseNotes: PrisonCaseNote[]
 
   constructor(application: Application, prisonCaseNotes: PrisonCaseNote[]) {
-    super('Prison information', application, 'access-and-healthcare', 'covid')
+    super('Prison information')
 
     cy.get('label').contains(
       `Are there additional circumstances that have helped ${application.person.name} do well in the past?`,

--- a/cypress_shared/pages/apply/caseNotes.ts
+++ b/cypress_shared/pages/apply/caseNotes.ts
@@ -1,0 +1,28 @@
+import { Application, PrisonCaseNote } from '@approved-premises/api'
+import { faker } from '@faker-js/faker'
+import { DateFormats } from '../../../server/utils/dateUtils'
+
+import ApplyPage from './applyPage'
+
+export default class CaseNotesPage extends ApplyPage {
+  prisonCaseNotes: PrisonCaseNote[]
+
+  constructor(application: Application, prisonCaseNotes: PrisonCaseNote[]) {
+    super('Prison information', application, 'access-and-healthcare', 'covid')
+
+    cy.get('label').contains(
+      `Are there additional circumstances that have helped ${application.person.name} do well in the past?`,
+    )
+    this.prisonCaseNotes = prisonCaseNotes
+  }
+
+  completeForm() {
+    this.prisonCaseNotes.forEach(note => {
+      cy.contains('label', `Select case note from ${DateFormats.isoDateToUIDate(note.createdAt)}`)
+        .siblings('input')
+        .check()
+    })
+
+    this.getTextInputByIdAndEnterDetails('moreDetail', faker.lorem.word())
+  }
+}

--- a/cypress_shared/pages/apply/checkYourAnswersPage.ts
+++ b/cypress_shared/pages/apply/checkYourAnswersPage.ts
@@ -1,4 +1,4 @@
-import type { Person } from '@approved-premises/api'
+import type { Person, PrisonCaseNote } from '@approved-premises/api'
 import { DateFormats } from '../../../server/utils/dateUtils'
 import ApplyPage from './applyPage'
 
@@ -50,6 +50,25 @@ export default class CheckYourAnswersPage extends Page {
 
   shouldShowMoveOnAnswers(pages: Array<ApplyPage>) {
     this.shouldShowAnswersForTask('move-on', pages)
+  }
+
+  shouldShowCaseNotes(caseNotes: Array<PrisonCaseNote>) {
+    cy.get(`[data-cy-check-your-answers-section="prison-information"]`).within(() => {
+      cy.get('dl.govuk-summary-list--embedded').then($items => {
+        cy.wrap($items).should('have.length', caseNotes.length)
+        caseNotes.forEach((caseNote, i) => {
+          cy.wrap($items[i]).within(() => {
+            this.assertDefinition('Date created', DateFormats.isoDateToUIDate(caseNote.createdAt))
+            this.assertDefinition('Date occurred', DateFormats.isoDateToUIDate(caseNote.occurredAt))
+            this.assertDefinition('Is the case note sensitive?', caseNote.sensitive ? 'Yes' : 'No')
+            this.assertDefinition('Name of author', caseNote.authorName)
+            this.assertDefinition('Type', caseNote.type)
+            this.assertDefinition('Subtype', caseNote.subType)
+            this.assertDefinition('Note', caseNote.note)
+          })
+        })
+      })
+    })
   }
 
   private shouldShowAnswersForTask(taskName: string, pages: Array<ApplyPage>) {

--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -62,6 +62,10 @@ export default abstract class Page {
     cy.get(`input[name="${name}"][value="${option}"]`).check()
   }
 
+  checkCheckboxByLabel(option: string): void {
+    cy.get(`input[value="${option}"]`).check()
+  }
+
   uncheckCheckboxbyNameAndValue(name: string, option: string): void {
     cy.get(`input[name="${name}"][value="${option}"]`).uncheck()
   }

--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -1,6 +1,6 @@
 import { SuperAgentRequest } from 'superagent'
 
-import type { Person, PersonRisks } from '@approved-premises/api'
+import type { Person, PersonRisks, PrisonCaseNote } from '@approved-premises/api'
 
 import { stubFor, getMatchingRequests } from '../../wiremock'
 
@@ -46,4 +46,17 @@ export default {
         url: `/people/search?crn=${args.person.crn}`,
       })
     ).body.requests,
+
+  stubPrisonCaseNotes: async (args: { person: Person; prisonCaseNotes: PrisonCaseNote[] }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/people/${args.person.crn}/prison-case-notes`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.prisonCaseNotes,
+      },
+    }),
 }

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -251,12 +251,13 @@ context('Apply', () => {
 
       // Given there is prison case notes for the person in the DB
       const prisonCaseNotes = prisonCaseNotesFactory.buildList(3)
+      const selectedPrisonCaseNotes = [prisonCaseNotes[0], prisonCaseNotes[1]]
       cy.task('stubPrisonCaseNotes', { prisonCaseNotes, person })
 
       // And I click the 'Review prison information' task
       cy.get('[data-cy-task-name="prison-information"]').click()
 
-      const caseNotesPage = new CaseNotesPage(application, prisonCaseNotes)
+      const caseNotesPage = new CaseNotesPage(application, selectedPrisonCaseNotes)
       caseNotesPage.completeForm()
       caseNotesPage.clickSubmit()
 
@@ -403,6 +404,7 @@ context('Apply', () => {
       checkYourAnswersPage.shouldShowBasicInformationAnswers(basicInformationPages)
       checkYourAnswersPage.shouldShowTypeOfApAnswers(typeOfApPages)
       checkYourAnswersPage.shouldShowRiskManagementAnswers(riskManagementPages)
+      checkYourAnswersPage.shouldShowCaseNotes(selectedPrisonCaseNotes)
       checkYourAnswersPage.shouldShowLocationFactorsAnswers(locationFactorsPages)
       checkYourAnswersPage.shouldShowAccessAndHealthcareAnswers(accessAndHealthcarePages)
       checkYourAnswersPage.shouldShowFurtherConsiderationsAnswers(furtherConsiderationsPages)

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -29,6 +29,7 @@ import TypeOfConvictedOffence from '../../../cypress_shared/pages/apply/typeOfCo
 
 import Page from '../../../cypress_shared/pages/page'
 import applicationFactory from '../../../server/testutils/factories/application'
+import prisonCaseNotesFactory from '../../../server/testutils/factories/prisonCaseNotes'
 import personFactory from '../../../server/testutils/factories/person'
 import risksFactory from '../../../server/testutils/factories/risks'
 import { mapApiPersonRisksForUi } from '../../../server/utils/utils'
@@ -39,6 +40,7 @@ import AccessNeedsAdditionalAdjustmentsPage from '../../../cypress_shared/pages/
 import RelocationRegionPage from '../../../cypress_shared/pages/apply/relocationRegion'
 import PlansInPlacePage from '../../../cypress_shared/pages/apply/plansInPlace'
 import TypeOfAccomodationPage from '../../../cypress_shared/pages/apply/typeOfAccommodation'
+import CaseNotesPage from '../../../cypress_shared/pages/apply/caseNotes'
 
 context('Apply', () => {
   beforeEach(() => {
@@ -246,6 +248,17 @@ context('Apply', () => {
       // Then I should be taken back to the task list
       // And the risk management task should show a completed status
       tasklistPage.shouldShowTaskStatus('risk-management-features', 'Completed')
+
+      // Given there is prison case notes for the person in the DB
+      const prisonCaseNotes = prisonCaseNotesFactory.buildList(3)
+      cy.task('stubPrisonCaseNotes', { prisonCaseNotes, person })
+
+      // And I click the 'Review prison information' task
+      cy.get('[data-cy-task-name="prison-information"]').click()
+
+      const caseNotesPage = new CaseNotesPage(application, prisonCaseNotes)
+      caseNotesPage.completeForm()
+      caseNotesPage.clickSubmit()
 
       // Given I click the 'Describe location factors' task
       cy.get('[data-cy-task-name="location-factors"]').click()

--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -9,6 +9,7 @@
     "resolveJsonModule": true,
     "moduleResolution": "node",
     "baseUrl": ".",
+    "skipLibCheck": true,
     "paths": {
       "@approved-premises/ui": ["../server/@types/ui/index.d.ts"],
       "@approved-premises/api": ["../server/@types/shared/index.d.ts"]

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -20,6 +20,7 @@ export type TaskNames =
   | 'basic-information'
   | 'type-of-ap'
   | 'risk-management-features'
+  | 'prison-information'
   | 'location-factors'
   | 'access-and-healthcare'
   | 'further-considerations'

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -171,5 +171,7 @@ export type GroupedListofBookings = {
 }
 
 export type DataServices = {
-  personService: PersonService
+  personService: {
+    getPrisonCaseNotes: (token: string, crn: string) => Promise<PrisonCaseNote[]>
+  }
 }

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -4,6 +4,8 @@ import PersonClient from './personClient'
 import config from '../config'
 import riskFactory from '../testutils/factories/risks'
 import personFactory from '../testutils/factories/person'
+import prisonCaseNotesFactory from '../testutils/factories/prisonCaseNotes'
+import paths from '../paths/api'
 
 describe('PersonClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
@@ -55,6 +57,23 @@ describe('PersonClient', () => {
       const result = await personClient.risks(crn)
 
       expect(result).toEqual(person)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+
+  describe('prison case notes', () => {
+    it('should return the risks for a person', async () => {
+      const crn = 'crn'
+      const prisonCaseNotes = prisonCaseNotesFactory.build()
+
+      fakeApprovedPremisesApi
+        .get(paths.people.prisonCaseNotes({ crn }))
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(201, prisonCaseNotes)
+
+      const result = await personClient.prisonCaseNotes(crn)
+
+      expect(result).toEqual(prisonCaseNotes)
       expect(nock.isDone()).toBeTruthy()
     })
   })

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -1,4 +1,4 @@
-import type { Person, PersonRisks } from '@approved-premises/api'
+import type { Person, PersonRisks, PrisonCaseNote } from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -24,5 +24,11 @@ export default class PersonClient {
     })
 
     return response as PersonRisks
+  }
+
+  async prisonCaseNotes(crn: string): Promise<PrisonCaseNote[]> {
+    const response = await this.restClient.get({ path: paths.people.prisonCaseNotes({ crn }) })
+
+    return response as PrisonCaseNote[]
   }
 }

--- a/server/form-pages/apply/index.ts
+++ b/server/form-pages/apply/index.ts
@@ -5,6 +5,7 @@ import type { TaskNames, FormSections } from '@approved-premises/ui'
 import basicInfomationPages from './basic-information'
 import typeOfApPages from './type-of-ap'
 import riskAndNeedPages from './risk-management-features'
+import prisonInformationPages from './prison-information'
 import locationFactorPages from './location-factors'
 import accessAndHealthcarePages from './access-and-healthcare'
 import furtherConsiderationsPages from './further-considerations'
@@ -17,6 +18,7 @@ const pages: {
   'basic-information': basicInfomationPages,
   'type-of-ap': typeOfApPages,
   'risk-management-features': riskAndNeedPages,
+  'prison-information': prisonInformationPages,
   'location-factors': locationFactorPages,
   'access-and-healthcare': accessAndHealthcarePages,
   'further-considerations': furtherConsiderationsPages,
@@ -47,6 +49,11 @@ const sections: FormSections = [
         id: 'risk-management-features',
         title: 'Add detail about managing risks and needs',
         pages: riskAndNeedPages,
+      },
+      {
+        id: 'prison-information',
+        title: 'Review prison information',
+        pages: prisonInformationPages,
       },
       {
         id: 'location-factors',

--- a/server/form-pages/apply/prison-information/caseNotes.test.ts
+++ b/server/form-pages/apply/prison-information/caseNotes.test.ts
@@ -120,29 +120,35 @@ describe('CaseNotes', () => {
     const page = new CaseNotes({ selectedCaseNotes: caseNotes, moreDetail: 'some detail' }, application)
 
     expect(page.response()).toEqual({
-      'Selected prison case notes that support this application': `\nDate created: Friday 31 January 2020,
-Date occurred: Wednesday 1 January 2020,
-Is the case note sensitive?: No,
-Name of author: Dennis Ziemann,
-Type: some type,
-Subtype: some subtype,
-Note: a note
-
-Date created: Sunday 31 January 2021,
-Date occurred: Friday 1 January 2021,
-Is the case note sensitive?: No,
-Name of author: Dennis Ziemann,
-Type: some type,
-Subtype: some subtype,
-Note: another note
-
-Date created: Monday 31 January 2022,
-Date occurred: Saturday 1 January 2022,
-Is the case note sensitive?: No,
-Name of author: Dennis Ziemann,
-Type: some type,
-Subtype: some subtype,
-Note: a further note`,
+      'Selected prison case notes that support this application': [
+        {
+          'Date created': 'Friday 31 January 2020',
+          'Date occurred': 'Wednesday 1 January 2020',
+          'Is the case note sensitive?': 'No',
+          'Name of author': 'Dennis Ziemann',
+          Note: 'a note',
+          Subtype: 'some subtype',
+          Type: 'some type',
+        },
+        {
+          'Date created': 'Sunday 31 January 2021',
+          'Date occurred': 'Friday 1 January 2021',
+          'Is the case note sensitive?': 'No',
+          'Name of author': 'Dennis Ziemann',
+          Note: 'another note',
+          Subtype: 'some subtype',
+          Type: 'some type',
+        },
+        {
+          'Date created': 'Monday 31 January 2022',
+          'Date occurred': 'Saturday 1 January 2022',
+          'Is the case note sensitive?': 'No',
+          'Name of author': 'Dennis Ziemann',
+          Note: 'a further note',
+          Subtype: 'some subtype',
+          Type: 'some type',
+        },
+      ],
       'Are there additional circumstances that have helped John Wayne do well in the past?': 'some detail',
     })
   })

--- a/server/form-pages/apply/prison-information/caseNotes.test.ts
+++ b/server/form-pages/apply/prison-information/caseNotes.test.ts
@@ -1,0 +1,207 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+import { PersonService } from '../../../services'
+
+import prisonCaseNotesFactory from '../../../testutils/factories/prisonCaseNotes'
+import { DateFormats } from '../../../utils/dateUtils'
+import applicationFactory from '../../../testutils/factories/application'
+import personFactory from '../../../testutils/factories/person'
+
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+
+import CaseNotes from './caseNotes'
+
+jest.mock('../../../services/personService.ts')
+
+describe('CaseNotes', () => {
+  const person = personFactory.build({ name: 'John Wayne' })
+  const application = applicationFactory.build({ person })
+
+  let personService: DeepMocked<PersonService>
+
+  const caseNotes = [
+    prisonCaseNotesFactory.build({
+      id: 'A',
+      createdAt: DateFormats.formatApiDate(new Date(2020, 1, 0)),
+      occurredAt: DateFormats.formatApiDate(new Date(2020, 0, 1)),
+      sensitive: false,
+      authorName: 'Dennis Ziemann',
+      subType: 'some subtype',
+      type: 'some type',
+      note: 'a note',
+    }),
+    prisonCaseNotesFactory.build({
+      id: 'B',
+      createdAt: DateFormats.formatApiDate(new Date(2021, 1, 0)),
+      occurredAt: DateFormats.formatApiDate(new Date(2021, 0, 1)),
+      sensitive: false,
+      authorName: 'Dennis Ziemann',
+      subType: 'some subtype',
+      type: 'some type',
+      note: 'another note',
+    }),
+    prisonCaseNotesFactory.build({
+      id: 'C',
+      createdAt: DateFormats.formatApiDate(new Date(2022, 1, 0)),
+      occurredAt: DateFormats.formatApiDate(new Date(2022, 0, 1)),
+      sensitive: false,
+      authorName: 'Dennis Ziemann',
+      subType: 'some subtype',
+      type: 'some type',
+      note: 'a further note',
+    }),
+  ]
+
+  describe('title', () => {
+    expect(new CaseNotes({}, application).title).toBe('Prison information')
+  })
+
+  describe('body', () => {
+    it('should strip unknown attributes from the body and marshal the IDs', () => {
+      const page = new CaseNotes(
+        { selectedCaseNotes: [caseNotes[0], caseNotes[1]], moreDetail: 'some detail', something: 'else' },
+        application,
+      )
+
+      expect(page.body).toEqual({
+        selectedCaseNotes: [caseNotes[0], caseNotes[1]],
+        moreDetail: 'some detail',
+        caseNoteIds: ['A', 'B'],
+      })
+    })
+  })
+
+  describe('initialize', () => {
+    const getPrisonCaseNotesMock = jest.fn().mockResolvedValue(caseNotes)
+
+    beforeEach(() => {
+      personService = createMock<PersonService>({ getPrisonCaseNotes: getPrisonCaseNotesMock })
+    })
+
+    it('calls the getPrisonCaseNotes method on the with a token and the persons CRN', async () => {
+      const page = await CaseNotes.initialize({}, application, 'some-token', { personService })
+
+      expect(page.caseNotes).toEqual(caseNotes)
+
+      expect(getPrisonCaseNotesMock).toHaveBeenCalledWith('some-token', application.person.crn)
+    })
+
+    it('initializes the caseNotes class with the selected case notes', async () => {
+      const page = await CaseNotes.initialize({ caseNoteIds: ['A'] }, application, 'some-token', { personService })
+
+      expect(page.body).toEqual({
+        caseNoteIds: ['A'],
+        selectedCaseNotes: [caseNotes[0]],
+      })
+    })
+
+    it('initializes the caseNotes class correctly when caseNoteIds is a string', async () => {
+      const page = await CaseNotes.initialize({ caseNoteIds: 'A' }, application, 'some-token', { personService })
+
+      expect(page.body).toEqual({
+        caseNoteIds: ['A'],
+        selectedCaseNotes: [caseNotes[0]],
+      })
+    })
+
+    it('initializes correctly when caseNoteIds is not present', async () => {
+      const page = await CaseNotes.initialize({}, application, 'some-token', { personService })
+
+      expect(page.body).toEqual({
+        caseNoteIds: [],
+        selectedCaseNotes: [],
+      })
+    })
+  })
+
+  itShouldHaveNextValue(new CaseNotes({}, application), '')
+  itShouldHavePreviousValue(new CaseNotes({}, application), '')
+
+  describe('response', () => {
+    const page = new CaseNotes({ selectedCaseNotes: caseNotes, moreDetail: 'some detail' }, application)
+
+    expect(page.response()).toEqual({
+      'Selected prison case notes that support this application': `\nDate created: Friday 31 January 2020,
+Date occurred: Wednesday 1 January 2020,
+Is the case note sensitive?: No,
+Name of author: Dennis Ziemann,
+Type: some type,
+Subtype: some subtype,
+Note: a note
+
+Date created: Sunday 31 January 2021,
+Date occurred: Friday 1 January 2021,
+Is the case note sensitive?: No,
+Name of author: Dennis Ziemann,
+Type: some type,
+Subtype: some subtype,
+Note: another note
+
+Date created: Monday 31 January 2022,
+Date occurred: Saturday 1 January 2022,
+Is the case note sensitive?: No,
+Name of author: Dennis Ziemann,
+Type: some type,
+Subtype: some subtype,
+Note: a further note`,
+      'Are there additional circumstances that have helped John Wayne do well in the past?': 'some detail',
+    })
+  })
+
+  describe('tableRows', () => {
+    const page = new CaseNotes(
+      { selectedCaseNotes: [caseNotes[0], caseNotes[1]], moreDetail: 'some detail' },
+      application,
+    )
+
+    page.caseNotes = caseNotes
+
+    expect(page.tableRows()).toEqual([
+      [
+        {
+          html: `<div class="govuk-checkboxes" data-module="govuk-checkboxes">
+              <div class="govuk-checkboxes__item">
+                <input type="checkbox" class="govuk-checkboxes__input" name="caseNoteIds" value="A" id="A" checked>
+                <label class="govuk-label govuk-checkboxes__label" for="A">
+                  <span class="govuk-visually-hidden">Select case note from Friday 31 January 2020</span>
+                </label>
+              </div>
+            </div>`,
+        },
+        { text: 'Friday 31 January 2020' },
+        { html: '<p><strong>Type: some type: some subtype</strong></p><p>a note</p>' },
+      ],
+      [
+        {
+          html: `<div class="govuk-checkboxes" data-module="govuk-checkboxes">
+              <div class="govuk-checkboxes__item">
+                <input type="checkbox" class="govuk-checkboxes__input" name="caseNoteIds" value="B" id="B" checked>
+                <label class="govuk-label govuk-checkboxes__label" for="B">
+                  <span class="govuk-visually-hidden">Select case note from Sunday 31 January 2021</span>
+                </label>
+              </div>
+            </div>`,
+        },
+        { text: 'Sunday 31 January 2021' },
+        { html: '<p><strong>Type: some type: some subtype</strong></p><p>another note</p>' },
+      ],
+      [
+        {
+          html: `<div class="govuk-checkboxes" data-module="govuk-checkboxes">
+              <div class="govuk-checkboxes__item">
+                <input type="checkbox" class="govuk-checkboxes__input" name="caseNoteIds" value="C" id="C" >
+                <label class="govuk-label govuk-checkboxes__label" for="C">
+                  <span class="govuk-visually-hidden">Select case note from Monday 31 January 2022</span>
+                </label>
+              </div>
+            </div>`,
+        },
+        { text: 'Monday 31 January 2022' },
+        { html: '<p><strong>Type: some type: some subtype</strong></p><p>a further note</p>' },
+      ],
+    ])
+  })
+
+  describe('errors', () => {
+    expect(new CaseNotes({}, application).errors()).toEqual({})
+  })
+})

--- a/server/form-pages/apply/prison-information/caseNotes.ts
+++ b/server/form-pages/apply/prison-information/caseNotes.ts
@@ -1,0 +1,139 @@
+import type { DataServices } from '@approved-premises/ui'
+
+import type { Application, PrisonCaseNote } from '@approved-premises/api'
+
+import TasklistPage from '../../tasklistPage'
+import { DateFormats } from '../../../utils/dateUtils'
+
+type CaseNotesBody = { caseNoteIds: Array<string>; selectedCaseNotes: Array<PrisonCaseNote>; moreDetail: string }
+
+export default class CaseNotes implements TasklistPage {
+  name = 'case-notes'
+
+  title = 'Prison information'
+
+  questions = {
+    caseNotesSelectionQuestion: 'Selected prison case notes that support this application',
+    moreDetailsQuestion: `Are there additional circumstances that have helped ${this.application.person.name} do well in the past?`,
+  }
+
+  tableHeaders = [{ text: 'Select' }, { text: 'Date, time and officer' }, { text: 'Comments' }]
+
+  body: CaseNotesBody
+
+  caseNotes: PrisonCaseNote[] | undefined
+
+  constructor(body: Record<string, unknown>, private readonly application: Application) {
+    const selectedCaseNotes = (body.selectedCaseNotes || []) as Array<PrisonCaseNote>
+    const caseNoteIds = body.caseNoteIds ? body.caseNoteIds : selectedCaseNotes.map(n => n.id)
+
+    this.body = {
+      caseNoteIds: caseNoteIds as Array<string>,
+      selectedCaseNotes,
+      moreDetail: body.moreDetail as string,
+    }
+  }
+
+  static async initialize(
+    body: Record<string, unknown>,
+    application: Application,
+    token: string,
+    dataServices: DataServices,
+  ) {
+    const caseNotes = await dataServices.personService.getPrisonCaseNotes(token, application.person.crn)
+
+    body.caseNoteIds = body.caseNoteIds ? [body.caseNoteIds].flat() : []
+
+    body.selectedCaseNotes = ((body.caseNoteIds || []) as Array<string>).map((noteId: string) => {
+      return caseNotes.find(caseNote => caseNote.id === noteId)
+    })
+
+    const page = new CaseNotes(body, application)
+    page.caseNotes = caseNotes
+
+    return page
+  }
+
+  previous() {
+    return ''
+  }
+
+  next() {
+    return ''
+  }
+
+  response() {
+    const response = {}
+
+    if (this.body.selectedCaseNotes) {
+      const res = this.body.selectedCaseNotes.reduce((prev, curr, i, arr) => {
+        const caseNotes: string = prev.concat(
+          `\nDate created: ${DateFormats.isoDateToUIDate(
+            curr.createdAt,
+          )},\nDate occurred: ${DateFormats.isoDateToUIDate(curr.occurredAt)},\nIs the case note sensitive?: ${
+            curr.sensitive ? 'Yes' : 'No'
+          },\nName of author: ${curr.authorName},\nType: ${curr.type},\nSubtype: ${curr.subType},\nNote: ${curr.note}`,
+        )
+        if (i !== arr.length - 1) {
+          return caseNotes.concat('\n')
+        }
+        return caseNotes
+      }, '')
+
+      response[this.questions.caseNotesSelectionQuestion] = res
+    }
+
+    if (this.body.moreDetail) {
+      response[this.questions.moreDetailsQuestion] = this.body.moreDetail
+    }
+
+    return response
+  }
+
+  errors() {
+    const errors = {}
+
+    return errors
+  }
+
+  tableRows() {
+    const rows = this.caseNotes.map(caseNote => {
+      return [
+        {
+          html: this.tableRowCheckbox(caseNote, this.caseNoteSelected(caseNote)),
+        },
+        {
+          text: `${DateFormats.isoDateToUIDate(caseNote.createdAt)}`,
+        },
+        {
+          html: `<p><strong>Type: ${caseNote.type}: ${caseNote.subType}</strong></p><p>${caseNote.note}</p>`,
+        },
+      ]
+    })
+
+    return rows
+  }
+
+  tableRowCheckbox(caseNote: PrisonCaseNote, checked: boolean) {
+    return `<div class="govuk-checkboxes" data-module="govuk-checkboxes">
+              <div class="govuk-checkboxes__item">
+                <input type="checkbox" class="govuk-checkboxes__input" name="caseNoteIds" value="${caseNote.id}" id="${
+      caseNote.id
+    }" ${checked ? 'checked' : ''}>
+                <label class="govuk-label govuk-checkboxes__label" for="${caseNote.id}">
+                  <span class="govuk-visually-hidden">Select case note from ${DateFormats.isoDateToUIDate(
+                    caseNote.createdAt,
+                  )}</span>
+                </label>
+              </div>
+            </div>`
+  }
+
+  caseNoteSelected(caseNote: PrisonCaseNote): boolean {
+    if (!this.body.selectedCaseNotes) {
+      return false
+    }
+
+    return this.body.caseNoteIds.includes(caseNote.id)
+  }
+}

--- a/server/form-pages/apply/prison-information/caseNotes.ts
+++ b/server/form-pages/apply/prison-information/caseNotes.ts
@@ -66,19 +66,17 @@ export default class CaseNotes implements TasklistPage {
     const response = {}
 
     if (this.body.selectedCaseNotes) {
-      const res = this.body.selectedCaseNotes.reduce((prev, curr, i, arr) => {
-        const caseNotes: string = prev.concat(
-          `\nDate created: ${DateFormats.isoDateToUIDate(
-            curr.createdAt,
-          )},\nDate occurred: ${DateFormats.isoDateToUIDate(curr.occurredAt)},\nIs the case note sensitive?: ${
-            curr.sensitive ? 'Yes' : 'No'
-          },\nName of author: ${curr.authorName},\nType: ${curr.type},\nSubtype: ${curr.subType},\nNote: ${curr.note}`,
-        )
-        if (i !== arr.length - 1) {
-          return caseNotes.concat('\n')
+      const res = this.body.selectedCaseNotes.map(caseNote => {
+        return {
+          'Date created': DateFormats.isoDateToUIDate(caseNote.createdAt),
+          'Date occurred': DateFormats.isoDateToUIDate(caseNote.occurredAt),
+          'Is the case note sensitive?': caseNote.sensitive ? 'Yes' : 'No',
+          'Name of author': caseNote.authorName,
+          Type: caseNote.type,
+          Subtype: caseNote.subType,
+          Note: caseNote.note,
         }
-        return caseNotes
-      }, '')
+      })
 
       response[this.questions.caseNotesSelectionQuestion] = res
     }

--- a/server/form-pages/apply/prison-information/index.ts
+++ b/server/form-pages/apply/prison-information/index.ts
@@ -1,0 +1,9 @@
+/* istanbul ignore file */
+
+import CaseNotes from './caseNotes'
+
+const pages = {
+  'case-notes': CaseNotes,
+}
+
+export default pages

--- a/server/form-pages/tasklistPage.ts
+++ b/server/form-pages/tasklistPage.ts
@@ -1,5 +1,5 @@
-import type { Request } from 'express'
 import type { TaskListErrors, DataServices } from '@approved-premises/ui'
+import { Application } from '@approved-premises/api'
 
 export default abstract class TasklistPage {
   abstract name: string
@@ -16,5 +16,5 @@ export default abstract class TasklistPage {
 
   abstract response(): Record<string, unknown>
 
-  async setup?(request: Request, dataServices: DataServices): Promise<void>
+  static async initialize?(application: Application, token: string, dataServices: DataServices): Promise<TasklistPage>
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -53,5 +53,6 @@ export default {
       show: personPath.path('risks'),
     },
     search: peoplePath.path('search'),
+    prisonCaseNotes: personPath.path('prison-case-notes'),
   },
 }

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -45,11 +45,10 @@ export default class ApplicationService {
 
     const application = await this.getApplicationFromSessionOrAPI(request)
     const body = this.getBody(application, request, userInput)
-    const page = new Page(body, application, request.session.previousPage)
 
-    if (page.setup) {
-      await page.setup(request, dataServices)
-    }
+    const page = Page.initialize
+      ? await Page.initialize(body, application, request.user.token, dataServices)
+      : new Page(body, application, request.session.previousPage)
 
     return page
   }

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -5,6 +5,7 @@ import PersonClient from '../data/personClient'
 import PersonFactory from '../testutils/factories/person'
 import risksFactory from '../testutils/factories/risks'
 import { mapApiPersonRisksForUi } from '../utils/utils'
+import prisonCaseNotesFactory from '../testutils/factories/prisonCaseNotes'
 
 jest.mock('../data/personClient.ts')
 
@@ -47,6 +48,21 @@ describe('PersonService', () => {
 
       expect(personClientFactory).toHaveBeenCalledWith(token)
       expect(personClient.risks).toHaveBeenCalledWith('crn')
+    })
+  })
+
+  describe('getPrisonCaseNotes', () => {
+    it("on success returns the person's prison case notes given their CRN", async () => {
+      const prisonCaseNotes = prisonCaseNotesFactory.buildList(3)
+
+      personClient.prisonCaseNotes.mockResolvedValue(prisonCaseNotes)
+
+      const servicePrisonCaseNotes = await service.getPrisonCaseNotes(token, 'crn')
+
+      expect(servicePrisonCaseNotes).toEqual(prisonCaseNotes)
+
+      expect(personClientFactory).toHaveBeenCalledWith(token)
+      expect(personClient.prisonCaseNotes).toHaveBeenCalledWith('crn')
     })
   })
 })

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -1,5 +1,5 @@
 import type { PersonRisksUI } from '@approved-premises/ui'
-import type { Person } from '@approved-premises/api'
+import type { Person, PrisonCaseNote } from '@approved-premises/api'
 import type { RestClientBuilder, PersonClient } from '../data'
 
 import { mapApiPersonRisksForUi } from '../utils/utils'
@@ -20,5 +20,13 @@ export default class PersonService {
     const risks = await personClient.risks(crn)
 
     return mapApiPersonRisksForUi(risks)
+  }
+
+  async getPrisonCaseNotes(token: string, crn: string): Promise<PrisonCaseNote[]> {
+    const personClient = this.personClientFactory(token)
+
+    const prisonCaseNotes = await personClient.prisonCaseNotes(crn)
+
+    return prisonCaseNotes
   }
 }

--- a/server/testutils/factories/prisonCaseNotes.ts
+++ b/server/testutils/factories/prisonCaseNotes.ts
@@ -1,0 +1,45 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { PrisonCaseNote } from '@approved-premises/api'
+
+import { DateFormats } from '../../utils/dateUtils'
+
+export default Factory.define<PrisonCaseNote>(() => ({
+  authorName: faker.name.fullName(),
+  id: faker.datatype.uuid(),
+  createdAt: DateFormats.formatApiDate(faker.date.past()),
+  occurredAt: DateFormats.formatApiDate(faker.date.past()),
+  sensitive: faker.datatype.boolean(),
+  subType: faker.helpers.arrayElement([
+    'Well--Being Check',
+    'Offender Supervisor Entry',
+    'History Sheet Entry',
+    'Ressettlement',
+    'Key Worker Session',
+    'De-selection',
+    'Quality Work',
+    'General Entry',
+    'Incentive Warning',
+    'Residence',
+    'Offender Management Unit',
+    'Education',
+    'Communication',
+    'Social Care',
+    'Safer Custody',
+  ]),
+  type: faker.helpers.arrayElement([
+    'General',
+    'Key Worker Activity',
+    'Accredited Programme',
+    'Positive Behaviour',
+    'Negative Behaviour',
+    'Report',
+    'Communication',
+    'Achievements',
+    'OMiC',
+    'Social Care',
+    'Observations',
+  ]),
+  note: faker.helpers.arrayElement([faker.lorem.paragraphs(), faker.lorem.sentence(), faker.lorem.paragraph()]),
+}))

--- a/server/testutils/factories/prisonCaseNotes.ts
+++ b/server/testutils/factories/prisonCaseNotes.ts
@@ -5,7 +5,7 @@ import type { PrisonCaseNote } from '@approved-premises/api'
 
 import { DateFormats } from '../../utils/dateUtils'
 
-export default Factory.define<PrisonCaseNote>(() => ({
+export default Factory.define<PrisonCaseNote>(({ sequence }) => ({
   authorName: faker.name.fullName(),
   id: faker.datatype.uuid(),
   createdAt: DateFormats.formatApiDate(faker.date.past()),
@@ -41,5 +41,5 @@ export default Factory.define<PrisonCaseNote>(() => ({
     'Social Care',
     'Observations',
   ]),
-  note: faker.helpers.arrayElement([faker.lorem.paragraphs(), faker.lorem.sentence(), faker.lorem.paragraph()]),
+  note: `Note ${sequence}`,
 }))

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -4,7 +4,8 @@ import applicationFactory from '../testutils/factories/application'
 import paths from '../paths/apply'
 import { pages } from '../form-pages/apply'
 
-import { taskLink, getTaskStatus, getCompleteSectionCount, getResponses } from './applicationUtils'
+import { taskLink, getTaskStatus, getCompleteSectionCount, getResponses, getPage } from './applicationUtils'
+import { UnknownPageError } from './errors'
 
 const FirstPage = jest.fn()
 const SecondPage = jest.fn()
@@ -149,6 +150,19 @@ describe('applicationUtils', () => {
       application.data = { 'basic-information': { first: '', second: '' } }
 
       expect(getResponses(application)).toEqual({ 'basic-information': [{ foo: 'bar' }, { bar: 'foo' }] })
+    })
+  })
+
+  describe('getPage', () => {
+    it('should return a page if it exists', () => {
+      expect(getPage('basic-information', 'first')).toEqual(FirstPage)
+      expect(getPage('basic-information', 'second')).toEqual(SecondPage)
+    })
+
+    it('should raise an error if the page is not found', async () => {
+      expect(() => {
+        getPage('basic-information', 'bar')
+      }).toThrow(UnknownPageError)
     })
   })
 })

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -4,7 +4,7 @@ import paths from '../paths/apply'
 import { pages } from '../form-pages/apply'
 import { UnknownPageError } from './errors'
 
-type PageResponse = Record<string, string>
+type PageResponse = Record<string, string | Array<Record<string, unknown>>>
 type ApplicationResponse = Record<string, Array<PageResponse>>
 
 const taskIds = Object.keys(pages)

--- a/server/utils/checkYourAnswersUtils.test.ts
+++ b/server/utils/checkYourAnswersUtils.test.ts
@@ -3,7 +3,7 @@ import applicationFactory from '../testutils/factories/application'
 import paths from '../paths/apply'
 import { pages } from '../form-pages/apply'
 
-import { checkYourAnswersSections } from './checkYourAnswersUtils'
+import { checkYourAnswersSections, embeddedSummaryListItem } from './checkYourAnswersUtils'
 
 const FirstPage = jest.fn()
 const SecondPage = jest.fn()
@@ -36,8 +36,58 @@ pages['basic-information'] = {
 }
 
 describe('applicationUtils', () => {
+  describe('embeddedSummaryListItem', () => {
+    it('returns a summary list for an array of records', () => {
+      const result = embeddedSummaryListItem([
+        { foo: 'bar', bar: 'baz' },
+        { foo: 'bar', bar: 'baz' },
+      ]).replace(/\s+/g, ``)
+
+      expect(result).toEqual(
+        `
+      <dl class="govuk-summary-list govuk-summary-list--embedded">
+        <div class="govuk-summary-list__row govuk-summary-list__row--embedded">
+          <dt class="govuk-summary-list__key govuk-summary-list__key--embedded">
+            foo
+          </dt>
+          <dd class="govuk-summary-list__value govuk-summary-list__value--embedded">
+            bar
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row govuk-summary-list__row--embedded">
+          <dt class="govuk-summary-list__key govuk-summary-list__key--embedded">
+            bar
+          </dt>
+          <dd class="govuk-summary-list__value govuk-summary-list__value--embedded">
+            baz
+          </dd>
+        </div>
+      </dl>
+
+      <dl class="govuk-summary-list govuk-summary-list--embedded">
+        <div class="govuk-summary-list__row govuk-summary-list__row--embedded">
+          <dt class="govuk-summary-list__key govuk-summary-list__key--embedded">
+            foo
+          </dt>
+          <dd class="govuk-summary-list__value govuk-summary-list__value--embedded">
+            bar
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row govuk-summary-list__row--embedded">
+          <dt class="govuk-summary-list__key govuk-summary-list__key--embedded">
+            bar
+          </dt>
+          <dd class="govuk-summary-list__value govuk-summary-list__value--embedded">
+            baz
+          </dd>
+        </div>
+      </dl>`.replace(/\s+/g, ``),
+      )
+    })
+  })
+
   describe('checkYourAnswersSections', () => {
-    it('removes the last section from the section list', () => {
+    it('returns the check your answers sections for an application', () => {
       FirstPage.mockReturnValue({
         response: () => {
           return { foo: 'bar' }
@@ -63,6 +113,80 @@ describe('applicationUtils', () => {
                 {
                   key: { text: 'foo' },
                   value: { text: 'bar' },
+                  actions: {
+                    items: [
+                      {
+                        href: paths.applications.pages.show({
+                          task: 'basic-information',
+                          page: 'first',
+                          id: application.id,
+                        }),
+                        text: 'Change',
+                        visuallyHiddenText: 'foo',
+                      },
+                    ],
+                  },
+                },
+                {
+                  key: { text: 'bar' },
+                  value: { text: 'foo' },
+                  actions: {
+                    items: [
+                      {
+                        href: paths.applications.pages.show({
+                          task: 'basic-information',
+                          page: 'second',
+                          id: application.id,
+                        }),
+                        text: 'Change',
+                        visuallyHiddenText: 'bar',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    it('returns an embeded summary list if the response is an array of objects', () => {
+      FirstPage.mockReturnValue({
+        response: () => {
+          return {
+            foo: [
+              { foo: 'bar', bar: 'baz' },
+              { foo: 'bar', bar: 'baz' },
+            ],
+          }
+        },
+      })
+
+      SecondPage.mockReturnValue({
+        response: () => {
+          return { bar: 'foo' }
+        },
+      })
+
+      const application = applicationFactory.build()
+      application.data = { 'basic-information': { first: '', second: '' } }
+
+      expect(checkYourAnswersSections(application)).toEqual([
+        {
+          title: 'First',
+          tasks: [
+            {
+              id: 'basic-information',
+              rows: [
+                {
+                  key: { text: 'foo' },
+                  value: {
+                    html: embeddedSummaryListItem([
+                      { foo: 'bar', bar: 'baz' },
+                      { foo: 'bar', bar: 'baz' },
+                    ]),
+                  },
                   actions: {
                     items: [
                       {

--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import { Application } from '@approved-premises/api'
-import { SummaryListItem, Task } from '@approved-premises/ui'
+import { HtmlItem, SummaryListItem, Task, TextItem } from '@approved-premises/ui'
 import { sections } from '../form-pages/apply'
 import paths from '../paths/apply'
 
@@ -35,16 +35,44 @@ const getTaskResponsesAsSummaryListItems = (task: Task, application: Application
     const response = getResponseForPage(application, task.id, pageName)
 
     Object.keys(response).forEach(key => {
-      items.push(summaryListItemForResponse(key, response[key], task, pageName, application))
+      const value =
+        typeof response[key] === 'string' || response[key] instanceof String
+          ? ({ text: response[key] } as TextItem)
+          : ({ html: embeddedSummaryListItem(response[key] as Array<Record<string, unknown>>) } as HtmlItem)
+
+      items.push(summaryListItemForResponse(key, value, task, pageName, application))
     })
   })
 
   return items
 }
 
+const embeddedSummaryListItem = (answers: Array<Record<string, unknown>>): string => {
+  let response = ''
+
+  answers.forEach(answer => {
+    response += '<dl class="govuk-summary-list govuk-summary-list--embedded">'
+    Object.keys(answer).forEach(key => {
+      response += `
+      <div class="govuk-summary-list__row govuk-summary-list__row--embedded">
+        <dt class="govuk-summary-list__key govuk-summary-list__key--embedded">
+          ${key}
+        </dt>
+        <dd class="govuk-summary-list__value govuk-summary-list__value--embedded">
+        ${answer[key]}
+        </dd>
+      </div>
+      `
+    })
+    response += '</dl>'
+  })
+
+  return response
+}
+
 const summaryListItemForResponse = (
   key: string,
-  value: string,
+  value: TextItem | HtmlItem,
   task: Task,
   pageName: string,
   application: Application,
@@ -53,9 +81,7 @@ const summaryListItemForResponse = (
     key: {
       text: key,
     },
-    value: {
-      text: value,
-    },
+    value,
     actions: {
       items: [
         {
@@ -68,4 +94,4 @@ const summaryListItemForResponse = (
   }
 }
 
-export { checkYourAnswersSections }
+export { checkYourAnswersSections, embeddedSummaryListItem }

--- a/server/views/applications/pages/layout.njk
+++ b/server/views/applications/pages/layout.njk
@@ -29,7 +29,7 @@
   {% endif %}
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="{{ columnClasses | default("govuk-grid-column-two-thirds") }}">
       <form action="{{ paths.applications.pages.update({ id: applicationId, task: task, page: page.name }) }}?_method=PUT" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 

--- a/server/views/applications/pages/prison-information/case-notes.njk
+++ b/server/views/applications/pages/prison-information/case-notes.njk
@@ -1,0 +1,56 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% extends "../layout.njk" %}
+
+{% set columnClasses = "govuk-grid-column-full" %}
+
+{% block questions %}
+  <div class="govuk-grid-row">
+
+    <div>
+      <h1 class="govuk-heading-l">{{page.title}}</h1>
+      <p>Select any prison case notes that will help Approved Premises (AP) managers understand factors that may help with the person's risk management in an AP. </p>
+      <p>Adjudications from the person's current sentence and ACCT (Assessment, Care in Custody and Teamwork) information will be sent automatically.</p>
+    </div>
+
+    <nav class="moj-sub-navigation" aria-label="Sub navigation">
+
+      <ul class="moj-sub-navigation__list">
+        <li class="moj-sub-navigation__item">
+          <a class="moj-sub-navigation__link"  aria-current="page" href="prison-behaviours.html">Prison case notes</a>
+        </li>
+
+        <li class="moj-sub-navigation__item">
+          <a class="moj-sub-navigation__link" href="prison-adjudications.html">Adjudications</a>
+        </li>
+
+        <li class="moj-sub-navigation__item">
+          <a class="moj-sub-navigation__link"  href="prison-acct.html">ACCT</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+
+  <div class="govuk-column-full-width">
+    <h3 class="govuk-heading-m">Prison case notes</h3>
+    {{
+      govukTable({
+        firstCellIsHeader: true,
+        head: page.tableHeaders,
+        rows: page.tableRows()
+      })
+    }}
+
+    {{ applyTextarea({
+      fieldName: 'moreDetail',
+      label: {
+        text: page.questions.moreDetailsQuestion,
+        classes: "govuk-label--s"
+      },
+      hint: {
+        text: "Provide details (optional)"
+      }
+    }) }}
+  </div>
+
+{% endblock %}

--- a/wiremock/prisonCaseNotes.ts
+++ b/wiremock/prisonCaseNotes.ts
@@ -1,0 +1,24 @@
+import { guidRegex } from '.'
+import prisonCaseNotesFactory from '../server/testutils/factories/prisonCaseNotes'
+
+export default [
+  {
+    priority: 99,
+    request: {
+      method: 'GET',
+      urlPathPattern: `/people/${guidRegex}/prison-case-notes`,
+      queryParameters: {
+        crn: {
+          matches: '.+',
+        },
+      },
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: prisonCaseNotesFactory.buildList(Math.floor(Math.random() * 5)),
+    },
+  },
+]


### PR DESCRIPTION
This adds the Prison behaviours screen to the Apply journey. There's been some tweaking to the async methods that pages optionally use (loads of context in the commit messages), and we've also had to make some changes to check your answers to support embedding definition lists inside definition lists, so the whole note is visible on Check Your Answers, but I feel it's pretty comprehensive!

## Screenshots

![image](https://user-images.githubusercontent.com/109774/203076427-c38b78f3-20cf-4827-8744-cb1d57154e51.png)

### Check Your Answers

![image](https://user-images.githubusercontent.com/109774/203076370-bfeb6e62-a689-42c0-9252-42447b9c5dce.png)
