### PR TITLE
(1058) Update ESAP screens with new questions and flow

### DIFF
--- a/cypress_shared/helpers/apply.ts
+++ b/cypress_shared/helpers/apply.ts
@@ -454,6 +454,22 @@ export default class ApplyHelper {
     tasklistPage.shouldShowTaskStatus('oasys-import', 'Not started')
   }
 
+  completeEsapFlow() {
+    // And I should be able to start the next task
+    cy.get('[data-cy-task-name="type-of-ap"]').click()
+    Page.verifyOnPage(ApplyPages.TypeOfApPage, this.application)
+
+    // Given I am on the Type of AP Page
+    const typeOfApPage = new ApplyPages.TypeOfApPage(this.application)
+
+    // When I complete the form and click submit
+    typeOfApPage.completeForm()
+    typeOfApPage.clickSubmit()
+
+    // Then I should be asked if the person is managed by the national security division
+    const isManagedByNationalSecurityDivision = Page.verifyOnPage(ApplyPages.NationalSecurityDivision, this.application)
+  }
+
   private completeOasysSection() {
     // Given I click the 'Import Oasys' task
     cy.get('[data-cy-task-name="oasys-import"]').click()

--- a/cypress_shared/helpers/apply.ts
+++ b/cypress_shared/helpers/apply.ts
@@ -474,14 +474,33 @@ export default class ApplyHelper {
     isManagedByNationalSecurityDivision.clickSubmit()
 
     // Then I should be asked if there has been an agreement with the Community Head of Public Protection
-    const exceptionalCase = Page.verifyOnPage(ApplyPages.EsapExceptionalCase, this.application)
+    let exceptionalCase = Page.verifyOnPage(ApplyPages.EsapExceptionalCase, this.application)
 
     // When I click yes
     exceptionalCase.completeForm()
     exceptionalCase.clickSubmit()
 
     // Then I should be taken to the rest of the Esap flow
-    Page.verifyOnPage(ApplyPages.EsapPlacementScreening, this.application)
+    const screeningPage = Page.verifyOnPage(ApplyPages.EsapPlacementScreening, this.application)
+
+    // When I click back
+    screeningPage.clickBack()
+
+    // Then I should be back on the exceptional case page
+    exceptionalCase = Page.verifyOnPage(ApplyPages.EsapExceptionalCase, this.application)
+
+    // When I choose No
+    exceptionalCase.completeForm('no')
+    exceptionalCase.clickSubmit()
+
+    // Then I should be told that my ESAP application is not valid
+    const notEligiblePage = Page.verifyOnPage(ApplyPages.EsapNotEligible, this.application)
+
+    // When I click the continue button
+    notEligiblePage.clickSubmit()
+
+    // Then I should be able to choose a different type of AP
+    Page.verifyOnPage(ApplyPages.TypeOfApPage, this.application)
   }
 
   private completeOasysSection() {

--- a/cypress_shared/helpers/apply.ts
+++ b/cypress_shared/helpers/apply.ts
@@ -468,6 +468,20 @@ export default class ApplyHelper {
 
     // Then I should be asked if the person is managed by the national security division
     const isManagedByNationalSecurityDivision = Page.verifyOnPage(ApplyPages.NationalSecurityDivision, this.application)
+
+    // When I answer no to the isManagedByNationalSecurityDivision question
+    isManagedByNationalSecurityDivision.completeForm('no')
+    isManagedByNationalSecurityDivision.clickSubmit()
+
+    // Then I should be asked if there has been an agreement with the Community Head of Public Protection
+    const exceptionalCase = Page.verifyOnPage(ApplyPages.EsapExceptionalCase, this.application)
+
+    // When I click yes
+    exceptionalCase.completeForm()
+    exceptionalCase.clickSubmit()
+
+    // Then I should be taken to the rest of the Esap flow
+    Page.verifyOnPage(ApplyPages.EsapPlacementScreening, this.application)
   }
 
   private completeOasysSection() {

--- a/cypress_shared/pages/apply/esapExceptionalCase.ts
+++ b/cypress_shared/pages/apply/esapExceptionalCase.ts
@@ -1,0 +1,16 @@
+import Page from '../page'
+
+export default class EsapExceptionalCase extends Page {
+  constructor() {
+    super(
+      'Has there been agreement with the Community Head of Public Protection that an application should be made as an exceptional case?',
+    )
+  }
+
+  completeForm() {
+    this.checkRadioByNameAndValue('agreedCaseWithCommunityHopp', 'yes')
+    this.getTextInputByIdAndEnterDetails('communityHoppName', 'Some Manager')
+    this.completeDateInputs('agreementDate', '2023-07-01')
+    this.completeTextArea('agreementSummary', 'Some Summary Text')
+  }
+}

--- a/cypress_shared/pages/apply/esapExceptionalCase.ts
+++ b/cypress_shared/pages/apply/esapExceptionalCase.ts
@@ -1,3 +1,4 @@
+import { YesOrNo } from '../../../server/@types/ui'
 import Page from '../page'
 
 export default class EsapExceptionalCase extends Page {
@@ -7,10 +8,12 @@ export default class EsapExceptionalCase extends Page {
     )
   }
 
-  completeForm() {
-    this.checkRadioByNameAndValue('agreedCaseWithCommunityHopp', 'yes')
-    this.getTextInputByIdAndEnterDetails('communityHoppName', 'Some Manager')
-    this.completeDateInputs('agreementDate', '2023-07-01')
-    this.completeTextArea('agreementSummary', 'Some Summary Text')
+  completeForm(response: YesOrNo = 'yes') {
+    this.checkRadioByNameAndValue('agreedCaseWithCommunityHopp', response)
+    if (response === 'yes') {
+      this.getTextInputByIdAndEnterDetails('communityHoppName', 'Some Manager')
+      this.completeDateInputs('agreementDate', '2023-07-01')
+      this.completeTextArea('agreementSummary', 'Some Summary Text')
+    }
   }
 }

--- a/cypress_shared/pages/apply/esapNotEligible.ts
+++ b/cypress_shared/pages/apply/esapNotEligible.ts
@@ -1,0 +1,8 @@
+import { ApprovedPremisesApplication as Application } from '../../../server/@types/shared'
+import Page from '../page'
+
+export default class EsapNotEligible extends Page {
+  constructor(application: Application) {
+    super(`${application.person.name} is not eligible for an ESAP placement`)
+  }
+}

--- a/cypress_shared/pages/apply/esapPlacementScreening.ts
+++ b/cypress_shared/pages/apply/esapPlacementScreening.ts
@@ -1,0 +1,8 @@
+import { ApprovedPremisesApplication } from '@approved-premises/api'
+import Page from '../page'
+
+export default class EsapPlacementScreening extends Page {
+  constructor(application: ApprovedPremisesApplication) {
+    super(`Why does ${application.person.name} require an enhanced security placement?`)
+  }
+}

--- a/cypress_shared/pages/apply/index.ts
+++ b/cypress_shared/pages/apply/index.ts
@@ -15,6 +15,8 @@ import DateOfOffence from './dateOfOffence'
 import DescribeLocationFactors from './describeLocationFactors'
 import EnterCRNPage from './enterCrn'
 import ExceptionDetailsPage from './ExceptionDetails'
+import EsapExceptionalCase from './esapExceptionalCase'
+import EsapPlacementScreening from './esapPlacementScreening'
 import ForeignNationalPage from './foreignNational'
 import IsExceptionalCasePage from './isExceptionalCase'
 import ListPage from './list'
@@ -67,6 +69,8 @@ export {
   DescribeLocationFactors,
   EnterCRNPage,
   ExceptionDetailsPage,
+  EsapExceptionalCase,
+  EsapPlacementScreening,
   ForeignNationalPage,
   IsExceptionalCasePage,
   ListPage,

--- a/cypress_shared/pages/apply/index.ts
+++ b/cypress_shared/pages/apply/index.ts
@@ -18,6 +18,7 @@ import ExceptionDetailsPage from './ExceptionDetails'
 import ForeignNationalPage from './foreignNational'
 import IsExceptionalCasePage from './isExceptionalCase'
 import ListPage from './list'
+import NationalSecurityDivision from './nationalSecurityDivision'
 import OffenceDetailsPage from './offenceDetails'
 import OptionalOasysSectionsPage from './optionalOasysSections'
 import PlacementDurationPage from './placementDuration'
@@ -69,6 +70,7 @@ export {
   ForeignNationalPage,
   IsExceptionalCasePage,
   ListPage,
+  NationalSecurityDivision,
   OffenceDetailsPage,
   OptionalOasysSectionsPage,
   PlacementDurationPage,

--- a/cypress_shared/pages/apply/index.ts
+++ b/cypress_shared/pages/apply/index.ts
@@ -17,6 +17,7 @@ import EnterCRNPage from './enterCrn'
 import ExceptionDetailsPage from './ExceptionDetails'
 import EsapExceptionalCase from './esapExceptionalCase'
 import EsapPlacementScreening from './esapPlacementScreening'
+import EsapNotEligible from './esapNotEligible'
 import ForeignNationalPage from './foreignNational'
 import IsExceptionalCasePage from './isExceptionalCase'
 import ListPage from './list'
@@ -71,6 +72,7 @@ export {
   ExceptionDetailsPage,
   EsapExceptionalCase,
   EsapPlacementScreening,
+  EsapNotEligible,
   ForeignNationalPage,
   IsExceptionalCasePage,
   ListPage,

--- a/cypress_shared/pages/apply/nationalSecurityDivision.ts
+++ b/cypress_shared/pages/apply/nationalSecurityDivision.ts
@@ -1,0 +1,13 @@
+import { YesOrNo } from '@approved-premises/ui'
+import { ApprovedPremisesApplication } from '../../../server/@types/shared/models/ApprovedPremisesApplication'
+import Page from '../page'
+
+export default class NationalSecurityDivision extends Page {
+  constructor(application: ApprovedPremisesApplication) {
+    super(`Is ${application.person.name} managed by the National Security Division?`)
+  }
+
+  completeForm(answer: YesOrNo) {
+    this.checkRadioByNameAndValue('managedByNationalSecurityDivision', answer)
+  }
+}

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -235,6 +235,30 @@ context('Apply', () => {
     apply.completeEmergencyApplication()
   })
 
+  it('allows completion of the ESAP flow', function test() {
+    // Given I have completed the basic information of a form
+    const uiRisks = mapApiPersonRisksForUi(this.application.risks)
+    const apply = new ApplyHelper(this.application, this.person, this.offences, 'integration')
+
+    this.application = addResponseToApplication(this.application, {
+      section: 'type-of-ap',
+      page: 'ap-type',
+      key: 'type',
+      value: 'esap',
+    })
+
+    apply.setupApplicationStubs(uiRisks)
+
+    // And I start the application
+    apply.startApplication()
+    apply.completeBasicInformation()
+
+    // And I complete the Esap flow
+    apply.completeEsapFlow()
+
+    // Then I should be asked if the person is managed by the National Security division
+  })
+
   it('allows completion of the form', function test() {
     // And I complete the application
     const uiRisks = mapApiPersonRisksForUi(this.application.risks)

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/apType.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/apType.test.ts
@@ -25,7 +25,7 @@ describe('ApType', () => {
   })
 
   describe('when type is set to esap', () => {
-    itShouldHaveNextValue(new ApType({ type: 'esap' }, application), 'esap-placement-screening')
+    itShouldHaveNextValue(new ApType({ type: 'esap' }, application), 'managed-by-national-security-division')
   })
 
   describe('when type is set to standard', () => {

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/apType.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/apType.ts
@@ -28,7 +28,7 @@ export default class SelectApType implements TasklistPage {
       return 'pipe-referral'
     }
     if (this.body.type === 'esap') {
-      return 'esap-placement-screening'
+      return 'managed-by-national-security-division'
     }
 
     return null

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapExceptionalCase.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapExceptionalCase.test.ts
@@ -30,7 +30,13 @@ describe('EsapExceptionalCase', () => {
 
   itShouldHavePreviousValue(new EsapExceptionalCase({}), 'managed-by-national-security-division')
 
-  itShouldHaveNextValue(new EsapExceptionalCase(body), 'esap-placement-screening')
+  describe('when agreedCaseWithCommunityHopp is yes', () => {
+    itShouldHaveNextValue(new EsapExceptionalCase(body), 'esap-placement-screening')
+  })
+
+  describe('when agreedCaseWithCommunityHopp is no', () => {
+    itShouldHaveNextValue(new EsapExceptionalCase({ ...body, agreedCaseWithCommunityHopp: 'no' }), 'not-esap-eligible')
+  })
 
   describe('errors', () => {
     it('should return an empty object if the body is provided correctly', () => {

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapExceptionalCase.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapExceptionalCase.test.ts
@@ -1,0 +1,90 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+
+import EsapExceptionalCase, { EsapExceptionalCaseBody } from './esapExceptionalCase'
+
+describe('EsapExceptionalCase', () => {
+  const body = {
+    agreedCaseWithCommunityHopp: 'yes',
+    communityHoppName: 'Mr Manager',
+    agreementSummary: 'Some Summary',
+    'agreementDate-year': '2023',
+    'agreementDate-month': '12',
+    'agreementDate-day': '1',
+  } as EsapExceptionalCaseBody
+
+  describe('body', () => {
+    it('should set the body', () => {
+      const page = new EsapExceptionalCase(body)
+
+      expect(page.body).toEqual({
+        agreedCaseWithCommunityHopp: 'yes',
+        communityHoppName: 'Mr Manager',
+        agreementSummary: 'Some Summary',
+        'agreementDate-year': '2023',
+        'agreementDate-month': '12',
+        'agreementDate-day': '1',
+        agreementDate: '2023-12-01',
+      })
+    })
+  })
+
+  itShouldHavePreviousValue(new EsapExceptionalCase({}), 'managed-by-national-security-division')
+
+  itShouldHaveNextValue(new EsapExceptionalCase(body), 'esap-placement-screening')
+
+  describe('errors', () => {
+    it('should return an empty object if the body is provided correctly', () => {
+      const page = new EsapExceptionalCase(body)
+      expect(page.errors()).toEqual({})
+    })
+
+    it('should return errors if agreedCaseWithCommunityHopp is blank', () => {
+      const page = new EsapExceptionalCase({})
+      expect(page.errors()).toEqual({
+        agreedCaseWithCommunityHopp:
+          'You must state if you have agreed the case with the Community Head of Public Protection',
+      })
+    })
+
+    it('should return errors if agreedCaseWithCommunityHopp is yes and the required fields are blank', () => {
+      const page = new EsapExceptionalCase({
+        ...body,
+        'agreementDate-year': '',
+        'agreementDate-month': '',
+        'agreementDate-day': '',
+        communityHoppName: '',
+        agreementSummary: '',
+      })
+      expect(page.errors()).toEqual({
+        agreementDate: 'You must provide an agreement date',
+        communityHoppName: 'You must provide the name of the Community Head of Public Protection',
+        agreementSummary: 'You must provide a summary of the reasons why this is an exempt application',
+      })
+    })
+
+    it('should return errors if the agreement date is invalid', () => {
+      const page = new EsapExceptionalCase({
+        ...body,
+        'agreementDate-year': '99999',
+        'agreementDate-month': '99999',
+        'agreementDate-day': '199999',
+      })
+      expect(page.errors()).toEqual({
+        agreementDate: 'The agreement date is an invalid date',
+      })
+    })
+  })
+
+  describe('response', () => {
+    it('should return a translated version of the response', () => {
+      const page = new EsapExceptionalCase(body)
+
+      expect(page.response()).toEqual({
+        [`${page.title}`]: 'Yes',
+        'Name of Community HOPP': 'Mr Manager',
+        'Provide a summary of the reasons why this is an exempt application': 'Some Summary',
+        'Date of agreement': 'Friday 1 December 2023',
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapExceptionalCase.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapExceptionalCase.ts
@@ -70,6 +70,9 @@ export default class EsapExceptionalCase implements TasklistPage {
   }
 
   next() {
+    if (this.body.agreedCaseWithCommunityHopp === 'no') {
+      return 'not-esap-eligible'
+    }
     return 'esap-placement-screening'
   }
 

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapExceptionalCase.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapExceptionalCase.ts
@@ -1,0 +1,102 @@
+import type { ObjectWithDateParts, TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import { sentenceCase } from '../../../../utils/utils'
+import { Page } from '../../../utils/decorators'
+import { DateFormats, dateAndTimeInputsAreValidDates } from '../../../../utils/dateUtils'
+
+import TasklistPage from '../../../tasklistPage'
+
+export type EsapExceptionalCaseBody = ObjectWithDateParts<'agreementDate'> & {
+  agreedCaseWithCommunityHopp: YesOrNo
+  communityHoppName: string
+  agreementSummary: string
+}
+
+@Page({
+  name: 'esap-exceptional-case',
+  bodyProperties: [
+    'agreedCaseWithCommunityHopp',
+    'communityHoppName',
+    'agreementDate',
+    'agreementDate-year',
+    'agreementDate-month',
+    'agreementDate-day',
+    'agreementSummary',
+  ],
+})
+export default class EsapExceptionalCase implements TasklistPage {
+  title =
+    'Has there been agreement with the Community Head of Public Protection that an application should be made as an exceptional case?'
+
+  questions = {
+    communityHoppName: 'Name of Community HOPP',
+    agreementDate: 'Date of agreement',
+    agreementSummary: 'Provide a summary of the reasons why this is an exempt application',
+  }
+
+  body: EsapExceptionalCaseBody
+
+  constructor(_body: Partial<EsapExceptionalCaseBody>) {
+    this.body = {
+      agreedCaseWithCommunityHopp: _body.agreedCaseWithCommunityHopp,
+      communityHoppName: _body.communityHoppName,
+      'agreementDate-year': _body['agreementDate-year'],
+      'agreementDate-month': _body['agreementDate-month'],
+      'agreementDate-day': _body['agreementDate-day'],
+      agreementDate: DateFormats.dateAndTimeInputsToIsoString(
+        _body as ObjectWithDateParts<'agreementDate'>,
+        'agreementDate',
+      ).agreementDate,
+      agreementSummary: _body.agreementSummary,
+    }
+  }
+
+  response() {
+    let response = { [this.title]: sentenceCase(this.body.agreedCaseWithCommunityHopp) }
+
+    if (this.body.agreedCaseWithCommunityHopp === 'yes') {
+      response = {
+        ...response,
+        [this.questions.communityHoppName]: this.body.communityHoppName,
+        [this.questions.agreementDate]: DateFormats.isoDateToUIDate(this.body.agreementDate),
+        [this.questions.agreementSummary]: this.body.agreementSummary,
+      }
+    }
+
+    return response
+  }
+
+  previous() {
+    return 'managed-by-national-security-division'
+  }
+
+  next() {
+    return 'esap-placement-screening'
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.agreedCaseWithCommunityHopp) {
+      errors.agreedCaseWithCommunityHopp =
+        'You must state if you have agreed the case with the Community Head of Public Protection'
+    }
+
+    if (this.body.agreedCaseWithCommunityHopp === 'yes') {
+      if (!this.body.agreementDate) {
+        errors.agreementDate = 'You must provide an agreement date'
+      } else if (!dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'agreementDate'>, 'agreementDate')) {
+        errors.agreementDate = 'The agreement date is an invalid date'
+      }
+
+      if (!this.body.communityHoppName) {
+        errors.communityHoppName = 'You must provide the name of the Community Head of Public Protection'
+      }
+
+      if (!this.body.agreementSummary) {
+        errors.agreementSummary = 'You must provide a summary of the reasons why this is an exempt application'
+      }
+    }
+
+    return errors
+  }
+}

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapNationalSecurityDivision.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapNationalSecurityDivision.test.ts
@@ -25,10 +25,19 @@ describe('EsapNationalSecurityDivisionBody', () => {
 
   itShouldHavePreviousValue(new EsapNationalSecurityDivisionBody({}, application), 'ap-type')
 
-  itShouldHaveNextValue(
-    new EsapNationalSecurityDivisionBody({ managedByNationalSecurityDivision: 'yes' }, application),
-    'esap-placement-screening',
-  )
+  describe('when the person is managed by the national security division', () => {
+    itShouldHaveNextValue(
+      new EsapNationalSecurityDivisionBody({ managedByNationalSecurityDivision: 'yes' }, application),
+      'esap-placement-screening',
+    )
+  })
+
+  describe('when the person is not managed by the national security division', () => {
+    itShouldHaveNextValue(
+      new EsapNationalSecurityDivisionBody({ managedByNationalSecurityDivision: 'no' }, application),
+      'esap-exceptional-case',
+    )
+  })
 
   describe('errors', () => {
     it('should return an empty object if isExceptionalCase is populated', () => {

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapNationalSecurityDivision.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapNationalSecurityDivision.test.ts
@@ -1,0 +1,56 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { applicationFactory, personFactory } from '../../../../testutils/factories'
+
+import EsapNationalSecurityDivisionBody from './esapNationalSecurityDivision'
+
+describe('EsapNationalSecurityDivisionBody', () => {
+  const person = personFactory.build({ name: 'John Wayne' })
+  const application = applicationFactory.build({ person })
+
+  describe('body', () => {
+    it('should set the body', () => {
+      const page = new EsapNationalSecurityDivisionBody({ managedByNationalSecurityDivision: 'yes' }, application)
+
+      expect(page.body).toEqual({ managedByNationalSecurityDivision: 'yes' })
+    })
+  })
+
+  describe('title', () => {
+    it("should return a title with the person's name", () => {
+      const page = new EsapNationalSecurityDivisionBody({ managedByNationalSecurityDivision: 'yes' }, application)
+
+      expect(page.title).toEqual('Is John Wayne managed by the National Security Division?')
+    })
+  })
+
+  itShouldHavePreviousValue(new EsapNationalSecurityDivisionBody({}, application), 'ap-type')
+
+  itShouldHaveNextValue(
+    new EsapNationalSecurityDivisionBody({ managedByNationalSecurityDivision: 'yes' }, application),
+    'esap-placement-screening',
+  )
+
+  describe('errors', () => {
+    it('should return an empty object if isExceptionalCase is populated', () => {
+      const page = new EsapNationalSecurityDivisionBody({ managedByNationalSecurityDivision: 'yes' }, application)
+      expect(page.errors()).toEqual({})
+    })
+
+    it('should return an errors if isExceptionalCase is not populated', () => {
+      const page = new EsapNationalSecurityDivisionBody({}, application)
+      expect(page.errors()).toEqual({
+        managedByNationalSecurityDivision: 'You must state if John Wayne is managed by the National Security Division',
+      })
+    })
+  })
+
+  describe('response', () => {
+    it('should return a translated version of the response', () => {
+      const page = new EsapNationalSecurityDivisionBody({ managedByNationalSecurityDivision: 'yes' }, application)
+
+      expect(page.response()).toEqual({
+        [page.title]: 'Yes',
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapNationalSecurityDivision.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapNationalSecurityDivision.ts
@@ -30,7 +30,10 @@ export default class EsapNationalSecurityDivision implements TasklistPage {
   }
 
   next() {
-    return 'esap-placement-screening'
+    if (this.body.managedByNationalSecurityDivision === 'yes') {
+      return 'esap-placement-screening'
+    }
+    return 'esap-exceptional-case'
   }
 
   errors() {

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapNationalSecurityDivision.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapNationalSecurityDivision.ts
@@ -1,0 +1,45 @@
+import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
+import { sentenceCase } from '../../../../utils/utils'
+import { Page } from '../../../utils/decorators'
+
+import TasklistPage from '../../../tasklistPage'
+
+type EsapNationalSecurityDivisionBody = {
+  managedByNationalSecurityDivision: YesOrNo
+}
+
+@Page({
+  name: 'managed-by-national-security-division',
+  bodyProperties: ['managedByNationalSecurityDivision'],
+})
+export default class EsapNationalSecurityDivision implements TasklistPage {
+  title = `Is ${this.application.person.name} managed by the National Security Division?`
+
+  constructor(
+    public body: Partial<EsapNationalSecurityDivisionBody>,
+    private readonly application: ApprovedPremisesApplication,
+  ) {}
+
+  response() {
+    return { [this.title]: sentenceCase(this.body.managedByNationalSecurityDivision) }
+  }
+
+  previous() {
+    return 'ap-type'
+  }
+
+  next() {
+    return 'esap-placement-screening'
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.managedByNationalSecurityDivision) {
+      errors.managedByNationalSecurityDivision = `You must state if ${this.application.person.name} is managed by the National Security Division`
+    }
+
+    return errors
+  }
+}

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapNotEligible.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapNotEligible.test.ts
@@ -1,0 +1,32 @@
+import { applicationFactory, personFactory } from '../../../../testutils/factories'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+
+import EsapNotEligible from './esapNotEligible'
+
+describe('EsapNotEligible', () => {
+  const person = personFactory.build()
+  const application = applicationFactory.build({ person })
+  const page = new EsapNotEligible({}, application)
+
+  describe('body', () => {
+    it('should set the body', () => {
+      expect(page.body).toEqual({})
+    })
+  })
+
+  itShouldHavePreviousValue(page, 'esap-exceptional-case')
+
+  itShouldHaveNextValue(page, 'ap-type')
+
+  describe('errors', () => {
+    it('should return an empty object', () => {
+      expect(page.errors()).toEqual({})
+    })
+  })
+
+  describe('response', () => {
+    it('should return an empty object', () => {
+      expect(page.response()).toEqual({})
+    })
+  })
+})

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapNotEligible.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapNotEligible.ts
@@ -1,0 +1,27 @@
+import { ApprovedPremisesApplication as Application } from '@approved-premises/api'
+import { Page } from '../../../utils/decorators'
+
+import TasklistPage from '../../../tasklistPage'
+
+@Page({ name: 'not-esap-eligible', bodyProperties: [] })
+export default class EsapNotEligible implements TasklistPage {
+  title = `${this.application.person.name} is not eligible for an ESAP placement`
+
+  constructor(readonly body: Record<string, never>, readonly application: Application) {}
+
+  response() {
+    return {}
+  }
+
+  previous() {
+    return 'esap-exceptional-case'
+  }
+
+  next() {
+    return 'ap-type'
+  }
+
+  errors() {
+    return {}
+  }
+}

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementScreening.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementScreening.test.ts
@@ -3,8 +3,10 @@ import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
 
 import EsapPlacementScreening, { esapFactors, esapReasons } from './esapPlacementScreening'
 import { applicationFactory, personFactory } from '../../../../testutils/factories'
+import { pageDataFromApplicationOrAssessment } from '../../../utils'
 
 jest.mock('../../../../utils/formUtils')
+jest.mock('../../../utils')
 
 describe('EsapPlacementScreening', () => {
   const person = personFactory.build({ name: 'John Wayne' })
@@ -18,7 +20,21 @@ describe('EsapPlacementScreening', () => {
     })
   })
 
-  itShouldHavePreviousValue(new EsapPlacementScreening({}, application), 'ap-type')
+  describe('when the user has answered the exceptional case question', () => {
+    beforeEach(() => {
+      ;(pageDataFromApplicationOrAssessment as jest.Mock).mockReturnValue({ agreedCaseWithCommunityHopp: 'yes' })
+    })
+
+    itShouldHavePreviousValue(new EsapPlacementScreening({}, application), 'esap-exceptional-case')
+  })
+
+  describe('when the user has not answered the exceptional case question', () => {
+    beforeEach(() => {
+      ;(pageDataFromApplicationOrAssessment as jest.Mock).mockReturnValue({})
+    })
+
+    itShouldHavePreviousValue(new EsapPlacementScreening({}, application), 'ap-type')
+  })
 
   describe('next', () => {
     describe('when esapReasons includes `secreting`', () => {

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementScreening.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementScreening.ts
@@ -4,6 +4,8 @@ import type { TaskListErrors } from '@approved-premises/ui'
 import TasklistPage from '../../../tasklistPage'
 import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
 import { Page } from '../../../utils/decorators'
+import EsapExceptionalCase from './esapExceptionalCase'
+import { pageDataFromApplicationOrAssessment } from '../../../utils'
 
 export const esapReasons = {
   secreting:
@@ -42,6 +44,9 @@ export default class EsapPlacementScreening implements TasklistPage {
   ) {}
 
   previous() {
+    if (Object.keys(pageDataFromApplicationOrAssessment(EsapExceptionalCase, this.application)).length) {
+      return 'esap-exceptional-case'
+    }
     return 'ap-type'
   }
 

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/index.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/index.ts
@@ -8,6 +8,7 @@ import EsapPlacementScreening from './esapPlacementScreening'
 import EsapPlacementSecreting from './esapPlacementSecreting'
 import EsapPlacementCCTV from './esapPlacementCCTV'
 import EsapNationalSecurityDivision from './esapNationalSecurityDivision'
+import EsapExceptionalCase from './esapExceptionalCase'
 
 @Task({
   slug: 'type-of-ap',
@@ -15,6 +16,7 @@ import EsapNationalSecurityDivision from './esapNationalSecurityDivision'
   pages: [
     ApType,
     EsapNationalSecurityDivision,
+    EsapExceptionalCase,
     PipeReferral,
     PipeOpdScreening,
     EsapPlacementScreening,

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/index.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/index.ts
@@ -7,10 +7,19 @@ import PipeOpdScreening from './pipeOpdScreening'
 import EsapPlacementScreening from './esapPlacementScreening'
 import EsapPlacementSecreting from './esapPlacementSecreting'
 import EsapPlacementCCTV from './esapPlacementCCTV'
+import EsapNationalSecurityDivision from './esapNationalSecurityDivision'
 
 @Task({
   slug: 'type-of-ap',
   name: 'Type of AP required',
-  pages: [ApType, PipeReferral, PipeOpdScreening, EsapPlacementScreening, EsapPlacementSecreting, EsapPlacementCCTV],
+  pages: [
+    ApType,
+    EsapNationalSecurityDivision,
+    PipeReferral,
+    PipeOpdScreening,
+    EsapPlacementScreening,
+    EsapPlacementSecreting,
+    EsapPlacementCCTV,
+  ],
 })
 export default class TypeOfAp {}

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/index.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/index.ts
@@ -9,6 +9,7 @@ import EsapPlacementSecreting from './esapPlacementSecreting'
 import EsapPlacementCCTV from './esapPlacementCCTV'
 import EsapNationalSecurityDivision from './esapNationalSecurityDivision'
 import EsapExceptionalCase from './esapExceptionalCase'
+import EsapNotEligible from './esapNotEligible'
 
 @Task({
   slug: 'type-of-ap',
@@ -17,6 +18,7 @@ import EsapExceptionalCase from './esapExceptionalCase'
     ApType,
     EsapNationalSecurityDivision,
     EsapExceptionalCase,
+    EsapNotEligible,
     PipeReferral,
     PipeOpdScreening,
     EsapPlacementScreening,

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -343,6 +343,73 @@
             }
           }
         },
+        "managed-by-national-security-division": {
+          "type": "object",
+          "properties": {
+            "managedByNationalSecurityDivision": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            }
+          }
+        },
+        "esap-exceptional-case": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "agreementDate-year": {
+                  "type": "string"
+                },
+                "agreementDate-month": {
+                  "type": "string"
+                },
+                "agreementDate-day": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "agreementDate-time": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "agreementDate": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "agreedCaseWithCommunityHopp": {
+                  "enum": [
+                    "no",
+                    "yes"
+                  ],
+                  "type": "string"
+                },
+                "communityHoppName": {
+                  "type": "string"
+                },
+                "agreementSummary": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        },
+        "not-esap-eligible": {
+          "type": "object"
+        },
         "pipe-referral": {
           "allOf": [
             {

--- a/server/views/applications/pages/type-of-ap/esap-exceptional-case.njk
+++ b/server/views/applications/pages/type-of-ap/esap-exceptional-case.njk
@@ -1,0 +1,73 @@
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  <h1 class="govuk-heading-l">
+    {{ page.title }}
+  </h1>
+
+  {% set conditionalHTML %}
+  {{ formPageInput({
+        fieldName: "communityHoppName",
+        label: {
+          text: page.questions.communityHoppName
+        }
+      },fetchContext()) }}
+
+  {{
+    formPageDateInput(
+      {
+        fieldName: "agreementDate",
+        fieldset: {
+          legend: {
+            text: page.questions.agreementDate
+          }
+        },
+        hint: {
+          text: "For example, 27 3 2007"
+        },
+        items: dateFieldValues('agreementDate', errors)
+      },
+      fetchContext()
+    )
+  }}
+
+  {{ formPageTextarea({
+      fieldName: 'agreementSummary',
+      label: {
+        text: page.questions.agreementSummary
+        }
+    }, fetchContext()) }}
+
+  {% endset -%}
+
+  {{ formPageRadios(
+      {
+        fieldset: {
+          legend: {
+            text: page.questions.agreedCaseWithCommunityHopp,
+            classes: "govuk-fieldset__legend--l",
+            isPageHeading: true
+          }
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes",
+            conditional: {
+              html: conditionalHTML
+            }
+          },
+          {
+            text: "No",
+            value: "no"
+          }
+        ],
+        fieldName: "agreedCaseWithCommunityHopp"
+      },
+      fetchContext()
+    )
+  }}
+
+{% endblock %}

--- a/server/views/applications/pages/type-of-ap/managed-by-national-security-division.njk
+++ b/server/views/applications/pages/type-of-ap/managed-by-national-security-division.njk
@@ -1,0 +1,34 @@
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  {{
+    formPageRadios(
+      {
+        fieldName: "managedByNationalSecurityDivision",
+        fieldset: {
+          legend: {
+            text: page.title,
+            classes: "govuk-fieldset__legend--l",
+            isPageHeading: true
+          }
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes"
+          },
+          {
+            text: "No",
+            value: "no"
+          }
+        ]
+      },
+      fetchContext()
+    )
+  }}
+
+{% endblock %}

--- a/server/views/applications/pages/type-of-ap/not-esap-eligible.njk
+++ b/server/views/applications/pages/type-of-ap/not-esap-eligible.njk
@@ -1,0 +1,47 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + page.title %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+
+  {{ govukBackLink({
+      text: "Back",
+      href: paths.applications.pages.show({ id: applicationId, task: task, page: page.previous() })
+    }) }}
+
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="{{ columnClasses | default("govuk-grid-column-two-thirds") }}">
+      <form action="{{ paths.applications.pages.update({ id: applicationId, task: task, page: page.name }) }}?_method=PUT" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
+        <p>You can continue with an application for a standard AP placement. Or you can withdraw your application by returning to the dashboard.</p>
+
+        <div class="govuk-button-group">
+          {{
+            govukButton({
+              text: "Continue with application"
+            })
+          }}
+          {{
+            linkTo(
+              paths.applications.index,
+              {},
+              {
+                text: 'Back to dashboard'
+              }
+            ) | safe
+          }}
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
This adds another couple of screens to the ESAP flow. 

When someone selects an ESAP AP, they are first asked if the person is managed by the National Security Division. If the answer is no, then they are asked if they have agreed the case with the Community Head of Public Protection. If the answer is yes, they are prompted for details (in a similar way to if the Tier is not valid) and they can continue with the flow. If the answer is no, they are told they cannot proceed with an ESAP application. 

They can then choose to continue with the application or exit to process. If they continue, they're taken back to choose an AP type.

## Screenshots

![Apply -- allows completion of the ESAP flow](https://user-images.githubusercontent.com/109774/230382801-214843ae-509e-4e8a-bd9a-03a6aa7b1fbe.png)

![Apply -- allows completion of the ESAP flow (1)](https://user-images.githubusercontent.com/109774/230382817-edfc3c61-1c2b-4d4a-8e83-288d9198a735.png)

![Apply -- allows completion of the ESAP flow (2)](https://user-images.githubusercontent.com/109774/230382827-4a5d7884-096d-4000-be9e-6e54339c505b.png)

![Apply -- allows completion of the ESAP flow (3)](https://user-images.githubusercontent.com/109774/230382840-eea0eaf1-10cd-4843-85d5-691236213abb.png)
