### PR TITLE
727 -  Apply -  OASys import:  Offence details

### DIFF
--- a/cypress_shared/pages/apply/offenceDetails.ts
+++ b/cypress_shared/pages/apply/offenceDetails.ts
@@ -1,0 +1,21 @@
+import { ApprovedPremisesApplication, ArrayOfOASysOffenceDetailsQuestions } from '@approved-premises/api'
+
+import ApplyPage from './applyPage'
+
+export default class OffenceDetails extends ApplyPage {
+  constructor(
+    application: ApprovedPremisesApplication,
+    private readonly offenceDetailSummaries: ArrayOfOASysOffenceDetailsQuestions,
+  ) {
+    super('Edit risk information', application, 'oasys-import', 'offence-details')
+  }
+
+  completeForm() {
+    this.offenceDetailSummaries.forEach(summary => {
+      cy.get('.govuk-label').contains(summary.label)
+      cy.get(`textarea[name="offenceDetailsAnswers[${summary.questionNumber}]"]`)
+        .should('contain', summary.answer)
+        .type(`. With an extra comment ${summary.questionNumber}`)
+    })
+  }
+}

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -70,6 +70,30 @@
           "answer": "Some answer for the third question"
         }
       ]
+    },
+    "offence-details": {
+      "offenceDetailsAnswers": [
+        "Some answer for the first question. With an extra comment 1",
+        "Some answer for the second question. With an extra comment 2",
+        "Some answer for the third question. With an extra comment 3"
+      ],
+      "offenceDetailsSummaries": [
+        {
+          "questionNumber": "1",
+          "label": "The first question",
+          "answer": "Some answer for the first question"
+        },
+        {
+          "questionNumber": "2",
+          "label": "The second question",
+          "answer": "Some answer for the second question"
+        },
+        {
+          "questionNumber": "3",
+          "label": "The third question",
+          "answer": "Some answer for the third question"
+        }
+      ]
     }
   },
   "risk-management-features": {

--- a/integration_tests/support/helpers.ts
+++ b/integration_tests/support/helpers.ts
@@ -1,6 +1,7 @@
-/* eslint-disable import/prefer-default-export */
 import {
   ApprovedPremisesApplication,
+  Application,
+  ArrayOfOASysOffenceDetailsQuestions,
   ArrayOfOASysRiskOfSeriousHarmSummaryQuestions,
   Document,
 } from '@approved-premises/api'
@@ -15,4 +16,9 @@ const roshSummariesFromApplication = (
   return application.data['oasys-import']['rosh-summary'].roshSummaries as ArrayOfOASysRiskOfSeriousHarmSummaryQuestions
 }
 
-export { documentsFromApplication, roshSummariesFromApplication }
+const offenceDetailSummariesFromApplication = (application: Application): ArrayOfOASysOffenceDetailsQuestions => {
+  return application.data['oasys-import']['offence-details']
+    .offenceDetailsSummaries as ArrayOfOASysRiskOfSeriousHarmSummaryQuestions
+}
+
+export { documentsFromApplication, roshSummariesFromApplication, offenceDetailSummariesFromApplication }

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -52,7 +52,12 @@ import SubmissionConfirmation from '../../../cypress_shared/pages/apply/submissi
 import OptionalOasysSectionsPage from '../../../cypress_shared/pages/apply/optionalOasysSections'
 import RoshSummaryPage from '../../../cypress_shared/pages/apply/roshSummary'
 
-import { documentsFromApplication, roshSummariesFromApplication } from '../../support/helpers'
+import {
+  documentsFromApplication,
+  offenceDetailSummariesFromApplication,
+  roshSummariesFromApplication,
+} from '../../support/helpers'
+import OffenceDetailsPage from '../../../cypress_shared/pages/apply/offenceDetails'
 
 context('Apply', () => {
   beforeEach(() => {
@@ -327,7 +332,11 @@ context('Apply', () => {
       cy.task('stubOasysSelection', { person, oasysSelection })
 
       const roshSummaries = roshSummariesFromApplication(application)
-      cy.task('stubOasysSections', { person, oasysSections: { roshSummary: roshSummaries } })
+      const offenceDetailSummaries = offenceDetailSummariesFromApplication(application)
+      cy.task('stubOasysSections', {
+        person,
+        oasysSections: { roshSummary: roshSummaries, offenceDetails: offenceDetailSummaries },
+      })
 
       // Given I click the 'Import Oasys' task
       cy.get('[data-cy-task-name="oasys-import"]').click()
@@ -342,6 +351,11 @@ context('Apply', () => {
       roshSummaryPage.completeForm()
       roshSummaryPage.clickSubmit()
 
+      const offenceDetailsPage = new OffenceDetailsPage(application, offenceDetailSummaries)
+      offenceDetailsPage.shouldShowRiskWidgets(uiRisks)
+      offenceDetailsPage.completeForm()
+      offenceDetailsPage.clickSubmit()
+
       // Then I should be taken back to the tasklist
       tasklistPage.shouldShowTaskStatus('oasys-import', 'Completed')
 
@@ -351,7 +365,7 @@ context('Apply', () => {
       // Given I click the 'Add detail about managing risks and needs' task
       cy.get('[data-cy-task-name="risk-management-features"]').click()
 
-      const oasysPages = [optionalOasysImportPage, roshSummaryPage]
+      const oasysPages = [optionalOasysImportPage, roshSummaryPage, offenceDetailsPage]
 
       // When I complete the form
       const riskManagementFeaturesPage = new RiskManagementFeatures(application)
@@ -643,8 +657,8 @@ context('Apply', () => {
 
       // Then the application should be submitted to the API
       cy.task('verifyApplicationUpdate', application.id).then(requests => {
-        expect(requests).to.have.length(33)
-        const requestBody = JSON.parse(requests[32].body)
+        expect(requests).to.have.length(34)
+        const requestBody = JSON.parse(requests[33].body)
 
         expect(requestBody.data).to.deep.equal(applicationData)
 

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -8,6 +8,11 @@ import {
   Person,
   OASysSection,
   Document,
+  ArrayOfOASysOffenceDetailsQuestions,
+  ArrayOfOASysRiskOfSeriousHarmSummaryQuestions,
+  ArrayOfOASysSupportingInformationQuestions,
+  ArrayOfOASysRiskToSelfQuestions,
+  ArrayOfOASysRiskManagementPlanQuestions,
 } from '@approved-premises/api'
 
 interface TasklistPage {
@@ -214,3 +219,10 @@ export interface ApplicationWithRisks extends Application {
 export interface PersonWithRisks extends Person {
   risks: PersonRisks
 }
+
+export type OasysImportArrays =
+  | ArrayOfOASysOffenceDetailsQuestions
+  | ArrayOfOASysRiskOfSeriousHarmSummaryQuestions
+  | ArrayOfOASysSupportingInformationQuestions
+  | ArrayOfOASysRiskToSelfQuestions
+  | ArrayOfOASysRiskManagementPlanQuestions

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/index.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/index.ts
@@ -3,10 +3,11 @@ import { Task } from '../../../utils/decorators'
 
 import OptionalOasysSections from './optionalOasysSections'
 import RoshSummary from './roshSummary'
+import OffenceDetails from './offenceDetails'
 
 @Task({
   slug: 'oasys-import',
   name: 'Choose sections of OASys to import',
-  pages: [OptionalOasysSections, RoshSummary],
+  pages: [OptionalOasysSections, RoshSummary, OffenceDetails],
 })
 export default class OasysImport {}

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.test.ts
@@ -1,0 +1,72 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+import { PersonService } from '../../../../services'
+import applicationFactory from '../../../../testutils/factories/application'
+import oasysSectionsFactory from '../../../../testutils/factories/oasysSections'
+import risksFactory from '../../../../testutils/factories/risks'
+import { oasysImportReponse } from '../../../../utils/oasysImportUtils'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+
+import OffenceDetails from './offenceDetails'
+
+jest.mock('../../../../services/personService.ts')
+
+describe('OffenceDetails', () => {
+  const oasysSections = oasysSectionsFactory.build()
+  const personRisks = risksFactory.build()
+  const application = applicationFactory.build()
+
+  describe('initialize', () => {
+    const getOasysSectionsMock = jest.fn().mockResolvedValue(oasysSections)
+    const getPersonRisksMock = jest.fn().mockResolvedValue(personRisks)
+    let personService: DeepMocked<PersonService>
+
+    beforeEach(() => {
+      personService = createMock<PersonService>({
+        getOasysSections: getOasysSectionsMock,
+        getPersonRisks: getPersonRisksMock,
+      })
+    })
+
+    it('calls the getOasysSections and getPersonRisks method on the client with a token and the persons CRN', async () => {
+      await OffenceDetails.initialize({}, application, 'some-token', { personService })
+
+      expect(getOasysSectionsMock).toHaveBeenCalledWith('some-token', application.person.crn)
+      expect(getPersonRisksMock).toHaveBeenCalledWith('some-token', application.person.crn)
+    })
+
+    it('adds the offenceDetailsSummaries and personRisks to the page object', async () => {
+      const page = await OffenceDetails.initialize({}, application, 'some-token', { personService })
+
+      expect(page.offenceDetailsSummaries).toEqual(oasysSections.offenceDetails)
+      expect(page.risks).toEqual(personRisks)
+    })
+
+    itShouldHaveNextValue(new OffenceDetails({}), '')
+
+    itShouldHavePreviousValue(new OffenceDetails({}), 'rosh-summary')
+
+    describe('errors', () => {
+      it('should return an empty object', () => {
+        const page = new OffenceDetails({})
+        expect(page.errors()).toEqual({})
+      })
+    })
+
+    describe('response', () => {
+      it('calls oasysImportReponse with the correct arguments', () => {
+        const answers = ['answer 1']
+        const summaries = [
+          {
+            questionNumber: '1',
+            label: 'The first question',
+            answer: 'Some answer for the first question',
+          },
+        ]
+        const page = new OffenceDetails({ offenceDetailsAnswers: answers, offenceDetailsSummaries: summaries })
+        const result = page.response()
+
+        expect(result).toEqual(oasysImportReponse(answers, summaries))
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.ts
@@ -1,0 +1,70 @@
+import type { DataServices, PersonRisksUI } from '@approved-premises/ui'
+
+import type { Application, ArrayOfOASysOffenceDetailsQuestions, OASysSections } from '@approved-premises/api'
+
+import TasklistPage from '../../../tasklistPage'
+
+import { Page } from '../../../utils/decorators'
+import { oasysImportReponse } from '../../../../utils/oasysImportUtils'
+
+type OffenceDetailsBody = {
+  offenceDetailsAnswers: Array<string> | Record<string, string>
+  offenceDetailsSummaries: ArrayOfOASysOffenceDetailsQuestions
+}
+
+@Page({
+  name: 'offence-details',
+  bodyProperties: ['offenceDetailsAnswers', 'offenceDetailsSummaries'],
+})
+export default class OffenceDetails implements TasklistPage {
+  title = 'Edit risk information'
+
+  offenceDetailsSummaries: OffenceDetailsBody['offenceDetailsSummaries']
+
+  offenceDetailsAnswers: OffenceDetailsBody['offenceDetailsAnswers']
+
+  risks: PersonRisksUI
+
+  constructor(public body: Partial<OffenceDetailsBody>) {}
+
+  static async initialize(
+    body: Record<string, unknown>,
+    application: Application,
+    token: string,
+    dataServices: DataServices,
+  ) {
+    const oasysSections: OASysSections = await dataServices.personService.getOasysSections(
+      token,
+      application.person.crn,
+    )
+    const risks = await dataServices.personService.getPersonRisks(token, application.person.crn)
+
+    const offenceDetails = oasysSections.offenceDetails.sort(
+      (a, b) => Number(a.questionNumber) - Number(b.questionNumber),
+    )
+
+    body.offenceDetailsSummaries = offenceDetails
+
+    const page = new OffenceDetails(body)
+    page.offenceDetailsSummaries = offenceDetails
+    page.risks = risks
+
+    return page
+  }
+
+  previous() {
+    return 'rosh-summary'
+  }
+
+  next() {
+    return ''
+  }
+
+  response() {
+    return oasysImportReponse(this.body.offenceDetailsAnswers, this.body.offenceDetailsSummaries)
+  }
+
+  errors() {
+    return {}
+  }
+}

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
@@ -1,10 +1,10 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 import { PersonService } from '../../../../services'
 import applicationFactory from '../../../../testutils/factories/application'
-import oasysSectionsFactory, { roshSummaryFactory } from '../../../../testutils/factories/oasysSections'
+import oasysSectionsFactory from '../../../../testutils/factories/oasysSections'
 import risksFactory from '../../../../testutils/factories/risks'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
-
+import { oasysImportReponse } from '../../../../utils/oasysImportUtils'
 import RoshSummary from './roshSummary'
 
 jest.mock('../../../../services/personService.ts')
@@ -52,24 +52,18 @@ describe('RoshSummary', () => {
     })
 
     describe('response', () => {
-      it('returns a human readable response for reach question', () => {
-        const roshSummaries = roshSummaryFactory.buildList(3)
-        const page = new RoshSummary({
-          roshAnswers: ['answer 1', 'answer 2', 'answer 3'],
-          roshSummaries,
-        })
-
-        expect(page.response()).toEqual({
-          [`${roshSummaries[0].questionNumber}. ${roshSummaries[0].label}`]: 'answer 1',
-          [`${roshSummaries[1].questionNumber}. ${roshSummaries[1].label}`]: 'answer 2',
-          [`${roshSummaries[2].questionNumber}. ${roshSummaries[2].label}`]: 'answer 3',
-        })
-      })
-
-      it('returns no response when there arent any questions', () => {
-        const page = new RoshSummary({})
-
-        expect(page.response()).toEqual({})
+      it('calls oasysImportReponse with the correct arguments', () => {
+        const answers = ['answer 1']
+        const summaries = [
+          {
+            questionNumber: '1',
+            label: 'The first question',
+            answer: 'Some answer for the first question',
+          },
+        ]
+        const page = new RoshSummary({ roshAnswers: answers, roshSummaries: summaries })
+        const result = page.response()
+        expect(result).toEqual(oasysImportReponse(answers, summaries))
       })
     })
   })

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
@@ -40,7 +40,7 @@ describe('RoshSummary', () => {
       expect(page.risks).toEqual(personRisks)
     })
 
-    itShouldHaveNextValue(new RoshSummary({}), '')
+    itShouldHaveNextValue(new RoshSummary({}), 'offence-details')
 
     itShouldHavePreviousValue(new RoshSummary({}), 'optional-oasys-sections')
 

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
@@ -71,35 +71,6 @@ describe('RoshSummary', () => {
 
         expect(page.response()).toEqual({})
       })
-
-      describe('roshTextAreas', () => {
-        it('it returns reoffending needs as textareas', () => {
-          const roshSummaries = roshSummaryFactory.buildList(2)
-          const page = new RoshSummary({})
-          page.roshSummary = roshSummaries
-          const items = page.roshTextAreas()
-
-          expect(items).toMatchStringIgnoringWhitespace(`
-        <div class="govuk-form-group">
-        <h3 class="govuk-label-wrapper">
-            <label class="govuk-label govuk-label--m" for=roshAnswers[${roshSummaries[0].questionNumber}]>
-                ${roshSummaries[0].label}
-            </label>
-        </h3>
-        <textarea class="govuk-textarea" id=roshAnswers[${roshSummaries[0].questionNumber}] name=roshAnswers[${roshSummaries[0].questionNumber}] rows="8">${roshSummaries[0].answer}</textarea>
-    </div>
-    <hr>
-    <div class="govuk-form-group">
-    <h3 class="govuk-label-wrapper">
-        <label class="govuk-label govuk-label--m" for=roshAnswers[${roshSummaries[1].questionNumber}]>
-            ${roshSummaries[1].label}
-        </label>
-    </h3>
-    <textarea class="govuk-textarea" id=roshAnswers[${roshSummaries[1].questionNumber}] name=roshAnswers[${roshSummaries[1].questionNumber}] rows="8">${roshSummaries[1].answer}</textarea>
-</div>
-<hr>`)
-        })
-      })
     })
   })
 })

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
@@ -6,7 +6,6 @@ import type { Application, ArrayOfOASysRiskOfSeriousHarmSummaryQuestions, OASysS
 import TasklistPage from '../../../tasklistPage'
 
 import { Page } from '../../../utils/decorators'
-import { escape } from '../../../../utils/formUtils'
 
 type RoshSummaryBody = {
   roshAnswers: Array<string> | Record<string, string>
@@ -57,24 +56,6 @@ export default class RoshSummary implements TasklistPage {
 
   next() {
     return ''
-  }
-
-  roshTextAreas() {
-    return this.roshSummary
-      .map(roshQuestion => {
-        return `<div class="govuk-form-group">
-                <h3 class="govuk-label-wrapper">
-                    <label class="govuk-label govuk-label--m" for=roshAnswers[${roshQuestion.questionNumber}]>
-                        ${roshQuestion.label}
-                    </label>
-                </h3>
-                <textarea class="govuk-textarea" id=roshAnswers[${roshQuestion.questionNumber}] name=roshAnswers[${
-          roshQuestion.questionNumber
-        }] rows="8">${escape(roshQuestion?.answer)}</textarea>
-            </div>
-            <hr>`
-      })
-      .join('')
   }
 
   response() {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
@@ -56,7 +56,7 @@ export default class RoshSummary implements TasklistPage {
   }
 
   next() {
-    return ''
+    return 'offence-details'
   }
 
   response() {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
@@ -20,11 +20,11 @@ type RoshSummaryBody = {
 export default class RoshSummary implements TasklistPage {
   title = 'Edit risk information'
 
-  roshSummary: ArrayOfOASysRiskOfSeriousHarmSummaryQuestions
+  roshSummary: RoshSummaryBody['roshSummaries']
 
   risks: PersonRisksUI
 
-  roshAnswers: Record<string, string>
+  roshAnswers: RoshSummaryBody['roshAnswers']
 
   constructor(public body: Partial<RoshSummaryBody>) {}
 

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
@@ -41,10 +41,8 @@ export default class RoshSummary implements TasklistPage {
     const risks = await dataServices.personService.getPersonRisks(token, application.person.crn)
 
     const roshSummaries = oasysSections.roshSummary.sort((a, b) => Number(a.questionNumber) - Number(b.questionNumber))
-    const roshAnswers = body?.roshAnswers ? body.roshAnswers : []
 
     body.roshSummaries = roshSummaries
-    body.roshAnswers = roshAnswers
 
     const page = new RoshSummary(body)
     page.roshSummary = roshSummaries

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
@@ -6,6 +6,7 @@ import type { Application, ArrayOfOASysRiskOfSeriousHarmSummaryQuestions, OASysS
 import TasklistPage from '../../../tasklistPage'
 
 import { Page } from '../../../utils/decorators'
+import { oasysImportReponse } from '../../../../utils/oasysImportUtils'
 
 type RoshSummaryBody = {
   roshAnswers: Array<string> | Record<string, string>
@@ -59,18 +60,7 @@ export default class RoshSummary implements TasklistPage {
   }
 
   response() {
-    if (Array.isArray(this.body.roshAnswers)) {
-      return (this.body.roshAnswers as Array<string>).reduce((prev, question, i) => {
-        return {
-          ...prev,
-          [`${this.body.roshSummaries[i].questionNumber}. ${this.body.roshSummaries[i].label}`]: question,
-        }
-      }, {}) as Record<string, string>
-    }
-    if (!this.body.roshAnswers) {
-      return {}
-    }
-    return this.body.roshAnswers
+    return oasysImportReponse(this.body.roshAnswers, this.body.roshSummaries)
   }
 
   errors() {

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -497,6 +497,41 @@
               }
             }
           }
+        },
+        "offence-details": {
+          "type": "object",
+          "properties": {
+            "offenceDetailsAnswers": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "object"
+                }
+              ]
+            },
+            "offenceDetailsSummaries": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": "string"
+                  },
+                  "questionNumber": {
+                    "type": "string"
+                  },
+                  "answer": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/server/testutils/factories/oasysSections.ts
+++ b/server/testutils/factories/oasysSections.ts
@@ -9,7 +9,7 @@ export default Factory.define<OASysSections>(() => ({
   assessmentState: faker.helpers.arrayElement(['Completed', 'Incomplete']),
   dateStarted: DateFormats.dateObjToIsoDate(faker.date.past()),
   dateCompleted: DateFormats.dateObjToIsoDate(faker.date.recent()),
-  offenceDetails: [],
+  offenceDetails: offenceDetailsFactory.buildList(5),
   roshSummary: roshSummaryFactory.buildList(5),
   supportingInformation: [],
   riskToSelf: [],
@@ -23,6 +23,20 @@ export const roshSummaryFactory = Factory.define<OASysQuestion>(options => ({
     'What is the nature of the risk?',
     'When is the risk likely to be greatest?',
     'What circumstances are likely to increase risk?',
+  ]),
+  answer: faker.lorem.paragraph(),
+}))
+
+const offenceDetailsFactory = Factory.define<OASysQuestion>(options => ({
+  questionNumber: options.sequence.toString(),
+  label: faker.helpers.arrayElement([
+    'Offence analysis',
+    'Others involved',
+    'Issues contributing to risk',
+    'Motivation and triggers',
+    'Victim impact',
+    'Victim Information',
+    'Previous offences',
   ]),
   answer: faker.lorem.paragraph(),
 }))

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -19,6 +19,7 @@ import { DateFormats } from './dateUtils'
 import * as AssessmentUtils from './assessmentUtils'
 import * as OffenceUtils from './offenceUtils'
 import * as AttachDocumentsUtils from './attachDocumentsUtils'
+import * as OasysImportUtils from './oasysImportUtils'
 
 import managePaths from '../paths/manage'
 import applyPaths from '../paths/apply'
@@ -131,4 +132,5 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('AssessmentUtils', AssessmentUtils)
   njkEnv.addGlobal('OffenceUtils', OffenceUtils)
   njkEnv.addGlobal('AttachDocumentsUtils', AttachDocumentsUtils)
+  njkEnv.addGlobal('OasysImportUtils', OasysImportUtils)
 }

--- a/server/utils/oasysImportUtils.test.ts
+++ b/server/utils/oasysImportUtils.test.ts
@@ -1,5 +1,5 @@
 import { roshSummaryFactory } from '../testutils/factories/oasysSections'
-import { textareas } from './oasysImportUtils'
+import { oasysImportReponse, textareas } from './oasysImportUtils'
 
 describe('OASysImportUtils', () => {
   describe('textareas', () => {
@@ -27,6 +27,42 @@ describe('OASysImportUtils', () => {
           <textarea class="govuk-textarea" id=${sectionName}[${roshSummaries[1].questionNumber}] name=${sectionName}[${roshSummaries[1].questionNumber}] rows="8">${roshSummaries[1].answer}</textarea>
       </div>
       <hr>`)
+    })
+  })
+
+  describe('oasysImportReponse', () => {
+    it('returns a human readable response for reach question', () => {
+      const answers = ['answer 1', 'answer 2', 'answer 3']
+      const summaries = [
+        {
+          questionNumber: '1',
+          label: 'The first question',
+          answer: 'Some answer for the first question',
+        },
+        {
+          questionNumber: '2',
+          label: 'The second question',
+          answer: 'Some answer for the second question',
+        },
+        {
+          questionNumber: '3',
+          label: 'The third question',
+          answer: 'Some answer for the third question',
+        },
+      ]
+      const result = oasysImportReponse(answers, summaries)
+
+      expect(result).toEqual({
+        [`${summaries[0].questionNumber}. ${summaries[0].label}`]: `${answers[0]}`,
+        [`${summaries[1].questionNumber}. ${summaries[1].label}`]: `${answers[1]}`,
+        [`${summaries[2].questionNumber}. ${summaries[2].label}`]: `${answers[2]}`,
+      })
+    })
+
+    it('returns no response when there arent any questions', () => {
+      const result = oasysImportReponse([], [])
+
+      expect(result).toEqual({})
     })
   })
 })

--- a/server/utils/oasysImportUtils.test.ts
+++ b/server/utils/oasysImportUtils.test.ts
@@ -1,0 +1,32 @@
+import { roshSummaryFactory } from '../testutils/factories/oasysSections'
+import { textareas } from './oasysImportUtils'
+
+describe('OASysImportUtils', () => {
+  describe('textareas', () => {
+    it('it returns reoffending needs as textareas', () => {
+      const roshSummaries = roshSummaryFactory.buildList(2)
+      const sectionName = 'roshAnswers'
+      const result = textareas(roshSummaries, sectionName)
+
+      expect(result).toMatchStringIgnoringWhitespace(`
+              <div class="govuk-form-group">
+              <h3 class="govuk-label-wrapper">
+                  <label class="govuk-label govuk-label--m" for=${sectionName}[${roshSummaries[0].questionNumber}]>
+                      ${roshSummaries[0].label}
+                  </label>
+              </h3>
+              <textarea class="govuk-textarea" id=${sectionName}[${roshSummaries[0].questionNumber}] name=${sectionName}[${roshSummaries[0].questionNumber}] rows="8">${roshSummaries[0].answer}</textarea>
+          </div>
+          <hr>
+          <div class="govuk-form-group">
+          <h3 class="govuk-label-wrapper">
+              <label class="govuk-label govuk-label--m" for=${sectionName}[${roshSummaries[1].questionNumber}]>
+                  ${roshSummaries[1].label}
+              </label>
+          </h3>
+          <textarea class="govuk-textarea" id=${sectionName}[${roshSummaries[1].questionNumber}] name=${sectionName}[${roshSummaries[1].questionNumber}] rows="8">${roshSummaries[1].answer}</textarea>
+      </div>
+      <hr>`)
+    })
+  })
+})

--- a/server/utils/oasysImportUtils.ts
+++ b/server/utils/oasysImportUtils.ts
@@ -1,0 +1,23 @@
+import { OASysQuestion } from '../@types/shared'
+import { OasysImportArrays } from '../@types/ui'
+import { escape } from './formUtils'
+
+export const textareas = (questions: OasysImportArrays, key: 'roshAnswers' | 'offenceDetails') => {
+  return questions
+    .map(question => {
+      return `<div class="govuk-form-group">
+                <h3 class="govuk-label-wrapper">
+                    <label class="govuk-label govuk-label--m" for=${key}[${question.questionNumber}]>
+                        ${question.label}
+                    </label>
+                </h3>
+                <textarea class="govuk-textarea" id=${key}[${question.questionNumber}] name=${key}[${
+        question.questionNumber
+      }] rows="8">${escape(question?.answer)}</textarea>
+            </div>
+            <hr>`
+    })
+    .join('')
+}
+
+export default textareas

--- a/server/utils/oasysImportUtils.ts
+++ b/server/utils/oasysImportUtils.ts
@@ -20,4 +20,22 @@ export const textareas = (questions: OasysImportArrays, key: 'roshAnswers' | 'of
     .join('')
 }
 
+export const oasysImportReponse = (
+  answers: Array<string> | Record<string, string>,
+  summaries: Array<OASysQuestion>,
+) => {
+  if (Array.isArray(answers)) {
+    return (answers as Array<string>).reduce((prev, question, i) => {
+      return {
+        ...prev,
+        [`${summaries[i].questionNumber}. ${summaries[i].label}`]: question,
+      }
+    }, {}) as Record<string, string>
+  }
+  if (!answers) {
+    return {}
+  }
+  return answers
+}
+
 export default textareas

--- a/server/views/applications/pages/oasys-import/offence-details.njk
+++ b/server/views/applications/pages/oasys-import/offence-details.njk
@@ -1,0 +1,50 @@
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+{% from "../../components/riskWidgets/macro.njk" import widgets %}
+
+{% extends "../layout.njk" %}
+
+{% set columnClasses = "govuk-grid-column-full" %}
+
+{% block questions %}
+  <div class="govuk-grid-row">
+    <div>
+      <h1 class="govuk-heading-l">{{page.title}}</h1>
+      <p>Imported from OASys 23 October 2022</p>
+    </div>
+
+    {{ mojSubNavigation({
+        label: 'Sub navigation',
+        attributes: {
+          'role': 'tablist'
+        },
+        items: [{
+          text: 'RoSH summary',
+          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'rosh-summary' })
+        }, 
+        {
+          text: 'Offence details',
+          active: true
+        }, 
+        {
+          text: 'Supporting information'
+        },  
+        {
+          text: 'Risk management plan'
+        },
+        {
+          text: 'Risk to self'
+        }]
+      }) }}
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds" id="offenceDetails" role="tabpanel" >
+      {{OasysImportUtils.textareas(page.offenceDetailsSummaries, 'offenceDetailsAnswers') | safe}}
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      {{ widgets(page.risks) }}
+    </div>
+  </div>
+
+{% endblock %}

--- a/server/views/applications/pages/oasys-import/rosh-summary.njk
+++ b/server/views/applications/pages/oasys-import/rosh-summary.njk
@@ -41,7 +41,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds" id="roshSummary" role="tabpanel" >
-      {{page.roshTextAreas() | safe }}
+      {{OasysImportUtils.textareas(page.roshSummary, 'roshAnswers') | safe}}
     </div>
 
     <div class="govuk-grid-column-one-third">

--- a/server/views/applications/pages/oasys-import/rosh-summary.njk
+++ b/server/views/applications/pages/oasys-import/rosh-summary.njk
@@ -20,12 +20,11 @@
         items: [{
           text: 'RoSH summary',
           href: '#roshSummary',
-          attributes: {
-            active: true
-          }
+          active: true
         }, 
         {
-          text: 'Offence details'
+          text: 'Offence details',
+          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'offence-details' }) 
         }, 
         {
           text: 'Supporting information'


### PR DESCRIPTION
# Context
Similar to #426 users need to be able to add and edit sections from the Offence Details section of OASys.

[Trello card](https://trello.com/c/PYl2WtOG/727-oasys-risk-and-needs-import)

# Changes in this PR
Firstly there is some tidying of the RoshSummary class. 
Then we extract some methods that are to be used by both the RoshSummary and OffenceDetails class.
Next we add the class and view themselves, they are very similar to the RoshSummary.
After that we're tidying up: making sure RoshSummary correctly links to the OffenceDetails page and updating the schema.

## Screenshots of UI changes
![Apply -- allows completion of the form](https://user-images.githubusercontent.com/44123869/207591374-c0c63c56-e9c3-47ad-ab4b-abe1f1a8a673.png)

