### PR TITLE
(1477) Improve contingency plan partners page

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -373,8 +373,7 @@
           "phoneNumber": "01234567892",
           "roleInPlan": "Test role 2"
         }
-      ],
-      "saveAndContinue": "1"
+      ]
     },
     "contingency-plan-questions": {
       "noReturn": "Action to be taken",

--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -155,7 +155,6 @@ export default class ApplyHelper {
       ...this.pages.locationFactors,
       ...this.pages.accessAndHealthcare,
       ...this.pages.furtherConsiderations,
-      ...this.contingencyPlanPartners,
       ...this.pages.contingencyPlanPartners,
       ...this.pages.moveOn,
       ...this.selectedDocuments,

--- a/integration_tests/pages/apply/contingencyPlanPartners.ts
+++ b/integration_tests/pages/apply/contingencyPlanPartners.ts
@@ -19,21 +19,12 @@ export default class ContingencyPlanPartnersPage extends ApplyPage {
   }
 
   completeForm() {
-    this.contigencyPlanPartners.forEach(partner => {
-      this.getTextInputByIdAndEnterDetails('partnerAgencyName', partner.partnerAgencyName)
-      this.getTextInputByIdAndEnterDetails('namedContact', partner.namedContact)
-      this.getTextInputByIdAndEnterDetails('phoneNumber', partner.phoneNumber)
-      this.getTextInputByIdAndEnterDetails('roleInPlan', partner.roleInPlan)
+    this.contigencyPlanPartners.forEach((partner, i) => {
+      this.getTextInputByIdAndEnterDetails(`partnerAgencyDetails_${i}_partnerAgencyName`, partner.partnerAgencyName)
+      this.getTextInputByIdAndEnterDetails(`partnerAgencyDetails_${i}_namedContact`, partner.namedContact)
+      this.getTextInputByIdAndEnterDetails(`partnerAgencyDetails_${i}_phoneNumber`, partner.phoneNumber)
+      this.getTextInputByIdAndEnterDetails(`partnerAgencyDetails_${i}_roleInPlan`, partner.roleInPlan)
       cy.get('button').contains('Add another agency').click()
-    })
-
-    cy.get('dl').each(() => {
-      this.contigencyPlanPartners.forEach(partner => {
-        this.assertDefinition('Named contact', partner.namedContact)
-        this.assertDefinition('Name of partner agency', partner.partnerAgencyName)
-        this.assertDefinition('Contact details (phone)', partner.phoneNumber)
-        this.assertDefinition('Role in contingency plan', partner.roleInPlan)
-      })
     })
   }
 

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanPartners.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/contingencyPlanPartners.test.ts
@@ -1,14 +1,14 @@
+import { PartnerAgencyDetails } from '@approved-premises/ui'
 import { contingencyPlanPartnerFactory } from '../../../../testutils/factories'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
-import ContingencyPlanPartners, { Body } from './contingencyPlanPartners'
+import ContingencyPlanPartners from './contingencyPlanPartners'
 
 describe('ContingencyPlanPartners', () => {
   const contigencyPlanPartner1 = contingencyPlanPartnerFactory.build()
   const contigencyPlanPartner2 = contingencyPlanPartnerFactory.build()
 
   const body = {
-    ...contigencyPlanPartner1,
-    partnerAgencyDetails: [contigencyPlanPartner2],
+    partnerAgencyDetails: [contigencyPlanPartner1, contigencyPlanPartner2, [] as Partial<PartnerAgencyDetails>],
   }
 
   describe('title', () => {
@@ -20,50 +20,40 @@ describe('ContingencyPlanPartners', () => {
   })
 
   describe('body', () => {
-    it('should push the form fields into a new item in the partnerAgencyDetails array', () => {
+    it('should set the body correctly', () => {
       const page = new ContingencyPlanPartners(body)
 
-      expect(page.partnerAgencyDetails).toEqual([contigencyPlanPartner2, contigencyPlanPartner1])
+      expect(page.body.partnerAgencyDetails).toEqual([contigencyPlanPartner1, contigencyPlanPartner2])
     })
   })
 
-  describe('if saveAndContinue is falsy ', () => {
-    itShouldHaveNextValue(new ContingencyPlanPartners(body), 'contingency-plan-partners')
-  })
-
-  describe('if saveAndContinue is truthy ', () => {
-    itShouldHaveNextValue(new ContingencyPlanPartners({ saveAndContinue: '1', ...body }), 'contingency-plan-questions')
-  })
+  itShouldHaveNextValue(new ContingencyPlanPartners(body), 'contingency-plan-questions')
 
   itShouldHavePreviousValue(new ContingencyPlanPartners(body), 'additional-circumstances')
 
   describe('errors', () => {
-    it('should return errors when responses are blank if saveAndContinue is falsy', () => {
-      const page = new ContingencyPlanPartners({} as Body)
+    it('should return errors when responses are blank', () => {
+      const page = new ContingencyPlanPartners({
+        partnerAgencyDetails: [
+          { namedContact: 'Someone' },
+          { partnerAgencyName: 'Agency name', phoneNumber: '123', roleInPlan: 'Role' },
+        ],
+      })
 
       expect(page.errors()).toEqual({
-        namedContact: 'You must specify a named contact',
-        partnerAgencyName: 'You must specify a partner agency name',
-        phoneNumber: 'You must specify a phone number',
-        roleInPlan: 'You must specify a role in plan',
+        partnerAgencyDetails_0_partnerAgencyName: 'You must specify a partner agency name',
+        partnerAgencyDetails_0_phoneNumber: 'You must specify a phone number',
+        partnerAgencyDetails_0_roleInPlan: 'You must specify a role in plan',
+        partnerAgencyDetails_1_namedContact: 'You must specify a named contact',
       })
     })
 
-    it('should return an error when there are no partner agencies added and saveAndContinue is truthy', () => {
-      const page = new ContingencyPlanPartners({ saveAndContinue: '1' } as Body)
+    it('should return an error when there are no partner agencies are specified', () => {
+      const page = new ContingencyPlanPartners({ partnerAgencyDetails: [] })
 
       expect(page.errors()).toEqual({
         partnerAgencyDetails: 'You must add at least one partner agency',
       })
-    })
-
-    it('shouldnt return an error if partnerAgencyDetails are added and saveAndContinue is truthy', () => {
-      const page = new ContingencyPlanPartners({
-        saveAndContinue: '1',
-        partnerAgencyDetails: contingencyPlanPartnerFactory.buildList(1),
-      } as Body)
-
-      expect(page.errors()).toEqual({})
     })
   })
 
@@ -74,16 +64,16 @@ describe('ContingencyPlanPartners', () => {
       expect(page.response()).toEqual({
         'Contingency plan partners': [
           {
-            'Named contact': contigencyPlanPartner2.namedContact,
-            'Partner agency name': contigencyPlanPartner2.partnerAgencyName,
-            'Phone number': contigencyPlanPartner2.phoneNumber,
-            'Role in plan': contigencyPlanPartner2.roleInPlan,
-          },
-          {
             'Named contact': contigencyPlanPartner1.namedContact,
             'Partner agency name': contigencyPlanPartner1.partnerAgencyName,
             'Phone number': contigencyPlanPartner1.phoneNumber,
             'Role in plan': contigencyPlanPartner1.roleInPlan,
+          },
+          {
+            'Named contact': contigencyPlanPartner2.namedContact,
+            'Partner agency name': contigencyPlanPartner2.partnerAgencyName,
+            'Phone number': contigencyPlanPartner2.phoneNumber,
+            'Role in plan': contigencyPlanPartner2.roleInPlan,
           },
         ],
       })

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -1487,53 +1487,29 @@
           }
         },
         "contingency-plan-partners": {
-          "allOf": [
-            {
-              "type": "object",
-              "properties": {
-                "partnerAgencyName": {
-                  "type": "string"
-                },
-                "namedContact": {
-                  "type": "string"
-                },
-                "phoneNumber": {
-                  "type": "string"
-                },
-                "roleInPlan": {
-                  "type": "string"
-                }
-              }
-            },
-            {
-              "type": "object",
-              "properties": {
-                "saveAndContinue": {
-                  "type": "string"
-                },
-                "partnerAgencyDetails": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "partnerAgencyName": {
-                        "type": "string"
-                      },
-                      "namedContact": {
-                        "type": "string"
-                      },
-                      "phoneNumber": {
-                        "type": "string"
-                      },
-                      "roleInPlan": {
-                        "type": "string"
-                      }
-                    }
+          "type": "object",
+          "properties": {
+            "partnerAgencyDetails": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "partnerAgencyName": {
+                    "type": "string"
+                  },
+                  "namedContact": {
+                    "type": "string"
+                  },
+                  "phoneNumber": {
+                    "type": "string"
+                  },
+                  "roleInPlan": {
+                    "type": "string"
                   }
                 }
               }
             }
-          ]
+          }
         },
         "contingency-plan-questions": {
           "type": "object",

--- a/server/views/applications/pages/further-considerations/contingency-plan-partners.njk
+++ b/server/views/applications/pages/further-considerations/contingency-plan-partners.njk
@@ -4,20 +4,68 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% extends "../../../partials/layout.njk" %}
 
-{% set hiddenInputs %}
+{% macro fieldset(index, includeButton = false) %}
+  {%
+    call govukFieldset({
+      classes: "govuk-fieldset moj-add-another__item",
+      legend: {
+        text: "Partner Agency " + (
+        index + 1),
+        classes: "govuk-fieldset__legend moj-add-another__title govuk-fieldset__legend--m"
+      }
+    })
+  %}
+  {% for id, label in page.fields %}
+    {% set type = "text" %}
+    {% set inputMode = 'text' %}
+    {% set value = page.body[index] %}
+    {% set fieldName = "partnerAgencyDetails[" + index + "][" + id + "]" %}
+    {% set fieldId = "partnerAgencyDetails_" + index + "_" + id %}
+    {% set context = fetchContext() %}
 
-{% for partnerAgency in page.partnerAgencyDetails%}
-  {% set iteration = loop.index0 %}
-  {% for id, value in partnerAgency %}
-    {% set fieldName = "partnerAgencyDetails[" + iteration + "][" + id + "]"%}
-    <input type="hidden" name="{{fieldName}}" value="{{value}}"/>
-  {%endfor %}
-{%endfor %}
+    {% if id == "phoneNumber" %}
+      {% set type = "number" %}
+      {% set inputMode = 'numeric'%}
+    {% endif %}
 
-{% endset %}
+    {{
+      govukInput({
+        label: {
+          text: label
+        },
+        id: fieldId,
+        name: fieldName,
+        type: type,
+        inputMode: inputMode,
+        errorMessage: errors[fieldId],
+        value: context.partnerAgencyDetails[index][id]
+      })
+    }}
+  {% endfor %}
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+  {% if includeButton %}
+    {{ addButton() }}
+  {% endif %}
+  {% endcall %}
+{% endmacro %}
+
+{% macro addButton() %}
+  {{
+    govukButton({
+      text: "Remove",
+      attributes: {
+        "data-remove-agency": "true"
+      },
+      classes: "govuk-button govuk-button--secondary moj-add-another__remove-button"
+    })
+  }}
+{% endmacro %}
 
 {% set pageTitle = applicationName + " - " + page.title %}
 {% set mainClasses = "app-container govuk-body" %}
@@ -30,59 +78,118 @@
 {% endblock %}
 
 {% block content %}
-  <form action="{{ paths.applications.pages.update({ id: applicationId, task: task, page: page.name }) }}?_method=PUT" method="post">
-    <h1 class="govuk-heading-l">{{page.title}}</h1>
-    <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form action="{{ paths.applications.pages.update({ id: applicationId, task: task, page: page.name }) }}?_method=PUT" method="post">
+        {% if errorSummary | length %}
+          {{ govukErrorSummary({
+            titleText: "There is a problem",
+            errorList: errorSummary
+          }) }}
+        {% endif %}
 
-    {{ hiddenInputs | safe }}
-    {{ showErrorSummary(errorSummary) }}
+        <h1 class="govuk-heading-l">{{page.title}}</h1>
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-    {% for id, label in page.fields %}
-      {% set type = "text" %}
-      {% set inputMode = 'text'%}
+        <div id="fieldset-wrapper">
+          {% for i in range(0, 5) -%}
+            {{ fieldset(i) }}
+          {% endfor %}
+        </div>
 
-      {% if id == "phoneNumber" %}
-        {% set type = "number" %}
-        {% set inputMode = 'numeric'%}
-      {% endif %}
-      {{ formPageInput({
-        label: {
-          text: label
-        },
-        type: type,
-        inputMode: inputMode,
-        fieldName: id,
-        classes: "govuk-input--width-20"
-      }) }}
-    {% endfor %}
+        {{
+          govukButton({
+            text: "Add another agency",
+            attributes: {
+              "data-add-agency": "true"
+            },
+            classes: "govuk-button--secondary"
+          })
+        }}
 
-    {{ govukButton({
-      text: "Add another agency",
-      classes: "govuk-button--secondary"
-    }) }}
-  </form>
+        {{
+          govukButton({
+            text: "Save and continue"
+          })
+        }}
+      </form>
+    </div>
+  </div>
+{% endblock %}
 
-  <form action="{{ paths.applications.pages.update({ id: applicationId, task: task, page: page.name }) }}?_method=PUT" method="post">
-    <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-    <input type="hidden" name="saveAndContinue" value="1"/>
+{% block extraScripts %}
+  <script type="text/javascript" nonce="{{ cspNonce }}">
+    function initializeAddButton() {
+      var addButton = document.querySelector('button[data-add-agency]');
 
-    {{ hiddenInputs | safe }}
+      addButton.addEventListener("click", (event) => {
+        var fieldsets = document.querySelectorAll('fieldset')
+        var hiddenFieldsets = document.querySelectorAll('fieldset[class*="govuk-visually-hidden"]');
 
-    {% if page.partnerAgencyDetails.length >= 1 %}
-      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-      <h2 class="govuk-heading-m">List of partner agencies</h2>
-      {% for partnerAgency in page.partnerAgencyDetails%}
-        {{ govukSummaryList({
-        rows: FormUtils.convertKeyValuePairsToSummaryListItems(partnerAgency, page.fields)
-      })}}
+        if (hiddenFieldsets.length) {
+          hiddenFieldsets[0]
+            .classList
+            .remove("govuk-visually-hidden");
+        } else {
+          var fieldsetWrapper = document.querySelector('#fieldset-wrapper')
+          var newFieldset = `{{ fieldset("INDEX", true) }}`
+            .replace('INDEX1', fieldsets.length)
+            .replaceAll('INDEX', fieldsets.length - 1)
+          fieldsetWrapper.innerHTML += newFieldset;
 
-      {%endfor %}
-    {% endif %}
+          var removeButtons = fieldsetWrapper.querySelectorAll('button[data-remove-agency]');
+          initializeRemoveButtons(removeButtons);
+        }
 
-    {{ govukButton({
-      text: "Save and continue"
-    }) }}
+        event.preventDefault();
+      })
+    }
 
-  </form>
+    function initializeRemoveButtons(buttons) {
+      for (let i = 0; i < buttons.length; i++) {
+        console.log(buttons[i])
+        buttons[i].addEventListener("click", (event) => {
+          var fieldset = event.target.parentElement;
+          var inputs = fieldset.querySelectorAll('input');
 
+          fieldset
+            .classList
+            .add('govuk-visually-hidden');
+
+          for (var i = 0; i < inputs.length; i++) {
+            inputs[i].value = '';
+          }
+
+          event.preventDefault();
+        })
+      }
+    }
+
+    function initializeFieldsets() {
+      var fieldsets = document.querySelectorAll('fieldset')
+
+      for (let i = 1; i < fieldsets.length; i++) {
+        var complete = false;
+        {% for id, label in page.fields %}
+          var {{ id }} = fieldsets[i].querySelector('input[name="partnerAgencyDetails[' + i + '][{{ id }}]"]');
+          if ({{ id }}.value.length > 0) {
+            complete = true;
+          }
+        {% endfor %}
+        if (complete === false) {
+          fieldsets[i]
+            .classList
+            .add('govuk-visually-hidden');
+        }
+        fieldsets[i].innerHTML += `{{ addButton() }}`
+      }
+
+      var removeButtons = document.querySelectorAll('button[data-remove-agency]');
+
+      initializeAddButton();
+      initializeRemoveButtons(removeButtons);
+    }
+
+    initializeFieldsets();
+  </script>
 {% endblock %}


### PR DESCRIPTION
This improves the contingency plan partners page to use frontend JS, rather than having to make a call for each partner. This was causing some issues when we're starting to remove the session functionality from Apply, and also making for a more confusing journey.

For accessibility purposes, we show an initial list of partner fields, then hide the ones we don't need. This diverges from the approach in the MOJ pattern (https://design-patterns.service.justice.gov.uk/components/add-another/), which clones the elements.

## Screenshot (well, GIF)

![](http://g.recordit.co/jUDKa2O5wO.gif)