### PR TITLE
Point to correct locations for applicationVersion

### DIFF
--- a/server/applicationVersion.ts
+++ b/server/applicationVersion.ts
@@ -2,10 +2,13 @@
 /* istanbul ignore file */
 
 import fs from 'fs'
+import path from 'path'
+
+const buildInfoPath = path.resolve(__dirname, '../build-info.json')
 
 const packageData = JSON.parse(fs.readFileSync('./package.json').toString())
-const { buildNumber, gitRef } = fs.existsSync('./build-info.json')
-  ? JSON.parse(fs.readFileSync('./build-info.json').toString())
+const { buildNumber, gitRef } = fs.existsSync(buildInfoPath)
+  ? JSON.parse(fs.readFileSync('../build-info.json').toString())
   : {
       buildNumber: packageData.version,
       gitRef: 'unknown',


### PR DESCRIPTION
The generated build-info.json and package.json files are in the parent directory.