### PR TITLE
(963) Use first class risk ratings in frontend for applications

### DIFF
--- a/cypress_shared/pages/apply/accessNeeds.ts
+++ b/cypress_shared/pages/apply/accessNeeds.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class AccessNeedsPage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super('Access needs', application, 'access-and-healthcare', 'access-needs')
   }
 

--- a/cypress_shared/pages/apply/accessNeedsAdditionalAdjustments.ts
+++ b/cypress_shared/pages/apply/accessNeedsAdditionalAdjustments.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class AccessNeedsAdditionalAdjustmentsPage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super('Access needs', application, 'access-and-healthcare', 'access-needs-additional-adjustments')
     cy.get('legend').contains(
       /Does the placement require adjustments for the mobility, learning disability and neurodivergent conditions needs you selected?/,

--- a/cypress_shared/pages/apply/accessNeedsMobility.ts
+++ b/cypress_shared/pages/apply/accessNeedsMobility.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class AccessNeedsMobilityPage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super('Access needs', application, 'access-and-healthcare', 'access-needs-mobility')
     cy.get('.govuk-form-group').contains(`Does ${application.person.name} require a wheelchair accessible room?`)
   }

--- a/cypress_shared/pages/apply/applyPage.ts
+++ b/cypress_shared/pages/apply/applyPage.ts
@@ -1,13 +1,13 @@
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 import Page from '../page'
 import TasklistPage from '../../../server/form-pages/tasklistPage'
-import { Application } from '../../../server/@types/shared/models/Application'
 
 import Apply from '../../../server/form-pages/apply'
 
 export default class ApplyPage extends Page {
   tasklistPage: TasklistPage
 
-  constructor(title: string, application: Application, taskName: string, pageName: string) {
+  constructor(title: string, application: ApprovedPremisesApplication, taskName: string, pageName: string) {
     super(title)
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/cypress_shared/pages/apply/arson.ts
+++ b/cypress_shared/pages/apply/arson.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class ArsonPage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super('Arson', application, 'further-considerations', 'arson')
     cy.get('.govuk-form-group').contains(`Does ${application.person.name} need a specialist arson room?`)
   }

--- a/cypress_shared/pages/apply/caseNotes.ts
+++ b/cypress_shared/pages/apply/caseNotes.ts
@@ -1,4 +1,4 @@
-import { Application, PrisonCaseNote, Adjudication } from '@approved-premises/api'
+import { ApprovedPremisesApplication, PrisonCaseNote, Adjudication } from '@approved-premises/api'
 
 import { DateFormats } from '../../../server/utils/dateUtils'
 import { sentenceCase } from '../../../server/utils/utils'
@@ -8,7 +8,7 @@ import Page from '../page'
 export default class CaseNotesPage extends Page {
   prisonCaseNotes: Array<PrisonCaseNote>
 
-  constructor(application: Application, prisonCaseNotes: Array<PrisonCaseNote>) {
+  constructor(application: ApprovedPremisesApplication, prisonCaseNotes: Array<PrisonCaseNote>) {
     super('Prison information')
 
     cy.get('label').contains(

--- a/cypress_shared/pages/apply/catering.ts
+++ b/cypress_shared/pages/apply/catering.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class CateringPage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super('Catering requirements', application, 'further-considerations', 'catering')
     cy.get('.govuk-form-group').contains(
       `Do you have any concerns about ${application.person.name} catering for themselves?`,

--- a/cypress_shared/pages/apply/complexCaseBoard.ts
+++ b/cypress_shared/pages/apply/complexCaseBoard.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class ComplexCaseBoardPage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super('Complex case board', application, 'further-considerations', 'complex-case-board')
     cy.get('.govuk-form-group').contains(
       `Does ${application.person.name}'s gender identity require a complex case board to review their application? `,

--- a/cypress_shared/pages/apply/convictedOffences.ts
+++ b/cypress_shared/pages/apply/convictedOffences.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class ConvictedOffences extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super(
       `Has ${application.person.name} ever been convicted of the following offences?`,
       application,

--- a/cypress_shared/pages/apply/covid.ts
+++ b/cypress_shared/pages/apply/covid.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class CovidPage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super('COVID information', application, 'access-and-healthcare', 'covid')
   }
 

--- a/cypress_shared/pages/apply/dateOfOffence.ts
+++ b/cypress_shared/pages/apply/dateOfOffence.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class DateOfOffence extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super('Convicted offences', application, 'risk-management-features', 'date-of-offence')
   }
 

--- a/cypress_shared/pages/apply/describeLocationFactors.ts
+++ b/cypress_shared/pages/apply/describeLocationFactors.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class DescribeLocationFactors extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super('Location factors', application, 'location-factors', 'describe-location-factors')
   }
 

--- a/cypress_shared/pages/apply/foreignNational.ts
+++ b/cypress_shared/pages/apply/foreignNational.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class ForeignNationalPage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super('Placement duration and move on', application, 'move-on', 'foreign-national')
   }
 

--- a/cypress_shared/pages/apply/list.ts
+++ b/cypress_shared/pages/apply/list.ts
@@ -1,7 +1,7 @@
 import Page from '../page'
 import paths from '../../../server/paths/apply'
 import { DateFormats } from '../../../server/utils/dateUtils'
-import { Application, PersonRisks } from '../../../server/@types/shared'
+import { ApprovedPremisesApplication, PersonRisks } from '../../../server/@types/shared'
 
 export default class ListPage extends Page {
   constructor() {
@@ -14,7 +14,7 @@ export default class ListPage extends Page {
     return new ListPage()
   }
 
-  shouldShowApplications(applications: Array<Application>, personRisks: Array<PersonRisks>): void {
+  shouldShowApplications(applications: Array<ApprovedPremisesApplication>, personRisks: Array<PersonRisks>): void {
     applications.forEach((application, i) => {
       cy.contains(application.person.name)
         .should('have.attr', 'href', paths.applications.show({ id: application.id }))

--- a/cypress_shared/pages/apply/list.ts
+++ b/cypress_shared/pages/apply/list.ts
@@ -1,7 +1,7 @@
 import Page from '../page'
 import paths from '../../../server/paths/apply'
 import { DateFormats } from '../../../server/utils/dateUtils'
-import { ApprovedPremisesApplication, PersonRisks } from '../../../server/@types/shared'
+import { ApprovedPremisesApplication } from '../../../server/@types/shared'
 
 export default class ListPage extends Page {
   constructor() {
@@ -14,8 +14,8 @@ export default class ListPage extends Page {
     return new ListPage()
   }
 
-  shouldShowApplications(applications: Array<ApprovedPremisesApplication>, personRisks: Array<PersonRisks>): void {
-    applications.forEach((application, i) => {
+  shouldShowApplications(applications: Array<ApprovedPremisesApplication>): void {
+    applications.forEach(application => {
       cy.contains(application.person.name)
         .should('have.attr', 'href', paths.applications.show({ id: application.id }))
         .parent()
@@ -23,7 +23,7 @@ export default class ListPage extends Page {
         .within(() => {
           cy.get('th').eq(0).contains(application.person.name)
           cy.get('td').eq(0).contains(application.person.crn)
-          cy.get('td').eq(1).contains(personRisks[i].tier.value.level)
+          cy.get('td').eq(1).contains(application.risks.tier.value.level)
           cy.get('td')
             .eq(2)
             .contains(

--- a/cypress_shared/pages/apply/optionalOasysSections.ts
+++ b/cypress_shared/pages/apply/optionalOasysSections.ts
@@ -1,9 +1,9 @@
-import { Application, OASysSection } from '@approved-premises/api'
+import { ApprovedPremisesApplication, OASysSection } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class OptionalOasysSectionsPage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super(
       'Which of the following sections of OASys do you want to import?',
       application,

--- a/cypress_shared/pages/apply/pduTransfer.ts
+++ b/cypress_shared/pages/apply/pduTransfer.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class PduTransferPage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super(
       `Have you agreed ${application.person.name}'s transfer/supervision with the receiving PDU?`,
       application,

--- a/cypress_shared/pages/apply/placementDuration.ts
+++ b/cypress_shared/pages/apply/placementDuration.ts
@@ -1,13 +1,13 @@
 import { add } from 'date-fns'
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 import { DateFormats } from '../../../server/utils/dateUtils'
 
 import ApplyPage from './applyPage'
 
 export default class PlacementDurationPage extends ApplyPage {
-  application: Application
+  application: ApprovedPremisesApplication
 
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super('Placement duration and move on', application, 'move-on', 'placement-duration')
     this.application = application
   }

--- a/cypress_shared/pages/apply/placementPurpose.ts
+++ b/cypress_shared/pages/apply/placementPurpose.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class PlacementPurposePage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super(
       'What is the purpose of the Approved Premises (AP) placement?',
       application,

--- a/cypress_shared/pages/apply/placementStart.ts
+++ b/cypress_shared/pages/apply/placementStart.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 import ApplyPage from './applyPage'
 import { DateFormats } from '../../../server/utils/dateUtils'
 
 export default class PlacementStartPage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     const { releaseDate } = application.data['basic-information']['release-date']
 
     super(

--- a/cypress_shared/pages/apply/plansInPlace.ts
+++ b/cypress_shared/pages/apply/plansInPlace.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class PlansInPlacePage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super('Placement duration and move on', application, 'move-on', 'plans-in-place')
   }
 

--- a/cypress_shared/pages/apply/previousPlacements.ts
+++ b/cypress_shared/pages/apply/previousPlacements.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class PreviousPlacementsPage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super('Previous placements', application, 'further-considerations', 'previous-placements')
     cy.get('.govuk-form-group').contains(
       `Has ${application.person.name} stayed or been offered a placement in an AP before?`,

--- a/cypress_shared/pages/apply/rehabilitativeInterventions.ts
+++ b/cypress_shared/pages/apply/rehabilitativeInterventions.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class RehabilitativeInterventions extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super(
       "Which rehabilitative interventions will support the person's Approved Premises (AP) placement?",
       application,

--- a/cypress_shared/pages/apply/releaseDate.ts
+++ b/cypress_shared/pages/apply/releaseDate.ts
@@ -1,9 +1,9 @@
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class ReleaseDatePage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super(`Do you know ${application.person.name}’s release date?`, application, 'basic-information', 'release-date')
   }
 

--- a/cypress_shared/pages/apply/relocationRegion.ts
+++ b/cypress_shared/pages/apply/relocationRegion.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class RelocationRegionPage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super('Placement duration and move on', application, 'move-on', 'relocation-region')
     cy.get('.govuk-form-group').contains(
       `Where is ${application.person.name} most likely to live when they move on from the AP?`,

--- a/cypress_shared/pages/apply/riskManagementFeatures.ts
+++ b/cypress_shared/pages/apply/riskManagementFeatures.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class RiskManagementFeatures extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super(
       'What features of AP will support the management of risk?',
       application,

--- a/cypress_shared/pages/apply/roomSharing.ts
+++ b/cypress_shared/pages/apply/roomSharing.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class RoomSharingPage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super('Room sharing', application, 'further-considerations', 'room-sharing')
   }
 

--- a/cypress_shared/pages/apply/roshSummary.ts
+++ b/cypress_shared/pages/apply/roshSummary.ts
@@ -1,9 +1,12 @@
-import { Application, ArrayOfOASysRiskOfSeriousHarmSummaryQuestions } from '@approved-premises/api'
+import { ApprovedPremisesApplication, ArrayOfOASysRiskOfSeriousHarmSummaryQuestions } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class RoshSummary extends ApplyPage {
-  constructor(application: Application, private readonly roshSummary: ArrayOfOASysRiskOfSeriousHarmSummaryQuestions) {
+  constructor(
+    application: ApprovedPremisesApplication,
+    private readonly roshSummary: ArrayOfOASysRiskOfSeriousHarmSummaryQuestions,
+  ) {
     super('Edit risk information', application, 'oasys-import', 'rosh-summary')
   }
 

--- a/cypress_shared/pages/apply/sentenceType.ts
+++ b/cypress_shared/pages/apply/sentenceType.ts
@@ -1,9 +1,9 @@
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class SentenceTypePage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super('Which of the following best describes the sentence type?', application, 'basic-information', 'sentence-type')
   }
 

--- a/cypress_shared/pages/apply/situationPage.ts
+++ b/cypress_shared/pages/apply/situationPage.ts
@@ -1,9 +1,9 @@
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class SituationPage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super('Which of the following options best describes the situation?', application, 'basic-information', 'situation')
   }
 

--- a/cypress_shared/pages/apply/typeOfAccommodation.ts
+++ b/cypress_shared/pages/apply/typeOfAccommodation.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class TypeOfAccomodationPage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super('Placement duration and move on', application, 'move-on', 'type-of-accommodation')
     cy.get('.govuk-form-group').contains(
       `What type of accommodation will ${application.person.name} have when they leave the AP?`,

--- a/cypress_shared/pages/apply/typeOfAp.ts
+++ b/cypress_shared/pages/apply/typeOfAp.ts
@@ -1,8 +1,8 @@
-import { Application } from '../../../server/@types/shared'
+import { ApprovedPremisesApplication } from '../../../server/@types/shared'
 import ApplyPage from './applyPage'
 
 export default class TypeOfApPage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super(`Which type of AP does ${application.person.name} require?`, application, 'type-of-ap', 'ap-type')
   }
 

--- a/cypress_shared/pages/apply/typeOfConvictedOffence.ts
+++ b/cypress_shared/pages/apply/typeOfConvictedOffence.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class TypeOfConvictedOffence extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super(
       `What type of offending has ${application.person.name} been convicted of?`,
       application,

--- a/cypress_shared/pages/apply/vulnerability.ts
+++ b/cypress_shared/pages/apply/vulnerability.ts
@@ -1,9 +1,9 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
 
 export default class VulnerabilityPage extends ApplyPage {
-  constructor(application: Application) {
+  constructor(application: ApprovedPremisesApplication) {
     super('Vulnerability', application, 'further-considerations', 'vulnerability')
     cy.get('.govuk-form-group').contains(
       `Are you aware that ${application.person.name} is vulnerable to exploitation from others?`,

--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -1,11 +1,11 @@
 import { SuperAgentRequest } from 'superagent'
 
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import { getMatchingRequests, stubFor } from '../../wiremock'
 
 export default {
-  stubApplications: (applications: Application): SuperAgentRequest =>
+  stubApplications: (applications: ApprovedPremisesApplication): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
@@ -17,7 +17,7 @@ export default {
         jsonBody: applications,
       },
     }),
-  stubApplicationCreate: (args: { application: Application }): SuperAgentRequest =>
+  stubApplicationCreate: (args: { application: ApprovedPremisesApplication }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'POST',
@@ -29,7 +29,7 @@ export default {
         jsonBody: { ...args.application, data: null },
       },
     }),
-  stubApplicationUpdate: (args: { application: Application }): SuperAgentRequest =>
+  stubApplicationUpdate: (args: { application: ApprovedPremisesApplication }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'PUT',
@@ -52,7 +52,7 @@ export default {
         transformers: ['response-template'],
       },
     }),
-  stubApplicationGet: (args: { application: Application }): SuperAgentRequest =>
+  stubApplicationGet: (args: { application: ApprovedPremisesApplication }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
@@ -64,7 +64,10 @@ export default {
         jsonBody: args.application,
       },
     }),
-  stubApplicationDocuments: (args: { application: Application; documents: Array<Document> }): SuperAgentRequest =>
+  stubApplicationDocuments: (args: {
+    application: ApprovedPremisesApplication
+    documents: Array<Document>
+  }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
@@ -76,7 +79,7 @@ export default {
         jsonBody: args.documents,
       },
     }),
-  stubApplicationSubmit: (args: { application: Application }): SuperAgentRequest =>
+  stubApplicationSubmit: (args: { application: ApprovedPremisesApplication }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'POST',

--- a/integration_tests/support/helpers.ts
+++ b/integration_tests/support/helpers.ts
@@ -1,11 +1,17 @@
 /* eslint-disable import/prefer-default-export */
-import { Application, ArrayOfOASysRiskOfSeriousHarmSummaryQuestions, Document } from '@approved-premises/api'
+import {
+  ApprovedPremisesApplication,
+  ArrayOfOASysRiskOfSeriousHarmSummaryQuestions,
+  Document,
+} from '@approved-premises/api'
 
-const documentsFromApplication = (application: Application): Array<Document> => {
+const documentsFromApplication = (application: ApprovedPremisesApplication): Array<Document> => {
   return application.data['attach-required-documents']['attach-documents'].selectedDocuments as Array<Document>
 }
 
-const roshSummariesFromApplication = (application: Application): ArrayOfOASysRiskOfSeriousHarmSummaryQuestions => {
+const roshSummariesFromApplication = (
+  application: ApprovedPremisesApplication,
+): ArrayOfOASysRiskOfSeriousHarmSummaryQuestions => {
   return application.data['oasys-import']['rosh-summary'].roshSummaries as ArrayOfOASysRiskOfSeriousHarmSummaryQuestions
 }
 

--- a/integration_tests/tests/apply/list.cy.ts
+++ b/integration_tests/tests/apply/list.cy.ts
@@ -1,7 +1,6 @@
 import { StartPage, ListPage } from '../../../cypress_shared/pages/apply'
 
 import applicationFactory from '../../../server/testutils/factories/application'
-import risksFactory from '../../../server/testutils/factories/risks'
 import Page from '../../../cypress_shared/pages/page'
 
 context('Applications dashboard', () => {
@@ -19,17 +18,11 @@ context('Applications dashboard', () => {
     const applications = applicationFactory.withReleaseDate().buildList(5)
     cy.task('stubApplications', applications)
 
-    // And there are risks for the persons related to these applications
-    const risks = risksFactory.buildList(5)
-    applications.forEach((application, i) => {
-      cy.task('stubPersonRisks', { person: application.person, risks: risks[i] })
-    })
-
     // When I visit the Previous Applications page
     const page = ListPage.visit()
 
     // Then I should see all of the application summaries listed
-    page.shouldShowApplications(applications, risks)
+    page.shouldShowApplications(applications)
 
     // And I the button should take me to the application start page
     page.clickSubmit()

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,5 +1,5 @@
 import type { ErrorMessages } from '@approved-premises/ui'
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 
 export default {}
 
@@ -8,7 +8,7 @@ declare module 'express-session' {
   interface SessionData {
     returnTo: string
     nowInMinutes: number
-    application: Application
+    application: ApprovedPremisesApplication
     previousPage: string
   }
 }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -3,7 +3,7 @@ import {
   RiskTier,
   FlagsEnvelope,
   Mappa,
-  Application,
+  ApprovedPremisesApplication,
   Assessment,
   Person,
   OASysSection,
@@ -193,7 +193,7 @@ export type DataServices = Partial<{
     getPersonRisks: (token: string, crn: string) => Promise<PersonRisksUI>
   }
   applicationService: {
-    getDocuments: (token: string, application: Application) => Promise<Array<Document>>
+    getDocuments: (token: string, application: ApprovedPremisesApplication) => Promise<Array<Document>>
   }
 }>
 
@@ -204,7 +204,7 @@ export interface GroupedAssessmentWithRisks {
 }
 
 export interface AssessmentWithRisks extends Assessment {
-  application: ApplicationWithRisks
+  application: ApprovedPremisesApplicationWithRisks
 }
 
 export interface ApplicationWithRisks extends Application {

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -2,7 +2,7 @@ import type { Request, Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 
 import type { ErrorsAndUserInput } from '@approved-premises/ui'
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import ApplicationsController from './applicationsController'
 import { ApplicationService, PersonService } from '../../services'
 import { fetchErrorsAndUserInput } from '../../utils/validation'
@@ -66,7 +66,7 @@ describe('applicationsController', () => {
   })
 
   describe('show', () => {
-    const application = createMock<Application>({ person: { crn: 'some-crn' } })
+    const application = createMock<ApprovedPremisesApplication>({ person: { crn: 'some-crn' } })
     const risks = mapApiPersonRisksForUi(risksFactory.build())
 
     beforeEach(() => {

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -38,18 +38,20 @@ describe('applicationsController', () => {
     response = createMock<Response>({})
   })
 
-  describe('list', () => {
-    it('renders the list view', async () => {
-      applicationService.dashboardTableRows.mockResolvedValue([])
+  describe('index', () => {
+    it('renders the index view', async () => {
+      const applications = applicationFactory.buildList(5)
+      applicationService.getAllForLoggedInUser.mockResolvedValue(applications)
+
       const requestHandler = applicationsController.index()
 
       await requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('applications/list', {
+      expect(response.render).toHaveBeenCalledWith('applications/index', {
         pageHeading: 'Approved Premises applications',
-        applicationTableRows: [],
+        applications,
       })
-      expect(applicationService.dashboardTableRows).toHaveBeenCalled()
+      expect(applicationService.getAllForLoggedInUser).toHaveBeenCalled()
     })
   })
 

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, RequestHandler } from 'express'
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplicationService from '../../services/applicationService'
 import { PersonService } from '../../services'
@@ -30,7 +30,7 @@ export default class ApplicationsController {
 
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const application: Application = req.session.application
+      const application: ApprovedPremisesApplication = req.session.application
         ? req.session.application
         : await this.applicationService.findApplication(req.user.token, req.params.id)
 

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -14,9 +14,9 @@ export default class ApplicationsController {
 
   index(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const applicationTableRows = await this.applicationService.dashboardTableRows(req.user.token)
+      const applications = await this.applicationService.getAllForLoggedInUser(req.user.token)
 
-      res.render('applications/list', { pageHeading: 'Approved Premises applications', applicationTableRows })
+      res.render('applications/index', { pageHeading: 'Approved Premises applications', applications })
     }
   }
 

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -1,4 +1,4 @@
-import type { ActiveOffence, Application, Document } from '@approved-premises/api'
+import type { ActiveOffence, ApprovedPremisesApplication, Document } from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -10,38 +10,40 @@ export default class ApplicationClient {
     this.restClient = new RestClient('applicationClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
-  async find(applicationId: string): Promise<Application> {
-    return (await this.restClient.get({ path: paths.applications.show({ id: applicationId }) })) as Application
+  async find(applicationId: string): Promise<ApprovedPremisesApplication> {
+    return (await this.restClient.get({
+      path: paths.applications.show({ id: applicationId }),
+    })) as ApprovedPremisesApplication
   }
 
-  async create(crn: string, activeOffence: ActiveOffence): Promise<Application> {
+  async create(crn: string, activeOffence: ActiveOffence): Promise<ApprovedPremisesApplication> {
     const { convictionId, deliusEventNumber, offenceId } = activeOffence
 
     return (await this.restClient.post({
       path: paths.applications.new.pattern,
       data: { crn, convictionId, deliusEventNumber, offenceId },
-    })) as Application
+    })) as ApprovedPremisesApplication
   }
 
-  async update(application: Application): Promise<Application> {
+  async update(application: ApprovedPremisesApplication): Promise<ApprovedPremisesApplication> {
     return (await this.restClient.put({
       path: paths.applications.update({ id: application.id }),
       data: { data: application.data },
-    })) as Application
+    })) as ApprovedPremisesApplication
   }
 
-  async all(): Promise<Array<Application>> {
-    return (await this.restClient.get({ path: paths.applications.index.pattern })) as Array<Application>
+  async all(): Promise<Array<ApprovedPremisesApplication>> {
+    return (await this.restClient.get({ path: paths.applications.index.pattern })) as Array<ApprovedPremisesApplication>
   }
 
-  async submit(application: Application): Promise<void> {
+  async submit(application: ApprovedPremisesApplication): Promise<void> {
     await this.restClient.post({
       path: paths.applications.submission({ id: application.id }),
       data: { translatedDocument: application.document },
     })
   }
 
-  async documents(application: Application): Promise<Array<Document>> {
+  async documents(application: ApprovedPremisesApplication): Promise<Array<Document>> {
     return (await this.restClient.get({
       path: paths.applications.documents({ id: application.id }),
     })) as Array<Document>

--- a/server/form-pages/apply/add-documents/attachDocuments.ts
+++ b/server/form-pages/apply/add-documents/attachDocuments.ts
@@ -1,4 +1,4 @@
-import type { Application, Document } from '@approved-premises/api'
+import type { ApprovedPremisesApplication, Document } from '@approved-premises/api'
 import { DataServices, TaskListErrors } from '@approved-premises/ui'
 import { Page } from '../../utils/decorators'
 
@@ -20,11 +20,11 @@ export default class AttachDocuments implements TasklistPage {
 
   documents: Array<Document> | undefined
 
-  constructor(public body: AttachDocumentsBody, public readonly application: Application) {}
+  constructor(public body: AttachDocumentsBody, public readonly application: ApprovedPremisesApplication) {}
 
   static async initialize(
     body: AttachDocumentsResponse,
-    application: Application,
+    application: ApprovedPremisesApplication,
     token: string,
     dataServices: DataServices,
   ): Promise<AttachDocuments> {

--- a/server/form-pages/apply/check-your-answers/review.ts
+++ b/server/form-pages/apply/check-your-answers/review.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors } from '@approved-premises/ui'
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import { Page } from '../../utils/decorators'
 
 import TasklistPage from '../../tasklistPage'
@@ -10,7 +10,7 @@ export default class Review implements TasklistPage {
 
   title = 'Check your answers'
 
-  constructor(public body: { reviewed?: string }, readonly application: Application) {}
+  constructor(public body: { reviewed?: string }, readonly application: ApprovedPremisesApplication) {}
 
   previous() {
     return ''

--- a/server/form-pages/apply/move-on/placementDuration.test.ts
+++ b/server/form-pages/apply/move-on/placementDuration.test.ts
@@ -1,4 +1,4 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
 import { SessionDataError } from '../../../utils/errors'
 
@@ -7,7 +7,7 @@ import applicationFactory from '../../../testutils/factories/application'
 
 describe('PlacementDuration', () => {
   let data: Record<string, unknown>
-  let application: Application
+  let application: ApprovedPremisesApplication
 
   beforeEach(() => {
     application = applicationFactory.withReleaseDate().build()

--- a/server/form-pages/apply/move-on/placementDuration.ts
+++ b/server/form-pages/apply/move-on/placementDuration.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors } from '@approved-premises/ui'
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 import { SessionDataError } from '../../../utils/errors'
 import { DateFormats } from '../../../utils/dateUtils'
 import { Page } from '../../utils/decorators'
@@ -22,7 +22,7 @@ export default class PlacementDuration implements TasklistPage {
     durationDetail: 'Provide any additional information',
   }
 
-  constructor(public body: Partial<PlacementDurationBody>, private readonly application: Application) {}
+  constructor(public body: Partial<PlacementDurationBody>, private readonly application: ApprovedPremisesApplication) {}
 
   previous() {
     return ''

--- a/server/form-pages/apply/move-on/relocationRegion.ts
+++ b/server/form-pages/apply/move-on/relocationRegion.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors } from '@approved-premises/ui'
-import { Application } from '../../../@types/shared'
+import { ApprovedPremisesApplication } from '../../../@types/shared'
 import { validPostcodeArea } from '../../../utils/formUtils'
 import { Page } from '../../utils/decorators'
 
@@ -19,7 +19,7 @@ export default class RelocationRegion implements TasklistPage {
     public body: {
       postcodeArea?: string
     },
-    private readonly application: Application,
+    private readonly application: ApprovedPremisesApplication,
   ) {}
 
   previous() {

--- a/server/form-pages/apply/move-on/typeOfAccommodation.ts
+++ b/server/form-pages/apply/move-on/typeOfAccommodation.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors } from '@approved-premises/ui'
-import { Application } from '../../../@types/shared'
+import { ApprovedPremisesApplication } from '../../../@types/shared'
 import { convertKeyValuePairToRadioItems } from '../../../utils/formUtils'
 import { Page } from '../../utils/decorators'
 
@@ -33,7 +33,10 @@ export default class TypeOfAccommodation implements TasklistPage {
 
   otherQuestion = accommodationType.other
 
-  constructor(public body: Partial<TypeOfAccommodationBody>, private readonly application: Application) {}
+  constructor(
+    public body: Partial<TypeOfAccommodationBody>,
+    private readonly application: ApprovedPremisesApplication,
+  ) {}
 
   previous() {
     return 'plans-in-place'

--- a/server/form-pages/apply/reasons-for-placement/basic-information/oralHearing.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/oralHearing.ts
@@ -1,5 +1,5 @@
 import type { ObjectWithDateParts, YesOrNo, TaskListErrors } from '@approved-premises/ui'
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import TasklistPage from '../../../tasklistPage'
 import { dateAndTimeInputsAreValidDates, dateIsBlank, DateFormats } from '../../../../utils/dateUtils'
@@ -23,7 +23,7 @@ type OralHearingBody = ObjectWithDateParts<'oralHearingDate'> & {
 export default class OralHearing implements TasklistPage {
   title = `Do you know ${this.application.person.name}’s oral hearing date?`
 
-  constructor(private _body: Partial<OralHearingBody>, private readonly application: Application) {}
+  constructor(private _body: Partial<OralHearingBody>, private readonly application: ApprovedPremisesApplication) {}
 
   public set body(value: Partial<OralHearingBody>) {
     this._body = {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
@@ -1,5 +1,5 @@
 import type { ObjectWithDateParts, YesOrNo, TaskListErrors } from '@approved-premises/ui'
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import TasklistPage from '../../../tasklistPage'
 import { retrieveQuestionResponseFromApplication, convertToTitleCase } from '../../../../utils/utils'
@@ -17,7 +17,7 @@ type PlacementDateBody = ObjectWithDateParts<'startDate'> & {
 export default class PlacementDate implements TasklistPage {
   title: string
 
-  constructor(private _body: Partial<PlacementDateBody>, application: Application) {
+  constructor(private _body: Partial<PlacementDateBody>, application: ApprovedPremisesApplication) {
     const formattedReleaseDate = DateFormats.isoDateToUIDate(
       retrieveQuestionResponseFromApplication(application, 'basic-information', 'releaseDate'),
     )

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors } from '@approved-premises/ui'
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
@@ -26,7 +26,7 @@ export default class PlacementPurpose implements TasklistPage {
 
   constructor(
     private _body: PlacementPurposeBody,
-    private readonly _application: Application,
+    private readonly _application: ApprovedPremisesApplication,
     private readonly previousPage: string,
   ) {
     this._body.placementPurposes = _body?.placementPurposes

--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.ts
@@ -1,5 +1,5 @@
 import type { ObjectWithDateParts, YesOrNo, TaskListErrors } from '@approved-premises/ui'
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
@@ -19,7 +19,7 @@ export default class ReleaseDate implements TasklistPage {
 
   constructor(
     private _body: Partial<ReleaseDateType>,
-    readonly application: Application,
+    readonly application: ApprovedPremisesApplication,
     readonly previousPage: string,
   ) {}
 

--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseType.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseType.ts
@@ -1,4 +1,4 @@
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import type { TaskListErrors } from '@approved-premises/ui'
 
 import { SessionDataError } from '../../../../utils/errors'
@@ -28,7 +28,7 @@ export default class ReleaseType implements TasklistPage {
 
   constructor(
     readonly body: { releaseType?: keyof AllReleaseTypes | keyof ReducedReleaseTypes },
-    readonly application: Application,
+    readonly application: ApprovedPremisesApplication,
   ) {
     const sessionSentenceType = retrieveQuestionResponseFromApplication<SentenceType>(
       application,

--- a/server/form-pages/apply/reasons-for-placement/basic-information/situation.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/situation.ts
@@ -1,4 +1,4 @@
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import type { TaskListErrors } from '@approved-premises/ui'
 import { Page } from '../../../utils/decorators'
 
@@ -26,7 +26,7 @@ export default class Situation implements TasklistPage {
 
   constructor(
     readonly body: { situation?: keyof CommunityOrderSituations | keyof BailPlacementSituations },
-    readonly application: Application,
+    readonly application: ApprovedPremisesApplication,
   ) {
     const sessionSentenceType = retrieveQuestionResponseFromApplication<SentenceType>(
       application,

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/apType.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/apType.ts
@@ -1,4 +1,4 @@
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import type { TaskListErrors } from '@approved-premises/ui'
 
 import TasklistPage from '../../../tasklistPage'
@@ -17,7 +17,7 @@ type ApTypes = typeof apTypes
 export default class ApType implements TasklistPage {
   title = `Which type of AP does ${this.application.person.name} require?`
 
-  constructor(public body: { type?: keyof ApTypes }, private readonly application: Application) {}
+  constructor(public body: { type?: keyof ApTypes }, private readonly application: ApprovedPremisesApplication) {}
 
   previous() {
     return ''

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementCCTV.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementCCTV.ts
@@ -1,5 +1,5 @@
 import type { YesOrNo, TaskListErrors } from '@approved-premises/ui'
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
@@ -40,7 +40,7 @@ export default class EsapPlacementCCTV implements TasklistPage {
       cctvIntelligenceDetails: string
       cctvNotes: string
     }>,
-    private readonly application: Application,
+    private readonly application: ApprovedPremisesApplication,
   ) {}
 
   previous() {

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementScreening.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementScreening.ts
@@ -1,4 +1,4 @@
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import type { TaskListErrors } from '@approved-premises/ui'
 
 import TasklistPage from '../../../tasklistPage'
@@ -38,7 +38,7 @@ export default class EsapPlacementScreening implements TasklistPage {
 
   constructor(
     public body: Partial<{ esapReasons: Array<keyof EsapReasons>; esapFactors: Array<keyof EsapFactors> }>,
-    private readonly application: Application,
+    private readonly application: ApprovedPremisesApplication,
   ) {}
 
   previous() {

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementSecreting.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementSecreting.ts
@@ -1,4 +1,4 @@
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import type { YesOrNo, TaskListErrors } from '@approved-premises/ui'
 
 import { Page } from '../../../utils/decorators'
@@ -41,7 +41,7 @@ export default class EsapPlacementSecreting implements TasklistPage {
       secretingIntelligenceDetails: string
       secretingNotes: string
     }>,
-    private readonly application: Application,
+    private readonly application: ApprovedPremisesApplication,
   ) {}
 
   previous() {

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/pipeOpdScreening.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/pipeOpdScreening.ts
@@ -1,5 +1,5 @@
 import type { YesOrNo, TaskListErrors } from '@approved-premises/ui'
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import { Page } from '../../../utils/decorators'
 import TasklistPage from '../../../tasklistPage'
@@ -16,7 +16,7 @@ export default class PipeOpdReferral implements TasklistPage {
 
   constructor(
     public body: Partial<{ pipeReferral: YesOrNo; pipeReferralMoreDetail: string }>,
-    private readonly application: Application,
+    private readonly application: ApprovedPremisesApplication,
   ) {}
 
   next() {

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/pipeReferral.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/pipeReferral.ts
@@ -1,5 +1,5 @@
 import type { YesOrNo, ObjectWithDateParts, TaskListErrors } from '@approved-premises/ui'
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
@@ -22,7 +22,7 @@ export default class PipeReferral implements TasklistPage {
     opdPathwayDate: `When was ${this.application.person.name}'s last consultation or formulation?`,
   }
 
-  constructor(private _body: Partial<PipeReferralBody>, private readonly application: Application) {}
+  constructor(private _body: Partial<PipeReferralBody>, private readonly application: ApprovedPremisesApplication) {}
 
   public set body(value: Partial<PipeReferralBody>) {
     this._body = {

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeeds.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeeds.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors, YesNoOrIDK, YesOrNo } from '@approved-premises/ui'
-import { Application } from '../../../../@types/shared'
+import { ApprovedPremisesApplication } from '../../../../@types/shared'
 import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
 import { pascalCase, sentenceCase } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
@@ -57,7 +57,7 @@ export default class AccessNeeds implements TasklistPage {
     careActAssessmentCompleted: 'Has a care act assessment been completed?',
   }
 
-  constructor(public body: Partial<AccessNeedsBody>, private readonly application: Application) {}
+  constructor(public body: Partial<AccessNeedsBody>, private readonly application: ApprovedPremisesApplication) {}
 
   previous() {
     return ''

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsAdditionalAdjustments.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsAdditionalAdjustments.test.ts
@@ -4,11 +4,11 @@ import AccessNeedsAdditionalAdjustments from './accessNeedsAdditionalAdjustments
 
 import applicationFactory from '../../../../testutils/factories/application'
 import personFactory from '../../../../testutils/factories/person'
-import { Application, Person } from '../../../../@types/shared'
+import { ApprovedPremisesApplication, Person } from '../../../../@types/shared'
 import { SessionDataError } from '../../../../utils/errors'
 
 describe('AccessNeedsAdditionalAdjustments', () => {
-  let application: Application
+  let application: ApprovedPremisesApplication
   let person: Person
   const previousPage = 'previousPage'
 

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsAdditionalAdjustments.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsAdditionalAdjustments.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors, YesOrNoWithDetail } from '@approved-premises/ui'
-import { Application } from '../../../../@types/shared'
+import { ApprovedPremisesApplication } from '../../../../@types/shared'
 import { SessionDataError } from '../../../../utils/errors'
 import { lowerCase } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
@@ -19,7 +19,7 @@ export default class AccessNeedsAdditionalAdjustments implements TasklistPage {
 
   constructor(
     body: Partial<YesOrNoWithDetail<'adjustments'>>,
-    private readonly application: Application,
+    private readonly application: ApprovedPremisesApplication,
     private readonly previousPage: string,
   ) {}
 

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsMobility.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsMobility.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
-import { Application } from '../../../../@types/shared'
+import { ApprovedPremisesApplication } from '../../../../@types/shared'
 import { sentenceCase } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
 
@@ -21,7 +21,10 @@ export default class AccessNeedsMobility implements TasklistPage {
     visualImpairment: 'Visual Impairment',
   }
 
-  constructor(public body: Partial<AccessNeedsMobilityBody>, private readonly application: Application) {}
+  constructor(
+    public body: Partial<AccessNeedsMobilityBody>,
+    private readonly application: ApprovedPremisesApplication,
+  ) {}
 
   previous() {
     return 'access-needs'

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/covid.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/covid.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors, YesNoOrIDK } from '@approved-premises/ui'
-import { Application } from '../../../../@types/shared'
+import { ApprovedPremisesApplication } from '../../../../@types/shared'
 import { sentenceCase } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
 
@@ -31,7 +31,7 @@ export default class Covid implements TasklistPage {
 
   constructor(
     public body: Partial<CovidBody>,
-    private readonly application: Application,
+    private readonly application: ApprovedPremisesApplication,
     private readonly previousPage: string,
   ) {}
 

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/arson.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/arson.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors, YesOrNoWithDetail } from '@approved-premises/ui'
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
@@ -36,7 +36,10 @@ export default class Arson implements TasklistPage {
     },
   }
 
-  constructor(public body: Partial<YesOrNoWithDetail<'arson'>>, private readonly application: Application) {}
+  constructor(
+    public body: Partial<YesOrNoWithDetail<'arson'>>,
+    private readonly application: ApprovedPremisesApplication,
+  ) {}
 
   previous() {
     return 'catering'

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/catering.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/catering.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors, YesOrNoWithDetail } from '@approved-premises/ui'
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
@@ -20,7 +20,10 @@ export default class Catering implements TasklistPage {
     catering: `Do you have any concerns about ${this.application.person.name} ${this.questionPredicates.catering}?`,
   }
 
-  constructor(public body: Partial<YesOrNoWithDetail<'catering'>>, private readonly application: Application) {}
+  constructor(
+    public body: Partial<YesOrNoWithDetail<'catering'>>,
+    private readonly application: ApprovedPremisesApplication,
+  ) {}
 
   previous() {
     return 'complex-case-board'

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/complexCaseBoard.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/complexCaseBoard.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors, YesOrNoWithDetail } from '@approved-premises/ui'
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
@@ -21,7 +21,10 @@ export default class ComplexCaseBoard implements TasklistPage {
     complexCaseBoard: `Does ${this.application.person.name}'s ${this.questionPredicates.complexCaseBoard}?`,
   }
 
-  constructor(public body: Partial<YesOrNoWithDetail<'complexCaseBoard'>>, private readonly application: Application) {}
+  constructor(
+    public body: Partial<YesOrNoWithDetail<'complexCaseBoard'>>,
+    private readonly application: ApprovedPremisesApplication,
+  ) {}
 
   previous() {
     return 'previous-placements'

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/previousPlacements.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/previousPlacements.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors, YesNoOrIDKWithDetail } from '@approved-premises/ui'
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
@@ -29,7 +29,7 @@ export default class PreviousPlacements implements TasklistPage {
 
   constructor(
     public body: Partial<YesNoOrIDKWithDetail<'previousPlacement'>>,
-    private readonly application: Application,
+    private readonly application: ApprovedPremisesApplication,
   ) {}
 
   previous() {

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/vulnerability.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/vulnerability.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors, YesOrNoWithDetail } from '@approved-premises/ui'
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
@@ -35,7 +35,7 @@ export default class Vulnerability implements TasklistPage {
     exploitOthers: `Is there ${this.questionPredicates.exploitOthers}?`,
   }
 
-  constructor(public body: Partial<VulnerabilityDetail>, private readonly application: Application) {}
+  constructor(public body: Partial<VulnerabilityDetail>, private readonly application: ApprovedPremisesApplication) {}
 
   previous() {
     return 'room-sharing'

--- a/server/form-pages/apply/risk-and-need-factors/location-factors/pduTransfer.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/pduTransfer.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors } from '@approved-premises/ui'
-import { Application } from '../../../../@types/shared'
+import { ApprovedPremisesApplication } from '../../../../@types/shared'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
@@ -20,7 +20,7 @@ export default class PduTransfer implements TasklistPage {
 
   constructor(
     public body: { transferStatus?: Response; probationPractitioner?: string },
-    private readonly application: Application,
+    private readonly application: ApprovedPremisesApplication,
   ) {}
 
   previous() {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
@@ -2,7 +2,7 @@ import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
 import { flattenCheckboxInput, isStringOrArrayOfStrings } from '../../../../utils/formUtils'
-import { Application, OASysSection } from '../../../../@types/shared'
+import { ApprovedPremisesApplication, OASysSection } from '../../../../@types/shared'
 import { DataServices } from '../../../../@types/ui'
 import { sentenceCase } from '../../../../utils/utils'
 
@@ -35,7 +35,7 @@ export default class OptionalOasysSections implements TasklistPage {
 
   static async initialize(
     body: Partial<Response>,
-    application: Application,
+    application: ApprovedPremisesApplication,
     token: string,
     dataServices: DataServices,
   ) {

--- a/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
+++ b/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
@@ -1,6 +1,6 @@
 import type { DataServices } from '@approved-premises/ui'
 
-import type { Application, PrisonCaseNote, Adjudication } from '@approved-premises/api'
+import type { ApprovedPremisesApplication, PrisonCaseNote, Adjudication } from '@approved-premises/api'
 
 import { sentenceCase } from '../../../../utils/utils'
 import TasklistPage from '../../../tasklistPage'
@@ -64,7 +64,7 @@ export default class CaseNotes implements TasklistPage {
 
   caseNotes: Array<PrisonCaseNote> | undefined
 
-  constructor(private _body: Partial<CaseNotesBody>, private readonly application: Application) {}
+  constructor(private _body: Partial<CaseNotesBody>, private readonly application: ApprovedPremisesApplication) {}
 
   public get body(): CaseNotesBody {
     return this._body as CaseNotesBody
@@ -84,7 +84,7 @@ export default class CaseNotes implements TasklistPage {
 
   static async initialize(
     body: Record<string, unknown>,
-    application: Application,
+    application: ApprovedPremisesApplication,
     token: string,
     dataServices: DataServices,
   ) {

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/convictedOffences.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/convictedOffences.ts
@@ -1,6 +1,6 @@
 import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
 import { Page } from '../../../utils/decorators'
-import { Application } from '../../../../@types/shared'
+import { ApprovedPremisesApplication } from '../../../../@types/shared'
 import { convertKeyValuePairToRadioItems } from '../../../../utils/formUtils'
 import { lowerCase, sentenceCase } from '../../../../utils/utils'
 
@@ -19,7 +19,7 @@ export default class ConvictedOffences implements TasklistPage {
 
   offences = ['Arson offences', 'Sexual offences', 'Hate crimes', 'Non-sexual offences against children']
 
-  constructor(public body: { response?: YesOrNo }, private readonly application: Application) {}
+  constructor(public body: { response?: YesOrNo }, private readonly application: ApprovedPremisesApplication) {}
 
   previous() {
     return 'risk-management-features'

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors } from '@approved-premises/ui'
-import { Application } from '../../../../@types/shared'
+import { ApprovedPremisesApplication } from '../../../../@types/shared'
 import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
 import { Page } from '../../../utils/decorators'
 
@@ -29,7 +29,7 @@ export default class RehabilitativeInterventions implements TasklistPage {
 
   constructor(
     private _body: RawRehabilitativeInterventionsBody,
-    private readonly _application: Application,
+    private readonly _application: ApprovedPremisesApplication,
     private readonly previousPage: string,
   ) {}
 

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/riskManagementFeatures.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/riskManagementFeatures.ts
@@ -1,4 +1,4 @@
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import type { TaskListErrors } from '@approved-premises/ui'
 
 import TasklistPage from '../../../tasklistPage'
@@ -16,7 +16,7 @@ export default class RiskManagementFeatures implements TasklistPage {
 
   constructor(
     public body: { manageRiskDetails?: string; additionalFeaturesDetails?: string },
-    private readonly application: Application,
+    private readonly application: ApprovedPremisesApplication,
   ) {}
 
   previous() {

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/typeOfConvictedOffence.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/typeOfConvictedOffence.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors } from '@approved-premises/ui'
-import { Application } from '../../../../@types/shared'
+import { ApprovedPremisesApplication } from '../../../../@types/shared'
 import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
 
 import TasklistPage from '../../../tasklistPage'
@@ -22,7 +22,10 @@ type RawTypeOfConvictedOffenceBody = { offenceConvictions?: RawOffences }
 export default class TypeOfConvictedOffence implements TasklistPage {
   title = `What type of offending has ${this.application.person.name} been convicted of?`
 
-  constructor(private _body: RawTypeOfConvictedOffenceBody, private readonly application: Application) {}
+  constructor(
+    private _body: RawTypeOfConvictedOffenceBody,
+    private readonly application: ApprovedPremisesApplication,
+  ) {}
 
   public get body(): TypeOfConvictedOffenceBody {
     return this._body as TypeOfConvictedOffenceBody

--- a/server/form-pages/tasklistPage.ts
+++ b/server/form-pages/tasklistPage.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors, DataServices } from '@approved-premises/ui'
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 export default abstract class TasklistPage {
   abstract title: string
@@ -14,5 +14,9 @@ export default abstract class TasklistPage {
 
   abstract response(): Record<string, unknown>
 
-  static async initialize?(application: Application, token: string, dataServices: DataServices): Promise<TasklistPage>
+  static async initialize?(
+    application: ApprovedPremisesApplication,
+    token: string,
+    dataServices: DataServices,
+  ): Promise<TasklistPage>
 }

--- a/server/form-pages/utils/decorators/page.decorator.test.ts
+++ b/server/form-pages/utils/decorators/page.decorator.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 import Page from './page.decorator'
 import applicationFactory from '../../../testutils/factories/application'
 
@@ -39,7 +39,7 @@ describe('tasklistPageDecorator', () => {
       name: 'Some Name',
     })
     class ClassWithApplication {
-      constructor(readonly body: Record<string, unknown>, readonly application: Application) {}
+      constructor(readonly body: Record<string, unknown>, readonly application: ApprovedPremisesApplication) {}
     }
 
     @Page({
@@ -49,7 +49,7 @@ describe('tasklistPageDecorator', () => {
     class ClassWithApplicationAndPreviousPage {
       constructor(
         readonly body: Record<string, unknown>,
-        readonly application: Application,
+        readonly application: ApprovedPremisesApplication,
         readonly previousPage: string,
       ) {}
     }

--- a/server/form-pages/utils/decorators/page.decorator.ts
+++ b/server/form-pages/utils/decorators/page.decorator.ts
@@ -1,4 +1,4 @@
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 import 'reflect-metadata'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
@@ -11,7 +11,7 @@ const Page = (options: { bodyProperties: Array<string>; name: string }) => {
 
       body: Record<string, unknown>
 
-      application: Application
+      application: ApprovedPremisesApplication
 
       previousPage: string
 

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -4,19 +4,14 @@ import type { TaskListErrors, DataServices } from '@approved-premises/ui'
 
 import type TasklistPage from '../form-pages/tasklistPage'
 import { ValidationError } from '../utils/errors'
+import { getPage } from '../utils/applicationUtils'
 import ApplicationService from './applicationService'
 import ApplicationClient from '../data/applicationClient'
-import PersonClient from '../data/personClient'
 
 import Apply from '../form-pages/apply'
-import paths from '../paths/apply'
 import applicationFactory from '../testutils/factories/application'
 import activeOffenceFactory from '../testutils/factories/activeOffence'
 import documentFactory from '../testutils/factories/document'
-import { DateFormats } from '../utils/dateUtils'
-import { getArrivalDate, getPage } from '../utils/applicationUtils'
-import { tierEnvelopeFactory } from '../testutils/factories/risks'
-import { PersonRisks } from '../@types/shared'
 
 const FirstPage = jest.fn()
 const SecondPage = jest.fn()
@@ -39,15 +34,12 @@ jest.mock('../utils/applicationUtils')
 describe('ApplicationService', () => {
   const applicationClient = new ApplicationClient(null) as jest.Mocked<ApplicationClient>
   const applicationClientFactory = jest.fn()
-  const personClient = new PersonClient(null) as jest.Mocked<PersonClient>
-  const personClientFactory = jest.fn()
 
-  const service = new ApplicationService(applicationClientFactory, personClientFactory)
+  const service = new ApplicationService(applicationClientFactory)
 
   beforeEach(() => {
     jest.resetAllMocks()
     applicationClientFactory.mockReturnValue(applicationClient)
-    personClientFactory.mockReturnValue(personClient)
   })
 
   describe('getAllForLoggedInUser', () => {
@@ -63,71 +55,6 @@ describe('ApplicationService', () => {
 
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
       expect(applicationClient.all).toHaveBeenCalled()
-    })
-  })
-
-  describe('dashboardTableRows', () => {
-    it('calls the all method on the client and returns the data in the correct format for the table in the view', async () => {
-      const arrivalDate = DateFormats.dateObjToIsoDate(new Date(2021, 0, 3))
-      const applicationA = applicationFactory.withReleaseDate(arrivalDate).build({
-        person: { name: 'A' },
-      })
-      const tierA = tierEnvelopeFactory.build({ value: { level: 'A1' } })
-      const applicationB = applicationFactory.withReleaseDate(arrivalDate).build({
-        person: { name: 'A' },
-      })
-      const tierB = tierEnvelopeFactory.build({ value: null })
-      const token = 'SOME_TOKEN'
-
-      applicationClient.all.mockResolvedValue([applicationA, applicationB])
-      personClient.risks.mockResolvedValueOnce({ tier: tierA } as PersonRisks)
-      personClient.risks.mockResolvedValueOnce({ tier: tierB } as PersonRisks)
-      ;(getArrivalDate as jest.Mock).mockReturnValue(arrivalDate)
-
-      const result = await service.dashboardTableRows(token)
-
-      expect(result).toEqual([
-        [
-          {
-            html: `<a href=${paths.applications.show({ id: applicationA.id })}>${applicationA.person.name}</a>`,
-          },
-          {
-            text: applicationA.person.crn,
-          },
-          {
-            html: `<span class="moj-badge moj-badge--red">${tierA.value.level}</span>`,
-          },
-          {
-            text: DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' }),
-          },
-          {
-            text: DateFormats.isoDateToUIDate(applicationA.submittedAt, { format: 'short' }),
-          },
-        ],
-        [
-          {
-            html: `<a href=${paths.applications.show({ id: applicationB.id })}>${applicationB.person.name}</a>`,
-          },
-          {
-            text: applicationB.person.crn,
-          },
-          {
-            html: '',
-          },
-          {
-            text: DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' }),
-          },
-          {
-            text: DateFormats.isoDateToUIDate(applicationB.submittedAt, { format: 'short' }),
-          },
-        ],
-      ])
-
-      expect(applicationClientFactory).toHaveBeenCalledWith(token)
-      expect(applicationClient.all).toHaveBeenCalled()
-      expect(personClientFactory).toHaveBeenCalledWith(token)
-      expect(personClient.risks).toHaveBeenCalledWith(applicationA.person.crn)
-      expect(personClient.risks).toHaveBeenCalledWith(applicationB.person.crn)
     })
   })
 

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -50,6 +50,22 @@ describe('ApplicationService', () => {
     personClientFactory.mockReturnValue(personClient)
   })
 
+  describe('getAllForLoggedInUser', () => {
+    it('fetches all applications', async () => {
+      const token = 'SOME_TOKEN'
+
+      const applications = applicationFactory.buildList(5)
+      applicationClient.all.mockResolvedValue(applications)
+
+      const result = await service.getAllForLoggedInUser(token)
+
+      expect(result).toEqual(applications)
+
+      expect(applicationClientFactory).toHaveBeenCalledWith(token)
+      expect(applicationClient.all).toHaveBeenCalled()
+    })
+  })
+
   describe('dashboardTableRows', () => {
     it('calls the all method on the client and returns the data in the correct format for the table in the view', async () => {
       const arrivalDate = DateFormats.dateObjToIsoDate(new Date(2021, 0, 3))

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -38,6 +38,12 @@ export default class ApplicationService {
     return application
   }
 
+  async getAllForLoggedInUser(token: string): Promise<Array<ApprovedPremisesApplication>> {
+    const applicationClient = this.applicationClientFactory(token)
+
+    return applicationClient.all()
+  }
+
   async getDocuments(token: string, application: ApprovedPremisesApplication): Promise<Array<Document>> {
     const applicationClient = this.applicationClientFactory(token)
 

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -1,6 +1,6 @@
 import type { Request } from 'express'
 import type { HtmlItem, TextItem, DataServices } from '@approved-premises/ui'
-import type { ActiveOffence, Application, Document } from '@approved-premises/api'
+import type { ActiveOffence, ApprovedPremisesApplication, Document } from '@approved-premises/api'
 
 import type TasklistPage from '../form-pages/tasklistPage'
 import type { RestClientBuilder, ApplicationClient, PersonClient } from '../data'
@@ -18,7 +18,11 @@ export default class ApplicationService {
     private readonly personClientFactory: RestClientBuilder<PersonClient>,
   ) {}
 
-  async createApplication(token: string, crn: string, activeOffence: ActiveOffence): Promise<Application> {
+  async createApplication(
+    token: string,
+    crn: string,
+    activeOffence: ActiveOffence,
+  ): Promise<ApprovedPremisesApplication> {
     const applicationClient = this.applicationClientFactory(token)
 
     const application = await applicationClient.create(crn, activeOffence)
@@ -26,7 +30,7 @@ export default class ApplicationService {
     return application
   }
 
-  async findApplication(token: string, id: string): Promise<Application> {
+  async findApplication(token: string, id: string): Promise<ApprovedPremisesApplication> {
     const applicationClient = this.applicationClientFactory(token)
 
     const application = await applicationClient.find(id)
@@ -34,7 +38,7 @@ export default class ApplicationService {
     return application
   }
 
-  async getDocuments(token: string, application: Application): Promise<Array<Document>> {
+  async getDocuments(token: string, application: ApprovedPremisesApplication): Promise<Array<Document>> {
     const applicationClient = this.applicationClientFactory(token)
 
     const documents = await applicationClient.documents(application)
@@ -82,7 +86,7 @@ export default class ApplicationService {
     }
   }
 
-  async submit(token: string, application: Application) {
+  async submit(token: string, application: ApprovedPremisesApplication) {
     const client = this.applicationClientFactory(token)
 
     await client.submit(application)
@@ -92,7 +96,9 @@ export default class ApplicationService {
     return Object.keys(Apply.pages[taskName])[0]
   }
 
-  private getApplicationFromSessionOrAPI(request: Request): Promise<Application> | Application {
+  private getApplicationFromSessionOrAPI(
+    request: Request,
+  ): Promise<ApprovedPremisesApplication> | ApprovedPremisesApplication {
     const { application } = request.session
 
     if (application && application.id === request.params.id) {
@@ -101,18 +107,18 @@ export default class ApplicationService {
     return this.findApplication(request.user.token, request.params.id)
   }
 
-  private async saveToSession(application: Application, page: TasklistPage, request: Request) {
+  private async saveToSession(application: ApprovedPremisesApplication, page: TasklistPage, request: Request) {
     request.session.application = application
     request.session.previousPage = request.params.page
   }
 
-  private async saveToApi(application: Application, request: Request) {
+  private async saveToApi(application: ApprovedPremisesApplication, request: Request) {
     const client = this.applicationClientFactory(request.user.token)
 
     await client.update(application)
   }
 
-  private getBody(application: Application, request: Request, userInput: Record<string, unknown>) {
+  private getBody(application: ApprovedPremisesApplication, request: Request, userInput: Record<string, unknown>) {
     if (userInput && Object.keys(userInput).length) {
       return userInput
     }
@@ -122,7 +128,7 @@ export default class ApplicationService {
     return this.getPageDataFromApplication(application, request)
   }
 
-  private getPageDataFromApplication(application: Application, request: Request) {
+  private getPageDataFromApplication(application: ApprovedPremisesApplication, request: Request) {
     return application.data?.[request.params.task]?.[request.params.page] || {}
   }
 

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -35,7 +35,7 @@ export const services = () => {
   const departureService = new DepartureService(bookingClientBuilder, referenceDataClientBuilder)
   const cancellationService = new CancellationService(bookingClientBuilder, referenceDataClientBuilder)
   const lostBedService = new LostBedService(lostBedClientBuilder, referenceDataClientBuilder)
-  const applicationService = new ApplicationService(applicationClientBuilder, personClient)
+  const applicationService = new ApplicationService(applicationClientBuilder)
   const assessmentService = new AssessmentService(assessmentClientBuilder, personClient)
 
   return {

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -1,12 +1,13 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
 
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import personFactory from './person'
+import risksFactory from './risks'
 import { DateFormats } from '../../utils/dateUtils'
 
-class ApplicationFactory extends Factory<Application> {
+class ApplicationFactory extends Factory<ApprovedPremisesApplication> {
   withReleaseDate(releaseDate = DateFormats.dateObjToIsoDate(faker.date.soon())) {
     return this.params({
       data: {
@@ -32,4 +33,5 @@ export default ApplicationFactory.define(() => ({
   outdatedSchema: faker.datatype.boolean(),
   isWomensApplication: faker.datatype.boolean(),
   isPipeApplication: faker.datatype.boolean(),
+  risks: risksFactory.build(),
 }))

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -203,7 +203,7 @@ describe('applicationUtils', () => {
       expect(getArrivalDate(application)).toEqual('2023-10-13')
     })
 
-    it('returns an empty string when the release date is not known', () => {
+    it('throws an error or returns null when the release date is not known', () => {
       const application = applicationFactory.build({
         data: {
           'basic-information': {
@@ -213,6 +213,7 @@ describe('applicationUtils', () => {
       })
 
       expect(() => getArrivalDate(application)).toThrow(new SessionDataError('No known release date'))
+      expect(getArrivalDate(application, false)).toEqual(null)
     })
   })
 
@@ -220,8 +221,10 @@ describe('applicationUtils', () => {
     it('returns an array of applications as table rows', async () => {
       const arrivalDate = DateFormats.dateObjToIsoDate(new Date(2021, 0, 3))
 
-      const applicationA = applicationFactory.withReleaseDate(arrivalDate).build({
+      const applicationA = applicationFactory.build({
         person: { name: 'A' },
+        data: {},
+        submittedAt: null,
         risks: { tier: tierEnvelopeFactory.build({ value: { level: 'A1' } }) },
       })
       const applicationB = applicationFactory.withReleaseDate(arrivalDate).build({
@@ -243,10 +246,10 @@ describe('applicationUtils', () => {
             html: tierBadge('A1'),
           },
           {
-            text: DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' }),
+            text: 'N/A',
           },
           {
-            text: DateFormats.isoDateToUIDate(applicationA.submittedAt, { format: 'short' }),
+            text: 'N/A',
           },
         ],
         [

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -1,8 +1,11 @@
 import type { Task } from '@approved-premises/ui'
 
 import applicationFactory from '../testutils/factories/application'
+import { tierEnvelopeFactory } from '../testutils/factories/risks'
 import paths from '../paths/apply'
 import Apply from '../form-pages/apply'
+import { DateFormats } from './dateUtils'
+import { tierBadge } from './personUtils'
 
 import {
   taskLink,
@@ -11,6 +14,7 @@ import {
   getResponses,
   getPage,
   getArrivalDate,
+  dashboardTableRows,
 } from './applicationUtils'
 import { SessionDataError, UnknownPageError } from './errors'
 
@@ -209,6 +213,60 @@ describe('applicationUtils', () => {
       })
 
       expect(() => getArrivalDate(application)).toThrow(new SessionDataError('No known release date'))
+    })
+  })
+
+  describe('dashboardTableRows', () => {
+    it('returns an array of applications as table rows', async () => {
+      const arrivalDate = DateFormats.dateObjToIsoDate(new Date(2021, 0, 3))
+
+      const applicationA = applicationFactory.withReleaseDate(arrivalDate).build({
+        person: { name: 'A' },
+        risks: { tier: tierEnvelopeFactory.build({ value: { level: 'A1' } }) },
+      })
+      const applicationB = applicationFactory.withReleaseDate(arrivalDate).build({
+        person: { name: 'A' },
+        risks: { tier: tierEnvelopeFactory.build({ value: { level: null } }) },
+      })
+
+      const result = dashboardTableRows([applicationA, applicationB])
+
+      expect(result).toEqual([
+        [
+          {
+            html: `<a href=${paths.applications.show({ id: applicationA.id })}>${applicationA.person.name}</a>`,
+          },
+          {
+            text: applicationA.person.crn,
+          },
+          {
+            html: tierBadge('A1'),
+          },
+          {
+            text: DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' }),
+          },
+          {
+            text: DateFormats.isoDateToUIDate(applicationA.submittedAt, { format: 'short' }),
+          },
+        ],
+        [
+          {
+            html: `<a href=${paths.applications.show({ id: applicationB.id })}>${applicationB.person.name}</a>`,
+          },
+          {
+            text: applicationB.person.crn,
+          },
+          {
+            html: '',
+          },
+          {
+            text: DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' }),
+          },
+          {
+            text: DateFormats.isoDateToUIDate(applicationB.submittedAt, { format: 'short' }),
+          },
+        ],
+      ])
     })
   })
 })

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -1,13 +1,39 @@
-import type { Task, FormSections, FormSection } from '@approved-premises/ui'
+import type { Task, FormSections, FormSection, TableRow } from '@approved-premises/ui'
 import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import paths from '../paths/apply'
 import Apply from '../form-pages/apply'
 import { SessionDataError, UnknownPageError } from './errors'
+import { tierBadge } from './personUtils'
+import { DateFormats } from './dateUtils'
 
 type PageResponse = Record<string, string | Array<Record<string, unknown>>>
 type ApplicationResponse = Record<string, Array<PageResponse>>
 
 const taskIds = Object.keys(Apply.pages)
+
+const dashboardTableRows = (applications: Array<ApprovedPremisesApplication>): Array<TableRow> => {
+  return applications.map(application => {
+    return [
+      createNameAnchorElement(application.person.name, application.id),
+      textValue(application.person.crn),
+      htmlValue(tierBadge(application.risks.tier.value?.level || '')),
+      textValue(DateFormats.isoDateToUIDate(getArrivalDate(application), { format: 'short' })),
+      textValue(DateFormats.isoDateToUIDate(application.submittedAt, { format: 'short' })),
+    ]
+  })
+}
+
+const textValue = (value: string) => {
+  return { text: value }
+}
+
+const htmlValue = (value: string) => {
+  return { html: value }
+}
+
+const createNameAnchorElement = (name: string, applicationId: string) => {
+  return htmlValue(`<a href=${paths.applications.show({ id: applicationId })}>${name}</a>`)
+}
 
 const taskIsComplete = (task: Task, application: ApprovedPremisesApplication): boolean => {
   return application.data[task.id]
@@ -128,4 +154,13 @@ const getArrivalDate = (application: ApprovedPremisesApplication): string | null
   return null
 }
 
-export { getTaskStatus, taskLink, getCompleteSectionCount, getResponses, getResponseForPage, getPage, getArrivalDate }
+export {
+  getTaskStatus,
+  taskLink,
+  getCompleteSectionCount,
+  getResponses,
+  getResponseForPage,
+  getPage,
+  getArrivalDate,
+  dashboardTableRows,
+}

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -1,5 +1,5 @@
 import type { Task, FormSections, FormSection } from '@approved-premises/ui'
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import paths from '../paths/apply'
 import Apply from '../form-pages/apply'
 import { SessionDataError, UnknownPageError } from './errors'
@@ -9,16 +9,16 @@ type ApplicationResponse = Record<string, Array<PageResponse>>
 
 const taskIds = Object.keys(Apply.pages)
 
-const taskIsComplete = (task: Task, application: Application): boolean => {
+const taskIsComplete = (task: Task, application: ApprovedPremisesApplication): boolean => {
   return application.data[task.id]
 }
 
-const previousTaskIsComplete = (task: Task, application: Application): boolean => {
+const previousTaskIsComplete = (task: Task, application: ApprovedPremisesApplication): boolean => {
   const previousTaskId = taskIds[taskIds.indexOf(task.id) - 1]
   return previousTaskId ? application.data[previousTaskId] : true
 }
 
-const getTaskStatus = (task: Task, application: Application): string => {
+const getTaskStatus = (task: Task, application: ApprovedPremisesApplication): string => {
   if (!taskIsComplete(task, application) && !previousTaskIsComplete(task, application)) {
     return `<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="${task.id}-status">Cannot start yet</strong>`
   }
@@ -30,13 +30,13 @@ const getTaskStatus = (task: Task, application: Application): string => {
   return `<strong class="govuk-tag app-task-list__tag" id="${task.id}-status">Completed</strong>`
 }
 
-const getCompleteSectionCount = (sections: FormSections, application: Application): number => {
+const getCompleteSectionCount = (sections: FormSections, application: ApprovedPremisesApplication): number => {
   return sections.filter((section: FormSection) => {
     return section.tasks.filter((task: Task) => taskIsComplete(task, application)).length === section.tasks.length
   }).length
 }
 
-const taskLink = (task: Task, application: Application): string => {
+const taskLink = (task: Task, application: ApprovedPremisesApplication): string => {
   if (previousTaskIsComplete(task, application)) {
     const firstPage = Object.keys(task.pages)[0]
 
@@ -49,7 +49,7 @@ const taskLink = (task: Task, application: Application): string => {
   return task.title
 }
 
-const getResponses = (application: Application): ApplicationResponse => {
+const getResponses = (application: ApprovedPremisesApplication): ApplicationResponse => {
   const responses = {}
 
   Object.keys(application.data).forEach(taskName => {
@@ -59,13 +59,17 @@ const getResponses = (application: Application): ApplicationResponse => {
   return responses
 }
 
-const getResponsesForTask = (application: Application, taskName: string): Array<PageResponse> => {
+const getResponsesForTask = (application: ApprovedPremisesApplication, taskName: string): Array<PageResponse> => {
   const pageNames = Object.keys(application.data[taskName])
   const responsesForPages = pageNames.map(pageName => getResponseForPage(application, taskName, pageName))
   return responsesForPages
 }
 
-const getResponseForPage = (application: Application, taskName: string, pageName: string): PageResponse => {
+const getResponseForPage = (
+  application: ApprovedPremisesApplication,
+  taskName: string,
+  pageName: string,
+): PageResponse => {
   const Page = getPage(taskName, pageName)
 
   const body = application?.data?.[taskName]?.[pageName]
@@ -86,7 +90,7 @@ const getPage = (taskName: string, pageName: string) => {
   return Page
 }
 
-const getArrivalDate = (application: Application): string | null => {
+const getArrivalDate = (application: ApprovedPremisesApplication): string | null => {
   const basicInformation = application.data['basic-information']
 
   if (!basicInformation) throw new SessionDataError('No basic information')

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -1,7 +1,7 @@
 import { TableRow, AssessmentWithRisks } from '@approved-premises/ui'
 import { format, differenceInDays, add } from 'date-fns'
 
-import { Assessment } from '@approved-premises/api'
+import { Assessment, ApprovedPremisesApplication } from '@approved-premises/api'
 import { tierBadge } from './personUtils'
 import { DateFormats } from './dateUtils'
 import { getArrivalDate } from './applicationUtils'
@@ -106,7 +106,7 @@ const assessmentLink = (assessment: Assessment): string => {
 }
 
 const formattedArrivalDate = (assessment: Assessment): string => {
-  const arrivalDate = getArrivalDate(assessment.application)
+  const arrivalDate = getArrivalDate(assessment.application as ApprovedPremisesApplication)
   return format(DateFormats.isoToDateObj(arrivalDate), 'd MMM yyyy')
 }
 

--- a/server/utils/attachDocumentsUtils.ts
+++ b/server/utils/attachDocumentsUtils.ts
@@ -1,4 +1,4 @@
-import { Document, Application } from '@approved-premises/api'
+import { Document, ApprovedPremisesApplication } from '@approved-premises/api'
 import { ErrorMessages, TableRow } from '@approved-premises/ui'
 
 import { DateFormats } from './dateUtils'
@@ -7,7 +7,7 @@ import paths from '../paths/apply'
 const tableRows = (
   documents: Array<Document>,
   selectedDocuments: Array<Document>,
-  application: Application,
+  application: ApprovedPremisesApplication,
   errors: ErrorMessages,
 ): Array<TableRow> => {
   const rows = [] as Array<TableRow>

--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -1,12 +1,12 @@
 /* eslint-disable import/prefer-default-export */
-import { Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 import { HtmlItem, SummaryListItem, Task, TextItem } from '@approved-premises/ui'
 import Apply from '../form-pages/apply'
 import paths from '../paths/apply'
 
 import { getResponseForPage } from './applicationUtils'
 
-const checkYourAnswersSections = (application: Application) => {
+const checkYourAnswersSections = (application: ApprovedPremisesApplication) => {
   const nonCheckYourAnswersSections = Apply.sections.slice(0, -1)
 
   return nonCheckYourAnswersSections.map(section => {
@@ -22,7 +22,10 @@ const checkYourAnswersSections = (application: Application) => {
   })
 }
 
-const getTaskResponsesAsSummaryListItems = (task: Task, application: Application): Array<SummaryListItem> => {
+const getTaskResponsesAsSummaryListItems = (
+  task: Task,
+  application: ApprovedPremisesApplication,
+): Array<SummaryListItem> => {
   const items: Array<SummaryListItem> = []
 
   if (!application.data[task.id]) {
@@ -75,7 +78,7 @@ const summaryListItemForResponse = (
   value: TextItem | HtmlItem,
   task: Task,
   pageName: string,
-  application: Application,
+  application: ApprovedPremisesApplication,
 ) => {
   return {
     key: {

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -9,7 +9,7 @@ import type { ErrorMessages, PersonStatus, Task } from '@approved-premises/ui'
 import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import { initialiseName, removeBlankSummaryListItems, sentenceCase } from './utils'
 import { dateFieldValues, convertObjectsToRadioItems, convertObjectsToSelectOptions } from './formUtils'
-import { getTaskStatus, taskLink, getCompleteSectionCount } from './applicationUtils'
+import { getTaskStatus, taskLink, getCompleteSectionCount, dashboardTableRows } from './applicationUtils'
 import { checkYourAnswersSections } from './checkYourAnswersUtils'
 
 import { statusTag } from './personUtils'
@@ -126,6 +126,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addFilter('sentenceCase', sentenceCase)
 
   njkEnv.addGlobal('checkYourAnswersSections', checkYourAnswersSections)
+  njkEnv.addGlobal('dashboardTableRows', dashboardTableRows)
 
   njkEnv.addGlobal('AssessmentUtils', AssessmentUtils)
   njkEnv.addGlobal('OffenceUtils', OffenceUtils)

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -6,7 +6,7 @@ import express from 'express'
 import * as pathModule from 'path'
 
 import type { ErrorMessages, PersonStatus, Task } from '@approved-premises/ui'
-import type { Application } from '@approved-premises/api'
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import { initialiseName, removeBlankSummaryListItems, sentenceCase } from './utils'
 import { dateFieldValues, convertObjectsToRadioItems, convertObjectsToSelectOptions } from './formUtils'
 import { getTaskStatus, taskLink, getCompleteSectionCount } from './applicationUtils'
@@ -104,11 +104,13 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
 
   njkEnv.addGlobal('getCompleteSectionCount', getCompleteSectionCount)
 
-  njkEnv.addGlobal('getTaskStatus', (task: Task, application: Application) =>
+  njkEnv.addGlobal('getTaskStatus', (task: Task, application: ApprovedPremisesApplication) =>
     markAsSafe(getTaskStatus(task, application)),
   )
 
-  njkEnv.addGlobal('taskLink', (task: Task, application: Application) => markAsSafe(taskLink(task, application)))
+  njkEnv.addGlobal('taskLink', (task: Task, application: ApprovedPremisesApplication) =>
+    markAsSafe(taskLink(task, application)),
+  )
 
   njkEnv.addGlobal('statusTag', (status: PersonStatus) => markAsSafe(statusTag(status)))
 

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,7 +1,7 @@
 import Case from 'case'
 
 import type { SummaryListItem, PersonRisksUI } from '@approved-premises/ui'
-import type { Application, PersonRisks } from '@approved-premises/api'
+import type { ApprovedPremisesApplication, PersonRisks } from '@approved-premises/api'
 
 import { SessionDataError } from './errors'
 import { DateFormats } from './dateUtils'
@@ -75,7 +75,7 @@ export const lowerCase = (string: string) => Case.lower(string)
  * @returns the response for the given task/page/question.
  */
 export const retrieveQuestionResponseFromApplication = <T>(
-  application: Application,
+  application: ApprovedPremisesApplication,
   task: string,
   page: string,
   question?: string,

--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -22,7 +22,7 @@
                         label: "Applications",
                         id: "applications",
                         panel: {
-                            html:applicationsTable("Applications", applicationTableRows)
+                            html: applicationsTable("Applications", dashboardTableRows(applications))
                         }
                     },
                     {


### PR DESCRIPTION
Now Risks are a first class citizen of Applications, we can update the app to use the new application-specific Application, as well as use the first-class ratings object that we now get from the API. This makes listing applications much easier to do, so we're not having to make multiple API calls each time we list the applications.

I've also removed the `dashboardTableRows` fuction from the service and made this a view helper, as well as fixing the issues with the missing dates in the application dashboard.