### PR TITLE
(1402) Handle missing release date on the Assessment Index

### DIFF
--- a/server/utils/assessments/dateUtils.test.ts
+++ b/server/utils/assessments/dateUtils.test.ts
@@ -70,7 +70,15 @@ describe('dateUtils', () => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
 
       expect(formattedArrivalDate(assessment)).toEqual('1 Jan 2022')
-      expect(arrivalDateFromApplication).toHaveBeenCalledWith(assessment.application)
+      expect(arrivalDateFromApplication).toHaveBeenCalledWith(assessment.application, false)
+    })
+
+    it('returns N/A if there is no arrival date for the application', () => {
+      const assessment = assessmentFactory.build()
+      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(null)
+
+      expect(formattedArrivalDate(assessment)).toEqual('N/A')
+      expect(arrivalDateFromApplication).toHaveBeenCalledWith(assessment.application, false)
     })
   })
 

--- a/server/utils/assessments/dateUtils.test.ts
+++ b/server/utils/assessments/dateUtils.test.ts
@@ -1,0 +1,94 @@
+import {
+  daysSinceInfoRequest,
+  daysSinceReceived,
+  daysUntilDue,
+  formatDays,
+  formatDaysUntilDueWithWarning,
+  formattedArrivalDate,
+} from './dateUtils'
+import { DateFormats } from '../dateUtils'
+import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
+
+import { assessmentFactory, clarificationNoteFactory } from '../../testutils/factories'
+
+jest.mock('../applications/arrivalDateFromApplication')
+
+describe('dateUtils', () => {
+  describe('daysSinceReceived', () => {
+    it('returns the difference in days since the assessment has been received', () => {
+      const assessment = assessmentFactory.createdXDaysAgo(10).build()
+
+      expect(daysSinceReceived(assessment)).toEqual(10)
+    })
+  })
+
+  describe('daysSinceInfoRequest', () => {
+    it('returns the difference in days since the assessment has been received', () => {
+      const today = new Date()
+
+      const date = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 4)
+      const infoRequest = clarificationNoteFactory.build({ createdAt: DateFormats.dateObjToIsoDate(date) })
+      const assessment = assessmentFactory.build({
+        clarificationNotes: [clarificationNoteFactory.build(), infoRequest],
+      })
+
+      expect(daysSinceInfoRequest(assessment)).toEqual(4)
+    })
+
+    it('returns undefined if there are no info requests', () => {
+      const assessment = assessmentFactory.build({ clarificationNotes: [] })
+
+      expect(daysSinceInfoRequest(assessment)).toEqual(undefined)
+    })
+  })
+
+  describe('formatDays', () => {
+    it('returns the singular form if there is 1 day', () => {
+      expect(formatDays(1)).toEqual('1 Day')
+    })
+
+    it('returns the plural form if there is more than 1 day', () => {
+      expect(formatDays(22)).toEqual('22 Days')
+    })
+
+    it('returns N/A if the day in undefined', () => {
+      expect(formatDays(undefined)).toEqual('N/A')
+    })
+  })
+
+  describe('daysUntilDue', () => {
+    it('returns the days until the assessment is due', () => {
+      const assessment = assessmentFactory.createdXDaysAgo(2).build()
+
+      expect(daysUntilDue(assessment)).toEqual(7)
+    })
+  })
+
+  describe('formattedArrivalDate', () => {
+    it('returns the formatted arrival date from the application', () => {
+      const assessment = assessmentFactory.build()
+      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
+
+      expect(formattedArrivalDate(assessment)).toEqual('1 Jan 2022')
+      expect(arrivalDateFromApplication).toHaveBeenCalledWith(assessment.application)
+    })
+  })
+
+  describe('formatDaysUntilDueWithWarning', () => {
+    it('returns the number of days without a warning if the due date is not soon', () => {
+      const assessment = assessmentFactory.build({
+        createdAt: DateFormats.dateObjToIsoDate(new Date()),
+      })
+
+      expect(formatDaysUntilDueWithWarning(assessment)).toEqual('9 Days')
+    })
+
+    it('returns the number of days with a warning if the due date is soon', () => {
+      const assessment = assessmentFactory.createdXDaysAgo(8).build()
+
+      expect(formatDaysUntilDueWithWarning(assessment)).toEqual(
+        '<strong class="assessments--index__warning">1 Day<span class="govuk-visually-hidden"> (Approaching due date)</span></strong>',
+      )
+    })
+  })
+})

--- a/server/utils/assessments/dateUtils.ts
+++ b/server/utils/assessments/dateUtils.ts
@@ -1,0 +1,68 @@
+import {
+  ApprovedPremisesApplication as Application,
+  ApprovedPremisesAssessment as Assessment,
+} from '@approved-premises/api'
+import { add, differenceInDays, format } from 'date-fns'
+import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
+import { DateFormats } from '../dateUtils'
+
+const DUE_DATE_APPROACHING_DAYS_WINDOW = 3
+
+const daysSinceReceived = (assessment: Assessment): number => {
+  const receivedDate = DateFormats.isoToDateObj(assessment.createdAt)
+
+  return differenceInDays(new Date(), receivedDate)
+}
+
+const daysSinceInfoRequest = (assessment: Assessment): number => {
+  const lastInfoRequest = assessment.clarificationNotes[assessment.clarificationNotes.length - 1]
+  if (!lastInfoRequest) {
+    return undefined
+  }
+  const infoRequestDate = DateFormats.isoToDateObj(lastInfoRequest.createdAt)
+
+  return differenceInDays(new Date(), infoRequestDate)
+}
+
+const formatDays = (days: number): string => {
+  if (days === undefined) {
+    return 'N/A'
+  }
+  return `${days} Day${days > 1 ? 's' : ''}`
+}
+
+const daysUntilDue = (assessment: Assessment): number => {
+  const receivedDate = DateFormats.isoToDateObj(assessment.createdAt)
+  const dueDate = add(receivedDate, { days: 10 })
+
+  return differenceInDays(dueDate, new Date())
+}
+
+const formatDaysUntilDueWithWarning = (assessment: Assessment): string => {
+  const days = daysUntilDue(assessment)
+  if (days < DUE_DATE_APPROACHING_DAYS_WINDOW) {
+    return `<strong class="assessments--index__warning">${formatDays(
+      days,
+    )}<span class="govuk-visually-hidden"> (Approaching due date)</span></strong>`
+  }
+  return formatDays(days)
+}
+
+const assessmentsApproachingDue = (assessments: Array<Assessment>): number => {
+  return assessments.filter(a => daysUntilDue(a) < DUE_DATE_APPROACHING_DAYS_WINDOW).length
+}
+
+const formattedArrivalDate = (assessment: Assessment): string => {
+  const arrivalDate = arrivalDateFromApplication(assessment.application as Application)
+  return format(DateFormats.isoToDateObj(arrivalDate), 'd MMM yyyy')
+}
+
+export {
+  daysSinceReceived,
+  daysSinceInfoRequest,
+  formatDays,
+  formatDaysUntilDueWithWarning,
+  assessmentsApproachingDue,
+  formattedArrivalDate,
+  daysUntilDue,
+}

--- a/server/utils/assessments/dateUtils.ts
+++ b/server/utils/assessments/dateUtils.ts
@@ -53,7 +53,10 @@ const assessmentsApproachingDue = (assessments: Array<Assessment>): number => {
 }
 
 const formattedArrivalDate = (assessment: Assessment): string => {
-  const arrivalDate = arrivalDateFromApplication(assessment.application as Application)
+  const arrivalDate = arrivalDateFromApplication(assessment.application as Application, false)
+  if (!arrivalDate) {
+    return 'N/A'
+  }
   return format(DateFormats.isoToDateObj(arrivalDate), 'd MMM yyyy')
 }
 

--- a/server/utils/assessments/tableUtils.test.ts
+++ b/server/utils/assessments/tableUtils.test.ts
@@ -1,0 +1,146 @@
+import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
+
+import * as personUtils from '../personUtils'
+import { assessmentFactory, clarificationNoteFactory } from '../../testutils/factories'
+import {
+  daysSinceInfoRequest,
+  daysSinceReceived,
+  formatDays,
+  formatDaysUntilDueWithWarning,
+  formattedArrivalDate,
+} from './dateUtils'
+import {
+  assessmentLink,
+  awaitingAssessmentTableRows,
+  completedTableRows,
+  getStatus,
+  requestedFurtherInformationTableRows,
+} from './tableUtils'
+import paths from '../../paths/assess'
+
+jest.mock('../applications/arrivalDateFromApplication')
+jest.mock('../personUtils')
+
+describe('tableUtils', () => {
+  describe('getStatus', () => {
+    it('returns Not started for an active assessment without data', () => {
+      const assessment = assessmentFactory.build({ status: 'active', data: undefined })
+
+      expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag--grey">Not started</strong>')
+    })
+
+    it('returns In Progress for an an active assessment with data', () => {
+      const assessment = assessmentFactory.build({ status: 'active' })
+
+      expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag--blue">In progress</strong>')
+    })
+
+    describe('completed assessments', () => {
+      it('returns "suitable" for an approved assessment assessment', () => {
+        const assessment = assessmentFactory.build({ status: 'completed', decision: 'accepted' })
+
+        expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag--green">Suitable</strong>')
+      })
+
+      it('returns "rejected" for an approved assessment assessment', () => {
+        const assessment = assessmentFactory.build({ status: 'completed', decision: 'rejected' })
+
+        expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag--red">Rejected</strong>')
+      })
+    })
+  })
+
+  describe('assessmentLink', () => {
+    const assessment = assessmentFactory.build({ id: '123', application: { person: { name: 'John Wayne' } } })
+
+    it('returns a link to an assessment', () => {
+      expect(assessmentLink(assessment)).toMatchStringIgnoringWhitespace(`
+        <a href="${paths.assessments.show({ id: '123' })}" data-cy-assessmentId="123">John Wayne</a>
+      `)
+    })
+
+    it('allows custom text to be specified', () => {
+      expect(assessmentLink(assessment, 'My Text')).toMatchStringIgnoringWhitespace(`
+        <a href="${paths.assessments.show({ id: '123' })}" data-cy-assessmentId="123">My Text</a>
+      `)
+    })
+
+    it('allows custom text and hidden text to be specified', () => {
+      expect(assessmentLink(assessment, 'My Text', 'and some hidden text')).toMatchStringIgnoringWhitespace(`
+        <a href="${paths.assessments.show({
+          id: '123',
+        })}" data-cy-assessmentId="123">My Text <span class="govuk-visually-hidden">and some hidden text</span></a>
+      `)
+    })
+  })
+
+  describe('awaitingAssessmentTableRows', () => {
+    it('returns table rows for the assessments', () => {
+      const assessment = assessmentFactory.build()
+
+      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
+
+      const tierBadgeSpy = jest.spyOn(personUtils, 'tierBadge').mockReturnValue('TIER_BADGE')
+
+      expect(awaitingAssessmentTableRows([assessment])).toEqual([
+        [
+          { html: assessmentLink(assessment) },
+          { html: assessment.application.person.crn },
+          { html: 'TIER_BADGE' },
+          { text: formattedArrivalDate(assessment) },
+          { text: assessment.application.person.prisonName },
+          { html: formatDaysUntilDueWithWarning(assessment) },
+          { html: getStatus(assessment) },
+        ],
+      ])
+
+      expect(tierBadgeSpy).toHaveBeenCalledWith(assessment.application.risks.tier.value.level)
+    })
+  })
+
+  describe('requestedInformationTableRows', () => {
+    it('returns table rows for the assessments', () => {
+      const assessment = assessmentFactory.build({ clarificationNotes: clarificationNoteFactory.buildList(2) })
+
+      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
+
+      const tierBadgeSpy = jest.spyOn(personUtils, 'tierBadge').mockReturnValue('TIER_BADGE')
+
+      expect(requestedFurtherInformationTableRows([assessment])).toEqual([
+        [
+          { html: assessmentLink(assessment) },
+          { html: assessment.application.person.crn },
+          { html: 'TIER_BADGE' },
+          { text: formattedArrivalDate(assessment) },
+          { text: formatDays(daysSinceReceived(assessment)) },
+          { text: formatDays(daysSinceInfoRequest(assessment)) },
+          { html: `<strong class="govuk-tag govuk-tag--yellow">Info Request</strong>` },
+        ],
+      ])
+
+      expect(tierBadgeSpy).toHaveBeenCalledWith(assessment.application.risks.tier.value.level)
+    })
+  })
+
+  describe('completedTableRows', () => {
+    it('returns table rows for the assessments', () => {
+      const assessment = assessmentFactory.build()
+
+      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
+
+      const tierBadgeSpy = jest.spyOn(personUtils, 'tierBadge').mockReturnValue('TIER_BADGE')
+
+      expect(completedTableRows([assessment])).toEqual([
+        [
+          { html: assessmentLink(assessment) },
+          { html: assessment.application.person.crn },
+          { html: 'TIER_BADGE' },
+          { text: formattedArrivalDate(assessment) },
+          { html: getStatus(assessment) },
+        ],
+      ])
+
+      expect(tierBadgeSpy).toHaveBeenCalledWith(assessment.application.risks.tier.value.level)
+    })
+  })
+})

--- a/server/utils/assessments/tableUtils.ts
+++ b/server/utils/assessments/tableUtils.ts
@@ -1,0 +1,155 @@
+import { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
+import { TableRow } from '@approved-premises/ui'
+import { linkTo } from '../utils'
+import {
+  daysSinceInfoRequest,
+  daysSinceReceived,
+  formatDays,
+  formatDaysUntilDueWithWarning,
+  formattedArrivalDate,
+} from './dateUtils'
+import { tierBadge } from '../personUtils'
+import paths from '../../paths/assess'
+
+const getStatus = (assessment: Assessment): string => {
+  if (assessment.status === 'completed') {
+    if (assessment.decision === 'accepted') return `<strong class="govuk-tag govuk-tag--green">Suitable</strong>`
+    if (assessment.decision === 'rejected') return `<strong class="govuk-tag govuk-tag--red">Rejected</strong>`
+  }
+
+  if (assessment.data) {
+    return `<strong class="govuk-tag govuk-tag--blue">In progress</strong>`
+  }
+
+  return `<strong class="govuk-tag govuk-tag--grey">Not started</strong>`
+}
+
+const assessmentLink = (assessment: Assessment, linkText = '', hiddenText = ''): string => {
+  return linkTo(
+    paths.assessments.show,
+    { id: assessment.id },
+    {
+      text: linkText || assessment.application.person.name,
+      hiddenText,
+      attributes: { 'data-cy-assessmentId': assessment.id },
+    },
+  )
+}
+
+const crnCell = (assessment: Assessment) => {
+  return {
+    html: assessment.application.person.crn,
+  }
+}
+
+const arrivalDateCell = (assessment: Assessment) => {
+  return {
+    text: formattedArrivalDate(assessment),
+  }
+}
+
+const daysUntilDueCell = (assessment: Assessment) => {
+  return {
+    html: formatDaysUntilDueWithWarning(assessment),
+  }
+}
+
+const statusCell = (assessment: Assessment) => {
+  return {
+    html: getStatus(assessment),
+  }
+}
+
+const linkCell = (assessment: Assessment) => {
+  return {
+    html: assessmentLink(assessment),
+  }
+}
+
+const tierCell = (assessment: Assessment) => {
+  return {
+    html: tierBadge(assessment.application.risks.tier.value.level),
+  }
+}
+
+const prisonCell = (assessment: Assessment) => {
+  return {
+    text: assessment.application.person.prisonName,
+  }
+}
+
+const daysSinceReceivedCell = (assessment: Assessment) => {
+  return {
+    text: formatDays(daysSinceReceived(assessment)),
+  }
+}
+
+const daysSinceInfoRequestCell = (assessment: Assessment) => {
+  return {
+    text: formatDays(daysSinceInfoRequest(assessment)),
+  }
+}
+
+const awaitingAssessmentTableRows = (assessments: Array<Assessment>): Array<TableRow> => {
+  const rows = [] as Array<TableRow>
+
+  assessments.forEach(assessment => {
+    rows.push([
+      linkCell(assessment),
+      crnCell(assessment),
+      tierCell(assessment),
+      arrivalDateCell(assessment),
+      prisonCell(assessment),
+      daysUntilDueCell(assessment),
+      statusCell(assessment),
+    ])
+  })
+
+  return rows
+}
+
+const completedTableRows = (assessments: Array<Assessment>): Array<TableRow> => {
+  const rows = [] as Array<TableRow>
+
+  assessments.forEach(assessment => {
+    rows.push([
+      linkCell(assessment),
+      crnCell(assessment),
+      tierCell(assessment),
+      arrivalDateCell(assessment),
+      statusCell(assessment),
+    ])
+  })
+
+  return rows
+}
+
+const requestedFurtherInformationTableRows = (assessments: Array<Assessment>): Array<TableRow> => {
+  const rows = [] as Array<TableRow>
+
+  const infoRequestStatusCell = {
+    html: `<strong class="govuk-tag govuk-tag--yellow">Info Request</strong>`,
+  }
+
+  assessments.forEach(assessment => {
+    rows.push([
+      linkCell(assessment),
+      crnCell(assessment),
+      tierCell(assessment),
+      arrivalDateCell(assessment),
+      daysSinceReceivedCell(assessment),
+      daysSinceInfoRequestCell(assessment),
+      infoRequestStatusCell,
+    ])
+  })
+
+  return rows
+}
+
+export {
+  getStatus,
+  assessmentLink,
+  awaitingAssessmentTableRows,
+  completedTableRows,
+  requestedFurtherInformationTableRows,
+}

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -1,10 +1,7 @@
 import {
   acctAlertsFromAssessment,
   adjudicationsFromAssessment,
-  allocatedTableRows,
-  allocationLink,
   allocationSummary,
-  arriveDateAsTimestamp,
   assessmentLink,
   assessmentSections,
   assessmentsApproachingDue,
@@ -29,7 +26,6 @@ import {
   rejectionRationaleFromAssessmentResponses,
   requestedFurtherInformationTableRows,
   reviewApplicationSections,
-  unallocatedTableRows,
 } from './utils'
 import { DateFormats } from '../dateUtils'
 import paths from '../../paths/assess'
@@ -218,16 +214,6 @@ describe('utils', () => {
     })
   })
 
-  describe('arriveDateAsTimestamp', () => {
-    it('returns the arrival date from the application as a unix timestamp', () => {
-      const assessment = assessmentFactory.build()
-      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
-
-      expect(arriveDateAsTimestamp(assessment)).toEqual(1640995200)
-      expect(arrivalDateFromApplication).toHaveBeenCalledWith(assessment.application)
-    })
-  })
-
   describe('getApplicationType', () => {
     it('returns standard when the application is not PIPE', () => {
       ;(applicationUtils.getApplicationType as jest.Mock).mockReturnValue('Standard')
@@ -246,69 +232,6 @@ describe('utils', () => {
       })
 
       expect(getApplicationType(assessment)).toEqual('PIPE')
-    })
-  })
-
-  describe('allocatedTableRows', () => {
-    it('returns table rows for the assessments', () => {
-      const staffMember = userFactory.build()
-      const assessment = assessmentFactory.build({
-        allocatedToStaffMember: staffMember,
-      })
-      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
-
-      expect(allocatedTableRows([assessment])).toEqual([
-        [
-          { text: assessment.application.person.name },
-          {
-            text: formattedArrivalDate(assessment),
-            attributes: {
-              'data-sort-value': `${arriveDateAsTimestamp(assessment)}`,
-            },
-          },
-          {
-            html: formatDaysUntilDueWithWarning(assessment),
-            attributes: {
-              'data-sort-value': `${daysUntilDue(assessment)}`,
-            },
-          },
-          { text: assessment.allocatedToStaffMember.name },
-          { text: getApplicationType(assessment) },
-          { html: getStatus(assessment) },
-          { html: allocationLink(assessment, 'Reallocate') },
-        ],
-      ])
-    })
-  })
-
-  describe('unallocatedTableRows', () => {
-    it('returns table rows for the assessments', () => {
-      const staffMember = userFactory.build()
-      const assessment = assessmentFactory.build({
-        allocatedToStaffMember: staffMember,
-      })
-      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
-
-      expect(unallocatedTableRows([assessment])).toEqual([
-        [
-          { text: assessment.application.person.name },
-          {
-            text: formattedArrivalDate(assessment),
-            attributes: {
-              'data-sort-value': `${arriveDateAsTimestamp(assessment)}`,
-            },
-          },
-          {
-            html: formatDaysUntilDueWithWarning(assessment),
-            attributes: {
-              'data-sort-value': `${daysUntilDue(assessment)}`,
-            },
-          },
-          { text: getApplicationType(assessment) },
-          { html: getStatus(assessment) },
-          { html: allocationLink(assessment, 'Allocate') },
-        ],
-      ])
     })
   })
 
@@ -451,20 +374,6 @@ describe('utils', () => {
         <a href="${paths.assessments.show({
           id: '123',
         })}" data-cy-assessmentId="123">My Text <span class="govuk-visually-hidden">and some hidden text</span></a>
-      `)
-    })
-  })
-
-  describe('allocationLink', () => {
-    const assessment = assessmentFactory.build({ application: { id: '123', person: { name: 'John Wayne' } } })
-
-    it('returns a link to an allocation', () => {
-      expect(allocationLink(assessment, 'Allocate')).toMatchStringIgnoringWhitespace(`
-        <a href="${paths.allocations.show({
-          id: '123',
-        })}" data-cy-assessmentId="${
-        assessment.id
-      }">Allocate <span class="govuk-visually-hidden">assessment for John Wayne</span></a>
       `)
     })
   })

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -2,35 +2,23 @@ import {
   acctAlertsFromAssessment,
   adjudicationsFromAssessment,
   allocationSummary,
-  assessmentLink,
   assessmentSections,
   assessmentsApproachingDue,
   assessmentsApproachingDueBadge,
-  awaitingAssessmentTableRows,
   caseNotesFromAssessment,
-  completedTableRows,
   confirmationPageMessage,
   confirmationPageResult,
-  daysSinceInfoRequest,
-  daysSinceReceived,
-  daysUntilDue,
-  formatDays,
-  formatDaysUntilDueWithWarning,
   formattedArrivalDate,
   getApplicationType,
   getPage,
   getReviewNavigationItems,
-  getStatus,
   getTaskResponsesAsSummaryListItems,
   groupAssessmements,
   rejectionRationaleFromAssessmentResponses,
-  requestedFurtherInformationTableRows,
   reviewApplicationSections,
 } from './utils'
 import { DateFormats } from '../dateUtils'
-import paths from '../../paths/assess'
 
-import * as personUtils from '../personUtils'
 import * as applicationUtils from '../applications/utils'
 
 import Assess from '../../form-pages/assess'
@@ -40,7 +28,6 @@ import {
   adjudicationFactory,
   applicationFactory,
   assessmentFactory,
-  clarificationNoteFactory,
   documentFactory,
   prisonCaseNotesFactory,
   userFactory,
@@ -55,7 +42,6 @@ const FirstPage = jest.fn()
 const SecondPage = jest.fn()
 
 jest.mock('../applications/utils')
-jest.mock('../personUtils')
 jest.mock('../reviewUtils')
 jest.mock('./documentUtils')
 jest.mock('../applications/arrivalDateFromApplication')
@@ -126,94 +112,6 @@ describe('utils', () => {
     })
   })
 
-  describe('daysSinceReceived', () => {
-    it('returns the difference in days since the assessment has been received', () => {
-      const assessment = assessmentFactory.createdXDaysAgo(10).build()
-
-      expect(daysSinceReceived(assessment)).toEqual(10)
-    })
-  })
-
-  describe('daysSinceInfoRequest', () => {
-    it('returns the difference in days since the assessment has been received', () => {
-      const today = new Date()
-
-      const date = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 4)
-      const infoRequest = clarificationNoteFactory.build({ createdAt: DateFormats.dateObjToIsoDate(date) })
-      const assessment = assessmentFactory.build({
-        clarificationNotes: [clarificationNoteFactory.build(), infoRequest],
-      })
-
-      expect(daysSinceInfoRequest(assessment)).toEqual(4)
-    })
-
-    it('returns undefined if there are no info requests', () => {
-      const assessment = assessmentFactory.build({ clarificationNotes: [] })
-
-      expect(daysSinceInfoRequest(assessment)).toEqual(undefined)
-    })
-  })
-
-  describe('formatDays', () => {
-    it('returns the singular form if there is 1 day', () => {
-      expect(formatDays(1)).toEqual('1 Day')
-    })
-
-    it('returns the plural form if there is more than 1 day', () => {
-      expect(formatDays(22)).toEqual('22 Days')
-    })
-
-    it('returns N/A if the day in undefined', () => {
-      expect(formatDays(undefined)).toEqual('N/A')
-    })
-  })
-
-  describe('getStatus', () => {
-    it('returns Not started for an active assessment without data', () => {
-      const assessment = assessmentFactory.build({ status: 'active', data: undefined })
-
-      expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag--grey">Not started</strong>')
-    })
-
-    it('returns In Progress for an an active assessment with data', () => {
-      const assessment = assessmentFactory.build({ status: 'active' })
-
-      expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag--blue">In progress</strong>')
-    })
-
-    describe('completed assessments', () => {
-      it('returns "suitable" for an approved assessment assessment', () => {
-        const assessment = assessmentFactory.build({ status: 'completed', decision: 'accepted' })
-
-        expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag--green">Suitable</strong>')
-      })
-
-      it('returns "rejected" for an approved assessment assessment', () => {
-        const assessment = assessmentFactory.build({ status: 'completed', decision: 'rejected' })
-
-        expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag--red">Rejected</strong>')
-      })
-    })
-  })
-
-  describe('daysUntilDue', () => {
-    it('returns the days until the assessment is due', () => {
-      const assessment = assessmentFactory.createdXDaysAgo(2).build()
-
-      expect(daysUntilDue(assessment)).toEqual(7)
-    })
-  })
-
-  describe('formattedArrivalDate', () => {
-    it('returns the formatted arrival date from the application', () => {
-      const assessment = assessmentFactory.build()
-      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
-
-      expect(formattedArrivalDate(assessment)).toEqual('1 Jan 2022')
-      expect(arrivalDateFromApplication).toHaveBeenCalledWith(assessment.application)
-    })
-  })
-
   describe('getApplicationType', () => {
     it('returns standard when the application is not PIPE', () => {
       ;(applicationUtils.getApplicationType as jest.Mock).mockReturnValue('Standard')
@@ -232,76 +130,6 @@ describe('utils', () => {
       })
 
       expect(getApplicationType(assessment)).toEqual('PIPE')
-    })
-  })
-
-  describe('awaitingAssessmentTableRows', () => {
-    it('returns table rows for the assessments', () => {
-      const assessment = assessmentFactory.build()
-
-      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
-
-      const tierBadgeSpy = jest.spyOn(personUtils, 'tierBadge').mockReturnValue('TIER_BADGE')
-
-      expect(awaitingAssessmentTableRows([assessment])).toEqual([
-        [
-          { html: assessmentLink(assessment) },
-          { html: assessment.application.person.crn },
-          { html: 'TIER_BADGE' },
-          { text: formattedArrivalDate(assessment) },
-          { text: assessment.application.person.prisonName },
-          { html: formatDaysUntilDueWithWarning(assessment) },
-          { html: getStatus(assessment) },
-        ],
-      ])
-
-      expect(tierBadgeSpy).toHaveBeenCalledWith(assessment.application.risks.tier.value.level)
-    })
-  })
-
-  describe('requestedInformationTableRows', () => {
-    it('returns table rows for the assessments', () => {
-      const assessment = assessmentFactory.build({ clarificationNotes: clarificationNoteFactory.buildList(2) })
-
-      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
-
-      const tierBadgeSpy = jest.spyOn(personUtils, 'tierBadge').mockReturnValue('TIER_BADGE')
-
-      expect(requestedFurtherInformationTableRows([assessment])).toEqual([
-        [
-          { html: assessmentLink(assessment) },
-          { html: assessment.application.person.crn },
-          { html: 'TIER_BADGE' },
-          { text: formattedArrivalDate(assessment) },
-          { text: formatDays(daysSinceReceived(assessment)) },
-          { text: formatDays(daysSinceInfoRequest(assessment)) },
-          { html: `<strong class="govuk-tag govuk-tag--yellow">Info Request</strong>` },
-        ],
-      ])
-
-      expect(tierBadgeSpy).toHaveBeenCalledWith(assessment.application.risks.tier.value.level)
-    })
-  })
-
-  describe('completedTableRows', () => {
-    it('returns table rows for the assessments', () => {
-      const assessment = assessmentFactory.build()
-
-      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
-
-      const tierBadgeSpy = jest.spyOn(personUtils, 'tierBadge').mockReturnValue('TIER_BADGE')
-
-      expect(completedTableRows([assessment])).toEqual([
-        [
-          { html: assessmentLink(assessment) },
-          { html: assessment.application.person.crn },
-          { html: 'TIER_BADGE' },
-          { text: formattedArrivalDate(assessment) },
-          { html: getStatus(assessment) },
-        ],
-      ])
-
-      expect(tierBadgeSpy).toHaveBeenCalledWith(assessment.application.risks.tier.value.level)
     })
   })
 
@@ -333,48 +161,6 @@ describe('utils', () => {
       expect(assessmentsApproachingDueBadge(assessments)).toEqual(
         '<span id="notifications" class="moj-notification-badge">2<span class="govuk-visually-hidden"> assessments approaching due date</span></span>',
       )
-    })
-  })
-
-  describe('formatDaysUntilDueWithWarning', () => {
-    it('returns the number of days without a warning if the due date is not soon', () => {
-      const assessment = assessmentFactory.build({
-        createdAt: DateFormats.dateObjToIsoDate(new Date()),
-      })
-
-      expect(formatDaysUntilDueWithWarning(assessment)).toEqual('9 Days')
-    })
-
-    it('returns the number of days with a warning if the due date is soon', () => {
-      const assessment = assessmentFactory.createdXDaysAgo(8).build()
-
-      expect(formatDaysUntilDueWithWarning(assessment)).toEqual(
-        '<strong class="assessments--index__warning">1 Day<span class="govuk-visually-hidden"> (Approaching due date)</span></strong>',
-      )
-    })
-  })
-
-  describe('assessmentLink', () => {
-    const assessment = assessmentFactory.build({ id: '123', application: { person: { name: 'John Wayne' } } })
-
-    it('returns a link to an assessment', () => {
-      expect(assessmentLink(assessment)).toMatchStringIgnoringWhitespace(`
-        <a href="${paths.assessments.show({ id: '123' })}" data-cy-assessmentId="123">John Wayne</a>
-      `)
-    })
-
-    it('allows custom text to be specified', () => {
-      expect(assessmentLink(assessment, 'My Text')).toMatchStringIgnoringWhitespace(`
-        <a href="${paths.assessments.show({ id: '123' })}" data-cy-assessmentId="123">My Text</a>
-      `)
-    })
-
-    it('allows custom text and hidden text to be specified', () => {
-      expect(assessmentLink(assessment, 'My Text', 'and some hidden text')).toMatchStringIgnoringWhitespace(`
-        <a href="${paths.assessments.show({
-          id: '123',
-        })}" data-cy-assessmentId="123">My Text <span class="govuk-visually-hidden">and some hidden text</span></a>
-      `)
     })
   })
 

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -95,77 +95,12 @@ const allocationSummary = (assessment: Assessment): Array<SummaryListItem> => {
   return summary
 }
 
-const allocatedTableRows = (assessments: Array<Assessment>): Array<TableRow> => {
-  const rows = [] as Array<TableRow>
 
-  assessments.forEach(assessment => {
-    rows.push([
-      {
-        text: assessment.application.person.name,
-      },
-      {
-        text: formattedArrivalDate(assessment),
-        attributes: {
-          'data-sort-value': `${arriveDateAsTimestamp(assessment)}`,
-        },
-      },
-      {
-        html: formatDaysUntilDueWithWarning(assessment),
-        attributes: {
-          'data-sort-value': `${daysUntilDue(assessment)}`,
-        },
-      },
-      {
-        text: assessment.allocatedToStaffMember.name,
-      },
-      {
-        text: getApplicationType(assessment),
-      },
-      {
-        html: getStatus(assessment),
-      },
-      {
-        html: allocationLink(assessment, 'Reallocate'),
-      },
-    ])
-  })
 
-  return rows
 }
 
-const unallocatedTableRows = (assessments: Array<Assessment>): Array<TableRow> => {
-  const rows = [] as Array<TableRow>
 
-  assessments.forEach(assessment => {
-    rows.push([
-      {
-        text: assessment.application.person.name,
-      },
-      {
-        text: formattedArrivalDate(assessment),
-        attributes: {
-          'data-sort-value': `${arriveDateAsTimestamp(assessment)}`,
-        },
-      },
-      {
-        html: formatDaysUntilDueWithWarning(assessment),
-        attributes: {
-          'data-sort-value': `${daysUntilDue(assessment)}`,
-        },
-      },
-      {
-        text: getApplicationType(assessment),
-      },
-      {
-        html: getStatus(assessment),
-      },
-      {
-        html: allocationLink(assessment, 'Allocate'),
-      },
-    ])
-  })
 
-  return rows
 }
 
 const awaitingAssessmentTableRows = (assessments: Array<Assessment>): Array<TableRow> => {
@@ -258,18 +193,6 @@ const requestedFurtherInformationTableRows = (assessments: Array<Assessment>): A
   return rows
 }
 
-const allocationLink = (assessment: Assessment, action: 'Allocate' | 'Reallocate'): string => {
-  return linkTo(
-    paths.allocations.show,
-    { id: assessment.application.id },
-    {
-      text: action,
-      hiddenText: `assessment for ${assessment.application.person.name}`,
-      attributes: { 'data-cy-assessmentId': assessment.id },
-    },
-  )
-}
-
 const assessmentLink = (assessment: Assessment, linkText = '', hiddenText = ''): string => {
   return linkTo(
     paths.assessments.show,
@@ -285,11 +208,6 @@ const assessmentLink = (assessment: Assessment, linkText = '', hiddenText = ''):
 const formattedArrivalDate = (assessment: Assessment): string => {
   const arrivalDate = arrivalDateFromApplication(assessment.application as ApprovedPremisesApplication)
   return format(DateFormats.isoToDateObj(arrivalDate), 'd MMM yyyy')
-}
-
-const arriveDateAsTimestamp = (assessment: Assessment): number => {
-  const arrivalDate = arrivalDateFromApplication(assessment.application as ApprovedPremisesApplication)
-  return DateFormats.isoToTimestamp(arrivalDate)
 }
 
 const formatDays = (days: number): string => {
@@ -490,10 +408,7 @@ const rejectionRationaleFromAssessmentResponses = (assessment: Assessment): stri
 export {
   acctAlertsFromAssessment,
   adjudicationsFromAssessment,
-  allocatedTableRows,
-  allocationLink,
   allocationSummary,
-  arriveDateAsTimestamp,
   assessmentLink,
   assessmentsApproachingDue,
   assessmentsApproachingDueBadge,
@@ -516,7 +431,6 @@ export {
   getTaskResponsesAsSummaryListItems,
   groupAssessmements,
   requestedFurtherInformationTableRows,
-  unallocatedTableRows,
   rejectionRationaleFromAssessmentResponses,
   reviewApplicationSections,
 }

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -95,12 +95,58 @@ const allocationSummary = (assessment: Assessment): Array<SummaryListItem> => {
   return summary
 }
 
-
-
+const crnCell = (assessment: Assessment) => {
+  return {
+    html: assessment.application.person.crn,
+  }
 }
 
+const arrivalDateCell = (assessment: Assessment) => {
+  return {
+    text: formattedArrivalDate(assessment),
+  }
+}
 
+const daysUntilDueCell = (assessment: Assessment) => {
+  return {
+    html: formatDaysUntilDueWithWarning(assessment),
+  }
+}
 
+const statusCell = (assessment: Assessment) => {
+  return {
+    html: getStatus(assessment),
+  }
+}
+
+const linkCell = (assessment: Assessment) => {
+  return {
+    html: assessmentLink(assessment),
+  }
+}
+
+const tierCell = (assessment: Assessment) => {
+  return {
+    html: tierBadge(assessment.application.risks.tier.value.level),
+  }
+}
+
+const prisonCell = (assessment: Assessment) => {
+  return {
+    text: assessment.application.person.prisonName,
+  }
+}
+
+const daysSinceReceivedCell = (assessment: Assessment) => {
+  return {
+    text: formatDays(daysSinceReceived(assessment)),
+  }
+}
+
+const daysSinceInfoRequestCell = (assessment: Assessment) => {
+  return {
+    text: formatDays(daysSinceInfoRequest(assessment)),
+  }
 }
 
 const awaitingAssessmentTableRows = (assessments: Array<Assessment>): Array<TableRow> => {
@@ -108,27 +154,13 @@ const awaitingAssessmentTableRows = (assessments: Array<Assessment>): Array<Tabl
 
   assessments.forEach(assessment => {
     rows.push([
-      {
-        html: assessmentLink(assessment),
-      },
-      {
-        html: assessment.application.person.crn,
-      },
-      {
-        html: tierBadge(assessment.application.risks.tier.value.level),
-      },
-      {
-        text: formattedArrivalDate(assessment),
-      },
-      {
-        text: assessment.application.person.prisonName,
-      },
-      {
-        html: formatDaysUntilDueWithWarning(assessment),
-      },
-      {
-        html: getStatus(assessment),
-      },
+      linkCell(assessment),
+      crnCell(assessment),
+      tierCell(assessment),
+      arrivalDateCell(assessment),
+      prisonCell(assessment),
+      daysUntilDueCell(assessment),
+      statusCell(assessment),
     ])
   })
 
@@ -140,21 +172,11 @@ const completedTableRows = (assessments: Array<Assessment>): Array<TableRow> => 
 
   assessments.forEach(assessment => {
     rows.push([
-      {
-        html: assessmentLink(assessment),
-      },
-      {
-        html: assessment.application.person.crn,
-      },
-      {
-        html: tierBadge(assessment.application.risks.tier.value.level),
-      },
-      {
-        text: formattedArrivalDate(assessment),
-      },
-      {
-        html: getStatus(assessment),
-      },
+      linkCell(assessment),
+      crnCell(assessment),
+      tierCell(assessment),
+      arrivalDateCell(assessment),
+      statusCell(assessment),
     ])
   })
 
@@ -164,29 +186,19 @@ const completedTableRows = (assessments: Array<Assessment>): Array<TableRow> => 
 const requestedFurtherInformationTableRows = (assessments: Array<Assessment>): Array<TableRow> => {
   const rows = [] as Array<TableRow>
 
+  const infoRequestStatusCell = {
+    html: `<strong class="govuk-tag govuk-tag--yellow">Info Request</strong>`,
+  }
+
   assessments.forEach(assessment => {
     rows.push([
-      {
-        html: assessmentLink(assessment),
-      },
-      {
-        html: assessment.application.person.crn,
-      },
-      {
-        html: tierBadge(assessment.application.risks.tier.value.level),
-      },
-      {
-        text: formattedArrivalDate(assessment),
-      },
-      {
-        text: formatDays(daysSinceReceived(assessment)),
-      },
-      {
-        text: formatDays(daysSinceInfoRequest(assessment)),
-      },
-      {
-        html: `<strong class="govuk-tag govuk-tag--yellow">Info Request</strong>`,
-      },
+      linkCell(assessment),
+      crnCell(assessment),
+      tierCell(assessment),
+      arrivalDateCell(assessment),
+      daysSinceReceivedCell(assessment),
+      daysSinceInfoRequestCell(assessment),
+      infoRequestStatusCell,
     ])
   })
 

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -102,14 +102,6 @@ export class DateFormats {
   }
 
   /**
-   * @param dateString an ISO date string.
-   * @returns the date as a timestamp, useful when sorting.
-   */
-  static isoToTimestamp(dateString: string) {
-    return getUnixTime(DateFormats.isoToDateObj(dateString))
-  }
-
-  /**
    * @param date1 first day to compare.
    * @param date2 second day to compare.
    * @returns {DifferenceInDays} an object with the difference in days as a string for UI purposes (EG '2 Days') and as a number.

--- a/server/utils/tasks/table.ts
+++ b/server/utils/tasks/table.ts
@@ -7,39 +7,6 @@ import { kebabCase, linkTo, sentenceCase } from '../utils'
 
 const DUE_DATE_APPROACHING_DAYS_WINDOW = 3
 
-const allocatedTableRows = (tasks: Array<Task>): Array<TableRow> => {
-  const rows: Array<TableRow> = []
-
-  tasks.forEach(task => {
-    rows.push([
-      nameCell(task),
-      daysUntilDueCell(task),
-      allocationCell(task),
-      statusCell(task),
-      taskTypeCell(task),
-      allocationLinkCell(task, 'Reallocate'),
-    ])
-  })
-
-  return rows
-}
-
-const unallocatedTableRows = (tasks: Array<Task>): Array<TableRow> => {
-  const rows = [] as Array<TableRow>
-
-  tasks.forEach(task => {
-    rows.push([
-      nameCell(task),
-      daysUntilDueCell(task),
-      statusCell(task),
-      taskTypeCell(task),
-      allocationLinkCell(task, 'Allocate'),
-    ])
-  })
-
-  return rows
-}
-
 const daysUntilDueCell = (task: Task): TableCell => ({
   html: formatDaysUntilDueWithWarning(task),
   attributes: {
@@ -102,6 +69,39 @@ const formatDaysUntilDueWithWarning = (task: Task): string => {
 
 const daysUntilDue = (task: Task): number => {
   return DateFormats.differenceInDays(DateFormats.isoToDateObj(task.dueDate), new Date()).number
+}
+
+const allocatedTableRows = (tasks: Array<Task>): Array<TableRow> => {
+  const rows: Array<TableRow> = []
+
+  tasks.forEach(task => {
+    rows.push([
+      nameCell(task),
+      daysUntilDueCell(task),
+      allocationCell(task),
+      statusCell(task),
+      taskTypeCell(task),
+      allocationLinkCell(task, 'Reallocate'),
+    ])
+  })
+
+  return rows
+}
+
+const unallocatedTableRows = (tasks: Array<Task>): Array<TableRow> => {
+  const rows = [] as Array<TableRow>
+
+  tasks.forEach(task => {
+    rows.push([
+      nameCell(task),
+      daysUntilDueCell(task),
+      statusCell(task),
+      taskTypeCell(task),
+      allocationLinkCell(task, 'Allocate'),
+    ])
+  })
+
+  return rows
 }
 
 export {


### PR DESCRIPTION
At the moment, if there is a ROTL / Parole application without a release date, then the application crashes when trying to show its assessment in the `/assessments` index page. This fixes this by returning `N/A` if there is no release date.

I've also done a bit of refactoring to tidy up the assessment utils. There's probably more scope, but this bit was hard enough! 😆 