### PR TITLE
(982) Fix dates in OASys apply screens

### DIFF
--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.test.ts
@@ -17,7 +17,7 @@ describe('OffenceDetails', () => {
   const application = applicationFactory.build({ risks: personRisks })
 
   describe('initialize', () => {
-    const getOasysSectionsMock = jest.fn().mockResolvedValue(oasysSections)
+    const getOasysSectionsMock = jest.fn()
 
     let personService: DeepMocked<PersonService>
 
@@ -25,6 +25,11 @@ describe('OffenceDetails', () => {
       personService = createMock<PersonService>({
         getOasysSections: getOasysSectionsMock,
       })
+      getOasysSectionsMock.mockResolvedValue(oasysSections)
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
     })
 
     it('calls the getOasysSections  method on the client with a token and the persons CRN', async () => {
@@ -38,6 +43,14 @@ describe('OffenceDetails', () => {
 
       expect(page.offenceDetailsSummaries).toEqual(oasysSections.offenceDetails)
       expect(page.risks).toEqual(mapApiPersonRisksForUi(personRisks))
+      expect(page.oasysCompleted).toEqual(oasysSections.dateCompleted)
+    })
+
+    it('sets dateCompleted to dateStarted if dateCompleted is null', async () => {
+      getOasysSectionsMock.mockResolvedValue({ ...oasysSections, dateCompleted: null })
+
+      const page = await OffenceDetails.initialize({}, application, 'some-token', { personService })
+      expect(page.oasysCompleted).toEqual(oasysSections.dateStarted)
     })
 
     itShouldHaveNextValue(new OffenceDetails({}), 'supporting-information')

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.ts
@@ -11,7 +11,6 @@ import TasklistPage from '../../../tasklistPage'
 import { Page } from '../../../utils/decorators'
 import { oasysImportReponse, sortOasysImportSummaries } from '../../../../utils/oasysImportUtils'
 import { mapApiPersonRisksForUi } from '../../../../utils/utils'
-import { DateFormats } from '../../../../utils/dateUtils'
 
 type OffenceDetailsBody = {
   offenceDetailsAnswers: Array<string> | Record<string, string>
@@ -52,7 +51,7 @@ export default class OffenceDetails implements TasklistPage {
 
     const page = new OffenceDetails(body)
     page.offenceDetailsSummaries = offenceDetails
-    page.oasysCompleted = DateFormats.isoDateToUIDate(oasysSections?.dateCompleted || '')
+    page.oasysCompleted = oasysSections?.dateCompleted || oasysSections?.dateStarted
     page.risks = mapApiPersonRisksForUi(application.risks)
 
     return page

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.test.ts
@@ -16,13 +16,18 @@ describe('RiskManagement', () => {
   const application = applicationFactory.build({ risks: personRisks })
 
   describe('initialize', () => {
-    const getOasysSectionsMock = jest.fn().mockResolvedValue(oasysSections)
+    const getOasysSectionsMock = jest.fn()
     let personService: DeepMocked<PersonService>
 
     beforeEach(() => {
       personService = createMock<PersonService>({
         getOasysSections: getOasysSectionsMock,
       })
+      getOasysSectionsMock.mockResolvedValue(oasysSections)
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
     })
 
     it('calls the getOasysSections and getPersonRisks method on the client with a token and the persons CRN', async () => {
@@ -36,6 +41,14 @@ describe('RiskManagement', () => {
 
       expect(page.riskManagementSummaries).toEqual(oasysSections.riskManagementPlan)
       expect(page.risks).toEqual(mapApiPersonRisksForUi(personRisks))
+      expect(page.oasysCompleted).toEqual(oasysSections.dateCompleted)
+    })
+
+    it('sets dateCompleted to dateStarted if dateCompleted is null', async () => {
+      getOasysSectionsMock.mockResolvedValue({ ...oasysSections, dateCompleted: null })
+
+      const page = await RiskManagementPlan.initialize({}, application, 'some-token', { personService })
+      expect(page.oasysCompleted).toEqual(oasysSections.dateStarted)
     })
 
     itShouldHaveNextValue(new RiskManagementPlan({}), 'risk-to-self')

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.ts
@@ -10,7 +10,6 @@ import TasklistPage from '../../../tasklistPage'
 
 import { Page } from '../../../utils/decorators'
 import { oasysImportReponse, sortOasysImportSummaries } from '../../../../utils/oasysImportUtils'
-import { DateFormats } from '../../../../utils/dateUtils'
 import { mapApiPersonRisksForUi } from '../../../../utils/utils'
 
 type RiskManagementBody = {
@@ -52,7 +51,7 @@ export default class RiskManagementPlan implements TasklistPage {
 
     const page = new RiskManagementPlan(body)
     page.riskManagementSummaries = riskManagement
-    page.oasysCompleted = DateFormats.isoDateToUIDate(oasysSections?.dateCompleted || '')
+    page.oasysCompleted = oasysSections?.dateCompleted || oasysSections?.dateStarted
     page.risks = mapApiPersonRisksForUi(application.risks)
 
     return page

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.test.ts
@@ -38,6 +38,14 @@ describe('RiskToSelf', () => {
 
       expect(page.riskToSelfSummaries).toEqual(oasysSections.riskToSelf)
       expect(page.risks).toEqual(mapApiPersonRisksForUi(personRisks))
+      expect(page.oasysCompleted).toEqual(oasysSections.dateCompleted)
+    })
+
+    it('sets dateCompleted to dateStarted if dateCompleted is null', async () => {
+      getOasysSectionsMock.mockResolvedValue({ ...oasysSections, dateCompleted: null })
+
+      const page = await RiskToSelf.initialize({}, application, 'some-token', { personService })
+      expect(page.oasysCompleted).toEqual(oasysSections.dateStarted)
     })
 
     itShouldHaveNextValue(new RiskToSelf({}), '')

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.ts
@@ -28,6 +28,8 @@ export default class RiskToSelf implements TasklistPage {
 
   riskToSelfAnswers: RiskToSelfBody['riskToSelfAnswers']
 
+  oasysCompleted: string
+
   risks: PersonRisksUI
 
   constructor(public body: Partial<RiskToSelfBody>) {}
@@ -49,6 +51,7 @@ export default class RiskToSelf implements TasklistPage {
 
     const page = new RiskToSelf(body)
     page.riskToSelfSummaries = riskToSelf
+    page.oasysCompleted = oasysSections?.dateCompleted || oasysSections?.dateStarted
     page.risks = mapApiPersonRisksForUi(application.risks)
 
     return page

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
@@ -16,7 +16,7 @@ describe('RoshSummary', () => {
   const application = applicationFactory.build({ risks: personRisks })
 
   describe('initialize', () => {
-    const getOasysSectionsMock = jest.fn().mockResolvedValue(oasysSections)
+    const getOasysSectionsMock = jest.fn()
 
     let personService: DeepMocked<PersonService>
 
@@ -24,6 +24,11 @@ describe('RoshSummary', () => {
       personService = createMock<PersonService>({
         getOasysSections: getOasysSectionsMock,
       })
+      getOasysSectionsMock.mockResolvedValue(oasysSections)
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
     })
 
     it('calls the getOasysSections method on the client with a token and the persons CRN', async () => {
@@ -37,6 +42,14 @@ describe('RoshSummary', () => {
 
       expect(page.roshSummary).toEqual(oasysSections.roshSummary)
       expect(page.risks).toEqual(mapApiPersonRisksForUi(personRisks))
+      expect(page.oasysCompleted).toEqual(oasysSections.dateCompleted)
+    })
+
+    it('sets dateCompleted to dateStarted if dateCompleted is null', async () => {
+      getOasysSectionsMock.mockResolvedValue({ ...oasysSections, dateCompleted: null })
+
+      const page = await RoshSummary.initialize({}, application, 'some-token', { personService })
+      expect(page.oasysCompleted).toEqual(oasysSections.dateStarted)
     })
 
     itShouldHaveNextValue(new RoshSummary({}), 'offence-details')

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
@@ -12,7 +12,6 @@ import TasklistPage from '../../../tasklistPage'
 import { Page } from '../../../utils/decorators'
 import { oasysImportReponse, sortOasysImportSummaries } from '../../../../utils/oasysImportUtils'
 import { mapApiPersonRisksForUi } from '../../../../utils/utils'
-import { DateFormats } from '../../../../utils/dateUtils'
 
 type RoshSummaryBody = {
   roshAnswers: Array<string> | Record<string, string>
@@ -52,7 +51,7 @@ export default class RoshSummary implements TasklistPage {
 
     const page = new RoshSummary(body)
     page.roshSummary = roshSummaries
-    page.oasysCompleted = DateFormats.isoDateToUIDate(oasysSections?.dateCompleted || '')
+    page.oasysCompleted = oasysSections?.dateCompleted || oasysSections?.dateStarted
     page.risks = mapApiPersonRisksForUi(application.risks)
 
     return page

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.test.ts
@@ -18,7 +18,7 @@ describe('SupportingInformation', () => {
   let application = applicationFactory.withOptionalOasysSectionsSelected([], []).build({ risks: personRisks })
 
   describe('initialize', () => {
-    const getOasysSectionsMock = jest.fn().mockResolvedValue(oasysSections)
+    const getOasysSectionsMock = jest.fn()
 
     let personService: DeepMocked<PersonService>
 
@@ -26,6 +26,11 @@ describe('SupportingInformation', () => {
       personService = createMock<PersonService>({
         getOasysSections: getOasysSectionsMock,
       })
+      getOasysSectionsMock.mockResolvedValue(oasysSections)
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
     })
 
     it('calls the getOasysSections and getPersonRisks method on the client with a token and the persons CRN', async () => {
@@ -45,6 +50,14 @@ describe('SupportingInformation', () => {
 
       expect(page.supportingInformationSummaries).toEqual(oasysSections.supportingInformation)
       expect(page.risks).toEqual(mapApiPersonRisksForUi(personRisks))
+      expect(page.oasysCompleted).toEqual(oasysSections.dateCompleted)
+    })
+
+    it('sets dateCompleted to dateStarted if dateCompleted is null', async () => {
+      getOasysSectionsMock.mockResolvedValue({ ...oasysSections, dateCompleted: null })
+
+      const page = await SupportingInformation.initialize({}, application, 'some-token', { personService })
+      expect(page.oasysCompleted).toEqual(oasysSections.dateStarted)
     })
 
     itShouldHaveNextValue(new SupportingInformation({}), 'risk-management-plan')

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.ts
@@ -14,7 +14,6 @@ import {
   oasysImportReponse,
   sortOasysImportSummaries,
 } from '../../../../utils/oasysImportUtils'
-import { DateFormats } from '../../../../utils/dateUtils'
 import { mapApiPersonRisksForUi } from '../../../../utils/utils'
 
 type SupportingInformationBody = {
@@ -57,7 +56,7 @@ export default class SupportingInformation implements TasklistPage {
 
     const page = new SupportingInformation(body)
     page.supportingInformationSummaries = supportingInformation
-    page.oasysCompleted = DateFormats.isoDateToUIDate(oasysSections?.dateCompleted || '')
+    page.oasysCompleted = oasysSections?.dateCompleted || oasysSections?.dateStarted
     page.risks = mapApiPersonRisksForUi(application.risks)
 
     return page

--- a/server/views/applications/pages/oasys-import/_oasys-screen.njk
+++ b/server/views/applications/pages/oasys-import/_oasys-screen.njk
@@ -1,0 +1,57 @@
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+{% from "../../components/riskWidgets/macro.njk" import widgets %}
+
+{% extends "../layout.njk" %}
+
+{% set columnClasses = "govuk-grid-column-full" %}
+
+{% block questions %}
+  <div class="govuk-grid-row">
+    <div>
+      <h1 class="govuk-heading-l">{{page.title}}</h1>
+      <p>OASys last updated: {{formatDate(page.oasysCompleted)}}</p>
+    </div>
+
+    {{ mojSubNavigation({
+        label: 'Sub navigation',
+        attributes: {
+          'role': 'tablist'
+        },
+        items: [{
+          text: 'RoSH summary',
+          active: (pageName === "roshSummary"),
+          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'rosh-summary' })
+        },
+        {
+          text: 'Offence details',
+          active: (pageName === "offenceDetails"),
+          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'offence-details' })
+        },
+        {
+          text: 'Supporting information',
+          active: (pageName === "supportingInformation"),
+          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'supporting-information' })
+        },
+         {
+          text: 'Risk management plan',
+          active: (pageName === "riskManagementPlan"),
+          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'risk-management-plan' })
+        },
+        {
+          text: 'Risk to self',
+          active: (pageName === "riskToSelf"),
+          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'risk-to-self' })
+        }]
+      }) }}
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds" id="{{ pageName }}">
+      {{OasysImportUtils.textareas(questions, key) | safe}}
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      {{ widgets(page.risks) }}
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/applications/pages/oasys-import/offence-details.njk
+++ b/server/views/applications/pages/oasys-import/offence-details.njk
@@ -1,53 +1,9 @@
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% from "../../components/riskWidgets/macro.njk" import widgets %}
 
-{% extends "../layout.njk" %}
+{% extends "./_oasys-screen.njk" %}
 
 {% set columnClasses = "govuk-grid-column-full" %}
-
-{% block questions %}
-  <div class="govuk-grid-row">
-    <div>
-      <h1 class="govuk-heading-l">{{page.title}}</h1>
-      <p>OASys last updated {{page.oasysCompleted}}</p>
-    </div>
-
-    {{ mojSubNavigation({
-        label: 'Sub navigation',
-        attributes: {
-          'role': 'tablist'
-        },
-        items: [{
-          text: 'RoSH summary',
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'rosh-summary' })
-        }, 
-        {
-          text: 'Offence details',
-          active: true
-        }, 
-        {
-          text: 'Supporting information', 
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'supporting-information' })
-        },  
-         {
-          text: 'Risk management plan',
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'risk-management-plan' }) 
-        },
-        {
-          text: 'Risk to self',
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'risk-to-self' })
-        }]
-      }) }}
-  </div>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds" id="offenceDetails" >
-      {{OasysImportUtils.textareas(page.offenceDetailsSummaries, 'offenceDetailsAnswers') | safe}}
-    </div>
-
-    <div class="govuk-grid-column-one-third">
-      {{ widgets(page.risks) }}
-    </div>
-  </div>
-
-{% endblock %}
+{% set pageName = "offenceDetails" %}
+{% set questions = page.offenceDetailsSummaries %}
+{% set key = "offenceDetailsAnswers" %}

--- a/server/views/applications/pages/oasys-import/risk-management-plan.njk
+++ b/server/views/applications/pages/oasys-import/risk-management-plan.njk
@@ -1,54 +1,9 @@
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% from "../../components/riskWidgets/macro.njk" import widgets %}
 
-{% extends "../layout.njk" %}
+{% extends "./_oasys-screen.njk" %}
 
 {% set columnClasses = "govuk-grid-column-full" %}
-
-{% block questions %}
-  <div class="govuk-grid-row">
-    <div>
-      <h1 class="govuk-heading-l">{{page.title}}</h1>
-      <p>OASys last updated {{page.oasysCompleted}}</p>
-    </div>
-
-    {{ mojSubNavigation({
-        label: 'Sub navigation',
-        attributes: {
-          'role': 'tablist'
-        },
-        items: [{
-          text: 'RoSH summary',
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'rosh-summary' })
-        }, 
-        {
-          text: 'Offence details',
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'offence-details' }) 
-        }, 
-        {
-          text: 'Supporting information', 
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'supporting-information' })
-        },  
-         {
-          text: 'Risk management plan',
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'risk-management-plan' }),
-          active: true
-        },
-        {
-          text: 'Risk to self',
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'risk-to-self' })
-        }]
-      }) }}
-  </div>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds" id="riskManagementPlan">
-      {{OasysImportUtils.textareas(page.riskManagementSummaries, 'riskManagementAnswers') | safe}}
-    </div>
-
-    <div class="govuk-grid-column-one-third">
-      {{ widgets(page.risks) }}
-    </div>
-  </div>
-
-{% endblock %}
+{% set pageName = "riskManagementPlan" %}
+{% set questions = page.riskManagementSummaries %}
+{% set key = "riskManagementAnswers" %}

--- a/server/views/applications/pages/oasys-import/risk-to-self.njk
+++ b/server/views/applications/pages/oasys-import/risk-to-self.njk
@@ -1,54 +1,9 @@
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% from "../../components/riskWidgets/macro.njk" import widgets %}
 
-{% extends "../layout.njk" %}
+{% extends "./_oasys-screen.njk" %}
 
 {% set columnClasses = "govuk-grid-column-full" %}
-
-{% block questions %}
-  <div class="govuk-grid-row">
-    <div>
-      <h1 class="govuk-heading-l">{{page.title}}</h1>
-      <p>OASys last updated {{page.oasysCompleted}}</p>
-    </div>
-
-    {{ mojSubNavigation({
-        label: 'Sub navigation',
-        attributes: {
-          'role': 'tablist'
-        },
-        items: [{
-          text: 'RoSH summary',
-          href: '#roshSummary'
-        }, 
-        {
-          text: 'Offence details',
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'offence-details' }) 
-        }, 
-        {
-          text: 'Supporting information',
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'supporting-information' })
-        },  
-        {
-          text: 'Risk management plan',
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'risk-management-plan' }) 
-        },
-        {
-          text: 'Risk to self',
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'risk-to-self' }),          
-          active: true
-        }]
-      }) }}
-  </div>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds" id="riskToSelf">
-      {{OasysImportUtils.textareas(page.riskToSelfSummaries, 'riskToSelfAnswers') | safe}}
-    </div>
-
-    <div class="govuk-grid-column-one-third">
-      {{ widgets(page.risks) }}
-    </div>
-  </div>
-
-{% endblock %}
+{% set pageName = "riskToSelf" %}
+{% set questions = page.riskToSelfSummaries %}
+{% set key = "riskToSelfAnswers" %}

--- a/server/views/applications/pages/oasys-import/rosh-summary.njk
+++ b/server/views/applications/pages/oasys-import/rosh-summary.njk
@@ -1,54 +1,9 @@
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% from "../../components/riskWidgets/macro.njk" import widgets %}
 
-{% extends "../layout.njk" %}
+{% extends "./_oasys-screen.njk" %}
 
 {% set columnClasses = "govuk-grid-column-full" %}
-
-{% block questions %}
-  <div class="govuk-grid-row">
-    <div>
-      <h1 class="govuk-heading-l">{{page.title}}</h1>
-      <p>OASys last updated {{page.oasysCompleted}}</p>
-    </div>
-
-    {{ mojSubNavigation({
-        label: 'Sub navigation',
-        attributes: {
-          'role': 'tablist'
-        },
-        items: [{
-          text: 'RoSH summary',
-          href: '#roshSummary',
-          active: true
-        }, 
-        {
-          text: 'Offence details',
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'offence-details' }) 
-        }, 
-        {
-          text: 'Supporting information',
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'supporting-information' })
-        },  
-        {
-          text: 'Risk management plan',
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'risk-management-plan' }) 
-        },
-        {
-          text: 'Risk to self',
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'risk-to-self' })
-        }]
-      }) }}
-  </div>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds" id="roshSummary">
-      {{OasysImportUtils.textareas(page.roshSummary, 'roshAnswers') | safe}}
-    </div>
-
-    <div class="govuk-grid-column-one-third">
-      {{ widgets(page.risks) }}
-    </div>
-  </div>
-
-{% endblock %}
+{% set pageName = "roshSummary" %}
+{% set questions = page.roshSummary %}
+{% set key = "roshAnswers" %}

--- a/server/views/applications/pages/oasys-import/supporting-information.njk
+++ b/server/views/applications/pages/oasys-import/supporting-information.njk
@@ -1,57 +1,9 @@
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% from "../../components/riskWidgets/macro.njk" import widgets %}
 
-{% extends "../layout.njk" %}
+{% extends "./_oasys-screen.njk" %}
 
 {% set columnClasses = "govuk-grid-column-full" %}
-
-{% block questions %}
-  <div class="govuk-grid-row">
-    <div>
-      <h1 class="govuk-heading-l">{{page.title}}</h1>
-      <p>Imported from OASys 23 October 2022</p>
-      <p>OASys last updated {{page.oasysCompleted}}</p>
-    </div>
-
-    {{ mojSubNavigation({
-        label: 'Sub navigation',
-        attributes: {
-          'role': 'tablist'
-        },
-        items: [
-        {
-          text: 'RoSH summary',
-          href:  paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'rosh-summary' })
-        }, 
-        {
-          text: 'Offence details',
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'offence-details' }) 
-        }, 
-        {
-          text: 'Supporting information',
-          href:'', 
-          active: true
-        },  
-        {
-          text: 'Risk management plan',
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'risk-management-plan' }) 
-        },
-        {
-          text: 'Risk to self',
-          href: paths.applications.pages.show({ id: applicationId, task: 'oasys-import', page: 'risk-to-self' })
-        }]
-      }) }}
-
-  </div>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds" id="supportingInformation">
-      {{OasysImportUtils.textareas(page.supportingInformationSummaries, 'supportingInformationAnswers') | safe }}
-    </div>
-
-    <div class="govuk-grid-column-one-third">
-      {{ widgets(page.risks) }}
-    </div>
-  </div>
-
-{% endblock %}
+{% set pageName = "supportingInformation" %}
+{% set questions = page.supportingInformationSummaries %}
+{% set key = "supportingInformationAnswers" %}


### PR DESCRIPTION
If `dateCompleted` is blank from an OASys response, we were getting an exception. After a discussion with the team, we decided that if the assessment was not completed, we'd use the `dateStarted` to get the date that OASys was last updated. This also uses a partial for those screens to DRY things up a bit.