### PR TITLE
Show Oasys Question names in Check Your Answers screens

### DIFF
--- a/cypress_shared/fixtures/applicationData.json
+++ b/cypress_shared/fixtures/applicationData.json
@@ -48,120 +48,120 @@
       ]
     },
     "rosh-summary": {
-      "roshAnswers": [
-        "Some answer for the first RoSH question. With an extra comment 1",
-        "Some answer for the second RoSH question. With an extra comment 2",
-        "Some answer for the third RoSH question. With an extra comment 3"
-      ],
+      "roshAnswers": {
+        "Q1": "Some answer for the first RoSH question. With an extra comment Q1",
+        "Q2": "Some answer for the second RoSH question. With an extra comment Q2",
+        "Q3": "Some answer for the third RoSH question. With an extra comment Q3"
+      },
       "roshSummaries": [
         {
-          "questionNumber": "1",
+          "questionNumber": "Q1",
           "label": "The first RoSH question",
           "answer": "Some answer for the first RoSH question"
         },
         {
-          "questionNumber": "2",
+          "questionNumber": "Q2",
           "label": "The second RoSH question",
           "answer": "Some answer for the second RoSH question"
         },
         {
-          "questionNumber": "3",
+          "questionNumber": "Q3",
           "label": "The third RoSH question",
           "answer": "Some answer for the third RoSH question"
         }
       ]
     },
     "offence-details": {
-      "offenceDetailsAnswers": [
-        "Some answer for the first offence details question. With an extra comment 1",
-        "Some answer for the second offence details question. With an extra comment 2",
-        "Some answer for the third offence details question. With an extra comment 3"
-      ],
+      "offenceDetailsAnswers": {
+        "Q1": "Some answer for the first offence details question. With an extra comment Q1",
+        "Q2": "Some answer for the second offence details question. With an extra comment Q2",
+        "Q3": "Some answer for the third offence details question. With an extra comment Q3"
+      },
       "offenceDetailsSummaries": [
         {
-          "questionNumber": "1",
+          "questionNumber": "Q1",
           "label": "The first offence details question",
           "answer": "Some answer for the first offence details question"
         },
         {
-          "questionNumber": "2",
+          "questionNumber": "Q2",
           "label": "The second offence details question",
           "answer": "Some answer for the second offence details question"
         },
         {
-          "questionNumber": "3",
+          "questionNumber": "Q3",
           "label": "The third offence details question",
           "answer": "Some answer for the third offence details question"
         }
       ]
     },
     "supporting-information": {
-      "supportingInformationAnswers": [
-        "Some answer for the first supporting information question. With an extra comment 1",
-        "Some answer for the second supporting information question. With an extra comment 2",
-        "Some answer for the third supporting information question. With an extra comment 3"
-      ],
+      "supportingInformationAnswers": {
+        "Q1": "Some answer for the first supporting information question. With an extra comment Q1",
+        "Q2": "Some answer for the second supporting information question. With an extra comment Q2",
+        "Q3": "Some answer for the third supporting information question. With an extra comment Q3"
+      },
       "supportingInformationSummaries": [
         {
-          "questionNumber": "1",
+          "questionNumber": "Q1",
           "label": "The first supporting information question",
           "answer": "Some answer for the first supporting information question"
         },
         {
-          "questionNumber": "2",
+          "questionNumber": "Q2",
           "label": "The second supporting information question",
           "answer": "Some answer for the second supporting information question"
         },
         {
-          "questionNumber": "3",
+          "questionNumber": "Q3",
           "label": "The third supporting information question",
           "answer": "Some answer for the third supporting information question"
         }
       ]
     },
     "risk-management-plan": {
-      "riskManagementAnswers": [
-        "Some answer for the first risk management question. With an extra comment 1",
-        "Some answer for the second risk management question. With an extra comment 2",
-        "Some answer for the third risk management question. With an extra comment 3"
-      ],
+      "riskManagementAnswers": {
+        "Q1": "Some answer for the first risk management question. With an extra comment Q1",
+        "Q2": "Some answer for the second risk management question. With an extra comment Q2",
+        "Q3": "Some answer for the third risk management question. With an extra comment Q3"
+      },
       "riskManagementSummaries": [
         {
-          "questionNumber": "1",
+          "questionNumber": "Q1",
           "label": "The first risk management question",
           "answer": "Some answer for the first risk management question"
         },
         {
-          "questionNumber": "2",
+          "questionNumber": "Q2",
           "label": "The second risk management question",
           "answer": "Some answer for the second risk management question"
         },
         {
-          "questionNumber": "3",
+          "questionNumber": "Q3",
           "label": "The third risk management question",
           "answer": "Some answer for the third risk management question"
         }
       ]
     },
     "risk-to-self": {
-      "riskToSelfAnswers": [
-        "Some answer for the first risk to self question. With an extra comment 1",
-        "Some answer for the second risk to self question. With an extra comment 2",
-        "Some answer for the third risk to self question. With an extra comment 3"
-      ],
+      "riskToSelfAnswers": {
+        "Q1": "Some answer for the first risk to self question. With an extra comment Q1",
+        "Q2": "Some answer for the second risk to self question. With an extra comment Q2",
+        "Q3": "Some answer for the third risk to self question. With an extra comment Q3"
+      },
       "riskToSelfSummaries": [
         {
-          "questionNumber": "1",
+          "questionNumber": "Q1",
           "label": "The first risk to self question",
           "answer": "Some answer for the first risk to self question"
         },
         {
-          "questionNumber": "2",
+          "questionNumber": "Q2",
           "label": "The second risk to self question",
           "answer": "Some answer for the second risk to self question"
         },
         {
-          "questionNumber": "3",
+          "questionNumber": "Q3",
           "label": "The third risk to self question",
           "answer": "Some answer for the third risk to self question"
         }

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.test.ts
@@ -64,7 +64,7 @@ describe('OffenceDetails', () => {
 
     describe('response', () => {
       it('calls oasysImportReponse with the correct arguments', () => {
-        const answers = ['answer 1']
+        const answers = { '1': 'answer 1' }
         const summaries = [
           {
             questionNumber: '1',

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.ts
@@ -13,7 +13,7 @@ import { oasysImportReponse, sortOasysImportSummaries } from '../../../../utils/
 import { mapApiPersonRisksForUi } from '../../../../utils/utils'
 
 type OffenceDetailsBody = {
-  offenceDetailsAnswers: Array<string> | Record<string, string>
+  offenceDetailsAnswers: Record<string, string>
   offenceDetailsSummaries: ArrayOfOASysOffenceDetailsQuestions
 }
 

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.test.ts
@@ -62,7 +62,7 @@ describe('RiskManagement', () => {
 
     describe('response', () => {
       it('calls oasysImportReponse with the correct arguments', () => {
-        const answers = ['answer 1']
+        const answers = { '1': 'answer 1' }
         const summaries = [
           {
             questionNumber: '1',

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.ts
@@ -13,7 +13,7 @@ import { oasysImportReponse, sortOasysImportSummaries } from '../../../../utils/
 import { mapApiPersonRisksForUi } from '../../../../utils/utils'
 
 type RiskManagementBody = {
-  riskManagementAnswers: Array<string> | Record<string, string>
+  riskManagementAnswers: Record<string, string>
   riskManagementSummaries: ArrayOfOASysRiskManagementQuestions
 }
 

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.test.ts
@@ -59,7 +59,7 @@ describe('RiskToSelf', () => {
 
     describe('response', () => {
       it('calls oasysImportReponse with the correct arguments', () => {
-        const answers = ['answer 1']
+        const answers = { '1': 'answer 1' }
         const summaries = [
           {
             questionNumber: '1',

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.ts
@@ -13,7 +13,7 @@ import { oasysImportReponse, sortOasysImportSummaries } from '../../../../utils/
 import { mapApiPersonRisksForUi } from '../../../../utils/utils'
 
 type RiskToSelfBody = {
-  riskToSelfAnswers: Array<string> | Record<string, string>
+  riskToSelfAnswers: Record<string, string>
   riskToSelfSummaries: ArrayOfOASysRiskToSelfQuestions
 }
 

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
@@ -63,7 +63,7 @@ describe('RoshSummary', () => {
 
     describe('response', () => {
       it('calls oasysImportReponse with the correct arguments', () => {
-        const answers = ['answer 1']
+        const answers = { '1': 'answer 1' }
         const summaries = [
           {
             questionNumber: '1',

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
@@ -14,7 +14,7 @@ import { oasysImportReponse, sortOasysImportSummaries } from '../../../../utils/
 import { mapApiPersonRisksForUi } from '../../../../utils/utils'
 
 type RoshSummaryBody = {
-  roshAnswers: Array<string> | Record<string, string>
+  roshAnswers: Record<string, string>
   roshSummaries: ArrayOfOASysRiskOfSeriousHarmSummaryQuestions
 }
 

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.test.ts
@@ -75,7 +75,7 @@ describe('SupportingInformation', () => {
 
     describe('response', () => {
       it('calls oasysImportReponse with the correct arguments', () => {
-        const answers = ['answer 1']
+        const answers = { '1': 'answer 1' }
         const summaries = [
           {
             questionNumber: '1',

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.ts
@@ -17,7 +17,7 @@ import {
 import { mapApiPersonRisksForUi } from '../../../../utils/utils'
 
 type SupportingInformationBody = {
-  supportingInformationAnswers: Array<string> | Record<string, string>
+  supportingInformationAnswers: Record<string, string>
   supportingInformationSummaries: ArrayOfOASysSupportingInformationQuestions
 }
 

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -552,17 +552,7 @@
           "type": "object",
           "properties": {
             "roshAnswers": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "object"
-                }
-              ]
+              "type": "object"
             },
             "roshSummaries": {
               "type": "array",
@@ -587,17 +577,7 @@
           "type": "object",
           "properties": {
             "offenceDetailsAnswers": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "object"
-                }
-              ]
+              "type": "object"
             },
             "offenceDetailsSummaries": {
               "type": "array",
@@ -622,17 +602,7 @@
           "type": "object",
           "properties": {
             "supportingInformationAnswers": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "object"
-                }
-              ]
+              "type": "object"
             },
             "supportingInformationSummaries": {
               "type": "array",
@@ -666,17 +636,7 @@
           "type": "object",
           "properties": {
             "riskManagementAnswers": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "object"
-                }
-              ]
+              "type": "object"
             },
             "riskManagementSummaries": {
               "type": "array",
@@ -701,17 +661,7 @@
           "type": "object",
           "properties": {
             "riskToSelfAnswers": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "object"
-                }
-              ]
+              "type": "object"
             },
             "riskToSelfSummaries": {
               "type": "array",

--- a/server/utils/oasysImportUtils.test.ts
+++ b/server/utils/oasysImportUtils.test.ts
@@ -39,20 +39,20 @@ describe('OASysImportUtils', () => {
 
   describe('oasysImportReponse', () => {
     it('returns a human readable response for reach question', () => {
-      const answers = ['answer 1', 'answer 2', 'answer 3']
+      const answers = { Q1: 'answer 1', Q2: 'answer 2', Q3: 'answer 3' }
       const summaries = [
         {
-          questionNumber: '1',
+          questionNumber: 'Q1',
           label: 'The first question',
           answer: 'Some answer for the first question',
         },
         {
-          questionNumber: '2',
+          questionNumber: 'Q2',
           label: 'The second question',
           answer: 'Some answer for the second question',
         },
         {
-          questionNumber: '3',
+          questionNumber: 'Q3',
           label: 'The third question',
           answer: 'Some answer for the third question',
         },
@@ -60,14 +60,14 @@ describe('OASysImportUtils', () => {
       const result = oasysImportReponse(answers, summaries)
 
       expect(result).toEqual({
-        [`${summaries[0].questionNumber}. ${summaries[0].label}`]: `${answers[0]}`,
-        [`${summaries[1].questionNumber}. ${summaries[1].label}`]: `${answers[1]}`,
-        [`${summaries[2].questionNumber}. ${summaries[2].label}`]: `${answers[2]}`,
+        [`Q1: The first question`]: `answer 1`,
+        [`Q2: The second question`]: `answer 2`,
+        [`Q3: The third question`]: `answer 3`,
       })
     })
 
     it('returns no response when there arent any questions', () => {
-      const result = oasysImportReponse([], [])
+      const result = oasysImportReponse({}, [])
 
       expect(result).toEqual({})
     })

--- a/server/utils/oasysImportUtils.ts
+++ b/server/utils/oasysImportUtils.ts
@@ -22,22 +22,17 @@ export const textareas = (questions: OasysImportArrays, key: 'roshAnswers' | 'of
     .join('')
 }
 
-export const oasysImportReponse = (
-  answers: Array<string> | Record<string, string>,
-  summaries: Array<OASysQuestion>,
-) => {
-  if (Array.isArray(answers)) {
-    return (answers as Array<string>).reduce((prev, question, i) => {
-      return {
-        ...prev,
-        [`${summaries[i].questionNumber}. ${summaries[i].label}`]: question,
-      }
-    }, {}) as Record<string, string>
-  }
-  if (!answers) {
-    return {}
-  }
-  return answers
+export const oasysImportReponse = (answers: Record<string, string>, summaries: Array<OASysQuestion>) => {
+  return Object.keys(answers).reduce((prev, k) => {
+    return {
+      ...prev,
+      [`${k}: ${findSummary(k, summaries).label}`]: answers[k],
+    }
+  }, {}) as Record<string, string>
+}
+
+const findSummary = (questionNumber: string, summaries: Array<OASysQuestion>) => {
+  return summaries.find(i => i.questionNumber === questionNumber)
 }
 
 export const fetchOptionalOasysSections = (application: Application): Array<number> => {


### PR DESCRIPTION
Before, there was an `Array.isArray` check, which never got called in reality, as the question responses will always be objects. As a result, all we were returning in the response was a Record with the question number as the key and the response as the value. This updates the method to fetch the summary by its question number, and return the human-readable question name to use that as the key. This makes for a prettier and more readable summary in the Check Your Answers pages.

I’ve also updated the typing of all the page classes, as well as the schema. The application data (which is used in the integration tests) has also been updated to reflect what the application data really looks like.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/109774/229819401-3e8446f3-8d4f-4ac2-b8b4-0641c8d07acb.png)

## After

![image](https://user-images.githubusercontent.com/109774/229819497-2588d0fa-ebae-490b-bb96-07e9e21e9fad.png)