### PR TITLE
(727) - Apply - OASys Import

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -58,7 +58,8 @@
             "printWidth": 120,
             "semi": false
           }
-        ]
+        ],
+        "no-underscore-dangle": [2, { "allowAfterThis": true }]
       }
     }
   ],

--- a/cypress_shared/pages/apply/checkYourAnswersPage.ts
+++ b/cypress_shared/pages/apply/checkYourAnswersPage.ts
@@ -34,6 +34,10 @@ export default class CheckYourAnswersPage extends Page {
     this.shouldShowAnswersForTask('type-of-ap', pages)
   }
 
+  shouldShowOptionalOasysSectionsAnswers(pages: Array<ApplyPage>) {
+    this.shouldShowAnswersForTask('oasys-import', pages)
+  }
+
   shouldShowRiskManagementAnswers(pages: Array<ApplyPage>) {
     this.shouldShowAnswersForTask('risk-management-features', pages)
   }

--- a/cypress_shared/pages/apply/optionalOasysSections.ts
+++ b/cypress_shared/pages/apply/optionalOasysSections.ts
@@ -1,0 +1,24 @@
+import { Application, OASysSection } from '@approved-premises/api'
+
+import ApplyPage from './applyPage'
+
+export default class OptionalOasysSectionsPage extends ApplyPage {
+  constructor(application: Application) {
+    super(
+      'Which of the following sections of OASys do you want to import?',
+      application,
+      'oasys-import',
+      'optional-oasys-sections',
+    )
+  }
+
+  completeForm(oasysSectionsLinkedToReoffending: Array<OASysSection>, otherOasysSections: Array<OASysSection>): void {
+    oasysSectionsLinkedToReoffending.forEach(oasysSection => {
+      this.checkCheckboxByNameAndValue('needsLinkedToReoffending', oasysSection.section.toString())
+    })
+
+    otherOasysSections.forEach(oasysSection => {
+      this.checkRadioByNameAndValue('otherNeeds', oasysSection.section.toString())
+    })
+  }
+}

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -26,6 +26,28 @@
       "type": "standard"
     }
   },
+  "oasys-import": {
+    "optional-oasys-sections": {
+      "needsLinkedToReoffending": [
+        { "section": 1, "name": "accommodation", "linkedToHarm": false, "linkedToReOffending": true },
+        { "section": 2, "name": "relationships", "linkedToHarm": false, "linkedToReOffending": true }
+      ],
+      "otherNeeds": [
+        {
+          "section": 3,
+          "name": "emotional",
+          "linkedToHarm": false,
+          "linkedToReOffending": false
+        },
+        {
+          "section": 4,
+          "name": "thinking",
+          "linkedToHarm": false,
+          "linkedToReOffending": false
+        }
+      ]
+    }
+  },
   "risk-management-features": {
     "risk-management-features": {
       "manageRiskDetails": "est vero nesciunt",

--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -1,6 +1,13 @@
 import { SuperAgentRequest } from 'superagent'
 
-import type { Person, PersonRisks, PrisonCaseNote, Adjudication, ActiveOffence } from '@approved-premises/api'
+import type {
+  Person,
+  PersonRisks,
+  PrisonCaseNote,
+  Adjudication,
+  ActiveOffence,
+  OASysSection,
+} from '@approved-premises/api'
 
 import { stubFor, getMatchingRequests } from '../../wiremock'
 
@@ -82,6 +89,19 @@ export default {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: args.adjudications,
+      },
+    }),
+
+  stubOasysSelection: (args: { person: Person; oasysSections: Array<OASysSection> }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/people/${args.person.crn}/oasys/selection`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.oasysSections,
       },
     }),
 }

--- a/script/test
+++ b/script/test
@@ -12,6 +12,10 @@ echo "==> Pulling the latest type from the API repo"
 
 npm run generate-types
 
+echo "==> Generating the schema"
+
+npm run generate:schema:apply
+
 echo "==> Typechecking the code"
 
 npm run typecheck

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,4 +1,13 @@
-import { RoshRisks, RiskTier, FlagsEnvelope, Mappa, Application, Assessment, Person } from '@approved-premises/api'
+import {
+  RoshRisks,
+  RiskTier,
+  FlagsEnvelope,
+  Mappa,
+  Application,
+  Assessment,
+  Person,
+  OASysSection,
+} from '@approved-premises/api'
 
 interface TasklistPage {
   body: Record<string, unknown>
@@ -178,6 +187,7 @@ export type DataServices = {
   personService: {
     getPrisonCaseNotes: (token: string, crn: string) => Promise<Array<PrisonCaseNote>>
     getAdjudications: (token: string, crn: string) => Promise<Array<Adjudication>>
+    getOasysSelections: (token: string, crn: string) => Promise<Array<OASysSection>>
   }
 }
 

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -8,6 +8,7 @@ import prisonCaseNotesFactory from '../testutils/factories/prisonCaseNotes'
 import paths from '../paths/api'
 import adjudicationsFactory from '../testutils/factories/adjudication'
 import activeOffenceFactory from '../testutils/factories/activeOffence'
+import oasysSectionFactory from '../testutils/factories/oasysSection'
 
 describe('PersonClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
@@ -94,6 +95,23 @@ describe('PersonClient', () => {
 
       expect(result).toEqual(adjudications)
       expect(nock.isDone()).toBeTruthy()
+    })
+
+    describe('oasysSelection', () => {
+      it('should return the importable sections of OASys', async () => {
+        const crn = 'crn'
+        const oasysSections = oasysSectionFactory.buildList(5)
+
+        fakeApprovedPremisesApi
+          .get(paths.people.oasys.selection({ crn }))
+          .matchHeader('authorization', `Bearer ${token}`)
+          .reply(201, oasysSections)
+
+        const result = await personClient.oasysSelections(crn)
+
+        expect(result).toEqual(oasysSections)
+        expect(nock.isDone()).toBeTruthy()
+      })
     })
   })
 

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -1,4 +1,12 @@
-import type { ActiveOffence, Adjudication, Person, PersonRisks, PrisonCaseNote } from '@approved-premises/api'
+import type {
+  ActiveOffence,
+  Adjudication,
+  Person,
+  PersonRisks,
+  PrisonCaseNote,
+  OASysSection,
+} from '@approved-premises/api'
+
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -42,5 +50,11 @@ export default class PersonClient {
     const response = await this.restClient.get({ path: paths.people.offences({ crn }) })
 
     return response as Array<ActiveOffence>
+  }
+
+  async oasysSelections(crn: string): Promise<Array<OASysSection>> {
+    const response = await this.restClient.get({ path: paths.people.oasys.selection({ crn }) })
+
+    return response as Array<OASysSection>
   }
 }

--- a/server/form-pages/apply/move-on/foreignNational.ts
+++ b/server/form-pages/apply/move-on/foreignNational.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import type { ObjectWithDateParts, TaskListErrors } from '@approved-premises/ui'
 import { sentenceCase } from '../../../utils/utils'
 

--- a/server/form-pages/apply/reasons-for-placement/basic-information/oralHearing.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/oralHearing.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import type { ObjectWithDateParts, YesOrNo, TaskListErrors } from '@approved-premises/ui'
 import type { Application } from '@approved-premises/api'
 

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import type { ObjectWithDateParts, YesOrNo, TaskListErrors } from '@approved-premises/ui'
 import type { Application } from '@approved-premises/api'
 

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.test.ts
@@ -114,7 +114,7 @@ describe('PlacementPurpose', () => {
 
       expect(page.response()).toEqual({
         [page.title]:
-          'Public protection, Prevent Contact, Help individual readjust to life outside custody, Provide drug or alcohol monitoring, Prevent self harm or suicide',
+          'Public protection, Prevent contact, Help individual readjust to life outside custody, Provide drug or alcohol monitoring, Prevent self harm or suicide',
       })
     })
 
@@ -142,7 +142,7 @@ describe('PlacementPurpose', () => {
 
       expect(items).toEqual([
         { checked: false, text: 'Public protection', value: 'publicProtection' },
-        { checked: false, text: 'Prevent Contact', value: 'preventContact' },
+        { checked: false, text: 'Prevent contact', value: 'preventContact' },
         { checked: false, text: 'Help individual readjust to life outside custody', value: 'readjust' },
         { checked: false, text: 'Provide drug or alcohol monitoring', value: 'drugAlcoholMonitoring' },
         { checked: false, text: 'Prevent self harm or suicide', value: 'preventSelfHarm' },

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.ts
@@ -7,7 +7,7 @@ import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
 
 export const placementPurposes = {
   publicProtection: 'Public protection',
-  preventContact: 'Prevent Contact',
+  preventContact: 'Prevent contact',
   readjust: 'Help individual readjust to life outside custody',
   drugAlcoholMonitoring: 'Provide drug or alcohol monitoring',
   preventSelfHarm: 'Prevent self harm or suicide',

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import type { TaskListErrors } from '@approved-premises/ui'
 import type { Application } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'

--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import type { ObjectWithDateParts, YesOrNo, TaskListErrors } from '@approved-premises/ui'
 import type { Application } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/pipeReferral.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/pipeReferral.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import type { YesOrNo, ObjectWithDateParts, TaskListErrors } from '@approved-premises/ui'
 import type { Application } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'

--- a/server/form-pages/apply/risk-and-need-factors/index.ts
+++ b/server/form-pages/apply/risk-and-need-factors/index.ts
@@ -3,11 +3,12 @@ import { Section } from '../../utils/decorators'
 import AccessAndHealthcare from './access-and-healthcare'
 import FurtherConsiderations from './further-considerations'
 import LocationFactors from './location-factors'
+import OasysImport from './oasys-import'
 import PrisonInformation from './prison-information'
 import RiskManagement from './risk-management-features'
 
 @Section({
   name: 'Risk and need factors',
-  tasks: [RiskManagement, PrisonInformation, LocationFactors, AccessAndHealthcare, FurtherConsiderations],
+  tasks: [OasysImport, RiskManagement, PrisonInformation, LocationFactors, AccessAndHealthcare, FurtherConsiderations],
 })
 export default class RiskAndNeedFactors {}

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/index.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/index.ts
@@ -1,0 +1,11 @@
+/* istanbul ignore file */
+import { Task } from '../../../utils/decorators'
+
+import OptionalOasysSections from './optionalOasysSections'
+
+@Task({
+  slug: 'oasys-import',
+  name: 'Choose sections of OASys to import',
+  pages: [OptionalOasysSections],
+})
+export default class OasysImport {}

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.test.ts
@@ -1,0 +1,240 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+import { PersonService } from '../../../../services'
+import applicationFactory from '../../../../testutils/factories/application'
+import oasysSectionFactory from '../../../../testutils/factories/oasysSection'
+import { sentenceCase } from '../../../../utils/utils'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+
+import OptionalOasysSections from './optionalOasysSections'
+
+jest.mock('../../../../services/personService.ts')
+
+describe('OptionalOasysSections', () => {
+  const oasysSections = oasysSectionFactory.buildList(3)
+  const needsLinkedToHarm = oasysSectionFactory.needsLinkedToHarm().buildList(2)
+  let needsLinkedToReoffending = oasysSectionFactory.needsLinkedToReoffending().buildList(2)
+  let otherNeeds = oasysSectionFactory.needsNotLinkedToReoffending().buildList(2)
+
+  const application = applicationFactory.build()
+
+  describe('initialize', () => {
+    const getOasysSelectionsMock = jest.fn().mockResolvedValue(oasysSections)
+    let personService: DeepMocked<PersonService>
+
+    beforeEach(() => {
+      personService = createMock<PersonService>({
+        getOasysSelections: getOasysSelectionsMock,
+      })
+    })
+
+    it('calls the getOasysSelections method on the client with a token and the persons CRN', async () => {
+      await OptionalOasysSections.initialize({}, application, 'some-token', { personService })
+
+      expect(getOasysSelectionsMock).toHaveBeenCalledWith('some-token', application.person.crn)
+    })
+
+    it('filters the OASys sections into needs linked to reoffending and other needs not linked to reoffending or harm', async () => {
+      personService.getOasysSelections.mockResolvedValue([
+        ...needsLinkedToHarm,
+        ...needsLinkedToReoffending,
+        ...otherNeeds,
+      ])
+
+      const page = await OptionalOasysSections.initialize({}, application, 'some-token', { personService })
+
+      expect(page.allNeedsLinkedToReoffending).toEqual(needsLinkedToReoffending)
+      expect(page.allOtherNeeds).toEqual(otherNeeds)
+    })
+
+    it('initializes the OptionalOasysSections class with the selected sections', async () => {
+      needsLinkedToReoffending = oasysSectionFactory.needsLinkedToReoffending().buildList(1, { section: 1 })
+      otherNeeds = oasysSectionFactory.needsNotLinkedToReoffending().buildList(1, { section: 2 })
+
+      getOasysSelectionsMock.mockResolvedValueOnce([...needsLinkedToReoffending, ...otherNeeds])
+
+      const page = await OptionalOasysSections.initialize(
+        { needsLinkedToReoffending: '1', otherNeeds: '2' },
+        application,
+        'some-token',
+        {
+          personService,
+        },
+      )
+
+      expect(page.body.needsLinkedToReoffending).toEqual([
+        {
+          linkedToHarm: false,
+          linkedToReOffending: true,
+          name: needsLinkedToReoffending[0].name,
+          section: 1,
+        },
+      ])
+      expect(page.body.otherNeeds).toEqual([
+        {
+          linkedToHarm: false,
+          linkedToReOffending: false,
+          name: otherNeeds[0].name,
+          section: 2,
+        },
+      ])
+    })
+  })
+
+  itShouldHaveNextValue(new OptionalOasysSections({}), '')
+
+  itShouldHavePreviousValue(new OptionalOasysSections({}), '')
+
+  describe('errors', () => {
+    it('should return an empty object', () => {
+      const page = new OptionalOasysSections({})
+      expect(page.errors()).toEqual({})
+    })
+  })
+
+  describe('response', () => {
+    const needLinkedToReoffendingA = oasysSectionFactory
+      .needsLinkedToReoffending()
+      .build({ section: 1, name: 'Some section' })
+    const needLinkedToReoffendingB = oasysSectionFactory
+      .needsLinkedToReoffending()
+      .build({ section: 2, name: 'Some other Section' })
+    const otherNeedA = oasysSectionFactory.needsNotLinkedToReoffending().build({ section: 3, name: 'Foo Section' })
+    const otherNeedB = oasysSectionFactory.needsNotLinkedToReoffending().build({ section: 4, name: 'Bar Section' })
+
+    describe('should return a translated version of the OASys sections', () => {
+      it('when every need is selected', () => {
+        const page = new OptionalOasysSections({
+          needsLinkedToReoffending: [needLinkedToReoffendingA, needLinkedToReoffendingB],
+          otherNeeds: [otherNeedA, otherNeedB],
+        })
+
+        page.allNeedsLinkedToReoffending = [needLinkedToReoffendingA, needLinkedToReoffendingB]
+
+        page.allOtherNeeds = [otherNeedA, otherNeedB]
+
+        expect(page.response()).toEqual({
+          [page.needsLinkedToReoffendingHeading]: '1. Some section, 2. Some other section',
+          [page.otherNeedsHeading]: '3. Foo section, 4. Bar section',
+        })
+      })
+
+      it('when only one need is selected', () => {
+        const needLinkedToReoffending = oasysSectionFactory
+          .needsLinkedToReoffending()
+          .build({ section: 1, name: 'Some section' })
+        const otherNeed = oasysSectionFactory
+          .needsNotLinkedToReoffending()
+          .build({ section: 2, name: 'Some other section' })
+
+        const page = new OptionalOasysSections({
+          needsLinkedToReoffending: [needLinkedToReoffending],
+          otherNeeds: [otherNeed],
+        })
+
+        page.allNeedsLinkedToReoffending = [needLinkedToReoffending]
+        page.allOtherNeeds = [otherNeed]
+
+        expect(page.response()).toEqual({
+          [page.needsLinkedToReoffendingHeading]: `1. Some section`,
+          [page.otherNeedsHeading]: `2. Some other section`,
+        })
+      })
+
+      it('returns an empty object when no needs are selected', () => {
+        const page = new OptionalOasysSections({})
+        expect(page.response()).toEqual({})
+      })
+
+      it('returns an object with only one key if only needsLinkedToReoffending or otherNeeds are given', () => {
+        const needLinkedToReoffending = oasysSectionFactory
+          .needsLinkedToReoffending()
+          .build({ section: 1, name: 'Some section' })
+
+        const pageWithOnlyNeedsLinkedToReoffending = new OptionalOasysSections({
+          needsLinkedToReoffending: [needLinkedToReoffending],
+        })
+        pageWithOnlyNeedsLinkedToReoffending.allNeedsLinkedToReoffending = [needLinkedToReoffending]
+
+        expect(pageWithOnlyNeedsLinkedToReoffending.response()).toEqual({
+          [pageWithOnlyNeedsLinkedToReoffending.needsLinkedToReoffendingHeading]: '1. Some section',
+        })
+
+        const otherNeed = oasysSectionFactory
+          .needsNotLinkedToReoffending()
+          .build({ section: 2, name: 'Some other section' })
+
+        const pageWithOnlyOtherNeeds = new OptionalOasysSections({
+          otherNeeds: [otherNeed],
+        })
+        pageWithOnlyOtherNeeds.allOtherNeeds = [otherNeed]
+
+        expect(pageWithOnlyOtherNeeds.response()).toEqual({
+          [pageWithOnlyOtherNeeds.otherNeedsHeading]: '2. Some other section',
+        })
+      })
+    })
+  })
+
+  describe('reoffendingNeedsItems', () => {
+    it('it returns reoffending needs as checkbox items', () => {
+      const needLinkedToReoffendingA = oasysSectionFactory
+        .needsLinkedToReoffending()
+        .build({ section: 1, name: 'emotional' })
+      const needLinkedToReoffendingB = oasysSectionFactory.needsLinkedToReoffending().build({ section: 2 })
+      const needLinkedToReoffendingC = oasysSectionFactory.needsLinkedToReoffending().build({ section: 3 })
+
+      const page = new OptionalOasysSections({ needsLinkedToReoffending: [needLinkedToReoffendingA] })
+      page.allNeedsLinkedToReoffending = [needLinkedToReoffendingA, needLinkedToReoffendingB, needLinkedToReoffendingC]
+      const items = page.reoffendingNeedsItems()
+
+      expect(items).toEqual([
+        {
+          checked: true,
+          text: `1. ${sentenceCase(needLinkedToReoffendingA.name)}`,
+          value: '1',
+        },
+        {
+          checked: false,
+          text: `2. ${sentenceCase(needLinkedToReoffendingB.name)}`,
+          value: '2',
+        },
+        {
+          checked: false,
+          text: `3. ${sentenceCase(needLinkedToReoffendingC.name)}`,
+          value: '3',
+        },
+      ])
+    })
+  })
+
+  describe('otherNeedsItems', () => {
+    it('it returns other needs as checkbox items', () => {
+      const otherNeedA = oasysSectionFactory.needsNotLinkedToReoffending().build({ section: 1 })
+      const otherNeedB = oasysSectionFactory.needsNotLinkedToReoffending().build({ section: 2, name: 'thinking' })
+      const otherNeedC = oasysSectionFactory.needsNotLinkedToReoffending().build({ section: 3 })
+
+      const page = new OptionalOasysSections({ otherNeeds: [otherNeedB] })
+      page.allOtherNeeds = [otherNeedA, otherNeedB, otherNeedC]
+
+      const items = page.otherNeedsItems()
+
+      expect(items).toEqual([
+        {
+          checked: false,
+          text: `1. ${sentenceCase(otherNeedA.name)}`,
+          value: '1',
+        },
+        {
+          checked: true,
+          text: `2. ${sentenceCase(otherNeedB.name)}`,
+          value: '2',
+        },
+        {
+          checked: false,
+          text: `3. ${sentenceCase(otherNeedC.name)}`,
+          value: '3',
+        },
+      ])
+    })
+  })
+})

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
@@ -1,0 +1,124 @@
+import { Page } from '../../../utils/decorators'
+
+import TasklistPage from '../../../tasklistPage'
+
+import { flattenCheckboxInput, isStringOrArrayOfStrings } from '../../../../utils/formUtils'
+import { Application, OASysSection } from '../../../../@types/shared'
+import { DataServices } from '../../../../@types/ui'
+import { sentenceCase } from '../../../../utils/utils'
+
+interface Response {
+  needsLinkedToReoffending: Array<string> | string | Array<OASysSection>
+  otherNeeds: Array<string> | string | Array<OASysSection>
+}
+
+interface Body {
+  needsLinkedToReoffending: Array<OASysSection>
+  otherNeeds: Array<OASysSection>
+}
+
+@Page({
+  name: 'optional-oasys-sections',
+  bodyProperties: ['needsLinkedToReoffending', 'otherNeeds'],
+})
+export default class OptionalOasysSections implements TasklistPage {
+  title = 'Which of the following sections of OASys do you want to import?'
+
+  needsLinkedToReoffendingHeading = 'Needs linked to reoffending'
+
+  allNeedsLinkedToReoffending: Array<OASysSection>
+
+  otherNeedsHeading = 'Needs not linked to risk of serious harm or reoffending'
+
+  allOtherNeeds: Array<OASysSection>
+
+  constructor(public body: Partial<Body>) {}
+
+  static async initialize(
+    body: Partial<Response>,
+    application: Application,
+    token: string,
+    dataServices: DataServices,
+  ) {
+    const oasysSelections = await dataServices.personService.getOasysSelections(token, application.person.crn)
+
+    const allNeedsLinkedToReoffending = oasysSelections.filter(
+      section => !section.linkedToHarm && section.linkedToReOffending,
+    )
+    const allOtherNeeds = oasysSelections.filter(section => !section.linkedToHarm && !section.linkedToReOffending)
+
+    const fullLists = {
+      needsLinkedToReoffending: allNeedsLinkedToReoffending,
+      otherNeeds: allOtherNeeds,
+    }
+
+    const lists = ['needsLinkedToReoffending', 'otherNeeds']
+
+    lists.forEach(section => {
+      if (isStringOrArrayOfStrings(body[section])) {
+        body[section] = flattenCheckboxInput(body[section])
+      }
+
+      body[section] = (body[section] || []).map((need: string) =>
+        fullLists[section].find((n: OASysSection) => need === n.section.toString()),
+      )
+    })
+
+    const page = new OptionalOasysSections(body as Body)
+
+    page.allNeedsLinkedToReoffending = allNeedsLinkedToReoffending
+    page.allOtherNeeds = allOtherNeeds
+
+    return page
+  }
+
+  previous() {
+    return ''
+  }
+
+  next() {
+    return ''
+  }
+
+  response() {
+    const response = {}
+
+    if (this.getResponseForTypeOfNeed(this.body.needsLinkedToReoffending))
+      response[this.needsLinkedToReoffendingHeading] = this.getResponseForTypeOfNeed(this.body.needsLinkedToReoffending)
+
+    if (this.getResponseForTypeOfNeed(this.body.otherNeeds))
+      response[this.otherNeedsHeading] = this.getResponseForTypeOfNeed(this.body.otherNeeds)
+
+    return response
+  }
+
+  getResponseForTypeOfNeed(typeOfNeed: Array<OASysSection>) {
+    if (Array.isArray(typeOfNeed) && typeOfNeed.length) {
+      return typeOfNeed.map(need => `${need.section}. ${sentenceCase(need.name)}`).join(', ')
+    }
+    return ''
+  }
+
+  reoffendingNeedsItems() {
+    return this.checkboxes(this.allNeedsLinkedToReoffending, this.body.needsLinkedToReoffending)
+  }
+
+  otherNeedsItems() {
+    return this.checkboxes(this.allOtherNeeds, this.body.otherNeeds)
+  }
+
+  private checkboxes(fullList: Array<OASysSection>, selectedList: Array<OASysSection>) {
+    return fullList.map(need => {
+      const sectionAndName = `${need.section}. ${sentenceCase(need.name)}`
+      return {
+        value: need.section.toString(),
+        text: sectionAndName,
+        checked: selectedList.map(n => n.section).includes(need.section),
+      }
+    })
+  }
+
+  errors() {
+    return {}
+  }
+}

--- a/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
+++ b/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import type { DataServices } from '@approved-premises/ui'
 
 import type { Application, PrisonCaseNote, Adjudication } from '@approved-premises/api'

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/dateOfOffence.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/dateOfOffence.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import type { TaskListErrors } from '@approved-premises/ui'
 import { Page } from '../../../utils/decorators'
 import { sentenceCase, lowerCase } from '../../../../utils/utils'

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import type { TaskListErrors } from '@approved-premises/ui'
 import { Application } from '../../../../@types/shared'
 import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/typeOfConvictedOffence.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/typeOfConvictedOffence.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import type { TaskListErrors } from '@approved-premises/ui'
 import { Application } from '../../../../@types/shared'
 import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -5,6 +5,7 @@
   "required": [
     "basic-information",
     "type-of-ap",
+    "oasys-import",
     "risk-management-features",
     "prison-information",
     "location-factors",
@@ -42,7 +43,6 @@
                 "hdc",
                 "license",
                 "pss",
-                "rerelease",
                 "rotl"
               ],
               "type": "string"
@@ -408,6 +408,56 @@
             },
             "cctvNotes": {
               "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "oasys-import": {
+      "type": "object",
+      "properties": {
+        "optional-oasys-sections": {
+          "type": "object",
+          "properties": {
+            "needsLinkedToReoffending": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "section": {
+                    "type": "number"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "linkedToHarm": {
+                    "type": "boolean"
+                  },
+                  "linkedToReOffending": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "otherNeeds": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "section": {
+                    "type": "number"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "linkedToHarm": {
+                    "type": "boolean"
+                  },
+                  "linkedToReOffending": {
+                    "type": "boolean"
+                  }
+                }
+              }
             }
           }
         }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -20,6 +20,7 @@ const singleApplicationPath = applicationsPath.path(':id')
 
 const peoplePath = path('/people')
 const personPath = peoplePath.path(':crn')
+const oasysPath = personPath.path('oasys')
 
 const assessmentsPath = path('/assessments')
 
@@ -64,5 +65,8 @@ export default {
     prisonCaseNotes: personPath.path('prison-case-notes'),
     adjudications: personPath.path('adjudications'),
     offences: personPath.path('offences'),
+    oasys: {
+      selection: oasysPath.path('selection'),
+    },
   },
 }

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -8,6 +8,7 @@ import { mapApiPersonRisksForUi } from '../utils/utils'
 import prisonCaseNotesFactory from '../testutils/factories/prisonCaseNotes'
 import adjudicationsFactory from '../testutils/factories/adjudication'
 import activeOffenceFactory from '../testutils/factories/activeOffence'
+import oasysSectionFactory from '../testutils/factories/oasysSection'
 
 jest.mock('../data/personClient.ts')
 
@@ -94,6 +95,21 @@ describe('PersonService', () => {
 
       expect(personClientFactory).toHaveBeenCalledWith(token)
       expect(personClient.adjudications).toHaveBeenCalledWith('crn')
+    })
+  })
+
+  describe('getOasysSections', () => {
+    it("on success returns the person's OASys selections given their CRN", async () => {
+      const oasysSections = oasysSectionFactory.buildList(3)
+
+      personClient.oasysSelections.mockResolvedValue(oasysSections)
+
+      const serviceOasysSelections = await service.getOasysSelections(token, 'crn')
+
+      expect(serviceOasysSelections).toEqual(oasysSections)
+
+      expect(personClientFactory).toHaveBeenCalledWith(token)
+      expect(personClient.oasysSelections).toHaveBeenCalledWith('crn')
     })
   })
 })

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -1,5 +1,5 @@
 import type { PersonRisksUI } from '@approved-premises/ui'
-import type { ActiveOffence, Adjudication, Person, PrisonCaseNote } from '@approved-premises/api'
+import type { ActiveOffence, Adjudication, Person, PrisonCaseNote, OASysSection } from '@approved-premises/api'
 import type { RestClientBuilder, PersonClient } from '../data'
 
 import { mapApiPersonRisksForUi } from '../utils/utils'
@@ -43,5 +43,13 @@ export default class PersonService {
     const adjudications = await personClient.adjudications(crn)
 
     return adjudications
+  }
+
+  async getOasysSelections(token: string, crn: string): Promise<Array<OASysSection>> {
+    const personClient = this.personClientFactory(token)
+
+    const oasysSections = await personClient.oasysSelections(crn)
+
+    return oasysSections
   }
 }

--- a/server/testutils/factories/oasysSection.ts
+++ b/server/testutils/factories/oasysSection.ts
@@ -1,0 +1,34 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { OASysSection } from '@approved-premises/api'
+
+class OasysSectionFactory extends Factory<OASysSection> {
+  needsLinkedToHarm() {
+    return this.params({ linkedToHarm: true, linkedToReOffending: true })
+  }
+
+  needsLinkedToReoffending() {
+    return this.params({ linkedToHarm: false, linkedToReOffending: true })
+  }
+
+  needsNotLinkedToReoffending() {
+    return this.params({ linkedToHarm: false, linkedToReOffending: false })
+  }
+}
+
+export default OasysSectionFactory.define(() => ({
+  section: faker.datatype.number({ min: 1, max: 20 }),
+  name: faker.helpers.arrayElement([
+    'accommodation',
+    'relationships',
+    'emotional',
+    'thinking',
+    'ete',
+    'lifestyle',
+    'health',
+    'attitudes',
+  ]),
+  linkedToHarm: faker.datatype.boolean(),
+  linkedToReOffending: faker.datatype.boolean(),
+}))

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -8,6 +8,8 @@ import {
   convertObjectsToSelectOptions,
   convertKeyValuePairToCheckBoxItems,
   validPostcodeArea,
+  flattenCheckboxInput,
+  isStringOrArrayOfStrings,
 } from './formUtils'
 
 describe('formUtils', () => {
@@ -311,6 +313,7 @@ describe('formUtils', () => {
       ])
     })
   })
+
   describe('validPostcodeArea', () => {
     it('when passed a postcode area it returns true', () => {
       expect(validPostcodeArea('HR1')).toBe(true)
@@ -318,6 +321,30 @@ describe('formUtils', () => {
 
     it('when passed a non-postcode string returns false', () => {
       expect(validPostcodeArea('foo')).toBe(false)
+    })
+  })
+
+  describe('flattenCheckboxInput', () => {
+    it('returns the input in an array', () => {
+      expect(flattenCheckboxInput('test')).toEqual(['test'])
+    })
+    it('returns the input if it is already an array', () => {
+      expect(flattenCheckboxInput(['test'])).toEqual(['test'])
+    })
+    it('returns an empty array if the value is falsy', () => {
+      expect(flattenCheckboxInput(null)).toEqual([])
+    })
+  })
+
+  describe('isStringOrArrayOfStrings', () => {
+    it('returns true if the input is a string', () => {
+      expect(isStringOrArrayOfStrings('test')).toEqual(true)
+    })
+    it('returns true if the input is an array of strings', () => {
+      expect(isStringOrArrayOfStrings(['test', 'test'])).toEqual(true)
+    })
+    it('returns false if array contains a non-string value ', () => {
+      expect(isStringOrArrayOfStrings(['test', 1, 'test'])).toEqual(false)
     })
   })
 })

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -95,3 +95,27 @@ export function convertKeyValuePairToCheckBoxItems<T>(
 export function validPostcodeArea(potentialPostcode: string) {
   return /[A-Z][0-9]{1,2}|[A-Z][A-HJ-Y][0-9]{1,2}|[A-Z][0-9][A-Z]|[A-Z][A-HJ-Y][0-9]?[A-Z]/.test(potentialPostcode)
 }
+
+/**
+ * Returns the input if it is an array other.
+ * If the input is truthy and not an array it returns the input in an array
+ * Useful for checkboxes where if a single value is returned it is string but when multiple values are selected they are an array of strings.
+ * @param input input to be put into a flat array.
+ * @returns a flat array or an empty array.
+ */
+export function flattenCheckboxInput<T extends string | Array<T>>(input: T | Array<T>) {
+  if (Array.isArray(input)) return input
+  if (input) return [input].flat()
+  return []
+}
+
+/**
+ * @param input any
+ * @returns true if the input is an empty array, an array of strings or a string otherwise false
+ */
+export function isStringOrArrayOfStrings(input: unknown) {
+  return (
+    (Array.isArray(input) && input.every((element: unknown) => typeof element === 'string')) ||
+    typeof input === 'string'
+  )
+}

--- a/server/views/applications/pages/oasys-import/optional-oasys-sections.njk
+++ b/server/views/applications/pages/oasys-import/optional-oasys-sections.njk
@@ -1,0 +1,50 @@
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+    <h1 class="govuk-heading-l">{{page.title}}</h1>
+
+    <p class="govuk-body">We'll automatically import:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+        <li>offence details</li>
+        <li>RoSH summary</li>
+        <li>any MAPPA or hate-based information</li>
+        <li>sections linked to RoSH</li>
+        <li>Risk Management plan</li>
+        <li>Section 9 - Alcohol misuse</li>
+        <li>Section 8 -  Drug misuse</li>
+    </ul>
+
+    <p>Select any sections that include additional detail that's relevant to the risk an AP will help mitigate or the needs an AP can meet.</p>
+    <p>You will be able to edit the information that is pulled in from OASys and this information will be presented at the assessment stage. </p>
+
+    <h2 class="govuk-heading-s">Needs linked to risk of serious harm are automatically imported</h2>
+
+    {{ applyCheckboxes({
+        fieldName: "needsLinkedToReoffending",
+        fieldset: {
+            legend: {
+            text: "Optional - Needs linked to reoffending",
+            classes: "govuk-fieldset__legend--m"
+            }
+        },
+        items: page.reoffendingNeedsItems()
+        }, 
+        fetchContext()) 
+    }}
+
+    {{ applyCheckboxes({
+        fieldName: "otherNeeds",
+        fieldset: {
+            legend: {
+            text: "Optional - Needs not linked to risk of serious harm or reoffending",
+            classes: "govuk-fieldset__legend--m"
+            }
+        },
+        items: page.otherNeedsItems()
+        }, 
+        fetchContext()) 
+    }}
+
+{% endblock %}


### PR DESCRIPTION
# Context

Probation officers need to be able to select which optional sections ([supporting information](https://github.com/ministryofjustice/hmpps-approved-premises-ui/blob/6ae4cc119e543e02408953f56c4b4ed54ee9e875/server/@types/shared/models/OASysSections.ts#L20)) of OASys they would like to add to the application.
On this page (OptionalOasysSections) they can select these sections from two lists the first is needs linked to reoffending and the other is needs not linked to serious harm or reoffending (otherNeeds).
For the check your answers page and the persisted JSON document we only record the section number and title on this page but on the subsequent page (yet to be built) we will record the content of the imported sections.

In order to glean which sections of OASys are available for import we need to call the `/people/{crn}/oasys/selection` endpoint and filter into the two lists of needs.

[Trello card](https://trello.com/c/PYl2WtOG/727-oasys-risk-and-needs-import)

# Changes in this PR

## Screenshots of UI changes

![image](https://user-images.githubusercontent.com/44123869/206255320-3036c12d-dd03-4d89-8843-01b48d906e1b.png)

