### PR TITLE
(1246) Apply - Contingency plan partners screens

### DIFF
--- a/cypress_shared/fixtures/applicationData.json
+++ b/cypress_shared/fixtures/applicationData.json
@@ -335,6 +335,23 @@
     "arson": {
       "arson": "yes",
       "arsonDetail": "Some details here"
+    },
+    "contingency-plan-partners": {
+      "partnerAgencyDetails": [
+        {
+          "partnerAgencyName": "Test agency 1",
+          "namedContact": "Test contact 1",
+          "phoneNumber": "01234567891",
+          "roleInPlan": "Test role 1"
+        },
+        {
+          "partnerAgencyName": "Test agency 2",
+          "namedContact": "Test contact 2",
+          "phoneNumber": "01234567892",
+          "roleInPlan": "Test role 2"
+        }
+      ],
+      "saveAndContinue": "1"
     }
   },
   "move-on": {

--- a/cypress_shared/helpers/apply.ts
+++ b/cypress_shared/helpers/apply.ts
@@ -15,48 +15,7 @@ import {
 } from '@approved-premises/api'
 import { PersonRisksUI, PartnerAgencyDetails } from '@approved-premises/ui'
 
-import {
-  AccessNeedsMobilityPage,
-  AccessNeedsPage,
-  ArsonPage,
-  AttachDocumentsPage,
-  CaseNotesPage,
-  CateringPage,
-  CheckYourAnswersPage,
-  ComplexCaseBoard,
-  ConfirmDetailsPage,
-  ConvictedOffences,
-  CovidPage,
-  DateOfOffence,
-  DescribeLocationFactors,
-  EnterCRNPage,
-  ForeignNationalPage,
-  OffenceDetailsPage,
-  OptionalOasysSectionsPage,
-  PlacementDurationPage,
-  PlacementPurposePage,
-  PlacementStartPage,
-  PlansInPlacePage,
-  PreviousPlacements,
-  RehabilitativeInterventions,
-  ReleaseDatePage,
-  RelocationRegionPage,
-  RiskManagementFeatures,
-  RiskManagementPlanPage,
-  RiskToSelfPage,
-  RoomSharingPage,
-  RoshSummaryPage,
-  SentenceTypePage,
-  SituationPage,
-  StartPage,
-  SupportingInformationPage,
-  TaskListPage,
-  TypeOfAccommodationPage,
-  TypeOfApPage,
-  TypeOfConvictedOffence,
-  VulnerabilityPage,
-  ContingencyPlanPartnersPage,
-} from '../pages/apply'
+import * as ApplyPages from '../pages/apply'
 
 import Page from '../pages'
 
@@ -77,8 +36,6 @@ import {
 } from './index'
 import ApplyPage from '../pages/apply/applyPage'
 import { documentsFromApplication } from '../../server/utils/assessments/documentUtils'
-import IsExceptionalCasePage from '../pages/apply/isExceptionalCase'
-import ExceptionDetailsPage from '../pages/apply/ExceptionDetails'
 
 export default class ApplyHelper {
   pages = {
@@ -150,16 +107,16 @@ export default class ApplyHelper {
 
   startApplication() {
     // Given I visit the start page
-    const startPage = StartPage.visit()
+    const startPage = ApplyPages.StartPage.visit()
     startPage.startApplication()
 
     // And I complete the first step
-    const crnPage = new EnterCRNPage()
+    const crnPage = new ApplyPages.EnterCRNPage()
     crnPage.enterCrn(this.person.crn)
     crnPage.clickSubmit()
 
     // And I see the person on the confirmation page
-    const confirmDetailsPage = new ConfirmDetailsPage(this.person)
+    const confirmDetailsPage = new ApplyPages.ConfirmDetailsPage(this.person)
     confirmDetailsPage.verifyPersonIsVisible()
 
     // And I confirm the person is who I expect to see
@@ -397,42 +354,42 @@ export default class ApplyHelper {
   }
 
   completeExceptionalCase() {
-    const isExceptionalCasePage = new IsExceptionalCasePage()
+    const isExceptionalCasePage = new ApplyPages.IsExceptionalCasePage()
 
     isExceptionalCasePage.completeForm('yes')
     isExceptionalCasePage.clickSubmit()
 
-    const exceptionDetailsPage = new ExceptionDetailsPage()
+    const exceptionDetailsPage = new ApplyPages.ExceptionDetailsPage()
 
     exceptionDetailsPage.completeForm()
     exceptionDetailsPage.clickSubmit()
   }
 
   completeBasicInformation() {
-    const sentenceTypePage = new SentenceTypePage(this.application)
+    const sentenceTypePage = new ApplyPages.SentenceTypePage(this.application)
     sentenceTypePage.completeForm()
     sentenceTypePage.clickSubmit()
 
-    const situationPage = new SituationPage(this.application)
+    const situationPage = new ApplyPages.SituationPage(this.application)
     situationPage.completeForm()
     situationPage.clickSubmit()
 
-    const releaseDatePage = new ReleaseDatePage(this.application)
+    const releaseDatePage = new ApplyPages.ReleaseDatePage(this.application)
     releaseDatePage.completeForm()
     releaseDatePage.clickSubmit()
 
-    const placementStartPage = new PlacementStartPage(this.application)
+    const placementStartPage = new ApplyPages.PlacementStartPage(this.application)
     placementStartPage.completeForm()
     placementStartPage.clickSubmit()
 
-    const placementPurposePage = new PlacementPurposePage(this.application)
+    const placementPurposePage = new ApplyPages.PlacementPurposePage(this.application)
     placementPurposePage.completeForm()
     placementPurposePage.clickSubmit()
 
     this.pages.basicInformation = [sentenceTypePage, releaseDatePage, placementStartPage, placementPurposePage]
 
     // Then I should be redirected to the task list
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+    const tasklistPage = Page.verifyOnPage(ApplyPages.TaskListPage)
 
     // And the task should be marked as completed
     tasklistPage.shouldShowTaskStatus('basic-information', 'Completed')
@@ -449,10 +406,10 @@ export default class ApplyHelper {
   private completeTypeOfApSection() {
     // And I should be able to start the next task
     cy.get('[data-cy-task-name="type-of-ap"]').click()
-    Page.verifyOnPage(TypeOfApPage, this.application)
+    Page.verifyOnPage(ApplyPages.TypeOfApPage, this.application)
 
     // Given I am on the Type of AP Page
-    const typeOfApPage = new TypeOfApPage(this.application)
+    const typeOfApPage = new ApplyPages.TypeOfApPage(this.application)
 
     // When I complete the form and click submit
     typeOfApPage.completeForm()
@@ -461,7 +418,7 @@ export default class ApplyHelper {
     this.pages.typeOfAp = [typeOfApPage]
 
     // Then I should be redirected to the task list
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+    const tasklistPage = Page.verifyOnPage(ApplyPages.TaskListPage)
 
     // Then the Type of AP task should show as completed
     tasklistPage.shouldShowTaskStatus('type-of-ap', 'Completed')
@@ -473,13 +430,13 @@ export default class ApplyHelper {
   private completeOasysSection() {
     // Given I click the 'Import Oasys' task
     cy.get('[data-cy-task-name="oasys-import"]').click()
-    const optionalOasysImportPage = new OptionalOasysSectionsPage(this.application)
+    const optionalOasysImportPage = new ApplyPages.OptionalOasysSectionsPage(this.application)
 
     // When I complete the form
     optionalOasysImportPage.completeForm(this.oasysSectionsLinkedToReoffending, this.otherOasysSections)
     optionalOasysImportPage.clickSubmit()
 
-    const roshSummaryPage = new RoshSummaryPage(this.application, this.roshSummaries)
+    const roshSummaryPage = new ApplyPages.RoshSummaryPage(this.application, this.roshSummaries)
 
     if (this.uiRisks) {
       roshSummaryPage.shouldShowRiskWidgets(this.uiRisks)
@@ -489,7 +446,7 @@ export default class ApplyHelper {
 
     roshSummaryPage.clickSubmit()
 
-    const offenceDetailsPage = new OffenceDetailsPage(this.application, this.offenceDetailSummaries)
+    const offenceDetailsPage = new ApplyPages.OffenceDetailsPage(this.application, this.offenceDetailSummaries)
 
     if (this.uiRisks) {
       offenceDetailsPage.shouldShowRiskWidgets(this.uiRisks)
@@ -498,18 +455,21 @@ export default class ApplyHelper {
     offenceDetailsPage.completeForm()
     offenceDetailsPage.clickSubmit()
 
-    const supportingInformationPage = new SupportingInformationPage(
+    const supportingInformationPage = new ApplyPages.SupportingInformationPage(
       this.application,
       this.supportingInformationSummaries,
     )
     supportingInformationPage.completeForm()
     supportingInformationPage.clickSubmit()
 
-    const riskManagementPlanPage = new RiskManagementPlanPage(this.application, this.riskManagementPlanSummaries)
+    const riskManagementPlanPage = new ApplyPages.RiskManagementPlanPage(
+      this.application,
+      this.riskManagementPlanSummaries,
+    )
     riskManagementPlanPage.completeForm()
     riskManagementPlanPage.clickSubmit()
 
-    const riskToSelfPage = new RiskToSelfPage(this.application, this.riskToSelfSummaries)
+    const riskToSelfPage = new ApplyPages.RiskToSelfPage(this.application, this.riskToSelfSummaries)
     riskToSelfPage.completeForm()
     riskToSelfPage.clickSubmit()
 
@@ -523,7 +483,7 @@ export default class ApplyHelper {
     ]
 
     // Then I should be redirected to the task list
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+    const tasklistPage = Page.verifyOnPage(ApplyPages.TaskListPage)
 
     // Then I should be taken back to the tasklist
     tasklistPage.shouldShowTaskStatus('oasys-import', 'Completed')
@@ -537,23 +497,23 @@ export default class ApplyHelper {
     cy.get('[data-cy-task-name="risk-management-features"]').click()
 
     // When I complete the form
-    const riskManagementFeaturesPage = new RiskManagementFeatures(this.application)
+    const riskManagementFeaturesPage = new ApplyPages.RiskManagementFeatures(this.application)
     riskManagementFeaturesPage.completeForm()
     riskManagementFeaturesPage.clickSubmit()
 
-    const convictedOffencesPage = new ConvictedOffences(this.application)
+    const convictedOffencesPage = new ApplyPages.ConvictedOffences(this.application)
     convictedOffencesPage.completeForm()
     convictedOffencesPage.clickSubmit()
 
-    const typeOfConvictedOffencePage = new TypeOfConvictedOffence(this.application)
+    const typeOfConvictedOffencePage = new ApplyPages.TypeOfConvictedOffence(this.application)
     typeOfConvictedOffencePage.completeForm()
     typeOfConvictedOffencePage.clickSubmit()
 
-    const dateOfOffencePage = new DateOfOffence(this.application)
+    const dateOfOffencePage = new ApplyPages.DateOfOffence(this.application)
     dateOfOffencePage.completeForm()
     dateOfOffencePage.clickSubmit()
 
-    const rehabilitativeInterventionsPage = new RehabilitativeInterventions(this.application)
+    const rehabilitativeInterventionsPage = new ApplyPages.RehabilitativeInterventions(this.application)
     rehabilitativeInterventionsPage.completeForm()
     rehabilitativeInterventionsPage.clickSubmit()
 
@@ -566,7 +526,7 @@ export default class ApplyHelper {
     ]
 
     // Then I should be redirected to the task list
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+    const tasklistPage = Page.verifyOnPage(ApplyPages.TaskListPage)
 
     // And the risk management task should show a completed status
     tasklistPage.shouldShowTaskStatus('risk-management-features', 'Completed')
@@ -576,7 +536,7 @@ export default class ApplyHelper {
     // And I click the 'Review prison information' task
     cy.get('[data-cy-task-name="prison-information"]').click()
 
-    const caseNotesPage = new CaseNotesPage(this.application, this.selectedPrisonCaseNotes)
+    const caseNotesPage = new ApplyPages.CaseNotesPage(this.application, this.selectedPrisonCaseNotes)
     caseNotesPage.shouldDisplayAdjudications(this.adjudications)
     caseNotesPage.shouldDisplayAcctAlerts(this.acctAlerts)
     caseNotesPage.completeForm(this.moreDetail)
@@ -586,14 +546,14 @@ export default class ApplyHelper {
     cy.get('[data-cy-task-name="location-factors"]').click()
 
     // When I complete the form
-    const describeLocationFactorsPage = new DescribeLocationFactors(this.application)
+    const describeLocationFactorsPage = new ApplyPages.DescribeLocationFactors(this.application)
     describeLocationFactorsPage.completeForm()
     describeLocationFactorsPage.clickSubmit()
 
     this.pages.locationFactors = [describeLocationFactorsPage]
 
     // Then I should be taken back to the task list
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+    const tasklistPage = Page.verifyOnPage(ApplyPages.TaskListPage)
 
     // And the location factors task should show a completed status
     tasklistPage.shouldShowTaskStatus('location-factors', 'Completed')
@@ -604,22 +564,22 @@ export default class ApplyHelper {
     cy.get('[data-cy-task-name="access-and-healthcare"]').click()
 
     // When I complete the form
-    const accessNeedsPage = new AccessNeedsPage(this.application)
+    const accessNeedsPage = new ApplyPages.AccessNeedsPage(this.application)
     accessNeedsPage.completeForm()
     accessNeedsPage.clickSubmit()
 
-    const accessNeedsMobilityPage = new AccessNeedsMobilityPage(this.application)
+    const accessNeedsMobilityPage = new ApplyPages.AccessNeedsMobilityPage(this.application)
     accessNeedsMobilityPage.completeForm()
     accessNeedsMobilityPage.clickSubmit()
 
-    const covidPage = new CovidPage(this.application)
+    const covidPage = new ApplyPages.CovidPage(this.application)
     covidPage.completeForm()
     covidPage.clickSubmit()
 
     this.pages.accessAndHealthcare = [accessNeedsPage, accessNeedsMobilityPage, covidPage]
 
     // Then I should be taken back to the task list
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+    const tasklistPage = Page.verifyOnPage(ApplyPages.TaskListPage)
 
     // And the access and healthcare task should show a completed status
     tasklistPage.shouldShowTaskStatus('access-and-healthcare', 'Completed')
@@ -630,37 +590,40 @@ export default class ApplyHelper {
     cy.get('[data-cy-task-name="further-considerations"]').click()
 
     // And I complete the Room Sharing page
-    const roomSharingPage = new RoomSharingPage(this.application)
+    const roomSharingPage = new ApplyPages.RoomSharingPage(this.application)
     roomSharingPage.completeForm()
     roomSharingPage.clickSubmit()
 
     // And I complete the Vulnerability page
-    const vulnerabilityPage = new VulnerabilityPage(this.application)
+    const vulnerabilityPage = new ApplyPages.VulnerabilityPage(this.application)
     vulnerabilityPage.completeForm()
     vulnerabilityPage.clickSubmit()
 
     // And I complete the Previous Placements page
-    const previousPlacementsPage = new PreviousPlacements(this.application)
+    const previousPlacementsPage = new ApplyPages.PreviousPlacements(this.application)
     previousPlacementsPage.completeForm()
     previousPlacementsPage.clickSubmit()
 
     // And I complete the Complex Case Board page
-    const complexCaseBoardPage = new ComplexCaseBoard(this.application)
+    const complexCaseBoardPage = new ApplyPages.ComplexCaseBoard(this.application)
     complexCaseBoardPage.completeForm()
     complexCaseBoardPage.clickSubmit()
 
     // And I complete the Catering page
-    const cateringPage = new CateringPage(this.application)
+    const cateringPage = new ApplyPages.CateringPage(this.application)
     cateringPage.completeForm()
     cateringPage.clickSubmit()
 
     // And I complete the Arson page
-    const arsonPage = new ArsonPage(this.application)
+    const arsonPage = new ApplyPages.ArsonPage(this.application)
     arsonPage.completeForm()
     arsonPage.clickSubmit()
 
     // And I complete the Contingency Plan Partners page
-    const contingencyPlanPartnersPage = new ContingencyPlanPartnersPage(this.application, this.contingencyPlanPartners)
+    const contingencyPlanPartnersPage = new ApplyPages.ContingencyPlanPartnersPage(
+      this.application,
+      this.contingencyPlanPartners,
+    )
     contingencyPlanPartnersPage.completeForm()
     contingencyPlanPartnersPage.clickSubmit()
 
@@ -675,7 +638,7 @@ export default class ApplyHelper {
     ]
 
     // Then I should be taken back to the task list
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+    const tasklistPage = Page.verifyOnPage(ApplyPages.TaskListPage)
 
     // And the further considerations task should show a completed status
     tasklistPage.shouldShowTaskStatus('further-considerations', 'Completed')
@@ -686,26 +649,26 @@ export default class ApplyHelper {
     cy.get('[data-cy-task-name="move-on"]').click()
 
     // And I complete the Placement Duration page
-    const placementDurationPage = new PlacementDurationPage(this.application)
+    const placementDurationPage = new ApplyPages.PlacementDurationPage(this.application)
     placementDurationPage.completeForm()
     placementDurationPage.clickSubmit()
 
     // And I complete the relocation region page
-    const relocationRegion = new RelocationRegionPage(this.application)
+    const relocationRegion = new ApplyPages.RelocationRegionPage(this.application)
     relocationRegion.completeForm()
     relocationRegion.clickSubmit()
 
     // And I complete the plans in place page
-    const plansInPlacePage = new PlansInPlacePage(this.application)
+    const plansInPlacePage = new ApplyPages.PlansInPlacePage(this.application)
     plansInPlacePage.completeForm()
     plansInPlacePage.clickSubmit()
 
     // And I complete the type of accommodation page
-    const typeOfAccommodationPage = new TypeOfAccommodationPage(this.application)
+    const typeOfAccommodationPage = new ApplyPages.TypeOfAccommodationPage(this.application)
     typeOfAccommodationPage.completeForm()
     typeOfAccommodationPage.clickSubmit()
 
-    const foreignNationalPage = new ForeignNationalPage(this.application)
+    const foreignNationalPage = new ApplyPages.ForeignNationalPage(this.application)
     foreignNationalPage.completeForm()
     foreignNationalPage.clickSubmit()
 
@@ -718,7 +681,7 @@ export default class ApplyHelper {
     ]
 
     // Then I should be taken back to the task list
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+    const tasklistPage = Page.verifyOnPage(ApplyPages.TaskListPage)
 
     // And the move on information task should show a completed status
     tasklistPage.shouldShowTaskStatus('move-on', 'Completed')
@@ -727,7 +690,11 @@ export default class ApplyHelper {
   private completeDocumentsSection() {
     // Given I click on the Attach Documents task
     cy.get('[data-cy-task-name="attach-required-documents"]').click()
-    const attachDocumentsPage = new AttachDocumentsPage(this.documents, this.selectedDocuments, this.application)
+    const attachDocumentsPage = new ApplyPages.AttachDocumentsPage(
+      this.documents,
+      this.selectedDocuments,
+      this.application,
+    )
 
     // Then I should be able to download the documents
     attachDocumentsPage.shouldBeAbleToDownloadDocuments(this.documents)
@@ -738,7 +705,7 @@ export default class ApplyHelper {
     attachDocumentsPage.clickSubmit()
 
     // Then I should be taken back to the task list
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+    const tasklistPage = Page.verifyOnPage(ApplyPages.TaskListPage)
 
     // And the Attach Documents task should show a completed status
     tasklistPage.shouldShowTaskStatus('attach-required-documents', 'Completed')
@@ -749,7 +716,7 @@ export default class ApplyHelper {
     cy.get('[data-cy-task-name="check-your-answers"]').click()
 
     // Then I should be on the check your answers page
-    const checkYourAnswersPage = new CheckYourAnswersPage(this.application)
+    const checkYourAnswersPage = new ApplyPages.CheckYourAnswersPage(this.application)
 
     // And the page should be populated with my answers
     checkYourAnswersPage.shouldShowPersonInformation(this.person)
@@ -774,14 +741,14 @@ export default class ApplyHelper {
     checkYourAnswersPage.clickSubmit()
 
     // Then I should be taken back to the task list
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+    const tasklistPage = Page.verifyOnPage(ApplyPages.TaskListPage)
 
     // And the check your answers task should show a completed status
     tasklistPage.shouldShowTaskStatus('check-your-answers', 'Completed')
   }
 
   private submitApplication() {
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+    const tasklistPage = Page.verifyOnPage(ApplyPages.TaskListPage)
     tasklistPage.checkCheckboxByLabel('submit')
 
     tasklistPage.clickSubmit()

--- a/cypress_shared/pages/apply/checkYourAnswersPage.ts
+++ b/cypress_shared/pages/apply/checkYourAnswersPage.ts
@@ -1,4 +1,5 @@
 import type { Person, PrisonCaseNote, Document, ApprovedPremisesApplication } from '@approved-premises/api'
+import { PartnerAgencyDetails } from '../../../server/@types/ui'
 import { DateFormats } from '../../../server/utils/dateUtils'
 import ApplyPage from './applyPage'
 
@@ -65,6 +66,27 @@ export default class CheckYourAnswersPage extends ApplyPage {
   shouldShowFurtherConsiderationsAnswers(pages: Array<ApplyPage>) {
     this.shouldShowCheckYourAnswersTitle('further-considerations', 'Detail further considerations for placement')
     this.shouldShowAnswersForTask('further-considerations', pages)
+  }
+
+  shouldShowContingencyPlanPartners(contingencyPlanPartners: Array<PartnerAgencyDetails>) {
+    cy.get(`[data-cy-check-your-answers-section="further-considerations"]`).within(() => {
+      cy.get('dt')
+        .contains('Contingency plan partners')
+        .parent()
+        .within(() => {
+          cy.get('dl.govuk-summary-list--embedded').then($items => {
+            cy.wrap($items).should('have.length', contingencyPlanPartners.length)
+            contingencyPlanPartners.forEach((partner, i) => {
+              cy.wrap($items[i]).within(() => {
+                this.assertDefinition('Named contact', partner.namedContact)
+                this.assertDefinition('Partner agency name', partner.partnerAgencyName)
+                this.assertDefinition('Phone number', partner.phoneNumber)
+                this.assertDefinition('Role in plan', partner.roleInPlan)
+              })
+            })
+          })
+        })
+    })
   }
 
   shouldShowMoveOnAnswers(pages: Array<ApplyPage>) {

--- a/cypress_shared/pages/apply/contingencyPlanPartners.ts
+++ b/cypress_shared/pages/apply/contingencyPlanPartners.ts
@@ -1,0 +1,42 @@
+import { ApprovedPremisesApplication } from '@approved-premises/api'
+import paths from '../../../server/paths/apply'
+
+import ApplyPage from './applyPage'
+
+export default class ContingencyPlanPartnersPage extends ApplyPage {
+  contigencyPlanPartners = []
+
+  constructor(application: ApprovedPremisesApplication, contigencyPlanPartners) {
+    super(
+      'Contingency plans',
+      application,
+      'further-considerations',
+      'contingency-plan-partners',
+      paths.applications.show({ id: application.id }),
+    )
+    this.contigencyPlanPartners = contigencyPlanPartners
+  }
+
+  completeForm() {
+    this.contigencyPlanPartners.forEach(partner => {
+      this.getTextInputByIdAndEnterDetails('partnerAgencyName', partner.partnerAgencyName)
+      this.getTextInputByIdAndEnterDetails('namedContact', partner.namedContact)
+      this.getTextInputByIdAndEnterDetails('phoneNumber', partner.phoneNumber)
+      this.getTextInputByIdAndEnterDetails('roleInPlan', partner.roleInPlan)
+      cy.get('button').contains('Add another agency').click()
+    })
+
+    cy.get('dl').each(() => {
+      this.contigencyPlanPartners.forEach(partner => {
+        this.assertDefinition('Named contact', partner.namedContact)
+        this.assertDefinition('Name of partner agency', partner.partnerAgencyName)
+        this.assertDefinition('Contact details (phone)', partner.phoneNumber)
+        this.assertDefinition('Role in contingency plan', partner.roleInPlan)
+      })
+    })
+  }
+
+  clickSubmit(): void {
+    cy.get('button').contains('Save and continue').click()
+  }
+}

--- a/cypress_shared/pages/apply/index.ts
+++ b/cypress_shared/pages/apply/index.ts
@@ -13,6 +13,8 @@ import CovidPage from './covid'
 import DateOfOffence from './dateOfOffence'
 import DescribeLocationFactors from './describeLocationFactors'
 import EnterCRNPage from './enterCrn'
+import IsExceptionalCasePage from './isExceptionalCase'
+import ExceptionDetailsPage from './ExceptionDetails'
 import ForeignNationalPage from './foreignNational'
 import ListPage from './list'
 import OffenceDetailsPage from './offenceDetails'
@@ -58,7 +60,9 @@ export {
   DateOfOffence,
   DescribeLocationFactors,
   EnterCRNPage,
+  ExceptionDetailsPage,
   ForeignNationalPage,
+  IsExceptionalCasePage,
   ListPage,
   OffenceDetailsPage,
   OptionalOasysSectionsPage,

--- a/cypress_shared/pages/apply/index.ts
+++ b/cypress_shared/pages/apply/index.ts
@@ -8,6 +8,7 @@ import CheckYourAnswersPage from './checkYourAnswersPage'
 import ComplexCaseBoard from './complexCaseBoard'
 import ConfirmDetailsPage from './confirmDetails'
 import ConvictedOffences from './convictedOffences'
+import ContingencyPlanPartnersPage from './contingencyPlanPartners'
 import CovidPage from './covid'
 import DateOfOffence from './dateOfOffence'
 import DescribeLocationFactors from './describeLocationFactors'
@@ -51,6 +52,7 @@ export {
   CheckYourAnswersPage,
   ComplexCaseBoard,
   ConfirmDetailsPage,
+  ContingencyPlanPartnersPage,
   ConvictedOffences,
   CovidPage,
   DateOfOffence,

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -268,3 +268,10 @@ export type UserDetails = {
   displayName: string
   roles: Array<UserRole>
 }
+
+export type PartnerAgencyDetails = {
+  partnerAgencyName: string
+  namedContact: string
+  phoneNumber: string
+  roleInPlan: string
+}

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/arson.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/arson.test.ts
@@ -32,7 +32,7 @@ describe('Arson', () => {
     })
   })
 
-  itShouldHaveNextValue(new Arson(body, application), '')
+  itShouldHaveNextValue(new Arson(body, application), 'contingency-plan-partners')
   itShouldHavePreviousValue(new Arson(body, application), 'catering')
 
   describe('errors', () => {

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/arson.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/arson.ts
@@ -46,7 +46,7 @@ export default class Arson implements TasklistPage {
   }
 
   next() {
-    return ''
+    return 'contingency-plan-partners'
   }
 
   response() {

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanPartners.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanPartners.test.ts
@@ -1,0 +1,69 @@
+import contingencyPlanPartnersFactory from '../../../../testutils/factories/contingencyPlanPartner'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import ContingencyPlanPartners, { Body } from './contingencyPlanPartners'
+
+describe('ContingencyPlanPartners', () => {
+  const contigencyPlanPartner1 = contingencyPlanPartnersFactory.build()
+  const contigencyPlanPartner2 = contingencyPlanPartnersFactory.build()
+
+  const body = {
+    ...contigencyPlanPartner1,
+    partnerAgencyDetails: [contigencyPlanPartner2],
+  }
+
+  describe('title', () => {
+    it('should set the title', () => {
+      const page = new ContingencyPlanPartners(body)
+
+      expect(page.title).toEqual('Contingency plans')
+    })
+  })
+
+  describe('body', () => {
+    it('should push the form fields into a new item in the partnerAgencyDetails array', () => {
+      const page = new ContingencyPlanPartners(body)
+
+      expect(page.partnerAgencyDetails).toEqual([contigencyPlanPartner2, contigencyPlanPartner1])
+    })
+  })
+
+  itShouldHaveNextValue(new ContingencyPlanPartners(body), '')
+
+  itShouldHavePreviousValue(new ContingencyPlanPartners(body), 'arson')
+
+  describe('errors', () => {
+    it('should return errors when responses are blank', () => {
+      const page = new ContingencyPlanPartners({} as Body)
+
+      expect(page.errors()).toEqual({
+        namedContact: 'You must specify a named contact',
+        partnerAgencyName: 'You must specify a partner agency name',
+        phoneNumber: 'You must specify a phone number',
+        roleInPlan: 'You must specify a role in plan',
+      })
+    })
+  })
+
+  describe('response', () => {
+    it('should return response', () => {
+      const page = new ContingencyPlanPartners(body)
+
+      expect(page.response()).toEqual({
+        'Contingency plan partners': [
+          {
+            'Named contact': contigencyPlanPartner2.namedContact,
+            'Partner agency name': contigencyPlanPartner2.partnerAgencyName,
+            'Phone number': contigencyPlanPartner2.phoneNumber,
+            'Role in plan': contigencyPlanPartner2.roleInPlan,
+          },
+          {
+            'Named contact': contigencyPlanPartner1.namedContact,
+            'Partner agency name': contigencyPlanPartner1.partnerAgencyName,
+            'Phone number': contigencyPlanPartner1.phoneNumber,
+            'Role in plan': contigencyPlanPartner1.roleInPlan,
+          },
+        ],
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanPartners.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanPartners.test.ts
@@ -27,12 +27,18 @@ describe('ContingencyPlanPartners', () => {
     })
   })
 
-  itShouldHaveNextValue(new ContingencyPlanPartners(body), '')
+  describe('if saveAndContinue is falsy ', () => {
+    itShouldHaveNextValue(new ContingencyPlanPartners(body), 'contingency-plan-partners')
+  })
+
+  describe('if saveAndContinue is truthy ', () => {
+    itShouldHaveNextValue(new ContingencyPlanPartners({ saveAndContinue: '1', ...body }), '')
+  })
 
   itShouldHavePreviousValue(new ContingencyPlanPartners(body), 'arson')
 
   describe('errors', () => {
-    it('should return errors when responses are blank', () => {
+    it('should return errors when responses are blank if saveAndContinue is falsy', () => {
       const page = new ContingencyPlanPartners({} as Body)
 
       expect(page.errors()).toEqual({
@@ -41,6 +47,23 @@ describe('ContingencyPlanPartners', () => {
         phoneNumber: 'You must specify a phone number',
         roleInPlan: 'You must specify a role in plan',
       })
+    })
+
+    it('should return an error when there are no partner agencies added and saveAndContinue is truthy', () => {
+      const page = new ContingencyPlanPartners({ saveAndContinue: '1' } as Body)
+
+      expect(page.errors()).toEqual({
+        partnerAgencyDetails: 'You must add at least one partner agency',
+      })
+    })
+
+    it('shouldnt return an error if partnerAgencyDetails are added and saveAndContinue is truthy', () => {
+      const page = new ContingencyPlanPartners({
+        saveAndContinue: '1',
+        partnerAgencyDetails: contingencyPlanPartnersFactory.buildList(1),
+      } as Body)
+
+      expect(page.errors()).toEqual({})
     })
   })
 

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanPartners.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanPartners.ts
@@ -12,12 +12,20 @@ const fields: PartnerAgencyDetails = {
 } as const
 
 export type Body = PartnerAgencyDetails & {
+  saveAndContinue?: string
   partnerAgencyDetails: Array<PartnerAgencyDetails>
 }
 
 @Page({
   name: 'contingency-plan-partners',
-  bodyProperties: ['partnerAgencyDetails', 'namedContact', 'phoneNumber', 'roleInPlan', 'partnerAgencyName'],
+  bodyProperties: [
+    'partnerAgencyName',
+    'namedContact',
+    'phoneNumber',
+    'roleInPlan',
+    'partnerAgencyDetails',
+    'saveAndContinue',
+  ],
 })
 export default class ContingencyPlanPartners implements TasklistPage {
   title = 'Contingency plans'
@@ -25,6 +33,8 @@ export default class ContingencyPlanPartners implements TasklistPage {
   fields: Record<string, string> = fields
 
   partnerAgencyDetails: Array<PartnerAgencyDetails> = []
+
+  saveAndContinue: string | undefined
 
   constructor(public body: Body) {
     const { namedContact, partnerAgencyName, phoneNumber, roleInPlan } = this.body
@@ -34,6 +44,7 @@ export default class ContingencyPlanPartners implements TasklistPage {
     if (this.isValid(newPartner)) {
       this.partnerAgencyDetails.push({ namedContact, partnerAgencyName, phoneNumber, roleInPlan })
     }
+    this.saveAndContinue = body.saveAndContinue
   }
 
   previous() {
@@ -41,7 +52,7 @@ export default class ContingencyPlanPartners implements TasklistPage {
   }
 
   next() {
-    return 'contingency-plan-partners'
+    return this.saveAndContinue ? '' : 'contingency-plan-partners'
   }
 
   private hasNeccessaryInputs() {
@@ -77,6 +88,12 @@ export default class ContingencyPlanPartners implements TasklistPage {
 
   errors() {
     const errors: TaskListErrors<this> = {}
+
+    if (this.saveAndContinue) {
+      if (this.partnerAgencyDetails.length) return errors
+      errors.partnerAgencyDetails = 'You must add at least one partner agency'
+      return errors
+    }
 
     Object.keys(fields).forEach(property => {
       if (!this.body[property]) {

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanPartners.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanPartners.ts
@@ -1,0 +1,89 @@
+import type { PartnerAgencyDetails, TaskListErrors } from '@approved-premises/ui'
+import { Page } from '../../../utils/decorators'
+
+import TasklistPage from '../../../tasklistPage'
+import { lowerCase, sentenceCase } from '../../../../utils/utils'
+
+const fields: PartnerAgencyDetails = {
+  partnerAgencyName: 'Name of partner agency',
+  namedContact: 'Named contact',
+  phoneNumber: 'Contact details (phone)',
+  roleInPlan: 'Role in contingency plan',
+} as const
+
+export type Body = PartnerAgencyDetails & {
+  partnerAgencyDetails: Array<PartnerAgencyDetails>
+}
+
+@Page({
+  name: 'contingency-plan-partners',
+  bodyProperties: ['partnerAgencyDetails', 'namedContact', 'phoneNumber', 'roleInPlan', 'partnerAgencyName'],
+})
+export default class ContingencyPlanPartners implements TasklistPage {
+  title = 'Contingency plans'
+
+  fields: Record<string, string> = fields
+
+  partnerAgencyDetails: Array<PartnerAgencyDetails> = []
+
+  constructor(public body: Body) {
+    const { namedContact, partnerAgencyName, phoneNumber, roleInPlan } = this.body
+    const newPartner: PartnerAgencyDetails = { namedContact, partnerAgencyName, phoneNumber, roleInPlan }
+    this.partnerAgencyDetails = this.body.partnerAgencyDetails || []
+
+    if (this.isValid(newPartner)) {
+      this.partnerAgencyDetails.push({ namedContact, partnerAgencyName, phoneNumber, roleInPlan })
+    }
+  }
+
+  previous() {
+    return 'arson'
+  }
+
+  next() {
+    return 'contingency-plan-partners'
+  }
+
+  private hasNeccessaryInputs() {
+    return Object.keys(this.errors()).length === 0
+  }
+
+  private isDuplicate(record: Record<string, string>) {
+    return this.partnerAgencyDetails.some(partner =>
+      Object.entries(record).every(([key, value]) => partner[key] === value),
+    )
+  }
+
+  private isValid(newPartner: PartnerAgencyDetails) {
+    return this.hasNeccessaryInputs() && !this.isDuplicate(newPartner)
+  }
+
+  response() {
+    return {
+      'Contingency plan partners': this.partnerAgencyDetails.map(partner => {
+        return this.responseForPartner(partner)
+      }),
+    }
+  }
+
+  private responseForPartner(partner: PartnerAgencyDetails) {
+    return Object.entries(partner).reduce((acc, [property, value]) => {
+      return {
+        [sentenceCase(property)]: value,
+        ...acc,
+      }
+    }, {})
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    Object.keys(fields).forEach(property => {
+      if (!this.body[property]) {
+        errors[property] = `You must specify a ${lowerCase(property)}`
+      }
+    })
+
+    return errors
+  }
+}

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/index.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/index.ts
@@ -7,10 +7,11 @@ import ComplexCaseBoard from './complexCaseBoard'
 import Catering from './catering'
 import Arson from './arson'
 import { Task } from '../../../utils/decorators'
+import ContingencyPlanPartners from './contingencyPlanPartners'
 
 @Task({
   name: 'Detail further considerations for placement',
   slug: 'further-considerations',
-  pages: [RoomSharing, Vulnerability, PreviousPlacements, ComplexCaseBoard, Catering, Arson],
+  pages: [RoomSharing, Vulnerability, PreviousPlacements, ComplexCaseBoard, Catering, Arson, ContingencyPlanPartners],
 })
 export default class FurtherConsiderations {}

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -1298,6 +1298,55 @@
               "type": "string"
             }
           }
+        },
+        "contingency-plan-partners": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "partnerAgencyName": {
+                  "type": "string"
+                },
+                "namedContact": {
+                  "type": "string"
+                },
+                "phoneNumber": {
+                  "type": "string"
+                },
+                "roleInPlan": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "saveAndContinue": {
+                  "type": "string"
+                },
+                "partnerAgencyDetails": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "partnerAgencyName": {
+                        "type": "string"
+                      },
+                      "namedContact": {
+                        "type": "string"
+                      },
+                      "phoneNumber": {
+                        "type": "string"
+                      },
+                      "roleInPlan": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ]
         }
       }
     },

--- a/server/testutils/factories/contingencyPlanPartner.ts
+++ b/server/testutils/factories/contingencyPlanPartner.ts
@@ -1,0 +1,11 @@
+/* istanbul ignore file */
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { PartnerAgencyDetails } from '../../@types/ui'
+
+export default Factory.define<PartnerAgencyDetails>(() => ({
+  partnerAgencyName: faker.company.name(),
+  namedContact: faker.name.fullName(),
+  phoneNumber: faker.phone.number(),
+  roleInPlan: 'Role in contingency plan',
+}))

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -12,6 +12,7 @@ import {
   isStringOrArrayOfStrings,
   escape,
   convertArrayToRadioItems,
+  convertKeyValuePairsToSummaryListItems,
 } from './formUtils'
 
 describe('formUtils', () => {
@@ -373,6 +374,21 @@ describe('formUtils', () => {
       expect(convertArrayToRadioItems(['one', 'two'], 'two')).toEqual([
         { text: 'One', value: 'one', checked: false },
         { text: 'Two', value: 'two', checked: true },
+      ])
+    })
+  })
+
+  describe('convertKeyValuePairsToSummaryListItems', () => {
+    it('returns the key value pairs as summary list items', () => {
+      expect(convertKeyValuePairsToSummaryListItems({ itemOne: 'someValue' }, { itemOne: 'First title' })).toEqual([
+        {
+          key: {
+            text: 'First title',
+          },
+          value: {
+            text: 'someValue',
+          },
+        },
       ])
     })
   })

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -1,5 +1,5 @@
 import * as nunjucks from 'nunjucks'
-import type { ErrorMessages, RadioItem, CheckBoxItem, SelectOption } from '@approved-premises/ui'
+import type { ErrorMessages, RadioItem, CheckBoxItem, SelectOption, SummaryListItem } from '@approved-premises/ui'
 import { sentenceCase } from './utils'
 import postcodeAreas from '../etc/postcodeAreas.json'
 
@@ -96,6 +96,22 @@ export function convertArrayToRadioItems(array: Array<string>, checkedItem: stri
       value: key,
       text: sentenceCase(key),
       checked: checkedItem === key,
+    }
+  })
+}
+
+export function convertKeyValuePairsToSummaryListItems<T>(
+  values: T,
+  titles: Record<string, string>,
+): Array<SummaryListItem> {
+  return Object.keys(values).map(key => {
+    return {
+      key: {
+        text: titles[key],
+      },
+      value: {
+        text: values[key],
+      },
     }
   })
 }

--- a/server/views/applications/pages/further-considerations/contingency-plan-partners.njk
+++ b/server/views/applications/pages/further-considerations/contingency-plan-partners.njk
@@ -1,0 +1,86 @@
+{% from "../../../components/formFields/form-page-input/macro.njk" import formPageInput %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% set hiddenInputs %}
+
+{% for partnerAgency in page.partnerAgencyDetails%}
+  {% set iteration = loop.index0 %}
+  {% for id, value in partnerAgency %}
+    {% set fieldName = "partnerAgencyDetails[" + iteration + "][" + id + "]"%}
+    <input type="hidden" name="{{fieldName}}" value="{{value}}"/>
+  {%endfor %}
+{%endfor %}
+
+{% endset %}
+
+{% set pageTitle = applicationName + " - " + page.title %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+      text: "Back",
+      href: paths.applications.pages.show({ id: applicationId, task: task, page: page.previous() })
+    }) }}
+{% endblock %}
+
+{% block content %}
+  <form action="{{ paths.applications.pages.update({ id: applicationId, task: task, page: page.name }) }}?_method=PUT" method="post">
+    <h1 class="govuk-heading-l">{{page.title}}</h1>
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+    {{ hiddenInputs | safe }}
+
+    {% for id, label in page.fields %}
+      {% set type = "text" %}
+      {% set inputMode = 'text'%}
+
+      {% if id == "phoneNumber" %}
+        {% set type = "number" %}
+        {% set inputMode = 'numeric'%}
+      {% endif %}
+      {{ formPageInput({
+        label: {
+          text: label
+        },
+        type: type,
+        inputMode: inputMode,
+        fieldName: id,
+        classes: "govuk-input--width-20"
+      }) }}
+    {% endfor %}
+
+    {{ govukButton({
+      text: "Add another agency",
+      classes: "govuk-button--secondary"
+    }) }}
+  </form>
+
+  <form action="{{ paths.applications.pages.update({ id: applicationId, task: task, page: page.name }) }}?_method=PUT" method="post">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+    <input type="hidden" name="saveAndContinue" value="1"/>
+
+    {{ hiddenInputs | safe }}
+
+    {% if page.partnerAgencyDetails.length >= 1 %}
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+      <h2 class="govuk-heading-m">List of partner agencies</h2>
+      {% for partnerAgency in page.partnerAgencyDetails%}
+        {{ govukSummaryList({
+        rows: FormUtils.convertKeyValuePairsToSummaryListItems(partnerAgency, page.fields)
+      })}}
+
+      {%endfor %}
+    {% endif %}
+
+    {{ govukButton({
+      text: "Save and continue"
+    }) }}
+
+  </form>
+
+{% endblock %}


### PR DESCRIPTION
# Context
This PR is part of a larger piece of work to add new screens which show dependent on certain answers given earlier in the questionaire. There are 4 screens and the logic to show them is relatively complex so in the interests of a simpler PR review process this PR just delivers the first slice of functionality. 
[Trello card](https://trello.com/c/Dpz6zjlr/1246-contingency-screens) 

We are adding a screen to add the Contingency Plan Partners. This will show for every user initially but later we will add conditions so it only shows for some users. The user can add a number of Contingency Plan Partners and then click 'Save and continue' to progress in the questionaire. 

# Changes in this PR 

At a high level: 

- Add the page class
- Add the view

However the designs necessitate that the user can add a partner agency, press a button and then remain on the same page in order to add further partner agencies. This means we need to do a few things that we don't have to do for other pages in the form: 
-  In order to do it we need to keep track of the `partnerAgencyDetails`and pass this in to the view and have it returned to us via hidden inputs. 
- We also need to be able to see when a partner agency has already been added to the array as when the user submits an agency they are redirected back to the page and that request is handled by the ‘show’ method of the pagesController with the same body.
- We need to use two forms one with a hidden input called 'saveAndContinue' that we use to tell if the user wants to add an agency or progress to the next page 
- When totalling up the number of requests there will be 3 from the 'Contingency plan partners' page as we submit it (2x for each new partner and 1x as a 'Save and continue'). We had previously assumed 1 page = 1 request but this page breaks that rule.

## Screenshots of UI changes
![Apply -- allows completion of the form](https://user-images.githubusercontent.com/44123869/220666154-25978e65-b8b8-4ce1-a2af-0d3dd5689e00.png)

