### PR TITLE
(789) - Apply - Submit application

### DIFF
--- a/cypress_shared/pages/apply/caseNotes.ts
+++ b/cypress_shared/pages/apply/caseNotes.ts
@@ -1,5 +1,5 @@
 import { Application, PrisonCaseNote, Adjudication } from '@approved-premises/api'
-import { faker } from '@faker-js/faker'
+
 import { DateFormats } from '../../../server/utils/dateUtils'
 import { sentenceCase } from '../../../server/utils/utils'
 
@@ -33,7 +33,7 @@ export default class CaseNotesPage extends Page {
     })
   }
 
-  completeForm() {
+  completeForm(moreDetail: string) {
     cy.get('a').contains('Prison case notes').click()
 
     this.prisonCaseNotes.forEach(note => {
@@ -42,6 +42,6 @@ export default class CaseNotesPage extends Page {
         .check()
     })
 
-    this.getTextInputByIdAndEnterDetails('moreDetail', faker.lorem.word())
+    this.getTextInputByIdAndEnterDetails('moreDetail', moreDetail)
   }
 }

--- a/cypress_shared/pages/apply/submissionConfirmation.ts
+++ b/cypress_shared/pages/apply/submissionConfirmation.ts
@@ -1,0 +1,11 @@
+import Page from '../page'
+
+export default class SubmissionConfirmation extends Page {
+  constructor() {
+    super('Application confirmation')
+  }
+
+  clickBackToDashboard() {
+    cy.contains('a', 'Back to dashboard').click()
+  }
+}

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -1,7 +1,11 @@
 {
   "basic-information": {
-    "sentence-type": { "sentenceType": "bailPlacement" },
-    "situation": { "situation": "bailSentence" },
+    "sentence-type": {
+      "sentenceType": "bailPlacement"
+    },
+    "situation": {
+      "situation": "bailSentence"
+    },
     "release-date": {
       "releaseDate-year": "2022",
       "releaseDate-month": "11",
@@ -15,15 +19,24 @@
       "startDate-day": "",
       "startDateSameAsReleaseDate": "yes"
     },
-    "placement-purpose": { "placementPurposes": ["drugAlcoholMonitoring", "otherReason"], "otherReason": "Reason" }
+    "placement-purpose": {
+      "placementPurposes": ["drugAlcoholMonitoring", "otherReason"],
+      "otherReason": "Reason"
+    }
   },
-  "type-of-ap": { "ap-type": { "type": "standard" } },
+  "type-of-ap": {
+    "ap-type": {
+      "type": "standard"
+    }
+  },
   "risk-management-features": {
     "risk-management-features": {
       "manageRiskDetails": "est vero nesciunt",
       "additionalFeaturesDetails": "deleniti enim necessitatibus"
     },
-    "convicted-offences": { "response": "yes" },
+    "convicted-offences": {
+      "response": "yes"
+    },
     "type-of-convicted-offence": {
       "offenceConvictions": ["arson", "sexualOffence", "hateCrimes", "childNonSexualOffence"]
     },
@@ -47,6 +60,60 @@
       "otherIntervention": "Another"
     }
   },
+  "prison-information": {
+    "case-notes": {
+      "caseNoteIds": ["a30173ca-061f-42c9-a1a2-28c70b282d3f", "4a477187-b77f-4fcc-a919-43a6633ee868"],
+      "selectedCaseNotes": [
+        {
+          "authorName": "Denise Collins",
+          "id": "a30173ca-061f-42c9-a1a2-28c70b282d3f",
+          "createdAt": "2022-11-10",
+          "occurredAt": "2022-10-19",
+          "sensitive": false,
+          "subType": "Ressettlement",
+          "type": "Social Care",
+          "note": "Note 1"
+        },
+        {
+          "authorName": "Leticia Mann",
+          "id": "4a477187-b77f-4fcc-a919-43a6633ee868",
+          "createdAt": "2022-07-24",
+          "occurredAt": "2022-09-22",
+          "sensitive": true,
+          "subType": "Quality Work",
+          "type": "General",
+          "note": "Note 2"
+        }
+      ],
+      "moreDetail": "some details",
+      "adjudications": [
+        {
+          "id": 69927,
+          "reportedAt": "2022-10-09",
+          "establishment": "Hawthorne",
+          "offenceDescription": "Nam vel nisi fugiat veniam possimus omnis.",
+          "hearingHeld": false,
+          "finding": "NOT_PROVED"
+        },
+        {
+          "id": 39963,
+          "reportedAt": "2022-07-10",
+          "establishment": "Oklahoma City",
+          "offenceDescription": "Illum maxime enim explicabo soluta sequi voluptas.",
+          "hearingHeld": true,
+          "finding": "PROVED"
+        },
+        {
+          "id": 77431,
+          "reportedAt": "2022-05-30",
+          "establishment": "Jurupa Valley",
+          "offenceDescription": "Quis porro nemo voluptates doloribus atque quis provident iure.",
+          "hearingHeld": false,
+          "finding": "PROVED"
+        }
+      ]
+    }
+  },
   "location-factors": {
     "describe-location-factors": {
       "postcodeArea": "SW1",
@@ -57,7 +124,10 @@
       "alternativeRadius": "70",
       "differentPDU": "no"
     },
-    "pdu-transfer": { "transferStatus": "yes", "probationPractitioner": "Probation Practicioner" }
+    "pdu-transfer": {
+      "transferStatus": "yes",
+      "probationPractitioner": "Probation Practicioner"
+    }
   },
   "access-and-healthcare": {
     "access-needs": {
@@ -73,8 +143,15 @@
       "mobilityNeeds": "laboriosam",
       "visualImpairment": "exercitationem"
     },
-    "access-needs-additional-adjustments": { "adjustments": "yes", "adjustmentsDetail": "Some details here" },
-    "covid": { "fullyVaccinated": "yes", "highRisk": "yes", "additionalCovidInfo": "additional info" }
+    "access-needs-additional-adjustments": {
+      "adjustments": "yes",
+      "adjustmentsDetail": "Some details here"
+    },
+    "covid": {
+      "fullyVaccinated": "yes",
+      "highRisk": "yes",
+      "additionalCovidInfo": "additional info"
+    }
   },
   "further-considerations": {
     "room-sharing": {
@@ -95,22 +172,49 @@
       "exploitOthers": "yes",
       "exploitOthersDetail": "Some details here"
     },
-    "previous-placements": { "previousPlacement": "yes", "previousPlacementDetail": "Some details here" },
-    "complex-case-board": { "complexCaseBoard": "yes", "complexCaseBoardDetail": "Some details here" },
-    "catering": { "catering": "yes", "cateringDetail": "Some details here" },
-    "arson": { "arson": "yes", "arsonDetail": "Some details here" }
+    "previous-placements": {
+      "previousPlacement": "yes",
+      "previousPlacementDetail": "Some details here"
+    },
+    "complex-case-board": {
+      "complexCaseBoard": "yes",
+      "complexCaseBoardDetail": "Some details here"
+    },
+    "catering": {
+      "catering": "yes",
+      "cateringDetail": "Some details here"
+    },
+    "arson": {
+      "arson": "yes",
+      "arsonDetail": "Some details here"
+    }
   },
   "move-on": {
-    "placement-duration": { "duration": "10", "durationDetail": "Some more information" },
-    "relocation-region": { "postcodeArea": "XX1" },
-    "plans-in-place": { "arePlansInPlace": "yes" },
-    "type-of-accommodation": { "accommodationType": "foreignNational" },
+    "placement-duration": {
+      "duration": "10",
+      "durationDetail": "Some more information"
+    },
+    "relocation-region": {
+      "postcodeArea": "XX1"
+    },
+    "plans-in-place": {
+      "arePlansInPlace": "yes"
+    },
+    "type-of-accommodation": {
+      "accommodationType": "foreignNational",
+      "otherAccommodationType": ""
+    },
     "foreign-national": {
       "response": "yes",
-      "date": "2015-01-01",
       "date-year": "2015",
-      "date-month": "01",
-      "date-day": "01"
+      "date-month": "1",
+      "date-day": "1",
+      "date": "2015-01-01"
+    }
+  },
+  "check-your-answers": {
+    "review": {
+      "reviewed": "1"
     }
   }
 }

--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -65,11 +65,29 @@ export default {
         jsonBody: args.application,
       },
     }),
+  stubApplicationSubmit: (args: { application: Application }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: `/applications/${args.application.id}/submission`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      },
+    }),
   verifyApplicationUpdate: async (applicationId: string) =>
     (
       await getMatchingRequests({
         method: 'PUT',
         url: `/applications/${applicationId}`,
+      })
+    ).body.requests,
+  verifyApplicationSubmit: async (applicationId: string) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: `/applications/${applicationId}/submission`,
       })
     ).body.requests,
 }

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -257,6 +257,7 @@ context('Apply', () => {
       const prisonCaseNotes = prisonCaseNotesFactory.buildList(3)
       const selectedPrisonCaseNotes = [prisonCaseNotes[0], prisonCaseNotes[1]]
       const adjudications = adjudicationsFactory.buildList(5)
+      const moreDetail = 'some details'
 
       cy.task('stubPrisonCaseNotes', { prisonCaseNotes, person })
       cy.task('stubAdjudications', { adjudications, person })
@@ -266,7 +267,7 @@ context('Apply', () => {
 
       const caseNotesPage = new CaseNotesPage(application, selectedPrisonCaseNotes)
       caseNotesPage.shouldDisplayAdjudications(adjudications)
-      caseNotesPage.completeForm()
+      caseNotesPage.completeForm(moreDetail)
       caseNotesPage.clickSubmit()
 
       // Given I click the 'Describe location factors' task

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -254,9 +254,55 @@ context('Apply', () => {
       tasklistPage.shouldShowTaskStatus('risk-management-features', 'Completed')
 
       // Given there is prison case notes for the person in the DB
-      const prisonCaseNotes = prisonCaseNotesFactory.buildList(3)
-      const selectedPrisonCaseNotes = [prisonCaseNotes[0], prisonCaseNotes[1]]
-      const adjudications = adjudicationsFactory.buildList(5)
+      const prisonCaseNote1 = prisonCaseNotesFactory.build({
+        authorName: 'Denise Collins',
+        id: 'a30173ca-061f-42c9-a1a2-28c70b282d3f',
+        createdAt: '2022-11-10',
+        occurredAt: '2022-10-19',
+        sensitive: false,
+        subType: 'Ressettlement',
+        type: 'Social Care',
+        note: 'Note 1',
+      })
+      const prisonCaseNote2 = prisonCaseNotesFactory.build({
+        authorName: 'Leticia Mann',
+        id: '4a477187-b77f-4fcc-a919-43a6633ee868',
+        createdAt: '2022-07-24',
+        occurredAt: '2022-09-22',
+        sensitive: true,
+        subType: 'Quality Work',
+        type: 'General',
+        note: 'Note 2',
+      })
+      const prisonCaseNote3 = prisonCaseNotesFactory.build()
+      const prisonCaseNotes = [prisonCaseNote1, prisonCaseNote2, prisonCaseNote3]
+      const selectedPrisonCaseNotes = [prisonCaseNote1, prisonCaseNote2]
+
+      const adjudication1 = adjudicationsFactory.build({
+        id: 69927,
+        reportedAt: '2022-10-09',
+        establishment: 'Hawthorne',
+        offenceDescription: 'Nam vel nisi fugiat veniam possimus omnis.',
+        hearingHeld: false,
+        finding: 'NOT_PROVED',
+      })
+      const adjudication2 = adjudicationsFactory.build({
+        id: 39963,
+        reportedAt: '2022-07-10',
+        establishment: 'Oklahoma City',
+        offenceDescription: 'Illum maxime enim explicabo soluta sequi voluptas.',
+        hearingHeld: true,
+        finding: 'PROVED',
+      })
+      const adjudication3 = adjudicationsFactory.build({
+        id: 77431,
+        reportedAt: '2022-05-30',
+        establishment: 'Jurupa Valley',
+        offenceDescription: 'Quis porro nemo voluptates doloribus atque quis provident iure.',
+        hearingHeld: false,
+        finding: 'PROVED',
+      })
+      const adjudications = [adjudication1, adjudication2, adjudication3]
       const moreDetail = 'some details'
 
       cy.task('stubPrisonCaseNotes', { prisonCaseNotes, person })

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -14,8 +14,10 @@ import { sections } from '../../form-pages/apply'
 import paths from '../../paths/apply'
 import { DateFormats } from '../../utils/dateUtils'
 import { mapApiPersonRisksForUi } from '../../utils/utils'
+import { getResponses } from '../../utils/applicationUtils'
 
 jest.mock('../../utils/validation')
+jest.mock('../../utils/applicationUtils')
 
 describe('applicationsController', () => {
   const token = 'SOME_TOKEN'
@@ -233,6 +235,27 @@ describe('applicationsController', () => {
       await requestHandler(request, response, next)
 
       expect(request.session.application).toEqual(application)
+    })
+  })
+
+  describe('submit', () => {
+    it('calls the application service with the application id', async () => {
+      const application = applicationFactory.build()
+      application.data = { 'basic-information': { 'sentence-type': '' } }
+      applicationService.findApplication.mockResolvedValue(application)
+
+      const requestHandler = applicationsController.submit()
+
+      request.params.id = 'some-id'
+
+      await requestHandler(request, response, next)
+
+      expect(applicationService.findApplication).toHaveBeenCalledWith(token, 'some-id')
+      expect(getResponses).toHaveBeenCalledWith(application)
+      expect(applicationService.submit).toHaveBeenCalledWith(token, application)
+      expect(response.render).toHaveBeenCalledWith('applications/confirm', {
+        pageHeading: 'Application confirmation',
+      })
     })
   })
 })

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -126,7 +126,7 @@ describe('applicationsController', () => {
 
         await requestHandler(request, response, next)
 
-        expect(response.render).toHaveBeenCalledWith('applications/confirm', {
+        expect(response.render).toHaveBeenCalledWith('applications/people/confirm', {
           pageHeading: `Confirm ${person.name}'s details`,
           ...person,
           date: DateFormats.dateObjtoUIDate(new Date()),
@@ -147,7 +147,7 @@ describe('applicationsController', () => {
 
         await requestHandler(request, response, next)
 
-        expect(response.render).toHaveBeenCalledWith('applications/confirm', {
+        expect(response.render).toHaveBeenCalledWith('applications/people/confirm', {
           pageHeading: `Confirm ${person.name}'s details`,
           ...person,
           date: DateFormats.dateObjtoUIDate(new Date()),

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -48,7 +48,7 @@ export default class ApplicationsController {
       if (crnArr.length) {
         const person = await this.personService.findByCrn(req.user.token, crnArr[0])
 
-        return res.render(`applications/confirm`, {
+        return res.render(`applications/people/confirm`, {
           pageHeading: `Confirm ${person.name}'s details`,
           ...person,
           date: DateFormats.dateObjtoUIDate(new Date()),

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -7,6 +7,7 @@ import { fetchErrorsAndUserInput } from '../../utils/validation'
 import paths from '../../paths/apply'
 import { DateFormats } from '../../utils/dateUtils'
 import { sections } from '../../form-pages/apply'
+import { getResponses } from '../../utils/applicationUtils'
 
 export default class ApplicationsController {
   constructor(private readonly applicationService: ApplicationService, private readonly personService: PersonService) {}
@@ -76,6 +77,16 @@ export default class ApplicationsController {
       res.redirect(
         paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'sentence-type' }),
       )
+    }
+  }
+
+  submit(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const application = await this.applicationService.findApplication(req.user.token, req.params.id)
+      application.document = getResponses(application)
+
+      await this.applicationService.submit(req.user.token, application)
+      res.render('applications/confirm', { pageHeading: 'Application confirmation' })
     }
   }
 }

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -90,4 +90,19 @@ describe('ApplicationClient', () => {
       expect(nock.isDone()).toBeTruthy()
     })
   })
+
+  describe('submit', () => {
+    it('should submit the application', async () => {
+      const application = applicationFactory.build()
+
+      fakeApprovedPremisesApi
+        .post(paths.applications.submission({ id: application.id }))
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(201, application)
+
+      await applicationClient.submit(application)
+
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
 })

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -29,4 +29,11 @@ export default class ApplicationClient {
   async all(): Promise<ApplicationSummary[]> {
     return (await this.restClient.get({ path: paths.applications.index.pattern })) as ApplicationSummary[]
   }
+
+  async submit(application: Application): Promise<void> {
+    await this.restClient.post({
+      path: paths.applications.submission({ id: application.id }),
+      data: { translatedDocument: application.document },
+    })
+  }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -27,6 +27,7 @@ const applyPaths = {
     create: applicationsPath,
     index: applicationsPath,
     update: singleApplicationPath,
+    submission: singleApplicationPath.path('submission'),
   },
 }
 
@@ -47,6 +48,7 @@ export default {
     index: applyPaths.applications.index,
     update: applyPaths.applications.update,
     new: applyPaths.applications.create,
+    submission: applyPaths.applications.submission,
   },
   people: {
     risks: {

--- a/server/paths/apply.ts
+++ b/server/paths/apply.ts
@@ -15,6 +15,7 @@ const paths = {
     show: applicationPath,
     update: applicationPath,
     checkYourAnswers: applicationPath.path('check-your-answers'),
+    submission: applicationPath.path('submission'),
     pages: {
       show: pagesPath,
       update: pagesPath,

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -16,6 +16,8 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(paths.applications.new.pattern, applicationsController.new())
   get(paths.applications.show.pattern, applicationsController.show())
   post(paths.applications.create.pattern, applicationsController.create())
+  post(paths.applications.submission.pattern, applicationsController.submit())
+
   post(paths.applications.people.pattern, peopleController.find())
 
   get(paths.applications.pages.show.pattern, pagesController.show())

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -290,4 +290,19 @@ describe('ApplicationService', () => {
       })
     })
   })
+
+  describe('submit', () => {
+    const token = 'some-token'
+    const request = createMock<Request>({
+      user: { token },
+    })
+    const application = applicationFactory.build()
+
+    it('saves data to the session', async () => {
+      await service.submit(request.user.token, application)
+
+      expect(applicationClientFactory).toHaveBeenCalledWith(token)
+      expect(applicationClient.submit).toHaveBeenCalledWith(application)
+    })
+  })
 })

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -70,6 +70,12 @@ export default class ApplicationService {
     }
   }
 
+  async submit(token: string, application: Application) {
+    const client = this.applicationClientFactory(token)
+
+    await client.submit(application)
+  }
+
   private firstPageForTask(taskName: string) {
     return Object.keys(pages[taskName])[0]
   }

--- a/server/views/applications/confirm.njk
+++ b/server/views/applications/confirm.njk
@@ -1,0 +1,43 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ govukPanel({
+                titleText: "Application confirmation"
+            }) }}
+            <p>
+          We’ve sent you a confirmation email.
+        </p>
+            <p>
+                <a href="">Download a copy of this application (PDF, 708 KB) </a>
+            </p>
+
+            <h2 class="govuk-heading-m">What happens next</h2>
+
+            <p>We’ve sent your application to the Midlands central referral unit (CRU) for Approved Premises (AP).</p>
+            <p>The Midlands CRU will review your application within 10 working days.</p>
+            <p>You'll receive an email when the status of your application changes, or you can check the status in your <a href="">AP applications dashboard.</a>
+            </p>
+            <p>If you could not provide a release date you will need to email the Midlands CRU as soon as this date is confirmed.</p>
+            <p>
+                <a href="https://www.gov.uk/service-manual/user-centred-design/resources/patterns/feedback-pages.html">What did you think of this service?</a> (takes 30 seconds)</p>
+
+        </div>
+    </div>
+
+    {{ govukButton({
+          text: "Back to dashboard",
+          href: paths.applications.index()
+        }) }}
+</div>
+</div>
+{% endblock %}

--- a/server/views/applications/people/confirm.njk
+++ b/server/views/applications/people/confirm.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% extends "../partials/layout.njk" %}
+{% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body" %}

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -80,9 +80,6 @@
     <div class="govuk-grid-column-one-third">
       {{ widgets(risks) }}
     </div>
-    <div class="risk-information">
-      <div class="govuk-grid-column-one-third"></div>
-    </div>
 
   </div>
 

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -64,10 +64,13 @@
         </li>
       </ol>
 
-      {{ govukButton({
-        text: "Submit application",
-        href: "/index.html"
-      }) }}
+      <form action="{{ paths.applications.submission({id: application.id}) }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {{ govukButton({
+          text: "Submit application"
+          }) }}
+      </form>
 
       {{ govukButton({
         text: "Save and come back later",


### PR DESCRIPTION
# Context
We need to submit completed applications to the API.
The word submission is perhaps misleading, maybe 'finalize' would be more accurate as we are only 'submitting' the Application ID as the API already holds all the data it needs. The user simply tells it the application is complete.

As part of this work I have added a confirmation screen as it was a small piece of work and we needed somewhere to redirect to.

[Submission Trello card](https://trello.com/c/Gjsg2teU/789-persist-submitted-documents-in-translated-json)
[Confirmation screen Trello card](https://trello.com/c/I8ngVZL4/657-confirmation-screen)

# Changes in this PR
We add the required methods to the client, service and controller and wire up the 'Submit application' button to confirm completion of the application to the API

## Screenshots of UI changes
![Apply -- allows completion of the form](https://user-images.githubusercontent.com/44123869/203367592-6fa71451-9053-4000-9aa2-83c52b510ea8.png)

