### PR TITLE
(1362) Don't ask for matching info when rejecting applications

### DIFF
--- a/cypress_shared/helpers/assess.ts
+++ b/cypress_shared/helpers/assess.ts
@@ -223,12 +223,12 @@ export default class AseessHelper {
     tasklistPage.shouldShowTaskStatus('required-actions', 'Completed')
   }
 
-  private completeMakeADecisionPage() {
+  completeMakeADecisionPage(decision?: string) {
     // When I click on the 'make-a-decision' link
     cy.get('[data-cy-task-name="make-a-decision"]').click()
 
     // Then I should be taken to the make a decision page
-    const page = new MakeADecisionPage(this.assessment)
+    const page = new MakeADecisionPage(this.assessment, decision)
     page.completeForm()
     page.clickSubmit()
     this.updateAssessmentAndStub(page)
@@ -259,7 +259,7 @@ export default class AseessHelper {
     tasklistPage.shouldShowTaskStatus('matching-information', 'Completed')
   }
 
-  private completeCheckYourAnswersPage() {
+  completeCheckYourAnswersPage() {
     // When I click on the 'check-your-answers' link
     cy.get('[data-cy-task-name="check-your-answers"]').click()
 
@@ -267,10 +267,20 @@ export default class AseessHelper {
     const page = new CheckYourAnswersPage(this.assessment)
     page.shouldShowReviewAnswer(this.pages.reviewApplication)
     page.shouldShowSufficientInformationAnswer(this.pages.sufficientInformation)
-    page.shouldShowAssessSuitabilityAnswers(this.pages.assessSuitability)
-    page.shouldShowRequirementsAnswers(this.pages.requiredActions)
+
+    if (this.pages.assessSuitability.length) {
+      page.shouldShowAssessSuitabilityAnswers(this.pages.assessSuitability)
+    }
+
+    if (this.pages.requiredActions.length) {
+      page.shouldShowRequirementsAnswers(this.pages.requiredActions)
+    }
+
     page.shouldShowDecision(this.pages.makeADecision)
-    page.shouldShowMatchingInformation(this.pages.matchingInformation)
+
+    if (this.pages.matchingInformation.length) {
+      page.shouldShowMatchingInformation(this.pages.matchingInformation)
+    }
 
     page.clickSubmit()
     this.updateAssessmentAndStub(page)
@@ -282,12 +292,12 @@ export default class AseessHelper {
     tasklistPage.shouldShowTaskStatus('check-your-answers', 'Completed')
   }
 
-  submitAssessment() {
+  submitAssessment(isSuitable = true) {
     const tasklistPage = Page.verifyOnPage(TaskListPage)
 
     tasklistPage.checkCheckboxByLabel('confirmed')
     tasklistPage.clickSubmit()
-    Page.verifyOnPage(SubmissionConfirmation)
+    Page.verifyOnPage(SubmissionConfirmation, isSuitable)
   }
 
   updateAssessmentAndStub(pageObject: AssessPage) {

--- a/cypress_shared/pages/assess/makeADecisionPage.ts
+++ b/cypress_shared/pages/assess/makeADecisionPage.ts
@@ -3,13 +3,13 @@ import MakeADecision from '../../../server/form-pages/assess/makeADecision/makeA
 import AssessPage from './assessPage'
 
 export default class MakeADecisionPage extends AssessPage {
-  pageClass = new MakeADecision({ decision: 'releaseDate' })
+  pageClass = new MakeADecision({ decision: this.decision })
 
-  constructor(assessment: Assessment) {
+  constructor(assessment: Assessment, private readonly decision: string = 'releaseDate') {
     super(assessment, 'Make a decision')
   }
 
   completeForm() {
-    this.checkRadioByNameAndValue('decision', 'releaseDate')
+    this.checkRadioByNameAndValue('decision', this.decision)
   }
 }

--- a/cypress_shared/pages/assess/submissionConfirmation.ts
+++ b/cypress_shared/pages/assess/submissionConfirmation.ts
@@ -1,8 +1,12 @@
 import Page from '../page'
 
 export default class SubmissionConfirmation extends Page {
-  constructor() {
-    super('You have marked this application as suitable.')
+  constructor(isSuitable = true) {
+    if (isSuitable) {
+      super('You have marked this application as suitable.')
+    } else {
+      super('You have marked this application as unsuitable.')
+    }
   }
 
   clickBackToDashboard() {

--- a/integration_tests/mockApis/assessments.ts
+++ b/integration_tests/mockApis/assessments.ts
@@ -150,4 +150,13 @@ export default {
         }),
       })
     ).body.requests,
+  verifyAssessmentRejection: async (assessment: Assessment) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: paths.assessments.rejection({
+          id: assessment.id,
+        }),
+      })
+    ).body.requests,
 }

--- a/integration_tests/tests/assess/assess.cy.ts
+++ b/integration_tests/tests/assess/assess.cy.ts
@@ -140,8 +140,26 @@ context('Assess', () => {
         // And I should not see the AssessApplication section
         tasklistPage.shouldNotShowSection('Assess application')
 
-        // And I should be able to start the make a decision task
-        tasklistPage.shouldShowTaskStatus('make-a-decision', 'Not started')
+        // When I make a decision
+        this.assessHelper.completeMakeADecisionPage('otherReasons')
+
+        // Then I should not see the MatchingInformation section
+        tasklistPage.shouldNotShowSection('Information for matching')
+
+        // When I check my answers
+        this.assessHelper.completeCheckYourAnswersPage()
+
+        // And I submit the application
+        this.assessHelper.submitAssessment(false)
+      })
+      .then(() => {
+        // Then the API should have received the correct data
+        cy.task('verifyAssessmentRejection', this.assessment).then(requests => {
+          expect(requests).to.have.length(1)
+
+          const body = JSON.parse(requests[0].body)
+          expect(body).to.have.keys('document', 'rejectionRationale')
+        })
       })
   })
 })

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.test.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.test.ts
@@ -49,7 +49,7 @@ describe('SufficientInformation', () => {
   })
 
   describe('when sufficientInformation is no', () => {
-    itShouldHaveNextValue(new SufficientInformation({ sufficientInformation: 'no' }), 'request-information')
+    itShouldHaveNextValue(new SufficientInformation({ sufficientInformation: 'no' }), 'information-received')
   })
 
   itShouldHavePreviousValue(new SufficientInformation({}), 'dashboard')

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.ts
@@ -39,7 +39,7 @@ export default class SufficientInformation implements TasklistPage {
   }
 
   next() {
-    return this.body.sufficientInformation === 'yes' ? '' : 'request-information'
+    return this.body.sufficientInformation === 'yes' ? '' : 'information-received'
   }
 
   response() {

--- a/server/services/assessmentService.ts
+++ b/server/services/assessmentService.ts
@@ -12,7 +12,8 @@ import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
 import { getBody, updateAssessmentData } from '../form-pages/utils'
 import { ValidationError } from '../utils/errors'
 import { getResponses } from '../utils/applications/utils'
-import { applicationAccepted, rejectionRationaleFromAssessmentResponses } from '../utils/assessments/utils'
+import { rejectionRationaleFromAssessmentResponses } from '../utils/assessments/utils'
+import { applicationAccepted } from '../utils/assessments/decisionUtils'
 
 export default class AssessmentService {
   constructor(private readonly assessmentClientFactory: RestClientBuilder<AssessmentClient>) {}

--- a/server/utils/assessments/decisionUtils.test.ts
+++ b/server/utils/assessments/decisionUtils.test.ts
@@ -1,46 +1,64 @@
+import { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
 import { applicationAccepted, decisionFromAssessment } from './decisionUtils'
 import assessmentFactory from '../../testutils/factories/assessment'
+import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromApplicationOrAssessment'
+
+jest.mock('../retrieveQuestionResponseFromApplicationOrAssessment')
 
 describe('decisionUtils', () => {
   describe('decisionFromAssessment', () => {
+    const assessment = assessmentFactory.build()
+
     it('returns the decision from the assessment if it exists', () => {
-      const assessment = assessmentFactory.build({
-        data: { 'make-a-decision': { 'make-a-decision': { decision: 'the decision' } } },
-      })
+      ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue('the decision')
+
       expect(decisionFromAssessment(assessment)).toEqual('the decision')
     })
 
     it('returns an empty string of the decision doesnt exist', () => {
-      const assessment = assessmentFactory.build({ data: {} })
+      ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue(undefined)
+
       expect(decisionFromAssessment(assessment)).toEqual('')
     })
   })
 
   describe('applicationAccepted', () => {
-    it('returns true if the assessment has either of the two decisions which accept an applicaiton', () => {
-      const acceptedAssessment1 = assessmentFactory.build({
-        data: { 'make-a-decision': { 'make-a-decision': { decision: 'releaseDate' } } },
-      })
-      const acceptedAssessment2 = assessmentFactory.build({
-        data: { 'make-a-decision': { 'make-a-decision': { decision: 'releaseDate' } } },
-      })
+    const acceptedAssessment1 = assessmentFactory.build()
+    const acceptedAssessment2 = assessmentFactory.build()
+    const rejectedAssessment = assessmentFactory.build()
+    const assessmentWithNoDecision = assessmentFactory.build()
 
+    beforeEach(() => {
+      ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockImplementation(
+        (assessment: Assessment) => {
+          if (assessment === acceptedAssessment1) {
+            return 'releaseDate'
+          }
+
+          if (assessment === acceptedAssessment2) {
+            return 'hold'
+          }
+
+          if (assessment === rejectedAssessment) {
+            return 'riskTooHigh'
+          }
+
+          return undefined
+        },
+      )
+    })
+
+    it('returns true if the assessment has either of the two decisions which accept an applicaiton', () => {
       expect(applicationAccepted(acceptedAssessment1)).toBe(true)
       expect(applicationAccepted(acceptedAssessment2)).toBe(true)
     })
 
     it('returns false if the assessment has any other decision', () => {
-      const rejectedAssessment = assessmentFactory.build({
-        data: { 'make-a-decision': { 'make-a-decision': { decision: 'reject' } } },
-      })
-
       expect(applicationAccepted(rejectedAssessment)).toBe(false)
     })
 
     it('returns false if the assessment has no decision', () => {
-      const rejectedAssessment = assessmentFactory.build()
-
-      expect(applicationAccepted(rejectedAssessment)).toBe(false)
+      expect(applicationAccepted(assessmentWithNoDecision)).toBe(false)
     })
   })
 })

--- a/server/utils/assessments/decisionUtils.test.ts
+++ b/server/utils/assessments/decisionUtils.test.ts
@@ -1,0 +1,46 @@
+import { applicationAccepted, decisionFromAssessment } from './decisionUtils'
+import assessmentFactory from '../../testutils/factories/assessment'
+
+describe('decisionUtils', () => {
+  describe('decisionFromAssessment', () => {
+    it('returns the decision from the assessment if it exists', () => {
+      const assessment = assessmentFactory.build({
+        data: { 'make-a-decision': { 'make-a-decision': { decision: 'the decision' } } },
+      })
+      expect(decisionFromAssessment(assessment)).toEqual('the decision')
+    })
+
+    it('returns an empty string of the decision doesnt exist', () => {
+      const assessment = assessmentFactory.build({ data: {} })
+      expect(decisionFromAssessment(assessment)).toEqual('')
+    })
+  })
+
+  describe('applicationAccepted', () => {
+    it('returns true if the assessment has either of the two decisions which accept an applicaiton', () => {
+      const acceptedAssessment1 = assessmentFactory.build({
+        data: { 'make-a-decision': { 'make-a-decision': { decision: 'releaseDate' } } },
+      })
+      const acceptedAssessment2 = assessmentFactory.build({
+        data: { 'make-a-decision': { 'make-a-decision': { decision: 'releaseDate' } } },
+      })
+
+      expect(applicationAccepted(acceptedAssessment1)).toBe(true)
+      expect(applicationAccepted(acceptedAssessment2)).toBe(true)
+    })
+
+    it('returns false if the assessment has any other decision', () => {
+      const rejectedAssessment = assessmentFactory.build({
+        data: { 'make-a-decision': { 'make-a-decision': { decision: 'reject' } } },
+      })
+
+      expect(applicationAccepted(rejectedAssessment)).toBe(false)
+    })
+
+    it('returns false if the assessment has no decision', () => {
+      const rejectedAssessment = assessmentFactory.build()
+
+      expect(applicationAccepted(rejectedAssessment)).toBe(false)
+    })
+  })
+})

--- a/server/utils/assessments/decisionUtils.ts
+++ b/server/utils/assessments/decisionUtils.ts
@@ -1,0 +1,15 @@
+import { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
+
+export const decisionFromAssessment = (assessment: Assessment) =>
+  assessment?.data?.['make-a-decision']?.['make-a-decision']?.decision || ''
+
+export const applicationAccepted = (assessment: Assessment) => {
+  switch (decisionFromAssessment(assessment)) {
+    case 'releaseDate':
+      return true
+    case 'hold':
+      return true
+    default:
+      return false
+  }
+}

--- a/server/utils/assessments/decisionUtils.ts
+++ b/server/utils/assessments/decisionUtils.ts
@@ -1,7 +1,9 @@
 import { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
+import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromApplicationOrAssessment'
+import MakeADecisionPage from '../../form-pages/assess/makeADecision/makeADecisionTask/makeADecision'
 
 export const decisionFromAssessment = (assessment: Assessment) =>
-  assessment?.data?.['make-a-decision']?.['make-a-decision']?.decision || ''
+  retrieveOptionalQuestionResponseFromApplicationOrAssessment(assessment, MakeADecisionPage, 'decision') || ''
 
 export const applicationAccepted = (assessment: Assessment) => {
   switch (decisionFromAssessment(assessment)) {

--- a/server/utils/assessments/getSections.test.ts
+++ b/server/utils/assessments/getSections.test.ts
@@ -1,12 +1,17 @@
 import Assess from '../../form-pages/assess'
 import assessmentFactory from '../../testutils/factories/assessment'
 import getSections from './getSections'
+import informationSetAsNotReceived from './informationSetAsNotReceived'
+import { applicationAccepted, decisionFromAssessment } from './decisionUtils'
+
+jest.mock('./informationSetAsNotReceived')
+jest.mock('./decisionUtils')
 
 describe('getSections', () => {
   const assessment = assessmentFactory.build({ status: 'pending' })
 
-  it('returns all sections if informationReceived is yes', () => {
-    assessment.data = { 'sufficient-information': { 'information-received': { informationReceived: 'yes' } } }
+  it('returns all sections if informationSetAsNotReceived is false', () => {
+    ;(informationSetAsNotReceived as jest.Mock).mockReturnValue(false)
 
     const sections = getSections(assessment)
     const sectionNames = sections.map(s => s.name)
@@ -15,23 +20,50 @@ describe('getSections', () => {
     expect(sectionNames).toContain('AssessApplication')
   })
 
-  it('returns all sections if informationReceived is not yet answered', () => {
-    assessment.data = {}
-
-    const sections = getSections(assessment)
-    const sectionNames = sections.map(s => s.name)
-
-    expect(sections.length).toEqual(Assess.sections.length)
-    expect(sectionNames).toContain('AssessApplication')
-  })
-
-  it('removes the assess section if informationReceived is no', () => {
-    assessment.data = { 'sufficient-information': { 'information-received': { informationReceived: 'no' } } }
+  it('removes the assess section if informationSetAsNotReceived is true', () => {
+    ;(informationSetAsNotReceived as jest.Mock).mockReturnValue(true)
 
     const sections = getSections(assessment)
     const sectionNames = sections.map(s => s.name)
 
     expect(sections.length).toEqual(Assess.sections.length - 1)
+    expect(sectionNames).not.toContain('AssessApplication')
+  })
+
+  it('removes the matching information section if the application has not been accepted', () => {
+    ;(informationSetAsNotReceived as jest.Mock).mockReturnValue(false)
+    ;(decisionFromAssessment as jest.Mock).mockReturnValue('decision')
+    ;(applicationAccepted as jest.Mock).mockReturnValue(false)
+
+    const sections = getSections(assessment)
+    const sectionNames = sections.map(s => s.name)
+
+    expect(sections.length).toEqual(Assess.sections.length - 1)
+    expect(sectionNames).not.toContain('MatchingInformation')
+  })
+
+  it('removes the matching information section if the application has not been accepted', () => {
+    ;(informationSetAsNotReceived as jest.Mock).mockReturnValue(false)
+    ;(decisionFromAssessment as jest.Mock).mockReturnValue('decision')
+    ;(applicationAccepted as jest.Mock).mockReturnValue(true)
+
+    const sections = getSections(assessment)
+    const sectionNames = sections.map(s => s.name)
+
+    expect(sections.length).toEqual(Assess.sections.length)
+    expect(sectionNames).toContain('MatchingInformation')
+  })
+
+  it('removes the assess and matching information section if informationSetAsNotReceived is true and the application has not been accepted', () => {
+    ;(informationSetAsNotReceived as jest.Mock).mockReturnValue(true)
+    ;(decisionFromAssessment as jest.Mock).mockReturnValue('decision')
+    ;(applicationAccepted as jest.Mock).mockReturnValue(false)
+
+    const sections = getSections(assessment)
+    const sectionNames = sections.map(s => s.name)
+
+    expect(sections.length).toEqual(Assess.sections.length - 2)
+    expect(sectionNames).not.toContain('MatchingInformation')
     expect(sectionNames).not.toContain('AssessApplication')
   })
 })

--- a/server/utils/assessments/getSections.ts
+++ b/server/utils/assessments/getSections.ts
@@ -2,12 +2,18 @@ import { ApprovedPremisesAssessment as Assessment } from '../../@types/shared'
 import Assess from '../../form-pages/assess'
 import informationSetAsNotReceived from './informationSetAsNotReceived'
 import AssessApplication from '../../form-pages/assess/assessApplication'
+import MatchingInformation from '../../form-pages/assess/matchingInformation'
+import { applicationAccepted, decisionFromAssessment } from './decisionUtils'
 
 export default (assessment: Assessment) => {
   let { sections } = Assess
 
   if (informationSetAsNotReceived(assessment)) {
     sections = sections.filter(section => section.name !== AssessApplication.name)
+  }
+
+  if (decisionFromAssessment(assessment) && !applicationAccepted(assessment)) {
+    sections = sections.filter(section => section.name !== MatchingInformation.name)
   }
 
   return sections

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -4,7 +4,6 @@ import {
   allocatedTableRows,
   allocationLink,
   allocationSummary,
-  applicationAccepted,
   arriveDateAsTimestamp,
   assessmentLink,
   assessmentSections,
@@ -18,7 +17,6 @@ import {
   daysSinceInfoRequest,
   daysSinceReceived,
   daysUntilDue,
-  decisionFromAssessment,
   formatDays,
   formatDaysUntilDueWithWarning,
   formattedArrivalDate,
@@ -581,48 +579,6 @@ describe('utils', () => {
           category: 'prison-information',
         })}">View additional prison information</a></p>`,
       )
-    })
-  })
-
-  describe('decisionFromAssessment', () => {
-    it('returns the decision from the assessment if it exists', () => {
-      const assessment = assessmentFactory.build({
-        data: { 'make-a-decision': { 'make-a-decision': { decision: 'the decision' } } },
-      })
-      expect(decisionFromAssessment(assessment)).toEqual('the decision')
-    })
-
-    it('returns an empty string of the decision doesnt exist', () => {
-      const assessment = assessmentFactory.build({ data: {} })
-      expect(decisionFromAssessment(assessment)).toEqual('')
-    })
-  })
-
-  describe('applicationAccepted', () => {
-    it('returns true if the assessment has either of the two decisions which accept an applicaiton', () => {
-      const acceptedAssessment1 = assessmentFactory.build({
-        data: { 'make-a-decision': { 'make-a-decision': { decision: 'releaseDate' } } },
-      })
-      const acceptedAssessment2 = assessmentFactory.build({
-        data: { 'make-a-decision': { 'make-a-decision': { decision: 'releaseDate' } } },
-      })
-
-      expect(applicationAccepted(acceptedAssessment1)).toBe(true)
-      expect(applicationAccepted(acceptedAssessment2)).toBe(true)
-    })
-
-    it('returns false if the assessment has any other decision', () => {
-      const rejectedAssessment = assessmentFactory.build({
-        data: { 'make-a-decision': { 'make-a-decision': { decision: 'reject' } } },
-      })
-
-      expect(applicationAccepted(rejectedAssessment)).toBe(false)
-    })
-
-    it('returns false if the assessment has no decision', () => {
-      const rejectedAssessment = assessmentFactory.build()
-
-      expect(applicationAccepted(rejectedAssessment)).toBe(false)
     })
   })
 

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -50,6 +50,7 @@ import userFactory from '../../testutils/factories/user'
 import reviewSections from '../reviewUtils'
 import { documentsFromApplication } from './documentUtils'
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
+import { applicationAccepted, decisionFromAssessment } from './decisionUtils'
 
 const FirstPage = jest.fn()
 const SecondPage = jest.fn()
@@ -60,6 +61,7 @@ jest.mock('../personUtils')
 jest.mock('../reviewUtils')
 jest.mock('./documentUtils')
 jest.mock('../applications/arrivalDateFromApplication')
+jest.mock('./decisionUtils')
 
 jest.mock('../../form-pages/assess', () => {
   return {
@@ -583,19 +585,19 @@ describe('utils', () => {
   })
 
   describe('confirmationPageMessage', () => {
+    const assessment = assessmentFactory.build()
+
     it('returns the release date copy if the decision is "releaseDate"', () => {
-      const assessment = assessmentFactory.build({
-        data: { 'make-a-decision': { 'make-a-decision': { decision: 'releaseDate' } } },
-      })
+      ;(decisionFromAssessment as jest.Mock).mockReturnValue('releaseDate')
+
       expect(confirmationPageMessage(assessment))
         .toMatchStringIgnoringWhitespace(`<p>We've notified the Probation Practitioner that this application has been assessed as suitable.</p>
       <p>The assessment can now be used to match Robert Brown to a bed in an Approved Premises.</p>`)
     })
 
     it('returns the hold copy if the decision is "hold"', () => {
-      const assessment = assessmentFactory.build({
-        data: { 'make-a-decision': { 'make-a-decision': { decision: 'hold' } } },
-      })
+      ;(decisionFromAssessment as jest.Mock).mockReturnValue('hold')
+
       expect(confirmationPageMessage(assessment))
         .toMatchStringIgnoringWhitespace(`<p>We've notified the Probation Practitioner that this application has been assessed as suitable.</p>
         <p>This case is now paused until the oral hearing outcome has been provided by the Probation Practitioner and a release date is confirmed.</p>
@@ -603,9 +605,8 @@ describe('utils', () => {
     })
 
     it('returns the rejection copy if the decision isnt "hold" or "releaseDate" ', () => {
-      const assessment = assessmentFactory.build({
-        data: { 'make-a-decision': { 'make-a-decision': { decision: '' } } },
-      })
+      ;(decisionFromAssessment as jest.Mock).mockReturnValue('')
+
       expect(confirmationPageMessage(assessment))
         .toMatchStringIgnoringWhitespace(`<p>We've sent you a confirmation email.</p>
         <p>We've notified the Probation Practitioner that this application has been rejected as unsuitable for an Approved Premises.</p>`)
@@ -613,24 +614,17 @@ describe('utils', () => {
   })
 
   describe('confirmationPageResult', () => {
-    it('returns the release date copy if the decision is "releaseDate"', () => {
-      const assessment = assessmentFactory.build({
-        data: { 'make-a-decision': { 'make-a-decision': { decision: 'releaseDate' } } },
-      })
+    const assessment = assessmentFactory.build()
+
+    it('returns suitable copy if the application has been accepted"', () => {
+      ;(applicationAccepted as jest.Mock).mockReturnValue(true)
+
       expect(confirmationPageResult(assessment)).toBe('You have marked this application as suitable.')
     })
 
-    it('returns the hold copy if the decision is "hold"', () => {
-      const assessment = assessmentFactory.build({
-        data: { 'make-a-decision': { 'make-a-decision': { decision: 'hold' } } },
-      })
-      expect(confirmationPageResult(assessment)).toBe('You have marked this application as suitable.')
-    })
+    it('returns suitable copy if the application has not been accepted"', () => {
+      ;(applicationAccepted as jest.Mock).mockReturnValue(false)
 
-    it('returns the rejection copy if the decision isnt "hold" or "releaseDate" ', () => {
-      const assessment = assessmentFactory.build({
-        data: { 'make-a-decision': { 'make-a-decision': { decision: '' } } },
-      })
       expect(confirmationPageResult(assessment)).toBe('You have marked this application as unsuitable.')
     })
   })

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -25,6 +25,7 @@ import reviewSections from '../reviewUtils'
 import Apply from '../../form-pages/apply'
 import { kebabCase, linkTo } from '../utils'
 import { documentsFromApplication } from './documentUtils'
+import { applicationAccepted, decisionFromAssessment } from './decisionUtils'
 
 const DUE_DATE_APPROACHING_DAYS_WINDOW = 3
 
@@ -485,20 +486,6 @@ const getSectionSuffix = (task: UiTask, assessmentId: string) => {
   return `<p><a href="${link}">${copy}</a></p>`
 }
 
-const decisionFromAssessment = (assessment: Assessment) =>
-  assessment?.data?.['make-a-decision']?.['make-a-decision']?.decision || ''
-
-const applicationAccepted = (assessment: Assessment) => {
-  switch (decisionFromAssessment(assessment)) {
-    case 'releaseDate':
-      return true
-    case 'hold':
-      return true
-    default:
-      return false
-  }
-}
-
 const confirmationPageMessage = (assessment: Assessment) => {
   switch (decisionFromAssessment(assessment)) {
     case 'releaseDate':
@@ -546,7 +533,6 @@ export {
   allocatedTableRows,
   allocationLink,
   allocationSummary,
-  applicationAccepted,
   arriveDateAsTimestamp,
   assessmentLink,
   assessmentsApproachingDue,
@@ -560,7 +546,6 @@ export {
   daysSinceInfoRequest,
   daysSinceReceived,
   daysUntilDue,
-  decisionFromAssessment,
   formatDays,
   formatDaysUntilDueWithWarning,
   formattedArrivalDate,


### PR DESCRIPTION
In the last PR #622, I noticed that we were still asking for matching info when rejecting applications. This didn't seem like something we'd want to do, so I've updated the `getSections` method to filter this section out when an application has been rejected. There was also a weird bug that was causing the tasklist to render incorrectly when the user does not receive information back from a PP in a timely manner, so I've fixed that too.

This builds on #622, so is in draft until that is merged.