### PR TITLE
(872) Assess - ACCT alerts review tab

### DIFF
--- a/cypress_shared/pages/apply/caseNotes.ts
+++ b/cypress_shared/pages/apply/caseNotes.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesApplication, PrisonCaseNote, PersonAcctAlert } from '@approved-premises/api'
+import { ApprovedPremisesApplication, PrisonCaseNote } from '@approved-premises/api'
 import paths from '../../../server/paths/apply'
 
 import { DateFormats } from '../../../server/utils/dateUtils'
@@ -33,21 +33,5 @@ export default class CaseNotesPage extends ApplyPage {
     })
 
     this.getTextInputByIdAndEnterDetails('moreDetail', moreDetail)
-  }
-
-  shouldDisplayAcctAlerts(acctAlerts: Array<PersonAcctAlert>) {
-    cy.get('a').contains('ACCT').click()
-    acctAlerts.forEach(acctAlert => {
-      cy.get('tr')
-        .contains(`${acctAlert.alertId}`)
-        .parent()
-        .within(() => {
-          cy.get('td').eq(1).contains(acctAlert.comment)
-          cy.get('td').eq(2).contains(DateFormats.isoDateToUIDate(acctAlert.dateCreated))
-          cy.get('td')
-            .eq(3)
-            .contains(DateFormats.isoDateToUIDate(acctAlert.dateExpires as string))
-        })
-    })
   }
 }

--- a/cypress_shared/pages/assess/reviewPage.ts
+++ b/cypress_shared/pages/assess/reviewPage.ts
@@ -1,7 +1,7 @@
 import type { Person, PrisonCaseNote, Document, ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
 import { DateFormats } from '../../../server/utils/dateUtils'
 
-import { Adjudication } from '../../../server/@types/shared'
+import { Adjudication, PersonAcctAlert } from '../../../server/@types/shared'
 import { sentenceCase } from '../../../server/utils/utils'
 import AssessPage from './assessPage'
 
@@ -85,11 +85,16 @@ export default class ReviewPage extends AssessPage {
     })
   }
 
-  prisonInformationPage(adjudications: Array<Adjudication>, prisonCaseNotes: Array<PrisonCaseNote>) {
+  prisonInformationPage(
+    adjudications: Array<Adjudication>,
+    prisonCaseNotes: Array<PrisonCaseNote>,
+    acctAlerts: Array<PersonAcctAlert>,
+  ) {
     cy.get('a').contains('View additional prison information').click()
 
     this.shouldDisplayPrisonCaseNotes(prisonCaseNotes)
     this.shouldDisplayAdjudications(adjudications)
+    this.shouldDisplayAcctAlerts(acctAlerts)
 
     this.clickBack()
   }
@@ -106,6 +111,7 @@ export default class ReviewPage extends AssessPage {
     this.prisonInformationPage(
       assessment.application.data?.['prison-information']['case-notes'].adjudications,
       assessment.application.data?.['prison-information']['case-notes'].selectedCaseNotes,
+      assessment.application.data?.['prison-information']['case-notes'].acctAlerts,
     )
   }
 

--- a/cypress_shared/pages/assess/reviewPage.ts
+++ b/cypress_shared/pages/assess/reviewPage.ts
@@ -85,7 +85,7 @@ export default class ReviewPage extends AssessPage {
     })
   }
 
-  adjudicationsPageShowsAdjudications(adjudications: Array<Adjudication>, prisonCaseNotes: Array<PrisonCaseNote>) {
+  prisonInformationPage(adjudications: Array<Adjudication>, prisonCaseNotes: Array<PrisonCaseNote>) {
     cy.get('a').contains('View additional prison information').click()
 
     this.shouldDisplayPrisonCaseNotes(prisonCaseNotes)
@@ -103,7 +103,7 @@ export default class ReviewPage extends AssessPage {
 
     this.shouldShowCaseNotes(assessment.application.data?.['prison-information']['case-notes'].selectedCaseNotes)
     this.shouldShowAdjudications(assessment.application.data?.['prison-information']['case-notes'].adjudications)
-    this.adjudicationsPageShowsAdjudications(
+    this.prisonInformationPage(
       assessment.application.data?.['prison-information']['case-notes'].adjudications,
       assessment.application.data?.['prison-information']['case-notes'].selectedCaseNotes,
     )

--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -1,4 +1,4 @@
-import { Adjudication, Document, PrisonCaseNote } from '../../server/@types/shared'
+import { Adjudication, Document, PersonAcctAlert, PrisonCaseNote } from '../../server/@types/shared'
 import { PersonRisksUI } from '../../server/@types/ui'
 import errorLookups from '../../server/i18n/en/errors.json'
 import { DateFormats } from '../../server/utils/dateUtils'
@@ -194,6 +194,22 @@ export default abstract class Page {
           cy.get('td')
             .eq(1)
             .contains(sentenceCase(caseNote.note || ''))
+        })
+    })
+  }
+
+  shouldDisplayAcctAlerts(acctAlerts: Array<PersonAcctAlert>) {
+    cy.get('a').contains('ACCT').click()
+    acctAlerts.forEach(acctAlert => {
+      cy.get('tr')
+        .contains(`${acctAlert.alertId}`)
+        .parent()
+        .within(() => {
+          cy.get('td').eq(1).contains(acctAlert.comment)
+          cy.get('td').eq(2).contains(DateFormats.isoDateToUIDate(acctAlert.dateCreated))
+          cy.get('td')
+            .eq(3)
+            .contains(DateFormats.isoDateToUIDate(acctAlert.dateExpires as string))
         })
     })
   }

--- a/server/controllers/assess/assessmentsController.ts
+++ b/server/controllers/assess/assessmentsController.ts
@@ -3,7 +3,11 @@ import type { Request, Response, RequestHandler } from 'express'
 import TasklistService from '../../services/tasklistService'
 import { AssessmentService } from '../../services'
 import informationSetAsNotReceived from '../../utils/assessments/informationSetAsNotReceived'
-import { adjudicationsFromAssessment, caseNotesFromAssessment } from '../../utils/assessments/utils'
+import {
+  acctAlertsFromAssessment,
+  adjudicationsFromAssessment,
+  caseNotesFromAssessment,
+} from '../../utils/assessments/utils'
 
 import getSections from '../../utils/assessments/getSections'
 
@@ -85,6 +89,7 @@ export default class AssessmentsController {
       res.render('assessments/pages/risk-information/prison-information', {
         adjudications: adjudicationsFromAssessment(assessment),
         caseNotes: caseNotesFromAssessment(assessment),
+        acctAlerts: acctAlertsFromAssessment(assessment),
         pageHeading: 'Prison information',
         dateOfImport: DateFormats.isoDateToUIDate(assessment.application.submittedAt),
         assessmentId: assessment.id,

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -518,7 +518,7 @@ describe('utils', () => {
       const assessment = assessmentFactory.build()
       assessment.application.data['prison-information'] = {}
 
-      expect(adjudicationsFromAssessment(assessment)).toEqual('')
+      expect(adjudicationsFromAssessment(assessment)).toEqual([])
     })
   })
 
@@ -535,7 +535,7 @@ describe('utils', () => {
       const assessment = assessmentFactory.build()
       assessment.application.data['prison-information'] = {}
 
-      expect(caseNotesFromAssessment(assessment)).toEqual('')
+      expect(caseNotesFromAssessment(assessment)).toEqual([])
     })
   })
 })

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -23,6 +23,7 @@ import {
   confirmationPageResult,
   adjudicationsFromAssessment,
   caseNotesFromAssessment,
+  acctAlertsFromAssessment,
 } from './utils'
 import { DateFormats } from '../dateUtils'
 import paths from '../../paths/assess'
@@ -30,16 +31,17 @@ import paths from '../../paths/assess'
 import * as personUtils from '../personUtils'
 import * as applicationUtils from '../applicationUtils'
 
-import assessmentFactory from '../../testutils/factories/assessment'
-import clarificationNoteFactory from '../../testutils/factories/clarificationNote'
 import Assess from '../../form-pages/assess'
 import { UnknownPageError } from '../errors'
+import assessmentFactory from '../../testutils/factories/assessment'
 import applicationFactory from '../../testutils/factories/application'
-import reviewSections from '../reviewUtils'
+import clarificationNoteFactory from '../../testutils/factories/clarificationNote'
 import documentFactory from '../../testutils/factories/document'
-import { documentsFromApplication } from './documentUtils'
 import adjudicationFactory from '../../testutils/factories/adjudication'
 import prisonCaseNotesFactory from '../../testutils/factories/prisonCaseNotes'
+import acctAlertFactory from '../../testutils/factories/acctAlert'
+import reviewSections from '../reviewUtils'
+import { documentsFromApplication } from './documentUtils'
 
 const FirstPage = jest.fn()
 const SecondPage = jest.fn()
@@ -536,6 +538,23 @@ describe('utils', () => {
       assessment.application.data['prison-information'] = {}
 
       expect(caseNotesFromAssessment(assessment)).toEqual([])
+    })
+  })
+
+  describe('acctAlertsFromAssessment', () => {
+    it('returns the acctAlerts from the assessment', () => {
+      const acctAlerts = acctAlertFactory.buildList(2)
+      const assessment = assessmentFactory.build()
+      assessment.application.data['prison-information'] = { 'case-notes': { acctAlerts } }
+
+      expect(acctAlertsFromAssessment(assessment)).toEqual(acctAlerts)
+    })
+
+    it('returns an empty string if the case notes are empty', () => {
+      const assessment = assessmentFactory.build()
+      assessment.application.data['prison-information'] = {}
+
+      expect(acctAlertsFromAssessment(assessment)).toEqual([])
     })
   })
 })

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -331,10 +331,10 @@ const confirmationPageResult = (assessment: Assessment) => {
 }
 
 const adjudicationsFromAssessment = (assessment: Assessment) =>
-  assessment.application?.data?.['prison-information']?.['case-notes']?.adjudications || ''
+  assessment.application?.data?.['prison-information']?.['case-notes']?.adjudications || []
 
 const caseNotesFromAssessment = (assessment: Assessment) =>
-  assessment.application?.data?.['prison-information']?.['case-notes']?.selectedCaseNotes || ''
+  assessment.application?.data?.['prison-information']?.['case-notes']?.selectedCaseNotes || []
 
 export {
   adjudicationsFromAssessment,

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -336,7 +336,11 @@ const adjudicationsFromAssessment = (assessment: Assessment) =>
 const caseNotesFromAssessment = (assessment: Assessment) =>
   assessment.application?.data?.['prison-information']?.['case-notes']?.selectedCaseNotes || []
 
+const acctAlertsFromAssessment = (assessment: Assessment) =>
+  assessment.application?.data?.['prison-information']?.['case-notes']?.acctAlerts || []
+
 export {
+  acctAlertsFromAssessment,
   adjudicationsFromAssessment,
   applicationAccepted,
   assessmentSections,

--- a/server/views/applications/pages/prison-information/case-notes.njk
+++ b/server/views/applications/pages/prison-information/case-notes.njk
@@ -1,80 +1,42 @@
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+{% from "../../../components/formFields/form-page-textarea/macro.njk" import formPageTextarea %}
+{% from "../../../partials/prisonInformationTable.njk" import prisonInformationTable %}
+
+{% set title = "Select prison case notes" %}
 
 {% extends "../layout.njk" %}
 
 {% set columnClasses = "govuk-grid-column-full" %}
 
-{% block questions %}
-  <div class="govuk-grid-row">
-    <div>
-      <h1 class="govuk-heading-l">{{page.title}}</h1>
-      <p>Select any prison case notes that will help Approved Premises (AP) managers understand factors that may help with the person's risk management in an AP. </p>
-      <p>Adjudications from the person's current sentence and ACCT (Assessment, Care in Custody and Teamwork) information will be sent automatically.</p>
-    </div>
+{% set caseNotes %}
+<table class="govuk-table">
+  <caption class="govuk-table__caption govuk-table__caption--m">Prison case notes</caption>
 
-    {{ mojSubNavigation({
-        label: 'Sub navigation',
-        attributes: {
-          'role': 'tablist'
-        },
-        items: [{
-          text: 'Prison case notes',
-          href: '#caseNotes',
-          attributes: {
-            'aria-controls': 'caseNotes',
-            'id': 'caseNotesTab',
-            role: 'tab',
-            'aria-selected': true
-          }
-        }, {
-          text: 'Adjudications',
-          href: '#adjudications',
-          attributes: {
-            'aria-controls': 'adjudications',
-            'id': 'adjudicationsTab',
-            role: 'tab'
-          }
-        }, {
-          text: 'ACCT',
-          href: '#acct',
-          attributes: {
-            'aria-controls': 'acct',
-            'id': 'acctTab',
-            role: 'tab'
-          }
-        }]
-      }) }}
-  </div>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Select</th>
+      <th scope="col" class="govuk-table__header">Created</th>
+      <th scope="col" class="govuk-table__header">Comments</th>
+    </tr>
+  </thead>
 
-  <div class="govuk-column-full-width" id="caseNotes" role="tabpanel" aria-labelledby="caseNotesTab" hidden>
-    <table class="govuk-table">
-      <caption class="govuk-table__caption govuk-table__caption--m">Prison case notes</caption>
+  <tbody class="govuk-table__body">
+    {% for caseNote in page.caseNotes %}
+      <tr class="govuk-table__row">
+        <td scope="row" class="govuk-table__cell">{{ page.checkBoxForCaseNoteId(caseNote.id) | safe }}</td>
+        <td scope="row" class="govuk-table__cell">{{ formatDate(caseNote.createdAt) }}</td>
+        <td scope="row" class="govuk-table__cell">
+          <p>
+            <strong>Type: {{caseNote.type}}: {{caseNote.subType}}</strong>
+          </p>
+          <p>{{caseNote.note}}</p>
+        </td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
 
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Select</th>
-          <th scope="col" class="govuk-table__header">Created</th>
-          <th scope="col" class="govuk-table__header">Comments</th>
-        </tr>
-      </thead>
-
-      <tbody class="govuk-table__body">
-        {% for caseNote in page.caseNotes %}
-          <tr class="govuk-table__row">
-            <td scope="row" class="govuk-table__cell">{{ page.checkBoxForCaseNoteId(caseNote.id) | safe }}</td>
-            <td scope="row" class="govuk-table__cell">{{ formatDate(caseNote.createdAt) }}</td>
-            <td scope="row" class="govuk-table__cell">
-              <p>
-                <strong>Type: {{caseNote.type}}: {{caseNote.subType}}</strong>
-              </p>
-              <p>{{caseNote.note}}</p>
-            </td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-
-    {{ formPageTextarea({
+{{ formPageTextarea({
       fieldName: 'moreDetail',
       label: {
         text: page.questions.moreDetailsQuestion,
@@ -84,104 +46,16 @@
         text: "Provide details (optional)"
       }
     }) }}
+{% endset %}
+
+{% block questions %}
+  <div class="govuk-grid-row">
+    <div>
+      <h1 class="govuk-heading-l">{{page.title}}</h1>
+      <p>Select any prison case notes that will help Approved Premises (AP) managers understand factors that may help with the person's risk management in an AP. </p>
+      <p>Adjudications from the person's current sentence and ACCT (Assessment, Care in Custody and Teamwork) information will be sent automatically.</p>
+    </div>
+
+    {{prisonInformationTable(caseNotes, page.body.adjudications, page.body.acctAlerts)}}
   </div>
-
-  <div class="govuk-column-full-width" id="adjudications" role="tabpanel" aria-labelledby="adjudicationsTab" hidden>
-    <table class="govuk-table">
-      <caption class="govuk-table__caption govuk-table__caption--m">Adjudications</caption>
-
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Adjudication number</th>
-          <th scope="col" class="govuk-table__header">Report date and time</th>
-          <th scope="col" class="govuk-table__header">Establishment</th>
-          <th scope="col" class="govuk-table__header govuk-!-width-one-third">Offence description	</th>
-          <th scope="col" class="govuk-table__header">Finding</th>
-        </tr>
-      </thead>
-
-      <tbody class="govuk-table__body">
-        {% for adjudication in page.body.adjudications %}
-          <tr class="govuk-table__row">
-            <td scope="row" class="govuk-table__cell">{{ adjudication.id }}</td>
-            <td scope="row" class="govuk-table__cell">{{ formatDateTime(adjudication.reportedAt) }}</td>
-            <td scope="row" class="govuk-table__cell">{{ adjudication.establishment }}</td>
-            <td scope="row" class="govuk-table__cell">{{ adjudication.offenceDescription }}</td>
-            <td scope="row" class="govuk-table__cell">{{ adjudication.finding | sentenceCase }}</td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-
-    <input name="adjudications" type="hidden" value="{{ page.body.adjudications | dump }}"/>
-  </div>
-
-  <div class="govuk-column-full-width" id="acct" role="tabpanel" aria-labelledby="acctTab" hidden>
-    <table class="govuk-table">
-      <caption class="govuk-table__caption govuk-table__caption--m">ACCT</caption>
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header" style="width:100px;">Alert type</th>
-          <th scope="col" class="govuk-table__header">ACCT description</th>
-          <th scope="col" class="govuk-table__header">Date created</th>
-          <th scope="col" class="govuk-table__header">Expiry date</th>
-        </tr>
-      </thead>
-
-      <tbody class="govuk-table__body">
-        {% for alert in page.body.acctAlerts %}
-          <tr class="govuk-table__row">
-            <td scope="row" class="govuk-table__cell">{{ alert.alertId }}</td>
-            <td scope="row" class="govuk-table__cell">{{ alert.comment }}</td>
-            <td scope="row" class="govuk-table__cell">{{ formatDate(alert.dateCreated) }}</td>
-            <td scope="row" class="govuk-table__cell">{{ formatDate(alert.dateExpires) }}</td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-
-{% endblock %}
-
-{% block extraScripts %}
-  <script type="text/javascript" nonce="{{ cspNonce }}">
-    function hidePanels() {
-      for (var i = 0; i < panels.length; i++) {
-        panels[i].setAttribute('hidden', 'true')
-      }
-    }
-
-    function showPanel(panel) {
-      hidePanels()
-      panel.removeAttribute('hidden')
-    }
-
-    function setCurrent(current) {
-      for (var i = 0; i < panels.length; i++) {
-        navLinks[i].removeAttribute('aria-selected')
-      }
-
-      current.setAttribute('aria-selected', 'true')
-    }
-
-    var navLinks = document.querySelectorAll('[role="tab"]')
-    var panels = document.querySelectorAll('[role="tabpanel"')
-
-    showPanel(panels[0])
-
-    for (var i = 0; i < navLinks.length; i++) {
-      navLinks[i].addEventListener('click', function (e) {
-        var link = e.target
-        var id = link
-          .attributes['aria-controls']
-          .value
-        var panel = document.querySelector('#' + id)
-
-        showPanel(panel)
-        setCurrent(link)
-
-        e.preventDefault()
-      })
-    }
-  </script>
 {% endblock %}

--- a/server/views/assessments/pages/risk-information/prison-information.njk
+++ b/server/views/assessments/pages/risk-information/prison-information.njk
@@ -50,10 +50,10 @@
                     }
                 },
                 {
-                    text: '',
+                    text: 'ACCT',
                     href: '#acct',
                     attributes: {
-                        'aria-controls': 'ACCT',
+                        'aria-controls': 'acct',
                         'id': 'acctTab',
                         role: 'tab'
                     }
@@ -114,6 +114,31 @@
                     </table>
 
                 </div>
+            </div>
+
+            <div class="govuk-column-full-width" id="acct" role="tabpanel" aria-labelledby="acctTab" hidden>
+                <table class="govuk-table">
+                    <caption class="govuk-table__caption govuk-table__caption--m">ACCT</caption>
+                    <thead class="govuk-table__head">
+                        <tr class="govuk-table__row">
+                            <th scope="col" class="govuk-table__header" style="width:100px;">Alert type</th>
+                            <th scope="col" class="govuk-table__header">ACCT description</th>
+                            <th scope="col" class="govuk-table__header">Date created</th>
+                            <th scope="col" class="govuk-table__header">Expiry date</th>
+                        </tr>
+                    </thead>
+
+                    <tbody class="govuk-table__body">
+                        {% for alert in acctAlerts %}
+                            <tr class="govuk-table__row">
+                                <td scope="row" class="govuk-table__cell">{{ alert.alertId }}</td>
+                                <td scope="row" class="govuk-table__cell">{{ alert.comment }}</td>
+                                <td scope="row" class="govuk-table__cell">{{ formatDate(alert.dateCreated) }}</td>
+                                <td scope="row" class="govuk-table__cell">{{ formatDate(alert.dateExpires) }}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
             </div>
 
             {% block extraScripts %}

--- a/server/views/assessments/pages/risk-information/prison-information.njk
+++ b/server/views/assessments/pages/risk-information/prison-information.njk
@@ -1,10 +1,37 @@
-{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "../../../partials/prisonInformationTable.njk" import prisonInformationTable %}
 
 {% extends "../../../partials/layout.njk" %}
 
 {% set columnClasses = "govuk-grid-column-full" %}
 {% set pageTitle = applicationName + " - " + pageHeading %}
+
+{% set caseNotes %}
+<table class="govuk-table">
+    <caption class="govuk-table__caption govuk-table__caption--m">Prison case notes</caption>
+
+    <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Created</th>
+            <th scope="col" class="govuk-table__header">Comments</th>
+        </tr>
+    </thead>
+
+    <tbody class="govuk-table__body">
+        {% for caseNote in caseNotes %}
+            <tr class="govuk-table__row">
+                <td scope="row" class="govuk-table__cell">{{ formatDate(caseNote.createdAt) }}</td>
+                <td scope="row" class="govuk-table__cell">
+                    <p>
+                        <strong>Type: {{caseNote.type}}: {{caseNote.subType}}</strong>
+                    </p>
+                    <p>{{caseNote.note}}</p>
+                </td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endset %}
 
 {% block content %}
 
@@ -25,162 +52,7 @@
                 <p>Applicants were asked to provide information to help Approved Premises (AP) managers understand factors that may help with the person's risk management.</p>
             </div>
 
-            {{ mojSubNavigation({
-                label: 'Sub navigation',
-                attributes: {
-                'role': 'tablist'
-                },
-                items: [{
-                    text: 'Prison case notes',
-                    href: '#caseNotes',
-                    attributes: {
-                        'aria-controls': 'caseNotes',
-                        'id': 'caseNotesTab',
-                        role: 'tab',
-                        'aria-selected': true
-                    }
-                },
-                {
-                    text: 'Adjudications',
-                    href: '#adjudications',
-                    attributes: {
-                        'aria-controls': 'adjudications',
-                        'id': 'adjudicationsTab',
-                        role: 'tab'
-                    }
-                },
-                {
-                    text: 'ACCT',
-                    href: '#acct',
-                    attributes: {
-                        'aria-controls': 'acct',
-                        'id': 'acctTab',
-                        role: 'tab'
-                    }
-                }]
-            }) }}
-
-            <div class="govuk-column-full-width" id="caseNotes" role="tabpanel" aria-labelledby="caseNotesTab" hidden>
-                <table class="govuk-table">
-                    <caption class="govuk-table__caption govuk-table__caption--m">Prison case notes</caption>
-
-                    <thead class="govuk-table__head">
-                        <tr class="govuk-table__row">
-                            <th scope="col" class="govuk-table__header">Created</th>
-                            <th scope="col" class="govuk-table__header">Comments</th>
-                        </tr>
-                    </thead>
-
-                    <tbody class="govuk-table__body">
-                        {% for caseNote in caseNotes %}
-                            <tr class="govuk-table__row">
-                                <td scope="row" class="govuk-table__cell">{{ formatDate(caseNote.createdAt) }}</td>
-                                <td scope="row" class="govuk-table__cell">
-                                    <p>
-                                        <strong>Type: {{caseNote.type}}: {{caseNote.subType}}</strong>
-                                    </p>
-                                    <p>{{caseNote.note}}</p>
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-
-                <div class="govuk-column-full-width" id="adjudications" role="tabpanel" aria-labelledby="adjudicationsTab" hidden>
-                    <table class="govuk-table">
-                        <caption class="govuk-table__caption govuk-table__caption--m">Adjudications</caption>
-
-                        <thead class="govuk-table__head">
-                            <tr class="govuk-table__row">
-                                <th scope="col" class="govuk-table__header">Adjudication number</th>
-                                <th scope="col" class="govuk-table__header">Report date and time</th>
-                                <th scope="col" class="govuk-table__header">Establishment</th>
-                                <th scope="col" class="govuk-table__header govuk-!-width-one-third">Offence description	</th>
-                                <th scope="col" class="govuk-table__header">Finding</th>
-                            </tr>
-                        </thead>
-
-                        <tbody class="govuk-table__body">
-                            {% for adjudication in adjudications %}
-                                <tr class="govuk-table__row">
-                                    <td scope="row" class="govuk-table__cell">{{ adjudication.id }}</td>
-                                    <td scope="row" class="govuk-table__cell">{{ formatDateTime(adjudication.reportedAt) }}</td>
-                                    <td scope="row" class="govuk-table__cell">{{ adjudication.establishment }}</td>
-                                    <td scope="row" class="govuk-table__cell">{{ adjudication.offenceDescription }}</td>
-                                    <td scope="row" class="govuk-table__cell">{{ adjudication.finding | sentenceCase }}</td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-
-                </div>
-            </div>
-
-            <div class="govuk-column-full-width" id="acct" role="tabpanel" aria-labelledby="acctTab" hidden>
-                <table class="govuk-table">
-                    <caption class="govuk-table__caption govuk-table__caption--m">ACCT</caption>
-                    <thead class="govuk-table__head">
-                        <tr class="govuk-table__row">
-                            <th scope="col" class="govuk-table__header" style="width:100px;">Alert type</th>
-                            <th scope="col" class="govuk-table__header">ACCT description</th>
-                            <th scope="col" class="govuk-table__header">Date created</th>
-                            <th scope="col" class="govuk-table__header">Expiry date</th>
-                        </tr>
-                    </thead>
-
-                    <tbody class="govuk-table__body">
-                        {% for alert in acctAlerts %}
-                            <tr class="govuk-table__row">
-                                <td scope="row" class="govuk-table__cell">{{ alert.alertId }}</td>
-                                <td scope="row" class="govuk-table__cell">{{ alert.comment }}</td>
-                                <td scope="row" class="govuk-table__cell">{{ formatDate(alert.dateCreated) }}</td>
-                                <td scope="row" class="govuk-table__cell">{{ formatDate(alert.dateExpires) }}</td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-
-            {% block extraScripts %}
-                <script type="text/javascript" nonce="{{ cspNonce }}">
-                    function hidePanels() {
-                        for (var i = 0; i < panels.length; i++) {
-                            panels[i].setAttribute('hidden', 'true')
-                        }
-                    }
-
-                    function showPanel(panel) {
-                        hidePanels()
-                        panel.removeAttribute('hidden')
-                    }
-
-                    function setCurrent(current) {
-                        for (var i = 0; i < panels.length; i++) {
-                            navLinks[i].removeAttribute('aria-selected')
-                        }
-
-                        current.setAttribute('aria-selected', 'true')
-                    }
-
-                    var navLinks = document.querySelectorAll('[role="tab"]')
-                    var panels = document.querySelectorAll('[role="tabpanel"')
-
-                    showPanel(panels[0])
-
-                    for (var i = 0; i < navLinks.length; i++) {
-                        navLinks[i].addEventListener('click', function (e) {
-                            var link = e.target
-                            var id = link
-                                .attributes['aria-controls']
-                                .value
-                            var panel = document.querySelector('#' + id)
-
-                            showPanel(panel)
-                            setCurrent(link)
-
-                            e.preventDefault()
-                        })
-                    }
-                </script>
-            {% endblock %}
-        {% endblock %}
+            {{prisonInformationTable(caseNotes, adjudications, acctAlerts)}}
+        </div>
+    </div>
+{% endblock %}

--- a/server/views/partials/prisonInformationTable.njk
+++ b/server/views/partials/prisonInformationTable.njk
@@ -1,0 +1,140 @@
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+
+{% macro prisonInformationTable(caseNotes, adjudications, acctAlerts) %}
+
+    {{ mojSubNavigation({
+                label: 'Sub navigation',
+                attributes: {
+                'role': 'tablist'
+                },
+                items: [{
+                    text: 'Prison case notes',
+                    href: '#caseNotes',
+                    attributes: {
+                        'aria-controls': 'caseNotes',
+                        'id': 'caseNotesTab',
+                        role: 'tab',
+                        'aria-selected': true
+                    }
+                },
+                {
+                    text: 'Adjudications',
+                    href: '#adjudications',
+                    attributes: {
+                        'aria-controls': 'adjudications',
+                        'id': 'adjudicationsTab',
+                        role: 'tab'
+                    }
+                },
+                {
+                    text: 'ACCT',
+                    href: '#acct',
+                    attributes: {
+                        'aria-controls': 'acct',
+                        'id': 'acctTab',
+                        role: 'tab'
+                    }
+                }]
+            }) }}
+
+    <div class="govuk-column-full-width" id="caseNotes" role="tabpanel" aria-labelledby="caseNotesTab" hidden>
+        {{caseNotes | safe}}
+    </div>
+
+    <div class="govuk-column-full-width" id="adjudications" role="tabpanel" aria-labelledby="adjudicationsTab" hidden>
+        <table class="govuk-table">
+            <caption class="govuk-table__caption govuk-table__caption--m">Adjudications</caption>
+
+            <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                    <th scope="col" class="govuk-table__header">Adjudication number</th>
+                    <th scope="col" class="govuk-table__header">Report date and time</th>
+                    <th scope="col" class="govuk-table__header">Establishment</th>
+                    <th scope="col" class="govuk-table__header govuk-!-width-one-third">Offence description	</th>
+                    <th scope="col" class="govuk-table__header">Finding</th>
+                </tr>
+            </thead>
+
+            <tbody class="govuk-table__body">
+                {% for adjudication in adjudications %}
+                    <tr class="govuk-table__row">
+                        <td scope="row" class="govuk-table__cell">{{ adjudication.id }}</td>
+                        <td scope="row" class="govuk-table__cell">{{ formatDateTime(adjudication.reportedAt) }}</td>
+                        <td scope="row" class="govuk-table__cell">{{ adjudication.establishment }}</td>
+                        <td scope="row" class="govuk-table__cell">{{ adjudication.offenceDescription }}</td>
+                        <td scope="row" class="govuk-table__cell">{{ adjudication.finding | sentenceCase }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <div class="govuk-column-full-width" id="acct" role="tabpanel" aria-labelledby="acctTab" hidden>
+        <table class="govuk-table">
+            <caption class="govuk-table__caption govuk-table__caption--m">ACCT</caption>
+            <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                    <th scope="col" class="govuk-table__header" style="width:100px;">Alert type</th>
+                    <th scope="col" class="govuk-table__header">ACCT description</th>
+                    <th scope="col" class="govuk-table__header">Date created</th>
+                    <th scope="col" class="govuk-table__header">Expiry date</th>
+                </tr>
+            </thead>
+
+            <tbody class="govuk-table__body">
+                {% for alert in acctAlerts %}
+                    <tr class="govuk-table__row">
+                        <td scope="row" class="govuk-table__cell">{{ alert.alertId }}</td>
+                        <td scope="row" class="govuk-table__cell">{{ alert.comment }}</td>
+                        <td scope="row" class="govuk-table__cell">{{ formatDate(alert.dateCreated) }}</td>
+                        <td scope="row" class="govuk-table__cell">{{ formatDate(alert.dateExpires) }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    {% block extraScripts %}
+        <script type="text/javascript" nonce="{{ cspNonce }}">
+            function hidePanels() {
+                for (var i = 0; i < panels.length; i++) {
+                    panels[i].setAttribute('hidden', 'true')
+                }
+            }
+
+            function showPanel(panel) {
+                hidePanels()
+                panel.removeAttribute('hidden')
+            }
+
+            function setCurrent(current) {
+                for (var i = 0; i < panels.length; i++) {
+                    navLinks[i].removeAttribute('aria-selected')
+                }
+
+                current.setAttribute('aria-selected', 'true')
+            }
+
+            var navLinks = document.querySelectorAll('[role="tab"]')
+            var panels = document.querySelectorAll('[role="tabpanel"')
+
+            showPanel(panels[0])
+
+            for (var i = 0; i < navLinks.length; i++) {
+                navLinks[i].addEventListener('click', function (e) {
+                    var link = e.target
+                    var id = link
+                        .attributes['aria-controls']
+                        .value
+                    var panel = document.querySelector('#' + id)
+
+                    showPanel(panel)
+                    setCurrent(link)
+
+                    e.preventDefault()
+                })
+            }
+        </script>
+    {% endblock %}
+
+    {% endmacro%}


### PR DESCRIPTION
# Context

Following on from #529 #533 we need to add a tab to the review information page for ACCT alerts which were added to the Application in #541 

# Changes in this PR
1. We add a util function for retrieving ACCT alerts from an assessment 
2. In the Assessments Controller we pass the ACCT alerts through to the view 
3. Renaming of a function the integration tests
4. We move a function from the caseNotes class to the general Page class so it can be used for both the Apply and Assess tests
5. Add the ACCT alerts to the view


## Screenshots of UI changes
![Assess -- allows me to assess an application](https://user-images.githubusercontent.com/44123869/217494973-1519a178-e062-4c81-9985-708500447af0.png)
