### PR TITLE
(983) Fix OptionalOasysSections page

### DIFF
--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.test.ts
@@ -2,7 +2,6 @@ import { createMock, DeepMocked } from '@golevelup/ts-jest'
 import { ApplicationService, PersonService } from '../../../../services'
 import applicationFactory from '../../../../testutils/factories/application'
 import oasysSelectionFactory from '../../../../testutils/factories/oasysSelection'
-import { sentenceCase } from '../../../../utils/utils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
 import OptionalOasysSections from './optionalOasysSections'
@@ -192,69 +191,6 @@ describe('OptionalOasysSections', () => {
           [pageWithOnlyOtherNeeds.otherNeedsHeading]: '2. Some other section',
         })
       })
-    })
-  })
-
-  describe('reoffendingNeedsItems', () => {
-    it('it returns reoffending needs as checkbox items', () => {
-      const needLinkedToReoffendingA = oasysSelectionFactory
-        .needsLinkedToReoffending()
-        .build({ section: 1, name: 'emotional' })
-      const needLinkedToReoffendingB = oasysSelectionFactory.needsLinkedToReoffending().build({ section: 2 })
-      const needLinkedToReoffendingC = oasysSelectionFactory.needsLinkedToReoffending().build({ section: 3 })
-
-      const page = new OptionalOasysSections({ needsLinkedToReoffending: [needLinkedToReoffendingA] })
-      page.allNeedsLinkedToReoffending = [needLinkedToReoffendingA, needLinkedToReoffendingB, needLinkedToReoffendingC]
-      const items = page.reoffendingNeedsItems()
-
-      expect(items).toEqual([
-        {
-          checked: true,
-          text: `1. ${sentenceCase(needLinkedToReoffendingA.name)}`,
-          value: '1',
-        },
-        {
-          checked: false,
-          text: `2. ${sentenceCase(needLinkedToReoffendingB.name)}`,
-          value: '2',
-        },
-        {
-          checked: false,
-          text: `3. ${sentenceCase(needLinkedToReoffendingC.name)}`,
-          value: '3',
-        },
-      ])
-    })
-  })
-
-  describe('otherNeedsItems', () => {
-    it('it returns other needs as checkbox items', () => {
-      const otherNeedA = oasysSelectionFactory.needsNotLinkedToReoffending().build({ section: 1 })
-      const otherNeedB = oasysSelectionFactory.needsNotLinkedToReoffending().build({ section: 2, name: 'thinking' })
-      const otherNeedC = oasysSelectionFactory.needsNotLinkedToReoffending().build({ section: 3 })
-
-      const page = new OptionalOasysSections({ otherNeeds: [otherNeedB] })
-      page.allOtherNeeds = [otherNeedA, otherNeedB, otherNeedC]
-
-      const items = page.otherNeedsItems()
-
-      expect(items).toEqual([
-        {
-          checked: false,
-          text: `1. ${sentenceCase(otherNeedA.name)}`,
-          value: '1',
-        },
-        {
-          checked: true,
-          text: `2. ${sentenceCase(otherNeedB.name)}`,
-          value: '2',
-        },
-        {
-          checked: false,
-          text: `3. ${sentenceCase(otherNeedC.name)}`,
-          value: '3',
-        },
-      ])
     })
   })
 })

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.test.ts
@@ -12,8 +12,6 @@ jest.mock('../../../../services/personService.ts')
 describe('OptionalOasysSections', () => {
   const oasysSelection = oasysSelectionFactory.buildList(3)
   const needsLinkedToHarm = oasysSelectionFactory.needsLinkedToHarm().buildList(2)
-  let needsLinkedToReoffending = oasysSelectionFactory.needsLinkedToReoffending().buildList(2)
-  let otherNeeds = oasysSelectionFactory.needsNotLinkedToReoffending().buildList(2)
 
   const application = applicationFactory.build()
 
@@ -22,10 +20,24 @@ describe('OptionalOasysSections', () => {
     let personService: DeepMocked<PersonService>
     const applicationService = createMock<ApplicationService>({})
 
+    const needsLinkedToReoffending = [
+      oasysSelectionFactory.needsLinkedToReoffending().build({ section: 1 }),
+      oasysSelectionFactory.needsLinkedToReoffending().build({ section: 2 }),
+      oasysSelectionFactory.needsLinkedToReoffending().build({ section: 3 }),
+    ]
+
+    const otherNeeds = [
+      oasysSelectionFactory.needsNotLinkedToReoffending().build({ section: 7 }),
+      oasysSelectionFactory.needsNotLinkedToReoffending().build({ section: 8 }),
+      oasysSelectionFactory.needsNotLinkedToReoffending().build({ section: 9 }),
+    ]
+
     beforeEach(() => {
       personService = createMock<PersonService>({
         getOasysSelections: getOasysSelectionsMock,
       })
+
+      getOasysSelectionsMock.mockResolvedValue([...needsLinkedToHarm, ...needsLinkedToReoffending, ...otherNeeds])
     })
 
     it('calls the getOasysSelections method on the client with a token and the persons CRN', async () => {
@@ -35,12 +47,6 @@ describe('OptionalOasysSections', () => {
     })
 
     it('filters the OASys sections into needs linked to reoffending and other needs not linked to reoffending or harm', async () => {
-      personService.getOasysSelections.mockResolvedValue([
-        ...needsLinkedToHarm,
-        ...needsLinkedToReoffending,
-        ...otherNeeds,
-      ])
-
       const page = await OptionalOasysSections.initialize({}, application, 'some-token', {
         personService,
         applicationService,
@@ -50,14 +56,22 @@ describe('OptionalOasysSections', () => {
       expect(page.allOtherNeeds).toEqual(otherNeeds)
     })
 
-    it('initializes the OptionalOasysSections class with the selected sections', async () => {
-      needsLinkedToReoffending = oasysSelectionFactory.needsLinkedToReoffending().buildList(1, { section: 1 })
-      otherNeeds = oasysSelectionFactory.needsNotLinkedToReoffending().buildList(1, { section: 2 })
+    it('returns an empty array for the selected needs if the body is empty', async () => {
+      const page = await OptionalOasysSections.initialize({}, application, 'some-token', {
+        personService,
+        applicationService,
+      })
 
-      getOasysSelectionsMock.mockResolvedValueOnce([...needsLinkedToReoffending, ...otherNeeds])
+      expect(page.body.needsLinkedToReoffending).toEqual([])
+      expect(page.body.otherNeeds).toEqual([])
+    })
 
+    it('initializes the OptionalOasysSections class with the selected sections when sections are a string', async () => {
       const page = await OptionalOasysSections.initialize(
-        { needsLinkedToReoffending: '1', otherNeeds: '2' },
+        {
+          needsLinkedToReoffending: needsLinkedToReoffending[0].section.toString(),
+          otherNeeds: [otherNeeds[0].section.toString(), otherNeeds[1].section.toString()],
+        },
         application,
         'some-token',
         {
@@ -66,22 +80,23 @@ describe('OptionalOasysSections', () => {
         },
       )
 
-      expect(page.body.needsLinkedToReoffending).toEqual([
+      expect(page.body.needsLinkedToReoffending).toEqual([needsLinkedToReoffending[0]])
+      expect(page.body.otherNeeds).toEqual([otherNeeds[0], otherNeeds[1]])
+    })
+
+    it('initializes the OptionalOasysSections class with the selected sections when sections are section objects', async () => {
+      const page = await OptionalOasysSections.initialize(
+        { needsLinkedToReoffending: [needsLinkedToReoffending[0]], otherNeeds: [otherNeeds[0], otherNeeds[1]] },
+        application,
+        'some-token',
         {
-          linkedToHarm: false,
-          linkedToReOffending: true,
-          name: needsLinkedToReoffending[0].name,
-          section: 1,
+          personService,
+          applicationService,
         },
-      ])
-      expect(page.body.otherNeeds).toEqual([
-        {
-          linkedToHarm: false,
-          linkedToReOffending: false,
-          name: otherNeeds[0].name,
-          section: 2,
-        },
-      ])
+      )
+
+      expect(page.body.needsLinkedToReoffending).toEqual([needsLinkedToReoffending[0]])
+      expect(page.body.otherNeeds).toEqual([otherNeeds[0], otherNeeds[1]])
     })
   })
 

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
@@ -104,25 +104,6 @@ export default class OptionalOasysSections implements TasklistPage {
     return ''
   }
 
-  reoffendingNeedsItems() {
-    return this.checkboxes(this.allNeedsLinkedToReoffending, this.body.needsLinkedToReoffending)
-  }
-
-  otherNeedsItems() {
-    return this.checkboxes(this.allOtherNeeds, this.body.otherNeeds)
-  }
-
-  private checkboxes(fullList: Array<OASysSection>, selectedList: Array<OASysSection>) {
-    return fullList.map(need => {
-      const sectionAndName = `${need.section}. ${sentenceCase(need.name)}`
-      return {
-        value: need.section.toString(),
-        text: sectionAndName,
-        checked: selectedList.map(n => n.section).includes(need.section),
-      }
-    })
-  }
-
   errors() {
     return {}
   }

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
@@ -46,22 +46,11 @@ export default class OptionalOasysSections implements TasklistPage {
     )
     const allOtherNeeds = oasysSelections.filter(section => !section.linkedToHarm && !section.linkedToReOffending)
 
-    const fullLists = {
-      needsLinkedToReoffending: allNeedsLinkedToReoffending,
-      otherNeeds: allOtherNeeds,
-    }
-
-    const lists = ['needsLinkedToReoffending', 'otherNeeds']
-
-    lists.forEach(section => {
-      if (isStringOrArrayOfStrings(body[section])) {
-        body[section] = flattenCheckboxInput(body[section])
-      }
-
-      body[section] = (body[section] || []).map((need: string) =>
-        fullLists[section].find((n: OASysSection) => need === n.section.toString()),
-      )
-    })
+    body.needsLinkedToReoffending = OptionalOasysSections.getSelectedNeeds(
+      body.needsLinkedToReoffending,
+      allNeedsLinkedToReoffending,
+    )
+    body.otherNeeds = OptionalOasysSections.getSelectedNeeds(body.otherNeeds, allOtherNeeds)
 
     const page = new OptionalOasysSections(body as Body)
 
@@ -69,6 +58,23 @@ export default class OptionalOasysSections implements TasklistPage {
     page.allOtherNeeds = allOtherNeeds
 
     return page
+  }
+
+  private static getSelectedNeeds(
+    selectedSections: string | Array<string> | Array<OASysSection>,
+    allSections: Array<OASysSection>,
+  ): Array<OASysSection> {
+    if (!selectedSections) {
+      return []
+    }
+
+    if (isStringOrArrayOfStrings(selectedSections)) {
+      const sectionIds = flattenCheckboxInput(selectedSections as string | Array<string>) || []
+
+      return sectionIds.map((need: string) => allSections.find((n: OASysSection) => need === n.section.toString()))
+    }
+
+    return selectedSections as Array<OASysSection>
   }
 
   previous() {

--- a/server/utils/oasysImportUtils.test.ts
+++ b/server/utils/oasysImportUtils.test.ts
@@ -1,7 +1,14 @@
 import applicationFactory from '../testutils/factories/application'
 import { roshSummaryFactory } from '../testutils/factories/oasysSections'
 import oasysSelectionFactory from '../testutils/factories/oasysSelection'
-import { fetchOptionalOasysSections, oasysImportReponse, textareas, sortOasysImportSummaries } from './oasysImportUtils'
+import { sentenceCase } from './utils'
+import {
+  fetchOptionalOasysSections,
+  oasysImportReponse,
+  textareas,
+  sortOasysImportSummaries,
+  sectionCheckBoxes,
+} from './oasysImportUtils'
 
 describe('OASysImportUtils', () => {
   describe('textareas', () => {
@@ -109,6 +116,39 @@ describe('OASysImportUtils', () => {
 
       const result = sortOasysImportSummaries([oasysSummary3, oasysSummary2, oasysSummary1])
       expect(result).toEqual([oasysSummary1, oasysSummary2, oasysSummary3])
+    })
+  })
+
+  describe('sectionCheckBoxes', () => {
+    it('it returns needs as checkbox items', () => {
+      const needLinkedToReoffendingA = oasysSelectionFactory
+        .needsLinkedToReoffending()
+        .build({ section: 1, name: 'emotional' })
+      const needLinkedToReoffendingB = oasysSelectionFactory.needsLinkedToReoffending().build({ section: 2 })
+      const needLinkedToReoffendingC = oasysSelectionFactory.needsLinkedToReoffending().build({ section: 3 })
+
+      const items = sectionCheckBoxes(
+        [needLinkedToReoffendingA, needLinkedToReoffendingB, needLinkedToReoffendingC],
+        [needLinkedToReoffendingA],
+      )
+
+      expect(items).toEqual([
+        {
+          checked: true,
+          text: `1. ${sentenceCase(needLinkedToReoffendingA.name)}`,
+          value: '1',
+        },
+        {
+          checked: false,
+          text: `2. ${sentenceCase(needLinkedToReoffendingB.name)}`,
+          value: '2',
+        },
+        {
+          checked: false,
+          text: `3. ${sentenceCase(needLinkedToReoffendingC.name)}`,
+          value: '3',
+        },
+      ])
     })
   })
 })

--- a/server/utils/oasysImportUtils.ts
+++ b/server/utils/oasysImportUtils.ts
@@ -2,6 +2,7 @@ import { OasysImportArrays } from '../@types/ui'
 import { Application, OASysQuestion, OASysSection } from '../@types/shared'
 import { SessionDataError } from './errors'
 import { escape } from './formUtils'
+import { sentenceCase } from './utils'
 
 export const textareas = (questions: OasysImportArrays, key: 'roshAnswers' | 'offenceDetails') => {
   return questions
@@ -59,4 +60,15 @@ export const fetchOptionalOasysSections = (application: Application): Array<numb
 
 export const sortOasysImportSummaries = (summaries: Array<OASysQuestion>): Array<OASysQuestion> => {
   return summaries.sort((a, b) => Number(a.questionNumber) - Number(b.questionNumber))
+}
+
+export const sectionCheckBoxes = (fullList: Array<OASysSection>, selectedList: Array<OASysSection>) => {
+  return fullList.map(need => {
+    const sectionAndName = `${need.section}. ${sentenceCase(need.name)}`
+    return {
+      value: need.section.toString(),
+      text: sectionAndName,
+      checked: selectedList.map(n => n.section).includes(need.section),
+    }
+  })
 }

--- a/server/views/applications/pages/oasys-import/optional-oasys-sections.njk
+++ b/server/views/applications/pages/oasys-import/optional-oasys-sections.njk
@@ -1,3 +1,5 @@
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+
 {% extends "../layout.njk" %}
 
 {% block questions %}
@@ -21,30 +23,34 @@
 
     <h2 class="govuk-heading-s">Needs linked to risk of serious harm are automatically imported</h2>
 
-    {{ applyCheckboxes({
-        fieldName: "needsLinkedToReoffending",
-        fieldset: {
-            legend: {
-            text: "Optional - Needs linked to reoffending",
-            classes: "govuk-fieldset__legend--m"
-            }
-        },
-        items: page.reoffendingNeedsItems()
-        }, 
-        fetchContext()) 
+    {{
+        govukCheckboxes({
+            idPrefix: "needsLinkedToReoffending",
+            name: "needsLinkedToReoffending",
+            errorMessage: errors.needsLinkedToReoffending,
+            fieldset: {
+                legend: {
+                    text: "Optional - Needs linked to reoffending",
+                    classes: "govuk-fieldset__legend--m"
+                }
+            },
+            items: page.reoffendingNeedsItems()
+        })
     }}
 
-    {{ applyCheckboxes({
-        fieldName: "otherNeeds",
-        fieldset: {
-            legend: {
-            text: "Optional - Needs not linked to risk of serious harm or reoffending",
-            classes: "govuk-fieldset__legend--m"
-            }
-        },
-        items: page.otherNeedsItems()
-        }, 
-        fetchContext()) 
+    {{
+        govukCheckboxes({
+            idPrefix: "otherNeeds",
+            name: "otherNeeds",
+            errorMessage: errors.otherNeeds,
+            fieldset: {
+                legend: {
+                    text: "Optional - Needs not linked to risk of serious harm or reoffending",
+                    classes: "govuk-fieldset__legend--m"
+                }
+            },
+            items: page.otherNeedsItems()
+        })
     }}
 
 {% endblock %}

--- a/server/views/applications/pages/oasys-import/optional-oasys-sections.njk
+++ b/server/views/applications/pages/oasys-import/optional-oasys-sections.njk
@@ -34,7 +34,7 @@
                     classes: "govuk-fieldset__legend--m"
                 }
             },
-            items: page.reoffendingNeedsItems()
+            items: OasysImportUtils.sectionCheckBoxes(page.allNeedsLinkedToReoffending, page.body.needsLinkedToReoffending)
         })
     }}
 
@@ -49,7 +49,7 @@
                     classes: "govuk-fieldset__legend--m"
                 }
             },
-            items: page.otherNeedsItems()
+            items: OasysImportUtils.sectionCheckBoxes(page.allOtherNeeds, page.body.otherNeeds)
         })
     }}
 


### PR DESCRIPTION
When we revisit the Oasys Sections page (for example, to change a response), the body contains the actual section objects, rather than the section IDs, before, we would get an error as the mapping was attempting to match the selected sections against the section ID oft he returned sections. This refactors the code to only do the mapping if the section IDs are present, otherwise pass the objects through as they are.

I've also fixed a bug in the template and moved the checkbox logic to a util method, to fit in with our latest way of doing things.