### PR TITLE
Use a decorator the define a Form

### DIFF
--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -54,14 +54,6 @@ export type FormSections = Array<FormSection>
 
 export type FormPages = { [key in TaskNames]: Record<string, unknown> }
 
-export interface Form {
-  pages: FormPages
-  sections: Array<{
-    title: string
-    tasks: Array<Task>
-  }>
-}
-
 export interface HtmlAttributes {
   [key: string]: string
 }

--- a/server/form-pages/apply/index.ts
+++ b/server/form-pages/apply/index.ts
@@ -1,19 +1,11 @@
 /* istanbul ignore file */
-
-import { Form } from '@approved-premises/ui'
-
 import CheckYourAnswers from './check-your-answers'
 import MoveOn from './move-on'
 import ReasonsForPlacement from './reasons-for-placement'
 import RiskAndNeedFactors from './risk-and-need-factors'
 
-import { getSection, getPagesForSections } from '../utils'
+import { Form } from '../utils/decorators'
+import BaseForm from '../baseForm'
 
-const sectionClasses = [ReasonsForPlacement, RiskAndNeedFactors, MoveOn, CheckYourAnswers]
-
-const Apply = {
-  pages: getPagesForSections([ReasonsForPlacement, RiskAndNeedFactors, MoveOn, CheckYourAnswers]),
-  sections: sectionClasses.map(s => getSection(s)),
-} as Form
-
-export default Apply
+@Form({ sections: [ReasonsForPlacement, RiskAndNeedFactors, MoveOn, CheckYourAnswers] })
+export default class Apply extends BaseForm {}

--- a/server/form-pages/baseForm.ts
+++ b/server/form-pages/baseForm.ts
@@ -1,0 +1,10 @@
+import { FormPages, Task } from '@approved-premises/ui'
+
+export default class BaseForm {
+  static pages: FormPages
+
+  static sections: Array<{
+    title: string
+    tasks: Array<Task>
+  }>
+}

--- a/server/form-pages/utils/decorators/form.decorator.test.ts
+++ b/server/form-pages/utils/decorators/form.decorator.test.ts
@@ -1,0 +1,49 @@
+import BaseForm from '../../baseForm'
+
+import Section from './section.decorator'
+import Form from './form.decorator'
+import Task from './task.decorator'
+
+describe('Task', () => {
+  it('records metadata about a class', () => {
+    @Task({ name: 'Task 1', slug: 'task-1', pages: [] })
+    class Task1 {}
+
+    @Task({ name: 'Task 2', slug: 'task-2', pages: [] })
+    class Task2 {}
+
+    @Task({ name: 'Task 3', slug: 'task-3', pages: [] })
+    class Task3 {}
+
+    @Section({ name: 'Section 1', tasks: [Task1] })
+    class Section1 {}
+
+    @Section({ name: 'Section 2', tasks: [Task2, Task3] })
+    class Section2 {}
+
+    @Section({ name: 'Section 3', tasks: [] })
+    class Section3 {}
+
+    @Form({ sections: [Section1, Section2, Section3] })
+    class MyForm extends BaseForm {}
+
+    expect(MyForm.pages).toEqual({ 'task-1': {}, 'task-2': {}, 'task-3': {} })
+    expect(MyForm.sections).toEqual([
+      {
+        title: 'Section 1',
+        tasks: [{ id: 'task-1', title: 'Task 1', pages: {} }],
+      },
+      {
+        title: 'Section 2',
+        tasks: [
+          { id: 'task-2', title: 'Task 2', pages: {} },
+          { id: 'task-3', title: 'Task 3', pages: {} },
+        ],
+      },
+      {
+        title: 'Section 3',
+        tasks: [],
+      },
+    ])
+  })
+})

--- a/server/form-pages/utils/decorators/form.decorator.ts
+++ b/server/form-pages/utils/decorators/form.decorator.ts
@@ -1,0 +1,20 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/ban-types */
+import 'reflect-metadata'
+import { getSection, getPagesForSections } from '../index'
+
+type Constructor = new (...args: any[]) => {}
+
+const Form = (options: { sections: Array<unknown> }) => {
+  return <T extends Constructor>(constructor: T) => {
+    const FormClass = class extends constructor {
+      static pages = getPagesForSections(options.sections)
+
+      static sections = options.sections.map(s => getSection(s))
+    }
+
+    return FormClass
+  }
+}
+
+export default Form

--- a/server/form-pages/utils/decorators/index.ts
+++ b/server/form-pages/utils/decorators/index.ts
@@ -1,5 +1,6 @@
 import Page from './page.decorator'
 import Task from './task.decorator'
 import Section from './section.decorator'
+import Form from './form.decorator'
 
-export { Page, Task, Section }
+export { Page, Task, Section, Form }


### PR DESCRIPTION
This keeps everything consistent and allows us to be able to create a whole form easily, without having to reuse code.

Each Form has to extend from the `BaseForm` class because we don’t get the typing on decorated classes yet, so we have to tell the compiler what type the class is (see https://stackoverflow.com/a/48152072/452684)