### PR TITLE
Content changes

### DIFF
--- a/cypress_shared/pages/apply/arson.ts
+++ b/cypress_shared/pages/apply/arson.ts
@@ -12,7 +12,7 @@ export default class ArsonPage extends ApplyPage {
       'arson',
       paths.applications.pages.show({ id: application.id, task: 'further-considerations', page: 'catering' }),
     )
-    cy.get('.govuk-form-group').contains(`Does ${application.person.name} need a specialist arson room?`)
+    cy.get('.govuk-form-group').contains(`Does ${application.person.name} pose an arson risk?`)
   }
 
   completeForm(): void {

--- a/cypress_shared/pages/apply/attachDocumentsPage.ts
+++ b/cypress_shared/pages/apply/attachDocumentsPage.ts
@@ -16,7 +16,7 @@ export default class AttachDocumentsPage extends ApplyPage {
     application: ApprovedPremisesApplication,
   ) {
     super(
-      'Select associated documents',
+      'Select any additional documents that are required to support your application',
       application,
       'attach-required-documents',
       'attach-documents',

--- a/cypress_shared/pages/apply/catering.ts
+++ b/cypress_shared/pages/apply/catering.ts
@@ -13,7 +13,7 @@ export default class CateringPage extends ApplyPage {
       paths.applications.pages.show({ id: application.id, task: 'further-considerations', page: 'complex-case-board' }),
     )
     cy.get('.govuk-form-group').contains(
-      `Do you have any concerns about ${application.person.name} catering for themselves?`,
+      `Can ${application.person.name} be placed in a self-catered Approved Premises?`,
     )
   }
 

--- a/cypress_shared/pages/apply/previousPlacements.ts
+++ b/cypress_shared/pages/apply/previousPlacements.ts
@@ -6,7 +6,7 @@ import ApplyPage from './applyPage'
 export default class PreviousPlacementsPage extends ApplyPage {
   constructor(application: ApprovedPremisesApplication) {
     super(
-      'Previous placements',
+      'Previous Approved Premises (AP) placements',
       application,
       'further-considerations',
       'previous-placements',

--- a/cypress_shared/pages/apply/rehabilitativeInterventions.ts
+++ b/cypress_shared/pages/apply/rehabilitativeInterventions.ts
@@ -5,7 +5,7 @@ import ApplyPage from './applyPage'
 export default class RehabilitativeInterventions extends ApplyPage {
   constructor(application: ApprovedPremisesApplication) {
     super(
-      "Which rehabilitative interventions will support the person's Approved Premises (AP) placement?",
+      "Which of the rehabilitative activities will assist the person's rehabilitation in the Approved Premises (AP)?",
       application,
       'risk-management-features',
       'rehabilitative-interventions',

--- a/cypress_shared/pages/apply/riskManagementFeatures.ts
+++ b/cypress_shared/pages/apply/riskManagementFeatures.ts
@@ -6,7 +6,7 @@ import ApplyPage from './applyPage'
 export default class RiskManagementFeatures extends ApplyPage {
   constructor(application: ApprovedPremisesApplication) {
     super(
-      'What features of an AP will support the management of risk?',
+      'What features of an Approved Premises (AP) will support the management of risk?',
       application,
       'risk-management-features',
       'risk-management-features',

--- a/server/form-pages/apply/add-documents/attachDocuments.ts
+++ b/server/form-pages/apply/add-documents/attachDocuments.ts
@@ -16,7 +16,7 @@ type AttachDocumentsResponse = {
 
 @Page({ name: 'attach-documents', bodyProperties: ['selectedDocuments'] })
 export default class AttachDocuments implements TasklistPage {
-  title = 'Select associated documents'
+  title = 'Select any additional documents that are required to support your application'
 
   documents: Array<Document> | undefined
 

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.test.ts
@@ -114,7 +114,7 @@ describe('PlacementPurpose', () => {
 
       expect(page.response()).toEqual({
         [page.title]:
-          'Public protection, Prevent contact, Help individual readjust to life outside custody, Provide drug or alcohol monitoring, Prevent self harm or suicide',
+          'Public protection, Prevent contact with known individuals or victims, Help individual readjust to life outside of custody, Provide drug or alcohol monitoring, Increased monitoring of risk factors',
       })
     })
 
@@ -129,7 +129,7 @@ describe('PlacementPurpose', () => {
       )
 
       expect(page.response()).toEqual({
-        [page.title]: 'Provide drug or alcohol monitoring, Other (please specify)',
+        [page.title]: 'Provide drug or alcohol monitoring, Other',
         'Other purpose for AP Placement': 'Another reason',
       })
     })
@@ -142,15 +142,15 @@ describe('PlacementPurpose', () => {
 
       expect(items).toEqual([
         { checked: false, text: 'Public protection', value: 'publicProtection' },
-        { checked: false, text: 'Prevent contact', value: 'preventContact' },
-        { checked: false, text: 'Help individual readjust to life outside custody', value: 'readjust' },
+        { checked: false, text: 'Prevent contact with known individuals or victims', value: 'preventContact' },
+        { checked: false, text: 'Help individual readjust to life outside of custody', value: 'readjust' },
         { checked: false, text: 'Provide drug or alcohol monitoring', value: 'drugAlcoholMonitoring' },
-        { checked: false, text: 'Prevent self harm or suicide', value: 'preventSelfHarm' },
+        { checked: false, text: 'Increased monitoring of risk factors', value: 'preventSelfHarm' },
         { divider: 'or' },
         {
           checked: false,
           conditional: { html: '<strong>Some HTML</strong>' },
-          text: 'Other (please specify)',
+          text: 'Other',
           value: 'otherReason',
         },
       ])

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.ts
@@ -7,11 +7,11 @@ import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
 
 export const placementPurposes = {
   publicProtection: 'Public protection',
-  preventContact: 'Prevent contact',
-  readjust: 'Help individual readjust to life outside custody',
+  preventContact: 'Prevent contact with known individuals or victims',
+  readjust: 'Help individual readjust to life outside of custody',
   drugAlcoholMonitoring: 'Provide drug or alcohol monitoring',
-  preventSelfHarm: 'Prevent self harm or suicide',
-  otherReason: 'Other (please specify)',
+  preventSelfHarm: 'Increased monitoring of risk factors',
+  otherReason: 'Other',
 } as const
 
 type PlacementPurposeT = keyof typeof placementPurposes

--- a/server/form-pages/apply/reasons-for-placement/basic-information/sentenceType.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/sentenceType.ts
@@ -7,11 +7,11 @@ import TasklistPage from '../../../tasklistPage'
 export const sentenceTypes = {
   standardDeterminate: 'Standard determinate custody',
   life: 'Life sentence',
-  ipp: 'Indeterminate Public Protection',
+  ipp: 'Indeterminate Public Protection (IPP)',
   extendedDeterminate: 'Extended determinate custody',
-  communityOrder: 'Community Order',
+  communityOrder: 'Community Order (CO) / Suspended Sentence Order (SSO)',
   bailPlacement: 'Bail placement',
-  nonStatutory: 'Non-statutory',
+  nonStatutory: 'Non-statutory, MAPPA case',
 } as const
 
 export type SentenceTypesT = keyof typeof sentenceTypes

--- a/server/form-pages/apply/reasons-for-placement/basic-information/situation.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/situation.test.ts
@@ -56,11 +56,11 @@ describe('Situation', () => {
 
         expect(items.length).toEqual(2)
         expect(items[0]).toEqual({
-          text: 'Bail assessment for community penalty',
+          text: 'Bail assessment for residency requirement as part of a community based Order',
           value: 'bailAssessment',
           checked: true,
         })
-        expect(items[1]).toEqual({ text: 'Bail sentence', value: 'bailSentence', checked: false })
+        expect(items[1]).toEqual({ text: 'Bail placement', value: 'bailSentence', checked: false })
       })
     })
 

--- a/server/form-pages/apply/reasons-for-placement/basic-information/situation.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/situation.ts
@@ -10,8 +10,8 @@ import { SentenceTypesT } from './sentenceType'
 const situations = {
   riskManagement: 'Referral for risk management',
   residencyManagement: 'Residency management',
-  bailAssessment: 'Bail assessment for community penalty',
-  bailSentence: 'Bail sentence',
+  bailAssessment: 'Bail assessment for residency requirement as part of a community based Order',
+  bailSentence: 'Bail placement',
 } as const
 
 type CommunityOrderSituations = Pick<typeof situations, 'riskManagement' | 'residencyManagement'>

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/covid.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/covid.test.ts
@@ -40,7 +40,7 @@ describe('Covid', () => {
     const page = new Covid({}, application, '')
     expect(page.errors()).toEqual({
       fullyVaccinated: 'You must confirm if John Wayne has been fully vaccinated',
-      highRisk: 'You must confirm if John Wayne is at a higher risk from COVID-19',
+      highRisk: 'You must confirm if John Wayne is at a higher risk from COVID-19 based on the NHS guidance',
     })
   })
 
@@ -57,7 +57,7 @@ describe('Covid', () => {
 
     expect(page.response()).toEqual({
       'Has John Wayne been fully vaccinated for COVID-19?': 'Yes',
-      'Is John Wayne at a higher risk from COVID-19?': 'Yes',
+      'Is John Wayne at a higher risk from COVID-19 based on the NHS guidance?': 'Yes',
       'Other considerations and comments on COVID-19': 'Some info',
     })
   })

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/covid.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/covid.ts
@@ -23,8 +23,8 @@ export default class Covid implements TasklistPage {
       hint: `A person is considered fully vaccinated if they have had two doses and a booster of a COVID-19 vaccine.`,
     },
     highRisk: {
-      question: `Is ${this.application.person.name} at a higher risk from COVID-19?`,
-      hint: `This includes autoimmune diseases and those eligible for nMAB treatment.`,
+      question: `Is ${this.application.person.name} at a higher risk from COVID-19 based on the NHS guidance?`,
+      hint: `This includes people with autoimmune diseases and those eligible for nMAB treatment.`,
     },
     additionalCovidInfo: 'Other considerations and comments on COVID-19',
   }
@@ -62,7 +62,7 @@ export default class Covid implements TasklistPage {
     }
 
     if (!this.body.highRisk) {
-      errors.highRisk = `You must confirm if ${this.application.person.name} is at a higher risk from COVID-19`
+      errors.highRisk = `You must confirm if ${this.application.person.name} is at a higher risk from COVID-19 based on the NHS guidance`
     }
 
     return errors

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/arson.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/arson.test.ts
@@ -19,7 +19,7 @@ describe('Arson', () => {
       const page = new Arson(body, application)
 
       expect(page.questions).toEqual({
-        arson: 'Does John Wayne need a specialist arson room?',
+        arson: 'Does John Wayne pose an arson risk?',
       })
     })
   })
@@ -40,7 +40,7 @@ describe('Arson', () => {
       const page = new Arson({}, application)
 
       expect(page.errors()).toEqual({
-        arson: 'You must specify if John Wayne needs a specialist arson room',
+        arson: 'You must specify if John Wayne poses an arson risk',
       })
     })
 
@@ -48,7 +48,7 @@ describe('Arson', () => {
       const page = new Arson({ ...body, arsonDetail: '' }, application)
 
       expect(page.errors()).toEqual({
-        arsonDetail: 'You must specify details about if John Wayne needs a specialist arson room',
+        arsonDetail: 'You must specify details if John Wayne poses an arson risk',
       })
     })
   })
@@ -58,7 +58,7 @@ describe('Arson', () => {
       const page = new Arson(body, application)
 
       expect(page.response()).toEqual({
-        'Does John Wayne need a specialist arson room?': 'Yes - Arson detail',
+        'Does John Wayne pose an arson risk?': 'Yes - Arson detail',
       })
     })
 
@@ -66,7 +66,7 @@ describe('Arson', () => {
       const page = new Arson({ ...body, arson: 'no' }, application)
 
       expect(page.response()).toEqual({
-        'Does John Wayne need a specialist arson room?': 'No',
+        'Does John Wayne pose an arson risk?': 'No',
       })
     })
   })

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/arson.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/arson.ts
@@ -14,11 +14,11 @@ export default class Arson implements TasklistPage {
   title = 'Arson'
 
   questionPredicates = {
-    arson: 'a specialist arson room',
+    arson: 'pose an arson risk',
   }
 
   questions = {
-    arson: `Does ${this.application.person.name} need ${this.questionPredicates.arson}?`,
+    arson: `Does ${this.application.person.name} ${this.questionPredicates.arson}?`,
   }
 
   hints = {
@@ -27,10 +27,10 @@ export default class Arson implements TasklistPage {
       <p class="govuk-body">Consider whether the person poses an ongoing risk of setting fires based on:</p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li>their current and previous offences,</li>
-        <li>factors outside of the offences they were charged for,</li>
-        <li>their behaviour in custody,</li>
-        <li>and your expectations for how they'll behave in an AP setting.</li>
+        <li>their current and previous offences</li>
+        <li>factors outside of the offences they were charged for</li>
+        <li>their behaviour in custody</li>
+        <li>your expectations for how they'll behave in an AP setting</li>
       </ul>
     `,
     },
@@ -59,11 +59,11 @@ export default class Arson implements TasklistPage {
     const errors: TaskListErrors<this> = {}
 
     if (!this.body.arson) {
-      errors.arson = `You must specify if ${this.application.person.name} needs ${this.questionPredicates.arson}`
+      errors.arson = `You must specify if ${this.application.person.name} poses an arson risk`
     }
 
     if (this.body.arson === 'yes' && !this.body.arsonDetail) {
-      errors.arsonDetail = `You must specify details about if ${this.application.person.name} needs ${this.questionPredicates.arson}`
+      errors.arsonDetail = `You must specify details if ${this.application.person.name} poses an arson risk`
     }
 
     return errors

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/catering.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/catering.test.ts
@@ -19,7 +19,7 @@ describe('Catering', () => {
       const page = new Catering(body, application)
 
       expect(page.questions).toEqual({
-        catering: 'Do you have any concerns about John Wayne catering for themselves?',
+        catering: 'Can John Wayne be placed in a self-catered Approved Premises?',
       })
     })
   })
@@ -40,7 +40,7 @@ describe('Catering', () => {
       const page = new Catering({}, application)
 
       expect(page.errors()).toEqual({
-        catering: 'You must specify if you have any concerns about John Wayne catering for themselves',
+        catering: 'You must specify if John Wayne can be placed in a self-catered Approved Premises',
       })
     })
 
@@ -48,8 +48,7 @@ describe('Catering', () => {
       const page = new Catering({ ...body, cateringDetail: '' }, application)
 
       expect(page.errors()).toEqual({
-        cateringDetail:
-          'You must specify details about if you have any concerns about John Wayne catering for themselves',
+        cateringDetail: 'You must specify details if you have any concerns about John Wayne catering for themselves',
       })
     })
   })
@@ -59,7 +58,7 @@ describe('Catering', () => {
       const page = new Catering(body, application)
 
       expect(page.response()).toEqual({
-        'Do you have any concerns about John Wayne catering for themselves?': 'Yes - Catering detail',
+        'Can John Wayne be placed in a self-catered Approved Premises?': 'Yes - Catering detail',
       })
     })
 
@@ -67,7 +66,7 @@ describe('Catering', () => {
       const page = new Catering({ ...body, catering: 'no' }, application)
 
       expect(page.response()).toEqual({
-        'Do you have any concerns about John Wayne catering for themselves?': 'No',
+        'Can John Wayne be placed in a self-catered Approved Premises?': 'No',
       })
     })
   })

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/catering.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/catering.ts
@@ -13,11 +13,11 @@ export default class Catering implements TasklistPage {
   title = 'Catering requirements'
 
   questionPredicates = {
-    catering: 'catering for themselves',
+    catering: 'be placed in a self-catered Approved Premises',
   }
 
   questions = {
-    catering: `Do you have any concerns about ${this.application.person.name} ${this.questionPredicates.catering}?`,
+    catering: `Can ${this.application.person.name} ${this.questionPredicates.catering}?`,
   }
 
   constructor(
@@ -43,11 +43,11 @@ export default class Catering implements TasklistPage {
     const errors: TaskListErrors<this> = {}
 
     if (!this.body.catering) {
-      errors.catering = `You must specify if you have any concerns about ${this.application.person.name} ${this.questionPredicates.catering}`
+      errors.catering = `You must specify if ${this.application.person.name} can ${this.questionPredicates.catering}`
     }
 
     if (this.body.catering === 'yes' && !this.body.cateringDetail) {
-      errors.cateringDetail = `You must specify details about if you have any concerns about ${this.application.person.name} ${this.questionPredicates.catering}`
+      errors.cateringDetail = `You must specify details if you have any concerns about ${this.application.person.name} catering for themselves`
     }
 
     return errors

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/previousPlacements.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/previousPlacements.ts
@@ -13,7 +13,7 @@ type QuestionKeys = (typeof questionKeys)[number]
 export default class PreviousPlacements implements TasklistPage {
   name = 'previous-placements'
 
-  title = 'Previous placements'
+  title = 'Previous Approved Premises (AP) placements'
 
   questionPredicates = {
     previousPlacement: `stayed or been offered a placement in an AP before`,

--- a/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.test.ts
@@ -87,10 +87,10 @@ describe('ConvictedOffences', () => {
       const page = new DescribeLocationFactors(body)
 
       expect(page.response()).toEqual({
-        'Give details of any positive factors for the person in this location.': 'Positive Factors',
+        'Give details of why this postcode area would benefit the person': 'Positive Factors',
         'What is the preferred postcode area for the Approved Premises (AP) placement?': 'E17',
         'Are there any restrictions linked to placement location?': 'Yes',
-        'Provide details of any restraining orders, exclusion zones, inclusion zones or other location based licence conditions.':
+        'Provide details of any restraining orders, exclusion zones or other location based licence conditions. You must also provide an exclusion zone map in the ‘attach required documents’ screen.':
           'Some restriction detail',
         'If an AP Placement is not available in the persons preferred area, would a placement further away be considered?':
           'Yes',
@@ -109,7 +109,7 @@ describe('ConvictedOffences', () => {
       const page = new DescribeLocationFactors(body)
 
       expect(page.response()).toEqual({
-        'Give details of any positive factors for the person in this location.': 'Positive Factors',
+        'Give details of why this postcode area would benefit the person': 'Positive Factors',
         'What is the preferred postcode area for the Approved Premises (AP) placement?': 'E17',
         'Are there any restrictions linked to placement location?': 'No',
         'If an AP Placement is not available in the persons preferred area, would a placement further away be considered?':

--- a/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.ts
@@ -32,10 +32,10 @@ export default class DescribeLocationFactors implements TasklistPage {
 
   questions = {
     postcodeArea: 'What is the preferred postcode area for the Approved Premises (AP) placement?',
-    positiveFactors: 'Give details of any positive factors for the person in this location.',
+    positiveFactors: 'Give details of why this postcode area would benefit the person',
     restrictions: 'Are there any restrictions linked to placement location?',
     restrictionDetail:
-      'Provide details of any restraining orders, exclusion zones, inclusion zones or other location based licence conditions.',
+      'Provide details of any restraining orders, exclusion zones or other location based licence conditions. You must also provide an exclusion zone map in the ‘attach required documents’ screen.',
     alternativeRadiusAccepted:
       'If an AP Placement is not available in the persons preferred area, would a placement further away be considered?',
     alternativeRadius: 'Choose the maximum radius (in miles)',

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/convictedOffences.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/convictedOffences.test.ts
@@ -48,7 +48,7 @@ describe('ConvictedOffences', () => {
       const page = new ConvictedOffences({ response: 'yes' }, application)
 
       expect(page.response()).toEqual({
-        'Has John Wayne ever been convicted of any arson offences, sexual offences, hate crimes or non-sexual offences against children?':
+        'Has John Wayne ever been convicted of any arson offences, sexual offences, hate crimes or offences against children?':
           'Yes',
       })
     })

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/convictedOffences.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/convictedOffences.ts
@@ -17,7 +17,7 @@ export default class ConvictedOffences implements TasklistPage {
 
   furtherDetails = `This includes any spent or unspent convictions over their lifetime.`
 
-  offences = ['Arson offences', 'Sexual offences', 'Hate crimes', 'Non-sexual offences against children']
+  offences = ['Arson offences', 'Sexual offences', 'Hate crimes', 'Offences against children']
 
   constructor(public body: { response?: YesOrNo }, private readonly application: ApprovedPremisesApplication) {}
 

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/dateOfOffence.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/dateOfOffence.ts
@@ -19,7 +19,7 @@ type Response = Array<'previous' | 'current'> | 'previous' | 'current'
 
 @Page({ name: 'date-of-offence', bodyProperties: Object.keys(offences) })
 export default class DateOfOffence implements TasklistPage {
-  title = `Date of convicted offences`
+  title = `Convicted offences`
 
   questions = {
     currentOrPrevious: 'Is the offence a current or previous offence?',

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.test.ts
@@ -85,7 +85,7 @@ describe('RehabilitativeInterventions', () => {
         )
 
         expect(page.response()).toEqual({
-          "Which rehabilitative interventions will support the person's Approved Premises (AP) placement?":
+          "Which of the rehabilitative activities will assist the person's rehabilitation in the Approved Premises (AP)?":
             'Accommodation, Drugs and alcohol, Children and families, Health, Education, training and employment, Finance, benefits and debt, Attitudes, thinking and behaviour, Abuse, Other',
           'Other intervention': 'Some intervention',
         })
@@ -99,7 +99,8 @@ describe('RehabilitativeInterventions', () => {
         )
 
         expect(page.response()).toEqual({
-          "Which rehabilitative interventions will support the person's Approved Premises (AP) placement?": 'Health',
+          "Which of the rehabilitative activities will assist the person's rehabilitation in the Approved Premises (AP)?":
+            'Health',
         })
       })
     })

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.ts
@@ -25,7 +25,8 @@ type RehabilitativeInterventionsBody = { rehabilitativeInterventions: Interventi
 
 @Page({ name: 'rehabilitative-interventions', bodyProperties: ['rehabilitativeInterventions', 'otherIntervention'] })
 export default class RehabilitativeInterventions implements TasklistPage {
-  title = `Which rehabilitative interventions will support the person's Approved Premises (AP) placement?`
+  title =
+    "Which of the rehabilitative activities will assist the person's rehabilitation in the Approved Premises (AP)?"
 
   constructor(
     private _body: RawRehabilitativeInterventionsBody,

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/typeOfConvictedOffence.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/typeOfConvictedOffence.test.ts
@@ -47,7 +47,7 @@ describe('TypeOfConvictedOffence', () => {
 
         expect(page.response()).toEqual({
           'What type of offending has John Wayne been convicted of?':
-            'Arson offences, Sexual offences, Hate crimes, Non-sexual offences against children',
+            'Arson offences, Sexual offences, Hate crimes, Offences against children',
         })
       })
 

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/typeOfConvictedOffence.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/typeOfConvictedOffence.ts
@@ -9,7 +9,7 @@ export const offences = {
   arson: 'Arson offences',
   sexualOffence: 'Sexual offences',
   hateCrimes: 'Hate crimes',
-  childNonSexualOffence: 'Non-sexual offences against children',
+  childNonSexualOffence: 'Offences against children',
 } as const
 
 type Offences = Array<keyof typeof offences>

--- a/server/testutils/factories/oasysSections.ts
+++ b/server/testutils/factories/oasysSections.ts
@@ -31,13 +31,13 @@ export const roshSummaryFactory = Factory.define<OASysQuestion>(options => ({
 export const offenceDetailsFactory = Factory.define<OASysQuestion>(options => ({
   questionNumber: options.sequence.toString(),
   label: faker.helpers.arrayElement([
-    'Offence analysis',
+    'Briefly describe the details of the offence(s)',
     'Others involved',
-    'Issues contributing to risk',
-    'Motivation and triggers',
-    'Victim impact',
+    'Identify issues related to the offence that contribute to the risk of offending and harm. Please include any positive factors',
+    'Provide evidence of the motivation and triggers for the offending',
+    'Provide details of the impact on the victim',
     'Victim Information',
-    'Previous offences',
+    'Is there a pattern of offending? Consider details of previous convictions',
   ]),
   answer: faker.lorem.paragraph(),
 }))
@@ -62,7 +62,7 @@ const riskManagementPlanFactory = Factory.define<OASysQuestion>(options => ({
     'Monitoring and control',
     'Intervention and treatment',
     'Victim safety planning',
-    'Contingency Plans',
+    'Contingency plans',
     'Additional comments',
   ]),
   answer: faker.lorem.paragraph(),

--- a/server/views/applications/pages/access-and-healthcare/access-needs.njk
+++ b/server/views/applications/pages/access-and-healthcare/access-needs.njk
@@ -1,3 +1,5 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
 {% extends "../layout.njk" %}
 
 {% block questions %}
@@ -60,6 +62,18 @@
       },fetchContext()) }}
   {% endset -%}
 
+  {% set bannerHTML %}
+  {% set html %}
+  <p>
+       If a Care Act assessment has been completed, you must upload it in the ‘attach required documents’ screen.
+      </p>
+  {% endset %}
+
+  {{ govukNotificationBanner({
+        html: html
+    }) }}
+  {% endset -%}
+
   {{ formPageRadios({
         fieldName: "needsInterpreter",
         fieldset: {
@@ -94,7 +108,10 @@
         items: [
           {
             value: "yes",
-            text: "Yes"
+            text: "Yes",
+            conditional: {
+              html: bannerHTML
+            }
           },
           {
             value: "no",

--- a/server/views/applications/pages/access-and-healthcare/covid.njk
+++ b/server/views/applications/pages/access-and-healthcare/covid.njk
@@ -43,7 +43,7 @@
         }
       },
       hint: {
-        text: page.questions.highRisk.question
+        text: page.questions.highRisk.hint
       },
       items: [
         {

--- a/server/views/applications/pages/attach-required-documents/attach-documents.njk
+++ b/server/views/applications/pages/attach-required-documents/attach-documents.njk
@@ -6,32 +6,38 @@
 {% set columnClasses = "govuk-grid-column-full applications--pages--attach-documents" %}
 
 {% block questions %}
-  <h1 class="govuk-heading-l">{{page.title}}</h1>
-
+  <h1 class="govuk-heading-l">{{page.title}}</h1> 
+  
+  <p>These documents are imported from NDelius. </p>
   <p>Select any additional documents that you want to include to support your application. </p>
 
   {% set detailsHTML %}
-  <p class="govuk-body">
-    Please ensure that identified documents have been attached to this application.
-  </p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li>Precons</li>
-    <li>CPS documents from current event</li>
-    <li>SO registration</li>
-    <li>Sexual harm prevention order (SOPO)  </li>
-    <li>Psychiatric reports</li>
-    <li>Parole reports</li>
-    <li>ARMS assessment</li>
-    <li>Pre sentence</li>
-    <li>Bail notice</li>
-    <li>VOO</li>
-    <li>Exclusion zone map</li>
-  </ul>
+  <strong>All applications should include the following documents:</strong>
+           <ul class="govuk-list govuk-list--bullet">
+              <li>CPS documents from current event</li>
+              <li>Previous convictions </li>
+          </ul>
+
+          <b>Applications should include the following documents where they are available:</b>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>Active Risk Management System (ARMS) assessment</li>
+            <li>Bail notice</li>
+            <li>Care Act assessment</li>
+            <li>Domestic violence prevention orders</li>
+            <li>Exclusion zone map</li>
+            <li>Parole reports</li>
+            <li>Pre-sentence reports  </li>
+            <li>Psychiatric reports</li>
+            <li>Restraining orders</li>
+            <li>Sexual harm prevention order (SHPO)</li>
+            <li>Sexual offence registrations</li>
+            <li>Violent Offender Order (VOO)</li>
+          </ul>
   {% endset %}
 
   {{
     govukDetails({
-      summaryText: "View required documents",
+      summaryText: "Which documents are required?",
       html: detailsHTML
     })
   }}
@@ -47,7 +53,7 @@
         classes: "applications--pages--attach-document__header-name"
       },
       {
-        text: "Date uploaded",
+        text: "Date uploaded to Delius",
         classes: "applications--pages--attach-document__header-date"
       },
       {

--- a/server/views/applications/pages/basic-information/release-date.njk
+++ b/server/views/applications/pages/basic-information/release-date.njk
@@ -11,7 +11,7 @@
         fieldName: "releaseDate",
         fieldset: {
           legend: {
-            text: "Expected release date"
+            text: "Expected date of release"
           }
         },
         hint: {
@@ -56,8 +56,11 @@
             }
           },
           {
-            text: "No",
-            value: "no"
+            text: "No, the release date is to be determined by the parole board or other hearing",
+            value: "no", 
+            conditional: {
+              html: bannerHtml
+            }
           }
         ]
       },

--- a/server/views/applications/pages/basic-information/sentence-type.njk
+++ b/server/views/applications/pages/basic-information/sentence-type.njk
@@ -13,6 +13,9 @@
             classes: "govuk-fieldset__legend--l"
           }
         },
+        hint: {
+        text: "Select the option which best describes the situation"
+      },
         items: page.items()
       },
       fetchContext()

--- a/server/views/applications/pages/further-considerations/arson.njk
+++ b/server/views/applications/pages/further-considerations/arson.njk
@@ -7,7 +7,7 @@
     {{ page.title }}
   </h1>
 
-  <p>This information is used to match a person with a suitable room in a suitable premises.</p>
+  <p>This information is used to match a person with a suitable room.</p>
 
   {% for key, value in page.questions %}
     {% include "./../../partials/_yes-no-with-detail.njk" %}

--- a/server/views/applications/pages/further-considerations/catering.njk
+++ b/server/views/applications/pages/further-considerations/catering.njk
@@ -7,7 +7,11 @@
      {{ page.title }}
   </h1>
 
-  <p>This information is used to match a person with a suitable room in a suitable premises.</p>
+    {{ govukDetails({
+      summaryText: "View guidance",
+      html: '<p>Approved Premises (AP) placements are usually self-catered unless there are specific circumstances where a person requires a catered placement. </p>
+            <p>For example, foreign national offenders (FNO) without access to funds cannot be placed in a self-catered AP.</p>'
+    }) }}
 
   {% for key, value in page.questions %}
     {% include "./../../partials/_yes-no-with-detail.njk" %}

--- a/server/views/applications/pages/further-considerations/previous-placements.njk
+++ b/server/views/applications/pages/further-considerations/previous-placements.njk
@@ -9,8 +9,54 @@
 
   <p>This information is used to match a person with a suitable room in a suitable premises.</p>
 
-  {% for key, value in page.questions %}
-    {% include "./../../partials/_yes-no-dont-know-with-detail.njk" %}
-  {% endfor %}
+
+    {% set yesDetails %}
+    {{
+      formPageTextarea(
+        {
+          fieldName: "previousPlacementDetail",
+          type: "textarea",
+          spellcheck: false,
+          label: {
+            text: "Summarise the person's response to the AP placement. Include whether the person successfully completed their placement, or if they were recalled."
+          }
+        },
+        fetchContext()
+      )
+    }}
+    {% endset -%}
+
+    {{
+      formPageRadios({
+        fieldName: "previousPlacement",
+        fieldset: {
+          legend: {
+            text: page.questions.previousPlacement,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        hint: page.hints.previousPlacements,
+        items: [
+          {
+            value: "yes",
+            text: "Yes",
+            conditional: {
+              html: yesDetails
+            }
+          },
+          {
+            value: "no",
+            text: "No"
+          },
+          {
+            value: "iDontKnow",
+            text: "I don't know"
+          }
+        ]
+      },
+      fetchContext()
+      )
+    }}
+      
 
 {% endblock %}

--- a/server/views/applications/pages/layout.njk
+++ b/server/views/applications/pages/layout.njk
@@ -7,6 +7,7 @@
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% from "../../components/formFields/form-page-radios/macro.njk" import formPageRadios %}
 {% from "../../components/formFields/form-page-date-input/macro.njk" import formPageDateInput %}
@@ -19,9 +20,9 @@
 {% set pageTitle = applicationName + " - " + page.title %}
 {% set mainClasses = "app-container govuk-body" %}
 
-{% block content %}
+{% block beforeContent %}
 
-  {% if page.previous() === 'dashboard' %}
+ {% if page.previous() === 'dashboard' %}
     {{ govukBackLink({
       text: "Back",
       href: paths.applications.show({ id: applicationId })
@@ -33,6 +34,9 @@
     }) }}
   {% endif %}
 
+{% endblock %}
+
+{% block content %}
   <div class="govuk-grid-row">
     <div class="{{ columnClasses | default("govuk-grid-column-two-thirds") }}">
       <form action="{{ paths.applications.pages.update({ id: applicationId, task: task, page: page.name }) }}?_method=PUT" method="post">
@@ -43,7 +47,7 @@
         {% block questions %}{% endblock %}
 
         {{ govukButton({
-            text: "Submit"
+            text: "Save and continue"
         }) }}
       </form>
     </div>

--- a/server/views/applications/pages/prison-information/case-notes.njk
+++ b/server/views/applications/pages/prison-information/case-notes.njk
@@ -52,6 +52,7 @@
   <div class="govuk-grid-row">
     <div>
       <h1 class="govuk-heading-l">{{page.title}}</h1>
+      <p>This information is imported from NOMIS</p>
       <p>Select any prison case notes that will help Approved Premises (AP) managers understand factors that may help with the person's risk management in an AP. </p>
       <p>Adjudications from the person's current sentence and ACCT (Assessment, Care in Custody and Teamwork) information will be sent automatically.</p>
     </div>

--- a/server/views/applications/pages/risk-management-features/rehabilitative-interventions.njk
+++ b/server/views/applications/pages/risk-management-features/rehabilitative-interventions.njk
@@ -10,6 +10,8 @@
 
   <p class="govuk-body">Formerly known as purposeful activities.</p>
   <p class="govuk-body">Select any additional needs the person has that an AP could help meet. For example, support getting qualifications or finding work.</p>
+  <p class="govuk-body">Further information about rehabilitative activities can be found on EQuip</p>
+
 
   {% set otherIntervention %}
   {{

--- a/server/views/applications/pages/risk-management-features/risk-management-features.njk
+++ b/server/views/applications/pages/risk-management-features/risk-management-features.njk
@@ -5,7 +5,7 @@
 
 {% block questions %}
 
-  <h1 class="govuk-heading-l">What features of an AP will support the management of risk?</h1>
+  <h1 class="govuk-heading-l">What features of an Approved Premises (AP) will support the management of risk?</h1>
   <p class="govuk-body">
     <b>AP placements provide the following support, restrictions, and monitoring as standard:</b>
   </p>

--- a/server/views/applications/pages/risk-management-features/risk-management-features.njk
+++ b/server/views/applications/pages/risk-management-features/risk-management-features.njk
@@ -14,7 +14,7 @@
     <li>Overnight curfew (from 11pm until 6am)</li>
     <li>CCTV</li>
     <li>Room searches</li>
-    <li>Rehabilitative interventions (formerly purposeful activities)</li>
+    <li>Rehabilitative activities (formerly purposeful activities)</li>
     <li>Medication monitoring</li>
     <li>Drug and alcohol testing</li>
   </ul>

--- a/server/views/applications/pages/risk-management-features/type-of-convicted-offence.njk
+++ b/server/views/applications/pages/risk-management-features/type-of-convicted-offence.njk
@@ -6,7 +6,7 @@
 
   <h1 class="govuk-heading-l">{{page.title}}</h1>
 
-  <p class="govuk-body">This information will be used to match them to a bed in an Approved Premises</p>
+  <p class="govuk-body">This information will be used to match the person to a bed in an Approved Premises.</p>
 
   {{
     formPageCheckboxes(

--- a/server/views/applications/pages/type-of-ap/ap-type.njk
+++ b/server/views/applications/pages/type-of-ap/ap-type.njk
@@ -5,12 +5,14 @@
 
 {% block questions %}
 
+<h1 class="govuk-heading-l"> {{page.title}} </h1>
+
     {{ govukDetails({
       summaryText: "What are the different types of AP?",
-      html: '<p><b>Standard AP</b> provide 24 hour staff support and monitoring, an overnight curfew, CCTV, room searches, rehabilitative activities, medication monitoring, and drug and alcohol testing.</p>
-            <p><b>Psychologically Informed Planned Environment (PIPE)</b> AP are for people who screen into the Offender Personality Disorder (OPD) pathway. PIPE staff have additional training to manage individuals and create an enhanced safe and supportive environment. </p>
-            <p><b>Enhanced Security AP (ESAP)</b> offer additional security measures and are intended to individuals whose risk management plan and ability to manage in the community are reliant on those measures. </p>
-            <p><b>Recovery Focused AP (RFAP)</b></p>'
+      html: '<p><strong>Standard APs</strong> provide 24 hour staff support and monitoring, an overnight curfew, CCTV, room searches, rehabilitative activities, medication monitoring, and drug and alcohol testing.</p>
+            <p><strong>Psychologically Informed Planned Environment (PIPE)</strong> AP are for people who screen into the Offender Personality Disorder (OPD) pathway. PIPE staff have additional training to manage individuals and create an enhanced safe and supportive environment. </p>
+            <p><strong>Enhanced Security AP (ESAP)</strong> offer additional security measures and are intended to individuals whose risk management plan and astrongility to manage in the community are reliant on those measures. </p>
+            <p><strong>Recovery Focused AP (RFAP)</strong> provide concentrated support for prison leavers who have begun to address their substance misuse in custody. RFAP work closely with key recovery partners and organisations within the local community to offer people on probation the best level of support available. RFAP staff will be trained as recovery coaches and take a personalised approach to rehabilitation, including committing a minimum of 10 hours to each individual to work on a recovery plan tailored to their needs. </p>'
     }) 
     }}
 
@@ -18,13 +20,6 @@
     formPageRadios(
       {
         fieldName: "type",
-        fieldset: {
-          legend: {
-            text: page.title,
-            isPageHeading: true,
-            classes: "govuk-fieldset__legend--l"
-          }
-        },
         items: page.items()
       },
       fetchContext()
@@ -32,3 +27,4 @@
   }}
 
 {% endblock %}
+

--- a/server/views/applications/people/confirm.njk
+++ b/server/views/applications/people/confirm.njk
@@ -128,7 +128,7 @@
           ]
         }) }}
 
-        <p>If these details are wrong, update this case in nDelius before you continue.</p>
+        <p>If these details are wrong, update this case in NDelius before you start.</p>
         <p>If you've entered the wrong CRN, go back to the CRN screen.</p>
 
         {{ govukButton({

--- a/server/views/applications/start.njk
+++ b/server/views/applications/start.njk
@@ -38,7 +38,6 @@
         <ul>
           <li>an up to date OASys - we'll use this to pre-fill some of your application</li>
           <li>the person's CRN </li>
-          <li>the oral hearing date, if applicable and if known</li>
         </ul>
 
         <h3>You need to know:</h3>


### PR DESCRIPTION
# Context

Ongoing content changes to front-end UI 

# Changes in this PR
- added details component on Type of AP screen. 
- updated <b> tags to <strong>

## Screenshots of UI changes

### Before
Details component above H1 - changed this to be below the header, before radio selectors
![screencapture-approved-premises-test-hmpps-service-justice-gov-uk-applications-a3ae72b1-0284-439b-9fd9-e1237fa57a19-tasks-type-of-ap-pages-ap-type-2023-01-25-09_31_02](https://user-images.githubusercontent.com/42937527/214532460-9e282294-585e-4736-b1a9-b543fdedf1ab.png)

Changed 'question' to .hint to show additional guidance
![Uploading screencapture-approved-premises-test-hmpps-service-justice-gov-uk-applications-09f35359-148a-47a8-b47f-da16904a48e5-tasks-access-and-healthcare-pages-covid-2023-01-25-11_35_13.png…]()


