### PR TITLE
Update to jQuery UI 1.13.2

### DIFF
--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -11,11 +11,11 @@
   <![endif]-->
 
   <script src="/assets/js/jquery.min.js"></script>
-  <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"
-          integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU="
+  <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"
+          integrity="sha256-lSjKY0/srUM9BE3dPm+c4fBo1dky2v27Gdjm2uoZaL0="
           nonce="{{ cspNonce }}"
           crossorigin="anonymous"></script>
-  <link href="https://code.jquery.com/ui/1.12.1/themes/ui-lightness/jquery-ui.css" rel="stylesheet" nonce="{{ cspNonce }}" crossorigin>
+  <link href="https://code.jquery.com/ui/1.13.2/themes/ui-lightness/jquery-ui.css" rel="stylesheet" nonce="{{ cspNonce }}" crossorigin>
 
 {% endblock %}
 


### PR DESCRIPTION
Updating jQuery as recommended follow pen testing. There appear to be no significant breaking changes between 1.12 and 1.13