### PR TITLE
Point to correct certificate for test environment

### DIFF
--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -8,7 +8,7 @@ generic-service:
     hosts:
       - approved-premises-test.hmpps.service.justice.gov.uk
     contextColour: green
-    tlsSecretName: approved-premises-test-cert
+    tlsSecretName: hmpps-approved-premises-test-cert
 
   env:
     ENVIRONMENT: test


### PR DESCRIPTION
The secret name is incorrect - should be prefixed with `hmpps`
