### PR TITLE
Upgrade to Node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ parameters:
 
   node-version:
     type: string
-    default: 16.15-browsers
+    default: 18.16-browsers
 
 jobs:
   check_outdated:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base image
-FROM node:16.15-bullseye-slim as base
+FROM node:18.16-bullseye-slim as base
 
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available


### PR DESCRIPTION
Package.json already referenced using version 18:

```
  "engines": {
    "node": "^18",
```

Now, CircleCI and docker containers will run with version 18.

This addresses high warnings via CVE-2022-29458

This is a straight copy of the PR in https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/334