### PR TITLE
Apply - Catch a 403 error from the createApplication method

### DIFF
--- a/cypress_shared/pages/apply/enterCrn.ts
+++ b/cypress_shared/pages/apply/enterCrn.ts
@@ -11,7 +11,7 @@ export default class EnterCRNPage extends Page {
     this.getTextInputByIdAndEnterDetails('crn', crn)
   }
 
-  public shouldShowErrorMessage(person: Person): void {
+  public shouldShowPersonNotFoundErrorMessage(person: Person): void {
     cy.get('.govuk-error-summary').should('contain', `No person with an CRN of '${person.crn}' was found`)
     cy.get(`[data-cy-error-crn]`).should('contain', `No person with an CRN of '${person.crn}' was found`)
   }

--- a/cypress_shared/pages/apply/enterCrn.ts
+++ b/cypress_shared/pages/apply/enterCrn.ts
@@ -15,4 +15,9 @@ export default class EnterCRNPage extends Page {
     cy.get('.govuk-error-summary').should('contain', `No person with an CRN of '${person.crn}' was found`)
     cy.get(`[data-cy-error-crn]`).should('contain', `No person with an CRN of '${person.crn}' was found`)
   }
+
+  public shouldShowPersonNotInCaseLoadErrorMessage(person: Person): void {
+    cy.get('.govuk-error-summary').should('contain', `${person.crn} is not in your caseload`)
+    cy.get(`[data-cy-error-crn]`).should('contain', `${person.crn} is not in your caseload`)
+  }
 }

--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -29,6 +29,18 @@ export default {
         jsonBody: { ...args.application, data: null },
       },
     }),
+  stubApplicationForUserNotInCaseload: (args: { application: ApprovedPremisesApplication }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: `/applications?createWithRisks=true`,
+      },
+      response: {
+        status: 403,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: { ...args.application, data: null },
+      },
+    }),
   stubApplicationUpdate: (args: { application: ApprovedPremisesApplication }): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -174,10 +174,22 @@ context('Apply', () => {
     crnPage.shouldShowPersonNotFoundErrorMessage(person)
   })
 
+  it('shows an error message if the person is not in the users caseload', function test() {
+    // And the person I am about to search for is not in my caseload
+    const apply = new ApplyHelper(this.application, this.person, this.offences, 'integration')
+    apply.setupApplicationStubs()
+    cy.task('stubApplicationForUserNotInCaseload', { application: this.application })
+
+    apply.startApplication()
+    // Then I should see an error message
+    new EnterCRNPage().shouldShowPersonNotInCaseLoadErrorMessage(this.person)
+  })
+
   it('allows completion of the form', function test() {
     // And I complete the application
     const uiRisks = mapApiPersonRisksForUi(this.application.risks)
     const apply = new ApplyHelper(this.application, this.person, this.offences, 'integration')
+
     apply.setupApplicationStubs(uiRisks)
     apply.startApplication()
     apply.completeApplication()

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -171,7 +171,7 @@ context('Apply', () => {
     crnPage.clickSubmit()
 
     // Then I should see an error message
-    crnPage.shouldShowErrorMessage(person)
+    crnPage.shouldShowPersonNotFoundErrorMessage(person)
   })
 
   it('allows completion of the form', function test() {

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -3,11 +3,13 @@ import type { Request, Response, RequestHandler } from 'express'
 import TasklistService from '../../services/tasklistService'
 import ApplicationService from '../../services/applicationService'
 import { PersonService } from '../../services'
-import { fetchErrorsAndUserInput } from '../../utils/validation'
+import { catchAPIErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
 import paths from '../../paths/apply'
 import { DateFormats } from '../../utils/dateUtils'
 import Apply from '../../form-pages/apply'
 import { firstPageOfApplicationJourney, getResponses, isUnapplicable } from '../../utils/applications/utils'
+import { ApprovedPremisesApplication as Application } from '../../@types/shared'
+import { TasklistAPIError } from '../../utils/errors'
 
 export const tasklistPageHeading = 'Apply for an Approved Premises (AP) placement'
 
@@ -80,17 +82,30 @@ export default class ApplicationsController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { crn, offenceId } = req.body
+
       if (!offenceId) {
-        res.redirect(paths.applications.people.selectOffence({ crn }))
-      } else {
-        const offences = await this.personService.getOffences(req.user.token, crn)
-        const indexOffence = offences.find(o => o.offenceId === offenceId)
-
-        const application = await this.applicationService.createApplication(req.user.token, crn, indexOffence)
-        req.session.application = application
-
-        res.redirect(firstPageOfApplicationJourney(application))
+        return res.redirect(paths.applications.people.selectOffence({ crn }))
       }
+
+      const offences = await this.personService.getOffences(req.user.token, crn)
+      const indexOffence = offences.find(o => o.offenceId === offenceId)
+      let application: Application
+
+      try {
+        application = await this.applicationService.createApplication(req.user.token, crn, indexOffence)
+      } catch (error) {
+        if (error.status === 403) {
+          return catchAPIErrorOrPropogate(
+            req,
+            res,
+            new TasklistAPIError(`${error?.data?.person?.crn || 'This CRN'} is not in your caseload`, 'crn'),
+          )
+        }
+        throw error
+      }
+      req.session.application = application
+
+      return res.redirect(firstPageOfApplicationJourney(application))
     }
   }
 


### PR DESCRIPTION
The API will return a 403 if the CRN is not in the users caseload. 
This PR shows an error when the 403 is thrown and informs the user that the CRN is not in their case load 

[Ticket](https://trello.com/c/q6Barsj1/1231-catch-a-403-if-a-crn-is-not-in-the-users-caseload)

## Screenshot
![Apply -- shows an error message if the person is not in the users caseload](https://user-images.githubusercontent.com/44123869/219395144-221c6382-37a2-4cd5-8c73-92389caad600.png)
