### PR TITLE
Fix - Move back button into beforeContent block

### DIFF
--- a/server/views/applications/pages/basic-information/is-exceptional-case.njk
+++ b/server/views/applications/pages/basic-information/is-exceptional-case.njk
@@ -3,10 +3,14 @@
 
 {% extends "../layout.njk" %}
 
-{{ govukBackLink({
+{% block beforeContent %}
+
+  {{ govukBackLink({
 		text: "Back",
 		href: paths.applications.people.selectOffence({ crn: page.application.person.crn })
 	}) }}
+
+{% endblock %}
 
 {% block questions %}
 


### PR DESCRIPTION
Previously it was outside any block meaning it did not show