### PR TITLE
Fix E2E tests - install g++

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - checkout
       - run:
           name: install
-          command: apt-get install xz-utils make
+          command: apt-get install xz-utils make g++
       - run:
           name: Update npm
           command: 'npm install -g npm@latest'


### PR DESCRIPTION
Following on from #661 we have [a new error in the logs](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-approved-premises-ui/3196/workflows/bc2db320-de15-470c-bdae-4b29a50e5a70/jobs/5880).
This time it looks like we need to install g++