### PR TITLE
Allow full error trace in Nunjucks

### DIFF
--- a/server/@types/nunjucks/index.d.ts
+++ b/server/@types/nunjucks/index.d.ts
@@ -1,0 +1,7 @@
+export default {}
+
+declare module 'nunjucks' {
+  export interface ConfigureOptions {
+    dev?: boolean | undefined
+  }
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -56,6 +56,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
     {
       autoescape: true,
       express: app,
+      dev: true, // This is set to true to allow us to see the full stacktrace from errors in global functions, otherwise it gets swallowed and tricky to see in logs
     },
   )
 


### PR DESCRIPTION
When a global function in a template throws an error, we don’t see the full trace of the error, which makes diagnosing issues really hard.

This makes use of the [undocumented dev argument](https://github.com/mozilla/nunjucks/issues/1430) which allows us to see the cause of the error in our logs and in Sentry.

I’ve had to extend the nunjucks types to allow for this option to be set, as it’s not in the type definition in `DefinitelyTyped`. However, I’ve [opened a PR to add this](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63968)