### PR TITLE
(1066) Fix - cancellation reason

### DIFF
--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -1,6 +1,6 @@
 import * as nunjucks from 'nunjucks'
 import type { CheckBoxItem, ErrorMessages, RadioItem, SelectOption, SummaryListItem } from '@approved-premises/ui'
-import { sentenceCase } from './utils'
+import { resolvePath, sentenceCase } from './utils'
 import postcodeAreas from '../etc/postcodeAreas.json'
 
 export const dateFieldValues = (fieldName: string, context: Record<string, unknown>, errors: ErrorMessages = {}) => {
@@ -35,7 +35,7 @@ export const convertObjectsToRadioItems = (
     return {
       text: item[textKey],
       value: item[valueKey],
-      checked: context[fieldName] === item[valueKey],
+      checked: resolvePath(context, fieldName) === item[valueKey],
     }
   })
 }

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -11,6 +11,7 @@ import {
   mapApiPersonRisksForUi,
   pascalCase,
   removeBlankSummaryListItems,
+  resolvePath,
   retrieveOptionalQuestionResponseFromApplication,
   retrieveQuestionResponseFromApplication,
 } from './utils'
@@ -341,5 +342,19 @@ describe('linkTo', () => {
     expect(
       linkTo(path('/foo/:id'), { id: '123' }, { text: 'Hello', attributes: { class: 'some-class' } }),
     ).toMatchStringIgnoringWhitespace('<a href="/foo/123" class="some-class">Hello</a>')
+  })
+})
+
+describe('resolvePath', () => {
+  it('returns a property when passed an object and a path', () => {
+    const object = { foo: { bar: 'baz' } }
+    expect(resolvePath(object, 'foo.bar')).toEqual('baz')
+    expect(resolvePath(object, 'foo[bar]')).toEqual('baz')
+  })
+
+  it('returns undefined when passed an object and a path and the property isnt found', () => {
+    const object = { foo: { bar: 'baz' } }
+
+    expect(resolvePath(object, 'foo.baz')).toEqual(undefined)
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -169,3 +169,16 @@ export const linkTo = <Pattern extends `/${string}`>(
 
   return `<a href="${path(params)}" ${attrBody}>${linkBody}</a>`
 }
+
+/**
+ * Returns a value from an object when given a path, the path can be in dot notation or array notation
+ * @param object object to find property in
+ * @param path path to property
+ * @param defaultValue value to return if property is not found
+ * @returns the property value or the default value
+ */
+export const resolvePath = (object: Record<string, unknown>, path: string) =>
+  path
+    .split(/[.[\]'"]/)
+    .filter(p => Boolean(p))
+    .reduce((acc, curr) => (acc ? acc[curr] : undefined), object)

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -18,6 +18,7 @@ import lostBedStubs from './lostBedStubs'
 import personStubs from './personStubs'
 import applicationStubs from './applicationStubs'
 import assessmentStubs from './assessmentStubs'
+import userStubs from './userStubs'
 
 import * as referenceDataStubs from './referenceDataStubs'
 import dateCapacityFactory from '../server/testutils/factories/dateCapacity'
@@ -138,6 +139,7 @@ stubs.push(
   ...personStubs,
   ...applicationStubs,
   ...assessmentStubs,
+  ...userStubs,
   ...Object.values(referenceDataStubs),
 )
 

--- a/wiremock/userStubs.ts
+++ b/wiremock/userStubs.ts
@@ -1,0 +1,19 @@
+import paths from '../server/paths/api'
+import userFactory from '../server/testutils/factories/user'
+
+export default [
+  {
+    priority: 99,
+    request: {
+      method: 'GET',
+      urlPathPattern: paths.users.profile.pattern,
+    },
+    response: {
+      status: 201,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: userFactory.build(),
+    },
+  },
+]


### PR DESCRIPTION
# Context
The screenshot on the ticket shows the input missing. Whilst I couldn't reproduce that bug I did notice that the value of the 'reason' input wasn't be retained on refreshes (IE if you fill in a 'reason' but not the date, when you see the error for missing the date the reason will be gone). 

[Trello](https://trello.com/c/JixgUl9x/1066-cancel-placement-screen-is-missing-reasons-for-cancelling-placement-radios)

# Changes in this PR
- Add a stub for the `/profile` endpoint 
- Add a util to resolve the path to a property in an object 
- Use that function in the `convertObjectsToRadioItems` function


