### PR TITLE
(727) - Apply - OASys RoSH summary

### DIFF
--- a/cypress_shared/pages/apply/roshSummary.ts
+++ b/cypress_shared/pages/apply/roshSummary.ts
@@ -1,0 +1,18 @@
+import { Application, ArrayOfOASysRiskOfSeriousHarmSummaryQuestions } from '@approved-premises/api'
+
+import ApplyPage from './applyPage'
+
+export default class RoshSummary extends ApplyPage {
+  constructor(application: Application, private readonly roshSummary: ArrayOfOASysRiskOfSeriousHarmSummaryQuestions) {
+    super('Edit risk information', application, 'oasys-import', 'rosh-summary')
+  }
+
+  completeForm() {
+    this.roshSummary.forEach(summary => {
+      cy.get('.govuk-label').contains(summary.label)
+      cy.get(`textarea[name="roshAnswers[${summary.questionNumber}]"]`)
+        .should('contain', summary.answer)
+        .type(`. With an extra comment ${summary.questionNumber}`)
+    })
+  }
+}

--- a/cypress_shared/pages/apply/taskListPage.ts
+++ b/cypress_shared/pages/apply/taskListPage.ts
@@ -1,5 +1,3 @@
-import type { PersonRisksUI } from '@approved-premises/ui'
-
 import Page from '../page'
 
 export default class TaskListPage extends Page {
@@ -9,43 +7,5 @@ export default class TaskListPage extends Page {
 
   shouldShowTaskStatus = (task: string, status: string): void => {
     cy.get(`#${task}-status`).should('contain', status)
-  }
-
-  shouldShowMappa = (): void => {
-    cy.get('h3').contains('MAPPA')
-    cy.get('h3').contains('CAT 2 / LEVEL 1')
-  }
-
-  shouldShowRosh = (risks: PersonRisksUI['roshRisks']): void => {
-    cy.get('h3').contains(`${risks.overallRisk.toLocaleUpperCase()} RoSH`)
-    cy.get('p').contains(`Last updated: ${risks.lastUpdated}`)
-
-    cy.get('.rosh-widget__table').within($row => {
-      cy.wrap($row).get('th').contains('Children').get('td').contains(risks.riskToChildren, { matchCase: false })
-      cy.wrap($row).get('th').contains('Public').get('td').contains(risks.riskToPublic, { matchCase: false })
-      cy.wrap($row).get('th').contains('Known adult').get('td').contains(risks.riskToKnownAdult, { matchCase: false })
-      cy.wrap($row).get('th').contains('Staff').get('td').contains(risks.riskToStaff, { matchCase: false })
-    })
-  }
-
-  shouldShowTier = (tier: PersonRisksUI['tier']): void => {
-    cy.get('h3').contains(`TIER ${tier.level}`)
-    cy.get('p').contains(`Last updated: ${tier.lastUpdated}`)
-  }
-
-  shouldShowDeliusRiskFlags = (flags: Array<string>): void => {
-    cy.get('h3').contains(`Delius risk flags (registers)`)
-    cy.get('.risk-flag-widget > ul').within($item => {
-      flags.forEach(flag => {
-        cy.wrap($item).get('li').should('contain', flag)
-      })
-    })
-  }
-
-  shouldShowRiskWidgets(risks: PersonRisksUI): void {
-    this.shouldShowMappa()
-    this.shouldShowRosh(risks.roshRisks)
-    this.shouldShowTier(risks.tier)
-    this.shouldShowDeliusRiskFlags(risks.flags)
   }
 }

--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -1,3 +1,4 @@
+import { PersonRisksUI } from '../../server/@types/ui'
 import errorLookups from '../../server/i18n/en/errors.json'
 import { DateFormats } from '../../server/utils/dateUtils'
 
@@ -87,5 +88,43 @@ export default abstract class Page {
 
   clickBack(): void {
     cy.get('a').contains('Back').click()
+  }
+
+  shouldShowMappa = (): void => {
+    cy.get('h3').contains('MAPPA')
+    cy.get('h3').contains('CAT 2 / LEVEL 1')
+  }
+
+  shouldShowRosh = (risks: PersonRisksUI['roshRisks']): void => {
+    cy.get('h3').contains(`${risks.overallRisk.toLocaleUpperCase()} RoSH`)
+    cy.get('p').contains(`Last updated: ${risks.lastUpdated}`)
+
+    cy.get('.rosh-widget__table').within($row => {
+      cy.wrap($row).get('th').contains('Children').get('td').contains(risks.riskToChildren, { matchCase: false })
+      cy.wrap($row).get('th').contains('Public').get('td').contains(risks.riskToPublic, { matchCase: false })
+      cy.wrap($row).get('th').contains('Known adult').get('td').contains(risks.riskToKnownAdult, { matchCase: false })
+      cy.wrap($row).get('th').contains('Staff').get('td').contains(risks.riskToStaff, { matchCase: false })
+    })
+  }
+
+  shouldShowTier = (tier: PersonRisksUI['tier']): void => {
+    cy.get('h3').contains(`TIER ${tier.level}`)
+    cy.get('p').contains(`Last updated: ${tier.lastUpdated}`)
+  }
+
+  shouldShowDeliusRiskFlags = (flags: Array<string>): void => {
+    cy.get('h3').contains(`Delius risk flags (registers)`)
+    cy.get('.risk-flag-widget > ul').within($item => {
+      flags.forEach(flag => {
+        cy.wrap($item).get('li').should('contain', flag)
+      })
+    })
+  }
+
+  shouldShowRiskWidgets(risks: PersonRisksUI): void {
+    this.shouldShowMappa()
+    this.shouldShowRosh(risks.roshRisks)
+    this.shouldShowTier(risks.tier)
+    this.shouldShowDeliusRiskFlags(risks.flags)
   }
 }

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -46,6 +46,30 @@
           "linkedToReOffending": false
         }
       ]
+    },
+    "rosh-summary": {
+      "roshAnswers": [
+        "Some answer for the first question. With an extra comment 1",
+        "Some answer for the second question. With an extra comment 2",
+        "Some answer for the third question. With an extra comment 3"
+      ],
+      "roshSummaries": [
+        {
+          "questionNumber": "1",
+          "label": "The first question",
+          "answer": "Some answer for the first question"
+        },
+        {
+          "questionNumber": "2",
+          "label": "The second question",
+          "answer": "Some answer for the second question"
+        },
+        {
+          "questionNumber": "3",
+          "label": "The third question",
+          "answer": "Some answer for the third question"
+        }
+      ]
     }
   },
   "risk-management-features": {

--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -9,6 +9,7 @@ import type {
   Adjudication,
   ActiveOffence,
   OASysSection,
+  OASysSections,
   Document,
 } from '@approved-premises/api'
 
@@ -101,10 +102,24 @@ export default {
         method: 'GET',
         url: `/people/${args.person.crn}/oasys/selection`,
       },
+
       response: {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: args.oasysSelection,
+      },
+    }),
+
+  stubOasysSections: (args: { person: Person; oasysSections: OASysSections }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/people/${args.person.crn}/oasys/sections`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.oasysSections,
       },
     }),
 

--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -95,7 +95,7 @@ export default {
       },
     }),
 
-  stubOasysSelection: (args: { person: Person; oasysSections: Array<OASysSection> }) =>
+  stubOasysSelection: (args: { person: Person; oasysSelection: Array<OASysSection> }) =>
     stubFor({
       request: {
         method: 'GET',
@@ -104,7 +104,7 @@ export default {
       response: {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: args.oasysSections,
+        jsonBody: args.oasysSelection,
       },
     }),
 

--- a/integration_tests/support/helpers.ts
+++ b/integration_tests/support/helpers.ts
@@ -1,8 +1,12 @@
 /* eslint-disable import/prefer-default-export */
-import { Application, Document } from '@approved-premises/api'
+import { Application, ArrayOfOASysRiskOfSeriousHarmSummaryQuestions, Document } from '@approved-premises/api'
 
 const documentsFromApplication = (application: Application): Array<Document> => {
   return application.data['attach-required-documents']['attach-documents'].selectedDocuments as Array<Document>
 }
 
-export { documentsFromApplication }
+const roshSummariesFromApplication = (application: Application): ArrayOfOASysRiskOfSeriousHarmSummaryQuestions => {
+  return application.data['oasys-import']['rosh-summary'].roshSummaries as ArrayOfOASysRiskOfSeriousHarmSummaryQuestions
+}
+
+export { documentsFromApplication, roshSummariesFromApplication }

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -33,7 +33,7 @@ import TypeOfConvictedOffence from '../../../cypress_shared/pages/apply/typeOfCo
 import Page from '../../../cypress_shared/pages/page'
 import applicationFactory from '../../../server/testutils/factories/application'
 import prisonCaseNotesFactory from '../../../server/testutils/factories/prisonCaseNotes'
-import oasysSectionFactory from '../../../server/testutils/factories/oasysSection'
+import oasysSelectionFactory from '../../../server/testutils/factories/oasysSelection'
 import personFactory from '../../../server/testutils/factories/person'
 import activeOffenceFactory from '../../../server/testutils/factories/activeOffence'
 import risksFactory from '../../../server/testutils/factories/risks'
@@ -298,32 +298,32 @@ context('Apply', () => {
       tasklistPage.shouldShowTaskStatus('oasys-import', 'Not started')
 
       // Given there are OASys sections in the db
-      const oasysSectionA = oasysSectionFactory.needsLinkedToReoffending().build({
+      const oasysSelectionA = oasysSelectionFactory.needsLinkedToReoffending().build({
         section: 1,
         name: 'accommodation',
       })
-      const oasysSectionB = oasysSectionFactory.needsLinkedToReoffending().build({
+      const oasysSelectionB = oasysSelectionFactory.needsLinkedToReoffending().build({
         section: 2,
         name: 'relationships',
         linkedToHarm: false,
         linkedToReOffending: true,
       })
-      const oasysSectionC = oasysSectionFactory.needsNotLinkedToReoffending().build({
+      const oasysSelectionC = oasysSelectionFactory.needsNotLinkedToReoffending().build({
         section: 3,
         name: 'emotional',
         linkedToHarm: false,
         linkedToReOffending: false,
       })
-      const oasysSectionD = oasysSectionFactory.needsNotLinkedToReoffending().build({
+      const oasysSelectionD = oasysSelectionFactory.needsNotLinkedToReoffending().build({
         section: 4,
         name: 'thinking',
         linkedToHarm: false,
         linkedToReOffending: false,
       })
-      const oasysSectionsLinkedToReoffending = [oasysSectionA, oasysSectionB]
-      const otherOasysSections = [oasysSectionC, oasysSectionD]
-      const oasysSections = [...oasysSectionsLinkedToReoffending, ...otherOasysSections]
-      cy.task('stubOasysSelection', { person, oasysSections })
+      const oasysSectionsLinkedToReoffending = [oasysSelectionA, oasysSelectionB]
+      const otherOasysSections = [oasysSelectionC, oasysSelectionD]
+      const oasysSelection = [...oasysSectionsLinkedToReoffending, ...otherOasysSections]
+      cy.task('stubOasysSelection', { person, oasysSelection })
 
       // Given I click the 'Import Oasys' task
       cy.get('[data-cy-task-name="oasys-import"]').click()

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "passport": "^0.6.0",
         "passport-oauth2": "^1.6.1",
         "prom-client": "^14.1.0",
+        "qs": "^6.11.0",
         "redis": "^4.3.1",
         "reflect-metadata": "^0.1.13",
         "static-path": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "passport": "^0.6.0",
     "passport-oauth2": "^1.6.1",
     "prom-client": "^14.1.0",
+    "qs": "^6.11.0",
     "redis": "^4.3.1",
     "reflect-metadata": "^0.1.13",
     "static-path": "^0.0.4",

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -184,7 +184,7 @@ export type GroupedListofBookings = {
   [K in 'arrivingToday' | 'departingToday' | 'upcomingArrivals' | 'upcomingDepartures']: Array<TableRow>
 }
 
-export type DataServices = {
+export type DataServices = Partial<{
   personService: {
     getPrisonCaseNotes: (token: string, crn: string) => Promise<Array<PrisonCaseNote>>
     getAdjudications: (token: string, crn: string) => Promise<Array<Adjudication>>
@@ -193,7 +193,7 @@ export type DataServices = {
   applicationService: {
     getDocuments: (token: string, application: Application) => Promise<Array<Document>>
   }
-}
+}>
 
 export interface GroupedAssessmentWithRisks {
   completed: Array<AssessmentWithRisks>

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -189,6 +189,8 @@ export type DataServices = Partial<{
     getPrisonCaseNotes: (token: string, crn: string) => Promise<Array<PrisonCaseNote>>
     getAdjudications: (token: string, crn: string) => Promise<Array<Adjudication>>
     getOasysSelections: (token: string, crn: string) => Promise<Array<OASysSection>>
+    getOasysSections: (token: string, crn: string) => Promise<OASysSections>
+    getPersonRisks: (token: string, crn: string) => Promise<PersonRisksUI>
   }
   applicationService: {
     getDocuments: (token: string, application: Application) => Promise<Array<Document>>

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -11,6 +11,7 @@ import paths from '../paths/api'
 import adjudicationsFactory from '../testutils/factories/adjudication'
 import activeOffenceFactory from '../testutils/factories/activeOffence'
 import oasysSelectionFactory from '../testutils/factories/oasysSelection'
+import oasysSectionsFactory from '../testutils/factories/oasysSections'
 
 describe('PersonClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
@@ -110,6 +111,39 @@ describe('PersonClient', () => {
           .reply(201, oasysSections)
 
         const result = await personClient.oasysSelections(crn)
+
+        expect(result).toEqual(oasysSections)
+        expect(nock.isDone()).toBeTruthy()
+      })
+    })
+
+    describe('oasysSection', () => {
+      it('should return the sections of OASys when there is optional selected sections', async () => {
+        const crn = 'crn'
+        const optionalSections = [1, 2, 3]
+        const oasysSections = oasysSectionsFactory.build()
+
+        fakeApprovedPremisesApi
+          .get(`${paths.people.oasys.sections({ crn })}?selected-sections=1&selected-sections=2&selected-sections=3`)
+          .matchHeader('authorization', `Bearer ${token}`)
+          .reply(201, oasysSections)
+
+        const result = await personClient.oasysSections(crn, optionalSections)
+
+        expect(result).toEqual(oasysSections)
+        expect(nock.isDone()).toBeTruthy()
+      })
+
+      it('should return the sections of OASys with no optional selected sections', async () => {
+        const crn = 'crn'
+        const oasysSections = oasysSectionsFactory.build()
+
+        fakeApprovedPremisesApi
+          .get(`${paths.people.oasys.sections({ crn })}`)
+          .matchHeader('authorization', `Bearer ${token}`)
+          .reply(201, oasysSections)
+
+        const result = await personClient.oasysSections(crn)
 
         expect(result).toEqual(oasysSections)
         expect(nock.isDone()).toBeTruthy()

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -10,7 +10,7 @@ import prisonCaseNotesFactory from '../testutils/factories/prisonCaseNotes'
 import paths from '../paths/api'
 import adjudicationsFactory from '../testutils/factories/adjudication'
 import activeOffenceFactory from '../testutils/factories/activeOffence'
-import oasysSectionFactory from '../testutils/factories/oasysSection'
+import oasysSelectionFactory from '../testutils/factories/oasysSelection'
 
 describe('PersonClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
@@ -102,7 +102,7 @@ describe('PersonClient', () => {
     describe('oasysSelection', () => {
       it('should return the importable sections of OASys', async () => {
         const crn = 'crn'
-        const oasysSections = oasysSectionFactory.buildList(5)
+        const oasysSections = oasysSelectionFactory.buildList(5)
 
         fakeApprovedPremisesApi
           .get(paths.people.oasys.selection({ crn }))

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -1,4 +1,6 @@
 import type { Response } from 'express'
+import qs from 'qs'
+
 import type {
   ActiveOffence,
   Adjudication,
@@ -6,6 +8,7 @@ import type {
   PersonRisks,
   PrisonCaseNote,
   OASysSection,
+  OASysSections,
 } from '@approved-premises/api'
 
 import RestClient from './restClient'
@@ -57,6 +60,18 @@ export default class PersonClient {
     const response = await this.restClient.get({ path: paths.people.oasys.selection({ crn }) })
 
     return response as Array<OASysSection>
+  }
+
+  async oasysSections(crn: string, selectedSections?: Array<number>): Promise<OASysSections> {
+    const queryString = qs.stringify({ 'selected-sections': selectedSections })
+      ? `?${qs.stringify({ 'selected-sections': selectedSections })}`
+      : ''
+
+    const path = `${paths.people.oasys.sections({ crn })}${queryString}`
+
+    const response = await this.restClient.get({ path })
+
+    return response as OASysSections
   }
 
   async document(crn: string, documentId: string, response: Response): Promise<void> {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/index.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/index.ts
@@ -2,10 +2,11 @@
 import { Task } from '../../../utils/decorators'
 
 import OptionalOasysSections from './optionalOasysSections'
+import RoshSummary from './roshSummary'
 
 @Task({
   slug: 'oasys-import',
   name: 'Choose sections of OASys to import',
-  pages: [OptionalOasysSections],
+  pages: [OptionalOasysSections, RoshSummary],
 })
 export default class OasysImport {}

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.test.ts
@@ -1,7 +1,7 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 import { ApplicationService, PersonService } from '../../../../services'
 import applicationFactory from '../../../../testutils/factories/application'
-import oasysSectionFactory from '../../../../testutils/factories/oasysSection'
+import oasysSelectionFactory from '../../../../testutils/factories/oasysSelection'
 import { sentenceCase } from '../../../../utils/utils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
@@ -10,15 +10,15 @@ import OptionalOasysSections from './optionalOasysSections'
 jest.mock('../../../../services/personService.ts')
 
 describe('OptionalOasysSections', () => {
-  const oasysSections = oasysSectionFactory.buildList(3)
-  const needsLinkedToHarm = oasysSectionFactory.needsLinkedToHarm().buildList(2)
-  let needsLinkedToReoffending = oasysSectionFactory.needsLinkedToReoffending().buildList(2)
-  let otherNeeds = oasysSectionFactory.needsNotLinkedToReoffending().buildList(2)
+  const oasysSelection = oasysSelectionFactory.buildList(3)
+  const needsLinkedToHarm = oasysSelectionFactory.needsLinkedToHarm().buildList(2)
+  let needsLinkedToReoffending = oasysSelectionFactory.needsLinkedToReoffending().buildList(2)
+  let otherNeeds = oasysSelectionFactory.needsNotLinkedToReoffending().buildList(2)
 
   const application = applicationFactory.build()
 
   describe('initialize', () => {
-    const getOasysSelectionsMock = jest.fn().mockResolvedValue(oasysSections)
+    const getOasysSelectionsMock = jest.fn().mockResolvedValue(oasysSelection)
     let personService: DeepMocked<PersonService>
     const applicationService = createMock<ApplicationService>({})
 
@@ -51,8 +51,8 @@ describe('OptionalOasysSections', () => {
     })
 
     it('initializes the OptionalOasysSections class with the selected sections', async () => {
-      needsLinkedToReoffending = oasysSectionFactory.needsLinkedToReoffending().buildList(1, { section: 1 })
-      otherNeeds = oasysSectionFactory.needsNotLinkedToReoffending().buildList(1, { section: 2 })
+      needsLinkedToReoffending = oasysSelectionFactory.needsLinkedToReoffending().buildList(1, { section: 1 })
+      otherNeeds = oasysSelectionFactory.needsNotLinkedToReoffending().buildList(1, { section: 2 })
 
       getOasysSelectionsMock.mockResolvedValueOnce([...needsLinkedToReoffending, ...otherNeeds])
 
@@ -97,14 +97,14 @@ describe('OptionalOasysSections', () => {
   })
 
   describe('response', () => {
-    const needLinkedToReoffendingA = oasysSectionFactory
+    const needLinkedToReoffendingA = oasysSelectionFactory
       .needsLinkedToReoffending()
       .build({ section: 1, name: 'Some section' })
-    const needLinkedToReoffendingB = oasysSectionFactory
+    const needLinkedToReoffendingB = oasysSelectionFactory
       .needsLinkedToReoffending()
       .build({ section: 2, name: 'Some other Section' })
-    const otherNeedA = oasysSectionFactory.needsNotLinkedToReoffending().build({ section: 3, name: 'Foo Section' })
-    const otherNeedB = oasysSectionFactory.needsNotLinkedToReoffending().build({ section: 4, name: 'Bar Section' })
+    const otherNeedA = oasysSelectionFactory.needsNotLinkedToReoffending().build({ section: 3, name: 'Foo Section' })
+    const otherNeedB = oasysSelectionFactory.needsNotLinkedToReoffending().build({ section: 4, name: 'Bar Section' })
 
     describe('should return a translated version of the OASys sections', () => {
       it('when every need is selected', () => {
@@ -124,10 +124,10 @@ describe('OptionalOasysSections', () => {
       })
 
       it('when only one need is selected', () => {
-        const needLinkedToReoffending = oasysSectionFactory
+        const needLinkedToReoffending = oasysSelectionFactory
           .needsLinkedToReoffending()
           .build({ section: 1, name: 'Some section' })
-        const otherNeed = oasysSectionFactory
+        const otherNeed = oasysSelectionFactory
           .needsNotLinkedToReoffending()
           .build({ section: 2, name: 'Some other section' })
 
@@ -151,7 +151,7 @@ describe('OptionalOasysSections', () => {
       })
 
       it('returns an object with only one key if only needsLinkedToReoffending or otherNeeds are given', () => {
-        const needLinkedToReoffending = oasysSectionFactory
+        const needLinkedToReoffending = oasysSelectionFactory
           .needsLinkedToReoffending()
           .build({ section: 1, name: 'Some section' })
 
@@ -164,7 +164,7 @@ describe('OptionalOasysSections', () => {
           [pageWithOnlyNeedsLinkedToReoffending.needsLinkedToReoffendingHeading]: '1. Some section',
         })
 
-        const otherNeed = oasysSectionFactory
+        const otherNeed = oasysSelectionFactory
           .needsNotLinkedToReoffending()
           .build({ section: 2, name: 'Some other section' })
 
@@ -182,11 +182,11 @@ describe('OptionalOasysSections', () => {
 
   describe('reoffendingNeedsItems', () => {
     it('it returns reoffending needs as checkbox items', () => {
-      const needLinkedToReoffendingA = oasysSectionFactory
+      const needLinkedToReoffendingA = oasysSelectionFactory
         .needsLinkedToReoffending()
         .build({ section: 1, name: 'emotional' })
-      const needLinkedToReoffendingB = oasysSectionFactory.needsLinkedToReoffending().build({ section: 2 })
-      const needLinkedToReoffendingC = oasysSectionFactory.needsLinkedToReoffending().build({ section: 3 })
+      const needLinkedToReoffendingB = oasysSelectionFactory.needsLinkedToReoffending().build({ section: 2 })
+      const needLinkedToReoffendingC = oasysSelectionFactory.needsLinkedToReoffending().build({ section: 3 })
 
       const page = new OptionalOasysSections({ needsLinkedToReoffending: [needLinkedToReoffendingA] })
       page.allNeedsLinkedToReoffending = [needLinkedToReoffendingA, needLinkedToReoffendingB, needLinkedToReoffendingC]
@@ -214,9 +214,9 @@ describe('OptionalOasysSections', () => {
 
   describe('otherNeedsItems', () => {
     it('it returns other needs as checkbox items', () => {
-      const otherNeedA = oasysSectionFactory.needsNotLinkedToReoffending().build({ section: 1 })
-      const otherNeedB = oasysSectionFactory.needsNotLinkedToReoffending().build({ section: 2, name: 'thinking' })
-      const otherNeedC = oasysSectionFactory.needsNotLinkedToReoffending().build({ section: 3 })
+      const otherNeedA = oasysSelectionFactory.needsNotLinkedToReoffending().build({ section: 1 })
+      const otherNeedB = oasysSelectionFactory.needsNotLinkedToReoffending().build({ section: 2, name: 'thinking' })
+      const otherNeedC = oasysSelectionFactory.needsNotLinkedToReoffending().build({ section: 3 })
 
       const page = new OptionalOasysSections({ otherNeeds: [otherNeedB] })
       page.allOtherNeeds = [otherNeedA, otherNeedB, otherNeedC]

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.test.ts
@@ -85,7 +85,7 @@ describe('OptionalOasysSections', () => {
     })
   })
 
-  itShouldHaveNextValue(new OptionalOasysSections({}), '')
+  itShouldHaveNextValue(new OptionalOasysSections({}), 'rosh-summary')
 
   itShouldHavePreviousValue(new OptionalOasysSections({}), '')
 

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
@@ -1,7 +1,6 @@
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
-
 import { flattenCheckboxInput, isStringOrArrayOfStrings } from '../../../../utils/formUtils'
 import { Application, OASysSection } from '../../../../@types/shared'
 import { DataServices } from '../../../../@types/ui'

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
@@ -76,7 +76,7 @@ export default class OptionalOasysSections implements TasklistPage {
   }
 
   next() {
-    return ''
+    return 'rosh-summary'
   }
 
   response() {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
@@ -1,0 +1,105 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+import { PersonService } from '../../../../services'
+import applicationFactory from '../../../../testutils/factories/application'
+import oasysSectionsFactory, { roshSummaryFactory } from '../../../../testutils/factories/oasysSections'
+import risksFactory from '../../../../testutils/factories/risks'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+
+import RoshSummary from './roshSummary'
+
+jest.mock('../../../../services/personService.ts')
+
+describe('RoshSummary', () => {
+  const oasysSections = oasysSectionsFactory.build()
+  const personRisks = risksFactory.build()
+  const application = applicationFactory.build()
+
+  describe('initialize', () => {
+    const getOasysSectionsMock = jest.fn().mockResolvedValue(oasysSections)
+    const getPersonRisksMock = jest.fn().mockResolvedValue(personRisks)
+    let personService: DeepMocked<PersonService>
+
+    beforeEach(() => {
+      personService = createMock<PersonService>({
+        getOasysSections: getOasysSectionsMock,
+        getPersonRisks: getPersonRisksMock,
+      })
+    })
+
+    it('calls the getOasysSections and getPersonRisks method on the client with a token and the persons CRN', async () => {
+      await RoshSummary.initialize({}, application, 'some-token', { personService })
+
+      expect(getOasysSectionsMock).toHaveBeenCalledWith('some-token', application.person.crn)
+      expect(getPersonRisksMock).toHaveBeenCalledWith('some-token', application.person.crn)
+    })
+
+    it('adds the roshSummary and personRisks to the page object', async () => {
+      const page = await RoshSummary.initialize({}, application, 'some-token', { personService })
+
+      expect(page.roshSummary).toEqual(oasysSections.roshSummary)
+      expect(page.risks).toEqual(personRisks)
+    })
+
+    itShouldHaveNextValue(new RoshSummary({}), '')
+
+    itShouldHavePreviousValue(new RoshSummary({}), 'optional-oasys-sections')
+
+    describe('errors', () => {
+      it('should return an empty object', () => {
+        const page = new RoshSummary({})
+        expect(page.errors()).toEqual({})
+      })
+    })
+
+    describe('response', () => {
+      it('returns a human readable response for reach question', () => {
+        const roshSummaries = roshSummaryFactory.buildList(3)
+        const page = new RoshSummary({
+          roshAnswers: ['answer 1', 'answer 2', 'answer 3'],
+          roshSummaries,
+        })
+
+        expect(page.response()).toEqual({
+          [`${roshSummaries[0].questionNumber}. ${roshSummaries[0].label}`]: 'answer 1',
+          [`${roshSummaries[1].questionNumber}. ${roshSummaries[1].label}`]: 'answer 2',
+          [`${roshSummaries[2].questionNumber}. ${roshSummaries[2].label}`]: 'answer 3',
+        })
+      })
+
+      it('returns no response when there arent any questions', () => {
+        const page = new RoshSummary({})
+
+        expect(page.response()).toEqual({})
+      })
+
+      describe('roshTextAreas', () => {
+        it('it returns reoffending needs as textareas', () => {
+          const roshSummaries = roshSummaryFactory.buildList(2)
+          const page = new RoshSummary({})
+          page.roshSummary = roshSummaries
+          const items = page.roshTextAreas()
+
+          expect(items).toMatchStringIgnoringWhitespace(`
+        <div class="govuk-form-group">
+        <h3 class="govuk-label-wrapper">
+            <label class="govuk-label govuk-label--m" for=roshAnswers[${roshSummaries[0].questionNumber}]>
+                ${roshSummaries[0].label}
+            </label>
+        </h3>
+        <textarea class="govuk-textarea" id=roshAnswers[${roshSummaries[0].questionNumber}] name=roshAnswers[${roshSummaries[0].questionNumber}] rows="8">${roshSummaries[0].answer}</textarea>
+    </div>
+    <hr>
+    <div class="govuk-form-group">
+    <h3 class="govuk-label-wrapper">
+        <label class="govuk-label govuk-label--m" for=roshAnswers[${roshSummaries[1].questionNumber}]>
+            ${roshSummaries[1].label}
+        </label>
+    </h3>
+    <textarea class="govuk-textarea" id=roshAnswers[${roshSummaries[1].questionNumber}] name=roshAnswers[${roshSummaries[1].questionNumber}] rows="8">${roshSummaries[1].answer}</textarea>
+</div>
+<hr>`)
+        })
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
@@ -1,0 +1,100 @@
+/* eslint-disable no-underscore-dangle */
+import type { DataServices, PersonRisksUI } from '@approved-premises/ui'
+
+import type { Application, ArrayOfOASysRiskOfSeriousHarmSummaryQuestions, OASysSections } from '@approved-premises/api'
+
+import TasklistPage from '../../../tasklistPage'
+
+import { Page } from '../../../utils/decorators'
+import { escape } from '../../../../utils/formUtils'
+
+type RoshSummaryBody = {
+  roshAnswers: Array<string> | Record<string, string>
+  roshSummaries: ArrayOfOASysRiskOfSeriousHarmSummaryQuestions
+}
+
+@Page({
+  name: 'rosh-summary',
+  bodyProperties: ['roshAnswers', 'roshSummaries'],
+})
+export default class RoshSummary implements TasklistPage {
+  title = 'Edit risk information'
+
+  roshSummary: ArrayOfOASysRiskOfSeriousHarmSummaryQuestions
+
+  risks: PersonRisksUI
+
+  roshAnswers: Record<string, string>
+
+  constructor(public body: Partial<RoshSummaryBody>) {}
+
+  static async initialize(
+    body: Record<string, unknown>,
+    application: Application,
+    token: string,
+    dataServices: DataServices,
+  ) {
+    const oasysSections: OASysSections = await dataServices.personService.getOasysSections(
+      token,
+      application.person.crn,
+    )
+    const risks = await dataServices.personService.getPersonRisks(token, application.person.crn)
+
+    const roshSummaries = oasysSections.roshSummary.sort((a, b) => Number(a.questionNumber) - Number(b.questionNumber))
+    const roshAnswers = body?.roshAnswers ? body.roshAnswers : []
+
+    body.roshSummaries = roshSummaries
+    body.roshAnswers = roshAnswers
+
+    const page = new RoshSummary(body)
+    page.roshSummary = roshSummaries
+    page.risks = risks
+
+    return page
+  }
+
+  previous() {
+    return 'optional-oasys-sections'
+  }
+
+  next() {
+    return ''
+  }
+
+  roshTextAreas() {
+    return this.roshSummary
+      .map(roshQuestion => {
+        return `<div class="govuk-form-group">
+                <h3 class="govuk-label-wrapper">
+                    <label class="govuk-label govuk-label--m" for=roshAnswers[${roshQuestion.questionNumber}]>
+                        ${roshQuestion.label}
+                    </label>
+                </h3>
+                <textarea class="govuk-textarea" id=roshAnswers[${roshQuestion.questionNumber}] name=roshAnswers[${
+          roshQuestion.questionNumber
+        }] rows="8">${escape(roshQuestion?.answer)}</textarea>
+            </div>
+            <hr>`
+      })
+      .join('')
+  }
+
+  response() {
+    if (Array.isArray(this.body.roshAnswers)) {
+      return (this.body.roshAnswers as Array<string>).reduce((prev, question, i) => {
+        return {
+          ...prev,
+          [`${this.body.roshSummaries[i].questionNumber}. ${this.body.roshSummaries[i].label}`]: question,
+        }
+      }, {}) as Record<string, string>
+    }
+    if (!this.body.roshAnswers) {
+      return {}
+    }
+    return this.body.roshAnswers
+  }
+
+  errors() {
+    return {}
+  }
+}

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -462,6 +462,41 @@
               }
             }
           }
+        },
+        "rosh-summary": {
+          "type": "object",
+          "properties": {
+            "roshAnswers": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "object"
+                }
+              ]
+            },
+            "roshSummaries": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": "string"
+                  },
+                  "questionNumber": {
+                    "type": "string"
+                  },
+                  "answer": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -69,6 +69,7 @@ export default {
     documents: path('/documents/:crn/:documentId'),
     oasys: {
       selection: oasysPath.path('selection'),
+      sections: oasysPath.path('sections'),
     },
   },
 }

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -10,7 +10,7 @@ import { mapApiPersonRisksForUi } from '../utils/utils'
 import prisonCaseNotesFactory from '../testutils/factories/prisonCaseNotes'
 import adjudicationsFactory from '../testutils/factories/adjudication'
 import activeOffenceFactory from '../testutils/factories/activeOffence'
-import oasysSectionFactory from '../testutils/factories/oasysSection'
+import oasysSelectionFactory from '../testutils/factories/oasysSelection'
 
 jest.mock('../data/personClient.ts')
 
@@ -100,15 +100,15 @@ describe('PersonService', () => {
     })
   })
 
-  describe('getOasysSections', () => {
+  describe('getOasysSelections', () => {
     it("on success returns the person's OASys selections given their CRN", async () => {
-      const oasysSections = oasysSectionFactory.buildList(3)
+      const oasysSelections = oasysSelectionFactory.buildList(3)
 
-      personClient.oasysSelections.mockResolvedValue(oasysSections)
+      personClient.oasysSelections.mockResolvedValue(oasysSelections)
 
       const serviceOasysSelections = await service.getOasysSelections(token, 'crn')
 
-      expect(serviceOasysSelections).toEqual(oasysSections)
+      expect(serviceOasysSelections).toEqual(oasysSelections)
 
       expect(personClientFactory).toHaveBeenCalledWith(token)
       expect(personClient.oasysSelections).toHaveBeenCalledWith('crn')

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -11,6 +11,7 @@ import prisonCaseNotesFactory from '../testutils/factories/prisonCaseNotes'
 import adjudicationsFactory from '../testutils/factories/adjudication'
 import activeOffenceFactory from '../testutils/factories/activeOffence'
 import oasysSelectionFactory from '../testutils/factories/oasysSelection'
+import oasysSectionsFactory from '../testutils/factories/oasysSections'
 
 jest.mock('../data/personClient.ts')
 
@@ -112,6 +113,21 @@ describe('PersonService', () => {
 
       expect(personClientFactory).toHaveBeenCalledWith(token)
       expect(personClient.oasysSelections).toHaveBeenCalledWith('crn')
+    })
+  })
+
+  describe('getOasysSections', () => {
+    it("on success returns the person's OASys selections given their CRN", async () => {
+      const oasysSections = oasysSectionsFactory.build()
+
+      personClient.oasysSections.mockResolvedValue(oasysSections)
+
+      const serviceOasysSections = await service.getOasysSections(token, 'crn')
+
+      expect(serviceOasysSections).toEqual(oasysSections)
+
+      expect(personClientFactory).toHaveBeenCalledWith(token)
+      expect(personClient.oasysSections).toHaveBeenCalledWith('crn')
     })
   })
 

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -1,6 +1,13 @@
 import type { Response } from 'express'
 import type { PersonRisksUI } from '@approved-premises/ui'
-import type { ActiveOffence, Adjudication, Person, PrisonCaseNote, OASysSection } from '@approved-premises/api'
+import type {
+  ActiveOffence,
+  Adjudication,
+  Person,
+  PrisonCaseNote,
+  OASysSection,
+  OASysSections,
+} from '@approved-premises/api'
 import type { RestClientBuilder, PersonClient } from '../data'
 
 import { mapApiPersonRisksForUi } from '../utils/utils'
@@ -50,6 +57,14 @@ export default class PersonService {
     const personClient = this.personClientFactory(token)
 
     const oasysSections = await personClient.oasysSelections(crn)
+
+    return oasysSections
+  }
+
+  async getOasysSections(token: string, crn: string): Promise<OASysSections> {
+    const personClient = this.personClientFactory(token)
+
+    const oasysSections = await personClient.oasysSections(crn)
 
     return oasysSections
   }

--- a/server/testutils/factories/oasysSections.ts
+++ b/server/testutils/factories/oasysSections.ts
@@ -1,0 +1,28 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { OASysQuestion, OASysSections } from '@approved-premises/api'
+import { DateFormats } from '../../utils/dateUtils'
+
+export default Factory.define<OASysSections>(() => ({
+  assessmentId: faker.datatype.number(),
+  assessmentState: faker.helpers.arrayElement(['Completed', 'Incomplete']),
+  dateStarted: DateFormats.dateObjToIsoDate(faker.date.past()),
+  dateCompleted: DateFormats.dateObjToIsoDate(faker.date.recent()),
+  offenceDetails: [],
+  roshSummary: roshSummaryFactory.buildList(5),
+  supportingInformation: [],
+  riskToSelf: [],
+  riskManagementPlan: [],
+}))
+
+export const roshSummaryFactory = Factory.define<OASysQuestion>(options => ({
+  questionNumber: options.sequence.toString(),
+  label: faker.helpers.arrayElement([
+    'Who is at risk?',
+    'What is the nature of the risk?',
+    'When is the risk likely to be greatest?',
+    'What circumstances are likely to increase risk?',
+  ]),
+  answer: faker.lorem.paragraph(),
+}))

--- a/server/testutils/factories/oasysSelection.ts
+++ b/server/testutils/factories/oasysSelection.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 
 import type { OASysSection } from '@approved-premises/api'
 
-class OasysSectionFactory extends Factory<OASysSection> {
+class OasysSelectionFactory extends Factory<OASysSection> {
   needsLinkedToHarm() {
     return this.params({ linkedToHarm: true, linkedToReOffending: true })
   }
@@ -17,7 +17,7 @@ class OasysSectionFactory extends Factory<OASysSection> {
   }
 }
 
-export default OasysSectionFactory.define(() => ({
+export default OasysSelectionFactory.define(() => ({
   section: faker.datatype.number({ min: 1, max: 20 }),
   name: faker.helpers.arrayElement([
     'accommodation',

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -10,6 +10,7 @@ import {
   validPostcodeArea,
   flattenCheckboxInput,
   isStringOrArrayOfStrings,
+  escape,
 } from './formUtils'
 
 describe('formUtils', () => {
@@ -345,6 +346,20 @@ describe('formUtils', () => {
     })
     it('returns false if array contains a non-string value ', () => {
       expect(isStringOrArrayOfStrings(['test', 1, 'test'])).toEqual(false)
+    })
+  })
+
+  describe('escape', () => {
+    it('escapes HTML tags', () => {
+      expect(escape('<b>Formatted text</b>')).toEqual('&lt;b&gt;Formatted text&lt;/b&gt;')
+    })
+
+    it('escapes reserved characters', () => {
+      expect(escape('"Quoted text"')).toEqual('&quot;Quoted text&quot;')
+    })
+
+    it('returns the empty string when given null', () => {
+      expect(escape(null)).toEqual('')
     })
   })
 })

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -1,3 +1,4 @@
+import * as nunjucks from 'nunjucks'
 import type { ErrorMessages, RadioItem, CheckBoxItem, SelectOption } from '@approved-premises/ui'
 
 export const dateFieldValues = (fieldName: string, context: Record<string, unknown>, errors: ErrorMessages = {}) => {
@@ -118,4 +119,9 @@ export function isStringOrArrayOfStrings(input: unknown) {
     (Array.isArray(input) && input.every((element: unknown) => typeof element === 'string')) ||
     typeof input === 'string'
   )
+}
+
+export const escape = (text: string): string => {
+  const escapeFilter = new nunjucks.Environment().getFilter('escape')
+  return escapeFilter(text).val
 }

--- a/server/views/applications/pages/oasys-import/rosh-summary.njk
+++ b/server/views/applications/pages/oasys-import/rosh-summary.njk
@@ -1,0 +1,52 @@
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+{% from "../../components/riskWidgets/macro.njk" import widgets %}
+
+{% extends "../layout.njk" %}
+
+{% set columnClasses = "govuk-grid-column-full" %}
+
+{% block questions %}
+  <div class="govuk-grid-row">
+    <div>
+      <h1 class="govuk-heading-l">{{page.title}}</h1>
+      <p>Imported from OASys 23 October 2022</p>
+    </div>
+
+    {{ mojSubNavigation({
+        label: 'Sub navigation',
+        attributes: {
+          'role': 'tablist'
+        },
+        items: [{
+          text: 'RoSH summary',
+          href: '#roshSummary',
+          attributes: {
+            active: true
+          }
+        }, 
+        {
+          text: 'Offence details'
+        }, 
+        {
+          text: 'Supporting information'
+        },  
+        {
+          text: 'Risk management plan'
+        },
+        {
+          text: 'Risk to self'
+        }]
+      }) }}
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds" id="roshSummary" role="tabpanel" >
+      {{page.roshTextAreas() | safe }}
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      {{ widgets(page.risks) }}
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
# Context
Users need to able to import and edit the RoSH (Risk of Serious Harm) summary questions from OASys. This page enables them to do that.

[Trello card](https://trello.com/c/PYl2WtOG/727-oasys-risk-and-needs-import)

# Changes in this PR
Firstly there is some tidying from #415 where we had misnamed some OASys '*selections*' '*sections*'.
Then we add the neccessary methods to the PersonClient and the PersonService.
We then add the Class for RoSH Summary which pulls the sections from the API. 
We also need to show the risks on this page so we call the API for those as well.
For the view we iterate over each question/answer from OAsys and display the answer in a text box (if it exists) for the user to edit.

## Screenshots of UI changes
![Apply -- allows completion of the form](https://user-images.githubusercontent.com/44123869/207318364-88093db9-e3a0-485b-91de-95cb3357572f.png)
