### PR TITLE
Update type generation action to use an app

### DIFF
--- a/.github/workflows/generate-types.yml
+++ b/.github/workflows/generate-types.yml
@@ -12,6 +12,12 @@ jobs:
   generate-types:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate Token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Check out code
         uses: actions/checkout@v3
       - name: Generate Types
@@ -19,7 +25,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
-          token: ${{ secrets.OPEN_PR_ACCESS_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           title: 'API model updates'
           commit-message: 'Updating hmpps-approved-premises-api models from OpenAPI specification'
           body: 'Updating hmpps-approved-premises-api models from OpenAPI specification.  This PR was created automatically from the generate-types.yml Workflow'


### PR DESCRIPTION
This updates the Type Generation action to use a Github App, as outlined here:

https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens

This uses the app to generate a one-time usage token, which is more broad than the included `GITHUB_TOKEN`, so when the PR opens, the CI gets run.