### PR TITLE
(963) Use first class risk ratings in frontend for assessments

### DIFF
--- a/cypress_shared/pages/assess/listPage.ts
+++ b/cypress_shared/pages/assess/listPage.ts
@@ -1,4 +1,4 @@
-import type { ApprovedPremisesAssessment as Assessment, PersonRisks } from '@approved-premises/api'
+import type { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
 import { format } from 'date-fns'
 
 import Page from '../page'
@@ -23,7 +23,7 @@ export default class ListPage extends Page {
     return new ListPage(awaitingAssessments, assessmentsCloseToDueDate, completedAssesssments)
   }
 
-  shouldShowAwaitingAssessments(risks: Record<string, PersonRisks>): void {
+  shouldShowAwaitingAssessments(): void {
     const assessments = [this.awaitingAssessments, this.assessmentsCloseToDueDate].flat()
     assessments.forEach((item: Assessment) => {
       cy.contains(item.application.person.name)
@@ -31,7 +31,7 @@ export default class ListPage extends Page {
         .parent()
         .within(() => {
           cy.get('td').eq(0).contains(item.application.person.crn)
-          cy.get('td').eq(1).contains(risks[item.application.person.crn].tier.value.level)
+          cy.get('td').eq(1).contains(item.application.risks.tier.value.level)
           cy.get('td')
             .eq(2)
             .contains(
@@ -66,7 +66,7 @@ export default class ListPage extends Page {
     })
   }
 
-  shouldShowCompletedAssessments(risks: Record<string, PersonRisks>): void {
+  shouldShowCompletedAssessments(): void {
     this.completedAssesssments.forEach((item: Assessment) => {
       cy.log(item.application.data['basic-information']['release-date'])
       cy.contains(item.application.person.name)
@@ -74,7 +74,7 @@ export default class ListPage extends Page {
         .parent()
         .within(() => {
           cy.get('td').eq(0).contains(item.application.person.crn)
-          cy.get('td').eq(1).contains(risks[item.application.person.crn].tier.value.level)
+          cy.get('td').eq(1).contains(item.application.risks.tier.value.level)
           cy.get('td')
             .eq(2)
             .contains(

--- a/integration_tests/tests/assess/assess.cy.ts
+++ b/integration_tests/tests/assess/assess.cy.ts
@@ -2,7 +2,6 @@ import { ListPage, TaskListPage } from '../../../cypress_shared/pages/assess'
 import Page from '../../../cypress_shared/pages/page'
 
 import assessmentFactory from '../../../server/testutils/factories/assessment'
-import risksFactory from '../../../server/testutils/factories/risks'
 
 context('Assess', () => {
   beforeEach(() => {
@@ -18,12 +17,8 @@ context('Assess', () => {
     // And there is an application awaiting assessment
     const assessment = assessmentFactory.build({ decision: undefined })
 
-    const { person } = assessment.application
-    const risks = risksFactory.build({ crn: person.crn })
-
     cy.task('stubAssessments', [assessment])
     cy.task('stubAssessment', assessment)
-    cy.task('stubPersonRisks', { person, risks })
 
     // When I visit the assessments dashboard
     const listPage = ListPage.visit([assessment])

--- a/integration_tests/tests/assess/listing.cy.ts
+++ b/integration_tests/tests/assess/listing.cy.ts
@@ -1,8 +1,6 @@
-import { PersonRisks } from '@approved-premises/api'
 import { ListPage } from '../../../cypress_shared/pages/assess'
 
 import assessmentFactory from '../../../server/testutils/factories/assessment'
-import risksFactory from '../../../server/testutils/factories/risks'
 
 context('Assess', () => {
   beforeEach(() => {
@@ -39,21 +37,11 @@ context('Assess', () => {
 
     cy.task('stubAssessments', assessments.flat())
 
-    const crnRisks: Record<string, PersonRisks> = {}
-
-    assessments.flat().forEach(assessment => {
-      const { person } = assessment.application
-      const risks = risksFactory.build({ crn: person.crn })
-      crnRisks[person.crn] = risks
-
-      cy.task('stubPersonRisks', { person, risks })
-    })
-
     // When I visit the assessments dashboard
     const listPage = ListPage.visit(assessmentsAwaiting, assessmentsCloseToDueDate, completedAssesssments)
 
     // Then I should see the assessments that are awaiting
-    listPage.shouldShowAwaitingAssessments(crnRisks)
+    listPage.shouldShowAwaitingAssessments()
 
     // And there should be a notification
     listPage.shouldShowNotification()
@@ -65,6 +53,6 @@ context('Assess', () => {
     listPage.clickCompleted()
 
     // Then I should see the completed assessments
-    listPage.shouldShowCompletedAssessments(crnRisks)
+    listPage.shouldShowCompletedAssessments()
   })
 })

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -4,7 +4,7 @@ import {
   FlagsEnvelope,
   Mappa,
   ApprovedPremisesApplication,
-  Assessment,
+  ApprovedPremisesAssessment as Assessment,
   Person,
   OASysSection,
   Document,
@@ -202,14 +202,10 @@ export type DataServices = Partial<{
   }
 }>
 
-export interface GroupedAssessmentWithRisks {
-  completed: Array<AssessmentWithRisks>
-  requestedFurtherInformation: Array<AssessmentWithRisks>
-  awaiting: Array<AssessmentWithRisks>
-}
-
-export interface AssessmentWithRisks extends Assessment {
-  application: ApprovedPremisesApplicationWithRisks
+export interface GroupedAssessments {
+  completed: Array<Assessment>
+  requestedFurtherInformation: Array<Assessment>
+  awaiting: Array<Assessment>
 }
 
 export interface ApplicationWithRisks extends Application {

--- a/server/controllers/assess/assessmentsController.test.ts
+++ b/server/controllers/assess/assessmentsController.test.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from 'express'
-import type { GroupedAssessmentWithRisks } from '@approved-premises/ui'
+import type { GroupedAssessments } from '@approved-premises/ui'
 
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 
@@ -26,7 +26,7 @@ describe('assessmentsController', () => {
 
   describe('index', () => {
     it('should list all the assessments for a user', async () => {
-      const assessments = { completed: [], requestedFurtherInformation: [], awaiting: [] } as GroupedAssessmentWithRisks
+      const assessments = { completed: [], requestedFurtherInformation: [], awaiting: [] } as GroupedAssessments
       assessmentService.getAllForLoggedInUser.mockResolvedValue(assessments)
       const requestHandler = assessmentsController.index()
 

--- a/server/services/assessmentService.test.ts
+++ b/server/services/assessmentService.test.ts
@@ -1,52 +1,36 @@
-import { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
-import { AssessmentClient, PersonClient } from '../data'
+import { AssessmentClient } from '../data'
 import AssessmentService from './assessmentService'
 
 import assessmentFactory from '../testutils/factories/assessment'
-import risksFactory from '../testutils/factories/risks'
 
 jest.mock('../data/assessmentClient.ts')
 jest.mock('../data/personClient.ts')
 
 describe('AssessmentService', () => {
   const assessmentClient = new AssessmentClient(null) as jest.Mocked<AssessmentClient>
-  const personClient = new PersonClient(null) as jest.Mocked<PersonClient>
 
   const assessmentClientFactory = jest.fn()
-  const personClientFactory = jest.fn()
 
-  const service = new AssessmentService(assessmentClientFactory, personClientFactory)
+  const service = new AssessmentService(assessmentClientFactory)
 
   beforeEach(() => {
     jest.resetAllMocks()
     assessmentClientFactory.mockReturnValue(assessmentClient)
-    personClientFactory.mockReturnValue(personClient)
   })
 
   it('gets all the assesments for the logged in user and groups them by status', async () => {
-    const risks = risksFactory.build()
     const acceptedAssessments = assessmentFactory.buildList(2, { decision: 'accepted' })
     const rejectedAssessments = assessmentFactory.buildList(3, { decision: 'rejected' })
     const awaitingAssessments = assessmentFactory.buildList(5, { decision: undefined })
 
     assessmentClient.all.mockResolvedValue([acceptedAssessments, rejectedAssessments, awaitingAssessments].flat())
-    personClient.risks.mockResolvedValue(risks)
 
     const result = await service.getAllForLoggedInUser('token')
 
-    const assessmentWithRisks = (assessments: Array<Assessment>) => {
-      return assessments.map(assessment => {
-        return {
-          ...assessment,
-          application: { ...assessment.application, person: { ...assessment.application.person, risks } },
-        }
-      })
-    }
-
     expect(result).toEqual({
-      completed: [assessmentWithRisks(acceptedAssessments), assessmentWithRisks(rejectedAssessments)].flat(),
+      completed: [acceptedAssessments, rejectedAssessments].flat(),
       requestedFurtherInformation: [],
-      awaiting: assessmentWithRisks(awaitingAssessments),
+      awaiting: awaitingAssessments,
     })
   })
 

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -36,7 +36,7 @@ export const services = () => {
   const cancellationService = new CancellationService(bookingClientBuilder, referenceDataClientBuilder)
   const lostBedService = new LostBedService(lostBedClientBuilder, referenceDataClientBuilder)
   const applicationService = new ApplicationService(applicationClientBuilder)
-  const assessmentService = new AssessmentService(assessmentClientBuilder, personClient)
+  const assessmentService = new AssessmentService(assessmentClientBuilder)
 
   return {
     userService,

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -1,4 +1,3 @@
-import { AssessmentWithRisks } from '@approved-premises/ui'
 import {
   daysSinceReceived,
   getStatus,
@@ -21,7 +20,6 @@ import * as personUtils from './personUtils'
 import * as applicationUtils from './applicationUtils'
 
 import assessmentFactory from '../testutils/factories/assessment'
-import risksFactory from '../testutils/factories/risks'
 import clarificationNoteFactory from '../testutils/factories/clarificationNote'
 
 jest.mock('./applicationUtils')
@@ -115,17 +113,12 @@ describe('assessmentUtils', () => {
   describe('awaitingAssessmentTableRows', () => {
     it('returns table rows for the assessments', () => {
       const assessment = assessmentFactory.build()
-      const risks = risksFactory.build()
-      const assessmentWithRisks = {
-        ...assessment,
-        application: { person: { ...assessment.application.person, risks } },
-      } as AssessmentWithRisks
 
       jest.spyOn(applicationUtils, 'getArrivalDate').mockReturnValue('2022-01-01')
 
       const tierBadgeSpy = jest.spyOn(personUtils, 'tierBadge').mockReturnValue('TIER_BADGE')
 
-      expect(awaitingAssessmentTableRows([assessmentWithRisks])).toEqual([
+      expect(awaitingAssessmentTableRows([assessment])).toEqual([
         [
           { html: assessmentLink(assessment) },
           { html: assessment.application.person.crn },
@@ -137,24 +130,19 @@ describe('assessmentUtils', () => {
         ],
       ])
 
-      expect(tierBadgeSpy).toHaveBeenCalledWith(risks.tier.value.level)
+      expect(tierBadgeSpy).toHaveBeenCalledWith(assessment.application.risks.tier.value.level)
     })
   })
 
   describe('requestedInformationTableRows', () => {
     it('returns table rows for the assessments', () => {
       const assessment = assessmentFactory.build({ clarificationNotes: clarificationNoteFactory.buildList(2) })
-      const risks = risksFactory.build()
-      const assessmentWithRisks = {
-        ...assessment,
-        application: { person: { ...assessment.application.person, risks } },
-      } as AssessmentWithRisks
 
       jest.spyOn(applicationUtils, 'getArrivalDate').mockReturnValue('2022-01-01')
 
       const tierBadgeSpy = jest.spyOn(personUtils, 'tierBadge').mockReturnValue('TIER_BADGE')
 
-      expect(requestedFurtherInformationTableRows([assessmentWithRisks])).toEqual([
+      expect(requestedFurtherInformationTableRows([assessment])).toEqual([
         [
           { html: assessmentLink(assessment) },
           { html: assessment.application.person.crn },
@@ -166,24 +154,19 @@ describe('assessmentUtils', () => {
         ],
       ])
 
-      expect(tierBadgeSpy).toHaveBeenCalledWith(risks.tier.value.level)
+      expect(tierBadgeSpy).toHaveBeenCalledWith(assessment.application.risks.tier.value.level)
     })
   })
 
   describe('completedTableRows', () => {
     it('returns table rows for the assessments', () => {
       const assessment = assessmentFactory.build()
-      const risks = risksFactory.build()
-      const assessmentWithRisks = {
-        ...assessment,
-        application: { person: { ...assessment.application.person, risks } },
-      } as AssessmentWithRisks
 
       jest.spyOn(applicationUtils, 'getArrivalDate').mockReturnValue('2022-01-01')
 
       const tierBadgeSpy = jest.spyOn(personUtils, 'tierBadge').mockReturnValue('TIER_BADGE')
 
-      expect(completedTableRows([assessmentWithRisks])).toEqual([
+      expect(completedTableRows([assessment])).toEqual([
         [
           { html: assessmentLink(assessment) },
           { html: assessment.application.person.crn },
@@ -193,7 +176,7 @@ describe('assessmentUtils', () => {
         ],
       ])
 
-      expect(tierBadgeSpy).toHaveBeenCalledWith(risks.tier.value.level)
+      expect(tierBadgeSpy).toHaveBeenCalledWith(assessment.application.risks.tier.value.level)
     })
   })
 

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -1,4 +1,4 @@
-import { TableRow, AssessmentWithRisks } from '@approved-premises/ui'
+import { TableRow } from '@approved-premises/ui'
 import { format, differenceInDays, add } from 'date-fns'
 
 import { ApprovedPremisesAssessment as Assessment, ApprovedPremisesApplication } from '@approved-premises/api'
@@ -9,7 +9,7 @@ import paths from '../paths/assess'
 
 const DUE_DATE_APPROACHING_DAYS_WINDOW = 3
 
-const awaitingAssessmentTableRows = (assessments: Array<AssessmentWithRisks>): Array<TableRow> => {
+const awaitingAssessmentTableRows = (assessments: Array<Assessment>): Array<TableRow> => {
   const rows = [] as Array<TableRow>
 
   assessments.forEach(assessment => {
@@ -21,7 +21,7 @@ const awaitingAssessmentTableRows = (assessments: Array<AssessmentWithRisks>): A
         html: assessment.application.person.crn,
       },
       {
-        html: tierBadge(assessment.application.person.risks.tier.value.level),
+        html: tierBadge(assessment.application.risks.tier.value.level),
       },
       {
         text: formattedArrivalDate(assessment),
@@ -41,7 +41,7 @@ const awaitingAssessmentTableRows = (assessments: Array<AssessmentWithRisks>): A
   return rows
 }
 
-const completedTableRows = (assessments: Array<AssessmentWithRisks>): Array<TableRow> => {
+const completedTableRows = (assessments: Array<Assessment>): Array<TableRow> => {
   const rows = [] as Array<TableRow>
 
   assessments.forEach(assessment => {
@@ -53,7 +53,7 @@ const completedTableRows = (assessments: Array<AssessmentWithRisks>): Array<Tabl
         html: assessment.application.person.crn,
       },
       {
-        html: tierBadge(assessment.application.person.risks.tier.value.level),
+        html: tierBadge(assessment.application.risks.tier.value.level),
       },
       {
         text: formattedArrivalDate(assessment),
@@ -67,7 +67,7 @@ const completedTableRows = (assessments: Array<AssessmentWithRisks>): Array<Tabl
   return rows
 }
 
-const requestedFurtherInformationTableRows = (assessments: Array<AssessmentWithRisks>): Array<TableRow> => {
+const requestedFurtherInformationTableRows = (assessments: Array<Assessment>): Array<TableRow> => {
   const rows = [] as Array<TableRow>
 
   assessments.forEach(assessment => {
@@ -79,7 +79,7 @@ const requestedFurtherInformationTableRows = (assessments: Array<AssessmentWithR
         html: assessment.application.person.crn,
       },
       {
-        html: tierBadge(assessment.application.person.risks.tier.value.level),
+        html: tierBadge(assessment.application.risks.tier.value.level),
       },
       {
         text: formattedArrivalDate(assessment),


### PR DESCRIPTION
Now the risk information is automatically included in the Application data, we no longer need to hit the risks endpoint each time.