### PR TITLE
Update namespace name in tail-logs

### DIFF
--- a/script/tail-logs
+++ b/script/tail-logs
@@ -25,9 +25,9 @@ else
 fi
 
 if [ "$app" = "api" ]; then
-  stern -n "hmpps-approved-premises-$environment" "hmpps-approved-premises-api" -t
+  stern -n "hmpps-community-accommodation-$environment" "hmpps-approved-premises-api" -t
 elif [ "$app" = "ui" ]; then
-  stern -n "hmpps-approved-premises-$environment" "hmpps-approved-premises-ui" -t
+  stern -n "hmpps-community-accommodation-$environment" "hmpps-approved-premises-ui" -t
 else
   echo "Unknown application $2"
   exit 1


### PR DESCRIPTION
We’re now using a unified namespace for all of CAS