### PR TITLE
(1216) Allow a workflow manager to reallocate an assessment

### DIFF
--- a/cypress_shared/pages/assess/allocationsPage.ts
+++ b/cypress_shared/pages/assess/allocationsPage.ts
@@ -26,10 +26,14 @@ export default class AllocationsPage extends Page {
   }
 
   shouldShowUsers(users: Array<User>) {
-    cy.get('select#staffMember option').should('have.length', users.length + 1)
+    cy.get('select#userId option').should('have.length', users.length + 1)
 
     users.forEach(u => {
-      cy.get('select#staffMember option').contains(u.name).should('be.visible')
+      cy.get('select#userId option').contains(u.name).should('be.visible')
     })
+  }
+
+  selectUser(user: User) {
+    this.getSelectInputByIdAndSelectAnEntry('userId', user.id)
   }
 }

--- a/integration_tests/mockApis/assessments.ts
+++ b/integration_tests/mockApis/assessments.ts
@@ -1,6 +1,7 @@
 import { SuperAgentRequest } from 'superagent'
 
 import type {
+  ApprovedPremisesApplication as Application,
   ApprovedPremisesAssessment as Assessment,
   NewClarificationNote,
   UpdatedClarificationNote,
@@ -8,6 +9,7 @@ import type {
 
 import { getMatchingRequests, stubFor } from '../../wiremock'
 import paths from '../../server/paths/api'
+import { errorStub } from '../../wiremock/utils'
 
 export default {
   stubAssessments: (assessments: Array<Assessment>): SuperAgentRequest =>
@@ -46,6 +48,27 @@ export default {
         jsonBody: assessment,
       },
     }),
+  stubAllocationCreate: (args: { application: Application; assessment: Assessment }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: paths.applications.allocation.create({ id: args.application.id }),
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.assessment,
+      },
+    }),
+  verifyAllocationCreate: async (application: Application) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: paths.applications.allocation.create({ id: application.id }),
+      })
+    ).body.requests,
+  stubAllocationErrors: (application: Application) =>
+    stubFor(errorStub(['userId'], paths.applications.allocation.create({ id: application.id }))),
   stubAssessmentRejection: (assessment: Assessment): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/tests/assess/allocations.cy.ts
+++ b/integration_tests/tests/assess/allocations.cy.ts
@@ -10,9 +10,12 @@ context('Assess', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-  })
 
-  it('allows me to reallocate an assessment', () => {
+    // Given there are some users in the database
+    const users = userFactory.buildList(3)
+    const selectedUser = users[0]
+    cy.task('stubUsers', { users, roles: ['assessor'], qualifications: ['pipe'] })
+
     // And there is an allocated assessment
     const application = applicationFactory.build({ isWomensApplication: false, isPipeApplication: true })
     const assessment = assessmentFactory.build({ allocatedToStaffMember: userFactory.build(), application })
@@ -21,28 +24,68 @@ context('Assess', () => {
     cy.task('stubAssessment', assessment)
     cy.task('stubApplicationAssessment', { application: assessment.application, assessment })
 
-    // Given there are some users in the database
-    const users = userFactory.buildList(3)
-    cy.task('stubUsers', { users, roles: ['assessor'], qualifications: ['pipe'] })
-
     // And I am logged in as a workflow manager
     const me = userFactory.build()
     cy.task('stubAuthUser', { roles: ['workflow_manager'], userId: me.id })
     cy.signIn()
 
+    cy.wrap(assessment).as('assessment')
+    cy.wrap(application).as('application')
+    cy.wrap(users).as('users')
+    cy.wrap(selectedUser).as('selectedUser')
+  })
+
+  it('allows me to reallocate an assessment', function test() {
+    cy.task('stubAllocationCreate', {
+      application: this.assessment.application,
+      assessment: { ...this.assessment, allocatedToStaffMember: this.selectedUser },
+    })
+
     // When I visit the allocations section
-    const allocationsListPage = AllocationsListPage.visit([assessment], [])
+    const allocationsListPage = AllocationsListPage.visit([this.assessment], [])
 
     // And I click to reallocate the assessment
-    allocationsListPage.clickAssessment(assessment)
+    allocationsListPage.clickAssessment(this.assessment)
 
     // Then I should be on the Allocations page for that assessment
-    const allocationsPage = Page.verifyOnPage(AllocationsPage, assessment)
+    const allocationsPage = Page.verifyOnPage(AllocationsPage, this.assessment)
 
     // And I should see some information about that assessment
     allocationsPage.shouldShowInformationAboutAssessment()
 
     // And I should see a list of staff members who can be allocated to that assessment
-    allocationsPage.shouldShowUsers(users)
+    allocationsPage.shouldShowUsers(this.users)
+
+    // When I select a new user to allocate the application to
+    allocationsPage.selectUser(this.selectedUser)
+    allocationsPage.clickSubmit()
+
+    // Then I should be redirected to the index page
+    Page.verifyOnPage(AllocationsListPage, [], [])
+
+    // And I should see a confirmation message
+    allocationsListPage.shouldShowBanner(`Case has been allocated to ${this.selectedUser.name}`)
+
+    // And the API should have received the correct data
+    cy.task('verifyAllocationCreate', this.application).then(requests => {
+      // Then the API should have had a clarification note added
+      expect(requests).to.have.length(1)
+      const body = JSON.parse(requests[0].body)
+
+      expect(body.userId).equal(this.selectedUser.id)
+    })
+  })
+
+  it('shows an error when I do not select a user', function test() {
+    cy.task('stubAllocationErrors', this.application)
+
+    // Given I am on the allocations page
+    const allocationsPage = AllocationsPage.visit(this.assessment)
+
+    // And I click submit without selecting a user
+    allocationsPage.clickSubmit()
+
+    // Then I should see an error
+    allocationsPage.shouldShowErrorMessagesForFields(['userId'])
   })
 })

--- a/server/controllers/assess/applications/allocationsController.test.ts
+++ b/server/controllers/assess/applications/allocationsController.test.ts
@@ -2,14 +2,19 @@ import type { Request, Response, NextFunction } from 'express'
 
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 
+import { ErrorsAndUserInput } from '@approved-premises/ui'
 import AllocationsController from './allocationsController'
 import { ApplicationService, UserService } from '../../../services'
 import { getQualificationsForApplication } from '../../../utils/applications/getQualificationsForApplication'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 
 import assessmentFactory from '../../../testutils/factories/assessment'
 import userFactory from '../../../testutils/factories/user'
 
+import paths from '../../../paths/assess'
+
 jest.mock('../../../utils/applications/getQualificationsForApplication')
+jest.mock('../../../utils/validation')
 
 describe('allocationsController', () => {
   const token = 'SOME_TOKEN'
@@ -28,16 +33,20 @@ describe('allocationsController', () => {
   })
 
   describe('show', () => {
-    it('fetches the assessment and a list of qualified users', async () => {
-      const requestHandler = allocationsController.show()
+    const assessment = assessmentFactory.build()
+    const users = userFactory.buildList(3)
+    const qualifications = ['foo', 'bar']
 
-      const assessment = assessmentFactory.build()
-      const users = userFactory.buildList(3)
-      const qualifications = ['foo', 'bar']
-
+    beforeEach(() => {
       applicationService.getAssessment.mockResolvedValue(assessment)
       userService.getUsers.mockResolvedValue(users)
       ;(getQualificationsForApplication as jest.Mock).mockReturnValue(qualifications)
+    })
+
+    it('fetches the assessment and a list of qualified users', async () => {
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [], userInput: {} })
+
+      const requestHandler = allocationsController.show()
 
       await requestHandler(request, response, next)
 
@@ -45,10 +54,70 @@ describe('allocationsController', () => {
         pageHeading: `Assessment for ${assessment.application.person.name}`,
         assessment,
         users,
+        errors: {},
+        errorSummary: [],
       })
 
       expect(applicationService.getAssessment).toHaveBeenCalledWith(request.user.token, request.params.id)
       expect(userService.getUsers).toHaveBeenCalledWith(request.user.token, ['assessor'], qualifications)
+    })
+
+    it('renders the form with errors and user input if an error has been sent to the flash', async () => {
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
+
+      const requestHandler = allocationsController.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('applications/allocations/show', {
+        pageHeading: `Assessment for ${assessment.application.person.name}`,
+        assessment,
+        users,
+        errors: errorsAndUserInput.errors,
+        errorSummary: errorsAndUserInput.errorSummary,
+        ...errorsAndUserInput.userInput,
+      })
+    })
+  })
+
+  describe('create', () => {
+    beforeEach(() => {
+      request.params.id = 'some-uuid'
+      request.body.userId = 'some-other-uuid'
+    })
+
+    it('should set a flash message and redirect when the API returns correctly', async () => {
+      const requestHandler = allocationsController.create()
+
+      const staffMember = userFactory.build()
+      const assessment = assessmentFactory.build({ allocatedToStaffMember: staffMember })
+      applicationService.allocate.mockResolvedValue(assessment)
+
+      await requestHandler(request, response, next)
+
+      expect(request.flash).toHaveBeenCalledWith('success', `Case has been allocated to ${staffMember.name}`)
+      expect(response.redirect).toHaveBeenCalledWith(paths.assessments.index({}))
+
+      expect(applicationService.allocate).toHaveBeenCalledWith(token, request.params.id, request.body.userId)
+    })
+
+    it('should redirect with errors if the API returns an error', async () => {
+      const requestHandler = allocationsController.create()
+
+      const err = new Error()
+
+      applicationService.allocate.mockImplementation(() => {
+        throw err
+      })
+
+      await requestHandler(request, response, next)
+
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+        request,
+        response,
+        err,
+        paths.allocations.show({ id: request.params.id }),
+      )
     })
   })
 })

--- a/server/controllers/assess/applications/allocationsController.ts
+++ b/server/controllers/assess/applications/allocationsController.ts
@@ -1,7 +1,10 @@
 import type { Request, Response, RequestHandler } from 'express'
 import { getQualificationsForApplication } from '../../../utils/applications/getQualificationsForApplication'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 
 import { ApplicationService, UserService } from '../../../services'
+
+import paths from '../../../paths/assess'
 
 export default class AllocationsController {
   constructor(private readonly applicationService: ApplicationService, private readonly userService: UserService) {}
@@ -14,12 +17,30 @@ export default class AllocationsController {
         ['assessor'],
         getQualificationsForApplication(assessment.application),
       )
+      const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
       res.render('applications/allocations/show', {
         pageHeading: `Assessment for ${assessment.application.person.name}`,
         assessment,
         users,
+        errors,
+        errorSummary,
+        ...userInput,
       })
+    }
+  }
+
+  create(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { id } = req.params
+      try {
+        const assessment = await this.applicationService.allocate(req.user.token, req.params.id, req.body.userId)
+
+        req.flash('success', `Case has been allocated to ${assessment.allocatedToStaffMember.name}`)
+        res.redirect(paths.assessments.index({}))
+      } catch (err) {
+        catchValidationErrorOrPropogate(req, res, err, paths.allocations.show({ id }))
+      }
     }
   }
 }

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -174,4 +174,22 @@ describe('ApplicationClient', () => {
       expect(nock.isDone()).toBeTruthy()
     })
   })
+
+  describe('allocate', () => {
+    it('should allocate an assessment', async () => {
+      const assessment = assessmentFactory.build()
+      const applicationId = 'some-application-id'
+      const userId = 'some-user-id'
+
+      fakeApprovedPremisesApi
+        .post(paths.applications.allocation.create({ id: applicationId }), { userId })
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(201, assessment)
+
+      const result = await applicationClient.allocate(applicationId, userId)
+
+      expect(result).toEqual(assessment)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
 })

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -59,4 +59,11 @@ export default class ApplicationClient {
       path: paths.applications.assessment({ id: applicationId }),
     })) as Assessment
   }
+
+  async allocate(applicationId: string, userId: string): Promise<Assessment> {
+    return (await this.restClient.post({
+      path: paths.applications.allocation.create({ id: applicationId }),
+      data: { userId },
+    })) as Assessment
+  }
 }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -60,5 +60,6 @@
   },
   "numberOfBeds": { "empty": "You must enter the number of beds lost", "isZero": "Number of beds lost cannot be zero" },
   "referenceNumber": { "empty": "You must enter a reference number" },
-  "query": { "empty": "You must enter a query" }
+  "query": { "empty": "You must enter a query" },
+  "userId": { "empty": "You must choose a user to allocate the application to" }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -65,6 +65,9 @@ export default {
     submission: applyPaths.applications.submission,
     documents: applyPaths.applications.show.path('documents'),
     assessment: applyPaths.applications.show.path('assessment'),
+    allocation: {
+      create: applyPaths.applications.show.path('allocations'),
+    },
   },
   assessments: {
     index: assessPaths.assessments,

--- a/server/paths/assess.ts
+++ b/server/paths/assess.ts
@@ -11,6 +11,8 @@ const supportingInformationPath = assessmentPath.path('supporting-information/:c
 
 const submission = assessmentPath.path('submission')
 
+const allocationPath = applyPaths.applications.show.path('allocation')
+
 const paths = {
   assessments: {
     index: assessmentsPath,
@@ -26,7 +28,8 @@ const paths = {
     submission,
   },
   allocations: {
-    show: applyPaths.applications.show.path('/allocation'),
+    show: allocationPath,
+    create: allocationPath,
   },
 }
 

--- a/server/routes/assess.ts
+++ b/server/routes/assess.ts
@@ -30,6 +30,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   post(paths.assessments.submission.pattern, assessmentsController.submit())
 
   get(paths.allocations.show.pattern, allocationsController.show())
+  post(paths.allocations.create.pattern, allocationsController.create())
 
   Object.keys(pages).forEach((taskKey: string) => {
     Object.keys(pages[taskKey]).forEach((pageKey: string) => {

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -367,4 +367,17 @@ describe('ApplicationService', () => {
       expect(applicationClient.assessment).toHaveBeenCalledWith(id)
     })
   })
+
+  describe('allocate', () => {
+    it('calls the client with the expected arguments', async () => {
+      const token = 'token'
+      const applicationId = 'some-application-id'
+      const userId = 'some-user-id'
+
+      await service.allocate(token, applicationId, userId)
+
+      expect(applicationClientFactory).toHaveBeenCalledWith(token)
+      expect(applicationClient.allocate).toHaveBeenCalledWith(applicationId, userId)
+    })
+  })
 })

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -133,6 +133,13 @@ export default class ApplicationService {
     return assessment
   }
 
+  async allocate(token: string, assessmentId: string, userId: string): Promise<Assessment> {
+    const client = this.applicationClientFactory(token)
+    const assessment = await client.allocate(assessmentId, userId)
+
+    return assessment
+  }
+
   private async saveToSession(application: ApprovedPremisesApplication, page: TasklistPage, request: Request) {
     request.session.application = application
     request.session.previousPage = request.params.page

--- a/server/views/applications/allocations/show.njk
+++ b/server/views/applications/allocations/show.njk
@@ -21,27 +21,28 @@
 
       {{ showErrorSummary(errorSummary) }}
 
-      <form action="#" method="post">
+      <form action="{{ paths.allocations.create({ id: assessment.application.id }) }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
         {{
-        govukSelect({
-          label: {
-            html: '<h2 class="govuk-heading-m">Reallocate Assessment</h2>'
-          },
-          hint: {
-            text: 'Select a staff member to allocate the assessment to'
-          },
-          id: "staffMember",
-          name: "staffMember",
-          items: convertObjectsToSelectOptions(users, 'Please select', 'name', 'id', 'staffMember'),
-          errorMessage: errors.staffMember
-        })
-      }}
+          govukSelect({
+            label: {
+              html: '<h2 class="govuk-heading-m">Reallocate Assessment</h2>'
+            },
+            hint: {
+              text: 'Select a staff member to allocate the assessment to'
+            },
+            id: "userId",
+            name: "userId",
+            items: convertObjectsToSelectOptions(users, 'Please select', 'name', 'id', 'userId'),
+            errorMessage: errors.userId
+          })
+        }}
 
         {{
-        govukButton({
-        text: "Submit"
-        })
-      }}
+          govukButton({
+          text: "Submit"
+          })
+        }}
       </form>
     </div>
 

--- a/server/views/assessments/index.njk
+++ b/server/views/assessments/index.njk
@@ -7,6 +7,7 @@
 {% set mainClasses = "app-container govuk-body assessments--index" %}
 
 {% block content %}
+  {% include "../_messages.njk" %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">


### PR DESCRIPTION
This follows on from #552 and adds service and client methods to allocate an assessment, as well as adding a controller method to call the allocation method and show a flash message to the user. 

# Screenshot

![Assess -- allows me to reallocate an assessment](https://user-images.githubusercontent.com/109774/218688836-dbd9c4b0-04e0-4405-af37-65737b5fc1a5.png)
