### PR TITLE
(1079) Fix error when not providing a release date

### DIFF
--- a/server/form-pages/apply/move-on/placementDuration.test.ts
+++ b/server/form-pages/apply/move-on/placementDuration.test.ts
@@ -65,12 +65,12 @@ describe('PlacementDuration', () => {
       )
     })
 
-    it('throws an error if the "placement-date" object is not present', () => {
+    it('returns undefined if the "placement-date" object is not present', () => {
       application = applicationFactory.build({ data: { 'basic-information': {} } })
 
-      expect(() => new PlacementDuration({}, application)).toThrow(
-        new SessionDataError('Move on information placement duration error: Error: No placement date'),
-      )
+      const page = new PlacementDuration({}, application)
+
+      expect(page.arrivalDate).toBeUndefined()
     })
 
     it('throws an error if the start date is the same as the release date and the "release-date" object is not present', () => {

--- a/server/form-pages/apply/move-on/placementDuration.ts
+++ b/server/form-pages/apply/move-on/placementDuration.ts
@@ -62,9 +62,9 @@ export default class PlacementDuration implements TasklistPage {
 
       const placementDate = basicInformation['placement-date']
 
-      if (!placementDate) throw new SessionDataError('No placement date')
+      if (!placementDate) return undefined
 
-      if (placementDate.startDateSameAsReleaseDate === 'yes') {
+      if (placementDate && placementDate.startDateSameAsReleaseDate === 'yes') {
         const releaseDate = basicInformation['release-date']
 
         if (!releaseDate) throw new SessionDataError('No release date')

--- a/server/views/applications/pages/move-on/placement-duration.njk
+++ b/server/views/applications/pages/move-on/placement-duration.njk
@@ -27,24 +27,28 @@
     )
   }}
 
-  <div
-    id="durationWrapper"
-    class="govuk-visually-hidden"
-    data-expected-dates
-    data-arrivalDate="{{ page.arrivalDate.toISOString() }}"
-    aria-live="polite"
-    aria-atomic="true"
-  >
-    <h3 class="govuk-heading-m">Expected dates of stay in Approved Premises:</h3>
-    <p>
-      <b>Arrival date:</b>
-      {{ formatDate(page.arrivalDate.toISOString()) }}</p>
-    <p>
-      <b>Departure date:</b>
-      <span data-departure-date></span></p>
-  </div>
+  {% if page.arrivalDate %}
 
-  <br>
+    <div
+      id="durationWrapper"
+      class="govuk-visually-hidden"
+      data-expected-dates
+      data-arrivalDate="{{ page.arrivalDate.toISOString() }}"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <h3 class="govuk-heading-m">Expected dates of stay in Approved Premises:</h3>
+      <p>
+        <b>Arrival date:</b>
+        {{ formatDate(page.arrivalDate.toISOString()) }}</p>
+      <p>
+        <b>Departure date:</b>
+        <span data-departure-date></span></p>
+    </div>
+
+    <br>
+
+  {% endif %}
 
   {{
     formPageTextarea(


### PR DESCRIPTION
If someone does not know the release date or the oral hearing date, then this question won’t be answered, so we’ll return undefined and hide the end date calculator instead of throwing an error. This is essential if we're going to handle parole board cases when the release date is not known.