### PR TITLE
Add Helm config to deploy to preprod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,21 +105,20 @@ workflows:
                 - main
           requires:
             - deploy_dev
+      - request-preprod-approval:
+          type: approval
+          requires:
+           - deploy_dev
+           - e2e_environment_test
+      - hmpps/deploy_env:
+          name: deploy_preprod
+          env: "preprod"
+          context:
+            - hmpps-common-vars
+            - approved-premises-ui-preprod
+          requires:
+            - request-preprod-approval
 
-  #      - request-preprod-approval:
-  #          type: approval
-  #          requires:
-  #            - deploy_dev
-  #      - hmpps/deploy_env:
-  #          name: deploy_preprod
-  #          env: "preprod"
-  #          jira_update: true
-  #          jira_env_type: staging
-  #          context:
-  #            - hmpps-common-vars
-  #            - approved-premises-ui-preprod
-  #          requires:
-  #            - request-preprod-approval
   #      - request-prod-approval:
   #          type: approval
   #          requires:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,0 +1,22 @@
+---
+# Per environment values which override defaults in approved-premises-ui/values.yaml
+
+generic-service:
+  ingress:
+    hosts:
+      - approved-premises-preprod.hmpps.service.justice.gov.uk
+    contextColour: green
+    tlsSecretName: hmpps-approved-premises-preprod-cert
+
+  env:
+    ENVIRONMENT: preprod
+    APPROVED_PREMISES_API_URL: 'https://approved-premises-api-preprod.hmpps.service.justice.gov.uk'
+    INGRESS_URL: 'https://approved-premises-preprod.hmpps.service.justice.gov.uk'
+    HMPPS_AUTH_URL: 'https://sign-in-preprod.hmpps.service.justice.gov.uk/auth'
+    TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-preprod.prison.service.justice.gov.uk'
+    COMMUNITY_ACCOMMODATION_API_SERVICE_NAME: approved-premises
+
+  allowlist: null
+
+generic-prometheus-alerts:
+  alertSeverity: digital-prison-service-dev


### PR DESCRIPTION
- New service certificate [1]
- Preprod hostnames for dependant APIs found in the certificate files within each relevant service in the Cloud Platform Environments repo[2]

[1] https://github.com/ministryofjustice/cloud-platform-environments/pull/9339
[2] https://github.com/ministryofjustice/cloud-platform-environments

