### PR TITLE
Send Gender data when submitting an application

### DIFF
--- a/server/utils/assessments/placementRequestData.test.ts
+++ b/server/utils/assessments/placementRequestData.test.ts
@@ -29,6 +29,7 @@ describe('placementRequestData', () => {
     mockOptionalQuestionResponse({ duration: '12', alternativeRadius: '100' })
 
     expect(placementRequestData(assessment)).toEqual({
+      gender: 'male',
       type: matchingInformation.apType,
       expectedArrival,
       duration: '12',

--- a/server/utils/assessments/placementRequestData.ts
+++ b/server/utils/assessments/placementRequestData.ts
@@ -44,6 +44,7 @@ export const placementRequestData = (assessment: Assessment): PlacementRequest =
   const criteria = criteriaFromMatchingInformation(matchingInformation)
 
   return {
+    gender: 'male', // Hardcoded for now as we only support Male APs
     type: matchingInformation.apType,
     expectedArrival: arrivalDateFromApplication(assessment.application),
     duration: placementDuration,


### PR DESCRIPTION
We removed the Gender option in #760, but we need to still send the gender to the API as part of the placement request data (it’s hardcoded for now)