### PR TITLE
(1217) - Fix UI crashes if tier is blank

### DIFF
--- a/server/views/applications/pages/basic-information/is-exceptional-case.njk
+++ b/server/views/applications/pages/basic-information/is-exceptional-case.njk
@@ -19,7 +19,11 @@
   </h1>
 
   <h2 class="govuk-heading-m">
-    This person is managed at <strong>Tier {{ page.tier }}</strong>
+    {% if page.tier %}
+      This person is managed at <strong>Tier {{ page.tier }}</strong>
+    {% else %}
+      This person does not have a tier
+    {% endif %}
   </h2>
 
   <p>People in prison or people on probation who are managed at the following Tiers would be eligible to apply for an Approved Premises (AP) placement.</p>

--- a/server/views/applications/pages/oasys-import/optional-oasys-sections.njk
+++ b/server/views/applications/pages/oasys-import/optional-oasys-sections.njk
@@ -14,8 +14,6 @@
         <li>any MAPPA or hate-based information</li>
         <li>sections linked to RoSH</li>
         <li>Risk Management Plan</li>
-        <li>Section 8 -  Drug misuse</li>
-        <li>Section 9 - Alcohol misuse</li>
     </ul>
 
     <p>Select any sections that include information that's relevant to the risk an Approved Premises (AP) will help manage or the needs an AP can support.</p>


### PR DESCRIPTION

Previously if the person who the application was about did not have a tier the app would crash. 
This was fixed in #557 this PR adds messaging to inform the user that the person doesn't have a tier. 
[Trello ticket](https://trello.com/c/bUjJNLw8/1217-ui-crashes-if-tier-is-blank)
Further we remove references to drug and alcohol sections of OASys being optionally imported. 
[Trello ticket](https://trello.com/c/27zZbIRv/1119-oasys-import-screen-remove-drug-and-alcohol-from-checklist)
