### PR TITLE
Update applicationClient#submit

### DIFF
--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -129,13 +129,14 @@ describe('ApplicationClient', () => {
   describe('submit', () => {
     it('should submit the application', async () => {
       const application = applicationFactory.build()
+      const data = { translatedDocument: application.document }
 
       fakeApprovedPremisesApi
         .post(paths.applications.submission({ id: application.id }))
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(201)
 
-      await applicationClient.submit(application)
+      await applicationClient.submit(application.id, data)
 
       expect(nock.isDone()).toBeTruthy()
     })

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -3,6 +3,7 @@ import type {
   ApprovedPremisesApplication as Application,
   ApprovedPremisesAssessment as Assessment,
   Document,
+  SubmitApplication,
 } from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
@@ -41,10 +42,10 @@ export default class ApplicationClient {
     return (await this.restClient.get({ path: paths.applications.index.pattern })) as Array<Application>
   }
 
-  async submit(application: Application): Promise<void> {
+  async submit(applicationId: string, submissionData: SubmitApplication): Promise<void> {
     await this.restClient.post({
-      path: paths.applications.submission({ id: application.id }),
-      data: { translatedDocument: application.document },
+      path: paths.applications.submission({ id: applicationId }),
+      data: { translatedDocument: submissionData },
     })
   }
 

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -346,7 +346,9 @@ describe('ApplicationService', () => {
       await service.submit(request.user.token, application)
 
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
-      expect(applicationClient.submit).toHaveBeenCalledWith(application)
+      expect(applicationClient.submit).toHaveBeenCalledWith(application.id, {
+        translatedDocument: application.document,
+      })
     })
   })
 

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -114,7 +114,7 @@ export default class ApplicationService {
   async submit(token: string, application: ApprovedPremisesApplication) {
     const client = this.applicationClientFactory(token)
 
-    await client.submit(application)
+    await client.submit(application.id, { translatedDocument: application.document })
   }
 
   async getApplicationFromSessionOrAPI(request: Request): Promise<ApprovedPremisesApplication> {


### PR DESCRIPTION
This is prep work for https://trello.com/c/U3x8YUZH/1247-fetch-important-data-from-the-application-in-the-frontend and makes the `submit` method accept only the data that will be sent to it. This means that it will be more strongly typed, and more likely to catch errors when the API spec changes.