### PR TITLE
Upgrade to Redis 7.0.11

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -5,6 +5,8 @@ services:
     image: 'bitnami/redis:7.0.11'
     networks:
       - hmpps_int
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
     ports:
       - '6380:6379'
 

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -2,7 +2,7 @@ version: '3.1'
 services:
 
   redis:
-    image: 'redis:6.2'
+    image: 'bitnami/redis:7.0.11'
     networks:
       - hmpps_int
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 services:
 
   redis:
-    image: 'bitnami/redis:5.0'
+    image: 'bitnami/redis:7.0.11'
     networks:
       - hmpps
     environment:


### PR DESCRIPTION
- Using the redis change applied through ap-tools I can still spin up this app and sign into it which should exercise the redis session store
- Our environments are currently running version 4.x.x
- We've been asked to upgrade due to EOL
- I can't find out why we are using bitnami rather than the official redis image, to avoid potential problems with the upgrade I'm going to keep the surface area of problems smaller by staying with the same maintainer - one for later
- apparently redis supports backwards compatibility even between major changes[1] so we should be able to attempt the otherwise big jump in one go

[1] https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/redis/upgrade.html#upgrade-paths
