### PR TITLE
(1310) Add a landing page

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -14,6 +14,7 @@ $path: "/assets/images/"
 
 @import './pages/assessments-index'
 @import './pages/applications-pages-attach-document'
+@import './pages/dashboard-index'
 
 @import './local'
 

--- a/assets/sass/pages/_dashboard-index.scss
+++ b/assets/sass/pages/_dashboard-index.scss
@@ -1,0 +1,50 @@
+.dashboard--index {
+  .card-container {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .card-container::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+
+  .card {
+    border: 1px solid govuk-colour("mid-grey");
+    border-bottom-width: 0.5em;
+    flex-basis: 100%;
+    flex-grow: 0;
+    margin-bottom: 2em;
+  }
+
+  @include govuk-media-query($from: tablet, $until: desktop, $media-type: screen) {
+    .card {
+      flex-basis: 48%;
+
+      &:nth-child(2n-1) {
+        margin-right: 1.5%;
+      }
+
+      &:nth-child(2n-2) {
+        margin-left: 1.5%;
+      }
+    }
+  }
+
+  @include govuk-media-query($from: desktop, $media-type: screen) {
+    .card {
+      flex-basis: 31%;
+
+      &:nth-child(3n-1) {
+        margin-left: 3%;
+        margin-right: 3%;
+      }
+    }
+  }
+
+  .card-body {
+    padding: govuk-spacing(3);
+    height: 300px;
+  }
+}

--- a/cypress_shared/helpers/index.ts
+++ b/cypress_shared/helpers/index.ts
@@ -6,6 +6,7 @@ import {
   ArrayOfOASysRiskOfSeriousHarmSummaryQuestions,
   ArrayOfOASysRiskToSelfQuestions,
   ArrayOfOASysSupportingInformationQuestions,
+  UserRole,
 } from '@approved-premises/api'
 import { TableRow } from '@approved-premises/ui'
 import { add } from 'date-fns'
@@ -81,6 +82,11 @@ const updateApplicationReleaseDate = (data: AnyValue) => {
   }
 }
 
+const signInWithRoles = (roles: Array<UserRole>) => {
+  cy.task('stubAuthUser', { roles })
+  cy.signIn()
+}
+
 export {
   roshSummariesFromApplication,
   offenceDetailSummariesFromApplication,
@@ -90,4 +96,5 @@ export {
   tableRowsToArrays,
   updateApplicationReleaseDate,
   shouldShowTableRows,
+  signInWithRoles,
 }

--- a/cypress_shared/pages/dashboard.ts
+++ b/cypress_shared/pages/dashboard.ts
@@ -1,0 +1,20 @@
+import Page from './page'
+
+export default class DashboardPage extends Page {
+  constructor() {
+    super('Approved Premises')
+  }
+
+  static visit(): DashboardPage {
+    cy.visit('/')
+    return new DashboardPage()
+  }
+
+  shouldShowCard(service: string) {
+    cy.get(`[data-cy-card-service="${service}"]`).should('exist')
+  }
+
+  shouldNotShowCard(service: string) {
+    cy.get(`[data-cy-card-service="${service}"]`).should('not.exist')
+  }
+}

--- a/integration_tests/tests/dashboard.cy.ts
+++ b/integration_tests/tests/dashboard.cy.ts
@@ -1,0 +1,52 @@
+import { signInWithRoles } from '../../cypress_shared/helpers'
+import DashboardPage from '../../cypress_shared/pages/dashboard'
+
+context('Dashboard', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+  })
+
+  it('displays all services when a user has all roles', () => {
+    signInWithRoles(['assessor', 'applicant', 'manager'])
+
+    const dashboardPage = DashboardPage.visit()
+
+    dashboardPage.shouldShowCard('apply')
+    dashboardPage.shouldShowCard('assess')
+    dashboardPage.shouldShowCard('manage')
+  })
+
+  it('only displays the assess service to assessors', () => {
+    signInWithRoles(['assessor'])
+
+    const dashboardPage = DashboardPage.visit()
+
+    dashboardPage.shouldShowCard('assess')
+
+    dashboardPage.shouldNotShowCard('apply')
+    dashboardPage.shouldNotShowCard('manage')
+  })
+
+  it('only displays the apply service to applicants', () => {
+    signInWithRoles(['applicant'])
+
+    const dashboardPage = DashboardPage.visit()
+
+    dashboardPage.shouldShowCard('apply')
+
+    dashboardPage.shouldNotShowCard('assess')
+    dashboardPage.shouldNotShowCard('manage')
+  })
+
+  it('only displays the manage service to managers', () => {
+    signInWithRoles(['manager'])
+
+    const dashboardPage = DashboardPage.visit()
+
+    dashboardPage.shouldShowCard('manage')
+
+    dashboardPage.shouldNotShowCard('apply')
+    dashboardPage.shouldNotShowCard('assess')
+  })
+})

--- a/server/controllers/dashboardController.test.ts
+++ b/server/controllers/dashboardController.test.ts
@@ -2,7 +2,6 @@ import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
 import DashboardController from './dashboardController'
-import paths from '../paths/manage'
 
 describe('DashboardController', () => {
   const request: DeepMocked<Request> = createMock<Request>({})
@@ -21,7 +20,7 @@ describe('DashboardController', () => {
 
       requestHandler(request, response, next)
 
-      expect(response.redirect).toHaveBeenCalledWith(paths.premises.index({}))
+      expect(response.render).toHaveBeenCalledWith('dashboard/index', { pageHeading: 'Approved Premises' })
     })
   })
 })

--- a/server/controllers/dashboardController.test.ts
+++ b/server/controllers/dashboardController.test.ts
@@ -1,22 +1,22 @@
 import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
-import ApplicationController from './applicationController'
+import DashboardController from './dashboardController'
 import paths from '../paths/manage'
 
-describe('ApplicationController', () => {
+describe('DashboardController', () => {
   const request: DeepMocked<Request> = createMock<Request>({})
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
-  let applicationController: ApplicationController
+  let applicationController: DashboardController
 
   beforeEach(() => {
-    applicationController = new ApplicationController()
+    applicationController = new DashboardController()
   })
 
   describe('index', () => {
-    it('should redirect to /premises', () => {
+    it('should render the dashboard template', () => {
       const requestHandler = applicationController.index()
 
       requestHandler(request, response, next)

--- a/server/controllers/dashboardController.ts
+++ b/server/controllers/dashboardController.ts
@@ -1,7 +1,7 @@
 import type { Request, RequestHandler, Response } from 'express'
 import paths from '../paths/manage'
 
-export default class ApplicationController {
+export default class DashboardController {
   index(): RequestHandler {
     return (_req: Request, res: Response) => {
       res.redirect(paths.premises.index({}))

--- a/server/controllers/dashboardController.ts
+++ b/server/controllers/dashboardController.ts
@@ -1,10 +1,9 @@
 import type { Request, RequestHandler, Response } from 'express'
-import paths from '../paths/manage'
 
 export default class DashboardController {
   index(): RequestHandler {
     return (_req: Request, res: Response) => {
-      res.redirect(paths.premises.index({}))
+      res.render('dashboard/index', { pageHeading: 'Approved Premises' })
     }
   }
 }

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -1,17 +1,17 @@
 /* istanbul ignore file */
 
-import ApplicationController from './applicationController'
 import { controllers as manageControllers } from './manage'
 import { controllers as applyControllers } from './apply'
 import { controllers as assessControllers } from './assess'
 
 import type { Services } from '../services'
+import DashboardController from './dashboardController'
 
 export const controllers = (services: Services) => {
-  const applicationController = new ApplicationController()
+  const dashboardController = new DashboardController()
 
   return {
-    applicationController,
+    dashboardController,
     ...manageControllers(services),
     ...applyControllers(services),
     ...assessControllers(services),

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -12,11 +12,11 @@ import assessRoutes from './assess'
 export default function routes(controllers: Controllers): Router {
   const router = Router()
 
-  const { applicationController } = controllers
+  const { dashboardController } = controllers
 
   const { get } = actions(router)
 
-  get('/', applicationController.index())
+  get('/', dashboardController.index())
 
   manageRoutes(controllers, router)
   applyRoutes(controllers, router)

--- a/server/views/dashboard/index.njk
+++ b/server/views/dashboard/index.njk
@@ -1,0 +1,50 @@
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName %}
+{% set mainClasses = "app-container govuk-body" %}
+{% set bodyClasses = "dashboard--index" %}
+
+{% block content %}
+
+  {% include "../_messages.njk" %}
+
+  <h1>{{ pageHeading }}</h1>
+
+  <div class="card-container">
+
+    {% if 'assessor' in user.roles %}
+      <div class="card" data-cy-card-service="assess">
+        <div class="card-body">
+          <h2 class="govuk-heading-s">
+            <a class="govuk-link" href="{{ paths.assessments.index({}) }}">Assess Approved Premises applications</a>
+          </h2>
+          <p class="govuk-body">Assess applications for placements in an Approved Premises</p>
+        </div>
+      </div>
+    {% endif %}
+
+    {% if 'applicant' in user.roles %}
+      <div class="card" data-cy-card-service="apply">
+        <div class="card-body">
+          <h2 class="govuk-heading-s">
+            <a class="govuk-link" href="{{ paths.applications.index({}) }}">Apply for an Approved Premises placement</a>
+          </h2>
+          <p class="govuk-body">Apply for a placement in an Approved Premises on behalf of a person on probation/in custody.</p>
+        </div>
+      </div>
+    {% endif %}
+
+    {% if 'manager' in user.roles %}
+      <div class="card" data-cy-card-service="manage">
+        <div class="card-body">
+          <h2 class="govuk-heading-s">
+            <a class="govuk-link" href="{{ paths.premises.index({}) }}">Manage an Approved Premises</a>
+          </h2>
+          <p class="govuk-body">Manage occupancy at an Approved Premises</p>
+        </div>
+      </div>
+    {% endif %}
+
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
This adds a dashboard / landing page, which is the first thing the user sees after logging in ([cribbed in part from CAS3](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/69)). They will see different links depending on what they have access to. We could be smarter by redirecting a user to one service if they can only access that one service, but that can come later. 

It has also raised the issue that at the moment, we don't control access by role. This should be something we address as some point before golive

![image](https://user-images.githubusercontent.com/109774/223410750-59b3dbc1-9ddc-4895-9282-4548a305d9c7.png)
