### PR TITLE
Add detail to the move on plans in place questions

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -399,7 +399,8 @@
       "postcodeArea": "SW11"
     },
     "plans-in-place": {
-      "arePlansInPlace": "yes"
+      "arePlansInPlace": "yes",
+      "plansInPlaceDetail": "Some detail"
     },
     "type-of-accommodation": {
       "accommodationType": "foreignNational",

--- a/integration_tests/pages/apply/plansInPlace.ts
+++ b/integration_tests/pages/apply/plansInPlace.ts
@@ -16,5 +16,6 @@ export default class PlansInPlacePage extends ApplyPage {
 
   completeForm() {
     this.checkRadioButtonFromPageBody('arePlansInPlace')
+    this.completeTextInputFromPageBody('plansInPlaceDetail')
   }
 }

--- a/server/form-pages/apply/move-on/plansInPlace.test.ts
+++ b/server/form-pages/apply/move-on/plansInPlace.test.ts
@@ -3,14 +3,25 @@ import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-e
 import PlansInPlace from './plansInPlace'
 
 describe('PlansInPlace', () => {
+  const body = {
+    arePlansInPlace: 'yes' as const,
+    plansInPlaceDetail: 'Plans in place detail',
+    plansNotInPlaceDetail: 'Plans not in place detail',
+  }
+
   describe('title', () => {
     expect(new PlansInPlace({}).title).toBe('Placement duration and move on')
   })
 
   describe('body', () => {
-    it('should set the body', () => {
-      const page = new PlansInPlace({ arePlansInPlace: 'yes' })
-      expect(page.body).toEqual({ arePlansInPlace: 'yes' })
+    it('should set the body when plans are in place', () => {
+      const page = new PlansInPlace(body)
+      expect(page.body).toEqual({ arePlansInPlace: 'yes', plansInPlaceDetail: 'Plans in place detail' })
+    })
+
+    it('should set the body when plans are not in place', () => {
+      const page = new PlansInPlace({ ...body, arePlansInPlace: 'no' })
+      expect(page.body).toEqual({ arePlansInPlace: 'no', plansNotInPlaceDetail: 'Plans not in place detail' })
     })
   })
 
@@ -18,17 +29,43 @@ describe('PlansInPlace', () => {
   itShouldHavePreviousValue(new PlansInPlace({}), 'relocation-region')
 
   describe('errors', () => {
-    const page = new PlansInPlace({})
-    expect(page.errors()).toEqual({
-      arePlansInPlace:
-        'You must answer whether move on arrangements are already in place for when the person leaves the AP',
+    it('returns an error when the body is empty', () => {
+      const page = new PlansInPlace({})
+      expect(page.errors()).toEqual({
+        arePlansInPlace:
+          'You must answer whether move on arrangements are already in place for when the person leaves the AP',
+      })
+    })
+
+    it('returns an error when arePlansInPlace is yes and plansInPlaceDetail is empty', () => {
+      const page = new PlansInPlace({ arePlansInPlace: 'yes' })
+      expect(page.errors()).toEqual({
+        plansInPlaceDetail: 'You must provide further details of the move on plan',
+      })
+    })
+
+    it('returns an error when arePlansInPlace is no and plansNotInPlaceDetail is empty', () => {
+      const page = new PlansInPlace({ arePlansInPlace: 'no' })
+      expect(page.errors()).toEqual({
+        plansNotInPlaceDetail:
+          'You must provide detail about any plans to secure accommodation in preparation for move on',
+      })
     })
   })
 
   describe('response', () => {
-    const page = new PlansInPlace({ arePlansInPlace: 'yes' })
-    expect(page.response()).toEqual({
-      'Are move on arrangements already in place for when the person leaves the AP?': 'Yes',
+    it('should return detail if yes is selected', () => {
+      const page = new PlansInPlace(body)
+      expect(page.response()).toEqual({
+        'Are move on arrangements already in place for when the person leaves the AP?': `Yes - Plans in place detail`,
+      })
+    })
+
+    it('should return detail if no is selected', () => {
+      const page = new PlansInPlace({ ...body, arePlansInPlace: 'no' })
+      expect(page.response()).toEqual({
+        'Are move on arrangements already in place for when the person leaves the AP?': `No - Plans not in place detail`,
+      })
     })
   })
 })

--- a/server/form-pages/apply/move-on/plansInPlace.ts
+++ b/server/form-pages/apply/move-on/plansInPlace.ts
@@ -1,18 +1,54 @@
-import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
-import { sentenceCase } from '../../../utils/utils'
+import type { TaskListErrors } from '@approved-premises/ui'
 import { Page } from '../../utils/decorators'
 
 import TasklistPage from '../../tasklistPage'
 
-@Page({ name: 'plans-in-place', bodyProperties: ['arePlansInPlace'] })
+type RawPlansInPlaceBody = Partial<PlansAreInPlaceBody | PlansNotInPlaceBody>
+
+type PlansAreInPlaceBody = {
+  arePlansInPlace: 'yes'
+  plansInPlaceDetail: string
+}
+
+type PlansNotInPlaceBody = {
+  arePlansInPlace: 'no'
+  plansNotInPlaceDetail: string
+}
+
+@Page({ name: 'plans-in-place', bodyProperties: ['arePlansInPlace', 'plansInPlaceDetail', 'plansNotInPlaceDetail'] })
 export default class PlansInPlace implements TasklistPage {
   name = 'plans-in-place'
 
   title = 'Placement duration and move on'
 
-  question = 'Are move on arrangements already in place for when the person leaves the AP?'
+  questions = {
+    arePlansInPlace: 'Are move on arrangements already in place for when the person leaves the AP?',
+    plansInPlaceDetail:
+      'Provide further detail about the accommodation type, including how the move on plan will be supported',
+    plansNotInPlaceDetail: 'Provide detail about any plans to secure accommodation in preparation for move on',
+  }
 
-  constructor(public body: { arePlansInPlace?: YesOrNo }) {}
+  constructor(private _body: RawPlansInPlaceBody) {}
+
+  public get body(): PlansAreInPlaceBody | PlansNotInPlaceBody {
+    if ('plansInPlaceDetail' in this._body) {
+      return this._body as PlansAreInPlaceBody
+    }
+    return this._body as PlansNotInPlaceBody
+  }
+
+  public set body(value: RawPlansInPlaceBody) {
+    this._body =
+      value.arePlansInPlace === 'yes'
+        ? ({
+            arePlansInPlace: value.arePlansInPlace,
+            plansInPlaceDetail: (value as PlansAreInPlaceBody).plansInPlaceDetail,
+          } as PlansAreInPlaceBody)
+        : ({
+            arePlansInPlace: value.arePlansInPlace,
+            plansNotInPlaceDetail: (value as PlansNotInPlaceBody).plansNotInPlaceDetail,
+          } as PlansNotInPlaceBody)
+  }
 
   previous() {
     return 'relocation-region'
@@ -23,19 +59,38 @@ export default class PlansInPlace implements TasklistPage {
   }
 
   response() {
-    return {
-      [this.question]: sentenceCase(this.body.arePlansInPlace),
+    if ('plansInPlaceDetail' in this.body && this.body.arePlansInPlace === 'yes') {
+      return {
+        [this.questions.arePlansInPlace]: `Yes - ${this.body.plansInPlaceDetail}`,
+      }
     }
+
+    if ('plansNotInPlaceDetail' in this.body && this.body.arePlansInPlace === 'no') {
+      return {
+        [this.questions.arePlansInPlace]: `No - ${this.body.plansNotInPlaceDetail}`,
+      }
+    }
+
+    return {}
   }
 
   errors() {
-    const errors: TaskListErrors<this> = {}
+    const errors = {} as Record<string, string>
 
     if (!this.body.arePlansInPlace) {
       errors.arePlansInPlace =
         'You must answer whether move on arrangements are already in place for when the person leaves the AP'
     }
 
-    return errors
+    if (this.body.arePlansInPlace === 'yes' && !this.body.plansInPlaceDetail) {
+      errors.plansInPlaceDetail = 'You must provide further details of the move on plan'
+    }
+
+    if (this.body.arePlansInPlace === 'no' && !this.body.plansNotInPlaceDetail) {
+      errors.plansNotInPlaceDetail =
+        'You must provide detail about any plans to secure accommodation in preparation for move on'
+    }
+
+    return errors as TaskListErrors<this>
   }
 }

--- a/server/views/applications/pages/move-on/plans-in-place.njk
+++ b/server/views/applications/pages/move-on/plans-in-place.njk
@@ -5,22 +5,60 @@
   <h1 class="govuk-heading-l">{{page.title}}
   </h1>
 
+  {% set yesDetails %}
+  {{
+      formPageTextarea(
+        {
+          fieldName: "plansInPlaceDetail",
+          type: "textarea",
+          spellcheck: false,
+          label: {
+            text: page.questions.plansInPlaceDetail
+          }
+        },
+        fetchContext()
+      )
+    }}
+  {% endset -%}
+
+  {% set noDetails %}
+  {{
+      formPageTextarea(
+        {
+          fieldName: "plansNotInPlaceDetail",
+          type: "textarea",
+          spellcheck: false,
+          label: {
+            text: page.questions.plansNotInPlaceDetail
+          }
+        },
+        fetchContext()
+      )
+    }}
+  {% endset -%}
+
   {{ formPageRadios({
         fieldName: "arePlansInPlace",
         fieldset: {
           legend: {
-            text: page.question,
+            text: page.questions.arePlansInPlace,
             classes: "govuk-fieldset__legend--m"
           }
         },
         items: [
           {
             value: "yes",
-            text: "Yes"
+            text: "Yes",
+            conditional: {
+              html: yesDetails
+            }
           },
           {
             value: "no",
-            text: "No"
+            text: "No",
+            conditional: {
+              html: noDetails
+            }
           }
         ]
     },fetchContext()) }}


### PR DESCRIPTION
This adds detail field to the ‘Yes’ and ‘No’ repsonses on the Move On plans questions. To be a bit more precise, I’ve added two seperate types, one for when the answer is no and one for when the answer is yes, which means we can clear any irrelevant data from the response if the user goes back and amends the response.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/109774/237040728-df8b76ad-b52e-4e7e-9ab3-edbe46798956.png)

### After

![image](https://user-images.githubusercontent.com/109774/237040582-64a1c171-7de3-4f2d-b7b0-d3c1f7cfef61.png)