### PR TITLE
Fix - Add proper rejectionRationale when rejecting an assessment

### DIFF
--- a/server/services/assessmentService.test.ts
+++ b/server/services/assessmentService.test.ts
@@ -11,7 +11,7 @@ import { getBody, updateAssessmentData } from '../form-pages/utils'
 import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
 import { DataServices, TaskListErrors } from '../@types/ui'
 import { ValidationError } from '../utils/errors'
-import { getResponses } from '../utils/applicationUtils'
+import { ApplicationOrAssessmentResponse, getResponseForPage, getResponses } from '../utils/applicationUtils'
 
 jest.mock('../data/assessmentClient.ts')
 jest.mock('../data/personClient.ts')
@@ -173,7 +173,7 @@ describe('AssessmentService', () => {
 
   describe('submit', () => {
     const token = 'some-token'
-    const document = { document: 'foo' }
+    let document = { foo: [{ bar: 'baz' }] } as ApplicationOrAssessmentResponse
 
     it('if the assessment is accepted the accept client method is called', async () => {
       const assessment = assessmentFactory.acceptedAssessment().build()
@@ -186,10 +186,15 @@ describe('AssessmentService', () => {
     })
 
     it('if the assessment is rejected the rejection client method is called with the rejectionRationale', async () => {
-      const assessment = assessmentFactory.build({
-        rejectionRationale: 'Reject, risk too high (must be approved by an AP Area Manager (APAM)',
-      })
+      const assessment = assessmentFactory.build()
+      document = {
+        ...document,
+        'make-a-decision': [{ Decision: 'Reject, risk too high (must be approved by an AP Area Manager (APAM)' }],
+      }
       ;(getResponses as jest.Mock).mockReturnValue(document)
+      ;(getResponseForPage as jest.Mock).mockReturnValue({
+        Decision: 'Reject, risk too high (must be approved by an AP Area Manager (APAM)',
+      })
 
       await service.submit(token, assessment)
 

--- a/server/services/assessmentService.ts
+++ b/server/services/assessmentService.ts
@@ -1,4 +1,4 @@
-import type { Request } from 'express'
+import { Request } from 'express'
 import {
   ApprovedPremisesAssessment as Assessment,
   NewClarificationNote,
@@ -11,7 +11,7 @@ import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
 import { getBody, updateAssessmentData } from '../form-pages/utils'
 import { ValidationError } from '../utils/errors'
 import { getResponses } from '../utils/applicationUtils'
-import { applicationAccepted } from '../utils/assessments/utils'
+import { applicationAccepted, rejectionRationaleFromAssessmentResponses } from '../utils/assessments/utils'
 
 export default class AssessmentService {
   constructor(private readonly assessmentClientFactory: RestClientBuilder<AssessmentClient>) {}
@@ -73,7 +73,7 @@ export default class AssessmentService {
     const responses = getResponses(assessment)
 
     if (!applicationAccepted(assessment)) {
-      return client.rejection(assessment.id, responses, assessment.rejectionRationale)
+      return client.rejection(assessment.id, responses, rejectionRationaleFromAssessmentResponses(assessment))
     }
 
     return client.acceptance(assessment.id, responses)

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -83,6 +83,27 @@ describe('applicationUtils', () => {
     })
   })
 
+  describe('getResponseForPage', () => {
+    it('returns the response for a given page', () => {
+      FirstApplyPage.mockReturnValue({
+        response: () => {
+          return { foo: 'bar' }
+        },
+      })
+
+      SecondApplyPage.mockReturnValue({
+        response: () => {
+          return { bar: 'foo' }
+        },
+      })
+
+      const application = applicationFactory.build()
+      application.data = { 'basic-information': { first: '', second: '' } }
+
+      expect(getResponses(application)).toEqual({ 'basic-information': [{ foo: 'bar' }, { bar: 'foo' }] })
+    })
+  })
+
   describe('getArrivalDate', () => {
     it('returns the arrival date when the release date is known and is the same as the start date', () => {
       const application = applicationFactory.build({

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -31,6 +31,7 @@ import {
   arriveDateAsTimestamp,
   allocationSummary,
   allocationLink,
+  rejectionRationaleFromAssessmentResponses,
 } from './utils'
 import { DateFormats } from '../dateUtils'
 import paths from '../../paths/assess'
@@ -797,6 +798,22 @@ describe('utils', () => {
           },
         },
       ])
+    })
+  })
+
+  describe('rejectionRationaleFromAssessmentResponses', () => {
+    it('returns the rejectionRationale from the assessment when it exists', () => {
+      const assessment = assessmentFactory.build()
+
+      ;(applicationUtils.getResponseForPage as jest.Mock).mockImplementation(() => ({ Decision: 'some rationale' }))
+
+      expect(rejectionRationaleFromAssessmentResponses(assessment)).toEqual('some rationale')
+    })
+
+    it('returns an empty string when the rationale doesnt exists', () => {
+      const assessment = assessmentFactory.build()
+
+      expect(rejectionRationaleFromAssessmentResponses(assessment)).toEqual('')
     })
   })
 })

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -530,6 +530,14 @@ const caseNotesFromAssessment = (assessment: Assessment) =>
 const acctAlertsFromAssessment = (assessment: Assessment) =>
   assessment.application?.data?.['prison-information']?.['case-notes']?.acctAlerts || []
 
+const rejectionRationaleFromAssessmentResponses = (assessment: Assessment): string => {
+  const response = getResponseForPage(assessment, 'make-a-decision', 'make-a-decision')?.Decision || ''
+
+  if (Array.isArray(response)) return ''
+
+  return response
+}
+
 export {
   acctAlertsFromAssessment,
   adjudicationsFromAssessment,
@@ -563,4 +571,5 @@ export {
   groupAssessmements,
   requestedFurtherInformationTableRows,
   unallocatedTableRows,
+  rejectionRationaleFromAssessmentResponses,
 }


### PR DESCRIPTION
Previously we weren't adding the rejection rationale when rejecting an assessment which meant the API was rejecting. 
Here we take the human readable response and add it to the POSTed object