### PR TITLE
(971) Refactor apply pages

### DIFF
--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -69,6 +69,8 @@ export type FormSections = Array<FormSection>
 
 export type FormPages = { [key in TaskNames]: Record<string, unknown> }
 
+export type PageResponse = Record<string, string | Array<string> | Array<Record<string, unknown>>>
+
 export interface HtmlAttributes {
   [key: string]: string
 }

--- a/server/controllers/apply/applications/pagesController.test.ts
+++ b/server/controllers/apply/applications/pagesController.test.ts
@@ -52,8 +52,6 @@ describe('pagesController', () => {
     beforeEach(() => {
       request.params = {
         id: 'some-uuid',
-        task: 'some-task',
-        page: 'some-page',
       }
       ;(viewPath as jest.Mock).mockReturnValue('applications/pages/some/view')
     })
@@ -63,16 +61,16 @@ describe('pagesController', () => {
         return { errors: {}, errorSummary: [], userInput: {} }
       })
 
-      const requestHandler = pagesController.show()
+      const requestHandler = pagesController.show('some-task', 'some-page')
 
       await requestHandler(request, response, next)
 
-      expect(getPage).toHaveBeenCalledWith(request.params.task, request.params.page)
+      expect(getPage).toHaveBeenCalledWith('some-task', 'some-page')
       expect(applicationService.initializePage).toHaveBeenCalledWith(PageConstructor, request, dataServices, {})
 
       expect(response.render).toHaveBeenCalledWith('applications/pages/some/view', {
         applicationId: request.params.id,
-        task: request.params.task,
+        task: 'some-task',
         page,
         errors: {},
         errorSummary: [],
@@ -84,7 +82,7 @@ describe('pagesController', () => {
       const errorsAndUserInput = createMock<ErrorsAndUserInput>()
       ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
 
-      const requestHandler = pagesController.show()
+      const requestHandler = pagesController.show('some-task', 'some-page')
 
       await requestHandler(request, response, next)
 
@@ -97,7 +95,7 @@ describe('pagesController', () => {
 
       expect(response.render).toHaveBeenCalledWith('applications/pages/some/view', {
         applicationId: request.params.id,
-        task: request.params.task,
+        task: 'some-task',
         page,
         errors: errorsAndUserInput.errors,
         errorSummary: errorsAndUserInput.errorSummary,
@@ -110,7 +108,7 @@ describe('pagesController', () => {
         throw new UnknownPageError()
       })
 
-      const requestHandler = pagesController.show()
+      const requestHandler = pagesController.show('some-task', 'some-page')
 
       await requestHandler(request, response, next)
 
@@ -124,7 +122,7 @@ describe('pagesController', () => {
         throw genericError
       })
 
-      const requestHandler = pagesController.show()
+      const requestHandler = pagesController.show('some-task', 'some-page')
 
       await requestHandler(request, response, next)
 
@@ -136,8 +134,6 @@ describe('pagesController', () => {
     beforeEach(() => {
       request.params = {
         id: 'some-uuid',
-        task: 'some-task',
-        page: 'page-name',
       }
 
       applicationService.initializePage.mockResolvedValue(page)
@@ -148,21 +144,21 @@ describe('pagesController', () => {
 
       applicationService.save.mockResolvedValue()
 
-      const requestHandler = pagesController.update()
+      const requestHandler = pagesController.update('some-task', 'page-name')
 
       await requestHandler({ ...request }, response)
 
       expect(applicationService.save).toHaveBeenCalledWith(page, request)
 
       expect(response.redirect).toHaveBeenCalledWith(
-        paths.applications.pages.show({ id: request.params.id, task: request.params.task, page: 'next-page' }),
+        paths.applications.pages.show({ id: request.params.id, task: 'some-task', page: 'next-page' }),
       )
     })
 
     it('redirects to the tasklist if there is no next page', async () => {
       page.next.mockReturnValue(undefined)
 
-      const requestHandler = pagesController.update()
+      const requestHandler = pagesController.update('some-task', 'page-name')
 
       await requestHandler(request, response)
 
@@ -177,7 +173,7 @@ describe('pagesController', () => {
         throw err
       })
 
-      const requestHandler = pagesController.update()
+      const requestHandler = pagesController.update('some-task', 'page-name')
 
       await requestHandler(request, response)
 
@@ -187,7 +183,7 @@ describe('pagesController', () => {
         request,
         response,
         err,
-        paths.applications.pages.show({ id: request.params.id, task: request.params.task, page: request.params.page }),
+        paths.applications.pages.show({ id: request.params.id, task: 'some-task', page: 'page-name' }),
       )
     })
   })

--- a/server/controllers/apply/applications/pagesController.ts
+++ b/server/controllers/apply/applications/pagesController.ts
@@ -2,6 +2,7 @@ import type { Request, Response, RequestHandler, NextFunction } from 'express'
 import createError from 'http-errors'
 
 import type { DataServices } from '@approved-premises/ui'
+import { getPage } from '../../../utils/applicationUtils'
 import { ApplicationService } from '../../../services'
 
 import {
@@ -19,8 +20,10 @@ export default class PagesController {
   show(): RequestHandler {
     return async (req: Request, res: Response, next: NextFunction) => {
       try {
+        const Page = getPage(req.params.task, req.params.page)
+
         const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
-        const page = await this.applicationService.getCurrentPage(req, this.dataServices, userInput)
+        const page = await this.applicationService.initializePage(Page, req, this.dataServices, userInput)
 
         res.render(viewPath(page), {
           applicationId: req.params.id,
@@ -42,7 +45,8 @@ export default class PagesController {
 
   update() {
     return async (req: Request, res: Response) => {
-      const page = await this.applicationService.getCurrentPage(req, this.dataServices)
+      const Page = getPage(req.params.task, req.params.page)
+      const page = await this.applicationService.initializePage(Page, req, this.dataServices)
 
       try {
         await this.applicationService.save(page, req)

--- a/server/controllers/apply/applications/pagesController.ts
+++ b/server/controllers/apply/applications/pagesController.ts
@@ -17,10 +17,10 @@ import { viewPath } from '../../../form-pages/utils'
 export default class PagesController {
   constructor(private readonly applicationService: ApplicationService, private readonly dataServices: DataServices) {}
 
-  show(): RequestHandler {
+  show(taskName: string, pageName: string): RequestHandler {
     return async (req: Request, res: Response, next: NextFunction) => {
       try {
-        const Page = getPage(req.params.task, req.params.page)
+        const Page = getPage(taskName, pageName)
 
         const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
         const page = await this.applicationService.initializePage(Page, req, this.dataServices, userInput)
@@ -29,7 +29,7 @@ export default class PagesController {
           applicationId: req.params.id,
           errors,
           errorSummary,
-          task: req.params.task,
+          task: taskName,
           page,
           ...page.body,
         })
@@ -43,16 +43,16 @@ export default class PagesController {
     }
   }
 
-  update() {
+  update(taskName: string, pageName: string) {
     return async (req: Request, res: Response) => {
-      const Page = getPage(req.params.task, req.params.page)
+      const Page = getPage(taskName, pageName)
       const page = await this.applicationService.initializePage(Page, req, this.dataServices)
 
       try {
         await this.applicationService.save(page, req)
         const next = page.next()
         if (next) {
-          res.redirect(paths.applications.pages.show({ id: req.params.id, task: req.params.task, page: page.next() }))
+          res.redirect(paths.applications.pages.show({ id: req.params.id, task: taskName, page: page.next() }))
         } else {
           res.redirect(paths.applications.show({ id: req.params.id }))
         }
@@ -61,7 +61,7 @@ export default class PagesController {
           req,
           res,
           err,
-          paths.applications.pages.show({ id: req.params.id, task: req.params.task, page: req.params.page }),
+          paths.applications.pages.show({ id: req.params.id, task: taskName, page: pageName }),
         )
       }
     }

--- a/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.test.ts
@@ -28,6 +28,32 @@ describe('ConvictedOffences', () => {
         restrictions: 'You must specify if there are any restrictions linked to placement location',
       })
     })
+
+    it('should show an error if the postcode area is invalid', () => {
+      const page = new DescribeLocationFactors({ postcodeArea: 'Not a postcode area' })
+
+      const errors = page.errors()
+
+      expect(errors.postcodeArea).toEqual('The preferred postcode area must be a valid postcode area (i.e SW1A)')
+    })
+
+    it('should show an error if restrictions is yes, but no detail is provided', () => {
+      const page = new DescribeLocationFactors({ restrictions: 'yes' })
+
+      const errors = page.errors()
+
+      expect(errors.restrictionDetail).toEqual(
+        'You must provide details of any restrictions linked to placement location',
+      )
+    })
+
+    it('should show an error if an alternative radius is required', () => {
+      const page = new DescribeLocationFactors({ alternativeRadiusAccepted: 'yes' })
+
+      const errors = page.errors()
+
+      expect(errors.alternativeRadius).toEqual('You must choose an alternative radius')
+    })
   })
 
   describe('response', () => {

--- a/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.ts
@@ -71,7 +71,7 @@ export default class DescribeLocationFactors implements TasklistPage {
     }
 
     if (this.body.restrictions === 'yes' && !this.body.restrictionDetail) {
-      errors.restrictionDetail = 'You must provide details of any restrictions  linked to placement location'
+      errors.restrictionDetail = 'You must provide details of any restrictions linked to placement location'
     }
 
     if (!this.body.alternativeRadiusAccepted) {

--- a/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
+++ b/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
@@ -1,4 +1,4 @@
-import type { DataServices } from '@approved-premises/ui'
+import type { DataServices, PageResponse } from '@approved-premises/ui'
 
 import type { ApprovedPremisesApplication, PrisonCaseNote, Adjudication } from '@approved-premises/api'
 
@@ -113,7 +113,7 @@ export default class CaseNotes implements TasklistPage {
   }
 
   response() {
-    const response: Record<string, unknown> = {}
+    const response: PageResponse = {}
 
     if (this.body.selectedCaseNotes) {
       response[this.questions.caseNotesSelectionQuestion] = this.body.selectedCaseNotes.map(caseNoteResponse)

--- a/server/form-pages/tasklistPage.ts
+++ b/server/form-pages/tasklistPage.ts
@@ -1,5 +1,17 @@
-import type { TaskListErrors, DataServices } from '@approved-premises/ui'
+/* istanbul ignore file */
+
+import type { TaskListErrors, DataServices, PageResponse } from '@approved-premises/ui'
 import { ApprovedPremisesApplication } from '@approved-premises/api'
+
+export interface TasklistPageInterface {
+  new (body: Record<string, unknown>, application?: ApprovedPremisesApplication, previousPage?: string): TasklistPage
+  initialize?(
+    body: Record<string, unknown>,
+    application: ApprovedPremisesApplication,
+    token: string,
+    dataServices: DataServices,
+  ): Promise<TasklistPage>
+}
 
 export default abstract class TasklistPage {
   abstract title: string
@@ -12,11 +24,5 @@ export default abstract class TasklistPage {
 
   abstract errors(): TaskListErrors<this>
 
-  abstract response(): Record<string, unknown>
-
-  static async initialize?(
-    application: ApprovedPremisesApplication,
-    token: string,
-    dataServices: DataServices,
-  ): Promise<TasklistPage>
+  abstract response(): PageResponse
 }

--- a/server/form-pages/utils/index.test.ts
+++ b/server/form-pages/utils/index.test.ts
@@ -132,17 +132,13 @@ describe('utils', () => {
 
     describe('getPageName', () => {
       it('returns the page name', () => {
-        const page = new Page1()
-
-        expect(utils.getPageName(page)).toEqual('page-1')
+        expect(utils.getPageName(Page1)).toEqual('page-1')
       })
     })
 
     describe('getTaskName', () => {
       it('returns the task name', () => {
-        const page = new Page1()
-
-        expect(utils.getTaskName(page)).toEqual('task-1')
+        expect(utils.getTaskName(Page1)).toEqual('task-1')
       })
     })
   })

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -61,16 +61,16 @@ export const getPagesForSections = <T>(sections: Array<T>) => {
 }
 
 export const viewPath = <T>(page: T) => {
-  const pageName = getPageName(page)
-  const taskName = getTaskName(page)
+  const pageName = getPageName(page.constructor)
+  const taskName = getTaskName(page.constructor)
 
   return `applications/pages/${taskName}/${pageName}`
 }
 
 export const getPageName = <T>(page: T) => {
-  return Reflect.getMetadata('page:name', page.constructor)
+  return Reflect.getMetadata('page:name', page)
 }
 
 export const getTaskName = <T>(page: T) => {
-  return Reflect.getMetadata('page:task', page.constructor)
+  return Reflect.getMetadata('page:task', page)
 }

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 
 import type { Router } from 'express'
+import Apply from '../form-pages/apply'
 
 import type { Controllers } from '../controllers'
 import paths from '../paths/apply'
@@ -8,6 +9,7 @@ import paths from '../paths/apply'
 import actions from './utils'
 
 export default function routes(controllers: Controllers, router: Router): Router {
+  const { pages } = Apply
   const { get, post, put } = actions(router)
   const { applicationsController, pagesController, peopleController, offencesController, documentsController } =
     controllers
@@ -23,8 +25,13 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(paths.applications.people.selectOffence.pattern, offencesController.selectOffence())
   get(paths.applications.people.documents.pattern, documentsController.show())
 
-  get(paths.applications.pages.show.pattern, pagesController.show())
-  put(paths.applications.pages.update.pattern, pagesController.update())
+  Object.keys(pages).forEach((taskKey: string) => {
+    Object.keys(pages[taskKey]).forEach((pageKey: string) => {
+      const { pattern } = paths.applications.show.path(`tasks/${taskKey}/pages/${pageKey}`)
+      get(pattern, pagesController.show(taskKey, pageKey))
+      put(pattern, pagesController.update(taskKey, pageKey))
+    })
+  })
 
   return router
 }

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -203,6 +203,8 @@ describe('ApplicationService', () => {
     it('should load from the session if the body and userInput are blank', async () => {
       request.body = {}
       request.session.application.data = { 'my-task': { first: { foo: 'bar' } } }
+      ;(getTaskName as jest.Mock).mockReturnValue('my-task')
+      ;(getPageName as jest.Mock).mockReturnValue('first')
 
       const result = await service.initializePage(Page, request, dataServices)
 

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -69,8 +69,8 @@ export default class ApplicationService {
     } else {
       const application = await this.getApplicationFromSessionOrAPI(request)
 
-      const pageName = getPageName(page)
-      const taskName = getTaskName(page)
+      const pageName = getPageName(page.constructor)
+      const taskName = getTaskName(page.constructor)
 
       application.data = application.data || {}
       application.data[taskName] = application.data[taskName] || {}

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -2,12 +2,10 @@ import type { Request } from 'express'
 import type { DataServices } from '@approved-premises/ui'
 import type { ActiveOffence, ApprovedPremisesApplication, Document } from '@approved-premises/api'
 
-import type TasklistPage from '../form-pages/tasklistPage'
+import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
 import type { RestClientBuilder, ApplicationClient } from '../data'
-import { UnknownPageError, ValidationError } from '../utils/errors'
+import { ValidationError } from '../utils/errors'
 
-import Apply from '../form-pages/apply'
-import { getPage } from '../utils/applicationUtils'
 import { getPageName, getTaskName } from '../form-pages/utils'
 
 export default class ApplicationService {
@@ -47,19 +45,12 @@ export default class ApplicationService {
     return documents
   }
 
-  async getCurrentPage(
+  async initializePage(
+    Page: TasklistPageInterface,
     request: Request,
     dataServices: DataServices,
     userInput?: Record<string, unknown>,
   ): Promise<TasklistPage> {
-    if (!request.params.task) {
-      throw new UnknownPageError()
-    }
-
-    request.params.page = request.params.page || this.firstPageForTask(request.params.task)
-
-    const Page = getPage(request.params.task, request.params.page)
-
     const application = await this.getApplicationFromSessionOrAPI(request)
     const body = this.getBody(application, request, userInput)
 
@@ -103,10 +94,6 @@ export default class ApplicationService {
       return application
     }
     return this.findApplication(request.user.token, request.params.id)
-  }
-
-  private firstPageForTask(taskName: string) {
-    return Object.keys(Apply.pages[taskName])[0]
   }
 
   private async saveToSession(application: ApprovedPremisesApplication, page: TasklistPage, request: Request) {

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -52,7 +52,7 @@ export default class ApplicationService {
     userInput?: Record<string, unknown>,
   ): Promise<TasklistPage> {
     const application = await this.getApplicationFromSessionOrAPI(request)
-    const body = this.getBody(application, request, userInput)
+    const body = this.getBody(Page, application, request, userInput)
 
     const page = Page.initialize
       ? await Page.initialize(body, application, request.user.token, dataServices)
@@ -107,17 +107,25 @@ export default class ApplicationService {
     await client.update(application)
   }
 
-  private getBody(application: ApprovedPremisesApplication, request: Request, userInput: Record<string, unknown>) {
+  private getBody(
+    Page: TasklistPageInterface,
+    application: ApprovedPremisesApplication,
+    request: Request,
+    userInput: Record<string, unknown>,
+  ) {
     if (userInput && Object.keys(userInput).length) {
       return userInput
     }
     if (Object.keys(request.body).length) {
       return request.body
     }
-    return this.getPageDataFromApplication(application, request)
+    return this.getPageDataFromApplication(Page, application)
   }
 
-  private getPageDataFromApplication(application: ApprovedPremisesApplication, request: Request) {
-    return application.data?.[request.params.task]?.[request.params.page] || {}
+  private getPageDataFromApplication(Page: TasklistPageInterface, application: ApprovedPremisesApplication) {
+    const pageName = getPageName(Page)
+    const taskName = getTaskName(Page)
+
+    return application.data?.[taskName]?.[pageName] || {}
   }
 }

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -1,12 +1,12 @@
-import type { Task, FormSections, FormSection, TableRow } from '@approved-premises/ui'
+import type { Task, FormSections, FormSection, TableRow, PageResponse } from '@approved-premises/ui'
 import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import paths from '../paths/apply'
 import Apply from '../form-pages/apply'
 import { SessionDataError, UnknownPageError } from './errors'
 import { tierBadge } from './personUtils'
 import { DateFormats } from './dateUtils'
+import { TasklistPageInterface } from '../form-pages/tasklistPage'
 
-type PageResponse = Record<string, string | Array<Record<string, unknown>>>
 type ApplicationResponse = Record<string, Array<PageResponse>>
 
 const taskIds = Object.keys(Apply.pages)
@@ -108,7 +108,7 @@ const getResponseForPage = (
   return page.response()
 }
 
-const getPage = (taskName: string, pageName: string) => {
+const getPage = (taskName: string, pageName: string): TasklistPageInterface => {
   const pageList = Apply.pages[taskName]
 
   const Page = pageList[pageName]
@@ -117,7 +117,7 @@ const getPage = (taskName: string, pageName: string) => {
     throw new UnknownPageError()
   }
 
-  return Page
+  return Page as TasklistPageInterface
 }
 
 const getArrivalDate = (application: ApprovedPremisesApplication, raiseOnMissing = true): string | null => {


### PR DESCRIPTION
This refactors the Apply pages so that the paths get built on boot, rather than having to pass request data into our code and making it susceptable to things like prototype pollution attacks. It also makes the way we build page paths tidier and more predictable, helping us as we move into Assess.