### PR TITLE
(948) Add in screens for eligibility screens if a person doesnt meet the tier model

### DIFF
--- a/cypress_shared/helpers/apply.ts
+++ b/cypress_shared/helpers/apply.ts
@@ -1,4 +1,5 @@
 import {
+  ActiveOffence,
   Adjudication,
   ApprovedPremisesApplication as Application,
   ArrayOfOASysOffenceDetailsQuestions,
@@ -114,6 +115,7 @@ export default class ApplyHelper {
   constructor(
     private readonly application: Application,
     private readonly person: Person,
+    private readonly offences: Array<ActiveOffence>,
     private readonly type: 'e2e' | 'integration',
   ) {}
 
@@ -122,13 +124,15 @@ export default class ApplyHelper {
     this.otherOasysSections = otherOasysSections
   }
 
-  setupApplicationStubs(uiRisks: PersonRisksUI) {
+  setupApplicationStubs(uiRisks?: PersonRisksUI) {
     this.uiRisks = uiRisks
+    this.stubPersonEndpoints()
     this.stubApplicationEndpoints()
     this.stubOasysEndpoints()
     this.stubPrisonCaseNoteEndpoints()
     this.stubAdjudicationEndpoints()
     this.stubDocumentEndpoints()
+    this.stubOffences()
   }
 
   startApplication() {
@@ -176,6 +180,15 @@ export default class ApplyHelper {
       ...this.pages.moveOn,
       ...this.selectedDocuments,
     ].length
+  }
+
+  private stubPersonEndpoints() {
+    cy.task('stubPersonRisks', { person: this.person, risks: this.application.risks })
+    cy.task('stubFindPerson', { person: this.person })
+  }
+
+  private stubOffences() {
+    cy.task('stubPersonOffences', { person: this.person, offences: this.offences })
   }
 
   private stubApplicationEndpoints() {

--- a/cypress_shared/pages/apply/ExceptionDetails.ts
+++ b/cypress_shared/pages/apply/ExceptionDetails.ts
@@ -1,0 +1,14 @@
+import Page from '../page'
+
+export default class ExceptionDetailsPage extends Page {
+  constructor() {
+    super('Provide details for exemption application')
+  }
+
+  completeForm() {
+    this.checkRadioByNameAndValue('agreedCaseWithManager', 'yes')
+    this.getTextInputByIdAndEnterDetails('managerName', 'Some Manager')
+    this.completeDateInputs('agreementDate', '2023-07-01')
+    this.completeTextArea('agreementSummary', 'Some Summary Text')
+  }
+}

--- a/cypress_shared/pages/apply/isExceptionalCase.ts
+++ b/cypress_shared/pages/apply/isExceptionalCase.ts
@@ -1,0 +1,11 @@
+import Page from '../page'
+
+export default class IsExceptionalCasePage extends Page {
+  constructor() {
+    super('This application is not eligible')
+  }
+
+  completeForm() {
+    this.checkRadioByNameAndValue('isExceptionalCase', 'yes')
+  }
+}

--- a/cypress_shared/pages/apply/isExceptionalCase.ts
+++ b/cypress_shared/pages/apply/isExceptionalCase.ts
@@ -1,3 +1,4 @@
+import { YesOrNo } from '@approved-premises/ui'
 import Page from '../page'
 
 export default class IsExceptionalCasePage extends Page {
@@ -5,7 +6,7 @@ export default class IsExceptionalCasePage extends Page {
     super('This application is not eligible')
   }
 
-  completeForm() {
-    this.checkRadioByNameAndValue('isExceptionalCase', 'yes')
+  completeForm(answer: YesOrNo) {
+    this.checkRadioByNameAndValue('isExceptionalCase', answer)
   }
 }

--- a/cypress_shared/pages/apply/notEligiblePage.ts
+++ b/cypress_shared/pages/apply/notEligiblePage.ts
@@ -1,0 +1,7 @@
+import Page from '../page'
+
+export default class NotEligiblePage extends Page {
+  constructor() {
+    super('This application is not eligible')
+  }
+}

--- a/e2e/tests/stepDefinitions/apply.ts
+++ b/e2e/tests/stepDefinitions/apply.ts
@@ -12,7 +12,7 @@ const person = personFactory.build(personData)
 const application = applicationFactory.build({ person, data: applicationData })
 
 Given('I start a new application', () => {
-  const apply = new ApplyHelper(application, person, 'e2e')
+  const apply = new ApplyHelper(application, person, [], 'e2e')
   apply.startApplication()
 })
 
@@ -21,7 +21,7 @@ Given('I fill in and complete an application', () => {
     const id = url.match(/applications\/(.+)\/tasks/)[1]
     application.id = id
 
-    const apply = new ApplyHelper(application, person, 'e2e')
+    const apply = new ApplyHelper(application, person, [], 'e2e')
 
     apply.completeApplication()
   })

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -17,6 +17,7 @@ import risksFactory, { tierEnvelopeFactory } from '../../../server/testutils/fac
 import SubmissionConfirmation from '../../../cypress_shared/pages/apply/submissionConfirmation'
 import IsExceptionalCasePage from '../../../cypress_shared/pages/apply/isExceptionalCase'
 import ExceptionDetailsPage from '../../../cypress_shared/pages/apply/ExceptionDetails'
+import NotEligiblePage from '../../../cypress_shared/pages/apply/notEligiblePage'
 
 context('Apply', () => {
   beforeEach(() => {
@@ -98,7 +99,7 @@ context('Apply', () => {
     const isExceptionalCasePage = Page.verifyOnPage(IsExceptionalCasePage)
 
     // And I select yes
-    isExceptionalCasePage.completeForm()
+    isExceptionalCasePage.completeForm('yes')
     isExceptionalCasePage.clickSubmit()
 
     // Then I should be prompted to enter the details of the exception
@@ -110,6 +111,29 @@ context('Apply', () => {
 
     // Then I should be on the Sentence Type page
     Page.verifyOnPage(SentenceTypePage, this.application)
+  })
+
+  it('tells the user that their application is not applicable if the tier is not eligible and it is not an exceptional case', function test() {
+    // And that person does not have an eligible risk tier
+    const risks = risksFactory.build({
+      crn: this.person.crn,
+      tier: tierEnvelopeFactory.build({ value: { level: 'D1' } }),
+    })
+    this.application.risks = risks
+
+    const apply = new ApplyHelper(this.application, this.person, this.offences, 'integration')
+    apply.setupApplicationStubs()
+    apply.startApplication()
+
+    // Then I should be prompted to confirm that the case is exceptional
+    const isExceptionalCasePage = Page.verifyOnPage(IsExceptionalCasePage)
+
+    // And I select no
+    isExceptionalCasePage.completeForm('no')
+    isExceptionalCasePage.clickSubmit()
+
+    // Then I should be told the application is not eligible
+    Page.verifyOnPage(NotEligiblePage)
   })
 
   it("creates and updates an application given a person's CRN", function test() {

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -13,7 +13,7 @@ import applicationFactory from '../../../server/testutils/factories/application'
 import ApplyHelper from '../../../cypress_shared/helpers/apply'
 import Page from '../../../cypress_shared/pages/page'
 import personFactory from '../../../server/testutils/factories/person'
-import risksFactory from '../../../server/testutils/factories/risks'
+import risksFactory, { tierEnvelopeFactory } from '../../../server/testutils/factories/risks'
 import SubmissionConfirmation from '../../../cypress_shared/pages/apply/submissionConfirmation'
 
 context('Apply', () => {
@@ -23,105 +23,95 @@ context('Apply', () => {
     cy.task('stubAuthUser')
   })
 
-  it('allows the user to select an index offence if there is more than one offence', () => {
+  beforeEach(() => {
     // Given I am logged in
     cy.signIn()
 
-    // And a person is in Delius
-    const person = personFactory.build()
-    cy.task('stubFindPerson', { person })
+    cy.fixture('applicationData.json').then(applicationData => {
+      const person = personFactory.build()
+      const application = applicationFactory.build({ person })
+      const risks = risksFactory.build({
+        crn: person.crn,
+        tier: tierEnvelopeFactory.build({ value: { level: 'A3' } }),
+      })
+      const offences = activeOffenceFactory.buildList(1)
+      application.data = applicationData
+      application.risks = risks
 
+      cy.wrap(person).as('person')
+      cy.wrap(offences).as('offences')
+      cy.wrap(application).as('application')
+      cy.wrap(applicationData).as('applicationData')
+    })
+  })
+
+  it('allows the user to select an index offence if there is more than one offence', function test() {
     // And that person has more than one offence listed under their CRN
     const offences = activeOffenceFactory.buildList(4)
-    cy.task('stubPersonOffences', { person, offences })
 
-    // And I have started an application
-    cy.fixture('applicationData.json').then(applicationData => {
-      const application = applicationFactory.build({ person, data: applicationData })
-      cy.task('stubApplicationCreate', { application })
+    const apply = new ApplyHelper(this.application, this.person, offences, 'integration')
+    apply.setupApplicationStubs()
+    apply.startApplication()
 
-      const apply = new ApplyHelper(application, person, 'integration')
-      apply.startApplication()
+    // Then I should be forwarded to select an offence
+    const selectOffencePage = Page.verifyOnPage(SelectOffencePage, this.person, offences)
+    selectOffencePage.shouldDisplayOffences()
 
-      // Then I should be forwarded to select an offence
-      const selectOffencePage = Page.verifyOnPage(SelectOffencePage, person, offences)
-      selectOffencePage.shouldDisplayOffences()
+    // When I select an offence
+    const selectedOffence = offences[0]
+    selectOffencePage.selectOffence(selectedOffence)
 
-      // When I select an offence
-      const selectedOffence = offences[0]
-      selectOffencePage.selectOffence(selectedOffence)
+    // And I click submit
+    selectOffencePage.clickSubmit()
 
-      // And I click submit
-      selectOffencePage.clickSubmit()
+    // Then the API should have created the application with my selected offence
+    cy.task('verifyApplicationCreate').then(requests => {
+      expect(requests).to.have.length(1)
 
-      // Then the API should have created the application with my selected offence
-      cy.task('verifyApplicationCreate').then(requests => {
-        expect(requests).to.have.length(1)
+      const body = JSON.parse(requests[0].body)
 
-        const body = JSON.parse(requests[0].body)
+      expect(body.crn).equal(this.person.crn)
+      expect(body.convictionId).equal(selectedOffence.convictionId)
+      expect(body.deliusEventNumber).equal(selectedOffence.deliusEventNumber)
+      expect(body.offenceId).equal(selectedOffence.offenceId)
+    })
 
-        expect(body.crn).equal(person.crn)
-        expect(body.convictionId).equal(selectedOffence.convictionId)
-        expect(body.deliusEventNumber).equal(selectedOffence.deliusEventNumber)
-        expect(body.offenceId).equal(selectedOffence.offenceId)
-      })
+    // Then I should be on the Sentence Type page
+    Page.verifyOnPage(SentenceTypePage, this.application)
+  })
 
-      // Then I should be on the Sentence Type page
-      Page.verifyOnPage(SentenceTypePage, application)
+  it("creates and updates an application given a person's CRN", function test() {
+    const apply = new ApplyHelper(this.application, this.person, this.offences, 'integration')
+    apply.setupApplicationStubs()
+    apply.startApplication()
+
+    // Then the API should have created the application
+    cy.task('verifyApplicationCreate').then(requests => {
+      expect(requests).to.have.length(1)
+
+      const body = JSON.parse(requests[0].body)
+      const offence = this.offences[0]
+
+      expect(body.crn).equal(this.person.crn)
+      expect(body.convictionId).equal(offence.convictionId)
+      expect(body.deliusEventNumber).equal(offence.deliusEventNumber)
+      expect(body.offenceId).equal(offence.offenceId)
+    })
+
+    // And I complete the basic information step
+    apply.completeBasicInformation()
+
+    // Then the API should have recieved the updated application
+    cy.task('verifyApplicationUpdate', this.application.id).then(requests => {
+      const firstRequestData = JSON.parse(requests[0].body).data
+      const secondRequestData = JSON.parse(requests[1].body).data
+
+      expect(firstRequestData['basic-information']['sentence-type'].sentenceType).equal('bailPlacement')
+      expect(secondRequestData['basic-information'].situation.situation).equal('bailSentence')
     })
   })
 
-  it("creates and updates an application given a person's CRN", () => {
-    // Given I am logged in
-    cy.signIn()
-
-    // And a person is in Delius
-    const person = personFactory.build()
-    const offences = activeOffenceFactory.buildList(1)
-    cy.task('stubFindPerson', { person })
-    cy.task('stubPersonOffences', { person, offences })
-
-    // And I have started an application
-    cy.fixture('applicationData.json').then(applicationData => {
-      const application = applicationFactory.build({ person, data: applicationData })
-      cy.task('stubApplicationCreate', { application })
-      cy.task('stubApplicationUpdate', { application })
-      cy.task('stubApplicationGet', { application })
-
-      const apply = new ApplyHelper(application, person, 'integration')
-      apply.startApplication()
-
-      // Then the API should have created the application
-      cy.task('verifyApplicationCreate').then(requests => {
-        expect(requests).to.have.length(1)
-
-        const body = JSON.parse(requests[0].body)
-        const offence = offences[0]
-
-        expect(body.crn).equal(person.crn)
-        expect(body.convictionId).equal(offence.convictionId)
-        expect(body.deliusEventNumber).equal(offence.deliusEventNumber)
-        expect(body.offenceId).equal(offence.offenceId)
-      })
-
-      // And I complete the basic information step
-      apply.completeBasicInformation()
-
-      // Then the API should have recieved the updated application
-      cy.task('verifyApplicationUpdate', application.id).then(requests => {
-        const firstRequestData = JSON.parse(requests[0].body).data
-        const secondRequestData = JSON.parse(requests[1].body).data
-
-        expect(firstRequestData['basic-information']['sentence-type'].sentenceType).equal('bailPlacement')
-        expect(secondRequestData['basic-information'].situation.situation).equal('bailSentence')
-      })
-    })
-  })
-
-  it('shows an error message if the person is not found', () => {
-    // Given I am logged in
-    cy.signIn()
-
+  it('shows an error message if the person is not found', function test() {
     // And the person I am about to search for is not in Delius
     const person = personFactory.build()
     cy.task('stubPersonNotFound', { person })
@@ -139,68 +129,49 @@ context('Apply', () => {
     crnPage.shouldShowErrorMessage(person)
   })
 
-  it('allows completion of the form', () => {
-    const person = personFactory.build()
-    const apiRisks = risksFactory.build({ crn: person.crn })
-    const uiRisks = mapApiPersonRisksForUi(apiRisks)
-    const offences = activeOffenceFactory.buildList(1)
+  it('allows completion of the form', function test() {
+    // And I complete the application
+    const uiRisks = mapApiPersonRisksForUi(this.application.risks)
+    const apply = new ApplyHelper(this.application, this.person, this.offences, 'integration')
+    apply.setupApplicationStubs(uiRisks)
+    apply.startApplication()
+    apply.completeApplication()
 
-    // Given I am logged in
-    cy.signIn()
+    // Then the application should be submitted to the API
+    cy.task('verifyApplicationUpdate', this.application.id).then((requests: Array<{ body: string }>) => {
+      expect(requests).to.have.length(apply.numberOfPages())
+      const requestBody = JSON.parse(requests[requests.length - 1].body)
 
-    // And a person is in Delius
-    cy.task('stubPersonRisks', { person, risks: apiRisks })
-    cy.task('stubFindPerson', { person })
-    cy.task('stubPersonOffences', { person, offences })
+      expect(requestBody.data).to.deep.equal(this.applicationData)
 
-    // And I have started an application
-    cy.fixture('applicationData.json').then(applicationData => {
-      const application = applicationFactory.build({ person })
-      application.data = applicationData
-      application.risks = apiRisks
-
-      // And I complete the application
-      const apply = new ApplyHelper(application, person, 'integration')
-      apply.setupApplicationStubs(uiRisks)
-      apply.startApplication()
-      apply.completeApplication()
-
-      // Then the application should be submitted to the API
-      cy.task('verifyApplicationUpdate', application.id).then((requests: Array<{ body: string }>) => {
-        expect(requests).to.have.length(apply.numberOfPages())
-        const requestBody = JSON.parse(requests[requests.length - 1].body)
-
-        expect(requestBody.data).to.deep.equal(applicationData)
-
-        cy.task('validateBodyAgainstApplySchema', requestBody.data).then(result => {
-          expect(result).to.equal(true)
-        })
+      cy.task('validateBodyAgainstApplySchema', requestBody.data).then(result => {
+        expect(result).to.equal(true)
       })
-
-      cy.task('verifyApplicationSubmit', application.id).then(requests => {
-        expect(requests).to.have.length(1)
-
-        expect(requests[0].url).to.equal(`/applications/${application.id}/submission`)
-      })
-
-      // And I should be taken to the confirmation page
-      const confirmationPage = new SubmissionConfirmation()
-
-      // Given there are applications in the database
-      const applications = applicationFactory.withReleaseDate().buildList(5)
-      cy.task('stubApplications', applications)
-
-      // And there are risks in the database
-      const risks = risksFactory.buildList(5)
-      applications.forEach((stubbedApplication, i) => {
-        cy.task('stubPersonRisks', { person: stubbedApplication.person, risks: risks[i] })
-      })
-
-      // When I click 'Back to dashboard'
-      confirmationPage.clickBackToDashboard()
-
-      // Then I am taken back to the dashboard
-      Page.verifyOnPage(ListPage)
     })
+
+    cy.task('verifyApplicationSubmit', this.application.id).then(requests => {
+      expect(requests).to.have.length(1)
+
+      expect(requests[0].url).to.equal(`/applications/${this.application.id}/submission`)
+    })
+
+    // And I should be taken to the confirmation page
+    const confirmationPage = new SubmissionConfirmation()
+
+    // Given there are applications in the database
+    const applications = applicationFactory.withReleaseDate().buildList(5)
+    cy.task('stubApplications', applications)
+
+    // And there are risks in the database
+    const risks = risksFactory.buildList(5)
+    applications.forEach((stubbedApplication, i) => {
+      cy.task('stubPersonRisks', { person: stubbedApplication.person, risks: risks[i] })
+    })
+
+    // When I click 'Back to dashboard'
+    confirmationPage.clickBackToDashboard()
+
+    // Then I am taken back to the dashboard
+    Page.verifyOnPage(ListPage)
   })
 })

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -13,7 +13,7 @@ import Apply from '../../form-pages/apply'
 
 import paths from '../../paths/apply'
 import { DateFormats } from '../../utils/dateUtils'
-import { getResponses } from '../../utils/applicationUtils'
+import { firstPageOfApplicationJourney, getResponses } from '../../utils/applicationUtils'
 
 jest.mock('../../utils/validation')
 jest.mock('../../utils/applicationUtils')
@@ -231,14 +231,16 @@ describe('applicationsController', () => {
     })
 
     it('creates an application and redirects to the first page of the first step', async () => {
+      const firstPage = '/foo/bar'
+      ;(firstPageOfApplicationJourney as jest.Mock).mockReturnValue(firstPage)
+
       const requestHandler = applicationsController.create()
 
       await requestHandler(request, response, next)
 
       expect(applicationService.createApplication).toHaveBeenCalledWith('SOME_TOKEN', 'some-crn', offences[0])
-      expect(response.redirect).toHaveBeenCalledWith(
-        paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'sentence-type' }),
-      )
+      expect(firstPageOfApplicationJourney).toHaveBeenCalledWith(application)
+      expect(response.redirect).toHaveBeenCalledWith(firstPage)
     })
 
     it('redirects to the select offences step if an offence has not been provided', async () => {

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -13,7 +13,7 @@ import Apply from '../../form-pages/apply'
 
 import paths from '../../paths/apply'
 import { DateFormats } from '../../utils/dateUtils'
-import { firstPageOfApplicationJourney, getResponses } from '../../utils/applicationUtils'
+import { firstPageOfApplicationJourney, getResponses, isUnapplicable } from '../../utils/applicationUtils'
 
 jest.mock('../../utils/validation')
 jest.mock('../../utils/applicationUtils')
@@ -90,6 +90,15 @@ describe('applicationsController', () => {
       })
 
       expect(applicationService.findApplication).not.toHaveBeenCalledWith(token, application.id)
+    })
+
+    it('renders the not applicable page if the application is not applicable', async () => {
+      const requestHandler = applicationsController.show()
+      ;(isUnapplicable as jest.Mock).mockReturnValue(true)
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('applications/notEligible')
     })
   })
 

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -6,7 +6,7 @@ import { fetchErrorsAndUserInput } from '../../utils/validation'
 import paths from '../../paths/apply'
 import { DateFormats } from '../../utils/dateUtils'
 import Apply from '../../form-pages/apply'
-import { firstPageOfApplicationJourney, getResponses } from '../../utils/applicationUtils'
+import { firstPageOfApplicationJourney, getResponses, isUnapplicable } from '../../utils/applicationUtils'
 
 export default class ApplicationsController {
   constructor(private readonly applicationService: ApplicationService, private readonly personService: PersonService) {}
@@ -31,7 +31,11 @@ export default class ApplicationsController {
     return async (req: Request, res: Response) => {
       const application = await this.applicationService.getApplicationFromSessionOrAPI(req)
 
-      res.render('applications/show', { application, sections: Apply.sections })
+      if (isUnapplicable(application)) {
+        res.render('applications/notEligible')
+      } else {
+        res.render('applications/show', { application, sections: Apply.sections })
+      }
     }
   }
 

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -6,7 +6,7 @@ import { fetchErrorsAndUserInput } from '../../utils/validation'
 import paths from '../../paths/apply'
 import { DateFormats } from '../../utils/dateUtils'
 import Apply from '../../form-pages/apply'
-import { getResponses } from '../../utils/applicationUtils'
+import { firstPageOfApplicationJourney, getResponses } from '../../utils/applicationUtils'
 
 export default class ApplicationsController {
   constructor(private readonly applicationService: ApplicationService, private readonly personService: PersonService) {}
@@ -81,9 +81,7 @@ export default class ApplicationsController {
         const application = await this.applicationService.createApplication(req.user.token, crn, indexOffence)
         req.session.application = application
 
-        res.redirect(
-          paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'sentence-type' }),
-        )
+        res.redirect(firstPageOfApplicationJourney(application))
       }
     }
   }

--- a/server/form-pages/apply/reasons-for-placement/basic-information/exceptionDetails.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/exceptionDetails.test.ts
@@ -1,0 +1,89 @@
+import { itShouldHavePreviousValue, itShouldHaveNextValue } from '../../../shared-examples'
+
+import ExceptionDetails, { ExceptionDetailsBody } from './exceptionDetails'
+
+describe('ExceptionDetails', () => {
+  const body = {
+    agreedCaseWithManager: 'yes',
+    managerName: 'Mr Manager',
+    agreementSummary: 'Some Summary',
+    'agreementDate-year': '2023',
+    'agreementDate-month': '12',
+    'agreementDate-day': '1',
+  } as ExceptionDetailsBody
+
+  describe('body', () => {
+    it('should set the body', () => {
+      const page = new ExceptionDetails(body)
+
+      expect(page.body).toEqual({
+        agreedCaseWithManager: 'yes',
+        managerName: 'Mr Manager',
+        agreementSummary: 'Some Summary',
+        'agreementDate-year': '2023',
+        'agreementDate-month': '12',
+        'agreementDate-day': '1',
+        agreementDate: '2023-12-01',
+      })
+    })
+  })
+
+  itShouldHavePreviousValue(new ExceptionDetails({}), 'is-exceptional-case')
+
+  itShouldHaveNextValue(new ExceptionDetails(body), 'sentence-type')
+
+  describe('errors', () => {
+    it('should return an empty object if the body is provided correctly', () => {
+      const page = new ExceptionDetails(body)
+      expect(page.errors()).toEqual({})
+    })
+
+    it('should return errors if agreedCaseWithManager is blank', () => {
+      const page = new ExceptionDetails({})
+      expect(page.errors()).toEqual({
+        agreedCaseWithManager: 'You must state if you have agreed the case with a senior manager',
+      })
+    })
+
+    it('should return errors if agreedCaseWithManager is yes and the required fields are blank', () => {
+      const page = new ExceptionDetails({
+        ...body,
+        'agreementDate-year': '',
+        'agreementDate-month': '',
+        'agreementDate-day': '',
+        managerName: '',
+        agreementSummary: '',
+      })
+      expect(page.errors()).toEqual({
+        agreementDate: 'You must provide an agreement date',
+        managerName: 'You must provide the name of the senior manager',
+        agreementSummary: 'You must provide a summary of the reasons why this is an exempt application',
+      })
+    })
+
+    it('should return errors if the agreement date is invalid', () => {
+      const page = new ExceptionDetails({
+        ...body,
+        'agreementDate-year': '99999',
+        'agreementDate-month': '99999',
+        'agreementDate-day': '199999',
+      })
+      expect(page.errors()).toEqual({
+        agreementDate: 'The agreement date is an invalid date',
+      })
+    })
+  })
+
+  describe('response', () => {
+    it('should return a translated version of the response', () => {
+      const page = new ExceptionDetails(body)
+
+      expect(page.response()).toEqual({
+        'Have you agreed the case with a senior manager?': 'Yes',
+        'Name of senior manager': 'Mr Manager',
+        'Provide a summary of the reasons why this is an exempt application': 'Some Summary',
+        'What date was this agreed?': 'Friday 1 December 2023',
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/reasons-for-placement/basic-information/exceptionDetails.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/exceptionDetails.ts
@@ -1,0 +1,101 @@
+import type { ObjectWithDateParts, TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import { sentenceCase } from '../../../../utils/utils'
+import { Page } from '../../../utils/decorators'
+import { dateAndTimeInputsAreValidDates, DateFormats } from '../../../../utils/dateUtils'
+
+import TasklistPage from '../../../tasklistPage'
+
+export type ExceptionDetailsBody = ObjectWithDateParts<'agreementDate'> & {
+  agreedCaseWithManager: YesOrNo
+  managerName: string
+  agreementSummary: string
+}
+
+@Page({
+  name: 'exception-details',
+  bodyProperties: [
+    'agreedCaseWithManager',
+    'managerName',
+    'agreementDate',
+    'agreementDate-year',
+    'agreementDate-month',
+    'agreementDate-day',
+    'agreementSummary',
+  ],
+})
+export default class ExceptionDetails implements TasklistPage {
+  title = 'Provide details for exemption application'
+
+  questions = {
+    agreedCaseWithManager: 'Have you agreed the case with a senior manager?',
+    managerName: 'Name of senior manager',
+    agreementDate: 'What date was this agreed?',
+    agreementSummary: 'Provide a summary of the reasons why this is an exempt application',
+  }
+
+  body: ExceptionDetailsBody
+
+  constructor(_body: Partial<ExceptionDetailsBody>) {
+    this.body = {
+      agreedCaseWithManager: _body.agreedCaseWithManager,
+      managerName: _body.managerName,
+      'agreementDate-year': _body['agreementDate-year'],
+      'agreementDate-month': _body['agreementDate-month'],
+      'agreementDate-day': _body['agreementDate-day'],
+      agreementDate: DateFormats.dateAndTimeInputsToIsoString(
+        _body as ObjectWithDateParts<'agreementDate'>,
+        'agreementDate',
+      ).agreementDate,
+      agreementSummary: _body.agreementSummary,
+    }
+  }
+
+  response() {
+    let response = { [this.questions.agreedCaseWithManager]: sentenceCase(this.body.agreedCaseWithManager) }
+
+    if (this.body.agreedCaseWithManager === 'yes') {
+      response = {
+        ...response,
+        [this.questions.managerName]: this.body.managerName,
+        [this.questions.agreementDate]: DateFormats.isoDateToUIDate(this.body.agreementDate),
+        [this.questions.agreementSummary]: this.body.agreementSummary,
+      }
+    }
+
+    return response
+  }
+
+  previous() {
+    return 'is-exceptional-case'
+  }
+
+  next() {
+    return 'sentence-type'
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.agreedCaseWithManager) {
+      errors.agreedCaseWithManager = 'You must state if you have agreed the case with a senior manager'
+    }
+
+    if (this.body.agreedCaseWithManager === 'yes') {
+      if (!this.body.agreementDate) {
+        errors.agreementDate = 'You must provide an agreement date'
+      } else if (!dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'agreementDate'>, 'agreementDate')) {
+        errors.agreementDate = 'The agreement date is an invalid date'
+      }
+
+      if (!this.body.managerName) {
+        errors.managerName = 'You must provide the name of the senior manager'
+      }
+
+      if (!this.body.agreementSummary) {
+        errors.agreementSummary = 'You must provide a summary of the reasons why this is an exempt application'
+      }
+    }
+
+    return errors
+  }
+}

--- a/server/form-pages/apply/reasons-for-placement/basic-information/index.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/index.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 
 import IsExceptionalCase from './isExceptionalCase'
+import ExceptionDetails from './exceptionDetails'
 import SentenceType from './sentenceType'
 import ReleaseType from './releaseType'
 import Situation from './situation'
@@ -15,6 +16,7 @@ import { Task } from '../../../utils/decorators'
   slug: 'basic-information',
   pages: [
     IsExceptionalCase,
+    ExceptionDetails,
     SentenceType,
     ReleaseType,
     Situation,

--- a/server/form-pages/apply/reasons-for-placement/basic-information/index.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/index.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 
+import IsExceptionalCase from './isExceptionalCase'
 import SentenceType from './sentenceType'
 import ReleaseType from './releaseType'
 import Situation from './situation'
@@ -12,6 +13,15 @@ import { Task } from '../../../utils/decorators'
 @Task({
   name: 'Basic Information',
   slug: 'basic-information',
-  pages: [SentenceType, ReleaseType, Situation, ReleaseDate, OralHearing, PlacementDate, PlacementPurpose],
+  pages: [
+    IsExceptionalCase,
+    SentenceType,
+    ReleaseType,
+    Situation,
+    ReleaseDate,
+    OralHearing,
+    PlacementDate,
+    PlacementPurpose,
+  ],
 })
 export default class BasicInformation {}

--- a/server/form-pages/apply/reasons-for-placement/basic-information/isExceptionalCase.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/isExceptionalCase.test.ts
@@ -1,0 +1,48 @@
+import { itShouldHavePreviousValue, itShouldHaveNextValue } from '../../../shared-examples'
+import applicationFactory from '../../../../testutils/factories/application'
+
+import IsExceptionalCase from './isExceptionalCase'
+
+describe('IsExceptionalCase', () => {
+  const application = applicationFactory.build()
+
+  describe('body', () => {
+    it('should set the body', () => {
+      const page = new IsExceptionalCase({ isExceptionalCase: 'yes' }, application)
+
+      expect(page.body).toEqual({ isExceptionalCase: 'yes' })
+    })
+  })
+
+  itShouldHavePreviousValue(new IsExceptionalCase({}, application), '')
+
+  describe('when isExceptionalCase is yes', () => {
+    itShouldHaveNextValue(new IsExceptionalCase({ isExceptionalCase: 'yes' }, application), 'exception-details')
+  })
+
+  describe('when isExceptionalCase is no', () => {
+    itShouldHaveNextValue(new IsExceptionalCase({ isExceptionalCase: 'no' }, application), '')
+  })
+
+  describe('errors', () => {
+    it('should return an empty object if isExceptionalCase is populated', () => {
+      const page = new IsExceptionalCase({ isExceptionalCase: 'yes' }, application)
+      expect(page.errors()).toEqual({})
+    })
+
+    it('should return an errors if isExceptionalCase is not populated', () => {
+      const page = new IsExceptionalCase({}, application)
+      expect(page.errors()).toEqual({ isExceptionalCase: 'You must state if this application is an exceptional case' })
+    })
+  })
+
+  describe('response', () => {
+    it('should return a translated version of the response', () => {
+      const page = new IsExceptionalCase({ isExceptionalCase: 'yes' }, application)
+
+      expect(page.response()).toEqual({
+        [page.title]: 'Yes',
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/reasons-for-placement/basic-information/isExceptionalCase.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/isExceptionalCase.ts
@@ -1,0 +1,40 @@
+import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import { ApprovedPremisesApplication as Application } from '@approved-premises/api'
+import { sentenceCase } from '../../../../utils/utils'
+import { Page } from '../../../utils/decorators'
+
+import TasklistPage from '../../../tasklistPage'
+
+@Page({ name: 'is-exceptional-case', bodyProperties: ['isExceptionalCase'] })
+export default class IsExceptionalCase implements TasklistPage {
+  title = 'Is this an exceptional case?'
+
+  tier = this.application?.risks?.tier?.value?.level
+
+  constructor(readonly body: { isExceptionalCase?: YesOrNo }, readonly application: Application) {}
+
+  response() {
+    return { [this.title]: sentenceCase(this.body.isExceptionalCase) }
+  }
+
+  previous() {
+    return ''
+  }
+
+  next() {
+    if (this.body.isExceptionalCase === 'yes') {
+      return 'exception-details'
+    }
+    return ''
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.isExceptionalCase) {
+      errors.isExceptionalCase = 'You must state if this application is an exceptional case'
+    }
+
+    return errors
+  }
+}

--- a/server/form-pages/apply/reasons-for-placement/basic-information/sentenceType.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/sentenceType.test.ts
@@ -1,11 +1,14 @@
+import applicationFactory from '../../../../testutils/factories/application'
 import { itShouldHavePreviousValue } from '../../../shared-examples'
 
 import SentenceType from './sentenceType'
 
 describe('SentenceType', () => {
+  const application = applicationFactory.build()
+
   describe('body', () => {
     it('should set the body', () => {
-      const page = new SentenceType({ sentenceType: 'standardDeterminate' })
+      const page = new SentenceType({ sentenceType: 'standardDeterminate' }, application)
 
       expect(page.body).toEqual({ sentenceType: 'standardDeterminate' })
     })
@@ -13,53 +16,65 @@ describe('SentenceType', () => {
 
   describe('next', () => {
     it('should return release-type for a standardDeterminate sentence', () => {
-      const page = new SentenceType({ sentenceType: 'standardDeterminate' })
+      const page = new SentenceType({ sentenceType: 'standardDeterminate' }, application)
       expect(page.next()).toEqual('release-type')
     })
 
     it('should return situation for a communityOrder sentence', () => {
-      const page = new SentenceType({ sentenceType: 'communityOrder' })
+      const page = new SentenceType({ sentenceType: 'communityOrder' }, application)
       expect(page.next()).toEqual('situation')
     })
 
     it('should return situation for a bailPlacement sentence', () => {
-      const page = new SentenceType({ sentenceType: 'bailPlacement' })
+      const page = new SentenceType({ sentenceType: 'bailPlacement' }, application)
       expect(page.next()).toEqual('situation')
     })
 
     it('should return release-type for an extendedDeterminate sentence', () => {
-      const page = new SentenceType({ sentenceType: 'extendedDeterminate' })
+      const page = new SentenceType({ sentenceType: 'extendedDeterminate' }, application)
       expect(page.next()).toEqual('release-type')
     })
 
     it('should return release-type for an ipp sentence', () => {
-      const page = new SentenceType({ sentenceType: 'ipp' })
+      const page = new SentenceType({ sentenceType: 'ipp' }, application)
       expect(page.next()).toEqual('release-type')
     })
 
     it('should return release-type for a life sentence', () => {
-      const page = new SentenceType({ sentenceType: 'life' })
+      const page = new SentenceType({ sentenceType: 'life' }, application)
       expect(page.next()).toEqual('release-type')
     })
   })
 
-  itShouldHavePreviousValue(new SentenceType({}), '')
+  describe('when the exception-details step was not completed', () => {
+    itShouldHavePreviousValue(new SentenceType({}, application), '')
+  })
+
+  describe('when the exception-details step was completed', () => {
+    itShouldHavePreviousValue(
+      new SentenceType(
+        {},
+        { ...application, data: { 'basic-information': { 'exception-details': { agreedCaseWithManager: 'yes' } } } },
+      ),
+      'exception-details',
+    )
+  })
 
   describe('errors', () => {
     it('should return an empty object if the sentence type is populated', () => {
-      const page = new SentenceType({ sentenceType: 'life' })
+      const page = new SentenceType({ sentenceType: 'life' }, application)
       expect(page.errors()).toEqual({})
     })
 
     it('should return an errors if the sentence type is not populated', () => {
-      const page = new SentenceType({})
+      const page = new SentenceType({}, application)
       expect(page.errors()).toEqual({ sentenceType: 'You must choose a sentence type' })
     })
   })
 
   describe('items', () => {
     it('marks an option as selected when the sentenceType is set', () => {
-      const page = new SentenceType({ sentenceType: 'life' })
+      const page = new SentenceType({ sentenceType: 'life' }, application)
 
       const selectedOptions = page.items().filter(item => item.checked)
 
@@ -68,7 +83,7 @@ describe('SentenceType', () => {
     })
 
     it('marks no options selected when the sentenceType is not set', () => {
-      const page = new SentenceType({})
+      const page = new SentenceType({}, application)
 
       const selectedOptions = page.items().filter(item => item.checked)
 
@@ -78,7 +93,7 @@ describe('SentenceType', () => {
 
   describe('response', () => {
     it('should return a translated version of the response', () => {
-      const page = new SentenceType({ sentenceType: 'life' })
+      const page = new SentenceType({ sentenceType: 'life' }, application)
 
       expect(page.response()).toEqual({ [page.title]: 'Life sentence' })
     })

--- a/server/form-pages/apply/reasons-for-placement/basic-information/sentenceType.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/sentenceType.ts
@@ -1,4 +1,5 @@
 import type { TaskListErrors } from '@approved-premises/ui'
+import { ApprovedPremisesApplication as Application } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
@@ -19,13 +20,16 @@ export type SentenceTypesT = keyof typeof sentenceTypes
 export default class SentenceType implements TasklistPage {
   title = 'Which of the following best describes the sentence type?'
 
-  constructor(readonly body: { sentenceType?: SentenceTypesT }) {}
+  constructor(readonly body: { sentenceType?: SentenceTypesT }, readonly application: Application) {}
 
   response() {
     return { [this.title]: sentenceTypes[this.body.sentenceType] }
   }
 
   previous() {
+    if (this.application.data?.['basic-information']?.['exception-details']) {
+      return 'exception-details'
+    }
     return ''
   }
 

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -20,6 +20,70 @@
     "basic-information": {
       "type": "object",
       "properties": {
+        "is-exceptional-case": {
+          "type": "object",
+          "properties": {
+            "isExceptionalCase": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            }
+          }
+        },
+        "exception-details": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "agreementDate-year": {
+                  "type": "string"
+                },
+                "agreementDate-month": {
+                  "type": "string"
+                },
+                "agreementDate-day": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "agreementDate-time": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "agreementDate": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "agreedCaseWithManager": {
+                  "enum": [
+                    "no",
+                    "yes"
+                  ],
+                  "type": "string"
+                },
+                "managerName": {
+                  "type": "string"
+                },
+                "agreementSummary": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        },
         "sentence-type": {
           "type": "object",
           "properties": {

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -2,6 +2,7 @@ import type { Request } from 'express'
 import type { DataServices } from '@approved-premises/ui'
 import type { ActiveOffence, ApprovedPremisesApplication, Document } from '@approved-premises/api'
 
+import { isUnapplicable } from '../utils/applicationUtils'
 import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
 import type { RestClientBuilder, ApplicationClient } from '../data'
 import { ValidationError } from '../utils/errors'
@@ -33,8 +34,9 @@ export default class ApplicationService {
 
   async getAllForLoggedInUser(token: string): Promise<Array<ApprovedPremisesApplication>> {
     const applicationClient = this.applicationClientFactory(token)
+    const applications = await applicationClient.all()
 
-    return applicationClient.all()
+    return applications.filter(application => !isUnapplicable(application))
   }
 
   async getDocuments(token: string, application: ApprovedPremisesApplication): Promise<Array<Document>> {

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -12,6 +12,7 @@ import {
   getArrivalDate,
   dashboardTableRows,
   firstPageOfApplicationJourney,
+  isUnapplicable,
 } from './applicationUtils'
 import { SessionDataError, UnknownPageError } from './errors'
 
@@ -197,6 +198,38 @@ describe('applicationUtils', () => {
       expect(firstPageOfApplicationJourney(application)).toEqual(
         paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'is-exceptional-case' }),
       )
+    })
+  })
+
+  describe('isUnapplicable', () => {
+    const application = applicationFactory.build()
+
+    it('should return true if the applicant has answered no to the isExceptionalCase question', () => {
+      application.data = {
+        'basic-information': {
+          'is-exceptional-case': {
+            isExceptionalCase: 'no',
+          },
+        },
+      }
+
+      expect(isUnapplicable(application)).toEqual(true)
+    })
+
+    it('should return false if the applicant has answered yes to the isExceptionalCase question', () => {
+      application.data = {
+        'basic-information': {
+          'is-exceptional-case': {
+            isExceptionalCase: 'yes',
+          },
+        },
+      }
+
+      expect(isUnapplicable(application)).toEqual(false)
+    })
+
+    it('should return false if the applicant has not answered the isExceptionalCase question', () => {
+      expect(isUnapplicable(application)).toEqual(false)
     })
   })
 })

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -3,7 +3,7 @@ import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import paths from '../paths/apply'
 import Apply from '../form-pages/apply'
 import { SessionDataError, UnknownPageError } from './errors'
-import { tierBadge } from './personUtils'
+import { isApplicableTier, tierBadge } from './personUtils'
 import { DateFormats } from './dateUtils'
 import { TasklistPageInterface } from '../form-pages/tasklistPage'
 import Assess from '../form-pages/assess'
@@ -126,4 +126,12 @@ const getArrivalDate = (application: ApprovedPremisesApplication, raiseOnMissing
   return null
 }
 
-export { getResponses, getResponseForPage, getPage, getArrivalDate, dashboardTableRows }
+const firstPageOfApplicationJourney = (application: ApprovedPremisesApplication) => {
+  if (isApplicableTier(application.person.sex, application.risks.tier.value.level)) {
+    return paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'sentence-type' })
+  }
+
+  return paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'is-exceptional-case' })
+}
+
+export { getResponses, getResponseForPage, getPage, getArrivalDate, dashboardTableRows, firstPageOfApplicationJourney }

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -126,6 +126,13 @@ const getArrivalDate = (application: ApprovedPremisesApplication, raiseOnMissing
   return null
 }
 
+const isUnapplicable = (application: ApprovedPremisesApplication): boolean => {
+  const basicInformation = application.data?.['basic-information']
+  const isExceptionalCase = basicInformation?.['is-exceptional-case']?.isExceptionalCase
+
+  return isExceptionalCase === 'no'
+}
+
 const firstPageOfApplicationJourney = (application: ApprovedPremisesApplication) => {
   if (isApplicableTier(application.person.sex, application.risks.tier.value.level)) {
     return paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'sentence-type' })
@@ -134,4 +141,12 @@ const firstPageOfApplicationJourney = (application: ApprovedPremisesApplication)
   return paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'is-exceptional-case' })
 }
 
-export { getResponses, getResponseForPage, getPage, getArrivalDate, dashboardTableRows, firstPageOfApplicationJourney }
+export {
+  getResponses,
+  getResponseForPage,
+  getPage,
+  getArrivalDate,
+  dashboardTableRows,
+  firstPageOfApplicationJourney,
+  isUnapplicable,
+}

--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -1,4 +1,4 @@
-import { statusTag, tierBadge } from './personUtils'
+import { isApplicableTier, statusTag, tierBadge } from './personUtils'
 
 describe('personUtils', () => {
   describe('statusTag', () => {
@@ -20,6 +20,32 @@ describe('personUtils', () => {
 
     it('returns the correct tier badge for B', () => {
       expect(tierBadge('B')).toEqual('<span class="moj-badge moj-badge--purple">B</span>')
+    })
+  })
+
+  describe('isApplicableTier', () => {
+    it(`returns true if the person's sex is male and has an applicable tier`, () => {
+      expect(isApplicableTier('Male', 'A3')).toBeTruthy()
+    })
+
+    it(`returns false if the person's sex is male and has a tier that is not applicable to males`, () => {
+      expect(isApplicableTier('Male', 'C3')).toBeFalsy()
+    })
+
+    it(`returns false if the person's sex is male and has an inapplicable tier`, () => {
+      expect(isApplicableTier('Male', 'D1')).toBeFalsy()
+    })
+
+    it(`returns true if the person's sex is female and has an applicable tier`, () => {
+      expect(isApplicableTier('Female', 'A3')).toBeTruthy()
+    })
+
+    it(`returns true if the person's sex is female and has a tier that is applicable to females`, () => {
+      expect(isApplicableTier('Female', 'C3')).toBeTruthy()
+    })
+
+    it(`returns false if the person's sex is female and has an inapplicable tier`, () => {
+      expect(isApplicableTier('Female', 'D1')).toBeFalsy()
     })
   })
 })

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -16,4 +16,13 @@ const tierBadge = (tier: string): string => {
   return `<span class="moj-badge ${colour}">${tier}</span>`
 }
 
-export { statusTag, tierBadge }
+const isApplicableTier = (sex: string, tier: string): boolean => {
+  const applicableTiersAll = ['A3', 'A2', 'B1', 'B3', 'B2', 'B1']
+  const applicableTiersWomen = ['C3']
+
+  const applicableTiers = sex === 'Female' ? [applicableTiersAll, applicableTiersWomen].flat() : applicableTiersAll
+
+  return applicableTiers.includes(tier)
+}
+
+export { statusTag, tierBadge, isApplicableTier }

--- a/server/views/applications/notEligible.njk
+++ b/server/views/applications/notEligible.njk
@@ -1,0 +1,21 @@
+{% extends "../partials/layout.njk" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">This application is not eligible</h1>
+
+      <p>
+        From the information you've provided this person is not eligible for an Approved Premises (AP) placement.
+      </p>
+
+      <p>
+        Consider referring the person to other accommodation providers.
+      </p>
+
+      <p>
+        <a href="{{ paths.applications.index() }}">Back to dashboard</a>
+      </p>
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/applications/pages/basic-information/exception-details.njk
+++ b/server/views/applications/pages/basic-information/exception-details.njk
@@ -1,0 +1,72 @@
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  <h1 class="govuk-heading-l">
+    {{ page.title }}
+  </h1>
+
+  {% set conditionalHTML %}
+  {{ formPageInput({
+        fieldName: "managerName",
+        label: {
+          text: page.questions.managerName
+        }
+      },fetchContext()) }}
+
+  {{
+    formPageDateInput(
+      {
+        fieldName: "agreementDate",
+        fieldset: {
+          legend: {
+            text: page.questions.agreementDate
+          }
+        },
+        hint: {
+          text: "For example, 27 3 2007"
+        },
+        items: dateFieldValues('agreementDate', errors)
+      },
+      fetchContext()
+    )
+  }}
+
+  {{ formPageTextarea({
+      fieldName: 'agreementSummary',
+      label: {
+        text: page.questions.agreementSummary
+        }
+    }, fetchContext()) }}
+
+  {% endset -%}
+
+  {{ formPageRadios(
+      {
+        fieldset: {
+          legend: {
+            text: page.questions.agreedCaseWithManager,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes",
+            conditional: {
+              html: conditionalHTML
+            }
+          },
+          {
+            text: "No",
+            value: "no"
+          }
+        ],
+        fieldName: "agreedCaseWithManager"
+      },
+      fetchContext()
+    )
+  }}
+
+{% endblock %}

--- a/server/views/applications/pages/basic-information/is-exceptional-case.njk
+++ b/server/views/applications/pages/basic-information/is-exceptional-case.njk
@@ -1,0 +1,79 @@
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  <h1 class="govuk-heading-l">
+    This application is not eligible
+  </h1>
+
+  <h2 class="govuk-heading-m">
+    This person is managed at <strong>Tier {{ page.tier }}</strong>
+  </h2>
+
+  <p>People in prison or people on probation who are managed at the following Tiers would be eligible to apply for an Approved Premises (AP) placement.</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>A3</li>
+    <li>A2</li>
+    <li>B1</li>
+    <li>B3</li>
+    <li>B2</li>
+    <li>B1</li>
+    <li>C3 (women only)</li>
+  </ul>
+
+  <p>Applications for an AP placement can still be made in exceptional circumstances.</p>
+
+  {% set detailsHTML %}
+  <p>An AP placement may occasionally be required to manage the risk posed by, or to, people managed in Tiers C3, C2, C1, or people in specific circumstances.</p>
+
+  <p>This may include (but is not limited to):</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>People in the community who have been convicted of sex offences and have been publicly identified, for example through social media (Tier C)</li>
+    <li>Life / IPP or other prisoners who have served long periods (over 10 years) in custody</li>
+    <li>People with a high national media profile (Tier C) </li>
+    <li>People managed at MAPPA Level 2 or 3 (Tier C) </li>
+    <li>People who are managed on Post Sentence Supervision or Community Orders without a multi-agency contingency plan in place </li>
+  </ul>
+
+  <p>Where this is being considered, there should be a discussion between the Head/Deputy Head of Probation Delivery Unit (PDU) or Community Head of Public Protection (HoPP) and an AP Area Manager / CRU Manager or Head of Public Protection (Residential).</p>
+  <p>In these exceptional cases an application to an AP can be made, but a placement is not guaranteed.</p>
+  {% endset %}
+
+  {% set hintHTML %}
+  {{ govukDetails({
+    summaryText: "What is an exceptional case?",
+    html: detailsHTML
+  }) }}
+  {% endset %}
+
+  {{
+    formPageRadios(
+      {
+        fieldName: "isExceptionalCase",
+        fieldset: {
+          legend: {
+            text: page.title,
+            classes: "govuk-fieldset__legend--l"
+          }
+        },
+        hint: {
+          html: hintHTML
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes"
+          },
+          {
+            text: "No",
+            value: "no"
+          }
+        ]
+      },
+      fetchContext()
+    )
+  }}
+
+{% endblock %}


### PR DESCRIPTION
This adds an extra flow to the start of the Apply journey to check an offender's tier before continuing. If they do not meet the requirements, they're prompted to confirm if it's an exceptional case, and if so, add the details before continuing.

If they answer `No`, then the journey ends.

# Screenshots

![Apply -- allows the user to specify if the case is exceptional if the offender's tier is not eligible](https://user-images.githubusercontent.com/109774/215749434-a5c46d9f-03bb-4d3b-a095-816edbce8c13.png)

![Apply -- allows the user to specify if the case is exceptional if the offender's tier is not eligible (1)](https://user-images.githubusercontent.com/109774/215749457-7579545e-d317-4d0b-98b0-ec6870bc919b.png)

![Apply -- tells the user that their application is not applicable if the tier is not eligible and it is not an exceptional case](https://user-images.githubusercontent.com/109774/215768607-1d5cd29b-3150-48d8-af67-0f963290eafd.png)

![Apply -- tells the user that their application is not applicable if the tier is not eligible and it is not an exceptional case (1)](https://user-images.githubusercontent.com/109774/215768613-598ab542-4341-4375-b7bb-3431cc457d24.png)

