### PR TITLE
Update dependencies in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available
 
 RUN apt-get update && \
-        apt-get install -y make python g++
+        apt-get install -y make python3 g++ bzip2
 
 COPY package*.json ./
 RUN CYPRESS_INSTALL_BINARY=0 npm ci --no-audit


### PR DESCRIPTION
Updating Shellcheck has introduced a bunch of new dependencies, including `node-gyp`, which needs `python3` and `bzip2` to be installed. This should fix the Docker build and allow the containers to be built cleanly again.