### PR TITLE
(1057) Allow us to skip oasys integration with a feature flag

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -21,7 +21,7 @@ export default {
     stubFor({
       request: {
         method: 'POST',
-        url: `/applications`,
+        url: `/applications?createWithRisks=true`,
       },
       response: {
         status: 201,
@@ -94,7 +94,7 @@ export default {
     (
       await getMatchingRequests({
         method: 'POST',
-        url: `/applications`,
+        url: `/applications?createWithRisks=true`,
       })
     ).body.requests,
   verifyApplicationUpdate: async (applicationId: string) =>

--- a/server/config.ts
+++ b/server/config.ts
@@ -38,6 +38,9 @@ export interface ApiConfig {
 export default {
   https: production,
   staticResourceCacheDuration: 20,
+  flags: {
+    oasysDisabled: process.env.OASYS_DISABLED || false,
+  },
   environment: process.env.ENVIRONMENT || 'local',
   sentry: {
     dsn: get('SENTRY_DSN', null, requiredInProduction),

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -20,7 +20,7 @@ export default class ApplicationClient {
     const { convictionId, deliusEventNumber, offenceId } = activeOffence
 
     return (await this.restClient.post({
-      path: paths.applications.new.pattern,
+      path: `${paths.applications.new.pattern}?createWithRisks=${!config.flags.oasysDisabled}`,
       data: { crn, convictionId, deliusEventNumber, offenceId },
     })) as ApprovedPremisesApplication
   }

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -15,6 +15,8 @@ import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
 
+import oasysStubs from './stubs/oasysStubs.json'
+
 export default class PersonClient {
   restClient: RestClient
 
@@ -63,14 +65,20 @@ export default class PersonClient {
   }
 
   async oasysSections(crn: string, selectedSections?: Array<number>): Promise<OASysSections> {
-    const queryString: string = qs.stringify(
-      { 'selected-sections': selectedSections },
-      { encode: false, indices: false },
-    )
+    let response: OASysSections
 
-    const path = `${paths.people.oasys.sections({ crn })}${queryString ? `?${queryString}` : ''}`
+    if (config.flags.oasysDisabled) {
+      response = oasysStubs as OASysSections
+    } else {
+      const queryString: string = qs.stringify(
+        { 'selected-sections': selectedSections },
+        { encode: false, indices: false },
+      )
 
-    const response = await this.restClient.get({ path })
+      const path = `${paths.people.oasys.sections({ crn })}${queryString ? `?${queryString}` : ''}`
+
+      response = (await this.restClient.get({ path })) as OASysSections
+    }
 
     return response as OASysSections
   }

--- a/server/data/stubs/oasysStubs.json
+++ b/server/data/stubs/oasysStubs.json
@@ -1,0 +1,211 @@
+{
+  "assessmentId": null,
+  "assessmentState": null,
+  "dateStarted": null,
+  "offenceDetails": [
+    {
+      "label": "Offence analysis",
+      "questionNumber": "2.1",
+      "answer": ""
+    },
+    {
+      "label": "Victim - perpetrator relationship",
+      "questionNumber": "2.4.1",
+      "answer": ""
+    },
+    {
+      "label": "Other victim information",
+      "questionNumber": "2.4.2",
+      "answer": ""
+    },
+    {
+      "label": "Impact on the victim",
+      "questionNumber": "2.5",
+      "answer": ""
+    },
+    {
+      "label": "Motivation and triggers",
+      "questionNumber": "2.8.3",
+      "answer": ""
+    },
+    {
+      "label": "Issues contributing to risks",
+      "questionNumber": "2.98",
+      "answer": ""
+    },
+    {
+      "label": "Pattern of offending",
+      "questionNumber": "2.12",
+      "answer": ""
+    }
+  ],
+  "roshSummary": [
+    {
+      "label": "Who is at risk",
+      "questionNumber": "R10.1",
+      "answer": ""
+    },
+    {
+      "label": "What is the nature of the risk",
+      "questionNumber": "R10.2",
+      "answer": ""
+    },
+    {
+      "label": "When is the risk likely to be the greatest",
+      "questionNumber": "R10.3",
+      "answer": ""
+    },
+    {
+      "label": "What circumstances are likely to increase risk",
+      "questionNumber": "R10.4",
+      "answer": ""
+    },
+    {
+      "label": "What circumstances are likely to reduce the risk",
+      "questionNumber": "R10.5",
+      "answer": ""
+    }
+  ],
+  "supportingInformation": [
+    {
+      "label": "Accommodation issues contributing to risks of offending and harm",
+      "questionNumber": "3.9",
+      "sectionNumber": 3,
+      "linkedToHarm": true,
+      "linkedToReOffending": true,
+      "answer": ""
+    },
+    {
+      "label": "Education, training and employability issues contributing to risks of offending and harm",
+      "questionNumber": "4.9",
+      "sectionNumber": 4,
+      "linkedToHarm": true,
+      "linkedToReOffending": true,
+      "answer": ""
+    },
+    {
+      "label": "Financial management issues contributing to risks of offending and harm",
+      "questionNumber": "5.9",
+      "sectionNumber": 5,
+      "linkedToHarm": false,
+      "linkedToReOffending": false,
+      "answer": ""
+    },
+    {
+      "label": "Relationship issues contributing to risks of offending and harm",
+      "questionNumber": "6.9",
+      "sectionNumber": 6,
+      "linkedToHarm": false,
+      "linkedToReOffending": false,
+      "answer": ""
+    },
+    {
+      "label": "Lifestyle issues contributing to risks of offending and harm",
+      "questionNumber": "7.9",
+      "sectionNumber": 7,
+      "linkedToHarm": false,
+      "linkedToReOffending": false,
+      "answer": ""
+    },
+    {
+      "label": "Drug misuse issues contributing to risks of offending and harm",
+      "questionNumber": "8.9",
+      "sectionNumber": 8,
+      "linkedToHarm": false,
+      "linkedToReOffending": false,
+      "answer": ""
+    },
+    {
+      "label": "Alcohol misuse issues contributing to risks of offending and harm",
+      "questionNumber": "9.9",
+      "sectionNumber": 9,
+      "linkedToHarm": false,
+      "linkedToReOffending": true,
+      "answer": ""
+    },
+    {
+      "label": "Issues of emotional well-being contributing to risks of offending and harm",
+      "questionNumber": "10.9",
+      "sectionNumber": 10,
+      "linkedToHarm": false,
+      "linkedToReOffending": false,
+      "answer": ""
+    },
+    {
+      "label": "Thinking / behavioural issues contributing to risks of offending and harm",
+      "questionNumber": "11.9",
+      "sectionNumber": 11,
+      "linkedToHarm": false,
+      "linkedToReOffending": false,
+      "answer": ""
+    },
+    {
+      "label": "Issues about attitudes contributing to risks of offending and harm",
+      "questionNumber": "12.9",
+      "sectionNumber": 12,
+      "linkedToHarm": false,
+      "linkedToReOffending": false,
+      "answer": ""
+    }
+  ],
+  "riskToSelf": [
+    {
+      "label": "Current concerns about self-harm or suicide",
+      "questionNumber": "R8.1.1",
+      "answer": ""
+    },
+    {
+      "label": "Current concerns about Coping in Custody or Hostel",
+      "questionNumber": "R8.2.1",
+      "answer": ""
+    },
+    {
+      "label": "Current concerns about Vulnerability",
+      "questionNumber": "R8.3.1",
+      "answer": ""
+    }
+  ],
+  "riskManagementPlan": [
+    {
+      "label": "Further considerations",
+      "questionNumber": "RM28",
+      "answer": ""
+    },
+    {
+      "label": "Additional comments",
+      "questionNumber": "RM35",
+      "answer": ""
+    },
+    {
+      "label": "Contingency plans",
+      "questionNumber": "RM34",
+      "answer": ""
+    },
+    {
+      "label": "Victim safety planning",
+      "questionNumber": "RM33",
+      "answer": ""
+    },
+    {
+      "label": "Interventions and treatment",
+      "questionNumber": "RM32",
+      "answer": ""
+    },
+    {
+      "label": "Monitoring and control",
+      "questionNumber": "RM31",
+      "answer": ""
+    },
+    {
+      "label": "Supervision",
+      "questionNumber": "RM30",
+      "answer": ""
+    },
+    {
+      "label": "Key information about current situation",
+      "questionNumber": "RM28.1",
+      "answer": ""
+    }
+  ],
+  "dateCompleted": null
+}

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/index.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/index.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 import { Task } from '../../../utils/decorators'
+import config from '../../../../config'
 
 import OptionalOasysSections from './optionalOasysSections'
 import RoshSummary from './roshSummary'
@@ -7,6 +8,10 @@ import OffenceDetails from './offenceDetails'
 import SupportingInformation from './supportingInformation'
 import RiskManagementPlan from './riskManagementPlan'
 import RiskToSelf from './riskToSelf'
+
+const pages = config.flags.oasysDisabled
+  ? [RoshSummary, OffenceDetails, SupportingInformation, RiskManagementPlan, RiskToSelf]
+  : [OptionalOasysSections, RoshSummary, OffenceDetails, SupportingInformation, RiskManagementPlan, RiskToSelf]
 
 @Task({
   slug: 'oasys-import',

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/index.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/index.ts
@@ -15,7 +15,7 @@ const pages = config.flags.oasysDisabled
 
 @Task({
   slug: 'oasys-import',
-  name: 'Choose sections of OASys to import',
-  pages: [OptionalOasysSections, RoshSummary, OffenceDetails, SupportingInformation, RiskManagementPlan, RiskToSelf],
+  name: config.flags.oasysDisabled ? 'Add OASys Information' : 'Choose sections of OASys to import',
+  pages,
 })
 export default class OasysImport {}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -32,6 +32,8 @@ import applyPaths from '../paths/apply'
 import assessPaths from '../paths/assess'
 import { radioMatrixTable } from './radioMatrixTable'
 
+import config from '../config'
+
 const production = process.env.NODE_ENV === 'production'
 
 export default function nunjucksSetup(app: express.Express, path: pathModule.PlatformPath): void {
@@ -137,6 +139,8 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('fetchContext', function fetchContext() {
     return this.ctx
   })
+
+  njkEnv.addGlobal('oasysDisabled', config.flags.oasysDisabled)
 
   njkEnv.addFilter('mapApiPersonRisksForUi', mapApiPersonRisksForUi)
 

--- a/server/views/applications/pages/oasys-import/_oasys-screen.njk
+++ b/server/views/applications/pages/oasys-import/_oasys-screen.njk
@@ -8,8 +8,12 @@
 {% block questions %}
   <div class="govuk-grid-row">
     <div>
-      <h1 class="govuk-heading-l">{{page.title}}</h1>
-      <p>OASys last updated: {{formatDate(page.oasysCompleted)}}</p>
+      {% if oasysDisabled %}
+        <h1 class="govuk-heading-l">Input risk information</h1>
+      {% else %}
+        <h1 class="govuk-heading-l">{{page.title}}</h1>
+        <p>OASys last updated: {{formatDate(page.oasysCompleted)}}</p>
+      {% endif %}
     </div>
 
     {{ mojSubNavigation({

--- a/server/views/applications/pages/oasys-import/_oasys-screen.njk
+++ b/server/views/applications/pages/oasys-import/_oasys-screen.njk
@@ -50,12 +50,18 @@
   </div>
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds" id="{{ pageName }}">
-      {{OasysImportUtils.textareas(questions, key) | safe}}
-    </div>
+    {% if oasysDisabled %}
+      <div class="govuk-grid-column-full" id="{{ pageName }}">
+        {{OasysImportUtils.textareas(questions, key) | safe}}
+      </div>
+    {% else %}
+      <div class="govuk-grid-column-two-thirds" id="{{ pageName }}">
+        {{OasysImportUtils.textareas(questions, key) | safe}}
+      </div>
 
-    <div class="govuk-grid-column-one-third">
-      {{ widgets(page.risks) }}
-    </div>
+      <div class="govuk-grid-column-one-third">
+        {{ widgets(page.risks) }}
+      </div>
+    {% endif %}
   </div>
 {% endblock %}

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -80,9 +80,11 @@
 
     </div>
 
-    <div class="govuk-grid-column-one-third">
-      {{ widgets(application.risks | mapApiPersonRisksForUi) }}
-    </div>
+    {% if not oasysDisabled %}
+      <div class="govuk-grid-column-one-third">
+        {{ widgets(application.risks | mapApiPersonRisksForUi) }}
+      </div>
+    {% endif %}
 
   </div>
 


### PR DESCRIPTION
This prepares us to (potentially) skip the OASys integration if it isn't fixed in time for the beta launch by setting an `OASYS_DISABLED` environment variable. This will tell the data service to return some stub data (so we still have the titles), change some titles, tweak the flow slightly and remove some page furniture (mainly displaying risks). It also adds a flag to the API request when creating an application (handled in https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/379).

Hopefully we won't need this, but this puts the groundwork in for us to skip the integration if we need to.