### PR TITLE
(979) Add Helm charts for test environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,24 @@ workflows:
             - hmpps-approved-premises-ui-preprod
           requires:
             - request-preprod-approval
+      - request-test-approval:
+          type: approval
+          requires:
+            - deploy_dev
+            - e2e_environment_test
+      - hmpps/deploy_env:
+          name: deploy_test
+          env: 'test'
+          jira_update: true
+          context: hmpps-common-vars
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - helm_lint
+            - build_docker
+            - request-test-approval
 
   #      - request-prod-approval:
   #          type: approval

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -1,0 +1,24 @@
+---
+# Per environment values which override defaults in approved-premises-ui/values.yaml
+
+generic-service:
+  replicaCount: 2
+
+  ingress:
+    hosts:
+      - approved-premises-test.hmpps.service.justice.gov.uk
+    contextColour: green
+    tlsSecretName: approved-premises-test-cert
+
+  env:
+    ENVIRONMENT: test
+    APPROVED_PREMISES_API_URL: 'https://approved-premises-api-test.hmpps.service.justice.gov.uk'
+    INGRESS_URL: 'https://approved-premises-test.hmpps.service.justice.gov.uk'
+    HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'
+    TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
+    COMMUNITY_ACCOMMODATION_API_SERVICE_NAME: approved-premises
+
+  allowlist: null
+
+generic-prometheus-alerts:
+  alertSeverity: digital-prison-service-dev


### PR DESCRIPTION
This adds Helm charts and CircleCI config for the new test environment. This will only work when the new `test` namespace is deployed.