### PR TITLE
(1246) Contingency Plan Question screen

### DIFF
--- a/cypress_shared/fixtures/applicationData.json
+++ b/cypress_shared/fixtures/applicationData.json
@@ -352,6 +352,15 @@
         }
       ],
       "saveAndContinue": "1"
+    },
+    "contingency-plan-questions": {
+      "noReturn": "Action to be taken",
+      "placementWithdrawn": "Further action to be taken",
+      "victimConsiderations": "Considerations for victim",
+      "unsuitableAddresses": "An unsuitable address",
+      "suitableAddresses": "Some suitable addresses",
+      "breachInformation": "Breach information to assist decision making",
+      "otherConsiderations": "Some other considerations"
     }
   },
   "move-on": {

--- a/cypress_shared/fixtures/applicationData.json
+++ b/cypress_shared/fixtures/applicationData.json
@@ -1,10 +1,10 @@
 {
   "basic-information": {
     "sentence-type": {
-      "sentenceType": "bailPlacement"
+      "sentenceType": "communityOrder"
     },
     "situation": {
-      "situation": "bailSentence"
+      "situation": "riskManagement"
     },
     "release-date": {
       "releaseDate-year": "2022",

--- a/cypress_shared/helpers/apply.ts
+++ b/cypress_shared/helpers/apply.ts
@@ -13,7 +13,7 @@ import {
   PersonAcctAlert,
   PrisonCaseNote,
 } from '@approved-premises/api'
-import { PartnerAgencyDetails, PersonRisksUI } from '@approved-premises/ui'
+import { ContingencyPlanQuestionsBody, PartnerAgencyDetails, PersonRisksUI } from '@approved-premises/ui'
 
 import * as ApplyPages from '../pages/apply'
 
@@ -26,6 +26,7 @@ import oasysSectionsFactory from '../../server/testutils/factories/oasysSections
 import oasysSelectionFactory from '../../server/testutils/factories/oasysSelection'
 import prisonCaseNotesFactory from '../../server/testutils/factories/prisonCaseNotes'
 import contingencyPlanPartnerFactory from '../../server/testutils/factories/contingencyPlanPartner'
+import contingencyPlanQuestionsFactory from '../../server/testutils/factories/contingencyPlanQuestionsBody'
 
 import {
   offenceDetailSummariesFromApplication,
@@ -80,6 +81,8 @@ export default class ApplyHelper {
 
   contingencyPlanPartners: Array<PartnerAgencyDetails> = []
 
+  contingencyPlanQuestions: ContingencyPlanQuestionsBody
+
   constructor(
     private readonly application: Application,
     private readonly person: Person,
@@ -102,7 +105,7 @@ export default class ApplyHelper {
     this.stubAcctAlertsEndpoint()
     this.stubDocumentEndpoints()
     this.stubOffences()
-    this.addContingencyPlanPartners()
+    this.addContingencyPlanDetails()
   }
 
   startApplication() {
@@ -336,7 +339,7 @@ export default class ApplyHelper {
     cy.task('stubApplicationSubmit', { application: this.application })
   }
 
-  private addContingencyPlanPartners() {
+  private addContingencyPlanDetails() {
     this.contingencyPlanPartners = [
       contingencyPlanPartnerFactory.build({
         partnerAgencyName: 'Test agency 1',
@@ -351,6 +354,15 @@ export default class ApplyHelper {
         roleInPlan: 'Test role 2',
       }),
     ]
+    this.contingencyPlanQuestions = contingencyPlanQuestionsFactory.build({
+      noReturn: 'Action to be taken',
+      placementWithdrawn: 'Further action to be taken',
+      victimConsiderations: 'Considerations for victim',
+      unsuitableAddresses: 'An unsuitable address',
+      suitableAddresses: 'Some suitable addresses',
+      breachInformation: 'Breach information to assist decision making',
+      otherConsiderations: 'Some other considerations',
+    })
   }
 
   completeExceptionalCase() {
@@ -419,7 +431,6 @@ export default class ApplyHelper {
 
     // Then I should be redirected to the task list
     const tasklistPage = Page.verifyOnPage(ApplyPages.TaskListPage)
-
     // Then the Type of AP task should show as completed
     tasklistPage.shouldShowTaskStatus('type-of-ap', 'Completed')
 
@@ -628,6 +639,15 @@ export default class ApplyHelper {
     contingencyPlanPartnersPage.clickSubmit()
 
     this.pages.contingencyPlanPartners = [contingencyPlanPartnersPage]
+
+    // And I complete the Contingency Plan Questions page
+    const contingencyPlanQuestionsPage = new ApplyPages.ContingencyPlanQuestionsPage(
+      this.application,
+      this.contingencyPlanQuestions,
+    )
+    contingencyPlanQuestionsPage.completeForm()
+    contingencyPlanQuestionsPage.clickSubmit()
+
     this.pages.furtherConsiderations = [
       roomSharingPage,
       vulnerabilityPage,
@@ -635,6 +655,7 @@ export default class ApplyHelper {
       complexCaseBoardPage,
       cateringPage,
       arsonPage,
+      contingencyPlanQuestionsPage,
     ]
 
     // Then I should be taken back to the task list

--- a/cypress_shared/pages/apply/contingencyPlanPartners.ts
+++ b/cypress_shared/pages/apply/contingencyPlanPartners.ts
@@ -2,9 +2,10 @@ import { ApprovedPremisesApplication } from '@approved-premises/api'
 import paths from '../../../server/paths/apply'
 
 import ApplyPage from './applyPage'
+import { PartnerAgencyDetails } from '../../../server/@types/ui'
 
 export default class ContingencyPlanPartnersPage extends ApplyPage {
-  contigencyPlanPartners = []
+  contigencyPlanPartners: Array<PartnerAgencyDetails>
 
   constructor(application: ApprovedPremisesApplication, contigencyPlanPartners) {
     super(

--- a/cypress_shared/pages/apply/contingencyPlanQuestions.ts
+++ b/cypress_shared/pages/apply/contingencyPlanQuestions.ts
@@ -1,0 +1,30 @@
+import { ApprovedPremisesApplication } from '@approved-premises/api'
+import { ContingencyPlanQuestionsBody } from '../../../server/@types/ui'
+import paths from '../../../server/paths/apply'
+
+import ApplyPage from './applyPage'
+
+export default class ContingencyPlanQuestionsPage extends ApplyPage {
+  contingencyPlanQuestions: ContingencyPlanQuestionsBody
+
+  constructor(application: ApprovedPremisesApplication, contingencyPlanQuestionsBody: ContingencyPlanQuestionsBody) {
+    super(
+      'Contingency plans',
+      application,
+      'further-considerations',
+      'contingency-plan-questions',
+      paths.applications.show({ id: application.id }),
+    )
+    this.contingencyPlanQuestions = contingencyPlanQuestionsBody
+  }
+
+  completeForm() {
+    Object.keys(this.contingencyPlanQuestions).forEach(key => {
+      cy.get(`[name="${key}"]`).type(this.contingencyPlanQuestions[key])
+    })
+  }
+
+  clickSubmit(): void {
+    cy.get('button').contains('Save and continue').click()
+  }
+}

--- a/cypress_shared/pages/apply/index.ts
+++ b/cypress_shared/pages/apply/index.ts
@@ -9,6 +9,7 @@ import ComplexCaseBoard from './complexCaseBoard'
 import ConfirmDetailsPage from './confirmDetails'
 import ConvictedOffences from './convictedOffences'
 import ContingencyPlanPartnersPage from './contingencyPlanPartners'
+import ContingencyPlanQuestionsPage from './contingencyPlanQuestions'
 import CovidPage from './covid'
 import DateOfOffence from './dateOfOffence'
 import DescribeLocationFactors from './describeLocationFactors'
@@ -55,6 +56,7 @@ export {
   ComplexCaseBoard,
   ConfirmDetailsPage,
   ContingencyPlanPartnersPage,
+  ContingencyPlanQuestionsPage,
   ConvictedOffences,
   CovidPage,
   DateOfOffence,

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -151,8 +151,8 @@ context('Apply', () => {
       const firstRequestData = JSON.parse(requests[0].body).data
       const secondRequestData = JSON.parse(requests[1].body).data
 
-      expect(firstRequestData['basic-information']['sentence-type'].sentenceType).equal('bailPlacement')
-      expect(secondRequestData['basic-information'].situation.situation).equal('bailSentence')
+      expect(firstRequestData['basic-information']['sentence-type'].sentenceType).equal('communityOrder')
+      expect(secondRequestData['basic-information'].situation.situation).equal('riskManagement')
     })
   })
 

--- a/server/@types/shared/models/LostBedReason.ts
+++ b/server/@types/shared/models/LostBedReason.ts
@@ -6,5 +6,6 @@ export type LostBedReason = {
     id: string;
     name: string;
     isActive: boolean;
+    serviceScope: string;
 };
 

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -275,3 +275,22 @@ export type PartnerAgencyDetails = {
   phoneNumber: string
   roleInPlan: string
 }
+
+export type ContingencyPlanQuestionId =
+  | 'noReturn'
+  | 'placementWithdrawn'
+  | 'victimConsiderations'
+  | 'unsuitableAddresses'
+  | 'suitableAddresses'
+  | 'breachInformation'
+  | 'otherConsiderations'
+
+export type ContingencyPlanQuestionsBody = Record<ContingencyPlanQuestionId, string>
+
+type ContingencyPlanQuestion = {
+  question: string
+  hint?: string
+  error: string
+}
+
+export type ContingencyPlanQuestionsRecord = Record<ContingencyPlanQuestionId, ContingencyPlanQuestion>

--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseType.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseType.ts
@@ -15,6 +15,7 @@ const allReleaseTypes = {
 } as const
 
 type AllReleaseTypes = typeof allReleaseTypes
+export type ReleaseTypeID = keyof AllReleaseTypes
 type ReducedReleaseTypes = Pick<AllReleaseTypes, 'rotl' | 'licence'>
 type SentenceType = Extract<
   SentenceTypesT,
@@ -30,7 +31,7 @@ export default class ReleaseType implements TasklistPage {
   releaseTypes: AllReleaseTypes | ReducedReleaseTypes
 
   constructor(
-    readonly body: { releaseType?: keyof AllReleaseTypes | keyof ReducedReleaseTypes },
+    readonly body: { releaseType?: ReleaseTypeID | keyof ReducedReleaseTypes },
     readonly application: ApprovedPremisesApplication,
   ) {
     const sessionSentenceType = retrieveQuestionResponseFromApplication<SentenceType>(
@@ -42,7 +43,7 @@ export default class ReleaseType implements TasklistPage {
     this.releaseTypes = this.getReleaseTypes(sessionSentenceType)
 
     this.body = {
-      releaseType: body.releaseType as keyof (AllReleaseTypes | ReducedReleaseTypes),
+      releaseType: body.releaseType as ReleaseTypeID | keyof ReducedReleaseTypes,
     }
   }
 

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/arson.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/arson.test.ts
@@ -1,9 +1,12 @@
 import { YesOrNo } from '@approved-premises/ui'
-import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { itShouldHavePreviousValue } from '../../../shared-examples'
 
 import Arson from './arson'
 import applicationFactory from '../../../../testutils/factories/application'
 import personFactory from '../../../../testutils/factories/person'
+import { shouldShowContingencyPlanPages } from '../../../../utils/applications/shouldShowContingencyPlanPages'
+
+jest.mock('../../../../utils/applications/shouldShowContingencyPlanPages')
 
 describe('Arson', () => {
   const person = personFactory.build({ name: 'John Wayne' })
@@ -32,7 +35,16 @@ describe('Arson', () => {
     })
   })
 
-  itShouldHaveNextValue(new Arson(body, application), 'contingency-plan-partners')
+  describe('if the contingency-plan-partners page should be shown', () => {
+    ;(shouldShowContingencyPlanPages as jest.Mock).mockReturnValue(true)
+    expect(new Arson(body, application).next()).toBe('contingency-plan-partners')
+  })
+
+  describe('if the contingency-plan-partners page should not be shown', () => {
+    ;(shouldShowContingencyPlanPages as jest.Mock).mockReturnValue(false)
+    expect(new Arson(body, application).next()).toBe('')
+  })
+
   itShouldHavePreviousValue(new Arson(body, application), 'catering')
 
   describe('errors', () => {

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/arson.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/arson.ts
@@ -1,9 +1,10 @@
 import type { TaskListErrors, YesOrNoWithDetail } from '@approved-premises/ui'
-import type { ApprovedPremisesApplication } from '@approved-premises/api'
+import type { ApprovedPremisesApplication as Application } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
 import { yesOrNoResponseWithDetail } from '../../../utils'
+import { shouldShowContingencyPlanPages } from '../../../../utils/applications/shouldShowContingencyPlanPages'
 
 export const questionKeys = ['arson'] as const
 
@@ -36,17 +37,14 @@ export default class Arson implements TasklistPage {
     },
   }
 
-  constructor(
-    public body: Partial<YesOrNoWithDetail<'arson'>>,
-    private readonly application: ApprovedPremisesApplication,
-  ) {}
+  constructor(public body: Partial<YesOrNoWithDetail<'arson'>>, private readonly application: Application) {}
 
   previous() {
     return 'catering'
   }
 
   next() {
-    return 'contingency-plan-partners'
+    return shouldShowContingencyPlanPages(this.application) ? 'contingency-plan-partners' : ''
   }
 
   response() {

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanPartners.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanPartners.test.ts
@@ -32,7 +32,7 @@ describe('ContingencyPlanPartners', () => {
   })
 
   describe('if saveAndContinue is truthy ', () => {
-    itShouldHaveNextValue(new ContingencyPlanPartners({ saveAndContinue: '1', ...body }), '')
+    itShouldHaveNextValue(new ContingencyPlanPartners({ saveAndContinue: '1', ...body }), 'contingency-plan-questions')
   })
 
   itShouldHavePreviousValue(new ContingencyPlanPartners(body), 'arson')

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanPartners.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanPartners.ts
@@ -52,7 +52,7 @@ export default class ContingencyPlanPartners implements TasklistPage {
   }
 
   next() {
-    return this.saveAndContinue ? '' : 'contingency-plan-partners'
+    return this.saveAndContinue ? 'contingency-plan-questions' : 'contingency-plan-partners'
   }
 
   private hasNeccessaryInputs() {

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanQuestions.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanQuestions.test.ts
@@ -1,0 +1,63 @@
+import { ContingencyPlanQuestionsBody } from '../../../../@types/ui'
+import contingencyPlanQuestionsBodyFactory from '../../../../testutils/factories/contingencyPlanQuestionsBody'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import ContingencyPlanQuestions from './contingencyPlanQuestions'
+
+describe('ContingencyPlanQuestions', () => {
+  const body = contingencyPlanQuestionsBodyFactory.build()
+
+  describe('title', () => {
+    it('should set the title', () => {
+      const page = new ContingencyPlanQuestions(body)
+
+      expect(page.title).toEqual('Contingency plans')
+    })
+  })
+
+  describe('body', () => {
+    const page = new ContingencyPlanQuestions(body)
+
+    expect(page.body).toEqual(body)
+  })
+
+  itShouldHaveNextValue(new ContingencyPlanQuestions(body), '')
+
+  itShouldHavePreviousValue(new ContingencyPlanQuestions(body), 'contingency-plan-partners')
+
+  describe('errors', () => {
+    const page = new ContingencyPlanQuestions({} as ContingencyPlanQuestionsBody)
+
+    expect(page.errors()).toEqual({
+      noReturn: 'You must detail the actions that should be taken if the person does not return to the AP for curfew',
+      placementWithdrawn:
+        "You must detail any actions that should be taken if the person's placement needs to be withdrawn out of hours",
+      victimConsiderations:
+        'You must detail any victim considerations that the AP need to be aware of when out of hours',
+      unsuitableAddresses: 'You must detail any unsuitable addresses that the person cannot reside at',
+      suitableAddresses: 'You must detail alternative suitable addresses that the person can reside at',
+      breachInformation: 'You must detail any further information to support OoH decision making',
+      otherConsiderations: 'You must detail any other considerations',
+    })
+  })
+
+  describe('response', () => {
+    it('should return the responses to the question in plain english', () => {
+      const page = new ContingencyPlanQuestions(body)
+
+      expect(page.response()).toEqual({
+        'Are there any other considerations?': body.otherConsiderations,
+        'If the person does not return to the AP for curfew, what actions should be taken?': body.noReturn,
+        "If the person's placement needs to be withdrawn out of hours, what actions should be taken?":
+          body.placementWithdrawn,
+        'In the event of a breach, provide any further information to support Out of Hours (OoH) decision making':
+          body.breachInformation,
+        'In the event of an out of hours placement withdrawal, provide alternative suitable addresses that the person can reside at':
+          body.suitableAddresses,
+        'In the event of an out of hours placement withdrawal, provide any unsuitable addresses that the person cannot reside at':
+          body.unsuitableAddresses,
+        'Provide any victim considerations that the AP need to be aware of when out of hours':
+          body.victimConsiderations,
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanQuestions.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanQuestions.ts
@@ -1,0 +1,93 @@
+import type {
+  ContingencyPlanQuestionId,
+  ContingencyPlanQuestionsBody,
+  ContingencyPlanQuestionsRecord,
+  TaskListErrors,
+} from '@approved-premises/ui'
+import { Page } from '../../../utils/decorators'
+
+import TasklistPage from '../../../tasklistPage'
+
+const questions: ContingencyPlanQuestionsRecord = {
+  noReturn: {
+    question: 'If the person does not return to the AP for curfew, what actions should be taken?',
+    hint: 'List all actions and agencies involved. Identify who is responsible for each section.',
+    error: 'You must detail the actions that should be taken if the person does not return to the AP for curfew',
+  },
+  placementWithdrawn: {
+    question: "If the person's placement needs to be withdrawn out of hours, what actions should be taken?",
+    hint: `Placements can be withdrawn due to safety, security or behavioural issues.
+    List all actions and agencies involved. Identify who is responsible for each section.`,
+    error:
+      "You must detail any actions that should be taken if the person's placement needs to be withdrawn out of hours",
+  },
+  victimConsiderations: {
+    question: 'Provide any victim considerations that the AP need to be aware of when out of hours',
+    error: 'You must detail any victim considerations that the AP need to be aware of when out of hours',
+  },
+  unsuitableAddresses: {
+    question:
+      'In the event of an out of hours placement withdrawal, provide any unsuitable addresses that the person cannot reside at',
+    hint: 'List all actions and agencies involved. Identify who is responsible for each section.',
+    error: 'You must detail any unsuitable addresses that the person cannot reside at',
+  },
+  suitableAddresses: {
+    question:
+      'In the event of an out of hours placement withdrawal, provide alternative suitable addresses that the person can reside at',
+    hint: 'For situations where a placement is withdrawn and recall action is not taken, the person will need to be directed to alternative places to reside in',
+    error: 'You must detail alternative suitable addresses that the person can reside at',
+  },
+  breachInformation: {
+    question: 'In the event of a breach, provide any further information to support Out of Hours (OoH) decision making',
+    hint: 'For example, include any required actions or views from the probation practicioner regarding OoH recall following curfew breach',
+    error: 'You must detail any further information to support OoH decision making',
+  },
+  otherConsiderations: {
+    question: 'Are there any other considerations?',
+    error: 'You must detail any other considerations',
+  },
+} as const
+
+const bodyProperties = Object.keys(questions) as Array<ContingencyPlanQuestionId>
+
+@Page({
+  name: 'contingency-plan-questions',
+  bodyProperties,
+})
+export default class ContingencyPlanQuestions implements TasklistPage {
+  title = 'Contingency plans'
+
+  questions: ContingencyPlanQuestionsRecord = questions
+
+  constructor(public body: ContingencyPlanQuestionsBody) {}
+
+  previous() {
+    return 'contingency-plan-partners'
+  }
+
+  next() {
+    return ''
+  }
+
+  response() {
+    const response = {}
+
+    Object.entries(this.body).forEach(([key, value]) => {
+      response[this.questions[key].question] = value
+    })
+
+    return response
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    bodyProperties.forEach(key => {
+      if (!this.body[key]) {
+        errors[key] = this.questions[key].error
+      }
+    })
+
+    return errors
+  }
+}

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/index.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/index.ts
@@ -6,12 +6,23 @@ import PreviousPlacements from './previousPlacements'
 import ComplexCaseBoard from './complexCaseBoard'
 import Catering from './catering'
 import Arson from './arson'
-import { Task } from '../../../utils/decorators'
 import ContingencyPlanPartners from './contingencyPlanPartners'
+import ContingencyPlanQuestions from './contingencyPlanQuestions'
+
+import { Task } from '../../../utils/decorators'
 
 @Task({
   name: 'Detail further considerations for placement',
   slug: 'further-considerations',
-  pages: [RoomSharing, Vulnerability, PreviousPlacements, ComplexCaseBoard, Catering, Arson, ContingencyPlanPartners],
+  pages: [
+    RoomSharing,
+    Vulnerability,
+    PreviousPlacements,
+    ComplexCaseBoard,
+    Catering,
+    Arson,
+    ContingencyPlanPartners,
+    ContingencyPlanQuestions,
+  ],
 })
 export default class FurtherConsiderations {}

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.test.ts
@@ -27,8 +27,8 @@ describe('RehabilitativeInterventions', () => {
   describe('if the user answered "yes" to convictedOffences', () => {
     application = applicationFactory
       .withPageResponse({
-        section: 'risk-management-features',
-        task: 'convicted-offences',
+        task: 'risk-management-features',
+        page: 'convicted-offences',
         key: 'response',
         value: 'yes',
       })
@@ -40,8 +40,8 @@ describe('RehabilitativeInterventions', () => {
   describe('if the user didnt answer "yes" to convictedOffences', () => {
     application = applicationFactory
       .withPageResponse({
-        section: 'risk-management-features',
-        task: 'convicted-offences',
+        task: 'risk-management-features',
+        page: 'convicted-offences',
         key: 'response',
         value: 'no',
       })

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -1347,6 +1347,32 @@
               }
             }
           ]
+        },
+        "contingency-plan-questions": {
+          "type": "object",
+          "properties": {
+            "noReturn": {
+              "type": "string"
+            },
+            "placementWithdrawn": {
+              "type": "string"
+            },
+            "victimConsiderations": {
+              "type": "string"
+            },
+            "unsuitableAddresses": {
+              "type": "string"
+            },
+            "suitableAddresses": {
+              "type": "string"
+            },
+            "breachInformation": {
+              "type": "string"
+            },
+            "otherConsiderations": {
+              "type": "string"
+            }
+          }
         }
       }
     },

--- a/server/testutils/addResponseToApplication.test.ts
+++ b/server/testutils/addResponseToApplication.test.ts
@@ -1,0 +1,20 @@
+import applicationFactory from './factories/application'
+import { addResponseToApplication } from './addResponseToApplication'
+
+describe('addResponseToApplication', () => {
+  it('adds a response to the application', () => {
+    const application = applicationFactory.build()
+    const response = { section: 'section', page: 'page', key: 'key', value: 'value' }
+
+    const updatedApplication = addResponseToApplication(application, response)
+
+    expect(updatedApplication.data).toEqual({
+      ...application.data,
+      [response.section]: {
+        [response.page]: {
+          [response.key]: response.value,
+        },
+      },
+    })
+  })
+})

--- a/server/testutils/addResponseToApplication.ts
+++ b/server/testutils/addResponseToApplication.ts
@@ -1,0 +1,16 @@
+import { ApprovedPremisesApplication as Application } from '../@types/shared'
+
+export const addResponseToApplication = (
+  application: Application,
+  { section, page, key, value }: { section: string; page: string; key: string; value: unknown },
+) => {
+  application.data = {
+    ...application.data,
+    [section]: {
+      ...application.data[section],
+      [page]: { [key]: value },
+    },
+  }
+
+  return application
+}

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -34,11 +34,11 @@ class ApplicationFactory extends Factory<ApprovedPremisesApplication> {
     })
   }
 
-  withPageResponse({ section, task, key, value }: { section: string; task: string; key: string; value: unknown }) {
+  withPageResponse({ task, page, key, value }: { task: string; page: string; key: string; value: unknown }) {
     return this.params({
       data: {
-        [section]: {
-          [task]: { [key]: value },
+        [task]: {
+          [page]: { [key]: value },
         },
       },
     })

--- a/server/testutils/factories/contingencyPlanQuestionsBody.ts
+++ b/server/testutils/factories/contingencyPlanQuestionsBody.ts
@@ -1,0 +1,14 @@
+/* istanbul ignore file */
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { ContingencyPlanQuestionsBody } from '../../@types/ui'
+
+export default Factory.define<ContingencyPlanQuestionsBody>(() => ({
+  noReturn: faker.lorem.sentence(),
+  placementWithdrawn: faker.lorem.sentence(),
+  victimConsiderations: faker.lorem.sentence(),
+  unsuitableAddresses: faker.lorem.sentence(),
+  suitableAddresses: faker.lorem.sentence(),
+  breachInformation: faker.lorem.sentence(),
+  otherConsiderations: faker.lorem.sentence(),
+}))

--- a/server/utils/applications/convictedOffenceResponseFromApplication.test.ts
+++ b/server/utils/applications/convictedOffenceResponseFromApplication.test.ts
@@ -6,8 +6,8 @@ describe('convictedOffenceResponseFromApplication', () => {
   it('should return the correct response', () => {
     const application = applicationFactory
       .withPageResponse({
-        section: 'risk-management-features',
-        task: 'convicted-offences',
+        task: 'risk-management-features',
+        page: 'convicted-offences',
         key: 'response',
         value: 'yes',
       })

--- a/server/utils/applications/shouldShowContingencyPlanPages.test.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.test.ts
@@ -1,0 +1,78 @@
+import { ApprovedPremisesApplication as Application } from '../../@types/shared'
+import { addResponseToApplication } from '../../testutils/addResponseToApplication'
+import applicationFactory from '../../testutils/factories/application'
+import { shouldShowContingencyPlanPages } from './shouldShowContingencyPlanPages'
+
+describe('shouldShowContingencyPlanPages', () => {
+  let defaultApplication: Application
+  beforeEach(() => {
+    defaultApplication = applicationFactory
+      .withPageResponse({
+        task: 'basic-information',
+        page: 'sentence-type',
+        key: 'sentenceType',
+        value: 'ipp',
+      })
+      .withPageResponse({
+        task: 'basic-information',
+        page: 'release-type',
+        key: 'releaseType',
+        value: 'other',
+      })
+      .withPageResponse({
+        task: 'type-of-ap',
+        page: 'ap-type',
+        key: 'apType',
+        value: 'other',
+      })
+      .build()
+  })
+
+  it('returns an empty string if none of the conditions are met', () => {
+    expect(shouldShowContingencyPlanPages(defaultApplication)).toEqual(false)
+  })
+
+  it('returns "contingency-plan-partners" if the application has a sentence type of "Community Order/SSO"', () => {
+    const application = addResponseToApplication(defaultApplication, {
+      section: 'basic-information',
+      page: 'sentence-type',
+      key: 'sentenceType',
+      value: 'communityOrder',
+    })
+
+    expect(shouldShowContingencyPlanPages(application)).toEqual(true)
+  })
+
+  it('returns "contingency-plan-partners" if the application has a sentence type of "Non-statutory, MAPPA case"', () => {
+    const application = addResponseToApplication(defaultApplication, {
+      section: 'basic-information',
+      page: 'sentence-type',
+      key: 'sentenceType',
+      value: 'nonStatutory',
+    })
+
+    expect(shouldShowContingencyPlanPages(application)).toEqual(true)
+  })
+
+  it('returns "contingency-plan-partners" if the application has a release type of "Post Sentence Supervision (PSS)"', () => {
+    const application = addResponseToApplication(defaultApplication, {
+      section: 'basic-information',
+      page: 'release-type',
+      key: 'releaseType',
+      value: 'pss',
+    })
+
+    expect(shouldShowContingencyPlanPages(application)).toEqual(true)
+  })
+
+  it('returns "contingency-plan-partners" if the application has a AP type of "ESAP"', () => {
+    const application = addResponseToApplication(defaultApplication, {
+      section: 'type-of-ap',
+      page: 'ap-type',
+      key: 'apType',
+      value: 'esap',
+    })
+
+    expect(shouldShowContingencyPlanPages(application)).toEqual(true)
+  })
+})

--- a/server/utils/applications/shouldShowContingencyPlanPages.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.ts
@@ -1,0 +1,39 @@
+import { ApprovedPremisesApplication as Application } from '../../@types/shared'
+import { ReleaseTypeID } from '../../form-pages/apply/reasons-for-placement/basic-information/releaseType'
+import { retrieveQuestionResponseFromApplication } from '../utils'
+
+export const shouldShowContingencyPlanPages = (application: Application) => {
+  let releaseType: ReleaseTypeID
+  const sentenceType = retrieveQuestionResponseFromApplication(
+    application,
+    'basic-information',
+    'sentence-type',
+    'sentenceType',
+  )
+
+  if (
+    sentenceType === 'standardDeterminate' ||
+    sentenceType === 'extendedDeterminate' ||
+    sentenceType === 'ipp' ||
+    sentenceType === 'life'
+  ) {
+    releaseType = retrieveQuestionResponseFromApplication(
+      application,
+      'basic-information',
+      'release-type',
+      'releaseType',
+    )
+  }
+
+  const apType = retrieveQuestionResponseFromApplication(application, 'type-of-ap', 'ap-type', 'apType')
+
+  if (
+    sentenceType === 'communityOrder' ||
+    sentenceType === 'nonStatutory' ||
+    releaseType === 'pss' ||
+    apType === 'esap'
+  )
+    return true
+
+  return false
+}

--- a/server/views/applications/pages/access-and-healthcare/access-needs.njk
+++ b/server/views/applications/pages/access-and-healthcare/access-needs.njk
@@ -57,7 +57,7 @@
   {{ formPageInput({
         fieldName: "interpreterLanguage",
         label: {
-          text: "Which language?"
+          text: page.questions.interpreter.language
         }
       },fetchContext()) }}
   {% endset -%}
@@ -78,7 +78,7 @@
         fieldName: "needsInterpreter",
         fieldset: {
           legend: {
-            text: page.questions.interpreter.language,
+            text: page.questions.interpreter.question,
             classes: "govuk-fieldset__legend--m"
           }
         },

--- a/server/views/applications/pages/further-considerations/contingency-plan-partners.njk
+++ b/server/views/applications/pages/further-considerations/contingency-plan-partners.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
 
 {% extends "../../../partials/layout.njk" %}
 
@@ -34,6 +35,7 @@
     <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
     {{ hiddenInputs | safe }}
+    {{ showErrorSummary(errorSummary) }}
 
     {% for id, label in page.fields %}
       {% set type = "text" %}

--- a/server/views/applications/pages/further-considerations/contingency-plan-questions.njk
+++ b/server/views/applications/pages/further-considerations/contingency-plan-questions.njk
@@ -1,0 +1,33 @@
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+    <h1 class="govuk-heading-l">
+        {{ page.title }}
+    </h1>
+
+    {% for questionId, question in page.questions %}
+        {% if question.hint %}
+            {{formPageTextarea({
+                fieldName: questionId,
+                label:{
+                    text:  question.question,
+                    classes: 'govuk-label--m'
+                },
+                hint: {
+                    text: question.hint
+                }
+            }, fetchContext())
+            }}
+        {% else %}
+            {{formPageTextarea({
+                fieldName: questionId,
+                label:{
+                    text:  question.question,
+                    classes: 'govuk-label--m'
+                }
+            }, fetchContext())
+            }}
+        {%endif%}
+        {% endfor %}
+    {% endblock %}

--- a/server/views/applications/pages/oasys-import/optional-oasys-sections.njk
+++ b/server/views/applications/pages/oasys-import/optional-oasys-sections.njk
@@ -14,6 +14,8 @@
         <li>any MAPPA or hate-based information</li>
         <li>sections linked to RoSH</li>
         <li>Risk Management Plan</li>
+        <li>Section 8 - Drug misuse</li>
+        <li>Section 9 - Alcohol misuse</li>
     </ul>
 
     <p>Select any sections that include information that's relevant to the risk an Approved Premises (AP) will help manage or the needs an AP can support.</p>


### PR DESCRIPTION
# Context
This screen follows on from the previously added Contingency Partners screen (#574). 
These screens are shown dependent on answers given to questions earlier in the questionaire, this PR also adds that logic.

[Trello ticket](https://trello.com/c/Dpz6zjlr/1246-contingency-screens)

# Changes in this PR
1. Updating of types 
2. Add copy to OASys import screen (unrelated but such a minor change it doesn't deserve its own PR)
3. Another small change to fix the copy for the Access Needs page
4. Some tidying up from #574 that I noticed whilst doing this work 
5. Setup the Integration tests in order to show the Contingency screens once the new logic to show them has been added
6. Adding the page class and the view for the Contingency Plan Questions page
7. We add the logic to determine when to show the newly added pages

## Screenshots of UI changes
![Apply -- allows completion of the form](https://user-images.githubusercontent.com/44123869/221217157-3e46f983-16d5-4f9e-8e75-cc30c41026aa.png)

