### PR TITLE
(1056) Add emergency question

### DIFF
--- a/cypress_shared/helpers/index.ts
+++ b/cypress_shared/helpers/index.ts
@@ -1,4 +1,5 @@
 import {
+  AnyValue,
   ApprovedPremisesApplication,
   ArrayOfOASysOffenceDetailsQuestions,
   ArrayOfOASysRiskManagementPlanQuestions,
@@ -7,6 +8,9 @@ import {
   ArrayOfOASysSupportingInformationQuestions,
 } from '@approved-premises/api'
 import { TableRow } from '@approved-premises/ui'
+import { add } from 'date-fns'
+
+import { DateFormats } from '../../server/utils/dateUtils'
 
 const roshSummariesFromApplication = (
   application: ApprovedPremisesApplication,
@@ -61,6 +65,22 @@ const shouldShowTableRows = <T>(items: Array<T>, tableRowFunction: (items: Array
   })
 }
 
+const updateApplicationReleaseDate = (data: AnyValue) => {
+  const releaseDate = add(new Date(), { months: 6 })
+
+  return {
+    ...data,
+    'basic-information': {
+      ...data['basic-information'],
+      'release-date': {
+        ...DateFormats.dateObjectToDateInputs(releaseDate, 'releaseDate'),
+        knowReleaseDate: 'yes',
+      },
+      'placement-date': { startDateSameAsReleaseDate: 'yes' },
+    },
+  }
+}
+
 export {
   roshSummariesFromApplication,
   offenceDetailSummariesFromApplication,
@@ -68,5 +88,6 @@ export {
   riskManagementPlanFromApplication,
   riskToSelfSummariesFromApplication,
   tableRowsToArrays,
+  updateApplicationReleaseDate,
   shouldShowTableRows,
 }

--- a/e2e/tests/stepDefinitions/apply.ts
+++ b/e2e/tests/stepDefinitions/apply.ts
@@ -7,9 +7,10 @@ import personFactory from '../../../server/testutils/factories/person'
 
 import personData from '../../../cypress_shared/fixtures/person.json'
 import applicationData from '../../../cypress_shared/fixtures/applicationData.json'
+import { updateApplicationReleaseDate } from '../../../cypress_shared/helpers/index'
 
 const person = personFactory.build(personData)
-const application = applicationFactory.build({ person, data: applicationData })
+const application = applicationFactory.build({ person, data: updateApplicationReleaseDate(applicationData) })
 
 Given('I start a new application', () => {
   const apply = new ApplyHelper(application, person, [], 'e2e')

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -17,6 +17,7 @@ import risksFactory, { tierEnvelopeFactory } from '../../../server/testutils/fac
 import SubmissionConfirmation from '../../../cypress_shared/pages/apply/submissionConfirmation'
 import IsExceptionalCasePage from '../../../cypress_shared/pages/apply/isExceptionalCase'
 import NotEligiblePage from '../../../cypress_shared/pages/apply/notEligiblePage'
+import { updateApplicationReleaseDate } from '../../../cypress_shared/helpers'
 
 context('Apply', () => {
   beforeEach(() => {
@@ -37,13 +38,13 @@ context('Apply', () => {
         tier: tierEnvelopeFactory.build({ value: { level: 'A3' } }),
       })
       const offences = activeOffenceFactory.buildList(1)
-      application.data = applicationData
+      application.data = updateApplicationReleaseDate(applicationData)
       application.risks = risks
 
       cy.wrap(person).as('person')
       cy.wrap(offences).as('offences')
       cy.wrap(application).as('application')
-      cy.wrap(applicationData).as('applicationData')
+      cy.wrap(application.data).as('applicationData')
     })
   })
 

--- a/server/form-pages/apply/reasons-for-placement/basic-information/index.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/index.ts
@@ -9,6 +9,7 @@ import ReleaseDate from './releaseDate'
 import OralHearing from './oralHearing'
 import PlacementDate from './placementDate'
 import PlacementPurpose from './placementPurpose'
+import ReasonForShortNotice from './reasonForShortNotice'
 import { Task } from '../../../utils/decorators'
 
 @Task({
@@ -24,6 +25,7 @@ import { Task } from '../../../utils/decorators'
     OralHearing,
     PlacementDate,
     PlacementPurpose,
+    ReasonForShortNotice,
   ],
 })
 export default class BasicInformation {}

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.test.ts
@@ -1,9 +1,12 @@
 import { add, sub } from 'date-fns'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
 
 import PlacementDate from './placementDate'
 import { DateFormats } from '../../../../utils/dateUtils'
 import applicationFactory from '../../../../testutils/factories/application'
+
+jest.mock('../../../../utils/applications/noticeTypeFromApplication')
 
 describe('PlacementDate', () => {
   const releaseDate = new Date().toISOString()
@@ -35,7 +38,30 @@ describe('PlacementDate', () => {
     })
   })
 
-  itShouldHaveNextValue(new PlacementDate({}, application), 'placement-purpose')
+  describe('when the notice type is standard', () => {
+    beforeEach(() => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('standard')
+    })
+
+    itShouldHaveNextValue(new PlacementDate({}, application), 'placement-purpose')
+  })
+
+  describe('when the notice type is emergency', () => {
+    beforeEach(() => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('emergency')
+    })
+
+    itShouldHaveNextValue(new PlacementDate({}, application), 'reason-for-short-notice')
+  })
+
+  describe('when the notice type is short_notice', () => {
+    beforeEach(() => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('short_notice')
+    })
+
+    itShouldHaveNextValue(new PlacementDate({}, application), 'reason-for-short-notice')
+  })
+
   itShouldHavePreviousValue(new PlacementDate({}, application), 'release-date')
 
   describe('errors', () => {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.test.ts
@@ -1,3 +1,4 @@
+import { add, sub } from 'date-fns'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
 import PlacementDate from './placementDate'
@@ -50,12 +51,11 @@ describe('PlacementDate', () => {
 
     describe('if the start date is not the same as the release date', () => {
       it('should return an empty object if the date is specified', () => {
+        const placementDate = add(new Date(), { days: 5 })
         const page = new PlacementDate(
           {
             startDateSameAsReleaseDate: 'no',
-            'startDate-year': '2020',
-            'startDate-month': '12',
-            'startDate-day': '1',
+            ...DateFormats.dateObjectToDateInputs(placementDate, 'startDate'),
           },
           application,
         )
@@ -83,6 +83,18 @@ describe('PlacementDate', () => {
           application,
         )
         expect(page.errors()).toEqual({ startDate: 'The start date is an invalid date' })
+      })
+
+      it('should return an error if the date is in the past', () => {
+        const placementDate = sub(new Date(), { months: 5 })
+        const page = new PlacementDate(
+          {
+            startDateSameAsReleaseDate: 'no',
+            ...DateFormats.dateObjectToDateInputs(placementDate, 'startDate'),
+          },
+          application,
+        )
+        expect(page.errors()).toEqual({ startDate: 'The start date must not be in the past' })
       })
     })
 

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
@@ -5,6 +5,7 @@ import TasklistPage from '../../../tasklistPage'
 import { retrieveQuestionResponseFromApplication, convertToTitleCase } from '../../../../utils/utils'
 import { dateIsBlank, dateAndTimeInputsAreValidDates, DateFormats, dateIsInThePast } from '../../../../utils/dateUtils'
 import { Page } from '../../../utils/decorators'
+import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
 
 type PlacementDateBody = ObjectWithDateParts<'startDate'> & {
   startDateSameAsReleaseDate: YesOrNo
@@ -17,7 +18,7 @@ type PlacementDateBody = ObjectWithDateParts<'startDate'> & {
 export default class PlacementDate implements TasklistPage {
   title: string
 
-  constructor(private _body: Partial<PlacementDateBody>, application: ApprovedPremisesApplication) {
+  constructor(private _body: Partial<PlacementDateBody>, public application: ApprovedPremisesApplication) {
     const formattedReleaseDate = DateFormats.isoDateToUIDate(
       retrieveQuestionResponseFromApplication(application, 'basic-information', 'releaseDate'),
     )
@@ -46,7 +47,11 @@ export default class PlacementDate implements TasklistPage {
   }
 
   next() {
-    return 'placement-purpose'
+    if (noticeTypeFromApplication(this.application) === 'standard') {
+      return 'placement-purpose'
+    }
+
+    return 'reason-for-short-notice'
   }
 
   previous() {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
@@ -3,7 +3,7 @@ import type { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import TasklistPage from '../../../tasklistPage'
 import { retrieveQuestionResponseFromApplication, convertToTitleCase } from '../../../../utils/utils'
-import { dateIsBlank, dateAndTimeInputsAreValidDates, DateFormats } from '../../../../utils/dateUtils'
+import { dateIsBlank, dateAndTimeInputsAreValidDates, DateFormats, dateIsInThePast } from '../../../../utils/dateUtils'
 import { Page } from '../../../utils/decorators'
 
 type PlacementDateBody = ObjectWithDateParts<'startDate'> & {
@@ -77,6 +77,8 @@ export default class PlacementDate implements TasklistPage {
         errors.startDate = 'You must enter a start date'
       } else if (!dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'startDate'>, 'startDate')) {
         errors.startDate = 'The start date is an invalid date'
+      } else if (dateIsInThePast(this.body.startDate)) {
+        errors.startDate = 'The start date must not be in the past'
       }
     }
 

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.test.ts
@@ -1,8 +1,11 @@
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
 
 import applicationFactory from '../../../../testutils/factories/application'
 
 import PlacementPurpose from './placementPurpose'
+
+jest.mock('../../../../utils/applications/noticeTypeFromApplication')
 
 describe('PlacementPurpose', () => {
   const application = applicationFactory.build()
@@ -66,7 +69,29 @@ describe('PlacementPurpose', () => {
 
   itShouldHaveNextValue(new PlacementPurpose({ placementPurposes: ['publicProtection'] }, application), '')
 
-  itShouldHavePreviousValue(new PlacementPurpose({}, application), 'placement-date')
+  describe('when the notice type is standard', () => {
+    beforeEach(() => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('standard')
+    })
+
+    itShouldHavePreviousValue(new PlacementPurpose({}, application), 'placement-purpose')
+  })
+
+  describe('when the notice type is emergency', () => {
+    beforeEach(() => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('emergency')
+    })
+
+    itShouldHavePreviousValue(new PlacementPurpose({}, application), 'reason-for-short-notice')
+  })
+
+  describe('when the notice type is short_notice', () => {
+    beforeEach(() => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('short_notice')
+    })
+
+    itShouldHavePreviousValue(new PlacementPurpose({}, application), 'reason-for-short-notice')
+  })
 
   describe('errors', () => {
     it('should return an empty object if the placement purpose is specified as a reason other than "Other reason"', () => {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.ts
@@ -4,6 +4,7 @@ import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
 import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
+import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
 
 export const placementPurposes = {
   publicProtection: 'Public protection',
@@ -24,7 +25,7 @@ export default class PlacementPurpose implements TasklistPage {
 
   purposes = placementPurposes
 
-  constructor(private _body: PlacementPurposeBody, private readonly _application: ApprovedPremisesApplication) {
+  constructor(private _body: PlacementPurposeBody, private readonly application: ApprovedPremisesApplication) {
     this._body.placementPurposes = _body?.placementPurposes
       ? ([_body.placementPurposes].flat() as Array<PlacementPurposeT>)
       : []
@@ -47,7 +48,11 @@ export default class PlacementPurpose implements TasklistPage {
   }
 
   previous() {
-    return 'placement-date'
+    if (noticeTypeFromApplication(this.application) === 'standard') {
+      return 'placement-purpose'
+    }
+
+    return 'reason-for-short-notice'
   }
 
   errors() {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/reasonForShortNotice.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/reasonForShortNotice.test.ts
@@ -1,0 +1,118 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
+
+import ReasonForShortNotice, { shortNoticeReasons } from './reasonForShortNotice'
+
+import applicationFactory from '../../../../testutils/factories/application'
+
+jest.mock('../../../../utils/applications/noticeTypeFromApplication')
+
+describe('ReasonForShortNotice', () => {
+  const application = applicationFactory.build()
+
+  it('should return the correct title and question for emergency applications', () => {
+    ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('emergency')
+    const page = new ReasonForShortNotice({}, application)
+
+    expect(page.title).toEqual('Emergency application')
+    expect(page.question).toEqual(
+      'What is the reason for submitting this application less than 7 days before the AP is needed?',
+    )
+  })
+
+  it('should return the correct title and question for short notice applications', () => {
+    ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('short_notice')
+    const page = new ReasonForShortNotice({}, application)
+
+    expect(page.title).toEqual('Short notice application')
+    expect(page.question).toEqual(
+      'What is the reason for submitting this application less than 4 months before the AP is needed?',
+    )
+  })
+
+  it('should set the body', () => {
+    const page = new ReasonForShortNotice(
+      {
+        reason: 'other',
+        other: 'Foo',
+      },
+      application,
+    )
+
+    expect(page.body).toEqual({
+      reason: 'other',
+      other: 'Foo',
+    })
+  })
+
+  itShouldHaveNextValue(new ReasonForShortNotice({}, application), '')
+  itShouldHavePreviousValue(new ReasonForShortNotice({}, application), '')
+
+  describe('errors', () => {
+    it('should return an empty object if all the fields are complete', () => {
+      const page = new ReasonForShortNotice(
+        {
+          reason: 'other',
+          other: 'Foo',
+        },
+        application,
+      )
+
+      expect(page.errors()).toEqual({})
+    })
+
+    it('should return an error if the reason is blank', () => {
+      const page = new ReasonForShortNotice({}, application)
+
+      expect(page.errors()).toEqual({ reason: 'You must specify a reason' })
+    })
+
+    it('should return an error if the other is selected and the other reason is blank', () => {
+      const page = new ReasonForShortNotice({ reason: 'other' }, application)
+
+      expect(page.errors()).toEqual({ other: 'You must specify what the other reason is' })
+    })
+  })
+
+  describe('response', () => {
+    it('should return the other reason if other is specified', () => {
+      const page = new ReasonForShortNotice(
+        {
+          reason: 'other',
+          other: 'Foo',
+        },
+        application,
+      )
+
+      expect(page.response()).toEqual({ [page.question]: 'Foo' })
+    })
+
+    it('should return a translated response', () => {
+      const page = new ReasonForShortNotice(
+        {
+          reason: 'alternativeToRecall',
+        },
+        application,
+      )
+
+      expect(page.response()).toEqual({ [page.question]: 'AP placement is an alternative to recall' })
+    })
+  })
+
+  describe('items', () => {
+    it('should return the reasons as radio items with a conditional in the `other` option', () => {
+      const page = new ReasonForShortNotice({}, application)
+      const items = page.items('SOME HTML')
+
+      expect(items.length).toEqual(Object.keys(shortNoticeReasons).length)
+      expect(items.pop()).toEqual({
+        checked: false,
+        conditional: {
+          html: 'SOME HTML',
+        },
+        text: 'Other, please specify',
+        value: 'other',
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/reasons-for-placement/basic-information/reasonForShortNotice.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/reasonForShortNotice.test.ts
@@ -45,8 +45,8 @@ describe('ReasonForShortNotice', () => {
     })
   })
 
-  itShouldHaveNextValue(new ReasonForShortNotice({}, application), '')
-  itShouldHavePreviousValue(new ReasonForShortNotice({}, application), '')
+  itShouldHaveNextValue(new ReasonForShortNotice({}, application), 'placement-purpose')
+  itShouldHavePreviousValue(new ReasonForShortNotice({}, application), 'placement-date')
 
   describe('errors', () => {
     it('should return an empty object if all the fields are complete', () => {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/reasonForShortNotice.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/reasonForShortNotice.ts
@@ -38,11 +38,11 @@ export default class ReasonForShortNotice implements TasklistPage {
   }
 
   next() {
-    return ''
+    return 'placement-purpose'
   }
 
   previous() {
-    return ''
+    return 'placement-date'
   }
 
   response() {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/reasonForShortNotice.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/reasonForShortNotice.ts
@@ -1,0 +1,74 @@
+import { ApprovedPremisesApplication as Application } from '@approved-premises/api'
+import { TaskListErrors } from '@approved-premises/ui'
+import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
+import TasklistPage from '../../../tasklistPage'
+import { Page } from '../../../utils/decorators'
+import { convertKeyValuePairToRadioItems } from '../../../../utils/formUtils'
+
+export const shortNoticeReasons = {
+  riskEscalated: 'The risk level has recently escalated',
+  planBrokenDown: 'The release plan or risk management plan has broken down',
+  furtherOffence: 'The individual has committed a further offence',
+  alternativeToRecall: 'AP placement is an alternative to recall',
+  paroleBoardOrPPCS: 'AP placement is a parole board or PPCS decision',
+  shortSentence: 'The sentence is shorter than 12 months',
+  onBail: 'The individual will be on bail',
+  other: 'Other, please specify',
+}
+
+type ShortNoticeReasons = keyof typeof shortNoticeReasons
+type ReasonForShortNoticeBody = { reason: ShortNoticeReasons; other: string }
+
+@Page({ name: 'reason-for-short-notice', bodyProperties: ['reason', 'other'] })
+export default class ReasonForShortNotice implements TasklistPage {
+  name = 'reason-for-short-notice'
+
+  title: string
+
+  question: string
+
+  constructor(public readonly body: Partial<ReasonForShortNoticeBody>, readonly application: Application) {
+    if (noticeTypeFromApplication(application) === 'emergency') {
+      this.title = 'Emergency application'
+      this.question = 'What is the reason for submitting this application less than 7 days before the AP is needed?'
+    } else {
+      this.title = 'Short notice application'
+      this.question = 'What is the reason for submitting this application less than 4 months before the AP is needed?'
+    }
+  }
+
+  next() {
+    return ''
+  }
+
+  previous() {
+    return ''
+  }
+
+  response() {
+    return {
+      [this.question]: this.body.reason === 'other' ? this.body.other : shortNoticeReasons[this.body.reason],
+    }
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.reason) {
+      errors.reason = 'You must specify a reason'
+    }
+
+    if (this.body.reason === 'other' && !this.body.other) {
+      errors.other = 'You must specify what the other reason is'
+    }
+
+    return errors
+  }
+
+  items(conditionalHtml: string) {
+    const items = convertKeyValuePairToRadioItems(shortNoticeReasons, this.body.reason)
+    const other = items.pop()
+
+    return [...items, { ...other, conditional: { html: conditionalHtml } }]
+  }
+}

--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.test.ts
@@ -1,3 +1,5 @@
+import { add, sub } from 'date-fns'
+import { DateFormats } from '../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
 import ReleaseDate from './releaseDate'
@@ -54,12 +56,11 @@ describe('ReleaseDate', () => {
   describe('errors', () => {
     describe('if the user knows the release date', () => {
       it('should return an empty object if the date is specified', () => {
+        const releaseDate = add(new Date(), { days: 5 })
         const page = new ReleaseDate(
           {
             knowReleaseDate: 'yes',
-            'releaseDate-year': '2022',
-            'releaseDate-month': '3',
-            'releaseDate-day': '3',
+            ...DateFormats.dateObjectToDateInputs(releaseDate, 'releaseDate'),
           },
           application,
           'somePage',
@@ -90,6 +91,19 @@ describe('ReleaseDate', () => {
           'somePage',
         )
         expect(page.errors()).toEqual({ releaseDate: 'The release date is an invalid date' })
+      })
+
+      it('should return an error if the date is in the past', () => {
+        const releaseDate = sub(new Date(), { days: 5 })
+        const page = new ReleaseDate(
+          {
+            knowReleaseDate: 'yes',
+            ...DateFormats.dateObjectToDateInputs(releaseDate, 'releaseDate'),
+          },
+          application,
+          'somePage',
+        )
+        expect(page.errors()).toEqual({ releaseDate: 'The release date must not be in the past' })
       })
     })
 

--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.ts
@@ -3,7 +3,7 @@ import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
-import { dateAndTimeInputsAreValidDates, dateIsBlank, DateFormats } from '../../../../utils/dateUtils'
+import { dateAndTimeInputsAreValidDates, dateIsBlank, DateFormats, dateIsInThePast } from '../../../../utils/dateUtils'
 import { convertToTitleCase } from '../../../../utils/utils'
 
 type ReleaseDateType = ObjectWithDateParts<'releaseDate'> & {
@@ -77,6 +77,8 @@ export default class ReleaseDate implements TasklistPage {
         errors.releaseDate = 'You must specify the release date'
       } else if (!dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'releaseDate'>, 'releaseDate')) {
         errors.releaseDate = 'The release date is an invalid date'
+      } else if (dateIsInThePast(this.body.releaseDate)) {
+        errors.releaseDate = 'The release date must not be in the past'
       }
     }
 

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -303,6 +303,27 @@
               "type": "string"
             }
           }
+        },
+        "reason-for-short-notice": {
+          "type": "object",
+          "properties": {
+            "reason": {
+              "enum": [
+                "alternativeToRecall",
+                "furtherOffence",
+                "onBail",
+                "other",
+                "paroleBoardOrPPCS",
+                "planBrokenDown",
+                "riskEscalated",
+                "shortSentence"
+              ],
+              "type": "string"
+            },
+            "other": {
+              "type": "string"
+            }
+          }
         }
       }
     },

--- a/server/utils/applications/arrivalDateFromApplication.test.ts
+++ b/server/utils/applications/arrivalDateFromApplication.test.ts
@@ -1,0 +1,43 @@
+import { arrivalDateFromApplication } from './arrivalDateFromApplication'
+import applicationFactory from '../../testutils/factories/application'
+import { SessionDataError } from '../errors'
+
+describe('arrivalDateFromApplication', () => {
+  it('returns the arrival date when the release date is known and is the same as the start date', () => {
+    const application = applicationFactory.build({
+      data: {
+        'basic-information': {
+          'release-date': { knowReleaseDate: 'yes', releaseDate: '2022-11-14' },
+          'placement-date': { startDateSameAsReleaseDate: 'yes' },
+        },
+      },
+    })
+    expect(arrivalDateFromApplication(application)).toEqual('2022-11-14')
+  })
+
+  it('returns the arrival date when the release date is known but there is a different start date', () => {
+    const application = applicationFactory.build({
+      data: {
+        'basic-information': {
+          'release-date': { knowReleaseDate: 'yes', releaseDate: '2022-11-14' },
+          'placement-date': { startDateSameAsReleaseDate: 'no', startDate: '2023-10-13' },
+        },
+      },
+    })
+
+    expect(arrivalDateFromApplication(application)).toEqual('2023-10-13')
+  })
+
+  it('throws an error or returns null when the release date is not known', () => {
+    const application = applicationFactory.build({
+      data: {
+        'basic-information': {
+          'release-date': { knowReleaseDate: 'no' },
+        },
+      },
+    })
+
+    expect(() => arrivalDateFromApplication(application)).toThrow(new SessionDataError('No known release date'))
+    expect(arrivalDateFromApplication(application, false)).toEqual(null)
+  })
+})

--- a/server/utils/applications/arrivalDateFromApplication.ts
+++ b/server/utils/applications/arrivalDateFromApplication.ts
@@ -1,0 +1,48 @@
+import type { ApprovedPremisesApplication as Application } from '@approved-premises/api'
+import { SessionDataError } from '../errors'
+
+export const arrivalDateFromApplication = (application: Application, raiseOnMissing = true): string | null => {
+  const throwOrReturnNull = (message: string): null => {
+    if (raiseOnMissing) {
+      throw new SessionDataError(message)
+    }
+
+    return null
+  }
+
+  const basicInformation = application.data?.['basic-information']
+
+  if (!basicInformation) return throwOrReturnNull('No basic information')
+
+  const {
+    knowReleaseDate = '',
+    startDateSameAsReleaseDate = '',
+    releaseDate = '',
+    startDate = '',
+  } = {
+    ...basicInformation['release-date'],
+    ...basicInformation['placement-date'],
+  }
+
+  if (!knowReleaseDate || knowReleaseDate === 'no') {
+    return throwOrReturnNull('No known release date')
+  }
+
+  if (knowReleaseDate === 'yes' && startDateSameAsReleaseDate === 'yes') {
+    if (!releaseDate) {
+      return throwOrReturnNull('No release date')
+    }
+
+    return releaseDate
+  }
+
+  if (startDateSameAsReleaseDate === 'no') {
+    if (!startDate) {
+      return throwOrReturnNull('No start date')
+    }
+
+    return startDate
+  }
+
+  return null
+}

--- a/server/utils/applications/noticeTypeFromApplication.test.ts
+++ b/server/utils/applications/noticeTypeFromApplication.test.ts
@@ -1,12 +1,12 @@
 import { add } from 'date-fns'
 
 import { DateFormats } from '../dateUtils'
-import { getArrivalDate } from './utils'
+import { arrivalDateFromApplication } from './arrivalDateFromApplication'
 import { noticeTypeFromApplication } from './noticeTypeFromApplication'
 
 import applicationFactory from '../../testutils/factories/application'
 
-jest.mock('./utils')
+jest.mock('./arrivalDateFromApplication')
 
 describe('noticeTypeFromApplication', () => {
   const application = applicationFactory.build({})

--- a/server/utils/applications/noticeTypeFromApplication.test.ts
+++ b/server/utils/applications/noticeTypeFromApplication.test.ts
@@ -1,0 +1,40 @@
+import { add } from 'date-fns'
+
+import { DateFormats } from '../dateUtils'
+import { getArrivalDate } from './utils'
+import { noticeTypeFromApplication } from './noticeTypeFromApplication'
+
+import applicationFactory from '../../testutils/factories/application'
+
+jest.mock('./utils')
+
+describe('noticeTypeFromApplication', () => {
+  const application = applicationFactory.build({})
+
+  it('returns emergency if the arrival date is less than seven days away', () => {
+    const date = add(new Date(), { days: 4 })
+    const arrivalDate = DateFormats.dateObjToIsoDate(date)
+
+    ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(arrivalDate)
+
+    expect(noticeTypeFromApplication(application)).toEqual('emergency')
+  })
+
+  it('returns short_notice if the arrival date is less than 4 months away', () => {
+    const date = add(new Date(), { months: 3 })
+    const arrivalDate = DateFormats.dateObjToIsoDate(date)
+
+    ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(arrivalDate)
+
+    expect(noticeTypeFromApplication(application)).toEqual('short_notice')
+  })
+
+  it('returns standard if the arrival date is more than 4 months away', () => {
+    const date = add(new Date(), { months: 6 })
+    const arrivalDate = DateFormats.dateObjToIsoDate(date)
+
+    ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(arrivalDate)
+
+    expect(noticeTypeFromApplication(application)).toEqual('standard')
+  })
+})

--- a/server/utils/applications/noticeTypeFromApplication.ts
+++ b/server/utils/applications/noticeTypeFromApplication.ts
@@ -1,0 +1,19 @@
+import { ApprovedPremisesApplication as Application } from '@approved-premises/api'
+import { differenceInDays, differenceInCalendarMonths } from 'date-fns'
+import { getArrivalDate } from './utils'
+import { DateFormats } from '../dateUtils'
+
+type ApplicationType = 'emergency' | 'short_notice' | 'standard'
+
+export const noticeTypeFromApplication = (application: Application): ApplicationType => {
+  const arrivalDate = DateFormats.isoToDateObj(arrivalDateFromApplication(application))
+
+  switch (true) {
+    case differenceInDays(arrivalDate, new Date()) < 7:
+      return 'emergency'
+    case differenceInCalendarMonths(arrivalDate, new Date()) < 4:
+      return 'short_notice'
+    default:
+      return 'standard'
+  }
+}

--- a/server/utils/applications/noticeTypeFromApplication.ts
+++ b/server/utils/applications/noticeTypeFromApplication.ts
@@ -1,6 +1,6 @@
 import { ApprovedPremisesApplication as Application } from '@approved-premises/api'
 import { differenceInDays, differenceInCalendarMonths } from 'date-fns'
-import { getArrivalDate } from './utils'
+import { arrivalDateFromApplication } from './arrivalDateFromApplication'
 import { DateFormats } from '../dateUtils'
 
 type ApplicationType = 'emergency' | 'short_notice' | 'standard'

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -9,13 +9,12 @@ import { tierBadge, isApplicableTier } from '../personUtils'
 import {
   getResponses,
   getPage,
-  getArrivalDate,
   dashboardTableRows,
   firstPageOfApplicationJourney,
   isUnapplicable,
   getStatus,
 } from './utils'
-import { SessionDataError, UnknownPageError } from '../errors'
+import { UnknownPageError } from '../errors'
 
 const FirstApplyPage = jest.fn()
 const SecondApplyPage = jest.fn()
@@ -102,46 +101,6 @@ describe('utils', () => {
       application.data = { 'basic-information': { first: '', second: '' } }
 
       expect(getResponses(application)).toEqual({ 'basic-information': [{ foo: 'bar' }, { bar: 'foo' }] })
-    })
-  })
-
-  describe('getArrivalDate', () => {
-    it('returns the arrival date when the release date is known and is the same as the start date', () => {
-      const application = applicationFactory.build({
-        data: {
-          'basic-information': {
-            'release-date': { knowReleaseDate: 'yes', releaseDate: '2022-11-14' },
-            'placement-date': { startDateSameAsReleaseDate: 'yes' },
-          },
-        },
-      })
-      expect(getArrivalDate(application)).toEqual('2022-11-14')
-    })
-
-    it('returns the arrival date when the release date is known but there is a different start date', () => {
-      const application = applicationFactory.build({
-        data: {
-          'basic-information': {
-            'release-date': { knowReleaseDate: 'yes', releaseDate: '2022-11-14' },
-            'placement-date': { startDateSameAsReleaseDate: 'no', startDate: '2023-10-13' },
-          },
-        },
-      })
-
-      expect(getArrivalDate(application)).toEqual('2023-10-13')
-    })
-
-    it('throws an error or returns null when the release date is not known', () => {
-      const application = applicationFactory.build({
-        data: {
-          'basic-information': {
-            'release-date': { knowReleaseDate: 'no' },
-          },
-        },
-      })
-
-      expect(() => getArrivalDate(application)).toThrow(new SessionDataError('No known release date'))
-      expect(getArrivalDate(application, false)).toEqual(null)
     })
   })
 

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -51,6 +51,7 @@ import acctAlertFactory from '../../testutils/factories/acctAlert'
 import userFactory from '../../testutils/factories/user'
 import reviewSections from '../reviewUtils'
 import { documentsFromApplication } from './documentUtils'
+import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
 
 const FirstPage = jest.fn()
 const SecondPage = jest.fn()
@@ -60,6 +61,7 @@ jest.mock('../checkYourAnswersUtils')
 jest.mock('../personUtils')
 jest.mock('../reviewUtils')
 jest.mock('./documentUtils')
+jest.mock('../applications/arrivalDateFromApplication')
 
 jest.mock('../../form-pages/assess', () => {
   return {
@@ -210,20 +212,20 @@ describe('utils', () => {
   describe('formattedArrivalDate', () => {
     it('returns the formatted arrival date from the application', () => {
       const assessment = assessmentFactory.build()
-      const getDateSpy = jest.spyOn(applicationUtils, 'getArrivalDate').mockReturnValue('2022-01-01')
+      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
 
       expect(formattedArrivalDate(assessment)).toEqual('1 Jan 2022')
-      expect(getDateSpy).toHaveBeenCalledWith(assessment.application)
+      expect(arrivalDateFromApplication).toHaveBeenCalledWith(assessment.application)
     })
   })
 
   describe('arriveDateAsTimestamp', () => {
     it('returns the arrival date from the application as a unix timestamp', () => {
       const assessment = assessmentFactory.build()
-      const getDateSpy = jest.spyOn(applicationUtils, 'getArrivalDate').mockReturnValue('2022-01-01')
+      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
 
       expect(arriveDateAsTimestamp(assessment)).toEqual(1640995200)
-      expect(getDateSpy).toHaveBeenCalledWith(assessment.application)
+      expect(arrivalDateFromApplication).toHaveBeenCalledWith(assessment.application)
     })
   })
 
@@ -251,7 +253,7 @@ describe('utils', () => {
       const assessment = assessmentFactory.build({
         allocatedToStaffMember: staffMember,
       })
-      jest.spyOn(applicationUtils, 'getArrivalDate').mockReturnValue('2022-01-01')
+      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
 
       expect(allocatedTableRows([assessment])).toEqual([
         [
@@ -283,7 +285,7 @@ describe('utils', () => {
       const assessment = assessmentFactory.build({
         allocatedToStaffMember: staffMember,
       })
-      jest.spyOn(applicationUtils, 'getArrivalDate').mockReturnValue('2022-01-01')
+      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
 
       expect(unallocatedTableRows([assessment])).toEqual([
         [
@@ -312,7 +314,7 @@ describe('utils', () => {
     it('returns table rows for the assessments', () => {
       const assessment = assessmentFactory.build()
 
-      jest.spyOn(applicationUtils, 'getArrivalDate').mockReturnValue('2022-01-01')
+      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
 
       const tierBadgeSpy = jest.spyOn(personUtils, 'tierBadge').mockReturnValue('TIER_BADGE')
 
@@ -336,7 +338,7 @@ describe('utils', () => {
     it('returns table rows for the assessments', () => {
       const assessment = assessmentFactory.build({ clarificationNotes: clarificationNoteFactory.buildList(2) })
 
-      jest.spyOn(applicationUtils, 'getArrivalDate').mockReturnValue('2022-01-01')
+      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
 
       const tierBadgeSpy = jest.spyOn(personUtils, 'tierBadge').mockReturnValue('TIER_BADGE')
 
@@ -360,7 +362,7 @@ describe('utils', () => {
     it('returns table rows for the assessments', () => {
       const assessment = assessmentFactory.build()
 
-      jest.spyOn(applicationUtils, 'getArrivalDate').mockReturnValue('2022-01-01')
+      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
 
       const tierBadgeSpy = jest.spyOn(personUtils, 'tierBadge').mockReturnValue('TIER_BADGE')
 
@@ -722,7 +724,7 @@ describe('utils', () => {
 
   describe('allocationSummary', () => {
     beforeEach(() => {
-      jest.spyOn(applicationUtils, 'getArrivalDate').mockReturnValue('2022-01-01')
+      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
     })
 
     it('returns the summary list when the assessment has a staff member allocated', () => {

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -14,7 +14,8 @@ import { format, differenceInDays, add, getUnixTime } from 'date-fns'
 import { ApprovedPremisesAssessment as Assessment, ApprovedPremisesApplication } from '@approved-premises/api'
 import { tierBadge } from '../personUtils'
 import { DateFormats } from '../dateUtils'
-import { getArrivalDate, getResponseForPage } from '../applications/utils'
+import { getResponseForPage } from '../applications/utils'
+import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
 import paths from '../../paths/assess'
 import { TasklistPageInterface } from '../../form-pages/tasklistPage'
 import Assess from '../../form-pages/assess'
@@ -308,12 +309,12 @@ const assessmentLink = (assessment: Assessment, linkText = '', hiddenText = ''):
 }
 
 const formattedArrivalDate = (assessment: Assessment): string => {
-  const arrivalDate = getArrivalDate(assessment.application as ApprovedPremisesApplication)
+  const arrivalDate = arrivalDateFromApplication(assessment.application as ApprovedPremisesApplication)
   return format(DateFormats.isoToDateObj(arrivalDate), 'd MMM yyyy')
 }
 
 const arriveDateAsTimestamp = (assessment: Assessment): number => {
-  const arrivalDate = getArrivalDate(assessment.application as ApprovedPremisesApplication)
+  const arrivalDate = arrivalDateFromApplication(assessment.application as ApprovedPremisesApplication)
   return getUnixTime(DateFormats.isoToDateObj(arrivalDate))
 }
 

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -1,5 +1,14 @@
 import type { ObjectWithDateParts } from '@approved-premises/ui'
-import { DateFormats, InvalidDateStringError, dateAndTimeInputsAreValidDates, dateIsBlank } from './dateUtils'
+import isPast from 'date-fns/isPast'
+import {
+  DateFormats,
+  InvalidDateStringError,
+  dateAndTimeInputsAreValidDates,
+  dateIsBlank,
+  dateIsInThePast,
+} from './dateUtils'
+
+jest.mock('date-fns/isPast')
 
 describe('DateFormats', () => {
   describe('convertIsoToDateObj', () => {
@@ -181,5 +190,19 @@ describe('dateIsBlank', () => {
     }
 
     expect(dateIsBlank(date)).toEqual(true)
+  })
+})
+
+describe('dateIsInThePast', () => {
+  it('returns true if the date is in the past', () => {
+    ;(isPast as jest.Mock).mockReturnValue(true)
+
+    expect(dateIsInThePast('2020-01-01')).toEqual(true)
+  })
+
+  it('returns false if the date is not in the past', () => {
+    ;(isPast as jest.Mock).mockReturnValue(false)
+
+    expect(dateIsInThePast('2020-01-01')).toEqual(false)
   })
 })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -93,6 +93,15 @@ export class DateFormats {
 
     return dateInputObj
   }
+
+  static dateObjectToDateInputs<K extends string>(date: Date, key: K): ObjectWithDateParts<K> {
+    return {
+      [`${key}-year`]: String(date.getFullYear()),
+      [`${key}-month`]: String(date.getMonth() + 1),
+      [`${key}-day`]: String(date.getDate()),
+      [`${key}`]: DateFormats.dateObjToIsoDate(date),
+    } as ObjectWithDateParts<K>
+  }
 }
 
 export const dateAndTimeInputsAreValidDates = <K extends string | number>(

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -4,6 +4,7 @@ import type { ObjectWithDateParts } from '@approved-premises/ui'
 import formatISO from 'date-fns/formatISO'
 import parseISO from 'date-fns/parseISO'
 import format from 'date-fns/format'
+import isPast from 'date-fns/isPast'
 
 export class DateFormats {
   /**
@@ -114,6 +115,11 @@ export const dateAndTimeInputsAreValidDates = <K extends string | number>(
 export const dateIsBlank = <T = ObjectWithDateParts<string | number>>(body: T): boolean => {
   const fields = Object.keys(body).filter(key => key.match(/-[year|month|day]/))
   return fields.every(field => !body[field])
+}
+
+export const dateIsInThePast = (dateString: string): boolean => {
+  const date = DateFormats.isoToDateObj(dateString)
+  return isPast(date)
 }
 
 export class InvalidDateStringError extends Error {}

--- a/server/views/applications/pages/basic-information/reason-for-short-notice.njk
+++ b/server/views/applications/pages/basic-information/reason-for-short-notice.njk
@@ -1,0 +1,38 @@
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
+  {% set conditionalHTML %}
+  {{ formPageInput({
+        fieldName: "other",
+        label: {
+          text: "Provide reason"
+        }
+      },fetchContext()) }}
+  {% endset %}
+
+  {{
+    formPageRadios(
+      {
+        fieldName: "reason",
+        fieldset: {
+          legend: {
+            text: page.question,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        hint: {
+          text: 'This information helps HMPPS to improve this service.'
+        },
+        items: page.items(conditionalHTML)
+      },
+      fetchContext()
+    )
+  }}
+
+{% endblock %}


### PR DESCRIPTION
This adds an question to ask why an applicant is making either a short notice or emergency application. Depending on if the application is emergency (less than 7 days notice) or short notice (less than 4 days notice), the copy is different. I've also added a helper to ensure the date that is provided is in the future, as this seems like it would be important!

## Screenshots

![image](https://user-images.githubusercontent.com/109774/219409567-a6bef15e-c9e5-42a1-b1a3-52ee3d1a0790.png)

![image](https://user-images.githubusercontent.com/109774/219409665-f86cd4e1-c817-4f03-b328-3f66756e8499.png)
