### PR TITLE
(1217) - Add optional chaining to tier level

### DIFF
--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -307,6 +307,15 @@ describe('applicationUtils', () => {
         paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'is-exceptional-case' }),
       )
     })
+
+    it('returns the is exceptional case page for an application for a person without a tier', () => {
+      const application = applicationFactory.build()
+      application.risks = undefined
+
+      expect(firstPageOfApplicationJourney(application)).toEqual(
+        paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'is-exceptional-case' }),
+      )
+    })
   })
 
   describe('isUnapplicable', () => {

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -150,7 +150,7 @@ const isUnapplicable = (application: Application): boolean => {
 }
 
 const firstPageOfApplicationJourney = (application: Application) => {
-  if (isApplicableTier(application.person.sex, application.risks.tier.value.level)) {
+  if (isApplicableTier(application.person.sex, application.risks?.tier?.value?.level)) {
     return paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'sentence-type' })
   }
 


### PR DESCRIPTION
It is possible for someone to not have a tier value. Previously this caused a crash whereas it should direct the user to the exceptional case screen.
Using optional chaining should fix this issue. 
We may will need to change the copy on the exceptional case screen but this can be done once we have the copy ready.