### PR TITLE
(890) Build schema for apply

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -13,6 +13,8 @@ import lostBed from './integration_tests/mockApis/lostBed'
 import person from './integration_tests/mockApis/person'
 import applications from './integration_tests/mockApis/applications'
 
+import schemaValidator from './integration_tests/tasks/schemaValidator'
+
 export default defineConfig({
   chromeWebSecurity: false,
   fixturesFolder: 'integration_tests/fixtures',
@@ -40,6 +42,7 @@ export default defineConfig({
         ...lostBed,
         ...person,
         ...applications,
+        ...schemaValidator,
       })
     },
     baseUrl: 'http://localhost:3007',

--- a/integration_tests/tasks/schemaValidator.ts
+++ b/integration_tests/tasks/schemaValidator.ts
@@ -1,0 +1,10 @@
+import { Validator } from 'jsonschema'
+import schema from '../../server/form-pages/apply/schema.json'
+
+export default {
+  validateBodyAgainstApplySchema: (body: Record<string, unknown>): boolean => {
+    const validator = new Validator()
+    const result = validator.validate(body, schema)
+    return result.valid
+  },
+}

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -486,6 +486,10 @@ context('Apply', () => {
         const requestBody = JSON.parse(requests[29].body)
 
         expect(requestBody.data).to.deep.equal(applicationData)
+
+        cy.task('validateBodyAgainstApplySchema', requestBody.data).then(result => {
+          expect(result).to.equal(true)
+        })
       })
 
       cy.task('verifyApplicationSubmit', application.id).then(requests => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "http-errors": "^2.0.0",
         "jquery": "^3.6.1",
         "jsonpath": "^1.1.1",
+        "jsonschema": "^1.4.1",
         "jwt-decode": "^3.1.2",
         "method-override": "^3.0.0",
         "nocache": "^3.0.4",
@@ -8544,6 +8545,14 @@
         "esprima": "1.2.2",
         "static-eval": "2.0.2",
         "underscore": "1.12.1"
+      }
+    },
+    "node_modules/jsonschema": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
+      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/JSONStream": {
@@ -17970,6 +17979,11 @@
         "static-eval": "2.0.2",
         "underscore": "1.12.1"
       }
+    },
+    "jsonschema": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
+      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ=="
     },
     "JSONStream": {
       "version": "1.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "reflect-metadata": "^0.1.13",
         "static-path": "^0.0.4",
         "superagent": "^8.0.2",
+        "typescript-json-schema": "^0.55.0",
         "url-value-parser": "^2.2.0",
         "uuid": "^9.0.0"
       },
@@ -2105,6 +2106,26 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@cucumber/cucumber-expressions": {
       "version": "16.0.1",
       "dev": true,
@@ -2722,7 +2743,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2738,7 +2758,6 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -3051,6 +3070,26 @@
       "dev": true,
       "license": "(Unlicense OR Apache-2.0)"
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
+    },
     "node_modules/@types/babel__core": {
       "version": "7.1.19",
       "dev": true,
@@ -3252,7 +3291,6 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -3667,7 +3705,6 @@
     },
     "node_modules/acorn": {
       "version": "8.8.1",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3682,6 +3719,14 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -3768,7 +3813,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3776,7 +3820,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3853,6 +3896,11 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4154,7 +4202,6 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -4260,7 +4307,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4667,7 +4713,6 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -4720,7 +4765,6 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4731,7 +4775,6 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -4827,7 +4870,6 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/concurrently": {
@@ -5043,6 +5085,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -5499,7 +5546,6 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -5677,7 +5723,6 @@
     },
     "node_modules/escalade": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6758,7 +6803,6 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -6819,7 +6863,6 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -6900,7 +6943,6 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -7309,7 +7351,6 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -9135,7 +9176,6 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -9276,7 +9316,6 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -10093,6 +10132,11 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/path-equal": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/path-equal/-/path-equal-1.2.5.tgz",
+      "integrity": "sha512-i73IctDr3F2W+bsOWDyyVm/lqsXO47aY9nsFZUjTT/aljSbkxHxxCoyZ9UUrM8jK0JVod+An+rl48RCsvWM+9g=="
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "dev": true,
@@ -10103,7 +10147,6 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10691,7 +10734,6 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10886,6 +10928,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
+      "integrity": "sha512-dVHE6bMtS/bnL2mwualjc6IxEv1F+OCUpA46pKUj6F8uDbUM0jCCulPqRNPSnWwGNKx5etqMjZYdXtrm5KJZGA==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/safer-buffer": {
@@ -11412,7 +11462,6 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -11425,7 +11474,6 @@
     },
     "node_modules/string-width/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11459,7 +11507,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -11767,6 +11814,56 @@
         "node": ">=12"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "dev": true,
@@ -11888,8 +11985,42 @@
     },
     "node_modules/typescript": {
       "version": "4.9.3",
-      "dev": true,
       "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/typescript-json-schema": {
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.55.0.tgz",
+      "integrity": "sha512-BXaivYecUdiXWWNiUqXgY6A9cMWerwmhtO+lQE7tDZGs7Mf38sORDeQZugfYOZOHPZ9ulsD+w0LWjFDOQoXcwg==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@types/node": "^16.9.2",
+        "glob": "^7.1.7",
+        "path-equal": "^1.1.2",
+        "safe-stable-stringify": "^2.2.0",
+        "ts-node": "^10.9.1",
+        "typescript": "~4.8.2",
+        "yargs": "^17.1.1"
+      },
+      "bin": {
+        "typescript-json-schema": "bin/typescript-json-schema"
+      }
+    },
+    "node_modules/typescript-json-schema/node_modules/@types/node": {
+      "version": "16.18.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.4.tgz",
+      "integrity": "sha512-9qGjJ5GyShZjUfx2ArBIGM+xExdfLvvaCyQR0t6yRXKPcWCVYF/WemtX/uIU3r7FYECXRXkIiw2Vnhn6y8d+pw=="
+    },
+    "node_modules/typescript-json-schema/node_modules/typescript": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12068,6 +12199,11 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
       "dev": true,
@@ -12188,7 +12324,6 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -12264,7 +12399,6 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -12284,7 +12418,6 @@
     },
     "node_modules/yargs": {
       "version": "17.6.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -12337,7 +12470,6 @@
     },
     "node_modules/yargs/node_modules/yargs-parser": {
       "version": "21.1.1",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -12350,6 +12482,14 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {
@@ -13617,6 +13757,25 @@
       "dev": true,
       "optional": true
     },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
+    },
     "@cucumber/cucumber-expressions": {
       "version": "16.0.1",
       "dev": true,
@@ -14061,16 +14220,14 @@
       }
     },
     "@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "dev": true
+      "version": "3.1.0"
     },
     "@jridgewell/set-array": {
       "version": "1.1.2",
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "dev": true
+      "version": "1.4.14"
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.17",
@@ -14284,6 +14441,26 @@
       "version": "0.7.2",
       "dev": true
     },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
+    },
     "@types/babel__core": {
       "version": "7.1.19",
       "dev": true,
@@ -14460,8 +14637,7 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.11",
-      "dev": true
+      "version": "7.0.11"
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -14752,13 +14928,17 @@
       }
     },
     "acorn": {
-      "version": "8.8.1",
-      "dev": true
+      "version": "8.8.1"
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "dev": true,
       "requires": {}
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
     },
     "agent-base": {
       "version": "6.0.2",
@@ -14810,12 +14990,10 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.1",
-      "dev": true
+      "version": "5.0.1"
     },
     "ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -14852,6 +15030,11 @@
     "arch": {
       "version": "2.2.0",
       "dev": true
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "argparse": {
       "version": "2.0.1",
@@ -15054,8 +15237,7 @@
       }
     },
     "balanced-match": {
-      "version": "1.0.2",
-      "devOptional": true
+      "version": "1.0.2"
     },
     "base64-js": {
       "version": "1.5.1",
@@ -15123,7 +15305,6 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "devOptional": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -15356,7 +15537,6 @@
     },
     "cliui": {
       "version": "8.0.1",
-      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -15389,14 +15569,12 @@
     },
     "color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
     },
     "color-name": {
-      "version": "1.1.4",
-      "dev": true
+      "version": "1.1.4"
     },
     "colorette": {
       "version": "2.0.19",
@@ -15459,8 +15637,7 @@
       }
     },
     "concat-map": {
-      "version": "0.0.1",
-      "devOptional": true
+      "version": "0.0.1"
     },
     "concurrently": {
       "version": "7.6.0",
@@ -15588,6 +15765,11 @@
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
       }
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -15877,8 +16059,7 @@
       "dev": true
     },
     "emoji-regex": {
-      "version": "8.0.0",
-      "dev": true
+      "version": "8.0.0"
     },
     "encodeurl": {
       "version": "1.0.2"
@@ -16005,8 +16186,7 @@
       "peer": true
     },
     "escalade": {
-      "version": "3.1.1",
-      "dev": true
+      "version": "3.1.1"
     },
     "escape-html": {
       "version": "1.0.3"
@@ -16697,8 +16877,7 @@
       }
     },
     "fs.realpath": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "fsevents": {
       "version": "2.3.2",
@@ -16730,8 +16909,7 @@
       "dev": true
     },
     "get-caller-file": {
-      "version": "2.0.5",
-      "dev": true
+      "version": "2.0.5"
     },
     "get-intrinsic": {
       "version": "1.1.3",
@@ -16780,7 +16958,6 @@
     },
     "glob": {
       "version": "7.2.3",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -17017,7 +17194,6 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "devOptional": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -18207,8 +18383,7 @@
       }
     },
     "make-error": {
-      "version": "1.3.6",
-      "dev": true
+      "version": "1.3.6"
     },
     "makeerror": {
       "version": "1.0.12",
@@ -18300,7 +18475,6 @@
     },
     "minimatch": {
       "version": "3.1.2",
-      "devOptional": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -18816,13 +18990,17 @@
     "passport-strategy": {
       "version": "1.0.0"
     },
+    "path-equal": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/path-equal/-/path-equal-1.2.5.tgz",
+      "integrity": "sha512-i73IctDr3F2W+bsOWDyyVm/lqsXO47aY9nsFZUjTT/aljSbkxHxxCoyZ9UUrM8jK0JVod+An+rl48RCsvWM+9g=="
+    },
     "path-exists": {
       "version": "4.0.0",
       "dev": true
     },
     "path-is-absolute": {
-      "version": "1.0.1",
-      "devOptional": true
+      "version": "1.0.1"
     },
     "path-key": {
       "version": "3.1.1",
@@ -19189,8 +19367,7 @@
       }
     },
     "require-directory": {
-      "version": "2.1.1",
-      "dev": true
+      "version": "2.1.1"
     },
     "requires-port": {
       "version": "1.0.0"
@@ -19311,6 +19488,11 @@
         "get-intrinsic": "^1.1.3",
         "is-regex": "^1.1.4"
       }
+    },
+    "safe-stable-stringify": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
+      "integrity": "sha512-dVHE6bMtS/bnL2mwualjc6IxEv1F+OCUpA46pKUj6F8uDbUM0jCCulPqRNPSnWwGNKx5etqMjZYdXtrm5KJZGA=="
     },
     "safer-buffer": {
       "version": "2.1.2"
@@ -19655,7 +19837,6 @@
     },
     "string-width": {
       "version": "4.2.3",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -19663,8 +19844,7 @@
       },
       "dependencies": {
         "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "dev": true
+          "version": "3.0.0"
         }
       }
     },
@@ -19688,7 +19868,6 @@
     },
     "strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -19874,6 +20053,33 @@
         }
       }
     },
+    "ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+        }
+      }
+    },
     "tsconfig-paths": {
       "version": "3.14.1",
       "dev": true,
@@ -19947,8 +20153,34 @@
       }
     },
     "typescript": {
-      "version": "4.9.3",
-      "dev": true
+      "version": "4.9.3"
+    },
+    "typescript-json-schema": {
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.55.0.tgz",
+      "integrity": "sha512-BXaivYecUdiXWWNiUqXgY6A9cMWerwmhtO+lQE7tDZGs7Mf38sORDeQZugfYOZOHPZ9ulsD+w0LWjFDOQoXcwg==",
+      "requires": {
+        "@types/json-schema": "^7.0.9",
+        "@types/node": "^16.9.2",
+        "glob": "^7.1.7",
+        "path-equal": "^1.1.2",
+        "safe-stable-stringify": "^2.2.0",
+        "ts-node": "^10.9.1",
+        "typescript": "~4.8.2",
+        "yargs": "^17.1.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "16.18.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.4.tgz",
+          "integrity": "sha512-9qGjJ5GyShZjUfx2ArBIGM+xExdfLvvaCyQR0t6yRXKPcWCVYF/WemtX/uIU3r7FYECXRXkIiw2Vnhn6y8d+pw=="
+        },
+        "typescript": {
+          "version": "4.8.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+          "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ=="
+        }
+      }
     },
     "uglify-js": {
       "version": "3.17.4",
@@ -20043,6 +20275,11 @@
     "uuid": {
       "version": "9.0.0"
     },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+    },
     "v8-to-istanbul": {
       "version": "9.0.1",
       "dev": true,
@@ -20124,7 +20361,6 @@
     },
     "wrap-ansi": {
       "version": "7.0.0",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -20174,8 +20410,7 @@
       }
     },
     "y18n": {
-      "version": "5.0.8",
-      "dev": true
+      "version": "5.0.8"
     },
     "yallist": {
       "version": "4.0.0"
@@ -20186,7 +20421,6 @@
     },
     "yargs": {
       "version": "17.6.2",
-      "dev": true,
       "requires": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -20198,8 +20432,7 @@
       },
       "dependencies": {
         "yargs-parser": {
-          "version": "21.1.1",
-          "dev": true
+          "version": "21.1.1"
         }
       }
     },
@@ -20233,6 +20466,11 @@
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "reflect-metadata": "^0.1.13",
     "static-path": "^0.0.4",
     "superagent": "^8.0.2",
+    "typescript-json-schema": "^0.55.0",
     "url-value-parser": "^2.2.0",
     "uuid": "^9.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "api-stubs:reset": "npx ts-node --transpile-only ./wiremock/resetStubs.ts",
     "start-test-wiremock": "docker-compose -f docker-compose-test.yml up -d",
     "generate-types": "script/generate-types",
-    "form-page:generate": "npx ts-node --transpile-only ./server/form-pages/utils/generator.ts"
+    "form-page:generate": "npx ts-node --transpile-only ./server/form-pages/utils/generator.ts",
+    "generate:schema:apply": "npx ts-node --transpile-only ./server/form-pages/apply/generateSchema.ts"
   },
   "engines": {
     "node": "^18",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "http-errors": "^2.0.0",
     "jquery": "^3.6.1",
     "jsonpath": "^1.1.1",
+    "jsonschema": "^1.4.1",
     "jwt-decode": "^3.1.2",
     "method-override": "^3.0.0",
     "nocache": "^3.0.4",

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -52,8 +52,10 @@ export type FormSection = {
 
 export type FormSections = Array<FormSection>
 
+export type FormPages = { [key in TaskNames]: Record<string, unknown> }
+
 export interface Form {
-  pages: { [key in TaskNames]: Record<string, unknown> }
+  pages: FormPages
   sections: Array<{
     title: string
     tasks: Array<Task>

--- a/server/form-pages/apply/check-your-answers/review.test.ts
+++ b/server/form-pages/apply/check-your-answers/review.test.ts
@@ -7,7 +7,7 @@ describe('Review', () => {
   const application = applicationFactory.build({})
 
   const body = {
-    reviewed: 1,
+    reviewed: '1',
   }
 
   describe('body', () => {

--- a/server/form-pages/apply/check-your-answers/review.ts
+++ b/server/form-pages/apply/check-your-answers/review.ts
@@ -10,7 +10,7 @@ export default class Review implements TasklistPage {
 
   title = 'Check your answers'
 
-  constructor(public body: { reviewed?: number }, readonly application: Application) {}
+  constructor(public body: { reviewed?: string }, readonly application: Application) {}
 
   previous() {
     return ''

--- a/server/form-pages/apply/generateSchema.ts
+++ b/server/form-pages/apply/generateSchema.ts
@@ -1,0 +1,9 @@
+/* istanbul ignore file */
+
+import path from 'path'
+
+import SchemaGenerator from '../utils/schemaGenerator'
+
+import Apply from '.'
+
+SchemaGenerator.run(Apply.pages, path.resolve(__dirname, 'schema.json'))

--- a/server/form-pages/apply/move-on/placementDuration.test.ts
+++ b/server/form-pages/apply/move-on/placementDuration.test.ts
@@ -15,7 +15,7 @@ describe('PlacementDuration', () => {
 
   describe('body', () => {
     it('should set the body', () => {
-      const body = { duration: 4, durationDetail: 'Some detail' }
+      const body = { duration: '4', durationDetail: 'Some detail' }
       const page = new PlacementDuration(body, application)
 
       expect(page.body).toEqual(body)
@@ -115,7 +115,7 @@ describe('PlacementDuration', () => {
 
   describe('response', () => {
     it('should return a translated version of the response', () => {
-      const page = new PlacementDuration({ duration: 4, durationDetail: 'Some detail' }, application)
+      const page = new PlacementDuration({ duration: '4', durationDetail: 'Some detail' }, application)
 
       expect(page.response()).toEqual({
         'What duration of placement do you recommend?': '4 weeks',
@@ -124,7 +124,7 @@ describe('PlacementDuration', () => {
     })
 
     it("should not include the detail if it's blank", () => {
-      const page = new PlacementDuration({ duration: 4, durationDetail: '' }, application)
+      const page = new PlacementDuration({ duration: '4', durationDetail: '' }, application)
 
       expect(page.response()).toEqual({ 'What duration of placement do you recommend?': '4 weeks' })
     })

--- a/server/form-pages/apply/move-on/placementDuration.ts
+++ b/server/form-pages/apply/move-on/placementDuration.ts
@@ -7,7 +7,7 @@ import { Page } from '../../utils/decorators'
 import TasklistPage from '../../tasklistPage'
 
 type PlacementDurationBody = {
-  duration: number
+  duration: string
   durationDetail: string
 }
 

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -1,0 +1,1121 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "type": "object",
+  "title": "Apply Schema",
+  "required": [
+    "basic-information",
+    "type-of-ap",
+    "risk-management-features",
+    "prison-information",
+    "location-factors",
+    "access-and-healthcare",
+    "further-considerations",
+    "move-on",
+    "check-your-answers"
+  ],
+  "properties": {
+    "basic-information": {
+      "type": "object",
+      "properties": {
+        "sentence-type": {
+          "type": "object",
+          "properties": {
+            "sentenceType": {
+              "enum": [
+                "bailPlacement",
+                "communityOrder",
+                "extendedDeterminate",
+                "ipp",
+                "life",
+                "nonStatutory",
+                "standardDeterminate"
+              ],
+              "type": "string"
+            }
+          }
+        },
+        "release-type": {
+          "type": "object",
+          "properties": {
+            "releaseType": {
+              "enum": [
+                "hdc",
+                "license",
+                "pss",
+                "rerelease",
+                "rotl"
+              ],
+              "type": "string"
+            }
+          }
+        },
+        "situation": {
+          "type": "object",
+          "properties": {
+            "situation": {
+              "enum": [
+                "bailAssessment",
+                "bailSentence",
+                "residencyManagement",
+                "riskManagement"
+              ],
+              "type": "string"
+            }
+          }
+        },
+        "release-date": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "releaseDate-year": {
+                  "type": "string"
+                },
+                "releaseDate-month": {
+                  "type": "string"
+                },
+                "releaseDate-day": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "releaseDate-time": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "releaseDate": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "knowReleaseDate": {
+                  "enum": [
+                    "no",
+                    "yes"
+                  ],
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        },
+        "oral-hearing": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "oralHearingDate-year": {
+                  "type": "string"
+                },
+                "oralHearingDate-month": {
+                  "type": "string"
+                },
+                "oralHearingDate-day": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "oralHearingDate-time": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "oralHearingDate": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "knowOralHearingDate": {
+                  "enum": [
+                    "no",
+                    "yes"
+                  ],
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        },
+        "placement-date": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "startDate-year": {
+                  "type": "string"
+                },
+                "startDate-month": {
+                  "type": "string"
+                },
+                "startDate-day": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "startDate-time": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "startDate": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "startDateSameAsReleaseDate": {
+                  "enum": [
+                    "no",
+                    "yes"
+                  ],
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        },
+        "placement-purpose": {
+          "type": "object",
+          "properties": {
+            "placementPurposes": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "enum": [
+                      "drugAlcoholMonitoring",
+                      "otherReason",
+                      "preventContact",
+                      "preventSelfHarm",
+                      "publicProtection",
+                      "readjust"
+                    ],
+                    "type": "string"
+                  }
+                },
+                {
+                  "enum": [
+                    "drugAlcoholMonitoring",
+                    "otherReason",
+                    "preventContact",
+                    "preventSelfHarm",
+                    "publicProtection",
+                    "readjust"
+                  ],
+                  "type": "string"
+                }
+              ]
+            },
+            "otherReason": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "type-of-ap": {
+      "type": "object",
+      "properties": {
+        "ap-type": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "esap",
+                "pipe",
+                "standard"
+              ],
+              "type": "string"
+            }
+          }
+        },
+        "pipe-referral": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "opdPathwayDate-year": {
+                  "type": "string"
+                },
+                "opdPathwayDate-month": {
+                  "type": "string"
+                },
+                "opdPathwayDate-day": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "opdPathwayDate-time": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "opdPathwayDate": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "opdPathway": {
+                  "enum": [
+                    "no",
+                    "yes"
+                  ],
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        },
+        "pipe-opd-screening": {
+          "type": "object",
+          "properties": {
+            "pipeReferral": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "pipeReferralMoreDetail": {
+              "type": "string"
+            }
+          }
+        },
+        "esap-placement-screening": {
+          "type": "object",
+          "properties": {
+            "esapReasons": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "cctv",
+                  "secreting"
+                ],
+                "type": "string"
+              }
+            },
+            "esapFactors": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "careAndSeperation",
+                  "complexPersonality",
+                  "corrupter",
+                  "neurodiverse",
+                  "nonNsd",
+                  "unlock"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        },
+        "esap-placement-secreting": {
+          "type": "object",
+          "properties": {
+            "secretingHistory": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "csaLiterature",
+                  "drugs",
+                  "electronicItems",
+                  "fire",
+                  "hateCrimeLiterature",
+                  "radicalisationLiterature",
+                  "weapons"
+                ],
+                "type": "string"
+              }
+            },
+            "secretingIntelligence": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "secretingIntelligenceDetails": {
+              "type": "string"
+            },
+            "secretingNotes": {
+              "type": "string"
+            }
+          }
+        },
+        "esap-placement-cctv": {
+          "type": "object",
+          "properties": {
+            "cctvHistory": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "appearance",
+                  "communityThreats",
+                  "networks",
+                  "prisonerAssualt",
+                  "staffAssualt",
+                  "threatsToLife"
+                ],
+                "type": "string"
+              }
+            },
+            "cctvIntelligence": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "cctvIntelligenceDetails": {
+              "type": "string"
+            },
+            "cctvNotes": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "risk-management-features": {
+      "type": "object",
+      "properties": {
+        "risk-management-features": {
+          "type": "object",
+          "properties": {
+            "manageRiskDetails": {
+              "type": "string"
+            },
+            "additionalFeaturesDetails": {
+              "type": "string"
+            }
+          }
+        },
+        "convicted-offences": {
+          "type": "object",
+          "properties": {
+            "response": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            }
+          }
+        },
+        "type-of-convicted-offence": {
+          "type": "object",
+          "properties": {
+            "offenceConvictions": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "arson",
+                  "childNonSexualOffence",
+                  "hateCrimes",
+                  "sexualOffence"
+                ],
+                "type": "string"
+              }
+            }
+          }
+        },
+        "date-of-offence": {
+          "type": "object",
+          "properties": {
+            "arsonOffence": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "enum": [
+                      "current",
+                      "previous"
+                    ],
+                    "type": "string"
+                  }
+                },
+                {
+                  "enum": [
+                    "current",
+                    "previous"
+                  ],
+                  "type": "string"
+                }
+              ]
+            },
+            "hateCrime": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "enum": [
+                      "current",
+                      "previous"
+                    ],
+                    "type": "string"
+                  }
+                },
+                {
+                  "enum": [
+                    "current",
+                    "previous"
+                  ],
+                  "type": "string"
+                }
+              ]
+            },
+            "inPersonSexualOffence": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "enum": [
+                      "current",
+                      "previous"
+                    ],
+                    "type": "string"
+                  }
+                },
+                {
+                  "enum": [
+                    "current",
+                    "previous"
+                  ],
+                  "type": "string"
+                }
+              ]
+            },
+            "onlineSexualOffence": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "enum": [
+                      "current",
+                      "previous"
+                    ],
+                    "type": "string"
+                  }
+                },
+                {
+                  "enum": [
+                    "current",
+                    "previous"
+                  ],
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        },
+        "rehabilitative-interventions": {
+          "type": "object",
+          "properties": {
+            "rehabilitativeInterventions": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "abuse",
+                  "accomodation",
+                  "attitudesAndBehaviour",
+                  "childrenAndFamilies",
+                  "drugsAndAlcohol",
+                  "educationTrainingAndEmployment",
+                  "financeBenefitsAndDebt",
+                  "health",
+                  "other"
+                ],
+                "type": "string"
+              }
+            },
+            "otherIntervention": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "prison-information": {
+      "type": "object",
+      "properties": {
+        "case-notes": {
+          "type": "object",
+          "properties": {
+            "caseNoteIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "selectedCaseNotes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "sensitive": {
+                    "type": "boolean"
+                  },
+                  "createdAt": {
+                    "type": "string"
+                  },
+                  "occurredAt": {
+                    "type": "string"
+                  },
+                  "authorName": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "subType": {
+                    "type": "string"
+                  },
+                  "note": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "moreDetail": {
+              "type": "string"
+            },
+            "adjudications": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "reportedAt": {
+                    "type": "string"
+                  },
+                  "establishment": {
+                    "type": "string"
+                  },
+                  "offenceDescription": {
+                    "type": "string"
+                  },
+                  "hearingHeld": {
+                    "type": "boolean"
+                  },
+                  "finding": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "location-factors": {
+      "type": "object",
+      "properties": {
+        "describe-location-factors": {
+          "type": "object",
+          "properties": {
+            "postcodeArea": {
+              "type": "string"
+            },
+            "positiveFactors": {
+              "type": "string"
+            },
+            "restrictions": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "restrictionDetail": {
+              "type": "string"
+            },
+            "alternativeRadiusAccepted": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "alternativeRadius": {
+              "enum": [
+                "100",
+                "110",
+                "120",
+                "130",
+                "140",
+                "150",
+                "60",
+                "70",
+                "80",
+                "90"
+              ],
+              "type": "string"
+            },
+            "differentPDU": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            }
+          }
+        },
+        "pdu-transfer": {
+          "type": "object",
+          "properties": {
+            "transferStatus": {
+              "enum": [
+                "noNeedToMakeArrangements",
+                "noProbationPractitioner",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "probationPractitioner": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "access-and-healthcare": {
+      "type": "object",
+      "properties": {
+        "access-needs": {
+          "type": "object",
+          "properties": {
+            "additionalNeeds": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "hearingImpairment",
+                  "learningDisability",
+                  "mobility",
+                  "neurodivergentConditions",
+                  "none",
+                  "other",
+                  "visualImpairment"
+                ],
+                "type": "string"
+              }
+            },
+            "religiousOrCulturalNeeds": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "religiousOrCulturalNeedsDetails": {
+              "type": "string"
+            },
+            "careActAssessmentCompleted": {
+              "enum": [
+                "iDontKnow",
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "needsInterpreter": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "interpreterLanguage": {
+              "type": "string"
+            }
+          }
+        },
+        "access-needs-mobility": {
+          "type": "object",
+          "properties": {
+            "needsWheelchair": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "mobilityNeeds": {
+              "type": "string"
+            },
+            "visualImpairment": {
+              "type": "string"
+            }
+          }
+        },
+        "covid": {
+          "type": "object",
+          "properties": {
+            "fullyVaccinated": {
+              "enum": [
+                "iDontKnow",
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "highRisk": {
+              "enum": [
+                "iDontKnow",
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "additionalCovidInfo": {
+              "type": "string"
+            }
+          }
+        },
+        "access-needs-additional-adjustments": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "adjustments": {
+                  "enum": [
+                    "no",
+                    "yes"
+                  ],
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "adjustmentsDetail": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "further-considerations": {
+      "type": "object",
+      "properties": {
+        "room-sharing": {
+          "type": "object",
+          "properties": {
+            "riskToStaff": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "riskToStaffDetail": {
+              "type": "string"
+            },
+            "riskToOthers": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "riskToOthersDetail": {
+              "type": "string"
+            },
+            "sharingConcerns": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "sharingConcernsDetail": {
+              "type": "string"
+            },
+            "traumaConcerns": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "traumaConcernsDetail": {
+              "type": "string"
+            },
+            "sharingBenefits": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "sharingBenefitsDetail": {
+              "type": "string"
+            }
+          }
+        },
+        "vulnerability": {
+          "type": "object",
+          "properties": {
+            "exploitable": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "exploitableDetail": {
+              "type": "string"
+            },
+            "exploitOthers": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "exploitOthersDetail": {
+              "type": "string"
+            }
+          }
+        },
+        "previous-placements": {
+          "type": "object",
+          "properties": {
+            "previousPlacement": {
+              "enum": [
+                "iDontKnow",
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "previousPlacementDetail": {
+              "type": "string"
+            }
+          }
+        },
+        "complex-case-board": {
+          "type": "object",
+          "properties": {
+            "complexCaseBoard": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "complexCaseBoardDetail": {
+              "type": "string"
+            }
+          }
+        },
+        "catering": {
+          "type": "object",
+          "properties": {
+            "catering": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "cateringDetail": {
+              "type": "string"
+            }
+          }
+        },
+        "arson": {
+          "type": "object",
+          "properties": {
+            "arson": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "arsonDetail": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "move-on": {
+      "type": "object",
+      "properties": {
+        "placement-duration": {
+          "type": "object",
+          "properties": {
+            "duration": {
+              "type": "string"
+            },
+            "durationDetail": {
+              "type": "string"
+            }
+          }
+        },
+        "relocation-region": {
+          "type": "object",
+          "properties": {
+            "postcodeArea": {
+              "type": "string"
+            }
+          }
+        },
+        "plans-in-place": {
+          "type": "object",
+          "properties": {
+            "arePlansInPlace": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            }
+          }
+        },
+        "type-of-accommodation": {
+          "type": "object",
+          "properties": {
+            "accommodationType": {
+              "enum": [
+                "cas3",
+                "foreignNational",
+                "livingWithPartnerFamilyOrFriends",
+                "other",
+                "ownAccomodation",
+                "privateRented",
+                "rentedThroughHousingAssociation",
+                "rentedThroughLocalAuthority",
+                "supportedAccommodation",
+                "supportedHousing"
+              ],
+              "type": "string"
+            },
+            "otherAccommodationType": {
+              "type": "string"
+            }
+          }
+        },
+        "foreign-national": {
+          "anyOf": [
+            {
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "response": {
+                      "type": "string",
+                      "enum": [
+                        "yes"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "date-year": {
+                      "type": "string"
+                    },
+                    "date-month": {
+                      "type": "string"
+                    },
+                    "date-day": {
+                      "type": "string"
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "date-time": {
+                      "type": "string"
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "date": {
+                      "type": "string"
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "response": {
+                  "type": "string",
+                  "enum": [
+                    "no"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "check-your-answers": {
+      "type": "object",
+      "properties": {
+        "review": {
+          "type": "object",
+          "properties": {
+            "reviewed": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/server/form-pages/utils/decorators/page.decorator.test.ts
+++ b/server/form-pages/utils/decorators/page.decorator.test.ts
@@ -24,9 +24,11 @@ describe('tasklistPageDecorator', () => {
 
     it('sets metadata for the class', () => {
       const name = Reflect.getMetadata('page:name', SimpleClass)
+      const className = Reflect.getMetadata('page:className', SimpleClass)
       const bodyProperties = Reflect.getMetadata('page:bodyProperties', SimpleClass)
 
       expect(name).toEqual('Some Name')
+      expect(className).toEqual('SimpleClass')
       expect(bodyProperties).toEqual(['foo', 'bar', 'baz'])
     })
   })

--- a/server/form-pages/utils/decorators/page.decorator.ts
+++ b/server/form-pages/utils/decorators/page.decorator.ts
@@ -36,6 +36,7 @@ const Page = (options: { bodyProperties: Array<string>; name: string }) => {
     }
 
     Reflect.defineMetadata('page:name', options.name, TaskListPage)
+    Reflect.defineMetadata('page:className', constructor.name, TaskListPage)
     Reflect.defineMetadata('page:bodyProperties', options.bodyProperties, TaskListPage)
 
     return TaskListPage

--- a/server/form-pages/utils/schemaGenerator.test.ts
+++ b/server/form-pages/utils/schemaGenerator.test.ts
@@ -1,0 +1,64 @@
+import fs from 'fs'
+
+import SchemaGenerator from './schemaGenerator'
+
+type SomeComplexType = {
+  id: number
+  string: string
+  enum: 'some' | 'enum' | 'values'
+}
+
+class Page {
+  body: {
+    foo: string
+    bar: SomeComplexType
+  }
+}
+
+describe('schemaGenerator', () => {
+  describe('run', () => {
+    it('generates a schema with the correct types', () => {
+      const fileSpy = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {
+        return null
+      })
+
+      const pages = { section: { page: Page } }
+
+      jest.spyOn(Reflect, 'getMetadata').mockReturnValue('Page')
+
+      SchemaGenerator.run(pages, 'schema.json')
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith('schema.json', expect.anything(), { flag: 'w+' })
+
+      const generatedSchema = JSON.parse(fileSpy.mock.calls[0][1] as string)
+
+      expect(generatedSchema.required).toEqual(['section'])
+
+      expect(Object.keys(generatedSchema.properties)).toEqual(['section'])
+      expect(Object.keys(generatedSchema.properties.section.properties)).toEqual(['page'])
+
+      const pageSchema = generatedSchema.properties.section.properties.page
+      expect(Object.keys(pageSchema.properties)).toEqual(['foo', 'bar'])
+
+      expect(pageSchema.properties.foo).toEqual({
+        type: 'string',
+      })
+
+      expect(pageSchema.properties.bar).toEqual({
+        type: 'object',
+        properties: {
+          id: {
+            type: 'number',
+          },
+          string: {
+            type: 'string',
+          },
+          enum: {
+            enum: ['enum', 'some', 'values'],
+            type: 'string',
+          },
+        },
+      })
+    })
+  })
+})

--- a/server/form-pages/utils/schemaGenerator.ts
+++ b/server/form-pages/utils/schemaGenerator.ts
@@ -1,0 +1,64 @@
+import 'reflect-metadata'
+
+import fs from 'fs'
+import path from 'path'
+import * as TJS from 'typescript-json-schema'
+
+export default class SchemaGenerator {
+  program = TJS.programFromConfig(path.resolve(__dirname, '..', '..', '..', 'tsconfig.json'))
+
+  schemaGeneratorSettings: TJS.PartialArgs = {
+    required: false,
+    ref: false,
+  }
+
+  generator: TJS.JsonSchemaGenerator
+
+  constructor(private readonly filePath: string) {
+    /* istanbul ignore next */
+    // eslint-disable-next-line no-console
+    console.warn = () => {
+      return null // Silence warnings
+    }
+    this.generator = TJS.buildGenerator(this.program, this.schemaGeneratorSettings)
+  }
+
+  run<T>(pages: T) {
+    const pageKeys = Object.keys(pages)
+
+    const schema = {
+      $schema: 'https://json-schema.org/draft/2019-09/schema',
+      type: 'object',
+      title: 'Apply Schema',
+      required: Object.keys(pages),
+      properties: {},
+    }
+
+    pageKeys.forEach(key => {
+      const properties = {}
+
+      Object.keys(pages[key]).forEach((k: string) => {
+        properties[k] = this.getSchemaForPage(pages[key][k])
+      })
+
+      schema.properties[key] = { type: 'object', properties }
+    })
+
+    fs.writeFileSync(this.filePath, JSON.stringify(schema, null, 2), {
+      flag: 'w+',
+    })
+  }
+
+  static run<T>(pages: T, filePath: string) {
+    const generator = new SchemaGenerator(filePath)
+    generator.run(pages)
+  }
+
+  getSchemaForPage = (page: unknown) => {
+    const className = Reflect.getMetadata('page:className', page)
+
+    const s = this.generator.getSchemaForSymbol(className)
+
+    return s.properties.body
+  }
+}


### PR DESCRIPTION
This puts all the decorator work into action and, combined with [typescript-json-schema](https://www.npmjs.com/package/typescript-json-schema) generates a schema for the Apply questionnaire based on the page objects within Apply. We store the schema against the code, and test the request body matches the schema in the integration tests. We don't currently loudly complain if/when the schema changes, but the integration tests and e2e tests failing when the schema changes should be enough of a prompt for now.