### PR TITLE
(1228) Add correct reference to sections in Assess

### DIFF
--- a/server/views/assessments/show.njk
+++ b/server/views/assessments/show.njk
@@ -28,7 +28,7 @@
           <li>
             <h2 class="app-task-list__section">
               <span class="app-task-list__section-number">
-                {{ (sections | length) + 1 }}.
+                {{ (taskList.sections | length) + 1 }}.
             </span>
             Submit your assessment
           </h2>


### PR DESCRIPTION
This was causing the last section number to show as `1`

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/109774/218984963-3ff28129-adca-4f66-b21c-f2a11263c4f7.png)

### After 

![image](https://user-images.githubusercontent.com/109774/218984879-43e038b5-9d32-49a7-a2e9-906501142d48.png)
