### PR TITLE
(868) Assessment dashboard

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -11,5 +11,8 @@ $path: "/assets/images/"
 @import './components/box'
 @import './components/summary-list'
 @import './components/sub-navigation'
+
+@import './pages/assessments-index'
+
 @import './local'
 

--- a/assets/sass/pages/_assessments-index.scss
+++ b/assets/sass/pages/_assessments-index.scss
@@ -1,0 +1,9 @@
+.assessments--index {
+  .govuk-tag {
+    white-space: nowrap;
+  }
+
+  &__warning {
+    color: #d4351c;
+  }
+}

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -12,6 +12,7 @@ import cancellation from './integration_tests/mockApis/cancellation'
 import lostBed from './integration_tests/mockApis/lostBed'
 import person from './integration_tests/mockApis/person'
 import applications from './integration_tests/mockApis/applications'
+import assessments from './integration_tests/mockApis/assessments'
 
 import schemaValidator from './integration_tests/tasks/schemaValidator'
 
@@ -43,6 +44,7 @@ export default defineConfig({
         ...person,
         ...applications,
         ...schemaValidator,
+        ...assessments,
       })
     },
     baseUrl: 'http://localhost:3007',

--- a/cypress_shared/pages/assess/index.ts
+++ b/cypress_shared/pages/assess/index.ts
@@ -1,0 +1,4 @@
+/* eslint-disable import/prefer-default-export */
+import ListPage from './listPage'
+
+export { ListPage }

--- a/cypress_shared/pages/assess/listPage.ts
+++ b/cypress_shared/pages/assess/listPage.ts
@@ -1,0 +1,94 @@
+import type { Assessment, PersonRisks } from '@approved-premises/api'
+import { format } from 'date-fns'
+
+import Page from '../page'
+import paths from '../../../server/paths/assess'
+import { DateFormats } from '../../../server/utils/dateUtils'
+
+export default class ListPage extends Page {
+  constructor(
+    private readonly awaitingAssessments: Array<Assessment>,
+    private readonly assessmentsCloseToDueDate: Array<Assessment>,
+    private readonly completedAssesssments: Array<Assessment>,
+  ) {
+    super('Approved Premises applications')
+  }
+
+  static visit(
+    awaitingAssessments: Array<Assessment>,
+    assessmentsCloseToDueDate: Array<Assessment>,
+    completedAssesssments: Array<Assessment>,
+  ): ListPage {
+    cy.visit(paths.assessments.index({}))
+    return new ListPage(awaitingAssessments, assessmentsCloseToDueDate, completedAssesssments)
+  }
+
+  shouldShowAwaitingAssessments(risks: Record<string, PersonRisks>): void {
+    const assessments = [this.awaitingAssessments, this.assessmentsCloseToDueDate].flat()
+    assessments.forEach((item: Assessment) => {
+      cy.contains(item.application.person.name)
+        .parent()
+        .parent()
+        .within(() => {
+          cy.get('td').eq(0).contains(item.application.person.crn)
+          cy.get('td').eq(1).contains(risks[item.application.person.crn].tier.value.level)
+          cy.get('td')
+            .eq(2)
+            .contains(
+              format(
+                DateFormats.isoToDateObj(item.application.data['basic-information']['release-date'].releaseDate),
+                'd MMM yyyy',
+              ),
+            )
+          cy.get('td').eq(3).contains(item.application.person.prisonName)
+          cy.get('td')
+            .eq(4)
+            .contains(this.awaitingAssessments.includes(item) ? '7 Days' : '1 Day')
+          cy.get('td').eq(5).contains('In progress')
+        })
+    })
+  }
+
+  shouldShowNotification(): void {
+    cy.get('.moj-notification-badge').contains(
+      `${this.assessmentsCloseToDueDate.length} assessments approaching due date`,
+    )
+  }
+
+  shouldHighlightAssessmentsApproachingDueDate(): void {
+    this.assessmentsCloseToDueDate.forEach((item: Assessment) => {
+      cy.contains(item.application.person.name)
+        .parent()
+        .parent()
+        .within(() => {
+          cy.get('td').eq(4).get('.assessments--index__warning').contains('(Approaching due date)')
+        })
+    })
+  }
+
+  shouldShowCompletedAssessments(risks: Record<string, PersonRisks>): void {
+    this.completedAssesssments.forEach((item: Assessment) => {
+      cy.log(item.application.data['basic-information']['release-date'])
+      cy.contains(item.application.person.name)
+        .parent()
+        .parent()
+        .within(() => {
+          cy.get('td').eq(0).contains(item.application.person.crn)
+          cy.get('td').eq(1).contains(risks[item.application.person.crn].tier.value.level)
+          cy.get('td')
+            .eq(2)
+            .contains(
+              format(
+                DateFormats.isoToDateObj(item.application.data['basic-information']['release-date'].releaseDate),
+                'd MMM yyyy',
+              ),
+            )
+          cy.get('td').eq(3).contains('Completed')
+        })
+    })
+  }
+
+  clickCompleted() {
+    cy.get('a').contains('Completed').click()
+  }
+}

--- a/integration_tests/mockApis/assessments.ts
+++ b/integration_tests/mockApis/assessments.ts
@@ -1,0 +1,20 @@
+import { SuperAgentRequest } from 'superagent'
+
+import type { Assessment } from '@approved-premises/api'
+
+import { stubFor } from '../../wiremock'
+
+export default {
+  stubAssessments: (assessments: Array<Assessment>): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/assessments`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: assessments,
+      },
+    }),
+}

--- a/integration_tests/tests/assess/listing.cy.ts
+++ b/integration_tests/tests/assess/listing.cy.ts
@@ -1,0 +1,70 @@
+import { PersonRisks } from '@approved-premises/api'
+import { ListPage } from '../../../cypress_shared/pages/assess'
+
+import assessmentFactory from '../../../server/testutils/factories/assessment'
+import risksFactory from '../../../server/testutils/factories/risks'
+
+context('Assess', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+  })
+
+  it('shows a list of assessments', () => {
+    // Given I am logged in
+    cy.signIn()
+
+    const assessments = []
+
+    // Given there are some applications awaiting assessment
+    const assessmentsAwaiting = assessmentFactory.createdXDaysAgo(2).buildList(3, { decision: undefined })
+    assessments.push(assessmentsAwaiting)
+
+    // And two of those assessments are running close to the due date
+    const assessmentsCloseToDueDate = [
+      assessmentFactory.createdXDaysAgo(8).build({ decision: undefined }),
+      assessmentFactory.createdXDaysAgo(8).build({ decision: undefined }),
+    ]
+
+    assessments.push(assessmentsCloseToDueDate)
+    // And there are some completed assessments
+    const completedAssesssments = [
+      assessmentFactory.build({ decision: 'accepted' }),
+      assessmentFactory.build({ decision: 'accepted' }),
+      assessmentFactory.build({ decision: 'rejected' }),
+    ]
+
+    assessments.push(completedAssesssments)
+
+    cy.task('stubAssessments', assessments.flat())
+
+    const crnRisks: Record<string, PersonRisks> = {}
+
+    assessments.flat().forEach(assessment => {
+      const { person } = assessment.application
+      const risks = risksFactory.build({ crn: person.crn })
+      crnRisks[person.crn] = risks
+
+      cy.task('stubPersonRisks', { person, risks })
+    })
+
+    // When I visit the assessments dashboard
+    const listPage = ListPage.visit(assessmentsAwaiting, assessmentsCloseToDueDate, completedAssesssments)
+
+    // Then I should see the assessments that are awaiting
+    listPage.shouldShowAwaitingAssessments(crnRisks)
+
+    // And there should be a notification
+    listPage.shouldShowNotification()
+
+    // And the assessments that are running close to the due date should be highlighted
+    listPage.shouldHighlightAssessmentsApproachingDueDate()
+
+    // When I click on the completed tab
+    listPage.clickCompleted()
+
+    // Then I should see the completed assessments
+    listPage.shouldShowCompletedAssessments(crnRisks)
+  })
+})

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,4 +1,4 @@
-import { RoshRisks, RiskTier, FlagsEnvelope, Mappa } from '@approved-premises/api'
+import { RoshRisks, RiskTier, FlagsEnvelope, Mappa, Application, Assessment, Person } from '@approved-premises/api'
 
 interface TasklistPage {
   body: Record<string, unknown>
@@ -181,8 +181,20 @@ export type DataServices = {
   }
 }
 
-export interface GroupedAssessment {
-  completed: Array<Assessment>
-  requestedFurtherInformation: Array<Assessment>
-  awaiting: Array<Assessment>
+export interface GroupedAssessmentWithRisks {
+  completed: Array<AssessmentWithRisks>
+  requestedFurtherInformation: Array<AssessmentWithRisks>
+  awaiting: Array<AssessmentWithRisks>
+}
+
+export interface AssessmentWithRisks extends Assessment {
+  application: ApplicationWithRisks
+}
+
+export interface ApplicationWithRisks extends Application {
+  person: PersonWithRisks
+}
+
+export interface PersonWithRisks extends Person {
+  risks: PersonRisks
 }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -180,3 +180,9 @@ export type DataServices = {
     getAdjudications: (token: string, crn: string) => Promise<Adjudication[]>
   }
 }
+
+export interface GroupedAssessment {
+  completed: Array<Assessment>
+  requestedFurtherInformation: Array<Assessment>
+  awaiting: Array<Assessment>
+}

--- a/server/controllers/assess/assessmentsController.test.ts
+++ b/server/controllers/assess/assessmentsController.test.ts
@@ -1,0 +1,39 @@
+import type { Request, Response, NextFunction } from 'express'
+import type { GroupedAssessmentWithRisks } from '@approved-premises/ui'
+
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+
+import AssessmentsController from './assessmentsController'
+import { AssessmentService } from '../../services'
+
+describe('assessmentsController', () => {
+  const token = 'SOME_TOKEN'
+
+  const request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = jest.fn()
+
+  const assessmentService = createMock<AssessmentService>({})
+
+  let assessmentsController: AssessmentsController
+
+  beforeEach(() => {
+    assessmentsController = new AssessmentsController(assessmentService)
+  })
+
+  describe('index', () => {
+    it('should list all the assessments for a user', async () => {
+      const assessments = { completed: [], requestedFurtherInformation: [], awaiting: [] } as GroupedAssessmentWithRisks
+      assessmentService.getAllForLoggedInUser.mockResolvedValue(assessments)
+      const requestHandler = assessmentsController.index()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('assessments/index', {
+        pageHeading: 'Approved Premises applications',
+        assessments,
+      })
+      expect(assessmentService.getAllForLoggedInUser).toHaveBeenCalled()
+    })
+  })
+})

--- a/server/controllers/assess/assessmentsController.ts
+++ b/server/controllers/assess/assessmentsController.ts
@@ -1,0 +1,15 @@
+import type { Request, Response, RequestHandler } from 'express'
+
+import { AssessmentService } from '../../services'
+
+export default class AssessmentsController {
+  constructor(private readonly assessmentService: AssessmentService) {}
+
+  index(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const assessments = await this.assessmentService.getAllForLoggedInUser(req.user.token)
+
+      res.render('assessments/index', { pageHeading: 'Approved Premises applications', assessments })
+    }
+  }
+}

--- a/server/controllers/assess/index.ts
+++ b/server/controllers/assess/index.ts
@@ -1,0 +1,16 @@
+/* istanbul ignore file */
+
+import AssessmentsController from './assessmentsController'
+
+import type { Services } from '../../services'
+
+export const controllers = (services: Services) => {
+  const { assessmentService } = services
+  const assessmentsController = new AssessmentsController(assessmentService)
+
+  return {
+    assessmentsController,
+  }
+}
+
+export { AssessmentsController }

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -3,6 +3,7 @@
 import ApplicationController from './applicationController'
 import { controllers as manageControllers } from './manage'
 import { controllers as applyControllers } from './apply'
+import { controllers as asssessControllers } from './assess'
 
 import type { Services } from '../services'
 
@@ -13,6 +14,7 @@ export const controllers = (services: Services) => {
     applicationController,
     ...manageControllers(services),
     ...applyControllers(services),
+    ...asssessControllers(services),
   }
 }
 

--- a/server/data/assessmentClient.test.ts
+++ b/server/data/assessmentClient.test.ts
@@ -1,0 +1,44 @@
+import nock from 'nock'
+
+import AssessmentClient from './assessmentClient'
+import config from '../config'
+import assessmentFactory from '../testutils/factories/assessment'
+import paths from '../paths/api'
+
+describe('AssessmentClient', () => {
+  let fakeApprovedPremisesApi: nock.Scope
+  let assessmentClient: AssessmentClient
+
+  const token = 'token-1'
+
+  beforeEach(() => {
+    config.apis.approvedPremises.url = 'http://localhost:8080'
+    fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
+    assessmentClient = new AssessmentClient(token)
+  })
+
+  afterEach(() => {
+    if (!nock.isDone()) {
+      nock.cleanAll()
+      throw new Error('Not all nock interceptors were used!')
+    }
+    nock.abortPendingRequests()
+    nock.cleanAll()
+  })
+
+  describe('all', () => {
+    it('should get all assessments', async () => {
+      const previousApplications = assessmentFactory.build()
+
+      fakeApprovedPremisesApi
+        .get(paths.assessments.index.pattern)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, previousApplications)
+
+      const result = await assessmentClient.all()
+
+      expect(result).toEqual(previousApplications)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+})

--- a/server/data/assessmentClient.ts
+++ b/server/data/assessmentClient.ts
@@ -1,0 +1,16 @@
+import type { Assessment } from '@approved-premises/api'
+import RestClient from './restClient'
+import config, { ApiConfig } from '../config'
+import paths from '../paths/api'
+
+export default class AssessmentClient {
+  restClient: RestClient
+
+  constructor(token: string) {
+    this.restClient = new RestClient('assessmentClient', config.apis.approvedPremises as ApiConfig, token)
+  }
+
+  async all(): Promise<Assessment[]> {
+    return (await this.restClient.get({ path: paths.assessments.index.pattern })) as Assessment[]
+  }
+}

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -20,6 +20,7 @@ import { createRedisClient } from './redisClient'
 import TokenStore from './tokenStore'
 import LostBedClient from './lostBedClient'
 import ApplicationClient from './applicationClient'
+import AssessmentClient from './assessmentClient'
 
 type RestClientBuilder<T> = (token: string) => T
 
@@ -32,6 +33,7 @@ export const dataAccess = () => ({
   lostBedClientBuilder: ((token: string) => new LostBedClient(token)) as RestClientBuilder<LostBedClient>,
   personClient: ((token: string) => new PersonClient(token)) as RestClientBuilder<PersonClient>,
   applicationClientBuilder: ((token: string) => new ApplicationClient(token)) as RestClientBuilder<ApplicationClient>,
+  assessmentClientBuilder: ((token: string) => new AssessmentClient(token)) as RestClientBuilder<AssessmentClient>,
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>
@@ -45,4 +47,5 @@ export {
   LostBedClient,
   PersonClient,
   ApplicationClient,
+  AssessmentClient,
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -21,6 +21,8 @@ const singleApplicationPath = applicationsPath.path(':id')
 const peoplePath = path('/people')
 const personPath = peoplePath.path(':crn')
 
+const assessmentsPath = path('/assessments')
+
 const applyPaths = {
   applications: {
     show: singleApplicationPath,
@@ -49,6 +51,9 @@ export default {
     update: applyPaths.applications.update,
     new: applyPaths.applications.create,
     submission: applyPaths.applications.submission,
+  },
+  assessments: {
+    index: assessmentsPath,
   },
   people: {
     risks: {

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -1,0 +1,11 @@
+import { path } from 'static-path'
+
+const assessmentsPath = path('/assessments')
+
+const paths = {
+  assessments: {
+    index: assessmentsPath,
+  },
+}
+
+export default paths

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -1,0 +1,17 @@
+/* istanbul ignore file */
+
+import type { Router } from 'express'
+
+import type { Controllers } from '../controllers'
+import paths from '../paths/assess'
+
+import actions from './utils'
+
+export default function routes(controllers: Controllers, router: Router): Router {
+  const { get } = actions(router)
+  const { assessmentsController } = controllers
+
+  get(paths.assessments.index.pattern, assessmentsController.index())
+
+  return router
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -7,6 +7,7 @@ import actions from './utils'
 
 import applyRoutes from './apply'
 import manageRoutes from './manage'
+import assessRoutes from './assess'
 
 export default function routes(controllers: Controllers): Router {
   const router = Router()
@@ -19,6 +20,7 @@ export default function routes(controllers: Controllers): Router {
 
   manageRoutes(controllers, router)
   applyRoutes(controllers, router)
+  assessRoutes(controllers, router)
 
   return router
 }

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -5,6 +5,7 @@ import type { ActiveOffence, Application } from '@approved-premises/api'
 import type TasklistPage from '../form-pages/tasklistPage'
 import type { RestClientBuilder, ApplicationClient, PersonClient } from '../data'
 import { UnknownPageError, ValidationError } from '../utils/errors'
+import { tierBadge } from '../utils/personUtils'
 
 import Apply from '../form-pages/apply'
 import paths from '../paths/apply'
@@ -130,7 +131,7 @@ export default class ApplicationService {
         return [
           this.createNameAnchorElement(application.person.name, application.id),
           this.textValue(application.person.crn),
-          this.createTierBadge(tier.value.level),
+          this.htmlValue(tierBadge(tier.value.level)),
           this.textValue(DateFormats.isoDateToUIDate(getArrivalDate(application), { format: 'short' })),
           this.textValue(DateFormats.isoDateToUIDate(application.submittedAt, { format: 'short' })),
         ]
@@ -146,12 +147,6 @@ export default class ApplicationService {
 
   private htmlValue(value: string) {
     return { html: value }
-  }
-
-  private createTierBadge(tier: string) {
-    const colour = { A: 'moj-badge--red', B: 'moj-badge--purple' }[tier[0]]
-
-    return this.htmlValue(`<span class="moj-badge ${colour}">${tier}</span>`)
   }
 
   private createNameAnchorElement(name: string, applicationId: string) {

--- a/server/services/assessmentService.test.ts
+++ b/server/services/assessmentService.test.ts
@@ -1,0 +1,34 @@
+import { AssessmentClient } from '../data'
+import AssessmentService from './assessmentService'
+
+import assessmentFactory from '../testutils/factories/assessment'
+
+jest.mock('../data/assessmentClient.ts')
+
+describe('AssessmentService', () => {
+  const assessmentClient = new AssessmentClient(null) as jest.Mocked<AssessmentClient>
+  const assessmentClientFactory = jest.fn()
+
+  const service = new AssessmentService(assessmentClientFactory)
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    assessmentClientFactory.mockReturnValue(assessmentClient)
+  })
+
+  it('gets all the assesments for the logged in user and groups them by status', async () => {
+    const acceptedAssessments = assessmentFactory.buildList(2, { decision: 'accepted' })
+    const rejectedAssessments = assessmentFactory.buildList(3, { decision: 'rejected' })
+    const awaitingAssessments = assessmentFactory.buildList(5, { decision: undefined })
+
+    assessmentClient.all.mockResolvedValue([acceptedAssessments, rejectedAssessments, awaitingAssessments].flat())
+
+    const result = await service.getAllForLoggedInUser('token')
+
+    expect(result).toEqual({
+      completed: [acceptedAssessments, rejectedAssessments].flat(),
+      requestedFurtherInformation: [],
+      awaiting: awaitingAssessments,
+    })
+  })
+})

--- a/server/services/assessmentService.test.ts
+++ b/server/services/assessmentService.test.ts
@@ -1,34 +1,52 @@
-import { AssessmentClient } from '../data'
+import { Assessment } from '@approved-premises/api'
+import { AssessmentClient, PersonClient } from '../data'
 import AssessmentService from './assessmentService'
 
 import assessmentFactory from '../testutils/factories/assessment'
+import risksFactory from '../testutils/factories/risks'
 
 jest.mock('../data/assessmentClient.ts')
+jest.mock('../data/personClient.ts')
 
 describe('AssessmentService', () => {
   const assessmentClient = new AssessmentClient(null) as jest.Mocked<AssessmentClient>
-  const assessmentClientFactory = jest.fn()
+  const personClient = new PersonClient(null) as jest.Mocked<PersonClient>
 
-  const service = new AssessmentService(assessmentClientFactory)
+  const assessmentClientFactory = jest.fn()
+  const personClientFactory = jest.fn()
+
+  const service = new AssessmentService(assessmentClientFactory, personClientFactory)
 
   beforeEach(() => {
     jest.resetAllMocks()
     assessmentClientFactory.mockReturnValue(assessmentClient)
+    personClientFactory.mockReturnValue(personClient)
   })
 
   it('gets all the assesments for the logged in user and groups them by status', async () => {
+    const risks = risksFactory.build()
     const acceptedAssessments = assessmentFactory.buildList(2, { decision: 'accepted' })
     const rejectedAssessments = assessmentFactory.buildList(3, { decision: 'rejected' })
     const awaitingAssessments = assessmentFactory.buildList(5, { decision: undefined })
 
     assessmentClient.all.mockResolvedValue([acceptedAssessments, rejectedAssessments, awaitingAssessments].flat())
+    personClient.risks.mockResolvedValue(risks)
 
     const result = await service.getAllForLoggedInUser('token')
 
+    const assessmentWithRisks = (assessments: Array<Assessment>) => {
+      return assessments.map(assessment => {
+        return {
+          ...assessment,
+          application: { ...assessment.application, person: { ...assessment.application.person, risks } },
+        }
+      })
+    }
+
     expect(result).toEqual({
-      completed: [acceptedAssessments, rejectedAssessments].flat(),
+      completed: [assessmentWithRisks(acceptedAssessments), assessmentWithRisks(rejectedAssessments)].flat(),
       requestedFurtherInformation: [],
-      awaiting: awaitingAssessments,
+      awaiting: assessmentWithRisks(awaitingAssessments),
     })
   })
 })

--- a/server/services/assessmentService.ts
+++ b/server/services/assessmentService.ts
@@ -1,0 +1,20 @@
+import type { GroupedAssessment } from '@approved-premises/ui'
+
+import type { RestClientBuilder, AssessmentClient } from '../data'
+
+export default class AssessmentService {
+  constructor(private readonly assessmentClientFactory: RestClientBuilder<AssessmentClient>) {}
+
+  async getAllForLoggedInUser(token: string): Promise<GroupedAssessment> {
+    const client = this.assessmentClientFactory(token)
+
+    const result = { completed: [], requestedFurtherInformation: [], awaiting: [] } as GroupedAssessment
+    const assessments = await client.all()
+
+    assessments.forEach(assessment =>
+      assessment.decision ? result.completed.push(assessment) : result.awaiting.push(assessment),
+    )
+
+    return result
+  }
+}

--- a/server/services/assessmentService.ts
+++ b/server/services/assessmentService.ts
@@ -1,18 +1,31 @@
-import type { GroupedAssessment } from '@approved-premises/ui'
+import type { AssessmentWithRisks, GroupedAssessmentWithRisks } from '@approved-premises/ui'
 
-import type { RestClientBuilder, AssessmentClient } from '../data'
+import type { RestClientBuilder, AssessmentClient, PersonClient } from '../data'
 
 export default class AssessmentService {
-  constructor(private readonly assessmentClientFactory: RestClientBuilder<AssessmentClient>) {}
+  constructor(
+    private readonly assessmentClientFactory: RestClientBuilder<AssessmentClient>,
+    private readonly personClientFactory: RestClientBuilder<PersonClient>,
+  ) {}
 
-  async getAllForLoggedInUser(token: string): Promise<GroupedAssessment> {
+  async getAllForLoggedInUser(token: string): Promise<GroupedAssessmentWithRisks> {
     const client = this.assessmentClientFactory(token)
+    const personClient = this.personClientFactory(token)
 
-    const result = { completed: [], requestedFurtherInformation: [], awaiting: [] } as GroupedAssessment
+    const result = { completed: [], requestedFurtherInformation: [], awaiting: [] } as GroupedAssessmentWithRisks
     const assessments = await client.all()
 
-    assessments.forEach(assessment =>
-      assessment.decision ? result.completed.push(assessment) : result.awaiting.push(assessment),
+    await Promise.all(
+      assessments.map(async assessment => {
+        const risks = await personClient.risks(assessment.application.person.crn)
+        const assessmentWithRisks = {
+          ...assessment,
+          application: { ...assessment.application, person: { ...assessment.application.person, risks } },
+        } as AssessmentWithRisks
+        return assessment.decision
+          ? result.completed.push(assessmentWithRisks)
+          : result.awaiting.push(assessmentWithRisks)
+      }),
     )
 
     return result

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -12,6 +12,7 @@ import DepartureService from './departureService'
 import CancellationService from './cancellationService'
 import LostBedService from './lostBedService'
 import ApplicationService from './applicationService'
+import AssessmentService from './assessmentService'
 
 export const services = () => {
   const {
@@ -22,6 +23,7 @@ export const services = () => {
     lostBedClientBuilder,
     personClient,
     applicationClientBuilder,
+    assessmentClientBuilder,
   } = dataAccess()
 
   const userService = new UserService(hmppsAuthClient)
@@ -34,6 +36,7 @@ export const services = () => {
   const cancellationService = new CancellationService(bookingClientBuilder, referenceDataClientBuilder)
   const lostBedService = new LostBedService(lostBedClientBuilder, referenceDataClientBuilder)
   const applicationService = new ApplicationService(applicationClientBuilder, personClient)
+  const assessmentService = new AssessmentService(assessmentClientBuilder, personClient)
 
   return {
     userService,
@@ -46,6 +49,7 @@ export const services = () => {
     cancellationService,
     lostBedService,
     applicationService,
+    assessmentService,
   }
 }
 
@@ -62,4 +66,5 @@ export {
   BookingService,
   LostBedService,
   ApplicationService,
+  AssessmentService,
 }

--- a/server/testutils/factories/assessment.ts
+++ b/server/testutils/factories/assessment.ts
@@ -1,0 +1,29 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+import type { Assessment } from '@approved-premises/api'
+
+import { DateFormats } from '../../utils/dateUtils'
+import applicationFactory from './application'
+
+class AssessmentFactory extends Factory<Assessment> {
+  createdXDaysAgo(days: number) {
+    const today = new Date()
+    return this.params({
+      createdAt: DateFormats.dateObjToIsoDate(new Date(today.getFullYear(), today.getMonth(), today.getDate() - days)),
+    })
+  }
+}
+
+export default AssessmentFactory.define(() => ({
+  id: faker.datatype.uuid(),
+  application: applicationFactory.withReleaseDate().build(),
+  allocatedToStaffMemberId: faker.datatype.uuid(),
+  schemaVersion: faker.datatype.uuid(),
+  outdatedSchema: false,
+  createdAt: DateFormats.dateObjToIsoDate(faker.date.past()),
+  allocatedAt: DateFormats.dateObjToIsoDate(faker.date.past()),
+  submittedAt: DateFormats.dateObjToIsoDate(faker.date.past()),
+  decision: 'accepted' as const,
+  data: JSON.parse(faker.datatype.json()),
+  clarificationNotes: [],
+}))

--- a/server/testutils/factories/clarificationNote.ts
+++ b/server/testutils/factories/clarificationNote.ts
@@ -1,0 +1,12 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+import type { ClarificationNote } from '@approved-premises/api'
+
+import { DateFormats } from '../../utils/dateUtils'
+
+export default Factory.define<ClarificationNote>(() => ({
+  id: faker.datatype.uuid(),
+  createdAt: DateFormats.dateObjToIsoDate(faker.date.past()),
+  createdByStaffMemberId: faker.datatype.uuid(),
+  text: faker.lorem.paragraph(),
+}))

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -8,6 +8,7 @@ import {
   daysUntilDue,
   daysSinceInfoRequest,
   requestedFurtherInformationTableRows,
+  completedTableRows,
 } from './assessmentUtils'
 import { DateFormats } from './dateUtils'
 
@@ -157,6 +158,33 @@ describe('assessmentUtils', () => {
           { text: formatDays(daysSinceReceived(assessment)) },
           { text: formatDays(daysSinceInfoRequest(assessment)) },
           { html: `<strong class="govuk-tag govuk-tag--yellow">Info Request</strong>` },
+        ],
+      ])
+
+      expect(tierBadgeSpy).toHaveBeenCalledWith(risks.tier.value.level)
+    })
+  })
+
+  describe('completedTableRows', () => {
+    it('returns table rows for the assessments', () => {
+      const assessment = assessmentFactory.build()
+      const risks = risksFactory.build()
+      const assessmentWithRisks = {
+        ...assessment,
+        application: { person: { ...assessment.application.person, risks } },
+      } as AssessmentWithRisks
+
+      jest.spyOn(applicationUtils, 'getArrivalDate').mockReturnValue('2022-01-01')
+
+      const tierBadgeSpy = jest.spyOn(personUtils, 'tierBadge').mockReturnValue('TIER_BADGE')
+
+      expect(completedTableRows([assessmentWithRisks])).toEqual([
+        [
+          { html: `<a href="#">${assessment.application.person.name}</a>` },
+          { html: assessment.application.person.crn },
+          { html: 'TIER_BADGE' },
+          { text: formattedArrivalDate(assessment) },
+          { html: getStatus(assessment) },
         ],
       ])
 

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -11,6 +11,7 @@ import {
   completedTableRows,
   assessmentsApproachingDue,
   assessmentsApproachingDueBadge,
+  formatDaysUntilDueWithWarning,
 } from './assessmentUtils'
 import { DateFormats } from './dateUtils'
 
@@ -129,7 +130,7 @@ describe('assessmentUtils', () => {
           { html: 'TIER_BADGE' },
           { text: formattedArrivalDate(assessment) },
           { text: assessment.application.person.prisonName },
-          { text: formatDays(daysUntilDue(assessment)) },
+          { html: formatDaysUntilDueWithWarning(assessment) },
           { html: getStatus(assessment) },
         ],
       ])
@@ -221,6 +222,24 @@ describe('assessmentUtils', () => {
 
       expect(assessmentsApproachingDueBadge(assessments)).toEqual(
         '<span id="notifications" class="moj-notification-badge">2<span class="govuk-visually-hidden"> assessments approaching due date</span></span>',
+      )
+    })
+  })
+
+  describe('formatDaysUntilDueWithWarning', () => {
+    it('returns the number of days without a warning if the due date is not soon', () => {
+      const assessment = assessmentFactory.build({
+        createdAt: DateFormats.dateObjToIsoDate(new Date()),
+      })
+
+      expect(formatDaysUntilDueWithWarning(assessment)).toEqual('9 Days')
+    })
+
+    it('returns the number of days with a warning if the due date is soon', () => {
+      const assessment = assessmentFactory.createdXDaysAgo(8).build()
+
+      expect(formatDaysUntilDueWithWarning(assessment)).toEqual(
+        '<strong class="assessments--index__warning">1 Day<span class="govuk-visually-hidden"> (Approaching due date)</span></strong>',
       )
     })
   })

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -1,0 +1,113 @@
+import { AssessmentWithRisks } from '@approved-premises/ui'
+import {
+  daysSinceReceived,
+  getStatus,
+  formattedArrivalDate,
+  awaitingAssessmentTableRows,
+  formatDays,
+  daysUntilDue,
+} from './assessmentUtils'
+
+import * as personUtils from './personUtils'
+import * as applicationUtils from './applicationUtils'
+
+import assessmentFactory from '../testutils/factories/assessment'
+import risksFactory from '../testutils/factories/risks'
+
+jest.mock('./applicationUtils')
+jest.mock('./personUtils')
+
+describe('assessmentUtils', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('daysSinceReceived', () => {
+    it('returns the difference in days since the assessment has been received', () => {
+      const assessment = assessmentFactory.createdXDaysAgo(10).build()
+
+      expect(daysSinceReceived(assessment)).toEqual(10)
+    })
+  })
+
+  describe('formatDays', () => {
+    it('returns the singular form if there is 1 day', () => {
+      expect(formatDays(1)).toEqual('1 Day')
+    })
+
+    it('returns the plural form if there is more than 1 day', () => {
+      expect(formatDays(22)).toEqual('22 Days')
+    })
+
+    it('returns N/A if the day in undefined', () => {
+      expect(formatDays(undefined)).toEqual('N/A')
+    })
+  })
+
+  describe('getStatus', () => {
+    it('returns Not started for an assessment without data', () => {
+      const assessment = assessmentFactory.build({ data: undefined })
+
+      expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag--grey">Not started</strong>')
+    })
+
+    it('returns In Progress for an assessment with data and no decision', () => {
+      const assessment = assessmentFactory.build({ decision: undefined })
+
+      expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag--blue">In progress</strong>')
+    })
+
+    it('returns Completed for an assessment with data and a decision', () => {
+      const assessment = assessmentFactory.build({ decision: 'accepted' })
+
+      expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag">Completed</strong>')
+    })
+  })
+
+  describe('daysUntilDue', () => {
+    it('returns the days until the assessment is due', () => {
+      const assessment = assessmentFactory.createdXDaysAgo(2).build()
+
+      expect(daysUntilDue(assessment)).toEqual(7)
+    })
+  })
+
+  describe('formattedArrivalDate', () => {
+    it('returns the formatted arrival date from the application', () => {
+      const assessment = assessmentFactory.build()
+      const getDateSpy = jest.spyOn(applicationUtils, 'getArrivalDate').mockReturnValue('2022-01-01')
+
+      expect(formattedArrivalDate(assessment)).toEqual('1 Jan 2022')
+      expect(getDateSpy).toHaveBeenCalledWith(assessment.application)
+    })
+  })
+
+  describe('awaitingAssessmentTableRows', () => {
+    it('returns table rows for the assessments', () => {
+      const assessment = assessmentFactory.build()
+      const risks = risksFactory.build()
+      const assessmentWithRisks = {
+        ...assessment,
+        application: { person: { ...assessment.application.person, risks } },
+      } as AssessmentWithRisks
+
+      jest.spyOn(applicationUtils, 'getArrivalDate').mockReturnValue('2022-01-01')
+
+      const tierBadgeSpy = jest.spyOn(personUtils, 'tierBadge').mockReturnValue('TIER_BADGE')
+
+      expect(awaitingAssessmentTableRows([assessmentWithRisks])).toEqual([
+        [
+          { html: `<a href="#">${assessment.application.person.name}</a>` },
+          { html: assessment.application.person.crn },
+          { html: 'TIER_BADGE' },
+          { text: formattedArrivalDate(assessment) },
+          { text: assessment.application.person.prisonName },
+          { text: formatDays(daysUntilDue(assessment)) },
+          { html: getStatus(assessment) },
+        ],
+      ])
+
+      expect(tierBadgeSpy).toHaveBeenCalledWith(risks.tier.value.level)
+    })
+  })
+})

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -9,6 +9,8 @@ import {
   daysSinceInfoRequest,
   requestedFurtherInformationTableRows,
   completedTableRows,
+  assessmentsApproachingDue,
+  assessmentsApproachingDueBadge,
 } from './assessmentUtils'
 import { DateFormats } from './dateUtils'
 
@@ -189,6 +191,37 @@ describe('assessmentUtils', () => {
       ])
 
       expect(tierBadgeSpy).toHaveBeenCalledWith(risks.tier.value.level)
+    })
+  })
+
+  describe('assessmentsApproachingDue', () => {
+    it('returns the number of assessments where the due date is less than DUE_DATE_APPROACHING_WINDOW away', () => {
+      const assessments = [
+        assessmentFactory.createdXDaysAgo(1).build(),
+        assessmentFactory.createdXDaysAgo(2).build(),
+        assessmentFactory.createdXDaysAgo(9).build(),
+        assessmentFactory.createdXDaysAgo(7).build(),
+      ]
+
+      expect(assessmentsApproachingDue(assessments)).toEqual(2)
+    })
+  })
+
+  describe('assessmentsApproachingDueBadge', () => {
+    it('returns blank when there are no assessments approaching the due date', () => {
+      const assessments = assessmentFactory.buildList(2, {
+        createdAt: DateFormats.dateObjToIsoDate(new Date()),
+      })
+
+      expect(assessmentsApproachingDueBadge(assessments)).toEqual('')
+    })
+
+    it('returns a badge when there are assessments approaching the due date', () => {
+      const assessments = assessmentFactory.createdXDaysAgo(9).buildList(2)
+
+      expect(assessmentsApproachingDueBadge(assessments)).toEqual(
+        '<span id="notifications" class="moj-notification-badge">2<span class="govuk-visually-hidden"> assessments approaching due date</span></span>',
+      )
     })
   })
 })

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -38,6 +38,38 @@ const awaitingAssessmentTableRows = (assessments: Array<AssessmentWithRisks>): A
   return rows
 }
 
+const requestedFurtherInformationTableRows = (assessments: Array<AssessmentWithRisks>): Array<TableRow> => {
+  const rows = [] as Array<TableRow>
+
+  assessments.forEach(assessment => {
+    rows.push([
+      {
+        html: `<a href="#">${assessment.application.person.name}</a>`,
+      },
+      {
+        html: assessment.application.person.crn,
+      },
+      {
+        html: tierBadge(assessment.application.person.risks.tier.value.level),
+      },
+      {
+        text: formattedArrivalDate(assessment),
+      },
+      {
+        text: formatDays(daysSinceReceived(assessment)),
+      },
+      {
+        text: formatDays(daysSinceInfoRequest(assessment)),
+      },
+      {
+        html: `<strong class="govuk-tag govuk-tag--yellow">Info Request</strong>`,
+      },
+    ])
+  })
+
+  return rows
+}
+
 const formattedArrivalDate = (assessment: Assessment): string => {
   const arrivalDate = getArrivalDate(assessment.application)
   return format(DateFormats.isoToDateObj(arrivalDate), 'd MMM yyyy')
@@ -73,4 +105,23 @@ const daysSinceReceived = (assessment: Assessment): number => {
   return differenceInDays(new Date(), receivedDate)
 }
 
-export { awaitingAssessmentTableRows, getStatus, daysSinceReceived, formattedArrivalDate, formatDays, daysUntilDue }
+const daysSinceInfoRequest = (assessment: Assessment): number => {
+  const lastInfoRequest = assessment.clarificationNotes[assessment.clarificationNotes.length - 1]
+  if (!lastInfoRequest) {
+    return undefined
+  }
+  const infoRequestDate = DateFormats.isoToDateObj(lastInfoRequest.createdAt)
+
+  return differenceInDays(new Date(), infoRequestDate)
+}
+
+export {
+  awaitingAssessmentTableRows,
+  getStatus,
+  daysSinceReceived,
+  formattedArrivalDate,
+  requestedFurtherInformationTableRows,
+  daysSinceInfoRequest,
+  formatDays,
+  daysUntilDue,
+}

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -38,6 +38,32 @@ const awaitingAssessmentTableRows = (assessments: Array<AssessmentWithRisks>): A
   return rows
 }
 
+const completedTableRows = (assessments: Array<AssessmentWithRisks>): Array<TableRow> => {
+  const rows = [] as Array<TableRow>
+
+  assessments.forEach(assessment => {
+    rows.push([
+      {
+        html: `<a href="#">${assessment.application.person.name}</a>`,
+      },
+      {
+        html: assessment.application.person.crn,
+      },
+      {
+        html: tierBadge(assessment.application.person.risks.tier.value.level),
+      },
+      {
+        text: formattedArrivalDate(assessment),
+      },
+      {
+        html: getStatus(assessment),
+      },
+    ])
+  })
+
+  return rows
+}
+
 const requestedFurtherInformationTableRows = (assessments: Array<AssessmentWithRisks>): Array<TableRow> => {
   const rows = [] as Array<TableRow>
 
@@ -124,4 +150,5 @@ export {
   daysSinceInfoRequest,
   formatDays,
   daysUntilDue,
+  completedTableRows,
 }

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -29,7 +29,7 @@ const awaitingAssessmentTableRows = (assessments: Array<AssessmentWithRisks>): A
         text: assessment.application.person.prisonName,
       },
       {
-        text: formatDays(daysUntilDue(assessment)),
+        html: formatDaysUntilDueWithWarning(assessment),
       },
       {
         html: getStatus(assessment),
@@ -133,6 +133,16 @@ const daysSinceReceived = (assessment: Assessment): number => {
   return differenceInDays(new Date(), receivedDate)
 }
 
+const formatDaysUntilDueWithWarning = (assessment: Assessment): string => {
+  const days = daysUntilDue(assessment)
+  if (days < DUE_DATE_APPROACHING_DAYS_WINDOW) {
+    return `<strong class="assessments--index__warning">${formatDays(
+      days,
+    )}<span class="govuk-visually-hidden"> (Approaching due date)</span></strong>`
+  }
+  return formatDays(days)
+}
+
 const daysSinceInfoRequest = (assessment: Assessment): number => {
   const lastInfoRequest = assessment.clarificationNotes[assessment.clarificationNotes.length - 1]
   if (!lastInfoRequest) {
@@ -168,4 +178,5 @@ export {
   completedTableRows,
   assessmentsApproachingDue,
   assessmentsApproachingDueBadge,
+  formatDaysUntilDueWithWarning,
 }

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -6,6 +6,8 @@ import { tierBadge } from './personUtils'
 import { DateFormats } from './dateUtils'
 import { getArrivalDate } from './applicationUtils'
 
+const DUE_DATE_APPROACHING_DAYS_WINDOW = 3
+
 const awaitingAssessmentTableRows = (assessments: Array<AssessmentWithRisks>): Array<TableRow> => {
   const rows = [] as Array<TableRow>
 
@@ -141,6 +143,19 @@ const daysSinceInfoRequest = (assessment: Assessment): number => {
   return differenceInDays(new Date(), infoRequestDate)
 }
 
+const assessmentsApproachingDueBadge = (assessments: Array<Assessment>): string => {
+  const dueCount = assessmentsApproachingDue(assessments)
+
+  if (dueCount === 0) {
+    return ''
+  }
+  return `<span id="notifications" class="moj-notification-badge">${dueCount}<span class="govuk-visually-hidden"> assessments approaching due date</span></span>`
+}
+
+const assessmentsApproachingDue = (assessments: Array<Assessment>): number => {
+  return assessments.filter(a => daysUntilDue(a) < DUE_DATE_APPROACHING_DAYS_WINDOW).length
+}
+
 export {
   awaitingAssessmentTableRows,
   getStatus,
@@ -151,4 +166,6 @@ export {
   formatDays,
   daysUntilDue,
   completedTableRows,
+  assessmentsApproachingDue,
+  assessmentsApproachingDueBadge,
 }

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -1,0 +1,76 @@
+import { TableRow, AssessmentWithRisks } from '@approved-premises/ui'
+import { format, differenceInDays, add } from 'date-fns'
+
+import { Assessment } from '@approved-premises/api'
+import { tierBadge } from './personUtils'
+import { DateFormats } from './dateUtils'
+import { getArrivalDate } from './applicationUtils'
+
+const awaitingAssessmentTableRows = (assessments: Array<AssessmentWithRisks>): Array<TableRow> => {
+  const rows = [] as Array<TableRow>
+
+  assessments.forEach(assessment => {
+    rows.push([
+      {
+        html: `<a href="#">${assessment.application.person.name}</a>`,
+      },
+      {
+        html: assessment.application.person.crn,
+      },
+      {
+        html: tierBadge(assessment.application.person.risks.tier.value.level),
+      },
+      {
+        text: formattedArrivalDate(assessment),
+      },
+      {
+        text: assessment.application.person.prisonName,
+      },
+      {
+        text: formatDays(daysUntilDue(assessment)),
+      },
+      {
+        html: getStatus(assessment),
+      },
+    ])
+  })
+
+  return rows
+}
+
+const formattedArrivalDate = (assessment: Assessment): string => {
+  const arrivalDate = getArrivalDate(assessment.application)
+  return format(DateFormats.isoToDateObj(arrivalDate), 'd MMM yyyy')
+}
+
+const formatDays = (days: number): string => {
+  if (days === undefined) {
+    return 'N/A'
+  }
+  return `${days} Day${days > 1 ? 's' : ''}`
+}
+
+const daysUntilDue = (assessment: Assessment): number => {
+  const receivedDate = DateFormats.isoToDateObj(assessment.createdAt)
+  const dueDate = add(receivedDate, { days: 10 })
+
+  return differenceInDays(dueDate, new Date())
+}
+
+const getStatus = (assessment: Assessment): string => {
+  if (assessment.data) {
+    if (!assessment.decision) {
+      return `<strong class="govuk-tag govuk-tag--blue">In progress</strong>`
+    }
+    return `<strong class="govuk-tag govuk-tag">Completed</strong>`
+  }
+  return `<strong class="govuk-tag govuk-tag--grey">Not started</strong>`
+}
+
+const daysSinceReceived = (assessment: Assessment): number => {
+  const receivedDate = DateFormats.isoToDateObj(assessment.createdAt)
+
+  return differenceInDays(new Date(), receivedDate)
+}
+
+export { awaitingAssessmentTableRows, getStatus, daysSinceReceived, formattedArrivalDate, formatDays, daysUntilDue }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -15,6 +15,7 @@ import { checkYourAnswersSections } from './checkYourAnswersUtils'
 import { statusTag } from './personUtils'
 import bookingActions from './bookingUtils'
 import { DateFormats } from './dateUtils'
+import * as AssessmentUtils from './assessmentUtils'
 
 import managePaths from '../paths/manage'
 import applyPaths from '../paths/apply'
@@ -120,4 +121,6 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addFilter('sentenceCase', sentenceCase)
 
   njkEnv.addGlobal('checkYourAnswersSections', checkYourAnswersSections)
+
+  njkEnv.addGlobal('AssessmentUtils', AssessmentUtils)
 }

--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -1,4 +1,4 @@
-import { statusTag } from './personUtils'
+import { statusTag, tierBadge } from './personUtils'
 
 describe('personUtils', () => {
   describe('statusTag', () => {
@@ -10,6 +10,16 @@ describe('personUtils', () => {
 
     it('returns an "In Custody" tag for an InCustody status', () => {
       expect(statusTag('InCustody')).toEqual(`<strong class="govuk-tag" data-cy-status="InCustody">In Custody</strong>`)
+    })
+  })
+
+  describe('tierBadge', () => {
+    it('returns the correct tier badge for A', () => {
+      expect(tierBadge('A')).toEqual('<span class="moj-badge moj-badge--red">A</span>')
+    })
+
+    it('returns the correct tier badge for B', () => {
+      expect(tierBadge('B')).toEqual('<span class="moj-badge moj-badge--purple">B</span>')
     })
   })
 })

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import type { PersonStatus } from '@approved-premises/ui'
 
 const statusTag = (status: PersonStatus): string => {
@@ -9,4 +8,10 @@ const statusTag = (status: PersonStatus): string => {
   return `<strong class="govuk-tag" data-cy-status="${status}">In Custody</strong>`
 }
 
-export { statusTag }
+const tierBadge = (tier: string): string => {
+  const colour = { A: 'moj-badge--red', B: 'moj-badge--purple' }[tier[0]]
+
+  return `<span class="moj-badge ${colour}">${tier}</span>`
+}
+
+export { statusTag, tierBadge }

--- a/server/views/assessments/index.njk
+++ b/server/views/assessments/index.njk
@@ -1,0 +1,139 @@
+{% extends "../partials/layout.njk" %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
+
+{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set mainClasses = "app-container govuk-body assessments--index" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+
+      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+      {% set awaitingHtml %}
+      {{
+        govukTable({
+          caption: "Applications to assess",
+          captionClasses: "govuk-table__caption--m",
+          firstCellIsHeader: true,
+          head: [
+            {
+              text: "Name"
+            },
+            {
+              text: "CRN"
+            },
+            {
+              text: "Tier"
+            },
+            {
+              text: "Arrival date"
+            },
+            {
+              text: "Current location"
+            },
+            {
+              text: "Days until application due"
+            },
+            {
+              text: "Status"
+            }
+          ],
+          rows: AssessmentUtils.awaitingAssessmentTableRows(assessments.awaiting)
+        })
+      }}
+      {% endset -%}
+
+      {% set infoRequestHtml %}
+      {{
+        govukTable({
+          caption: "Requested further information",
+          captionClasses: "govuk-table__caption--m",
+          firstCellIsHeader: true,
+          head: [
+            {
+              text: "Name"
+            },
+            {
+              text: "CRN"
+            },
+            {
+              text: "Tier"
+            },
+            {
+              text: "Arrival date"
+            },
+            {
+              text: "Days since application received"
+            },
+            {
+              text: "Date of info request"
+            },
+            {
+              text: "Status"
+            }
+          ],
+          rows: AssessmentUtils.requestedFurtherInformationTableRows(assessments.requestedFurtherInformation)
+        })
+      }}
+      {% endset -%}
+
+      {% set completedHtml %}
+      {{
+        govukTable({
+          caption: "Completed Assessments",
+          captionClasses: "govuk-table__caption--m",
+          firstCellIsHeader: true,
+          head: [
+            {
+              text: "Name"
+            },
+            {
+              text: "CRN"
+            },
+            {
+              text: "Tier"
+            },
+            {
+              text: "Arrival date"
+            },
+            {
+              text: "Status"
+            }
+          ],
+          rows: AssessmentUtils.completedTableRows(assessments.completed)
+        })
+      }}
+      {% endset -%}
+
+      {{ govukTabs({
+        items: [
+          {
+            label: ('Applications' + AssessmentUtils.assessmentsApproachingDueBadge(assessments.awaiting)) | safe,
+            id: "applications",
+            panel: {
+              html: awaitingHtml
+            }
+          },
+          {
+            label: "Requested further information",
+            id: "infoRequest",
+            panel: {
+              html: infoRequestHtml
+            }
+          },
+          {
+            label: "Completed",
+            id: "completed",
+            panel: {
+              html: completedHtml
+            }
+          }
+        ]
+      }) }}
+
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
This PR adds functionality for a user to view all their upcoming and approved assessments. There is also the ability to show asssessments that have had further information requested, but this is not yet baked into the API, so the tab for that information is currently blank.

I've tried to seperate concerns out in the PR a bit, with the clients dealing with the fetching of the data, the services marshalling the data into the correct format (in this case seperating the assessments by type) and the helper methods dealing with the presentation layer. This makes testing easier, and also helps make the functionality of each part of the application clearer. Before a bunch of presentation layer stuff was getting mixed in with the service layer (my fault!) and I think this made the service layer unweildy and difficult to use in other parts of the application. 

I've also broken down some of the bigger helper functions into smaller sub functions, which I then unit test, this makes testing more simple when we test the table row methods, so we don't have to spend ages setting up state to test every edge case is covered.

## Screenshots

![Assess -- shows a list of assessments](https://user-images.githubusercontent.com/109774/206154835-2e93068c-bda9-4dde-ba6d-7f5fdbcda264.png)

![Assess -- shows a list of assessments (1)](https://user-images.githubusercontent.com/109774/206154847-305ae668-1af3-450c-be99-b4b97e0efde5.png)
