### PR TITLE
Fall back to display document type description when extendedDescription blank

### DIFF
--- a/server/utils/attachDocumentsUtils.test.ts
+++ b/server/utils/attachDocumentsUtils.test.ts
@@ -112,6 +112,20 @@ describe('attachDocumentsUtils', () => {
       })
     })
 
+    it('uses the typeDescription if the document description is undefined', () => {
+      const document = documentFactory.build({ id: '123', description: null })
+      const selectedDocument = documentFactory.build({
+        id: '123',
+        description: undefined,
+        typeDescription: 'PNC previous convictions',
+      })
+
+      expect(documentWithDescription(document, [selectedDocument, documentFactory.build()])).toEqual({
+        ...document,
+        description: 'PNC previous convictions',
+      })
+    })
+
     it('returns the document if the document with the same ID is not in the selectedDocuments argument', () => {
       const document = documentFactory.build({ id: '123', description: null })
 

--- a/server/utils/attachDocumentsUtils.ts
+++ b/server/utils/attachDocumentsUtils.ts
@@ -84,7 +84,7 @@ const documentWithDescription = (document: Document, selectedDocuments: Array<Do
     return document
   }
 
-  return { ...document, description: selectedDocument.description }
+  return { ...document, description: selectedDocument.description || selectedDocument?.typeDescription }
 }
 
 export { tableRows, documentCheckbox, descriptionTextArea, documentWithDescription }


### PR DESCRIPTION
Trello:  https://trello.com/c/NM38D3Ms/1224-documenttypedescription-is-needed-if-documentextendeddescription-not-present

The `description` field is taken from the `Document.extendedDescription` which often contains an excellent description such as "Non Statutory Intervention for OPD Community Pathway on 23/08/2016". However it can be blank. In that case it's important to show the applicant more than the document name which in many cases is not very helpful.

A document name might be `e davey.pdf`. If there is no `description` to supplement this meagre information we now supply the `typeDescription`, perhaps "PNC previous convictions" which indicates that this is an important document to include in the application.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
