### PR TITLE
(947) Allow the index offence to be selected at the start of the journey if an offender has more than one offence

### DIFF
--- a/cypress_shared/pages/apply/index.ts
+++ b/cypress_shared/pages/apply/index.ts
@@ -18,6 +18,7 @@ import ArsonPage from './arson'
 import PlacementDurationPage from './placementDuration'
 import ForeignNationalPage from './foreignNational'
 import CheckYourAnswersPage from './checkYourAnswersPage'
+import SelectOffencePage from './selectOffence'
 
 export {
   ConfirmDetailsPage,
@@ -40,4 +41,5 @@ export {
   PlacementDurationPage,
   ForeignNationalPage,
   CheckYourAnswersPage,
+  SelectOffencePage,
 }

--- a/cypress_shared/pages/apply/selectOffence.ts
+++ b/cypress_shared/pages/apply/selectOffence.ts
@@ -1,0 +1,25 @@
+import { ActiveOffence, Person } from '@approved-premises/api'
+import { DateFormats } from '../../../server/utils/dateUtils'
+import Page from '../page'
+
+export default class SelectOffencePage extends Page {
+  constructor(private readonly person: Person, private readonly offences: Array<ActiveOffence>) {
+    super(`Select index offence for ${person.name}`)
+  }
+
+  shouldDisplayOffences(): void {
+    this.offences.forEach((item: ActiveOffence) => {
+      cy.contains(item.offenceId)
+        .parent()
+        .within(() => {
+          cy.get('td').eq(2).contains(item.offenceDescription)
+          cy.get('td').eq(3).contains(DateFormats.isoDateToUIDate(item.offenceDate))
+          cy.get('td').eq(4).contains(item.convictionId)
+        })
+    })
+  }
+
+  selectOffence(selectedOffence: ActiveOffence): void {
+    this.checkRadioByNameAndValue('offenceId', selectedOffence.offenceId)
+  }
+}

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -59,7 +59,7 @@ context('Apply', () => {
 
     // And a person is in Delius
     const person = personFactory.build()
-    const offences = activeOffenceFactory.buildList(2)
+    const offences = activeOffenceFactory.buildList(1)
     cy.task('stubFindPerson', { person })
     cy.task('stubPersonOffences', { person, offences })
 
@@ -153,7 +153,7 @@ context('Apply', () => {
     const person = personFactory.build()
     const apiRisks = risksFactory.build({ crn: person.crn })
     const uiRisks = mapApiPersonRisksForUi(apiRisks)
-    const offences = activeOffenceFactory.buildList(2)
+    const offences = activeOffenceFactory.buildList(1)
 
     // Given I am logged in
     cy.signIn()

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -19,6 +19,7 @@ import {
   ForeignNationalPage,
   CheckYourAnswersPage,
   ListPage,
+  SelectOffencePage,
 } from '../../../cypress_shared/pages/apply'
 import ConvictedOffences from '../../../cypress_shared/pages/apply/convictedOffences'
 import DateOfOffence from '../../../cypress_shared/pages/apply/dateOfOffence'
@@ -51,6 +52,63 @@ context('Apply', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+  })
+
+  it('allows the user to select an index offence if there is more than one offence', () => {
+    // Given I am logged in
+    cy.signIn()
+
+    // And a person is in Delius
+    const person = personFactory.build()
+    cy.task('stubFindPerson', { person })
+
+    // And that person has more than one offence listed under their CRN
+    const offences = activeOffenceFactory.buildList(4)
+    cy.task('stubPersonOffences', { person, offences })
+
+    // And I have started an application
+    cy.fixture('applicationData.json').then(applicationData => {
+      const application = applicationFactory.build({ person, data: applicationData })
+      cy.task('stubApplicationCreate', { application })
+
+      const startPage = StartPage.visit()
+      startPage.startApplication()
+
+      // When I enter a CRN
+      const crnPage = new EnterCRNPage()
+      crnPage.enterCrn(person.crn)
+      crnPage.clickSubmit()
+
+      // And I click submit
+      const confirmDetailsPage = new ConfirmDetailsPage(person)
+      confirmDetailsPage.clickSubmit()
+
+      // Then I should be forwarded to select an offence
+      const selectOffencePage = Page.verifyOnPage(SelectOffencePage, person, offences)
+      selectOffencePage.shouldDisplayOffences()
+
+      // When I select an offence
+      const selectedOffence = offences[0]
+      selectOffencePage.selectOffence(selectedOffence)
+
+      // And I click submit
+      selectOffencePage.clickSubmit()
+
+      // Then the API should have created the application with my selected offence
+      cy.task('verifyApplicationCreate').then(requests => {
+        expect(requests).to.have.length(1)
+
+        const body = JSON.parse(requests[0].body)
+
+        expect(body.crn).equal(person.crn)
+        expect(body.convictionId).equal(selectedOffence.convictionId)
+        expect(body.deliusEventNumber).equal(selectedOffence.deliusEventNumber)
+        expect(body.offenceId).equal(selectedOffence.offenceId)
+      })
+
+      // Then I should be on the Sentence Type page
+      Page.verifyOnPage(SentenceTypePage, application)
+    })
   })
 
   it('shows the details of a person from their CRN', () => {

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -264,6 +264,20 @@ describe('applicationsController', () => {
       )
     })
 
+    it('redirects to the select offences step if an offence has not been provided', async () => {
+      request.body.offenceId = null
+
+      const requestHandler = applicationsController.create()
+
+      await requestHandler(request, response, next)
+
+      expect(response.redirect).toHaveBeenCalledWith(
+        paths.applications.people.selectOffence({
+          crn: request.body.crn,
+        }),
+      )
+    })
+
     it('saves the application to the session', async () => {
       const requestHandler = applicationsController.create()
 

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -119,7 +119,7 @@ describe('applicationsController', () => {
   describe('new', () => {
     describe('If there is a CRN in the flash', () => {
       const person = personFactory.build()
-      const offences = activeOffenceFactory.buildList(2)
+      const offence = activeOffenceFactory.build()
 
       beforeEach(() => {
         request = createMock<Request>({
@@ -127,29 +127,51 @@ describe('applicationsController', () => {
           flash: jest.fn().mockReturnValue([person.crn]),
         })
         personService.findByCrn.mockResolvedValue(person)
-        personService.getOffences.mockResolvedValue(offences)
+        personService.getOffences.mockResolvedValue([offence])
       })
 
-      it('it should render the start of the application form', async () => {
-        ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
-          return { errors: {}, errorSummary: [], userInput: {} }
+      describe('if an error has not been sent to the flash', () => {
+        beforeEach(() => {
+          ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
+            return { errors: {}, errorSummary: [], userInput: {} }
+          })
         })
 
-        const requestHandler = applicationsController.new()
+        it('it should render the start of the application form', async () => {
+          const requestHandler = applicationsController.new()
 
-        await requestHandler(request, response, next)
+          await requestHandler(request, response, next)
 
-        expect(response.render).toHaveBeenCalledWith('applications/people/confirm', {
-          pageHeading: `Confirm ${person.name}'s details`,
-          ...person,
-          date: DateFormats.dateObjtoUIDate(new Date()),
-          dateOfBirth: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
-          offenceId: offences[0].offenceId,
-          errors: {},
-          errorSummary: [],
+          expect(response.render).toHaveBeenCalledWith('applications/people/confirm', {
+            pageHeading: `Confirm ${person.name}'s details`,
+            ...person,
+            date: DateFormats.dateObjtoUIDate(new Date()),
+            dateOfBirth: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
+            offenceId: offence.offenceId,
+            errors: {},
+            errorSummary: [],
+          })
+          expect(personService.findByCrn).toHaveBeenCalledWith(token, person.crn)
+          expect(request.flash).toHaveBeenCalledWith('crn')
         })
-        expect(personService.findByCrn).toHaveBeenCalledWith(token, person.crn)
-        expect(request.flash).toHaveBeenCalledWith('crn')
+
+        it('should not send an offence ID to the view if there are more than one offences returned', async () => {
+          const offences = activeOffenceFactory.buildList(2)
+          personService.getOffences.mockResolvedValue(offences)
+
+          const requestHandler = applicationsController.new()
+          await requestHandler(request, response, next)
+
+          expect(response.render).toHaveBeenCalledWith('applications/people/confirm', {
+            pageHeading: `Confirm ${person.name}'s details`,
+            ...person,
+            date: DateFormats.dateObjtoUIDate(new Date()),
+            dateOfBirth: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
+            offenceId: null,
+            errors: {},
+            errorSummary: [],
+          })
+        })
       })
 
       it('renders the form with errors and user input if an error has been sent to the flash', async () => {
@@ -166,7 +188,7 @@ describe('applicationsController', () => {
           ...person,
           date: DateFormats.dateObjtoUIDate(new Date()),
           dateOfBirth: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
-          offenceId: offences[0].offenceId,
+          offenceId: offence.offenceId,
           errors: errorsAndUserInput.errors,
           errorSummary: errorsAndUserInput.errorSummary,
           ...errorsAndUserInput.userInput,

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -76,16 +76,20 @@ export default class ApplicationsController {
 
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { crn } = req.body
-      const offences = await this.personService.getOffences(req.user.token, crn)
-      const indexOffence = offences.find(o => o.offenceId === req.body.offenceId)
+      const { crn, offenceId } = req.body
+      if (!offenceId) {
+        res.redirect(paths.applications.people.selectOffence({ crn }))
+      } else {
+        const offences = await this.personService.getOffences(req.user.token, crn)
+        const indexOffence = offences.find(o => o.offenceId === offenceId)
 
-      const application = await this.applicationService.createApplication(req.user.token, crn, indexOffence)
-      req.session.application = application
+        const application = await this.applicationService.createApplication(req.user.token, crn, indexOffence)
+        req.session.application = application
 
-      res.redirect(
-        paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'sentence-type' }),
-      )
+        res.redirect(
+          paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'sentence-type' }),
+        )
+      }
     }
   }
 

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -51,17 +51,14 @@ export default class ApplicationsController {
         const person = await this.personService.findByCrn(req.user.token, crn)
         const offences = await this.personService.getOffences(req.user.token, crn)
 
-        // TODO: For now, we treat the first offence as the index offence, going
-        // forward, we'll need to design an approach to select one if there are
-        // more than one
-        const offence = offences[0]
+        const offenceId = offences.length === 1 ? offences[0].offenceId : null
 
         return res.render(`applications/people/confirm`, {
           pageHeading: `Confirm ${person.name}'s details`,
           ...person,
           date: DateFormats.dateObjtoUIDate(new Date()),
           dateOfBirth: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
-          offenceId: offence.offenceId,
+          offenceId,
           errors,
           errorSummary,
           ...userInput,

--- a/server/controllers/apply/index.ts
+++ b/server/controllers/apply/index.ts
@@ -2,6 +2,7 @@
 
 import ApplicationsController from './applicationsController'
 import PagesController from './applications/pagesController'
+import OffencesController from './people/offencesController'
 
 import type { Services } from '../../services'
 
@@ -9,10 +10,12 @@ export const controllers = (services: Services) => {
   const { applicationService, personService } = services
   const applicationsController = new ApplicationsController(applicationService, personService)
   const pagesController = new PagesController(applicationService, { personService })
+  const offencesController = new OffencesController(personService)
 
   return {
     applicationsController,
     pagesController,
+    offencesController,
   }
 }
 

--- a/server/controllers/apply/people/offencesController.test.ts
+++ b/server/controllers/apply/people/offencesController.test.ts
@@ -1,0 +1,51 @@
+import type { Request, Response, NextFunction } from 'express'
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+
+import OffencesController from './offencesController'
+import PersonService from '../../../services/personService'
+import personFactory from '../../../testutils/factories/person'
+import activeOffenceFactory from '../../../testutils/factories/activeOffence'
+
+describe('OffencesController', () => {
+  const token = 'SOME_TOKEN'
+
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const personService = createMock<PersonService>({})
+
+  let offencesController: OffencesController
+  let request: DeepMocked<Request>
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    offencesController = new OffencesController(personService)
+    request = createMock<Request>({
+      user: { token },
+      params: { crn: 'some-crn' },
+    })
+  })
+
+  describe('selectOffence', () => {
+    it('should return the a list of offences for the person', async () => {
+      const person = personFactory.build()
+      const offences = activeOffenceFactory.buildList(5)
+
+      personService.findByCrn.mockResolvedValue(person)
+      personService.getOffences.mockResolvedValue(offences)
+
+      const requestHandler = offencesController.selectOffence()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('applications/people/selectOffence', {
+        pageHeading: `Select index offence for ${person.name}`,
+        person,
+        offences,
+      })
+
+      expect(personService.findByCrn).toHaveBeenCalledWith(token, 'some-crn')
+      expect(personService.getOffences).toHaveBeenCalledWith(token, 'some-crn')
+    })
+  })
+})

--- a/server/controllers/apply/people/offencesController.ts
+++ b/server/controllers/apply/people/offencesController.ts
@@ -1,0 +1,21 @@
+import type { Request, Response, RequestHandler } from 'express'
+
+import { PersonService } from '../../../services'
+
+export default class OffencesController {
+  constructor(private readonly personService: PersonService) {}
+
+  selectOffence(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { crn } = req.params
+      const person = await this.personService.findByCrn(req.user.token, crn)
+      const offences = await this.personService.getOffences(req.user.token, crn)
+
+      res.render('applications/people/selectOffence', {
+        pageHeading: `Select index offence for ${person.name}`,
+        person,
+        offences,
+      })
+    }
+  }
+}

--- a/server/paths/apply.ts
+++ b/server/paths/apply.ts
@@ -4,12 +4,16 @@ const applicationsPath = path('/applications')
 const applicationPath = applicationsPath.path(':id')
 
 const pagesPath = applicationPath.path('tasks/:task/pages/:page')
+const peoplePath = applicationsPath.path('people')
 
 const paths = {
   applications: {
     new: applicationsPath.path('new'),
     start: applicationsPath.path('start'),
-    people: applicationsPath.path('people').path('find'),
+    people: {
+      find: peoplePath.path('find'),
+      selectOffence: peoplePath.path(':crn').path('select-offence'),
+    },
     create: applicationsPath,
     index: applicationsPath,
     show: applicationPath,

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -9,7 +9,7 @@ import actions from './utils'
 
 export default function routes(controllers: Controllers, router: Router): Router {
   const { get, post, put } = actions(router)
-  const { applicationsController, pagesController, peopleController } = controllers
+  const { applicationsController, pagesController, peopleController, offencesController } = controllers
 
   get(paths.applications.start.pattern, applicationsController.start())
   get(paths.applications.index.pattern, applicationsController.index())
@@ -18,7 +18,8 @@ export default function routes(controllers: Controllers, router: Router): Router
   post(paths.applications.create.pattern, applicationsController.create())
   post(paths.applications.submission.pattern, applicationsController.submit())
 
-  post(paths.applications.people.pattern, peopleController.find())
+  post(paths.applications.people.find.pattern, peopleController.find())
+  get(paths.applications.people.selectOffence.pattern, offencesController.selectOffence())
 
   get(paths.applications.pages.show.pattern, pagesController.show())
   put(paths.applications.pages.update.pattern, pagesController.update())

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -15,7 +15,9 @@ import { checkYourAnswersSections } from './checkYourAnswersUtils'
 import { statusTag } from './personUtils'
 import bookingActions from './bookingUtils'
 import { DateFormats } from './dateUtils'
+
 import * as AssessmentUtils from './assessmentUtils'
+import * as OffenceUtils from './offenceUtils'
 
 import managePaths from '../paths/manage'
 import applyPaths from '../paths/apply'
@@ -123,4 +125,5 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('checkYourAnswersSections', checkYourAnswersSections)
 
   njkEnv.addGlobal('AssessmentUtils', AssessmentUtils)
+  njkEnv.addGlobal('OffenceUtils', OffenceUtils)
 }

--- a/server/utils/offenceUtils.test.ts
+++ b/server/utils/offenceUtils.test.ts
@@ -1,0 +1,67 @@
+import { DateFormats } from './dateUtils'
+
+import { offenceRadioButton, offenceTableRows } from './offenceUtils'
+
+import activeOffenceFactory from '../testutils/factories/activeOffence'
+
+describe('offenceUtils', () => {
+  describe('offenceRadioButton', () => {
+    it('returns a radio button for the offence', () => {
+      const offence = activeOffenceFactory.build({ offenceId: '123', offenceDescription: 'Description goes here' })
+
+      expect(offenceRadioButton(offence)).toMatchStringIgnoringWhitespace(`
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="offenceId" name="offenceId" type="radio" value="123" />
+        <label class="govuk-label govuk-radios__label" for="where-do-you-live">
+          <span class="govuk-visually-hidden">
+            Select Description goes here as index offence
+          </span>
+        </label>
+      </div>
+      `)
+    })
+  })
+
+  describe('offenceTableRows', () => {
+    it('returns table rows for the index offences', () => {
+      const offences = activeOffenceFactory.buildList(2)
+
+      expect(offenceTableRows(offences)).toEqual([
+        [
+          {
+            html: offenceRadioButton(offences[0]),
+          },
+          {
+            text: offences[0].offenceId,
+          },
+          {
+            text: offences[0].offenceDescription,
+          },
+          {
+            text: DateFormats.isoDateToUIDate(offences[0].offenceDate),
+          },
+          {
+            text: String(offences[0].convictionId),
+          },
+        ],
+        [
+          {
+            html: offenceRadioButton(offences[1]),
+          },
+          {
+            text: offences[1].offenceId,
+          },
+          {
+            text: offences[1].offenceDescription,
+          },
+          {
+            text: DateFormats.isoDateToUIDate(offences[1].offenceDate),
+          },
+          {
+            text: String(offences[1].convictionId),
+          },
+        ],
+      ])
+    })
+  })
+})

--- a/server/utils/offenceUtils.ts
+++ b/server/utils/offenceUtils.ts
@@ -1,0 +1,44 @@
+import { ActiveOffence } from '@approved-premises/api'
+import { TableRow } from '@approved-premises/ui'
+import { DateFormats } from './dateUtils'
+
+const offenceTableRows = (offences: Array<ActiveOffence>): Array<TableRow> => {
+  const rows = [] as Array<TableRow>
+
+  offences.forEach(offence => {
+    rows.push([
+      {
+        html: offenceRadioButton(offence),
+      },
+      {
+        text: offence.offenceId,
+      },
+      {
+        text: offence.offenceDescription,
+      },
+      {
+        text: DateFormats.isoDateToUIDate(offence.offenceDate),
+      },
+      {
+        text: String(offence.convictionId),
+      },
+    ])
+  })
+
+  return rows
+}
+
+const offenceRadioButton = (offence: ActiveOffence) => {
+  return `
+  <div class="govuk-radios__item">
+    <input class="govuk-radios__input" id="offenceId" name="offenceId" type="radio" value="${offence.offenceId}" />
+    <label class="govuk-label govuk-radios__label" for="where-do-you-live">
+      <span class="govuk-visually-hidden">
+        Select ${offence.offenceDescription} as index offence
+      </span>
+    </label>
+  </div>
+  `
+}
+
+export { offenceTableRows, offenceRadioButton }

--- a/server/views/applications/new.njk
+++ b/server/views/applications/new.njk
@@ -12,7 +12,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="{{ paths.applications.people() }}" method="post">
+      <form action="{{ paths.applications.people.find() }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ showErrorSummary(errorSummary) }}

--- a/server/views/applications/people/selectOffence.njk
+++ b/server/views/applications/people/selectOffence.njk
@@ -1,0 +1,58 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1>{{ pageHeading}}</h1>
+
+      <p class="govuk-body">
+        {{ person.name }} has more than one offence identified against their CRN.
+
+      <p class="govuk-body">
+        Please select the main offence that will be used to assess their sutability
+        for an Approved Premises (the 'index offence') below:
+      </p>
+
+        <form action="{{ paths.applications.create() }}" method="post">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+          <input type="hidden" name="crn" value="{{ person.crn }}"/>
+
+          {{
+            govukTable({
+              firstCellIsHeader: false,
+              head: [
+                {
+                  html: '<span class="govuk-visually-hidden">Select offence</span>'
+                },
+                {
+                  text: "Offence ID"
+                },
+                {
+                  text: "Offence description"
+                },
+                {
+                  text: "Date"
+                },
+                {
+                  text: "Conviction ID"
+                }
+              ],
+              rows: OffenceUtils.offenceTableRows(offences)
+            })
+          }}
+
+          {{ govukButton({
+            text: "Save and continue"
+        }) }}
+
+        </form>
+      </div>
+    </div>
+  {% endblock %}


### PR DESCRIPTION
This adds a new page to the start of the Apply journey if an offender has more than one offence associated with them. The guidance notes could use some work, but this is probably enough as a started for ten.

## Screenshot

![image](https://user-images.githubusercontent.com/109774/206401149-97a71f19-cc35-4472-98bd-fecb69bfafca.png)
