### PR TITLE
(1496) List all rooms in a property

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -18,6 +18,7 @@ import users from './integration_tests/mockApis/users'
 import tasks from './integration_tests/mockApis/tasks'
 import placementRequests from './integration_tests/mockApis/placementRequests'
 import bedSearch from './integration_tests/mockApis/beds'
+import rooms from './integration_tests/mockApis/rooms'
 
 import schemaValidator from './integration_tests/tasks/schemaValidator'
 
@@ -56,6 +57,7 @@ export default defineConfig({
         ...tasks,
         ...placementRequests,
         ...bedSearch,
+        ...rooms,
         stubApplicationJourney,
       })
     },

--- a/integration_tests/mockApis/rooms.ts
+++ b/integration_tests/mockApis/rooms.ts
@@ -1,0 +1,23 @@
+import type { SuperAgentRequest } from 'superagent'
+
+import type { Room } from '@approved-premises/api'
+
+import { stubFor } from '../../wiremock'
+import paths from '../../server/paths/manage'
+
+export default {
+  stubRooms: (args: { premisesId: string; rooms: Array<Room> }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: paths.premises.rooms({ premisesId: args.premisesId }),
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: args.rooms,
+      },
+    }),
+}

--- a/integration_tests/pages/manage/index.ts
+++ b/integration_tests/pages/manage/index.ts
@@ -5,6 +5,8 @@ import LostBedCreatePage from './lostBedCreate'
 import PremisesListPage from './premisesList'
 import PremisesShowPage from './premisesShow'
 
+import RoomsListPage from './roomsList'
+
 import BookingConfirmationPage from './booking/confirmation'
 import BookingFindPage from './booking/find'
 import BookingNewPage from './booking/new'
@@ -25,4 +27,5 @@ export {
   BookingShowPage,
   BookingExtensionConfirmationPage,
   BookingExtensionCreatePage,
+  RoomsListPage,
 }

--- a/integration_tests/pages/manage/roomsList.ts
+++ b/integration_tests/pages/manage/roomsList.ts
@@ -1,0 +1,29 @@
+import { Room } from '../../../server/@types/shared'
+
+import Page from '../page'
+import paths from '../../../server/paths/manage'
+
+export default class RoomsListPage extends Page {
+  constructor() {
+    super('Manage rooms')
+  }
+
+  static visit(premisesId: string): RoomsListPage {
+    cy.visit(paths.premises.rooms({ premisesId }))
+    return new RoomsListPage()
+  }
+
+  shouldShowRooms(rooms: Array<Room>, premisesId: string): void {
+    rooms.forEach((item: Room) => {
+      cy.contains(item.name)
+        .parent()
+        .within(() => {
+          cy.get('td').eq(0).contains(item.beds.length.toString())
+          cy.get('td')
+            .eq(1)
+            .contains('Manage')
+            .should('have.attr', 'href', paths.premises.room({ roomId: item.id, premisesId }))
+        })
+    })
+  }
+}

--- a/integration_tests/tests/manage/rooms.cy.ts
+++ b/integration_tests/tests/manage/rooms.cy.ts
@@ -1,0 +1,28 @@
+import { roomFactory } from '../../../server/testutils/factories'
+
+import { RoomsListPage } from '../../pages/manage'
+
+context('Rooms', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+  })
+
+  it('should list all rooms', () => {
+    const premisesId = 'premisesId'
+
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are rooms in the database
+    const rooms = roomFactory.buildList(5)
+    cy.task('stubRooms', { premisesId, rooms })
+
+    // When I visit the rooms page
+    const page = RoomsListPage.visit(premisesId)
+
+    // Then I should see all of the rooms listed
+    page.shouldShowRooms(rooms, premisesId)
+  })
+})

--- a/server/controllers/manage/index.ts
+++ b/server/controllers/manage/index.ts
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
 
-import PremisesController from './premisesController'
+import PremisesController from './premises/premisesController'
 import BookingsController from './bookingsController'
 import BookingExtensionsController from './bookingExtensionsController'
 import ArrivalsController from './arrivalsController'

--- a/server/controllers/manage/index.ts
+++ b/server/controllers/manage/index.ts
@@ -9,6 +9,7 @@ import DeparturesController from './departuresController'
 import CancellationsController from './cancellationsController'
 import LostBedsController from './lostBedsController'
 import PeopleController from '../peopleController'
+import RoomsController from './premises/roomsController'
 
 import type { Services } from '../../services'
 
@@ -26,6 +27,7 @@ export const controllers = (services: Services) => {
   const cancellationsController = new CancellationsController(services.cancellationService, services.bookingService)
   const lostBedsController = new LostBedsController(services.lostBedService)
   const peopleController = new PeopleController(services.personService)
+  const roomsController = new RoomsController(services.premisesService)
 
   return {
     premisesController,
@@ -37,6 +39,7 @@ export const controllers = (services: Services) => {
     cancellationsController,
     lostBedsController,
     peopleController,
+    roomsController,
   }
 }
 
@@ -48,4 +51,5 @@ export {
   NonArrivalsController,
   DeparturesController,
   PeopleController,
+  RoomsController,
 }

--- a/server/controllers/manage/premises/premisesController.test.ts
+++ b/server/controllers/manage/premises/premisesController.test.ts
@@ -3,8 +3,8 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
 import type { GroupedListofBookings, SummaryListItem } from '@approved-premises/ui'
 import { Booking } from '@approved-premises/api'
-import PremisesService from '../../services/premisesService'
-import BookingService from '../../services/bookingService'
+import PremisesService from '../../../services/premisesService'
+import BookingService from '../../../services/bookingService'
 import PremisesController from './premisesController'
 
 describe('PremisesController', () => {

--- a/server/controllers/manage/premises/premisesController.ts
+++ b/server/controllers/manage/premises/premisesController.ts
@@ -1,7 +1,7 @@
 import type { Request, RequestHandler, Response } from 'express'
 
-import PremisesService from '../../services/premisesService'
-import BookingService from '../../services/bookingService'
+import PremisesService from '../../../services/premisesService'
+import BookingService from '../../../services/bookingService'
 
 export default class PremisesController {
   constructor(private readonly premisesService: PremisesService, private readonly bookingService: BookingService) {}

--- a/server/controllers/manage/premises/roomsController.test.ts
+++ b/server/controllers/manage/premises/roomsController.test.ts
@@ -1,0 +1,38 @@
+import type { NextFunction, Request, Response } from 'express'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+
+import PremisesService from '../../../services/premisesService'
+import RoomsController from './roomsController'
+import { roomFactory } from '../../../testutils/factories'
+
+describe('RoomsController', () => {
+  const token = 'SOME_TOKEN'
+
+  const request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const premisesService = createMock<PremisesService>({})
+  const roomsController = new RoomsController(premisesService)
+
+  describe('index', () => {
+    it('should return the rooms to the template', async () => {
+      const rooms = roomFactory.buildList(1)
+      const premisesId = 'premisesId'
+      request.params.premisesId = premisesId
+
+      premisesService.getRooms.mockResolvedValue(rooms)
+
+      const requestHandler = roomsController.index()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('premises/rooms/index', {
+        rooms,
+        premisesId,
+        pageHeading: 'Manage rooms',
+      })
+
+      expect(premisesService.getRooms).toHaveBeenCalledWith(token, premisesId)
+    })
+  })
+})

--- a/server/controllers/manage/premises/roomsController.ts
+++ b/server/controllers/manage/premises/roomsController.ts
@@ -1,0 +1,19 @@
+import type { Request, RequestHandler, Response } from 'express'
+
+import PremisesService from '../../../services/premisesService'
+
+export default class RoomsController {
+  constructor(private readonly premisesService: PremisesService) {}
+
+  index(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const rooms = await this.premisesService.getRooms(req.user.token, req.params.premisesId)
+
+      return res.render('premises/rooms/index', {
+        rooms,
+        premisesId: req.params.premisesId,
+        pageHeading: 'Manage rooms',
+      })
+    }
+  }
+}

--- a/server/data/premisesClient.test.ts
+++ b/server/data/premisesClient.test.ts
@@ -1,4 +1,4 @@
-import { dateCapacityFactory, premisesFactory, staffMemberFactory } from '../testutils/factories'
+import { dateCapacityFactory, premisesFactory, roomFactory, staffMemberFactory } from '../testutils/factories'
 import PremisesClient from './premisesClient'
 import paths from '../paths/api'
 import describeClient from '../testutils/describeClient'
@@ -111,6 +111,32 @@ describeClient('PremisesClient', provider => {
 
       const output = await premisesClient.getStaffMembers(premises.id)
       expect(output).toEqual(staffMembers)
+    })
+  })
+
+  describe('getRooms', () => {
+    it('should return a list of rooms for a given premises', async () => {
+      const premises = premisesFactory.build()
+      const rooms = roomFactory.buildList(1)
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get rooms for a premises',
+        withRequest: {
+          method: 'GET',
+          path: paths.premises.rooms({ premisesId: premises.id }),
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: rooms,
+        },
+      })
+
+      const output = await premisesClient.getRooms(premises.id)
+      expect(output).toEqual(rooms)
     })
   })
 })

--- a/server/data/premisesClient.ts
+++ b/server/data/premisesClient.ts
@@ -1,4 +1,4 @@
-import type { ApprovedPremises, DateCapacity, StaffMember } from '@approved-premises/api'
+import type { ApprovedPremises, DateCapacity, Room, StaffMember } from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -26,5 +26,9 @@ export default class PremisesClient {
     return (await this.restClient.get({
       path: paths.premises.staffMembers.index({ premisesId }),
     })) as Array<StaffMember>
+  }
+
+  async getRooms(premisesId: string): Promise<Array<Room>> {
+    return (await this.restClient.get({ path: paths.premises.rooms({ premisesId }) })) as Array<Room>
   }
 }

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -1660,16 +1660,36 @@
           }
         },
         "plans-in-place": {
-          "type": "object",
-          "properties": {
-            "arePlansInPlace": {
-              "enum": [
-                "no",
-                "yes"
-              ],
-              "type": "string"
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "arePlansInPlace": {
+                  "type": "string",
+                  "enum": [
+                    "yes"
+                  ]
+                },
+                "plansInPlaceDetail": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "arePlansInPlace": {
+                  "type": "string",
+                  "enum": [
+                    "no"
+                  ]
+                },
+                "plansNotInPlaceDetail": {
+                  "type": "string"
+                }
+              }
             }
-          }
+          ]
         },
         "type-of-accommodation": {
           "type": "object",

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -13,6 +13,7 @@ const managePaths = {
   lostBeds: {
     create: lostBedsPath,
   },
+  rooms: singlePremisesPath.path('rooms'),
 }
 
 const applicationsPath = path('/applications')
@@ -74,6 +75,7 @@ export default {
     staffMembers: {
       index: managePaths.premises.show.path('staff'),
     },
+    rooms: managePaths.rooms,
   },
   applications: {
     show: applyPaths.applications.show,

--- a/server/paths/manage.ts
+++ b/server/paths/manage.ts
@@ -20,11 +20,14 @@ const departuresPath = bookingPath.path('departures')
 
 const lostBedsPath = singlePremisesPath.path('lost-beds')
 
+const roomsPath = singlePremisesPath.path('rooms')
+
 const paths = {
   premises: {
     index: premisesPath,
     show: singlePremisesPath,
     capacity: singlePremisesPath.path('capacity'),
+    rooms: roomsPath,
   },
   bookings: {
     new: bookingsPath.path('new'),

--- a/server/paths/manage.ts
+++ b/server/paths/manage.ts
@@ -28,6 +28,7 @@ const paths = {
     show: singlePremisesPath,
     capacity: singlePremisesPath.path('capacity'),
     rooms: roomsPath,
+    room: roomsPath.path(':roomId'),
   },
   bookings: {
     new: bookingsPath.path('new'),

--- a/server/routes/manage.ts
+++ b/server/routes/manage.ts
@@ -20,10 +20,13 @@ export default function routes(controllers: Controllers, router: Router): Router
     cancellationsController,
     lostBedsController,
     peopleController,
+    roomsController,
   } = controllers
 
   get(paths.premises.index.pattern, premisesController.index())
   get(paths.premises.show.pattern, premisesController.show())
+
+  get(paths.premises.rooms.pattern, roomsController.index())
 
   get(paths.bookings.new.pattern, bookingsController.new())
   get(paths.bookings.show.pattern, bookingsController.show())

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -1,6 +1,6 @@
 import PremisesService from './premisesService'
 import PremisesClient from '../data/premisesClient'
-import { dateCapacityFactory, premisesFactory, staffMemberFactory } from '../testutils/factories'
+import { dateCapacityFactory, premisesFactory, roomFactory, staffMemberFactory } from '../testutils/factories'
 import getDateRangesWithNegativeBeds from '../utils/premisesUtils'
 import paths from '../paths/manage'
 
@@ -32,6 +32,20 @@ describe('PremisesService', () => {
 
       expect(premisesClientFactory).toHaveBeenCalledWith(token)
       expect(premisesClient.getStaffMembers).toHaveBeenCalledWith(premisesId)
+    })
+  })
+
+  describe('getRooms', () => {
+    it('on success returns the rooms given a premises ID', async () => {
+      const rooms = roomFactory.buildList(1)
+      premisesClient.getRooms.mockResolvedValue(rooms)
+
+      const result = await service.getRooms(token, premisesId)
+
+      expect(result).toEqual(rooms)
+
+      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClient.getRooms).toHaveBeenCalledWith(premisesId)
     })
   })
 

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -1,5 +1,5 @@
 import type { SummaryList, TableRow } from '@approved-premises/ui'
-import type { ApprovedPremises, StaffMember } from '@approved-premises/api'
+import type { ApprovedPremises, Room, StaffMember } from '@approved-premises/api'
 import type { PremisesClient, RestClientBuilder } from '../data'
 import paths from '../paths/manage'
 
@@ -15,6 +15,14 @@ export default class PremisesService {
     const staffMembers = await premisesClient.getStaffMembers(premisesId)
 
     return staffMembers
+  }
+
+  async getRooms(token: string, premisesId: string): Promise<Array<Room>> {
+    const premisesClient = this.premisesClientFactory(token)
+
+    const rooms = await premisesClient.getRooms(premisesId)
+
+    return rooms
   }
 
   async tableRows(token: string): Promise<Array<TableRow>> {

--- a/server/testutils/factories/bedSearchResult.ts
+++ b/server/testutils/factories/bedSearchResult.ts
@@ -6,6 +6,7 @@ import {
   BedSearchResults,
   CharacteristicPair,
 } from '../../@types/shared'
+import { roomCharacteristicPairFactory } from './room'
 
 export const bedSearchResultsFactory = Factory.define<BedSearchResults>(() => ({
   results: bedSearchResultFactory.buildList(3),
@@ -59,28 +60,8 @@ export const apCharacteristicPairFactory = Factory.define<CharacteristicPair>(()
   premises: faker.company.name(),
 }))
 
-const roomCharacteristicFactory = Factory.define<CharacteristicPair>(() => ({
-  name: faker.helpers.arrayElement([
-    'acceptsSexOffenders',
-    'acceptsChildSexOffenders',
-    'acceptsNonSexualChildOffenders',
-    'acceptsHateCrimeOffenders',
-    'isCatered',
-    'hasWideStepFreeAccess',
-    'hasWideAccessToCommunalAreas',
-    'hasStepFreeAccessToCommunalAreas',
-    'hasWheelChairAccessibleBathrooms',
-    'hasLift',
-    'hasTactileFlooring',
-    'hasBrailleSignage',
-    'hasHearingLoop',
-    'additionalRestrictions',
-  ]),
-  premises: faker.company.name(),
-}))
-
 const roomSummaryFactory = Factory.define<BedSearchResult['room']>(() => ({
-  characteristics: roomCharacteristicFactory.buildList(3),
+  characteristics: roomCharacteristicPairFactory.buildList(3),
   id: faker.datatype.uuid(),
   name: faker.company.name(),
 }))

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -39,6 +39,7 @@ import prisonCaseNotesFactory from './prisonCaseNotes'
 import reallocationFactory from './reallocation'
 import referenceDataFactory from './referenceData'
 import risksFactory, { tierEnvelopeFactory } from './risks'
+import roomFactory from './room'
 import staffMemberFactory from './staffMember'
 import taskFactory from './task'
 import taskWrapperFactory from './taskWrapperFactory'
@@ -86,6 +87,7 @@ export {
   reallocationFactory,
   referenceDataFactory,
   risksFactory,
+  roomFactory,
   roshSummaryFactory,
   staffMemberFactory,
   taskFactory,

--- a/server/testutils/factories/room.ts
+++ b/server/testutils/factories/room.ts
@@ -1,0 +1,64 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { Bed, Characteristic, CharacteristicPair, Room } from '@approved-premises/api'
+
+export default Factory.define<Room>(() => ({
+  id: faker.datatype.uuid(),
+  name: faker.lorem.words(3),
+  beds: bedFactory.buildList(faker.datatype.number({ min: 1, max: 2 })),
+  code: faker.lorem.words(1).toLocaleUpperCase(),
+  notes: faker.lorem.sentence(),
+  characteristics: roomCharacteristicFactory.buildList(faker.datatype.number({ min: 1, max: 1 })),
+}))
+
+export const roomCharacteristicPairFactory = Factory.define<CharacteristicPair>(() => ({
+  name: faker.helpers.arrayElement([
+    'acceptsSexOffenders',
+    'acceptsChildSexOffenders',
+    'acceptsNonSexualChildOffenders',
+    'acceptsHateCrimeOffenders',
+    'isCatered',
+    'hasWideStepFreeAccess',
+    'hasWideAccessToCommunalAreas',
+    'hasStepFreeAccessToCommunalAreas',
+    'hasWheelChairAccessibleBathrooms',
+    'hasLift',
+    'hasTactileFlooring',
+    'hasBrailleSignage',
+    'hasHearingLoop',
+    'additionalRestrictions',
+  ]),
+  premises: faker.company.name(),
+}))
+
+export const bedFactory = Factory.define<Bed>(() => ({
+  id: faker.datatype.uuid(),
+  name: faker.lorem.words(3),
+  code: faker.lorem.words(1).toLocaleUpperCase(),
+  notes: faker.lorem.sentence(),
+  characteristics: roomCharacteristicFactory.buildList(faker.datatype.number({ min: 1, max: 1 })),
+}))
+
+const roomCharacteristicFactory = Factory.define<Characteristic>(() => ({
+  id: faker.datatype.uuid(),
+  name: faker.helpers.arrayElement([
+    'acceptsSexOffenders',
+    'acceptsChildSexOffenders',
+    'acceptsNonSexualChildOffenders',
+    'acceptsHateCrimeOffenders',
+    'isCatered',
+    'hasWideStepFreeAccess',
+    'hasWideAccessToCommunalAreas',
+    'hasStepFreeAccessToCommunalAreas',
+    'hasWheelChairAccessibleBathrooms',
+    'hasLift',
+    'hasTactileFlooring',
+    'hasBrailleSignage',
+    'hasHearingLoop',
+    'additionalRestrictions',
+  ]),
+  propertyName: faker.lorem.word(),
+  serviceScope: 'approved-premises',
+  modelScope: 'room',
+}))

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -38,6 +38,7 @@ import * as UserUtils from './userUtils'
 import * as TaskUtils from './tasks'
 import * as PlacementRequestUtils from './placementRequests'
 import * as MatchUtils from './matchUtils'
+import * as RoomUtils from './roomUtils'
 import * as SummaryListUtils from './applications/summaryListUtils'
 
 import managePaths from '../paths/manage'
@@ -186,4 +187,5 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('PlacementRequestUtils', PlacementRequestUtils)
   njkEnv.addGlobal('MatchUtils', MatchUtils)
   njkEnv.addGlobal('SummaryListUtils', SummaryListUtils)
+  njkEnv.addGlobal('RoomUtils', RoomUtils)
 }

--- a/server/utils/roomUtils.test.ts
+++ b/server/utils/roomUtils.test.ts
@@ -1,0 +1,24 @@
+import { roomFactory } from '../testutils/factories'
+import { tableRows } from './roomUtils'
+
+describe('roomUtils', () => {
+  describe('tableRows', () => {
+    it('returns the table rows given the rooms', () => {
+      const rooms = roomFactory.buildList(1)
+
+      expect(tableRows(rooms, 'premisesId')).toEqual([
+        [
+          {
+            text: rooms[0].name,
+          },
+          {
+            text: rooms[0].beds.length.toString(),
+          },
+          {
+            html: `<a href="/premises/premisesId/rooms/${rooms[0].id}" data-cy-roomId="${rooms[0].id}">Manage <span class="govuk-visually-hidden">Manage room</span></a>`,
+          },
+        ],
+      ])
+    })
+  })
+})

--- a/server/utils/roomUtils.ts
+++ b/server/utils/roomUtils.ts
@@ -1,0 +1,27 @@
+import { Room } from '../@types/shared'
+import { TableCell } from '../@types/ui'
+import paths from '../paths/manage'
+import { linkTo } from './utils'
+
+export const tableRows = (rooms: Array<Room>, premisesId: string) => {
+  const mappedRooms = rooms.map(room => [nameCell(room), numberOfBedsCell(room), actionCell(room, premisesId)])
+  return mappedRooms
+}
+const nameCell = (room: Room): TableCell => ({ text: room.name })
+
+const numberOfBedsCell = (room: Room): TableCell => ({ text: room.beds.length.toString() })
+
+const actionCell = (room: Room, premisesId: string): TableCell => ({
+  html: roomLink(room, premisesId),
+})
+
+const roomLink = (room: Room, premisesId: string): string =>
+  linkTo(
+    paths.premises.room,
+    { roomId: room.id, premisesId },
+    {
+      text: 'Manage',
+      hiddenText: 'Manage room',
+      attributes: { 'data-cy-roomId': room.id },
+    },
+  )

--- a/server/views/premises/rooms/index.njk
+++ b/server/views/premises/rooms/index.njk
@@ -1,0 +1,28 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+  {{
+      govukTable({
+        captionClasses: "govuk-table__caption--m",
+        firstCellIsHeader: true,
+        head: [
+          {
+            text: "Name"
+          },
+          {
+            text: "Number of beds"
+          },
+          {
+            html: 'Action'
+          }
+        ],
+        rows: RoomUtils.tableRows(rooms, premisesId)
+      })
+    }}
+
+{% endblock %}

--- a/server/views/premises/show.njk
+++ b/server/views/premises/show.njk
@@ -32,13 +32,9 @@
           classes: "govuk-button--secondary",
           href: paths.bookings.new({premisesId: premisesId})
         }, {
-          text: "Mark bed as out of service",
+          text: "Manage rooms",
           classes: "govuk-button--secondary",
-          href: paths.lostBeds.new({premisesId: premisesId})
-        },
-        {
-          text: "Manage out of service beds",
-          classes: "govuk-button--secondary"
+          href: paths.premises.rooms({premisesId: premisesId})
         }]
       }]
     }) }}


### PR DESCRIPTION
# Context
Users need to be able to manage the rooms within a property. 
The first step towards this functionality is being able to *see* the rooms within a property, so we need a list page.

# Changes in this PR
1. Add a link from the premises page to the Room list page
2. Add a method to the Premises client to get rooms
3. Add a method to the Premises service to get rooms
4. Add a new controller for Rooms
5. Add the view for listing rooms


## Screenshots of UI changes

![rooms-list](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/54a239ba-76df-4515-8072-9ce873b0ab89)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
