### PR TITLE
(1369) Support mutliple assessment types for allocations

### DIFF
--- a/cypress_shared/pages/tasks/allocationPage.ts
+++ b/cypress_shared/pages/tasks/allocationPage.ts
@@ -1,18 +1,23 @@
-import type { ApprovedPremisesApplication as Application, ApprovedPremisesUser as User } from '@approved-premises/api'
+import type {
+  ApprovedPremisesApplication as Application,
+  Task,
+  ApprovedPremisesUser as User,
+} from '@approved-premises/api'
 
 import Page from '../page'
 import paths from '../../../server/paths/tasks'
 
 import { applicationSummary } from '../../../server/utils/tasks'
+import { kebabCase } from '../../../server/utils/utils'
 
 export default class AllocationsPage extends Page {
-  constructor(private readonly application: Application) {
-    super(`Task for allocation`)
+  constructor(private readonly application: Application, private readonly task: Task) {
+    super(`Reallocate`)
   }
 
-  static visit(application: Application): AllocationsPage {
-    cy.visit(paths.allocations.show({ id: application.id }))
-    return new AllocationsPage(application)
+  static visit(application: Application, task: Task): AllocationsPage {
+    cy.visit(paths.show({ id: application.id, taskType: kebabCase(task.taskType) }))
+    return new AllocationsPage(application, task)
   }
 
   shouldShowInformationAboutTask() {

--- a/integration_tests/mockApis/assessments.ts
+++ b/integration_tests/mockApis/assessments.ts
@@ -51,7 +51,7 @@ export default {
     stubFor({
       request: {
         method: 'POST',
-        url: paths.applications.allocation.create({ id: args.application.id }),
+        url: paths.applications.tasks.allocations.create({ id: args.application.id, taskType: 'assessment' }),
       },
       response: {
         status: 201,

--- a/integration_tests/mockApis/tasks.ts
+++ b/integration_tests/mockApis/tasks.ts
@@ -4,6 +4,7 @@ import type { ApprovedPremisesApplication as Application, Reallocation, Task } f
 import { getMatchingRequests, stubFor } from '../../wiremock'
 import paths from '../../server/paths/api'
 import { errorStub } from '../../wiremock/utils'
+import { kebabCase } from '../../server/utils/utils'
 
 export default {
   stubTasks: (tasks: Array<Task>): SuperAgentRequest =>
@@ -20,26 +21,53 @@ export default {
         jsonBody: tasks,
       },
     }),
-
+  stubTaskGet: (args: { application: Application; task: Task }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: paths.applications.tasks.show({ id: args.application.id, taskType: kebabCase(args.task.taskType) }),
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: args.task,
+      },
+    }),
   stubTaskAllocationCreate: (args: { task: Task; reallocation: Reallocation }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'POST',
-        url: paths.applications.allocation.create({ id: args.task.applicationId }),
+        url: paths.applications.tasks.allocations.create({
+          id: args.task.applicationId,
+          taskType: kebabCase(args.task.taskType),
+        }),
       },
       response: {
         status: 201,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: args.task,
+        jsonBody: args.reallocation,
       },
     }),
-  verifyAllocationCreate: async (application: Application) =>
+  verifyAllocationCreate: async (args: { application: Application; task: Task }) =>
     (
       await getMatchingRequests({
         method: 'POST',
-        url: paths.applications.allocation.create({ id: application.id }),
+        url: paths.applications.tasks.allocations.create({
+          id: args.application.id,
+          taskType: kebabCase(args.task.taskType),
+        }),
       })
     ).body.requests,
-  stubAllocationErrors: (application: Application) =>
-    stubFor(errorStub(['userId'], paths.applications.allocation.create({ id: application.id }))),
+  stubAllocationErrors: (args: { application: Application; task: Task }) =>
+    stubFor(
+      errorStub(
+        ['userId'],
+        paths.applications.tasks.allocations.create({
+          id: args.application.id,
+          taskType: kebabCase(args.task.taskType),
+        }),
+      ),
+    ),
 }

--- a/server/@types/shared/models/NewReallocation.ts
+++ b/server/@types/shared/models/NewReallocation.ts
@@ -2,10 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import type { TaskType } from './TaskType';
-
 export type NewReallocation = {
     userId: string;
-    taskType: TaskType;
 };
 

--- a/server/@types/shared/models/Reallocation.ts
+++ b/server/@types/shared/models/Reallocation.ts
@@ -2,11 +2,11 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import type { ApprovedPremisesUser } from './ApprovedPremisesUser';
 import type { TaskType } from './TaskType';
-import type { User } from './User';
 
 export type Reallocation = {
-    user?: User;
+    user: ApprovedPremisesUser;
     taskType: TaskType;
 };
 

--- a/server/@types/shared/models/Task.ts
+++ b/server/@types/shared/models/Task.ts
@@ -8,10 +8,10 @@ import type { TaskType } from './TaskType';
 
 export type Task = {
     applicationId: string;
-    person?: Person;
-    dueDate?: string;
-    allocatedToStaffMember?: ApprovedPremisesUser;
-    status?: 'not_started' | 'in_progress' | 'complete';
-    taskType?: TaskType;
+    person: Person;
+    dueDate: string;
+    allocatedToStaffMember: ApprovedPremisesUser;
+    status: 'not_started' | 'in_progress' | 'complete';
+    taskType: TaskType;
 };
 

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -5,6 +5,7 @@ import { controllers as assessControllers } from './assess'
 import { controllers as matchControllers } from './match'
 import { controllers as manageControllers } from './manage'
 import TasksController from './tasksController'
+import AllocationsController from './tasks/allocationsController'
 
 import type { Services } from '../services'
 import DashboardController from './dashboardController'
@@ -12,9 +13,11 @@ import DashboardController from './dashboardController'
 export const controllers = (services: Services) => {
   const dashboardController = new DashboardController()
   const tasksController = new TasksController(services.taskService, services.applicationService, services.userService)
+  const allocationsController = new AllocationsController(services.taskService)
   return {
     dashboardController,
     tasksController,
+    allocationsController,
     ...applyControllers(services),
     ...assessControllers(services),
     ...matchControllers(services),

--- a/server/controllers/tasks/allocationsController.test.ts
+++ b/server/controllers/tasks/allocationsController.test.ts
@@ -1,0 +1,80 @@
+import type { NextFunction, Request, Response } from 'express'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+
+import AllocationsController from './allocationsController'
+import { TaskService } from '../../services'
+import userFactory from '../../testutils/factories/user'
+import reallocationFactory from '../../testutils/factories/reallocation'
+import { catchValidationErrorOrPropogate } from '../../utils/validation'
+import paths from '../../paths/tasks'
+
+jest.mock('../../utils/validation')
+
+describe('AllocationsController', () => {
+  const token = 'SOME_TOKEN'
+
+  const request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const taskService = createMock<TaskService>({})
+
+  let allocationsController: AllocationsController
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    allocationsController = new AllocationsController(taskService)
+  })
+
+  describe('create', () => {
+    beforeEach(() => {
+      request.params.id = 'some-uuid'
+      request.body.userId = 'some-other-uuid'
+      request.user.token = token
+    })
+
+    it('should set a flash message and redirect when the API returns correctly', async () => {
+      const requestHandler = allocationsController.create()
+
+      const user = userFactory.build({
+        name: 'Some User',
+      })
+      const reallocation = reallocationFactory.build({ user, taskType: 'Assessment' })
+      taskService.createAllocation.mockResolvedValue(reallocation)
+      request.params.taskType = 'assessment'
+
+      await requestHandler(request, response, next)
+
+      expect(taskService.createAllocation).toHaveBeenCalledWith(
+        request.user.token,
+        request.params.id,
+        request.body.userId,
+        request.params.taskType,
+      )
+
+      expect(request.flash).toHaveBeenCalledWith('success', `Assessment has been allocated to Some User`)
+      expect(response.redirect).toHaveBeenCalledWith(paths.index({}))
+    })
+
+    it('should redirect with errors if the API returns an error', async () => {
+      const requestHandler = allocationsController.create()
+
+      const err = new Error()
+
+      taskService.createAllocation.mockImplementation(() => {
+        throw err
+      })
+
+      request.params.taskType = 'assessment'
+
+      await requestHandler(request, response, next)
+
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+        request,
+        response,
+        err,
+        paths.show({ id: request.params.id, taskType: 'assessment' }),
+      )
+    })
+  })
+})

--- a/server/controllers/tasks/allocationsController.ts
+++ b/server/controllers/tasks/allocationsController.ts
@@ -1,0 +1,30 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+import { convertToTitleCase, sentenceCase } from '../../utils/utils'
+import paths from '../../paths/tasks'
+import { TaskService } from '../../services'
+import { catchValidationErrorOrPropogate } from '../../utils/validation'
+
+export default class AllocationsController {
+  constructor(private readonly taskService: TaskService) {}
+
+  create(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      try {
+        const reallocation = await this.taskService.createAllocation(
+          req.user.token,
+          req.params.id,
+          req.body.userId,
+          req.params.taskType,
+        )
+
+        req.flash(
+          'success',
+          `${convertToTitleCase(sentenceCase(reallocation.taskType))} has been allocated to ${reallocation.user.name}`,
+        )
+        res.redirect(paths.index({}))
+      } catch (err) {
+        catchValidationErrorOrPropogate(req, res, err, paths.show({ id: req.params.id, taskType: req.params.taskType }))
+      }
+    }
+  }
+}

--- a/server/controllers/tasksController.test.ts
+++ b/server/controllers/tasksController.test.ts
@@ -70,7 +70,7 @@ describe('TasksController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('tasks/allocations/show', {
+      expect(response.render).toHaveBeenCalledWith('tasks/show', {
         pageHeading: `Reallocate Placement Request`,
         application,
         task,
@@ -91,7 +91,7 @@ describe('TasksController', () => {
       const requestHandler = tasksController.show()
       await requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('tasks/allocations/show', {
+      expect(response.render).toHaveBeenCalledWith('tasks/show', {
         pageHeading: `Reallocate Placement Request`,
         application,
         task,

--- a/server/controllers/tasksController.test.ts
+++ b/server/controllers/tasksController.test.ts
@@ -52,11 +52,13 @@ describe('TasksController', () => {
   })
 
   describe('show', () => {
+    const task = taskFactory.build({ taskType: 'PlacementRequest' })
     const application = applicationFactory.build()
     const users = userFactory.buildList(3)
     const qualifications = ['foo', 'bar']
 
     beforeEach(() => {
+      taskService.find.mockResolvedValue(task)
       applicationService.findApplication.mockResolvedValue(application)
       userService.getUsers.mockResolvedValue(users)
       ;(getQualificationsForApplication as jest.Mock).mockReturnValue(qualifications)
@@ -66,17 +68,20 @@ describe('TasksController', () => {
       ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [], userInput: {} })
 
       const requestHandler = tasksController.show()
+      request.params.taskType = 'placement-request'
 
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('tasks/allocations/show', {
-        pageHeading: `Task for allocation`,
+        pageHeading: `Reallocate Placement Request`,
         application,
+        task,
         users,
         errors: {},
         errorSummary: [],
       })
 
+      expect(taskService.find).toHaveBeenCalledWith(request.user.token, request.params.id, request.params.taskType)
       expect(applicationService.findApplication).toHaveBeenCalledWith(request.user.token, request.params.id)
       expect(userService.getUsers).toHaveBeenCalledWith(request.user.token, ['assessor'], qualifications)
     })
@@ -89,8 +94,9 @@ describe('TasksController', () => {
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('tasks/allocations/show', {
-        pageHeading: `Task for allocation`,
+        pageHeading: `Reallocate Placement Request`,
         application,
+        task,
         users,
         errors: errorsAndUserInput.errors,
         errorSummary: errorsAndUserInput.errorSummary,

--- a/server/controllers/tasksController.test.ts
+++ b/server/controllers/tasksController.test.ts
@@ -8,10 +8,8 @@ import { ApplicationService, TaskService, UserService } from '../services'
 import { getQualificationsForApplication } from '../utils/applications/getQualificationsForApplication'
 import userFactory from '../testutils/factories/user'
 import applicationFactory from '../testutils/factories/application'
-import reallocationFactory from '../testutils/factories/reallocation'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../utils/validation'
+import { fetchErrorsAndUserInput } from '../utils/validation'
 import { ErrorsAndUserInput } from '../@types/ui'
-import paths from '../paths/tasks'
 
 jest.mock('../utils/applications/getQualificationsForApplication')
 jest.mock('../utils/validation')
@@ -102,52 +100,6 @@ describe('TasksController', () => {
         errorSummary: errorsAndUserInput.errorSummary,
         ...errorsAndUserInput.userInput,
       })
-    })
-  })
-
-  describe('create', () => {
-    beforeEach(() => {
-      request.params.id = 'some-uuid'
-      request.body.userId = 'some-other-uuid'
-      request.user.token = token
-    })
-
-    it('should set a flash message and redirect when the API returns correctly', async () => {
-      const requestHandler = tasksController.create()
-
-      const reallocation = reallocationFactory.build()
-      applicationService.allocate.mockResolvedValue(reallocation)
-
-      await requestHandler(request, response, next)
-
-      expect(applicationService.allocate).toHaveBeenCalledWith(
-        request.user.token,
-        request.params.id,
-        request.body.userId,
-        'Assessment',
-      )
-
-      expect(request.flash).toHaveBeenCalledWith('success', `Case has been allocated`)
-      expect(response.redirect).toHaveBeenCalledWith(paths.index({}))
-    })
-
-    it('should redirect with errors if the API returns an error', async () => {
-      const requestHandler = tasksController.create()
-
-      const err = new Error()
-
-      applicationService.allocate.mockImplementation(() => {
-        throw err
-      })
-
-      await requestHandler(request, response, next)
-
-      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
-        request,
-        response,
-        err,
-        paths.allocations.show({ id: request.params.id }),
-      )
     })
   })
 })

--- a/server/controllers/tasksController.ts
+++ b/server/controllers/tasksController.ts
@@ -3,7 +3,7 @@ import { convertToTitleCase, sentenceCase } from '../utils/utils'
 import { ApplicationService, TaskService, UserService } from '../services'
 import { getQualificationsForApplication } from '../utils/applications/getQualificationsForApplication'
 import { groupByAllocation } from '../utils/tasks'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../utils/validation'
+import { fetchErrorsAndUserInput } from '../utils/validation'
 
 export default class TasksController {
   constructor(
@@ -40,19 +40,6 @@ export default class TasksController {
         errorSummary,
         ...userInput,
       })
-    }
-  }
-
-  create(): TypedRequestHandler<Request, Response> {
-    return async (req: Request, res: Response) => {
-      try {
-        await this.applicationService.allocate(req.user.token, req.params.id, req.body.userId, 'Assessment')
-
-        req.flash('success', `Case has been allocated`)
-        res.redirect(paths.index({}))
-      } catch (err) {
-        catchValidationErrorOrPropogate(req, res, err, paths.allocations.show({ id: req.params.id }))
-      }
     }
   }
 }

--- a/server/controllers/tasksController.ts
+++ b/server/controllers/tasksController.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
-import paths from '../paths/tasks'
+import { convertToTitleCase, sentenceCase } from '../utils/utils'
 import { ApplicationService, TaskService, UserService } from '../services'
 import { getQualificationsForApplication } from '../utils/applications/getQualificationsForApplication'
 import { groupByAllocation } from '../utils/tasks'
@@ -22,6 +22,7 @@ export default class TasksController {
 
   show(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
+      const task = await this.taskService.find(req.user.token, req.params.id, req.params.taskType)
       const application = await this.applicationService.findApplication(req.user.token, req.params.id)
       const users = await this.userService.getUsers(
         req.user.token,
@@ -31,8 +32,9 @@ export default class TasksController {
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
       res.render('tasks/allocations/show', {
-        pageHeading: `Task for allocation`,
+        pageHeading: `Reallocate ${convertToTitleCase(sentenceCase(task.taskType))}`,
         application,
+        task,
         users,
         errors,
         errorSummary,

--- a/server/controllers/tasksController.ts
+++ b/server/controllers/tasksController.ts
@@ -31,7 +31,7 @@ export default class TasksController {
       )
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
-      res.render('tasks/allocations/show', {
+      res.render('tasks/show', {
         pageHeading: `Reallocate ${convertToTitleCase(sentenceCase(task.taskType))}`,
         application,
         task,

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -256,34 +256,4 @@ describeClient('ApplicationClient', provider => {
       expect(result).toEqual(assessment)
     })
   })
-
-  describe('allocate', () => {
-    it('should allocate an assessment', async () => {
-      const assessment = assessmentFactory.build()
-      const applicationId = 'some-application-id'
-      const userId = 'some-user-id'
-      const taskType = 'Assessment'
-
-      provider.addInteraction({
-        state: 'Server is healthy',
-        uponReceiving: 'A request for to allocate an assessement',
-        withRequest: {
-          method: 'POST',
-          path: paths.applications.allocation.create({ id: applicationId }),
-          body: { userId, taskType: 'Assessment' },
-          headers: {
-            authorization: `Bearer ${token}`,
-          },
-        },
-        willRespondWith: {
-          status: 201,
-          body: assessment,
-        },
-      })
-
-      const result = await applicationClient.allocate(applicationId, userId, taskType)
-
-      expect(result).toEqual(assessment)
-    })
-  })
 })

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -3,9 +3,7 @@ import type {
   ApprovedPremisesApplication as Application,
   ApprovedPremisesAssessment as Assessment,
   Document,
-  Reallocation,
   SubmitApplication,
-  TaskType,
 } from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
@@ -61,12 +59,5 @@ export default class ApplicationClient {
     return (await this.restClient.get({
       path: paths.applications.assessment({ id: applicationId }),
     })) as Assessment
-  }
-
-  async allocate(applicationId: string, userId: string, taskType: TaskType): Promise<Reallocation> {
-    return (await this.restClient.post({
-      path: paths.applications.allocation.create({ id: applicationId }),
-      data: { userId, taskType },
-    })) as Reallocation
   }
 }

--- a/server/data/taskClient.test.ts
+++ b/server/data/taskClient.test.ts
@@ -39,6 +39,35 @@ describeClient('taskClient', provider => {
     })
   })
 
+  describe('find', () => {
+    it('should get a task', async () => {
+      const task = taskFactory.build()
+
+      const applicationId = 'some-application-id'
+      const taskType = 'placement-request'
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get a task',
+        withRequest: {
+          method: 'GET',
+          path: paths.applications.tasks.show({ id: applicationId, taskType }),
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: task,
+        },
+      })
+
+      const result = await taskClient.find(applicationId, taskType)
+
+      expect(result).toEqual(task)
+    })
+  })
+
   describe('createAllocation', () => {
     it('should allocate a task', async () => {
       const task = taskFactory.build()

--- a/server/data/taskClient.test.ts
+++ b/server/data/taskClient.test.ts
@@ -38,4 +38,35 @@ describeClient('taskClient', provider => {
       expect(result).toEqual(tasks)
     })
   })
+
+  describe('createAllocation', () => {
+    it('should allocate a task', async () => {
+      const task = taskFactory.build()
+
+      const applicationId = 'some-application-id'
+      const userId = 'some-user-id'
+      const taskType = 'placement-request'
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to allocate a task',
+        withRequest: {
+          method: 'POST',
+          path: paths.applications.tasks.allocations.create({ id: applicationId, taskType }),
+          body: { userId },
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 201,
+          body: task,
+        },
+      })
+
+      const result = await taskClient.createAllocation(applicationId, userId, taskType)
+
+      expect(result).toEqual(task)
+    })
+  })
 })

--- a/server/data/taskClient.ts
+++ b/server/data/taskClient.ts
@@ -1,7 +1,7 @@
 import config, { ApiConfig } from '../config'
 import RestClient from './restClient'
 import paths from '../paths/api'
-import { Task } from '../@types/shared'
+import { Reallocation, Task } from '../@types/shared'
 
 export default class TaskClient {
   restClient: RestClient
@@ -12,5 +12,12 @@ export default class TaskClient {
 
   async all(): Promise<Array<Task>> {
     return (await this.restClient.get({ path: paths.tasks.index.pattern })) as Promise<Array<Task>>
+  }
+
+  async createAllocation(applicationId: string, userId: string, taskType: string): Promise<Reallocation> {
+    return (await this.restClient.post({
+      path: paths.applications.tasks.allocations.create({ id: applicationId, taskType }),
+      data: { userId },
+    })) as Reallocation
   }
 }

--- a/server/data/taskClient.ts
+++ b/server/data/taskClient.ts
@@ -14,6 +14,12 @@ export default class TaskClient {
     return (await this.restClient.get({ path: paths.tasks.index.pattern })) as Promise<Array<Task>>
   }
 
+  async find(applicationId: string, taskType: string): Promise<Task> {
+    return (await this.restClient.get({
+      path: paths.applications.tasks.show({ id: applicationId, taskType }),
+    })) as Promise<Task>
+  }
+
   async createAllocation(applicationId: string, userId: string, taskType: string): Promise<Reallocation> {
     return (await this.restClient.post({
       path: paths.applications.tasks.allocations.create({ id: applicationId, taskType }),

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -45,6 +45,12 @@ const applyPaths = {
   },
 }
 
+const taskPaths = {
+  tasks: {
+    show: singleApplicationPath.path('tasks/:taskType'),
+  },
+}
+
 const assessPaths = {
   assessments: path('/assessments'),
   singleAssessment: path('/assessments/:id'),
@@ -76,8 +82,11 @@ export default {
     submission: applyPaths.applications.submission,
     documents: applyPaths.applications.show.path('documents'),
     assessment: applyPaths.applications.show.path('assessment'),
-    allocation: {
-      create: applyPaths.applications.show.path('allocations'),
+    tasks: {
+      show: taskPaths.tasks.show,
+      allocations: {
+        create: taskPaths.tasks.show.path('allocations'),
+      },
     },
   },
   assessments: {
@@ -93,9 +102,6 @@ export default {
   },
   tasks: {
     index: tasksPaths.index,
-    allocations: {
-      create: tasksPaths.allocations.create,
-    },
   },
   placementRequests: {
     index: placementRequestsPath,

--- a/server/paths/tasks.ts
+++ b/server/paths/tasks.ts
@@ -5,13 +5,12 @@ import applyPaths from './apply'
 
 const tasksPath = path('/tasks')
 
-const allocationPath = applyPaths.applications.show.path('allocation')
 const taskPath = applyPaths.applications.show.path('tasks/:taskType')
 
 export default {
   index: tasksPath,
   show: taskPath,
   allocations: {
-    create: allocationPath,
+    create: taskPath.path('allocations'),
   },
 }

--- a/server/paths/tasks.ts
+++ b/server/paths/tasks.ts
@@ -6,11 +6,12 @@ import applyPaths from './apply'
 const tasksPath = path('/tasks')
 
 const allocationPath = applyPaths.applications.show.path('allocation')
+const taskPath = applyPaths.applications.show.path('tasks/:taskType')
 
 export default {
   index: tasksPath,
+  show: taskPath,
   allocations: {
-    show: allocationPath,
     create: allocationPath,
   },
 }

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -5,11 +5,11 @@ import { Controllers } from '../controllers'
 import paths from '../paths/tasks'
 
 export default function routes(controllers: Controllers, router: Router): Router {
-  const { tasksController } = controllers
+  const { tasksController, allocationsController } = controllers
 
   router.get(paths.index.pattern, tasksController.index())
   router.get(paths.show.pattern, tasksController.show())
-  router.post(paths.allocations.create.pattern, tasksController.create())
+  router.post(paths.allocations.create.pattern, allocationsController.create())
 
   return router
 }

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -8,8 +8,8 @@ export default function routes(controllers: Controllers, router: Router): Router
   const { tasksController } = controllers
 
   router.get(paths.index.pattern, tasksController.index())
-  router.get(paths.allocations.show.pattern, tasksController.show())
-  router.post(paths.allocations.show.pattern, tasksController.create())
+  router.get(paths.show.pattern, tasksController.show())
+  router.post(paths.allocations.create.pattern, tasksController.create())
 
   return router
 }

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -373,17 +373,4 @@ describe('ApplicationService', () => {
       expect(applicationClient.assessment).toHaveBeenCalledWith(id)
     })
   })
-
-  describe('allocate', () => {
-    it('calls the client with the expected arguments', async () => {
-      const token = 'token'
-      const applicationId = 'some-application-id'
-      const userId = 'some-user-id'
-
-      await service.allocate(token, applicationId, userId, 'Assessment')
-
-      expect(applicationClientFactory).toHaveBeenCalledWith(token)
-      expect(applicationClient.allocate).toHaveBeenCalledWith(applicationId, userId, 'Assessment')
-    })
-  })
 })

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -5,8 +5,6 @@ import type {
   ApprovedPremisesApplication,
   ApprovedPremisesAssessment as Assessment,
   Document,
-  Reallocation,
-  TaskType,
 } from '@approved-premises/api'
 
 import { applicationSubmissionData } from '../utils/applications/applicationSubmissionData'
@@ -134,13 +132,6 @@ export default class ApplicationService {
     const assessment = await client.assessment(assessmentId)
 
     return assessment
-  }
-
-  async allocate(token: string, applicationId: string, userId: string, taskType: TaskType): Promise<Reallocation> {
-    const client = this.applicationClientFactory(token)
-    const reallocation = await client.allocate(applicationId, userId, taskType)
-
-    return reallocation
   }
 
   private async saveToSession(application: ApprovedPremisesApplication, page: TasklistPage, request: Request) {

--- a/server/services/taskService.test.ts
+++ b/server/services/taskService.test.ts
@@ -31,4 +31,16 @@ describe('taskService', () => {
       expect(taskClient.all).toHaveBeenCalled()
     })
   })
+
+  describe('createAllocation', () => {
+    it('calls the client with the expected arguments', async () => {
+      const applicationId = 'some-application-id'
+      const userId = 'some-user-id'
+
+      await service.createAllocation(token, applicationId, userId, 'assessment')
+
+      expect(taskClientFactory).toHaveBeenCalledWith(token)
+      expect(taskClient.createAllocation).toHaveBeenCalledWith(applicationId, userId, 'assessment')
+    })
+  })
 })

--- a/server/services/taskService.test.ts
+++ b/server/services/taskService.test.ts
@@ -32,6 +32,22 @@ describe('taskService', () => {
     })
   })
 
+  describe('find', () => {
+    it('calls the find method on the task client', async () => {
+      const applicationId = 'some-application-id'
+
+      const task = taskFactory.build()
+      taskClient.find.mockResolvedValue(task)
+
+      const result = await service.find(token, applicationId, 'assessment')
+
+      expect(result).toEqual(task)
+
+      expect(taskClientFactory).toHaveBeenCalledWith(token)
+      expect(taskClient.find).toHaveBeenCalledWith(applicationId, 'assessment')
+    })
+  })
+
   describe('createAllocation', () => {
     it('calls the client with the expected arguments', async () => {
       const applicationId = 'some-application-id'

--- a/server/services/taskService.ts
+++ b/server/services/taskService.ts
@@ -1,3 +1,4 @@
+import { Reallocation, TaskType } from '@approved-premises/api'
 import { RestClientBuilder } from '../data'
 import TaskClient from '../data/taskClient'
 
@@ -9,5 +10,18 @@ export default class TaskService {
 
     const tasks = await taskClient.all()
     return tasks
+  }
+
+  async createAllocation(
+    token: string,
+    applicationId: string,
+    userId: string,
+    taskType: string,
+  ): Promise<Reallocation> {
+    const taskClient = this.taskClientFactory(token)
+
+    const allocation = await taskClient.createAllocation(applicationId, userId, taskType)
+
+    return allocation
   }
 }

--- a/server/services/taskService.ts
+++ b/server/services/taskService.ts
@@ -1,4 +1,4 @@
-import { Reallocation, TaskType } from '@approved-premises/api'
+import { Reallocation, Task } from '@approved-premises/api'
 import { RestClientBuilder } from '../data'
 import TaskClient from '../data/taskClient'
 
@@ -10,6 +10,14 @@ export default class TaskService {
 
     const tasks = await taskClient.all()
     return tasks
+  }
+
+  async find(token: string, premisesId: string, taskType: string): Promise<Task> {
+    const taskClient = this.taskClientFactory(token)
+
+    const task = await taskClient.find(premisesId, taskType)
+
+    return task
   }
 
   async createAllocation(

--- a/server/utils/tasks/table.test.ts
+++ b/server/utils/tasks/table.test.ts
@@ -14,7 +14,6 @@ import {
 } from './table'
 import { sentenceCase } from '../utils'
 import { DateFormats } from '../dateUtils'
-import { Task } from '../../@types/shared'
 
 describe('table', () => {
   describe('allocatedTableRows', () => {
@@ -48,40 +47,6 @@ describe('table', () => {
         ])
       })
     })
-
-    describe('when all the optional task properties are not defined', () => {
-      it('returns an array of table rows with empty strings for the undefined values', () => {
-        const task = taskFactory.build({
-          person: undefined,
-          dueDate: undefined,
-          allocatedToStaffMember: undefined,
-          status: undefined,
-          taskType: undefined,
-        })
-
-        expect(allocatedTableRows([task])).toEqual([
-          [
-            {
-              text: '',
-            },
-            {
-              html: '',
-              attributes: {
-                'data-sort-value': 0,
-              },
-            },
-            { text: '' },
-            {
-              html: '',
-            },
-            {
-              html: '',
-            },
-            allocationLinkCell(task, 'Reallocate'),
-          ],
-        ])
-      })
-    })
   })
 
   describe('unallocatedTableRows', () => {
@@ -105,38 +70,6 @@ describe('table', () => {
             },
             {
               html: `<strong class="govuk-tag">${sentenceCase(task.taskType)}</strong>`,
-            },
-            allocationLinkCell(task, 'Allocate'),
-          ],
-        ])
-      })
-    })
-    describe('when all the optional task properties are not defined', () => {
-      it('returns an array of table rows with empty strings for the undefined values', () => {
-        const task = taskFactory.build({
-          person: undefined,
-          dueDate: undefined,
-          allocatedToStaffMember: undefined,
-          status: undefined,
-          taskType: undefined,
-        })
-
-        expect(unallocatedTableRows([task])).toEqual([
-          [
-            {
-              text: '',
-            },
-            {
-              html: '',
-              attributes: {
-                'data-sort-value': 0,
-              },
-            },
-            {
-              html: '',
-            },
-            {
-              html: '',
             },
             allocationLinkCell(task, 'Allocate'),
           ],
@@ -197,13 +130,6 @@ describe('table', () => {
       const inProgressTask = taskFactory.build({ status: 'in_progress' })
       expect(statusBadge(inProgressTask)).toEqual('<strong class="govuk-tag govuk-tag--grey">In progress</strong>')
     })
-
-    it('returns an empty string for an unknown status', () => {
-      const unknownStatusTask = taskFactory.build({ status: undefined })
-      const unknownStatusTask2 = undefined as unknown as Task
-      expect(statusBadge(unknownStatusTask)).toEqual('')
-      expect(statusBadge(unknownStatusTask2)).toEqual('')
-    })
   })
 
   describe('daysUntilDue', () => {
@@ -213,10 +139,6 @@ describe('table', () => {
     })
     it('returns 0 if the task is due', () => {
       const task = taskFactory.build({ dueDate: DateFormats.dateObjToIsoDate(new Date()) })
-      expect(daysUntilDue(task)).toEqual(0)
-    })
-    it('returns 0 if the task has no due date', () => {
-      const task = taskFactory.build({ dueDate: undefined })
       expect(daysUntilDue(task)).toEqual(0)
     })
   })
@@ -239,25 +161,15 @@ describe('table', () => {
         }<span class="govuk-visually-hidden"> (Approaching due date)</span></strong>`,
       )
     })
-
-    it('returns "no due date" if the task has no due date', () => {
-      const task = taskFactory.build({ dueDate: undefined })
-      expect(formatDaysUntilDueWithWarning(task)).toEqual('')
-    })
   })
 
   describe('allocationLinkCell', () => {
     it('returns the cell when there is a person present in the task', () => {
-      const task = taskFactory.build()
-      expect(allocationLinkCell(task, 'Allocate')).toEqual({
-        html: `<a href="/applications/${task.applicationId}/allocation" data-cy-taskId="${task.applicationId}">Allocate <span class="govuk-visually-hidden">task for ${task.person.name}</span></a>`,
+      const task = taskFactory.build({
+        taskType: 'Assessment',
       })
-    })
-
-    it('returns the cell when there is not a person present in the task', () => {
-      const task = taskFactory.build({ person: undefined })
       expect(allocationLinkCell(task, 'Allocate')).toEqual({
-        html: `<a href="/applications/${task.applicationId}/allocation" data-cy-taskId="${task.applicationId}">Allocate</a>`,
+        html: `<a href="/applications/${task.applicationId}/tasks/assessment" data-cy-taskId="${task.applicationId}">Allocate <span class="govuk-visually-hidden">task for ${task.person.name}</span></a>`,
       })
     })
   })

--- a/server/utils/tasks/table.ts
+++ b/server/utils/tasks/table.ts
@@ -3,7 +3,7 @@ import { TableCell, TableRow } from '../../@types/ui'
 import paths from '../../paths/tasks'
 import { DateFormats } from '../dateUtils'
 import { nameCell } from '../tableUtils'
-import { linkTo, sentenceCase } from '../utils'
+import { kebabCase, linkTo, sentenceCase } from '../utils'
 
 const DUE_DATE_APPROACHING_DAYS_WINDOW = 3
 
@@ -52,20 +52,20 @@ const statusCell = (task: Task): TableCell => ({
 })
 
 const taskTypeCell = (task: Task): TableCell => ({
-  html: task.taskType ? `<strong class="govuk-tag">${sentenceCase(task.taskType)}</strong>` : '',
+  html: `<strong class="govuk-tag">${sentenceCase(task.taskType)}</strong>`,
 })
 
 const allocationCell = (task: Task): TableCell => ({
-  text: task.allocatedToStaffMember?.name || '',
+  text: task.allocatedToStaffMember?.name,
 })
 
 const allocationLinkCell = (task: Task, action: 'Allocate' | 'Reallocate'): TableCell => {
-  const hiddenText = task.person ? `task for ${task.person.name}` : ''
+  const hiddenText = `task for ${task.person.name}`
 
   return {
     html: linkTo(
-      paths.allocations.show,
-      { id: task.applicationId },
+      paths.show,
+      { id: task.applicationId, taskType: kebabCase(task.taskType) },
       {
         text: action,
         hiddenText,
@@ -76,22 +76,19 @@ const allocationLinkCell = (task: Task, action: 'Allocate' | 'Reallocate'): Tabl
 }
 
 const statusBadge = (task: Task): string => {
-  const status = task?.status || ''
-  switch (status) {
+  switch (task.status) {
     case 'complete':
-      return `<strong class="govuk-tag">${sentenceCase(status)}</strong>`
+      return `<strong class="govuk-tag">${sentenceCase(task.status)}</strong>`
     case 'not_started':
-      return `<strong class="govuk-tag govuk-tag--yellow">${sentenceCase(status)}</strong>`
+      return `<strong class="govuk-tag govuk-tag--yellow">${sentenceCase(task.status)}</strong>`
     case 'in_progress':
-      return `<strong class="govuk-tag govuk-tag--grey">${sentenceCase(status)}</strong>`
+      return `<strong class="govuk-tag govuk-tag--grey">${sentenceCase(task.status)}</strong>`
     default:
       return ''
   }
 }
 
 const formatDaysUntilDueWithWarning = (task: Task): string => {
-  if (!task.dueDate) return ''
-
   const differenceInDays = DateFormats.differenceInDays(DateFormats.isoToDateObj(task.dueDate), new Date())
 
   if (differenceInDays.number < DUE_DATE_APPROACHING_DAYS_WINDOW) {
@@ -104,8 +101,6 @@ const formatDaysUntilDueWithWarning = (task: Task): string => {
 }
 
 const daysUntilDue = (task: Task): number => {
-  if (!task.dueDate) return 0
-
   return DateFormats.differenceInDays(DateFormats.isoToDateObj(task.dueDate), new Date()).number
 }
 

--- a/server/views/tasks/show.njk
+++ b/server/views/tasks/show.njk
@@ -2,9 +2,9 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 
-{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "../partials/showErrorSummary.njk" import showErrorSummary %}
 
-{% extends "../../partials/layout.njk" %}
+{% extends "../partials/layout.njk" %}
 
 {% block content %}
   <div class="govuk-grid-row">
@@ -21,7 +21,7 @@
 
       {{ showErrorSummary(errorSummary) }}
 
-      <form action="{{ paths.allocations.show({ id: application.id }) }}" method="post">
+      <form action="{{ paths.allocations.create({ id: application.id, taskType: (task.taskType | kebabCase) }) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
         {{
           govukSelect({


### PR DESCRIPTION
This updates the allocations endpoints to support multiple types of task. I've had a bit of a change around with some of the controllers to be a bit more RESTful, and there's some tweaks I'd like to make at the API end, but this gets the functionality working and the tests passing for now.