### PR TITLE
Return user to tasklist after answering oral hearing question

### DIFF
--- a/server/form-pages/apply/basic-information/oralHearing.test.ts
+++ b/server/form-pages/apply/basic-information/oralHearing.test.ts
@@ -38,7 +38,7 @@ describe('OralHearing', () => {
     })
   })
 
-  itShouldHaveNextValue(new OralHearing({}, application), 'placement-date')
+  itShouldHaveNextValue(new OralHearing({}, application), '')
   itShouldHavePreviousValue(new OralHearing({}, application), 'release-date')
 
   describe('errors', () => {

--- a/server/form-pages/apply/basic-information/oralHearing.ts
+++ b/server/form-pages/apply/basic-information/oralHearing.ts
@@ -25,7 +25,7 @@ export default class OralHearing implements TasklistPage {
   }
 
   next() {
-    return 'placement-date'
+    return ''
   }
 
   previous() {


### PR DESCRIPTION
Previously we took the user to the Placement Date page. 
The Placement Date page requires there to be a release date in the session however on the Release Date page they answered that they don’t know the the release date. There doesn’t make sense to move them on to the placement date page so instead we return them to the tasklist.

This has been confirmed by our SME [here](https://mojdt.slack.com/archives/C02SHKETZ7F/p1668418539408919?thread_ts=1668174667.005489&cid=C02SHKETZ7F)
[Sentry Issue here](https://sentry.io/organizations/ministryofjustice/issues/3760879622)