### PR TITLE
Refactor question retrieval

### DIFF
--- a/cypress_shared/pages/apply/placementStart.ts
+++ b/cypress_shared/pages/apply/placementStart.ts
@@ -1,15 +1,12 @@
 import { ApprovedPremisesApplication } from '@approved-premises/api'
 import ApplyPage from './applyPage'
 import { DateFormats } from '../../../server/utils/dateUtils'
-import { retrieveQuestionResponseFromApplication } from '../../../server/utils/utils'
+import { retrieveQuestionResponseFromApplicationOrAssessment } from '../../../server/utils/retrieveQuestionResponseFromApplicationOrAssessment'
+import ReleaseDate from '../../../server/form-pages/apply/reasons-for-placement/basic-information/releaseDate'
 
 export default class PlacementStartPage extends ApplyPage {
   constructor(application: ApprovedPremisesApplication) {
-    const releaseDate = retrieveQuestionResponseFromApplication(
-      application,
-      'basic-information',
-      'releaseDate',
-    ) as string
+    const releaseDate = retrieveQuestionResponseFromApplicationOrAssessment(application, ReleaseDate) as string
 
     super(
       `Is ${DateFormats.isoDateToUIDate(releaseDate)} the date you want the placement to start?`,

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.test.ts
@@ -6,11 +6,15 @@ import PlacementDate from './placementDate'
 import { DateFormats } from '../../../../utils/dateUtils'
 import applicationFactory from '../../../../testutils/factories/application'
 
+const releaseDate = new Date().toISOString()
+
 jest.mock('../../../../utils/applications/noticeTypeFromApplication')
+jest.mock('../../../../utils/retrieveQuestionResponseFromApplicationOrAssessment', () => {
+  return { retrieveQuestionResponseFromApplicationOrAssessment: jest.fn(() => releaseDate) }
+})
 
 describe('PlacementDate', () => {
-  const releaseDate = new Date().toISOString()
-  const application = applicationFactory.withReleaseDate(releaseDate).build()
+  const application = applicationFactory.build()
 
   describe('title', () => {
     it('set the title and body correctly', () => {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
@@ -1,11 +1,13 @@
 import type { ObjectWithDateParts, TaskListErrors, YesOrNo } from '@approved-premises/ui'
 import type { ApprovedPremisesApplication } from '@approved-premises/api'
 
+import { retrieveQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromApplicationOrAssessment'
 import TasklistPage from '../../../tasklistPage'
-import { convertToTitleCase, retrieveQuestionResponseFromApplication } from '../../../../utils/utils'
+import { convertToTitleCase } from '../../../../utils/utils'
 import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank, dateIsInThePast } from '../../../../utils/dateUtils'
 import { Page } from '../../../utils/decorators'
 import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
+import ReleaseDate from './releaseDate'
 
 type PlacementDateBody = ObjectWithDateParts<'startDate'> & {
   startDateSameAsReleaseDate: YesOrNo
@@ -20,7 +22,7 @@ export default class PlacementDate implements TasklistPage {
 
   constructor(private _body: Partial<PlacementDateBody>, public application: ApprovedPremisesApplication) {
     const formattedReleaseDate = DateFormats.isoDateToUIDate(
-      retrieveQuestionResponseFromApplication(application, 'basic-information', 'releaseDate'),
+      retrieveQuestionResponseFromApplicationOrAssessment(application, ReleaseDate),
     )
 
     this.title = `Is ${formattedReleaseDate} the date you want the placement to start?`

--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseType.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseType.test.ts
@@ -1,7 +1,12 @@
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import applicationFactory from '../../../../testutils/factories/application'
+import { retrieveQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromApplicationOrAssessment'
 
 import ReleaseType from './releaseType'
+
+jest.mock('../../../../utils/retrieveQuestionResponseFromApplicationOrAssessment', () => {
+  return { retrieveQuestionResponseFromApplicationOrAssessment: jest.fn(() => 'standardDeterminate') }
+})
 
 describe('ReleaseType', () => {
   const application = applicationFactory.build({
@@ -34,12 +39,9 @@ describe('ReleaseType', () => {
   describe('items', () => {
     describe('releaseType', () => {
       it('if the sentence type is "standardDeterminate" then all the items should be shown', () => {
-        const items = new ReleaseType(
-          {},
-          applicationFactory.build({
-            data: { 'basic-information': { 'sentence-type': { sentenceType: 'standardDeterminate' } } },
-          }),
-        ).items()
+        ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue('standardDeterminate')
+
+        const items = new ReleaseType({}, application).items()
 
         expect(items.length).toEqual(4)
         expect(items[0].value).toEqual('licence')
@@ -49,12 +51,9 @@ describe('ReleaseType', () => {
       })
 
       it('if the sentence type is "extendedDeterminate" then the reduced list of items should be shown', () => {
-        const items = new ReleaseType(
-          {},
-          applicationFactory.build({
-            data: { 'basic-information': { 'sentence-type': { sentenceType: 'extendedDeterminate' } } },
-          }),
-        ).items()
+        ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue('extendedDeterminate')
+
+        const items = new ReleaseType({}, application).items()
 
         expect(items.length).toEqual(2)
         expect(items[0].value).toEqual('rotl')
@@ -62,10 +61,9 @@ describe('ReleaseType', () => {
       })
 
       it('if the sentence type is "ipp" then the reduced list of items should be shown', () => {
-        const items = new ReleaseType(
-          {},
-          applicationFactory.build({ data: { 'basic-information': { 'sentence-type': { sentenceType: 'ipp' } } } }),
-        ).items()
+        ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue('ipp')
+
+        const items = new ReleaseType({}, application).items()
 
         expect(items.length).toEqual(2)
         expect(items[0].value).toEqual('rotl')
@@ -73,10 +71,9 @@ describe('ReleaseType', () => {
       })
 
       it('if the sentence type is "life" then the reduced list of items should be shown', () => {
-        const items = new ReleaseType(
-          {},
-          applicationFactory.build({ data: { 'basic-information': { 'sentence-type': { sentenceType: 'life' } } } }),
-        ).items()
+        ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue('life')
+
+        const items = new ReleaseType({}, application).items()
 
         expect(items.length).toEqual(2)
         expect(items[0].value).toEqual('rotl')

--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseType.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseType.ts
@@ -2,9 +2,9 @@ import type { ApprovedPremisesApplication, ReleaseTypeOption } from '@approved-p
 import type { TaskListErrors } from '@approved-premises/ui'
 
 import { SessionDataError } from '../../../../utils/errors'
-import { retrieveQuestionResponseFromApplication } from '../../../../utils/utils'
+import { retrieveQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromApplicationOrAssessment'
 import TasklistPage from '../../../tasklistPage'
-import { SentenceTypesT } from './sentenceType'
+import SentenceType, { SentenceTypesT } from './sentenceType'
 import { Page } from '../../../utils/decorators'
 
 type SelectableReleaseTypes = Exclude<ReleaseTypeOption, 'in_community'>
@@ -20,7 +20,7 @@ const allReleaseTypes: ReleaseTypeOptions = {
 type ReducedReleaseTypeOptions = Pick<ReleaseTypeOptions, 'rotl' | 'licence'>
 type ReducedReleaseTypes = keyof ReducedReleaseTypeOptions
 
-type SentenceType = Extract<
+type SentenceTypeResponse = Extract<
   SentenceTypesT,
   'standardDeterminate' | 'extendedDeterminate' | 'ipp' | 'life' | 'nonStatutory'
 >
@@ -37,11 +37,7 @@ export default class ReleaseType implements TasklistPage {
     readonly body: { releaseType?: SelectableReleaseTypes | ReducedReleaseTypes },
     readonly application: ApprovedPremisesApplication,
   ) {
-    const sessionSentenceType = retrieveQuestionResponseFromApplication<SentenceType>(
-      application,
-      'basic-information',
-      'sentenceType',
-    )
+    const sessionSentenceType = retrieveQuestionResponseFromApplicationOrAssessment(application, SentenceType)
 
     this.releaseTypes = this.getReleaseTypes(sessionSentenceType)
 
@@ -82,7 +78,7 @@ export default class ReleaseType implements TasklistPage {
     })
   }
 
-  getReleaseTypes(sessionReleaseType: SentenceType): ReleaseTypeOptions | ReducedReleaseTypeOptions {
+  getReleaseTypes(sessionReleaseType: SentenceTypeResponse): ReleaseTypeOptions | ReducedReleaseTypeOptions {
     if (sessionReleaseType === 'standardDeterminate' || sessionReleaseType === 'nonStatutory') {
       return allReleaseTypes
     }

--- a/server/form-pages/apply/reasons-for-placement/basic-information/situation.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/situation.test.ts
@@ -1,7 +1,12 @@
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import applicationFactory from '../../../../testutils/factories/application'
+import { retrieveQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromApplicationOrAssessment'
 
 import Situation from './situation'
+
+jest.mock('../../../../utils/retrieveQuestionResponseFromApplicationOrAssessment', () => {
+  return { retrieveQuestionResponseFromApplicationOrAssessment: jest.fn(() => 'communityOrder') }
+})
 
 describe('Situation', () => {
   const application = applicationFactory.build({
@@ -34,12 +39,9 @@ describe('Situation', () => {
   describe('items', () => {
     describe('sentenceType', () => {
       it('if the sentence type is "communityOrder" then the items should be correct', () => {
-        const items = new Situation(
-          { situation: 'riskManagement' },
-          applicationFactory.build({
-            data: { 'basic-information': { 'sentence-type': { sentenceType: 'communityOrder' } } },
-          }),
-        ).items()
+        ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue('communityOrder')
+
+        const items = new Situation({ situation: 'riskManagement' }, application).items()
 
         expect(items.length).toEqual(2)
         expect(items[0]).toEqual({
@@ -55,12 +57,9 @@ describe('Situation', () => {
       })
 
       it('if the sentence type is "bailPlacement" then the items should be correct', () => {
-        const items = new Situation(
-          { situation: 'bailAssessment' },
-          applicationFactory.build({
-            data: { 'basic-information': { 'sentence-type': { sentenceType: 'bailPlacement' } } },
-          }),
-        ).items()
+        ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue('bailPlacement')
+
+        const items = new Situation({ situation: 'bailAssessment' }, application).items()
 
         expect(items.length).toEqual(2)
         expect(items[0]).toEqual({
@@ -73,6 +72,8 @@ describe('Situation', () => {
     })
 
     it('marks an option as selected when the releaseType is set', () => {
+      ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue('communityOrder')
+
       const page = new Situation({ situation: 'riskManagement' }, application)
 
       const selectedOptions = page.items().filter(item => item.checked)

--- a/server/form-pages/apply/reasons-for-placement/basic-information/situation.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/situation.ts
@@ -3,9 +3,9 @@ import type { TaskListErrors } from '@approved-premises/ui'
 import { Page } from '../../../utils/decorators'
 
 import { SessionDataError } from '../../../../utils/errors'
-import { retrieveQuestionResponseFromApplication } from '../../../../utils/utils'
+import { retrieveQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromApplicationOrAssessment'
 import TasklistPage from '../../../tasklistPage'
-import { SentenceTypesT } from './sentenceType'
+import SentenceType, { SentenceTypesT } from './sentenceType'
 
 const situations = {
   riskManagement: 'Referral for risk management/public protection',
@@ -16,7 +16,7 @@ const situations = {
 
 type CommunityOrderSituations = Pick<typeof situations, 'riskManagement' | 'residencyManagement'>
 type BailPlacementSituations = Pick<typeof situations, 'bailAssessment' | 'bailSentence'>
-type SentenceType = Extract<SentenceTypesT, 'communityOrder' | 'bailPlacement'>
+type SentenceTypeResponse = Extract<SentenceTypesT, 'communityOrder' | 'bailPlacement'>
 
 @Page({ name: 'situation', bodyProperties: ['situation'] })
 export default class Situation implements TasklistPage {
@@ -28,11 +28,7 @@ export default class Situation implements TasklistPage {
     readonly body: { situation?: keyof CommunityOrderSituations | keyof BailPlacementSituations },
     readonly application: ApprovedPremisesApplication,
   ) {
-    const sessionSentenceType = retrieveQuestionResponseFromApplication<SentenceType>(
-      application,
-      'basic-information',
-      'sentenceType',
-    )
+    const sessionSentenceType = retrieveQuestionResponseFromApplicationOrAssessment(application, SentenceType)
 
     this.situations = this.getSituationsForSentenceType(sessionSentenceType)
   }
@@ -69,7 +65,9 @@ export default class Situation implements TasklistPage {
     })
   }
 
-  getSituationsForSentenceType(sessionSentenceType: SentenceType): CommunityOrderSituations | BailPlacementSituations {
+  getSituationsForSentenceType(
+    sessionSentenceType: SentenceTypeResponse,
+  ): CommunityOrderSituations | BailPlacementSituations {
     if (sessionSentenceType === 'communityOrder') {
       return { riskManagement: situations.riskManagement, residencyManagement: situations.residencyManagement }
     }

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementCCTV.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementCCTV.test.ts
@@ -4,8 +4,12 @@ import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
 import EsapPlacementCCTV, { cctvHistory } from './esapPlacementCCTV'
 import applicationFactory from '../../../../testutils/factories/application'
 import personFactory from '../../../../testutils/factories/person'
+import { retrieveQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromApplicationOrAssessment'
 
 jest.mock('../../../../utils/formUtils')
+jest.mock('../../../../utils/retrieveQuestionResponseFromApplicationOrAssessment', () => {
+  return { retrieveQuestionResponseFromApplicationOrAssessment: jest.fn(() => []) }
+})
 
 describe('EsapPlacementCCTV', () => {
   const application = applicationFactory.build()
@@ -15,13 +19,7 @@ describe('EsapPlacementCCTV', () => {
   describe('previous', () => {
     describe('when the application has a previous response that includes `secreting`', () => {
       beforeEach(() => {
-        application.data = {
-          'type-of-ap': {
-            'esap-placement-screening': {
-              esapReasons: ['cctv', 'secreting'],
-            },
-          },
-        }
+        ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue(['cctv', 'secreting'])
       })
 
       itShouldHavePreviousValue(new EsapPlacementCCTV({}, application), 'esap-placement-secreting')
@@ -29,13 +27,7 @@ describe('EsapPlacementCCTV', () => {
 
     describe('when the application has a previous response does not include `secreting`', () => {
       beforeEach(() => {
-        application.data = {
-          'type-of-ap': {
-            'esap-placement-screening': {
-              esapReasons: ['cctv'],
-            },
-          },
-        }
+        ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue(['cctv'])
       })
 
       itShouldHavePreviousValue(new EsapPlacementCCTV({}, application), 'esap-placement-screening')

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementCCTV.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementCCTV.ts
@@ -3,9 +3,11 @@ import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
-import { convertToTitleCase, retrieveQuestionResponseFromApplication } from '../../../../utils/utils'
+import { convertToTitleCase } from '../../../../utils/utils'
+import { retrieveQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromApplicationOrAssessment'
 import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
 import { EsapReasons } from './esapPlacementScreening'
+import ApType from './apType'
 
 export const cctvHistory = {
   appearance: 'Changed their appearance or clothing to offend',
@@ -44,10 +46,9 @@ export default class EsapPlacementCCTV implements TasklistPage {
   ) {}
 
   previous() {
-    const esapReasons = retrieveQuestionResponseFromApplication(
+    const esapReasons = retrieveQuestionResponseFromApplicationOrAssessment(
       this.application,
-      'type-of-ap',
-      'esap-placement-screening',
+      ApType,
       'esapReasons',
     ) as Array<keyof EsapReasons>
 

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementSecreting.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementSecreting.test.ts
@@ -4,8 +4,12 @@ import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
 import EsapPlacementSecreting, { secretingHistory } from './esapPlacementSecreting'
 import applicationFactory from '../../../../testutils/factories/application'
 import personFactory from '../../../../testutils/factories/person'
+import { retrieveQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromApplicationOrAssessment'
 
 jest.mock('../../../../utils/formUtils')
+jest.mock('../../../../utils/retrieveQuestionResponseFromApplicationOrAssessment', () => {
+  return { retrieveQuestionResponseFromApplicationOrAssessment: jest.fn(() => []) }
+})
 
 describe('EsapPlacementSecreting', () => {
   const application = applicationFactory.build()
@@ -34,13 +38,7 @@ describe('EsapPlacementSecreting', () => {
   describe('next', () => {
     describe('when the application has a previous response that includes `cctv`', () => {
       beforeEach(() => {
-        application.data = {
-          'type-of-ap': {
-            'esap-placement-screening': {
-              esapReasons: ['cctv', 'secreting'],
-            },
-          },
-        }
+        ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue(['cctv', 'secreting'])
       })
 
       itShouldHaveNextValue(new EsapPlacementSecreting({}, application), 'esap-placement-cctv')
@@ -48,13 +46,7 @@ describe('EsapPlacementSecreting', () => {
 
     describe('when the application has a previous response does not include `cctv`', () => {
       beforeEach(() => {
-        application.data = {
-          'type-of-ap': {
-            'esap-placement-screening': {
-              esapReasons: ['secreting'],
-            },
-          },
-        }
+        ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue(['secreting'])
       })
 
       itShouldHaveNextValue(new EsapPlacementSecreting({}, application), '')

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementSecreting.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementSecreting.ts
@@ -3,9 +3,11 @@ import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
 
 import { Page } from '../../../utils/decorators'
 import TasklistPage from '../../../tasklistPage'
-import { convertToTitleCase, retrieveQuestionResponseFromApplication } from '../../../../utils/utils'
+import { convertToTitleCase } from '../../../../utils/utils'
+import { retrieveQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromApplicationOrAssessment'
 import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
 import { EsapReasons } from './esapPlacementScreening'
+import ApType from './apType'
 
 export const secretingHistory = {
   radicalisationLiterature: 'Literature and materials supporting radicalisation ideals',
@@ -49,10 +51,9 @@ export default class EsapPlacementSecreting implements TasklistPage {
   }
 
   next() {
-    const esapReasons = retrieveQuestionResponseFromApplication(
+    const esapReasons = retrieveQuestionResponseFromApplicationOrAssessment(
       this.application,
-      'type-of-ap',
-      'esap-placement-screening',
+      ApType,
       'esapReasons',
     ) as Array<keyof EsapReasons>
 

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanQuestions.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanQuestions.test.ts
@@ -4,14 +4,21 @@ import contingencyPlanPartner from '../../../../testutils/factories/contingencyP
 import contingencyPlanQuestionsBodyFactory from '../../../../testutils/factories/contingencyPlanQuestionsBody'
 import { shouldShowTriggerPlanPages } from '../../../../utils/applications/shouldShowTriggerPlanPage'
 import { itShouldHavePreviousValue } from '../../../shared-examples'
+
 import ContingencyPlanQuestions from './contingencyPlanQuestions'
 
+const contingencyPlanPartners = contingencyPlanPartner.buildList(2)
+
 jest.mock('../../../../utils/applications/shouldShowTriggerPlanPage')
+jest.mock('../../../../utils/retrieveQuestionResponseFromApplicationOrAssessment', () => {
+  return {
+    retrieveOptionalQuestionResponseFromApplicationOrAssessment: jest.fn(() => contingencyPlanPartners),
+  }
+})
 
 describe('ContingencyPlanQuestions', () => {
   const body = contingencyPlanQuestionsBodyFactory.build()
-  const contingencyPlanPartners = contingencyPlanPartner.buildList(2)
-  const application = applicationFactory.withContingencyPlanPartners(contingencyPlanPartners).build()
+  const application = applicationFactory.build()
 
   describe('title', () => {
     it('should set the title', () => {

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanQuestions.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanQuestions.ts
@@ -2,7 +2,6 @@ import {
   ContingencyPlanQuestionId,
   ContingencyPlanQuestionsBody,
   ContingencyPlanQuestionsRecord,
-  PartnerAgencyDetails,
   TaskListErrors,
 } from '@approved-premises/ui'
 import { Page } from '../../../utils/decorators'
@@ -10,7 +9,8 @@ import { Page } from '../../../utils/decorators'
 import TasklistPage from '../../../tasklistPage'
 import { shouldShowTriggerPlanPages } from '../../../../utils/applications/shouldShowTriggerPlanPage'
 import { ApprovedPremisesApplication as Application } from '../../../../@types/shared'
-import { retrieveOptionalQuestionResponseFromApplication } from '../../../../utils/utils'
+import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromApplicationOrAssessment'
+import ContingencyPlanPartners from './contingencyPlanPartners'
 
 const questions: ContingencyPlanQuestionsRecord = {
   noReturn: {
@@ -67,10 +67,9 @@ export default class ContingencyPlanQuestions implements TasklistPage {
 
   constructor(public body: ContingencyPlanQuestionsBody, private readonly application: Application) {
     const contingencyPlanPartners =
-      retrieveOptionalQuestionResponseFromApplication<Array<PartnerAgencyDetails>>(
+      retrieveOptionalQuestionResponseFromApplicationOrAssessment(
         application,
-        'further-considerations',
-        'contingency-plan-partners',
+        ContingencyPlanPartners,
         'partnerAgencyDetails',
       ) || []
 

--- a/server/form-pages/utils/index.test.ts
+++ b/server/form-pages/utils/index.test.ts
@@ -176,7 +176,9 @@ describe('utils', () => {
       jest.spyOn(utils, 'getPageName').mockImplementation(() => 'page')
       jest.spyOn(utils, 'getTaskName').mockImplementation(() => 'task')
 
-      jest.spyOn(utils, 'getPageDataFromApplication').mockImplementation((_, applicationInput) => applicationInput.data)
+      jest
+        .spyOn(utils, 'pageDataFromApplicationOrAssessment')
+        .mockImplementation((_, applicationInput) => applicationInput.data)
 
       expect(utils.getBody(page, application, { body: {} } as Request, {})).toBe('returnMe')
     })

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -107,10 +107,10 @@ export function getBody(
   if (Object.keys(request.body).length) {
     return request.body
   }
-  return getPageDataFromApplication(Page, application)
+  return pageDataFromApplicationOrAssessment(Page, application)
 }
 
-export function getPageDataFromApplication(
+export function pageDataFromApplicationOrAssessment(
   Page: TasklistPageInterface,
   application: ApprovedPremisesApplication | ApprovedPremisesAssessment,
 ) {

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { addDays } from 'date-fns'

--- a/server/testutils/mockQuestionResponse.ts
+++ b/server/testutils/mockQuestionResponse.ts
@@ -1,0 +1,31 @@
+import { ApprovedPremisesApplication as Application } from '@approved-premises/api'
+import { retrieveQuestionResponseFromApplicationOrAssessment } from '../utils/retrieveQuestionResponseFromApplicationOrAssessment'
+
+const mockQuestionResponse = ({
+  postcodeArea = 'ABC 123',
+  type = 'standard',
+  sentenceType = 'standardDeterminate',
+}: {
+  postcodeArea?: string
+  type?: string
+  sentenceType?: string
+}) => {
+  ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockImplementation(
+    // eslint-disable-next-line consistent-return
+    (_application: Application, _Page: unknown, question: string) => {
+      if (question === 'postcodeArea') {
+        return postcodeArea
+      }
+
+      if (question === 'type') {
+        return type
+      }
+
+      if (question === 'sentenceType') {
+        return sentenceType
+      }
+    },
+  )
+}
+
+export default mockQuestionResponse

--- a/server/testutils/mockQuestionResponse.ts
+++ b/server/testutils/mockQuestionResponse.ts
@@ -5,10 +5,12 @@ const mockQuestionResponse = ({
   postcodeArea = 'ABC 123',
   type = 'standard',
   sentenceType = 'standardDeterminate',
+  releaseType = 'other',
 }: {
   postcodeArea?: string
   type?: string
   sentenceType?: string
+  releaseType?: string
 }) => {
   ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockImplementation(
     // eslint-disable-next-line consistent-return
@@ -23,6 +25,10 @@ const mockQuestionResponse = ({
 
       if (question === 'sentenceType') {
         return sentenceType
+      }
+
+      if (question === 'releaseType') {
+        return releaseType
       }
     },
   )

--- a/server/utils/applications/applicationSubmissionData.test.ts
+++ b/server/utils/applications/applicationSubmissionData.test.ts
@@ -2,6 +2,7 @@ import { ReleaseTypeOption } from '@approved-premises/api'
 import applicationFactory from '../../testutils/factories/application'
 import { applicationSubmissionData } from './applicationSubmissionData'
 import mockQuestionResponse from '../../testutils/mockQuestionResponse'
+import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromApplicationOrAssessment'
 
 jest.mock('../retrieveQuestionResponseFromApplicationOrAssessment')
 
@@ -9,10 +10,14 @@ describe('applicationSubmissionData', () => {
   const releaseType = 'license' as ReleaseTypeOption
   const targetLocation = 'ABC 123'
 
+  beforeEach(() => {
+    ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue(releaseType)
+  })
+
   it('returns the correct data for a pipe application', () => {
     mockQuestionResponse({ type: 'pipe', postcodeArea: targetLocation })
 
-    const application = applicationFactory.withReleaseType(releaseType).build()
+    const application = applicationFactory.build()
 
     expect(applicationSubmissionData(application)).toEqual({
       translatedDocument: application.document,
@@ -26,7 +31,7 @@ describe('applicationSubmissionData', () => {
   it('returns the correct data for a non-pipe application', () => {
     mockQuestionResponse({ type: 'standard', postcodeArea: targetLocation })
 
-    const application = applicationFactory.withReleaseType(releaseType).build()
+    const application = applicationFactory.build()
 
     expect(applicationSubmissionData(application)).toEqual({
       translatedDocument: application.document,
@@ -38,6 +43,8 @@ describe('applicationSubmissionData', () => {
   })
 
   it('handles when a release type is missing', () => {
+    ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue(undefined)
+
     mockQuestionResponse({ postcodeArea: targetLocation })
 
     const application = applicationFactory.build()

--- a/server/utils/applications/applicationSubmissionData.test.ts
+++ b/server/utils/applications/applicationSubmissionData.test.ts
@@ -1,90 +1,81 @@
 import { ReleaseTypeOption } from '@approved-premises/api'
 import applicationFactory from '../../testutils/factories/application'
 import { applicationSubmissionData } from './applicationSubmissionData'
+import mockQuestionResponse from '../../testutils/mockQuestionResponse'
+
+jest.mock('../retrieveQuestionResponseFromApplicationOrAssessment')
 
 describe('applicationSubmissionData', () => {
-  const postcodeArea = 'ABC 123'
   const releaseType = 'license' as ReleaseTypeOption
+  const targetLocation = 'ABC 123'
 
   it('returns the correct data for a pipe application', () => {
-    const application = applicationFactory
-      .withApType('pipe')
-      .withPostcodeArea(postcodeArea)
-      .withSentenceType('standardDeterminate')
-      .withReleaseType(releaseType)
-      .build()
+    mockQuestionResponse({ type: 'pipe', postcodeArea: targetLocation })
+
+    const application = applicationFactory.withReleaseType(releaseType).build()
 
     expect(applicationSubmissionData(application)).toEqual({
       translatedDocument: application.document,
       isPipeApplication: true,
       isWomensApplication: false,
       releaseType,
-      targetLocation: postcodeArea,
+      targetLocation,
     })
   })
 
   it('returns the correct data for a non-pipe application', () => {
-    const application = applicationFactory
-      .withApType('standard')
-      .withPostcodeArea(postcodeArea)
-      .withSentenceType('standardDeterminate')
-      .withReleaseType(releaseType)
-      .build()
+    mockQuestionResponse({ type: 'standard', postcodeArea: targetLocation })
+
+    const application = applicationFactory.withReleaseType(releaseType).build()
 
     expect(applicationSubmissionData(application)).toEqual({
       translatedDocument: application.document,
       isPipeApplication: false,
       isWomensApplication: false,
       releaseType,
-      targetLocation: postcodeArea,
+      targetLocation,
     })
   })
 
   it('handles when a release type is missing', () => {
-    const application = applicationFactory
-      .withApType('standard')
-      .withSentenceType('standardDeterminate')
-      .withPostcodeArea(postcodeArea)
-      .build()
+    mockQuestionResponse({ postcodeArea: targetLocation })
+
+    const application = applicationFactory.build()
 
     expect(applicationSubmissionData(application)).toEqual({
       translatedDocument: application.document,
       isPipeApplication: false,
       isWomensApplication: false,
       releaseType: undefined,
-      targetLocation: postcodeArea,
+      targetLocation: 'ABC 123',
     })
   })
 
   it('returns in_community for a community order application', () => {
-    const application = applicationFactory
-      .withApType('standard')
-      .withPostcodeArea(postcodeArea)
-      .withSentenceType('communityOrder')
-      .build()
+    mockQuestionResponse({ sentenceType: 'communityOrder', postcodeArea: targetLocation })
+
+    const application = applicationFactory.build()
 
     expect(applicationSubmissionData(application)).toEqual({
       translatedDocument: application.document,
       isPipeApplication: false,
       isWomensApplication: false,
       releaseType: 'in_community',
-      targetLocation: postcodeArea,
+      targetLocation,
     })
   })
 
   it('returns in_community for a bail placement application', () => {
-    const application = applicationFactory
-      .withApType('standard')
-      .withPostcodeArea(postcodeArea)
-      .withSentenceType('bailPlacement')
-      .build()
+    mockQuestionResponse({ sentenceType: 'bailPlacement', postcodeArea: targetLocation })
+
+    const application = applicationFactory.build()
 
     expect(applicationSubmissionData(application)).toEqual({
       translatedDocument: application.document,
       isPipeApplication: false,
       isWomensApplication: false,
       releaseType: 'in_community',
-      targetLocation: postcodeArea,
+      targetLocation,
     })
   })
 })

--- a/server/utils/applications/applicationSubmissionData.ts
+++ b/server/utils/applications/applicationSubmissionData.ts
@@ -3,12 +3,15 @@ import type {
   ReleaseTypeOption,
   SubmitApplication,
 } from '@approved-premises/api'
-import LocationFactors from '../../form-pages/apply/risk-and-need-factors/location-factors'
+import ReleaseType from '../../form-pages/apply/reasons-for-placement/basic-information/releaseType'
+import DescribeLocationFactors from '../../form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors'
 import ApType from '../../form-pages/apply/reasons-for-placement/type-of-ap/apType'
 import SentenceType from '../../form-pages/apply/reasons-for-placement/basic-information/sentenceType'
 
-import { retrieveOptionalQuestionResponseFromApplication } from '../utils'
-import { retrieveQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromApplicationOrAssessment'
+import {
+  retrieveOptionalQuestionResponseFromApplicationOrAssessment,
+  retrieveQuestionResponseFromApplicationOrAssessment,
+} from '../retrieveQuestionResponseFromApplicationOrAssessment'
 
 export const applicationSubmissionData = (application: Application): SubmitApplication => {
   const apType = retrieveQuestionResponseFromApplicationOrAssessment(application, ApType, 'type')
@@ -35,10 +38,5 @@ const getReleaseType = (application: Application): ReleaseTypeOption => {
     return 'in_community'
   }
 
-  return retrieveOptionalQuestionResponseFromApplication<ReleaseTypeOption>(
-    application,
-    'basic-information',
-    'release-type',
-    'releaseType',
-  )
+  return retrieveOptionalQuestionResponseFromApplicationOrAssessment(application, ReleaseType, 'releaseType')
 }

--- a/server/utils/applications/applicationSubmissionData.ts
+++ b/server/utils/applications/applicationSubmissionData.ts
@@ -3,17 +3,18 @@ import type {
   ReleaseTypeOption,
   SubmitApplication,
 } from '@approved-premises/api'
-import { SentenceTypesT } from '../../form-pages/apply/reasons-for-placement/basic-information/sentenceType'
-import type { ApTypes } from '../../form-pages/apply/reasons-for-placement/type-of-ap/apType'
+import LocationFactors from '../../form-pages/apply/risk-and-need-factors/location-factors'
+import ApType from '../../form-pages/apply/reasons-for-placement/type-of-ap/apType'
+import SentenceType from '../../form-pages/apply/reasons-for-placement/basic-information/sentenceType'
 
-import { retrieveOptionalQuestionResponseFromApplication, retrieveQuestionResponseFromApplication } from '../utils'
+import { retrieveOptionalQuestionResponseFromApplication } from '../utils'
+import { retrieveQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromApplicationOrAssessment'
 
 export const applicationSubmissionData = (application: Application): SubmitApplication => {
-  const apType = retrieveQuestionResponseFromApplication<keyof ApTypes>(application, 'type-of-ap', 'ap-type', 'type')
-  const targetLocation = retrieveQuestionResponseFromApplication<string>(
+  const apType = retrieveQuestionResponseFromApplicationOrAssessment(application, ApType, 'type')
+  const targetLocation = retrieveQuestionResponseFromApplicationOrAssessment(
     application,
-    'location-factors',
-    'describe-location-factors',
+    DescribeLocationFactors,
     'postcodeArea',
   )
   const releaseType = getReleaseType(application)
@@ -28,12 +29,7 @@ export const applicationSubmissionData = (application: Application): SubmitAppli
 }
 
 const getReleaseType = (application: Application): ReleaseTypeOption => {
-  const sentenceType = retrieveQuestionResponseFromApplication<SentenceTypesT>(
-    application,
-    'basic-information',
-    'sentence-type',
-    'sentenceType',
-  )
+  const sentenceType = retrieveQuestionResponseFromApplicationOrAssessment(application, SentenceType, 'sentenceType')
 
   if (sentenceType === 'communityOrder' || sentenceType === 'bailPlacement') {
     return 'in_community'

--- a/server/utils/applications/shouldShowContingencyPlanPages.test.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.test.ts
@@ -1,77 +1,37 @@
-import { ApprovedPremisesApplication as Application } from '../../@types/shared'
-import { addResponseToApplication } from '../../testutils/addToApplication'
 import applicationFactory from '../../testutils/factories/application'
 import { shouldShowContingencyPlanPages } from './shouldShowContingencyPlanPages'
+import mockQuestionResponse from '../../testutils/mockQuestionResponse'
+
+jest.mock('../retrieveQuestionResponseFromApplicationOrAssessment')
 
 describe('shouldShowContingencyPlanPages', () => {
-  let defaultApplication: Application
-  beforeEach(() => {
-    defaultApplication = applicationFactory
-      .withPageResponse({
-        task: 'basic-information',
-        page: 'sentence-type',
-        key: 'sentenceType',
-        value: 'ipp',
-      })
-      .withPageResponse({
-        task: 'basic-information',
-        page: 'release-type',
-        key: 'releaseType',
-        value: 'other',
-      })
-      .withPageResponse({
-        task: 'type-of-ap',
-        page: 'ap-type',
-        key: 'apType',
-        value: 'other',
-      })
-      .build()
+  const application = applicationFactory.build()
+
+  it('returns false if none of the conditions are met', () => {
+    mockQuestionResponse({ sentenceType: 'ipp', type: 'other' })
+    expect(shouldShowContingencyPlanPages(application)).toEqual(false)
   })
 
-  it('returns an empty string if none of the conditions are met', () => {
-    expect(shouldShowContingencyPlanPages(defaultApplication)).toEqual(false)
-  })
-
-  it('returns "contingency-plan-partners" if the application has a sentence type of "Community Order/SSO"', () => {
-    const application = addResponseToApplication(defaultApplication, {
-      section: 'basic-information',
-      page: 'sentence-type',
-      key: 'sentenceType',
-      value: 'communityOrder',
-    })
+  it('returns true if the application has a sentence type of "Community Order/SSO"', () => {
+    mockQuestionResponse({ sentenceType: 'communityOrder' })
 
     expect(shouldShowContingencyPlanPages(application)).toEqual(true)
   })
 
-  it('returns "contingency-plan-partners" if the application has a sentence type of "Non-statutory, MAPPA case"', () => {
-    const application = addResponseToApplication(defaultApplication, {
-      section: 'basic-information',
-      page: 'sentence-type',
-      key: 'sentenceType',
-      value: 'nonStatutory',
-    })
+  it('returns true if the application has a sentence type of "Non-statutory, MAPPA case"', () => {
+    mockQuestionResponse({ sentenceType: 'nonStatutory' })
 
     expect(shouldShowContingencyPlanPages(application)).toEqual(true)
   })
 
-  it('returns "contingency-plan-partners" if the application has a release type of "Post Sentence Supervision (PSS)"', () => {
-    const application = addResponseToApplication(defaultApplication, {
-      section: 'basic-information',
-      page: 'release-type',
-      key: 'releaseType',
-      value: 'pss',
-    })
+  it('returns true if the application has a release type of "Post Sentence Supervision (PSS)"', () => {
+    mockQuestionResponse({ sentenceType: 'ipp', releaseType: 'pss' })
 
     expect(shouldShowContingencyPlanPages(application)).toEqual(true)
   })
 
-  it('returns "contingency-plan-partners" if the application has a AP type of "ESAP"', () => {
-    const application = addResponseToApplication(defaultApplication, {
-      section: 'type-of-ap',
-      page: 'ap-type',
-      key: 'apType',
-      value: 'esap',
-    })
+  it('returns false if the application has a AP type of "ESAP"', () => {
+    mockQuestionResponse({ type: 'esap' })
 
     expect(shouldShowContingencyPlanPages(application)).toEqual(true)
   })

--- a/server/utils/applications/shouldShowContingencyPlanPages.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.ts
@@ -1,14 +1,12 @@
+import ApType from '../../form-pages/apply/reasons-for-placement/type-of-ap/apType'
+import ReleaseType from '../../form-pages/apply/reasons-for-placement/basic-information/releaseType'
+import SentenceType from '../../form-pages/apply/reasons-for-placement/basic-information/sentenceType'
 import { ApprovedPremisesApplication as Application, ReleaseTypeOption } from '../../@types/shared'
-import { retrieveQuestionResponseFromApplication } from '../utils'
+import { retrieveQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromApplicationOrAssessment'
 
 export const shouldShowContingencyPlanPages = (application: Application) => {
   let releaseType: ReleaseTypeOption
-  const sentenceType = retrieveQuestionResponseFromApplication(
-    application,
-    'basic-information',
-    'sentence-type',
-    'sentenceType',
-  )
+  const sentenceType = retrieveQuestionResponseFromApplicationOrAssessment(application, SentenceType, 'sentenceType')
 
   if (
     sentenceType === 'standardDeterminate' ||
@@ -16,15 +14,10 @@ export const shouldShowContingencyPlanPages = (application: Application) => {
     sentenceType === 'ipp' ||
     sentenceType === 'life'
   ) {
-    releaseType = retrieveQuestionResponseFromApplication(
-      application,
-      'basic-information',
-      'release-type',
-      'releaseType',
-    )
+    releaseType = retrieveQuestionResponseFromApplicationOrAssessment(application, ReleaseType, 'releaseType')
   }
 
-  const apType = retrieveQuestionResponseFromApplication(application, 'type-of-ap', 'ap-type', 'apType')
+  const apType = retrieveQuestionResponseFromApplicationOrAssessment(application, ApType, 'type')
 
   if (
     sentenceType === 'communityOrder' ||

--- a/server/utils/retrieveQuestionResponseFromApplicationOrAssessment.test.ts
+++ b/server/utils/retrieveQuestionResponseFromApplicationOrAssessment.test.ts
@@ -1,0 +1,72 @@
+import { createMock } from '@golevelup/ts-jest'
+import { TasklistPageInterface } from '../form-pages/tasklistPage'
+import {
+  retrieveOptionalQuestionResponseFromApplicationOrAssessment,
+  retrieveQuestionResponseFromApplicationOrAssessment,
+} from './retrieveQuestionResponseFromApplicationOrAssessment'
+import applicationFactory from '../testutils/factories/application'
+import { SessionDataError } from './errors'
+import * as utils from '../form-pages/utils'
+
+jest.spyOn(utils, 'getTaskName').mockImplementation(() => 'my-task')
+jest.spyOn(utils, 'getPageName').mockImplementation(() => 'my-page')
+
+describe('retrieveQuestionResponseFromApplicationOrAssessment', () => {
+  it("throws a SessionDataError if the property doesn't exist", () => {
+    const application = applicationFactory.build()
+
+    expect(() =>
+      retrieveQuestionResponseFromApplicationOrAssessment(application, createMock<TasklistPageInterface>()),
+    ).toThrow(SessionDataError)
+  })
+
+  it('returns the property if it does exist and a question is not provided', () => {
+    const application = applicationFactory.build({
+      data: {
+        'my-task': { 'my-page': { myPage: 'no' } },
+      },
+    })
+
+    const questionResponse = retrieveQuestionResponseFromApplicationOrAssessment(
+      application,
+      createMock<TasklistPageInterface>(),
+    )
+    expect(questionResponse).toBe('no')
+  })
+
+  it('returns the property if it does exist and a question is provided', () => {
+    const application = applicationFactory.build({
+      data: {
+        'my-task': { 'my-page': { questionResponse: 'no' } },
+      },
+    })
+
+    const questionResponse = retrieveQuestionResponseFromApplicationOrAssessment(
+      application,
+      createMock<TasklistPageInterface>(),
+      'questionResponse',
+    )
+    expect(questionResponse).toBe('no')
+  })
+})
+
+describe('retrieveOptionalQuestionResponseFromApplicationOrAssessment', () => {
+  it("returns undefined if the property doesn't exist", () => {
+    const application = applicationFactory.build()
+    expect(
+      retrieveOptionalQuestionResponseFromApplicationOrAssessment(application, createMock<TasklistPageInterface>()),
+    ).toEqual(undefined)
+  })
+
+  it('returns the property if it does exist', () => {
+    const application = applicationFactory.build({
+      data: {
+        'my-task': { 'my-page': { myPage: 'no' } },
+      },
+    })
+
+    expect(
+      retrieveOptionalQuestionResponseFromApplicationOrAssessment(application, createMock<TasklistPageInterface>()),
+    ).toEqual(retrieveQuestionResponseFromApplicationOrAssessment(application, createMock<TasklistPageInterface>()))
+  })
+})

--- a/server/utils/retrieveQuestionResponseFromApplicationOrAssessment.ts
+++ b/server/utils/retrieveQuestionResponseFromApplicationOrAssessment.ts
@@ -1,0 +1,60 @@
+import {
+  ApprovedPremisesApplication as Application,
+  ApprovedPremisesAssessment as Assessment,
+} from '@approved-premises/api'
+import { TasklistPageInterface } from '../form-pages/tasklistPage'
+import { getPageName, pageDataFromApplicationOrAssessment } from '../form-pages/utils'
+import { SessionDataError } from './errors'
+import { camelCase } from './utils'
+
+/**
+ * Retrieves response for a given question from the application object or throws an error if it does not exist.
+ * @param applicationOrAssessment the application or assessment to fetch the response from.
+ * @param Page the page to retrieve the response from.
+ * @param {string} question the question that we need the response for. Defaults to the camel-cased name of the `Page`.
+ * @returns the response for the given Page/question.
+ */
+export const retrieveQuestionResponseFromApplicationOrAssessment = (
+  applicationOrAssessment: Application | Assessment,
+  Page: unknown,
+  question?: string,
+) => {
+  const pageData = pageDataFromApplicationOrAssessment(Page as TasklistPageInterface, applicationOrAssessment)
+  const pageName = getPageName(Page)
+  const q = question || camelCase(pageName)
+
+  if (!pageData) {
+    throw new SessionDataError(`Question ${q} was not found in the session`)
+  }
+
+  const response = pageData[q]
+
+  if (!response) {
+    throw new SessionDataError(`Question ${q} was not found in the session`)
+  }
+
+  return response
+}
+
+/**
+ * Retrieves response for a given question from the application object or returns undefined if it does not exist.
+ * @param applicationOrAssessment the application or assessment to fetch the response from.
+ * @param Page the page to retrieve the response from.
+ * @param {string} question the question that we need the response for. Defaults to the camel-cased name of the `Page`.
+ * @returns the response for the given page/question.
+ */
+export const retrieveOptionalQuestionResponseFromApplicationOrAssessment = (
+  applicationOrAssessment: Application | Assessment,
+  Page: TasklistPageInterface,
+  question?: string,
+) => {
+  let response
+
+  try {
+    response = retrieveQuestionResponseFromApplicationOrAssessment(applicationOrAssessment, Page, question)
+  } catch (e) {
+    response = undefined
+  }
+
+  return response
+}

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,8 +1,6 @@
 import { path } from 'static-path'
 import type { SummaryListItem } from '@approved-premises/ui'
 import { PersonRisks } from '@approved-premises/api'
-import { SessionDataError } from './errors'
-import applicationFactory from '../testutils/factories/application'
 import {
   camelCase,
   convertToTitleCase,
@@ -12,8 +10,6 @@ import {
   pascalCase,
   removeBlankSummaryListItems,
   resolvePath,
-  retrieveOptionalQuestionResponseFromApplication,
-  retrieveQuestionResponseFromApplication,
 } from './utils'
 import risksFactory from '../testutils/factories/risks'
 import { DateFormats } from './dateUtils'
@@ -56,61 +52,6 @@ describe('initialise name', () => {
     ['Double barrelled', 'Robert-John Smith-Jones-Wilson', 'R. Smith-Jones-Wilson'],
   ])('%s initialiseName(%s, %s)', (_: string, a: string, expected: string) => {
     expect(initialiseName(a)).toEqual(expected)
-  })
-})
-
-describe('retrieveQuestionResponseFromApplication', () => {
-  it("throws a SessionDataError if the property doesn't exist", () => {
-    const application = applicationFactory.build()
-    expect(() => retrieveQuestionResponseFromApplication(application, 'basic-information', '')).toThrow(
-      SessionDataError,
-    )
-  })
-
-  it('returns the property if it does exist and a question is not provided', () => {
-    const application = applicationFactory.build({
-      data: {
-        'basic-information': { 'my-page': { myPage: 'no' } },
-      },
-    })
-
-    const questionResponse = retrieveQuestionResponseFromApplication(application, 'basic-information', 'myPage')
-    expect(questionResponse).toBe('no')
-  })
-
-  it('returns the property if it does exist and a question is provided', () => {
-    const application = applicationFactory.build({
-      data: {
-        'basic-information': { 'my-page': { questionResponse: 'no' } },
-      },
-    })
-
-    const questionResponse = retrieveQuestionResponseFromApplication(
-      application,
-      'basic-information',
-      'myPage',
-      'questionResponse',
-    )
-    expect(questionResponse).toBe('no')
-  })
-})
-
-describe('retrieveOptionalQuestionResponseFromApplication', () => {
-  it("returns undefined if the property doesn't exist", () => {
-    const application = applicationFactory.build()
-    expect(retrieveOptionalQuestionResponseFromApplication(application, 'basic-information', '')).toEqual(undefined)
-  })
-
-  it('returns the property if it does exist', () => {
-    const application = applicationFactory.build({
-      data: {
-        'basic-information': { 'my-page': { myPage: 'no' } },
-      },
-    })
-
-    expect(retrieveOptionalQuestionResponseFromApplication(application, 'basic-information', 'myPage')).toEqual(
-      retrieveQuestionResponseFromApplication(application, 'basic-information', 'myPage'),
-    )
   })
 })
 

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -2,9 +2,8 @@ import Case from 'case'
 import { Params, Path } from 'static-path'
 
 import type { PersonRisksUI, SummaryListItem } from '@approved-premises/ui'
-import type { ApprovedPremisesApplication, PersonRisks } from '@approved-premises/api'
+import type { PersonRisks } from '@approved-premises/api'
 
-import { SessionDataError } from './errors'
 import { DateFormats } from './dateUtils'
 
 /* istanbul ignore next */
@@ -66,52 +65,6 @@ export const pascalCase = (string: string) => camelCase(string).replace(/\w/, s 
 export const sentenceCase = (string: string) => Case.sentence(string)
 
 export const lowerCase = (string: string) => Case.lower(string)
-
-/**
- * Retrieves response for a given question from the application object or throws an error if it does not exist.
- * @param application the application to fetch the response from.
- * @param task the task to retrieve the response for.
- * @param page the page that we need the response for in camelCase.
- * @param {string} question [question=page] the page that we need the response for. Defaults to the value of `page`.
- * @returns the response for the given task/page/question.
- */
-export const retrieveQuestionResponseFromApplication = <T>(
-  application: ApprovedPremisesApplication,
-  task: string,
-  page: string,
-  question?: string,
-) => {
-  try {
-    return application.data[task][kebabCase(page)][question || page] as T
-  } catch (e) {
-    throw new SessionDataError(`Question ${question} was not found in the session`)
-  }
-}
-
-/**
- * Retrieves response for a given question from the application object or returns undefined if it does not exist.
- * @param application the application to fetch the response from.
- * @param task the task to retrieve the response for.
- * @param page the page that we need the response for in camelCase.
- * @param {string} question [question=page] the page that we need the response for. Defaults to the value of `page`.
- * @returns the response for the given task/page/question.
- */
-export const retrieveOptionalQuestionResponseFromApplication = <T>(
-  application: ApprovedPremisesApplication,
-  task: string,
-  page: string,
-  question?: string,
-) => {
-  let response: T
-
-  try {
-    response = retrieveQuestionResponseFromApplication<T>(application, task, page, question)
-  } catch (e) {
-    response = undefined
-  }
-
-  return response
-}
 
 /**
  * Removes any items in an array of summary list items that are blank or undefined


### PR DESCRIPTION
This refactors the `retrieveQuestionResponseFromApplication` and `retrieveOptionalQuestionResponseFromApplication` methods to support Assessments too, as well as using the actual Page classes to use the decorator metadata to determine the name of the task and the page, rather than hardcoding. 

There's a lot of commits here, but they're mainly just replacing the calls to the new helpers. Rather than building the application data, we're mocking, which we have to do, as the tests don't have access to all the metadata at run time. This is alos better practice as we're making our tests less sociable.