### PR TITLE
Fix/Assessment type guard

### DIFF
--- a/server/utils/assessments/isAssessment.test.ts
+++ b/server/utils/assessments/isAssessment.test.ts
@@ -1,0 +1,15 @@
+import isAssessment from './isAssessment'
+import assessmentFactory from '../../testutils/factories/assessment'
+import applicationFactory from '../../testutils/factories/application'
+
+describe('isAssessment', () => {
+  it('returns true if the document is an assessment', () => {
+    const assessment = assessmentFactory.build()
+    expect(isAssessment(assessment)).toBe(true)
+  })
+
+  it('returns false if the document is an application', () => {
+    const application = applicationFactory.build()
+    expect(isAssessment(application)).toBe(false)
+  })
+})

--- a/server/utils/assessments/isAssessment.ts
+++ b/server/utils/assessments/isAssessment.ts
@@ -3,6 +3,5 @@ import {
   ApprovedPremisesAssessment as Assessment,
 } from '../../@types/shared'
 
-export default (applicationOrAssessment: Application | Assessment): applicationOrAssessment is Assessment => {
-  return 'allocatedToStaffMemberId' in applicationOrAssessment
-}
+export default (applicationOrAssessment: Application | Assessment): applicationOrAssessment is Assessment =>
+  (applicationOrAssessment as Assessment)?.allocatedAt !== undefined


### PR DESCRIPTION
The property that we used to assert than an assessment is an assessment (allocatedToStaffMemberId) changed its name and became optional. 
This meant that we were showing the application tasklist for assessments. 
Our types should have alerted us to this error but I *think* that because we were using the `in` operator we weren't. I have replaced the `in` operator with a more typesafe check and now we are testing for the 'allocatedAt' property which always exists for assessments.
Furthermore because this was a simple type guard which only exists in TS land the test coverage check didn't alert us to the lack of tests around the functionality. So I have added some tests around the functionality too. 
Hopefully with these tests and typechecks again we will prevent reoccurence.