### PR TITLE
More temporary Pact files to project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ integration_tests/screenshots/
 /e2e.env
 .DS_Store
 /integration_tests/downloads
+/tmp

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "jest": {
     "preset": "ts-jest",
+    "globalSetup": "./server/testutils/setup.ts",
     "collectCoverage": true,
     "collectCoverageFrom": [
       "server/**/*.{ts,js,jsx,mjs}",

--- a/server/testutils/describeClient.ts
+++ b/server/testutils/describeClient.ts
@@ -1,11 +1,12 @@
 import { pactWith } from 'jest-pact'
 import { Pact } from '@pact-foundation/pact'
+import path from 'path'
 
 import config from '../config'
 
 const describeClient = (consumer: string, fn: (provider: Pact) => void) => {
   const provider = 'API'
-  const dir = '/tmp/pacts'
+  const dir = path.join(__dirname, '..', '..', 'tmp', 'pacts')
 
   describe(consumer, () => {
     pactWith({ consumer, provider, dir }, pact => {

--- a/server/testutils/jest.setup.ts
+++ b/server/testutils/jest.setup.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 import { execSync } from 'child_process'
+import path from 'path'
 
 export {}
 
@@ -27,13 +28,15 @@ expect.extend({
     const openAPIUrl =
       'https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/main/src/main/resources/static/api.yml'
 
+    const openAPIPath = path.join(__dirname, '..', '..', 'tmp', 'api.yml')
+
     try {
       execSync(`
-        if [ ! -f /tmp/api.yml ]; then
-          curl -s "${openAPIUrl}" > /tmp/api.yml
+        if [ ! -f ${openAPIPath} ]; then
+          curl -s "${openAPIUrl}" > ${openAPIPath}
         fi
       `)
-      execSync(`npx swagger-mock-validator /tmp/api.yml ${pactPath}`)
+      execSync(`npx swagger-mock-validator ${openAPIPath} ${pactPath}`)
       return {
         message: () => `Swagger mock validator for ${pactPath} did not fail`,
         pass: true,

--- a/server/testutils/setup.ts
+++ b/server/testutils/setup.ts
@@ -1,0 +1,8 @@
+/* eslint-disable import/no-import-module-exports */
+import path from 'path'
+import { rmSync } from 'fs'
+
+module.exports = async () => {
+  const tmpDir = path.join(__dirname, '..', '..', 'tmp')
+  rmSync(tmpDir, { recursive: true, force: true })
+}


### PR DESCRIPTION
This is a more logical place for them to live. Also I've added a setup task to delete the `tmp` file at the start of the test run, to prevent stale files from giving us false positives/negatives.