### PR TITLE
Don’t build Docker multiplatform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ workflows:
     jobs:
       - hmpps/helm_lint:
           name: helm_lint
-      - hmpps/build_multiplatform_docker:
+      - hmpps/build_docker:
           name: build_docker
           filters:
             branches:


### PR DESCRIPTION
We don't use the Docker images for local development, and multiplatform builds make the build times considerably longer. This build time will be significantly extended by https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/530. Reports from other projects on Slack suggest it could be as much as an hour!