### PR TITLE
1249 - Add a 'Rejected'/'Suitable' tag if an Assessment has been completed

### DIFF
--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -194,10 +194,18 @@ describe('utils', () => {
       expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag--blue">In progress</strong>')
     })
 
-    it('returns Completed for a completed assessment', () => {
-      const assessment = assessmentFactory.build({ status: 'completed' })
+    describe('completed assessments', () => {
+      it('returns "suitable" for an approved assessment assessment', () => {
+        const assessment = assessmentFactory.build({ status: 'completed', decision: 'accepted' })
 
-      expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag">Completed</strong>')
+        expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag--green">Suitable</strong>')
+      })
+
+      it('returns "rejected" for an approved assessment assessment', () => {
+        const assessment = assessmentFactory.build({ status: 'completed', decision: 'rejected' })
+
+        expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag--red">Rejected</strong>')
+      })
     })
   })
 

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -334,7 +334,8 @@ const daysUntilDue = (assessment: Assessment): number => {
 
 const getStatus = (assessment: Assessment): string => {
   if (assessment.status === 'completed') {
-    return `<strong class="govuk-tag govuk-tag">Completed</strong>`
+    if (assessment.decision === 'accepted') return `<strong class="govuk-tag govuk-tag--green">Suitable</strong>`
+    if (assessment.decision === 'rejected') return `<strong class="govuk-tag govuk-tag--red">Rejected</strong>`
   }
 
   if (assessment.data) {


### PR DESCRIPTION
# Context
PPs would like to be able to see if an assessment has been accepted or rejected rather than simply 'completed'

# Changes in this PR
If an assessment has been completed we check if it has a status of 'accepted' or 'rejected' and return the most suitable tag.

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/44123869/223753710-18c5fc2c-27af-4400-add5-c31f7c0db510.png)

### After
![Assess -- shows a list of assessments](https://user-images.githubusercontent.com/44123869/223755820-39512303-a15e-4698-a4be-8bcc9c60e4a1.png)
ts of UI changes

