### PR TITLE
(1529) Send and display notes in placement requests

### DIFF
--- a/integration_tests/tests/assess/assess.cy.ts
+++ b/integration_tests/tests/assess/assess.cy.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../server/testutils/factories'
 
 import { overwriteApplicationDocuments } from '../../../server/utils/assessments/documentUtils'
+import { placementRequestData } from '../../../server/utils/assessments/placementRequestData'
 
 import AssessHelper from '../../helpers/assess'
 import { ListPage, ShowPage, TaskListPage } from '../../pages/assess'
@@ -58,6 +59,7 @@ context('Assess', () => {
 
       const body = JSON.parse(requests[0].body)
       expect(body).to.have.keys('document', 'requirements')
+      expect(body.requirements).to.deep.equal(placementRequestData(this.assessHelper.assessment))
     })
   })
 

--- a/server/testutils/mockQuestionResponse.ts
+++ b/server/testutils/mockQuestionResponse.ts
@@ -60,6 +60,7 @@ export const mockOptionalQuestionResponse = ({
   shouldPersonBePlacedInMaleAp,
   agreedCaseWithManager,
   lengthOfStayAgreedDetail,
+  cruInformation,
 }: {
   releaseType?: string
   duration?: string
@@ -71,6 +72,7 @@ export const mockOptionalQuestionResponse = ({
   shouldPersonBePlacedInMaleAp?: string
   agreedCaseWithManager?: string
   lengthOfStayAgreedDetail?: string
+  cruInformation?: string
 }) => {
   ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockImplementation(
     // eslint-disable-next-line consistent-return
@@ -113,6 +115,10 @@ export const mockOptionalQuestionResponse = ({
 
       if (question === 'lengthOfStayAgreedDetail') {
         return lengthOfStayAgreedDetail
+      }
+
+      if (question === 'cruInformation') {
+        return cruInformation
       }
     },
   )

--- a/server/utils/assessments/placementRequestData.test.ts
+++ b/server/utils/assessments/placementRequestData.test.ts
@@ -27,7 +27,11 @@ describe('placementRequestData', () => {
 
   it('converts matching data into a placement request', () => {
     mockQuestionResponse({ postcodeArea: 'ABC123', type: 'normal', duration: '12' })
-    mockOptionalQuestionResponse({ lengthOfStayAgreedDetail: '12', alternativeRadius: '100' })
+    mockOptionalQuestionResponse({
+      lengthOfStayAgreedDetail: '12',
+      alternativeRadius: '100',
+      cruInformation: 'Some notes',
+    })
 
     expect(placementRequestData(assessment)).toEqual({
       gender: 'male',
@@ -38,6 +42,7 @@ describe('placementRequestData', () => {
       radius: '100',
       essentialCriteria: criteriaFromMatchingInformation(matchingInformation).essentialCriteria,
       desirableCriteria: criteriaFromMatchingInformation(matchingInformation).desirableCriteria,
+      notes: 'Some notes',
     })
   })
 

--- a/server/utils/assessments/placementRequestData.ts
+++ b/server/utils/assessments/placementRequestData.ts
@@ -49,6 +49,12 @@ export const placementRequestData = (assessment: Assessment): PlacementRequireme
 
   const criteria = criteriaFromMatchingInformation(matchingInformation)
 
+  const notes = retrieveOptionalQuestionResponseFromApplicationOrAssessment(
+    assessment,
+    MatchingInformation,
+    'cruInformation',
+  )
+
   return {
     gender: 'male', // Hardcoded for now as we only support Male APs
     type: apType(matchingInformation.apType),
@@ -56,6 +62,7 @@ export const placementRequestData = (assessment: Assessment): PlacementRequireme
     duration: placementDuration,
     location,
     radius: alternativeRadius || 50,
+    notes,
     ...criteria,
   } as PlacementRequirements
 }

--- a/server/utils/placementRequests/matchingInformationSummaryList.test.ts
+++ b/server/utils/placementRequests/matchingInformationSummaryList.test.ts
@@ -19,6 +19,30 @@ describe('matchingInformationSummaryList', () => {
         ],
       })
     })
+
+    it('should add notes if provided', () => {
+      const placementRequest = placementRequestFactory.build({ notes: 'Some notes' })
+
+      expect(matchingInformationSummary(placementRequest)).toEqual({
+        card: {
+          title: {
+            text: 'Information for Matching',
+          },
+        },
+        rows: [
+          placementRequirementsRow(placementRequest, 'essential'),
+          placementRequirementsRow(placementRequest, 'desirable'),
+          {
+            key: {
+              text: 'Observations from assessor',
+            },
+            value: {
+              text: placementRequest.notes,
+            },
+          },
+        ],
+      })
+    })
   })
 
   describe('placementRequirementsRow', () => {

--- a/server/utils/placementRequests/matchingInformationSummaryList.ts
+++ b/server/utils/placementRequests/matchingInformationSummaryList.ts
@@ -4,16 +4,29 @@ import { sentenceCase } from '../utils'
 import { mapSearchParamCharacteristicsForUi } from '../matchUtils'
 
 export const matchingInformationSummary = (placementRequest: PlacementRequest): SummaryListWithCard => {
+  const rows = [
+    placementRequirementsRow(placementRequest, 'essential'),
+    placementRequirementsRow(placementRequest, 'desirable'),
+  ]
+
+  if (placementRequest.notes) {
+    rows.push({
+      key: {
+        text: 'Observations from assessor',
+      },
+      value: {
+        text: placementRequest.notes,
+      },
+    })
+  }
+
   return {
     card: {
       title: {
         text: 'Information for Matching',
       },
     },
-    rows: [
-      placementRequirementsRow(placementRequest, 'essential'),
-      placementRequirementsRow(placementRequest, 'desirable'),
-    ],
+    rows,
   }
 }
 


### PR DESCRIPTION
In #784 we included the concept of notes to sent to the matcher. The API has now been updated to accept these notes when an assessment is approved, so we can now send this data along with the rest of the placement request data, as well as display it to the matcher before they proceed to the search screen.

## Screenshot

### Before

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/1374d3cb-522c-4c31-8100-f1a5228226e6)

### After

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/a33d4136-616f-439f-9a7f-9cd9538f6848)
