### PR TITLE
(1265) - Make noms number optional

### DIFF
--- a/cypress_shared/pages/apply/placementStart.ts
+++ b/cypress_shared/pages/apply/placementStart.ts
@@ -1,9 +1,22 @@
 import { ApprovedPremisesApplication } from '@approved-premises/api'
 import ApplyPage from './applyPage'
+import { DateFormats } from '../../../server/utils/dateUtils'
+import { retrieveQuestionResponseFromApplication } from '../../../server/utils/utils'
 
 export default class PlacementStartPage extends ApplyPage {
   constructor(application: ApprovedPremisesApplication) {
-    super(`the date you want the placement to start?`, application, 'basic-information', 'placement-date')
+    const releaseDate = retrieveQuestionResponseFromApplication(
+      application,
+      'basic-information',
+      'releaseDate',
+    ) as string
+
+    super(
+      `Is ${DateFormats.isoDateToUIDate(releaseDate)} the date you want the placement to start?`,
+      application,
+      'basic-information',
+      'placement-date',
+    )
   }
 
   completeForm() {

--- a/server/views/applications/pages/check-your-answers/review.njk
+++ b/server/views/applications/pages/check-your-answers/review.njk
@@ -7,6 +7,9 @@
 {% set pageTitle = applicationName + " - " + page.title %}
 {% set mainClasses = "app-container govuk-body" %}
 
+{% set nomsNumber = page.application.person.nomsNumber if page.application.person.nomsNumber else 
+  "" %}
+
 {% block content %}
   {{ govukBackLink({
       text: "Back",
@@ -55,7 +58,7 @@
                 text: "NOMS Number"
               },
               value: {
-                text: page.application.person.nomsNumber
+                text: nomsNumber
               }
             },
             {

--- a/server/views/assessments/pages/review-application/review.njk
+++ b/server/views/assessments/pages/review-application/review.njk
@@ -5,6 +5,8 @@
 {% extends "../layout.njk" %}
 
 {% set columnClasses= "govuk-grid-column-full" %}
+{% set nomsNumber = page.document.application.person.nomsNumber if page.document.application.person.nomsNumber else 
+  "" %}
 
 {% block questions %}
 
@@ -56,7 +58,7 @@
                 text: "NOMS Number"
               },
               value: {
-                text: page.document.application.person.nomsNumber
+                text: nomsNumber
               }
             },
             {


### PR DESCRIPTION
This PR adds fixes to a couple of more places where not having a number could break things (building on #589). 
It also reinstates part of the Release Date integration test that was removed in #596 