### PR TITLE
Uppercase both postcodes used in application

### DIFF
--- a/server/form-pages/apply/move-on/relocationRegion.test.ts
+++ b/server/form-pages/apply/move-on/relocationRegion.test.ts
@@ -12,9 +12,9 @@ describe('RelocationRegion', () => {
   })
 
   describe('body', () => {
-    it('should set the body', () => {
+    it('should uppercase and set the body', () => {
       const page = new RelocationRegion({ postcodeArea: 'some code' }, application)
-      expect(page.body).toEqual({ postcodeArea: 'some code' })
+      expect(page.body).toEqual({ postcodeArea: 'SOME CODE' })
     })
   })
 

--- a/server/form-pages/apply/move-on/relocationRegion.ts
+++ b/server/form-pages/apply/move-on/relocationRegion.ts
@@ -21,7 +21,9 @@ export default class RelocationRegion implements TasklistPage {
       postcodeArea?: string
     },
     private readonly application: ApprovedPremisesApplication,
-  ) {}
+  ) {
+    this.body.postcodeArea = body?.postcodeArea?.toUpperCase()
+  }
 
   previous() {
     return 'placement-duration'

--- a/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.test.ts
@@ -5,8 +5,8 @@ import DescribeLocationFactors from './describeLocationFactors'
 
 describe('ConvictedOffences', () => {
   describe('body', () => {
-    it('should set the body', () => {
-      const page = new DescribeLocationFactors({ postcodeArea: 'E17' })
+    it('should set the body and uppercase the postcode', () => {
+      const page = new DescribeLocationFactors({ postcodeArea: 'e17' })
 
       expect(page.body).toEqual({ postcodeArea: 'E17' })
     })

--- a/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.ts
@@ -50,6 +50,7 @@ export default class DescribeLocationFactors implements TasklistPage {
       delete body.alternativeRadius
       this.body = body as DescribeLocationFactorsBody
     }
+    this.body.postcodeArea = body?.postcodeArea?.toUpperCase()
   }
 
   previous() {


### PR DESCRIPTION
The API can't handle lowercased postcodes so we have to uppercase them before sending them
