### PR TITLE
Make adjudication findings nullable

### DIFF
--- a/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
+++ b/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
@@ -7,11 +7,16 @@ import TasklistPage from '../../../tasklistPage'
 import { DateFormats } from '../../../../utils/dateUtils'
 import { Page } from '../../../utils/decorators'
 
+type CaseNotesAdjudication = Omit<Adjudication, 'finding'> & {
+  /** @nullable */
+  finding?: string | null
+}
+
 type CaseNotesBody = {
   caseNoteIds: Array<string>
   selectedCaseNotes: Array<PrisonCaseNote>
   moreDetail: string
-  adjudications: Array<Adjudication>
+  adjudications: Array<CaseNotesAdjudication>
 }
 
 export const caseNoteResponse = (caseNote: PrisonCaseNote) => {

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -922,27 +922,39 @@
             "adjudications": {
               "type": "array",
               "items": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "number"
+                "allOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "reportedAt": {
+                        "type": "string"
+                      },
+                      "establishment": {
+                        "type": "string"
+                      },
+                      "offenceDescription": {
+                        "type": "string"
+                      },
+                      "hearingHeld": {
+                        "type": "boolean"
+                      }
+                    }
                   },
-                  "reportedAt": {
-                    "type": "string"
-                  },
-                  "establishment": {
-                    "type": "string"
-                  },
-                  "offenceDescription": {
-                    "type": "string"
-                  },
-                  "hearingHeld": {
-                    "type": "boolean"
-                  },
-                  "finding": {
-                    "type": "string"
+                  {
+                    "type": "object",
+                    "properties": {
+                      "finding": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
                   }
-                }
+                ]
               }
             }
           }


### PR DESCRIPTION
Adjudication findings are optional, but if a finding has a null entry, this causes the schema validator to choke. This extends the `Adjudication` type to be truly nullable, as well as adding a magic comment to ensure the schema generator does the right thing.