### PR TITLE
Sort Oasys questions by number and letter

### DIFF
--- a/server/utils/oasysImportUtils.test.ts
+++ b/server/utils/oasysImportUtils.test.ts
@@ -115,6 +115,15 @@ describe('OASysImportUtils', () => {
       const result = sortOasysImportSummaries([oasysSummary3, oasysSummary2, oasysSummary1])
       expect(result).toEqual([oasysSummary1, oasysSummary2, oasysSummary3])
     })
+
+    it('removes non-numeric ', () => {
+      const oasysSummary1 = roshSummaryFactory.build({ questionNumber: 'AB1' })
+      const oasysSummary2 = roshSummaryFactory.build({ questionNumber: 'AB2' })
+      const oasysSummary3 = roshSummaryFactory.build({ questionNumber: 'AB3' })
+
+      const result = sortOasysImportSummaries([oasysSummary3, oasysSummary2, oasysSummary1])
+      expect(result).toEqual([oasysSummary1, oasysSummary2, oasysSummary3])
+    })
   })
 
   describe('sectionCheckBoxes', () => {

--- a/server/utils/oasysImportUtils.ts
+++ b/server/utils/oasysImportUtils.ts
@@ -54,7 +54,7 @@ export const fetchOptionalOasysSections = (application: Application): Array<numb
 }
 
 export const sortOasysImportSummaries = (summaries: Array<OASysQuestion>): Array<OASysQuestion> => {
-  return summaries.sort((a, b) => Number(a.questionNumber) - Number(b.questionNumber))
+  return summaries.sort((a, b) => a.questionNumber.localeCompare(b.questionNumber, 'en', { numeric: true }))
 }
 
 export const sectionCheckBoxes = (fullList: Array<OASysSection>, selectedList: Array<OASysSection>) => {


### PR DESCRIPTION
In reality, the Oasys questions are prefixed with letters, so sorting didn’t work as expected We can use `localeCompare` to sort alphabetically and numerically.

## Screenshot

### Before

![image](https://user-images.githubusercontent.com/109774/236456777-a009c957-a00f-412c-ac43-a6d0b6993669.png)

### After

![image](https://user-images.githubusercontent.com/109774/236456724-61c5763c-7c5d-430f-b8da-7afbdc1bbf67.png)
