### PR TITLE
(1319) Send placement request data when approving an assessment

### DIFF
--- a/cypress_shared/helpers/assess.ts
+++ b/cypress_shared/helpers/assess.ts
@@ -60,6 +60,7 @@ export default class AseessHelper {
       cy.task('stubPersonDocument', { person: this.assessment.application.person, document })
     })
     cy.task('stubAssessmentRejection', this.assessment)
+    cy.task('stubAssessmentAcceptance', this.assessment)
   }
 
   updateAssessmentStatus(status: AssessmentStatus) {

--- a/cypress_shared/pages/assess/makeADecisionPage.ts
+++ b/cypress_shared/pages/assess/makeADecisionPage.ts
@@ -3,13 +3,13 @@ import MakeADecision from '../../../server/form-pages/assess/makeADecision/makeA
 import AssessPage from './assessPage'
 
 export default class MakeADecisionPage extends AssessPage {
-  pageClass = new MakeADecision({ decision: 'riskTooLow' })
+  pageClass = new MakeADecision({ decision: 'releaseDate' })
 
   constructor(assessment: Assessment) {
     super(assessment, 'Make a decision')
   }
 
   completeForm() {
-    this.checkRadioByNameAndValue('decision', 'insufficientMoveOnPlan')
+    this.checkRadioByNameAndValue('decision', 'releaseDate')
   }
 }

--- a/cypress_shared/pages/assess/submissionConfirmation.ts
+++ b/cypress_shared/pages/assess/submissionConfirmation.ts
@@ -2,7 +2,7 @@ import Page from '../page'
 
 export default class SubmissionConfirmation extends Page {
   constructor() {
-    super('You have marked this application as unsuitable.')
+    super('You have marked this application as suitable.')
   }
 
   clickBackToDashboard() {

--- a/integration_tests/mockApis/assessments.ts
+++ b/integration_tests/mockApis/assessments.ts
@@ -80,6 +80,17 @@ export default {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       },
     }),
+  stubAssessmentAcceptance: (assessment: Assessment): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: paths.assessments.acceptance({ id: assessment.id }),
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      },
+    }),
   stubClarificationNoteCreate: (args: { assessment: Assessment; note: NewClarificationNote }): SuperAgentRequest =>
     stubFor({
       request: {
@@ -127,6 +138,15 @@ export default {
         url: paths.assessments.clarificationNotes.update({
           id: assessment.id,
           clarificationNoteId: assessment.clarificationNotes[0].id,
+        }),
+      })
+    ).body.requests,
+  verifyAssessmentAcceptance: async (assessment: Assessment) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: paths.assessments.acceptance({
+          id: assessment.id,
         }),
       })
     ).body.requests,

--- a/integration_tests/tests/assess/assess.cy.ts
+++ b/integration_tests/tests/assess/assess.cy.ts
@@ -48,6 +48,14 @@ context('Assess', () => {
 
     // And I complete an assessment
     this.assessHelper.completeAssessment()
+
+    // Then the API should have received the correct data
+    cy.task('verifyAssessmentAcceptance', this.assessment).then(requests => {
+      expect(requests).to.have.length(1)
+
+      const body = JSON.parse(requests[0].body)
+      expect(body).to.have.keys('document', 'requirements')
+    })
   })
 
   it('allows me to create and update a clarification note', function test() {

--- a/server/data/assessmentClient.test.ts
+++ b/server/data/assessmentClient.test.ts
@@ -1,5 +1,7 @@
 import nock from 'nock'
 
+import { createMock } from '@golevelup/ts-jest'
+import { AssessmentAcceptance } from '@approved-premises/api'
 import AssessmentClient from './assessmentClient'
 import config from '../config'
 import assessmentFactory from '../testutils/factories/assessment'
@@ -78,14 +80,14 @@ describe('AssessmentClient', () => {
   describe('acceptance', () => {
     it('should call the acceptance endpoint with the assessment', async () => {
       const assessmentId = 'some-id'
-      const document = { section: [{ task: 'response' }] }
+      const data = createMock<AssessmentAcceptance>()
 
       fakeApprovedPremisesApi
-        .post(paths.assessments.acceptance({ id: assessmentId }), { document })
+        .post(paths.assessments.acceptance({ id: assessmentId }), data)
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(201)
 
-      await assessmentClient.acceptance(assessmentId, document)
+      await assessmentClient.acceptance(assessmentId, data)
 
       expect(nock.isDone()).toBeTruthy()
     })

--- a/server/data/assessmentClient.ts
+++ b/server/data/assessmentClient.ts
@@ -1,5 +1,6 @@
 import type {
   ApprovedPremisesAssessment as Assessment,
+  AssessmentAcceptance,
   ClarificationNote,
   NewClarificationNote,
   UpdatedClarificationNote,
@@ -31,10 +32,10 @@ export default class AssessmentClient {
     })) as Assessment
   }
 
-  async acceptance(assessmentId: string, document: ApplicationOrAssessmentResponse): Promise<void> {
+  async acceptance(assessmentId: string, data: AssessmentAcceptance): Promise<void> {
     await this.restClient.post({
       path: paths.assessments.acceptance({ id: assessmentId }),
-      data: { document },
+      data,
     })
   }
 

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -3,8 +3,8 @@ import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../share
 import MatchingInformation from './matchingInformation'
 
 const defaultArguments = {
-  apGender: 'female',
-  apType: 'esap',
+  apGender: 'female' as const,
+  apType: 'esap' as const,
   wheelchairAccessible: 'essential',
   mentalHealthSupport: '1',
   singleRoom: 'essential',

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
@@ -1,3 +1,4 @@
+import type { ApType, Gender } from '@approved-premises/api'
 import type { TaskListErrors } from '@approved-premises/ui'
 
 import { Page } from '../../../utils/decorators'
@@ -5,16 +6,14 @@ import { Page } from '../../../utils/decorators'
 import TasklistPage from '../../../tasklistPage'
 import { lowerCase, sentenceCase } from '../../../../utils/utils'
 
-const apTypes = {
-  standard: 'Standard AP',
+const apTypes: Record<ApType, string> = {
+  normal: 'Standard AP',
   pipe: 'Psychologically Informed Planned Environment (PIPE)',
   esap: 'Enhanced Security AP (ESAP)',
   rfap: 'Recovery Focused Approved Premises (RFAP)',
 } as const
-type ApTypes = keyof typeof apTypes
 
-const apGenders = ['male' as const, 'female' as const]
-type ApGenders = typeof apGenders
+const apGenders: Array<Gender> = ['male', 'female']
 
 const placementRequirementPreferences = ['essential' as const, 'desirable' as const, 'notRelevant' as const]
 type PlacementRequirementPreference = (typeof placementRequirementPreferences)[number]
@@ -41,6 +40,26 @@ export const offenceAndRiskInformationKeys = [
 
 const offenceAndRiskInformationRelevance = ['relevant', 'notRelevant']
 type OffenceAndRiskInformationRelevance = (typeof offenceAndRiskInformationRelevance)[number]
+
+export type MatchingInformationBody = {
+  apType: ApType
+  apGender: Gender
+  mentalHealthSupport?: '1' | '' | undefined
+  wheelchairAccessible: PlacementRequirementPreference
+  singleRoom: PlacementRequirementPreference
+  adaptedForHearingImpairments: PlacementRequirementPreference
+  adaptedForVisualImpairments: PlacementRequirementPreference
+  adaptedForRestrictedMobility: PlacementRequirementPreference
+  cateringRequired: PlacementRequirementPreference
+  contactSexualOffencesAgainstAnAdultAdults: OffenceAndRiskInformationRelevance
+  nonContactSexualOffencesAgainstAnAdultAdults: OffenceAndRiskInformationRelevance
+  contactSexualOffencesAgainstChildren: OffenceAndRiskInformationRelevance
+  nonContactSexualOffencesAgainstChildren: OffenceAndRiskInformationRelevance
+  nonSexualOffencesAgainstChildren: OffenceAndRiskInformationRelevance
+  arsonOffences: OffenceAndRiskInformationRelevance
+  hateBasedOffences: OffenceAndRiskInformationRelevance
+  vulnerableToExploitation: OffenceAndRiskInformationRelevance
+}
 
 @Page({
   name: 'matching-information',
@@ -84,27 +103,7 @@ export default class MatchingInformation implements TasklistPage {
     value: '',
   }
 
-  constructor(
-    public body: {
-      apType: ApTypes
-      apGender: ApGenders[number]
-      mentalHealthSupport?: '1' | '' | undefined
-      wheelchairAccessible: PlacementRequirementPreference
-      singleRoom: PlacementRequirementPreference
-      adaptedForHearingImpairments: PlacementRequirementPreference
-      adaptedForVisualImpairments: PlacementRequirementPreference
-      adaptedForRestrictedMobility: PlacementRequirementPreference
-      cateringRequired: PlacementRequirementPreference
-      contactSexualOffencesAgainstAnAdultAdults: OffenceAndRiskInformationRelevance
-      nonContactSexualOffencesAgainstAnAdultAdults: OffenceAndRiskInformationRelevance
-      contactSexualOffencesAgainstChildren: OffenceAndRiskInformationRelevance
-      nonContactSexualOffencesAgainstChildren: OffenceAndRiskInformationRelevance
-      nonSexualOffencesAgainstChildren: OffenceAndRiskInformationRelevance
-      arsonOffences: OffenceAndRiskInformationRelevance
-      hateBasedOffences: OffenceAndRiskInformationRelevance
-      vulnerableToExploitation: OffenceAndRiskInformationRelevance
-    },
-  ) {
+  constructor(public body: MatchingInformationBody) {
     this.mentalHealthSupport.value = body.mentalHealthSupport
   }
 

--- a/server/services/assessmentService.test.ts
+++ b/server/services/assessmentService.test.ts
@@ -1,5 +1,6 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import { Request } from 'express'
+import { PlacementRequest } from '@approved-premises/api'
 
 import { AssessmentClient } from '../data'
 import AssessmentService from './assessmentService'
@@ -7,6 +8,7 @@ import assessmentFactory from '../testutils/factories/assessment'
 import clarificationNoteFactory from '../testutils/factories/clarificationNote'
 import userFactory from '../testutils/factories/user'
 
+import { placementRequestData } from '../utils/assessments/placementRequestData'
 import { getBody, updateAssessmentData } from '../form-pages/utils'
 import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
 import { DataServices, TaskListErrors } from '../@types/ui'
@@ -17,6 +19,7 @@ jest.mock('../data/assessmentClient.ts')
 jest.mock('../data/personClient.ts')
 jest.mock('../form-pages/utils')
 jest.mock('../utils/applications/utils')
+jest.mock('../utils/assessments/placementRequestData')
 
 describe('AssessmentService', () => {
   const assessmentClient = new AssessmentClient(null) as jest.Mocked<AssessmentClient>
@@ -174,15 +177,17 @@ describe('AssessmentService', () => {
   describe('submit', () => {
     const token = 'some-token'
     let document = { foo: [{ bar: 'baz' }] } as ApplicationOrAssessmentResponse
+    const requirements = createMock<PlacementRequest>()
 
     it('if the assessment is accepted the accept client method is called', async () => {
       const assessment = assessmentFactory.acceptedAssessment().build()
       ;(getResponses as jest.Mock).mockReturnValue(document)
+      ;(placementRequestData as jest.Mock).mockReturnValue(requirements)
 
       await service.submit(token, assessment)
 
       expect(assessmentClientFactory).toHaveBeenCalledWith(token)
-      expect(assessmentClient.acceptance).toHaveBeenCalledWith(assessment.id, document)
+      expect(assessmentClient.acceptance).toHaveBeenCalledWith(assessment.id, { document, requirements })
     })
 
     it('if the assessment is rejected the rejection client method is called with the rejectionRationale', async () => {

--- a/server/services/assessmentService.ts
+++ b/server/services/assessmentService.ts
@@ -6,6 +6,7 @@ import {
 } from '@approved-premises/api'
 import type { DataServices } from '@approved-premises/ui'
 
+import { placementRequestData } from '../utils/assessments/placementRequestData'
 import type { AssessmentClient, RestClientBuilder } from '../data'
 import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
 import { getBody, updateAssessmentData } from '../form-pages/utils'
@@ -70,13 +71,14 @@ export default class AssessmentService {
   async submit(token: string, assessment: Assessment) {
     const client = this.assessmentClientFactory(token)
 
-    const responses = getResponses(assessment)
+    const document = getResponses(assessment)
+    const requirements = placementRequestData(assessment)
 
     if (!applicationAccepted(assessment)) {
-      return client.rejection(assessment.id, responses, rejectionRationaleFromAssessmentResponses(assessment))
+      return client.rejection(assessment.id, document, rejectionRationaleFromAssessmentResponses(assessment))
     }
 
-    return client.acceptance(assessment.id, responses)
+    return client.acceptance(assessment.id, { document, requirements })
   }
 
   async createClarificationNote(token: string, assessmentId: string, clarificationNote: NewClarificationNote) {

--- a/server/testutils/mockQuestionResponse.ts
+++ b/server/testutils/mockQuestionResponse.ts
@@ -6,11 +6,15 @@ const mockQuestionResponse = ({
   type = 'standard',
   sentenceType = 'standardDeterminate',
   releaseType = 'other',
+  alternativeRadius,
+  duration,
 }: {
   postcodeArea?: string
   type?: string
   sentenceType?: string
   releaseType?: string
+  duration?: string
+  alternativeRadius?: string
 }) => {
   ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockImplementation(
     // eslint-disable-next-line consistent-return
@@ -29,6 +33,14 @@ const mockQuestionResponse = ({
 
       if (question === 'releaseType') {
         return releaseType
+      }
+
+      if (question === 'alternativeRadius') {
+        return alternativeRadius
+      }
+
+      if (question === 'duration') {
+        return duration
       }
     },
   )

--- a/server/utils/assessments/placementRequestData.test.ts
+++ b/server/utils/assessments/placementRequestData.test.ts
@@ -1,0 +1,158 @@
+import { createMock } from '@golevelup/ts-jest'
+import mockQuestionResponse from '../../testutils/mockQuestionResponse'
+import { MatchingInformationBody } from '../../form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation'
+import { criteriaFromMatchingInformation, placementRequestData } from './placementRequestData'
+import assessmentFactory from '../../testutils/factories/assessment'
+import { pageDataFromApplicationOrAssessment } from '../../form-pages/utils'
+import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
+
+jest.mock('../../form-pages/utils')
+jest.mock('../retrieveQuestionResponseFromApplicationOrAssessment')
+jest.mock('../applications/arrivalDateFromApplication')
+
+describe('placementRequestData', () => {
+  const assessment = assessmentFactory.build()
+  const expectedArrival = '2020-01-01'
+
+  let matchingInformation = createMock<MatchingInformationBody>({
+    apType: 'normal',
+    apGender: 'male',
+    mentalHealthSupport: '1',
+  })
+
+  ;(pageDataFromApplicationOrAssessment as jest.Mock).mockReturnValue(matchingInformation)
+  ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2020-01-01')
+
+  it('converts matching data into a placement request', () => {
+    mockQuestionResponse({ postcodeArea: 'ABC123', type: 'normal', duration: '12', alternativeRadius: '100' })
+
+    expect(placementRequestData(assessment)).toEqual({
+      gender: matchingInformation.apGender,
+      type: matchingInformation.apType,
+      expectedArrival,
+      duration: '12',
+      location: 'ABC123',
+      radius: '100',
+      mentalHealthSupport: true,
+      essentialCriteria: criteriaFromMatchingInformation(matchingInformation).essentialCriteria,
+      desirableCriteria: criteriaFromMatchingInformation(matchingInformation).desirableCriteria,
+    })
+  })
+
+  it('returns a default radius if one is not present', () => {
+    mockQuestionResponse({ alternativeRadius: undefined })
+
+    const result = placementRequestData(assessment)
+
+    expect(result.radius).toEqual(50)
+  })
+
+  it('returns a false mentalHealthSupport requirement if the mentalHealthSupport matching information is blank', () => {
+    matchingInformation = createMock<MatchingInformationBody>({
+      mentalHealthSupport: '',
+    })
+    ;(pageDataFromApplicationOrAssessment as jest.Mock).mockReturnValue(matchingInformation)
+
+    const result = placementRequestData(assessment)
+
+    expect(result.mentalHealthSupport).toEqual(false)
+  })
+
+  describe('criteriaFromMatchingInformation', () => {
+    it('returns all essential criteria for essential and relevant matching information', () => {
+      matchingInformation = createMock<MatchingInformationBody>({
+        wheelchairAccessible: 'essential',
+        adaptedForHearingImpairments: 'essential',
+        adaptedForVisualImpairments: 'essential',
+        adaptedForRestrictedMobility: 'essential',
+        cateringRequired: 'essential',
+        contactSexualOffencesAgainstAnAdultAdults: 'relevant',
+        nonContactSexualOffencesAgainstAnAdultAdults: 'relevant',
+        contactSexualOffencesAgainstChildren: 'relevant',
+        nonContactSexualOffencesAgainstChildren: 'relevant',
+        nonSexualOffencesAgainstChildren: 'relevant',
+        arsonOffences: 'relevant',
+        hateBasedOffences: 'relevant',
+        vulnerableToExploitation: 'relevant',
+      })
+
+      expect(criteriaFromMatchingInformation(matchingInformation)).toEqual({
+        desirableCriteria: [],
+        essentialCriteria: [
+          'hasWideStepFreeAccess',
+          'hasWideAccessToCommunalAreas',
+          'hasStepFreeAccessToCommunalAreas',
+          'hasWheelChairAccessibleBathrooms',
+          'hasLift',
+          'hasWheelChairAccessibleBathrooms',
+          'hasHearingLoop',
+          'hasTactileFlooring',
+          'hasBrailleSignage',
+          'hasWideStepFreeAccess',
+          'hasStepFreeAccessToCommunalAreas',
+          'hasLift',
+          'isCatered',
+          'acceptsSexOffenders',
+          'acceptsSexOffenders',
+          'acceptsChildSexOffenders',
+          'acceptsChildSexOffenders',
+          'acceptsNonSexualChildOffenders',
+          'acceptsHateCrimeOffenders',
+          'isSuitableForVulnerable',
+        ],
+      })
+    })
+
+    it('returns all desirable criteria for desirable matching information', () => {
+      matchingInformation = createMock<MatchingInformationBody>({
+        wheelchairAccessible: 'desirable',
+        adaptedForHearingImpairments: 'desirable',
+        adaptedForVisualImpairments: 'desirable',
+        adaptedForRestrictedMobility: 'desirable',
+        cateringRequired: 'desirable',
+      })
+
+      expect(criteriaFromMatchingInformation(matchingInformation)).toEqual({
+        desirableCriteria: [
+          'hasWideStepFreeAccess',
+          'hasWideAccessToCommunalAreas',
+          'hasStepFreeAccessToCommunalAreas',
+          'hasWheelChairAccessibleBathrooms',
+          'hasLift',
+          'hasWheelChairAccessibleBathrooms',
+          'hasHearingLoop',
+          'hasTactileFlooring',
+          'hasBrailleSignage',
+          'hasWideStepFreeAccess',
+          'hasStepFreeAccessToCommunalAreas',
+          'hasLift',
+          'isCatered',
+        ],
+        essentialCriteria: [],
+      })
+    })
+
+    it('returns empty objects for not relevant matching information', () => {
+      matchingInformation = createMock<MatchingInformationBody>({
+        wheelchairAccessible: 'notRelevant',
+        adaptedForHearingImpairments: 'notRelevant',
+        adaptedForVisualImpairments: 'notRelevant',
+        adaptedForRestrictedMobility: 'notRelevant',
+        cateringRequired: 'notRelevant',
+        contactSexualOffencesAgainstAnAdultAdults: 'notRelevant',
+        nonContactSexualOffencesAgainstAnAdultAdults: 'notRelevant',
+        contactSexualOffencesAgainstChildren: 'notRelevant',
+        nonContactSexualOffencesAgainstChildren: 'notRelevant',
+        nonSexualOffencesAgainstChildren: 'notRelevant',
+        arsonOffences: 'notRelevant',
+        hateBasedOffences: 'notRelevant',
+        vulnerableToExploitation: 'notRelevant',
+      })
+
+      expect(criteriaFromMatchingInformation(matchingInformation)).toEqual({
+        desirableCriteria: [],
+        essentialCriteria: [],
+      })
+    })
+  })
+})

--- a/server/utils/assessments/placementRequestData.ts
+++ b/server/utils/assessments/placementRequestData.ts
@@ -1,0 +1,125 @@
+import { ApprovedPremisesAssessment as Assessment, PlacementCriteria, PlacementRequest } from '@approved-premises/api'
+import { pageDataFromApplicationOrAssessment } from '../../form-pages/utils'
+import { retrieveQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromApplicationOrAssessment'
+
+import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
+import MatchingInformation, {
+  MatchingInformationBody,
+  offenceAndRiskInformationKeys,
+  placementRequirements,
+} from '../../form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation'
+import LocationFactors from '../../form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors'
+import PlacementDuration from '../../form-pages/apply/move-on/placementDuration'
+
+type Requirement = (typeof placementRequirements)[number]
+type RiskInformationKey = (typeof offenceAndRiskInformationKeys)[number]
+
+export const placementRequestData = (assessment: Assessment): PlacementRequest => {
+  const matchingInformation = pageDataFromApplicationOrAssessment(
+    MatchingInformation,
+    assessment,
+  ) as MatchingInformationBody
+
+  const location = retrieveQuestionResponseFromApplicationOrAssessment(
+    assessment.application,
+    LocationFactors,
+    'postcodeArea',
+  )
+  const alternativeRadius = retrieveQuestionResponseFromApplicationOrAssessment(
+    assessment.application,
+    LocationFactors,
+    'alternativeRadius',
+  )
+  const placementDuration = retrieveQuestionResponseFromApplicationOrAssessment(
+    assessment.application,
+    PlacementDuration,
+    'duration',
+  )
+
+  const criteria = criteriaFromMatchingInformation(matchingInformation)
+
+  return {
+    gender: matchingInformation.apGender,
+    type: matchingInformation.apType,
+    expectedArrival: arrivalDateFromApplication(assessment.application),
+    duration: placementDuration,
+    location,
+    radius: alternativeRadius || 50,
+    mentalHealthSupport: !!matchingInformation.mentalHealthSupport,
+    ...criteria,
+  } as PlacementRequest
+}
+
+export const criteriaFromMatchingInformation = (
+  matchingInformation: MatchingInformationBody,
+): { essentialCriteria: Array<PlacementCriteria>; desirableCriteria: Array<PlacementCriteria> } => {
+  const essentialCriteria = [] as Array<PlacementCriteria>
+  const desirableCriteria = [] as Array<PlacementCriteria>
+
+  placementRequirements.forEach(requirement => {
+    if (matchingInformation[requirement] === 'essential') {
+      essentialCriteria.push(...requirementToCriteria(requirement))
+    }
+
+    if (matchingInformation[requirement] === 'desirable') {
+      desirableCriteria.push(...requirementToCriteria(requirement))
+    }
+  })
+
+  offenceAndRiskInformationKeys.forEach(key => {
+    if (matchingInformation[key] === 'relevant') {
+      essentialCriteria.push(...riskInformationToCriteria(key))
+    }
+  })
+
+  return { essentialCriteria, desirableCriteria }
+}
+
+export const riskInformationToCriteria = (riskKey: RiskInformationKey): Array<PlacementCriteria> => {
+  switch (riskKey) {
+    case 'contactSexualOffencesAgainstAnAdultAdults':
+      return ['acceptsSexOffenders']
+    case 'nonContactSexualOffencesAgainstAnAdultAdults':
+      return ['acceptsSexOffenders']
+    case 'contactSexualOffencesAgainstChildren':
+      return ['acceptsChildSexOffenders']
+    case 'nonContactSexualOffencesAgainstChildren':
+      return ['acceptsChildSexOffenders']
+    case 'nonSexualOffencesAgainstChildren':
+      return ['acceptsNonSexualChildOffenders']
+    case 'arsonOffences':
+      return []
+    case 'hateBasedOffences':
+      return ['acceptsHateCrimeOffenders']
+    case 'vulnerableToExploitation':
+      return ['isSuitableForVulnerable']
+    default:
+      return []
+  }
+}
+
+export const requirementToCriteria = (requirement: Requirement): Array<PlacementCriteria> => {
+  switch (requirement) {
+    case 'wheelchairAccessible':
+      return [
+        'hasWideStepFreeAccess',
+        'hasWideAccessToCommunalAreas',
+        'hasStepFreeAccessToCommunalAreas',
+        'hasWheelChairAccessibleBathrooms',
+        'hasLift',
+        'hasWheelChairAccessibleBathrooms',
+      ]
+    case 'singleRoom':
+      return []
+    case 'adaptedForHearingImpairments':
+      return ['hasHearingLoop']
+    case 'adaptedForVisualImpairments':
+      return ['hasTactileFlooring', 'hasBrailleSignage']
+    case 'adaptedForRestrictedMobility':
+      return ['hasWideStepFreeAccess', 'hasStepFreeAccessToCommunalAreas', 'hasLift']
+    case 'cateringRequired':
+      return ['isCatered']
+    default:
+      return []
+  }
+}


### PR DESCRIPTION
This adds a new helper to fetch all the relevant information for matching/booking when an assessment is completed. During this process, I've realised that the integration tests were rejecting an assessment, but still completing matching information. I've updated this test to accept an assessment now, so we can check the placement request data is sent to the API.