### PR TITLE
Use GITHUB_TOKEN to open PRs

### DIFF
--- a/.github/workflows/generate-types.yml
+++ b/.github/workflows/generate-types.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
-          token: ${{ secrets.OPEN_PR_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           title: 'API model updates'
           commit-message: 'Updating hmpps-approved-premises-api models from OpenAPI specification'
           body: 'Updating hmpps-approved-premises-api models from OpenAPI specification.  This PR was created automatically from the generate-types.yml Workflow'


### PR DESCRIPTION
Rather than using `secrets.OPEN_PR_ACCESS_TOKEN`, which is tied to one of our personal accounts, we can use the included `secrets.GITHUB_TOKEN` secret, which opens the PR as a bot user, meaning we don’t have to keep updating the token whenever it expires, and also so everyone can review the resulting PR.

The token is a one-time-only token too, and has quite wide-ranging permissions, so we use the `permissions` argument to restrict the permissions allowed.