### PR TITLE
Fix E2E tests for Apply and Manage

### DIFF
--- a/cypress.config.e2e.ts
+++ b/cypress.config.e2e.ts
@@ -37,5 +37,5 @@ export default defineConfig({
     supportFile: false,
   },
   viewportHeight: 3000,
-  viewportWidth: 660,
+  viewportWidth: 1000,
 })

--- a/cypress_shared/helpers/apply.ts
+++ b/cypress_shared/helpers/apply.ts
@@ -14,6 +14,7 @@ import {
   PrisonCaseNote,
 } from '@approved-premises/api'
 import { ContingencyPlanQuestionsBody, PartnerAgencyDetails, PersonRisksUI } from '@approved-premises/ui'
+
 import * as ApplyPages from '../pages/apply'
 import {
   offenceDetailSummariesFromApplication,
@@ -87,9 +88,8 @@ export default class ApplyHelper {
     private readonly type: 'e2e' | 'integration',
   ) {}
 
-  initializeE2e(oasysSectionsLinkedToReoffending: Array<OASysSection>, otherOasysSections: Array<OASysSection>) {
-    this.oasysSectionsLinkedToReoffending = oasysSectionsLinkedToReoffending
-    this.otherOasysSections = otherOasysSections
+  initializeE2e() {
+    this.addContingencyPlanDetails()
   }
 
   setupApplicationStubs(uiRisks?: PersonRisksUI) {
@@ -160,9 +160,7 @@ export default class ApplyHelper {
       ...this.pages.locationFactors,
       ...this.pages.accessAndHealthcare,
       ...this.pages.furtherConsiderations,
-      // we submit the contingency plan partners page 3x (2x adding partners, 1x submitting)
-      ...this.pages.contingencyPlanPartners,
-      ...this.pages.contingencyPlanPartners,
+      ...this.contingencyPlanPartners,
       ...this.pages.contingencyPlanPartners,
       ...this.pages.moveOn,
       ...this.selectedDocuments,
@@ -362,6 +360,7 @@ export default class ApplyHelper {
         roleInPlan: 'Test role 2',
       }),
     ]
+
     this.contingencyPlanQuestions = contingencyPlanQuestionsFactory.build({
       noReturn: 'Action to be taken',
       placementWithdrawn: 'Further action to be taken',

--- a/cypress_shared/pages/manage/lostBedCreate.ts
+++ b/cypress_shared/pages/manage/lostBedCreate.ts
@@ -17,6 +17,8 @@ export default class LostBedCreatePage extends Page {
     const startDate = new Date(Date.parse(lostBed.startDate))
     const endDate = new Date(Date.parse(lostBed.endDate))
 
+    cy.get('input[name="lostBed[numberOfBeds]"]').type(String(lostBed.numberOfBeds))
+
     cy.get('input[name="startDate-day"]').type(String(startDate.getDate()))
     cy.get('input[name="startDate-month"]').type(String(startDate.getMonth() + 1))
     cy.get('input[name="startDate-year"]').type(String(startDate.getFullYear()))

--- a/e2e/tests/stepDefinitions/apply.ts
+++ b/e2e/tests/stepDefinitions/apply.ts
@@ -23,6 +23,7 @@ Given('I fill in and complete an application', () => {
     application.id = id
 
     const apply = new ApplyHelper(application, person, [], 'e2e')
+    apply.initializeE2e()
 
     apply.completeApplication(true)
   })

--- a/script/local_e2e
+++ b/script/local_e2e
@@ -20,4 +20,4 @@ set -a
 
 set +a
 
-npx cypress open -C cypress.config.e2e.ts --config '{"baseUrl":"http://localhost:3000"}'
+npx cypress open --e2e --browser chrome -C cypress.config.e2e.ts --config '{"baseUrl":"http://localhost:3000"}'

--- a/server/controllers/manage/lostBedsController.test.ts
+++ b/server/controllers/manage/lostBedsController.test.ts
@@ -91,12 +91,14 @@ describe('LostBedsController', () => {
         notes: lostBed.notes,
         reason: lostBed.reason,
         referenceNumber: lostBed.referenceNumber,
+        numberOfBeds: lostBed.numberOfBeds,
       }
 
       await requestHandler(request, response, next)
 
       expect(lostBedService.createLostBed).toHaveBeenCalledWith(token, request.params.premisesId, {
         ...request.body.lostBed,
+        numberOfBeds: Number(lostBed.numberOfBeds),
         startDate: '2022-08-22',
         endDate: '2022-09-22',
       })

--- a/server/controllers/manage/lostBedsController.ts
+++ b/server/controllers/manage/lostBedsController.ts
@@ -32,8 +32,9 @@ export default class LostBedsController {
 
       const { startDate } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'startDate')
       const { endDate } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'endDate')
+      const numberOfBeds = Number(req.body.numberOfBeds)
 
-      const lostBed: NewLostBed = { ...req.body.lostBed, startDate, endDate }
+      const lostBed: NewLostBed = { ...req.body.lostBed, startDate, endDate, numberOfBeds }
 
       try {
         await this.lostBedService.createLostBed(req.user.token, premisesId, lostBed)

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -68,7 +68,7 @@ export const sentenceCase = (string: string) => Case.sentence(string)
 export const lowerCase = (string: string) => Case.lower(string)
 
 /**
- * Retrieves response for a given question from the application object.
+ * Retrieves response for a given question from the application object or throws an error if it does not exist.
  * @param application the application to fetch the response from.
  * @param task the task to retrieve the response for.
  * @param page the page that we need the response for in camelCase.
@@ -88,6 +88,14 @@ export const retrieveQuestionResponseFromApplication = <T>(
   }
 }
 
+/**
+ * Retrieves response for a given question from the application object or returns undefined if it does not exist.
+ * @param application the application to fetch the response from.
+ * @param task the task to retrieve the response for.
+ * @param page the page that we need the response for in camelCase.
+ * @param {string} question [question=page] the page that we need the response for. Defaults to the value of `page`.
+ * @returns the response for the given task/page/question.
+ */
 export const retrieveOptionalQuestionResponseFromApplication = <T>(
   application: ApprovedPremisesApplication,
   task: string,

--- a/server/views/applications/pages/oasys-import/optional-oasys-sections.njk
+++ b/server/views/applications/pages/oasys-import/optional-oasys-sections.njk
@@ -23,7 +23,8 @@
 
     <h2 class="govuk-heading-s">Needs linked to risk of serious harm are automatically imported</h2>
 
-    {{
+    {% if page.allNeedsLinkedToReoffending.length %}
+        {{
         govukCheckboxes({
             idPrefix: "needsLinkedToReoffending",
             name: "needsLinkedToReoffending",
@@ -37,8 +38,10 @@
             items: OasysImportUtils.sectionCheckBoxes(page.allNeedsLinkedToReoffending, page.body.needsLinkedToReoffending)
         })
     }}
+    {% endif %}
 
-    {{
+    {% if page.allOtherNeeds.length %}
+        {{
         govukCheckboxes({
             idPrefix: "otherNeeds",
             name: "otherNeeds",
@@ -52,5 +55,7 @@
             items: OasysImportUtils.sectionCheckBoxes(page.allOtherNeeds, page.body.otherNeeds)
         })
     }}
+
+    {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
This tidies up some of the testing for the Partner Agency page and makes sure we submit the number of lost beds in the correct format. 
 
There are also some other miscelaneous fixes/improvements in the PR