### PR TITLE
Ensure false items don’t get stripped out

### DIFF
--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -210,6 +210,15 @@ context('Apply', () => {
       expect(requests).to.have.length(1)
 
       expect(requests[0].url).to.equal(`/applications/${this.application.id}/submission`)
+
+      const body = JSON.parse(requests[0].body)
+      expect(body).to.have.keys(
+        'translatedDocument',
+        'isPipeApplication',
+        'isWomensApplication',
+        'targetLocation',
+        'releaseType',
+      )
     })
 
     // And I should be taken to the confirmation page

--- a/server/data/restClient.test.ts
+++ b/server/data/restClient.test.ts
@@ -84,13 +84,15 @@ describe('restClient', () => {
   describe('post', () => {
     it('should filter out blank values', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const data = { some: 'data', empty: '', undefinedItem: undefined, nullItem: null } as any
+      const data = { some: 'data', empty: '', undefinedItem: undefined, nullItem: null, falseItem: false } as any
 
-      fakeApprovedPremisesApi.post(`/some/path`, { some: 'data' }).reply(201, { some: 'data' })
+      fakeApprovedPremisesApi
+        .post(`/some/path`, { some: 'data', falseItem: false })
+        .reply(201, { some: 'data', falseItem: false })
 
       const result = await restClient.post({ path: '/some/path', data })
 
-      expect(result).toEqual({ some: 'data' })
+      expect(result).toEqual({ some: 'data', falseItem: false })
       expect(nock.isDone()).toBeTruthy()
     })
   })
@@ -98,13 +100,15 @@ describe('restClient', () => {
   describe('put', () => {
     it('should filter out blank values', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const data = { some: 'data', empty: '', undefinedItem: undefined, nullItem: null } as any
+      const data = { some: 'data', empty: '', undefinedItem: undefined, nullItem: null, falseItem: false } as any
 
-      fakeApprovedPremisesApi.put(`/some/path`, { some: 'data' }).reply(201, { some: 'data' })
+      fakeApprovedPremisesApi
+        .put(`/some/path`, { some: 'data', falseItem: false })
+        .reply(201, { some: 'data', falseItem: false })
 
       const result = await restClient.put({ path: '/some/path', data })
 
-      expect(result).toEqual({ some: 'data' })
+      expect(result).toEqual({ some: 'data', falseItem: false })
       expect(nock.isDone()).toBeTruthy()
     })
   })

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -188,7 +188,7 @@ export default class RestClient {
   }
 
   private filterBlanksFromData(data: Record<string, unknown>): Record<string, unknown> {
-    Object.keys(data).forEach(k => !data[k] && delete data[k])
+    Object.keys(data).forEach(k => typeof data[k] !== 'boolean' && !data[k] && delete data[k])
 
     return data
   }


### PR DESCRIPTION
We have a `filterBlanksFromData` method which strips out any empty variables that are passed to the API. However, this also strips out any literal `false` values, which we do want to send.

This updates the `filterBlanksFromData` helper to check if the item is a literal boolean before checking it is ‘falsy’ (i.e. null, undefined or a blank string). This ensures any literal `false` values are sent to the API as expected.

I’ve also added a check to ensure all the expected keys are passed to the API when submitting an application (where the error was first identified).