### PR TITLE
(1528) Update matching information

### DIFF
--- a/integration_tests/pages/assess/assessPage.ts
+++ b/integration_tests/pages/assess/assessPage.ts
@@ -11,7 +11,7 @@ export default class AssessPage extends Page {
   // Initialize this to ensure all the decorators are called for the Assess journey
   pages = Assess.pages
 
-  constructor(private readonly assessment: Assessment, title: string) {
+  constructor(public readonly assessment: Assessment, title: string) {
     super(title)
   }
 }

--- a/integration_tests/pages/assess/matchingInformationPage.ts
+++ b/integration_tests/pages/assess/matchingInformationPage.ts
@@ -6,19 +6,22 @@ import { offenceAndRiskOptions, placementRequirementOptions } from '../../../ser
 export default class MatchingInformationPage extends AssessPage {
   pageClass = new MatchingInformation({
     apType: 'isEsap',
-    mentalHealthSupport: '1',
+    accessibilityCriteria: ['hasBrailleSignage'],
+    specialistSupportCriteria: ['isSemiSpecialistMentalHealth'],
+    isArsonDesignated: 'essential',
     isWheelchairDesignated: 'essential',
     isSingleRoom: 'desirable',
-    isStepFreeDesignated: 'essential',
-    isCatered: 'desirable',
-    isGroundFloor: 'desirable',
-    acceptsSexOffenders: 'relevant',
-    acceptsNonSexualChildOffenders: 'notRelevant',
-    acceptsChildSexOffenders: 'relevant',
-    isArsonSuitable: 'notRelevant',
-    acceptsHateCrimeOffenders: 'relevant',
-    isSuitableForVulnerable: 'notRelevant',
+    isStepFreeDesignated: 'desirable',
+    isCatered: 'notRelevant',
+    isGroundFloor: 'notRelevant',
     hasEnSuite: 'notRelevant',
+    isSuitableForVulnerable: 'relevant',
+    acceptsSexOffenders: 'relevant',
+    acceptsChildSexOffenders: 'relevant',
+    acceptsNonSexualChildOffenders: 'relevant',
+    acceptsHateCrimeOffenders: 'relevant',
+    isArsonSuitable: 'relevant',
+    isSuitedForSexOffenders: 'essential',
   })
 
   constructor(assessment: Assessment) {
@@ -27,7 +30,14 @@ export default class MatchingInformationPage extends AssessPage {
 
   completeForm() {
     this.checkRadioByNameAndValue('apType', this.pageClass.body.apType)
-    this.checkCheckboxByNameAndValue('mentalHealthSupport', '1')
+
+    this.pageClass.body.accessibilityCriteria.forEach(requirement => {
+      this.checkCheckboxByLabel(requirement)
+    })
+
+    this.pageClass.body.specialistSupportCriteria.forEach(requirement => {
+      this.checkCheckboxByLabel(requirement)
+    })
 
     Object.keys(placementRequirementOptions).forEach(requirement => {
       this.checkRadioByNameAndValue(requirement, this.pageClass.body[requirement])

--- a/integration_tests/pages/assess/matchingInformationPage.ts
+++ b/integration_tests/pages/assess/matchingInformationPage.ts
@@ -4,25 +4,30 @@ import AssessPage from './assessPage'
 import { offenceAndRiskOptions, placementRequirementOptions } from '../../../server/utils/placementCriteriaUtils'
 
 export default class MatchingInformationPage extends AssessPage {
-  pageClass = new MatchingInformation({
-    apType: 'isEsap',
-    accessibilityCriteria: ['hasBrailleSignage'],
-    specialistSupportCriteria: ['isSemiSpecialistMentalHealth'],
-    isArsonDesignated: 'essential',
-    isWheelchairDesignated: 'essential',
-    isSingleRoom: 'desirable',
-    isStepFreeDesignated: 'desirable',
-    isCatered: 'notRelevant',
-    isGroundFloor: 'notRelevant',
-    hasEnSuite: 'notRelevant',
-    isSuitableForVulnerable: 'relevant',
-    acceptsSexOffenders: 'relevant',
-    acceptsChildSexOffenders: 'relevant',
-    acceptsNonSexualChildOffenders: 'relevant',
-    acceptsHateCrimeOffenders: 'relevant',
-    isArsonSuitable: 'relevant',
-    isSuitedForSexOffenders: 'essential',
-  })
+  pageClass = new MatchingInformation(
+    {
+      apType: 'isEsap',
+      accessibilityCriteria: ['hasBrailleSignage'],
+      specialistSupportCriteria: ['isSemiSpecialistMentalHealth'],
+      isArsonDesignated: 'essential',
+      isWheelchairDesignated: 'essential',
+      isSingleRoom: 'desirable',
+      isStepFreeDesignated: 'desirable',
+      isCatered: 'notRelevant',
+      isGroundFloor: 'notRelevant',
+      hasEnSuite: 'notRelevant',
+      isSuitableForVulnerable: 'relevant',
+      acceptsSexOffenders: 'relevant',
+      acceptsChildSexOffenders: 'relevant',
+      acceptsNonSexualChildOffenders: 'relevant',
+      acceptsHateCrimeOffenders: 'relevant',
+      isArsonSuitable: 'relevant',
+      isSuitedForSexOffenders: 'essential',
+      lengthOfStayAgreed: 'yes',
+      cruInformation: 'Some info',
+    },
+    this.assessment,
+  )
 
   constructor(assessment: Assessment) {
     super(assessment, 'Matching information')
@@ -46,5 +51,9 @@ export default class MatchingInformationPage extends AssessPage {
     Object.keys(offenceAndRiskOptions).forEach(offenceAndRiskInformationKey => {
       this.checkRadioByNameAndValue(offenceAndRiskInformationKey, this.pageClass.body[offenceAndRiskInformationKey])
     })
+
+    this.checkRadioByNameAndValue('lengthOfStayAgreed', this.pageClass.body.lengthOfStayAgreed)
+
+    this.completeTextArea('cruInformation', this.pageClass.body.cruInformation)
   }
 }

--- a/server/@types/shared/models/PlacementCriteria.ts
+++ b/server/@types/shared/models/PlacementCriteria.ts
@@ -2,4 +2,4 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type PlacementCriteria = 'isPipe' | 'isEsap' | 'isSemiSpecialistMentalHealth' | 'isRecoveryFocussed' | 'isSuitableForVulnerable' | 'acceptsSexOffenders' | 'acceptsChildSexOffenders' | 'acceptsNonSexualChildOffenders' | 'acceptsHateCrimeOffenders' | 'isWheelchairDesignated' | 'isSingleRoom' | 'isStepFreeDesignated' | 'isCatered' | 'isGroundFloor' | 'hasEnSuite' | 'isSuitedForSexOffenders' | 'isArsonSuitable';
+export type PlacementCriteria = 'isPipe' | 'isEsap' | 'isSemiSpecialistMentalHealth' | 'isRecoveryFocussed' | 'hasBrailleSignage' | 'hasTactileFlooring' | 'hasHearingLoop' | 'isStepFreeDesignated' | 'isArsonDesignated' | 'isWheelchairDesignated' | 'isSingleRoom' | 'isCatered' | 'isSuitedForSexOffenders' | 'isSuitableForVulnerable' | 'acceptsSexOffenders' | 'acceptsHateCrimeOffenders' | 'acceptsChildSexOffenders' | 'acceptsNonSexualChildOffenders' | 'isArsonSuitable' | 'isGroundFloor' | 'hasEnSuite';

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -4,7 +4,9 @@ import MatchingInformation, { MatchingInformationBody } from './matchingInformat
 
 const defaultArguments = {
   apType: 'isEsap' as const,
-  mentalHealthSupport: '1',
+  accessibilityCriteria: ['hasHearingLoop'],
+  specialistSupportCriteria: ['isSemiSpecialistMentalHealth', 'isRecoveryFocussed'],
+  isArsonDesignated: 'essential',
   isWheelchairDesignated: 'essential',
   isSingleRoom: 'desirable',
   isStepFreeDesignated: 'desirable',
@@ -17,6 +19,7 @@ const defaultArguments = {
   acceptsNonSexualChildOffenders: 'relevant',
   acceptsHateCrimeOffenders: 'relevant',
   isArsonSuitable: 'relevant',
+  isSuitedForSexOffenders: 'relevant',
 } as MatchingInformationBody
 
 describe('MatchingInformation', () => {
@@ -44,6 +47,7 @@ describe('MatchingInformation', () => {
         apType: 'You must select the type of AP required',
         isWheelchairDesignated: 'You must specify a preference for wheelchair accessible',
         isSingleRoom: 'You must specify a preference for single room',
+        isArsonDesignated: 'You must specify a preference for designated arson room',
         isStepFreeDesignated: 'You must specify a preference for has step-free access',
         isCatered: 'You must specify a preference for catering required',
         isGroundFloor: 'You must specify a preference for ground floor room',
@@ -53,6 +57,7 @@ describe('MatchingInformation', () => {
         acceptsChildSexOffenders: 'You must specify if sexual offences against children is relevant',
         acceptsNonSexualChildOffenders: 'You must specify if non sexual offences against children is relevant',
         acceptsHateCrimeOffenders: 'You must specify if hate based offences is relevant',
+        isSuitedForSexOffenders: 'You must specify a preference for is suited for sex offenders',
         isArsonSuitable: 'You must specify if arson offences is relevant',
       })
     })
@@ -64,8 +69,9 @@ describe('MatchingInformation', () => {
 
       expect(page.response()).toEqual({
         'What type of AP is required?': 'Enhanced Security AP (ESAP)',
-        'If this person requires specialist mental health support, select the box below':
-          'Semi-specialist mental health selected',
+        'Accessibility needs': 'Hearing loop',
+        'Is arson designated': 'Essential',
+        'Is suited for sex offenders': 'Relevant',
         'Is wheelchair designated': 'Essential',
         'Is single room': 'Desirable',
         'Is step free designated': 'Desirable',
@@ -78,7 +84,21 @@ describe('MatchingInformation', () => {
         'Accepts non sexual child offenders': 'Relevant',
         'Accepts hate crime offenders': 'Relevant',
         'Is arson suitable': 'Relevant',
+        'Specialist support needs': 'Semi-specialist mental health, Recovery Focused Approved Premises (RAP)',
       })
+    })
+
+    it('returns none if accessiblity or specialist support needs are not selected', () => {
+      const page = new MatchingInformation({
+        ...defaultArguments,
+        accessibilityCriteria: [],
+        specialistSupportCriteria: [],
+      })
+
+      const response = page.response()
+
+      expect(response['Accessibility needs']).toEqual('None')
+      expect(response['Specialist support needs']).toEqual('None')
     })
   })
 })

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -20,6 +20,8 @@ const defaultArguments = {
   acceptsHateCrimeOffenders: 'relevant',
   isArsonSuitable: 'relevant',
   isSuitedForSexOffenders: 'relevant',
+  lengthOfStayAgreed: 'yes',
+  cruInformation: 'Some info',
 } as MatchingInformationBody
 
 describe('MatchingInformation', () => {
@@ -59,6 +61,15 @@ describe('MatchingInformation', () => {
         acceptsHateCrimeOffenders: 'You must specify if hate based offences is relevant',
         isSuitedForSexOffenders: 'You must specify a preference for is suited for sex offenders',
         isArsonSuitable: 'You must specify if arson offences is relevant',
+        lengthOfStayAgreed: 'You must state if you agree with the length of the stay',
+      })
+    })
+
+    it('should add an error if lengthOfStayAgreed is no and the details are not provided', () => {
+      const page = new MatchingInformation({ ...defaultArguments, lengthOfStayAgreed: 'no' })
+
+      expect(page.errors()).toEqual({
+        lengthOfStayAgreedDetail: 'You must provide a recommended length of stay',
       })
     })
   })
@@ -85,6 +96,8 @@ describe('MatchingInformation', () => {
         'Accepts hate crime offenders': 'Relevant',
         'Is arson suitable': 'Relevant',
         'Specialist support needs': 'Semi-specialist mental health, Recovery Focused Approved Premises (RAP)',
+        'Do you agree with the suggested length of stay?': 'Yes',
+        'Information for Central Referral Unit (CRU) manager': 'Some info',
       })
     })
 
@@ -99,6 +112,19 @@ describe('MatchingInformation', () => {
 
       expect(response['Accessibility needs']).toEqual('None')
       expect(response['Specialist support needs']).toEqual('None')
+    })
+
+    it('adds the recommended length of stay if lengthOfStayAgreed is no', () => {
+      const page = new MatchingInformation({
+        ...defaultArguments,
+        lengthOfStayAgreed: 'no',
+        lengthOfStayAgreedDetail: '12',
+      })
+
+      const response = page.response()
+
+      expect(response['Do you agree with the suggested length of stay?']).toEqual('No')
+      expect(response['Recommended length of stay']).toEqual('12 weeks')
     })
   })
 

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -101,4 +101,43 @@ describe('MatchingInformation', () => {
       expect(response['Specialist support needs']).toEqual('None')
     })
   })
+
+  describe('specialistSupportCheckboxes', () => {
+    it('returns an array of checkboxes with chosen options selected', () => {
+      const page = new MatchingInformation({ ...defaultArguments, specialistSupportCriteria: ['isRecoveryFocussed'] })
+
+      expect(page.specialistSupportCheckboxes).toEqual([
+        {
+          value: 'isRecoveryFocussed',
+          text: 'Recovery Focused Approved Premises (RAP)',
+          checked: true,
+        },
+        {
+          value: 'isSemiSpecialistMentalHealth',
+          text: 'Semi-specialist mental health',
+          checked: false,
+        },
+      ])
+    })
+  })
+
+  describe('accessibilityCheckBoxes', () => {
+    it('returns an array of checkboxes with chosen options selected', () => {
+      const page = new MatchingInformation({ ...defaultArguments, accessibilityCriteria: ['hasBrailleSignage'] })
+
+      expect(page.accessibilityCheckBoxes).toEqual([
+        {
+          value: 'hasBrailleSignage',
+          text: 'Braille signage',
+          checked: true,
+        },
+        {
+          value: 'hasTactileFlooring',
+          text: 'Tactile Flooring',
+          checked: false,
+        },
+        { value: 'hasHearingLoop', text: 'Hearing loop', checked: false },
+      ])
+    })
+  })
 })

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
@@ -1,4 +1,4 @@
-import type { TaskListErrors } from '@approved-premises/ui'
+import type { TaskListErrors, YesOrNoWithDetail } from '@approved-premises/ui'
 
 import { Page } from '../../../utils/decorators'
 
@@ -36,7 +36,8 @@ export type MatchingInformationBody = {
   apType: ApTypeCriteria | 'normal'
   accessibilityCriteria: Array<AccessibilityCriteria>
   specialistSupportCriteria: Array<SpecialistSupportCriteria>
-}
+  cruInformation: string
+} & YesOrNoWithDetail<'lengthOfStayAgreed'>
 
 @Page({
   name: 'matching-information',
@@ -44,6 +45,9 @@ export type MatchingInformationBody = {
     'apType',
     'accessibilityCriteria',
     'specialistSupportCriteria',
+    'lengthOfStayAgreed',
+    'lengthOfStayAgreedDetail',
+    'cruInformation',
     ...placementRequirements,
     ...offenceAndRiskInformationKeys,
   ],
@@ -99,6 +103,16 @@ export default class MatchingInformation implements TasklistPage {
       response[`${sentenceCase(offenceOrRiskInformation)}`] = `${sentenceCase(this.body[offenceOrRiskInformation])}`
     })
 
+    response['Do you agree with the suggested length of stay?'] = sentenceCase(this.body.lengthOfStayAgreed)
+
+    if (this.body.lengthOfStayAgreedDetail) {
+      response['Recommended length of stay'] = `${this.body.lengthOfStayAgreedDetail} weeks`
+    }
+
+    if (this.body.cruInformation) {
+      response['Information for Central Referral Unit (CRU) manager'] = this.body.cruInformation
+    }
+
     return response
   }
 
@@ -122,6 +136,14 @@ export default class MatchingInformation implements TasklistPage {
         )} is relevant`
       }
     })
+
+    if (!this.body.lengthOfStayAgreed) {
+      errors.lengthOfStayAgreed = 'You must state if you agree with the length of the stay'
+    }
+
+    if (this.body.lengthOfStayAgreed === 'no' && !this.body.lengthOfStayAgreedDetail) {
+      errors.lengthOfStayAgreedDetail = 'You must provide a recommended length of stay'
+    }
 
     return errors
   }

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
@@ -1,5 +1,7 @@
 import type { TaskListErrors, YesOrNoWithDetail } from '@approved-premises/ui'
 
+import { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
+import { placementDurationFromApplication } from '../../../../utils/assessments/placementDurationFromApplication'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
@@ -77,7 +79,7 @@ export default class MatchingInformation implements TasklistPage {
 
   specialistSupportOptions = specialistSupportOptions
 
-  constructor(public body: Partial<MatchingInformationBody>) {}
+  constructor(public body: Partial<MatchingInformationBody>, public assessment: Assessment) {}
 
   previous() {
     return 'dashboard'
@@ -146,6 +148,10 @@ export default class MatchingInformation implements TasklistPage {
     }
 
     return errors
+  }
+
+  get suggestedLengthOfStay() {
+    return placementDurationFromApplication(this.assessment.application)
   }
 
   get specialistSupportCheckboxes() {

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
@@ -57,13 +57,13 @@ export default class MatchingInformation implements TasklistPage {
 
   apTypes = apTypeOptions
 
-  placementRequirementTableHeadings = ['Placement requirements', 'Essential', 'Desirable', 'Not relevant']
+  placementRequirementTableHeadings = ['Specify placement requirements', 'Essential', 'Desirable', 'Not relevant']
 
   placementRequirements = placementRequirements
 
   placementRequirementPreferences = placementRequirementPreferences
 
-  relevantInformationTableHeadings = ['Offence and risk information', 'Relevant', 'Not relevant']
+  relevantInformationTableHeadings = ['Risks and offences to consider', 'Relevant', 'Not relevant']
 
   offenceAndRiskInformationKeys = offenceAndRiskInformationKeys
 

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
@@ -126,6 +126,26 @@ export default class MatchingInformation implements TasklistPage {
     return errors
   }
 
+  get specialistSupportCheckboxes() {
+    return Object.keys(specialistSupportOptions).map((k: SpecialistSupportCriteria) => {
+      return {
+        value: k,
+        text: specialistSupportOptions[k],
+        checked: (this.body.specialistSupportCriteria || []).includes(k),
+      }
+    })
+  }
+
+  get accessibilityCheckBoxes() {
+    return Object.keys(accessibilityOptions).map((k: AccessibilityCriteria) => {
+      return {
+        value: k,
+        text: accessibilityOptions[k],
+        checked: (this.body.accessibilityCriteria || []).includes(k),
+      }
+    })
+  }
+
   private selectedOptions(key: 'specialistSupport' | 'accessibility') {
     const selectedOptions = this.body[`${key}Criteria`] || []
 

--- a/server/testutils/mockQuestionResponse.ts
+++ b/server/testutils/mockQuestionResponse.ts
@@ -59,6 +59,7 @@ export const mockOptionalQuestionResponse = ({
   isExceptionalCase,
   shouldPersonBePlacedInMaleAp,
   agreedCaseWithManager,
+  lengthOfStayAgreedDetail,
 }: {
   releaseType?: string
   duration?: string
@@ -69,6 +70,7 @@ export const mockOptionalQuestionResponse = ({
   isExceptionalCase?: string
   shouldPersonBePlacedInMaleAp?: string
   agreedCaseWithManager?: string
+  lengthOfStayAgreedDetail?: string
 }) => {
   ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockImplementation(
     // eslint-disable-next-line consistent-return
@@ -107,6 +109,10 @@ export const mockOptionalQuestionResponse = ({
 
       if (question === 'agreedCaseWithManager') {
         return agreedCaseWithManager
+      }
+
+      if (question === 'lengthOfStayAgreedDetail') {
+        return lengthOfStayAgreedDetail
       }
     },
   )

--- a/server/utils/assessments/placementDurationFromApplication.test.ts
+++ b/server/utils/assessments/placementDurationFromApplication.test.ts
@@ -1,0 +1,43 @@
+import { applicationFactory } from '../../testutils/factories'
+import PlacementDuration from '../../form-pages/apply/move-on/placementDuration'
+import { getDefaultPlacementDurationInWeeks } from '../applications/getDefaultPlacementDurationInWeeks'
+import { placementDurationFromApplication } from './placementDurationFromApplication'
+import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromApplicationOrAssessment'
+
+jest.mock('../retrieveQuestionResponseFromApplicationOrAssessment')
+jest.mock('../applications/getDefaultPlacementDurationInWeeks')
+
+describe('placementDurationFromApplication', () => {
+  const application = applicationFactory.build()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return the duration if provided', () => {
+    ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValueOnce(52)
+
+    expect(placementDurationFromApplication(application)).toEqual(52)
+
+    expect(retrieveOptionalQuestionResponseFromApplicationOrAssessment).toHaveBeenCalledWith(
+      application,
+      PlacementDuration,
+      'duration',
+    )
+    expect(getDefaultPlacementDurationInWeeks).not.toHaveBeenCalled()
+  })
+
+  it('should return the default duration an alternative duration is not provided', () => {
+    ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValueOnce(undefined)
+    ;(getDefaultPlacementDurationInWeeks as jest.Mock).mockReturnValueOnce(12)
+
+    expect(placementDurationFromApplication(application)).toEqual(12)
+
+    expect(retrieveOptionalQuestionResponseFromApplicationOrAssessment).toHaveBeenCalledWith(
+      application,
+      PlacementDuration,
+      'duration',
+    )
+    expect(getDefaultPlacementDurationInWeeks).toHaveBeenCalledWith(application)
+  })
+})

--- a/server/utils/assessments/placementDurationFromApplication.ts
+++ b/server/utils/assessments/placementDurationFromApplication.ts
@@ -1,0 +1,11 @@
+import { ApprovedPremisesApplication as Application } from '@approved-premises/api'
+import PlacementDuration from '../../form-pages/apply/move-on/placementDuration'
+import { getDefaultPlacementDurationInWeeks } from '../applications/getDefaultPlacementDurationInWeeks'
+import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromApplicationOrAssessment'
+
+export const placementDurationFromApplication = (application: Application) => {
+  return (
+    retrieveOptionalQuestionResponseFromApplicationOrAssessment(application, PlacementDuration, 'duration') ||
+    getDefaultPlacementDurationInWeeks(application)
+  )
+}

--- a/server/utils/assessments/placementRequestData.test.ts
+++ b/server/utils/assessments/placementRequestData.test.ts
@@ -5,12 +5,12 @@ import { criteriaFromMatchingInformation, placementRequestData } from './placeme
 import { assessmentFactory } from '../../testutils/factories'
 import { pageDataFromApplicationOrAssessment } from '../../form-pages/utils'
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
-import { getDefaultPlacementDurationInWeeks } from '../applications/getDefaultPlacementDurationInWeeks'
+import { placementDurationFromApplication } from './placementDurationFromApplication'
 
 jest.mock('../../form-pages/utils')
 jest.mock('../retrieveQuestionResponseFromApplicationOrAssessment')
-jest.mock('../applications/getDefaultPlacementDurationInWeeks')
 jest.mock('../applications/arrivalDateFromApplication')
+jest.mock('./placementDurationFromApplication')
 
 describe('placementRequestData', () => {
   const assessment = assessmentFactory.build()
@@ -27,7 +27,7 @@ describe('placementRequestData', () => {
 
   it('converts matching data into a placement request', () => {
     mockQuestionResponse({ postcodeArea: 'ABC123', type: 'normal', duration: '12' })
-    mockOptionalQuestionResponse({ duration: '12', alternativeRadius: '100' })
+    mockOptionalQuestionResponse({ lengthOfStayAgreedDetail: '12', alternativeRadius: '100' })
 
     expect(placementRequestData(assessment)).toEqual({
       gender: 'male',
@@ -42,7 +42,7 @@ describe('placementRequestData', () => {
   })
 
   it('returns a default radius if one is not present', () => {
-    mockOptionalQuestionResponse({ duration: '12', alternativeRadius: undefined })
+    mockOptionalQuestionResponse({ lengthOfStayAgreedDetail: '12', alternativeRadius: undefined })
 
     const result = placementRequestData(assessment)
 
@@ -50,7 +50,7 @@ describe('placementRequestData', () => {
   })
 
   it('returns the default placement duration if one is not present', () => {
-    ;(getDefaultPlacementDurationInWeeks as jest.Mock).mockReturnValueOnce(52)
+    ;(placementDurationFromApplication as jest.Mock).mockReturnValueOnce(52)
     mockOptionalQuestionResponse({ duration: undefined, alternativeRadius: '100' })
 
     const result = placementRequestData(assessment)

--- a/server/utils/assessments/placementRequestData.test.ts
+++ b/server/utils/assessments/placementRequestData.test.ts
@@ -18,7 +18,8 @@ describe('placementRequestData', () => {
 
   let matchingInformation = createMock<MatchingInformationBody>({
     apType: 'isEsap',
-    mentalHealthSupport: '1',
+    specialistSupportCriteria: [],
+    accessibilityCriteria: [],
   })
 
   ;(pageDataFromApplicationOrAssessment as jest.Mock).mockReturnValue(matchingInformation)
@@ -35,7 +36,6 @@ describe('placementRequestData', () => {
       duration: '12',
       location: 'ABC123',
       radius: '100',
-      mentalHealthSupport: true,
       essentialCriteria: criteriaFromMatchingInformation(matchingInformation).essentialCriteria,
       desirableCriteria: criteriaFromMatchingInformation(matchingInformation).desirableCriteria,
     })
@@ -58,22 +58,12 @@ describe('placementRequestData', () => {
     expect(result.duration).toEqual(52)
   })
 
-  it('returns a false mentalHealthSupport requirement if the mentalHealthSupport matching information is blank', () => {
-    matchingInformation = createMock<MatchingInformationBody>({
-      mentalHealthSupport: '',
-    })
-    ;(pageDataFromApplicationOrAssessment as jest.Mock).mockReturnValue(matchingInformation)
-
-    const result = placementRequestData(assessment)
-
-    expect(result.mentalHealthSupport).toEqual(false)
-  })
-
   describe('criteriaFromMatchingInformation', () => {
     it('returns all essential criteria for essential and relevant matching information', () => {
       matchingInformation = createMock<MatchingInformationBody>({
         apType: 'isEsap',
-        mentalHealthSupport: '1',
+        specialistSupportCriteria: ['isSemiSpecialistMentalHealth'],
+        accessibilityCriteria: ['hasHearingLoop', 'hasTactileFlooring'],
         isWheelchairDesignated: 'essential',
         isStepFreeDesignated: 'essential',
         isCatered: 'essential',
@@ -94,6 +84,9 @@ describe('placementRequestData', () => {
           'isWheelchairDesignated',
           'isStepFreeDesignated',
           'isCatered',
+          'isSemiSpecialistMentalHealth',
+          'hasHearingLoop',
+          'hasTactileFlooring',
           'acceptsSexOffenders',
           'acceptsChildSexOffenders',
           'acceptsNonSexualChildOffenders',
@@ -101,18 +94,18 @@ describe('placementRequestData', () => {
           'acceptsHateCrimeOffenders',
           'isSuitableForVulnerable',
           'isSuitedForSexOffenders',
-          'isSemiSpecialistMentalHealth',
         ].sort(),
       )
     })
 
     it('returns all desirable criteria for desirable matching information', () => {
       matchingInformation = createMock<MatchingInformationBody>({
-        mentalHealthSupport: undefined,
         apType: 'normal',
         isWheelchairDesignated: 'desirable',
         isStepFreeDesignated: 'desirable',
         isCatered: 'desirable',
+        specialistSupportCriteria: [],
+        accessibilityCriteria: [],
       })
 
       const result = criteriaFromMatchingInformation(matchingInformation)
@@ -126,7 +119,6 @@ describe('placementRequestData', () => {
     it('returns empty objects for not relevant matching information', () => {
       matchingInformation = createMock<MatchingInformationBody>({
         apType: 'normal',
-        mentalHealthSupport: '',
         isWheelchairDesignated: 'notRelevant',
         isStepFreeDesignated: 'notRelevant',
         isCatered: 'notRelevant',
@@ -136,6 +128,8 @@ describe('placementRequestData', () => {
         isArsonSuitable: 'notRelevant',
         acceptsHateCrimeOffenders: 'notRelevant',
         isSuitableForVulnerable: 'notRelevant',
+        specialistSupportCriteria: [],
+        accessibilityCriteria: [],
       })
 
       expect(criteriaFromMatchingInformation(matchingInformation)).toEqual({

--- a/server/utils/assessments/placementRequestData.ts
+++ b/server/utils/assessments/placementRequestData.ts
@@ -57,7 +57,6 @@ export const placementRequestData = (assessment: Assessment): PlacementRequireme
     duration: placementDuration,
     location,
     radius: alternativeRadius || 50,
-    mentalHealthSupport: !!matchingInformation.mentalHealthSupport,
     ...criteria,
   } as PlacementRequirements
 }
@@ -85,9 +84,8 @@ export const criteriaFromMatchingInformation = (
     essentialCriteria.push(matchingInformation.apType)
   }
 
-  if (matchingInformation.mentalHealthSupport) {
-    essentialCriteria.push('isSemiSpecialistMentalHealth')
-  }
+  essentialCriteria.push(...matchingInformation.specialistSupportCriteria)
+  essentialCriteria.push(...matchingInformation.accessibilityCriteria)
 
   Object.keys(placementRequirementOptions).forEach((requirement: PlacementRequirementCriteria) => {
     if (matchingInformation[requirement] === 'essential') {

--- a/server/utils/assessments/placementRequestData.ts
+++ b/server/utils/assessments/placementRequestData.ts
@@ -15,8 +15,6 @@ import MatchingInformation, {
   MatchingInformationBody,
 } from '../../form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation'
 import LocationFactors from '../../form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors'
-import PlacementDuration from '../../form-pages/apply/move-on/placementDuration'
-import { getDefaultPlacementDurationInWeeks } from '../applications/getDefaultPlacementDurationInWeeks'
 import {
   ApTypeCriteria,
   OffenceAndRiskCriteria,
@@ -24,6 +22,7 @@ import {
   offenceAndRiskOptions,
   placementRequirementOptions,
 } from '../placementCriteriaUtils'
+import { placementDurationFromApplication } from './placementDurationFromApplication'
 
 export const placementRequestData = (assessment: Assessment): PlacementRequirements => {
   const matchingInformation = pageDataFromApplicationOrAssessment(
@@ -43,10 +42,10 @@ export const placementRequestData = (assessment: Assessment): PlacementRequireme
   )
   const placementDuration =
     retrieveOptionalQuestionResponseFromApplicationOrAssessment(
-      assessment.application,
-      PlacementDuration,
-      'duration',
-    ) || getDefaultPlacementDurationInWeeks(assessment.application)
+      assessment,
+      MatchingInformation,
+      'lengthOfStayAgreedDetail',
+    ) || placementDurationFromApplication(assessment.application)
 
   const criteria = criteriaFromMatchingInformation(matchingInformation)
 

--- a/server/utils/placementCriteriaUtils.test.ts
+++ b/server/utils/placementCriteriaUtils.test.ts
@@ -1,20 +1,20 @@
 import {
   apTypeOptions,
-  mentalHealthOptions,
   offenceAndRiskOptions,
   placementRequirementOptions,
+  specialistSupportOptions,
 } from './placementCriteriaUtils'
 
 describe('placementCriteriaUtils', () => {
   describe('apTypeOptions', () => {
     it('should return all the AP Type options', () => {
-      expect(Object.keys(apTypeOptions)).toEqual(['normal', 'isPipe', 'isEsap', 'isRecoveryFocussed'])
+      expect(Object.keys(apTypeOptions)).toEqual(['normal', 'isPipe', 'isEsap'])
     })
   })
 
-  describe('mentalHealthOptions', () => {
+  describe('specialistSupportOptions', () => {
     it('should return all the mental health options', () => {
-      expect(Object.keys(mentalHealthOptions)).toEqual(['isSemiSpecialistMentalHealth'])
+      expect(Object.keys(specialistSupportOptions)).toEqual(['isRecoveryFocussed', 'isSemiSpecialistMentalHealth'])
     })
   })
 
@@ -40,6 +40,8 @@ describe('placementCriteriaUtils', () => {
         'isCatered',
         'isGroundFloor',
         'hasEnSuite',
+        'isSuitedForSexOffenders',
+        'isArsonDesignated',
       ])
     })
   })

--- a/server/utils/placementCriteriaUtils.ts
+++ b/server/utils/placementCriteriaUtils.ts
@@ -1,7 +1,8 @@
 import { PlacementCriteria } from '@approved-premises/api'
 
-const apTypes = ['isPipe', 'isEsap', 'isRecoveryFocussed']
-const mentalHealthTypes = ['isSemiSpecialistMentalHealth']
+const apTypes = ['isPipe', 'isEsap']
+const specialistSupportCriteria = ['isSemiSpecialistMentalHealth', 'isRecoveryFocussed']
+const accessibilityCriteria = ['hasBrailleSignage', 'hasTactileFlooring', 'hasHearingLoop']
 const offenceAndRiskCriteria = [
   'isSuitableForVulnerable',
   'acceptsSexOffenders',
@@ -12,26 +13,27 @@ const offenceAndRiskCriteria = [
 ]
 const placementRequirementCriteria = [
   'isWheelchairDesignated',
+  'isArsonDesignated',
   'isSingleRoom',
   'isStepFreeDesignated',
   'isCatered',
   'isGroundFloor',
   'hasEnSuite',
+  'isSuitedForSexOffenders',
 ]
-const additionalCriteria = ['isSuitedForSexOffenders']
 
 export type ApTypeCriteria = Extract<PlacementCriteria, (typeof apTypes)[number]>
-export type MentalHealthCriteria = Extract<PlacementCriteria, (typeof mentalHealthTypes)[number]>
+export type SpecialistSupportCriteria = Extract<PlacementCriteria, (typeof specialistSupportCriteria)[number]>
 export type OffenceAndRiskCriteria = Extract<PlacementCriteria, (typeof offenceAndRiskCriteria)[number]>
+export type AccessibilityCriteria = Extract<PlacementCriteria, (typeof accessibilityCriteria)[number]>
 export type PlacementRequirementCriteria = Extract<PlacementCriteria, (typeof placementRequirementCriteria)[number]>
-export type AdditionalCriteria = Extract<PlacementCriteria, (typeof additionalCriteria)[number]>
 
 type PlacementCriteriaCategory =
   | ApTypeCriteria
-  | MentalHealthCriteria
+  | SpecialistSupportCriteria
   | OffenceAndRiskCriteria
   | PlacementRequirementCriteria
-  | AdditionalCriteria
+  | AccessibilityCriteria
 
 export const placementCriteria: Record<PlacementCriteria, string> = {
   isPipe: 'Psychologically Informed Planned Environment (PIPE)',
@@ -51,6 +53,10 @@ export const placementCriteria: Record<PlacementCriteria, string> = {
   hasEnSuite: 'En-suite',
   isSuitedForSexOffenders: 'Is suited for sex offenders',
   isArsonSuitable: 'Arson offences',
+  hasBrailleSignage: 'Braille signage',
+  hasTactileFlooring: 'Tactile Flooring',
+  hasHearingLoop: 'Hearing loop',
+  isArsonDesignated: 'Designated arson room',
 }
 
 const filterByType = <T extends PlacementCriteriaCategory>(keys: Array<string>): Record<T, string> => {
@@ -63,6 +69,7 @@ export const apTypeOptions = {
   normal: 'Standard AP',
   ...filterByType<ApTypeCriteria>(apTypes),
 } as Record<ApTypeCriteria & 'normal', string>
-export const mentalHealthOptions = filterByType<MentalHealthCriteria>(mentalHealthTypes)
+export const specialistSupportOptions = filterByType<SpecialistSupportCriteria>(specialistSupportCriteria)
+export const accessibilityOptions = filterByType<AccessibilityCriteria>(accessibilityCriteria)
 export const offenceAndRiskOptions = filterByType<OffenceAndRiskCriteria>(offenceAndRiskCriteria)
 export const placementRequirementOptions = filterByType<PlacementRequirementCriteria>(placementRequirementCriteria)

--- a/server/views/assessments/pages/matching-information/matching-information.njk
+++ b/server/views/assessments/pages/matching-information/matching-information.njk
@@ -56,4 +56,72 @@
 
   {{placementRequirementsTable(page.relevantInformationTableHeadings, page.offenceAndRiskInformationKeys, page.offenceAndRiskInformationRelevance, page.body) | safe}}
 
+  {% set noDetails %}
+  {{
+    formPageInput(
+      {
+        fieldName: "lengthOfStayAgreedDetail",
+        spellcheck: false,
+        inputmode: "numeric",
+        label: {
+          text: "Provide recommended length of stay"
+        },
+        suffix: {
+          text: "weeks"
+        },
+        classes: "govuk-input--width-2"
+      },
+      fetchContext()
+    )
+  }}
+  {% endset -%}
+
+  {{
+    formPageRadios({
+      fieldName: "lengthOfStayAgreed",
+      fieldset: {
+        legend: {
+          text: "Do you agree with the recommended length of stay?",
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      hint: {
+        text: "Recommended length of stay: " + page.suggestedLengthOfStay + " weeks"
+      },
+      items: [
+        {
+          value: "yes",
+          text: "Yes"
+        },
+        {
+          value: "no",
+          text: "No",
+          conditional: {
+            html: noDetails
+          }
+        }
+      ]
+    },
+    fetchContext()
+    )
+  }}
+
+  {{
+    formPageTextarea(
+      {
+        fieldName: "cruInformation",
+        type: "textarea",
+        spellcheck: false,
+        label: {
+          text: "Information for Central Referral Unit (CRU) manager (optional)",
+          classes: "govuk-label--m"
+        },
+        hint: {
+          text: "Record any observations you think would benefit the CRU manager. They will use this information to match the person to a suitable AP."
+        }
+      },
+      fetchContext()
+    )
+  }}
+
 {% endblock %}

--- a/server/views/assessments/pages/matching-information/matching-information.njk
+++ b/server/views/assessments/pages/matching-information/matching-information.njk
@@ -18,32 +18,41 @@
   {{
     formPageCheckboxes(
       {
-        fieldName: "mentalHealthSupport",
+        fieldName: "specialistSupportCriteria",
         fieldset: {
           legend: {
-            text: page.mentalHealthSupport.question,
+            text: "If this person would benefit from specialist support, select the relevant option below",
             classes: "govuk-fieldset__legend--m"
           }
         },
         hint: {
-          text: page.mentalHealthSupport.hint
+          html: "<p>There are only two AP with a semi-specialism in mental health nationally. Placement in one of these AP is not guaranteed.</p><p>Recovery Focused AP's are currently being piloted nationally. Placement is not guaranteed.</p>"
         },
-      items: [
-      {
-        value: "1",
-        text: page.mentalHealthSupport.label,
-        checked: page.mentalHealthSupport.value === '1'
-      }]
-      }, 
+      items: page.specialistSupportCheckboxes
+      },
       fetchContext()
     )
   }}
 
-  <h2 class="govuk-heading-m">Specify placement requirements</h2>
+  {{
+    formPageCheckboxes(
+      {
+        fieldName: "accessibilityCriteria",
+        fieldset: {
+          legend: {
+            text: "Would the person benefit from any of the following?",
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+      items: page.accessibilityCheckBoxes
+      },
+      fetchContext()
+    )
+  }}
+
+  <h2 class="govuk-heading-m">Placement requirements</h2>
 
   {{placementRequirementsTable(page.placementRequirementTableHeadings, page.placementRequirements, page.placementRequirementPreferences, page.body) | safe}}
-
-  <h2 class="govuk-heading-m">Provide relevant offence and risk information</h2>
 
   {{placementRequirementsTable(page.relevantInformationTableHeadings, page.offenceAndRiskInformationKeys, page.offenceAndRiskInformationRelevance, page.body) | safe}}
 


### PR DESCRIPTION
This adds some new requirement fields to the matching information, as well as some additional fields to provide an alternative placement length, and provide some information to the CRU manager (matcher). The latter field is not yet shown to the matcher in the frontend, but some API work is required to put this in place, and the PR was already big enough!

## Screenshot

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/aa8cc350-afbf-4c03-9182-7a1ee0bab659)
