### PR TITLE
Don't render Tier badge if risk, tier or tier value is missing

### DIFF
--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -169,13 +169,85 @@ describe('applicationUtils', () => {
             text: applicationB.person.crn,
           },
           {
-            html: 'TIER_BADGE',
+            html: '',
           },
           {
             text: DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' }),
           },
           {
             html: getStatus(applicationB),
+          },
+        ],
+      ])
+    })
+  })
+
+  describe('dashboardTableRows when tier is undefined', () => {
+    it('returns a blank tier badge', async () => {
+      ;(tierBadge as jest.Mock).mockClear()
+      const arrivalDate = DateFormats.dateObjToIsoDate(new Date(2021, 0, 3))
+
+      const application = applicationFactory.withReleaseDate(arrivalDate).build({
+        person: { name: 'My Name' },
+        risks: { tier: undefined },
+      })
+
+      const result = dashboardTableRows([application])
+
+      expect(tierBadge).not.toHaveBeenCalled()
+
+      expect(result).toEqual([
+        [
+          {
+            html: `<a href=${paths.applications.show({ id: application.id })}>My Name</a>`,
+          },
+          {
+            text: application.person.crn,
+          },
+          {
+            html: '',
+          },
+          {
+            text: DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' }),
+          },
+          {
+            html: getStatus(application),
+          },
+        ],
+      ])
+    })
+  })
+
+  describe('dashboardTableRows when risks is undefined', () => {
+    it('returns a blank tier badge', async () => {
+      ;(tierBadge as jest.Mock).mockClear()
+      const arrivalDate = DateFormats.dateObjToIsoDate(new Date(2021, 0, 3))
+
+      const application = applicationFactory.withReleaseDate(arrivalDate).build({
+        person: { name: 'My Name' },
+        risks: undefined,
+      })
+
+      const result = dashboardTableRows([application])
+
+      expect(tierBadge).not.toHaveBeenCalled()
+
+      expect(result).toEqual([
+        [
+          {
+            html: `<a href=${paths.applications.show({ id: application.id })}>My Name</a>`,
+          },
+          {
+            text: application.person.crn,
+          },
+          {
+            html: '',
+          },
+          {
+            text: DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' }),
+          },
+          {
+            html: getStatus(application),
           },
         ],
       ])

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -15,11 +15,12 @@ import isAssessment from './assessments/isAssessment'
 const dashboardTableRows = (applications: Array<Application>): Array<TableRow> => {
   return applications.map(application => {
     const arrivalDate = getArrivalDate(application, false)
+    const tier = application.risks?.tier?.value?.level
 
     return [
       createNameAnchorElement(application.person.name, application.id),
       textValue(application.person.crn),
-      htmlValue(tierBadge(application.risks.tier.value?.level || '')),
+      htmlValue(tier == null ? '' : tierBadge(tier)),
       textValue(arrivalDate ? DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' }) : 'N/A'),
       htmlValue(getStatus(application)),
     ]


### PR DESCRIPTION
The dashboard list of applications will fail with something like:

```
Template render error
(/app/dist/server/views/applications/index.njk) [Line 24, Column 86]
  TypeError: Cannot read properties of null (reading 'tier')
```

