### PR TITLE
Fix/E2E test fail due to 'Back to dashboard' link changing

### DIFF
--- a/cypress_shared/pages/manage/booking/confirmation.ts
+++ b/cypress_shared/pages/manage/booking/confirmation.ts
@@ -28,7 +28,7 @@ export default class BookingConfirmationPage extends Page {
     })
   }
 
-  clickToViewBooking(): void {
+  clickBackToDashboard(): void {
     cy.get('a').contains('Back to dashboard').click()
   }
 

--- a/e2e/tests/stepDefinitions/bookingExtensions.ts
+++ b/e2e/tests/stepDefinitions/bookingExtensions.ts
@@ -13,7 +13,8 @@ const extensionDate = DateFormats.dateObjToIsoDate(new Date(2050, 0, 1))
 
 Given('I extend that booking', () => {
   cy.get('@bookingConfirmationPage').then((bookingConfirmationPage: BookingConfirmationPage) => {
-    bookingConfirmationPage.clickToViewBooking()
+    bookingConfirmationPage.clickBackToDashboard()
+    cy.get('.govuk-table__cell').contains('Manage').click()
   })
 
   const bookingShowPage = new BookingShowPage()
@@ -32,7 +33,8 @@ Then('I should see a message on the booking page confirming the extension', () =
 
 Then('I attempt to extend that booking without entering the date', () => {
   cy.get('@bookingConfirmationPage').then((bookingConfirmationPage: BookingConfirmationPage) => {
-    bookingConfirmationPage.clickToViewBooking()
+    bookingConfirmationPage.clickBackToDashboard()
+    cy.get('.govuk-table__cell').contains('Manage').click()
   })
 
   const bookingShowPage = new BookingShowPage()

--- a/server/form-pages/apply/move-on/typeOfAccommodation.ts
+++ b/server/form-pages/apply/move-on/typeOfAccommodation.ts
@@ -6,7 +6,7 @@ import { Page } from '../../utils/decorators'
 import TasklistPage from '../../tasklistPage'
 
 export const accommodationType = {
-  ownaccommodation: 'Own accommodation',
+  ownAccommodation: 'Own accommodation',
   livingWithPartnerFamilyOrFriends: 'Living with partner, family or friends',
   rentedThroughLocalAuthority: 'Rented through local authority',
   rentedThroughHousingAssociation: 'Rented through housing association',

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.test.ts
@@ -86,7 +86,7 @@ describe('RehabilitativeInterventions', () => {
 
         expect(page.response()).toEqual({
           "Which rehabilitative interventions will support the person's Approved Premises (AP) placement?":
-            'accommodation, Drugs and alcohol, Children and families, Health, Education, training and employment, Finance, benefits and debt, Attitudes, thinking and behaviour, Abuse, Other',
+            'Accommodation, Drugs and alcohol, Children and families, Health, Education, training and employment, Finance, benefits and debt, Attitudes, thinking and behaviour, Abuse, Other',
           'Other intervention': 'Some intervention',
         })
       })

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.ts
@@ -6,7 +6,7 @@ import { Page } from '../../../utils/decorators'
 import TasklistPage from '../../../tasklistPage'
 
 export const interventionsTranslations = {
-  accommodation: 'accommodation',
+  accommodation: 'Accommodation',
   drugsAndAlcohol: 'Drugs and alcohol',
   childrenAndFamilies: 'Children and families',
   health: 'Health',


### PR DESCRIPTION
The adjustment of the 'Back To Dashboard' link in #450 broke the booking extension E2E tests but it didn't show up until they ran post-merge.
