### PR TITLE
Checkout repo before attempting to generate types

### DIFF
--- a/.github/workflows/generate-types.yml
+++ b/.github/workflows/generate-types.yml
@@ -12,6 +12,8 @@ jobs:
   generate-types:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code
+        uses: actions/checkout@v3
       - name: Generate Types
         run: ./script/generate-types
       - name: Create Pull Request


### PR DESCRIPTION
Checkout the repository when running the generate types workflow