### PR TITLE
(1063) Fix task manager bugs

### DIFF
--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -64,8 +64,11 @@ export type Task = {
 
 export type TaskStatus = 'not_started' | 'in_progress' | 'complete' | 'cannot_start'
 
+export type TaskWithStatus = Task & { status: TaskStatus }
+
 export type FormSection = {
   title: string
+  name: string
   tasks: Array<Task>
 }
 

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -62,6 +62,8 @@ export type Task = {
   pages: Record<string, unknown>
 }
 
+export type TaskStatus = 'not_started' | 'in_progress' | 'complete' | 'cannot_start'
+
 export type FormSection = {
   title: string
   tasks: Array<Task>

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -3,6 +3,7 @@ import { createMock, DeepMocked } from '@golevelup/ts-jest'
 
 import type { ErrorsAndUserInput, GroupedApplications } from '@approved-premises/ui'
 import type { ApprovedPremisesApplication } from '@approved-premises/api'
+import TasklistService from '../../services/tasklistService'
 import ApplicationsController, { tasklistPageHeading } from './applicationsController'
 import { ApplicationService, PersonService } from '../../services'
 import { fetchErrorsAndUserInput } from '../../utils/validation'
@@ -17,6 +18,7 @@ import { firstPageOfApplicationJourney, getResponses, isUnapplicable } from '../
 
 jest.mock('../../utils/validation')
 jest.mock('../../utils/applicationUtils')
+jest.mock('../../services/tasklistService')
 
 describe('applicationsController', () => {
   const token = 'SOME_TOKEN'
@@ -80,14 +82,18 @@ describe('applicationsController', () => {
 
     it('fetches the application from session or the API and renders the task list', async () => {
       const requestHandler = applicationsController.show()
+      const stubTaskList = jest.fn()
 
       applicationService.getApplicationFromSessionOrAPI.mockResolvedValue(application)
+      ;(TasklistService as jest.Mock).mockImplementation(() => {
+        return stubTaskList
+      })
 
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('applications/show', {
         application,
-        sections: Apply.sections,
+        taskList: stubTaskList,
       })
 
       expect(applicationService.findApplication).not.toHaveBeenCalledWith(token, application.id)

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, RequestHandler } from 'express'
 
+import TasklistService from '../../services/tasklistService'
 import ApplicationService from '../../services/applicationService'
 import { PersonService } from '../../services'
 import { fetchErrorsAndUserInput } from '../../utils/validation'
@@ -32,11 +33,12 @@ export default class ApplicationsController {
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
       const application = await this.applicationService.getApplicationFromSessionOrAPI(req)
+      const taskList = new TasklistService(application)
 
       if (isUnapplicable(application)) {
         res.render('applications/notEligible')
       } else {
-        res.render('applications/show', { application, sections: Apply.sections })
+        res.render('applications/show', { application, taskList })
       }
     }
   }

--- a/server/controllers/assess/assessmentsController.test.ts
+++ b/server/controllers/assess/assessmentsController.test.ts
@@ -3,6 +3,7 @@ import type { GroupedAssessments } from '@approved-premises/ui'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 import { Adjudication, ApprovedPremisesAssessment as Assessment, PrisonCaseNote } from '../../@types/shared'
 
+import TasklistService from '../../services/tasklistService'
 import AssessmentsController, { tasklistPageHeading } from './assessmentsController'
 import { AssessmentService } from '../../services'
 
@@ -17,7 +18,7 @@ import { DateFormats } from '../../utils/dateUtils'
 
 jest.mock('../../utils/assessments/utils')
 jest.mock('../../utils/assessments/informationSetAsNotReceived')
-jest.mock('../../utils/assessments/getSections')
+jest.mock('../../services/tasklistService')
 
 describe('assessmentsController', () => {
   const token = 'SOME_TOKEN'
@@ -54,11 +55,15 @@ describe('assessmentsController', () => {
 
   describe('show', () => {
     const assessment = assessmentFactory.build()
+    const stubTaskList = jest.fn()
 
     beforeEach(() => {
       request.params.id = assessment.id
 
       assessmentService.findAssessment.mockResolvedValue(assessment)
+      ;(TasklistService as jest.Mock).mockImplementation(() => {
+        return stubTaskList
+      })
     })
 
     it('fetches the assessment and renders the task list', async () => {
@@ -69,7 +74,7 @@ describe('assessmentsController', () => {
       expect(response.render).toHaveBeenCalledWith('assessments/show', {
         assessment,
         pageHeading: 'Assess an Approved Premises (AP) application',
-        sections: getSections(assessment),
+        taskList: stubTaskList,
       })
 
       expect(assessmentService.findAssessment).toHaveBeenCalledWith(token, assessment.id)
@@ -105,7 +110,7 @@ describe('assessmentsController', () => {
       expect(response.render).toHaveBeenCalledWith('assessments/show', {
         assessment,
         pageHeading: 'Assess an Approved Premises (AP) application',
-        sections: getSections(assessment),
+        taskList: stubTaskList,
       })
 
       expect(assessmentService.findAssessment).toHaveBeenCalledWith(token, assessment.id)

--- a/server/controllers/assess/assessmentsController.ts
+++ b/server/controllers/assess/assessmentsController.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, RequestHandler } from 'express'
 
+import TasklistService from '../../services/tasklistService'
 import { AssessmentService } from '../../services'
 import informationSetAsNotReceived from '../../utils/assessments/informationSetAsNotReceived'
 import { adjudicationsFromAssessment, caseNotesFromAssessment } from '../../utils/assessments/utils'
@@ -26,6 +27,7 @@ export default class AssessmentsController {
     return async (req: Request, res: Response) => {
       const assessment = await this.assessmentService.findAssessment(req.user.token, req.params.id)
       const noteAwaitingResponse = assessment.status === 'pending' && !informationSetAsNotReceived(assessment)
+      const taskList = new TasklistService(assessment)
 
       if (noteAwaitingResponse) {
         res.redirect(
@@ -39,7 +41,7 @@ export default class AssessmentsController {
         res.render('assessments/show', {
           assessment,
           pageHeading: tasklistPageHeading,
-          sections: getSections(assessment),
+          taskList,
         })
       }
     }

--- a/server/form-pages/baseForm.ts
+++ b/server/form-pages/baseForm.ts
@@ -1,11 +1,7 @@
-import { FormPages, Task } from '@approved-premises/ui'
+import { FormPages, FormSections } from '@approved-premises/ui'
 
 export default class BaseForm {
   static pages: FormPages
 
-  static sections: Array<{
-    title: string
-    name: string
-    tasks: Array<Task>
-  }>
+  static sections: FormSections
 }

--- a/server/form-pages/utils/getTaskStatus.test.ts
+++ b/server/form-pages/utils/getTaskStatus.test.ts
@@ -1,0 +1,146 @@
+import { createMock } from '@golevelup/ts-jest'
+import applicationFactory from '../../testutils/factories/application'
+import getTaskStatus from './getTaskStatus'
+import TasklistPage from '../tasklistPage'
+
+describe('getTaskStatus', () => {
+  const page1Instance = createMock<TasklistPage>()
+  const page2Instance = createMock<TasklistPage>()
+  const page3Instance = createMock<TasklistPage>()
+
+  const Page1 = jest.fn(() => page1Instance)
+  const Page2 = jest.fn(() => page2Instance)
+  const Page3 = jest.fn(() => page3Instance)
+
+  const task = {
+    id: 'my-task',
+    title: 'My Task',
+    pages: {
+      'page-1': Page1,
+      'page-2': Page2,
+      'page-3': Page3,
+    },
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns not_started when there is no data for the first question in the task', () => {
+    const application = applicationFactory.build({})
+
+    expect(getTaskStatus(task, application)).toEqual('not_started')
+
+    expect(Page1).not.toHaveBeenCalled()
+    expect(Page2).not.toHaveBeenCalled()
+    expect(Page3).not.toHaveBeenCalled()
+  })
+
+  it('returns in_progress when there is no data for the second question in the task', () => {
+    const application = applicationFactory.build({ data: { 'my-task': { 'page-1': { foo: 'bar' } } } })
+
+    page1Instance.errors.mockReturnValue({})
+    page1Instance.next.mockReturnValue('page-2')
+
+    expect(getTaskStatus(task, application)).toEqual('in_progress')
+
+    expect(Page1).toHaveBeenCalled()
+    expect(page1Instance.errors).toHaveBeenCalled()
+
+    expect(Page2).not.toHaveBeenCalled()
+    expect(Page3).not.toHaveBeenCalled()
+  })
+
+  it('returns in_progress when there are errors', () => {
+    const application = applicationFactory.build({
+      data: { 'my-task': { 'page-1': { foo: 'bar' }, 'page-2': { foo: 'bar' } } },
+    })
+
+    page1Instance.errors.mockReturnValue({ some: 'errors' })
+
+    expect(getTaskStatus(task, application)).toEqual('in_progress')
+
+    expect(Page1).toHaveBeenCalled()
+    expect(page1Instance.errors).toHaveBeenCalled()
+    expect(page1Instance.next).toHaveBeenCalled()
+  })
+
+  it('returns complete when the second page does not have a next page', () => {
+    const application = applicationFactory.build({
+      data: { 'my-task': { 'page-1': { foo: 'bar' }, 'page-2': { foo: 'bar' } } },
+    })
+
+    page1Instance.errors.mockReturnValue({})
+    page1Instance.next.mockReturnValue('page-2')
+
+    page2Instance.errors.mockReturnValue({})
+    page2Instance.next.mockReturnValue('')
+
+    expect(getTaskStatus(task, application)).toEqual('complete')
+
+    expect(Page1).toHaveBeenCalled()
+    expect(page1Instance.errors).toHaveBeenCalled()
+    expect(page1Instance.next).toHaveBeenCalled()
+
+    expect(Page2).toHaveBeenCalled()
+    expect(page2Instance.errors).toHaveBeenCalled()
+    expect(page2Instance.next).toHaveBeenCalled()
+
+    expect(Page3).not.toHaveBeenCalled()
+  })
+
+  it('returns complete when the third page does not have a next page', () => {
+    const application = applicationFactory.build({
+      data: { 'my-task': { 'page-1': { foo: 'bar' }, 'page-2': { foo: 'bar' }, 'page-3': { foo: 'bar' } } },
+    })
+
+    page1Instance.errors.mockReturnValue({})
+    page1Instance.next.mockReturnValue('page-2')
+
+    page2Instance.errors.mockReturnValue({})
+    page2Instance.next.mockReturnValue('page-3')
+
+    page3Instance.errors.mockReturnValue({})
+    page3Instance.next.mockReturnValue('')
+
+    expect(getTaskStatus(task, application)).toEqual('complete')
+
+    expect(Page1).toHaveBeenCalled()
+    expect(page1Instance.errors).toHaveBeenCalled()
+    expect(page1Instance.next).toHaveBeenCalled()
+
+    expect(Page2).toHaveBeenCalled()
+    expect(page2Instance.errors).toHaveBeenCalled()
+    expect(page2Instance.next).toHaveBeenCalled()
+
+    expect(Page3).toHaveBeenCalled()
+    expect(page3Instance.errors).toHaveBeenCalled()
+    expect(page3Instance.next).toHaveBeenCalled()
+  })
+
+  it('returns complete when the first page does not have data, but subsequent ones do', () => {
+    const application = applicationFactory.build({
+      data: { 'my-task': { 'page-2': { foo: 'bar' }, 'page-3': { foo: 'bar' } } },
+    })
+
+    page2Instance.errors.mockReturnValue({})
+    page2Instance.next.mockReturnValue('page-3')
+
+    page3Instance.errors.mockReturnValue({})
+    page3Instance.next.mockReturnValue('')
+
+    expect(getTaskStatus(task, application)).toEqual('complete')
+
+    expect(Page1).not.toHaveBeenCalled()
+    expect(page1Instance.errors).not.toHaveBeenCalled()
+    expect(page1Instance.next).not.toHaveBeenCalled()
+
+    expect(Page2).toHaveBeenCalled()
+    expect(page2Instance.errors).toHaveBeenCalled()
+    expect(page2Instance.next).toHaveBeenCalled()
+
+    expect(Page3).toHaveBeenCalled()
+    expect(page3Instance.errors).toHaveBeenCalled()
+    expect(page3Instance.next).toHaveBeenCalled()
+  })
+})

--- a/server/form-pages/utils/getTaskStatus.ts
+++ b/server/form-pages/utils/getTaskStatus.ts
@@ -1,0 +1,61 @@
+import type { TaskStatus, Task } from '@approved-premises/ui'
+import {
+  ApprovedPremisesApplication as Application,
+  ApprovedPremisesAssessment as Assessment,
+} from '@approved-premises/api'
+import { TasklistPageInterface } from '../tasklistPage'
+
+const getPageData = (applicationOrAssessment: Application | Assessment, taskName: string, pageName: string) => {
+  return applicationOrAssessment.data?.[taskName]?.[pageName]
+}
+
+const getTaskStatus = (task: Task, applicationOrAssessment: Application | Assessment): TaskStatus => {
+  // Find the first page that has an answer
+  let pageId = Object.keys(task.pages).find(
+    (pageName: string) => !!getPageData(applicationOrAssessment, task.id, pageName),
+  )
+
+  let status: TaskStatus
+
+  // If there's no page that's been completed, then we know the task is incomplete
+  if (!pageId) {
+    return 'not_started'
+  }
+
+  while (pageId) {
+    const pageData = getPageData(applicationOrAssessment, task.id, pageId)
+
+    // If there's no page data for this page, then we know it's incomplete
+    if (!pageData) {
+      status = 'in_progress'
+      break
+    }
+
+    // Let's initialize this page
+    const Page = task.pages[pageId] as TasklistPageInterface
+    const page = new Page(pageData, applicationOrAssessment)
+
+    // Get the errors for this page
+    const errors = page.errors()
+    // And the next page ID
+    pageId = page.next()
+
+    if (errors.length) {
+      // Are there any errors? Then the task is incomplete
+      status = 'in_progress'
+      break
+    }
+
+    if (!pageId) {
+      // Is the next page blank? Then the task is complete
+      status = 'complete'
+      break
+    }
+
+    // If none of the above is true, we loop round again!
+  }
+
+  return status
+}
+
+export default getTaskStatus

--- a/server/services/tasklistService.test.ts
+++ b/server/services/tasklistService.test.ts
@@ -116,6 +116,24 @@ describe('tasklistService', () => {
     })
   })
 
+  describe('status', () => {
+    it('returns complete when all sections are complete', () => {
+      ;(getTaskStatus as jest.Mock).mockReturnValue('complete')
+
+      const tasklistService = new TasklistService(application)
+
+      expect(tasklistService.status).toEqual('complete')
+    })
+
+    it('returns incomplete when not all sections are complete', () => {
+      ;(getTaskStatus as jest.Mock).mockReturnValue('not_started')
+
+      const tasklistService = new TasklistService(application)
+
+      expect(tasklistService.status).toEqual('incomplete')
+    })
+  })
+
   describe('sections', () => {
     it('returns the section data with the status of each task and the section number', () => {
       ;(getTaskStatus as jest.Mock).mockReturnValue('cannot_start')

--- a/server/services/tasklistService.test.ts
+++ b/server/services/tasklistService.test.ts
@@ -1,0 +1,146 @@
+import applicationFactory from '../testutils/factories/application'
+import TasklistService from './tasklistService'
+import getTaskStatus from '../form-pages/utils/getTaskStatus'
+
+jest.mock('../form-pages/apply', () => {
+  return {
+    sections: [
+      {
+        title: 'First Section',
+        tasks: [
+          {
+            id: 'first-task',
+            title: 'First task',
+          },
+          {
+            id: 'second-task',
+            title: 'Second task',
+          },
+        ],
+      },
+      {
+        title: 'Second Section',
+        tasks: [
+          {
+            id: 'third-task',
+            title: 'Third task',
+          },
+          {
+            id: 'fourth-task',
+            title: 'Fourth task',
+          },
+          {
+            id: 'fifth-task',
+            title: 'Fifth task',
+          },
+        ],
+      },
+    ],
+  }
+})
+
+jest.mock('../form-pages/utils/getTaskStatus')
+
+describe('tasklistService', () => {
+  const application = applicationFactory.build({ id: 'some-uuid' })
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('taskStatuses', () => {
+    it('returns cannot_start for any subsequent tasks when no tasks are complete', () => {
+      ;(getTaskStatus as jest.Mock).mockReturnValue('not_started')
+
+      const tasklistService = new TasklistService(application)
+
+      expect(tasklistService.taskStatuses).toEqual({
+        'first-task': 'not_started',
+        'second-task': 'cannot_start',
+        'third-task': 'cannot_start',
+        'fourth-task': 'cannot_start',
+        'fifth-task': 'cannot_start',
+      })
+    })
+
+    it('returns a status when the previous task is complete', () => {
+      ;(getTaskStatus as jest.Mock).mockImplementation(t => {
+        if (t.id === 'first-task') {
+          return 'complete'
+        }
+        if (t.id === 'second-task') {
+          return 'in_progress'
+        }
+        return undefined
+      })
+
+      const tasklistService = new TasklistService(application)
+
+      expect(tasklistService.taskStatuses).toEqual({
+        'first-task': 'complete',
+        'second-task': 'in_progress',
+        'third-task': 'cannot_start',
+        'fourth-task': 'cannot_start',
+        'fifth-task': 'cannot_start',
+      })
+
+      expect(getTaskStatus).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('completeSectionCount', () => {
+    it('returns zero when there are no complete sections', () => {
+      ;(getTaskStatus as jest.Mock).mockReturnValue('not_started')
+
+      const tasklistService = new TasklistService(application)
+
+      expect(tasklistService.completeSectionCount).toEqual(0)
+    })
+
+    it('returns 1 when there one section is complete', () => {
+      ;(getTaskStatus as jest.Mock).mockImplementation(t =>
+        ['first-task', 'second-task', 'third-task'].includes(t.id) ? 'complete' : 'not_started',
+      )
+
+      const tasklistService = new TasklistService(application)
+
+      expect(tasklistService.completeSectionCount).toEqual(1)
+    })
+
+    it('returns 2 when all sections are complete', () => {
+      ;(getTaskStatus as jest.Mock).mockReturnValue('complete')
+
+      const tasklistService = new TasklistService(application)
+
+      expect(tasklistService.completeSectionCount).toEqual(2)
+    })
+  })
+
+  describe('sections', () => {
+    it('returns the section data with the status of each task and the section number', () => {
+      ;(getTaskStatus as jest.Mock).mockReturnValue('cannot_start')
+
+      const tasklistService = new TasklistService(application)
+
+      expect(tasklistService.sections).toEqual([
+        {
+          sectionNumber: 1,
+          title: 'First Section',
+          tasks: [
+            { id: 'first-task', title: 'First task', status: 'cannot_start' },
+            { id: 'second-task', title: 'Second task', status: 'cannot_start' },
+          ],
+        },
+        {
+          sectionNumber: 2,
+          title: 'Second Section',
+          tasks: [
+            { id: 'third-task', title: 'Third task', status: 'cannot_start' },
+            { id: 'fourth-task', title: 'Fourth task', status: 'cannot_start' },
+            { id: 'fifth-task', title: 'Fifth task', status: 'cannot_start' },
+          ],
+        },
+      ])
+    })
+  })
+})

--- a/server/services/tasklistService.ts
+++ b/server/services/tasklistService.ts
@@ -48,6 +48,11 @@ export default class TasklistService {
     })
   }
 
+  get status() {
+    const completeTasks = Object.values(this.taskStatuses).filter(t => t === 'complete')
+    return completeTasks.length === Object.keys(this.taskStatuses).length ? 'complete' : 'incomplete'
+  }
+
   addStatusToTask(task: Task): TaskWithStatus {
     return { ...task, status: this.taskStatuses[task.id] }
   }

--- a/server/services/tasklistService.ts
+++ b/server/services/tasklistService.ts
@@ -1,0 +1,54 @@
+import {
+  ApprovedPremisesApplication as Application,
+  ApprovedPremisesAssessment as Assessment,
+} from '@approved-premises/api'
+import { TaskStatus, FormSections, TaskWithStatus, Task } from '@approved-premises/ui'
+import getSections from '../utils/assessments/getSections'
+import Apply from '../form-pages/apply'
+import isAssessment from '../utils/assessments/isAssessment'
+import getTaskStatus from '../form-pages/utils/getTaskStatus'
+
+export default class TasklistService {
+  taskStatuses: Record<string, TaskStatus>
+
+  formSections: FormSections
+
+  constructor(applicationOrAssessment: Application | Assessment) {
+    this.formSections = isAssessment(applicationOrAssessment) ? getSections(applicationOrAssessment) : Apply.sections
+    this.taskStatuses = {}
+
+    this.formSections.forEach(section => {
+      section.tasks.forEach(task => {
+        const previousTaskKey = Object.keys(this.taskStatuses).at(-1)
+        const previousTaskStatus = this.taskStatuses[previousTaskKey]
+
+        if (!previousTaskStatus || previousTaskStatus === 'complete') {
+          this.taskStatuses[task.id] = getTaskStatus(task, applicationOrAssessment)
+        } else {
+          this.taskStatuses[task.id] = 'cannot_start'
+        }
+      })
+    })
+  }
+
+  get completeSectionCount() {
+    return this.formSections.filter(section => {
+      const taskIds = section.tasks.map(s => s.id)
+      const completeTasks = Object.keys(this.taskStatuses)
+        .filter(k => taskIds.includes(k))
+        .filter(k => this.taskStatuses[k] === 'complete')
+      return completeTasks.length === taskIds.length
+    }).length
+  }
+
+  get sections() {
+    return this.formSections.map((s, i) => {
+      const tasks = s.tasks.map(t => this.addStatusToTask(t))
+      return { sectionNumber: i + 1, title: s.title, tasks }
+    })
+  }
+
+  addStatusToTask(task: Task): TaskWithStatus {
+    return { ...task, status: this.taskStatuses[task.id] }
+  }
+}

--- a/server/utils/taskListUtils.test.ts
+++ b/server/utils/taskListUtils.test.ts
@@ -1,161 +1,95 @@
-import { Task } from '../@types/ui'
+import { TaskWithStatus } from '../@types/ui'
 import applyPaths from '../paths/apply'
 import assessPaths from '../paths/assess'
 import applicationFactory from '../testutils/factories/application'
 import assessmentFactory from '../testutils/factories/assessment'
-import { getTaskStatus, getCompleteSectionCount, taskLink } from './taskListUtils'
-import Apply from '../form-pages/apply'
-
-const FirstPage = jest.fn()
-const SecondPage = jest.fn()
-
-jest.mock('../form-pages/apply', () => {
-  return {
-    pages: { 'first-task': {}, 'second-task': {} },
-  }
-})
-
-jest.mock('./assessments/getSections', () => {
-  return () => {
-    return { 'first-task': {}, 'second-task': {} }
-  }
-})
-
-Apply.pages['basic-information'] = {
-  first: FirstPage,
-  second: SecondPage,
-}
+import { statusTag, taskLink } from './taskListUtils'
 
 describe('taskListUtils', () => {
   const task = {
     id: 'second-task',
     title: 'Second Task',
     pages: { foo: 'bar', bar: 'baz' },
-  } as Task
+    status: 'in_progress',
+  } as TaskWithStatus
 
-  ;[
-    {
-      type: 'applications',
-      object: applicationFactory.build({ id: 'some-uuid' }),
-      paths: applyPaths.applications.pages,
-    },
-    {
-      type: 'assessments',
-      object: assessmentFactory.build({ id: 'some-uuid' }),
-      paths: assessPaths.assessments.pages,
-    },
-  ].forEach(item => {
-    describe(`with ${item.type}`, () => {
-      describe('taskLink', () => {
-        it('should return a link to a task when the previous task is complete', () => {
-          item.object.data = { 'first-task': { foo: 'bar' } }
+  describe('taskLink', () => {
+    describe('with an application', () => {
+      const application = applicationFactory.build({ id: 'some-uuid' })
 
-          expect(taskLink(task, item.object)).toEqual(
-            `<a href="${item.paths.show({
-              id: 'some-uuid',
-              task: 'second-task',
-              page: 'foo',
-            })}" aria-describedby="eligibility-second-task" data-cy-task-name="second-task">Second Task</a>`,
-          )
-        })
+      it('should return a link to a task the task can be started', () => {
+        task.status = 'in_progress'
 
-        it('should return the task name when the previous task is incomplete', () => {
-          item.object.data = {}
-
-          expect(taskLink(task, item.object)).toEqual(`Second Task`)
-        })
-
-        it('should return the task name when the application has no data', () => {
-          item.object.data = null
-
-          expect(taskLink(task, item.object)).toEqual(`Second Task`)
-        })
+        expect(taskLink(task, application)).toEqual(
+          `<a href="${applyPaths.applications.pages.show({
+            id: 'some-uuid',
+            task: 'second-task',
+            page: 'foo',
+          })}" aria-describedby="eligibility-second-task" data-cy-task-name="second-task">Second Task</a>`,
+        )
       })
 
-      describe('getTaskStatus', () => {
-        it('returns a cannot start tag when the task is incomplete and the previous task is also complete', () => {
-          expect(getTaskStatus(task, item.object)).toEqual(
-            '<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="second-task-status">Cannot start yet</strong>',
-          )
-        })
+      it('should return the task name when the task cannot be started', () => {
+        task.status = 'cannot_start'
 
-        it('returns a not started tag when the task is incomplete and the previous task is complete', () => {
-          item.object.data = { 'first-task': { foo: 'bar' } }
+        expect(taskLink(task, application)).toEqual(`Second Task`)
+      })
+    })
 
-          expect(getTaskStatus(task, item.object)).toEqual(
-            '<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="second-task-status">Not started</strong>',
-          )
-        })
+    describe('with an assessment', () => {
+      const application = assessmentFactory.build({ id: 'some-uuid' })
 
-        it('returns a completed tag when the task is complete', () => {
-          item.object.data = { 'first-task': { foo: 'bar' }, 'second-task': { foo: 'bar' } }
+      it('should return a link to a task the task can be started', () => {
+        task.status = 'in_progress'
 
-          expect(getTaskStatus(task, item.object)).toEqual(
-            '<strong class="govuk-tag app-task-list__tag" id="second-task-status">Completed</strong>',
-          )
-        })
-
-        it('works when the application has no data', () => {
-          item.object.data = null
-
-          expect(getTaskStatus(task, item.object)).toEqual(
-            '<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="second-task-status">Cannot start yet</strong>',
-          )
-        })
+        expect(taskLink(task, application)).toEqual(
+          `<a href="${assessPaths.assessments.pages.show({
+            id: 'some-uuid',
+            task: 'second-task',
+            page: 'foo',
+          })}" aria-describedby="eligibility-second-task" data-cy-task-name="second-task">Second Task</a>`,
+        )
       })
 
-      describe('getCompleteSectionCount', () => {
-        const sections = [
-          {
-            title: 'Section 1',
-            tasks: [
-              {
-                id: 'first-task',
-                title: 'Basic Information',
-                pages: { foo: 'bar', bar: 'baz' },
-              },
-              task,
-            ],
-          },
-          {
-            title: 'Section 2',
-            tasks: [
-              {
-                id: 'something-else',
-                title: 'Something Else',
-                pages: { foo: 'bar', bar: 'baz' },
-              },
-            ],
-          },
-        ]
+      it('should return the task name when the task cannot be started', () => {
+        task.status = 'cannot_start'
 
-        it('returns zero when no sections are completed', () => {
-          item.object.data = {}
-
-          expect(getCompleteSectionCount(sections, item.object)).toEqual(0)
-        })
-
-        it('returns zero when a section is part completed', () => {
-          item.object.data = { 'second-task': { foo: 'bar' } }
-
-          expect(getCompleteSectionCount(sections, item.object)).toEqual(0)
-        })
-
-        it('returns 1 when a section is complete', () => {
-          item.object.data = { 'second-task': { foo: 'bar' }, 'first-task': { foo: 'baz' } }
-          expect(getCompleteSectionCount(sections, item.object)).toEqual(1)
-        })
-
-        it('returns 2 when a both sections are complete', () => {
-          item.object.data = {
-            'second-task': { foo: 'bar' },
-            'first-task': { foo: 'baz' },
-            'something-else': { foo: 'baz' },
-          }
-
-          expect(getCompleteSectionCount(sections, item.object)).toEqual(2)
-        })
+        expect(taskLink(task, application)).toEqual(`Second Task`)
       })
+    })
+  })
+
+  describe('statusTag', () => {
+    it('returns a an in progress tag when the task is in progress', () => {
+      task.status = 'in_progress'
+
+      expect(statusTag(task)).toEqual(
+        '<strong class="govuk-tag govuk-tag--blue app-task-list__tag" id="second-task-status">In progress</strong>',
+      )
+    })
+
+    it('returns an in progress tag when the task is has not been started', () => {
+      task.status = 'in_progress'
+
+      expect(statusTag(task)).toEqual(
+        '<strong class="govuk-tag govuk-tag--blue app-task-list__tag" id="second-task-status">In progress</strong>',
+      )
+    })
+
+    it('returns a not started tag when the task is has not been started', () => {
+      task.status = 'not_started'
+
+      expect(statusTag(task)).toEqual(
+        '<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="second-task-status">Not started</strong>',
+      )
+    })
+
+    it('returns a cannot start tag when the task cannot be started', () => {
+      task.status = 'cannot_start'
+
+      expect(statusTag(task)).toEqual(
+        '<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="second-task-status">Cannot start yet</strong>',
+      )
     })
   })
 })

--- a/server/utils/taskListUtils.ts
+++ b/server/utils/taskListUtils.ts
@@ -1,49 +1,24 @@
-import type { FormSections, FormSection } from '@approved-premises/ui'
+import type { TaskWithStatus } from '@approved-premises/ui'
 import { ApprovedPremisesApplication as Application, ApprovedPremisesAssessment as Assessment } from '../@types/shared'
-import { Task } from '../@types/ui'
-import getAssessmentSections from './assessments/getSections'
 import applyPaths from '../paths/apply'
 import assessPaths from '../paths/assess'
-import Apply from '../form-pages/apply'
 import isAssessment from './assessments/isAssessment'
 
-const taskIsComplete = (task: Task, applicationOrAssessment: Application | Assessment): boolean => {
-  return applicationOrAssessment.data?.[task.id]
-}
-
-const previousTaskIsComplete = (task: Task, applicationOrAssessment: Application | Assessment): boolean => {
-  const taskIds = isAssessment(applicationOrAssessment)
-    ? Object.keys(getAssessmentSections(applicationOrAssessment))
-    : Object.keys(Apply.pages)
-
-  const previousTaskId = taskIds[taskIds.indexOf(task.id) - 1]
-
-  return previousTaskId ? applicationOrAssessment.data?.[previousTaskId] : true
-}
-
-const getTaskStatus = (task: Task, applicationOrAssessment: Application | Assessment): string => {
-  if (!taskIsComplete(task, applicationOrAssessment) && !previousTaskIsComplete(task, applicationOrAssessment)) {
-    return `<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="${task.id}-status">Cannot start yet</strong>`
+export const statusTag = (task: TaskWithStatus): string => {
+  switch (task.status) {
+    case 'complete':
+      return `<strong class="govuk-tag app-task-list__tag" id="${task.id}-status">Completed</strong>`
+    case 'in_progress':
+      return `<strong class="govuk-tag govuk-tag--blue app-task-list__tag" id="${task.id}-status">In progress</strong>`
+    case 'not_started':
+      return `<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="${task.id}-status">Not started</strong>`
+    default:
+      return `<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="${task.id}-status">Cannot start yet</strong>`
   }
-
-  if (!taskIsComplete(task, applicationOrAssessment) && previousTaskIsComplete(task, applicationOrAssessment)) {
-    return `<strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="${task.id}-status">Not started</strong>`
-  }
-
-  return `<strong class="govuk-tag app-task-list__tag" id="${task.id}-status">Completed</strong>`
 }
 
-const getCompleteSectionCount = (sections: FormSections, applicationOrAssessment: Application | Assessment): number => {
-  return sections.filter((section: FormSection) => {
-    return (
-      section.tasks.filter((task: Task) => taskIsComplete(task, applicationOrAssessment)).length ===
-      section.tasks.length
-    )
-  }).length
-}
-
-const taskLink = (task: Task, applicationOrAssessment: Application | Assessment): string => {
-  if (previousTaskIsComplete(task, applicationOrAssessment)) {
+export const taskLink = (task: TaskWithStatus, applicationOrAssessment: Application | Assessment): string => {
+  if (task.status !== 'cannot_start') {
     const firstPage = Object.keys(task.pages)[0]
 
     const link = isAssessment(applicationOrAssessment)
@@ -62,5 +37,3 @@ const taskLink = (task: Task, applicationOrAssessment: Application | Assessment)
   }
   return task.title
 }
-
-export { taskLink, getCompleteSectionCount, getTaskStatus, previousTaskIsComplete, taskIsComplete }

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -19,7 +19,7 @@
         Apply for an Approved Premises (AP) placement
       </h1>
 
-      <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Application incomplete</h2>
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-2" data-cy-status>Application {{ taskList.status }}</h2>
       <p class="govuk-body govuk-!-margin-bottom-7">You have completed {{ taskList.completeSectionCount }} of {{ (taskList.sections | length) }} sections.</p>
     </div>
     {{ showErrorSummary(errorSummary) }}

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -20,7 +20,7 @@
       </h1>
 
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Application incomplete</h2>
-      <p class="govuk-body govuk-!-margin-bottom-7">You have completed {{ taskList.completeSectionCount }} of {{ (sections | length) }} sections.</p>
+      <p class="govuk-body govuk-!-margin-bottom-7">You have completed {{ taskList.completeSectionCount }} of {{ (taskList.sections | length) }} sections.</p>
     </div>
     {{ showErrorSummary(errorSummary) }}
 
@@ -28,24 +28,8 @@
       <form action="{{ paths.applications.submission({id: application.id}) }}" method="post">
 
         <ol class="app-task-list">
-          {% for section in taskList.sections %}
-            <li>
-              <h2 class="app-task-list__section">
-                <span class="app-task-list__section-number">{{ section.sectionNumber }}. </span>
-                {{ section.title }}
-              </h2>
-              <ul class="app-task-list__items">
-                {% for task in section.tasks %}
-                  <li class="app-task-list__item">
-                    <span class="app-task-list__task-name">
-                      {{ TasklistUtils.taskLink(task, application) | safe   }}
-                    </span>
-                    {{ TasklistUtils.statusTag(task) | safe  }}
-                  </li>
-                {% endfor %}
-              </ul>
-            </li>
-          {% endfor %}
+          {% set applicationOrAssessment = application %}
+          {% include '../partials/taskListItems.njk' %}
 
           <li>
             <h2 class="app-task-list__section">

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -20,7 +20,7 @@
       </h1>
 
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Application incomplete</h2>
-      <p class="govuk-body govuk-!-margin-bottom-7">You have completed {{ TasklistUtils.getCompleteSectionCount(sections, application) }} of {{ (sections | length) }} sections.</p>
+      <p class="govuk-body govuk-!-margin-bottom-7">You have completed {{ taskList.completeSectionCount }} of {{ (sections | length) }} sections.</p>
     </div>
     {{ showErrorSummary(errorSummary) }}
 
@@ -28,19 +28,19 @@
       <form action="{{ paths.applications.submission({id: application.id}) }}" method="post">
 
         <ol class="app-task-list">
-          {% for section in sections %}
+          {% for section in taskList.sections %}
             <li>
               <h2 class="app-task-list__section">
-                <span class="app-task-list__section-number">{{loop.index}}. </span>
+                <span class="app-task-list__section-number">{{ section.sectionNumber }}. </span>
                 {{ section.title }}
               </h2>
               <ul class="app-task-list__items">
                 {% for task in section.tasks %}
                   <li class="app-task-list__item">
                     <span class="app-task-list__task-name">
-                      {{ TasklistUtils.taskLink(task, application) | safe  }}
+                      {{ TasklistUtils.taskLink(task, application) | safe   }}
                     </span>
-                    {{ TasklistUtils.getTaskStatus(task, application) | safe }}
+                    {{ TasklistUtils.statusTag(task) | safe  }}
                   </li>
                 {% endfor %}
               </ul>
@@ -50,7 +50,7 @@
           <li>
             <h2 class="app-task-list__section">
               <span class="app-task-list__section-number">
-                {{ (sections | length) + 1 }}.
+                {{ (taskList.sections | length) + 1 }}.
             </span>
             Submit your application
           </h2>

--- a/server/views/assessments/show.njk
+++ b/server/views/assessments/show.njk
@@ -13,17 +13,19 @@
       </h1>
 
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Assessment incomplete</h2>
+      <p class="govuk-body govuk-!-margin-bottom-7">You have completed {{ taskList.completeSectionCount }} of {{ (sections | length) }} sections.</p>
     </div>
 
     {{ showErrorSummary(errorSummary) }}
+
     <form action="{{ paths.assessments.submission({id: assessment.id}) }}" method="post">
 
       <div class="govuk-grid-column-two-thirds">
         <ol class="app-task-list">
-          {% for section in sections %}
+          {% for section in taskList.sections %}
             <li>
               <h2 class="app-task-list__section">
-                <span class="app-task-list__section-number">{{loop.index}}. </span>
+                <span class="app-task-list__section-number">{{ section.sectionNumber }}. </span>
                 {{ section.title }}
               </h2>
               <ul class="app-task-list__items">
@@ -32,7 +34,7 @@
                     <span class="app-task-list__task-name">
                       {{ TasklistUtils.taskLink(task, assessment) | safe   }}
                     </span>
-                    {{ TasklistUtils.getTaskStatus(task, assessment) | safe  }}
+                    {{ TasklistUtils.statusTag(task) | safe  }}
                   </li>
                 {% endfor %}
               </ul>

--- a/server/views/assessments/show.njk
+++ b/server/views/assessments/show.njk
@@ -13,7 +13,7 @@
       </h1>
 
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Assessment incomplete</h2>
-      <p class="govuk-body govuk-!-margin-bottom-7">You have completed {{ taskList.completeSectionCount }} of {{ (sections | length) }} sections.</p>
+      <p class="govuk-body govuk-!-margin-bottom-7">You have completed {{ taskList.completeSectionCount }} of {{ (taskList.sections | length) }} sections.</p>
     </div>
 
     {{ showErrorSummary(errorSummary) }}
@@ -22,24 +22,8 @@
 
       <div class="govuk-grid-column-two-thirds">
         <ol class="app-task-list">
-          {% for section in taskList.sections %}
-            <li>
-              <h2 class="app-task-list__section">
-                <span class="app-task-list__section-number">{{ section.sectionNumber }}. </span>
-                {{ section.title }}
-              </h2>
-              <ul class="app-task-list__items">
-                {% for task in section.tasks %}
-                  <li class="app-task-list__item">
-                    <span class="app-task-list__task-name">
-                      {{ TasklistUtils.taskLink(task, assessment) | safe   }}
-                    </span>
-                    {{ TasklistUtils.statusTag(task) | safe  }}
-                  </li>
-                {% endfor %}
-              </ul>
-            </li>
-          {% endfor %}
+          {% set applicationOrAssessment = assessment %}
+          {% include '../partials/taskListItems.njk' %}
 
           <li>
             <h2 class="app-task-list__section">

--- a/server/views/assessments/show.njk
+++ b/server/views/assessments/show.njk
@@ -12,7 +12,7 @@
         {{ pageHeading }}
       </h1>
 
-      <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Assessment incomplete</h2>
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-2" data-cy-status>Assessment {{ taskList.status }}</h2>
       <p class="govuk-body govuk-!-margin-bottom-7">You have completed {{ taskList.completeSectionCount }} of {{ (taskList.sections | length) }} sections.</p>
     </div>
 

--- a/server/views/partials/taskListItems.njk
+++ b/server/views/partials/taskListItems.njk
@@ -1,0 +1,18 @@
+{% for section in taskList.sections %}
+  <li>
+    <h2 class="app-task-list__section">
+      <span class="app-task-list__section-number">{{ section.sectionNumber }}. </span>
+      {{ section.title }}
+    </h2>
+    <ul class="app-task-list__items">
+      {% for task in section.tasks %}
+        <li class="app-task-list__item">
+          <span class="app-task-list__task-name">
+            {{ TasklistUtils.taskLink(task, applicationOrAssessment) | safe   }}
+          </span>
+          {{ TasklistUtils.statusTag(task) | safe  }}
+        </li>
+      {% endfor %}
+    </ul>
+  </li>
+{% endfor %}


### PR DESCRIPTION
Before, how we worked out the status of a task was rather "dumb", i.e. we checked if there was any data for the task, and assumed it was complete. This resulted in some unexpected behaviour, and also made it harder to work out if a task was partially complete.

This PR adds a new helper function that walks through the pages of a task and works out if each page in the journey is complete or not, returning a status for that task. This is then used in a new Service class, which memoizes all theses statuses for use in the frontend.

This means that we can much more reliably work out the status of a task, and also makes some of the util functionality much easier to deal with.

At the moment, in the integrations tests, Assess returns "Completed" for all the tasks, as the stubs are not working / updating in the way we expect (so we're stubbing the complete application each time). Given the time constraints we're under, I'm going to leave this for now, but I would like us to work out how our tests for the Assess journey could be more stateful, but that's not for now.