### PR TITLE
Show the Apply service to all users

### DIFF
--- a/integration_tests/tests/dashboard.cy.ts
+++ b/integration_tests/tests/dashboard.cy.ts
@@ -8,7 +8,7 @@ context('Dashboard', () => {
   })
 
   it('displays all services when a user has all roles', () => {
-    signInWithRoles(['assessor', 'applicant', 'manager'])
+    signInWithRoles(['assessor', 'manager'])
 
     const dashboardPage = DashboardPage.visit()
 
@@ -17,19 +17,19 @@ context('Dashboard', () => {
     dashboardPage.shouldShowCard('manage')
   })
 
-  it('only displays the assess service to assessors', () => {
+  it('only displays the apply and assess services to assessors', () => {
     signInWithRoles(['assessor'])
 
     const dashboardPage = DashboardPage.visit()
 
+    dashboardPage.shouldShowCard('apply')
     dashboardPage.shouldShowCard('assess')
 
-    dashboardPage.shouldNotShowCard('apply')
     dashboardPage.shouldNotShowCard('manage')
   })
 
-  it('only displays the apply service to applicants', () => {
-    signInWithRoles(['applicant'])
+  it('only displays the apply service when someone has no roles', () => {
+    signInWithRoles([])
 
     const dashboardPage = DashboardPage.visit()
 
@@ -39,14 +39,14 @@ context('Dashboard', () => {
     dashboardPage.shouldNotShowCard('manage')
   })
 
-  it('only displays the manage service to managers', () => {
+  it('only displays the apply and manage services to managers', () => {
     signInWithRoles(['manager'])
 
     const dashboardPage = DashboardPage.visit()
 
     dashboardPage.shouldShowCard('manage')
+    dashboardPage.shouldShowCard('apply')
 
-    dashboardPage.shouldNotShowCard('apply')
     dashboardPage.shouldNotShowCard('assess')
   })
 })

--- a/server/views/dashboard/index.njk
+++ b/server/views/dashboard/index.njk
@@ -11,6 +11,14 @@
   <h1>{{ pageHeading }}</h1>
 
   <div class="card-container">
+    <div class="card" data-cy-card-service="apply">
+      <div class="card-body">
+        <h2 class="govuk-heading-s">
+          <a class="govuk-link" href="{{ paths.applications.index({}) }}">Apply for an Approved Premises placement</a>
+        </h2>
+        <p class="govuk-body">Apply for a placement in an Approved Premises on behalf of a person on probation/in custody.</p>
+      </div>
+    </div>
 
     {% if 'assessor' in user.roles %}
       <div class="card" data-cy-card-service="assess">
@@ -19,17 +27,6 @@
             <a class="govuk-link" href="{{ paths.assessments.index({}) }}">Assess Approved Premises applications</a>
           </h2>
           <p class="govuk-body">Assess applications for placements in an Approved Premises</p>
-        </div>
-      </div>
-    {% endif %}
-
-    {% if 'applicant' in user.roles %}
-      <div class="card" data-cy-card-service="apply">
-        <div class="card-body">
-          <h2 class="govuk-heading-s">
-            <a class="govuk-link" href="{{ paths.applications.index({}) }}">Apply for an Approved Premises placement</a>
-          </h2>
-          <p class="govuk-body">Apply for a placement in an Approved Premises on behalf of a person on probation/in custody.</p>
         </div>
       </div>
     {% endif %}


### PR DESCRIPTION
The “Applicant” role does not exist, so we should show the Apply service in all cases. Users will be limited to what offenders they can make an application for by virtue of who is in their caseload.