### PR TITLE
(873) Use assessment statuses in listing

### DIFF
--- a/cypress_shared/pages/assess/listPage.ts
+++ b/cypress_shared/pages/assess/listPage.ts
@@ -10,6 +10,7 @@ export default class ListPage extends Page {
     private readonly awaitingAssessments: Array<Assessment>,
     private readonly assessmentsCloseToDueDate: Array<Assessment>,
     private readonly completedAssesssments: Array<Assessment>,
+    private readonly pendingAssessments: Array<Assessment>,
   ) {
     super('Approved Premises applications')
   }
@@ -18,9 +19,10 @@ export default class ListPage extends Page {
     awaitingAssessments: Array<Assessment>,
     assessmentsCloseToDueDate: Array<Assessment> = [],
     completedAssesssments: Array<Assessment> = [],
+    pendingAssessments: Array<Assessment> = [],
   ): ListPage {
     cy.visit(paths.assessments.index({}))
-    return new ListPage(awaitingAssessments, assessmentsCloseToDueDate, completedAssesssments)
+    return new ListPage(awaitingAssessments, assessmentsCloseToDueDate, completedAssesssments, pendingAssessments)
   }
 
   shouldShowAwaitingAssessments(): void {
@@ -45,6 +47,29 @@ export default class ListPage extends Page {
             .eq(4)
             .contains(this.awaitingAssessments.includes(item) ? '7 Days' : '1 Day')
           cy.get('td').eq(5).contains('In progress')
+        })
+    })
+  }
+
+  shouldShowPendingAssessments(): void {
+    this.pendingAssessments.forEach((item: Assessment) => {
+      cy.contains(item.application.person.name)
+        .parent()
+        .parent()
+        .within(() => {
+          cy.get('td').eq(0).contains(item.application.person.crn)
+          cy.get('td').eq(1).contains(item.application.risks.tier.value.level)
+          cy.get('td')
+            .eq(2)
+            .contains(
+              format(
+                DateFormats.isoToDateObj(item.application.data['basic-information']['release-date'].releaseDate),
+                'd MMM yyyy',
+              ),
+            )
+          cy.get('td').eq(3).contains('3 Days')
+          cy.get('td').eq(4).contains('1 Day')
+          cy.get('td').eq(5).contains('Info Request')
         })
     })
   }
@@ -94,5 +119,9 @@ export default class ListPage extends Page {
 
   clickAssessment(assessment: Assessment): void {
     cy.get(`a[data-cy-assessmentId="${assessment.id}"]`).click()
+  }
+
+  clickRequestedFurtherInformation() {
+    cy.get('a').contains('Requested further information').click()
   }
 }

--- a/integration_tests/tests/assess/listing.cy.ts
+++ b/integration_tests/tests/assess/listing.cy.ts
@@ -1,6 +1,7 @@
 import { ListPage } from '../../../cypress_shared/pages/assess'
 
 import assessmentFactory from '../../../server/testutils/factories/assessment'
+import clarificationNoteFactory from '../../../server/testutils/factories/clarificationNote'
 
 context('Assess', () => {
   beforeEach(() => {
@@ -16,21 +17,29 @@ context('Assess', () => {
     const assessments = []
 
     // Given there are some applications awaiting assessment
-    const assessmentsAwaiting = assessmentFactory.createdXDaysAgo(2).buildList(3, { decision: undefined })
+    const assessmentsAwaiting = assessmentFactory.createdXDaysAgo(2).buildList(3, { status: 'active' })
     assessments.push(assessmentsAwaiting)
 
     // And two of those assessments are running close to the due date
     const assessmentsCloseToDueDate = [
-      assessmentFactory.createdXDaysAgo(8).build({ decision: undefined }),
-      assessmentFactory.createdXDaysAgo(8).build({ decision: undefined }),
+      assessmentFactory.createdXDaysAgo(8).build({ status: 'active' }),
+      assessmentFactory.createdXDaysAgo(8).build({ status: 'active' }),
     ]
 
     assessments.push(assessmentsCloseToDueDate)
+
+    // And there are some pending assessments
+    const pendingAssessments = assessmentFactory
+      .createdXDaysAgo(3)
+      .buildList(4, { status: 'pending', clarificationNotes: [clarificationNoteFactory.createdXDaysAgo(1).build()] })
+
+    assessments.push(pendingAssessments)
+
     // And there are some completed assessments
     const completedAssesssments = [
-      assessmentFactory.build({ decision: 'accepted' }),
-      assessmentFactory.build({ decision: 'accepted' }),
-      assessmentFactory.build({ decision: 'rejected' }),
+      assessmentFactory.build({ status: 'completed' }),
+      assessmentFactory.build({ status: 'completed' }),
+      assessmentFactory.build({ status: 'completed' }),
     ]
 
     assessments.push(completedAssesssments)
@@ -48,6 +57,12 @@ context('Assess', () => {
 
     // And the assessments that are running close to the due date should be highlighted
     listPage.shouldHighlightAssessmentsApproachingDueDate()
+
+    // When I click on the awaiting tab
+    listPage.clickRequestedFurtherInformation()
+
+    // Then I should see the assessments that are pending
+    listPage.shouldShowPendingAssessments()
 
     // When I click on the completed tab
     listPage.clickCompleted()

--- a/server/services/assessmentService.test.ts
+++ b/server/services/assessmentService.test.ts
@@ -28,18 +28,18 @@ describe('AssessmentService', () => {
   })
 
   it('gets all the assesments for the logged in user and groups them by status', async () => {
-    const acceptedAssessments = assessmentFactory.buildList(2, { decision: 'accepted' })
-    const rejectedAssessments = assessmentFactory.buildList(3, { decision: 'rejected' })
-    const awaitingAssessments = assessmentFactory.buildList(5, { decision: undefined })
+    const completedAssessments = assessmentFactory.buildList(2, { status: 'completed' })
+    const pendingAssessments = assessmentFactory.buildList(3, { status: 'pending' })
+    const activeAssessments = assessmentFactory.buildList(5, { status: 'active' })
 
-    assessmentClient.all.mockResolvedValue([acceptedAssessments, rejectedAssessments, awaitingAssessments].flat())
+    assessmentClient.all.mockResolvedValue([completedAssessments, pendingAssessments, activeAssessments].flat())
 
     const result = await service.getAllForLoggedInUser('token')
 
     expect(result).toEqual({
-      completed: [acceptedAssessments, rejectedAssessments].flat(),
-      requestedFurtherInformation: [],
-      awaiting: awaitingAssessments,
+      completed: completedAssessments,
+      requestedFurtherInformation: pendingAssessments,
+      awaiting: activeAssessments,
     })
   })
 

--- a/server/services/assessmentService.ts
+++ b/server/services/assessmentService.ts
@@ -18,7 +18,17 @@ export default class AssessmentService {
 
     await Promise.all(
       assessments.map(async assessment => {
-        return assessment.decision ? result.completed.push(assessment) : result.awaiting.push(assessment)
+        switch (assessment.status) {
+          case 'completed':
+            result.completed.push(assessment)
+            break
+          case 'pending':
+            result.requestedFurtherInformation.push(assessment)
+            break
+          default:
+            result.awaiting.push(assessment)
+            break
+        }
       }),
     )
 

--- a/server/testutils/factories/assessment.ts
+++ b/server/testutils/factories/assessment.ts
@@ -14,12 +14,6 @@ class AssessmentFactory extends Factory<ApprovedPremisesAssessment> {
       createdAt: DateFormats.dateObjToIsoDate(new Date(today.getFullYear(), today.getMonth(), today.getDate() - days)),
     })
   }
-
-  completedAssessment() {
-    return this.params({
-      decision: 'accepted' as const,
-    })
-  }
 }
 
 export default AssessmentFactory.define(() => ({

--- a/server/testutils/factories/clarificationNote.ts
+++ b/server/testutils/factories/clarificationNote.ts
@@ -1,10 +1,21 @@
+/* istanbul ignore file */
+
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
 import type { ClarificationNote } from '@approved-premises/api'
 
 import { DateFormats } from '../../utils/dateUtils'
 
-export default Factory.define<ClarificationNote>(() => ({
+class ClarificationNoteFactory extends Factory<ClarificationNote> {
+  createdXDaysAgo(days: number) {
+    const today = new Date()
+    return this.params({
+      createdAt: DateFormats.dateObjToIsoDate(new Date(today.getFullYear(), today.getMonth(), today.getDate() - days)),
+    })
+  }
+}
+
+export default ClarificationNoteFactory.define(() => ({
   id: faker.datatype.uuid(),
   createdAt: DateFormats.dateObjToIsoDate(faker.date.past()),
   createdByStaffMemberId: faker.datatype.uuid(),

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -121,20 +121,20 @@ describe('assessmentUtils', () => {
   })
 
   describe('getStatus', () => {
-    it('returns Not started for an assessment without data', () => {
-      const assessment = assessmentFactory.build({ data: undefined })
+    it('returns Not started for an active assessment without data', () => {
+      const assessment = assessmentFactory.build({ status: 'active', data: undefined })
 
       expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag--grey">Not started</strong>')
     })
 
-    it('returns In Progress for an assessment with data and no decision', () => {
-      const assessment = assessmentFactory.build({ decision: undefined })
+    it('returns In Progress for an an active assessment with data', () => {
+      const assessment = assessmentFactory.build({ status: 'active' })
 
       expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag--blue">In progress</strong>')
     })
 
-    it('returns Completed for an assessment with data and a decision', () => {
-      const assessment = assessmentFactory.build({ decision: 'accepted' })
+    it('returns Completed for a completed assessment', () => {
+      const assessment = assessmentFactory.build({ status: 'completed' })
 
       expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag">Completed</strong>')
     })

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -132,12 +132,14 @@ const daysUntilDue = (assessment: Assessment): number => {
 }
 
 const getStatus = (assessment: Assessment): string => {
-  if (assessment.data) {
-    if (!assessment.decision) {
-      return `<strong class="govuk-tag govuk-tag--blue">In progress</strong>`
-    }
+  if (assessment.status === 'completed') {
     return `<strong class="govuk-tag govuk-tag">Completed</strong>`
   }
+
+  if (assessment.data) {
+    return `<strong class="govuk-tag govuk-tag--blue">In progress</strong>`
+  }
+
   return `<strong class="govuk-tag govuk-tag--grey">Not started</strong>`
 }
 


### PR DESCRIPTION
Assessments now have a "status", which we can use to glean what tab they are listed in. I've also updated the code to include the "pending" assessments (i.e. assessments that have a note without a response)