### PR TITLE
(1215) Add an applications view for a workflow manager to view all assessments

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,6 +34,7 @@
       ],
       "rules": {
         "@typescript-eslint/no-use-before-define": 0,
+        "import/prefer-default-export": 0,
         "no-shadow": "off",
         "max-classes-per-file": "off",
         "@typescript-eslint/no-shadow": "error",

--- a/cypress_shared/helpers/index.ts
+++ b/cypress_shared/helpers/index.ts
@@ -6,6 +6,7 @@ import {
   ArrayOfOASysRiskToSelfQuestions,
   ArrayOfOASysSupportingInformationQuestions,
 } from '@approved-premises/api'
+import { TableRow } from '@approved-premises/ui'
 
 const roshSummariesFromApplication = (
   application: ApprovedPremisesApplication,
@@ -40,10 +41,32 @@ const riskToSelfSummariesFromApplication = (
   return application.data['oasys-import']['risk-to-self'].riskToSelfSummaries as ArrayOfOASysRiskToSelfQuestions
 }
 
+const tableRowsToArrays = (tableRows: Array<TableRow>): Array<Array<string>> => {
+  return tableRows.map(row => Object.keys(row).map(i => (row[i].html ? Cypress.$(row[i].html).text() : row[i].text)))
+}
+
+const shouldShowTableRows = <T>(items: Array<T>, tableRowFunction: (items: Array<T>) => Array<TableRow>): void => {
+  const tableRows = tableRowFunction(items)
+  const rowItems = tableRowsToArrays(tableRows)
+
+  rowItems.forEach(columns => {
+    const headerCell = columns.shift()
+    cy.contains('th', headerCell)
+      .parent('tr')
+      .within(() => {
+        columns.forEach((e, i) => {
+          cy.get('td').eq(i).invoke('text').should('contain', e)
+        })
+      })
+  })
+}
+
 export {
   roshSummariesFromApplication,
   offenceDetailSummariesFromApplication,
   supportInformationFromApplication,
   riskManagementPlanFromApplication,
   riskToSelfSummariesFromApplication,
+  tableRowsToArrays,
+  shouldShowTableRows,
 }

--- a/cypress_shared/pages/assess/allocationsListPage.ts
+++ b/cypress_shared/pages/assess/allocationsListPage.ts
@@ -1,0 +1,39 @@
+import type { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
+
+import Page from '../page'
+import paths from '../../../server/paths/assess'
+import { allocatedTableRows, unallocatedTableRows } from '../../../server/utils/assessments/utils'
+import { shouldShowTableRows } from '../../helpers'
+
+export default class AllocationsListPage extends Page {
+  constructor(
+    private readonly allocatedAssessments: Array<Assessment>,
+    private readonly unallocatedAssessments: Array<Assessment>,
+  ) {
+    super('Approved Premises applications')
+  }
+
+  static visit(
+    allocatedAssessments: Array<Assessment>,
+    unallocatedAssessments: Array<Assessment>,
+  ): AllocationsListPage {
+    cy.visit(paths.assessments.index({}))
+    return new AllocationsListPage(allocatedAssessments, unallocatedAssessments)
+  }
+
+  shouldShowAllocatedAssessments(): void {
+    shouldShowTableRows(this.allocatedAssessments, allocatedTableRows)
+  }
+
+  shouldShowUnallocatedAssessments(): void {
+    shouldShowTableRows(this.unallocatedAssessments, unallocatedTableRows)
+  }
+
+  clickMyAssessments() {
+    cy.get('a').contains('My Assessments').click()
+  }
+
+  clickUnallocated() {
+    cy.get('a').contains('Unallocated').click()
+  }
+}

--- a/cypress_shared/pages/assess/index.ts
+++ b/cypress_shared/pages/assess/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import ClarificationNoteConfirmPage from './clarificationNoteConfirmPage'
 import InformationReceivedPage from './informationReceivedPage'
 import ListPage from './listPage'

--- a/cypress_shared/pages/assess/index.ts
+++ b/cypress_shared/pages/assess/index.ts
@@ -1,3 +1,4 @@
+import AllocationsListPage from './allocationsListPage'
 import ClarificationNoteConfirmPage from './clarificationNoteConfirmPage'
 import InformationReceivedPage from './informationReceivedPage'
 import ListPage from './listPage'
@@ -12,6 +13,7 @@ import CheckYourAnswersPage from './checkYourAnswersPage'
 import SubmissionConfirmation from './submissionConfirmation'
 
 export {
+  AllocationsListPage,
   ClarificationNoteConfirmPage,
   InformationReceivedPage,
   ListPage,

--- a/cypress_shared/pages/assess/listPage.ts
+++ b/cypress_shared/pages/assess/listPage.ts
@@ -1,9 +1,13 @@
 import type { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
-import { format } from 'date-fns'
 
 import Page from '../page'
 import paths from '../../../server/paths/assess'
-import { DateFormats } from '../../../server/utils/dateUtils'
+import { shouldShowTableRows } from '../../helpers'
+import {
+  awaitingAssessmentTableRows,
+  completedTableRows,
+  requestedFurtherInformationTableRows,
+} from '../../../server/utils/assessments/utils'
 
 export default class ListPage extends Page {
   constructor(
@@ -27,51 +31,11 @@ export default class ListPage extends Page {
 
   shouldShowAwaitingAssessments(): void {
     const assessments = [this.awaitingAssessments, this.assessmentsCloseToDueDate].flat()
-    assessments.forEach((item: Assessment) => {
-      cy.contains(item.application.person.name)
-        .parent()
-        .parent()
-        .within(() => {
-          cy.get('td').eq(0).contains(item.application.person.crn)
-          cy.get('td').eq(1).contains(item.application.risks.tier.value.level)
-          cy.get('td')
-            .eq(2)
-            .contains(
-              format(
-                DateFormats.isoToDateObj(item.application.data['basic-information']['release-date'].releaseDate),
-                'd MMM yyyy',
-              ),
-            )
-          cy.get('td').eq(3).contains(item.application.person.prisonName)
-          cy.get('td')
-            .eq(4)
-            .contains(this.awaitingAssessments.includes(item) ? '7 Days' : '1 Day')
-          cy.get('td').eq(5).contains('In progress')
-        })
-    })
+    shouldShowTableRows(assessments, awaitingAssessmentTableRows)
   }
 
   shouldShowPendingAssessments(): void {
-    this.pendingAssessments.forEach((item: Assessment) => {
-      cy.contains(item.application.person.name)
-        .parent()
-        .parent()
-        .within(() => {
-          cy.get('td').eq(0).contains(item.application.person.crn)
-          cy.get('td').eq(1).contains(item.application.risks.tier.value.level)
-          cy.get('td')
-            .eq(2)
-            .contains(
-              format(
-                DateFormats.isoToDateObj(item.application.data['basic-information']['release-date'].releaseDate),
-                'd MMM yyyy',
-              ),
-            )
-          cy.get('td').eq(3).contains('3 Days')
-          cy.get('td').eq(4).contains('1 Day')
-          cy.get('td').eq(5).contains('Info Request')
-        })
-    })
+    shouldShowTableRows(this.pendingAssessments, requestedFurtherInformationTableRows)
   }
 
   shouldShowNotification(): void {
@@ -92,25 +56,7 @@ export default class ListPage extends Page {
   }
 
   shouldShowCompletedAssessments(): void {
-    this.completedAssesssments.forEach((item: Assessment) => {
-      cy.log(item.application.data['basic-information']['release-date'])
-      cy.contains(item.application.person.name)
-        .parent()
-        .parent()
-        .within(() => {
-          cy.get('td').eq(0).contains(item.application.person.crn)
-          cy.get('td').eq(1).contains(item.application.risks.tier.value.level)
-          cy.get('td')
-            .eq(2)
-            .contains(
-              format(
-                DateFormats.isoToDateObj(item.application.data['basic-information']['release-date'].releaseDate),
-                'd MMM yyyy',
-              ),
-            )
-          cy.get('td').eq(3).contains('Completed')
-        })
-    })
+    shouldShowTableRows(this.completedAssesssments, completedTableRows)
   }
 
   clickCompleted() {

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -1,5 +1,6 @@
 import jwt from 'jsonwebtoken'
 import { Response } from 'superagent'
+import { UserRole } from '../../server/@types/shared/models/UserRole'
 
 import { stubFor, getMatchingRequests } from '../../wiremock'
 import tokenVerification from './tokenVerification'
@@ -138,7 +139,7 @@ const stubUser = (name: string) =>
     },
   })
 
-const stubProfile = () =>
+const stubProfile = (roles = [], userId = '70596333-63d4-4fb2-8acc-9ca55563d878') =>
   stubFor({
     request: {
       method: 'GET',
@@ -150,8 +151,8 @@ const stubProfile = () =>
         'Content-Type': 'application/json;charset=UTF-8',
       },
       jsonBody: {
-        id: '70596333-63d4-4fb2-8acc-9ca55563d878',
-        roles: [],
+        id: userId,
+        roles,
       },
     },
   })
@@ -176,6 +177,8 @@ export default {
   stubAuthPing: ping,
   stubSignIn: (): Promise<[Response, Response, Response, Response, Response, Response]> =>
     Promise.all([favicon(), redirect(), signOut(), manageDetails(), token(), tokenVerification.stubVerifyToken()]),
-  stubAuthUser: (name = 'john smith'): Promise<[Response, Response, Response]> =>
-    Promise.all([stubUser(name), stubUserRoles(), stubProfile()]),
+  stubAuthUser: (
+    args: { name?: string; userId?: string; roles?: Array<UserRole> } = {},
+  ): Promise<[Response, Response, Response]> =>
+    Promise.all([stubUser(args.name || 'john smith'), stubUserRoles(), stubProfile(args.roles || [], args.userId)]),
 }

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -150,6 +150,7 @@ const stubProfile = () =>
         'Content-Type': 'application/json;charset=UTF-8',
       },
       jsonBody: {
+        id: '70596333-63d4-4fb2-8acc-9ca55563d878',
         roles: [],
       },
     },

--- a/integration_tests/tests/assess/listing.cy.ts
+++ b/integration_tests/tests/assess/listing.cy.ts
@@ -1,16 +1,19 @@
-import { ListPage } from '../../../cypress_shared/pages/assess'
+import { AllocationsListPage, ListPage } from '../../../cypress_shared/pages/assess'
+import Page from '../../../cypress_shared/pages/page'
 
 import assessmentFactory from '../../../server/testutils/factories/assessment'
 import clarificationNoteFactory from '../../../server/testutils/factories/clarificationNote'
+import userFactory from '../../../server/testutils/factories/user'
 
 context('Assess', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
   })
 
   it('shows a list of assessments', () => {
+    cy.task('stubAuthUser')
+
     // Given I am logged in
     cy.signIn()
 
@@ -69,5 +72,50 @@ context('Assess', () => {
 
     // Then I should see the completed assessments
     listPage.shouldShowCompletedAssessments()
+  })
+
+  it('shows a list of assigned and unassigned assessments', () => {
+    const me = userFactory.build()
+
+    // Given there are some allocated assessments
+    const allocatedAssessments = assessmentFactory.buildList(5, { allocatedToStaffMember: userFactory.build() })
+
+    // And there are some unallocated assessments
+    const unallocatedAssessments = assessmentFactory.buildList(5, { allocatedToStaffMember: null })
+
+    // And there are some assessments allocated to me
+    const assessmentsAllocatedToMe = assessmentFactory
+      .createdXDaysAgo(2)
+      .buildList(3, { status: 'active', allocatedToStaffMember: me })
+
+    cy.task('stubAssessments', [assessmentsAllocatedToMe, allocatedAssessments, unallocatedAssessments].flat())
+
+    // And I am logged in as a workflow manager
+    cy.task('stubAuthUser', { roles: ['workflow_manager'], userId: me.id })
+    cy.signIn()
+
+    // When I visit the allocations section
+    const allocationsListPage = AllocationsListPage.visit(
+      [allocatedAssessments, assessmentsAllocatedToMe].flat(),
+      unallocatedAssessments,
+    )
+
+    // Then I should see the allocated assessments
+    allocationsListPage.shouldShowAllocatedAssessments()
+
+    // When I click the unallocated tab
+    allocationsListPage.clickUnallocated()
+
+    // Then I should see the unallocated assessments
+    allocationsListPage.shouldShowUnallocatedAssessments()
+
+    // When I click to see my assessments
+    allocationsListPage.clickMyAssessments()
+
+    // Then I should see the default list page view
+    const listPage = Page.verifyOnPage(ListPage, assessmentsAllocatedToMe, [], [])
+
+    // Then I should see my assessments
+    listPage.shouldShowAwaitingAssessments()
   })
 })

--- a/integration_tests/tests/login.cy.ts
+++ b/integration_tests/tests/login.cy.ts
@@ -60,7 +60,7 @@ context('SignIn', () => {
     cy.request('/').its('body').should('contain', 'Sign in')
 
     cy.task('stubVerifyToken', true)
-    cy.task('stubAuthUser', 'bobby brown')
+    cy.task('stubAuthUser', { name: 'bobby brown' })
     cy.signIn()
 
     indexPage.headerUserName().contains('B. Brown')

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -153,6 +153,8 @@ export type TierNumber = '1' | '2' | '3' | '4'
 export type TierLetter = 'A' | 'B' | 'C' | 'D'
 export type RiskTierLevel = `${TierLetter}${TierNumber}`
 
+export type ApplicationType = 'Standard' | 'PIPE'
+
 export interface ErrorMessage {
   text: string
   attributes: {

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -16,6 +16,7 @@ import {
   Booking,
   Application,
   PersonAcctAlert,
+  UserRole,
 } from '@approved-premises/api'
 
 interface TasklistPage {
@@ -244,3 +245,10 @@ export type OasysImportArrays =
   | ArrayOfOASysRiskManagementPlanQuestions
 
 export type JourneyType = 'applications' | 'assessments'
+
+export type UserDetails = {
+  id: string
+  name: string
+  displayName: string
+  roles: Array<UserRole>
+}

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -217,10 +217,22 @@ export type DataServices = Partial<{
   }
 }>
 
-export interface GroupedAssessments {
-  completed: Array<Assessment>
-  requestedFurtherInformation: Array<Assessment>
-  awaiting: Array<Assessment>
+export type AssessmentGroupingCategory = 'status' | 'allocation'
+
+export type GroupedAssessments<T extends AssessmentGroupingCategory> = T extends 'status'
+  ? {
+      completed: Array<Assessment>
+      requestedFurtherInformation: Array<Assessment>
+      awaiting: Array<Assessment>
+    }
+  : {
+      allocated: Array<Assessment>
+      unallocated: Array<Assessment>
+    }
+
+export interface AllocatedAndUnallocatedAssessments {
+  allocated: Array<Assessment>
+  unallocated: Array<Assessment>
 }
 
 export interface GroupedApplications {

--- a/server/controllers/assess/assessmentsController.test.ts
+++ b/server/controllers/assess/assessmentsController.test.ts
@@ -49,7 +49,11 @@ describe('assessmentsController', () => {
   describe('index', () => {
     it('should list all the assessments when the user is not a workflow manager', async () => {
       const assesments = assessmentFactory.buildList(3)
-      const groupedAssessments = { completed: [], requestedFurtherInformation: [], awaiting: [] } as GroupedAssessments
+      const groupedAssessments = {
+        completed: [],
+        requestedFurtherInformation: [],
+        awaiting: [],
+      } as GroupedAssessments<'status'>
 
       assessmentService.getAll.mockResolvedValue(assesments)
       ;(groupAssessmements as jest.Mock).mockReturnValue(groupedAssessments)
@@ -63,29 +67,63 @@ describe('assessmentsController', () => {
         pageHeading: 'Approved Premises applications',
         assessments: groupedAssessments,
       })
+      expect(groupAssessmements).toHaveBeenCalledWith(assesments, 'status')
       expect(assessmentService.getAll).toHaveBeenCalled()
     })
 
-    it('should list all the assessments for a given user when the user is a workflow manager', async () => {
-      const assesments = assessmentFactory.buildList(3)
-      const groupedAssessments = { completed: [], requestedFurtherInformation: [], awaiting: [] } as GroupedAssessments
-
-      assessmentService.getAllForUser.mockResolvedValue(assesments)
-      ;(groupAssessmements as jest.Mock).mockReturnValue(groupedAssessments)
-      ;(hasRole as jest.Mock).mockReturnValue(true)
-
-      const requestHandler = assessmentsController.index()
-
+    describe('when the user is a workflow manager', () => {
       const user = { id: 'some-id ' }
-      response = createMock<Response>({ locals: { user } })
+      const assesments = assessmentFactory.buildList(3)
 
-      await requestHandler(request, response, next)
-
-      expect(response.render).toHaveBeenCalledWith('assessments/index', {
-        pageHeading: 'Approved Premises applications',
-        assessments: groupedAssessments,
+      beforeEach(() => {
+        ;(hasRole as jest.Mock).mockReturnValue(true)
+        response = createMock<Response>({ locals: { user } })
       })
-      expect(assessmentService.getAllForUser).toHaveBeenCalledWith(token, user.id)
+
+      it('should list all the assessments for a given user when `myAssessments` is set', async () => {
+        const groupedAssessments = {
+          completed: [],
+          requestedFurtherInformation: [],
+          awaiting: [],
+        } as GroupedAssessments<'status'>
+
+        assessmentService.getAllForUser.mockResolvedValue(assesments)
+        ;(groupAssessmements as jest.Mock).mockReturnValue(groupedAssessments)
+
+        const requestHandler = assessmentsController.index()
+        request.query = { type: 'myAssessments' }
+
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith('assessments/index', {
+          pageHeading: 'Approved Premises applications',
+          assessments: groupedAssessments,
+          type: 'myAssessments',
+        })
+        expect(groupAssessmements).toHaveBeenCalledWith(assesments, 'status')
+        expect(assessmentService.getAllForUser).toHaveBeenCalledWith(token, user.id)
+      })
+
+      it('should list all allocated and unallocated assessments when `user` is not set', async () => {
+        const groupedAssessments = {
+          allocated: [],
+          unallocated: [],
+        } as GroupedAssessments<'allocation'>
+
+        assessmentService.getAll.mockResolvedValue(assesments)
+        ;(groupAssessmements as jest.Mock).mockReturnValue(groupedAssessments)
+
+        const requestHandler = assessmentsController.index()
+
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith('assessments/index', {
+          pageHeading: 'Approved Premises applications',
+          assessments: groupedAssessments,
+        })
+        expect(groupAssessmements).toHaveBeenCalledWith(assesments, 'allocation')
+        expect(assessmentService.getAll).toHaveBeenCalledWith(token)
+      })
     })
   })
 

--- a/server/controllers/assess/assessmentsController.ts
+++ b/server/controllers/assess/assessmentsController.ts
@@ -7,12 +7,14 @@ import {
   acctAlertsFromAssessment,
   adjudicationsFromAssessment,
   caseNotesFromAssessment,
+  groupAssessmements,
 } from '../../utils/assessments/utils'
 
 import getSections from '../../utils/assessments/getSections'
 
 import paths from '../../paths/assess'
 import { DateFormats } from '../../utils/dateUtils'
+import { hasRole } from '../../utils/userUtils'
 
 export const tasklistPageHeading = 'Assess an Approved Premises (AP) application'
 
@@ -21,9 +23,14 @@ export default class AssessmentsController {
 
   index(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const assessments = await this.assessmentService.getAllForLoggedInUser(req.user.token)
+      const assessments = hasRole(res.locals.user, 'workflow_manager')
+        ? await this.assessmentService.getAllForUser(req.user.token, res.locals.user.id)
+        : await this.assessmentService.getAll(req.user.token)
 
-      res.render('assessments/index', { pageHeading: 'Approved Premises applications', assessments })
+      res.render('assessments/index', {
+        pageHeading: 'Approved Premises applications',
+        assessments: groupAssessmements(assessments),
+      })
     }
   }
 

--- a/server/services/assessmentService.test.ts
+++ b/server/services/assessmentService.test.ts
@@ -67,22 +67,6 @@ describe('AssessmentService', () => {
     })
   })
 
-  it('gets all the assesments for the logged in user and groups them by status', async () => {
-    const completedAssessments = assessmentFactory.buildList(2, { status: 'completed' })
-    const pendingAssessments = assessmentFactory.buildList(3, { status: 'pending' })
-    const activeAssessments = assessmentFactory.buildList(5, { status: 'active' })
-
-    assessmentClient.all.mockResolvedValue([completedAssessments, pendingAssessments, activeAssessments].flat())
-
-    const result = await service.getAllForLoggedInUser('token')
-
-    expect(result).toEqual({
-      completed: completedAssessments,
-      requestedFurtherInformation: pendingAssessments,
-      awaiting: activeAssessments,
-    })
-  })
-
   it('finds an assessment by its ID', async () => {
     const assessment = assessmentFactory.build()
 

--- a/server/services/assessmentService.ts
+++ b/server/services/assessmentService.ts
@@ -4,7 +4,7 @@ import {
   NewClarificationNote,
   UpdatedClarificationNote,
 } from '@approved-premises/api'
-import type { DataServices, GroupedAssessments } from '@approved-premises/ui'
+import type { DataServices } from '@approved-premises/ui'
 
 import type { RestClientBuilder, AssessmentClient } from '../data'
 import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
@@ -27,31 +27,6 @@ export default class AssessmentService {
     const assessments = await client.all()
 
     return assessments.filter(a => a.allocatedToStaffMember?.id === userId)
-  }
-
-  async getAllForLoggedInUser(token: string): Promise<GroupedAssessments> {
-    const client = this.assessmentClientFactory(token)
-
-    const result = { completed: [], requestedFurtherInformation: [], awaiting: [] } as GroupedAssessments
-    const assessments = await client.all()
-
-    await Promise.all(
-      assessments.map(async assessment => {
-        switch (assessment.status) {
-          case 'completed':
-            result.completed.push(assessment)
-            break
-          case 'pending':
-            result.requestedFurtherInformation.push(assessment)
-            break
-          default:
-            result.awaiting.push(assessment)
-            break
-        }
-      }),
-    )
-
-    return result
   }
 
   async findAssessment(token: string, id: string): Promise<Assessment> {

--- a/server/services/assessmentService.ts
+++ b/server/services/assessmentService.ts
@@ -16,6 +16,19 @@ import { applicationAccepted } from '../utils/assessments/utils'
 export default class AssessmentService {
   constructor(private readonly assessmentClientFactory: RestClientBuilder<AssessmentClient>) {}
 
+  async getAll(token: string): Promise<Array<Assessment>> {
+    const client = this.assessmentClientFactory(token)
+
+    return client.all()
+  }
+
+  async getAllForUser(token: string, userId: string): Promise<Array<Assessment>> {
+    const client = this.assessmentClientFactory(token)
+    const assessments = await client.all()
+
+    return assessments.filter(a => a.allocatedToStaffMember?.id === userId)
+  }
+
   async getAllForLoggedInUser(token: string): Promise<GroupedAssessments> {
     const client = this.assessmentClientFactory(token)
 

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -37,11 +37,12 @@ describe('User service', () => {
       expect(result.displayName).toEqual('John Smith')
     })
 
-    it('retrieves and populates roles', async () => {
+    it('retrieves and populates information from the API', async () => {
       hmppsAuthClient.getActingUser.mockResolvedValue({ name: 'john smith' } as User)
 
       const result = await userService.getActingUser(token)
 
+      expect(result.id).toEqual(userProfile.id)
       expect(result.roles).toEqual(['workflow_manager', 'assessor'])
     })
 

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,14 +1,8 @@
-import { User, UserRole } from '@approved-premises/api'
+import { User } from '@approved-premises/api'
+import { UserDetails } from '@approved-premises/ui'
 import { RestClientBuilder, UserClient } from '../data'
 import { convertToTitleCase } from '../utils/utils'
 import type HmppsAuthClient from '../data/hmppsAuthClient'
-
-interface UserDetails {
-  id: string
-  name: string
-  displayName: string
-  roles: Array<UserRole>
-}
 
 export default class UserService {
   constructor(

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -4,6 +4,7 @@ import { convertToTitleCase } from '../utils/utils'
 import type HmppsAuthClient from '../data/hmppsAuthClient'
 
 interface UserDetails {
+  id: string
   name: string
   displayName: string
   roles: Array<UserRole>
@@ -19,7 +20,7 @@ export default class UserService {
     const user = await this.hmppsAuthClient.getActingUser(token)
     const client = this.userClientFactory(token)
     const profile = await client.getUserProfile()
-    return { ...user, displayName: convertToTitleCase(user.name), roles: profile.roles }
+    return { ...user, id: profile.id, displayName: convertToTitleCase(user.name), roles: profile.roles }
   }
 
   async getUserById(token: string, id: string): Promise<User> {

--- a/server/testutils/factories/userDetails.ts
+++ b/server/testutils/factories/userDetails.ts
@@ -1,0 +1,11 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { UserDetails } from '@approved-premises/ui'
+
+export default Factory.define<UserDetails>(() => ({
+  id: faker.datatype.uuid(),
+  name: faker.internet.userName(),
+  displayName: faker.name.fullName(),
+  roles: [],
+}))

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -28,6 +28,7 @@ import {
   acctAlertsFromAssessment,
   groupAssessmements,
   unallocatedTableRows,
+  arriveDateAsTimestamp,
 } from './utils'
 import { DateFormats } from '../dateUtils'
 import paths from '../../paths/assess'
@@ -213,6 +214,16 @@ describe('utils', () => {
     })
   })
 
+  describe('arriveDateAsTimestamp', () => {
+    it('returns the arrival date from the application as a unix timestamp', () => {
+      const assessment = assessmentFactory.build()
+      const getDateSpy = jest.spyOn(applicationUtils, 'getArrivalDate').mockReturnValue('2022-01-01')
+
+      expect(arriveDateAsTimestamp(assessment)).toEqual(1640995200)
+      expect(getDateSpy).toHaveBeenCalledWith(assessment.application)
+    })
+  })
+
   describe('getApplicationType', () => {
     it('returns standard when the application is not PIPE', () => {
       const assessment = assessmentFactory.build({
@@ -241,9 +252,19 @@ describe('utils', () => {
 
       expect(allocatedTableRows([assessment])).toEqual([
         [
-          { html: assessment.application.person.name },
-          { text: formattedArrivalDate(assessment) },
-          { html: formatDaysUntilDueWithWarning(assessment) },
+          { text: assessment.application.person.name },
+          {
+            text: formattedArrivalDate(assessment),
+            attributes: {
+              'data-sort-value': `${arriveDateAsTimestamp(assessment)}`,
+            },
+          },
+          {
+            html: formatDaysUntilDueWithWarning(assessment),
+            attributes: {
+              'data-sort-value': `${daysUntilDue(assessment)}`,
+            },
+          },
           { text: assessment.allocatedToStaffMember.name },
           { text: getApplicationType(assessment) },
           { html: getStatus(assessment) },
@@ -263,9 +284,19 @@ describe('utils', () => {
 
       expect(unallocatedTableRows([assessment])).toEqual([
         [
-          { html: assessment.application.person.name },
-          { text: formattedArrivalDate(assessment) },
-          { html: formatDaysUntilDueWithWarning(assessment) },
+          { text: assessment.application.person.name },
+          {
+            text: formattedArrivalDate(assessment),
+            attributes: {
+              'data-sort-value': `${arriveDateAsTimestamp(assessment)}`,
+            },
+          },
+          {
+            html: formatDaysUntilDueWithWarning(assessment),
+            attributes: {
+              'data-sort-value': `${daysUntilDue(assessment)}`,
+            },
+          },
           { text: getApplicationType(assessment) },
           { html: getStatus(assessment) },
           { html: assessmentLink(assessment, 'Allocate', `assessment for ${assessment.application.person.name}`) },

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -329,11 +329,25 @@ describe('utils', () => {
   })
 
   describe('assessmentLink', () => {
-    it('returns a link to an assessment', () => {
-      const assessment = assessmentFactory.build({ id: '123', application: { person: { name: 'John Wayne' } } })
+    const assessment = assessmentFactory.build({ id: '123', application: { person: { name: 'John Wayne' } } })
 
+    it('returns a link to an assessment', () => {
       expect(assessmentLink(assessment)).toMatchStringIgnoringWhitespace(`
         <a href="${paths.assessments.show({ id: '123' })}" data-cy-assessmentId="123">John Wayne</a>
+      `)
+    })
+
+    it('allows custom text to be specified', () => {
+      expect(assessmentLink(assessment, 'My Text')).toMatchStringIgnoringWhitespace(`
+        <a href="${paths.assessments.show({ id: '123' })}" data-cy-assessmentId="123">My Text</a>
+      `)
+    })
+
+    it('allows custom text and hidden text to be specified', () => {
+      expect(assessmentLink(assessment, 'My Text', 'and some hidden text')).toMatchStringIgnoringWhitespace(`
+        <a href="${paths.assessments.show({
+          id: '123',
+        })}" data-cy-assessmentId="123">My Text <span class="govuk-visually-hidden">and some hidden text</span></a>
       `)
     })
   })

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -24,6 +24,7 @@ import {
   adjudicationsFromAssessment,
   caseNotesFromAssessment,
   acctAlertsFromAssessment,
+  groupAssessmements,
 } from './utils'
 import { DateFormats } from '../dateUtils'
 import paths from '../../paths/assess'
@@ -98,6 +99,22 @@ Assess.pages['review-application'] = {
 describe('utils', () => {
   beforeEach(() => {
     jest.resetAllMocks()
+  })
+
+  describe('groupAssessmements', () => {
+    it('groups assessments by their status', () => {
+      const completedAssessments = assessmentFactory.buildList(2, { status: 'completed' })
+      const pendingAssessments = assessmentFactory.buildList(3, { status: 'pending' })
+      const activeAssessments = assessmentFactory.buildList(5, { status: 'active' })
+
+      const assessments = [completedAssessments, pendingAssessments, activeAssessments].flat()
+
+      expect(groupAssessmements(assessments)).toEqual({
+        completed: completedAssessments,
+        requestedFurtherInformation: pendingAssessments,
+        awaiting: activeAssessments,
+      })
+    })
   })
 
   describe('daysSinceReceived', () => {

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -109,10 +109,22 @@ describe('utils', () => {
 
       const assessments = [completedAssessments, pendingAssessments, activeAssessments].flat()
 
-      expect(groupAssessmements(assessments)).toEqual({
+      expect(groupAssessmements(assessments, 'status')).toEqual({
         completed: completedAssessments,
         requestedFurtherInformation: pendingAssessments,
         awaiting: activeAssessments,
+      })
+    })
+
+    it('groups assessments by their allocation', () => {
+      const allocatedAssessments = assessmentFactory.buildList(2, { allocatedToStaffMember: userFactory.build() })
+      const unallocatedAssessments = assessmentFactory.buildList(3, { allocatedToStaffMember: null })
+
+      const assessments = [allocatedAssessments, unallocatedAssessments].flat()
+
+      expect(groupAssessmements(assessments, 'allocation')).toEqual({
+        allocated: allocatedAssessments,
+        unallocated: unallocatedAssessments,
       })
     })
   })

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -1,4 +1,5 @@
 import {
+  AssessmentGroupingCategory,
   GroupedAssessments,
   HtmlItem,
   PageResponse,
@@ -25,10 +26,10 @@ import { documentsFromApplication } from './documentUtils'
 
 const DUE_DATE_APPROACHING_DAYS_WINDOW = 3
 
-const groupAssessmements = (assessments: Array<Assessment>): GroupedAssessments => {
-  const result = { completed: [], requestedFurtherInformation: [], awaiting: [] } as GroupedAssessments
+const groupAssessmementsByStatus = (assessments: Array<Assessment>): GroupedAssessments<'status'> => {
+  const result = { completed: [], requestedFurtherInformation: [], awaiting: [] } as GroupedAssessments<'status'>
 
-  assessments.map(async assessment => {
+  assessments.forEach(assessment => {
     switch (assessment.status) {
       case 'completed':
         result.completed.push(assessment)
@@ -43,6 +44,30 @@ const groupAssessmements = (assessments: Array<Assessment>): GroupedAssessments 
   })
 
   return result
+}
+
+const groupAssessmementsByAllocation = (assessments: Array<Assessment>): GroupedAssessments<'allocation'> => {
+  const result = { allocated: [], unallocated: [] } as GroupedAssessments<'allocation'>
+
+  assessments.forEach(assessment => {
+    if (assessment.allocatedToStaffMember) {
+      result.allocated.push(assessment)
+    } else {
+      result.unallocated.push(assessment)
+    }
+  })
+
+  return result
+}
+
+const groupAssessmements = <T extends AssessmentGroupingCategory>(
+  assessments: Array<Assessment>,
+  category: T,
+): GroupedAssessments<T> => {
+  const result =
+    category === 'status' ? groupAssessmementsByStatus(assessments) : groupAssessmementsByAllocation(assessments)
+
+  return result as GroupedAssessments<T>
 }
 
 const awaitingAssessmentTableRows = (assessments: Array<Assessment>): Array<TableRow> => {

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -1,4 +1,12 @@
-import { HtmlItem, PageResponse, SummaryListItem, TableRow, Task, TextItem } from '@approved-premises/ui'
+import {
+  GroupedAssessments,
+  HtmlItem,
+  PageResponse,
+  SummaryListItem,
+  TableRow,
+  Task,
+  TextItem,
+} from '@approved-premises/ui'
 import { format, differenceInDays, add } from 'date-fns'
 
 import { ApprovedPremisesAssessment as Assessment, ApprovedPremisesApplication } from '@approved-premises/api'
@@ -16,6 +24,26 @@ import { kebabCase } from '../utils'
 import { documentsFromApplication } from './documentUtils'
 
 const DUE_DATE_APPROACHING_DAYS_WINDOW = 3
+
+const groupAssessmements = (assessments: Array<Assessment>): GroupedAssessments => {
+  const result = { completed: [], requestedFurtherInformation: [], awaiting: [] } as GroupedAssessments
+
+  assessments.map(async assessment => {
+    switch (assessment.status) {
+      case 'completed':
+        result.completed.push(assessment)
+        break
+      case 'pending':
+        result.requestedFurtherInformation.push(assessment)
+        break
+      default:
+        result.awaiting.push(assessment)
+        break
+    }
+  })
+
+  return result
+}
 
 const awaitingAssessmentTableRows = (assessments: Array<Assessment>): Array<TableRow> => {
   const rows = [] as Array<TableRow>
@@ -365,4 +393,5 @@ export {
   assessmentsApproachingDue,
   assessmentsApproachingDueBadge,
   formatDaysUntilDueWithWarning,
+  groupAssessmements,
 }

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -9,7 +9,7 @@ import {
   Task,
   TextItem,
 } from '@approved-premises/ui'
-import { format, differenceInDays, add } from 'date-fns'
+import { format, differenceInDays, add, getUnixTime } from 'date-fns'
 
 import { ApprovedPremisesAssessment as Assessment, ApprovedPremisesApplication } from '@approved-premises/api'
 import { tierBadge } from '../personUtils'
@@ -88,9 +88,15 @@ const allocatedTableRows = (assessments: Array<Assessment>): Array<TableRow> => 
       },
       {
         text: formattedArrivalDate(assessment),
+        attributes: {
+          'data-sort-value': `${arriveDateAsTimestamp(assessment)}`,
+        },
       },
       {
         html: formatDaysUntilDueWithWarning(assessment),
+        attributes: {
+          'data-sort-value': `${daysUntilDue(assessment)}`,
+        },
       },
       {
         text: assessment.allocatedToStaffMember.name,
@@ -120,9 +126,15 @@ const unallocatedTableRows = (assessments: Array<Assessment>): Array<TableRow> =
       },
       {
         text: formattedArrivalDate(assessment),
+        attributes: {
+          'data-sort-value': `${arriveDateAsTimestamp(assessment)}`,
+        },
       },
       {
         html: formatDaysUntilDueWithWarning(assessment),
+        attributes: {
+          'data-sort-value': `${daysUntilDue(assessment)}`,
+        },
       },
       {
         text: getApplicationType(assessment),
@@ -243,6 +255,11 @@ const assessmentLink = (assessment: Assessment, linkText = '', hiddenText = ''):
 const formattedArrivalDate = (assessment: Assessment): string => {
   const arrivalDate = getArrivalDate(assessment.application as ApprovedPremisesApplication)
   return format(DateFormats.isoToDateObj(arrivalDate), 'd MMM yyyy')
+}
+
+const arriveDateAsTimestamp = (assessment: Assessment): number => {
+  const arrivalDate = getArrivalDate(assessment.application as ApprovedPremisesApplication)
+  return getUnixTime(DateFormats.isoToDateObj(arrivalDate))
 }
 
 const formatDays = (days: number): string => {
@@ -496,4 +513,5 @@ export {
   allocatedTableRows,
   unallocatedTableRows,
   getApplicationType,
+  arriveDateAsTimestamp,
 }

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -1,4 +1,5 @@
 import {
+  ApplicationType,
   AssessmentGroupingCategory,
   GroupedAssessments,
   HtmlItem,
@@ -68,6 +69,74 @@ const groupAssessmements = <T extends AssessmentGroupingCategory>(
     category === 'status' ? groupAssessmementsByStatus(assessments) : groupAssessmementsByAllocation(assessments)
 
   return result as GroupedAssessments<T>
+}
+
+const getApplicationType = (assessment: Assessment): ApplicationType => {
+  if (assessment.application.isPipeApplication) {
+    return 'PIPE'
+  }
+  return 'Standard'
+}
+
+const allocatedTableRows = (assessments: Array<Assessment>): Array<TableRow> => {
+  const rows = [] as Array<TableRow>
+
+  assessments.forEach(assessment => {
+    rows.push([
+      {
+        text: assessment.application.person.name,
+      },
+      {
+        text: formattedArrivalDate(assessment),
+      },
+      {
+        html: formatDaysUntilDueWithWarning(assessment),
+      },
+      {
+        text: assessment.allocatedToStaffMember.name,
+      },
+      {
+        text: getApplicationType(assessment),
+      },
+      {
+        html: getStatus(assessment),
+      },
+      {
+        html: assessmentLink(assessment, 'Reallocate', `assessment for ${assessment.application.person.name}`),
+      },
+    ])
+  })
+
+  return rows
+}
+
+const unallocatedTableRows = (assessments: Array<Assessment>): Array<TableRow> => {
+  const rows = [] as Array<TableRow>
+
+  assessments.forEach(assessment => {
+    rows.push([
+      {
+        text: assessment.application.person.name,
+      },
+      {
+        text: formattedArrivalDate(assessment),
+      },
+      {
+        html: formatDaysUntilDueWithWarning(assessment),
+      },
+      {
+        text: getApplicationType(assessment),
+      },
+      {
+        html: getStatus(assessment),
+      },
+      {
+        html: assessmentLink(assessment, 'Allocate', `assessment for ${assessment.application.person.name}`),
+      },
+    ])
+  })
+
+  return rows
 }
 
 const awaitingAssessmentTableRows = (assessments: Array<Assessment>): Array<TableRow> => {
@@ -424,4 +493,7 @@ export {
   assessmentsApproachingDueBadge,
   formatDaysUntilDueWithWarning,
   groupAssessmements,
+  allocatedTableRows,
+  unallocatedTableRows,
+  getApplicationType,
 }

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -160,10 +160,15 @@ const requestedFurtherInformationTableRows = (assessments: Array<Assessment>): A
   return rows
 }
 
-const assessmentLink = (assessment: Assessment): string => {
-  return `<a href="${paths.assessments.show({ id: assessment.id })}" data-cy-assessmentId="${assessment.id}">${
-    assessment.application.person.name
-  }</a>`
+const assessmentLink = (assessment: Assessment, linkText = '', hiddenText = ''): string => {
+  let linkBody = linkText || assessment.application.person.name
+
+  if (hiddenText) {
+    linkBody = `${linkBody} <span class="govuk-visually-hidden">${hiddenText}</span>`
+  }
+  return `<a href="${paths.assessments.show({ id: assessment.id })}" data-cy-assessmentId="${
+    assessment.id
+  }">${linkBody}</a>`
 }
 
 const formattedArrivalDate = (assessment: Assessment): string => {

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -26,6 +26,7 @@ import * as OasysImportUtils from './oasysImportUtils'
 import * as BookingUtils from './bookingUtils'
 import * as TasklistUtils from './taskListUtils'
 import * as FormUtils from './formUtils'
+import * as UserUtils from './userUtils'
 
 import managePaths from '../paths/manage'
 import applyPaths from '../paths/apply'
@@ -158,4 +159,5 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('BookingUtils', BookingUtils)
   njkEnv.addGlobal('TasklistUtils', TasklistUtils)
   njkEnv.addGlobal('FormUtils', FormUtils)
+  njkEnv.addGlobal('UserUtils', UserUtils)
 }

--- a/server/utils/userUtils.test.ts
+++ b/server/utils/userUtils.test.ts
@@ -1,0 +1,18 @@
+import userDetailsFactory from '../testutils/factories/userDetails'
+import { hasRole } from './userUtils'
+
+describe('userUtils', () => {
+  describe('hasRole', () => {
+    it('returns true when the user has the role', () => {
+      const user = userDetailsFactory.build({ roles: ['applicant'] })
+
+      expect(hasRole(user, 'applicant')).toEqual(true)
+    })
+
+    it('returns false when the user does not have the role', () => {
+      const user = userDetailsFactory.build({ roles: ['assessor'] })
+
+      expect(hasRole(user, 'applicant')).toEqual(false)
+    })
+  })
+})

--- a/server/utils/userUtils.ts
+++ b/server/utils/userUtils.ts
@@ -1,0 +1,6 @@
+import { UserRole } from '@approved-premises/api'
+import { UserDetails } from '@approved-premises/ui'
+
+export const hasRole = (user: UserDetails, role: UserRole): boolean => {
+  return (user.roles || []).includes(role)
+}

--- a/server/views/assessments/_assessmentAllocationList.njk
+++ b/server/views/assessments/_assessmentAllocationList.njk
@@ -1,0 +1,101 @@
+{% set allocatedHtml %}
+{{
+  govukTable({
+    attributes: {
+      'data-module': 'moj-sortable-table'
+    },
+    caption: "Allocated Assessments",
+    captionClasses: "govuk-table__caption--m",
+    firstCellIsHeader: true,
+    head: [
+      {
+        text: "Name"
+      },
+      {
+        text: "Arrival date",
+        attributes: {
+          "aria-sort": "none"
+        }
+      },
+      {
+        text: "Days until Assessment Due",
+        attributes: {
+          "aria-sort": "none"
+        }
+      },
+      {
+        text: "Assessor name"
+      },
+      {
+        text: "Application type"
+      },
+      {
+        text: "Status"
+      },
+      {
+        html: '<span class="govuk-visually-hidden">Actions</span>'
+      }
+    ],
+    rows: AssessmentUtils.allocatedTableRows(assessments.allocated)
+  })
+}}
+{% endset -%}
+
+{% set unallocatedHtml %}
+{{
+  govukTable({
+    attributes: {
+      'data-module': 'moj-sortable-table'
+    },
+    caption: "Unallocated Assessments",
+    captionClasses: "govuk-table__caption--m",
+    firstCellIsHeader: true,
+    head: [
+      {
+        text: "Name"
+      },
+      {
+        text: "Arrival date",
+        attributes: {
+          "aria-sort": "none"
+        }
+      },
+      {
+        text: "Days until Assessment Due",
+        attributes: {
+          "aria-sort": "none"
+        }
+      },
+      {
+        text: "Application type"
+      },
+      {
+        text: "Status"
+      },
+      {
+        html: '<span class="govuk-visually-hidden">Actions</span>'
+      }
+    ],
+    rows: AssessmentUtils.unallocatedTableRows(assessments.unallocated)
+  })
+}}
+{% endset -%}
+
+{{ govukTabs({
+  items: [
+    {
+      label: "Allocated",
+      id: "allocated",
+      panel: {
+        html: allocatedHtml
+      }
+    },
+    {
+      label: "Unallocated",
+      id: "unallocated",
+      panel: {
+        html: unallocatedHtml
+      }
+    }
+  ]
+}) }}

--- a/server/views/assessments/_assessmentsForUser.njk
+++ b/server/views/assessments/_assessmentsForUser.njk
@@ -1,0 +1,121 @@
+{% set awaitingHtml %}
+{{
+  govukTable({
+    caption: "Applications to assess",
+    captionClasses: "govuk-table__caption--m",
+    firstCellIsHeader: true,
+    head: [
+      {
+        text: "Name"
+      },
+      {
+        text: "CRN"
+      },
+      {
+        text: "Tier"
+      },
+      {
+        text: "Arrival date"
+      },
+      {
+        text: "Current location"
+      },
+      {
+        text: "Days until application due"
+      },
+      {
+        text: "Status"
+      }
+    ],
+    rows: AssessmentUtils.awaitingAssessmentTableRows(assessments.awaiting)
+  })
+}}
+{% endset -%}
+
+{% set infoRequestHtml %}
+{{
+  govukTable({
+      caption: "Requested further information",
+      captionClasses: "govuk-table__caption--m",
+      firstCellIsHeader: true,
+      head: [
+        {
+          text: "Name"
+        },
+        {
+          text: "CRN"
+        },
+        {
+          text: "Tier"
+        },
+        {
+          text: "Arrival date"
+        },
+        {
+          text: "Days since application received"
+        },
+        {
+          text: "Date of info request"
+        },
+        {
+          text: "Status"
+        }
+      ],
+      rows: AssessmentUtils.requestedFurtherInformationTableRows(assessments.requestedFurtherInformation)
+    })
+  }}
+{% endset -%}
+
+{% set completedHtml %}
+{{
+    govukTable({
+      caption: "Completed Assessments",
+      captionClasses: "govuk-table__caption--m",
+      firstCellIsHeader: true,
+      head: [
+        {
+          text: "Name"
+        },
+        {
+          text: "CRN"
+        },
+        {
+          text: "Tier"
+        },
+        {
+          text: "Arrival date"
+        },
+        {
+          text: "Status"
+        }
+      ],
+      rows: AssessmentUtils.completedTableRows(assessments.completed)
+    })
+  }}
+{% endset -%}
+
+{{ govukTabs({
+  items: [
+    {
+      label: ('Applications' + AssessmentUtils.assessmentsApproachingDueBadge(assessments.awaiting)) | safe,
+      id: "applications",
+      panel: {
+        html: awaitingHtml
+      }
+    },
+    {
+      label: "Requested further information",
+      id: "infoRequest",
+      panel: {
+        html: infoRequestHtml
+      }
+    },
+    {
+      label: "Completed",
+      id: "completed",
+      panel: {
+        html: completedHtml
+      }
+    }
+  ]
+}) }}

--- a/server/views/assessments/index.njk
+++ b/server/views/assessments/index.njk
@@ -45,5 +45,38 @@
     window
       .MOJFrontend
       .initAll()
+
+    // This is a temporary fix to ensure table sorting works correctly with row headers
+    // This can be removed once https://github.com/ministryofjustice/moj-frontend/pull/442 is merged
+    window.MOJFrontend.SortableTable.prototype.sort = function (rows, columnNumber, sortDirection) {
+      var newRows = rows.sort($.proxy(function (rowA, rowB) {
+        var tdA = $(rowA)
+          .find('td,th')
+          .eq(columnNumber);
+        var tdB = $(rowB)
+          .find('td,th')
+          .eq(columnNumber);
+        var valueA = this.getCellValue(tdA);
+        var valueB = this.getCellValue(tdB);
+        if (sortDirection === 'ascending') {
+          if (valueA < valueB) {
+            return -1;
+          }
+          if (valueA > valueB) {
+            return 1;
+          }
+          return 0;
+        } else {
+          if (valueB < valueA) {
+            return -1;
+          }
+          if (valueB > valueA) {
+            return 1;
+          }
+          return 0;
+        }
+      }, this));
+      return newRows;
+    };
   </script>
 {% endblock %}

--- a/server/views/assessments/index.njk
+++ b/server/views/assessments/index.njk
@@ -1,6 +1,7 @@
 {% extends "../partials/layout.njk" %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 
 {% set pageTitle = applicationName + " - " + pageHeading  %}
 {% set mainClasses = "app-container govuk-body assessments--index" %}
@@ -12,128 +13,37 @@
 
       <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
-      {% set awaitingHtml %}
-      {{
-        govukTable({
-          caption: "Applications to assess",
-          captionClasses: "govuk-table__caption--m",
-          firstCellIsHeader: true,
-          head: [
-            {
-              text: "Name"
-            },
-            {
-              text: "CRN"
-            },
-            {
-              text: "Tier"
-            },
-            {
-              text: "Arrival date"
-            },
-            {
-              text: "Current location"
-            },
-            {
-              text: "Days until application due"
-            },
-            {
-              text: "Status"
-            }
-          ],
-          rows: AssessmentUtils.awaitingAssessmentTableRows(assessments.awaiting)
-        })
-      }}
-      {% endset -%}
-
-      {% set infoRequestHtml %}
-      {{
-        govukTable({
-          caption: "Requested further information",
-          captionClasses: "govuk-table__caption--m",
-          firstCellIsHeader: true,
-          head: [
-            {
-              text: "Name"
-            },
-            {
-              text: "CRN"
-            },
-            {
-              text: "Tier"
-            },
-            {
-              text: "Arrival date"
-            },
-            {
-              text: "Days since application received"
-            },
-            {
-              text: "Date of info request"
-            },
-            {
-              text: "Status"
-            }
-          ],
-          rows: AssessmentUtils.requestedFurtherInformationTableRows(assessments.requestedFurtherInformation)
-        })
-      }}
-      {% endset -%}
-
-      {% set completedHtml %}
-      {{
-        govukTable({
-          caption: "Completed Assessments",
-          captionClasses: "govuk-table__caption--m",
-          firstCellIsHeader: true,
-          head: [
-            {
-              text: "Name"
-            },
-            {
-              text: "CRN"
-            },
-            {
-              text: "Tier"
-            },
-            {
-              text: "Arrival date"
-            },
-            {
-              text: "Status"
-            }
-          ],
-          rows: AssessmentUtils.completedTableRows(assessments.completed)
-        })
-      }}
-      {% endset -%}
-
-      {{ govukTabs({
-        items: [
-          {
-            label: ('Applications' + AssessmentUtils.assessmentsApproachingDueBadge(assessments.awaiting)) | safe,
-            id: "applications",
-            panel: {
-              html: awaitingHtml
-            }
+      {% if UserUtils.hasRole(user, 'workflow_manager') %}
+        {{ mojSubNavigation({
+          label: 'Sub navigation',
+          items: [{
+            text: 'All Assessments',
+            href: paths.assessments.index({}),
+            active: (type !== 'myAssessments')
           },
           {
-            label: "Requested further information",
-            id: "infoRequest",
-            panel: {
-              html: infoRequestHtml
-            }
-          },
-          {
-            label: "Completed",
-            id: "completed",
-            panel: {
-              html: completedHtml
-            }
-          }
-        ]
-      }) }}
+            text: 'My Assessments',
+            href: paths.assessments.index({}) + '?type=myAssessments',
+            active: (type === 'myAssessments')
+          }]
+        }) }}
 
+        {% if type === 'myAssessments' %}
+          {% include './_assessmentsForUser.njk' %}
+        {% else %}
+          {% include './_assessmentAllocationList.njk' %}
+        {% endif %}
+      {% else %}
+        {% include './_assessmentsForUser.njk' %}
+      {% endif %}
     </div>
   </div>
+{% endblock %}
+
+{% block extraScripts %}
+  <script type="text/javascript" nonce="{{ cspNonce }}">
+    window
+      .MOJFrontend
+      .initAll()
+  </script>
 {% endblock %}


### PR DESCRIPTION
This adds a view for a Workflow Manager to view all assessments, seperated out by if they have a staff member allocated to them. If the logged in user is a workflow manager, they see an option to view all assessments, or just their own (defaulting to all assessments). 

Clicking through to Allocate/Reallocate currently links to the tasklist. Fixing this will come in the next PR.

I've diverged a bit from the [original prototype](https://approved-premises-prototype-main.apps.live.cloud-platform.service.justice.gov.uk/cru-allocation/cru-allocation-dashboard), but we can iterate as we go if it's not quite right.

This is a fairly big PR, but hopefully the commit history makes enough sense for it to be reviewed as one, but lemme know if it needs trimming down!

## Screenshots

![Assess -- shows a list of assigned and unassigned assessments](https://user-images.githubusercontent.com/109774/217824170-946fedfe-e6ab-4a34-90a0-bf37690eb673.png)
![Assess -- shows a list of assigned and unassigned assessments (1)](https://user-images.githubusercontent.com/109774/217824159-1014c423-02fa-42bf-8f6e-b785973800e6.png)
![Assess -- shows a list of assigned and unassigned assessments (2)](https://user-images.githubusercontent.com/109774/217824164-9fddae9e-40fe-43ed-ad13-404fc4181dcf.png)



