### PR TITLE
(1317) Correct response from allocations endpoint

### DIFF
--- a/integration_tests/mockApis/tasks.ts
+++ b/integration_tests/mockApis/tasks.ts
@@ -1,6 +1,6 @@
 import { SuperAgentRequest } from 'superagent'
 
-import type { ApprovedPremisesApplication as Application, Task } from '@approved-premises/api'
+import type { ApprovedPremisesApplication as Application, Reallocation, Task } from '@approved-premises/api'
 import { getMatchingRequests, stubFor } from '../../wiremock'
 import paths from '../../server/paths/api'
 import { errorStub } from '../../wiremock/utils'
@@ -21,7 +21,7 @@ export default {
       },
     }),
 
-  stubTaskAllocationCreate: (args: { task: Task }): SuperAgentRequest =>
+  stubTaskAllocationCreate: (args: { task: Task; reallocation: Reallocation }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'POST',

--- a/integration_tests/tests/tasks/allocations.cy.ts
+++ b/integration_tests/tests/tasks/allocations.cy.ts
@@ -5,6 +5,7 @@ import Page from '../../../cypress_shared/pages/page'
 import taskFactory from '../../../server/testutils/factories/task'
 import userFactory from '../../../server/testutils/factories/user'
 import applicationFactory from '../../../server/testutils/factories/application'
+import reallocationFactory from '../../../server/testutils/factories/reallocation'
 
 context('Tasks', () => {
   beforeEach(() => {
@@ -41,6 +42,7 @@ context('Tasks', () => {
     cy.task('stubTaskAllocationCreate', {
       application: this.application,
       task: { ...this.task, allocatedToStaffMember: this.selectedUser },
+      reallocation: reallocationFactory.build(),
     })
 
     // When I visit the task list page
@@ -66,7 +68,7 @@ context('Tasks', () => {
     Page.verifyOnPage(TaskListPage, [], [])
 
     // And I should see a confirmation message
-    taskListPage.shouldShowBanner(`Case has been allocated to ${this.selectedUser.name}`)
+    taskListPage.shouldShowBanner(`Case has been allocated`)
 
     // And the API should have received the correct data
     cy.task('verifyAllocationCreate', this.application).then(requests => {

--- a/server/controllers/tasksController.test.ts
+++ b/server/controllers/tasksController.test.ts
@@ -8,7 +8,7 @@ import { ApplicationService, TaskService, UserService } from '../services'
 import { getQualificationsForApplication } from '../utils/applications/getQualificationsForApplication'
 import userFactory from '../testutils/factories/user'
 import applicationFactory from '../testutils/factories/application'
-import assessmentFactory from '../testutils/factories/assessment'
+import reallocationFactory from '../testutils/factories/reallocation'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../utils/validation'
 import { ErrorsAndUserInput } from '../@types/ui'
 import paths from '../paths/tasks'
@@ -108,8 +108,8 @@ describe('TasksController', () => {
     it('should set a flash message and redirect when the API returns correctly', async () => {
       const requestHandler = tasksController.create()
 
-      const assessment = assessmentFactory.build()
-      applicationService.allocate.mockResolvedValue(assessment)
+      const reallocation = reallocationFactory.build()
+      applicationService.allocate.mockResolvedValue(reallocation)
 
       await requestHandler(request, response, next)
 
@@ -120,10 +120,7 @@ describe('TasksController', () => {
         'Assessment',
       )
 
-      expect(request.flash).toHaveBeenCalledWith(
-        'success',
-        `Case has been allocated to ${assessment.allocatedToStaffMember.name}`,
-      )
+      expect(request.flash).toHaveBeenCalledWith('success', `Case has been allocated`)
       expect(response.redirect).toHaveBeenCalledWith(paths.index({}))
     })
 

--- a/server/controllers/tasksController.ts
+++ b/server/controllers/tasksController.ts
@@ -44,14 +44,9 @@ export default class TasksController {
   create(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       try {
-        const assessment = await this.applicationService.allocate(
-          req.user.token,
-          req.params.id,
-          req.body.userId,
-          'Assessment',
-        )
+        await this.applicationService.allocate(req.user.token, req.params.id, req.body.userId, 'Assessment')
 
-        req.flash('success', `Case has been allocated to ${assessment.allocatedToStaffMember.name}`)
+        req.flash('success', `Case has been allocated`)
         res.redirect(paths.index({}))
       } catch (err) {
         catchValidationErrorOrPropogate(req, res, err, paths.allocations.show({ id: req.params.id }))

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -3,6 +3,7 @@ import type {
   ApprovedPremisesApplication as Application,
   ApprovedPremisesAssessment as Assessment,
   Document,
+  Reallocation,
   SubmitApplication,
   TaskType,
 } from '@approved-premises/api'
@@ -62,10 +63,10 @@ export default class ApplicationClient {
     })) as Assessment
   }
 
-  async allocate(applicationId: string, userId: string, taskType: TaskType): Promise<Assessment> {
+  async allocate(applicationId: string, userId: string, taskType: TaskType): Promise<Reallocation> {
     return (await this.restClient.post({
       path: paths.applications.allocation.create({ id: applicationId }),
       data: { userId, taskType },
-    })) as Assessment
+    })) as Reallocation
   }
 }

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -5,6 +5,7 @@ import type {
   ApprovedPremisesApplication,
   ApprovedPremisesAssessment as Assessment,
   Document,
+  Reallocation,
   TaskType,
 } from '@approved-premises/api'
 
@@ -135,11 +136,11 @@ export default class ApplicationService {
     return assessment
   }
 
-  async allocate(token: string, applicationId: string, userId: string, taskType: TaskType): Promise<Assessment> {
+  async allocate(token: string, applicationId: string, userId: string, taskType: TaskType): Promise<Reallocation> {
     const client = this.applicationClientFactory(token)
-    const assessment = await client.allocate(applicationId, userId, taskType)
+    const reallocation = await client.allocate(applicationId, userId, taskType)
 
-    return assessment
+    return reallocation
   }
 
   private async saveToSession(application: ApprovedPremisesApplication, page: TasklistPage, request: Request) {

--- a/server/testutils/factories/reallocation.ts
+++ b/server/testutils/factories/reallocation.ts
@@ -1,0 +1,11 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { Reallocation } from '@approved-premises/api'
+
+import userFactory from './user'
+
+export default Factory.define<Reallocation>(() => ({
+  taskType: faker.helpers.arrayElement(['Assessment', 'PlacementRequest', 'PlacementRequestReview', 'BookingAppeal']),
+  user: userFactory.build(),
+}))


### PR DESCRIPTION
I had assumed the response from the ` /applications/{applicationId}/allocations` endpioint would be an assessment object which would contain the name of the person it has been assigned to. However it returns a User object.
We could look up the user by the ID returned but I want to fix ASAP and can improve later.
 
