### PR TITLE
Fix the Suitability and Required Actions Radios

### DIFF
--- a/server/views/assessments/pages/required-actions/required-actions.njk
+++ b/server/views/assessments/pages/required-actions/required-actions.njk
@@ -1,3 +1,5 @@
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+
 {% extends "../layout.njk" %}
 
 {% block questions %}
@@ -5,7 +7,34 @@
     <h1 class="govuk-heading-l">{{page.title}}</h1>
 
     {% for sectionName, question in page.sections %}
+        {%
+            call govukFieldset({
+                legend: {
+                    text: question,
+                    classes: "govuk-fieldset__legend--m"
+                }
+            })
+        %}
+
+        {% set hintHtml %}
+        <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                View guidance notes
+                </span>
+            </summary>
+
+            <div class="govuk-details__text">
+                {% include './partials/' + sectionName + '.njk' %}
+            </div>
+        </details>
+        {% endset %}
+
         {% if sectionName === 'concernsOfUnmanagableRisk' %}
+
+            <div class="govuk-hint">
+                If yes, the application must be discussed with the Approved Premises Area Manager (APAM) to identify additional support that may be required
+            </div>
 
             {% set unmanageableRisks %}
 
@@ -44,14 +73,8 @@
 
             {{ formPageRadios({
                 fieldName: sectionName,
-                fieldset: {
-                    legend: {
-                        text: question,
-                        classes: "govuk-fieldset__legend--s"
-                    }
-                },
                 hint: {
-                    text: "If yes, the application must be discussed with the Approved Premises Area Manager (APAM) to identify additional support that may be required"
+                    html: hintHtml
                 },
                 items: [
                     {
@@ -71,11 +94,8 @@
         {% else %}
             {{ formPageRadios({
                 fieldName: sectionName,
-                fieldset: {
-                    legend: {
-                        text: question,
-                        classes: "govuk-fieldset__legend--s"
-                    }
+                hint: {
+                    html: hintHtml
                 },
                 items: [
                     {
@@ -91,18 +111,6 @@
 
         {% endif %}
 
-        <details class="govuk-details" data-module="govuk-details">
-            <summary class="govuk-details__summary">
-                <span class="govuk-details__summary-text">
-                          View guidance notes
-                        </span>
-            </summary>
-
-            <div class="govuk-details__text">
-                {% include './partials/' + sectionName + '.njk' %}
-            </div>
-        </details>
-
         {{ formPageTextarea({
                     fieldName: sectionName + "Comments",
                     label: {
@@ -110,7 +118,7 @@
                         classes: "govuk-label--s"
                     }
                 }, fetchContext()) }}
-
-    {%endfor %}
+        {% endcall %}
+    {% endfor %}
 
 {% endblock %}

--- a/server/views/assessments/pages/suitability-assessment/suitability-assessment.njk
+++ b/server/views/assessments/pages/suitability-assessment/suitability-assessment.njk
@@ -1,29 +1,41 @@
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+
 {% extends "../layout.njk" %}
 
 {% block questions %}
-
     <h1 class="govuk-heading-l">Suitability assessment</h1>
 
     {% for sectionName, question in page.sections %}
+        {%
+            call govukFieldset({
+                legend: {
+                    text: question,
+                    classes: "govuk-fieldset__legend--m"
+                }
+            })
+        %}
 
-    <label class="govuk-fieldset__legend--s" for="{{sectionName}}">{{question}}</label>
+        {% set hintHtml %}
+        <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                View guidance notes
+                </span>
+            </summary>
 
+            <div class="govuk-details__text">
+                {% include './partials/' + sectionName + '.njk' %}
+            </div>
+        </details>
+        {% endset %}
 
-    <details class="govuk-details" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-                        View guidance notes
-                    </span>
-        </summary>
-
-        <div class="govuk-details__text">
-            {% include './partials/' + sectionName + '.njk' %}
-        </div>
-    </details>
-        
-        {{ formPageRadios({
-                fieldName: sectionName,
-                items: [
+        {{
+            formPageRadios({
+                hint: {
+                    html: hintHtml
+                },
+                    fieldName: sectionName,
+                    items: [
                     {
                         value: "yes",
                         text: "Yes"
@@ -32,18 +44,21 @@
                         value: "no",
                         text: "No"
                     }
-                ]
-            }, fetchContext()) }}
+                    ]
+                }, fetchContext()
+            )
+        }}
 
+        {{
+            formPageTextarea({
+                fieldName: sectionName + "Comments",
+                label: {
+                    text: "Additional comments",
+                    classes: "govuk-label--s"
+                }
+            }, fetchContext())
+        }}
 
-        {{ formPageTextarea({
-                    fieldName: sectionName + "Comments",
-                    label: {
-                        text: "Additional comments",
-                        classes: "govuk-label--s"
-                    }
-                }, fetchContext()) }}
-
-    {%endfor %}
-
+        {% endcall %}
+    {% endfor %}
 {% endblock %}


### PR DESCRIPTION
All the fields related to each question should be wrapped in their own fieldsets. I’ve also moved the Required Actions hints to above the radio buttons to match what is in the Suitability Page.

## Screenshots

### Before

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/e571d8df-cf29-43c0-a75f-3bd219f7e63f)

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/e3a943b0-4358-461b-9c17-b5f384834713)

### After

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/feffdd06-ab07-454f-8047-f7ed0b97ea6d)

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/fe7a251d-7a37-4b9e-865d-f25d729e7af3)
