### PR TITLE
Fix: Allow application dashboard to handle cases when tier value is null

### DIFF
--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -131,7 +131,7 @@ export default class ApplicationService {
         return [
           this.createNameAnchorElement(application.person.name, application.id),
           this.textValue(application.person.crn),
-          this.htmlValue(tierBadge(tier.value.level)),
+          this.htmlValue(tierBadge(tier.value?.level || '')),
           this.textValue(DateFormats.isoDateToUIDate(getArrivalDate(application), { format: 'short' })),
           this.textValue(DateFormats.isoDateToUIDate(application.submittedAt, { format: 'short' })),
         ]

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -9,6 +9,8 @@ const statusTag = (status: PersonStatus): string => {
 }
 
 const tierBadge = (tier: string): string => {
+  if (!tier) return ''
+
   const colour = { A: 'moj-badge--red', B: 'moj-badge--purple' }[tier[0]]
 
   return `<span class="moj-badge ${colour}">${tier}</span>`

--- a/server/views/applications/components/riskWidgets/tier-widget/template.njk
+++ b/server/views/applications/components/riskWidgets/tier-widget/template.njk
@@ -1,8 +1,8 @@
-<div class="tier-widget">
-    <h3 class="govuk-heading-m">
-        <strong>TIER {{ params.level }}</strong>
-    </h3>
-    {% if params.level %}
+{% if params.level %}
+    <div class="tier-widget">
+        <h3 class="govuk-heading-m">
+            <strong>TIER {{ params.level }}</strong>
+        </h3>
         <p class="govuk-hint govuk-body-m">Last updated: {{ params.lastUpdated | default("Not known") }}</p>
-    {% endif %}
-</div>
+    </div>
+{% endif %}


### PR DESCRIPTION
This fixes the following [error in Sentry](https://sentry.io/organizations/ministryofjustice/issues/3783016406/events/d511cc5b34e647e5ad3aa8dbe016233b/?project=4503931667742720&referrer=alert-rule-issue-list)
Sometimes a tier's value is null and previously this would break application dashboard.