### PR TITLE
Handle non-array requiredCharacteristics

### DIFF
--- a/server/controllers/match/search/bedSearchController.test.ts
+++ b/server/controllers/match/search/bedSearchController.test.ts
@@ -64,6 +64,31 @@ describe('bedSearchController', () => {
         expect(bedService.search).toHaveBeenCalledWith(token, { ...query, ...body })
         expect(placementRequestService.getPlacementRequest).toHaveBeenCalledWith(token, placementRequest.id)
       })
+
+      it('should handle when a single selectedRequiredCharacteristic is sent', async () => {
+        const query = mapPlacementRequestToBedSearchParams(placementRequest)
+        const body = { requiredCharacteristics: 'someRequiredCharacteristic' }
+
+        const requestHandler = bedsController.search()
+
+        await requestHandler({ ...request, body }, response, next)
+
+        expect(response.render).toHaveBeenCalledWith('match/search', {
+          pageHeading: 'Find a bed',
+          bedSearchResults,
+          placementRequest,
+          tier: placementRequest.risks.tier.value.level,
+          formPath,
+          placementCriteria,
+          ...query,
+          requiredCharacteristics: ['someRequiredCharacteristic'],
+        })
+        expect(bedService.search).toHaveBeenCalledWith(token, {
+          ...query,
+          ...{ requiredCharacteristics: ['someRequiredCharacteristic'] },
+        })
+        expect(placementRequestService.getPlacementRequest).toHaveBeenCalledWith(token, placementRequest.id)
+      })
     })
 
     describe('no body params are sent', () => {

--- a/server/controllers/match/search/bedSearchController.ts
+++ b/server/controllers/match/search/bedSearchController.ts
@@ -52,7 +52,7 @@ export default class BedSearchController {
       }
 
       params.startDate = startDateObjFromParams(params).startDate
-      params.requiredCharacteristics = [...(params.selectedRequiredCharacteristics || params.requiredCharacteristics)]
+      params.requiredCharacteristics = [params.selectedRequiredCharacteristics || params.requiredCharacteristics].flat()
 
       const bedSearchResults = await this.bedService.search(req.user.token, params as BedSearchParametersUi)
       const tier = placementRequest?.risks?.tier?.value?.level || 'N/A'


### PR DESCRIPTION
When one requiredCharacteristic is selected, Express “helpfully” flattens this down to a single string, rather than an array. This is not in any way helpful, and has been the cause of many a flickering integration test. To get round this, we need to cast the characteristic into an array and flatten it before sending the characteristics on their merry way to the API.