### PR TITLE
(1276) Check a CRN is in a user's caseload when searching at the start of an application

### DIFF
--- a/cypress_shared/helpers/apply.ts
+++ b/cypress_shared/helpers/apply.ts
@@ -165,6 +165,7 @@ export default class ApplyHelper {
   private stubPersonEndpoints() {
     cy.task('stubPersonRisks', { person: this.person, risks: this.application.risks })
     cy.task('stubFindPerson', { person: this.person })
+    cy.task('stubFindPersonAndCheckCaseload', { person: this.person })
   }
 
   private stubOffences() {

--- a/cypress_shared/pages/apply/enterCrn.ts
+++ b/cypress_shared/pages/apply/enterCrn.ts
@@ -17,7 +17,7 @@ export default class EnterCRNPage extends Page {
   }
 
   public shouldShowPersonNotInCaseLoadErrorMessage(person: Person): void {
-    cy.get('.govuk-error-summary').should('contain', `${person.crn} is not in your caseload`)
-    cy.get(`[data-cy-error-crn]`).should('contain', `${person.crn} is not in your caseload`)
+    cy.get('.govuk-error-summary').should('contain', `The CRN '${person.crn}' is not in your caseload`)
+    cy.get(`[data-cy-error-crn]`).should('contain', `The CRN '${person.crn}' is not in your caseload`)
   }
 }

--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -29,18 +29,6 @@ export default {
         jsonBody: { ...args.application, data: null },
       },
     }),
-  stubApplicationForUserNotInCaseload: (args: { application: ApprovedPremisesApplication }): SuperAgentRequest =>
-    stubFor({
-      request: {
-        method: 'POST',
-        url: `/applications?createWithRisks=true`,
-      },
-      response: {
-        status: 403,
-        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: { ...args.application, data: null },
-      },
-    }),
   stubApplicationUpdate: (args: { application: ApprovedPremisesApplication }): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -31,6 +31,28 @@ export default {
         jsonBody: args.person,
       },
     }),
+  stubFindPersonAndCheckCaseload: (args: { person: Person }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/people/search?crn=${args.person.crn}&checkCaseload=true`,
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.person,
+      },
+    }),
+  stubFindPersonNotInCaseload: (args: { person: Person }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/people/search?crn=${args.person.crn}&checkCaseload=true`,
+      },
+      response: {
+        status: 403,
+      },
+    }),
   stubPersonNotFound: (args: { person: Person }): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -176,11 +176,17 @@ context('Apply', () => {
 
   it('shows an error message if the person is not in the users caseload', function test() {
     // And the person I am about to search for is not in my caseload
-    const apply = new ApplyHelper(this.application, this.person, this.offences, 'integration')
-    apply.setupApplicationStubs()
-    cy.task('stubApplicationForUserNotInCaseload', { application: this.application })
+    cy.task('stubFindPersonNotInCaseload', { person: this.person })
 
-    apply.startApplication()
+    // And I have started an application
+    const startPage = StartPage.visit()
+    startPage.startApplication()
+
+    // When I enter a CRN
+    const crnPage = new EnterCRNPage()
+    crnPage.enterCrn(this.person.crn)
+    crnPage.clickSubmit()
+
     // Then I should see an error message
     new EnterCRNPage().shouldShowPersonNotInCaseLoadErrorMessage(this.person)
   })

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -6,7 +6,7 @@ import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import TasklistService from '../../services/tasklistService'
 import ApplicationsController, { tasklistPageHeading } from './applicationsController'
 import { ApplicationService, PersonService } from '../../services'
-import { catchAPIErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
+import { fetchErrorsAndUserInput } from '../../utils/validation'
 import personFactory from '../../testutils/factories/person'
 import applicationFactory from '../../testutils/factories/application'
 import activeOffenceFactory from '../../testutils/factories/activeOffence'
@@ -15,7 +15,6 @@ import Apply from '../../form-pages/apply'
 import paths from '../../paths/apply'
 import { DateFormats } from '../../utils/dateUtils'
 import { firstPageOfApplicationJourney, getResponses, isUnapplicable } from '../../utils/applications/utils'
-import { TasklistAPIError } from '../../utils/errors'
 
 jest.mock('../../utils/validation')
 jest.mock('../../utils/applications/utils')
@@ -281,21 +280,6 @@ describe('applicationsController', () => {
       await requestHandler(request, response, next)
 
       expect(request.session.application).toEqual(application)
-    })
-
-    it('renders the CRN lookup page with errors if the API returns a 403', async () => {
-      applicationService.createApplication.mockRejectedValue({ status: 403 })
-
-      const requestHandler = applicationsController.create()
-
-      await requestHandler(request, response, next)
-
-      expect(firstPageOfApplicationJourney).not.toHaveBeenCalled()
-      expect(catchAPIErrorOrPropogate).toHaveBeenCalledWith(
-        request,
-        response,
-        new TasklistAPIError(`This CRN is not in your caseload`, 'crn'),
-      )
     })
   })
 

--- a/server/controllers/peopleController.test.ts
+++ b/server/controllers/peopleController.test.ts
@@ -62,6 +62,28 @@ describe('PeopleController', () => {
       expect(personService.findByCrn).toHaveBeenCalledWith(token, person.crn, true)
     })
 
+    it('send an error to the flash if the error is a 403 and checkCaseload is set', async () => {
+      const err = { status: 403 }
+
+      personService.findByCrn.mockImplementation(() => {
+        throw err
+      })
+
+      const requestHandler = peopleController.find()
+
+      request.body.crn = 'CRN123'
+      request.body.checkCaseload = '1'
+
+      await requestHandler(request, response, next)
+
+      expect(flashSpy).toHaveBeenCalledWith('errors', {
+        crn: errorMessage('crn', "The CRN 'CRN123' is not in your caseload"),
+      })
+      expect(flashSpy).toHaveBeenCalledWith('errorSummary', [
+        errorSummary('crn', "The CRN 'CRN123' is not in your caseload"),
+      ])
+    })
+
     it('sends an error to the flash if a crn has not been provided', async () => {
       request.body = {}
 
@@ -110,6 +132,20 @@ describe('PeopleController', () => {
       request.body.crn = 'SOME_CRN'
 
       expect(async () => requestHandler(request, response, next)).rejects.toThrow(err)
+    })
+
+    it('throws the error if the error is a 403 and checkCaseload is not set', async () => {
+      const requestHandler = peopleController.find()
+
+      const err = { status: 403 }
+
+      personService.findByCrn.mockImplementation(() => {
+        throw err
+      })
+
+      request.body.crn = 'SOME_CRN'
+
+      expect(async () => requestHandler(request, response, next)).rejects.toMatchObject(err)
     })
   })
 })

--- a/server/controllers/peopleController.test.ts
+++ b/server/controllers/peopleController.test.ts
@@ -44,8 +44,22 @@ describe('PeopleController', () => {
       await requestHandler(request, response, next)
 
       expect(response.redirect).toHaveBeenCalledWith('some-referrer/')
-      expect(personService.findByCrn).toHaveBeenCalledWith(token, person.crn)
+      expect(personService.findByCrn).toHaveBeenCalledWith(token, person.crn, false)
       expect(flashSpy).toHaveBeenCalledWith('crn', person.crn)
+    })
+
+    it('should send checkCaseload to the service if it is set', async () => {
+      const person = personFactory.build()
+      personService.findByCrn.mockResolvedValue(person)
+
+      const requestHandler = peopleController.find()
+
+      request.body.crn = person.crn
+      request.body.checkCaseload = '1'
+
+      await requestHandler(request, response, next)
+
+      expect(personService.findByCrn).toHaveBeenCalledWith(token, person.crn, true)
     })
 
     it('sends an error to the flash if a crn has not been provided', async () => {

--- a/server/controllers/peopleController.ts
+++ b/server/controllers/peopleController.ts
@@ -8,11 +8,11 @@ export default class PeopleController {
 
   find(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { crn } = req.body
+      const { crn, checkCaseload } = req.body
 
       if (crn) {
         try {
-          const person = await this.personService.findByCrn(req.user.token, crn)
+          const person = await this.personService.findByCrn(req.user.token, crn, !!checkCaseload)
           req.flash('crn', person.crn)
         } catch (err) {
           if ('data' in err && err.status === 404) {

--- a/server/controllers/peopleController.ts
+++ b/server/controllers/peopleController.ts
@@ -17,6 +17,8 @@ export default class PeopleController {
         } catch (err) {
           if ('data' in err && err.status === 404) {
             this.addErrorMessagesToFlash(req, `No person with an CRN of '${crn}' was found`)
+          } else if (checkCaseload && err.status === 403) {
+            this.addErrorMessagesToFlash(req, `The CRN '${crn}' is not in your caseload`)
           } else {
             throw err
           }

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -47,7 +47,21 @@ describe('PersonClient', () => {
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(201, person)
 
-      const result = await personClient.search('crn')
+      const result = await personClient.search('crn', false)
+
+      expect(result).toEqual(person)
+      expect(nock.isDone()).toBeTruthy()
+    })
+
+    it('should return append checkCaseload if checkCaseload is true', async () => {
+      const person = personFactory.build()
+
+      fakeApprovedPremisesApi
+        .get(`/people/search?crn=crn&checkCaseload=true`)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(201, person)
+
+      const result = await personClient.search('crn', true)
 
       expect(result).toEqual(person)
       expect(nock.isDone()).toBeTruthy()

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -25,9 +25,17 @@ export default class PersonClient {
     this.restClient = new RestClient('personClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
-  async search(crn: string): Promise<Person> {
+  async search(crn: string, checkCaseload: boolean): Promise<Person> {
+    let query = { crn } as Record<string, string | boolean>
+
+    if (checkCaseload) {
+      query = { ...query, checkCaseload: true }
+    }
+    const queryString: string = qs.stringify(query, { encode: false, indices: false })
+
+    const path = `${paths.people.search({})}?${queryString}`
     const response = await this.restClient.get({
-      path: `${paths.people.search({})}?crn=${crn}`,
+      path,
     })
 
     return response as Person

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -39,7 +39,19 @@ describe('PersonService', () => {
       expect(postedPerson).toEqual(person)
 
       expect(personClientFactory).toHaveBeenCalledWith(token)
-      expect(personClient.search).toHaveBeenCalledWith('crn')
+      expect(personClient.search).toHaveBeenCalledWith('crn', false)
+    })
+
+    it('sends the checkCaseload boolean to the client method if set', async () => {
+      const person: Person = PersonFactory.build()
+      personClient.search.mockResolvedValue(person)
+
+      const postedPerson = await service.findByCrn(token, 'crn', true)
+
+      expect(postedPerson).toEqual(person)
+
+      expect(personClientFactory).toHaveBeenCalledWith(token)
+      expect(personClient.search).toHaveBeenCalledWith('crn', true)
     })
   })
 

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -16,10 +16,10 @@ import { mapApiPersonRisksForUi } from '../utils/utils'
 export default class PersonService {
   constructor(private readonly personClientFactory: RestClientBuilder<PersonClient>) {}
 
-  async findByCrn(token: string, crn: string): Promise<Person> {
+  async findByCrn(token: string, crn: string, checkCaseload = false): Promise<Person> {
     const personClient = this.personClientFactory(token)
 
-    const person = await personClient.search(crn)
+    const person = await personClient.search(crn, checkCaseload)
     return person
   }
 

--- a/server/views/applications/new.njk
+++ b/server/views/applications/new.njk
@@ -14,6 +14,7 @@
     <div class="govuk-grid-column-two-thirds">
       <form action="{{ paths.applications.people.find() }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+        <input type="hidden" name="checkCaseload" value="true"/>
 
         {{ showErrorSummary(errorSummary) }}
 


### PR DESCRIPTION
There was originally a check for this after the user confirmed the person's details, but this was not getting caught as the API was returning a 400, not a 403. After some reflection, I decided that this was too late in the flow, and we should be catching this error when searching. 

We've now added a `checkCaseload` option to the person search API endpoint, which returns a 403 if the person is not in the user's caseload. 

This PR optionally adds this flag to the search, catches the 403 and displays an error. It's worth pointing out that we may get a 403 for limited access offenders too, but we can iterate as we go with this.