### PR TITLE
Set default placement duration if not set

### DIFF
--- a/server/form-pages/apply/move-on/placementDuration.test.ts
+++ b/server/form-pages/apply/move-on/placementDuration.test.ts
@@ -1,14 +1,14 @@
 import { addDays } from 'date-fns'
 import { ApprovedPremisesApplication } from '@approved-premises/api'
+import { DateFormats } from '../../../utils/dateUtils'
+import { getDefaultPlacementDurationInWeeks } from '../../../utils/applications/getDefaultPlacementDurationInWeeks'
 import { SessionDataError } from '../../../utils/errors'
 
 import PlacementDuration from './placementDuration'
 import { applicationFactory } from '../../../testutils/factories'
-import { DateFormats } from '../../../utils/dateUtils'
-import { addResponseToApplication, addResponsesToApplication } from '../../../testutils/addToApplication'
-import { retrieveQuestionResponseFromApplicationOrAssessment } from '../../../utils/retrieveQuestionResponseFromApplicationOrAssessment'
+import { addResponsesToApplication } from '../../../testutils/addToApplication'
 
-jest.mock('../../../utils/retrieveQuestionResponseFromApplicationOrAssessment.ts')
+jest.mock('../../../utils/applications/getDefaultPlacementDurationInWeeks')
 
 describe('PlacementDuration', () => {
   let data: Record<string, unknown>
@@ -101,43 +101,12 @@ describe('PlacementDuration', () => {
   describe('departureDate', () => {
     const releaseDate = new Date(2023, 1, 1)
 
-    it('returns the arrival date plus 12 weeks if the ap type is standard', () => {
-      ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValueOnce('standard')
+    it('returns the arrival date plus the default placement duration', () => {
+      ;(getDefaultPlacementDurationInWeeks as jest.Mock).mockReturnValueOnce(12)
 
-      application = applicationFactory
-        .withReleaseDate(DateFormats.dateObjToIsoDate(releaseDate))
-        .withPageResponse({ task: 'type-of-ap', page: 'ap-type', key: 'type', value: 'standard' })
-        .build()
+      application = applicationFactory.withReleaseDate(DateFormats.dateObjToIsoDate(releaseDate)).build()
 
       expect(new PlacementDuration({}, application).departureDate).toEqual(addDays(releaseDate, 7 * 12))
-    })
-
-    it('returns the arrival date plus 26 weeks if the ap type is PIPE', () => {
-      ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValueOnce('pipe')
-
-      application = applicationFactory.withReleaseDate(DateFormats.dateObjToIsoDate(releaseDate)).build()
-      application = addResponseToApplication(application, {
-        section: 'type-of-ap',
-        page: 'ap-type',
-        key: 'type',
-        value: 'pipe',
-      })
-
-      expect(new PlacementDuration({}, application).departureDate).toEqual(addDays(releaseDate, 7 * 26))
-    })
-
-    it('returns the arrival date plus 56 weeks if the ap type is ESAP', () => {
-      ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValueOnce('esap')
-
-      application = applicationFactory.withReleaseDate(DateFormats.dateObjToIsoDate(releaseDate)).build()
-      application = addResponseToApplication(application, {
-        section: 'type-of-ap',
-        page: 'ap-type',
-        key: 'type',
-        value: 'esap',
-      })
-
-      expect(new PlacementDuration({}, application).departureDate).toEqual(addDays(releaseDate, 7 * 56))
     })
   })
 

--- a/server/form-pages/apply/move-on/placementDuration.ts
+++ b/server/form-pages/apply/move-on/placementDuration.ts
@@ -6,9 +6,8 @@ import { DateFormats } from '../../../utils/dateUtils'
 import { Page } from '../../utils/decorators'
 
 import TasklistPage from '../../tasklistPage'
-import SelectApType, { ApType } from '../reasons-for-placement/type-of-ap/apType'
-import { retrieveQuestionResponseFromApplicationOrAssessment } from '../../../utils/retrieveQuestionResponseFromApplicationOrAssessment'
 import { sentenceCase } from '../../../utils/utils'
+import { getDefaultPlacementDurationInWeeks } from '../../../utils/applications/getDefaultPlacementDurationInWeeks'
 
 type PlacementDurationBody = {
   differentDuration: YesOrNo
@@ -96,12 +95,9 @@ export default class PlacementDuration implements TasklistPage {
     }
   }
 
-  private fetchDepartureDate(): Date | null {
-    const apType = retrieveQuestionResponseFromApplicationOrAssessment(this.application, SelectApType, 'type') as ApType
+  private fetchDepartureDate(): Date {
+    const standardPlacementDuration = getDefaultPlacementDurationInWeeks(this.application)
 
-    if (apType === 'standard') return addDays(this.arrivalDate, 7 * 12)
-    if (apType === 'pipe') return addDays(this.arrivalDate, 7 * 26)
-    if (apType === 'esap') return addDays(this.arrivalDate, 7 * 56)
-    return null
+    return addDays(this.arrivalDate, 7 * standardPlacementDuration)
   }
 }

--- a/server/testutils/mockQuestionResponse.ts
+++ b/server/testutils/mockQuestionResponse.ts
@@ -1,7 +1,10 @@
 import { ApprovedPremisesApplication as Application } from '@approved-premises/api'
-import { retrieveQuestionResponseFromApplicationOrAssessment } from '../utils/retrieveQuestionResponseFromApplicationOrAssessment'
+import {
+  retrieveOptionalQuestionResponseFromApplicationOrAssessment,
+  retrieveQuestionResponseFromApplicationOrAssessment,
+} from '../utils/retrieveQuestionResponseFromApplicationOrAssessment'
 
-const mockQuestionResponse = ({
+export const mockQuestionResponse = ({
   postcodeArea = 'ABC 123',
   type = 'standard',
   sentenceType = 'standardDeterminate',
@@ -46,4 +49,29 @@ const mockQuestionResponse = ({
   )
 }
 
-export default mockQuestionResponse
+export const mockOptionalQuestionResponse = ({
+  releaseType = 'other',
+  alternativeRadius,
+  duration,
+}: {
+  releaseType?: string
+  duration?: string
+  alternativeRadius?: string
+}) => {
+  ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockImplementation(
+    // eslint-disable-next-line consistent-return
+    (_application: Application, _Page: unknown, question: string) => {
+      if (question === 'alternativeRadius') {
+        return alternativeRadius
+      }
+
+      if (question === 'duration') {
+        return duration
+      }
+
+      if (question === 'releaseType') {
+        return releaseType
+      }
+    },
+  )
+}

--- a/server/utils/applications/applicationSubmissionData.test.ts
+++ b/server/utils/applications/applicationSubmissionData.test.ts
@@ -1,7 +1,7 @@
 import { ReleaseTypeOption } from '@approved-premises/api'
 import { applicationFactory } from '../../testutils/factories'
 import { applicationSubmissionData } from './applicationSubmissionData'
-import mockQuestionResponse from '../../testutils/mockQuestionResponse'
+import { mockQuestionResponse } from '../../testutils/mockQuestionResponse'
 import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromApplicationOrAssessment'
 
 jest.mock('../retrieveQuestionResponseFromApplicationOrAssessment')

--- a/server/utils/applications/getDefaultPlacementDurationInWeeks.test.ts
+++ b/server/utils/applications/getDefaultPlacementDurationInWeeks.test.ts
@@ -1,0 +1,27 @@
+import { applicationFactory } from '../../testutils/factories'
+import { retrieveQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromApplicationOrAssessment'
+import { getDefaultPlacementDurationInWeeks } from './getDefaultPlacementDurationInWeeks'
+
+jest.mock('../retrieveQuestionResponseFromApplicationOrAssessment.ts')
+
+describe('getDefaultPlacementDurationInWeeks', () => {
+  const application = applicationFactory.build()
+
+  it('returns 12 weeks if the ap type is standard', () => {
+    ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValueOnce('standard')
+
+    expect(getDefaultPlacementDurationInWeeks(application)).toEqual(12)
+  })
+
+  it('returns 26 weeks if the ap type is standard', () => {
+    ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValueOnce('pipe')
+
+    expect(getDefaultPlacementDurationInWeeks(application)).toEqual(26)
+  })
+
+  it('returns 56 weeks if the ap type is standard', () => {
+    ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValueOnce('esap')
+
+    expect(getDefaultPlacementDurationInWeeks(application)).toEqual(56)
+  })
+})

--- a/server/utils/applications/getDefaultPlacementDurationInWeeks.ts
+++ b/server/utils/applications/getDefaultPlacementDurationInWeeks.ts
@@ -1,0 +1,12 @@
+import { ApprovedPremisesApplication as Application } from '@approved-premises/api'
+import SelectApType, { ApType } from '../../form-pages/apply/reasons-for-placement/type-of-ap/apType'
+import { retrieveQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromApplicationOrAssessment'
+
+export const getDefaultPlacementDurationInWeeks = (application: Application) => {
+  const apType = retrieveQuestionResponseFromApplicationOrAssessment(application, SelectApType, 'type') as ApType
+
+  if (apType === 'standard') return 12
+  if (apType === 'pipe') return 26
+  if (apType === 'esap') return 56
+  return null
+}

--- a/server/utils/applications/shouldShowContingencyPlanPages.test.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.test.ts
@@ -1,6 +1,6 @@
 import { applicationFactory } from '../../testutils/factories'
 import { shouldShowContingencyPlanPages } from './shouldShowContingencyPlanPages'
-import mockQuestionResponse from '../../testutils/mockQuestionResponse'
+import { mockQuestionResponse } from '../../testutils/mockQuestionResponse'
 
 jest.mock('../retrieveQuestionResponseFromApplicationOrAssessment')
 

--- a/server/utils/assessments/placementRequestData.test.ts
+++ b/server/utils/assessments/placementRequestData.test.ts
@@ -1,5 +1,5 @@
 import { createMock } from '@golevelup/ts-jest'
-import mockQuestionResponse from '../../testutils/mockQuestionResponse'
+import { mockQuestionResponse } from '../../testutils/mockQuestionResponse'
 import { MatchingInformationBody } from '../../form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation'
 import { criteriaFromMatchingInformation, placementRequestData } from './placementRequestData'
 import { assessmentFactory } from '../../testutils/factories'

--- a/server/utils/assessments/placementRequestData.test.ts
+++ b/server/utils/assessments/placementRequestData.test.ts
@@ -1,14 +1,15 @@
 import { createMock } from '@golevelup/ts-jest'
-import { mockQuestionResponse } from '../../testutils/mockQuestionResponse'
+import { mockOptionalQuestionResponse, mockQuestionResponse } from '../../testutils/mockQuestionResponse'
 import { MatchingInformationBody } from '../../form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation'
 import { criteriaFromMatchingInformation, placementRequestData } from './placementRequestData'
 import { assessmentFactory } from '../../testutils/factories'
 import { pageDataFromApplicationOrAssessment } from '../../form-pages/utils'
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
-import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromApplicationOrAssessment'
+import { getDefaultPlacementDurationInWeeks } from '../applications/getDefaultPlacementDurationInWeeks'
 
 jest.mock('../../form-pages/utils')
 jest.mock('../retrieveQuestionResponseFromApplicationOrAssessment')
+jest.mock('../applications/getDefaultPlacementDurationInWeeks')
 jest.mock('../applications/arrivalDateFromApplication')
 
 describe('placementRequestData', () => {
@@ -26,7 +27,7 @@ describe('placementRequestData', () => {
 
   it('converts matching data into a placement request', () => {
     mockQuestionResponse({ postcodeArea: 'ABC123', type: 'normal', duration: '12' })
-    ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue('100')
+    mockOptionalQuestionResponse({ duration: '12', alternativeRadius: '100' })
 
     expect(placementRequestData(assessment)).toEqual({
       gender: matchingInformation.apGender,
@@ -42,11 +43,20 @@ describe('placementRequestData', () => {
   })
 
   it('returns a default radius if one is not present', () => {
-    ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue(undefined)
+    mockOptionalQuestionResponse({ duration: '12', alternativeRadius: undefined })
 
     const result = placementRequestData(assessment)
 
     expect(result.radius).toEqual(50)
+  })
+
+  it('returns the default placement duration if one is not present', () => {
+    ;(getDefaultPlacementDurationInWeeks as jest.Mock).mockReturnValueOnce(52)
+    mockOptionalQuestionResponse({ duration: undefined, alternativeRadius: '100' })
+
+    const result = placementRequestData(assessment)
+
+    expect(result.duration).toEqual(52)
   })
 
   it('returns a false mentalHealthSupport requirement if the mentalHealthSupport matching information is blank', () => {

--- a/server/utils/assessments/placementRequestData.ts
+++ b/server/utils/assessments/placementRequestData.ts
@@ -13,6 +13,7 @@ import MatchingInformation, {
 } from '../../form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation'
 import LocationFactors from '../../form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors'
 import PlacementDuration from '../../form-pages/apply/move-on/placementDuration'
+import { getDefaultPlacementDurationInWeeks } from '../applications/getDefaultPlacementDurationInWeeks'
 
 type Requirement = (typeof placementRequirements)[number]
 type RiskInformationKey = (typeof offenceAndRiskInformationKeys)[number]
@@ -33,11 +34,12 @@ export const placementRequestData = (assessment: Assessment): PlacementRequest =
     LocationFactors,
     'alternativeRadius',
   )
-  const placementDuration = retrieveQuestionResponseFromApplicationOrAssessment(
-    assessment.application,
-    PlacementDuration,
-    'duration',
-  )
+  const placementDuration =
+    retrieveOptionalQuestionResponseFromApplicationOrAssessment(
+      assessment.application,
+      PlacementDuration,
+      'duration',
+    ) || getDefaultPlacementDurationInWeeks(assessment.application)
 
   const criteria = criteriaFromMatchingInformation(matchingInformation)
 


### PR DESCRIPTION
Since #710 the placement duration is no longer a required response, as we assume it's the default. This meant that when we submit an assessment and try to send the duration, we get an error.

This adds a new `getDefaultPlacementDurationInWeeks` helper which we use as the source of truth for the default placement lengths. If the duration is not set, we send the default length to the API.