### PR TITLE
Fix risk widget helper to support missing risks

### DIFF
--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,4 +1,5 @@
 import type { SummaryListItem } from '@approved-premises/ui'
+import { PersonRisks } from '@approved-premises/api'
 import { SessionDataError } from './errors'
 import applicationFactory from '../testutils/factories/application'
 import {
@@ -165,8 +166,13 @@ describe('removeBlankSummaryListItems', () => {
 })
 
 describe('mapApiPersonRiskForUI', () => {
+  let risks: PersonRisks
+
+  beforeEach(() => {
+    risks = risksFactory.build()
+  })
+
   it('maps the PersonRisks from the API into a shape thats useful for the UI', () => {
-    const risks = risksFactory.build()
     const actual = mapApiPersonRisksForUi(risks)
     expect(actual).toEqual({
       crn: risks.crn,
@@ -190,9 +196,8 @@ describe('mapApiPersonRiskForUI', () => {
     })
   })
 
-  it('handles the case where roshRisks lastUpdated is null', () => {
-    const risks = risksFactory.build()
-    risks.roshRisks.value.lastUpdated = null
+  it('handles the case where roshRisks is null', () => {
+    risks.roshRisks = null
 
     const actual = mapApiPersonRisksForUi(risks)
 
@@ -205,6 +210,80 @@ describe('mapApiPersonRiskForUI', () => {
       },
       roshRisks: {
         lastUpdated: '',
+      },
+      tier: {
+        lastUpdated: DateFormats.isoDateToUIDate(risks.tier.value.lastUpdated),
+        level: risks.tier.value.level,
+      },
+    })
+  })
+
+  it('handles the case where mappa is null', () => {
+    risks.mappa = null
+
+    const actual = mapApiPersonRisksForUi(risks)
+
+    expect(actual).toEqual({
+      crn: risks.crn,
+      flags: risks.flags.value,
+      mappa: {
+        lastUpdated: '',
+      },
+      roshRisks: {
+        lastUpdated: DateFormats.isoDateToUIDate(risks.roshRisks.value.lastUpdated),
+        overallRisk: risks.roshRisks.value.overallRisk,
+        riskToChildren: risks.roshRisks.value.riskToChildren,
+        riskToKnownAdult: risks.roshRisks.value.riskToKnownAdult,
+        riskToPublic: risks.roshRisks.value.riskToPublic,
+        riskToStaff: risks.roshRisks.value.riskToStaff,
+      },
+      tier: {
+        lastUpdated: DateFormats.isoDateToUIDate(risks.tier.value.lastUpdated),
+        level: risks.tier.value.level,
+      },
+    })
+  })
+
+  it('handles the case where tier is null', () => {
+    risks.tier = null
+
+    const actual = mapApiPersonRisksForUi(risks)
+
+    expect(actual).toEqual({
+      crn: risks.crn,
+      flags: risks.flags.value,
+      mappa: {
+        lastUpdated: DateFormats.isoDateToUIDate(risks.mappa.value.lastUpdated),
+        level: 'CAT 2 / LEVEL 1',
+      },
+      roshRisks: {
+        lastUpdated: DateFormats.isoDateToUIDate(risks.roshRisks.value.lastUpdated),
+        overallRisk: risks.roshRisks.value.overallRisk,
+        riskToChildren: risks.roshRisks.value.riskToChildren,
+        riskToKnownAdult: risks.roshRisks.value.riskToKnownAdult,
+        riskToPublic: risks.roshRisks.value.riskToPublic,
+        riskToStaff: risks.roshRisks.value.riskToStaff,
+      },
+      tier: {
+        lastUpdated: '',
+      },
+    })
+  })
+
+  it('handles the case where flags is null', () => {
+    risks.flags.value = null
+
+    const actual = mapApiPersonRisksForUi(risks)
+
+    expect(actual).toEqual({
+      crn: risks.crn,
+      flags: null,
+      mappa: {
+        lastUpdated: DateFormats.isoDateToUIDate(risks.mappa.value.lastUpdated),
+        level: 'CAT 2 / LEVEL 1',
+      },
+      roshRisks: {
+        lastUpdated: DateFormats.isoDateToUIDate(risks.roshRisks.value.lastUpdated),
         overallRisk: risks.roshRisks.value.overallRisk,
         riskToChildren: risks.roshRisks.value.riskToChildren,
         riskToKnownAdult: risks.roshRisks.value.riskToKnownAdult,

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -108,18 +108,18 @@ export const mapApiPersonRisksForUi = (risks: PersonRisks): PersonRisksUI => {
   return {
     ...risks,
     roshRisks: {
-      ...risks.roshRisks.value,
-      lastUpdated: risks.roshRisks.value.lastUpdated
+      ...risks.roshRisks?.value,
+      lastUpdated: risks.roshRisks?.value?.lastUpdated
         ? DateFormats.isoDateToUIDate(risks.roshRisks.value.lastUpdated)
         : '',
     },
     mappa: {
-      ...risks.mappa.value,
-      lastUpdated: DateFormats.isoDateToUIDate(risks.mappa.value.lastUpdated),
+      ...risks.mappa?.value,
+      lastUpdated: risks.mappa?.value?.lastUpdated ? DateFormats.isoDateToUIDate(risks.mappa.value.lastUpdated) : '',
     },
     tier: {
-      ...risks.tier.value,
-      lastUpdated: DateFormats.isoDateToUIDate(risks.tier.value.lastUpdated),
+      ...risks.tier?.value,
+      lastUpdated: risks.tier?.value?.lastUpdated ? DateFormats.isoDateToUIDate(risks.tier.value.lastUpdated) : '',
     },
     flags: risks.flags.value,
   }


### PR DESCRIPTION
Addresses: https://sentry.io/organizations/ministryofjustice/issues/3765047768/?project=4503931667742720&query=is%3Aunresolved&referrer=issue-stream

We didn’t always have appropriate safeguards for if any of the items in the risks endpoint did not return any data. This has now been fixed to be more defensive, with the appropriate tests added.