### PR TITLE
(1526) Return error when a booking or lost bed overlaps

### DIFF
--- a/integration_tests/components/bedspaceConflictErrorComponent.ts
+++ b/integration_tests/components/bedspaceConflictErrorComponent.ts
@@ -1,0 +1,47 @@
+import type { Booking, LostBed } from '@approved-premises/api'
+import errorLookups from '../../server/i18n/en/errors.json'
+import Page from '../pages/page'
+import BookingShowPage from '../pages/manage/booking/show'
+import LostBedShowPage from '../pages/manage/lostBedShow'
+
+export default class BedspaceConflictErrorComponent {
+  constructor(private readonly premisesId: string, private readonly source: 'booking' | 'lost-bed') {}
+
+  shouldShowDateConflictErrorMessages(
+    fields: Array<string>,
+    conflictingEntity: Booking | LostBed,
+    conflictingEntityType: 'booking' | 'lost-bed',
+  ): void {
+    fields.forEach(field => {
+      cy.get(`[data-cy-error-${field}]`).should('contain', errorLookups[field].conflict)
+    })
+
+    const title = this.getTitle(fields)
+    const message = this.getMessage(fields, conflictingEntityType)
+
+    cy.get('.govuk-error-summary h2').should('contain', title)
+    cy.get('.govuk-error-summary ul').should('contain', message)
+
+    cy.get('.govuk-error-summary a').click()
+
+    if (conflictingEntityType === 'booking') {
+      Page.verifyOnPage(BookingShowPage, [this.premisesId, conflictingEntity as Booking])
+    } else {
+      Page.verifyOnPage(LostBedShowPage, conflictingEntity as LostBed)
+    }
+
+    cy.go('back')
+  }
+
+  private getTitle(fields: Array<string>): string {
+    return fields.length === 1
+      ? 'This bedspace is not available for the date entered'
+      : 'This bedspace is not available for the dates entered'
+  }
+
+  private getMessage(fields: Array<string>, conflictingEntityType: 'booking' | 'lost-bed'): string {
+    const noun = conflictingEntityType === 'booking' ? 'booking' : 'lost bed'
+
+    return fields.length === 1 ? `It conflicts with an existing ${noun}` : `They conflict with an existing ${noun}`
+  }
+}

--- a/integration_tests/mockApis/booking.ts
+++ b/integration_tests/mockApis/booking.ts
@@ -1,7 +1,7 @@
 import type { Booking } from '@approved-premises/api'
 
 import { getMatchingRequests, stubFor } from '../../wiremock'
-import { errorStub } from '../../wiremock/utils'
+import { bedspaceConflictResponseBody, errorStub } from '../../wiremock/utils'
 
 export default {
   stubBookingCreate: (args: { premisesId: string; booking: Booking }) =>
@@ -16,6 +16,24 @@ export default {
           'Content-Type': 'application/json;charset=UTF-8',
         },
         jsonBody: args.booking,
+      },
+    }),
+  stubBookingCreateConflictError: (args: {
+    premisesId: string
+    conflictingEntityId: string
+    conflictingEntityType: 'booking' | 'lost-bed'
+  }) =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: `/premises/${args.premisesId}/bookings`,
+      },
+      response: {
+        status: 409,
+        headers: {
+          'Content-Type': 'application/problem+json;charset=UTF-8',
+        },
+        jsonBody: bedspaceConflictResponseBody(args.conflictingEntityId, args.conflictingEntityType),
       },
     }),
   stubBookingErrors: (args: { premisesId: string; params: Array<string> }) =>

--- a/integration_tests/mockApis/lostBed.ts
+++ b/integration_tests/mockApis/lostBed.ts
@@ -3,8 +3,9 @@ import { Response, SuperAgentRequest } from 'superagent'
 import type { LostBed } from '@approved-premises/api'
 
 import { getMatchingRequests, stubFor } from '../../wiremock'
-import { errorStub } from '../../wiremock/utils'
+import { bedspaceConflictResponseBody, errorStub } from '../../wiremock/utils'
 import { lostBedReasons } from '../../wiremock/referenceDataStubs'
+import paths from '../../server/paths/api'
 
 export default {
   stubLostBedCreate: (args: { premisesId: string; lostBed: LostBed }): SuperAgentRequest =>
@@ -33,6 +34,24 @@ export default {
       },
     }),
 
+  stubLostBedConflictError: (args: {
+    premisesId: string
+    conflictingEntityId: string
+    conflictingEntityType: 'booking' | 'lost-bed'
+  }) =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: paths.premises.lostBeds.create({ premisesId: args.premisesId }),
+      },
+      response: {
+        status: 409,
+        headers: {
+          'Content-Type': 'application/problem+json;charset=UTF-8',
+        },
+        jsonBody: bedspaceConflictResponseBody(args.conflictingEntityId, args.conflictingEntityType),
+      },
+    }),
   stubLostBedErrors: (args: { premisesId: string; params: Array<string> }): SuperAgentRequest =>
     stubFor(errorStub(args.params, `/premises/${args.premisesId}/lost-beds`)),
 

--- a/integration_tests/mockApis/lostBed.ts
+++ b/integration_tests/mockApis/lostBed.ts
@@ -20,6 +20,19 @@ export default {
       },
     }),
 
+  stubLostBed: (args: { premisesId: string; lostBed: LostBed }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/premises/${args.premisesId}/lost-beds/${args.lostBed.id}`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.lostBed,
+      },
+    }),
+
   stubLostBedErrors: (args: { premisesId: string; params: Array<string> }): SuperAgentRequest =>
     stubFor(errorStub(args.params, `/premises/${args.premisesId}/lost-beds`)),
 

--- a/integration_tests/pages/manage/booking/new.ts
+++ b/integration_tests/pages/manage/booking/new.ts
@@ -1,16 +1,21 @@
-import type { Booking, Person } from '@approved-premises/api'
+import type { Booking, LostBed, Person } from '@approved-premises/api'
+import BedspaceConflictErrorComponent from '../../../components/bedspaceConflictErrorComponent'
 import Page, { PageElement } from '../../page'
 import paths from '../../../../server/paths/manage'
 
 export default class BookingNewPage extends Page {
-  constructor() {
+  private readonly bedspaceConflictErrorComponent: BedspaceConflictErrorComponent
+
+  constructor(premisesId: string) {
     super('Create a placement')
+
+    this.bedspaceConflictErrorComponent = new BedspaceConflictErrorComponent(premisesId, 'booking')
   }
 
   static visit(premisesId: string, bedId: string): BookingNewPage {
     cy.visit(paths.bookings.new({ premisesId, bedId }))
 
-    return new BookingNewPage()
+    return new BookingNewPage(premisesId)
   }
 
   verifyPersonIsVisible(person: Person): void {
@@ -60,5 +65,16 @@ export default class BookingNewPage extends Page {
     this.expectedDepartureDay().type(departureDate.getDate().toString())
     this.expectedDepartureMonth().type(`${departureDate.getMonth() + 1}`)
     this.expectedDepartureYear().type(departureDate.getFullYear().toString())
+  }
+
+  shouldShowDateConflictErrorMessages(
+    conflictingEntity: Booking | LostBed,
+    conflictingEntityType: 'booking' | 'lost-bed',
+  ): void {
+    this.bedspaceConflictErrorComponent.shouldShowDateConflictErrorMessages(
+      ['arrivalDate', 'departureDate'],
+      conflictingEntity,
+      conflictingEntityType,
+    )
   }
 }

--- a/integration_tests/pages/manage/index.ts
+++ b/integration_tests/pages/manage/index.ts
@@ -2,6 +2,7 @@ import ArrivalCreatePage from './arrivalCreate'
 import CancellationCreatePage from './cancellationCreate'
 import DepartureCreatePage from './departureCreate'
 import LostBedCreatePage from './lostBedCreate'
+import LostBedShowPage from './lostBedShow'
 import PremisesListPage from './premisesList'
 import PremisesShowPage from './premisesShow'
 
@@ -19,6 +20,7 @@ export {
   CancellationCreatePage,
   DepartureCreatePage,
   LostBedCreatePage,
+  LostBedShowPage,
   PremisesListPage,
   PremisesShowPage,
   BookingConfirmationPage,

--- a/integration_tests/pages/manage/lostBedCreate.ts
+++ b/integration_tests/pages/manage/lostBedCreate.ts
@@ -1,16 +1,21 @@
-import type { LostBed } from '@approved-premises/api'
+import type { Booking, LostBed } from '@approved-premises/api'
 import paths from '../../../server/paths/manage'
 
 import Page from '../page'
+import BedspaceConflictErrorComponent from '../../components/bedspaceConflictErrorComponent'
 
 export default class LostBedCreatePage extends Page {
-  constructor() {
+  private readonly bedspaceConflictErrorComponent: BedspaceConflictErrorComponent
+
+  constructor(premisesId: string) {
     super('Mark a bed as out of service')
+
+    this.bedspaceConflictErrorComponent = new BedspaceConflictErrorComponent(premisesId, 'lost-bed')
   }
 
   static visit(premisesId: string, bedId: string): LostBedCreatePage {
     cy.visit(paths.lostBeds.new({ premisesId, bedId }))
-    return new LostBedCreatePage()
+    return new LostBedCreatePage(premisesId)
   }
 
   public completeForm(lostBed: LostBed): void {
@@ -34,5 +39,16 @@ export default class LostBedCreatePage extends Page {
 
   public clickSubmit(): void {
     cy.get('[name="lostBed[submit]"]').click()
+  }
+
+  shouldShowDateConflictErrorMessages(
+    conflictingEntity: Booking | LostBed,
+    conflictingEntityType: 'booking' | 'lost-bed',
+  ): void {
+    this.bedspaceConflictErrorComponent.shouldShowDateConflictErrorMessages(
+      ['startDate', 'endDate'],
+      conflictingEntity,
+      conflictingEntityType,
+    )
   }
 }

--- a/integration_tests/pages/manage/lostBedShow.ts
+++ b/integration_tests/pages/manage/lostBedShow.ts
@@ -1,0 +1,22 @@
+import type { LostBed } from '@approved-premises/api'
+import paths from '../../../server/paths/manage'
+
+import Page from '../page'
+import { DateFormats } from '../../../server/utils/dateUtils'
+
+export default class LostBedShowPage extends Page {
+  constructor(private readonly lostBed: LostBed) {
+    super('Lost bed details')
+  }
+
+  static visit(premisesId: string, lostBed: LostBed): LostBedShowPage {
+    cy.visit(paths.lostBeds.show({ premisesId, id: lostBed.id, bedId: lostBed.bedId }))
+    return new LostBedShowPage(lostBed)
+  }
+
+  shouldShowLostBedDetail(): void {
+    this.assertDefinition('Start date', DateFormats.isoDateToUIDate(this.lostBed.startDate, { format: 'short' }))
+    this.assertDefinition('End date', DateFormats.isoDateToUIDate(this.lostBed.startDate, { format: 'short' }))
+    this.assertDefinition('Reason', this.lostBed.reason.name)
+  }
+}

--- a/integration_tests/tests/manage/lostBed.cy.ts
+++ b/integration_tests/tests/manage/lostBed.cy.ts
@@ -1,6 +1,6 @@
 import { dateCapacityFactory, lostBedFactory, premisesFactory } from '../../../server/testutils/factories'
 
-import { LostBedCreatePage } from '../../pages/manage'
+import { LostBedCreatePage, LostBedShowPage } from '../../pages/manage'
 
 context('LostBed', () => {
   beforeEach(() => {
@@ -74,5 +74,22 @@ context('LostBed', () => {
 
     // Then I should see error messages relating to that field
     page.shouldShowErrorMessagesForFields(['startDate', 'endDate', 'reason', 'referenceNumber'])
+  })
+
+  it('should show a lost bed', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And I have created a lost bed
+    const premises = premisesFactory.build()
+    const lostBed = lostBedFactory.build()
+
+    cy.task('stubLostBed', { premisesId: premises.id, lostBed })
+
+    // And I visit that lost bed's show page
+    const page = LostBedShowPage.visit(premises.id, lostBed)
+
+    // Then I should see the details of that lost bed
+    page.shouldShowLostBedDetail()
   })
 })

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -177,14 +177,20 @@ export interface ErrorMessages {
 }
 
 export interface ErrorSummary {
-  text: string
-  href: string
+  text?: string
+  html?: string
+  href?: string
 }
 
 export interface ErrorsAndUserInput {
   errors: ErrorMessages
   errorSummary: Array<string>
   userInput: Record<string, unknown>
+}
+
+export interface BespokeError {
+  errorTitle: string
+  errorSummary: Array<ErrorSummary>
 }
 
 export type TaskListErrors<K extends TasklistPage> = Partial<Record<keyof K['body'], unknown>>

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -183,6 +183,7 @@ export interface ErrorSummary {
 }
 
 export interface ErrorsAndUserInput {
+  errorTitle?: string
   errors: ErrorMessages
   errorSummary: Array<string>
   userInput: Record<string, unknown>

--- a/server/controllers/manage/lostBedsController.test.ts
+++ b/server/controllers/manage/lostBedsController.test.ts
@@ -100,7 +100,8 @@ describe('LostBedsController', () => {
       await requestHandler(request, response, next)
 
       expect(lostBedService.createLostBed).toHaveBeenCalledWith(token, request.params.premisesId, {
-        ...request.body.lostBed,
+        ...lostBed,
+        bedId: request.params.bedId,
         startDate: '2022-08-22',
         endDate: '2022-09-22',
         serviceName: 'approved-premises',

--- a/server/controllers/manage/lostBedsController.test.ts
+++ b/server/controllers/manage/lostBedsController.test.ts
@@ -2,13 +2,19 @@ import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
 import type { ErrorsAndUserInput } from '@approved-premises/ui'
+import { SanitisedError } from '../../sanitisedError'
 import LostBedService, { LostBedReferenceData } from '../../services/lostBedService'
 import LostBedsController from './lostBedsController'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
+import {
+  catchValidationErrorOrPropogate,
+  fetchErrorsAndUserInput,
+  generateConflictErrorAndRedirect,
+} from '../../utils/validation'
 import { lostBedFactory } from '../../testutils/factories'
 import paths from '../../paths/manage'
 
 jest.mock('../../utils/validation')
+jest.mock('../../utils/bookingUtils')
 
 describe('LostBedsController', () => {
   const token = 'SOME_TOKEN'
@@ -22,6 +28,10 @@ describe('LostBedsController', () => {
   const lostBedController = new LostBedsController(lostBedService)
   const premisesId = 'premisesId'
   const bedId = 'bedId'
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
 
   describe('new', () => {
     it('renders the form', async () => {
@@ -44,6 +54,7 @@ describe('LostBedsController', () => {
         lostBedReasons,
         errors: {},
         errorSummary: [],
+        errorTitle: undefined,
       })
       expect(lostBedService.getReferenceData).toHaveBeenCalledWith(token)
     })
@@ -70,6 +81,7 @@ describe('LostBedsController', () => {
         lostBedReasons,
         errors: errorsAndUserInput.errors,
         errorSummary: errorsAndUserInput.errorSummary,
+        errorTitle: errorsAndUserInput.errorTitle,
         ...errorsAndUserInput.userInput,
       })
     })
@@ -110,28 +122,50 @@ describe('LostBedsController', () => {
       expect(response.redirect).toHaveBeenCalledWith(paths.premises.show({ premisesId: request.params.premisesId }))
     })
 
-    it('renders with errors if the API returns an error', async () => {
-      const requestHandler = lostBedController.create()
-
+    describe('when errors are raised', () => {
       request.params = {
         premisesId,
         bedId,
       }
 
-      const err = new Error()
+      const requestHandler = lostBedController.create()
 
-      lostBedService.createLostBed.mockImplementation(() => {
-        throw err
+      it('should call catchValidationErrorOrPropogate with a standard error', async () => {
+        const err = new Error()
+
+        lostBedService.createLostBed.mockImplementation(() => {
+          throw err
+        })
+
+        await requestHandler(request, response, next)
+
+        expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+          request,
+          response,
+          err,
+          paths.lostBeds.new({ premisesId, bedId }),
+        )
       })
 
-      await requestHandler(request, response, next)
+      it('should call generateConflictErrorAndRedirect if the error is a 409', async () => {
+        const err = createMock<SanitisedError>({ status: 409, data: 'some data' })
 
-      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
-        request,
-        response,
-        err,
-        paths.lostBeds.new({ premisesId: request.params.premisesId, bedId: request.params.bedId }),
-      )
+        lostBedService.createLostBed.mockImplementation(() => {
+          throw err
+        })
+
+        await requestHandler(request, response, next)
+
+        expect(generateConflictErrorAndRedirect).toHaveBeenCalledWith(
+          request,
+          response,
+          premisesId,
+          bedId,
+          ['startDate', 'endDate'],
+          err,
+          paths.lostBeds.new({ premisesId, bedId }),
+        )
+      })
     })
   })
 

--- a/server/controllers/manage/lostBedsController.test.ts
+++ b/server/controllers/manage/lostBedsController.test.ts
@@ -133,4 +133,21 @@ describe('LostBedsController', () => {
       )
     })
   })
+
+  describe('show', () => {
+    it('shows the lost bed', async () => {
+      const lostBed = lostBedFactory.build()
+      lostBedService.getLostBed.mockResolvedValue(lostBed)
+
+      const requestHandler = lostBedController.show()
+
+      await requestHandler({ ...request, params: { premisesId, id: lostBed.id } }, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('lostBeds/show', {
+        premisesId,
+        lostBed,
+      })
+      expect(lostBedService.getLostBed).toHaveBeenCalledWith(token, premisesId, lostBed.id)
+    })
+  })
 })

--- a/server/controllers/manage/lostBedsController.ts
+++ b/server/controllers/manage/lostBedsController.ts
@@ -36,6 +36,7 @@ export default class LostBedsController {
 
       const lostBed: NewLostBed = {
         ...req.body.lostBed,
+        bedId,
         startDate,
         endDate,
         serviceName: 'approved-premises',

--- a/server/controllers/manage/lostBedsController.ts
+++ b/server/controllers/manage/lostBedsController.ts
@@ -51,4 +51,17 @@ export default class LostBedsController {
       }
     }
   }
+
+  show(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, id } = req.params
+
+      const lostBed = await this.lostBedService.getLostBed(req.user.token, premisesId, id)
+
+      res.render('lostBeds/show', {
+        premisesId,
+        lostBed,
+      })
+    }
+  }
 }

--- a/server/data/lostBedClient.test.ts
+++ b/server/data/lostBedClient.test.ts
@@ -40,4 +40,32 @@ describeClient('LostBedClient', provider => {
       expect(result).toEqual(lostBed)
     })
   })
+
+  describe('find', () => {
+    it('should fetch a lostBed', async () => {
+      const lostBed = lostBedFactory.build({
+        cancellation: {},
+      })
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to find a lost bed',
+        withRequest: {
+          method: 'GET',
+          path: `/premises/premisesId/lost-beds/lostBedId`,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: lostBed,
+        },
+      })
+
+      const result = await lostBedClient.find('premisesId', 'lostBedId')
+
+      expect(result).toEqual(lostBed)
+    })
+  })
 })

--- a/server/data/lostBedClient.ts
+++ b/server/data/lostBedClient.ts
@@ -18,4 +18,8 @@ export default class LostBedClient {
 
     return response as LostBed
   }
+
+  async find(premisesId: string, id: string): Promise<LostBed> {
+    return (await this.restClient.get({ path: paths.premises.lostBeds.show({ premisesId, id }) })) as LostBed
+  }
 }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -15,7 +15,8 @@
   },
   "arrivalDate": {
     "empty": "You must enter an arrival date",
-    "invalid": "The arrival date is an invalid date"
+    "invalid": "The arrival date is an invalid date",
+    "conflict": "This bedspace is not available for these dates"
   },
   "date": {
     "empty": "You must enter a valid departure date",
@@ -30,7 +31,8 @@
   },
   "departureDate": {
     "empty": "You must enter a departure date",
-    "invalid": "The departure date is an invalid date"
+    "invalid": "The departure date is an invalid date",
+    "conflict": "This bedspace is not available for these dates"
   },
   "expectedDepartureDate": {
     "empty": "You must enter an expected departure date",

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -57,11 +57,16 @@
     "invalid": "The departure date is an invalid date",
     "beforeExistingDepartureDate": "The new departure date must be after the Booking's current departure date"
   },
-  "startDate": { "empty": "You must enter a start date", "invalid": "The start date is an invalid date" },
+  "startDate": {
+    "empty": "You must enter a start date",
+    "invalid": "The start date is an invalid date",
+    "conflict": "This bedspace is not available for these dates"
+  },
   "endDate": {
     "empty": "You must enter a end date",
     "invalid": "The end date is an invalid date",
-    "beforeStartDate": "The end date must be before the start date"
+    "beforeStartDate": "The end date must be before the start date",
+    "conflict": "This bedspace is not available for these dates"
   },
   "referenceNumber": { "empty": "You must enter a reference number" },
   "query": { "empty": "You must enter a query" },

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -12,6 +12,7 @@ const managePaths = {
   },
   lostBeds: {
     create: lostBedsPath,
+    show: lostBedsPath.path(':id'),
   },
   rooms: singlePremisesPath.path('rooms'),
   room: singlePremisesPath.path('rooms/:roomId'),
@@ -72,6 +73,7 @@ export default {
     capacity: managePaths.premises.show.path('capacity'),
     lostBeds: {
       create: managePaths.lostBeds.create,
+      show: managePaths.lostBeds.show,
     },
     staffMembers: {
       index: managePaths.premises.show.path('staff'),

--- a/server/paths/manage.ts
+++ b/server/paths/manage.ts
@@ -64,6 +64,7 @@ const paths = {
   lostBeds: {
     new: lostBedsPath.path('new'),
     create: lostBedsPath,
+    show: lostBedsPath.path(':id'),
   },
 }
 

--- a/server/routes/manage.ts
+++ b/server/routes/manage.ts
@@ -54,6 +54,7 @@ export default function routes(controllers: Controllers, router: Router): Router
 
   get(paths.lostBeds.new.pattern, lostBedsController.new())
   post(paths.lostBeds.create.pattern, lostBedsController.create())
+  get(paths.lostBeds.show.pattern, lostBedsController.show())
 
   return router
 }

--- a/server/services/lostBedService.test.ts
+++ b/server/services/lostBedService.test.ts
@@ -40,6 +40,21 @@ describe('LostBedService', () => {
     })
   })
 
+  describe('getLostBed', () => {
+    it('on success returns the lostBed that has been posted', async () => {
+      const lostBed: LostBed = lostBedFactory.build()
+
+      const token = 'SOME_TOKEN'
+      lostBedClient.find.mockResolvedValue(lostBed)
+
+      const postedLostBed = await service.getLostBed(token, 'premisesID', 'id')
+
+      expect(postedLostBed).toEqual(lostBed)
+      expect(LostBedClientFactory).toHaveBeenCalledWith(token)
+      expect(lostBedClient.find).toHaveBeenCalledWith('premisesID', 'id')
+    })
+  })
+
   describe('getReferenceData', () => {
     it('should return the lost bed reasons data needed', async () => {
       const lostBedReasons = referenceDataFactory.buildList(2)

--- a/server/services/lostBedService.ts
+++ b/server/services/lostBedService.ts
@@ -17,6 +17,14 @@ export default class LostBedService {
     return confirmedLostBed
   }
 
+  async getLostBed(token: string, premisesId: string, id: string): Promise<LostBed> {
+    const lostBedClient = this.lostBedClientFactory(token)
+
+    const lostBed = await lostBedClient.find(premisesId, id)
+
+    return lostBed
+  }
+
   async getReferenceData(token: string): Promise<LostBedReferenceData> {
     const referenceDataClient = this.referenceDataClientFactory(token)
 

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -153,6 +153,7 @@ describe('fetchErrorsAndUserInput', () => {
   let errors: ErrorMessages
   let userInput: Record<string, unknown>
   let errorSummary: ErrorSummary
+  let errorTitle: string
 
   beforeEach(() => {
     ;(request.flash as jest.Mock).mockImplementation((message: string) => {
@@ -160,6 +161,7 @@ describe('fetchErrorsAndUserInput', () => {
         errors: [errors],
         userInput: [userInput],
         errorSummary,
+        errorTitle: [errorTitle],
       }[message]
     })
   })
@@ -167,16 +169,17 @@ describe('fetchErrorsAndUserInput', () => {
   it('returns default values if there is nothing present', () => {
     const result = fetchErrorsAndUserInput(request)
 
-    expect(result).toEqual({ errors: {}, errorSummary: [], userInput: {} })
+    expect(result).toEqual({ errors: {}, errorSummary: [], userInput: {}, errorTitle: undefined })
   })
 
   it('fetches the values from the flash', () => {
     errors = createMock<ErrorMessages>()
     errorSummary = createMock<ErrorSummary>()
     userInput = { foo: 'bar' }
+    errorTitle = 'Some title'
 
     const result = fetchErrorsAndUserInput(request)
 
-    expect(result).toEqual({ errors, errorSummary, userInput })
+    expect(result).toEqual({ errors, errorSummary, userInput, errorTitle })
   })
 })

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -1,7 +1,13 @@
 import type { Request, Response } from 'express'
 import jsonpath from 'jsonpath'
 
-import type { ErrorMessage, ErrorMessages, ErrorSummary, ErrorsAndUserInput } from '@approved-premises/ui'
+import type {
+  ErrorMessage,
+  ErrorMessages,
+  ErrorSummary,
+  ErrorsAndUserInput,
+  ErrorsTitleAndUserInput,
+} from '@approved-premises/ui'
 import { SanitisedError } from '../sanitisedError'
 import errorLookup from '../i18n/en/errors.json'
 import { TasklistAPIError, ValidationError } from './errors'
@@ -46,8 +52,9 @@ export const fetchErrorsAndUserInput = (request: Request): ErrorsAndUserInput =>
   const errors = firstFlashItem(request, 'errors') || {}
   const errorSummary = request.flash('errorSummary') || []
   const userInput = firstFlashItem(request, 'userInput') || {}
+  const errorTitle = firstFlashItem(request, 'errorTitle')
 
-  return { errors, errorSummary, userInput }
+  return { errors, errorTitle, errorSummary, userInput }
 }
 
 export const errorSummary = (field: string, text: string): ErrorSummary => {

--- a/server/views/bookings/new.njk
+++ b/server/views/bookings/new.njk
@@ -19,14 +19,14 @@
       href: paths.premises.show({premisesId: premisesId})
     }) }}
 
-    <h1>{{pageHeading}}</h1>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
+            {{ showErrorSummary(errorSummary, errorTitle) }}
+
+            <h1>{{pageHeading}}</h1>
             <form action="{{ paths.bookings.create({ premisesId: premisesId, bedId: bedId }) }}" method="post">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
                 <input type="hidden" name="crn" value="{{ crn }}"/>
-
-                {{ showErrorSummary(errorSummary) }}
 
                 {{ govukSummaryList({
                 rows: [

--- a/server/views/lostBeds/new.njk
+++ b/server/views/lostBeds/new.njk
@@ -24,7 +24,7 @@
       <form action="{{ paths.lostBeds.create({ premisesId: premisesId, bedId: bedId }) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-        {{ showErrorSummary(errorSummary) }}
+        {{ showErrorSummary(errorSummary, errorTitle) }}
 
         <h1 class="govuk-!-margin-bottom-0">Mark a bed as out of service</h1>
         <p> Provide details of beds that are out of service within your AP estate</p>

--- a/server/views/lostBeds/show.njk
+++ b/server/views/lostBeds/show.njk
@@ -1,0 +1,58 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+  {% include "../_messages.njk" %}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: paths.premises.show({premisesId: premisesId})
+  }) }}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+
+      <h1>Lost bed details</h1>
+
+      {{
+        govukSummaryList({
+          classes: 'govuk-summary-list',
+          rows: [
+            {
+              key: {
+                text: "Start date"
+              },
+              value: {
+                text: formatDate(lostBed.startDate, {format: 'short'})
+              }
+            },
+            {
+              key: {
+                text: "End date"
+              },
+              value: {
+                text: formatDate(lostBed.endDate, {format: 'short'})
+              }
+            },
+            {
+              key: {
+                text: "Reason"
+              },
+              value: {
+                text: lostBed.reason.name
+              }
+            }
+          ]
+        })
+      }}
+
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/partials/showErrorSummary.njk
+++ b/server/views/partials/showErrorSummary.njk
@@ -1,10 +1,10 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-{% macro showErrorSummary(errorList) %}
+{% macro showErrorSummary(errorList, errorTitle) %}
 
   {% if errorList | length %}
     {{ govukErrorSummary({
-      titleText: "There is a problem",
+      titleText: errorTitle if errorTitle else "There is a problem",
       errorList: errorList
     }) }}
   {% endif %}

--- a/wiremock/utils.ts
+++ b/wiremock/utils.ts
@@ -1,3 +1,5 @@
+import { LostBed } from '@approved-premises/api'
+
 const getCombinations = (arr: Array<string>) => {
   const result: Array<Array<string>> = []
   arr.forEach(item => {
@@ -49,4 +51,10 @@ const errorStub = (fields: Array<string>, pattern: string) => {
   }
 }
 
-export { getCombinations, errorStub }
+const bedspaceConflictResponseBody = (entityId: string | LostBed, entityType: 'booking' | 'lost-bed') => ({
+  title: 'Conflict',
+  status: 409,
+  detail: `${entityType === 'booking' ? 'Booking' : 'Lost Bed'}: ${entityId}`,
+})
+
+export { getCombinations, errorStub, bedspaceConflictResponseBody }


### PR DESCRIPTION
This borrows heavily from the Temporary Accommodation work to handle conflict errors. I've also had to add a view / endpoint to view a lost bed. This is a simple stub at the moment, just to allow users to follow the link to see the conflicting lost bed.

## Screenshots

![Booking -- should show errors when there is a booking conflict](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/ae4f18a8-2c20-460e-b8a4-23df7d798758)

![LostBed -- should show an error when there are booking conflicts](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/aa98eae2-4924-4556-859a-6a331bd0c91d)
