### PR TITLE
Remove the alternativeRadius if blank

### DIFF
--- a/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.test.ts
@@ -10,6 +10,26 @@ describe('ConvictedOffences', () => {
 
       expect(page.body).toEqual({ postcodeArea: 'E17' })
     })
+
+    it('should remove the radius if alternativeRadiusAccepted is no', () => {
+      const page = new DescribeLocationFactors({
+        postcodeArea: 'E17',
+        alternativeRadiusAccepted: 'no',
+        alternativeRadius: '60',
+      })
+
+      expect(page.body).toEqual({ postcodeArea: 'E17', alternativeRadiusAccepted: 'no' })
+    })
+
+    it('should not remove the radius if alternativeRadiusAccepted is yes', () => {
+      const page = new DescribeLocationFactors({
+        postcodeArea: 'E17',
+        alternativeRadiusAccepted: 'yes',
+        alternativeRadius: '60',
+      })
+
+      expect(page.body).toEqual({ postcodeArea: 'E17', alternativeRadiusAccepted: 'yes', alternativeRadius: '60' })
+    })
   })
 
   itShouldHavePreviousValue(new DescribeLocationFactors({}), 'dashboard')

--- a/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.ts
@@ -13,7 +13,7 @@ type DescribeLocationFactorsBody = {
   restrictions: YesOrNo
   restrictionDetail: string
   alternativeRadiusAccepted: YesOrNo
-  alternativeRadius: (typeof radiuses)[number]
+  alternativeRadius?: (typeof radiuses)[number]
 }
 
 @Page({
@@ -41,7 +41,16 @@ export default class DescribeLocationFactors implements TasklistPage {
     alternativeRadius: 'Choose the maximum radius (in miles)',
   }
 
-  constructor(public body: Partial<DescribeLocationFactorsBody>) {}
+  body: DescribeLocationFactorsBody
+
+  constructor(body: Partial<DescribeLocationFactorsBody>) {
+    if (body.alternativeRadiusAccepted === 'yes') {
+      this.body = body as DescribeLocationFactorsBody
+    } else {
+      delete body.alternativeRadius
+      this.body = body as DescribeLocationFactorsBody
+    }
+  }
 
   previous() {
     return 'dashboard'


### PR DESCRIPTION
If the answer to `alternativeRadiusAccepted` is ‘no’, then the user does not answer the `alternativeRadius` question, so it defaults to a blank string, which causes the schema to choke. This updates the page class to remove the field entirely if the answer to `alternativeRadiusAccepted` is `no`