### PR TITLE
Allow more errors to propagate to standard error handler

### DIFF
--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -68,7 +68,7 @@ describe('catchValidationErrorOrPropogate', () => {
   })
 
   it('gets errors from a ValidationError type', () => {
-    const error = createMock<ValidationError<TaskListPage>>({
+    const error = new ValidationError<TaskListPage>({
       data: {
         crn: 'You must enter a valid crn',
         error: 'You must enter a valid arrival date',


### PR DESCRIPTION
AP contains multiple endpoints that receive POSTed form data that is then forward to the API. In these endpoints, the API call is generally wrapped in a try...catch block, and any error is passed to catchValidationErrorOrPropogate.

In cases where the error is expected - for instance, a field is required but the user has left it blank - this allows us to display friendly error messages that link to the relevant part of the form. The API tells us in an invalid-params block which fields have failed validation and why, and this allows us to lookup an error message in our errors.json file. For example:
![image](https://user-images.githubusercontent.com/44123869/221521988-7958abe1-ca53-4733-9729-f223920462d7.png)
![image](https://user-images.githubusercontent.com/44123869/221522004-f5b4f0de-19e3-439a-b0d8-6c58eb11e315.png)
In this instance the 500 status field from the API has been wrongly interpreted as relating to the "status" field in the form.

This PR changes our error handling so that if the API give an error that does not contain an invalid-params block, and isn't a UI-generated ValidationError, catchValidationErrorOrPropogate will simply allow the error to propagate, resulting in the user seeing our standard error screen ("Something went wrong. The error has been logged. Please try again" on production, and a stack trace elsewhere)