### PR TITLE
Make form pages safer

### DIFF
--- a/server/controllers/apply/applications/pagesController.test.ts
+++ b/server/controllers/apply/applications/pagesController.test.ts
@@ -14,8 +14,10 @@ import {
 } from '../../../utils/validation'
 import { UnknownPageError } from '../../../utils/errors'
 import paths from '../../../paths/apply'
+import { viewPath } from '../../../form-pages/utils'
 
 jest.mock('../../../utils/validation')
+jest.mock('../../../form-pages/utils')
 
 describe('pagesController', () => {
   const request: DeepMocked<Request> = createMock<Request>({})
@@ -42,6 +44,7 @@ describe('pagesController', () => {
       }
 
       applicationService.getCurrentPage.mockResolvedValue(page)
+      ;(viewPath as jest.Mock).mockReturnValue('applications/pages/some/view')
     })
 
     it('renders a page', async () => {
@@ -55,7 +58,7 @@ describe('pagesController', () => {
 
       expect(applicationService.getCurrentPage).toHaveBeenCalledWith(request, dataServices, {})
 
-      expect(response.render).toHaveBeenCalledWith(`applications/pages/${request.params.task}/${request.params.page}`, {
+      expect(response.render).toHaveBeenCalledWith('applications/pages/some/view', {
         applicationId: request.params.id,
         task: request.params.task,
         page,
@@ -79,7 +82,7 @@ describe('pagesController', () => {
         errorsAndUserInput.userInput,
       )
 
-      expect(response.render).toHaveBeenCalledWith(`applications/pages/${request.params.task}/${request.params.page}`, {
+      expect(response.render).toHaveBeenCalledWith('applications/pages/some/view', {
         applicationId: request.params.id,
         task: request.params.task,
         page,

--- a/server/controllers/apply/applications/pagesController.ts
+++ b/server/controllers/apply/applications/pagesController.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../utils/validation'
 import paths from '../../../paths/apply'
 import { UnknownPageError } from '../../../utils/errors'
+import { viewPath } from '../../../form-pages/utils'
 
 export default class PagesController {
   constructor(private readonly applicationService: ApplicationService, private readonly dataServices: DataServices) {}
@@ -21,7 +22,7 @@ export default class PagesController {
         const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
         const page = await this.applicationService.getCurrentPage(req, this.dataServices, userInput)
 
-        res.render(`applications/pages/${req.params.task}/${req.params.page}`, {
+        res.render(viewPath(page), {
           applicationId: req.params.id,
           errors,
           errorSummary,

--- a/server/form-pages/utils/decorators/task.decorator.test.ts
+++ b/server/form-pages/utils/decorators/task.decorator.test.ts
@@ -51,5 +51,9 @@ describe('Task', () => {
     expect(slug).toEqual('my-task')
     expect(name).toEqual('My Task')
     expect(pages).toEqual([Page1, Page2, Page3])
+
+    expect(Reflect.getMetadata('page:task', Page1)).toEqual('my-task')
+    expect(Reflect.getMetadata('page:task', Page2)).toEqual('my-task')
+    expect(Reflect.getMetadata('page:task', Page3)).toEqual('my-task')
   })
 })

--- a/server/form-pages/utils/decorators/task.decorator.ts
+++ b/server/form-pages/utils/decorators/task.decorator.ts
@@ -14,6 +14,9 @@ const Task = (options: { name: string; slug: string; pages: Array<Type<TasklistP
     Reflect.defineMetadata('task:slug', options.slug, constructor)
     Reflect.defineMetadata('task:name', options.name, constructor)
     Reflect.defineMetadata('task:pages', options.pages, constructor)
+    options.pages.forEach(page => {
+      Reflect.defineMetadata('page:task', options.slug, page)
+    })
   }
 }
 

--- a/server/form-pages/utils/index.test.ts
+++ b/server/form-pages/utils/index.test.ts
@@ -60,8 +60,11 @@ describe('utils', () => {
     class Page2 {}
 
     beforeEach(() => {
-      Reflect.defineMetadata('page:name', 'Page 1', Page1)
-      Reflect.defineMetadata('page:name', 'Page 2', Page2)
+      Reflect.defineMetadata('page:name', 'page-1', Page1)
+      Reflect.defineMetadata('page:name', 'page-2', Page2)
+
+      Reflect.defineMetadata('page:task', 'task-1', Page1)
+      Reflect.defineMetadata('page:task', 'task-2', Page2)
 
       Reflect.defineMetadata('task:slug', 'slug', Task)
       Reflect.defineMetadata('task:name', 'Name', Task)
@@ -73,7 +76,7 @@ describe('utils', () => {
 
     describe('getTask', () => {
       it('fetches metadata for a specific task and pages', () => {
-        expect(utils.getTask(Task)).toEqual({ id: 'slug', title: 'Name', pages: { 'Page 1': Page1, 'Page 2': Page2 } })
+        expect(utils.getTask(Task)).toEqual({ id: 'slug', title: 'Name', pages: { 'page-1': Page1, 'page-2': Page2 } })
       })
     })
 
@@ -114,6 +117,16 @@ describe('utils', () => {
             'page-4': Page2,
           },
         })
+      })
+    })
+
+    describe('viewPath', () => {
+      it('returns the view path for a page', () => {
+        const page1 = new Page1()
+        const page2 = new Page2()
+
+        expect(utils.viewPath(page1)).toEqual('applications/pages/task-1/page-1')
+        expect(utils.viewPath(page2)).toEqual('applications/pages/task-2/page-2')
       })
     })
   })

--- a/server/form-pages/utils/index.test.ts
+++ b/server/form-pages/utils/index.test.ts
@@ -129,5 +129,21 @@ describe('utils', () => {
         expect(utils.viewPath(page2)).toEqual('applications/pages/task-2/page-2')
       })
     })
+
+    describe('getPageName', () => {
+      it('returns the page name', () => {
+        const page = new Page1()
+
+        expect(utils.getPageName(page)).toEqual('page-1')
+      })
+    })
+
+    describe('getTaskName', () => {
+      it('returns the task name', () => {
+        const page = new Page1()
+
+        expect(utils.getTaskName(page)).toEqual('task-1')
+      })
+    })
   })
 })

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -61,8 +61,16 @@ export const getPagesForSections = <T>(sections: Array<T>) => {
 }
 
 export const viewPath = <T>(page: T) => {
-  const pageName = Reflect.getMetadata('page:name', page.constructor)
-  const taskName = Reflect.getMetadata('page:task', page.constructor)
+  const pageName = getPageName(page)
+  const taskName = getTaskName(page)
 
   return `applications/pages/${taskName}/${pageName}`
+}
+
+export const getPageName = <T>(page: T) => {
+  return Reflect.getMetadata('page:name', page.constructor)
+}
+
+export const getTaskName = <T>(page: T) => {
+  return Reflect.getMetadata('page:task', page.constructor)
 }

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -59,3 +59,10 @@ export const getPagesForSections = <T>(sections: Array<T>) => {
   })
   return pages
 }
+
+export const viewPath = <T>(page: T) => {
+  const pageName = Reflect.getMetadata('page:name', page.constructor)
+  const taskName = Reflect.getMetadata('page:task', page.constructor)
+
+  return `applications/pages/${taskName}/${pageName}`
+}

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -7,6 +7,7 @@ import { ValidationError } from '../utils/errors'
 import { getPage } from '../utils/applicationUtils'
 import ApplicationService from './applicationService'
 import ApplicationClient from '../data/applicationClient'
+import { getPageName, getTaskName } from '../form-pages/utils'
 
 import Apply from '../form-pages/apply'
 import applicationFactory from '../testutils/factories/application'
@@ -30,6 +31,7 @@ Apply.pages['my-task'] = {
 jest.mock('../data/applicationClient.ts')
 jest.mock('../data/personClient.ts')
 jest.mock('../utils/applicationUtils')
+jest.mock('../form-pages/utils')
 
 describe('ApplicationService', () => {
   const applicationClient = new ApplicationClient(null) as jest.Mocked<ApplicationClient>
@@ -246,6 +248,8 @@ describe('ApplicationService', () => {
           },
           body: { foo: 'bar' },
         })
+        ;(getPageName as jest.Mock).mockReturnValue('some-page')
+        ;(getTaskName as jest.Mock).mockReturnValue('some-task')
       })
 
       it('does not throw an error', () => {

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -8,6 +8,7 @@ import { UnknownPageError, ValidationError } from '../utils/errors'
 
 import Apply from '../form-pages/apply'
 import { getPage } from '../utils/applicationUtils'
+import { getPageName, getTaskName } from '../form-pages/utils'
 
 export default class ApplicationService {
   constructor(private readonly applicationClientFactory: RestClientBuilder<ApplicationClient>) {}
@@ -77,9 +78,12 @@ export default class ApplicationService {
     } else {
       const application = await this.getApplicationFromSessionOrAPI(request)
 
+      const pageName = getPageName(page)
+      const taskName = getTaskName(page)
+
       application.data = application.data || {}
-      application.data[request.params.task] = application.data[request.params.task] || {}
-      application.data[request.params.task][request.params.page] = page.body
+      application.data[taskName] = application.data[taskName] || {}
+      application.data[taskName][pageName] = page.body
 
       this.saveToSession(application, page, request)
       await this.saveToApi(application, request)


### PR DESCRIPTION
When introducing CodeQL in #437, we've had a couple of alerts  about using using user-provided values in the Apply journey:

- https://github.com/ministryofjustice/hmpps-approved-premises-ui/security/code-scanning/1
- https://github.com/ministryofjustice/hmpps-approved-premises-ui/security/code-scanning/11

Through the power of decorators and metadata, we can glean the name of the page and its associated task, thereby solving those two issues.