### PR TITLE
(1316) List tasks to a workflow manager

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -14,6 +14,7 @@ import person from './integration_tests/mockApis/person'
 import applications from './integration_tests/mockApis/applications'
 import assessments from './integration_tests/mockApis/assessments'
 import users from './integration_tests/mockApis/users'
+import tasks from './integration_tests/mockApis/tasks'
 
 import schemaValidator from './integration_tests/tasks/schemaValidator'
 
@@ -49,6 +50,7 @@ export default defineConfig({
         ...schemaValidator,
         ...assessments,
         ...users,
+        ...tasks,
       })
     },
     baseUrl: 'http://localhost:3007',

--- a/cypress_shared/pages/tasks/listPage.ts
+++ b/cypress_shared/pages/tasks/listPage.ts
@@ -1,0 +1,29 @@
+import Page from '../page'
+import paths from '../../../server/paths/tasks'
+
+import { allocatedTableRows, unallocatedTableRows } from '../../../server/utils/tasks/table'
+
+import { Task } from '../../../server/@types/shared'
+import { shouldShowTableRows } from '../../helpers'
+
+export default class ListPage extends Page {
+  constructor(private readonly allocatedTasks: Array<Task>, private readonly unallocatedTasks: Array<Task>) {
+    super('Tasks')
+    this.allocatedTasks = allocatedTasks
+    this.unallocatedTasks = unallocatedTasks
+  }
+
+  static visit(allocatedTasks: Array<Task>, unallocatedTasks: Array<Task>): ListPage {
+    cy.visit(paths.index({}))
+    return new ListPage(allocatedTasks, unallocatedTasks)
+  }
+
+  shouldShowAllocatedTasks(): void {
+    shouldShowTableRows(this.allocatedTasks, allocatedTableRows)
+  }
+
+  shouldShowUnallocatedTasks(): void {
+    cy.get('a').contains('Unallocated').click()
+    shouldShowTableRows(this.unallocatedTasks, unallocatedTableRows)
+  }
+}

--- a/integration_tests/mockApis/tasks.ts
+++ b/integration_tests/mockApis/tasks.ts
@@ -1,0 +1,22 @@
+import type { Task } from '@approved-premises/api'
+
+import { stubFor } from '../../wiremock'
+
+import paths from '../../server/paths/api'
+
+const stubTasks = (tasks: Array<Task>) =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: paths.tasks.index.pattern,
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: tasks,
+    },
+  })
+
+export default { stubTasks }

--- a/integration_tests/tests/tasks/list.cy.ts
+++ b/integration_tests/tests/tasks/list.cy.ts
@@ -1,0 +1,31 @@
+import ListPage from '../../../cypress_shared/pages/tasks/listPage'
+
+import taskFactory from '../../../server/testutils/factories/task'
+
+context('Tasks', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+  })
+
+  it('shows a list of tasks', () => {
+    cy.task('stubAuthUser')
+
+    // Given I am logged in
+    cy.signIn()
+
+    const allocatedTasks = taskFactory.buildList(5)
+    const unallocatedTasks = taskFactory.buildList(5, { allocatedToStaffMember: undefined })
+
+    cy.task('stubTasks', [...allocatedTasks, ...unallocatedTasks])
+
+    // When I visit the tasks dashboard
+    const listPage = ListPage.visit(allocatedTasks, unallocatedTasks)
+
+    // Then I should see the tasks that are allocated
+    listPage.shouldShowAllocatedTasks()
+
+    // And the tasks that are unallocated
+    listPage.shouldShowUnallocatedTasks()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.5.0",
-    "@ministryofjustice/frontend": "^1.6.0",
+    "@ministryofjustice/frontend": "^1.6.5",
     "@sentry/node": "^7.14.1",
     "@sentry/tracing": "^7.14.1",
     "agentkeepalive": "^4.2.1",

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -58,7 +58,7 @@ export type YesNoOrIDKWithDetail<T extends string> = {
   [K in `${T}Detail`]: string
 }
 
-export type Task = {
+export type UiTask = {
   id: string
   title: string
   pages: Record<string, unknown>
@@ -66,12 +66,12 @@ export type Task = {
 
 export type TaskStatus = 'not_started' | 'in_progress' | 'complete' | 'cannot_start'
 
-export type TaskWithStatus = Task & { status: TaskStatus }
+export type TaskWithStatus = UiTask & { status: TaskStatus }
 
 export type FormSection = {
   title: string
   name: string
-  tasks: Array<Task>
+  tasks: Array<UiTask>
 }
 
 export type FormSections = Array<FormSection>

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -81,7 +81,7 @@ export type FormPages = { [key in TaskNames]: Record<string, unknown> }
 export type PageResponse = Record<string, string | Array<string> | Array<Record<string, unknown>>>
 
 export interface HtmlAttributes {
-  [key: string]: string
+  [key: string]: string | number
 }
 
 export interface TextItem {
@@ -93,9 +93,8 @@ export interface HtmlItem {
 }
 
 export type TableCell = { text: string; attributes?: HtmlAttributes; classes?: string } | { html: string }
-export interface TableRow {
-  [index: number]: TableCell
-}
+
+export type TableRow = Array<TableCell>
 
 export interface RadioItem {
   text: string

--- a/server/controllers/dashboardController.test.ts
+++ b/server/controllers/dashboardController.test.ts
@@ -8,15 +8,15 @@ describe('DashboardController', () => {
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
-  let applicationController: DashboardController
+  let dashboardController: DashboardController
 
   beforeEach(() => {
-    applicationController = new DashboardController()
+    dashboardController = new DashboardController()
   })
 
   describe('index', () => {
     it('should render the dashboard template', () => {
-      const requestHandler = applicationController.index()
+      const requestHandler = dashboardController.index()
 
       requestHandler(request, response, next)
 

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -3,15 +3,17 @@
 import { controllers as manageControllers } from './manage'
 import { controllers as applyControllers } from './apply'
 import { controllers as assessControllers } from './assess'
+import TasksController from './tasksController'
 
 import type { Services } from '../services'
 import DashboardController from './dashboardController'
 
 export const controllers = (services: Services) => {
   const dashboardController = new DashboardController()
-
+  const tasksController = new TasksController(services.taskService)
   return {
     dashboardController,
+    tasksController,
     ...manageControllers(services),
     ...applyControllers(services),
     ...assessControllers(services),

--- a/server/controllers/tasksController.test.ts
+++ b/server/controllers/tasksController.test.ts
@@ -1,0 +1,38 @@
+import type { NextFunction, Request, Response } from 'express'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+
+import TasksController from './tasksController'
+import TaskService from '../services/taskService'
+import taskFactory from '../testutils/factories/task'
+import { groupByAllocation } from '../utils/tasks'
+
+describe('TasksController', () => {
+  const request: DeepMocked<Request> = createMock<Request>({})
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const tasksService = createMock<TaskService>({})
+
+  let tasksController: TasksController
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    tasksController = new TasksController(tasksService)
+  })
+
+  describe('index', () => {
+    it('should render the tasks template', async () => {
+      const tasks = taskFactory.buildList(1)
+      tasksService.getAll.mockResolvedValue(tasks)
+
+      const requestHandler = tasksController.index()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('tasks/index', {
+        pageHeading: 'Tasks',
+        tasks: groupByAllocation(tasks),
+      })
+    })
+  })
+})

--- a/server/controllers/tasksController.ts
+++ b/server/controllers/tasksController.ts
@@ -1,0 +1,15 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+import TaskService from '../services/taskService'
+import { groupByAllocation } from '../utils/tasks'
+
+export default class TasksController {
+  constructor(private readonly taskService: TaskService) {}
+
+  index(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      const tasks = await this.taskService.getAll(req.user.token)
+
+      res.render('tasks/index', { pageHeading: 'Tasks', tasks: groupByAllocation(tasks) })
+    }
+  }
+}

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -22,6 +22,7 @@ import TokenStore from './tokenStore'
 import LostBedClient from './lostBedClient'
 import ApplicationClient from './applicationClient'
 import AssessmentClient from './assessmentClient'
+import TaskClient from './taskClient'
 
 type RestClientBuilder<T> = (token: string) => T
 
@@ -36,6 +37,7 @@ export const dataAccess = () => ({
   applicationClientBuilder: ((token: string) => new ApplicationClient(token)) as RestClientBuilder<ApplicationClient>,
   assessmentClientBuilder: ((token: string) => new AssessmentClient(token)) as RestClientBuilder<AssessmentClient>,
   userClientBuilder: ((token: string) => new UserClient(token)) as RestClientBuilder<UserClient>,
+  taskClientBuilder: ((token: string) => new TaskClient(token)) as RestClientBuilder<TaskClient>,
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>
@@ -51,4 +53,5 @@ export {
   ApplicationClient,
   AssessmentClient,
   UserClient,
+  TaskClient,
 }

--- a/server/data/taskClient.test.ts
+++ b/server/data/taskClient.test.ts
@@ -1,0 +1,44 @@
+import nock from 'nock'
+
+import TaskClient from './taskClient'
+import config from '../config'
+import paths from '../paths/api'
+
+import taskFactory from '../testutils/factories/task'
+
+describe('taskClient', () => {
+  let fakeApprovedPremisesApi: nock.Scope
+  let taskClient: TaskClient
+
+  const token = 'token-1'
+
+  beforeEach(() => {
+    config.apis.approvedPremises.url = 'http://localhost:8080'
+    config.flags.oasysDisabled = false
+    fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
+    taskClient = new TaskClient(token)
+  })
+
+  afterEach(() => {
+    if (!nock.isDone()) {
+      nock.cleanAll()
+      throw new Error('Not all nock interceptors were used!')
+    }
+    nock.abortPendingRequests()
+    nock.cleanAll()
+  })
+
+  it('makes a get request to the tasks endpoint', async () => {
+    const tasks = taskFactory.buildList(2)
+
+    fakeApprovedPremisesApi
+      .get(paths.tasks.index.pattern)
+      .matchHeader('authorization', `Bearer ${token}`)
+      .reply(200, tasks)
+
+    const result = await taskClient.all()
+
+    expect(result).toEqual(tasks)
+    expect(nock.isDone()).toBeTruthy()
+  })
+})

--- a/server/data/taskClient.ts
+++ b/server/data/taskClient.ts
@@ -1,0 +1,16 @@
+import config, { ApiConfig } from '../config'
+import RestClient from './restClient'
+import paths from '../paths/api'
+import { Task } from '../@types/shared'
+
+export default class TaskClient {
+  restClient: RestClient
+
+  constructor(token: string) {
+    this.restClient = new RestClient('applicationClient', config.apis.approvedPremises as ApiConfig, token)
+  }
+
+  async all(): Promise<Array<Task>> {
+    return (await this.restClient.get({ path: paths.tasks.index.pattern })) as Promise<Array<Task>>
+  }
+}

--- a/server/form-pages/utils/getTaskStatus.ts
+++ b/server/form-pages/utils/getTaskStatus.ts
@@ -1,4 +1,5 @@
-import type { Task, TaskStatus } from '@approved-premises/ui'
+import type { TaskStatus, UiTask } from '@approved-premises/ui'
+
 import {
   ApprovedPremisesApplication as Application,
   ApprovedPremisesAssessment as Assessment,
@@ -9,7 +10,7 @@ const getPageData = (applicationOrAssessment: Application | Assessment, taskName
   return applicationOrAssessment.data?.[taskName]?.[pageName]
 }
 
-const getTaskStatus = (task: Task, applicationOrAssessment: Application | Assessment): TaskStatus => {
+const getTaskStatus = (task: UiTask, applicationOrAssessment: Application | Assessment): TaskStatus => {
   // Find the first page that has an answer
   let pageId = Object.keys(task.pages).find(
     (pageName: string) => !!getPageData(applicationOrAssessment, task.id, pageName),

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -1,4 +1,4 @@
-import type { JourneyType, Task, YesOrNo, YesOrNoWithDetail } from '@approved-premises/ui'
+import type { JourneyType, UiTask, YesOrNo, YesOrNoWithDetail } from '@approved-premises/ui'
 import type { Request } from 'express'
 import TasklistPage, { TasklistPageInterface } from '../tasklistPage'
 import { ApprovedPremisesApplication, ApprovedPremisesAssessment } from '../../@types/shared'
@@ -38,7 +38,7 @@ export const getTask = <T>(task: T) => {
 }
 
 export const getSection = <T>(section: T) => {
-  const tasks: Array<Task> = []
+  const tasks: Array<UiTask> = []
   const title = Reflect.getMetadata('section:title', section)
   const name = Reflect.getMetadata('section:name', section)
   const taskClasses = Reflect.getMetadata('section:tasks', section)

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -24,6 +24,8 @@ const oasysPath = personPath.path('oasys')
 
 const usersPath = path('/users')
 
+const tasksPath = path('/tasks')
+
 const applyPaths = {
   applications: {
     show: singleApplicationPath,
@@ -79,6 +81,9 @@ export default {
       create: clarificationNotePaths.notes,
       update: clarificationNotePaths.notes.path(':clarificationNoteId'),
     },
+  },
+  tasks: {
+    index: tasksPath,
   },
   people: {
     risks: {

--- a/server/paths/tasks.ts
+++ b/server/paths/tasks.ts
@@ -1,0 +1,5 @@
+/* istanbul ignore file */
+
+import { path } from 'static-path'
+
+export default { index: path('/tasks') }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -8,6 +8,7 @@ import actions from './utils'
 import applyRoutes from './apply'
 import manageRoutes from './manage'
 import assessRoutes from './assess'
+import tasksRoutes from './tasks'
 
 export default function routes(controllers: Controllers): Router {
   const router = Router()
@@ -21,6 +22,7 @@ export default function routes(controllers: Controllers): Router {
   manageRoutes(controllers, router)
   applyRoutes(controllers, router)
   assessRoutes(controllers, router)
+  tasksRoutes(controllers, router)
 
   return router
 }

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -1,0 +1,12 @@
+/* istanbul ignore file */
+
+import { Router } from 'express'
+import { Controllers } from '../controllers'
+
+export default function routes(controllers: Controllers, router: Router): Router {
+  const { tasksController } = controllers
+
+  router.get('/tasks', tasksController.index())
+
+  return router
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -13,6 +13,7 @@ import CancellationService from './cancellationService'
 import LostBedService from './lostBedService'
 import ApplicationService from './applicationService'
 import AssessmentService from './assessmentService'
+import TaskService from './taskService'
 
 export const services = () => {
   const {
@@ -25,6 +26,7 @@ export const services = () => {
     applicationClientBuilder,
     assessmentClientBuilder,
     userClientBuilder,
+    taskClientBuilder,
   } = dataAccess()
 
   const userService = new UserService(hmppsAuthClient, userClientBuilder)
@@ -38,6 +40,7 @@ export const services = () => {
   const lostBedService = new LostBedService(lostBedClientBuilder, referenceDataClientBuilder)
   const applicationService = new ApplicationService(applicationClientBuilder)
   const assessmentService = new AssessmentService(assessmentClientBuilder)
+  const taskService = new TaskService(taskClientBuilder)
 
   return {
     userService,
@@ -51,6 +54,7 @@ export const services = () => {
     lostBedService,
     applicationService,
     assessmentService,
+    taskService,
   }
 }
 
@@ -68,4 +72,5 @@ export {
   LostBedService,
   ApplicationService,
   AssessmentService,
+  TaskService,
 }

--- a/server/services/taskService.test.ts
+++ b/server/services/taskService.test.ts
@@ -1,0 +1,34 @@
+import { Task } from '../@types/shared'
+import TaskClient from '../data/taskClient'
+import taskFactory from '../testutils/factories/task'
+import TaskService from './taskService'
+
+jest.mock('../data/taskClient.ts')
+
+describe('taskService', () => {
+  const taskClient = new TaskClient(null) as jest.Mocked<TaskClient>
+  const taskClientFactory = jest.fn()
+
+  const service = new TaskService(taskClientFactory)
+
+  const token = 'SOME_TOKEN'
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    taskClientFactory.mockReturnValue(taskClient)
+  })
+
+  describe('getAll', () => {
+    it('calls the all method on the task client', async () => {
+      const tasks: Array<Task> = taskFactory.buildList(2)
+      taskClient.all.mockResolvedValue(tasks)
+
+      const result = await service.getAll(token)
+
+      expect(result).toEqual(tasks)
+
+      expect(taskClientFactory).toHaveBeenCalledWith(token)
+      expect(taskClient.all).toHaveBeenCalled()
+    })
+  })
+})

--- a/server/services/taskService.ts
+++ b/server/services/taskService.ts
@@ -1,0 +1,13 @@
+import { RestClientBuilder } from '../data'
+import TaskClient from '../data/taskClient'
+
+export default class TaskService {
+  constructor(private readonly taskClientFactory: RestClientBuilder<TaskClient>) {}
+
+  async getAll(token: string) {
+    const taskClient = this.taskClientFactory(token)
+
+    const tasks = await taskClient.all()
+    return tasks
+  }
+}

--- a/server/services/tasklistService.ts
+++ b/server/services/tasklistService.ts
@@ -2,7 +2,7 @@ import {
   ApprovedPremisesApplication as Application,
   ApprovedPremisesAssessment as Assessment,
 } from '@approved-premises/api'
-import { FormSections, Task, TaskStatus, TaskWithStatus } from '@approved-premises/ui'
+import { FormSections, TaskStatus, TaskWithStatus, UiTask } from '@approved-premises/ui'
 import getSections from '../utils/assessments/getSections'
 import Apply from '../form-pages/apply'
 import isAssessment from '../utils/assessments/isAssessment'
@@ -53,7 +53,7 @@ export default class TasklistService {
     return completeTasks.length === Object.keys(this.taskStatuses).length ? 'complete' : 'incomplete'
   }
 
-  addStatusToTask(task: Task): TaskWithStatus {
+  addStatusToTask(task: UiTask): TaskWithStatus {
     return { ...task, status: this.taskStatuses[task.id] }
   }
 }

--- a/server/testutils/factories/task.ts
+++ b/server/testutils/factories/task.ts
@@ -1,0 +1,17 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { Task } from '@approved-premises/api'
+import { DateFormats } from '../../utils/dateUtils'
+
+import UserFactory from './user'
+import PersonFactory from './person'
+
+export default Factory.define<Task>(() => ({
+  allocatedToStaffMember: UserFactory.build(),
+  applicationId: faker.datatype.uuid(),
+  dueDate: DateFormats.dateObjToIsoDate(faker.date.future()),
+  status: faker.helpers.arrayElement(['not_started', 'in_progress', 'complete']),
+  taskType: faker.helpers.arrayElement(['Assessment', 'PlacementRequest', 'PlacementRequestReview', 'BookingAppeal']),
+  person: PersonFactory.build(),
+}))

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -9,7 +9,7 @@ import {
   TextItem,
   UiTask,
 } from '@approved-premises/ui'
-import { add, differenceInDays, format, getUnixTime } from 'date-fns'
+import { add, differenceInDays, format } from 'date-fns'
 
 import { ApprovedPremisesApplication, ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
 import { tierBadge } from '../personUtils'
@@ -315,7 +315,7 @@ const formattedArrivalDate = (assessment: Assessment): string => {
 
 const arriveDateAsTimestamp = (assessment: Assessment): number => {
   const arrivalDate = arrivalDateFromApplication(assessment.application as ApprovedPremisesApplication)
-  return getUnixTime(DateFormats.isoToDateObj(arrivalDate))
+  return DateFormats.isoToTimestamp(arrivalDate)
 }
 
 const formatDays = (days: number): string => {

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -6,8 +6,8 @@ import {
   PageResponse,
   SummaryListItem,
   TableRow,
-  Task,
   TextItem,
+  UiTask,
 } from '@approved-premises/ui'
 import { add, differenceInDays, format, getUnixTime } from 'date-fns'
 
@@ -401,7 +401,7 @@ const assessmentSections = (application: ApprovedPremisesApplication) => {
 }
 
 const getTaskResponsesAsSummaryListItems = (
-  task: Task,
+  task: UiTask,
   application: ApprovedPremisesApplication,
 ): Array<SummaryListItem> => {
   if (!application.data[task.id]) {
@@ -466,7 +466,7 @@ const getReviewNavigationItems = () => {
   })
 }
 
-const getSectionSuffix = (task: Task, assessmentId: string) => {
+const getSectionSuffix = (task: UiTask, assessmentId: string) => {
   let link: string
   let copy: string
 

--- a/server/utils/checkYourAnswersUtils.ts
+++ b/server/utils/checkYourAnswersUtils.ts
@@ -1,5 +1,5 @@
 import { ApprovedPremisesApplication } from '@approved-premises/api'
-import { HtmlItem, SummaryListItem, Task, TextItem } from '@approved-premises/ui'
+import { HtmlItem, SummaryListItem, TextItem, UiTask } from '@approved-premises/ui'
 
 import paths from '../paths/apply'
 
@@ -10,7 +10,7 @@ const checkYourAnswersSections = (application: ApprovedPremisesApplication) =>
   reviewSections(application, getTaskResponsesAsSummaryListItems)
 
 export const getTaskResponsesAsSummaryListItems = (
-  task: Task,
+  task: UiTask,
   application: ApprovedPremisesApplication,
 ): Array<SummaryListItem> => {
   const items: Array<SummaryListItem> = []
@@ -63,7 +63,7 @@ const embeddedSummaryListItem = (answers: Array<Record<string, unknown>>): strin
 const summaryListItemForResponse = (
   key: string,
   value: TextItem | HtmlItem,
-  task: Task,
+  task: UiTask,
   pageName: string,
   application: ApprovedPremisesApplication,
 ) => {

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -1,5 +1,11 @@
+/* eslint-disable import/no-duplicates */
+
 import type { ObjectWithDateParts } from '@approved-premises/ui'
+
 import isPast from 'date-fns/isPast'
+import differenceInDays from 'date-fns/differenceInDays'
+import formatDistanceStrict from 'date-fns/formatDistanceStrict'
+
 import {
   DateFormats,
   InvalidDateStringError,
@@ -9,6 +15,8 @@ import {
 } from './dateUtils'
 
 jest.mock('date-fns/isPast')
+jest.mock('date-fns/formatDistanceStrict')
+jest.mock('date-fns/differenceInDays')
 
 describe('DateFormats', () => {
   describe('convertIsoToDateObj', () => {
@@ -141,6 +149,22 @@ describe('DateFormats', () => {
       const result = DateFormats.dateAndTimeInputsToIsoString(obj, 'date')
 
       expect(result.date.toString()).toEqual('twothousandtwentytwo-20-oo')
+    })
+  })
+
+  describe('differenceInDays', () => {
+    it('calls the date-fns functions and returns the results as an object', () => {
+      const date1 = new Date(2023, 3, 12)
+      const date2 = new Date(2023, 3, 11)
+      ;(formatDistanceStrict as jest.Mock).mockReturnValue('1 day')
+      ;(differenceInDays as jest.Mock).mockReturnValue(1)
+
+      expect(DateFormats.differenceInDays(date1, date2)).toEqual({
+        ui: '1 day',
+        number: 1,
+      })
+      expect(formatDistanceStrict).toHaveBeenCalledWith(date1, date2, { unit: 'day' })
+      expect(differenceInDays).toHaveBeenCalledWith(date1, date2)
     })
   })
 })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,12 +1,9 @@
 /* eslint-disable */
 import type { ObjectWithDateParts } from '@approved-premises/ui'
 
-import formatISO from 'date-fns/formatISO'
-import parseISO from 'date-fns/parseISO'
-import format from 'date-fns/format'
-import isPast from 'date-fns/isPast'
-import { getUnixTime } from 'date-fns'
+import { differenceInDays, formatDistanceStrict, getUnixTime, formatISO, parseISO, format, isPast } from 'date-fns'
 
+type DifferenceInDays = { ui: string; number: number }
 export class DateFormats {
   /**
    * @param date JS Date object.
@@ -110,6 +107,15 @@ export class DateFormats {
    */
   static isoToTimestamp(dateString: string) {
     return getUnixTime(DateFormats.isoToDateObj(dateString))
+  }
+
+  /**
+   * @param date1 first day to compare.
+   * @param date2 second day to compare.
+   * @returns {DifferenceInDays} an object with the difference in days as a string for UI purposes (EG '2 Days') and as a number.
+   */
+  static differenceInDays(date1: Date, date2: Date): { ui: string; number: number } {
+    return { ui: formatDistanceStrict(date1, date2, { unit: 'day' }), number: differenceInDays(date1, date2) }
   }
 }
 

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -5,6 +5,7 @@ import formatISO from 'date-fns/formatISO'
 import parseISO from 'date-fns/parseISO'
 import format from 'date-fns/format'
 import isPast from 'date-fns/isPast'
+import { getUnixTime } from 'date-fns'
 
 export class DateFormats {
   /**
@@ -101,6 +102,14 @@ export class DateFormats {
       [`${key}-day`]: String(date.getDate()),
       [`${key}`]: DateFormats.dateObjToIsoDate(date),
     } as ObjectWithDateParts<K>
+  }
+
+  /**
+   * @param dateString an ISO date string.
+   * @returns the date as a timestamp, useful when sorting.
+   */
+  static isoToTimestamp(dateString: string) {
+    return getUnixTime(DateFormats.isoToDateObj(dateString))
   }
 }
 

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -35,6 +35,7 @@ import * as BookingUtils from './bookingUtils'
 import * as TasklistUtils from './taskListUtils'
 import * as FormUtils from './formUtils'
 import * as UserUtils from './userUtils'
+import * as TaskUtils from './tasks'
 
 import managePaths from '../paths/manage'
 import applyPaths from '../paths/apply'
@@ -171,4 +172,5 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('TasklistUtils', TasklistUtils)
   njkEnv.addGlobal('FormUtils', FormUtils)
   njkEnv.addGlobal('UserUtils', UserUtils)
+  njkEnv.addGlobal('TaskUtils', TaskUtils)
 }

--- a/server/utils/reviewUtils.ts
+++ b/server/utils/reviewUtils.ts
@@ -1,12 +1,12 @@
 import { ApprovedPremisesApplication as Application, ApprovedPremisesAssessment as Assessment } from '../@types/shared'
-import { SummaryListItem, Task } from '../@types/ui'
+import { SummaryListItem, UiTask } from '../@types/ui'
 import Apply from '../form-pages/apply'
 import getSections from './assessments/getSections'
 import isAssessment from './assessments/isAssessment'
 
 const reviewSections = (
   applicationOrAssessment: Application | Assessment,
-  rowFunction: (task: Task, document: Application | Assessment) => Array<SummaryListItem>,
+  rowFunction: (task: UiTask, document: Application | Assessment) => Array<SummaryListItem>,
 ) => {
   const nonCheckYourAnswersSections = isAssessment(applicationOrAssessment)
     ? getSections(applicationOrAssessment).slice(0, -1)

--- a/server/utils/tasks/index.test.ts
+++ b/server/utils/tasks/index.test.ts
@@ -1,0 +1,18 @@
+import { groupByAllocation } from '.'
+import taskFactory from '../../testutils/factories/task'
+import userFactory from '../../testutils/factories/user'
+
+describe('index', () => {
+  describe('groupByAllocation', () => {
+    it('should return an object with allocated and unallocated tasks', () => {
+      const allocatedTask = taskFactory.build({ allocatedToStaffMember: userFactory.build() })
+      const unallocatedTask = taskFactory.build({ allocatedToStaffMember: undefined })
+      const tasks = [allocatedTask, unallocatedTask]
+
+      const result = groupByAllocation(tasks)
+
+      expect(result.allocated).toEqual([allocatedTask])
+      expect(result.unallocated).toEqual([unallocatedTask])
+    })
+  })
+})

--- a/server/utils/tasks/index.ts
+++ b/server/utils/tasks/index.ts
@@ -1,0 +1,23 @@
+import { Task } from '../../@types/shared'
+import * as tableUtils from './table'
+
+type GroupedTasks = {
+  allocated: Array<Task>
+  unallocated: Array<Task>
+}
+
+const groupByAllocation = (tasks: Array<Task>) => {
+  const result: GroupedTasks = { allocated: [], unallocated: [] }
+
+  tasks.forEach(task => {
+    if (task.allocatedToStaffMember) {
+      result.allocated.push(task)
+    } else {
+      result.unallocated.push(task)
+    }
+  })
+
+  return result
+}
+
+export { groupByAllocation, tableUtils }

--- a/server/utils/tasks/index.ts
+++ b/server/utils/tasks/index.ts
@@ -1,5 +1,7 @@
+/* istanbul ignore file */
+
 import { Task } from '../../@types/shared'
-import * as tableUtils from './table'
+import { allocatedTableRows, unallocatedTableRows } from './table'
 
 type GroupedTasks = {
   allocated: Array<Task>
@@ -19,5 +21,4 @@ const groupByAllocation = (tasks: Array<Task>) => {
 
   return result
 }
-
-export { groupByAllocation, tableUtils }
+export { groupByAllocation, allocatedTableRows, unallocatedTableRows }

--- a/server/utils/tasks/table.test.ts
+++ b/server/utils/tasks/table.test.ts
@@ -1,0 +1,256 @@
+import { add } from 'date-fns'
+import taskFactory from '../../testutils/factories/task'
+import {
+  allocatedTableRows,
+  allocationCell,
+  daysUntilDue,
+  daysUntilDueCell,
+  formatDaysUntilDueWithWarning,
+  nameCell,
+  statusBadge,
+  statusCell,
+  taskTypeCell,
+  unallocatedTableRows,
+} from './table'
+import { sentenceCase } from '../utils'
+import { DateFormats } from '../dateUtils'
+import { Task } from '../../@types/shared'
+
+describe('table', () => {
+  describe('allocatedTableRows', () => {
+    describe('when all the optional task properties are populated', () => {
+      it('returns an array of table rows', () => {
+        const task = taskFactory.build()
+
+        expect(allocatedTableRows([task])).toEqual([
+          [
+            {
+              text: task.person.name,
+            },
+            {
+              text: formatDaysUntilDueWithWarning(task),
+              attributes: {
+                'data-sort-value': daysUntilDue(task),
+              },
+            },
+            {
+              text: task?.allocatedToStaffMember?.name,
+            },
+            {
+              html: statusBadge(task),
+            },
+            {
+              html: `<strong class="govuk-tag">${sentenceCase(task.taskType)}</strong>`,
+            },
+          ],
+        ])
+      })
+    })
+
+    describe('when all the optional task properties are not defined', () => {
+      it('returns an array of table rows with empty strings for the undefined values', () => {
+        const task = taskFactory.build({
+          applicationId: undefined,
+          person: undefined,
+          dueDate: undefined,
+          allocatedToStaffMember: undefined,
+          status: undefined,
+          taskType: undefined,
+        })
+
+        expect(allocatedTableRows([task])).toEqual([
+          [
+            {
+              text: '',
+            },
+            {
+              text: '',
+              attributes: {
+                'data-sort-value': 0,
+              },
+            },
+            { text: '' },
+            {
+              html: '',
+            },
+            {
+              html: '',
+            },
+          ],
+        ])
+      })
+    })
+  })
+
+  describe('unallocatedTableRows', () => {
+    describe('when all the optional task properties are populated', () => {
+      it('returns an array of table rows', () => {
+        const task = taskFactory.build()
+
+        expect(unallocatedTableRows([task])).toEqual([
+          [
+            {
+              text: task.person.name,
+            },
+            {
+              text: formatDaysUntilDueWithWarning(task),
+              attributes: {
+                'data-sort-value': daysUntilDue(task),
+              },
+            },
+            {
+              html: statusBadge(task),
+            },
+            {
+              html: `<strong class="govuk-tag">${sentenceCase(task.taskType)}</strong>`,
+            },
+          ],
+        ])
+      })
+    })
+    describe('when all the optional task properties are not defined', () => {
+      it('returns an array of table rows with empty strings for the undefined values', () => {
+        const task = taskFactory.build({
+          applicationId: undefined,
+          person: undefined,
+          dueDate: undefined,
+          allocatedToStaffMember: undefined,
+          status: undefined,
+          taskType: undefined,
+        })
+
+        expect(unallocatedTableRows([task])).toEqual([
+          [
+            {
+              text: '',
+            },
+            {
+              text: '',
+              attributes: {
+                'data-sort-value': 0,
+              },
+            },
+            {
+              html: '',
+            },
+            {
+              html: '',
+            },
+          ],
+        ])
+      })
+    })
+  })
+
+  describe('nameCell', () => {
+    it('returns the name of the person the task is assigned to as a TableCell object', () => {
+      const task = taskFactory.build()
+      expect(nameCell(task)).toEqual({ text: task.person.name })
+    })
+
+    it('returns an empty string as a TableCell object if the task doesnt have a person', () => {
+      const taskWithNoPersonName = taskFactory.build({ person: { name: undefined } })
+      const taskWithNoPerson = taskFactory.build({ person: undefined })
+
+      expect(nameCell(taskWithNoPersonName)).toEqual({ text: '' })
+      expect(nameCell(taskWithNoPerson)).toEqual({ text: '' })
+    })
+  })
+
+  describe('daysUntilDueCell', () => {
+    it('returns the days until due formatted for the UI as a TableCell object', () => {
+      const task = taskFactory.build()
+      expect(daysUntilDueCell(task)).toEqual({
+        text: formatDaysUntilDueWithWarning(task),
+        attributes: {
+          'data-sort-value': daysUntilDue(task),
+        },
+      })
+    })
+  })
+
+  describe('statusCell', () => {
+    it('returns the status of the task as a TableCell object', () => {
+      const task = taskFactory.build()
+      expect(statusCell(task)).toEqual({
+        html: statusBadge(task),
+      })
+    })
+  })
+
+  describe('taskTypeCell', () => {
+    it('returns the task type formatted for the UI as a TableCell object', () => {
+      const task = taskFactory.build()
+      expect(taskTypeCell(task)).toEqual({
+        html: `<strong class="govuk-tag">${sentenceCase(task.taskType)}</strong>`,
+      })
+    })
+  })
+
+  describe('allocationCell', () => {
+    it('returns the name of the staff member the task is allocated to as a TableCell object', () => {
+      const task = taskFactory.build()
+      expect(allocationCell(task)).toEqual({ text: task.allocatedToStaffMember.name })
+    })
+  })
+
+  describe('statusBadge', () => {
+    it('returns the "complete" status tag', () => {
+      const completedTask = taskFactory.build({ status: 'complete' })
+      expect(statusBadge(completedTask)).toEqual('<strong class="govuk-tag">Complete</strong>')
+    })
+
+    it('returns the "not started" status tag', () => {
+      const notStartedTask = taskFactory.build({ status: 'not_started' })
+      expect(statusBadge(notStartedTask)).toEqual('<strong class="govuk-tag govuk-tag--yellow">Not started</strong>')
+    })
+
+    it('returns the "in_progress" status tag', () => {
+      const inProgressTask = taskFactory.build({ status: 'in_progress' })
+      expect(statusBadge(inProgressTask)).toEqual('<strong class="govuk-tag govuk-tag--grey">In progress</strong>')
+    })
+
+    it('returns an empty string for an unknown status', () => {
+      const unknownStatusTask = taskFactory.build({ status: undefined })
+      const unknownStatusTask2 = undefined as unknown as Task
+      expect(statusBadge(unknownStatusTask)).toEqual('')
+      expect(statusBadge(unknownStatusTask2)).toEqual('')
+    })
+  })
+
+  describe('daysUntilDue', () => {
+    it('returns the number of days until the task is due', () => {
+      const task = taskFactory.build({ dueDate: DateFormats.dateObjToIsoDate(add(new Date(), { days: 2 })) })
+      expect(daysUntilDue(task)).toEqual(1)
+    })
+    it('returns 0 if the task is due', () => {
+      const task = taskFactory.build({ dueDate: DateFormats.dateObjToIsoDate(new Date()) })
+      expect(daysUntilDue(task)).toEqual(0)
+    })
+    it('returns 0 if the task has no due date', () => {
+      const task = taskFactory.build({ dueDate: undefined })
+      expect(daysUntilDue(task)).toEqual(0)
+    })
+  })
+
+  describe('formatDaysUntilDueWithWarning', () => {
+    it('returns the number of days until the task is due', () => {
+      const task = taskFactory.build({ dueDate: DateFormats.dateObjToIsoDate(add(new Date(), { days: 2 })) })
+      expect(formatDaysUntilDueWithWarning(task)).toEqual(
+        '<strong class="task--index__warning">1 day<span class="govuk-visually-hidden"> (Approaching due date)</span></strong>',
+      )
+    })
+
+    it('returns "overdue" if the task is overdue', () => {
+      const task = taskFactory.build({ dueDate: DateFormats.dateObjToIsoDate(add(new Date(), { days: -2 })) })
+      expect(formatDaysUntilDueWithWarning(task)).toEqual(
+        '<strong class="task--index__warning">-3 days<span class="govuk-visually-hidden"> (Approaching due date)</span></strong>',
+      )
+    })
+
+    it('returns "no due date" if the task has no due date', () => {
+      const task = taskFactory.build({ dueDate: undefined })
+      expect(formatDaysUntilDueWithWarning(task)).toEqual('')
+    })
+  })
+})

--- a/server/utils/tasks/table.ts
+++ b/server/utils/tasks/table.ts
@@ -1,0 +1,96 @@
+import { Task } from '../../@types/shared'
+import { TableCell, TableRow } from '../../@types/ui'
+import { DateFormats } from '../dateUtils'
+import { sentenceCase } from '../utils'
+
+const DUE_DATE_APPROACHING_DAYS_WINDOW = 3
+
+const allocatedTableRows = (tasks: Array<Task>): Array<TableRow> => {
+  const rows: Array<TableRow> = []
+
+  tasks.forEach(task => {
+    rows.push([nameCell(task), daysUntilDueCell(task), allocationCell(task), statusCell(task), taskTypeCell(task)])
+  })
+
+  return rows
+}
+
+const unallocatedTableRows = (tasks: Array<Task>): Array<TableRow> => {
+  const rows = [] as Array<TableRow>
+
+  tasks.forEach(task => {
+    rows.push([nameCell(task), daysUntilDueCell(task), statusCell(task), taskTypeCell(task)])
+  })
+
+  return rows
+}
+
+const nameCell = (task: Task): TableCell => ({
+  text: task?.person?.name || '',
+})
+
+const daysUntilDueCell = (task: Task): TableCell => ({
+  text: formatDaysUntilDueWithWarning(task),
+  attributes: {
+    'data-sort-value': daysUntilDue(task),
+  },
+})
+
+const statusCell = (task: Task): TableCell => ({
+  html: statusBadge(task),
+})
+
+const taskTypeCell = (task: Task): TableCell => ({
+  html: task.taskType ? `<strong class="govuk-tag">${sentenceCase(task.taskType)}</strong>` : '',
+})
+
+const allocationCell = (task: Task): TableCell => ({
+  text: task.allocatedToStaffMember?.name || '',
+})
+
+const statusBadge = (task: Task): string => {
+  const status = task?.status || ''
+  switch (status) {
+    case 'complete':
+      return `<strong class="govuk-tag">${sentenceCase(status)}</strong>`
+    case 'not_started':
+      return `<strong class="govuk-tag govuk-tag--yellow">${sentenceCase(status)}</strong>`
+    case 'in_progress':
+      return `<strong class="govuk-tag govuk-tag--grey">${sentenceCase(status)}</strong>`
+    default:
+      return ''
+  }
+}
+
+const formatDaysUntilDueWithWarning = (task: Task): string => {
+  if (!task.dueDate) return ''
+
+  const differenceInDays = DateFormats.differenceInDays(DateFormats.isoToDateObj(task.dueDate), new Date())
+
+  if (differenceInDays.number < DUE_DATE_APPROACHING_DAYS_WINDOW) {
+    return `<strong class="task--index__warning">${differenceInDays.number < 0 ? '-' : ''}${
+      differenceInDays.ui
+    }<span class="govuk-visually-hidden"> (Approaching due date)</span></strong>`
+  }
+
+  return differenceInDays.ui
+}
+
+const daysUntilDue = (task: Task): number => {
+  if (!task.dueDate) return 0
+
+  return DateFormats.differenceInDays(DateFormats.isoToDateObj(task.dueDate), new Date()).number
+}
+
+export {
+  allocatedTableRows,
+  daysUntilDue,
+  formatDaysUntilDueWithWarning,
+  nameCell,
+  daysUntilDueCell,
+  statusCell,
+  taskTypeCell,
+  allocationCell,
+  statusBadge,
+  unallocatedTableRows,
+}

--- a/server/views/tasks/index.njk
+++ b/server/views/tasks/index.njk
@@ -1,0 +1,110 @@
+{% extends "../partials/layout.njk" %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+
+{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set mainClasses = "app-container govuk-body assessments--index" %}
+
+{% set allocatedHtml %}
+{{
+    govukTable({
+        attributes: {
+        'data-module': 'moj-sortable-table'
+        },
+        caption: "Allocated Tasks",
+        captionClasses: "govuk-table__caption--m",
+        firstCellIsHeader: true,
+        head: [
+        {
+            text: "Person"
+        },
+        {
+            text: "Days until due date",
+            attributes: {
+            "aria-sort": "none"
+            }
+        },
+        {
+            text: "Allocated to"
+        },
+        {
+            text: "Status"
+        },
+        {
+            text: "Task type"
+        }
+        ],
+        rows: TaskUtils.allocatedTableRows(tasks.allocated)
+    })
+    }}
+{% endset -%}
+
+{% set unallocatedHtml %}
+{{
+  govukTable({
+    attributes: {
+      'data-module': 'moj-sortable-table'
+    },
+    caption: "Unallocated Tasks",
+    captionClasses: "govuk-table__caption--m",
+    firstCellIsHeader: true,
+    head: [
+        {
+          text: "Person"
+        },
+        {
+          text: "Days until due date",
+          attributes: {
+            "aria-sort": "none"
+          }
+        },
+        {
+          text: "Status"
+        },
+        {
+          text: "Task type"
+        }
+      ],
+    rows: TaskUtils.unallocatedTableRows(tasks.unallocated)
+  })
+}}
+{% endset -%}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+
+            <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+            {{ govukTabs({
+                items: [
+                    {
+                    label: "Allocated",
+                    id: "allocated",
+                    panel: {
+                        html: allocatedHtml
+                    }
+                    },
+                    {
+                    label: "Unallocated",
+                    id: "unallocated",
+                    panel: {
+                        html: unallocatedHtml
+                    }
+                    }
+                ]
+            }) }}
+
+        </div>
+    </div>
+{% endblock %}
+
+{% block extraScripts %}
+    <script type="text/javascript" nonce="{{ cspNonce }}">
+        window
+            .MOJFrontend
+            .initAll()
+    </script>
+{% endblock %}

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -18,6 +18,7 @@ import lostBedStubs from './lostBedStubs'
 import personStubs from './personStubs'
 import applicationStubs from './applicationStubs'
 import assessmentStubs from './assessmentStubs'
+import taskStubs from './taskStubs'
 import userStubs from './userStubs'
 
 import * as referenceDataStubs from './referenceDataStubs'
@@ -139,6 +140,7 @@ stubs.push(
   ...personStubs,
   ...applicationStubs,
   ...assessmentStubs,
+  ...taskStubs,
   ...userStubs,
   ...Object.values(referenceDataStubs),
 )

--- a/wiremock/taskStubs.ts
+++ b/wiremock/taskStubs.ts
@@ -1,0 +1,19 @@
+import paths from '../server/paths/api'
+import tasksFactory from '../server/testutils/factories/task'
+
+export default [
+  {
+    priority: 99,
+    request: {
+      method: 'GET',
+      urlPathPattern: paths.tasks.index.pattern,
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: tasksFactory.buildList(5),
+    },
+  },
+]


### PR DESCRIPTION
# Context
Workflow managers need to be able to see tasks that are allocated as well as tasks that are unallocated.
This is similar to and will in future replace the assessment lists but I think it's worth keeping the assessment lists around for now until tasks are more feature-complete.

[Trello](https://trello.com/c/UlWNtoEL/1316-list-tasks-to-a-workflow-manager)

# Changes in this PR
1. We begin with some general housekeeping
2. We add the task client
3. We add the task service
4. We add a simple controller for the view
5. We add some util functions for generating the tables in the views and handling the neccessary dates
6. We add the view

## Screenshots of UI changes
![Allocated tasks](https://user-images.githubusercontent.com/44123869/225074156-2dbc81db-103a-4974-86d7-f4b61decd33c.png)
![Unallocated tasks](https://user-images.githubusercontent.com/44123869/225074168-fdf19bfc-7ddd-4dfe-956c-b043d4ff7095.png)


