### PR TITLE
Fix E2E tests - add -y flag to apt-get install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - checkout
       - run:
           name: install
-          command: apt-get install xz-utils make g++
+          command: apt-get install -y xz-utils make g++
       - run:
           name: Update npm
           command: 'npm install -g npm@latest'


### PR DESCRIPTION
Following on from #662 we have [a new error in the logs](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-approved-premises-ui/3206/workflows/b4f5edc2-6e42-46e5-b146-3ec40974df19/jobs/5900)

This should fix this one