### PR TITLE
Send page name to UnknownPageError

### DIFF
--- a/server/controllers/apply/applications/pagesController.test.ts
+++ b/server/controllers/apply/applications/pagesController.test.ts
@@ -105,7 +105,7 @@ describe('pagesController', () => {
 
     it('returns a 404 when the page cannot be found', async () => {
       applicationService.initializePage.mockImplementation(() => {
-        throw new UnknownPageError()
+        throw new UnknownPageError('some-page')
       })
 
       const requestHandler = pagesController.show('some-task', 'some-page')

--- a/server/controllers/assess/pagesController.test.ts
+++ b/server/controllers/assess/pagesController.test.ts
@@ -101,7 +101,7 @@ describe('pagesController', () => {
 
     it('returns a 404 when the page cannot be found', async () => {
       assessmentService.initializePage.mockImplementation(() => {
-        throw new UnknownPageError()
+        throw new UnknownPageError('some-page')
       })
       const requestHandler = pagesController.show('some-task', 'some-page')
       await requestHandler(request, response, next)

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -72,7 +72,7 @@ const getPage = (taskName: string, pageName: string): TasklistPageInterface => {
   const Page = pageList[pageName]
 
   if (!Page) {
-    throw new UnknownPageError()
+    throw new UnknownPageError(pageName)
   }
 
   return Page as TasklistPageInterface

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -186,7 +186,7 @@ const getPage = (taskName: string, pageName: string): TasklistPageInterface => {
   const Page = pageList[pageName]
 
   if (!Page) {
-    throw new UnknownPageError()
+    throw new UnknownPageError(pageName)
   }
 
   return Page as TasklistPageInterface

--- a/server/utils/errors.ts
+++ b/server/utils/errors.ts
@@ -11,7 +11,11 @@ export class ValidationError<T extends TaskListPage> extends Error {
 }
 
 export class SessionDataError extends Error {}
-export class UnknownPageError extends Error {}
+export class UnknownPageError extends Error {
+  constructor(pageName: string) {
+    super(`Cannot find the page ${pageName}`)
+  }
+}
 
 export class TasklistAPIError extends Error {
   field: string


### PR DESCRIPTION
This will make it easier to diagnose when this error is raised.