### PR TITLE
(1059) Submitted applications stay in the open application screen

### DIFF
--- a/cypress_shared/pages/apply/list.ts
+++ b/cypress_shared/pages/apply/list.ts
@@ -23,15 +23,15 @@ export default class ListPage extends Page {
   }
 
   shouldShowInProgressApplications(): void {
-    this.shouldShowApplications(this.inProgressApplications)
+    this.shouldShowApplications(this.inProgressApplications, 'In Progress')
   }
 
   shouldShowFurtherInformationRequestedApplications(): void {
-    this.shouldShowApplications(this.requestedFurtherInformationApplications)
+    this.shouldShowApplications(this.requestedFurtherInformationApplications, 'Info Request')
   }
 
   shouldShowSubmittedApplications(): void {
-    this.shouldShowApplications(this.submittedApplications)
+    this.shouldShowApplications(this.submittedApplications, 'Submitted')
   }
 
   clickSubmit() {
@@ -46,7 +46,7 @@ export default class ListPage extends Page {
     cy.get('a').contains('Submitted').click()
   }
 
-  private shouldShowApplications(applications: Array<Application>): void {
+  private shouldShowApplications(applications: Array<Application>, status: string): void {
     applications.forEach(application => {
       cy.contains(application.person.name)
         .should('have.attr', 'href', paths.applications.show({ id: application.id }))
@@ -63,9 +63,7 @@ export default class ListPage extends Page {
                 format: 'short',
               }),
             )
-          cy.get('td')
-            .eq(3)
-            .contains(DateFormats.isoDateToUIDate(application.submittedAt, { format: 'short' }))
+          cy.get('td').eq(3).contains(status)
         })
     })
   }

--- a/cypress_shared/pages/apply/list.ts
+++ b/cypress_shared/pages/apply/list.ts
@@ -1,20 +1,52 @@
 import Page from '../page'
 import paths from '../../../server/paths/apply'
 import { DateFormats } from '../../../server/utils/dateUtils'
-import { ApprovedPremisesApplication } from '../../../server/@types/shared'
+import { ApprovedPremisesApplication as Application } from '../../../server/@types/shared'
 
 export default class ListPage extends Page {
-  constructor() {
+  constructor(
+    private readonly inProgressApplications: Array<Application>,
+    private readonly submittedApplications: Array<Application>,
+    private readonly requestedFurtherInformationApplications: Array<Application>,
+  ) {
     super('Approved Premises applications')
   }
 
-  static visit(): ListPage {
+  static visit(
+    inProgressApplications: Array<Application>,
+    submittedApplications: Array<Application>,
+    requestedFurtherInformationApplications: Array<Application>,
+  ): ListPage {
     cy.visit(paths.applications.index.pattern)
 
-    return new ListPage()
+    return new ListPage(inProgressApplications, submittedApplications, requestedFurtherInformationApplications)
   }
 
-  shouldShowApplications(applications: Array<ApprovedPremisesApplication>): void {
+  shouldShowInProgressApplications(): void {
+    this.shouldShowApplications(this.inProgressApplications)
+  }
+
+  shouldShowFurtherInformationRequestedApplications(): void {
+    this.shouldShowApplications(this.requestedFurtherInformationApplications)
+  }
+
+  shouldShowSubmittedApplications(): void {
+    this.shouldShowApplications(this.submittedApplications)
+  }
+
+  clickSubmit() {
+    cy.get('.govuk-button').click()
+  }
+
+  clickFurtherInformationRequestedTab() {
+    cy.get('a').contains('Further information requested').click()
+  }
+
+  clickSubmittedTab() {
+    cy.get('a').contains('Submitted').click()
+  }
+
+  private shouldShowApplications(applications: Array<Application>): void {
     applications.forEach(application => {
       cy.contains(application.person.name)
         .should('have.attr', 'href', paths.applications.show({ id: application.id }))
@@ -36,9 +68,5 @@ export default class ListPage extends Page {
             .contains(DateFormats.isoDateToUIDate(application.submittedAt, { format: 'short' }))
         })
     })
-  }
-
-  clickSubmit() {
-    cy.get('.govuk-button').click()
   }
 }

--- a/integration_tests/tests/apply/list.cy.ts
+++ b/integration_tests/tests/apply/list.cy.ts
@@ -15,14 +15,34 @@ context('Applications dashboard', () => {
     cy.signIn()
 
     // And there are applications in the database
-    const applications = applicationFactory.withReleaseDate().buildList(5)
-    cy.task('stubApplications', applications)
+    const inProgressApplications = applicationFactory.withReleaseDate().buildList(5, { status: 'inProgress' })
+    const submittedApplications = applicationFactory.withReleaseDate().buildList(5, { status: 'submitted' })
+    const requestedFurtherInformationApplications = applicationFactory
+      .withReleaseDate()
+      .buildList(5, { status: 'requestedFurtherInformation' })
+
+    cy.task(
+      'stubApplications',
+      [inProgressApplications, submittedApplications, requestedFurtherInformationApplications].flat(),
+    )
 
     // When I visit the Previous Applications page
-    const page = ListPage.visit()
+    const page = ListPage.visit(inProgressApplications, submittedApplications, requestedFurtherInformationApplications)
 
-    // Then I should see all of the application summaries listed
-    page.shouldShowApplications(applications)
+    // Then I should see all of the in progress applications
+    page.shouldShowInProgressApplications()
+
+    // And I click on the Further Information Requested tab
+    page.clickFurtherInformationRequestedTab()
+
+    // Then I should see the applications where further information has been requested
+    page.shouldShowFurtherInformationRequestedApplications()
+
+    // And I click on the submitted tab
+    page.clickSubmittedTab()
+
+    // Then I should see the applications that have been submitted
+    page.shouldShowSubmittedApplications()
 
     // And I the button should take me to the application start page
     page.clickSubmit()

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -14,6 +14,7 @@ import {
   ArrayOfOASysRiskToSelfQuestions,
   ArrayOfOASysRiskManagementPlanQuestions,
   Booking,
+  Application,
 } from '@approved-premises/api'
 
 interface TasklistPage {
@@ -212,6 +213,12 @@ export interface GroupedAssessments {
   completed: Array<Assessment>
   requestedFurtherInformation: Array<Assessment>
   awaiting: Array<Assessment>
+}
+
+export interface GroupedApplications {
+  inProgress: Array<Application>
+  requestedFurtherInformation: Array<Application>
+  submitted: Array<Application>
 }
 
 export interface ApplicationWithRisks extends Application {

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 
-import type { ErrorsAndUserInput } from '@approved-premises/ui'
+import type { ErrorsAndUserInput, GroupedApplications } from '@approved-premises/ui'
 import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import ApplicationsController, { tasklistPageHeading } from './applicationsController'
 import { ApplicationService, PersonService } from '../../services'
@@ -38,7 +38,8 @@ describe('applicationsController', () => {
 
   describe('index', () => {
     it('renders the index view', async () => {
-      const applications = applicationFactory.buildList(5)
+      const applications: GroupedApplications = { inProgress: [], requestedFurtherInformation: [], submitted: [] }
+
       applicationService.getAllForLoggedInUser.mockResolvedValue(applications)
 
       const requestHandler = applicationsController.index()

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -48,14 +48,24 @@ describe('ApplicationService', () => {
 
   describe('getAllForLoggedInUser', () => {
     const token = 'SOME_TOKEN'
-    const applications = applicationFactory.buildList(5)
+    const submittedApplications = applicationFactory.buildList(5, { status: 'submitted' })
+    const inProgressApplications = applicationFactory.buildList(2, { status: 'inProgress' })
+    const requestedFurtherInformationApplications = applicationFactory.buildList(1, {
+      status: 'requestedFurtherInformation',
+    })
+
+    const applications = [submittedApplications, inProgressApplications, requestedFurtherInformationApplications].flat()
 
     it('fetches all applications', async () => {
       applicationClient.all.mockResolvedValue(applications)
 
       const result = await service.getAllForLoggedInUser(token)
 
-      expect(result).toEqual(applications)
+      expect(result).toEqual({
+        inProgress: inProgressApplications,
+        requestedFurtherInformation: requestedFurtherInformationApplications,
+        submitted: submittedApplications,
+      })
 
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
       expect(applicationClient.all).toHaveBeenCalled()
@@ -69,7 +79,11 @@ describe('ApplicationService', () => {
 
       const result = await service.getAllForLoggedInUser(token)
 
-      expect(result).toEqual(applications)
+      expect(result).toEqual({
+        inProgress: inProgressApplications,
+        requestedFurtherInformation: requestedFurtherInformationApplications,
+        submitted: submittedApplications,
+      })
     })
   })
 

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -13,6 +13,7 @@ import {
   dashboardTableRows,
   firstPageOfApplicationJourney,
   isUnapplicable,
+  getStatus,
 } from './applicationUtils'
 import { SessionDataError, UnknownPageError } from './errors'
 
@@ -157,7 +158,7 @@ describe('applicationUtils', () => {
             text: 'N/A',
           },
           {
-            text: 'N/A',
+            html: getStatus(applicationB),
           },
         ],
         [
@@ -174,10 +175,24 @@ describe('applicationUtils', () => {
             text: DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' }),
           },
           {
-            text: DateFormats.isoDateToUIDate(applicationB.submittedAt, { format: 'short' }),
+            html: getStatus(applicationB),
           },
         ],
       ])
+    })
+  })
+
+  describe('getStatus', () => {
+    it('returns the correct tag for each status', () => {
+      const inProgressApplication = applicationFactory.build({ status: 'inProgress' })
+      const submittedApplication = applicationFactory.build({ status: 'submitted' })
+      const informationRequestedApplication = applicationFactory.build({ status: 'requestedFurtherInformation' })
+
+      expect(getStatus(inProgressApplication)).toEqual('<strong class="govuk-tag govuk-tag--blue">In Progress</strong>')
+      expect(getStatus(submittedApplication)).toEqual('<strong class="govuk-tag">Submitted</strong>')
+      expect(getStatus(informationRequestedApplication)).toEqual(
+        '<strong class="govuk-tag govuk-tag--yellow">Info Request</strong>',
+      )
     })
   })
 

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -21,11 +21,20 @@ const dashboardTableRows = (applications: Array<Application>): Array<TableRow> =
       textValue(application.person.crn),
       htmlValue(tierBadge(application.risks.tier.value?.level || '')),
       textValue(arrivalDate ? DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' }) : 'N/A'),
-      textValue(
-        application.submittedAt ? DateFormats.isoDateToUIDate(application.submittedAt, { format: 'short' }) : 'N/A',
-      ),
+      htmlValue(getStatus(application)),
     ]
   })
+}
+
+const getStatus = (application: Application): string => {
+  switch (application.status) {
+    case 'submitted':
+      return `<strong class="govuk-tag">Submitted</strong>`
+    case 'requestedFurtherInformation':
+      return `<strong class="govuk-tag govuk-tag--yellow">Info Request</strong>`
+    default:
+      return `<strong class="govuk-tag govuk-tag--blue">In Progress</strong>`
+  }
 }
 
 const textValue = (value: string) => {
@@ -155,4 +164,5 @@ export {
   dashboardTableRows,
   firstPageOfApplicationJourney,
   isUnapplicable,
+  getStatus,
 }

--- a/server/views/applications/_table.njk
+++ b/server/views/applications/_table.njk
@@ -21,7 +21,7 @@
               text: "Arrival date"
             },
             {
-              text: 'Submitted at'
+              text: "Status"
             }
           ],
           rows: rows

--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -19,24 +19,24 @@
             {{ govukTabs({
                 items: [
                     {
-                        label: "Applications",
+                        label: "In Progress",
                         id: "applications",
                         panel: {
-                            html: applicationsTable("Applications", dashboardTableRows(applications))
+                            html: applicationsTable("Applications", dashboardTableRows(applications.inProgress))
                         }
                     },
                     {
                         label: "Further information requested",
                         id: "further-information-requested",
                         panel: {
-                            html: '<h3>TODO</h3>'
+                            html: applicationsTable("Applications", dashboardTableRows(applications.requestedFurtherInformation))
                         }
                     },
                     {
                         label: "Submitted",
                         id: "applications-submitted",
                         panel: {
-                            html: '<h3>TODO</h3>'
+                            html: applicationsTable("Applications", dashboardTableRows(applications.submitted))
                         }
                     }
                 ]


### PR DESCRIPTION
This fixes the application dashboard to group applications by the newly added `status` attribute. I've also updated the tables to be more in line with the prototype.

## Screenshot

![image](https://user-images.githubusercontent.com/109774/216081455-9899f1a6-2f8c-41e0-abc1-cbd47e4fd5d2.png)


