### PR TITLE
(1017) Allow a response to be added to a clarification note

### DIFF
--- a/cypress_shared/pages/assess/clarificationNoteConfirmPage.ts
+++ b/cypress_shared/pages/assess/clarificationNoteConfirmPage.ts
@@ -4,7 +4,7 @@ import Page from '../page'
 
 export default class SufficientInformationPage extends Page {
   constructor() {
-    super('Request information from probation practicioner')
+    super('Request information from probation practitioner')
   }
 
   clickBackToDashboard() {

--- a/cypress_shared/pages/assess/index.ts
+++ b/cypress_shared/pages/assess/index.ts
@@ -1,15 +1,17 @@
 /* eslint-disable import/prefer-default-export */
 import ClarificationNoteConfirmPage from './clarificationNoteConfirmPage'
+import InformationReceivedPage from './informationReceivedPage'
 import ListPage from './listPage'
+import MakeADecisionPage from './makeADecisionPage'
 import RequiredActionsPage from './requiredActionsPage'
 import ReviewPage from './reviewPage'
 import SufficientInformationPage from './sufficientInformationPage'
 import SuitabilityAssessmentPage from './suitabilityAssessmentPage'
-import MakeADecisionPage from './makeADecisionPage'
 import TaskListPage from './taskListPage'
 
 export {
   ClarificationNoteConfirmPage,
+  InformationReceivedPage,
   ListPage,
   MakeADecisionPage,
   RequiredActionsPage,

--- a/cypress_shared/pages/assess/informationReceivedPage.ts
+++ b/cypress_shared/pages/assess/informationReceivedPage.ts
@@ -1,0 +1,42 @@
+import type { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
+import type { YesOrNo } from '@approved-premises/ui'
+
+import AssessPage from './assessPage'
+
+import InformationReceived from '../../../server/form-pages/assess/reviewApplication/sufficientInformation/informationReceived'
+import { DateFormats } from '../../../server/utils/dateUtils'
+
+export default class InformationReceivedPage extends AssessPage {
+  pageClass: InformationReceived
+
+  constructor(
+    assessment: Assessment,
+    body: {
+      informationReceived: YesOrNo
+      response: string
+      responseReceivedOn: string
+    },
+  ) {
+    super(assessment, 'Additional information')
+    const parsedDate = DateFormats.isoToDateObj(body.responseReceivedOn)
+
+    this.pageClass = new InformationReceived({
+      ...body,
+      'responseReceivedOn-day': String(parsedDate.getDate()),
+      'responseReceivedOn-month': String(parsedDate.getMonth() + 1),
+      'responseReceivedOn-year': String(parsedDate.getFullYear()),
+    })
+  }
+
+  completeForm() {
+    this.checkRadioByNameAndValue('informationReceived', this.pageClass.body.informationReceived)
+    if (this.pageClass.body.informationReceived === 'yes') {
+      this.completeTextArea('response', this.pageClass.body.response)
+      this.completeDateInputs('responseReceivedOn', this.pageClass.body.responseReceivedOn)
+    }
+  }
+
+  addNote(note: string) {
+    this.completeTextArea('query', note)
+  }
+}

--- a/integration_tests/mockApis/assessments.ts
+++ b/integration_tests/mockApis/assessments.ts
@@ -1,6 +1,10 @@
 import { SuperAgentRequest } from 'superagent'
 
-import type { ApprovedPremisesAssessment as Assessment, NewClarificationNote } from '@approved-premises/api'
+import type {
+  ApprovedPremisesAssessment as Assessment,
+  NewClarificationNote,
+  UpdatedClarificationNote,
+} from '@approved-premises/api'
 
 import { getMatchingRequests, stubFor } from '../../wiremock'
 import paths from '../../server/paths/api'
@@ -46,7 +50,28 @@ export default {
     stubFor({
       request: {
         method: 'POST',
-        url: paths.assessments.clarificationNotes.create({ id: args.assessment.id }),
+        url: paths.assessments.clarificationNotes.create({
+          id: args.assessment.id,
+        }),
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.note,
+      },
+    }),
+  stubClarificationNoteUpdate: (args: {
+    assessment: Assessment
+    clarificationNoteId: string
+    note: UpdatedClarificationNote
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'PUT',
+        url: paths.assessments.clarificationNotes.update({
+          id: args.assessment.id,
+          clarificationNoteId: args.clarificationNoteId,
+        }),
       },
       response: {
         status: 201,
@@ -59,6 +84,16 @@ export default {
       await getMatchingRequests({
         method: 'POST',
         url: paths.assessments.clarificationNotes.create({ id: assessment.id }),
+      })
+    ).body.requests,
+  verifyClarificationNoteUpdate: async (assessment: Assessment) =>
+    (
+      await getMatchingRequests({
+        method: 'PUT',
+        url: paths.assessments.clarificationNotes.update({
+          id: assessment.id,
+          clarificationNoteId: assessment.clarificationNotes[0].id,
+        }),
       })
     ).body.requests,
 }

--- a/server/controllers/assess/assessments/clarificationNotesController.test.ts
+++ b/server/controllers/assess/assessments/clarificationNotesController.test.ts
@@ -37,7 +37,7 @@ describe('clarificationNotesController', () => {
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('assessments/clarificationNotes/confirmation', {
-        pageHeading: 'Request information from probation practicioner',
+        pageHeading: 'Request information from probation practitioner',
         user,
       })
 

--- a/server/controllers/assess/assessments/clarificationNotesController.ts
+++ b/server/controllers/assess/assessments/clarificationNotesController.ts
@@ -11,7 +11,7 @@ export default class ClarificationNotesController {
       const user = await this.userService.getUserById(req.user.token, assessment.application.createdByUserId)
 
       res.render('assessments/clarificationNotes/confirmation', {
-        pageHeading: 'Request information from probation practicioner',
+        pageHeading: 'Request information from probation practitioner',
         user,
       })
     }

--- a/server/controllers/assess/assessments/pagesController.test.ts
+++ b/server/controllers/assess/assessments/pagesController.test.ts
@@ -19,6 +19,7 @@ import paths from '../../../paths/assess'
 import { viewPath } from '../../../form-pages/utils'
 
 import clarificationNoteFactory from '../../../testutils/factories/clarificationNote'
+import assessmentFactory from '../../../testutils/factories/assessment'
 
 jest.mock('../../../utils/validation')
 jest.mock('../../../form-pages/utils')
@@ -46,6 +47,8 @@ describe('pagesController', () => {
   const PageConstructor = jest.fn()
   const page = createMock<TasklistPage>({})
 
+  const assessment = assessmentFactory.build()
+
   let pagesController: PagesController
 
   describe('show', () => {
@@ -54,6 +57,7 @@ describe('pagesController', () => {
     beforeEach(() => {
       ;(viewPath as jest.Mock).mockReturnValue('assessments/pages/some/view')
       ;(getPage as jest.Mock).mockReturnValue(PageConstructor)
+      assessmentService.findAssessment.mockResolvedValue(assessment)
       assessmentService.initializePage.mockResolvedValue(page)
       pagesController = new PagesController(assessmentService, dataServices)
     })
@@ -67,7 +71,7 @@ describe('pagesController', () => {
       await requestHandler(request, response, next)
 
       expect(getPage).toHaveBeenCalledWith('some-task', 'some-page')
-      expect(assessmentService.initializePage).toHaveBeenCalledWith(PageConstructor, request, {}, {})
+      expect(assessmentService.initializePage).toHaveBeenCalledWith(PageConstructor, assessment, request, {}, {})
       expect(response.render).toHaveBeenCalledWith('assessments/pages/some/view', {
         assessmentId: request.params.id,
         task: 'some-task',
@@ -87,6 +91,7 @@ describe('pagesController', () => {
 
       expect(assessmentService.initializePage).toHaveBeenCalledWith(
         PageConstructor,
+        assessment,
         request,
         errorsAndUserInput.userInput,
         {},

--- a/server/controllers/assess/assessmentsController.test.ts
+++ b/server/controllers/assess/assessmentsController.test.ts
@@ -9,6 +9,8 @@ import { AssessmentService } from '../../services'
 import assessmentFactory from '../../testutils/factories/assessment'
 import Assess from '../../form-pages/assess'
 
+import paths from '../../paths/assess'
+
 describe('assessmentsController', () => {
   const token = 'SOME_TOKEN'
 
@@ -59,6 +61,24 @@ describe('assessmentsController', () => {
         pageHeading: 'Assess an Approved Premises (AP) application',
         sections: Assess.sections,
       })
+
+      expect(assessmentService.findAssessment).toHaveBeenCalledWith(token, assessment.id)
+    })
+
+    it('redirects if the assessment is in a pending state', async () => {
+      assessment.status = 'pending'
+
+      const requestHandler = assessmentsController.show()
+
+      await requestHandler(request, response, next)
+
+      expect(response.redirect).toHaveBeenCalledWith(
+        paths.assessments.pages.show({
+          id: assessment.id,
+          task: 'sufficient-information',
+          page: 'information-received',
+        }),
+      )
 
       expect(assessmentService.findAssessment).toHaveBeenCalledWith(token, assessment.id)
     })

--- a/server/controllers/assess/assessmentsController.ts
+++ b/server/controllers/assess/assessmentsController.ts
@@ -3,6 +3,8 @@ import type { Request, Response, RequestHandler } from 'express'
 import { AssessmentService } from '../../services'
 import Assess from '../../form-pages/assess'
 
+import paths from '../../paths/assess'
+
 export default class AssessmentsController {
   constructor(private readonly assessmentService: AssessmentService) {}
 
@@ -18,11 +20,21 @@ export default class AssessmentsController {
     return async (req: Request, res: Response) => {
       const assessment = await this.assessmentService.findAssessment(req.user.token, req.params.id)
 
-      res.render('assessments/show', {
-        assessment,
-        pageHeading: 'Assess an Approved Premises (AP) application',
-        sections: Assess.sections,
-      })
+      if (assessment.status === 'pending') {
+        res.redirect(
+          paths.assessments.pages.show({
+            id: assessment.id,
+            task: 'sufficient-information',
+            page: 'information-received',
+          }),
+        )
+      } else {
+        res.render('assessments/show', {
+          assessment,
+          pageHeading: 'Assess an Approved Premises (AP) application',
+          sections: Assess.sections,
+        })
+      }
     }
   }
 }

--- a/server/data/assessmentClient.test.ts
+++ b/server/data/assessmentClient.test.ts
@@ -91,4 +91,28 @@ describe('AssessmentClient', () => {
       expect(nock.isDone()).toBeTruthy()
     })
   })
+
+  describe('updateClarificationNote', () => {
+    it('should return a note when a PUT request is made', async () => {
+      const assessmentId = 'some-id'
+      const note = clarificationNoteFactory.build()
+      const updatedNote = {
+        response: note.response,
+        responseReceivedOn: note.responseReceivedOn,
+      }
+
+      fakeApprovedPremisesApi
+        .put(
+          paths.assessments.clarificationNotes.update({ id: assessmentId, clarificationNoteId: note.id }),
+          updatedNote,
+        )
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(201, note)
+
+      const result = await assessmentClient.updateClarificationNote(assessmentId, note.id, updatedNote)
+
+      expect(result).toEqual(note)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
 })

--- a/server/data/assessmentClient.ts
+++ b/server/data/assessmentClient.ts
@@ -2,6 +2,7 @@ import type {
   ApprovedPremisesAssessment as Assessment,
   ClarificationNote,
   NewClarificationNote,
+  UpdatedClarificationNote,
 } from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
@@ -35,6 +36,17 @@ export default class AssessmentClient {
   ): Promise<ClarificationNote> {
     return (await this.restClient.post({
       path: paths.assessments.clarificationNotes.create({ id: assessmentId }),
+      data: clarificationNote,
+    })) as ClarificationNote
+  }
+
+  async updateClarificationNote(
+    assessmentId: string,
+    clarificationNoteId: string,
+    clarificationNote: UpdatedClarificationNote,
+  ): Promise<ClarificationNote> {
+    return (await this.restClient.put({
+      path: paths.assessments.clarificationNotes.update({ id: assessmentId, clarificationNoteId }),
       data: clarificationNote,
     })) as ClarificationNote
   }

--- a/server/form-pages/assess/assessApplication/requiredActions/requiredActions.test.ts
+++ b/server/form-pages/assess/assessApplication/requiredActions/requiredActions.test.ts
@@ -95,7 +95,7 @@ describe('RequiredActions', () => {
 
       expect(page.errors()).toEqual({
         additionalActions:
-          'You must state if there are additional actions required by the probation practicioner to make a placement viable',
+          'You must state if there are additional actions required by the probation practitioner to make a placement viable',
         curfewsOrSignIns: 'You must state if there are any additional curfews or sign ins recommended',
         concernsOfUnmanagableRisk:
           'You must state if there are any concerns that the person poses an potentially unmanageable risk to staff or others',

--- a/server/form-pages/assess/assessApplication/requiredActions/requiredActions.ts
+++ b/server/form-pages/assess/assessApplication/requiredActions/requiredActions.ts
@@ -98,7 +98,7 @@ export default class RequiredActions implements TasklistPage {
 
     if (!this.body.additionalActions)
       errors.additionalActions =
-        'You must state if there are additional actions required by the probation practicioner to make a placement viable'
+        'You must state if there are additional actions required by the probation practitioner to make a placement viable'
 
     if (!this.body.curfewsOrSignIns)
       errors.curfewsOrSignIns = 'You must state if there are any additional curfews or sign ins recommended'

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/index.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/index.ts
@@ -1,10 +1,11 @@
 import { Task } from '../../../utils/decorators'
 
 import SufficentInformationPage from './sufficientInformation'
+import InformationReceived from './informationReceived'
 
 @Task({
   slug: 'sufficient-information',
   name: 'Check there is sufficient information to make a decision',
-  pages: [SufficentInformationPage],
+  pages: [SufficentInformationPage, InformationReceived],
 })
 export default class SufficientInformation {}

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/informationReceived.test.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/informationReceived.test.ts
@@ -1,0 +1,93 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+
+import InformationReceived from './informationReceived'
+
+describe('InformationReceived', () => {
+  describe('title', () => {
+    expect(new InformationReceived({ informationReceived: 'yes' }).title).toBe(
+      'Have you received additional information from the probation practitioner?',
+    )
+  })
+
+  describe('body', () => {
+    it('should set the body', () => {
+      const page = new InformationReceived({
+        informationReceived: 'yes',
+        'responseReceivedOn-year': '2022',
+        'responseReceivedOn-month': '3',
+        'responseReceivedOn-day': '3',
+        response: 'some text',
+      })
+      expect(page.body).toEqual({
+        informationReceived: 'yes',
+        response: 'some text',
+        'responseReceivedOn-year': '2022',
+        'responseReceivedOn-month': '3',
+        'responseReceivedOn-day': '3',
+        responseReceivedOn: '2022-03-03',
+      })
+    })
+  })
+
+  itShouldHaveNextValue(new InformationReceived({ informationReceived: 'yes' }), '')
+  itShouldHavePreviousValue(new InformationReceived({ informationReceived: 'yes' }), '')
+
+  describe('errors', () => {
+    it('should have an error if there is no answer', () => {
+      const page = new InformationReceived({})
+
+      expect(page.errors()).toEqual({
+        informationReceived:
+          'You must confirm if you have received additional information from the probation practitioner',
+      })
+    })
+
+    it('should have an error if the answer is yes and no response is specified', () => {
+      const page = new InformationReceived({
+        informationReceived: 'yes',
+        'responseReceivedOn-year': '2022',
+        'responseReceivedOn-month': '3',
+        'responseReceivedOn-day': '3',
+      })
+
+      expect(page.errors()).toEqual({
+        response: 'You must specify the information you have received',
+      })
+    })
+
+    it('should have an error if the answer is yes and no date is specified', () => {
+      const page = new InformationReceived({
+        informationReceived: 'yes',
+        response: 'some text',
+      })
+
+      expect(page.errors()).toEqual({
+        responseReceivedOn: 'You must specify when you received the information',
+      })
+    })
+
+    it('should have an error if the answer is yes and the date is invalid', () => {
+      const page = new InformationReceived({
+        informationReceived: 'yes',
+        response: 'some text',
+        'responseReceivedOn-year': '5765757567',
+        'responseReceivedOn-month': '6453',
+        'responseReceivedOn-day': '3',
+      })
+
+      expect(page.errors()).toEqual({
+        responseReceivedOn: 'The date is invalid',
+      })
+    })
+  })
+
+  describe('response', () => {
+    it('returns the response', () => {
+      const page = new InformationReceived({ informationReceived: 'yes' })
+
+      expect(page.response()).toEqual({
+        'Have you received additional information from the probation practitioner?': 'Yes',
+      })
+    })
+  })
+})

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/informationReceived.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/informationReceived.ts
@@ -1,0 +1,94 @@
+import type { TaskListErrors, YesOrNo, ObjectWithDateParts } from '@approved-premises/ui'
+import type { User } from '@approved-premises/api'
+
+import { Page } from '../../../utils/decorators'
+import { sentenceCase } from '../../../../utils/utils'
+import { dateAndTimeInputsAreValidDates, dateIsBlank, DateFormats } from '../../../../utils/dateUtils'
+
+import TasklistPage from '../../../tasklistPage'
+
+type InformationReceivedBody = ObjectWithDateParts<'responseReceivedOn'> & {
+  informationReceived?: YesOrNo
+  response?: string
+}
+
+@Page({
+  name: 'information-received',
+  bodyProperties: [
+    'informationReceived',
+    'response',
+    'responseReceivedOn',
+    'responseReceivedOn-year',
+    'responseReceivedOn-month',
+    'responseReceivedOn-day',
+  ],
+  controllerActions: { update: 'updateInformationRecieved' },
+})
+export default class InformationReceived implements TasklistPage {
+  name = 'information-received'
+
+  title = 'Have you received additional information from the probation practitioner?'
+
+  user: User
+
+  constructor(private _body: Partial<InformationReceivedBody>) {}
+
+  public set body(value: Partial<InformationReceivedBody>) {
+    this._body = {
+      informationReceived: value.informationReceived as YesOrNo,
+    }
+    this._body = {
+      informationReceived: value.informationReceived as YesOrNo,
+      response: value.response,
+      'responseReceivedOn-year': value['responseReceivedOn-year'] as string,
+      'responseReceivedOn-month': value['responseReceivedOn-month'] as string,
+      'responseReceivedOn-day': value['responseReceivedOn-day'] as string,
+      responseReceivedOn: DateFormats.dateAndTimeInputsToIsoString(
+        value as ObjectWithDateParts<'responseReceivedOn'>,
+        'responseReceivedOn',
+      ).responseReceivedOn,
+    }
+  }
+
+  public get body(): InformationReceivedBody {
+    return this._body as InformationReceivedBody
+  }
+
+  previous() {
+    return ''
+  }
+
+  next() {
+    return ''
+  }
+
+  response() {
+    return {
+      [`${this.title}`]: sentenceCase(this.body.informationReceived),
+    }
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.informationReceived)
+      errors.informationReceived =
+        'You must confirm if you have received additional information from the probation practitioner'
+
+    if (this.body.informationReceived === 'yes' && !this.body.response) {
+      errors.response = 'You must specify the information you have received'
+    }
+
+    if (this.body.informationReceived === 'yes') {
+      if (dateIsBlank(this.body)) {
+        errors.responseReceivedOn = 'You must specify when you received the information'
+      } else if (
+        !dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'responseReceivedOn'>, 'responseReceivedOn')
+      ) {
+        errors.responseReceivedOn = 'The date is invalid'
+      }
+    }
+
+    return errors
+  }
+}

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.ts
@@ -8,7 +8,7 @@ import TasklistPage from '../../../tasklistPage'
 
 @Page({
   name: 'sufficient-information',
-  bodyProperties: ['sufficientInformation'],
+  bodyProperties: ['sufficientInformation', 'query'],
   controllerActions: { update: 'updateSufficientInformation' },
 })
 export default class SufficientInformation implements TasklistPage {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -69,6 +69,7 @@ export default {
     update: assessPaths.singleAssessment,
     clarificationNotes: {
       create: clarificationNotePaths.notes,
+      update: clarificationNotePaths.notes.path(':clarificationNoteId'),
     },
   },
   people: {

--- a/server/services/assessmentService.test.ts
+++ b/server/services/assessmentService.test.ts
@@ -166,4 +166,25 @@ describe('AssessmentService', () => {
       expect(assessmentClient.createClarificationNote).toHaveBeenCalledWith(id, clarificationNote)
     })
   })
+
+  describe('updateClarificationNote', () => {
+    it('calls the client with the expected arguments', async () => {
+      const token = 'token'
+      const id = 'some-uuid'
+      const clarificationNote = clarificationNoteFactory.build()
+      const updatedNote = {
+        response: clarificationNote.response,
+        responseReceivedOn: clarificationNote.responseReceivedOn,
+      }
+
+      assessmentClient.updateClarificationNote.mockResolvedValue(clarificationNote)
+
+      const result = await service.updateClarificationNote(token, id, clarificationNote.id, updatedNote)
+
+      expect(result).toEqual(clarificationNote)
+
+      expect(assessmentClientFactory).toHaveBeenCalledWith(token)
+      expect(assessmentClient.updateClarificationNote).toHaveBeenCalledWith(id, clarificationNote.id, updatedNote)
+    })
+  })
 })

--- a/server/services/assessmentService.test.ts
+++ b/server/services/assessmentService.test.ts
@@ -69,26 +69,23 @@ describe('AssessmentService', () => {
       })
     })
 
-    it('should fetch the assessment from the API', async () => {
-      assessmentClient.find.mockResolvedValue(assessment)
+    it('should return a page', async () => {
       ;(getBody as jest.Mock).mockReturnValue(request.body)
 
-      const result = await service.initializePage(Page, request, {})
+      const result = await service.initializePage(Page, assessment, request, {})
 
       expect(result).toBeInstanceOf(Page)
 
       expect(Page).toHaveBeenCalledWith(request.body, assessment, '')
-      expect(assessmentClient.find).toHaveBeenCalledWith(request.params.id)
     })
 
-    it("should call a service's initialize method if it exists", async () => {
+    it("should call a page's initialize method if it exists", async () => {
       const dataServices = createMock<DataServices>({}) as DataServices
-      assessmentClient.find.mockResolvedValue(assessment)
       ;(getBody as jest.Mock).mockReturnValue(request.body)
 
       const TestPage = { initialize: jest.fn() } as unknown as TasklistPageInterface
 
-      await service.initializePage(TestPage, request, dataServices)
+      await service.initializePage(TestPage, assessment, request, dataServices)
 
       expect(TestPage.initialize).toHaveBeenCalledWith(request.body, assessment, request.user.token, dataServices)
     })

--- a/server/services/assessmentService.ts
+++ b/server/services/assessmentService.ts
@@ -1,5 +1,9 @@
 import type { Request } from 'express'
-import { ApprovedPremisesAssessment as Assessment, NewClarificationNote } from '@approved-premises/api'
+import {
+  ApprovedPremisesAssessment as Assessment,
+  NewClarificationNote,
+  UpdatedClarificationNote,
+} from '@approved-premises/api'
 import type { DataServices, GroupedAssessments } from '@approved-premises/ui'
 
 import type { RestClientBuilder, AssessmentClient } from '../data'
@@ -77,5 +81,16 @@ export default class AssessmentService {
     const client = this.assessmentClientFactory(token)
 
     return client.createClarificationNote(assessmentId, clarificationNote)
+  }
+
+  async updateClarificationNote(
+    token: string,
+    assessmentId: string,
+    clarificationNoteId: string,
+    clarificationNote: UpdatedClarificationNote,
+  ) {
+    const client = this.assessmentClientFactory(token)
+
+    return client.updateClarificationNote(assessmentId, clarificationNoteId, clarificationNote)
   }
 }

--- a/server/services/assessmentService.ts
+++ b/server/services/assessmentService.ts
@@ -48,11 +48,11 @@ export default class AssessmentService {
 
   async initializePage(
     Page: TasklistPageInterface,
+    assessment: Assessment,
     request: Request,
     dataServices: DataServices,
     userInput?: Record<string, unknown>,
   ) {
-    const assessment = await this.findAssessment(request.user.token, request.params.id)
     const body = getBody(Page, assessment, request, userInput)
 
     const page = Page.initialize

--- a/server/views/assessments/clarificationNotes/confirmation.njk
+++ b/server/views/assessments/clarificationNotes/confirmation.njk
@@ -23,7 +23,7 @@
       You will not be able to continue with your assessment until either the information is provided, or 5 days have passed.
     </p>
 
-    <p class="govuk-label--m">Probation practicioner contact information</p>
+    <p class="govuk-label--m">Probation practitioner contact information</p>
 
     {{
       govukSummaryList({

--- a/server/views/assessments/pages/sufficient-information/information-received.njk
+++ b/server/views/assessments/pages/sufficient-information/information-received.njk
@@ -1,0 +1,55 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% extends "../layout.njk" %}
+
+{% block questions %}
+  <h1 class="govuk-heading-l">
+    Additional information
+  </h1>
+
+  {% set informationReceivedHtml %}
+  {{ formPageTextarea({
+            fieldName: 'response',
+            label: {
+              text: "Provide the additional information received from the probation practitioner"
+            }
+          }, fetchContext()) }}
+
+  {{
+    formPageDateInput(
+      {
+        fieldName: "responseReceivedOn",
+        fieldset: {
+          legend: {
+            text: "When did you receive this information?"
+          }
+        },
+        items: dateFieldValues('responseReceivedOn', errors)
+      },
+      fetchContext()
+    )
+  }}
+  {% endset -%}
+
+  {{ formPageRadios({
+        fieldName: "informationReceived",
+        fieldset: {
+          legend: {
+            html: '<h2 class="govuk-heading-m">' + page.title + '</h2>'
+          }
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes",
+            conditional: {
+              html: informationReceivedHtml
+            }
+          },
+          {
+            value: "no",
+            text: "No"
+          }
+        ]
+    },fetchContext()) }}
+{% endblock %}


### PR DESCRIPTION
This allows a response to be added to a clarification note. I've had to tweak the way our custom controller update actions work slightly, but this is better, as they update the page data too, as well as carrying out any associated actions. 

After a note is completed, and the user returns to the assessment, they are then prompted to answer if the response has been received. If they click "Yes", then they can add the response, and the date it was received, they are then redirected to complete the journey. 

I still need to handle what happens when they click "no", and this will require a bit of tweaking to the tasklist, but this is the next job!

I had to deviate from the design a bit, so would appreciate feedback from @beth-dixxon and @selina-dxw too 👍 

## Screenshots

![Assess -- allows me to create and update a clarification note](https://user-images.githubusercontent.com/109774/213670463-7f2432f8-f7cb-4b42-a7f6-2078d910862c.png)

