### PR TITLE
(1247) Set `in_community` release type

### DIFF
--- a/server/@types/shared/index.d.ts
+++ b/server/@types/shared/index.d.ts
@@ -85,6 +85,7 @@ export type { ProbationRegion } from './models/ProbationRegion';
 export type { Problem } from './models/Problem';
 export type { PropertyStatus } from './models/PropertyStatus';
 export type { Reallocation } from './models/Reallocation';
+export type { ReleaseTypeOption } from './models/ReleaseTypeOption';
 export type { RiskEnvelopeStatus } from './models/RiskEnvelopeStatus';
 export type { RiskTier } from './models/RiskTier';
 export type { RiskTierEnvelope } from './models/RiskTierEnvelope';

--- a/server/@types/shared/models/ReleaseTypeOption.ts
+++ b/server/@types/shared/models/ReleaseTypeOption.ts
@@ -1,0 +1,5 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type ReleaseTypeOption = 'licence' | 'rotl' | 'hdc' | 'pss' | 'in_community';

--- a/server/@types/shared/models/SubmitApplication.ts
+++ b/server/@types/shared/models/SubmitApplication.ts
@@ -3,12 +3,13 @@
 /* eslint-disable */
 
 import type { AnyValue } from './AnyValue';
+import type { ReleaseTypeOption } from './ReleaseTypeOption';
 
 export type SubmitApplication = {
     translatedDocument: AnyValue;
-    isPipeApplication?: boolean;
-    isWomensApplication?: boolean;
-    targetLocation?: string;
-    releaseType?: 'licence' | 'rotl' | 'hdc' | 'pss';
+    isPipeApplication: boolean;
+    isWomensApplication: boolean;
+    targetLocation: string;
+    releaseType: ReleaseTypeOption;
 };
 

--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseType.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseType.ts
@@ -1,4 +1,4 @@
-import type { ApprovedPremisesApplication } from '@approved-premises/api'
+import type { ApprovedPremisesApplication, ReleaseTypeOption } from '@approved-premises/api'
 import type { TaskListErrors } from '@approved-premises/ui'
 
 import { SessionDataError } from '../../../../utils/errors'
@@ -7,16 +7,19 @@ import TasklistPage from '../../../tasklistPage'
 import { SentenceTypesT } from './sentenceType'
 import { Page } from '../../../utils/decorators'
 
-const allReleaseTypes = {
+type SelectableReleaseTypes = Exclude<ReleaseTypeOption, 'in_community'>
+type ReleaseTypeOptions = Record<SelectableReleaseTypes, string>
+
+const allReleaseTypes: ReleaseTypeOptions = {
   licence: 'Licence',
   rotl: 'Release on Temporary Licence (ROTL)',
   hdc: 'Home detention curfew (HDC)',
   pss: 'Post Sentence Supervision (PSS)',
 } as const
 
-type AllReleaseTypes = typeof allReleaseTypes
-export type ReleaseTypeID = keyof AllReleaseTypes
-type ReducedReleaseTypes = Pick<AllReleaseTypes, 'rotl' | 'licence'>
+type ReducedReleaseTypeOptions = Pick<ReleaseTypeOptions, 'rotl' | 'licence'>
+type ReducedReleaseTypes = keyof ReducedReleaseTypeOptions
+
 type SentenceType = Extract<
   SentenceTypesT,
   'standardDeterminate' | 'extendedDeterminate' | 'ipp' | 'life' | 'nonStatutory'
@@ -28,10 +31,10 @@ export default class ReleaseType implements TasklistPage {
 
   title = 'What type of release will the application support?'
 
-  releaseTypes: AllReleaseTypes | ReducedReleaseTypes
+  releaseTypes: ReleaseTypeOptions | ReducedReleaseTypeOptions
 
   constructor(
-    readonly body: { releaseType?: ReleaseTypeID | keyof ReducedReleaseTypes },
+    readonly body: { releaseType?: SelectableReleaseTypes | ReducedReleaseTypes },
     readonly application: ApprovedPremisesApplication,
   ) {
     const sessionSentenceType = retrieveQuestionResponseFromApplication<SentenceType>(
@@ -43,7 +46,7 @@ export default class ReleaseType implements TasklistPage {
     this.releaseTypes = this.getReleaseTypes(sessionSentenceType)
 
     this.body = {
-      releaseType: body.releaseType as ReleaseTypeID | keyof ReducedReleaseTypes,
+      releaseType: body.releaseType as SelectableReleaseTypes | ReducedReleaseTypes,
     }
   }
 
@@ -79,7 +82,7 @@ export default class ReleaseType implements TasklistPage {
     })
   }
 
-  getReleaseTypes(sessionReleaseType: SentenceType): AllReleaseTypes | ReducedReleaseTypes {
+  getReleaseTypes(sessionReleaseType: SentenceType): ReleaseTypeOptions | ReducedReleaseTypeOptions {
     if (sessionReleaseType === 'standardDeterminate' || sessionReleaseType === 'nonStatutory') {
       return allReleaseTypes
     }

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -2,9 +2,8 @@ import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { addDays } from 'date-fns'
 
-import type { ApprovedPremisesApplication, OASysSection } from '@approved-premises/api'
+import type { ApprovedPremisesApplication, OASysSection, ReleaseTypeOption } from '@approved-premises/api'
 
-import type { ReleaseTypeID } from '../../form-pages/apply/reasons-for-placement/basic-information/releaseType'
 import type { ApTypes } from '../../form-pages/apply/reasons-for-placement/type-of-ap/apType'
 import personFactory from './person'
 import risksFactory from './risks'
@@ -64,7 +63,7 @@ class ApplicationFactory extends Factory<ApprovedPremisesApplication> {
     })
   }
 
-  withReleaseType(releaseType: ReleaseTypeID) {
+  withReleaseType(releaseType: ReleaseTypeOption) {
     return this.withPageResponse({
       task: 'basic-information',
       page: 'release-type',

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -4,6 +4,7 @@ import { addDays } from 'date-fns'
 
 import type { ApprovedPremisesApplication, OASysSection, ReleaseTypeOption } from '@approved-premises/api'
 
+import { SentenceTypesT } from '../../form-pages/apply/reasons-for-placement/basic-information/sentenceType'
 import type { ApTypes } from '../../form-pages/apply/reasons-for-placement/type-of-ap/apType'
 import personFactory from './person'
 import risksFactory from './risks'
@@ -60,6 +61,15 @@ class ApplicationFactory extends Factory<ApprovedPremisesApplication> {
       page: 'describe-location-factors',
       key: 'postcodeArea',
       value: postcodeArea,
+    })
+  }
+
+  withSentenceType(sentenceType: SentenceTypesT) {
+    return this.withPageResponse({
+      task: 'basic-information',
+      page: 'sentence-type',
+      key: 'sentenceType',
+      value: sentenceType,
     })
   }
 

--- a/server/utils/applications/applicationSubmissionData.test.ts
+++ b/server/utils/applications/applicationSubmissionData.test.ts
@@ -1,11 +1,10 @@
-import type { ReleaseTypeID } from '../../form-pages/apply/reasons-for-placement/basic-information/releaseType'
-
+import { ReleaseTypeOption } from '@approved-premises/api'
 import applicationFactory from '../../testutils/factories/application'
 import { applicationSubmissionData } from './applicationSubmissionData'
 
 describe('applicationSubmissionData', () => {
   const postcodeArea = 'ABC 123'
-  const releaseType = 'license' as ReleaseTypeID
+  const releaseType = 'license' as ReleaseTypeOption
 
   it('returns the correct data for a pipe application', () => {
     const application = applicationFactory

--- a/server/utils/applications/applicationSubmissionData.test.ts
+++ b/server/utils/applications/applicationSubmissionData.test.ts
@@ -10,6 +10,7 @@ describe('applicationSubmissionData', () => {
     const application = applicationFactory
       .withApType('pipe')
       .withPostcodeArea(postcodeArea)
+      .withSentenceType('standardDeterminate')
       .withReleaseType(releaseType)
       .build()
 
@@ -26,6 +27,7 @@ describe('applicationSubmissionData', () => {
     const application = applicationFactory
       .withApType('standard')
       .withPostcodeArea(postcodeArea)
+      .withSentenceType('standardDeterminate')
       .withReleaseType(releaseType)
       .build()
 
@@ -39,13 +41,49 @@ describe('applicationSubmissionData', () => {
   })
 
   it('handles when a release type is missing', () => {
-    const application = applicationFactory.withApType('standard').withPostcodeArea(postcodeArea).build()
+    const application = applicationFactory
+      .withApType('standard')
+      .withSentenceType('standardDeterminate')
+      .withPostcodeArea(postcodeArea)
+      .build()
 
     expect(applicationSubmissionData(application)).toEqual({
       translatedDocument: application.document,
       isPipeApplication: false,
       isWomensApplication: false,
       releaseType: undefined,
+      targetLocation: postcodeArea,
+    })
+  })
+
+  it('returns in_community for a community order application', () => {
+    const application = applicationFactory
+      .withApType('standard')
+      .withPostcodeArea(postcodeArea)
+      .withSentenceType('communityOrder')
+      .build()
+
+    expect(applicationSubmissionData(application)).toEqual({
+      translatedDocument: application.document,
+      isPipeApplication: false,
+      isWomensApplication: false,
+      releaseType: 'in_community',
+      targetLocation: postcodeArea,
+    })
+  })
+
+  it('returns in_community for a bail placement application', () => {
+    const application = applicationFactory
+      .withApType('standard')
+      .withPostcodeArea(postcodeArea)
+      .withSentenceType('bailPlacement')
+      .build()
+
+    expect(applicationSubmissionData(application)).toEqual({
+      translatedDocument: application.document,
+      isPipeApplication: false,
+      isWomensApplication: false,
+      releaseType: 'in_community',
       targetLocation: postcodeArea,
     })
   })

--- a/server/utils/applications/applicationSubmissionData.ts
+++ b/server/utils/applications/applicationSubmissionData.ts
@@ -3,6 +3,7 @@ import type {
   ReleaseTypeOption,
   SubmitApplication,
 } from '@approved-premises/api'
+import { SentenceTypesT } from '../../form-pages/apply/reasons-for-placement/basic-information/sentenceType'
 import type { ApTypes } from '../../form-pages/apply/reasons-for-placement/type-of-ap/apType'
 
 import { retrieveOptionalQuestionResponseFromApplication, retrieveQuestionResponseFromApplication } from '../utils'
@@ -15,12 +16,7 @@ export const applicationSubmissionData = (application: Application): SubmitAppli
     'describe-location-factors',
     'postcodeArea',
   )
-  const releaseType = retrieveOptionalQuestionResponseFromApplication<ReleaseTypeOption>(
-    application,
-    'basic-information',
-    'release-type',
-    'releaseType',
-  )
+  const releaseType = getReleaseType(application)
 
   return {
     translatedDocument: application.document,
@@ -29,4 +25,24 @@ export const applicationSubmissionData = (application: Application): SubmitAppli
     targetLocation,
     releaseType,
   }
+}
+
+const getReleaseType = (application: Application): ReleaseTypeOption => {
+  const sentenceType = retrieveQuestionResponseFromApplication<SentenceTypesT>(
+    application,
+    'basic-information',
+    'sentence-type',
+    'sentenceType',
+  )
+
+  if (sentenceType === 'communityOrder' || sentenceType === 'bailPlacement') {
+    return 'in_community'
+  }
+
+  return retrieveOptionalQuestionResponseFromApplication<ReleaseTypeOption>(
+    application,
+    'basic-information',
+    'release-type',
+    'releaseType',
+  )
 }

--- a/server/utils/applications/applicationSubmissionData.ts
+++ b/server/utils/applications/applicationSubmissionData.ts
@@ -1,5 +1,8 @@
-import type { ApprovedPremisesApplication as Application, SubmitApplication } from '@approved-premises/api'
-import type { ReleaseTypeID } from '../../form-pages/apply/reasons-for-placement/basic-information/releaseType'
+import type {
+  ApprovedPremisesApplication as Application,
+  ReleaseTypeOption,
+  SubmitApplication,
+} from '@approved-premises/api'
 import type { ApTypes } from '../../form-pages/apply/reasons-for-placement/type-of-ap/apType'
 
 import { retrieveOptionalQuestionResponseFromApplication, retrieveQuestionResponseFromApplication } from '../utils'
@@ -12,7 +15,7 @@ export const applicationSubmissionData = (application: Application): SubmitAppli
     'describe-location-factors',
     'postcodeArea',
   )
-  const releaseType = retrieveOptionalQuestionResponseFromApplication<ReleaseTypeID>(
+  const releaseType = retrieveOptionalQuestionResponseFromApplication<ReleaseTypeOption>(
     application,
     'basic-information',
     'release-type',

--- a/server/utils/applications/shouldShowContingencyPlanPages.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.ts
@@ -1,9 +1,8 @@
-import { ApprovedPremisesApplication as Application } from '../../@types/shared'
-import { ReleaseTypeID } from '../../form-pages/apply/reasons-for-placement/basic-information/releaseType'
+import { ApprovedPremisesApplication as Application, ReleaseTypeOption } from '../../@types/shared'
 import { retrieveQuestionResponseFromApplication } from '../utils'
 
 export const shouldShowContingencyPlanPages = (application: Application) => {
-  let releaseType: ReleaseTypeID
+  let releaseType: ReleaseTypeOption
   const sentenceType = retrieveQuestionResponseFromApplication(
     application,
     'basic-information',


### PR DESCRIPTION
If the release type for a person is either a community order or a bail placement, then the person is currently in the community, so we don’t ask what the release type is. In these circumstances, we return a releaseType of `in_community`