### PR TITLE
Fix - submitting an allocation

### DIFF
--- a/server/controllers/tasksController.test.ts
+++ b/server/controllers/tasksController.test.ts
@@ -117,6 +117,7 @@ describe('TasksController', () => {
         request.user.token,
         request.params.id,
         request.body.userId,
+        'Assessment',
       )
 
       expect(request.flash).toHaveBeenCalledWith(

--- a/server/controllers/tasksController.ts
+++ b/server/controllers/tasksController.ts
@@ -44,7 +44,12 @@ export default class TasksController {
   create(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       try {
-        const assessment = await this.applicationService.allocate(req.user.token, req.params.id, req.body.userId)
+        const assessment = await this.applicationService.allocate(
+          req.user.token,
+          req.params.id,
+          req.body.userId,
+          'Assessment',
+        )
 
         req.flash('success', `Case has been allocated to ${assessment.allocatedToStaffMember.name}`)
         res.redirect(paths.index({}))

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -187,13 +187,14 @@ describe('ApplicationClient', () => {
       const assessment = assessmentFactory.build()
       const applicationId = 'some-application-id'
       const userId = 'some-user-id'
+      const taskType = 'Assessment'
 
       fakeApprovedPremisesApi
-        .post(paths.applications.allocation.create({ id: applicationId }), { userId })
+        .post(paths.applications.allocation.create({ id: applicationId }), { userId, taskType })
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(201, assessment)
 
-      const result = await applicationClient.allocate(applicationId, userId)
+      const result = await applicationClient.allocate(applicationId, userId, taskType)
 
       expect(result).toEqual(assessment)
       expect(nock.isDone()).toBeTruthy()

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -4,6 +4,7 @@ import type {
   ApprovedPremisesAssessment as Assessment,
   Document,
   SubmitApplication,
+  TaskType,
 } from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
@@ -61,10 +62,10 @@ export default class ApplicationClient {
     })) as Assessment
   }
 
-  async allocate(applicationId: string, userId: string): Promise<Assessment> {
+  async allocate(applicationId: string, userId: string, taskType: TaskType): Promise<Assessment> {
     return (await this.restClient.post({
       path: paths.applications.allocation.create({ id: applicationId }),
-      data: { userId },
+      data: { userId, taskType },
     })) as Assessment
   }
 }

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -380,10 +380,10 @@ describe('ApplicationService', () => {
       const applicationId = 'some-application-id'
       const userId = 'some-user-id'
 
-      await service.allocate(token, applicationId, userId)
+      await service.allocate(token, applicationId, userId, 'Assessment')
 
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
-      expect(applicationClient.allocate).toHaveBeenCalledWith(applicationId, userId)
+      expect(applicationClient.allocate).toHaveBeenCalledWith(applicationId, userId, 'Assessment')
     })
   })
 })

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -5,6 +5,7 @@ import type {
   ApprovedPremisesApplication,
   ApprovedPremisesAssessment as Assessment,
   Document,
+  TaskType,
 } from '@approved-premises/api'
 
 import { applicationSubmissionData } from '../utils/applications/applicationSubmissionData'
@@ -134,9 +135,9 @@ export default class ApplicationService {
     return assessment
   }
 
-  async allocate(token: string, assessmentId: string, userId: string): Promise<Assessment> {
+  async allocate(token: string, applicationId: string, userId: string, taskType: TaskType): Promise<Assessment> {
     const client = this.applicationClientFactory(token)
-    const assessment = await client.allocate(assessmentId, userId)
+    const assessment = await client.allocate(applicationId, userId, taskType)
 
     return assessment
   }


### PR DESCRIPTION
Previously we were omitting a `taskType` in the call to the `/applications/{applicationId}/allocations` endpoint and it was required. 
We do not know what type an application could be in `taskController.show` method. 
We could pass the type via the URL or through a flash but we may also want to implement an API endpoint that we can call to get the next neccessary taskType for the application in question. Whilst we decide the best way forward we can hardcode the `taskType` to be 'Assessment'