### PR TITLE
1176 - Add 'summary' text area to Rehabilitative Interventions page

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -206,6 +206,7 @@
         "financeBenefitsAndDebt",
         "attitudesAndBehaviour",
         "abuse",
+        "sexWorking",
         "other"
       ],
       "otherIntervention": "Another",

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -208,7 +208,8 @@
         "abuse",
         "other"
       ],
-      "otherIntervention": "Another"
+      "otherIntervention": "Another",
+      "summary": "A summary of how these interventions will assist the person rehabilitation"
     }
   },
   "prison-information": {

--- a/integration_tests/pages/apply/rehabilitativeInterventions.ts
+++ b/integration_tests/pages/apply/rehabilitativeInterventions.ts
@@ -15,5 +15,6 @@ export default class RehabilitativeInterventions extends ApplyPage {
   completeForm(): void {
     this.checkCheckboxesFromPageBody('rehabilitativeInterventions')
     this.completeTextInputFromPageBody('otherIntervention')
+    this.completeTextInputFromPageBody('summary')
   }
 }

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.test.ts
@@ -1,3 +1,5 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
 import { applicationFactory, personFactory } from '../../../../testutils/factories'
@@ -10,6 +12,11 @@ jest.mock('../../../../utils/formUtils')
 describe('RehabilitativeInterventions', () => {
   const person = personFactory.build({ name: 'John Wayne' })
   let application: Application
+  const body = {
+    rehabilitativeInterventions: 'accommodation' as const,
+    summary: 'a summary',
+    otherIntervention: 'some intervention',
+  }
 
   beforeEach(() => {
     application = applicationFactory.build({ person })
@@ -17,9 +24,13 @@ describe('RehabilitativeInterventions', () => {
 
   describe('body', () => {
     it('should set the body', () => {
-      const page = new RehabilitativeInterventions({ rehabilitativeInterventions: 'accommodation' }, application)
+      const page = new RehabilitativeInterventions(body, application)
 
-      expect(page.body).toEqual({ rehabilitativeInterventions: ['accommodation'] })
+      expect(page.body).toEqual({
+        rehabilitativeInterventions: ['accommodation'],
+        summary: 'a summary',
+        otherIntervention: 'some intervention',
+      })
     })
   })
 
@@ -33,7 +44,7 @@ describe('RehabilitativeInterventions', () => {
       })
       .build()
 
-    itShouldHavePreviousValue(new RehabilitativeInterventions({}, application), 'convicted-offences')
+    itShouldHavePreviousValue(new RehabilitativeInterventions(body, application), 'convicted-offences')
   })
 
   describe('if the user didnt answer "yes" to convictedOffences', () => {
@@ -46,33 +57,56 @@ describe('RehabilitativeInterventions', () => {
       })
       .build()
 
-    itShouldHavePreviousValue(new RehabilitativeInterventions({}, application), 'date-of-offence')
+    itShouldHavePreviousValue(new RehabilitativeInterventions(body, application), 'date-of-offence')
   })
 
-  itShouldHaveNextValue(new RehabilitativeInterventions({}, application), '')
+  itShouldHaveNextValue(new RehabilitativeInterventions(body, application), '')
 
   describe('errors', () => {
     it("should return an error if 'rehabilitativeInterventions' isn't populated", () => {
-      const page = new RehabilitativeInterventions({}, application)
+      const page = new RehabilitativeInterventions(
+        fromPartial({ ...body, rehabilitativeInterventions: undefined }),
+        application,
+      )
       expect(page.errors()).toEqual({ rehabilitativeInterventions: 'You must select at least one option' })
-    })
-
-    it('should return an empty object if "rehabilitativeInterventions" is populated with an array of interventions', () => {
-      const page = new RehabilitativeInterventions({ rehabilitativeInterventions: ['accommodation'] }, application)
-      expect(page.errors()).toEqual({})
     })
 
     it('should return an error if "rehabilitativeInterventions" includes "other" and no other intervention is supplied', () => {
       expect(
         new RehabilitativeInterventions(
-          { rehabilitativeInterventions: ['other', 'accommodation'] },
+          { ...body, rehabilitativeInterventions: ['other', 'accommodation'], otherIntervention: '' },
           application,
         ).errors(),
       ).toEqual({ otherIntervention: 'You must specify the other intervention' })
 
-      expect(new RehabilitativeInterventions({ rehabilitativeInterventions: 'other' }, application).errors()).toEqual({
+      expect(
+        new RehabilitativeInterventions(
+          { ...body, rehabilitativeInterventions: 'other', otherIntervention: '' },
+          application,
+        ).errors(),
+      ).toEqual({
         otherIntervention: 'You must specify the other intervention',
       })
+    })
+
+    it('should return an error if no summary is given', () => {
+      expect(
+        new RehabilitativeInterventions(
+          fromPartial({ rehabilitativeInterventions: ['accommodation'] }),
+          application,
+        ).errors(),
+      ).toEqual({
+        summary:
+          'You must provide a summary of how these interventions will assist the persons rehabilitation in the AP',
+      })
+    })
+
+    it('should return an empty object if "rehabilitativeInterventions" is populated with an array of interventions and a summary is provided', () => {
+      const page = new RehabilitativeInterventions(
+        { ...body, rehabilitativeInterventions: ['accommodation'] },
+        application,
+      )
+      expect(page.errors()).toEqual({})
     })
   })
 
@@ -81,6 +115,7 @@ describe('RehabilitativeInterventions', () => {
       it('When there are multiple interventions', () => {
         const page = new RehabilitativeInterventions(
           {
+            ...body,
             rehabilitativeInterventions: [
               'accommodation',
               'drugsAndAlcohol',
@@ -101,15 +136,17 @@ describe('RehabilitativeInterventions', () => {
           "Which of the rehabilitative activities will assist the person's rehabilitation in the Approved Premises (AP)?":
             'Accommodation, Drugs and alcohol, Children and families, Health, Education, training and employment, Finance, benefits and debt, Attitudes, thinking and behaviour, Abuse, Other',
           'Other intervention': 'Some intervention',
+          'Provide a summary of how these interventions will assist the persons rehabilitation in the AP.': 'a summary',
         })
       })
 
       it('When there is a single intervention', () => {
-        const page = new RehabilitativeInterventions({ rehabilitativeInterventions: 'health' }, application)
+        const page = new RehabilitativeInterventions({ ...body, rehabilitativeInterventions: 'health' }, application)
 
         expect(page.response()).toEqual({
           "Which of the rehabilitative activities will assist the person's rehabilitation in the Approved Premises (AP)?":
             'Health',
+          'Provide a summary of how these interventions will assist the persons rehabilitation in the AP.': 'a summary',
         })
       })
     })
@@ -117,7 +154,7 @@ describe('RehabilitativeInterventions', () => {
   describe('items', () => {
     it('calls convertKeyValuePairToCheckBoxItems with the correct arguments', () => {
       const { other, ...interventionsForCheckboxes } = interventionsTranslations
-      new RehabilitativeInterventions({ rehabilitativeInterventions: 'health' }, application).items()
+      new RehabilitativeInterventions({ ...body, rehabilitativeInterventions: 'health' }, application).items()
       expect(convertKeyValuePairToCheckBoxItems).toHaveBeenCalledWith(interventionsForCheckboxes, ['health'])
     })
   })

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.ts
@@ -20,13 +20,24 @@ export const interventionsTranslations = {
 type Interventions = Array<keyof typeof interventionsTranslations>
 type RawInterventions = Interventions | keyof typeof interventionsTranslations
 
-type RawRehabilitativeInterventionsBody = { rehabilitativeInterventions?: RawInterventions; otherIntervention?: string }
-type RehabilitativeInterventionsBody = { rehabilitativeInterventions: Interventions; otherIntervention?: string }
+type RawRehabilitativeInterventionsBody = {
+  rehabilitativeInterventions?: RawInterventions
+  otherIntervention?: string
+  summary: string
+}
+type RehabilitativeInterventionsBody = RawRehabilitativeInterventionsBody & {
+  rehabilitativeInterventions: Interventions
+}
 
-@Page({ name: 'rehabilitative-interventions', bodyProperties: ['rehabilitativeInterventions', 'otherIntervention'] })
+@Page({
+  name: 'rehabilitative-interventions',
+  bodyProperties: ['rehabilitativeInterventions', 'otherIntervention', 'summary'],
+})
 export default class RehabilitativeInterventions implements TasklistPage {
   title =
     "Which of the rehabilitative activities will assist the person's rehabilitation in the Approved Premises (AP)?"
+
+  summaryQuestion = 'Provide a summary of how these interventions will assist the persons rehabilitation in the AP.'
 
   constructor(
     private _body: RawRehabilitativeInterventionsBody,
@@ -42,10 +53,11 @@ export default class RehabilitativeInterventions implements TasklistPage {
       ? [value.rehabilitativeInterventions].flat()
       : []
 
-    this._body = { rehabilitativeInterventions }
+    this._body = { ...value, rehabilitativeInterventions }
 
     if (this.responseContainsOther(rehabilitativeInterventions)) {
       this._body = {
+        ...value,
         rehabilitativeInterventions,
         otherIntervention: value.otherIntervention as string,
       }
@@ -67,6 +79,7 @@ export default class RehabilitativeInterventions implements TasklistPage {
       [this.title]: this.body.rehabilitativeInterventions
         .map(intervention => interventionsTranslations[intervention])
         .join(', '),
+      [this.summaryQuestion]: this.body.summary,
     }
 
     if (!this.responseContainsOther(this.body.rehabilitativeInterventions)) {
@@ -87,6 +100,10 @@ export default class RehabilitativeInterventions implements TasklistPage {
       errors.otherIntervention = 'You must specify the other intervention'
     }
 
+    if (!this.body?.summary) {
+      errors.summary =
+        'You must provide a summary of how these interventions will assist the persons rehabilitation in the AP'
+    }
     return errors
   }
 

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.ts
@@ -14,6 +14,7 @@ export const interventionsTranslations = {
   financeBenefitsAndDebt: 'Finance, benefits and debt',
   attitudesAndBehaviour: 'Attitudes, thinking and behaviour',
   abuse: 'Abuse',
+  sexWorking: 'Sex working',
   other: 'Other',
 } as const
 

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -938,29 +938,79 @@
           }
         },
         "rehabilitative-interventions": {
-          "type": "object",
-          "properties": {
-            "rehabilitativeInterventions": {
-              "type": "array",
-              "items": {
-                "enum": [
-                  "abuse",
-                  "accommodation",
-                  "attitudesAndBehaviour",
-                  "childrenAndFamilies",
-                  "drugsAndAlcohol",
-                  "educationTrainingAndEmployment",
-                  "financeBenefitsAndDebt",
-                  "health",
-                  "other"
-                ],
-                "type": "string"
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "rehabilitativeInterventions": {
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "enum": [
+                          "abuse",
+                          "accommodation",
+                          "attitudesAndBehaviour",
+                          "childrenAndFamilies",
+                          "drugsAndAlcohol",
+                          "educationTrainingAndEmployment",
+                          "financeBenefitsAndDebt",
+                          "health",
+                          "other",
+                          "sexWorking"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "enum": [
+                        "abuse",
+                        "accommodation",
+                        "attitudesAndBehaviour",
+                        "childrenAndFamilies",
+                        "drugsAndAlcohol",
+                        "educationTrainingAndEmployment",
+                        "financeBenefitsAndDebt",
+                        "health",
+                        "other",
+                        "sexWorking"
+                      ],
+                      "type": "string"
+                    }
+                  ]
+                },
+                "otherIntervention": {
+                  "type": "string"
+                },
+                "summary": {
+                  "type": "string"
+                }
               }
             },
-            "otherIntervention": {
-              "type": "string"
+            {
+              "type": "object",
+              "properties": {
+                "rehabilitativeInterventions": {
+                  "type": "array",
+                  "items": {
+                    "enum": [
+                      "abuse",
+                      "accommodation",
+                      "attitudesAndBehaviour",
+                      "childrenAndFamilies",
+                      "drugsAndAlcohol",
+                      "educationTrainingAndEmployment",
+                      "financeBenefitsAndDebt",
+                      "health",
+                      "other",
+                      "sexWorking"
+                    ],
+                    "type": "string"
+                  }
+                }
+              }
             }
-          }
+          ]
         }
       }
     },

--- a/server/views/applications/pages/risk-management-features/rehabilitative-interventions.njk
+++ b/server/views/applications/pages/risk-management-features/rehabilitative-interventions.njk
@@ -6,15 +6,14 @@
 
 {% block questions %}
 
-  <h1 class="govuk-heading-l">{{page.title}}</h1>
+    <h1 class="govuk-heading-l">{{page.title}}</h1>
 
-  <p class="govuk-body">Formerly known as purposeful activities.</p>
-  <p class="govuk-body">Select any additional needs the person has that an AP could help meet. For example, support getting qualifications or finding work.</p>
-  <p class="govuk-body">Further information about rehabilitative activities can be found on EQuip</p>
+    <p class="govuk-body">Formerly known as purposeful activities.</p>
+    <p class="govuk-body">Select any additional needs the person has that an AP could help meet. For example, support getting qualifications or finding work.</p>
+    <p class="govuk-body">Further information about rehabilitative activities can be found on EQuip</p>
 
-
-  {% set otherIntervention %}
-  {{
+    {% set otherIntervention %}
+    {{
         formPageInput(
             {
                 fieldName: "otherIntervention",
@@ -29,9 +28,9 @@
             fetchContext()
         )
     }}
-  {% endset %}
+    {% endset %}
 
-  {{
+    {{
         formPageCheckboxes(
             {
                 fieldName: "rehabilitativeInterventions",
@@ -51,5 +50,13 @@
             fetchContext()
         )
     }}
+
+    {{ formPageTextarea({
+        fieldName: 'summary',
+        label: {
+            text: page.summaryQuestion,
+            classes: 'govuk-label--m'
+        }
+    }, fetchContext()) }}
 
 {% endblock %}


### PR DESCRIPTION
# Context

We need to add a text area for users to explain how the rehabilitative interventions will assist in rehabilitation. 
We also need to add the option 'Sex Worker' to the list of possible interventions.

[Trello ticket](https://trello.com/c/U9GFzgdS/1176-add-textarea-to-the-rehabilitative-activities-screen-and-add-checklist-option)

## Screenshots of UI changes

### Before
![Apply -- allows completion of application emergency flow (1)](https://user-images.githubusercontent.com/44123869/232785098-136d6242-1c0e-449b-99ea-1bb9e1fbb803.png)

### After
![Apply -- allows completion of the form](https://user-images.githubusercontent.com/44123869/232785118-4ec239e4-f24a-43d0-a004-f7fd4fbe2b2a.png)
