### PR TITLE
Remove reliance on e2e tests for test deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,6 @@ workflows:
           type: approval
           requires:
             - deploy_dev
-            - e2e_environment_test
       - hmpps/deploy_env:
           name: deploy_test
           env: 'test'


### PR DESCRIPTION
This is currently blocking the test deploy, and it’s arguable we don’t need it