### PR TITLE
Speed up tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,4 +24,4 @@ jobs:
       - uses: ./.github/shared/setup
 
       - name: Running unit tests
-        run: npm test
+        run: npm run test:ci

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint:fix": "eslint . --cache --max-warnings 0 --fix && node_modules/.bin/shellcheck ./script/**/*[^utils] ./script/utils/**",
     "typecheck": "tsc && tsc -p integration_tests",
     "test": "jest --collectCoverage",
+    "test:ci": "jest --collectCoverage --maxWorkers=50%",
     "test:integration": "npm run start-test-wiremock && start-server-and-test start-feature http://localhost:3007/ping int-test",
     "test:integration:ui": "npm run start-test-wiremock && start-server-and-test start-feature:dev http://localhost:3007/ping int-test-ui",
     "security_audit": "npx audit-ci --config audit-ci.json",
@@ -84,7 +85,15 @@
       "json",
       "node",
       "ts"
-    ]
+    ],
+    "transform": {
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "isolatedModules": true
+        }
+      ]
+    }
   },
   "nodemonConfig": {
     "ignore": [


### PR DESCRIPTION
This reinstates changes to run jest tests without typechecking first. 
It was initially introduced in #158 but then erroneously removed in this commit: https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/314/commits/08d4ef7307e0503d9e1c2e7702fd0ab86ea6b82d because it was causing a warning in the console. 
This reinstates the change with the latest config format to remove the warning