### PR TITLE
Allow tasklist helpers to work with no data

### DIFF
--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -65,6 +65,13 @@ describe('applicationUtils', () => {
         '<strong class="govuk-tag app-task-list__tag" id="type-of-ap-status">Completed</strong>',
       )
     })
+
+    it('works when the application has no data', () => {
+      const application = applicationFactory.build({ data: null })
+      expect(getTaskStatus(task, application)).toEqual(
+        '<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="type-of-ap-status">Cannot start yet</strong>',
+      )
+    })
   })
 
   describe('getCompleteSectionCount', () => {

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -40,12 +40,12 @@ const createNameAnchorElement = (name: string, applicationId: string) => {
 }
 
 const taskIsComplete = (task: Task, application: ApprovedPremisesApplication): boolean => {
-  return application.data[task.id]
+  return application.data?.[task.id]
 }
 
 const previousTaskIsComplete = (task: Task, application: ApprovedPremisesApplication): boolean => {
   const previousTaskId = taskIds[taskIds.indexOf(task.id) - 1]
-  return previousTaskId ? application.data[previousTaskId] : true
+  return previousTaskId ? application.data?.[previousTaskId] : true
 }
 
 const getTaskStatus = (task: Task, application: ApprovedPremisesApplication): string => {

--- a/server/utils/taskListUtils.test.ts
+++ b/server/utils/taskListUtils.test.ts
@@ -28,5 +28,11 @@ describe('taskListUtils', () => {
 
       expect(taskLinkHelper(task, application, 'applications')).toEqual(`Type of Approved Premises required`)
     })
+
+    it('should return the task name when the application has no data', () => {
+      const application = applicationFactory.build({ id: 'some-uuid', data: null })
+
+      expect(taskLinkHelper(task, application, 'applications')).toEqual(`Type of Approved Premises required`)
+    })
   })
 })


### PR DESCRIPTION
When an asessment is first initialized, the data is in a `null` state, so we see errors when viewing the tasklist. This adds some guards to those helpers to allow us to query the data safely.