### PR TITLE
(1216) Show basic information and user list for workflow managers

### DIFF
--- a/cypress_shared/pages/assess/allocationsListPage.ts
+++ b/cypress_shared/pages/assess/allocationsListPage.ts
@@ -36,4 +36,8 @@ export default class AllocationsListPage extends Page {
   clickUnallocated() {
     cy.get('a').contains('Unallocated').click()
   }
+
+  clickAssessment(assessment: Assessment) {
+    cy.get(`a[data-cy-assessmentId="${assessment.id}"]`).click()
+  }
 }

--- a/cypress_shared/pages/assess/allocationsPage.ts
+++ b/cypress_shared/pages/assess/allocationsPage.ts
@@ -1,0 +1,35 @@
+import type { ApprovedPremisesAssessment as Assessment, ApprovedPremisesUser as User } from '@approved-premises/api'
+
+import Page from '../page'
+import paths from '../../../server/paths/assess'
+
+import { allocationSummary } from '../../../server/utils/assessments/utils'
+
+export default class AllocationsPage extends Page {
+  constructor(private readonly assessment: Assessment) {
+    super(`Assessment for ${assessment.application.person.name}`)
+  }
+
+  static visit(assessment: Assessment): AllocationsPage {
+    cy.visit(paths.allocations.show({ id: assessment.application.id }))
+    return new AllocationsPage(assessment)
+  }
+
+  shouldShowInformationAboutAssessment() {
+    const summaryListItems = allocationSummary(this.assessment)
+
+    summaryListItems.forEach(item => {
+      const key = 'text' in item.key ? item.key.text : item.key.html
+      const value = 'text' in item.value ? item.value.text : item.value.html
+      this.assertDefinition(key, value)
+    })
+  }
+
+  shouldShowUsers(users: Array<User>) {
+    cy.get('select#staffMember option').should('have.length', users.length + 1)
+
+    users.forEach(u => {
+      cy.get('select#staffMember option').contains(u.name).should('be.visible')
+    })
+  }
+}

--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -1,6 +1,6 @@
 import { SuperAgentRequest } from 'superagent'
 
-import type { ApprovedPremisesApplication } from '@approved-premises/api'
+import type { ApprovedPremisesApplication, ApprovedPremisesAssessment } from '@approved-premises/api'
 
 import { getMatchingRequests, stubFor } from '../../wiremock'
 
@@ -62,6 +62,21 @@ export default {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: args.application,
+      },
+    }),
+  stubApplicationAssessment: (args: {
+    application: ApprovedPremisesApplication
+    assessment: ApprovedPremisesAssessment
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/applications/${args.application.id}/assessment`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.assessment,
       },
     }),
   stubApplicationDocuments: (args: {

--- a/integration_tests/mockApis/assessments.ts
+++ b/integration_tests/mockApis/assessments.ts
@@ -14,7 +14,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: paths.assessments.index,
+        url: paths.assessments.index({}),
       },
       response: {
         status: 200,

--- a/integration_tests/mockApis/users.ts
+++ b/integration_tests/mockApis/users.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesUser as User } from '@approved-premises/api'
+import { ApprovedPremisesUser as User, UserQualification, UserRole } from '@approved-premises/api'
 import { stubFor } from '../../wiremock'
 import paths from '../../server/paths/api'
 
@@ -17,4 +17,39 @@ const stubFindUser = (args: { user: User; id: string }) =>
     },
   })
 
-export default { stubFindUser }
+const stubUsers = (args: {
+  users: Array<User>
+  roles?: Array<UserRole>
+  qualifications?: Array<UserQualification>
+}) => {
+  let url = paths.users.index({})
+  const queries = []
+
+  if (args.roles) {
+    queries.push(`roles=${args.roles.join(',')}`)
+  }
+
+  if (args.qualifications) {
+    queries.push(`qualifications=${args.qualifications.join(',')}`)
+  }
+
+  if (args.roles || args.qualifications) {
+    url += `?${queries.join('&')}`
+  }
+
+  return stubFor({
+    request: {
+      method: 'GET',
+      url,
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: args.users,
+    },
+  })
+}
+
+export default { stubFindUser, stubUsers }

--- a/integration_tests/tests/assess/allocations.cy.ts
+++ b/integration_tests/tests/assess/allocations.cy.ts
@@ -1,0 +1,48 @@
+import { AllocationsListPage } from '../../../cypress_shared/pages/assess'
+import AllocationsPage from '../../../cypress_shared/pages/assess/allocationsPage'
+import Page from '../../../cypress_shared/pages/page'
+import applicationFactory from '../../../server/testutils/factories/application'
+
+import assessmentFactory from '../../../server/testutils/factories/assessment'
+import userFactory from '../../../server/testutils/factories/user'
+
+context('Assess', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+  })
+
+  it('allows me to reallocate an assessment', () => {
+    // And there is an allocated assessment
+    const application = applicationFactory.build({ isWomensApplication: false, isPipeApplication: true })
+    const assessment = assessmentFactory.build({ allocatedToStaffMember: userFactory.build(), application })
+
+    cy.task('stubAssessments', [assessment])
+    cy.task('stubAssessment', assessment)
+    cy.task('stubApplicationAssessment', { application: assessment.application, assessment })
+
+    // Given there are some users in the database
+    const users = userFactory.buildList(3)
+    cy.task('stubUsers', { users, roles: ['assessor'], qualifications: ['pipe'] })
+
+    // And I am logged in as a workflow manager
+    const me = userFactory.build()
+    cy.task('stubAuthUser', { roles: ['workflow_manager'], userId: me.id })
+    cy.signIn()
+
+    // When I visit the allocations section
+    const allocationsListPage = AllocationsListPage.visit([assessment], [])
+
+    // And I click to reallocate the assessment
+    allocationsListPage.clickAssessment(assessment)
+
+    // Then I should be on the Allocations page for that assessment
+    const allocationsPage = Page.verifyOnPage(AllocationsPage, assessment)
+
+    // And I should see some information about that assessment
+    allocationsPage.shouldShowInformationAboutAssessment()
+
+    // And I should see a list of staff members who can be allocated to that assessment
+    allocationsPage.shouldShowUsers(users)
+  })
+})

--- a/server/controllers/assess/applications/allocationsController.test.ts
+++ b/server/controllers/assess/applications/allocationsController.test.ts
@@ -1,0 +1,54 @@
+import type { Request, Response, NextFunction } from 'express'
+
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+
+import AllocationsController from './allocationsController'
+import { ApplicationService, UserService } from '../../../services'
+import { getQualificationsForApplication } from '../../../utils/applications/getQualificationsForApplication'
+
+import assessmentFactory from '../../../testutils/factories/assessment'
+import userFactory from '../../../testutils/factories/user'
+
+jest.mock('../../../utils/applications/getQualificationsForApplication')
+
+describe('allocationsController', () => {
+  const token = 'SOME_TOKEN'
+
+  const request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = jest.fn()
+
+  const applicationService = createMock<ApplicationService>({})
+  const userService = createMock<UserService>({})
+
+  let allocationsController: AllocationsController
+
+  beforeEach(() => {
+    allocationsController = new AllocationsController(applicationService, userService)
+  })
+
+  describe('show', () => {
+    it('fetches the assessment and a list of qualified users', async () => {
+      const requestHandler = allocationsController.show()
+
+      const assessment = assessmentFactory.build()
+      const users = userFactory.buildList(3)
+      const qualifications = ['foo', 'bar']
+
+      applicationService.getAssessment.mockResolvedValue(assessment)
+      userService.getUsers.mockResolvedValue(users)
+      ;(getQualificationsForApplication as jest.Mock).mockReturnValue(qualifications)
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('applications/allocations/show', {
+        pageHeading: `Assessment for ${assessment.application.person.name}`,
+        assessment,
+        users,
+      })
+
+      expect(applicationService.getAssessment).toHaveBeenCalledWith(request.user.token, request.params.id)
+      expect(userService.getUsers).toHaveBeenCalledWith(request.user.token, ['assessor'], qualifications)
+    })
+  })
+})

--- a/server/controllers/assess/applications/allocationsController.ts
+++ b/server/controllers/assess/applications/allocationsController.ts
@@ -1,0 +1,25 @@
+import type { Request, Response, RequestHandler } from 'express'
+import { getQualificationsForApplication } from '../../../utils/applications/getQualificationsForApplication'
+
+import { ApplicationService, UserService } from '../../../services'
+
+export default class AllocationsController {
+  constructor(private readonly applicationService: ApplicationService, private readonly userService: UserService) {}
+
+  show(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const assessment = await this.applicationService.getAssessment(req.user.token, req.params.id)
+      const users = await this.userService.getUsers(
+        req.user.token,
+        ['assessor'],
+        getQualificationsForApplication(assessment.application),
+      )
+
+      res.render('applications/allocations/show', {
+        pageHeading: `Assessment for ${assessment.application.person.name}`,
+        assessment,
+        users,
+      })
+    }
+  }
+}

--- a/server/controllers/assess/index.ts
+++ b/server/controllers/assess/index.ts
@@ -4,6 +4,7 @@ import AssessmentsController from './assessmentsController'
 import AssessmentPagesController from './assessments/pagesController'
 import ClarificationNotesController from './assessments/clarificationNotesController'
 import SupportingInformationController from './supportingInformationController'
+import AllocationsController from './applications/allocationsController'
 
 import type { Services } from '../../services'
 
@@ -17,11 +18,13 @@ export const controllers = (services: Services) => {
   })
   const clarificationNotesController = new ClarificationNotesController(assessmentService, userService)
   const supportingInformationController = new SupportingInformationController(assessmentService)
+  const allocationsController = new AllocationsController(applicationService, userService)
 
   return {
     assessmentsController,
     assessmentPagesController,
     clarificationNotesController,
     supportingInformationController,
+    allocationsController,
   }
 }

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -3,6 +3,7 @@ import nock from 'nock'
 import ApplicationClient from './applicationClient'
 import config from '../config'
 import applicationFactory from '../testutils/factories/application'
+import assessmentFactory from '../testutils/factories/assessment'
 import activeOffenceFactory from '../testutils/factories/activeOffence'
 import documentFactory from '../testutils/factories/document'
 import paths from '../paths/api'
@@ -153,6 +154,23 @@ describe('ApplicationClient', () => {
       const result = await applicationClient.documents(application)
 
       expect(result).toEqual(documents)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+
+  describe('assessment', () => {
+    it('should return an assessment for an application', async () => {
+      const applicationId = 'some-uuid'
+      const assessment = assessmentFactory.build()
+
+      fakeApprovedPremisesApi
+        .get(paths.applications.assessment({ id: applicationId }))
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, assessment)
+
+      const result = await applicationClient.assessment(applicationId)
+
+      expect(result).toEqual(assessment)
       expect(nock.isDone()).toBeTruthy()
     })
   })

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -1,4 +1,9 @@
-import type { ActiveOffence, ApprovedPremisesApplication as Application, Document } from '@approved-premises/api'
+import type {
+  ActiveOffence,
+  ApprovedPremisesApplication as Application,
+  ApprovedPremisesAssessment as Assessment,
+  Document,
+} from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -47,5 +52,11 @@ export default class ApplicationClient {
     return (await this.restClient.get({
       path: paths.applications.documents({ id: application.id }),
     })) as Array<Document>
+  }
+
+  async assessment(applicationId: string): Promise<Assessment> {
+    return (await this.restClient.get({
+      path: paths.applications.assessment({ id: applicationId }),
+    })) as Assessment
   }
 }

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -1,4 +1,4 @@
-import type { ActiveOffence, ApprovedPremisesApplication, Document } from '@approved-premises/api'
+import type { ActiveOffence, ApprovedPremisesApplication as Application, Document } from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -10,40 +10,40 @@ export default class ApplicationClient {
     this.restClient = new RestClient('applicationClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
-  async find(applicationId: string): Promise<ApprovedPremisesApplication> {
+  async find(applicationId: string): Promise<Application> {
     return (await this.restClient.get({
       path: paths.applications.show({ id: applicationId }),
-    })) as ApprovedPremisesApplication
+    })) as Application
   }
 
-  async create(crn: string, activeOffence: ActiveOffence): Promise<ApprovedPremisesApplication> {
+  async create(crn: string, activeOffence: ActiveOffence): Promise<Application> {
     const { convictionId, deliusEventNumber, offenceId } = activeOffence
 
     return (await this.restClient.post({
       path: `${paths.applications.new.pattern}?createWithRisks=${!config.flags.oasysDisabled}`,
       data: { crn, convictionId, deliusEventNumber, offenceId },
-    })) as ApprovedPremisesApplication
+    })) as Application
   }
 
-  async update(application: ApprovedPremisesApplication): Promise<ApprovedPremisesApplication> {
+  async update(application: Application): Promise<Application> {
     return (await this.restClient.put({
       path: paths.applications.update({ id: application.id }),
       data: { data: application.data },
-    })) as ApprovedPremisesApplication
+    })) as Application
   }
 
-  async all(): Promise<Array<ApprovedPremisesApplication>> {
-    return (await this.restClient.get({ path: paths.applications.index.pattern })) as Array<ApprovedPremisesApplication>
+  async all(): Promise<Array<Application>> {
+    return (await this.restClient.get({ path: paths.applications.index.pattern })) as Array<Application>
   }
 
-  async submit(application: ApprovedPremisesApplication): Promise<void> {
+  async submit(application: Application): Promise<void> {
     await this.restClient.post({
       path: paths.applications.submission({ id: application.id }),
       data: { translatedDocument: application.document },
     })
   }
 
-  async documents(application: ApprovedPremisesApplication): Promise<Array<Document>> {
+  async documents(application: Application): Promise<Array<Document>> {
     return (await this.restClient.get({
       path: paths.applications.documents({ id: application.id }),
     })) as Array<Document>

--- a/server/data/userClient.test.ts
+++ b/server/data/userClient.test.ts
@@ -54,4 +54,48 @@ describe('UserClient', () => {
       expect(output).toEqual(user)
     })
   })
+
+  describe('getUsers', () => {
+    const users = userFactory.buildList(4)
+
+    it('should return all users when no queries are specified', async () => {
+      fakeApprovedPremisesApi
+        .get(paths.users.index({}))
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, users)
+
+      const output = await userClient.getUsers()
+      expect(output).toEqual(users)
+    })
+
+    it('should query by role', async () => {
+      fakeApprovedPremisesApi
+        .get(`${paths.users.index({})}?roles=assessor,matcher`)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, users)
+
+      const output = await userClient.getUsers(['assessor', 'matcher'])
+      expect(output).toEqual(users)
+    })
+
+    it('should query by qualifications', async () => {
+      fakeApprovedPremisesApi
+        .get(`${paths.users.index({})}?qualifications=pipe,womens`)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, users)
+
+      const output = await userClient.getUsers([], ['pipe', 'womens'])
+      expect(output).toEqual(users)
+    })
+
+    it('should query by qualifications and roles', async () => {
+      fakeApprovedPremisesApi
+        .get(`${paths.users.index({})}?roles=assessor,matcher&qualifications=pipe,womens`)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, users)
+
+      const output = await userClient.getUsers(['assessor', 'matcher'], ['pipe', 'womens'])
+      expect(output).toEqual(users)
+    })
+  })
 })

--- a/server/data/userClient.ts
+++ b/server/data/userClient.ts
@@ -1,4 +1,5 @@
-import type { ApprovedPremisesUser as User } from '@approved-premises/api'
+import type { ApprovedPremisesUser as User, UserQualification, UserRole } from '@approved-premises/api'
+import qs from 'qs'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -16,5 +17,17 @@ export default class UserClient {
 
   async getUserProfile(): Promise<User> {
     return (await this.restClient.get({ path: paths.users.profile({}) })) as User
+  }
+
+  async getUsers(roles: Array<UserRole> = [], qualifications: Array<UserQualification> = []): Promise<Array<User>> {
+    const query = qs.stringify(
+      {
+        roles,
+        qualifications,
+      },
+      { arrayFormat: 'comma', encode: false },
+    )
+
+    return (await this.restClient.get({ path: paths.users.index({}), query })) as Array<User>
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -64,6 +64,7 @@ export default {
     new: applyPaths.applications.create,
     submission: applyPaths.applications.submission,
     documents: applyPaths.applications.show.path('documents'),
+    assessment: applyPaths.applications.show.path('assessment'),
   },
   assessments: {
     index: assessPaths.assessments,

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -92,6 +92,7 @@ export default {
     },
   },
   users: {
+    index: usersPath,
     show: usersPath.path(':id'),
     profile: path('/profile'),
   },

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -1,4 +1,5 @@
 import { path } from 'static-path'
+import applyPaths from './apply'
 
 const assessmentsPath = path('/assessments')
 
@@ -23,6 +24,9 @@ const paths = {
       confirm: assessmentPath.path('clarification-notes/confirmation'),
     },
     submission,
+  },
+  allocations: {
+    show: applyPaths.applications.show.path('/allocation'),
   },
 }
 

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -16,6 +16,7 @@ export default function routes(controllers: Controllers, router: Router): Router
     assessmentsController,
     assessmentPagesController,
     clarificationNotesController,
+    allocationsController,
     supportingInformationController,
   } = controllers
 
@@ -27,6 +28,8 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(paths.assessments.supportingInformationPath.pattern, supportingInformationController.show())
 
   post(paths.assessments.submission.pattern, assessmentsController.submit())
+
+  get(paths.allocations.show.pattern, allocationsController.show())
 
   Object.keys(pages).forEach((taskKey: string) => {
     Object.keys(pages[taskKey]).forEach((pageKey: string) => {

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -10,6 +10,7 @@ import { getBody, getPageName, getTaskName } from '../form-pages/utils'
 
 import Apply from '../form-pages/apply'
 import applicationFactory from '../testutils/factories/application'
+import assessmentFactory from '../testutils/factories/assessment'
 import activeOffenceFactory from '../testutils/factories/activeOffence'
 import documentFactory from '../testutils/factories/document'
 import { TasklistPageInterface } from '../form-pages/tasklistPage'
@@ -347,6 +348,23 @@ describe('ApplicationService', () => {
 
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
       expect(applicationClient.submit).toHaveBeenCalledWith(application)
+    })
+  })
+
+  describe('getAssessment', () => {
+    const token = 'some-token'
+    const id = 'some-uuid'
+    const assessment = assessmentFactory.build()
+
+    it('saves data to the session', async () => {
+      applicationClient.assessment.mockResolvedValue(assessment)
+
+      const result = await service.getAssessment(token, id)
+
+      expect(result).toEqual(assessment)
+
+      expect(applicationClientFactory).toHaveBeenCalledWith(token)
+      expect(applicationClient.assessment).toHaveBeenCalledWith(id)
     })
   })
 })

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -1,6 +1,11 @@
 import type { Request } from 'express'
 import type { DataServices, GroupedApplications } from '@approved-premises/ui'
-import type { ActiveOffence, ApprovedPremisesApplication, Document } from '@approved-premises/api'
+import type {
+  ActiveOffence,
+  ApprovedPremisesApplication,
+  ApprovedPremisesAssessment as Assessment,
+  Document,
+} from '@approved-premises/api'
 
 import { isUnapplicable } from '../utils/applicationUtils'
 import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
@@ -119,6 +124,13 @@ export default class ApplicationService {
       return application
     }
     return this.findApplication(request.user.token, request.params.id)
+  }
+
+  async getAssessment(token: string, assessmentId: string): Promise<Assessment> {
+    const client = this.applicationClientFactory(token)
+    const assessment = await client.assessment(assessmentId)
+
+    return assessment
   }
 
   private async saveToSession(application: ApprovedPremisesApplication, page: TasklistPage, request: Request) {

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -67,4 +67,18 @@ describe('User service', () => {
       expect(userClient.getActingUser).toHaveBeenCalledWith(id)
     })
   })
+
+  describe('getUsers', () => {
+    it('returns users by role and qualification', async () => {
+      const users = userFactory.buildList(4)
+
+      userClient.getUsers.mockResolvedValue(users)
+
+      const result = await userService.getUsers(token, ['applicant', 'assessor'], ['pipe'])
+
+      expect(result).toEqual(users)
+
+      expect(userClient.getUsers).toHaveBeenCalledWith(['applicant', 'assessor'], ['pipe'])
+    })
+  })
 })

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,4 +1,4 @@
-import { User } from '@approved-premises/api'
+import { User, UserQualification, UserRole } from '@approved-premises/api'
 import { UserDetails } from '@approved-premises/ui'
 import { RestClientBuilder, UserClient } from '../data'
 import { convertToTitleCase } from '../utils/utils'
@@ -21,5 +21,15 @@ export default class UserService {
     const client = this.userClientFactory(token)
 
     return client.getActingUser(id)
+  }
+
+  async getUsers(
+    token: string,
+    roles: Array<UserRole> = [],
+    qualifications: Array<UserQualification> = [],
+  ): Promise<Array<User>> {
+    const client = this.userClientFactory(token)
+
+    return client.getUsers(roles, qualifications)
   }
 }

--- a/server/utils/applications/getQualificationsForApplication.test.ts
+++ b/server/utils/applications/getQualificationsForApplication.test.ts
@@ -1,0 +1,22 @@
+import applicationFactory from '../../testutils/factories/application'
+import { getQualificationsForApplication } from './getQualificationsForApplication'
+
+describe('getQualificationsForAssessment', () => {
+  it('returns the correct qualifications for a pipe application', () => {
+    const application = applicationFactory.build({ isPipeApplication: true, isWomensApplication: false })
+
+    expect(getQualificationsForApplication(application)).toEqual(['pipe'])
+  })
+
+  it(`returns the correct qualifications for a women's application`, () => {
+    const application = applicationFactory.build({ isWomensApplication: true, isPipeApplication: false })
+
+    expect(getQualificationsForApplication(application)).toEqual(['womens'])
+  })
+
+  it(`returns the correct qualifications for a women's and pipe application`, () => {
+    const application = applicationFactory.build({ isWomensApplication: true, isPipeApplication: true })
+
+    expect(getQualificationsForApplication(application)).toEqual(['pipe', 'womens'])
+  })
+})

--- a/server/utils/applications/getQualificationsForApplication.ts
+++ b/server/utils/applications/getQualificationsForApplication.ts
@@ -1,0 +1,15 @@
+import { UserQualification, ApprovedPremisesApplication as Application } from '@approved-premises/api'
+
+export const getQualificationsForApplication = (application: Application): Array<UserQualification> => {
+  const qualifications: Array<UserQualification> = []
+
+  if (application.isPipeApplication) {
+    qualifications.push('pipe')
+  }
+
+  if (application.isWomensApplication) {
+    qualifications.push('womens')
+  }
+
+  return qualifications
+}

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -30,6 +30,7 @@ import {
   unallocatedTableRows,
   arriveDateAsTimestamp,
   allocationSummary,
+  allocationLink,
 } from './utils'
 import { DateFormats } from '../dateUtils'
 import paths from '../../paths/assess'
@@ -269,7 +270,7 @@ describe('utils', () => {
           { text: assessment.allocatedToStaffMember.name },
           { text: getApplicationType(assessment) },
           { html: getStatus(assessment) },
-          { html: assessmentLink(assessment, 'Reallocate', `assessment for ${assessment.application.person.name}`) },
+          { html: allocationLink(assessment, 'Reallocate') },
         ],
       ])
     })
@@ -300,7 +301,7 @@ describe('utils', () => {
           },
           { text: getApplicationType(assessment) },
           { html: getStatus(assessment) },
-          { html: assessmentLink(assessment, 'Allocate', `assessment for ${assessment.application.person.name}`) },
+          { html: allocationLink(assessment, 'Allocate') },
         ],
       ])
     })
@@ -445,6 +446,20 @@ describe('utils', () => {
         <a href="${paths.assessments.show({
           id: '123',
         })}" data-cy-assessmentId="123">My Text <span class="govuk-visually-hidden">and some hidden text</span></a>
+      `)
+    })
+  })
+
+  describe('allocationLink', () => {
+    const assessment = assessmentFactory.build({ application: { id: '123', person: { name: 'John Wayne' } } })
+
+    it('returns a link to an allocation', () => {
+      expect(allocationLink(assessment, 'Allocate')).toMatchStringIgnoringWhitespace(`
+        <a href="${paths.allocations.show({
+          id: '123',
+        })}" data-cy-assessmentId="${
+        assessment.id
+      }">Allocate <span class="govuk-visually-hidden">assessment for John Wayne</span></a>
       `)
     })
   })

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -29,6 +29,7 @@ import {
   groupAssessmements,
   unallocatedTableRows,
   arriveDateAsTimestamp,
+  allocationSummary,
 } from './utils'
 import { DateFormats } from '../dateUtils'
 import paths from '../../paths/assess'
@@ -700,6 +701,87 @@ describe('utils', () => {
       assessment.application.data['prison-information'] = {}
 
       expect(acctAlertsFromAssessment(assessment)).toEqual([])
+    })
+  })
+
+  describe('allocationSummary', () => {
+    beforeEach(() => {
+      jest.spyOn(applicationUtils, 'getArrivalDate').mockReturnValue('2022-01-01')
+    })
+
+    it('returns the summary list when the assessment has a staff member allocated', () => {
+      const staffMember = userFactory.build()
+      const assessment = assessmentFactory.build({
+        allocatedToStaffMember: staffMember,
+      })
+
+      expect(allocationSummary(assessment)).toEqual([
+        {
+          key: {
+            text: 'CRN',
+          },
+          value: {
+            text: assessment.application.person.crn,
+          },
+        },
+        {
+          key: {
+            text: 'Arrival date',
+          },
+          value: {
+            text: formattedArrivalDate(assessment),
+          },
+        },
+        {
+          key: {
+            text: 'Application Type',
+          },
+          value: {
+            text: getApplicationType(assessment),
+          },
+        },
+        {
+          key: {
+            text: 'Allocated To',
+          },
+          value: {
+            text: assessment.allocatedToStaffMember.name,
+          },
+        },
+      ])
+    })
+
+    it('returns the summary list when the assessment does not have a staff member allocated', () => {
+      const assessment = assessmentFactory.build({
+        allocatedToStaffMember: null,
+      })
+
+      expect(allocationSummary(assessment)).toEqual([
+        {
+          key: {
+            text: 'CRN',
+          },
+          value: {
+            text: assessment.application.person.crn,
+          },
+        },
+        {
+          key: {
+            text: 'Arrival date',
+          },
+          value: {
+            text: formattedArrivalDate(assessment),
+          },
+        },
+        {
+          key: {
+            text: 'Application Type',
+          },
+          value: {
+            text: getApplicationType(assessment),
+          },
+        },
+      ])
     })
   })
 })

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -22,7 +22,7 @@ import { UnknownPageError } from '../errors'
 import { embeddedSummaryListItem } from '../checkYourAnswersUtils'
 import reviewSections from '../reviewUtils'
 import Apply from '../../form-pages/apply'
-import { kebabCase } from '../utils'
+import { kebabCase, linkTo } from '../utils'
 import { documentsFromApplication } from './documentUtils'
 
 const DUE_DATE_APPROACHING_DAYS_WINDOW = 3
@@ -284,14 +284,15 @@ const requestedFurtherInformationTableRows = (assessments: Array<Assessment>): A
 }
 
 const assessmentLink = (assessment: Assessment, linkText = '', hiddenText = ''): string => {
-  let linkBody = linkText || assessment.application.person.name
-
-  if (hiddenText) {
-    linkBody = `${linkBody} <span class="govuk-visually-hidden">${hiddenText}</span>`
-  }
-  return `<a href="${paths.assessments.show({ id: assessment.id })}" data-cy-assessmentId="${
-    assessment.id
-  }">${linkBody}</a>`
+  return linkTo(
+    paths.assessments.show,
+    { id: assessment.id },
+    {
+      text: linkText || assessment.application.person.name,
+      hiddenText,
+      attributes: { 'data-cy-assessmentId': assessment.id },
+    },
+  )
 }
 
 const formattedArrivalDate = (assessment: Assessment): string => {

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -150,7 +150,7 @@ const allocatedTableRows = (assessments: Array<Assessment>): Array<TableRow> => 
         html: getStatus(assessment),
       },
       {
-        html: assessmentLink(assessment, 'Reallocate', `assessment for ${assessment.application.person.name}`),
+        html: allocationLink(assessment, 'Reallocate'),
       },
     ])
   })
@@ -185,7 +185,7 @@ const unallocatedTableRows = (assessments: Array<Assessment>): Array<TableRow> =
         html: getStatus(assessment),
       },
       {
-        html: assessmentLink(assessment, 'Allocate', `assessment for ${assessment.application.person.name}`),
+        html: allocationLink(assessment, 'Allocate'),
       },
     ])
   })
@@ -281,6 +281,18 @@ const requestedFurtherInformationTableRows = (assessments: Array<Assessment>): A
   })
 
   return rows
+}
+
+const allocationLink = (assessment: Assessment, action: 'Allocate' | 'Reallocate'): string => {
+  return linkTo(
+    paths.allocations.show,
+    { id: assessment.application.id },
+    {
+      text: action,
+      hiddenText: `assessment for ${assessment.application.person.name}`,
+      attributes: { 'data-cy-assessmentId': assessment.id },
+    },
+  )
 }
 
 const assessmentLink = (assessment: Assessment, linkText = '', hiddenText = ''): string => {
@@ -522,6 +534,7 @@ export {
   acctAlertsFromAssessment,
   adjudicationsFromAssessment,
   allocatedTableRows,
+  allocationLink,
   allocationSummary,
   applicationAccepted,
   arriveDateAsTimestamp,

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -78,6 +78,48 @@ const getApplicationType = (assessment: Assessment): ApplicationType => {
   return 'Standard'
 }
 
+const allocationSummary = (assessment: Assessment): Array<SummaryListItem> => {
+  const summary = [
+    {
+      key: {
+        text: 'CRN',
+      },
+      value: {
+        text: assessment.application.person.crn,
+      },
+    },
+    {
+      key: {
+        text: 'Arrival date',
+      },
+      value: {
+        text: formattedArrivalDate(assessment),
+      },
+    },
+    {
+      key: {
+        text: 'Application Type',
+      },
+      value: {
+        text: getApplicationType(assessment),
+      },
+    },
+  ]
+
+  if (assessment.allocatedToStaffMember) {
+    summary.push({
+      key: {
+        text: 'Allocated To',
+      },
+      value: {
+        text: assessment.allocatedToStaffMember.name,
+      },
+    })
+  }
+
+  return summary
+}
+
 const allocatedTableRows = (assessments: Array<Assessment>): Array<TableRow> => {
   const rows = [] as Array<TableRow>
 
@@ -479,12 +521,13 @@ export {
   acctAlertsFromAssessment,
   adjudicationsFromAssessment,
   allocatedTableRows,
+  allocationSummary,
   applicationAccepted,
   arriveDateAsTimestamp,
   assessmentLink,
-  assessmentSections,
   assessmentsApproachingDue,
   assessmentsApproachingDueBadge,
+  assessmentSections,
   awaitingAssessmentTableRows,
   caseNotesFromAssessment,
   completedTableRows,

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -6,7 +6,14 @@ import express from 'express'
 import * as pathModule from 'path'
 
 import type { ErrorMessages, PersonStatus } from '@approved-premises/ui'
-import { initialiseName, removeBlankSummaryListItems, sentenceCase, mapApiPersonRisksForUi, kebabCase } from './utils'
+import {
+  initialiseName,
+  removeBlankSummaryListItems,
+  sentenceCase,
+  mapApiPersonRisksForUi,
+  kebabCase,
+  linkTo,
+} from './utils'
 import {
   dateFieldValues,
   convertObjectsToRadioItems,
@@ -131,6 +138,8 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   )
 
   njkEnv.addGlobal('paths', { ...managePaths, ...applyPaths, ...assessPaths })
+
+  njkEnv.addGlobal('linkTo', linkTo)
 
   njkEnv.addGlobal('statusTag', (status: PersonStatus) => markAsSafe(statusTag(status)))
 

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,3 +1,4 @@
+import { path } from 'static-path'
 import type { SummaryListItem } from '@approved-premises/ui'
 import { PersonRisks } from '@approved-premises/api'
 import { SessionDataError } from './errors'
@@ -10,6 +11,7 @@ import {
   mapApiPersonRisksForUi,
   pascalCase,
   camelCase,
+  linkTo,
 } from './utils'
 import risksFactory from '../testutils/factories/risks'
 import { DateFormats } from './dateUtils'
@@ -295,5 +297,29 @@ describe('mapApiPersonRiskForUI', () => {
         level: risks.tier.value.level,
       },
     })
+  })
+})
+
+describe('linkTo', () => {
+  it('returns a generic link', () => {
+    expect(linkTo(path('/foo'), {}, { text: 'Hello' })).toMatchStringIgnoringWhitespace('<a href="/foo">Hello</a>')
+  })
+
+  it('allows params to be specified', () => {
+    expect(linkTo(path('/foo/:id'), { id: '123' }, { text: 'Hello' })).toMatchStringIgnoringWhitespace(
+      '<a href="/foo/123">Hello</a>',
+    )
+  })
+
+  it('allows hidden text to be specified', () => {
+    expect(
+      linkTo(path('/foo/:id'), { id: '123' }, { text: 'Hello', hiddenText: 'Hidden' }),
+    ).toMatchStringIgnoringWhitespace('<a href="/foo/123">Hello <span class="govuk-visually-hidden">Hidden</span></a>')
+  })
+
+  it('allows attributes to be specified', () => {
+    expect(
+      linkTo(path('/foo/:id'), { id: '123' }, { text: 'Hello', attributes: { class: 'some-class' } }),
+    ).toMatchStringIgnoringWhitespace('<a href="/foo/123" class="some-class">Hello</a>')
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,4 +1,5 @@
 import Case from 'case'
+import { Path, Params } from 'static-path'
 
 import type { SummaryListItem, PersonRisksUI } from '@approved-premises/ui'
 import type { ApprovedPremisesApplication, PersonRisks } from '@approved-premises/api'
@@ -123,4 +124,31 @@ export const mapApiPersonRisksForUi = (risks: PersonRisks): PersonRisksUI => {
     },
     flags: risks.flags.value,
   }
+}
+
+export const linkTo = <Pattern extends `/${string}`>(
+  path: Path<Pattern>,
+  params: Params<Pattern>,
+  {
+    text,
+    attributes = {},
+    hiddenText = '',
+  }: {
+    text: string
+    params?: Params<Pattern>
+    attributes?: Record<string, string>
+    hiddenText?: string
+  },
+): string => {
+  let linkBody = text
+
+  if (hiddenText) {
+    linkBody = `${linkBody} <span class="govuk-visually-hidden">${hiddenText}</span>`
+  }
+
+  const attrBody = Object.keys(attributes)
+    .map(a => `${a}="${attributes[a]}"`)
+    .join(' ')
+
+  return `<a href="${path(params)}" ${attrBody}>${linkBody}</a>`
 }

--- a/server/views/applications/allocations/show.njk
+++ b/server/views/applications/allocations/show.njk
@@ -1,0 +1,52 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">
+        {{ pageHeading }}
+      </h1>
+
+      {{
+      govukSummaryList({
+        rows: AssessmentUtils.allocationSummary(assessment)
+      })
+    }}
+
+      {{ showErrorSummary(errorSummary) }}
+
+      <form action="#" method="post">
+        {{
+        govukSelect({
+          label: {
+            html: '<h2 class="govuk-heading-m">Reallocate Assessment</h2>'
+          },
+          hint: {
+            text: 'Select a staff member to allocate the assessment to'
+          },
+          id: "staffMember",
+          name: "staffMember",
+          items: convertObjectsToSelectOptions(users, 'Please select', 'name', 'id', 'staffMember'),
+          errorMessage: errors.staffMember
+        })
+      }}
+
+        {{
+        govukButton({
+        text: "Submit"
+        })
+      }}
+      </form>
+    </div>
+
+  </div>
+
+</div>
+
+{% endblock %}


### PR DESCRIPTION
This changes the link to an assessment on the Workflow Manager's view to show basic information about an assessment, who it is allocated, as well as fetching the list of users who can be allocated to the assessment. The next PR will do the actual allocation, but I thought it'd be better to break the featue up into two PRs

## Screenshot 

![image](https://user-images.githubusercontent.com/109774/218418028-c7c8cda2-605c-4e16-9864-a313edc59d17.png)
