### PR TITLE
(873) Reject assessment if no information

### DIFF
--- a/cypress_shared/helpers/assess.ts
+++ b/cypress_shared/helpers/assess.ts
@@ -34,17 +34,15 @@ export default class AseessHelper {
     cy.task('stubAssessment', this.assessment)
     cy.task('stubFindUser', { user: this.user, id: this.assessment.application.createdByUserId })
     cy.task('stubAssessmentUpdate', this.assessment)
-    if (this.clarificationNote) {
-      cy.task('stubClarificationNoteCreate', {
-        assessment: this.assessment,
-        clarificationNote: { query: this.clarificationNote },
-      })
-      cy.task('stubClarificationNoteUpdate', {
-        assessment: this.assessment,
-        clarificationNoteId: this.clarificationNote.id,
-        clarificationNote: { query: this.clarificationNote },
-      })
-    }
+    cy.task('stubClarificationNoteCreate', {
+      assessment: this.assessment,
+      clarificationNote: { query: this.clarificationNote },
+    })
+    cy.task('stubClarificationNoteUpdate', {
+      assessment: this.assessment,
+      clarificationNoteId: this.clarificationNote.id,
+      clarificationNote: { query: this.clarificationNote },
+    })
     cy.task('stubApplicationDocuments', { application: this.assessment.application, documents: this.documents })
     this.documents.forEach(document => {
       cy.task('stubPersonDocument', { person: this.assessment.application.person, document })

--- a/cypress_shared/helpers/assess.ts
+++ b/cypress_shared/helpers/assess.ts
@@ -5,6 +5,7 @@ import {
   Document,
   User,
 } from '@approved-premises/api'
+import { YesOrNo } from '@approved-premises/ui'
 import {
   ClarificationNoteConfirmPage,
   ListPage,
@@ -107,24 +108,27 @@ export default class AseessHelper {
     confirmationScreen.confirmUserDetails(this.user)
 
     // And I should be able to return to the dashboard
-    confirmationScreen.clickBackToDashboard()
-
-    Page.verifyOnPage(ListPage)
+    return confirmationScreen.clickBackToDashboard()
   }
 
-  updateClarificationNote(response: string, responseReceivedOn: string) {
-    this.updateAssessmentStatus('active').then(() => {
+  updateClarificationNote(informationReceived: YesOrNo, response?: string, responseReceivedOn?: string) {
+    const assessmentStatus = informationReceived === 'yes' ? 'active' : 'pending'
+    this.updateAssessmentStatus(assessmentStatus).then(() => {
       const informationReceivedPage = Page.verifyOnPage(InformationReceivedPage, this.assessment, {
-        informationReceived: 'yes',
+        informationReceived,
         response,
         responseReceivedOn,
       })
 
-      this.updateAssessmentAndStub(informationReceivedPage).then(() => {
-        // When I complete the form
-        informationReceivedPage.completeForm()
-        informationReceivedPage.clickSubmit()
-      })
+      this.updateAssessmentAndStub(informationReceivedPage)
+        .then(() => {
+          // When I complete the form
+          informationReceivedPage.completeForm()
+          informationReceivedPage.clickSubmit()
+        })
+        .then(() => {
+          this.updateAssessmentAndStub(informationReceivedPage)
+        })
     })
   }
 

--- a/cypress_shared/pages/assess/clarificationNoteConfirmPage.ts
+++ b/cypress_shared/pages/assess/clarificationNoteConfirmPage.ts
@@ -8,7 +8,7 @@ export default class SufficientInformationPage extends Page {
   }
 
   clickBackToDashboard() {
-    cy.get('a').contains('Back to dashboard').click()
+    return cy.get('a').contains('Back to dashboard').click()
   }
 
   confirmUserDetails(user: User) {

--- a/cypress_shared/pages/assess/informationReceivedPage.ts
+++ b/cypress_shared/pages/assess/informationReceivedPage.ts
@@ -18,14 +18,17 @@ export default class InformationReceivedPage extends AssessPage {
     },
   ) {
     super(assessment, 'Additional information')
-    const parsedDate = DateFormats.isoToDateObj(body.responseReceivedOn)
-
-    this.pageClass = new InformationReceived({
-      ...body,
-      'responseReceivedOn-day': String(parsedDate.getDate()),
-      'responseReceivedOn-month': String(parsedDate.getMonth() + 1),
-      'responseReceivedOn-year': String(parsedDate.getFullYear()),
-    })
+    if (body.responseReceivedOn) {
+      const parsedDate = DateFormats.isoToDateObj(body.responseReceivedOn)
+      this.pageClass = new InformationReceived({
+        ...body,
+        'responseReceivedOn-day': String(parsedDate.getDate()),
+        'responseReceivedOn-month': String(parsedDate.getMonth() + 1),
+        'responseReceivedOn-year': String(parsedDate.getFullYear()),
+      })
+    } else {
+      this.pageClass = new InformationReceived(body)
+    }
   }
 
   completeForm() {

--- a/cypress_shared/pages/assess/taskListPage.ts
+++ b/cypress_shared/pages/assess/taskListPage.ts
@@ -8,4 +8,8 @@ export default class TaskListPage extends Page {
   shouldShowTaskStatus = (task: string, status: string): void => {
     cy.get(`#${task}-status`).should('contain', status)
   }
+
+  shouldNotShowSection = (section: string): void => {
+    cy.get('.app-task-list').should('not.contain', section)
+  }
 }

--- a/integration_tests/tests/assess/assess.cy.ts
+++ b/integration_tests/tests/assess/assess.cy.ts
@@ -16,37 +16,11 @@ context('Assess', () => {
     cy.task('stubAuthUser')
   })
 
-  it('allows me to assess an application', () => {
+  beforeEach(() => {
     // Given I am logged in
     cy.signIn()
+    // And there is an application awaiting assessment
     cy.fixture('applicationData.json').then(applicationData => {
-      // And there is an application awaiting assessment
-      const assessment = assessmentFactory.build({
-        decision: undefined,
-        application: { data: applicationData },
-      })
-      assessment.data = {}
-      const documents = documentFactory.buildList(4)
-      assessment.application = overwriteApplicationDocuments(assessment.application, documents)
-      const user = userFactory.build()
-
-      const assessHelper = new AssessHelper(assessment, documents, user)
-
-      assessHelper.setupStubs()
-
-      // And I start an assessment
-      assessHelper.startAssessment()
-
-      // And I complete an assessment
-      assessHelper.completeAssessment()
-    })
-  })
-
-  it('allows me to create and update a clarification note', () => {
-    // Given I am logged in
-    cy.signIn()
-    cy.fixture('applicationData.json').then(applicationData => {
-      // And there is an application awaiting assessment
       const clarificationNote = clarificationNoteFactory.build({ response: undefined })
       const assessment = assessmentFactory.build({
         decision: undefined,
@@ -60,102 +34,105 @@ context('Assess', () => {
 
       const assessHelper = new AssessHelper(assessment, documents, user, clarificationNote)
 
-      assessHelper.setupStubs()
-
-      // And I start an assessment
-      assessHelper.startAssessment()
-
-      // And I add a clarification note
-      const note = 'Note goes here'
-      assessHelper.addClarificationNote(note)
-
-      // Then the API should have had a clarification note added
-      cy.task('verifyClarificationNoteCreate', assessment)
-        .then(requests => {
-          expect(requests).to.have.length(1)
-          const body = JSON.parse(requests[0].body)
-
-          expect(body.query).equal(note)
-        })
-        .then(() => {
-          // And I should be on redirected to the dashboard
-          const listPage = Page.verifyOnPage(ListPage)
-
-          // And my assessment should be put into a pending state
-          assessHelper.updateAssessmentStatus('pending').then(() => {
-            // When I click on my assessment
-            listPage.clickAssessment(assessment)
-
-            // And I complete the form
-            assessHelper.updateClarificationNote('yes', 'response text', '2023-09-02')
-
-            // Then I should be redirected to the tasklist page
-            const tasklistPage = Page.verifyOnPage(TaskListPage)
-
-            // And the sufficient information task should show a completed status
-            tasklistPage.shouldShowTaskStatus('review-application', 'Completed')
-
-            // And the API should have had a clarification note update request
-            cy.task('verifyClarificationNoteUpdate', assessment).then(requests => {
-              expect(requests).to.have.length(1)
-              const body = JSON.parse(requests[0].body)
-
-              expect(body.response).equal('response text')
-              expect(body.responseReceivedOn).equal('2023-09-02')
-            })
-          })
-        })
+      cy.wrap(assessment).as('assessment')
+      cy.wrap(assessHelper).as('assessHelper')
     })
   })
 
-  it('should allow me to reject an application where I have not received the correct information', () => {
-    // Given I am logged in
-    cy.signIn()
-    cy.fixture('applicationData.json').then(applicationData => {
-      // And there is an application awaiting assessment
-      const clarificationNote = clarificationNoteFactory.build({ response: undefined })
-      const assessment = assessmentFactory.build({
-        application: { data: applicationData },
-        clarificationNotes: [clarificationNote],
-        status: 'active',
+  it('allows me to assess an application', function test() {
+    this.assessHelper.setupStubs()
+
+    // And I start an assessment
+    this.assessHelper.startAssessment()
+
+    // And I complete an assessment
+    this.assessHelper.completeAssessment()
+  })
+
+  it('allows me to create and update a clarification note', function test() {
+    this.assessHelper.setupStubs()
+
+    // And I start an assessment
+    this.assessHelper.startAssessment()
+
+    // And I add a clarification note
+    const note = 'Note goes here'
+    this.assessHelper.addClarificationNote(note)
+
+    cy.task('verifyClarificationNoteCreate', this.assessment)
+      .then(requests => {
+        // Then the API should have had a clarification note added
+        expect(requests).to.have.length(1)
+        const body = JSON.parse(requests[0].body)
+
+        expect(body.query).equal(note)
       })
-      assessment.data = {}
-      const documents = documentFactory.buildList(4)
-      assessment.application = overwriteApplicationDocuments(assessment.application, documents)
-      const user = userFactory.build()
-
-      const assessHelper = new AssessHelper(assessment, documents, user, clarificationNote)
-
-      assessHelper.setupStubs()
-
-      // And I start an assessment
-      assessHelper.startAssessment()
-
-      // And I add a clarification note
-      assessHelper.addClarificationNote('Note goes here').then(() => {
+      .then(() => {
+        // Given my assessment is put into a pending state
+        this.assessHelper.updateAssessmentStatus('pending')
+      })
+      .then(() => {
+        // When I am redirected to the dashboard
         const listPage = Page.verifyOnPage(ListPage)
 
-        // And my assessment should be put into a pending state
-        assessHelper.updateAssessmentStatus('pending').then(() => {
-          // When I click on my assessment
-          listPage.clickAssessment(assessment)
+        // And I click on my assessment
+        listPage.clickAssessment(this.assessment)
 
-          // And I respond 'no' to the 'informationReceived' question
-          assessHelper.updateClarificationNote('no')
+        // And I complete the form
+        this.assessHelper.updateClarificationNote('yes', 'response text', '2023-09-02')
 
-          // Then I should be redirected to the tasklist page
-          const tasklistPage = Page.verifyOnPage(TaskListPage)
+        // Then I should be redirected to the tasklist page
+        const tasklistPage = Page.verifyOnPage(TaskListPage)
 
-          // And the sufficient information task should show a completed status
-          tasklistPage.shouldShowTaskStatus('review-application', 'Completed')
-
-          // And I should not see the AssessApplication section
-          tasklistPage.shouldNotShowSection('Assess application')
-
-          // And I should be able to start the make a decision task
-          tasklistPage.shouldShowTaskStatus('make-a-decision', 'Not started')
-        })
+        // And the sufficient information task should show a completed status
+        tasklistPage.shouldShowTaskStatus('review-application', 'Completed')
       })
-    })
+      .then(() => {
+        cy.task('verifyClarificationNoteUpdate', this.assessment)
+      })
+      .then(requests => {
+        // And the API should have had a clarification note update request
+        expect(requests).to.have.length(1)
+        const body = JSON.parse(requests[0].body)
+
+        expect(body.response).equal('response text')
+        expect(body.responseReceivedOn).equal('2023-09-02')
+      })
+  })
+
+  it('should allow me to reject an application where I have not received the correct information', function test() {
+    this.assessHelper.setupStubs()
+
+    // Given I start an assessment
+    this.assessHelper.startAssessment()
+
+    // And I add a clarification note
+    this.assessHelper
+      .addClarificationNote('Note goes here')
+      .then(() => {
+        // And my assessment is put into a pending state
+        this.assessHelper.updateAssessmentStatus('pending')
+      })
+      .then(() => {
+        const listPage = Page.verifyOnPage(ListPage)
+
+        // When I click on my assessment
+        listPage.clickAssessment(this.assessment)
+
+        // And I respond 'no' to the 'informationReceived' question
+        this.assessHelper.updateClarificationNote('no')
+
+        // Then I should be redirected to the tasklist page
+        const tasklistPage = Page.verifyOnPage(TaskListPage)
+
+        // And the sufficient information task should show a completed status
+        tasklistPage.shouldShowTaskStatus('review-application', 'Completed')
+
+        // And I should not see the AssessApplication section
+        tasklistPage.shouldNotShowSection('Assess application')
+
+        // And I should be able to start the make a decision task
+        tasklistPage.shouldShowTaskStatus('make-a-decision', 'Not started')
+      })
   })
 })

--- a/server/controllers/assess/assessmentsController.test.ts
+++ b/server/controllers/assess/assessmentsController.test.ts
@@ -10,6 +10,9 @@ import assessmentFactory from '../../testutils/factories/assessment'
 import Assess from '../../form-pages/assess'
 
 import paths from '../../paths/assess'
+import { informationSetAsNotReceived } from '../../utils/assessmentUtils'
+
+jest.mock('../../utils/assessmentUtils')
 
 describe('assessmentsController', () => {
   const token = 'SOME_TOKEN'
@@ -65,7 +68,8 @@ describe('assessmentsController', () => {
       expect(assessmentService.findAssessment).toHaveBeenCalledWith(token, assessment.id)
     })
 
-    it('redirects if the assessment is in a pending state', async () => {
+    it('redirects if the assessment is in a pending state and informationSetAsNotReceived is false', async () => {
+      ;(informationSetAsNotReceived as jest.Mock).mockReturnValue(false)
       assessment.status = 'pending'
 
       const requestHandler = assessmentsController.show()
@@ -79,6 +83,23 @@ describe('assessmentsController', () => {
           page: 'information-received',
         }),
       )
+
+      expect(assessmentService.findAssessment).toHaveBeenCalledWith(token, assessment.id)
+    })
+
+    it('fetches the assessment and renders the task list  if the assessment is in a pending state and informationSetAsNotReceived is true', async () => {
+      ;(informationSetAsNotReceived as jest.Mock).mockReturnValue(true)
+      assessment.status = 'pending'
+
+      const requestHandler = assessmentsController.show()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('assessments/show', {
+        assessment,
+        pageHeading: 'Assess an Approved Premises (AP) application',
+        sections: Assess.sections,
+      })
 
       expect(assessmentService.findAssessment).toHaveBeenCalledWith(token, assessment.id)
     })

--- a/server/controllers/assess/assessmentsController.test.ts
+++ b/server/controllers/assess/assessmentsController.test.ts
@@ -7,10 +7,9 @@ import AssessmentsController from './assessmentsController'
 import { AssessmentService } from '../../services'
 
 import assessmentFactory from '../../testutils/factories/assessment'
-import Assess from '../../form-pages/assess'
 
 import paths from '../../paths/assess'
-import { informationSetAsNotReceived } from '../../utils/assessmentUtils'
+import { getSections, informationSetAsNotReceived } from '../../utils/assessmentUtils'
 
 jest.mock('../../utils/assessmentUtils')
 
@@ -62,7 +61,7 @@ describe('assessmentsController', () => {
       expect(response.render).toHaveBeenCalledWith('assessments/show', {
         assessment,
         pageHeading: 'Assess an Approved Premises (AP) application',
-        sections: Assess.sections,
+        sections: getSections(assessment),
       })
 
       expect(assessmentService.findAssessment).toHaveBeenCalledWith(token, assessment.id)
@@ -98,7 +97,7 @@ describe('assessmentsController', () => {
       expect(response.render).toHaveBeenCalledWith('assessments/show', {
         assessment,
         pageHeading: 'Assess an Approved Premises (AP) application',
-        sections: Assess.sections,
+        sections: getSections(assessment),
       })
 
       expect(assessmentService.findAssessment).toHaveBeenCalledWith(token, assessment.id)

--- a/server/controllers/assess/assessmentsController.ts
+++ b/server/controllers/assess/assessmentsController.ts
@@ -1,8 +1,7 @@
 import type { Request, Response, RequestHandler } from 'express'
 
 import { AssessmentService } from '../../services'
-import Assess from '../../form-pages/assess'
-import { informationSetAsNotReceived } from '../../utils/assessmentUtils'
+import { getSections, informationSetAsNotReceived } from '../../utils/assessmentUtils'
 
 import paths from '../../paths/assess'
 
@@ -34,7 +33,7 @@ export default class AssessmentsController {
         res.render('assessments/show', {
           assessment,
           pageHeading: 'Assess an Approved Premises (AP) application',
-          sections: Assess.sections,
+          sections: getSections(assessment),
         })
       }
     }

--- a/server/controllers/assess/assessmentsController.ts
+++ b/server/controllers/assess/assessmentsController.ts
@@ -2,6 +2,7 @@ import type { Request, Response, RequestHandler } from 'express'
 
 import { AssessmentService } from '../../services'
 import Assess from '../../form-pages/assess'
+import { informationSetAsNotReceived } from '../../utils/assessmentUtils'
 
 import paths from '../../paths/assess'
 
@@ -19,8 +20,9 @@ export default class AssessmentsController {
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
       const assessment = await this.assessmentService.findAssessment(req.user.token, req.params.id)
+      const noteAwaitingResponse = assessment.status === 'pending' && !informationSetAsNotReceived(assessment)
 
-      if (assessment.status === 'pending') {
+      if (noteAwaitingResponse) {
         res.redirect(
           paths.assessments.pages.show({
             id: assessment.id,

--- a/server/form-pages/apply/add-documents/index.ts
+++ b/server/form-pages/apply/add-documents/index.ts
@@ -9,7 +9,7 @@ import { Task, Section } from '../../utils/decorators'
   pages: [AttachDocuments],
 })
 @Section({
-  name: 'Add documents',
+  title: 'Add documents',
   tasks: [AddDocuments],
 })
 export default class AddDocuments {}

--- a/server/form-pages/apply/check-your-answers/index.ts
+++ b/server/form-pages/apply/check-your-answers/index.ts
@@ -9,7 +9,7 @@ import { Task, Section } from '../../utils/decorators'
   pages: [Review],
 })
 @Section({
-  name: 'Check your answers',
+  title: 'Check your answers',
   tasks: [CheckYourAnswers],
 })
 export default class CheckYourAnswers {}

--- a/server/form-pages/apply/move-on/index.ts
+++ b/server/form-pages/apply/move-on/index.ts
@@ -13,7 +13,7 @@ import ForeignNational from './foreignNational'
   pages: [PlacementDuration, RelocationRegion, PlansInPlace, TypeOfAccommodation, ForeignNational],
 })
 @Section({
-  name: 'Considerations for when the placement ends',
+  title: 'Considerations for when the placement ends',
   tasks: [MoveOn],
 })
 export default class MoveOn {}

--- a/server/form-pages/apply/reasons-for-placement/index.ts
+++ b/server/form-pages/apply/reasons-for-placement/index.ts
@@ -3,5 +3,5 @@ import { Section } from '../../utils/decorators'
 import BasicInformation from './basic-information'
 import TypeOfAp from './type-of-ap'
 
-@Section({ name: 'Type of AP required', tasks: [BasicInformation, TypeOfAp] })
+@Section({ title: 'Type of AP required', tasks: [BasicInformation, TypeOfAp] })
 export default class ReasonsForPlacement {}

--- a/server/form-pages/apply/risk-and-need-factors/index.ts
+++ b/server/form-pages/apply/risk-and-need-factors/index.ts
@@ -8,7 +8,7 @@ import PrisonInformation from './prison-information'
 import RiskManagement from './risk-management-features'
 
 @Section({
-  name: 'Risk and need factors',
+  title: 'Risk and need factors',
   tasks: [OasysImport, RiskManagement, PrisonInformation, LocationFactors, AccessAndHealthcare, FurtherConsiderations],
 })
 export default class RiskAndNeedFactors {}

--- a/server/form-pages/assess/assessApplication/index.ts
+++ b/server/form-pages/assess/assessApplication/index.ts
@@ -3,7 +3,7 @@ import SuitabilityAssessment from './suitablityAssessment'
 import RequiredActions from './requiredActions'
 
 @Section({
-  name: 'Assess application',
+  title: 'Assess application',
   tasks: [SuitabilityAssessment, RequiredActions],
 })
 export default class AssessApplication {}

--- a/server/form-pages/assess/makeADecision/index.ts
+++ b/server/form-pages/assess/makeADecision/index.ts
@@ -2,7 +2,7 @@ import { Section } from '../../utils/decorators'
 import MakeADecisionTask from './makeADecisionPage'
 
 @Section({
-  name: 'Make a decision',
+  title: 'Make a decision',
   tasks: [MakeADecisionTask],
 })
 export default class MakeADecision {}

--- a/server/form-pages/assess/reviewApplication/index.ts
+++ b/server/form-pages/assess/reviewApplication/index.ts
@@ -4,7 +4,7 @@ import ReviewApplicationAndDocuments from './reviewApplicationAndDocuments'
 import SufficientInformation from './sufficientInformation'
 
 @Section({
-  name: 'Review application',
+  title: 'Review application',
   tasks: [ReviewApplicationAndDocuments, SufficientInformation],
 })
 export default class ReviewApplication {}

--- a/server/form-pages/baseForm.ts
+++ b/server/form-pages/baseForm.ts
@@ -5,6 +5,7 @@ export default class BaseForm {
 
   static sections: Array<{
     title: string
+    name: string
     tasks: Array<Task>
   }>
 }

--- a/server/form-pages/utils/decorators/form.decorator.test.ts
+++ b/server/form-pages/utils/decorators/form.decorator.test.ts
@@ -15,13 +15,13 @@ describe('Task', () => {
     @Task({ name: 'Task 3', slug: 'task-3', pages: [] })
     class Task3 {}
 
-    @Section({ name: 'Section 1', tasks: [Task1] })
+    @Section({ title: 'Section 1', tasks: [Task1] })
     class Section1 {}
 
-    @Section({ name: 'Section 2', tasks: [Task2, Task3] })
+    @Section({ title: 'Section 2', tasks: [Task2, Task3] })
     class Section2 {}
 
-    @Section({ name: 'Section 3', tasks: [] })
+    @Section({ title: 'Section 3', tasks: [] })
     class Section3 {}
 
     @Form({ sections: [Section1, Section2, Section3] })
@@ -31,10 +31,12 @@ describe('Task', () => {
     expect(MyForm.sections).toEqual([
       {
         title: 'Section 1',
+        name: 'Section1',
         tasks: [{ id: 'task-1', title: 'Task 1', pages: {} }],
       },
       {
         title: 'Section 2',
+        name: 'Section2',
         tasks: [
           { id: 'task-2', title: 'Task 2', pages: {} },
           { id: 'task-3', title: 'Task 3', pages: {} },
@@ -42,6 +44,7 @@ describe('Task', () => {
       },
       {
         title: 'Section 3',
+        name: 'Section3',
         tasks: [],
       },
     ])

--- a/server/form-pages/utils/decorators/section.decorator.test.ts
+++ b/server/form-pages/utils/decorators/section.decorator.test.ts
@@ -8,13 +8,15 @@ describe('Task', () => {
 
     class Task3 {}
 
-    @Section({ name: 'My Section', tasks: [Task1, Task2, Task3] })
+    @Section({ title: 'My Section', tasks: [Task1, Task2, Task3] })
     class MySection {}
 
+    const title = Reflect.getMetadata('section:title', MySection)
     const name = Reflect.getMetadata('section:name', MySection)
     const tasks = Reflect.getMetadata('section:tasks', MySection)
 
-    expect(name).toEqual('My Section')
+    expect(title).toEqual('My Section')
+    expect(name).toEqual('MySection')
     expect(tasks).toEqual([Task1, Task2, Task3])
   })
 })

--- a/server/form-pages/utils/decorators/section.decorator.ts
+++ b/server/form-pages/utils/decorators/section.decorator.ts
@@ -4,9 +4,10 @@ import 'reflect-metadata'
 
 type Constructor = new (...args: Array<any>) => {}
 
-const Section = (options: { name: string; tasks: Array<Constructor> }) => {
+const Section = (options: { title: string; tasks: Array<Constructor> }) => {
   return <T extends Constructor>(constructor: T) => {
-    Reflect.defineMetadata('section:name', options.name, constructor)
+    Reflect.defineMetadata('section:title', options.title, constructor)
+    Reflect.defineMetadata('section:name', constructor.name, constructor)
     Reflect.defineMetadata('section:tasks', options.tasks, constructor)
   }
 }

--- a/server/form-pages/utils/index.test.ts
+++ b/server/form-pages/utils/index.test.ts
@@ -78,7 +78,7 @@ describe('utils', () => {
       Reflect.defineMetadata('task:name', 'Name', Task)
       Reflect.defineMetadata('task:pages', [Page1, Page2], Task)
 
-      Reflect.defineMetadata('section:name', 'Section', Section)
+      Reflect.defineMetadata('section:title', 'Section', Section)
       Reflect.defineMetadata('section:tasks', [Task], Section)
     })
 
@@ -106,11 +106,13 @@ describe('utils', () => {
           if (section === Section1) {
             return {
               title: 'Section 1',
+              name: 'Section1',
               tasks: [{ id: 'foo', title: 'Foo', pages: { 'page-1': Page1, 'page-2': Page2 } }],
             }
           }
           return {
             title: 'Section 2',
+            name: 'Section2',
             tasks: [{ id: 'bar', title: 'Bar', pages: { 'page-3': Page1, 'page-4': Page2 } }],
           }
         })

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -39,6 +39,7 @@ export const getTask = <T>(task: T) => {
 
 export const getSection = <T>(section: T) => {
   const tasks: Array<Task> = []
+  const title = Reflect.getMetadata('section:title', section)
   const name = Reflect.getMetadata('section:name', section)
   const taskClasses = Reflect.getMetadata('section:tasks', section)
 
@@ -47,7 +48,8 @@ export const getSection = <T>(section: T) => {
   })
 
   return {
-    title: name,
+    title,
+    name,
     tasks,
   }
 }

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -18,6 +18,7 @@ import {
   getReviewNavigationItems,
   getSectionSuffix,
   informationSetAsNotReceived,
+  getSections,
 } from './assessmentUtils'
 import { DateFormats } from './dateUtils'
 import paths from '../paths/assess'
@@ -44,6 +45,16 @@ jest.mock('./reviewUtils')
 jest.mock('../form-pages/assess', () => {
   return {
     pages: { 'review-application': {}, 'sufficient-information': {} },
+    sections: [
+      {
+        title: 'Review Application',
+        name: 'ReviewApplication',
+      },
+      {
+        title: 'Assess Application',
+        name: 'AssessApplication',
+      },
+    ],
   }
 })
 
@@ -415,6 +426,40 @@ describe('assessmentUtils', () => {
       assessment.status = 'active'
 
       expect(informationSetAsNotReceived(assessment)).toEqual(false)
+    })
+  })
+
+  describe('getSections', () => {
+    const assessment = assessmentFactory.build({ status: 'pending' })
+
+    it('returns all sections if informationReceived is yes', () => {
+      assessment.data = { 'sufficient-information': { 'information-received': { informationReceived: 'yes' } } }
+
+      const sections = getSections(assessment)
+      const sectionNames = sections.map(s => s.name)
+
+      expect(sections.length).toEqual(Assess.sections.length)
+      expect(sectionNames).toContain('AssessApplication')
+    })
+
+    it('returns all sections if informationReceived is not yet answered', () => {
+      assessment.data = {}
+
+      const sections = getSections(assessment)
+      const sectionNames = sections.map(s => s.name)
+
+      expect(sections.length).toEqual(Assess.sections.length)
+      expect(sectionNames).toContain('AssessApplication')
+    })
+
+    it('removes the assess section if informationReceived is no', () => {
+      assessment.data = { 'sufficient-information': { 'information-received': { informationReceived: 'no' } } }
+
+      const sections = getSections(assessment)
+      const sectionNames = sections.map(s => s.name)
+
+      expect(sections.length).toEqual(Assess.sections.length - 1)
+      expect(sectionNames).not.toContain('AssessApplication')
     })
   })
 })

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -17,6 +17,7 @@ import {
   getTaskResponsesAsSummaryListItems,
   getReviewNavigationItems,
   getSectionSuffix,
+  informationSetAsNotReceived,
 } from './assessmentUtils'
 import { DateFormats } from './dateUtils'
 import paths from '../paths/assess'
@@ -386,6 +387,34 @@ describe('assessmentUtils', () => {
       expect(getSectionSuffix({ id: 'prison-information', title: '', pages: {} })).toBe(
         '<p><a href="prison-link">View additional prison information</a></p>',
       )
+    })
+  })
+
+  describe('informationSetAsNotReceived', () => {
+    const assessment = assessmentFactory.build({ status: 'pending' })
+
+    it('returns false when there is no data', () => {
+      assessment.data = {}
+
+      expect(informationSetAsNotReceived(assessment)).toEqual(false)
+    })
+
+    it('returns false when informationReceived is set to yes', () => {
+      assessment.data = { 'sufficient-information': { 'information-received': { informationReceived: 'yes' } } }
+
+      expect(informationSetAsNotReceived(assessment)).toEqual(false)
+    })
+
+    it('returns true when informationReceived is set to no', () => {
+      assessment.data = { 'sufficient-information': { 'information-received': { informationReceived: 'no' } } }
+
+      expect(informationSetAsNotReceived(assessment)).toEqual(true)
+    })
+
+    it('returns false when the application is not pending', () => {
+      assessment.status = 'active'
+
+      expect(informationSetAsNotReceived(assessment)).toEqual(false)
     })
   })
 })

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -2,6 +2,7 @@ import { HtmlItem, PageResponse, SummaryListItem, TableRow, Task, TextItem } fro
 import { format, differenceInDays, add } from 'date-fns'
 
 import { ApprovedPremisesAssessment as Assessment, ApprovedPremisesApplication } from '@approved-premises/api'
+import AssessApplication from '../form-pages/assess/assessApplication'
 import { tierBadge } from './personUtils'
 import { DateFormats } from './dateUtils'
 import { getArrivalDate, getResponseForPage, documentsFromApplication } from './applicationUtils'
@@ -112,6 +113,16 @@ const informationSetAsNotReceived = (assessment: Assessment): boolean => {
     return response === 'no'
   }
   return false
+}
+
+const getSections = (assessment: Assessment) => {
+  let { sections } = Assess
+
+  if (informationSetAsNotReceived(assessment)) {
+    sections = sections.filter(section => section.name !== AssessApplication.name)
+  }
+
+  return sections
 }
 
 const assessmentLink = (assessment: Assessment): string => {
@@ -311,4 +322,5 @@ export {
   assessmentsApproachingDueBadge,
   formatDaysUntilDueWithWarning,
   informationSetAsNotReceived,
+  getSections,
 }

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -106,6 +106,14 @@ const requestedFurtherInformationTableRows = (assessments: Array<Assessment>): A
   return rows
 }
 
+const informationSetAsNotReceived = (assessment: Assessment): boolean => {
+  if (assessment.status === 'pending' && assessment.data) {
+    const response = assessment.data?.['sufficient-information']?.['information-received']?.informationReceived
+    return response === 'no'
+  }
+  return false
+}
+
 const assessmentLink = (assessment: Assessment): string => {
   return `<a href="${paths.assessments.show({ id: assessment.id })}" data-cy-assessmentId="${assessment.id}">${
     assessment.application.person.name
@@ -302,4 +310,5 @@ export {
   assessmentsApproachingDue,
   assessmentsApproachingDueBadge,
   formatDaysUntilDueWithWarning,
+  informationSetAsNotReceived,
 }

--- a/server/utils/taskListUtils.test.ts
+++ b/server/utils/taskListUtils.test.ts
@@ -15,9 +15,11 @@ jest.mock('../form-pages/apply', () => {
   }
 })
 
-jest.mock('../form-pages/assess', () => {
+jest.mock('./assessmentUtils', () => {
   return {
-    pages: { 'first-task': {}, 'second-task': {} },
+    getSections: () => {
+      return { 'first-task': {}, 'second-task': {} }
+    },
   }
 })
 

--- a/server/utils/taskListUtils.ts
+++ b/server/utils/taskListUtils.ts
@@ -1,17 +1,19 @@
 import type { FormSections, FormSection } from '@approved-premises/ui'
 import { ApprovedPremisesApplication as Application, ApprovedPremisesAssessment as Assessment } from '../@types/shared'
 import { Task } from '../@types/ui'
+import { getSections as getAssessmentSections } from './assessmentUtils'
 import applyPaths from '../paths/apply'
 import assessPaths from '../paths/assess'
 import Apply from '../form-pages/apply'
-import Assess from '../form-pages/assess'
 
 const taskIsComplete = (task: Task, applicationOrAssessment: Application | Assessment): boolean => {
   return applicationOrAssessment.data?.[task.id]
 }
 
 const previousTaskIsComplete = (task: Task, applicationOrAssessment: Application | Assessment): boolean => {
-  const taskIds = isAssessment(applicationOrAssessment) ? Object.keys(Assess.pages) : Object.keys(Apply.pages)
+  const taskIds = isAssessment(applicationOrAssessment)
+    ? Object.keys(getAssessmentSections(applicationOrAssessment))
+    : Object.keys(Apply.pages)
   const previousTaskId = taskIds[taskIds.indexOf(task.id) - 1]
 
   return previousTaskId ? applicationOrAssessment.data?.[previousTaskId] : true


### PR DESCRIPTION
This allows a user to continue on the application journey if the additional information requested has not been recieved. This also means that users won't have to complete the "Assess Application" section, so we add some helpers to check 
if the answer to the InformationReceived question was "no". If it is, we can remove the assess question from the flow.

I've also taken the liberty of tidying up the Assess integration tests, as they were getting a little unweildy. I'm still not 100% happy with them, but they are better. I wonder if going forward we should think about using the Cucumber preprocessor for integration tests too?

## Screenshots

![Assess -- should allow me to reject an application where I have not received the correct information (3)](https://user-images.githubusercontent.com/109774/214266741-496dddbb-f0a6-42f1-bbb9-7bfeeadf63fb.png)

![Assess -- should allow me to reject an application where I have not received the correct information (4)](https://user-images.githubusercontent.com/109774/214266951-c6e6e2b0-5fb1-4cc0-83cb-facf465aeba6.png)
