### PR TITLE
(1246) Trigger plan screen 

### DIFF
--- a/cypress_shared/helpers/apply.ts
+++ b/cypress_shared/helpers/apply.ts
@@ -645,6 +645,8 @@ export default class ApplyHelper {
       this.application,
       this.contingencyPlanQuestions,
     )
+
+    contingencyPlanQuestionsPage.shouldShowPartnerAgencyNames(this.contingencyPlanPartners)
     contingencyPlanQuestionsPage.completeForm()
     contingencyPlanQuestionsPage.clickSubmit()
 

--- a/cypress_shared/pages/apply/contingencyPlanQuestions.ts
+++ b/cypress_shared/pages/apply/contingencyPlanQuestions.ts
@@ -1,5 +1,5 @@
 import { ApprovedPremisesApplication } from '@approved-premises/api'
-import { ContingencyPlanQuestionsBody } from '../../../server/@types/ui'
+import { ContingencyPlanQuestionsBody, PartnerAgencyDetails } from '../../../server/@types/ui'
 import paths from '../../../server/paths/apply'
 
 import ApplyPage from './applyPage'
@@ -16,6 +16,15 @@ export default class ContingencyPlanQuestionsPage extends ApplyPage {
       paths.applications.show({ id: application.id }),
     )
     this.contingencyPlanQuestions = contingencyPlanQuestionsBody
+  }
+
+  shouldShowPartnerAgencyNames(partnerAgencies: Array<PartnerAgencyDetails>) {
+    cy.get('h3').contains('Partner agencies added to application').should('be.visible')
+    cy.get('dl').within(() => {
+      partnerAgencies.forEach(partnerAgency => {
+        this.assertDefinition('Partner agency', partnerAgency.partnerAgencyName)
+      })
+    })
   }
 
   completeForm() {

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanQuestions.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanQuestions.test.ts
@@ -1,5 +1,6 @@
 import { ContingencyPlanQuestionsBody } from '../../../../@types/ui'
 import applicationFactory from '../../../../testutils/factories/application'
+import contingencyPlanPartner from '../../../../testutils/factories/contingencyPlanPartner'
 import contingencyPlanQuestionsBodyFactory from '../../../../testutils/factories/contingencyPlanQuestionsBody'
 import { shouldShowTriggerPlanPages } from '../../../../utils/applications/shouldShowTriggerPlanPage'
 import { itShouldHavePreviousValue } from '../../../shared-examples'
@@ -9,7 +10,8 @@ jest.mock('../../../../utils/applications/shouldShowTriggerPlanPage')
 
 describe('ContingencyPlanQuestions', () => {
   const body = contingencyPlanQuestionsBodyFactory.build()
-  const application = applicationFactory.build()
+  const contingencyPlanPartners = contingencyPlanPartner.buildList(2)
+  const application = applicationFactory.withContingencyPlanPartners(contingencyPlanPartners).build()
 
   describe('title', () => {
     it('should set the title', () => {
@@ -20,9 +22,20 @@ describe('ContingencyPlanQuestions', () => {
   })
 
   describe('body', () => {
-    const page = new ContingencyPlanQuestions(body, application)
+    it('should set the body', () => {
+      const page = new ContingencyPlanQuestions(body, application)
 
-    expect(page.body).toEqual(body)
+      expect(page.body).toEqual(body)
+    })
+
+    it('should add the contingency plan partners name to the body', () => {
+      const page = new ContingencyPlanQuestions(body, application)
+
+      expect(page.contingencyPlanPartnerNames).toEqual([
+        contingencyPlanPartners[0].partnerAgencyName,
+        contingencyPlanPartners[1].partnerAgencyName,
+      ])
+    })
   })
 
   describe('if shouldShowTriggerPlanPages returns true', () => {

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanQuestions.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanQuestions.test.ts
@@ -1,31 +1,45 @@
 import { ContingencyPlanQuestionsBody } from '../../../../@types/ui'
+import applicationFactory from '../../../../testutils/factories/application'
 import contingencyPlanQuestionsBodyFactory from '../../../../testutils/factories/contingencyPlanQuestionsBody'
-import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { shouldShowTriggerPlanPages } from '../../../../utils/applications/shouldShowTriggerPlanPage'
+import { itShouldHavePreviousValue } from '../../../shared-examples'
 import ContingencyPlanQuestions from './contingencyPlanQuestions'
+
+jest.mock('../../../../utils/applications/shouldShowTriggerPlanPage')
 
 describe('ContingencyPlanQuestions', () => {
   const body = contingencyPlanQuestionsBodyFactory.build()
+  const application = applicationFactory.build()
 
   describe('title', () => {
     it('should set the title', () => {
-      const page = new ContingencyPlanQuestions(body)
+      const page = new ContingencyPlanQuestions(body, application)
 
       expect(page.title).toEqual('Contingency plans')
     })
   })
 
   describe('body', () => {
-    const page = new ContingencyPlanQuestions(body)
+    const page = new ContingencyPlanQuestions(body, application)
 
     expect(page.body).toEqual(body)
   })
 
-  itShouldHaveNextValue(new ContingencyPlanQuestions(body), '')
+  describe('if shouldShowTriggerPlanPages returns true', () => {
+    ;(shouldShowTriggerPlanPages as jest.Mock).mockReturnValue(true)
 
-  itShouldHavePreviousValue(new ContingencyPlanQuestions(body), 'contingency-plan-partners')
+    expect(new ContingencyPlanQuestions(body, application).next()).toBe('trigger-plan')
+  })
 
+  describe('if shouldShowTriggerPlanPages returns false', () => {
+    ;(shouldShowTriggerPlanPages as jest.Mock).mockReturnValue(false)
+
+    expect(new ContingencyPlanQuestions(body, application).next()).toBe('')
+  })
+
+  itShouldHavePreviousValue(new ContingencyPlanQuestions(body, application), 'contingency-plan-partners')
   describe('errors', () => {
-    const page = new ContingencyPlanQuestions({} as ContingencyPlanQuestionsBody)
+    const page = new ContingencyPlanQuestions({} as ContingencyPlanQuestionsBody, application)
 
     expect(page.errors()).toEqual({
       noReturn: 'You must detail the actions that should be taken if the person does not return to the AP for curfew',
@@ -42,7 +56,7 @@ describe('ContingencyPlanQuestions', () => {
 
   describe('response', () => {
     it('should return the responses to the question in plain english', () => {
-      const page = new ContingencyPlanQuestions(body)
+      const page = new ContingencyPlanQuestions(body, application)
 
       expect(page.response()).toEqual({
         'Are there any other considerations?': body.otherConsiderations,

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanQuestions.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanQuestions.ts
@@ -1,7 +1,8 @@
-import type {
+import {
   ContingencyPlanQuestionId,
   ContingencyPlanQuestionsBody,
   ContingencyPlanQuestionsRecord,
+  PartnerAgencyDetails,
   TaskListErrors,
 } from '@approved-premises/ui'
 import { Page } from '../../../utils/decorators'
@@ -9,6 +10,7 @@ import { Page } from '../../../utils/decorators'
 import TasklistPage from '../../../tasklistPage'
 import { shouldShowTriggerPlanPages } from '../../../../utils/applications/shouldShowTriggerPlanPage'
 import { ApprovedPremisesApplication as Application } from '../../../../@types/shared'
+import { retrieveOptionalQuestionResponseFromApplication } from '../../../../utils/utils'
 
 const questions: ContingencyPlanQuestionsRecord = {
   noReturn: {
@@ -61,7 +63,23 @@ export default class ContingencyPlanQuestions implements TasklistPage {
 
   questions: ContingencyPlanQuestionsRecord = questions
 
-  constructor(public body: ContingencyPlanQuestionsBody, private readonly application: Application) {}
+  contingencyPlanPartnerNames: Array<string>
+
+  constructor(public body: ContingencyPlanQuestionsBody, private readonly application: Application) {
+    const contingencyPlanPartners =
+      retrieveOptionalQuestionResponseFromApplication<Array<PartnerAgencyDetails>>(
+        application,
+        'further-considerations',
+        'contingency-plan-partners',
+        'partnerAgencyDetails',
+      ) || []
+
+    const contingencyPlanPartnersNames = contingencyPlanPartners.map(
+      (partner: { partnerAgencyName: string }) => partner.partnerAgencyName,
+    )
+
+    this.contingencyPlanPartnerNames = contingencyPlanPartnersNames
+  }
 
   previous() {
     return 'contingency-plan-partners'

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanQuestions.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanQuestions.ts
@@ -7,6 +7,8 @@ import type {
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
+import { shouldShowTriggerPlanPages } from '../../../../utils/applications/shouldShowTriggerPlanPage'
+import { ApprovedPremisesApplication as Application } from '../../../../@types/shared'
 
 const questions: ContingencyPlanQuestionsRecord = {
   noReturn: {
@@ -59,14 +61,14 @@ export default class ContingencyPlanQuestions implements TasklistPage {
 
   questions: ContingencyPlanQuestionsRecord = questions
 
-  constructor(public body: ContingencyPlanQuestionsBody) {}
+  constructor(public body: ContingencyPlanQuestionsBody, private readonly application: Application) {}
 
   previous() {
     return 'contingency-plan-partners'
   }
 
   next() {
-    return ''
+    return shouldShowTriggerPlanPages(this.application) ? 'trigger-plan' : ''
   }
 
   response() {

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/index.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/index.ts
@@ -8,6 +8,7 @@ import Catering from './catering'
 import Arson from './arson'
 import ContingencyPlanPartners from './contingencyPlanPartners'
 import ContingencyPlanQuestions from './contingencyPlanQuestions'
+import TriggerPlan from './triggerPlan'
 
 import { Task } from '../../../utils/decorators'
 
@@ -23,6 +24,7 @@ import { Task } from '../../../utils/decorators'
     Arson,
     ContingencyPlanPartners,
     ContingencyPlanQuestions,
+    TriggerPlan,
   ],
 })
 export default class FurtherConsiderations {}

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/triggerPlan.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/triggerPlan.test.ts
@@ -1,0 +1,58 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import TriggerPlan, { TriggerPlanBody } from './triggerPlan'
+
+describe('TriggerPlan', () => {
+  const body = {
+    planInPlace: 'yes' as const,
+    additionalConditions: 'yes' as const,
+    additionalConditionsDetail: 'some details',
+  }
+  describe('title', () => {
+    it('should set the title', () => {
+      const page = new TriggerPlan(body)
+
+      expect(page.title).toEqual('Contingency plans')
+    })
+  })
+
+  describe('body', () => {
+    const page = new TriggerPlan(body)
+
+    expect(page.body).toEqual(body)
+  })
+
+  itShouldHaveNextValue(new TriggerPlan(body), '')
+
+  itShouldHavePreviousValue(new TriggerPlan(body), 'contingency-plan-questions')
+
+  describe('errors', () => {
+    describe('if there are no responses', () => {
+      const page = new TriggerPlan({} as TriggerPlanBody)
+
+      expect(page.errors()).toEqual({
+        additionalConditions:
+          'You must confirm if additional Licence conditions have been requested as an alternative to recall',
+        planInPlace: 'You must confirm if there is a trigger plan in place',
+      })
+    })
+    describe('if the responses to "additionalConditions" is "yes" but no details are given', () => {
+      const page = new TriggerPlan({ planInPlace: 'yes', additionalConditions: 'yes' } as TriggerPlanBody)
+
+      expect(page.errors()).toEqual({
+        additionalConditionsDetail:
+          'You must detail additional Licence conditions have been requested as an alternative to recall',
+      })
+    })
+  })
+
+  describe('response', () => {
+    it('should return the responses to the question in plain english', () => {
+      const page = new TriggerPlan(body)
+
+      expect(page.response()).toEqual({
+        'Is there a trigger plan in place?': 'Yes',
+        'Have additional Licence conditions been requested as an alternative to recall?': 'Yes - some details',
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/triggerPlan.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/triggerPlan.ts
@@ -1,0 +1,73 @@
+import type { TaskListErrors, YesOrNo, YesOrNoWithDetail } from '@approved-premises/ui'
+import { Page } from '../../../utils/decorators'
+
+import TasklistPage from '../../../tasklistPage'
+import { yesNoOrDontKnowResponseWithDetail } from '../../../utils'
+import { sentenceCase } from '../../../../utils/utils'
+
+const questions = {
+  planInPlace: {
+    question: 'Is there a trigger plan in place?',
+    hint: 'If the document is available on Delius, attach it to this application. If the document is not available, share with the AP manager once the placement is confirmed.',
+    error: 'You must confirm if there is a trigger plan in place',
+  },
+  additionalConditions: {
+    question: 'Have additional Licence conditions been requested as an alternative to recall?',
+    error: 'You must confirm if additional Licence conditions have been requested as an alternative to recall',
+    detailsError: 'You must detail additional Licence conditions have been requested as an alternative to recall',
+  },
+}
+
+export type TriggerPlanBody = {
+  planInPlace: YesOrNo
+} & YesOrNoWithDetail<'additionalConditions'>
+
+@Page({
+  name: 'trigger-plan',
+  bodyProperties: ['planInPlace', 'additionalConditions', 'additionalConditionsDetail'],
+})
+export default class TriggerPlan implements TasklistPage {
+  title = 'Contingency plans'
+
+  questions = questions
+
+  constructor(public body: TriggerPlanBody) {}
+
+  previous() {
+    return 'contingency-plan-questions'
+  }
+
+  next() {
+    return ''
+  }
+
+  response() {
+    const response = {}
+
+    response[questions.planInPlace.question] = sentenceCase(this.body.planInPlace)
+    response[questions.additionalConditions.question] = yesNoOrDontKnowResponseWithDetail(
+      'additionalConditions',
+      this.body,
+    )
+
+    return response
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.planInPlace) {
+      errors.planInPlace = this.questions.planInPlace.error
+    }
+
+    if (!this.body.additionalConditions) {
+      errors.additionalConditions = this.questions.additionalConditions.error
+    }
+
+    if (this.body.additionalConditions === 'yes' && !this.body.additionalConditionsDetail) {
+      errors.additionalConditionsDetail = this.questions.additionalConditions.detailsError
+    }
+
+    return errors
+  }
+}

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -1373,6 +1373,42 @@
               "type": "string"
             }
           }
+        },
+        "trigger-plan": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "planInPlace": {
+                  "enum": [
+                    "no",
+                    "yes"
+                  ],
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "additionalConditions": {
+                  "enum": [
+                    "no",
+                    "yes"
+                  ],
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "additionalConditionsDetail": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
         }
       }
     },

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -1,5 +1,6 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
+import { addDays } from 'date-fns'
 
 import type { ApprovedPremisesApplication, OASysSection } from '@approved-premises/api'
 
@@ -20,6 +21,14 @@ class ApplicationFactory extends Factory<ApprovedPremisesApplication> {
         },
       },
     })
+  }
+
+  emergencyApplication() {
+    return this.withReleaseDate(DateFormats.dateObjToIsoDate(addDays(new Date(), 1)))
+  }
+
+  nonemergencyApplication() {
+    return this.withReleaseDate(DateFormats.dateObjToIsoDate(addDays(new Date(), 200)))
   }
 
   withOptionalOasysSectionsSelected(needsLinkedToReoffending: Array<OASysSection>, otherNeeds: Array<OASysSection>) {

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -9,6 +9,7 @@ import type { ApTypes } from '../../form-pages/apply/reasons-for-placement/type-
 import personFactory from './person'
 import risksFactory from './risks'
 import { DateFormats } from '../../utils/dateUtils'
+import { PartnerAgencyDetails } from '../../@types/ui'
 
 class ApplicationFactory extends Factory<ApprovedPremisesApplication> {
   withReleaseDate(releaseDate = DateFormats.dateObjToIsoDate(faker.date.soon())) {
@@ -69,6 +70,15 @@ class ApplicationFactory extends Factory<ApprovedPremisesApplication> {
       page: 'release-type',
       key: 'releaseType',
       value: releaseType,
+    })
+  }
+
+  withContingencyPlanPartners(contingencyPlanPartners: Array<PartnerAgencyDetails>) {
+    return this.withPageResponse({
+      task: 'further-considerations',
+      page: 'contingency-plan-partners',
+      key: 'partnerAgencyDetails',
+      value: contingencyPlanPartners,
     })
   }
 

--- a/server/utils/applications/shouldShowTriggerPlanPage.test.ts
+++ b/server/utils/applications/shouldShowTriggerPlanPage.test.ts
@@ -1,0 +1,16 @@
+import applicationFactory from '../../testutils/factories/application'
+import { shouldShowTriggerPlanPages } from './shouldShowTriggerPlanPage'
+
+describe('shouldShowTriggerPlanPage', () => {
+  it('returns true if the application is an emergency application', () => {
+    const application = applicationFactory.emergencyApplication().build()
+
+    expect(shouldShowTriggerPlanPages(application)).toBe(true)
+  })
+
+  it('returns true if the application is an emergency application', () => {
+    const application = applicationFactory.nonemergencyApplication().build()
+
+    expect(shouldShowTriggerPlanPages(application)).toBe(false)
+  })
+})

--- a/server/utils/applications/shouldShowTriggerPlanPage.ts
+++ b/server/utils/applications/shouldShowTriggerPlanPage.ts
@@ -1,0 +1,5 @@
+import { ApprovedPremisesApplication as Application } from '../../@types/shared'
+import { noticeTypeFromApplication } from './noticeTypeFromApplication'
+
+export const shouldShowTriggerPlanPages = (application: Application) =>
+  noticeTypeFromApplication(application) === 'emergency'

--- a/server/views/applications/pages/further-considerations/contingency-plan-questions.njk
+++ b/server/views/applications/pages/further-considerations/contingency-plan-questions.njk
@@ -6,6 +6,24 @@
         {{ page.title }}
     </h1>
 
+    {% if page.contingencyPlanPartnerNames.length > 0%}
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-1">Partner agencies added to application</h3>
+        <dl class="govuk-summary-list">
+            {% for contingencyPlanPartnerName in page.contingencyPlanPartnerNames %}
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Partner agency
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {{contingencyPlanPartnerName}}
+                    </dd>
+
+                </div>
+            {% endfor %}
+        </dl>
+
+    {% endif %}
+
     {% for questionId, question in page.questions %}
         {% if question.hint %}
             {{formPageTextarea({
@@ -29,5 +47,5 @@
             }, fetchContext())
             }}
         {%endif%}
-        {% endfor %}
+    {% endfor %}
     {% endblock %}

--- a/server/views/applications/pages/further-considerations/trigger-plan.njk
+++ b/server/views/applications/pages/further-considerations/trigger-plan.njk
@@ -1,0 +1,36 @@
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+    <h1 class="govuk-heading-l">
+        {{ page.title }}
+    </h1>
+
+    {{ formPageRadios({
+      fieldName: "planInPlace",
+      fieldset: {
+        legend: {
+          text: page.questions.planInPlace.question,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      hint: {
+        text: page.questions.planInPlace.hint
+      },
+      items: [
+        {
+          value: "yes",
+          text: "Yes"
+        },
+        {
+          value: "no",
+          text: "No"
+        }
+      ]
+    }, fetchContext()) }}
+
+    {% set key = 'additionalConditions' %}
+    {% set value = page.questions.additionalConditions.question %}
+    {% include "./../../partials/_yes-no-with-detail.njk" %}
+
+{% endblock %}


### PR DESCRIPTION
# Context
This ticket adds the trigger plan screen to the Apply journey as well as showing a list of Contingency Plan Partners on the Contingency Plan Questions screen which was added in #578
It is worth stating the logic here for when the pages show (copied from Trello). 

### If an application has a :
- Sentence type of “Community Order / SSO”
- Sentence type of “Non-statutory, MAPPA case”
- Release type of “Post Sentence Supervision (PSS)”
- AP Type of ESAP

Then we ask for:
1. [Contingency Plan Partners](https://approved-premises-prototype-main.apps.live.cloud-platform.service.justice.gov.uk/multi-agency-partners);
2. [Contingency Plan Questions](https://approved-premises-prototype-main.apps.live.cloud-platform.service.justice.gov.uk/multi-agency-questions)

### If an application is an emergency application:
Then we ask for:
1. [Contingency Plan Questions](https://approved-premises-prototype-main.apps.live.cloud-platform.service.justice.gov.uk/multi-agency-questions) (without the list of partners)
2. [Trigger Plan and Licence conditions](https://approved-premises-prototype-main.apps.live.cloud-platform.service.justice.gov.uk/emergency-additional-qs)

So it is possible for an application to see all three screens, Contingency Plan Partners and Contingency Plan Questions or Contingency Plan Questions and Trigger Plan Questions but never Contingency Plan Partners and Trigger Plan Questions.

[Trello card](https://trello.com/c/Dpz6zjlr/1246-contingency-screens)

# Changes in this PR

- We add the Trigger plan page 
- We add a util to decide if the Trigger plan page should show (IE if the application is an emergency application)
- Use the util on the contingency plan questions page
- Add the partner agency names to the Partner Agency Questions page as per the mocks
- Update the schema.

It is also notable that the Trigger Plan page doesn't currently have any integration tests as the emergency flow doesn't appear to be tested.

## Screenshots of UI changes
![image](https://user-images.githubusercontent.com/44123869/221646462-551d42f5-a827-4773-81ab-3fcff5abbb55.png)

### Before
![image](https://user-images.githubusercontent.com/44123869/221646377-6fe90ed5-e2c8-48d6-8967-bae432cf5934.png)

### After
![image](https://user-images.githubusercontent.com/44123869/221646293-f6f1c542-9686-4d10-89e6-f881b27b3c2a.png)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
