### PR TITLE
Update API request fixture with prison name rather than code

### DIFF
--- a/cypress.config.e2e.ts
+++ b/cypress.config.e2e.ts
@@ -39,4 +39,6 @@ export default defineConfig({
     setupNodeEvents,
     supportFile: false,
   },
+  viewportHeight: 3000,
+  viewportWidth: 660,
 })

--- a/cypress_shared/fixtures/person.json
+++ b/cypress_shared/fixtures/person.json
@@ -4,7 +4,7 @@
   "dateOfBirth": "1993-04-24",
   "nomsNumber": "A7779DY",
   "status": "InCustody",
-  "prisonName": "1-3",
+  "prisonName": "Moorland (HMP & YOI)",
   "religionOrBelief": "Apostolic",
   "nationality": "British",
   "sex": "Male"


### PR DESCRIPTION
On the API side we recently fixed the response to include the prison name rather than a code. See

It would be helpful to change the settings in Circle CI to show a taller screenshot of the page with an error 
so that the problem element is less likely to be hidden "below the fold".

![ci_screenshot_height](https://user-images.githubusercontent.com/20245/218694471-0614d5cf-ae0e-4c1d-98c7-d1a380bed5b5.png)
