### PR TITLE
Apply - Add ACCT alerts

### DIFF
--- a/cypress_shared/fixtures/applicationData.json
+++ b/cypress_shared/fixtures/applicationData.json
@@ -250,6 +250,24 @@
           "hearingHeld": false,
           "finding": "PROVED"
         }
+      ],
+      "acctAlerts": [
+        {
+          "alertId": 47419,
+          "dateCreated": "2022-12-05",
+          "dateExpires": "2023-05-29",
+          "comment": "Soluta harum harum hic maxime reprehenderit quis harum necessitatibus.",
+          "expired": false,
+          "active": true
+        },
+        {
+          "alertId": 429,
+          "dateCreated": "2022-05-21",
+          "dateExpires": "2023-12-16",
+          "comment": "Quia ex nisi deserunt voluptatibus sit ipsa.",
+          "expired": false,
+          "active": true
+        }
       ]
     }
   },

--- a/cypress_shared/helpers/apply.ts
+++ b/cypress_shared/helpers/apply.ts
@@ -10,6 +10,7 @@ import {
   Document,
   OASysSection,
   Person,
+  PersonAcctAlert,
   PrisonCaseNote,
 } from '@approved-premises/api'
 import { PersonRisksUI } from '@approved-premises/ui'
@@ -59,6 +60,7 @@ import {
 import Page from '../pages'
 
 import adjudicationsFactory from '../../server/testutils/factories/adjudication'
+import acctAlertFactory from '../../server/testutils/factories/acctAlert'
 import documentFactory from '../../server/testutils/factories/document'
 import oasysSectionsFactory from '../../server/testutils/factories/oasysSections'
 import oasysSelectionFactory from '../../server/testutils/factories/oasysSelection'
@@ -108,6 +110,8 @@ export default class ApplyHelper {
 
   adjudications: Array<Adjudication> = []
 
+  acctAlerts: Array<PersonAcctAlert> = []
+
   moreDetail = 'Some detail'
 
   documents: Array<Document> = []
@@ -133,6 +137,7 @@ export default class ApplyHelper {
     this.stubOasysEndpoints()
     this.stubPrisonCaseNoteEndpoints()
     this.stubAdjudicationEndpoints()
+    this.stubAcctAlertsEndpoint()
     this.stubDocumentEndpoints()
     this.stubOffences()
   }
@@ -325,6 +330,29 @@ export default class ApplyHelper {
     this.moreDetail = 'some details'
 
     cy.task('stubAdjudications', { adjudications: this.adjudications, person: this.person })
+  }
+
+  private stubAcctAlertsEndpoint() {
+    const acctAlert1 = acctAlertFactory.build({
+      alertId: 47419,
+      dateCreated: '2022-12-05',
+      dateExpires: '2023-05-29',
+      comment: 'Soluta harum harum hic maxime reprehenderit quis harum necessitatibus.',
+      expired: false,
+      active: true,
+    })
+    const acctAlert2 = acctAlertFactory.build({
+      alertId: 429,
+      dateCreated: '2022-05-21',
+      dateExpires: '2023-12-16',
+      comment: 'Quia ex nisi deserunt voluptatibus sit ipsa.',
+      expired: false,
+      active: true,
+    })
+
+    this.acctAlerts = [acctAlert1, acctAlert2]
+
+    cy.task('stubAcctAlerts', { person: this.person, acctAlerts: this.acctAlerts })
   }
 
   private stubDocumentEndpoints() {
@@ -523,6 +551,7 @@ export default class ApplyHelper {
 
     const caseNotesPage = new CaseNotesPage(this.application, this.selectedPrisonCaseNotes)
     caseNotesPage.shouldDisplayAdjudications(this.adjudications)
+    caseNotesPage.shouldDisplayAcctAlerts(this.acctAlerts)
     caseNotesPage.completeForm(this.moreDetail)
     caseNotesPage.clickSubmit()
 

--- a/cypress_shared/pages/apply/caseNotes.ts
+++ b/cypress_shared/pages/apply/caseNotes.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesApplication, PrisonCaseNote } from '@approved-premises/api'
+import { ApprovedPremisesApplication, PrisonCaseNote, PersonAcctAlert } from '@approved-premises/api'
 import paths from '../../../server/paths/apply'
 
 import { DateFormats } from '../../../server/utils/dateUtils'
@@ -33,5 +33,21 @@ export default class CaseNotesPage extends ApplyPage {
     })
 
     this.getTextInputByIdAndEnterDetails('moreDetail', moreDetail)
+  }
+
+  shouldDisplayAcctAlerts(acctAlerts: Array<PersonAcctAlert>) {
+    cy.get('a').contains('ACCT').click()
+    acctAlerts.forEach(acctAlert => {
+      cy.get('tr')
+        .contains(`${acctAlert.alertId}`)
+        .parent()
+        .within(() => {
+          cy.get('td').eq(1).contains(acctAlert.comment)
+          cy.get('td').eq(2).contains(DateFormats.isoDateToUIDate(acctAlert.dateCreated))
+          cy.get('td')
+            .eq(3)
+            .contains(DateFormats.isoDateToUIDate(acctAlert.dateExpires as string))
+        })
+    })
   }
 }

--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -12,9 +12,11 @@ import type {
   OASysSection,
   OASysSections,
   Document,
+  PersonAcctAlert,
 } from '@approved-premises/api'
 
 import { stubFor, getMatchingRequests } from '../../wiremock'
+import paths from '../../server/paths/api'
 
 export default {
   stubFindPerson: (args: { person: Person }): SuperAgentRequest =>
@@ -94,6 +96,19 @@ export default {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: args.adjudications,
+      },
+    }),
+
+  stubAcctAlerts: (args: { person: Person; acctAlerts: Array<PersonAcctAlert> }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: paths.people.acctAlerts({ crn: args.person.crn }),
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.acctAlerts,
       },
     }),
 

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -15,6 +15,7 @@ import {
   ArrayOfOASysRiskManagementPlanQuestions,
   Booking,
   Application,
+  PersonAcctAlert,
 } from '@approved-premises/api'
 
 interface TasklistPage {
@@ -202,6 +203,7 @@ export type DataServices = Partial<{
   personService: {
     getPrisonCaseNotes: (token: string, crn: string) => Promise<Array<PrisonCaseNote>>
     getAdjudications: (token: string, crn: string) => Promise<Array<Adjudication>>
+    getAcctAlerts: (token: string, crn: string) => Promise<Array<PersonAcctAlert>>
     getOasysSelections: (token: string, crn: string) => Promise<Array<OASysSection>>
     getOasysSections: (token: string, crn: string, selectedSections?: Array<number>) => Promise<OASysSections>
     getPersonRisks: (token: string, crn: string) => Promise<PersonRisksUI>

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -9,6 +9,7 @@ import personFactory from '../testutils/factories/person'
 import prisonCaseNotesFactory from '../testutils/factories/prisonCaseNotes'
 import paths from '../paths/api'
 import adjudicationsFactory from '../testutils/factories/adjudication'
+import acctAlertFactory from '../testutils/factories/acctAlert'
 import activeOffenceFactory from '../testutils/factories/activeOffence'
 import oasysSelectionFactory from '../testutils/factories/oasysSelection'
 import oasysSectionsFactory from '../testutils/factories/oasysSections'
@@ -100,6 +101,23 @@ describe('PersonClient', () => {
       const result = await personClient.adjudications(crn)
 
       expect(result).toEqual(adjudications)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+
+  describe('acctAlerts', () => {
+    it('should return the acctAlerts for a person', async () => {
+      const crn = 'crn'
+      const acctAlerts = acctAlertFactory.buildList(5)
+
+      fakeApprovedPremisesApi
+        .get(paths.people.acctAlerts({ crn }))
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(201, acctAlerts)
+
+      const result = await personClient.acctAlerts(crn)
+
+      expect(result).toEqual(acctAlerts)
       expect(nock.isDone()).toBeTruthy()
     })
   })

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -9,6 +9,7 @@ import type {
   PrisonCaseNote,
   OASysSection,
   OASysSections,
+  PersonAcctAlert,
 } from '@approved-premises/api'
 
 import RestClient from './restClient'
@@ -50,6 +51,12 @@ export default class PersonClient {
     const response = await this.restClient.get({ path: paths.people.adjudications({ crn }) })
 
     return response as Array<Adjudication>
+  }
+
+  async acctAlerts(crn: string): Promise<Array<PersonAcctAlert>> {
+    const response = await this.restClient.get({ path: paths.people.acctAlerts({ crn }) })
+
+    return response as Array<PersonAcctAlert>
   }
 
   async offences(crn: string): Promise<Array<ActiveOffence>> {

--- a/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.test.ts
@@ -122,6 +122,7 @@ describe('CaseNotes', () => {
 
       expect(page.body).toEqual({
         selectedCaseNotes: [caseNotes[0], caseNotes[1]],
+        acctAlerts: [],
         moreDetail: 'some detail',
         caseNoteIds: [caseNotes[0].id, caseNotes[1].id],
         adjudications,

--- a/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
+++ b/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
@@ -1,6 +1,6 @@
 import type { DataServices, PageResponse } from '@approved-premises/ui'
 
-import type { ApprovedPremisesApplication, PrisonCaseNote, Adjudication } from '@approved-premises/api'
+import type { ApprovedPremisesApplication, PrisonCaseNote, Adjudication, PersonAcctAlert } from '@approved-premises/api'
 
 import { sentenceCase } from '../../../../utils/utils'
 import TasklistPage from '../../../tasklistPage'
@@ -16,7 +16,8 @@ type CaseNotesBody = {
   caseNoteIds: Array<string>
   selectedCaseNotes: Array<PrisonCaseNote>
   moreDetail: string
-  adjudications: Array<CaseNotesAdjudication>
+  adjudications: Array<Adjudication>
+  acctAlerts: Array<PersonAcctAlert>
 }
 
 export const caseNoteResponse = (caseNote: PrisonCaseNote) => {
@@ -58,7 +59,10 @@ export const caseNoteCheckbox = (caseNote: PrisonCaseNote, checked: boolean) => 
   `
 }
 
-@Page({ name: 'case-notes', bodyProperties: ['caseNoteIds', 'selectedCaseNotes', 'moreDetail', 'adjudications'] })
+@Page({
+  name: 'case-notes',
+  bodyProperties: ['caseNoteIds', 'selectedCaseNotes', 'moreDetail', 'adjudications', 'acctAlerts'],
+})
 export default class CaseNotes implements TasklistPage {
   title = 'Prison information'
 
@@ -83,7 +87,8 @@ export default class CaseNotes implements TasklistPage {
       caseNoteIds: caseNoteIds as Array<string>,
       selectedCaseNotes,
       moreDetail: value.moreDetail as string,
-      adjudications: (value.adjudications || []) as Array<Adjudication>,
+      adjudications: (value.adjudications || []) as Array<CaseNotesAdjudication>,
+      acctAlerts: (value.acctAlerts || []) as Array<PersonAcctAlert>,
     }
   }
 
@@ -95,9 +100,11 @@ export default class CaseNotes implements TasklistPage {
   ) {
     const caseNotes = await dataServices.personService.getPrisonCaseNotes(token, application.person.crn)
     const adjudications = await dataServices.personService.getAdjudications(token, application.person.crn)
+    const acctAlerts = await dataServices.personService.getAcctAlerts(token, application.person.crn)
 
     body.caseNoteIds = body.caseNoteIds ? [body.caseNoteIds].flat() : []
     body.adjudications = adjudications
+    body.acctAlerts = acctAlerts
 
     body.selectedCaseNotes = ((body.caseNoteIds || []) as Array<string>).map((noteId: string) => {
       return caseNotes.find(caseNote => caseNote.id === noteId)

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -922,39 +922,53 @@
             "adjudications": {
               "type": "array",
               "items": {
-                "allOf": [
-                  {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "number"
-                      },
-                      "reportedAt": {
-                        "type": "string"
-                      },
-                      "establishment": {
-                        "type": "string"
-                      },
-                      "offenceDescription": {
-                        "type": "string"
-                      },
-                      "hearingHeld": {
-                        "type": "boolean"
-                      }
-                    }
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
                   },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "finding": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+                  "reportedAt": {
+                    "type": "string"
+                  },
+                  "establishment": {
+                    "type": "string"
+                  },
+                  "offenceDescription": {
+                    "type": "string"
+                  },
+                  "hearingHeld": {
+                    "type": "boolean"
+                  },
+                  "finding": {
+                    "type": "string"
                   }
-                ]
+                }
+              }
+            },
+            "acctAlerts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "alertId": {
+                    "type": "number"
+                  },
+                  "comment": {
+                    "type": "string"
+                  },
+                  "dateCreated": {
+                    "type": "string"
+                  },
+                  "dateExpires": {
+                    "type": "string"
+                  },
+                  "expired": {
+                    "type": "boolean"
+                  },
+                  "active": {
+                    "type": "boolean"
+                  }
+                }
               }
             }
           }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -83,6 +83,7 @@ export default {
     search: peoplePath.path('search'),
     prisonCaseNotes: personPath.path('prison-case-notes'),
     adjudications: personPath.path('adjudications'),
+    acctAlerts: personPath.path('acct-alerts'),
     offences: personPath.path('offences'),
     documents: path('/documents/:crn/:documentId'),
     oasys: {

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -12,6 +12,7 @@ import adjudicationsFactory from '../testutils/factories/adjudication'
 import activeOffenceFactory from '../testutils/factories/activeOffence'
 import oasysSelectionFactory from '../testutils/factories/oasysSelection'
 import oasysSectionsFactory from '../testutils/factories/oasysSections'
+import acctAlertFactory from '../testutils/factories/acctAlert'
 
 jest.mock('../data/personClient.ts')
 
@@ -98,6 +99,21 @@ describe('PersonService', () => {
 
       expect(personClientFactory).toHaveBeenCalledWith(token)
       expect(personClient.adjudications).toHaveBeenCalledWith('crn')
+    })
+  })
+
+  describe('getAcctAlerts', () => {
+    it("on success returns the person's adjudications notes given their CRN", async () => {
+      const acctAlerts = acctAlertFactory.buildList(3)
+
+      personClient.acctAlerts.mockResolvedValue(acctAlerts)
+
+      const serviceAcctAlerts = await service.getAcctAlerts(token, 'crn')
+
+      expect(serviceAcctAlerts).toEqual(acctAlerts)
+
+      expect(personClientFactory).toHaveBeenCalledWith(token)
+      expect(personClient.acctAlerts).toHaveBeenCalledWith('crn')
     })
   })
 

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -7,6 +7,7 @@ import type {
   PrisonCaseNote,
   OASysSection,
   OASysSections,
+  PersonAcctAlert,
 } from '@approved-premises/api'
 import type { RestClientBuilder, PersonClient } from '../data'
 
@@ -51,6 +52,14 @@ export default class PersonService {
     const adjudications = await personClient.adjudications(crn)
 
     return adjudications
+  }
+
+  async getAcctAlerts(token: string, crn: string): Promise<Array<PersonAcctAlert>> {
+    const personClient = this.personClientFactory(token)
+
+    const acctAlerts = await personClient.acctAlerts(crn)
+
+    return acctAlerts
   }
 
   async getOasysSelections(token: string, crn: string): Promise<Array<OASysSection>> {

--- a/server/testutils/factories/acctAlert.ts
+++ b/server/testutils/factories/acctAlert.ts
@@ -1,0 +1,15 @@
+import type { PersonAcctAlert } from '@approved-premises/api'
+
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import { DateFormats } from '../../utils/dateUtils'
+
+export default Factory.define<PersonAcctAlert>(() => ({
+  alertId: faker.datatype.number(),
+  dateCreated: DateFormats.dateObjToIsoDate(faker.date.past()),
+  dateExpires: DateFormats.dateObjToIsoDate(faker.date.future()),
+  comment: faker.lorem.sentence(),
+  expired: faker.datatype.boolean(),
+  active: faker.datatype.boolean(),
+}))

--- a/server/views/applications/pages/prison-information/case-notes.njk
+++ b/server/views/applications/pages/prison-information/case-notes.njk
@@ -38,7 +38,7 @@
           text: 'ACCT',
           href: '#acct',
           attributes: {
-            'aria-controls': 'ACCT',
+            'aria-controls': 'acct',
             'id': 'acctTab',
             role: 'tab'
           }
@@ -114,6 +114,31 @@
     </table>
 
     <input name="adjudications" type="hidden" value="{{ page.body.adjudications | dump }}"/>
+  </div>
+
+  <div class="govuk-column-full-width" id="acct" role="tabpanel" aria-labelledby="acctTab" hidden>
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m">ACCT</caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header" style="width:100px;">Alert type</th>
+          <th scope="col" class="govuk-table__header">ACCT description</th>
+          <th scope="col" class="govuk-table__header">Date created</th>
+          <th scope="col" class="govuk-table__header">Expiry date</th>
+        </tr>
+      </thead>
+
+      <tbody class="govuk-table__body">
+        {% for alert in page.body.acctAlerts %}
+          <tr class="govuk-table__row">
+            <td scope="row" class="govuk-table__cell">{{ alert.alertId }}</td>
+            <td scope="row" class="govuk-table__cell">{{ alert.comment }}</td>
+            <td scope="row" class="govuk-table__cell">{{ formatDate(alert.dateCreated) }}</td>
+            <td scope="row" class="govuk-table__cell">{{ formatDate(alert.dateExpires) }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
   </div>
 
 {% endblock %}


### PR DESCRIPTION
# Context

When viewing prison case notes and adjudications probation officers also need to see any relevant ACCT alerts there may be. 
Adding these in was missed the first time around doing Apply.

# Changes in this PR

We add in a client and service for the alerts. 
Then we add them to the view for prison information. Since the alerts are read only it's relatively simple

## Screenshots of UI changes

![acct-alerts](https://user-images.githubusercontent.com/44123869/217322310-402cf7e5-1379-4567-b6c2-6b919a124501.png)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
