### PR TITLE
(1215) Add user role to session object

### DIFF
--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -138,6 +138,23 @@ const stubUser = (name: string) =>
     },
   })
 
+const stubProfile = () =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/profile',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: {
+        roles: [],
+      },
+    },
+  })
+
 const stubUserRoles = () =>
   stubFor({
     request: {
@@ -158,5 +175,6 @@ export default {
   stubAuthPing: ping,
   stubSignIn: (): Promise<[Response, Response, Response, Response, Response, Response]> =>
     Promise.all([favicon(), redirect(), signOut(), manageDetails(), token(), tokenVerification.stubVerifyToken()]),
-  stubAuthUser: (name = 'john smith'): Promise<[Response, Response]> => Promise.all([stubUser(name), stubUserRoles()]),
+  stubAuthUser: (name = 'john smith'): Promise<[Response, Response, Response]> =>
+    Promise.all([stubUser(name), stubUserRoles(), stubProfile()]),
 }

--- a/server/data/userClient.test.ts
+++ b/server/data/userClient.test.ts
@@ -40,4 +40,18 @@ describe('UserClient', () => {
       expect(output).toEqual(user)
     })
   })
+
+  describe('getUserProfile', () => {
+    const user = userFactory.build()
+
+    it('should return a user', async () => {
+      fakeApprovedPremisesApi
+        .get(paths.users.profile({}))
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, user)
+
+      const output = await userClient.getUserProfile()
+      expect(output).toEqual(user)
+    })
+  })
 })

--- a/server/data/userClient.ts
+++ b/server/data/userClient.ts
@@ -13,4 +13,8 @@ export default class UserClient {
   async getActingUser(id: string): Promise<User> {
     return (await this.restClient.get({ path: paths.users.show({ id }) })) as User
   }
+
+  async getUserProfile(): Promise<User> {
+    return (await this.restClient.get({ path: paths.users.profile({}) })) as User
+  }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -92,5 +92,6 @@ export default {
   },
   users: {
     show: usersPath.path(':id'),
+    profile: path('/profile'),
   },
 }

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -12,6 +12,7 @@ const token = 'some token'
 describe('User service', () => {
   const userClient: jest.Mocked<UserClient> = new UserClient(null) as jest.Mocked<UserClient>
   const userClientFactory = jest.fn()
+  const userProfile = userFactory.build({ roles: ['workflow_manager', 'assessor'] })
 
   let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
   let userService: UserService
@@ -23,6 +24,8 @@ describe('User service', () => {
     userClientFactory.mockReturnValue(userClient)
 
     userService = new UserService(hmppsAuthClient, userClientFactory)
+
+    userClient.getUserProfile.mockResolvedValue(userProfile)
   })
 
   describe('getUser', () => {
@@ -32,6 +35,14 @@ describe('User service', () => {
       const result = await userService.getActingUser(token)
 
       expect(result.displayName).toEqual('John Smith')
+    })
+
+    it('retrieves and populates roles', async () => {
+      hmppsAuthClient.getActingUser.mockResolvedValue({ name: 'john smith' } as User)
+
+      const result = await userService.getActingUser(token)
+
+      expect(result.roles).toEqual(['workflow_manager', 'assessor'])
     })
 
     it('Propagates error', async () => {

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,4 +1,4 @@
-import { User } from '@approved-premises/api'
+import { User, UserRole } from '@approved-premises/api'
 import { RestClientBuilder, UserClient } from '../data'
 import { convertToTitleCase } from '../utils/utils'
 import type HmppsAuthClient from '../data/hmppsAuthClient'
@@ -6,6 +6,7 @@ import type HmppsAuthClient from '../data/hmppsAuthClient'
 interface UserDetails {
   name: string
   displayName: string
+  roles: Array<UserRole>
 }
 
 export default class UserService {
@@ -16,7 +17,9 @@ export default class UserService {
 
   async getActingUser(token: string): Promise<UserDetails> {
     const user = await this.hmppsAuthClient.getActingUser(token)
-    return { ...user, displayName: convertToTitleCase(user.name) }
+    const client = this.userClientFactory(token)
+    const profile = await client.getUserProfile()
+    return { ...user, displayName: convertToTitleCase(user.name), roles: profile.roles }
   }
 
   async getUserById(token: string, id: string): Promise<User> {


### PR DESCRIPTION
To ensure only certain users can only access certain pages, we need to fetch the user's details from the `/profile` endpoint and append the roles to the `user` object in the session. 