### PR TITLE
(1517) Update placement requirements to use characteristics

### DIFF
--- a/integration_tests/pages/assess/matchingInformationPage.ts
+++ b/integration_tests/pages/assess/matchingInformationPage.ts
@@ -1,28 +1,24 @@
 import { ApprovedPremisesAssessment as Assessment } from '../../../server/@types/shared'
-import MatchingInformation, {
-  offenceAndRiskInformationKeys,
-  placementRequirements,
-} from '../../../server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation'
+import MatchingInformation from '../../../server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation'
 import AssessPage from './assessPage'
+import { offenceAndRiskOptions, placementRequirementOptions } from '../../../server/utils/placementCriteriaUtils'
 
 export default class MatchingInformationPage extends AssessPage {
   pageClass = new MatchingInformation({
-    apType: 'esap',
+    apType: 'isEsap',
     mentalHealthSupport: '1',
-    wheelchairAccessible: 'essential',
-    singleRoom: 'desirable',
-    adaptedForHearingImpairments: 'notRelevant',
-    adaptedForVisualImpairments: 'desirable',
-    adaptedForRestrictedMobility: 'essential',
-    cateringRequired: 'desirable',
-    contactSexualOffencesAgainstAnAdultAdults: 'relevant',
-    nonContactSexualOffencesAgainstAnAdultAdults: 'notRelevant',
-    contactSexualOffencesAgainstChildren: 'relevant',
-    nonContactSexualOffencesAgainstChildren: 'notRelevant',
-    nonSexualOffencesAgainstChildren: 'relevant',
-    arsonOffences: 'notRelevant',
-    hateBasedOffences: 'relevant',
-    vulnerableToExploitation: 'notRelevant',
+    isWheelchairDesignated: 'essential',
+    isSingleRoom: 'desirable',
+    isStepFreeDesignated: 'essential',
+    isCatered: 'desirable',
+    isGroundFloor: 'desirable',
+    acceptsSexOffenders: 'relevant',
+    acceptsNonSexualChildOffenders: 'notRelevant',
+    acceptsChildSexOffenders: 'relevant',
+    isArsonSuitable: 'notRelevant',
+    acceptsHateCrimeOffenders: 'relevant',
+    isSuitableForVulnerable: 'notRelevant',
+    hasEnSuite: 'notRelevant',
   })
 
   constructor(assessment: Assessment) {
@@ -33,11 +29,11 @@ export default class MatchingInformationPage extends AssessPage {
     this.checkRadioByNameAndValue('apType', this.pageClass.body.apType)
     this.checkCheckboxByNameAndValue('mentalHealthSupport', '1')
 
-    placementRequirements.forEach(requirement => {
+    Object.keys(placementRequirementOptions).forEach(requirement => {
       this.checkRadioByNameAndValue(requirement, this.pageClass.body[requirement])
     })
 
-    offenceAndRiskInformationKeys.forEach(offenceAndRiskInformationKey => {
+    Object.keys(offenceAndRiskOptions).forEach(offenceAndRiskInformationKey => {
       this.checkRadioByNameAndValue(offenceAndRiskInformationKey, this.pageClass.body[offenceAndRiskInformationKey])
     })
   }

--- a/server/controllers/match/search/bedSearchController.test.ts
+++ b/server/controllers/match/search/bedSearchController.test.ts
@@ -1,7 +1,7 @@
 import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
-import BedsController, { placementCriteria } from './bedSearchController'
+import BedsController from './bedSearchController'
 import { bedSearchResultsFactory, placementRequestFactory } from '../../../testutils/factories'
 
 import { BedService, PlacementRequestService } from '../../../services'
@@ -57,7 +57,6 @@ describe('bedSearchController', () => {
           placementRequest,
           tier: placementRequest.risks.tier.value.level,
           formPath,
-          placementCriteria,
           ...query,
           ...body,
         })
@@ -79,7 +78,6 @@ describe('bedSearchController', () => {
           placementRequest,
           tier: placementRequest.risks.tier.value.level,
           formPath,
-          placementCriteria,
           ...query,
           requiredCharacteristics: ['someRequiredCharacteristic'],
         })
@@ -104,7 +102,6 @@ describe('bedSearchController', () => {
           placementRequest,
           tier: placementRequest.risks.tier.value.level,
           formPath,
-          placementCriteria,
           ...query,
         })
         expect(bedService.search).toHaveBeenCalledWith(token, query)

--- a/server/controllers/match/search/bedSearchController.ts
+++ b/server/controllers/match/search/bedSearchController.ts
@@ -9,26 +9,6 @@ import BedService from '../../../services/bedService'
 import { startDateObjFromParams } from '../../../utils/matchUtils'
 import { objectIfNotEmpty } from '../../../utils/utils'
 
-export const placementCriteria = [
-  'isPipe',
-  'isEsap',
-  'isSemiSpecialistMentalHealth',
-  'isRecoveryFocussed',
-  'isSuitableForVulnerable',
-  'acceptsSexOffenders',
-  'acceptsChildSexOffenders',
-  'acceptsNonSexualChildOffenders',
-  'acceptsHateCrimeOffenders',
-  'isWheelchairDesignated',
-  'isSingleRoom',
-  'isStepFreeDesignated',
-  'isCatered',
-  'isGroundFloor',
-  'hasEnSuite',
-  'isSuitedForSexOffenders',
-  'isArsonSuitable',
-]
-
 export default class BedSearchController {
   constructor(
     private readonly bedService: BedService,
@@ -62,7 +42,6 @@ export default class BedSearchController {
         formPath: matchPaths.placementRequests.beds.search({ id: placementRequest.id }),
         ...params,
         ...startDateObjFromParams(params),
-        placementCriteria,
       })
     }
   }

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -1,25 +1,23 @@
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
-import MatchingInformation from './matchingInformation'
+import MatchingInformation, { MatchingInformationBody } from './matchingInformation'
 
 const defaultArguments = {
-  apType: 'esap' as const,
-  wheelchairAccessible: 'essential',
+  apType: 'isEsap' as const,
   mentalHealthSupport: '1',
-  singleRoom: 'essential',
-  adaptedForHearingImpairments: 'essential',
-  adaptedForVisualImpairments: 'essential',
-  adaptedForRestrictedMobility: 'essential',
-  cateringRequired: 'essential',
-  contactSexualOffencesAgainstAnAdultAdults: 'relevant',
-  nonContactSexualOffencesAgainstAnAdultAdults: 'relevant',
-  contactSexualOffencesAgainstChildren: 'relevant',
-  nonContactSexualOffencesAgainstChildren: 'relevant',
-  nonSexualOffencesAgainstChildren: 'relevant',
-  arsonOffences: 'relevant',
-  hateBasedOffences: 'relevant',
-  vulnerableToExploitation: 'relevant',
-} as const
+  isWheelchairDesignated: 'essential',
+  isSingleRoom: 'desirable',
+  isStepFreeDesignated: 'desirable',
+  isCatered: 'notRelevant',
+  isGroundFloor: 'notRelevant',
+  hasEnSuite: 'notRelevant',
+  isSuitableForVulnerable: 'relevant',
+  acceptsSexOffenders: 'relevant',
+  acceptsChildSexOffenders: 'relevant',
+  acceptsNonSexualChildOffenders: 'relevant',
+  acceptsHateCrimeOffenders: 'relevant',
+  isArsonSuitable: 'relevant',
+} as MatchingInformationBody
 
 describe('MatchingInformation', () => {
   describe('title', () => {
@@ -40,29 +38,22 @@ describe('MatchingInformation', () => {
 
   describe('errors', () => {
     it('should have an error if there is no answers', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const page = new MatchingInformation({} as any)
+      const page = new MatchingInformation({})
 
       expect(page.errors()).toEqual({
-        adaptedForHearingImpairments: 'You must specify a preference for adapted for hearing impairments',
-        adaptedForRestrictedMobility: 'You must specify a preference for adapted for restricted mobility',
-        adaptedForVisualImpairments: 'You must specify a preference for adapted for visual impairments',
         apType: 'You must select the type of AP required',
-        arsonOffences: 'You must specify if arson offences is relevant',
-        cateringRequired: 'You must specify a preference for catering required',
-        contactSexualOffencesAgainstAnAdultAdults:
-          'You must specify if contact sexual offences against an adult adults is relevant',
-        contactSexualOffencesAgainstChildren:
-          'You must specify if contact sexual offences against children is relevant',
-        hateBasedOffences: 'You must specify if hate based offences is relevant',
-        nonContactSexualOffencesAgainstAnAdultAdults:
-          'You must specify if non contact sexual offences against an adult adults is relevant',
-        nonContactSexualOffencesAgainstChildren:
-          'You must specify if non contact sexual offences against children is relevant',
-        nonSexualOffencesAgainstChildren: 'You must specify if non sexual offences against children is relevant',
-        singleRoom: 'You must specify a preference for single room',
-        vulnerableToExploitation: 'You must specify if vulnerable to exploitation is relevant',
-        wheelchairAccessible: 'You must specify a preference for wheelchair accessible',
+        isWheelchairDesignated: 'You must specify a preference for wheelchair accessible',
+        isSingleRoom: 'You must specify a preference for single room',
+        isStepFreeDesignated: 'You must specify a preference for has step-free access',
+        isCatered: 'You must specify a preference for catering required',
+        isGroundFloor: 'You must specify a preference for ground floor room',
+        hasEnSuite: 'You must specify a preference for en suite',
+        isSuitableForVulnerable: 'You must specify if vulnerable to exploitation is relevant',
+        acceptsSexOffenders: 'You must specify if sexual offences against an adult is relevant',
+        acceptsChildSexOffenders: 'You must specify if sexual offences against children is relevant',
+        acceptsNonSexualChildOffenders: 'You must specify if non sexual offences against children is relevant',
+        acceptsHateCrimeOffenders: 'You must specify if hate based offences is relevant',
+        isArsonSuitable: 'You must specify if arson offences is relevant',
       })
     })
   })
@@ -75,20 +66,18 @@ describe('MatchingInformation', () => {
         'What type of AP is required?': 'Enhanced Security AP (ESAP)',
         'If this person requires specialist mental health support, select the box below':
           'Semi-specialist mental health selected',
-        'Wheelchair accessible': 'Essential',
-        'Single room': 'Essential',
-        'Adapted for hearing impairments': 'Essential',
-        'Adapted for restricted mobility': 'Essential',
-        'Adapted for visual impairments': 'Essential',
-        'Catering required': 'Essential',
-        'Arson offences': 'Relevant',
-        'Contact sexual offences against an adult adults': 'Relevant',
-        'Contact sexual offences against children': 'Relevant',
-        'Hate based offences': 'Relevant',
-        'Non contact sexual offences against an adult adults': 'Relevant',
-        'Non contact sexual offences against children': 'Relevant',
-        'Non sexual offences against children': 'Relevant',
-        'Vulnerable to exploitation': 'Relevant',
+        'Is wheelchair designated': 'Essential',
+        'Is single room': 'Desirable',
+        'Is step free designated': 'Desirable',
+        'Is catered': 'Not relevant',
+        'Is ground floor': 'Not relevant',
+        'Has en suite': 'Not relevant',
+        'Is suitable for vulnerable': 'Relevant',
+        'Accepts sex offenders': 'Relevant',
+        'Accepts child sex offenders': 'Relevant',
+        'Accepts non sexual child offenders': 'Relevant',
+        'Accepts hate crime offenders': 'Relevant',
+        'Is arson suitable': 'Relevant',
       })
     })
   })

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
@@ -1,61 +1,36 @@
-import type { ApType } from '@approved-premises/api'
 import type { TaskListErrors } from '@approved-premises/ui'
 
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
 import { lowerCase, sentenceCase } from '../../../../utils/utils'
+import {
+  ApTypeCriteria,
+  OffenceAndRiskCriteria,
+  PlacementRequirementCriteria,
+  apTypeOptions,
+  offenceAndRiskOptions,
+  placementCriteria,
+  placementRequirementOptions,
+} from '../../../../utils/placementCriteriaUtils'
 
-const apTypes: Record<ApType, string> = {
-  normal: 'Standard AP',
-  pipe: 'Psychologically Informed Planned Environment (PIPE)',
-  esap: 'Enhanced Security AP (ESAP)',
-  rfap: 'Recovery Focused Approved Premises (RFAP)',
-} as const
-
+const placementRequirements = Object.keys(placementRequirementOptions)
 const placementRequirementPreferences = ['essential' as const, 'desirable' as const, 'notRelevant' as const]
 type PlacementRequirementPreference = (typeof placementRequirementPreferences)[number]
 
-export const placementRequirements = [
-  'wheelchairAccessible' as const,
-  'singleRoom' as const,
-  'adaptedForHearingImpairments' as const,
-  'adaptedForVisualImpairments' as const,
-  'adaptedForRestrictedMobility' as const,
-  'cateringRequired' as const,
-]
-
-export const offenceAndRiskInformationKeys = [
-  'contactSexualOffencesAgainstAnAdultAdults',
-  'nonContactSexualOffencesAgainstAnAdultAdults',
-  'contactSexualOffencesAgainstChildren',
-  'nonContactSexualOffencesAgainstChildren',
-  'nonSexualOffencesAgainstChildren',
-  'arsonOffences',
-  'hateBasedOffences',
-  'vulnerableToExploitation',
-]
-
+const offenceAndRiskInformationKeys = Object.keys(offenceAndRiskOptions)
 const offenceAndRiskInformationRelevance = ['relevant', 'notRelevant']
 type OffenceAndRiskInformationRelevance = (typeof offenceAndRiskInformationRelevance)[number]
 
 export type MatchingInformationBody = {
-  apType: ApType
-  mentalHealthSupport?: '1' | '' | undefined
-  wheelchairAccessible: PlacementRequirementPreference
-  singleRoom: PlacementRequirementPreference
-  adaptedForHearingImpairments: PlacementRequirementPreference
-  adaptedForVisualImpairments: PlacementRequirementPreference
-  adaptedForRestrictedMobility: PlacementRequirementPreference
-  cateringRequired: PlacementRequirementPreference
-  contactSexualOffencesAgainstAnAdultAdults: OffenceAndRiskInformationRelevance
-  nonContactSexualOffencesAgainstAnAdultAdults: OffenceAndRiskInformationRelevance
-  contactSexualOffencesAgainstChildren: OffenceAndRiskInformationRelevance
-  nonContactSexualOffencesAgainstChildren: OffenceAndRiskInformationRelevance
-  nonSexualOffencesAgainstChildren: OffenceAndRiskInformationRelevance
-  arsonOffences: OffenceAndRiskInformationRelevance
-  hateBasedOffences: OffenceAndRiskInformationRelevance
-  vulnerableToExploitation: OffenceAndRiskInformationRelevance
+  [Key in OffenceAndRiskCriteria | PlacementRequirementCriteria]: Key extends OffenceAndRiskCriteria
+    ? OffenceAndRiskInformationRelevance
+    : Key extends PlacementRequirementCriteria
+    ? PlacementRequirementPreference
+    : never
+} & {
+  apType: ApTypeCriteria | 'normal'
+  mentalHealthSupport: '1' | '' | undefined
 }
 
 @Page({
@@ -69,7 +44,7 @@ export default class MatchingInformation implements TasklistPage {
 
   apTypeQuestion = 'What type of AP is required?'
 
-  apTypes = apTypes
+  apTypes = apTypeOptions
 
   placementRequirementTableHeadings = ['Placement requirements', 'Essential', 'Desirable', 'Not relevant']
 
@@ -90,7 +65,7 @@ export default class MatchingInformation implements TasklistPage {
     value: '',
   }
 
-  constructor(public body: MatchingInformationBody) {
+  constructor(public body: Partial<MatchingInformationBody>) {
     this.mentalHealthSupport.value = body.mentalHealthSupport
   }
 
@@ -127,13 +102,17 @@ export default class MatchingInformation implements TasklistPage {
 
     this.placementRequirements.forEach(placementRequirement => {
       if (!this.body[placementRequirement]) {
-        errors[placementRequirement] = `You must specify a preference for ${lowerCase(placementRequirement)}`
+        errors[placementRequirement] = `You must specify a preference for ${lowerCase(
+          placementCriteria[placementRequirement],
+        )}`
       }
     })
 
     this.offenceAndRiskInformationKeys.forEach(offenceOrRiskInformation => {
       if (!this.body[offenceOrRiskInformation]) {
-        errors[offenceOrRiskInformation] = `You must specify if ${lowerCase(offenceOrRiskInformation)} is relevant`
+        errors[offenceOrRiskInformation] = `You must specify if ${lowerCase(
+          placementCriteria[offenceOrRiskInformation],
+        )} is relevant`
       }
     })
 

--- a/server/services/assessmentService.test.ts
+++ b/server/services/assessmentService.test.ts
@@ -207,6 +207,7 @@ describe('AssessmentService', () => {
 
       expect(assessmentClientFactory).toHaveBeenCalledWith(token)
       expect(assessmentClient.rejection).toHaveBeenCalledWith(assessment.id, document, response.Decision)
+      expect(placementRequestData).not.toHaveBeenCalled()
     })
   })
 

--- a/server/services/assessmentService.ts
+++ b/server/services/assessmentService.ts
@@ -73,11 +73,12 @@ export default class AssessmentService {
     const client = this.assessmentClientFactory(token)
 
     const document = getResponses(assessment)
-    const requirements = placementRequestData(assessment)
 
     if (!applicationAccepted(assessment)) {
       return client.rejection(assessment.id, document, rejectionRationaleFromAssessmentResponses(assessment))
     }
+
+    const requirements = placementRequestData(assessment)
 
     return client.acceptance(assessment.id, { document, requirements })
   }

--- a/server/utils/assessments/placementRequestData.test.ts
+++ b/server/utils/assessments/placementRequestData.test.ts
@@ -17,7 +17,7 @@ describe('placementRequestData', () => {
   const expectedArrival = '2020-01-01'
 
   let matchingInformation = createMock<MatchingInformationBody>({
-    apType: 'normal',
+    apType: 'isEsap',
     mentalHealthSupport: '1',
   })
 
@@ -30,7 +30,7 @@ describe('placementRequestData', () => {
 
     expect(placementRequestData(assessment)).toEqual({
       gender: 'male',
-      type: matchingInformation.apType,
+      type: 'esap',
       expectedArrival,
       duration: '12',
       location: 'ABC123',
@@ -72,68 +72,70 @@ describe('placementRequestData', () => {
   describe('criteriaFromMatchingInformation', () => {
     it('returns all essential criteria for essential and relevant matching information', () => {
       matchingInformation = createMock<MatchingInformationBody>({
-        wheelchairAccessible: 'essential',
-        adaptedForHearingImpairments: 'essential',
-        adaptedForVisualImpairments: 'essential',
-        adaptedForRestrictedMobility: 'essential',
-        cateringRequired: 'essential',
-        contactSexualOffencesAgainstAnAdultAdults: 'relevant',
-        nonContactSexualOffencesAgainstAnAdultAdults: 'relevant',
-        contactSexualOffencesAgainstChildren: 'relevant',
-        nonContactSexualOffencesAgainstChildren: 'relevant',
-        nonSexualOffencesAgainstChildren: 'relevant',
-        arsonOffences: 'relevant',
-        hateBasedOffences: 'relevant',
-        vulnerableToExploitation: 'relevant',
+        apType: 'isEsap',
+        mentalHealthSupport: '1',
+        isWheelchairDesignated: 'essential',
+        isStepFreeDesignated: 'essential',
+        isCatered: 'essential',
+        acceptsSexOffenders: 'relevant',
+        acceptsChildSexOffenders: 'relevant',
+        acceptsNonSexualChildOffenders: 'relevant',
+        isArsonSuitable: 'relevant',
+        acceptsHateCrimeOffenders: 'relevant',
+        isSuitableForVulnerable: 'relevant',
       })
 
-      expect(criteriaFromMatchingInformation(matchingInformation)).toEqual({
-        desirableCriteria: [],
-        essentialCriteria: [
-          'isStepFreeDesignated',
+      const result = criteriaFromMatchingInformation(matchingInformation)
+
+      expect(result.desirableCriteria).toEqual([])
+      expect(result.essentialCriteria.sort()).toEqual(
+        [
+          'isEsap',
           'isWheelchairDesignated',
+          'isStepFreeDesignated',
           'isCatered',
           'acceptsSexOffenders',
-          'acceptsSexOffenders',
-          'acceptsChildSexOffenders',
           'acceptsChildSexOffenders',
           'acceptsNonSexualChildOffenders',
+          'isArsonSuitable',
           'acceptsHateCrimeOffenders',
           'isSuitableForVulnerable',
-        ],
-      })
+          'isSuitedForSexOffenders',
+          'isSemiSpecialistMentalHealth',
+        ].sort(),
+      )
     })
 
     it('returns all desirable criteria for desirable matching information', () => {
       matchingInformation = createMock<MatchingInformationBody>({
-        wheelchairAccessible: 'desirable',
-        adaptedForHearingImpairments: 'desirable',
-        adaptedForVisualImpairments: 'desirable',
-        adaptedForRestrictedMobility: 'desirable',
-        cateringRequired: 'desirable',
+        mentalHealthSupport: undefined,
+        apType: 'normal',
+        isWheelchairDesignated: 'desirable',
+        isStepFreeDesignated: 'desirable',
+        isCatered: 'desirable',
       })
 
-      expect(criteriaFromMatchingInformation(matchingInformation)).toEqual({
-        desirableCriteria: ['isStepFreeDesignated', 'isWheelchairDesignated', 'isCatered'],
-        essentialCriteria: [],
-      })
+      const result = criteriaFromMatchingInformation(matchingInformation)
+
+      expect(result.desirableCriteria.sort()).toEqual(
+        ['isStepFreeDesignated', 'isWheelchairDesignated', 'isCatered'].sort(),
+      )
+      expect(result.essentialCriteria).toEqual([])
     })
 
     it('returns empty objects for not relevant matching information', () => {
       matchingInformation = createMock<MatchingInformationBody>({
-        wheelchairAccessible: 'notRelevant',
-        adaptedForHearingImpairments: 'notRelevant',
-        adaptedForVisualImpairments: 'notRelevant',
-        adaptedForRestrictedMobility: 'notRelevant',
-        cateringRequired: 'notRelevant',
-        contactSexualOffencesAgainstAnAdultAdults: 'notRelevant',
-        nonContactSexualOffencesAgainstAnAdultAdults: 'notRelevant',
-        contactSexualOffencesAgainstChildren: 'notRelevant',
-        nonContactSexualOffencesAgainstChildren: 'notRelevant',
-        nonSexualOffencesAgainstChildren: 'notRelevant',
-        arsonOffences: 'notRelevant',
-        hateBasedOffences: 'notRelevant',
-        vulnerableToExploitation: 'notRelevant',
+        apType: 'normal',
+        mentalHealthSupport: '',
+        isWheelchairDesignated: 'notRelevant',
+        isStepFreeDesignated: 'notRelevant',
+        isCatered: 'notRelevant',
+        acceptsSexOffenders: 'notRelevant',
+        acceptsChildSexOffenders: 'notRelevant',
+        acceptsNonSexualChildOffenders: 'notRelevant',
+        isArsonSuitable: 'notRelevant',
+        acceptsHateCrimeOffenders: 'notRelevant',
+        isSuitableForVulnerable: 'notRelevant',
       })
 
       expect(criteriaFromMatchingInformation(matchingInformation)).toEqual({

--- a/server/utils/matchUtils.test.ts
+++ b/server/utils/matchUtils.test.ts
@@ -35,6 +35,16 @@ import {
   unmatchedCharacteristics,
 } from './matchUtils'
 
+jest.mock('./placementCriteriaUtils', () => {
+  return {
+    placementCriteria: {
+      isESAP: 'ESAP',
+      isIAP: 'IAP',
+      isSemiSpecialistMentalHealth: 'Semi specialist mental health',
+    },
+  }
+})
+
 describe('matchUtils', () => {
   describe('matchedCharacteristics', () => {
     it('returns a list of the matched characteristics', () => {
@@ -167,8 +177,10 @@ describe('matchUtils', () => {
   })
 
   describe('searchFilter', () => {
-    it('maps the placementCriteria array and selectedValues array into the array of objects for checkbox inputs', () => {
-      expect(searchFilter(['isESAP', 'isIAP', 'isSemiSpecialistMentalHealth'], ['isESAP', 'isIAP'])).toEqual([
+    it('returns an array of checkboxes with the selectedValues selected and any empty values removed', () => {
+      const result = searchFilter(['isESAP', 'isIAP'])
+
+      expect(result).toEqual([
         {
           checked: true,
           text: 'ESAP',

--- a/server/utils/matchUtils.ts
+++ b/server/utils/matchUtils.ts
@@ -8,6 +8,7 @@ import { BedSearchParametersUi, ObjectWithDateParts, SummaryListItem } from '../
 import { DateFormats } from './dateUtils'
 import { linkTo, sentenceCase } from './utils'
 import matchPaths from '../paths/match'
+import { placementCriteria } from './placementCriteriaUtils'
 
 type PlacementDates = {
   placementLength: number
@@ -255,9 +256,11 @@ export const startDateObjFromParams = (params: { startDate: string } | ObjectWit
   return { startDate: params.startDate, ...DateFormats.isoDateToDateInputs(params.startDate, 'startDate') }
 }
 
-export const searchFilter = (placementCriteria: Array<string>, selectedValues: Array<string>) =>
-  placementCriteria.map(criterion => ({
-    text: translateApiCharacteristicForUi(criterion),
-    value: criterion,
-    checked: selectedValues.includes(criterion),
-  }))
+export const searchFilter = (selectedValues: Array<string>) =>
+  Object.keys(placementCriteria)
+    .map(criterion => ({
+      text: placementCriteria[criterion],
+      value: criterion,
+      checked: selectedValues.includes(criterion),
+    }))
+    .filter(item => item.text.length > 0)

--- a/server/utils/placementCriteriaUtils.test.ts
+++ b/server/utils/placementCriteriaUtils.test.ts
@@ -1,0 +1,46 @@
+import {
+  apTypeOptions,
+  mentalHealthOptions,
+  offenceAndRiskOptions,
+  placementRequirementOptions,
+} from './placementCriteriaUtils'
+
+describe('placementCriteriaUtils', () => {
+  describe('apTypeOptions', () => {
+    it('should return all the AP Type options', () => {
+      expect(Object.keys(apTypeOptions)).toEqual(['normal', 'isPipe', 'isEsap', 'isRecoveryFocussed'])
+    })
+  })
+
+  describe('mentalHealthOptions', () => {
+    it('should return all the mental health options', () => {
+      expect(Object.keys(mentalHealthOptions)).toEqual(['isSemiSpecialistMentalHealth'])
+    })
+  })
+
+  describe('offenceAndRiskOptions', () => {
+    it('should return all the Offence and Risk options', () => {
+      expect(Object.keys(offenceAndRiskOptions)).toEqual([
+        'isSuitableForVulnerable',
+        'acceptsSexOffenders',
+        'acceptsChildSexOffenders',
+        'acceptsNonSexualChildOffenders',
+        'acceptsHateCrimeOffenders',
+        'isArsonSuitable',
+      ])
+    })
+  })
+
+  describe('placementRequirementOptions', () => {
+    it('should return all the placement requirement options', () => {
+      expect(Object.keys(placementRequirementOptions)).toEqual([
+        'isWheelchairDesignated',
+        'isSingleRoom',
+        'isStepFreeDesignated',
+        'isCatered',
+        'isGroundFloor',
+        'hasEnSuite',
+      ])
+    })
+  })
+})

--- a/server/utils/placementCriteriaUtils.ts
+++ b/server/utils/placementCriteriaUtils.ts
@@ -1,0 +1,68 @@
+import { PlacementCriteria } from '@approved-premises/api'
+
+const apTypes = ['isPipe', 'isEsap', 'isRecoveryFocussed']
+const mentalHealthTypes = ['isSemiSpecialistMentalHealth']
+const offenceAndRiskCriteria = [
+  'isSuitableForVulnerable',
+  'acceptsSexOffenders',
+  'acceptsChildSexOffenders',
+  'acceptsNonSexualChildOffenders',
+  'acceptsHateCrimeOffenders',
+  'isArsonSuitable',
+]
+const placementRequirementCriteria = [
+  'isWheelchairDesignated',
+  'isSingleRoom',
+  'isStepFreeDesignated',
+  'isCatered',
+  'isGroundFloor',
+  'hasEnSuite',
+]
+const additionalCriteria = ['isSuitedForSexOffenders']
+
+export type ApTypeCriteria = Extract<PlacementCriteria, (typeof apTypes)[number]>
+export type MentalHealthCriteria = Extract<PlacementCriteria, (typeof mentalHealthTypes)[number]>
+export type OffenceAndRiskCriteria = Extract<PlacementCriteria, (typeof offenceAndRiskCriteria)[number]>
+export type PlacementRequirementCriteria = Extract<PlacementCriteria, (typeof placementRequirementCriteria)[number]>
+export type AdditionalCriteria = Extract<PlacementCriteria, (typeof additionalCriteria)[number]>
+
+type PlacementCriteriaCategory =
+  | ApTypeCriteria
+  | MentalHealthCriteria
+  | OffenceAndRiskCriteria
+  | PlacementRequirementCriteria
+  | AdditionalCriteria
+
+export const placementCriteria: Record<PlacementCriteria, string> = {
+  isPipe: 'Psychologically Informed Planned Environment (PIPE)',
+  isEsap: 'Enhanced Security AP (ESAP)',
+  isRecoveryFocussed: 'Recovery Focused Approved Premises (RAP)',
+  isSemiSpecialistMentalHealth: 'Semi-specialist mental health',
+  isSuitableForVulnerable: 'Vulnerable to exploitation',
+  acceptsSexOffenders: 'Sexual offences against an adult',
+  acceptsChildSexOffenders: 'Sexual offences against children',
+  acceptsNonSexualChildOffenders: 'Non sexual offences against children',
+  acceptsHateCrimeOffenders: 'Hate based offences',
+  isWheelchairDesignated: 'Wheelchair accessible',
+  isSingleRoom: 'Single room',
+  isStepFreeDesignated: 'Has step-free access',
+  isCatered: 'Catering required',
+  isGroundFloor: 'Ground floor room',
+  hasEnSuite: 'En-suite',
+  isSuitedForSexOffenders: 'Is suited for sex offenders',
+  isArsonSuitable: 'Arson offences',
+}
+
+const filterByType = <T extends PlacementCriteriaCategory>(keys: Array<string>): Record<T, string> => {
+  return Object.keys(placementCriteria)
+    .filter(k => keys.includes(k))
+    .reduce((criteria, key) => ({ ...criteria, [key]: placementCriteria[key] }), {}) as Record<T, string>
+}
+
+export const apTypeOptions = {
+  normal: 'Standard AP',
+  ...filterByType<ApTypeCriteria>(apTypes),
+} as Record<ApTypeCriteria & 'normal', string>
+export const mentalHealthOptions = filterByType<MentalHealthCriteria>(mentalHealthTypes)
+export const offenceAndRiskOptions = filterByType<OffenceAndRiskCriteria>(offenceAndRiskCriteria)
+export const placementRequirementOptions = filterByType<PlacementRequirementCriteria>(placementRequirementCriteria)

--- a/server/utils/radioMatrixTable.test.ts
+++ b/server/utils/radioMatrixTable.test.ts
@@ -1,5 +1,13 @@
 import { cell, heading, radioMatrixTable, row } from './radioMatrixTable'
 
+jest.mock('./placementCriteriaUtils', () => {
+  return {
+    placementCriteria: {
+      test: 'Test',
+    },
+  }
+})
+
 describe('radioMatrixTable', () => {
   describe('cell', () => {
     it('returns the markup given the name and preference', () => {

--- a/server/utils/radioMatrixTable.ts
+++ b/server/utils/radioMatrixTable.ts
@@ -1,3 +1,4 @@
+import { placementCriteria } from './placementCriteriaUtils'
 import { sentenceCase } from './utils'
 
 export const cell = (requirement: string, preference: string, checked?: boolean) => {
@@ -17,7 +18,7 @@ export const cell = (requirement: string, preference: string, checked?: boolean)
 
 export const row = (rowName: string, option: Array<string>, value: string) => {
   return `<tr>
-  <th class="govuk-table__cell" scope="row">${sentenceCase(rowName)}</td>
+  <th class="govuk-table__cell" scope="row">${placementCriteria[rowName]}</td>
     ${option.map(preference => cell(rowName, preference, value === preference)).join('')}
 </tr>`
 }

--- a/server/views/match/search.njk
+++ b/server/views/match/search.njk
@@ -80,7 +80,7 @@
 									classes: 'govuk-fieldset__legend--s'
 								}
 							},
-						items: MatchUtils.searchFilter(placementCriteria, requiredCharacteristics)
+						items: MatchUtils.searchFilter(requiredCharacteristics)
 					})}}
 						</div>
 


### PR DESCRIPTION
When asking assessors for placement requirements, we used to have a bit of a hodge-podge of room / premises requirements, which didn't necessarily map 1:1 to the room and premises characteristics in the API. We've now rationalised these characteristics, and updated the requirements in the API to map 1:1 to characteristics. 

This PR now uses that generated `PlacementCriteria` type to generate a list of criteria that we can use in both the Assessment and the Matching stages, together with translations. This is all strongly-typed, so if/when the criteria in the API changes, then we'll get a TypeError in the API and know where to make the changes.