### PR TITLE
Fetch build info correctly

### DIFF
--- a/server/applicationVersion.ts
+++ b/server/applicationVersion.ts
@@ -2,16 +2,20 @@
 /* istanbul ignore file */
 
 import fs from 'fs'
-import path from 'path'
 
-const buildInfoPath = path.resolve(__dirname, '../build-info.json')
+function getBuild() {
+  try {
+    // eslint-disable-next-line import/no-unresolved,global-require
+    return require('../build-info.json')
+  } catch (ex) {
+    return null
+  }
+}
 
 const packageData = JSON.parse(fs.readFileSync('./package.json').toString())
-const { buildNumber, gitRef } = fs.existsSync(buildInfoPath)
-  ? JSON.parse(fs.readFileSync('../build-info.json').toString())
-  : {
-      buildNumber: packageData.version,
-      gitRef: 'unknown',
-    }
+const { buildNumber, gitRef } = getBuild() || {
+  buildNumber: packageData.version,
+  gitRef: 'unknown',
+}
 
 export default { buildNumber, gitRef, packageData }


### PR DESCRIPTION
The original attempted fix in #588 has broken the deploy. This approach is stolen from [`healthCheck.ts`](https://github.com/ministryofjustice/hmpps-approved-premises-ui/blob/main/server/services/healthCheck.ts), which seems to work fine.