### PR TITLE
Fix - E2E tests

### DIFF
--- a/cypress.config.e2e.ts
+++ b/cypress.config.e2e.ts
@@ -36,6 +36,6 @@ export default defineConfig({
     setupNodeEvents,
     supportFile: false,
   },
-  viewportHeight: 3000,
+  viewportHeight: 1500,
   viewportWidth: 1000,
 })

--- a/server/controllers/manage/lostBedsController.test.ts
+++ b/server/controllers/manage/lostBedsController.test.ts
@@ -101,6 +101,7 @@ describe('LostBedsController', () => {
         numberOfBeds: Number(lostBed.numberOfBeds),
         startDate: '2022-08-22',
         endDate: '2022-09-22',
+        serviceName: 'approved-premises',
       })
       expect(request.flash).toHaveBeenCalledWith('success', 'Lost bed logged')
       expect(response.redirect).toHaveBeenCalledWith(paths.premises.show({ premisesId: request.params.premisesId }))

--- a/server/controllers/manage/lostBedsController.ts
+++ b/server/controllers/manage/lostBedsController.ts
@@ -32,9 +32,13 @@ export default class LostBedsController {
 
       const { startDate } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'startDate')
       const { endDate } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'endDate')
-      const numberOfBeds = Number(req.body.numberOfBeds)
 
-      const lostBed: NewLostBed = { ...req.body.lostBed, startDate, endDate, numberOfBeds }
+      const lostBed: NewLostBed = {
+        ...req.body.lostBed,
+        startDate,
+        endDate,
+        numberOfBeds: req.body.numberOfBeds ? Number(req.body.numberOfBeds) : undefined,
+      }
 
       try {
         await this.lostBedService.createLostBed(req.user.token, premisesId, lostBed)

--- a/server/controllers/manage/lostBedsController.ts
+++ b/server/controllers/manage/lostBedsController.ts
@@ -38,6 +38,7 @@ export default class LostBedsController {
         startDate,
         endDate,
         numberOfBeds: req.body.numberOfBeds ? Number(req.body.numberOfBeds) : undefined,
+        serviceName: 'approved-premises',
       }
 
       try {

--- a/server/testutils/factories/newLostBed.ts
+++ b/server/testutils/factories/newLostBed.ts
@@ -19,7 +19,7 @@ export default Factory.define<NewLostBed>(() => {
     'endDate-day': endDate.getDate().toString(),
     'endDate-month': endDate.getMonth().toString(),
     'endDate-year': endDate.getFullYear().toString(),
-    numberOfBeds: faker.datatype.number({ max: 10 }),
+    numberOfBeds: faker.datatype.number({ max: 10 }).toString(),
     referenceNumber: faker.datatype.uuid(),
     reason: referenceDataFactory.lostBedReasons().build().id,
     serviceName: 'approved-premises',


### PR DESCRIPTION
Following on from #606 this PR fixes some further E2E test breakages. 

We were previously passing `NaN` to the API if a `numberOfBeds` is not supplied. 
Also we need to pass a service name to the lost bed endpoint otherwise it errors. This is being addressed in the API but it may take a while.