### PR TITLE
(1000) Add person names to bookings

### DIFF
--- a/cypress_shared/pages/manage/premisesShow.ts
+++ b/cypress_shared/pages/manage/premisesShow.ts
@@ -86,12 +86,13 @@ export default class PremisesShowPage extends Page {
   private tableShouldContainBookings(bookings: Array<Booking>, type: 'arrival' | 'departure') {
     bookings.forEach((item: Booking) => {
       const date = type === 'arrival' ? item.arrivalDate : item.departureDate
-      cy.contains(item.person.crn)
+      cy.contains(item.person.name)
         .parent()
         .within(() => {
-          cy.get('td').eq(0).contains(DateFormats.isoDateToUIDate(date))
+          cy.get('td').eq(0).contains(item.person.crn)
+          cy.get('td').eq(1).contains(DateFormats.isoDateToUIDate(date))
           cy.get('td')
-            .eq(1)
+            .eq(2)
             .contains('Manage')
             .should('have.attr', 'href', paths.bookings.show({ premisesId: this.premises.id, bookingId: item.id }))
         })
@@ -101,12 +102,13 @@ export default class PremisesShowPage extends Page {
   shouldShowCurrentResidents(currentResidents: Array<Booking>) {
     cy.get('h2').should('contain', 'Current residents')
     currentResidents.forEach((item: Booking) => {
-      cy.contains(item.person.crn)
+      cy.contains(item.person.name)
         .parent()
         .within(() => {
-          cy.get('td').eq(0).contains(DateFormats.isoDateToUIDate(item.departureDate))
+          cy.get('td').eq(0).contains(item.person.crn)
+          cy.get('td').eq(1).contains(DateFormats.isoDateToUIDate(item.departureDate))
           cy.get('td')
-            .eq(1)
+            .eq(2)
             .contains('Manage')
             .should('have.attr', 'href', paths.bookings.show({ premisesId: this.premises.id, bookingId: item.id }))
         })

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -13,6 +13,7 @@ import {
   ArrayOfOASysSupportingInformationQuestions,
   ArrayOfOASysRiskToSelfQuestions,
   ArrayOfOASysRiskManagementPlanQuestions,
+  Booking,
 } from '@approved-premises/api'
 
 interface TasklistPage {
@@ -188,7 +189,7 @@ export interface PersonRisksUI {
 }
 
 export type GroupedListofBookings = {
-  [K in 'arrivingToday' | 'departingToday' | 'upcomingArrivals' | 'upcomingDepartures']: Array<TableRow>
+  [K in 'arrivingToday' | 'departingToday' | 'upcomingArrivals' | 'upcomingDepartures']: Array<Booking>
 }
 
 export type DataServices = Partial<{

--- a/server/controllers/manage/premisesController.test.ts
+++ b/server/controllers/manage/premisesController.test.ts
@@ -1,7 +1,8 @@
 import type { Request, Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 
-import type { SummaryListItem, GroupedListofBookings, TableRow } from '@approved-premises/ui'
+import type { SummaryListItem, GroupedListofBookings } from '@approved-premises/ui'
+import { Booking } from '@approved-premises/api'
 import PremisesService from '../../services/premisesService'
 import BookingService from '../../services/bookingService'
 import PremisesController from './premisesController'
@@ -34,7 +35,7 @@ describe('PremisesController', () => {
     it('should return the premises detail to the template', async () => {
       const premises = { name: 'Some premises', summaryList: { rows: [] as Array<SummaryListItem> } }
       const bookings = createMock<GroupedListofBookings>()
-      const currentResidents = createMock<Array<TableRow>>()
+      const currentResidents = createMock<Array<Booking>>()
       const overcapacityMessage = 'The premises is over capacity for the period January 1st 2023 to Feburary 3rd 2023'
       premisesService.getPremisesDetails.mockResolvedValue(premises)
       premisesService.getOvercapacityMessage.mockResolvedValue([overcapacityMessage])

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -940,19 +940,35 @@
           "type": "object",
           "properties": {
             "additionalNeeds": {
-              "type": "array",
-              "items": {
-                "enum": [
-                  "hearingImpairment",
-                  "learningDisability",
-                  "mobility",
-                  "neurodivergentConditions",
-                  "none",
-                  "other",
-                  "visualImpairment"
-                ],
-                "type": "string"
-              }
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "enum": [
+                      "hearingImpairment",
+                      "learningDisability",
+                      "mobility",
+                      "neurodivergentConditions",
+                      "none",
+                      "other",
+                      "visualImpairment"
+                    ],
+                    "type": "string"
+                  }
+                },
+                {
+                  "enum": [
+                    "hearingImpairment",
+                    "learningDisability",
+                    "mobility",
+                    "neurodivergentConditions",
+                    "none",
+                    "other",
+                    "visualImpairment"
+                  ],
+                  "type": "string"
+                }
+              ]
             },
             "religiousOrCulturalNeeds": {
               "enum": [

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -6,9 +6,6 @@ import newBookingFactory from '../testutils/factories/newBooking'
 import bookingExtensionFactory from '../testutils/factories/bookingExtension'
 import bookingFactory from '../testutils/factories/booking'
 
-import paths from '../paths/manage'
-import { DateFormats } from '../utils/dateUtils'
-
 jest.mock('../data/bookingClient.ts')
 jest.mock('../data/referenceDataClient.ts')
 
@@ -71,7 +68,7 @@ describe('BookingService', () => {
 
       const results = await service.listOfBookingsForPremisesId(token, premisesId)
 
-      expect(results).toEqual(service.bookingsToTableRows(bookings, premisesId, 'arrival'))
+      expect(results).toEqual(bookings)
 
       expect(bookingClient.allBookingsForPremisesId).toHaveBeenCalledWith(premisesId)
 
@@ -108,14 +105,10 @@ describe('BookingService', () => {
 
       const results = await service.groupedListOfBookingsForPremisesId(token, 'some-uuid')
 
-      expect(results.arrivingToday).toEqual(service.bookingsToTableRows(bookingsArrivingToday, premisesId, 'arrival'))
-      expect(results.departingToday).toEqual(
-        service.bookingsToTableRows(bookingsDepartingToday, premisesId, 'departure'),
-      )
-      expect(results.upcomingArrivals).toEqual(service.bookingsToTableRows(bookingsArrivingSoon, premisesId, 'arrival'))
-      expect(results.upcomingDepartures).toEqual(
-        service.bookingsToTableRows(bookingsDepartingSoon, premisesId, 'departure'),
-      )
+      expect(results.arrivingToday).toEqual(bookingsArrivingToday)
+      expect(results.departingToday).toEqual(bookingsDepartingToday)
+      expect(results.upcomingArrivals).toEqual(bookingsArrivingSoon)
+      expect(results.upcomingDepartures).toEqual(bookingsDepartingSoon)
 
       expect(bookingClient.allBookingsForPremisesId).toHaveBeenCalledWith(premisesId)
 
@@ -144,60 +137,6 @@ describe('BookingService', () => {
     })
   })
 
-  describe('bookingsToTableRows', () => {
-    it('should convert bookings to table rows with an arrival date', () => {
-      const premisesId = 'some-uuid'
-
-      const booking1Date = new Date(2022, 10, 22)
-      const booking2Date = new Date(2022, 2, 11)
-
-      const bookings = [
-        bookingFactory.build({ arrivalDate: booking1Date.toISOString() }),
-        bookingFactory.build({ arrivalDate: booking2Date.toISOString() }),
-      ]
-
-      const results = service.bookingsToTableRows(bookings, premisesId, 'arrival')
-
-      expect(results[0][0]).toEqual({ text: bookings[0].person.crn })
-      expect(results[0][1]).toEqual({ text: DateFormats.dateObjtoUIDate(booking1Date) })
-      expect(results[0][2]).toEqual({
-        html: expect.stringMatching(paths.bookings.show({ premisesId, bookingId: bookings[0].id })),
-      })
-
-      expect(results[1][0]).toEqual({ text: bookings[1].person.crn })
-      expect(results[1][1]).toEqual({ text: DateFormats.dateObjtoUIDate(booking2Date) })
-      expect(results[1][2]).toEqual({
-        html: expect.stringMatching(paths.bookings.show({ premisesId, bookingId: bookings[1].id })),
-      })
-    })
-
-    it('should convert bookings to table rows with a departure date', () => {
-      const premisesId = 'some-uuid'
-
-      const booking1Date = new Date(2022, 10, 22)
-      const booking2Date = new Date(2022, 2, 11)
-
-      const bookings = [
-        bookingFactory.build({ departureDate: booking1Date.toISOString() }),
-        bookingFactory.build({ departureDate: booking2Date.toISOString() }),
-      ]
-
-      const results = service.bookingsToTableRows(bookings, premisesId, 'departure')
-
-      expect(results[0][0]).toEqual({ text: bookings[0].person.crn })
-      expect(results[0][1]).toEqual({ text: DateFormats.dateObjtoUIDate(booking1Date) })
-      expect(results[0][2]).toEqual({
-        html: expect.stringMatching(paths.bookings.show({ premisesId, bookingId: bookings[0].id })),
-      })
-
-      expect(results[1][0]).toEqual({ text: bookings[1].person.crn })
-      expect(results[1][1]).toEqual({ text: DateFormats.dateObjtoUIDate(booking2Date) })
-      expect(results[1][2]).toEqual({
-        html: expect.stringMatching(paths.bookings.show({ premisesId, bookingId: bookings[1].id })),
-      })
-    })
-  })
-
   describe('currentResidents', () => {
     it('should return table rows of the current residents', async () => {
       const bookingsArrivingToday = bookingFactory.arrivingToday().buildList(2)
@@ -208,7 +147,7 @@ describe('BookingService', () => {
 
       const results = await service.currentResidents(token, 'some-uuid')
 
-      expect(results).toEqual(service.currentResidentsToTableRows(currentResidents, premisesId))
+      expect(results).toEqual(currentResidents)
 
       expect(bookingClient.allBookingsForPremisesId).toHaveBeenCalledWith(premisesId)
 

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -41,6 +41,9 @@ describe('bookingUtils', () => {
       expect(bookingsToTableRows(bookings, premisesId, 'arrival')).toEqual([
         [
           {
+            text: bookings[0].person.name,
+          },
+          {
             text: bookings[0].person.crn,
           },
           {
@@ -51,6 +54,9 @@ describe('bookingUtils', () => {
           },
         ],
         [
+          {
+            text: bookings[1].person.name,
+          },
           {
             text: bookings[1].person.crn,
           },
@@ -68,6 +74,9 @@ describe('bookingUtils', () => {
       expect(bookingsToTableRows(bookings, premisesId, 'departure')).toEqual([
         [
           {
+            text: bookings[0].person.name,
+          },
+          {
             text: bookings[0].person.crn,
           },
           {
@@ -78,6 +87,9 @@ describe('bookingUtils', () => {
           },
         ],
         [
+          {
+            text: bookings[1].person.name,
+          },
           {
             text: bookings[1].person.crn,
           },

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -1,8 +1,97 @@
-import bookingActions from './bookingUtils'
+import { bookingActions, bookingsToTableRows, manageBookingLink } from './bookingUtils'
 import bookingFactory from '../testutils/factories/booking'
+import personFactory from '../testutils/factories/person'
 import paths from '../paths/manage'
+import { DateFormats } from './dateUtils'
 
 describe('bookingUtils', () => {
+  const premisesId = 'e8f29a4a-dd4d-40a2-aa58-f3f60245c8fc'
+
+  describe('manageBookingLink', () => {
+    it('returns a link for a booking', () => {
+      const booking = bookingFactory.build()
+
+      expect(manageBookingLink(premisesId, booking)).toMatchStringIgnoringWhitespace(`<a href="${paths.bookings.show({
+        premisesId,
+        bookingId: booking.id,
+      })}">
+      Manage
+      <span class="govuk-visually-hidden">
+        booking for ${booking.person.crn}
+      </span>
+    </a>`)
+    })
+  })
+
+  describe('bookingsToTableRows', () => {
+    const bookings = [
+      bookingFactory.build({
+        person: personFactory.build({ crn: 'ABC123' }),
+        arrivalDate: '2022-01-01',
+        departureDate: '2022-03-01',
+      }),
+      bookingFactory.build({
+        person: personFactory.build({ crn: 'XYZ345' }),
+        arrivalDate: '2022-01-02',
+        departureDate: '2022-03-02',
+      }),
+    ]
+
+    it('casts a group of bookings to table rows with the arrival date', () => {
+      expect(bookingsToTableRows(bookings, premisesId, 'arrival')).toEqual([
+        [
+          {
+            text: bookings[0].person.crn,
+          },
+          {
+            text: DateFormats.isoDateToUIDate(bookings[0].arrivalDate),
+          },
+          {
+            html: manageBookingLink(premisesId, bookings[0]),
+          },
+        ],
+        [
+          {
+            text: bookings[1].person.crn,
+          },
+          {
+            text: DateFormats.isoDateToUIDate(bookings[1].arrivalDate),
+          },
+          {
+            html: manageBookingLink(premisesId, bookings[1]),
+          },
+        ],
+      ])
+    })
+
+    it('casts a group of bookings to table rows with the departure date', () => {
+      expect(bookingsToTableRows(bookings, premisesId, 'departure')).toEqual([
+        [
+          {
+            text: bookings[0].person.crn,
+          },
+          {
+            text: DateFormats.isoDateToUIDate(bookings[0].departureDate),
+          },
+          {
+            html: manageBookingLink(premisesId, bookings[0]),
+          },
+        ],
+        [
+          {
+            text: bookings[1].person.crn,
+          },
+          {
+            text: DateFormats.isoDateToUIDate(bookings[1].departureDate),
+          },
+          {
+            html: manageBookingLink(premisesId, bookings[1]),
+          },
+        ],
+      ])
+    })
+  })
+
   describe('bookingActions', () => {
     it('should return null when the booking is cancelled, departed or did not arrive', () => {
       const cancelledBooking = bookingFactory.cancelledWithFutureArrivalDate().build()

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -19,6 +19,9 @@ export const bookingsToTableRows = (
 ): Array<TableRow> => {
   return bookings.map(booking => [
     {
+      text: booking.person.name,
+    },
+    {
       text: booking.person.crn,
     },
     {

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -1,8 +1,36 @@
-import type { IdentityBarMenu } from '@approved-premises/ui'
+import type { IdentityBarMenu, TableRow } from '@approved-premises/ui'
 import type { Booking } from '@approved-premises/api'
 import paths from '../paths/manage'
+import { DateFormats } from './dateUtils'
 
-export default function bookingActions(booking: Booking, premisesId: string): Array<IdentityBarMenu> {
+export const manageBookingLink = (premisesId: string, booking: Booking): string => {
+  return `<a href="${paths.bookings.show({ premisesId, bookingId: booking.id })}">
+    Manage
+    <span class="govuk-visually-hidden">
+      booking for ${booking.person.crn}
+    </span>
+  </a>`
+}
+
+export const bookingsToTableRows = (
+  bookings: Array<Booking>,
+  premisesId: string,
+  type: 'arrival' | 'departure',
+): Array<TableRow> => {
+  return bookings.map(booking => [
+    {
+      text: booking.person.crn,
+    },
+    {
+      text: DateFormats.isoDateToUIDate(type === 'arrival' ? booking.arrivalDate : booking.departureDate),
+    },
+    {
+      html: manageBookingLink(premisesId, booking),
+    },
+  ])
+}
+
+export const bookingActions = (booking: Booking, premisesId: string): Array<IdentityBarMenu> => {
   if (booking.status === 'awaiting-arrival' || booking.status === 'arrived') {
     const items = []
 

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -13,13 +13,13 @@ import { getTaskStatus, taskLink, getCompleteSectionCount, dashboardTableRows } 
 import { checkYourAnswersSections } from './checkYourAnswersUtils'
 
 import { statusTag } from './personUtils'
-import bookingActions from './bookingUtils'
 import { DateFormats } from './dateUtils'
 
 import * as AssessmentUtils from './assessmentUtils'
 import * as OffenceUtils from './offenceUtils'
 import * as AttachDocumentsUtils from './attachDocumentsUtils'
 import * as OasysImportUtils from './oasysImportUtils'
+import * as BookingUtils from './bookingUtils'
 
 import managePaths from '../paths/manage'
 import applyPaths from '../paths/apply'
@@ -99,8 +99,6 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
     },
   )
 
-  njkEnv.addGlobal('bookingActions', bookingActions)
-
   njkEnv.addGlobal('paths', { ...managePaths, ...applyPaths })
 
   njkEnv.addGlobal('getCompleteSectionCount', getCompleteSectionCount)
@@ -135,4 +133,5 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('OffenceUtils', OffenceUtils)
   njkEnv.addGlobal('AttachDocumentsUtils', AttachDocumentsUtils)
   njkEnv.addGlobal('OasysImportUtils', OasysImportUtils)
+  njkEnv.addGlobal('BookingUtils', BookingUtils)
 }

--- a/server/views/bookings/_table.njk
+++ b/server/views/bookings/_table.njk
@@ -1,13 +1,16 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% macro bookingTable(title, dateField, rows) %}
-	{% if rows %}
-		{{
+  {% if rows %}
+    {{
       govukTable({
         caption: title,
         captionClasses: "govuk-table__caption--m",
         firstCellIsHeader: true,
         head: [
+          {
+            text: "Name"
+          },
           {
             text: "CRN"
           },
@@ -21,5 +24,5 @@
         rows: rows
       })
     }}
-	{% endif %}
+  {% endif %}
 {% endmacro %}

--- a/server/views/bookings/show.njk
+++ b/server/views/bookings/show.njk
@@ -22,7 +22,7 @@
          title: {
           html: "<h1>" + pageHeading + "</h1>"
         },
-        menus: bookingActions(booking, premisesId)
+        menus: BookingUtils.bookingActions(booking, premisesId)
       }) }}
 
       <br>
@@ -152,4 +152,3 @@
     new MOJFrontend.ButtonMenu({container: $('.moj-button-menu'), mq: "(min-width: 200em)", buttonText: "Actions", menuClasses: "moj-button-menu__wrapper--right"});
   </script>
 {% endblock %}
-

--- a/server/views/premises/show.njk
+++ b/server/views/premises/show.njk
@@ -91,7 +91,10 @@
     firstCellIsHeader: true,
     head: [
       {
-        text: "Resident"
+        text: "Resident Name"
+      },
+      {
+        text: "CRN"
       },
       {
         text: "Expected Departure Date"

--- a/server/views/premises/show.njk
+++ b/server/views/premises/show.njk
@@ -55,28 +55,28 @@
       label: "Arriving Today",
       id: "arriving-today",
       panel: {
-        html: bookingTable("Arriving Today", "Arrival", bookings.arrivingToday)
+        html: bookingTable("Arriving Today", "Arrival", BookingUtils.bookingsToTableRows(bookings.arrivingToday, premisesId, 'arrival'))
       }
     },
     {
       label: "Departing Today",
       id: "departing-today",
       panel: {
-        html: bookingTable("Departing Today", "Departure", bookings.departingToday)
+        html: bookingTable("Departing Today", "Departure", BookingUtils.bookingsToTableRows(bookings.departingToday, premisesId, 'departure'))
       }
     },
     {
       label: "Upcoming Arrivals",
       id: "upcoming-arrivals",
       panel: {
-        html: bookingTable("Upcoming Arrivals", "Arrival", bookings.upcomingArrivals)
+        html: bookingTable("Upcoming Arrivals", "Arrival", BookingUtils.bookingsToTableRows(bookings.upcomingArrivals, premisesId, 'arrival'))
       }
     },
     {
       label: "Upcoming Departures",
       id: "upcoming-departures",
       panel: {
-        html: bookingTable("Upcoming Departures", "Departure", bookings.upcomingDepartures)
+        html: bookingTable("Upcoming Departures", "Departure", BookingUtils.bookingsToTableRows(bookings.upcomingDepartures, premisesId, 'departure'))
       }
     }
   ]
@@ -100,7 +100,7 @@
         text: "Actions"
       }
     ],
-    rows: currentResidents
+    rows: BookingUtils.bookingsToTableRows(currentResidents, premisesId, 'departure')
   }) }}
 
 {% endblock %}


### PR DESCRIPTION
This adds a person's name when viewing Bookings on the premises page. Before we didn't have access to this information via the API, but now we do, I think it makes sense to show this information upfront. I've also taken the opportunity to add some quality of life improvements to better match the patterns we're using in services and views.

## Before

![before](https://user-images.githubusercontent.com/109774/211003322-80be9b23-27bb-4985-b1ed-a1907552641a.png)

## After

![after](https://user-images.githubusercontent.com/109774/211003344-e38530e8-618d-4fe0-8e93-6346daedcc81.png)
