### PR TITLE
(1290) Fetch non arrival reasons from the reference data endpoint

### DIFF
--- a/cypress_shared/pages/manage/nonarrivalCreate.ts
+++ b/cypress_shared/pages/manage/nonarrivalCreate.ts
@@ -21,6 +21,7 @@ export default class NonarrivalCreatePage extends Page {
     cy.get('input[name="nonArrivalDate-year"]').type(String(date.getFullYear()))
 
     cy.get('input[type="radio"]').last().check()
+    this.checkRadioByNameAndValue('nonArrival[reason]', nonArrival.reason.id)
 
     cy.get('[name="nonArrival[notes]"]').type(nonArrival.notes)
 

--- a/integration_tests/mockApis/nonArrival.ts
+++ b/integration_tests/mockApis/nonArrival.ts
@@ -2,6 +2,7 @@ import { SuperAgentRequest } from 'superagent'
 
 import type { Nonarrival } from '@approved-premises/api'
 
+import { ReferenceData } from '@approved-premises/ui'
 import { getMatchingRequests, stubFor } from '../../wiremock'
 import { errorStub } from '../../wiremock/utils'
 
@@ -27,4 +28,16 @@ export default {
         url: `/premises/${args.premisesId}/bookings/${args.bookingId}/non-arrivals`,
       })
     ).body.requests,
+  stubNonArrivalReasons: (referenceData: Array<ReferenceData>): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/reference-data/non-arrival-reasons`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: referenceData,
+      },
+    }),
 }

--- a/integration_tests/tests/manage/nonarrivals.cy.ts
+++ b/integration_tests/tests/manage/nonarrivals.cy.ts
@@ -4,6 +4,7 @@ import nonArrivalFactory from '../../../server/testutils/factories/nonArrival'
 import { PremisesShowPage } from '../../../cypress_shared/pages/manage'
 import dateCapacityFactory from '../../../server/testutils/factories/dateCapacity'
 import NonarrivalCreatePage from '../../../cypress_shared/pages/manage/nonarrivalCreate'
+import referenceDataFactory from '../../../server/testutils/factories/referenceData'
 
 context('Nonarrivals', () => {
   it('creates a non-arrival', () => {
@@ -11,10 +12,12 @@ context('Nonarrivals', () => {
     cy.signIn()
 
     // And I have a booking for a premises
+    const nonArrivalReasons = referenceDataFactory.buildList(5)
     const premises = premisesFactory.build()
     const bookingId = 'some-uuid'
     const nonArrival = nonArrivalFactory.build({
       date: '2021-11-01',
+      reason: nonArrivalReasons[1],
     })
 
     cy.task('stubSinglePremises', premises)
@@ -23,6 +26,7 @@ context('Nonarrivals', () => {
       premisesId: premises.id,
       dateCapacities: dateCapacityFactory.buildList(5),
     })
+    cy.task('stubNonArrivalReasons', nonArrivalReasons)
 
     // When I mark the booking as having not arrived
     const page = NonarrivalCreatePage.visit(premises.id, bookingId)
@@ -35,7 +39,7 @@ context('Nonarrivals', () => {
 
       expect(requestBody.notes).equal(nonArrival.notes)
       expect(requestBody.date).equal(nonArrival.date)
-      expect(requestBody.reason).equal('recalled')
+      expect(requestBody.reason).equal(nonArrival.reason.id)
     })
 
     // And I should be redirected to the premises page

--- a/server/controllers/manage/nonArrivalsController.test.ts
+++ b/server/controllers/manage/nonArrivalsController.test.ts
@@ -6,6 +6,7 @@ import NonArrivalService from '../../services/nonArrivalService'
 import NonArrivalsController from './nonArrivalsController'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
 import paths from '../../paths/manage'
+import referenceDataFactory from '../../testutils/factories/referenceData'
 
 jest.mock('../../utils/validation')
 
@@ -18,6 +19,12 @@ describe('NonArrivalsController', () => {
 
   const nonArrivalService = createMock<NonArrivalService>({})
   const nonarrivalsController = new NonArrivalsController(nonArrivalService)
+
+  const nonArrivalReasons = referenceDataFactory.buildList(5)
+
+  beforeEach(() => {
+    nonArrivalService.getReasons.mockResolvedValue(nonArrivalReasons)
+  })
 
   describe('new', () => {
     it('renders the form', async () => {
@@ -37,6 +44,7 @@ describe('NonArrivalsController', () => {
         pageHeading: 'Record a non-arrival',
         errors: {},
         errorSummary: [],
+        nonArrivalReasons,
       })
     })
 
@@ -60,6 +68,7 @@ describe('NonArrivalsController', () => {
         pageHeading: 'Record a non-arrival',
         errors: errorsAndUserInput.errors,
         errorSummary: errorsAndUserInput.errorSummary,
+        nonArrivalReasons,
         ...errorsAndUserInput.userInput,
       })
     })

--- a/server/controllers/manage/nonArrivalsController.ts
+++ b/server/controllers/manage/nonArrivalsController.ts
@@ -15,11 +15,14 @@ export default class NonArrivalsController {
       const { premisesId, bookingId } = req.params
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
+      const nonArrivalReasons = await this.nonArrivalService.getReasons(req.user.token)
+
       res.render('nonarrivals/new', {
         premisesId,
         bookingId,
         errors,
         errorSummary,
+        nonArrivalReasons,
         pageHeading: 'Record a non-arrival',
         ...userInput,
       })

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -32,7 +32,7 @@ export const services = () => {
   const personService = new PersonService(personClient)
   const bookingService = new BookingService(bookingClientBuilder)
   const arrivalService = new ArrivalService(bookingClientBuilder)
-  const nonArrivalService = new NonArrivalService(bookingClientBuilder)
+  const nonArrivalService = new NonArrivalService(bookingClientBuilder, referenceDataClientBuilder)
   const departureService = new DepartureService(bookingClientBuilder, referenceDataClientBuilder)
   const cancellationService = new CancellationService(bookingClientBuilder, referenceDataClientBuilder)
   const lostBedService = new LostBedService(lostBedClientBuilder, referenceDataClientBuilder)

--- a/server/services/nonArrivalService.test.ts
+++ b/server/services/nonArrivalService.test.ts
@@ -1,21 +1,26 @@
 import NonarrivalService from './nonArrivalService'
-import BookingClient from '../data/bookingClient'
 import nonArrivalFactory from '../testutils/factories/nonArrival'
 import newNonarrivalFactory from '../testutils/factories/newNonArrival'
+import referenceDataFactory from '../testutils/factories/referenceData'
+import { BookingClient, ReferenceDataClient } from '../data'
 
-jest.mock('../data/bookingClient.ts')
+jest.mock('../data')
 
 describe('NonarrivalService', () => {
   const bookingClient = new BookingClient(null) as jest.Mocked<BookingClient>
-  const bookingClientFactory = jest.fn()
+  const referenceDataClient = new ReferenceDataClient(null) as jest.Mocked<ReferenceDataClient>
 
-  const service = new NonarrivalService(bookingClientFactory)
+  const bookingClientFactory = jest.fn()
+  const referenceDataClientFactory = jest.fn()
+
+  const service = new NonarrivalService(bookingClientFactory, referenceDataClientFactory)
 
   const token = 'SOME_TOKEN'
 
   beforeEach(() => {
     jest.resetAllMocks()
     bookingClientFactory.mockReturnValue(bookingClient)
+    referenceDataClientFactory.mockReturnValue(referenceDataClient)
   })
 
   describe('createNonarrival', () => {
@@ -31,6 +36,20 @@ describe('NonarrivalService', () => {
 
       expect(bookingClientFactory).toHaveBeenCalledWith(token)
       expect(bookingClient.markNonArrival).toHaveBeenCalledWith('premisesID', 'bookingId', payload)
+    })
+  })
+
+  describe('getReasons', () => {
+    it('returns an array of reasons', async () => {
+      const reasons = referenceDataFactory.buildList(5)
+      referenceDataClient.getReferenceData.mockResolvedValue(reasons)
+
+      const result = await service.getReasons(token)
+
+      expect(result).toEqual(reasons)
+
+      expect(referenceDataClientFactory).toHaveBeenCalledWith(token)
+      expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('non-arrival-reasons')
     })
   })
 })

--- a/server/services/nonArrivalService.ts
+++ b/server/services/nonArrivalService.ts
@@ -1,8 +1,11 @@
-import type { NewNonarrival, Nonarrival } from '@approved-premises/api'
-import type { BookingClient, RestClientBuilder } from '../data'
+import type { NewNonarrival, NonArrivalReason, Nonarrival } from '@approved-premises/api'
+import type { BookingClient, ReferenceDataClient, RestClientBuilder } from '../data'
 
 export default class NonarrivalService {
-  constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
+  constructor(
+    private readonly bookingClientFactory: RestClientBuilder<BookingClient>,
+    private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
+  ) {}
 
   async createNonArrival(
     token: string,
@@ -15,5 +18,11 @@ export default class NonarrivalService {
     const confirmedNonArrival = await bookingClient.markNonArrival(premisesId, bookingId, arrival)
 
     return confirmedNonArrival
+  }
+
+  async getReasons(token: string): Promise<Array<NonArrivalReason>> {
+    const referenceDataClient = this.referenceDataClientFactory(token)
+
+    return referenceDataClient.getReferenceData('non-arrival-reasons')
   }
 }

--- a/server/views/nonarrivals/new.njk
+++ b/server/views/nonarrivals/new.njk
@@ -50,16 +50,7 @@
                         }
                     },
                     errorMessage: errors.reason,
-                    items: [
-                        {
-                        value: "absconded",
-                        text: "Absconded"
-                        },
-                        {
-                        value: "recalled",
-                        text: "Recalled"
-                        }
-                    ]
+                    items: convertObjectsToRadioItems(nonArrivalReasons, 'name', 'id', 'nonArrival[reason]')
                     }) }}
 
                 {{ govukTextarea({


### PR DESCRIPTION
This fetches the Non arrival reasons from the newly-created `non-arrival-reasons` reference data endpoint, rather than hardcoding them.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/109774/221870271-5a588bd5-c9b4-433e-87a4-476a9bb68aa1.png)

### After

![image](https://user-images.githubusercontent.com/109774/221870320-4486b50e-7513-4f91-975d-f5788787febc.png)
