### PR TITLE
Add a script to create an application/assessment

### DIFF
--- a/script/create_application
+++ b/script/create_application
@@ -1,0 +1,104 @@
+#!/bin/sh
+
+# script/create_application: Create an application and associated assessment in the local dev database
+
+application_data=$(curl -s https://raw.githubusercontent.com/ministryofjustice/hmpps-community-accommodation-wiremock/main/data/applicationData.json | jq -c)
+application_document=$(curl -s https://raw.githubusercontent.com/ministryofjustice/hmpps-community-accommodation-wiremock/main/data/applicationDocument.json | jq -c | tr -d '\\r\\n')
+
+sql="""
+DO \$$
+DECLARE
+   applicationData json := '$application_data';
+   applicationDocument json := '$application_document';
+   applicationId uuid := '$(uuidgen)';
+   assessmentId uuid := '$(uuidgen)';
+BEGIN
+  insert into applications (
+    \"id\",
+    \"created_at\",
+    \"created_by_user_id\",
+    \"crn\",
+    \"data\",
+    \"document\",
+    \"schema_version\",
+    \"service\",
+    \"submitted_at\"
+  )
+  values
+    (
+      applicationId,
+      CURRENT_DATE + 7,
+      ( SELECT id FROM users WHERE delius_username='JIMSNOWLDAP' ),
+      'X320741',
+      applicationData,
+      applicationDocument,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_APPLICATION'
+        LIMIT 1
+      ),
+      'approved-premises',
+      CURRENT_DATE + 16
+    );
+
+
+  insert into approved_premises_applications (
+      \"conviction_id\",
+      \"event_number\",
+      \"id\",
+      \"is_pipe_application\",
+      \"is_womens_application\",
+      \"offence_id\",
+      \"risk_ratings\"
+    )
+  values
+    (
+      '2500295345',
+      '2',
+      applicationId,
+      false,
+      false,
+      'M2500295343',
+      '{\"roshRisks\":{\"status\":\"Error\",\"value\":null},\"mappa\":{\"status\":\"Retrieved\",\"value\":{\"level\":\"CAT M2/LEVEL M2\",\"lastUpdated\":[2021,2,1]}},\"tier\":{\"status\":\"Retrieved\",\"value\":{\"level\":\"D2\",\"lastUpdated\":[2022,9,5]}},\"flags\":{\"status\":\"Retrieved\",\"value\":[\"Risk to Known Adult\"]}}'
+    );
+
+
+  INSERT into
+  assessments (
+    \"id\",
+    \"application_id\",
+    \"allocated_to_user_id\",
+    \"created_at\",
+    \"allocated_at\",
+    \"schema_version\"
+  )
+  VALUES
+    (
+      assessmentId,
+      applicationId,
+      ( SELECT id FROM users WHERE delius_username='JIMSNOWLDAP' ),
+      CURRENT_DATE,
+      CURRENT_DATE,
+      (
+        SELECT
+          id
+        FROM
+          json_schemas
+        WHERE
+          type = 'APPROVED_PREMISES_ASSESSMENT'
+        LIMIT 1
+      )
+    );
+
+END \$$;
+"""
+
+echo "==> Creating an application and assessment..."
+
+echo "$sql" | psql -q postgresql://localdev:localdev_password@localhost:5431/approved_premises_localdev
+
+echo "Done!"


### PR DESCRIPTION
Creating local data for applications and assessments can be a pain sometimes, so I’ve generated a script that gets application data from the Wiremock repo and creates an application in the local API database for the dev user (JIMSNOWLDAP) and an associated assessment, again associated with the dev user.