### PR TITLE
Increase window that upcomming booking/departures are shown for

### DIFF
--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -8,7 +8,7 @@ import BookingClient from '../data/bookingClient'
 import { DateFormats } from '../utils/dateUtils'
 
 export default class BookingService {
-  UPCOMING_WINDOW_IN_DAYS = 5
+  UPCOMING_WINDOW_IN_DAYS = 40
 
   constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
 


### PR DESCRIPTION
To unblock testing/content work. 
This screen will be revisted before go-live so it's safe to have a big number for now.