### PR TITLE
Fix E2E tests - install make

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - checkout
       - run:
           name: install
-          command: apt-get install xz-utils
+          command: apt-get install xz-utils make
       - run:
           name: Update npm
           command: 'npm install -g npm@latest'


### PR DESCRIPTION
The E2E tests are broken. 
[The logs are complaining that `make` isn't installed.](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-approved-premises-ui/3185/workflows/f70b398a-8a33-4ffa-a968-98b0b4eddc41/jobs/5866)
In our [dockerfile](https://github.com/ministryofjustice/hmpps-approved-premises-ui/blob/5b0ba278e93d7b490f913b135924f271b03aa7e5/Dockerfile#L23) we install it.
I think we should install it here too.
