### PR TITLE
Fix characteristic helpers

### DIFF
--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -1258,20 +1258,11 @@
                   ],
                   "type": "string"
                 },
-                "mobilityNeeds": {
-                  "type": "string"
-                },
-                "visualImpairment": {
-                  "type": "string"
-                },
                 "isPersonPregnant": {
                   "enum": [
                     "no",
                     "yes"
                   ],
-                  "type": "string"
-                },
-                "otherPregnancyConsiderations": {
                   "type": "string"
                 },
                 "childRemoved": {
@@ -1280,6 +1271,9 @@
                     "no",
                     "yes"
                   ],
+                  "type": "string"
+                },
+                "additionalAdjustments": {
                   "type": "string"
                 }
               }
@@ -1310,6 +1304,67 @@
               "type": "object",
               "properties": {
                 "expectedDeliveryDate": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "healthConditions": {
+                  "enum": [
+                    "no",
+                    "yes"
+                  ],
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "healthConditionsDetail": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "prescribedMedication": {
+                  "enum": [
+                    "iDontKnow",
+                    "no",
+                    "yes"
+                  ],
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "prescribedMedicationDetail": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "otherPregnancyConsiderations": {
+                  "enum": [
+                    "no",
+                    "yes"
+                  ],
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "otherPregnancyConsiderationsDetail": {
                   "type": "string"
                 }
               }

--- a/server/testutils/factories/bedSearchResult.ts
+++ b/server/testutils/factories/bedSearchResult.ts
@@ -33,7 +33,8 @@ const premisesSummaryFactory = Factory.define<BedSearchResult['premises']>(() =>
 }))
 
 export const apCharacteristicPairFactory = Factory.define<CharacteristicPair>(() => ({
-  name: faker.helpers.arrayElement([
+  name: faker.lorem.sentence(),
+  propertyName: faker.helpers.arrayElement([
     'isIAP',
     'isPIPE',
     'isESAP',

--- a/server/utils/matchUtils.test.ts
+++ b/server/utils/matchUtils.test.ts
@@ -1,4 +1,5 @@
 import {
+  apCharacteristicPairFactory,
   bedSearchParametersFactory,
   bedSearchParametersUiFactory,
   bedSearchResultFactory,
@@ -19,6 +20,7 @@ import {
   mapSearchParamCharacteristicsForUi,
   mapSearchResultCharacteristicsForUi,
   mapUiParamsForApi,
+  matchedCharacteristics,
   matchedCharacteristicsRow,
   placementDates,
   placementLength,
@@ -30,9 +32,40 @@ import {
   summaryCardRows,
   townRow,
   translateApiCharacteristicForUi,
+  unmatchedCharacteristics,
 } from './matchUtils'
 
 describe('matchUtils', () => {
+  describe('matchedCharacteristics', () => {
+    it('returns a list of the matched characteristics', () => {
+      const actualCharacteristics = [
+        apCharacteristicPairFactory.build({ propertyName: 'isSemiSpecialistMentalHealth' }),
+        apCharacteristicPairFactory.build({ propertyName: 'isPIPE' }),
+        apCharacteristicPairFactory.build({ propertyName: 'isCatered' }),
+      ]
+      const requiredCharacteristics = ['isPIPE', 'isCatered']
+
+      expect(matchedCharacteristics(actualCharacteristics, requiredCharacteristics)).toEqual(
+        mapSearchParamCharacteristicsForUi(['isPIPE', 'isCatered']),
+      )
+    })
+  })
+
+  describe('unmatchedCharacteristics', () => {
+    it('returns a list of the unmatched characteristics', () => {
+      const actualCharacteristics = [
+        apCharacteristicPairFactory.build({ propertyName: 'isSemiSpecialistMentalHealth' }),
+        apCharacteristicPairFactory.build({ propertyName: 'isPIPE' }),
+        apCharacteristicPairFactory.build({ propertyName: 'isCatered' }),
+      ]
+      const requiredCharacteristics = ['isPIPE']
+
+      expect(unmatchedCharacteristics(actualCharacteristics, requiredCharacteristics)).toEqual(
+        mapSearchParamCharacteristicsForUi(['isSemiSpecialistMentalHealth', 'isCatered']),
+      )
+    })
+  })
+
   describe('mapUiParamsForApi', () => {
     it('converts string properties to numbers', () => {
       const uiParams = bedSearchParametersUiFactory.build({ durationWeeks: '2' })

--- a/server/utils/matchUtils.ts
+++ b/server/utils/matchUtils.ts
@@ -46,18 +46,24 @@ export const mapSearchParamCharacteristicsForUi = (characteristics: Array<string
     .join('')}</ul>`
 }
 
-export const matchedCharacteristics = (bedSearchResult: BedSearchResult, requiredCharacteristics: Array<string>) => {
+export const matchedCharacteristics = (
+  actualCharacteristics: Array<CharacteristicPair>,
+  requiredCharacteristics: Array<string>,
+) => {
   const characteristics = requiredCharacteristics.filter(characteristic =>
-    bedSearchResult.premises.characteristics.map(c => c.name).includes(characteristic),
+    actualCharacteristics.map(c => c.propertyName).includes(characteristic),
   )
 
   return mapSearchParamCharacteristicsForUi(characteristics)
 }
 
-export const unmatchedCharacteristics = (bedSearchResult: BedSearchResult, requiredCharacteristics: Array<string>) => {
-  const characteristics = requiredCharacteristics.filter(
-    characteristic => !bedSearchResult.premises.characteristics.map(c => c.name).includes(characteristic),
-  )
+export const unmatchedCharacteristics = (
+  actualCharacteristics: Array<CharacteristicPair>,
+  requiredCharacteristics: Array<string>,
+) => {
+  const characteristics = actualCharacteristics
+    .map(c => c.propertyName)
+    .filter(characteristic => !requiredCharacteristics.includes(characteristic))
 
   return mapSearchParamCharacteristicsForUi(characteristics)
 }
@@ -214,7 +220,7 @@ export const matchedCharacteristicsRow = (
     text: 'Matched characteristics',
   },
   value: {
-    html: matchedCharacteristics(bedSearchResult, requiredCharacteristics),
+    html: matchedCharacteristics(bedSearchResult.premises.characteristics, requiredCharacteristics),
   },
 })
 
@@ -226,7 +232,7 @@ export const additionalCharacteristicsRow = (
     text: 'Additional characteristics',
   },
   value: {
-    html: unmatchedCharacteristics(bedSearchResult, requiredCharacteristics),
+    html: unmatchedCharacteristics(bedSearchResult.premises.characteristics, requiredCharacteristics),
   },
 })
 


### PR DESCRIPTION
These weren’t working with real data, because we should be matching on the `propertyName`, not the `name`. I’ve updated the factory, as well as adding some tests, which were missing too. To make testing easier, I’ve also updated `matchedCharacteristics` and `unmatchedCharacteristics` to  accept the characteristic pairs, not just the bed search result.