### PR TITLE
Run tests in Parallel

### DIFF
--- a/.github/shared/setup/action.yml
+++ b/.github/shared/setup/action.yml
@@ -1,0 +1,25 @@
+name: Build project
+description: Specific steps to setup the repo
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v3.6.0
+      with:
+        node-version-file: '.node-version'
+
+    - uses: actions/setup-node@v3
+      with:
+        cache: 'npm'
+
+    - name: Installing dependencies
+      run: npm install
+      shell: bash
+
+    - name: Generate Types
+      run: npm run generate-types
+      shell: bash
+
+    - name: Typechecking the code
+      run: npm run typecheck
+      shell: bash

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Integration Tests
 
 on:
   pull_request:
@@ -21,21 +21,15 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v3.6.0
-        with:
-          node-version-file: '.node-version'
-
-      - uses: actions/setup-node@v3
-        with:
-          cache: 'npm'
-
-      - name: Installing dependencies
-        run: npm install
+      - uses: ./.github/shared/setup
 
       - name: Building source
         run: npm run build
 
-      - name: Run tests
-        id: test
-        run: script/test
+      - name: Starting the backing services in Docker
+        run: |
+          script/utils/launch-docker.sh
+          docker-compose -f docker-compose-test.yml up -d
+
+      - name: Running integration tests
+        run: npm run test:integration

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+name: Lint
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - main
+      - develop
+
+env:
+  NODE_ENV: test
+  API_CLIENT_ID: approved-premises
+  API_CLIENT_SECRET: clientsecret
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - uses: ./.github/shared/setup
+
+      - name: Linting the code
+        run: npm run lint
+
+      - name: Checking shell scripts
+        run: node_modules/.bin/shellcheck ./script/**/*[^utils] ./script/utils/**

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,27 @@
+name: Unit Tests
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - main
+      - develop
+
+env:
+  NODE_ENV: test
+  API_CLIENT_ID: approved-premises
+  API_CLIENT_SECRET: clientsecret
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - uses: ./.github/shared/setup
+
+      - name: Running unit tests
+        run: npm test


### PR DESCRIPTION
This breaks all the parts of our test suite into constituent parts, so we can run them in parallel. It doesn’t save a ton of time (maybe 2 minutes at the most), but ensures we get quick feedback from any failures, and keeps things just that little bit tidier.

We also share a bunch of the setup in a new shared action, which installs the dependencies, generates the types, and runs typecheck.