### PR TITLE
Ensure numberOfBeds is sent to the API

### DIFF
--- a/integration_tests/tests/manage/lostBed.cy.ts
+++ b/integration_tests/tests/manage/lostBed.cy.ts
@@ -50,6 +50,7 @@ context('LostBed', () => {
       expect(requestBody.notes).equal(lostBed.notes)
       expect(requestBody.reason).equal(lostBed.reason.id)
       expect(requestBody.referenceNumber).equal(lostBed.referenceNumber)
+      expect(requestBody.numberOfBeds).equal(lostBed.numberOfBeds)
     })
 
     // And I should be navigated to the premises detail page and see the confirmation message

--- a/server/controllers/manage/lostBedsController.test.ts
+++ b/server/controllers/manage/lostBedsController.test.ts
@@ -88,10 +88,7 @@ describe('LostBedsController', () => {
         'endDate-year': 2022,
         'endDate-month': 9,
         'endDate-day': 22,
-        notes: lostBed.notes,
-        reason: lostBed.reason,
-        referenceNumber: lostBed.referenceNumber,
-        numberOfBeds: lostBed.numberOfBeds,
+        lostBed,
       }
 
       await requestHandler(request, response, next)

--- a/server/controllers/manage/lostBedsController.ts
+++ b/server/controllers/manage/lostBedsController.ts
@@ -37,7 +37,7 @@ export default class LostBedsController {
         ...req.body.lostBed,
         startDate,
         endDate,
-        numberOfBeds: req.body.numberOfBeds ? Number(req.body.numberOfBeds) : undefined,
+        numberOfBeds: req.body.lostBed?.numberOfBeds ? Number(req.body.lostBed.numberOfBeds) : undefined,
         serviceName: 'approved-premises',
       }
 


### PR DESCRIPTION
The code here mistakenly assumed the value for numberOfBeds a first-class entitity in the body. There was also an expectation missing in the integration tests, so this slipped through.