### PR TITLE
(1515) Update the assessments index page to show summaries

### DIFF
--- a/integration_tests/helpers/assess.ts
+++ b/integration_tests/helpers/assess.ts
@@ -1,6 +1,7 @@
 import {
   ApprovedPremisesAssessment as Assessment,
   AssessmentStatus,
+  AssessmentSummary,
   ClarificationNote,
   Document,
   ApprovedPremisesUser as User,
@@ -23,8 +24,11 @@ import {
 import Page from '../pages/page'
 import { updateAssessmentData } from '../../server/form-pages/utils'
 import AssessPage from '../pages/assess/assessPage'
+import { assessmentSummaryFactory } from '../../server/testutils/factories'
 
 export default class AseessHelper {
+  assessmentSummary: AssessmentSummary
+
   pages = {
     reviewApplication: [] as Array<AssessPage>,
     sufficientInformation: [] as Array<AssessPage>,
@@ -39,10 +43,12 @@ export default class AseessHelper {
     private readonly documents: Array<Document>,
     private readonly user: User,
     private readonly clarificationNote?: ClarificationNote,
-  ) {}
+  ) {
+    this.assessmentSummary = assessmentSummaryFactory.build({ id: this.assessment.id })
+  }
 
   setupStubs() {
-    cy.task('stubAssessments', [this.assessment])
+    cy.task('stubAssessments', [this.assessmentSummary])
     cy.task('stubAssessment', this.assessment)
     cy.task('stubFindUser', { user: this.user, id: this.assessment.application.createdByUserId })
     cy.task('stubAssessmentUpdate', this.assessment)
@@ -64,8 +70,9 @@ export default class AseessHelper {
   }
 
   updateAssessmentStatus(status: AssessmentStatus) {
+    this.assessmentSummary.status = status
     this.assessment.status = status
-    cy.task('stubAssessments', [this.assessment])
+    cy.task('stubAssessments', [this.assessmentSummary])
     return cy.task('stubAssessment', this.assessment)
   }
 

--- a/integration_tests/mockApis/assessments.ts
+++ b/integration_tests/mockApis/assessments.ts
@@ -3,6 +3,7 @@ import { SuperAgentRequest } from 'superagent'
 import type {
   ApprovedPremisesApplication as Application,
   ApprovedPremisesAssessment as Assessment,
+  AssessmentSummary,
   NewClarificationNote,
   UpdatedClarificationNote,
 } from '@approved-premises/api'
@@ -11,7 +12,7 @@ import { getMatchingRequests, stubFor } from '../../wiremock'
 import paths from '../../server/paths/api'
 
 export default {
-  stubAssessments: (assessments: Array<Assessment>): SuperAgentRequest =>
+  stubAssessments: (assessments: Array<AssessmentSummary>): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',

--- a/integration_tests/tests/assess/assess.cy.ts
+++ b/integration_tests/tests/assess/assess.cy.ts
@@ -1,5 +1,6 @@
 import {
   assessmentFactory,
+  assessmentSummaryFactory,
   clarificationNoteFactory,
   documentFactory,
   userFactory,
@@ -168,8 +169,9 @@ context('Assess', () => {
   it('shows a read-only version of the assessment', function test() {
     // Given I have completed an assessment
     const updatedAssessment = { ...this.assessment, status: 'completed' }
+    const updatedAssessmentSummary = assessmentSummaryFactory.build({ id: this.assessment.id, status: 'completed' })
     cy.task('stubAssessment', updatedAssessment)
-    cy.task('stubAssessments', [updatedAssessment])
+    cy.task('stubAssessments', [updatedAssessmentSummary])
 
     // And I visit the list page
     const listPage = ListPage.visit()

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -239,9 +239,9 @@ export type DataServices = Partial<{
 export type AssessmentGroupingCategory = 'status' | 'allocation'
 
 export type GroupedAssessments = {
-  completed: Array<Assessment>
-  requestedFurtherInformation: Array<Assessment>
-  awaiting: Array<Assessment>
+  completed: Array<AssessmentSummary>
+  requestedFurtherInformation: Array<AssessmentSummary>
+  awaiting: Array<AssessmentSummary>
 }
 
 export interface AllocatedAndUnallocatedAssessments {

--- a/server/controllers/assess/assessmentsController.test.ts
+++ b/server/controllers/assess/assessmentsController.test.ts
@@ -6,7 +6,7 @@ import TasklistService from '../../services/tasklistService'
 import AssessmentsController, { tasklistPageHeading } from './assessmentsController'
 import { AssessmentService } from '../../services'
 
-import { assessmentFactory } from '../../testutils/factories'
+import { assessmentFactory, assessmentSummaryFactory } from '../../testutils/factories'
 
 import paths from '../../paths/assess'
 import informationSetAsNotReceived from '../../utils/assessments/informationSetAsNotReceived'
@@ -39,7 +39,7 @@ describe('assessmentsController', () => {
 
   describe('index', () => {
     it('should list all the assessments', async () => {
-      const assesments = assessmentFactory.buildList(3)
+      const assesments = assessmentSummaryFactory.buildList(3)
       const groupedAssessments = {
         completed: [],
         requestedFurtherInformation: [],

--- a/server/data/assessmentClient.test.ts
+++ b/server/data/assessmentClient.test.ts
@@ -1,5 +1,10 @@
 import AssessmentClient from './assessmentClient'
-import { assessmentFactory, clarificationNoteFactory, placementRequestFactory } from '../testutils/factories'
+import {
+  assessmentFactory,
+  assessmentSummaryFactory,
+  clarificationNoteFactory,
+  placementRequestFactory,
+} from '../testutils/factories'
 import paths from '../paths/api'
 import describeClient from '../testutils/describeClient'
 
@@ -14,7 +19,7 @@ describeClient('AssessmentClient', provider => {
 
   describe('all', () => {
     it('should get all assessments', async () => {
-      const assessments = assessmentFactory.buildList(3)
+      const assessments = assessmentSummaryFactory.buildList(3)
 
       provider.addInteraction({
         state: 'Server is healthy',

--- a/server/data/assessmentClient.ts
+++ b/server/data/assessmentClient.ts
@@ -1,6 +1,7 @@
 import type {
   ApprovedPremisesAssessment as Assessment,
   AssessmentAcceptance,
+  AssessmentSummary,
   ClarificationNote,
   NewClarificationNote,
   UpdatedClarificationNote,
@@ -17,8 +18,8 @@ export default class AssessmentClient {
     this.restClient = new RestClient('assessmentClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
-  async all(): Promise<Array<Assessment>> {
-    return (await this.restClient.get({ path: paths.assessments.index.pattern })) as Array<Assessment>
+  async all(): Promise<Array<AssessmentSummary>> {
+    return (await this.restClient.get({ path: paths.assessments.index.pattern })) as Array<AssessmentSummary>
   }
 
   async find(assessmentId: string): Promise<Assessment> {

--- a/server/services/assessmentService.test.ts
+++ b/server/services/assessmentService.test.ts
@@ -4,7 +4,7 @@ import { PlacementRequest } from '@approved-premises/api'
 
 import { AssessmentClient } from '../data'
 import AssessmentService from './assessmentService'
-import { assessmentFactory, clarificationNoteFactory, userFactory } from '../testutils/factories'
+import { assessmentFactory, assessmentSummaryFactory, clarificationNoteFactory } from '../testutils/factories'
 
 import { placementRequestData } from '../utils/assessments/placementRequestData'
 import { getBody, updateAssessmentData } from '../form-pages/utils'
@@ -33,40 +33,13 @@ describe('AssessmentService', () => {
     assessmentClientFactory.mockReturnValue(assessmentClient)
   })
 
-  describe('getting all assessments', () => {
-    const user = userFactory.build({ id: 'some-uuid' })
-    const otherUser = userFactory.build({ id: 'some-other-uuid' })
+  describe('getAll', () => {
+    it('should return all assessments', async () => {
+      const assessments = assessmentSummaryFactory.buildList(5)
+      assessmentClient.all.mockResolvedValue(assessments)
+      const result = await service.getAll('token')
 
-    const assessmentsForUser = assessmentFactory.buildList(2, {
-      allocatedToStaffMember: user,
-    })
-    const assessmentsForDifferentUser = assessmentFactory.buildList(2, {
-      status: 'completed',
-      allocatedToStaffMember: otherUser,
-    })
-    const unallocatedAssessments = assessmentFactory.buildList(2, {
-      allocatedToStaffMember: null,
-    })
-
-    beforeEach(() => {
-      assessmentClient.all.mockResolvedValue(
-        [assessmentsForUser, assessmentsForDifferentUser, unallocatedAssessments].flat(),
-      )
-    })
-
-    describe('getAll', () => {
-      it('should return all assessments', async () => {
-        const result = await service.getAll('token')
-
-        expect(result).toEqual([assessmentsForUser, assessmentsForDifferentUser, unallocatedAssessments].flat())
-      })
-    })
-
-    describe('getAllForUser', () => {
-      it('should return all assessments for that user', async () => {
-        const result = await service.getAllForUser('token', user.id)
-        expect(result).toEqual(assessmentsForUser)
-      })
+      expect(result).toEqual(assessments)
     })
   })
 

--- a/server/services/assessmentService.ts
+++ b/server/services/assessmentService.ts
@@ -1,6 +1,7 @@
 import { Request } from 'express'
 import {
   ApprovedPremisesAssessment as Assessment,
+  AssessmentSummary,
   NewClarificationNote,
   UpdatedClarificationNote,
 } from '@approved-premises/api'
@@ -18,17 +19,10 @@ import { applicationAccepted } from '../utils/assessments/decisionUtils'
 export default class AssessmentService {
   constructor(private readonly assessmentClientFactory: RestClientBuilder<AssessmentClient>) {}
 
-  async getAll(token: string): Promise<Array<Assessment>> {
+  async getAll(token: string): Promise<Array<AssessmentSummary>> {
     const client = this.assessmentClientFactory(token)
 
     return client.all()
-  }
-
-  async getAllForUser(token: string, userId: string): Promise<Array<Assessment>> {
-    const client = this.assessmentClientFactory(token)
-    const assessments = await client.all()
-
-    return assessments.filter(a => a.allocatedToStaffMember?.id === userId)
   }
 
   async findAssessment(token: string, id: string): Promise<Assessment> {

--- a/server/testutils/factories/assessmentSummary.ts
+++ b/server/testutils/factories/assessmentSummary.ts
@@ -5,14 +5,23 @@ import { DateFormats } from '../../utils/dateUtils'
 import risksFactory from './risks'
 import personFactory from './person'
 
-export default Factory.define<AssessmentSummary>(() => ({
-  type: 'CAS1',
+class AssessmentSummaryFactory extends Factory<AssessmentSummary> {
+  createdXDaysAgo(days: number) {
+    const today = new Date()
+    return this.params({
+      createdAt: DateFormats.dateObjToIsoDate(new Date(today.getFullYear(), today.getMonth(), today.getDate() - days)),
+    })
+  }
+}
+
+export default AssessmentSummaryFactory.define(() => ({
+  type: 'CAS1' as const,
   id: faker.string.uuid(),
   applicationId: faker.string.uuid(),
   arrivalDate: DateFormats.dateObjToIsoDateTime(faker.date.future()),
   createdAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
   dateOfInfoRequest: DateFormats.dateObjToIsoDateTime(faker.date.past()),
-  status: 'not_started',
+  status: 'not_started' as const,
   risks: risksFactory.build(),
   person: personFactory.build(),
 }))

--- a/server/testutils/factories/assessmentSummary.ts
+++ b/server/testutils/factories/assessmentSummary.ts
@@ -1,0 +1,18 @@
+import { AssessmentSummary } from '@approved-premises/api'
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
+import { DateFormats } from '../../utils/dateUtils'
+import risksFactory from './risks'
+import personFactory from './person'
+
+export default Factory.define<AssessmentSummary>(() => ({
+  type: 'CAS1',
+  id: faker.string.uuid(),
+  applicationId: faker.string.uuid(),
+  arrivalDate: DateFormats.dateObjToIsoDateTime(faker.date.future()),
+  createdAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
+  dateOfInfoRequest: DateFormats.dateObjToIsoDateTime(faker.date.past()),
+  status: 'not_started',
+  risks: risksFactory.build(),
+  person: personFactory.build(),
+}))

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -7,6 +7,7 @@ import applicationFactory from './application'
 import applicationSummaryFactory from './applicationSummary'
 import arrivalFactory from './arrival'
 import assessmentFactory from './assessment'
+import assessmentSummaryFactory from './assessmentSummary'
 import { bedSearchParametersFactory, bedSearchParametersUiFactory } from './bedSearchParameters'
 import { apCharacteristicPairFactory, bedSearchResultFactory, bedSearchResultsFactory } from './bedSearchResult'
 import bookingFactory from './booking'
@@ -55,6 +56,7 @@ export {
   applicationSummaryFactory,
   arrivalFactory,
   assessmentFactory,
+  assessmentSummaryFactory,
   bedSearchParametersFactory,
   bedSearchParametersUiFactory,
   bedSearchResultFactory,

--- a/server/utils/assessments/tableUtils.test.ts
+++ b/server/utils/assessments/tableUtils.test.ts
@@ -1,7 +1,7 @@
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
 
 import * as personUtils from '../personUtils'
-import { assessmentFactory, clarificationNoteFactory } from '../../testutils/factories'
+import { assessmentSummaryFactory } from '../../testutils/factories'
 import {
   daysSinceInfoRequest,
   daysSinceReceived,
@@ -23,27 +23,27 @@ jest.mock('../personUtils')
 
 describe('tableUtils', () => {
   describe('getStatus', () => {
-    it('returns Not started for an active assessment without data', () => {
-      const assessment = assessmentFactory.build({ status: 'not_started', data: undefined })
+    it('returns Not started for an assessment that has not been started', () => {
+      const assessment = assessmentSummaryFactory.build({ status: 'not_started' })
 
       expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag--grey">Not started</strong>')
     })
 
-    it('returns In Progress for an an active assessment with data', () => {
-      const assessment = assessmentFactory.build({ status: 'in_progress' })
+    it('returns In Progress for an an in progress assessment', () => {
+      const assessment = assessmentSummaryFactory.build({ status: 'in_progress' })
 
       expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag--blue">In progress</strong>')
     })
 
     describe('completed assessments', () => {
       it('returns "suitable" for an approved assessment assessment', () => {
-        const assessment = assessmentFactory.build({ status: 'completed', decision: 'accepted' })
+        const assessment = assessmentSummaryFactory.build({ status: 'completed', decision: 'accepted' })
 
         expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag--green">Suitable</strong>')
       })
 
       it('returns "rejected" for an approved assessment assessment', () => {
-        const assessment = assessmentFactory.build({ status: 'completed', decision: 'rejected' })
+        const assessment = assessmentSummaryFactory.build({ status: 'completed', decision: 'rejected' })
 
         expect(getStatus(assessment)).toEqual('<strong class="govuk-tag govuk-tag--red">Rejected</strong>')
       })
@@ -51,7 +51,7 @@ describe('tableUtils', () => {
   })
 
   describe('assessmentLink', () => {
-    const assessment = assessmentFactory.build({ id: '123', application: { person: { name: 'John Wayne' } } })
+    const assessment = assessmentSummaryFactory.build({ id: '123', person: { name: 'John Wayne' } })
 
     it('returns a link to an assessment', () => {
       expect(assessmentLink(assessment)).toMatchStringIgnoringWhitespace(`
@@ -76,7 +76,7 @@ describe('tableUtils', () => {
 
   describe('awaitingAssessmentTableRows', () => {
     it('returns table rows for the assessments', () => {
-      const assessment = assessmentFactory.build()
+      const assessment = assessmentSummaryFactory.build()
 
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
 
@@ -85,22 +85,22 @@ describe('tableUtils', () => {
       expect(awaitingAssessmentTableRows([assessment])).toEqual([
         [
           { html: assessmentLink(assessment) },
-          { html: assessment.application.person.crn },
+          { html: assessment.person.crn },
           { html: 'TIER_BADGE' },
           { text: formattedArrivalDate(assessment) },
-          { text: assessment.application.person.prisonName },
+          { text: assessment.person.prisonName },
           { html: formatDaysUntilDueWithWarning(assessment) },
           { html: getStatus(assessment) },
         ],
       ])
 
-      expect(tierBadgeSpy).toHaveBeenCalledWith(assessment.application.risks.tier.value.level)
+      expect(tierBadgeSpy).toHaveBeenCalledWith(assessment.risks.tier.value.level)
     })
   })
 
   describe('requestedInformationTableRows', () => {
     it('returns table rows for the assessments', () => {
-      const assessment = assessmentFactory.build({ clarificationNotes: clarificationNoteFactory.buildList(2) })
+      const assessment = assessmentSummaryFactory.build({ status: 'awaiting_response' })
 
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
 
@@ -109,7 +109,7 @@ describe('tableUtils', () => {
       expect(requestedFurtherInformationTableRows([assessment])).toEqual([
         [
           { html: assessmentLink(assessment) },
-          { html: assessment.application.person.crn },
+          { html: assessment.person.crn },
           { html: 'TIER_BADGE' },
           { text: formattedArrivalDate(assessment) },
           { text: formatDays(daysSinceReceived(assessment)) },
@@ -118,13 +118,13 @@ describe('tableUtils', () => {
         ],
       ])
 
-      expect(tierBadgeSpy).toHaveBeenCalledWith(assessment.application.risks.tier.value.level)
+      expect(tierBadgeSpy).toHaveBeenCalledWith(assessment.risks.tier.value.level)
     })
   })
 
   describe('completedTableRows', () => {
     it('returns table rows for the assessments', () => {
-      const assessment = assessmentFactory.build()
+      const assessment = assessmentSummaryFactory.build()
 
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
 
@@ -133,14 +133,14 @@ describe('tableUtils', () => {
       expect(completedTableRows([assessment])).toEqual([
         [
           { html: assessmentLink(assessment) },
-          { html: assessment.application.person.crn },
+          { html: assessment.person.crn },
           { html: 'TIER_BADGE' },
           { text: formattedArrivalDate(assessment) },
           { html: getStatus(assessment) },
         ],
       ])
 
-      expect(tierBadgeSpy).toHaveBeenCalledWith(assessment.application.risks.tier.value.level)
+      expect(tierBadgeSpy).toHaveBeenCalledWith(assessment.risks.tier.value.level)
     })
   })
 })

--- a/server/utils/assessments/tableUtils.ts
+++ b/server/utils/assessments/tableUtils.ts
@@ -1,96 +1,92 @@
-import { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
+import { AssessmentSummary } from '@approved-premises/api'
 import { TableRow } from '@approved-premises/ui'
+import { format } from 'date-fns'
 import { linkTo } from '../utils'
-import {
-  daysSinceInfoRequest,
-  daysSinceReceived,
-  formatDays,
-  formatDaysUntilDueWithWarning,
-  formattedArrivalDate,
-} from './dateUtils'
+import { daysSinceInfoRequest, daysSinceReceived, formatDays, formatDaysUntilDueWithWarning } from './dateUtils'
 import { tierBadge } from '../personUtils'
 import paths from '../../paths/assess'
+import { DateFormats } from '../dateUtils'
 
-const getStatus = (assessment: Assessment): string => {
+const getStatus = (assessment: AssessmentSummary): string => {
   if (assessment.status === 'completed') {
     if (assessment.decision === 'accepted') return `<strong class="govuk-tag govuk-tag--green">Suitable</strong>`
     if (assessment.decision === 'rejected') return `<strong class="govuk-tag govuk-tag--red">Rejected</strong>`
   }
 
-  if (assessment.data) {
+  if (assessment.status === 'in_progress') {
     return `<strong class="govuk-tag govuk-tag--blue">In progress</strong>`
   }
 
   return `<strong class="govuk-tag govuk-tag--grey">Not started</strong>`
 }
 
-const assessmentLink = (assessment: Assessment, linkText = '', hiddenText = ''): string => {
+const assessmentLink = (assessment: AssessmentSummary, linkText = '', hiddenText = ''): string => {
   return linkTo(
     paths.assessments.show,
     { id: assessment.id },
     {
-      text: linkText || assessment.application.person.name,
+      text: linkText || assessment.person.name,
       hiddenText,
       attributes: { 'data-cy-assessmentId': assessment.id },
     },
   )
 }
 
-const crnCell = (assessment: Assessment) => {
+const crnCell = (assessment: AssessmentSummary) => {
   return {
-    html: assessment.application.person.crn,
+    html: assessment.person.crn,
   }
 }
 
-const arrivalDateCell = (assessment: Assessment) => {
+const arrivalDateCell = (assessment: AssessmentSummary) => {
   return {
-    text: formattedArrivalDate(assessment),
+    text: format(DateFormats.isoToDateObj(assessment.arrivalDate), 'd MMM yyyy'),
   }
 }
 
-const daysUntilDueCell = (assessment: Assessment) => {
+const daysUntilDueCell = (assessment: AssessmentSummary) => {
   return {
     html: formatDaysUntilDueWithWarning(assessment),
   }
 }
 
-const statusCell = (assessment: Assessment) => {
+const statusCell = (assessment: AssessmentSummary) => {
   return {
     html: getStatus(assessment),
   }
 }
 
-const linkCell = (assessment: Assessment) => {
+const linkCell = (assessment: AssessmentSummary) => {
   return {
     html: assessmentLink(assessment),
   }
 }
 
-const tierCell = (assessment: Assessment) => {
+const tierCell = (assessment: AssessmentSummary) => {
   return {
-    html: tierBadge(assessment.application.risks.tier?.value?.level),
+    html: tierBadge(assessment.risks.tier?.value?.level),
   }
 }
 
-const prisonCell = (assessment: Assessment) => {
+const prisonCell = (assessment: AssessmentSummary) => {
   return {
-    text: assessment.application.person.prisonName,
+    text: assessment.person.prisonName,
   }
 }
 
-const daysSinceReceivedCell = (assessment: Assessment) => {
+const daysSinceReceivedCell = (assessment: AssessmentSummary) => {
   return {
     text: formatDays(daysSinceReceived(assessment)),
   }
 }
 
-const daysSinceInfoRequestCell = (assessment: Assessment) => {
+const daysSinceInfoRequestCell = (assessment: AssessmentSummary) => {
   return {
     text: formatDays(daysSinceInfoRequest(assessment)),
   }
 }
 
-const awaitingAssessmentTableRows = (assessments: Array<Assessment>): Array<TableRow> => {
+const awaitingAssessmentTableRows = (assessments: Array<AssessmentSummary>): Array<TableRow> => {
   const rows = [] as Array<TableRow>
 
   assessments.forEach(assessment => {
@@ -108,7 +104,7 @@ const awaitingAssessmentTableRows = (assessments: Array<Assessment>): Array<Tabl
   return rows
 }
 
-const completedTableRows = (assessments: Array<Assessment>): Array<TableRow> => {
+const completedTableRows = (assessments: Array<AssessmentSummary>): Array<TableRow> => {
   const rows = [] as Array<TableRow>
 
   assessments.forEach(assessment => {
@@ -124,7 +120,7 @@ const completedTableRows = (assessments: Array<Assessment>): Array<TableRow> => 
   return rows
 }
 
-const requestedFurtherInformationTableRows = (assessments: Array<Assessment>): Array<TableRow> => {
+const requestedFurtherInformationTableRows = (assessments: Array<AssessmentSummary>): Array<TableRow> => {
   const rows = [] as Array<TableRow>
 
   const infoRequestStatusCell = {

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -131,10 +131,10 @@ describe('utils', () => {
   describe('assessmentsApproachingDue', () => {
     it('returns the number of assessments where the due date is less than DUE_DATE_APPROACHING_WINDOW away', () => {
       const assessments = [
-        assessmentFactory.createdXDaysAgo(1).build(),
-        assessmentFactory.createdXDaysAgo(2).build(),
-        assessmentFactory.createdXDaysAgo(9).build(),
-        assessmentFactory.createdXDaysAgo(7).build(),
+        assessmentSummaryFactory.createdXDaysAgo(1).build(),
+        assessmentSummaryFactory.createdXDaysAgo(2).build(),
+        assessmentSummaryFactory.createdXDaysAgo(9).build(),
+        assessmentSummaryFactory.createdXDaysAgo(7).build(),
       ]
 
       expect(assessmentsApproachingDue(assessments)).toEqual(2)
@@ -143,7 +143,7 @@ describe('utils', () => {
 
   describe('assessmentsApproachingDueBadge', () => {
     it('returns blank when there are no assessments approaching the due date', () => {
-      const assessments = assessmentFactory.buildList(2, {
+      const assessments = assessmentSummaryFactory.buildList(2, {
         createdAt: DateFormats.dateObjToIsoDate(new Date()),
       })
 
@@ -151,7 +151,7 @@ describe('utils', () => {
     })
 
     it('returns a badge when there are assessments approaching the due date', () => {
-      const assessments = assessmentFactory.createdXDaysAgo(9).buildList(2)
+      const assessments = assessmentSummaryFactory.createdXDaysAgo(9).buildList(2)
 
       expect(assessmentsApproachingDueBadge(assessments)).toEqual(
         '<span id="notifications" class="moj-notification-badge">2<span class="govuk-visually-hidden"> assessments approaching due date</span></span>',

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -25,6 +25,7 @@ import {
   adjudicationFactory,
   applicationFactory,
   assessmentFactory,
+  assessmentSummaryFactory,
   prisonCaseNotesFactory,
   userFactory,
 } from '../../testutils/factories'
@@ -92,9 +93,9 @@ describe('utils', () => {
 
   describe('groupAssessmements', () => {
     it('groups assessments by their status', () => {
-      const completedAssessments = assessmentFactory.buildList(2, { status: 'completed' })
-      const pendingAssessments = assessmentFactory.buildList(3, { status: 'awaiting_response' })
-      const activeAssessments = assessmentFactory.buildList(5, { status: 'not_started' })
+      const completedAssessments = assessmentSummaryFactory.buildList(2, { status: 'completed' })
+      const pendingAssessments = assessmentSummaryFactory.buildList(3, { status: 'awaiting_response' })
+      const activeAssessments = assessmentSummaryFactory.buildList(5, { status: 'not_started' })
 
       const assessments = [completedAssessments, pendingAssessments, activeAssessments].flat()
 

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -77,7 +77,7 @@ const allocationSummary = (assessment: Assessment): Array<SummaryListItem> => {
   return summary
 }
 
-const assessmentsApproachingDueBadge = (assessments: Array<Assessment>): string => {
+const assessmentsApproachingDueBadge = (assessments: Array<AssessmentSummary>): string => {
   const dueCount = assessmentsApproachingDue(assessments)
 
   if (dueCount === 0) {

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -1,6 +1,6 @@
 import { ApplicationType, GroupedAssessments, SummaryListItem } from '@approved-premises/ui'
 
-import { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
+import { ApprovedPremisesAssessment as Assessment, AssessmentSummary } from '@approved-premises/api'
 import { TasklistPageInterface } from '../../form-pages/tasklistPage'
 import Assess from '../../form-pages/assess'
 import { UnknownPageError } from '../errors'
@@ -11,7 +11,7 @@ import { applicationAccepted, decisionFromAssessment } from './decisionUtils'
 import { assessmentsApproachingDue, formattedArrivalDate } from './dateUtils'
 import { awaitingAssessmentTableRows, completedTableRows, requestedFurtherInformationTableRows } from './tableUtils'
 
-const groupAssessmements = (assessments: Array<Assessment>): GroupedAssessments => {
+const groupAssessmements = (assessments: Array<AssessmentSummary>): GroupedAssessments => {
   const result = { completed: [], requestedFurtherInformation: [], awaiting: [] } as GroupedAssessments
 
   assessments.forEach(assessment => {


### PR DESCRIPTION
Following on from the change to the API in https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/629 the call to `/assessments` now returns a subset of assessment data using a `AssessmentSummary` object. This PR updates all the relevant parts that are touched by the Assessments index to support an AssessmentSummary, rather than a full-blown assessment.