### PR TITLE
(1014) Create a clarification note in the frontend

### DIFF
--- a/cypress_shared/pages/assess/clarificationNoteConfirmPage.ts
+++ b/cypress_shared/pages/assess/clarificationNoteConfirmPage.ts
@@ -1,0 +1,11 @@
+import Page from '../page'
+
+export default class SufficientInformationPage extends Page {
+  constructor() {
+    super('Note Created')
+  }
+
+  clickBackToDashboard() {
+    cy.get('a').contains('Back to dashboard').click()
+  }
+}

--- a/cypress_shared/pages/assess/index.ts
+++ b/cypress_shared/pages/assess/index.ts
@@ -1,9 +1,20 @@
 /* eslint-disable import/prefer-default-export */
+import ClarificationNoteConfirmPage from './clarificationNoteConfirmPage'
 import ListPage from './listPage'
-import TaskListPage from './taskListPage'
+import RequestInformationPage from './requestInformationPage'
+import RequiredActionsPage from './requiredActionsPage'
 import ReviewPage from './reviewPage'
 import SufficientInformationPage from './sufficientInformationPage'
 import SuitabilityAssessmentPage from './suitabilityAssessmentPage'
-import RequiredActionsPage from './requiredActionsPage'
+import TaskListPage from './taskListPage'
 
-export { ListPage, TaskListPage, ReviewPage, SufficientInformationPage, SuitabilityAssessmentPage, RequiredActionsPage }
+export {
+  ClarificationNoteConfirmPage,
+  ListPage,
+  RequestInformationPage,
+  RequiredActionsPage,
+  ReviewPage,
+  SufficientInformationPage,
+  SuitabilityAssessmentPage,
+  TaskListPage,
+}

--- a/cypress_shared/pages/assess/requestInformationPage.ts
+++ b/cypress_shared/pages/assess/requestInformationPage.ts
@@ -1,0 +1,11 @@
+import Page from '../page'
+
+export default class RequestInformationPage extends Page {
+  constructor() {
+    super('Request information from probation practicioner')
+  }
+
+  completeForm() {
+    this.completeTextArea('query', 'Note goes here')
+  }
+}

--- a/cypress_shared/pages/assess/sufficientInformationPage.ts
+++ b/cypress_shared/pages/assess/sufficientInformationPage.ts
@@ -1,14 +1,16 @@
 import type { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
+import type { YesOrNo } from '@approved-premises/ui'
 
 import AssessPage from './assessPage'
 
 import SufficientInformation from '../../../server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation'
 
 export default class SufficientInformationPage extends AssessPage {
-  pageClass = new SufficientInformation({ sufficientInformation: 'yes' })
+  pageClass: SufficientInformation
 
-  constructor(assessment: Assessment) {
+  constructor(assessment: Assessment, answer: YesOrNo = 'yes') {
     super(assessment, 'Suitability Assessment')
+    this.pageClass = new SufficientInformation({ sufficientInformation: answer })
   }
 
   completeForm() {

--- a/integration_tests/mockApis/assessments.ts
+++ b/integration_tests/mockApis/assessments.ts
@@ -1,9 +1,9 @@
 import { SuperAgentRequest } from 'superagent'
 
-import type { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
+import type { ApprovedPremisesAssessment as Assessment, NewClarificationNote } from '@approved-premises/api'
 
 import { stubFor } from '../../wiremock'
-import paths from '../../server/paths/assess'
+import paths from '../../server/paths/api'
 
 export default {
   stubAssessments: (assessments: Array<Assessment>): SuperAgentRequest =>
@@ -40,6 +40,18 @@ export default {
         status: 201,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: assessment,
+      },
+    }),
+  stubClarificationNoteCreate: (args: { assessment: Assessment; note: NewClarificationNote }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: paths.assessments.clarificationNotes.create({ id: args.assessment.id }),
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.note,
       },
     }),
 }

--- a/integration_tests/tests/assess/assess.cy.ts
+++ b/integration_tests/tests/assess/assess.cy.ts
@@ -1,5 +1,7 @@
 import assessmentFactory from '../../../server/testutils/factories/assessment'
 import documentFactory from '../../../server/testutils/factories/document'
+import clarificationNoteFactory from '../../../server/testutils/factories/clarificationNote'
+
 import { overwriteApplicationDocuments } from '../../../server/utils/applicationUtils'
 
 import AssessHelper from '../../../cypress_shared/helpers/assess'
@@ -33,6 +35,32 @@ context('Assess', () => {
 
       // And I complete an assessment
       assessHelper.completeAssessment()
+    })
+  })
+
+  it('allows me to create and update a clarification note', () => {
+    // Given I am logged in
+    cy.signIn()
+    cy.fixture('applicationData.json').then(applicationData => {
+      // And there is an application awaiting assessment
+      const assessment = assessmentFactory.build({
+        decision: undefined,
+        application: { data: applicationData },
+      })
+      assessment.data = {}
+      const documents = documentFactory.buildList(4)
+      const clarificationNote = clarificationNoteFactory.build()
+      assessment.application = overwriteApplicationDocuments(assessment.application, documents)
+
+      const assessHelper = new AssessHelper(assessment, documents, clarificationNote)
+
+      assessHelper.setupStubs()
+
+      // And I start an assessment
+      assessHelper.startAssessment()
+
+      // And I add a clarification note
+      assessHelper.addClarificationNote()
     })
   })
 })

--- a/server/controllers/assess/assessments/clarificationNotesController.test.ts
+++ b/server/controllers/assess/assessments/clarificationNotesController.test.ts
@@ -1,0 +1,89 @@
+import type { Request, Response, NextFunction } from 'express'
+
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+
+import ClarificationNotesController from './clarificationNotesController'
+import { AssessmentService } from '../../../services'
+import { catchValidationErrorOrPropogate } from '../../../utils/validation'
+
+import clarificationNoteFactory from '../../../testutils/factories/clarificationNote'
+import paths from '../../../paths/assess'
+
+jest.mock('../../../utils/validation')
+
+describe('clarificationNotesController', () => {
+  const token = 'SOME_TOKEN'
+
+  const request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = jest.fn()
+
+  const assessmentService = createMock<AssessmentService>({})
+
+  let clarificationNotesController: ClarificationNotesController
+
+  beforeEach(() => {
+    clarificationNotesController = new ClarificationNotesController(assessmentService)
+  })
+
+  describe('create', () => {
+    const id = 'some-uuid'
+    const note = clarificationNoteFactory.build()
+
+    beforeEach(() => {
+      request.params.id = id
+      request.body = note
+
+      assessmentService.createClarificationNote.mockResolvedValue(note)
+    })
+
+    it('creates a note and renders the confirmation', async () => {
+      const requestHandler = clarificationNotesController.create()
+
+      await requestHandler(request, response, next)
+
+      expect(response.redirect).toHaveBeenCalledWith(paths.assessments.clarificationNotes.confirm({ id }))
+
+      expect(assessmentService.createClarificationNote).toHaveBeenCalledWith(token, id, note)
+    })
+
+    it('redirects with errors if the API returns an error', async () => {
+      const requestHandler = clarificationNotesController.create()
+
+      request.params = {
+        id: 'some-uuid',
+      }
+
+      const err = new Error()
+
+      assessmentService.createClarificationNote.mockImplementation(() => {
+        throw err
+      })
+
+      await requestHandler(request, response, next)
+
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+        request,
+        response,
+        err,
+        paths.assessments.pages.show({
+          id,
+          task: 'suitability-assessment',
+          page: 'request-information',
+        }),
+      )
+    })
+  })
+
+  describe('confirm', () => {
+    it('renders the template', async () => {
+      const requestHandler = clarificationNotesController.confirm()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('assessments/clarificationNotes/confirmation', {
+        pageHeading: 'Note Created',
+      })
+    })
+  })
+})

--- a/server/controllers/assess/assessments/clarificationNotesController.ts
+++ b/server/controllers/assess/assessments/clarificationNotesController.ts
@@ -1,0 +1,37 @@
+import type { Request, Response, RequestHandler } from 'express'
+import { catchValidationErrorOrPropogate } from '../../../utils/validation'
+
+import { AssessmentService } from '../../../services'
+
+import paths from '../../../paths/assess'
+
+export default class ClarificationNotesController {
+  constructor(private readonly assessmentService: AssessmentService) {}
+
+  create(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      try {
+        await this.assessmentService.createClarificationNote(req.user.token, req.params.id, req.body)
+
+        res.redirect(paths.assessments.clarificationNotes.confirm({ id: req.params.id }))
+      } catch (err) {
+        catchValidationErrorOrPropogate(
+          req,
+          res,
+          err,
+          paths.assessments.pages.show({
+            id: req.params.id,
+            task: 'suitability-assessment',
+            page: 'request-information',
+          }),
+        )
+      }
+    }
+  }
+
+  confirm(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      res.render('assessments/clarificationNotes/confirmation', { pageHeading: 'Note Created' })
+    }
+  }
+}

--- a/server/controllers/assess/index.ts
+++ b/server/controllers/assess/index.ts
@@ -2,6 +2,7 @@
 
 import AssessmentsController from './assessmentsController'
 import AssessmentPagesController from './pagesController'
+import ClarificationNotesController from './assessments/clarificationNotesController'
 
 import type { Services } from '../../services'
 
@@ -13,10 +14,12 @@ export const controllers = (services: Services) => {
     applicationService,
     userService,
   })
+  const clarificationNotesController = new ClarificationNotesController(assessmentService)
 
   return {
     assessmentsController,
     assessmentPagesController,
+    clarificationNotesController,
   }
 }
 

--- a/server/data/assessmentClient.test.ts
+++ b/server/data/assessmentClient.test.ts
@@ -3,6 +3,7 @@ import nock from 'nock'
 import AssessmentClient from './assessmentClient'
 import config from '../config'
 import assessmentFactory from '../testutils/factories/assessment'
+import clarificationNoteFactory from '../testutils/factories/clarificationNote'
 import paths from '../paths/api'
 
 describe('AssessmentClient', () => {
@@ -70,6 +71,23 @@ describe('AssessmentClient', () => {
       const result = await assessmentClient.update(assessment)
 
       expect(result).toEqual(assessment)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+
+  describe('createClarificationNote', () => {
+    it('should return a note when a POST request is made', async () => {
+      const assessmentId = 'some-id'
+      const note = clarificationNoteFactory.build()
+
+      fakeApprovedPremisesApi
+        .post(paths.assessments.clarificationNotes.create({ id: assessmentId }), note)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(201, note)
+
+      const result = await assessmentClient.createClarificationNote(assessmentId, note)
+
+      expect(result).toEqual(note)
       expect(nock.isDone()).toBeTruthy()
     })
   })

--- a/server/data/assessmentClient.ts
+++ b/server/data/assessmentClient.ts
@@ -1,4 +1,8 @@
-import type { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
+import type {
+  ApprovedPremisesAssessment as Assessment,
+  ClarificationNote,
+  NewClarificationNote,
+} from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -23,5 +27,15 @@ export default class AssessmentClient {
       path: paths.assessments.update({ id: assessment.id }),
       data: { data: assessment.data },
     })) as Assessment
+  }
+
+  async createClarificationNote(
+    assessmentId: string,
+    clarificationNote: NewClarificationNote,
+  ): Promise<ClarificationNote> {
+    return (await this.restClient.post({
+      path: paths.assessments.clarificationNotes.create({ id: assessmentId }),
+      data: clarificationNote,
+    })) as ClarificationNote
   }
 }

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/index.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/index.ts
@@ -1,10 +1,11 @@
 import { Task } from '../../../utils/decorators'
 
 import SufficentInformationPage from './sufficientInformation'
+import RequestInformation from './requestInformation'
 
 @Task({
   slug: 'sufficient-information',
   name: 'Check there is sufficient information to make a decision',
-  pages: [SufficentInformationPage],
+  pages: [SufficentInformationPage, RequestInformation],
 })
 export default class SufficientInformation {}

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/requestInformation.test.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/requestInformation.test.ts
@@ -1,0 +1,64 @@
+import { createMock } from '@golevelup/ts-jest'
+
+import { UserService } from '../../../../services'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+
+import RequestInformation from './requestInformation'
+
+import assessmentFactory from '../../../../testutils/factories/assessment'
+import userFactory from '../../../../testutils/factories/user'
+
+describe('RequestInformation', () => {
+  const user = userFactory.build()
+  const assessment = assessmentFactory.build()
+
+  describe('title', () => {
+    expect(new RequestInformation().title).toBe('Request information from probation practicioner')
+  })
+
+  describe('body', () => {
+    it('should set have an empty body', () => {
+      const page = new RequestInformation()
+      expect(page.body).toEqual({})
+    })
+  })
+
+  describe('initialize', () => {
+    it('should fetch the user and return the page', async () => {
+      const getUserByIdMock = jest.fn()
+
+      const userService = createMock<UserService>({
+        getUserById: getUserByIdMock,
+      })
+
+      getUserByIdMock.mockResolvedValue(user)
+
+      const page = await RequestInformation.initialize({}, assessment, 'some-token', { userService })
+
+      expect(page).toBeInstanceOf(RequestInformation)
+      expect(page.user).toEqual(user)
+
+      expect(userService.getUserById).toHaveBeenCalledWith('some-token', assessment.application.createdByUserId)
+    })
+  })
+
+  itShouldHaveNextValue(new RequestInformation(), '')
+
+  itShouldHavePreviousValue(new RequestInformation(), 'sufficient-information')
+
+  describe('errors', () => {
+    it('should return blank', () => {
+      const page = new RequestInformation()
+
+      expect(page.errors()).toEqual({})
+    })
+  })
+
+  describe('response', () => {
+    it('returns blank', () => {
+      const page = new RequestInformation()
+
+      expect(page.response()).toEqual({})
+    })
+  })
+})

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/requestInformation.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/requestInformation.ts
@@ -1,0 +1,45 @@
+import type { DataServices } from '@approved-premises/ui'
+import type { ApprovedPremisesAssessment as Assessment, User } from '@approved-premises/api'
+
+import { Page } from '../../../utils/decorators'
+
+import TasklistPage from '../../../tasklistPage'
+
+@Page({ name: 'request-information', bodyProperties: [] })
+export default class RequestInformation implements TasklistPage {
+  body = {}
+
+  title = 'Request information from probation practicioner'
+
+  user: User
+
+  static async initialize(
+    _body: Record<string, unknown>,
+    assessment: Assessment,
+    token: string,
+    dataServices: DataServices,
+  ) {
+    const user = await dataServices.userService.getUserById(token, assessment.application.createdByUserId)
+
+    const page = new RequestInformation()
+    page.user = user
+
+    return page
+  }
+
+  previous() {
+    return 'sufficient-information'
+  }
+
+  next() {
+    return ''
+  }
+
+  response() {
+    return {}
+  }
+
+  errors() {
+    return {}
+  }
+}

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.test.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.test.ts
@@ -44,7 +44,13 @@ describe('SufficientInformation', () => {
     })
   })
 
-  itShouldHaveNextValue(new SufficientInformation({}), '')
+  describe('when sufficientInformation is yes', () => {
+    itShouldHaveNextValue(new SufficientInformation({ sufficientInformation: 'yes' }), '')
+  })
+
+  describe('when sufficientInformation is no', () => {
+    itShouldHaveNextValue(new SufficientInformation({ sufficientInformation: 'no' }), 'request-information')
+  })
 
   itShouldHavePreviousValue(new SufficientInformation({}), 'dashboard')
 

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.ts
@@ -35,7 +35,7 @@ export default class SufficientInformation implements TasklistPage {
   }
 
   next() {
-    return ''
+    return this.body.sufficientInformation === 'yes' ? '' : 'request-information'
   }
 
   response() {

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -59,5 +59,6 @@
     "beforeStartDate": "The end date must be before the start date"
   },
   "numberOfBeds": { "empty": "You must enter the number of beds lost", "isZero": "Number of beds lost cannot be zero" },
-  "referenceNumber": { "empty": "You must enter a reference number" }
+  "referenceNumber": { "empty": "You must enter a reference number" },
+  "query": { "empty": "You must enter a query" }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -39,6 +39,10 @@ const assessPaths = {
   singleAssessment: path('/assessments/:id'),
 }
 
+const clarificationNotePaths = {
+  notes: assessPaths.singleAssessment.path('notes'),
+}
+
 export default {
   premises: {
     show: managePaths.premises.show,
@@ -63,6 +67,9 @@ export default {
     index: assessPaths.assessments,
     show: assessPaths.singleAssessment,
     update: assessPaths.singleAssessment,
+    clarificationNotes: {
+      create: clarificationNotePaths.notes,
+    },
   },
   people: {
     risks: {

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -5,6 +5,7 @@ const assessmentsPath = path('/assessments')
 const assessmentPath = assessmentsPath.path(':id')
 
 const pagesPath = assessmentPath.path('tasks/:task/pages/:page')
+const clarificationNotesPath = assessmentPath.path('/clarification-notes')
 
 const paths = {
   assessments: {
@@ -13,6 +14,10 @@ const paths = {
     pages: {
       show: pagesPath,
       update: pagesPath,
+    },
+    clarificationNotes: {
+      create: clarificationNotesPath,
+      confirm: assessmentPath.path('/confirmation'),
     },
   },
 }

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -10,11 +10,14 @@ import actions from './utils'
 
 export default function routes(controllers: Controllers, router: Router): Router {
   const { pages } = Assess
-  const { get, put } = actions(router)
-  const { assessmentsController, assessmentPagesController } = controllers
+  const { get, put, post } = actions(router)
+  const { assessmentsController, assessmentPagesController, clarificationNotesController } = controllers
 
   get(paths.assessments.index.pattern, assessmentsController.index())
   get(paths.assessments.show.pattern, assessmentsController.show())
+
+  post(paths.assessments.clarificationNotes.create.pattern, clarificationNotesController.create())
+  get(paths.assessments.clarificationNotes.confirm.pattern, clarificationNotesController.confirm())
 
   Object.keys(pages).forEach((taskKey: string) => {
     Object.keys(pages[taskKey]).forEach((pageKey: string) => {

--- a/server/services/assessmentService.test.ts
+++ b/server/services/assessmentService.test.ts
@@ -4,6 +4,7 @@ import { Request } from 'express'
 import { AssessmentClient } from '../data'
 import AssessmentService from './assessmentService'
 import assessmentFactory from '../testutils/factories/assessment'
+import clarificationNoteFactory from '../testutils/factories/clarificationNote'
 
 import { getBody, updateAssessmentData } from '../form-pages/utils'
 import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
@@ -146,6 +147,23 @@ describe('AssessmentService', () => {
           expect(e).toEqual(new ValidationError(errors))
         }
       })
+    })
+  })
+
+  describe('createClarificationNote', () => {
+    it('calls the client with the expected arguments', async () => {
+      const token = 'token'
+      const id = 'some-uuid'
+      const clarificationNote = clarificationNoteFactory.build()
+
+      assessmentClient.createClarificationNote.mockResolvedValue(clarificationNote)
+
+      const result = await service.createClarificationNote(token, id, clarificationNote)
+
+      expect(result).toEqual(clarificationNote)
+
+      expect(assessmentClientFactory).toHaveBeenCalledWith(token)
+      expect(assessmentClient.createClarificationNote).toHaveBeenCalledWith(id, clarificationNote)
     })
   })
 })

--- a/server/services/assessmentService.ts
+++ b/server/services/assessmentService.ts
@@ -1,5 +1,5 @@
 import type { Request } from 'express'
-import { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
+import { ApprovedPremisesAssessment as Assessment, NewClarificationNote } from '@approved-premises/api'
 import type { DataServices, GroupedAssessments } from '@approved-premises/ui'
 
 import type { RestClientBuilder, AssessmentClient } from '../data'
@@ -61,5 +61,11 @@ export default class AssessmentService {
 
       await client.update(updatedAssessment)
     }
+  }
+
+  async createClarificationNote(token: string, assessmentId: string, clarificationNote: NewClarificationNote) {
+    const client = this.assessmentClientFactory(token)
+
+    return client.createClarificationNote(assessmentId, clarificationNote)
   }
 }

--- a/server/views/assessments/clarificationNotes/confirmation.njk
+++ b/server/views/assessments/clarificationNotes/confirmation.njk
@@ -1,0 +1,26 @@
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set mainClasses = "app-container govuk-body assessments--index" %}
+
+{% block content %}
+  <div class="govuk-grid-column-two-thirds">
+    {{ govukPanel({
+      titleText: pageHeading
+    }) }}
+
+    <p>
+      Some confirmation text here
+    </p>
+
+    {{ govukButton({
+      text: "Back to dashboard",
+      href: paths.assessments.index()
+    }) }}
+
+  </div>
+</div>
+{% endblock %}

--- a/server/views/assessments/pages/sufficient-information/request-information.njk
+++ b/server/views/assessments/pages/sufficient-information/request-information.njk
@@ -1,0 +1,41 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "../../../components/formFields/form-page-textarea/macro.njk" import formPageTextarea %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + page.title %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: paths.assessments.pages.show({ id: assessmentId, task: task, page: page.previous() })
+  }) }}
+
+  <div class="govuk-grid-row">
+    <div class="{{ columnClasses | default("govuk-grid-column-two-thirds") }}">
+      <form action="{{ paths.assessments.clarificationNotes.create({ id: assessmentId }) }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        <h1>{{ page.title }}</h1>
+
+        {{ showErrorSummary(errorSummary) }}
+
+        {{ formPageTextarea({
+            fieldName: 'query',
+            label: {
+              text: "What do you need to ask the PP?"
+            }
+          }, fetchContext()) }}
+
+        {{ govukButton({
+            text: "Submit"
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
This allows a user to create a clarification note if there is not enough information to proceed. The copy and design are very rough, but this nails in the journey:

## Screenshots

![Assess -- allows me to create and update a clarification note](https://user-images.githubusercontent.com/109774/213246450-40ea83ec-ed96-4ae5-8b38-ba4ab0e5c51b.png)

![Assess -- allows me to create and update a clarification note (1)](https://user-images.githubusercontent.com/109774/213246453-3bbf473c-e4d8-4725-b972-dedfb03330d8.png)
