### PR TITLE
(1529) Update the match screen filters

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -12,6 +12,7 @@ $path: "/assets/images/"
 @import './components/sub-navigation'
 @import './components/bed-search-identity'
 @import './components/bed-search-inputs'
+@import './components/filter'
 
 @import './pages/assessments-index'
 @import './pages/applications-pages-attach-document'

--- a/assets/sass/components/_filter.scss
+++ b/assets/sass/components/_filter.scss
@@ -1,0 +1,19 @@
+.moj-filter {
+  margin-bottom: govuk-spacing(6);
+
+  .moj-filter-tags {
+    span {
+      &.moj-filter__tag {
+        &::after {
+          background-image: none;
+          content: none;
+        }
+
+        &:hover {
+          background-color: govuk-colour('white');
+          color:govuk-colour('black');
+        }
+      }
+    }
+  }
+}

--- a/integration_tests/pages/match/searchPage.ts
+++ b/integration_tests/pages/match/searchPage.ts
@@ -1,12 +1,27 @@
 import { BedSearchParametersUi, TextItem } from '@approved-premises/ui'
-import { BedSearchResult, BedSearchResults } from '@approved-premises/api'
+import { BedSearchResult, BedSearchResults, PlacementCriteria } from '@approved-premises/api'
 import Page from '../page'
 import { uiObjectValue } from '../../helpers'
 import { summaryCardRows } from '../../../server/utils/matchUtils'
+import { placementCriteria } from '../../../server/utils/placementCriteriaUtils'
 
 export default class SearchPage extends Page {
   constructor(name: string) {
     super(name)
+  }
+
+  shouldShowEssentialCriteria(criteria: Array<PlacementCriteria>) {
+    criteria.forEach(c => {
+      cy.get('span.moj-filter__tag').should('contain', placementCriteria[c])
+    })
+  }
+
+  shouldHaveCriteriaSelected(criteria: Array<PlacementCriteria>) {
+    cy.get('input:checked[type="checkbox"][name="requiredCharacteristics"]').should('have.length', criteria.length)
+
+    criteria.forEach(c => {
+      cy.get(`input[name="requiredCharacteristics"][value="${c}"]`).should('be.checked')
+    })
   }
 
   shouldDisplaySearchResults(bedSearchResults: BedSearchResults, searchParams: BedSearchParametersUi): void {
@@ -46,7 +61,7 @@ export default class SearchPage extends Page {
     cy.get('[type="checkbox"]').uncheck()
 
     newSearchParameters.requiredCharacteristics.forEach(characteristic => {
-      this.checkCheckboxByNameAndValue('selectedRequiredCharacteristics', characteristic)
+      this.checkCheckboxByNameAndValue('requiredCharacteristics', characteristic)
     })
   }
 }

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -13,24 +13,22 @@ import {
 } from '../../../server/testutils/factories'
 import Page from '../../pages/page'
 import { DateFormats } from '../../../server/utils/dateUtils'
+import { PlacementCriteria } from '../../../server/@types/shared/models/PlacementCriteria'
+import { mapPlacementRequestToBedSearchParams } from '../../../server/utils/placementRequests/utils'
 
 context('Placement Requests', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+
+    // Given I am logged in
+    cy.signIn()
   })
 
   it('shows a list of placementRequests', () => {
-    // Given I am logged in
-    cy.signIn()
-
-    // And there are beds and placement requests in the database
-    const bedSearchResults = bedSearchResultsFactory.build()
-    cy.task('stubBedSearch', { bedSearchResults })
-    const person = personFactory.build()
-    cy.task('stubFindPerson', { person })
-    const activePlacementRequests = placementRequestFactory.buildList(1, { person, status: 'notMatched' })
+    // Given there placement requests in the database
+    const activePlacementRequests = placementRequestFactory.buildList(1, { status: 'notMatched' })
     const unableToMatchPlacementRequests = placementRequestFactory.buildList(3, { status: 'unableToMatch' })
     const matchedPlacementRequests = placementRequestFactory.buildList(5, { status: 'matched' })
 
@@ -39,13 +37,6 @@ context('Placement Requests', () => {
       ...unableToMatchPlacementRequests,
       ...matchedPlacementRequests,
     ])
-    const activePlacementRequest = activePlacementRequests[0]
-    const firstBedSearchParameters = bedSearchParametersUiFactory.build({
-      requiredCharacteristics: activePlacementRequest.essentialCriteria,
-    })
-
-    cy.task('stubPlacementRequest', activePlacementRequest)
-    cy.task('stubBookingFromPlacementRequest', activePlacementRequest)
 
     // When I visit the placementRequests dashboard
     const listPage = ListPage.visit()
@@ -68,11 +59,43 @@ context('Placement Requests', () => {
     // When I click on the active cases tab
     listPage.clickActive()
 
+    // Then I should see the placement requests that are allocated to me
+    listPage.shouldShowPlacementRequests(activePlacementRequests)
+  })
+
+  it('allows me to search for available rooms', () => {
+    // Given there is a placement request waiting for me to match
+    const person = personFactory.build()
+
+    const essentialCriteria = ['isPipe', 'acceptsHateCrimeOffenders', 'isGroundFloor'] as Array<PlacementCriteria>
+    const desirableCriteria = ['isCatered', 'isGroundFloor', 'hasEnSuite'] as Array<PlacementCriteria>
+
+    const placementRequest = placementRequestFactory.build({
+      person,
+      status: 'notMatched',
+      essentialCriteria,
+      desirableCriteria,
+    })
+
+    const firstBedSearchParameters = bedSearchParametersUiFactory.build({
+      requiredCharacteristics: [...essentialCriteria, ...desirableCriteria],
+    })
+
+    const bedSearchResults = bedSearchResultsFactory.build()
+
+    cy.task('stubPlacementRequests', [placementRequest])
+    cy.task('stubBedSearch', { bedSearchResults })
+    cy.task('stubPlacementRequest', placementRequest)
+    cy.task('stubBookingFromPlacementRequest', placementRequest)
+
+    // When I visit the placementRequests dashboard
+    const listPage = ListPage.visit()
+
     // And I click on a placement request
-    listPage.clickFindBed(activePlacementRequest)
+    listPage.clickFindBed(placementRequest)
 
     // Then I should be taken to the placement request's page
-    const showPage = Page.verifyOnPage(PlacementRequestPage, activePlacementRequest)
+    const showPage = Page.verifyOnPage(PlacementRequestPage, placementRequest)
 
     // And I should see the placement request information
     showPage.shouldShowAssessmentDetails()
@@ -85,12 +108,20 @@ context('Placement Requests', () => {
     // Then I should be taken to the search page
     const searchPage = Page.verifyOnPage(SearchPage, person.name)
 
+    // Then I should see the essential criteria
+    searchPage.shouldShowEssentialCriteria(placementRequest.essentialCriteria)
+
+    // And the desirable criteria should be selected
+    searchPage.shouldHaveCriteriaSelected(placementRequest.desirableCriteria)
+
     // And I should see the search results
     let numberOfSearches = 0
     searchPage.shouldDisplaySearchResults(bedSearchResults, firstBedSearchParameters)
     numberOfSearches += 1
 
-    const newSearchParameters = bedSearchParametersUiFactory.build()
+    const newSearchParameters = bedSearchParametersUiFactory.build({
+      requiredCharacteristics: [desirableCriteria[0], desirableCriteria[1]],
+    })
 
     // When I enter details on the search page
     searchPage.changeSearchParameters(newSearchParameters)
@@ -100,6 +131,12 @@ context('Placement Requests', () => {
     // Then I should see the search results
     Page.verifyOnPage(SearchPage, person.name)
 
+    // Then I should still see the essential criteria
+    searchPage.shouldShowEssentialCriteria(placementRequest.essentialCriteria)
+
+    // And the new desirable criteria should be selected
+    searchPage.shouldHaveCriteriaSelected(newSearchParameters.requiredCharacteristics)
+
     // And the parameters should be submitted to the API
     cy.task('verifySearchSubmit').then(requests => {
       expect(requests).to.have.length(numberOfSearches)
@@ -107,15 +144,20 @@ context('Placement Requests', () => {
       const initialSearchRequestBody = JSON.parse(requests[0].body)
       const secondSearchRequestBody = JSON.parse(requests[1].body)
 
+      // And the first request to the API should contain the criteria from the placement request
       expect(initialSearchRequestBody).to.contain({
-        durationDays: activePlacementRequest.duration * 7,
-        startDate: activePlacementRequest.expectedArrival,
-        postcodeDistrict: activePlacementRequest.location,
-        maxDistanceMiles: activePlacementRequest.radius,
+        durationDays: placementRequest.duration * 7,
+        startDate: placementRequest.expectedArrival,
+        postcodeDistrict: placementRequest.location,
+        maxDistanceMiles: placementRequest.radius,
       })
 
-      expect(initialSearchRequestBody.requiredCharacteristics).to.have.members(activePlacementRequest.essentialCriteria)
+      expect(initialSearchRequestBody.requiredCharacteristics).to.have.members([
+        ...placementRequest.essentialCriteria,
+        ...placementRequest.desirableCriteria,
+      ])
 
+      // And the second request to the API should contain the new criteria I submitted
       const durationDays = Number(newSearchParameters.durationWeeks) * 7
 
       expect(secondSearchRequestBody).to.contain({
@@ -125,19 +167,44 @@ context('Placement Requests', () => {
         maxDistanceMiles: Number(newSearchParameters.maxDistanceMiles),
       })
 
-      expect(secondSearchRequestBody.requiredCharacteristics).to.have.members(
-        newSearchParameters.requiredCharacteristics,
-      )
+      expect(secondSearchRequestBody.requiredCharacteristics).to.have.members([
+        ...placementRequest.essentialCriteria,
+        ...newSearchParameters.requiredCharacteristics,
+      ])
     })
+  })
 
-    // When I click on a booking
+  it('allows me to make a booking', () => {
+    // Given there is a placement request waiting for me to match
+    const placementRequest = placementRequestFactory.build({ status: 'notMatched' })
+    const bedSearchResults = bedSearchResultsFactory.build()
+
+    const bedSearchParameters = mapPlacementRequestToBedSearchParams(placementRequest)
+
+    cy.task('stubPlacementRequests', [placementRequest])
+    cy.task('stubBedSearch', { bedSearchResults })
+    cy.task('stubPlacementRequest', placementRequest)
+    cy.task('stubBookingFromPlacementRequest', placementRequest)
+
+    // When I visit the placementRequests dashboard
+    const listPage = ListPage.visit()
+
+    // And I click on a placement request
+    listPage.clickFindBed(placementRequest)
+
+    // And I click on the search button
+    const showPage = new PlacementRequestPage(placementRequest)
+    showPage.clickSearch()
+
+    // And I click to book a room
+    const searchPage = new SearchPage(placementRequest.person.name)
     searchPage.clickSearchResult(bedSearchResults.results[0])
 
     // Then I should be shown the confirmation page
     const confirmationPage = Page.verifyOnPage(ConfirmationPage)
 
     // And the confirmation page should contain the details of my booking
-    confirmationPage.shouldShowConfirmationDetails(bedSearchResults.results[0], newSearchParameters)
+    confirmationPage.shouldShowConfirmationDetails(bedSearchResults.results[0], bedSearchParameters)
 
     // When I click on the confirm button
     confirmationPage.clickConfirm()
@@ -146,16 +213,16 @@ context('Placement Requests', () => {
     Page.verifyOnPage(SuccessPage)
 
     // And the booking details should have been sent to the API
-    cy.task('verifyBookingFromPlacementRequest', activePlacementRequest).then(requests => {
+    cy.task('verifyBookingFromPlacementRequest', placementRequest).then(requests => {
       expect(requests).to.have.length(1)
 
       const body = JSON.parse(requests[0].body)
 
       expect(body).to.contain({
         bedId: bedSearchResults.results[0].bed.id,
-        arrivalDate: newSearchParameters.startDate,
+        arrivalDate: bedSearchParameters.startDate,
         departureDate: DateFormats.dateObjToIsoDate(
-          addWeeks(DateFormats.isoToDateObj(newSearchParameters.startDate), Number(newSearchParameters.durationWeeks)),
+          addWeeks(DateFormats.isoToDateObj(bedSearchParameters.startDate), Number(bedSearchParameters.durationWeeks)),
         ),
       })
     })

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -323,7 +323,6 @@ export interface BedSearchParametersUi {
   startDate: string
   postcodeDistrict: string
   requiredCharacteristics: Array<PlacementCriteria>
-  selectedRequiredCharacteristics?: Array<PlacementCriteria>
   crn: string
   applicationId: string
   assessmentId: string

--- a/server/controllers/match/search/bedSearchController.test.ts
+++ b/server/controllers/match/search/bedSearchController.test.ts
@@ -45,7 +45,7 @@ describe('bedSearchController', () => {
     describe('body params are sent', () => {
       it('it should render the search template with body params taking precedence over the placement request params', async () => {
         const query = mapPlacementRequestToBedSearchParams(placementRequest)
-        const body = { durationWeeks: '2' }
+        const body = { durationWeeks: '2', requiredCharacteristics: [] as Array<string> }
 
         const requestHandler = bedsController.search()
 
@@ -55,6 +55,7 @@ describe('bedSearchController', () => {
           pageHeading: 'Find a bed',
           bedSearchResults,
           placementRequest,
+          selectedDesirableCriteria: [],
           tier: placementRequest.risks.tier.value.level,
           formPath,
           ...query,
@@ -66,7 +67,7 @@ describe('bedSearchController', () => {
 
       it('should handle when a single selectedRequiredCharacteristic is sent', async () => {
         const query = mapPlacementRequestToBedSearchParams(placementRequest)
-        const body = { requiredCharacteristics: 'someRequiredCharacteristic' }
+        const body = { requiredCharacteristics: placementRequest.desirableCriteria[0] }
 
         const requestHandler = bedsController.search()
 
@@ -76,14 +77,17 @@ describe('bedSearchController', () => {
           pageHeading: 'Find a bed',
           bedSearchResults,
           placementRequest,
+          selectedDesirableCriteria: [placementRequest.desirableCriteria[0]],
           tier: placementRequest.risks.tier.value.level,
           formPath,
           ...query,
-          requiredCharacteristics: ['someRequiredCharacteristic'],
+          requiredCharacteristics: [placementRequest.desirableCriteria[0]],
         })
         expect(bedService.search).toHaveBeenCalledWith(token, {
           ...query,
-          ...{ requiredCharacteristics: ['someRequiredCharacteristic'] },
+          ...{
+            requiredCharacteristics: [placementRequest.desirableCriteria[0]],
+          },
         })
         expect(placementRequestService.getPlacementRequest).toHaveBeenCalledWith(token, placementRequest.id)
       })
@@ -100,6 +104,7 @@ describe('bedSearchController', () => {
           pageHeading: 'Find a bed',
           bedSearchResults,
           placementRequest,
+          selectedDesirableCriteria: placementRequest.desirableCriteria,
           tier: placementRequest.risks.tier.value.level,
           formPath,
           ...query,

--- a/server/controllers/match/search/bedSearchController.ts
+++ b/server/controllers/match/search/bedSearchController.ts
@@ -29,16 +29,20 @@ export default class BedSearchController {
       }
 
       params.startDate = startDateObjFromParams(params).startDate
-      params.requiredCharacteristics = [params.selectedRequiredCharacteristics || params.requiredCharacteristics].flat()
+      params.requiredCharacteristics = [params.requiredCharacteristics].flat()
 
       const bedSearchResults = await this.bedService.search(req.user.token, params as BedSearchParametersUi)
       const tier = placementRequest?.risks?.tier?.value?.level || 'N/A'
+      const selectedDesirableCriteria = placementRequest.desirableCriteria.filter(x =>
+        params.requiredCharacteristics.includes(x),
+      )
 
       res.render('match/search', {
         pageHeading: 'Find a bed',
         bedSearchResults,
         placementRequest,
         tier,
+        selectedDesirableCriteria,
         formPath: matchPaths.placementRequests.beds.search({ id: placementRequest.id }),
         ...params,
         ...startDateObjFromParams(params),

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -41,6 +41,34 @@ describe('MatchingInformation', () => {
 
       expect(page.body).toEqual(defaultArguments)
     })
+
+    it('should return accessibilityCriteria and specialistSupportCriteria as arrays if strings are provided', () => {
+      const page = new MatchingInformation(
+        {
+          ...defaultArguments,
+          accessibilityCriteria: 'hasHearingLoop',
+          specialistSupportCriteria: 'isSemiSpecialistMentalHealth',
+        } as unknown as MatchingInformationBody,
+        assessment,
+      )
+
+      expect(page.body.accessibilityCriteria).toEqual(['hasHearingLoop'])
+      expect(page.body.specialistSupportCriteria).toEqual(['isSemiSpecialistMentalHealth'])
+    })
+
+    it('should return empty arrays for accessibilityCriteria and specialistSupportCriteria as arrays if no data is provided', () => {
+      const page = new MatchingInformation(
+        {
+          ...defaultArguments,
+          accessibilityCriteria: undefined,
+          specialistSupportCriteria: undefined,
+        } as unknown as MatchingInformationBody,
+        assessment,
+      )
+
+      expect(page.body.accessibilityCriteria).toEqual([])
+      expect(page.body.specialistSupportCriteria).toEqual([])
+    })
   })
 
   itShouldHaveNextValue(new MatchingInformation(defaultArguments, assessment), '')

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
@@ -79,7 +79,21 @@ export default class MatchingInformation implements TasklistPage {
 
   specialistSupportOptions = specialistSupportOptions
 
-  constructor(public body: Partial<MatchingInformationBody>, public assessment: Assessment) {}
+  constructor(private _body: Partial<MatchingInformationBody>, public assessment: Assessment) {}
+
+  set body(value: MatchingInformationBody) {
+    this._body = value
+  }
+
+  get body(): MatchingInformationBody {
+    return {
+      ...this._body,
+      accessibilityCriteria: this._body.accessibilityCriteria ? [this._body.accessibilityCriteria].flat() : [],
+      specialistSupportCriteria: this._body.specialistSupportCriteria
+        ? [this._body.specialistSupportCriteria].flat()
+        : [],
+    } as MatchingInformationBody
+  }
 
   previous() {
     return 'dashboard'

--- a/server/testutils/factories/bedSearchParameters.ts
+++ b/server/testutils/factories/bedSearchParameters.ts
@@ -20,7 +20,6 @@ export const bedSearchParametersUiFactory = Factory.define<BedSearchParametersUi
   startDate: DateFormats.dateObjToIsoDate(faker.date.soon()),
   postcodeDistrict: 'SW11',
   requiredCharacteristics: faker.helpers.arrayElements(placementCriteria),
-  selectedRequiredCharacteristics: faker.helpers.arrayElements(placementCriteria),
   crn: 'ABC123',
   applicationId: faker.string.uuid(),
   assessmentId: faker.string.uuid(),

--- a/server/utils/assessments/placementRequestData.test.ts
+++ b/server/utils/assessments/placementRequestData.test.ts
@@ -67,8 +67,8 @@ describe('placementRequestData', () => {
     it('returns all essential criteria for essential and relevant matching information', () => {
       matchingInformation = createMock<MatchingInformationBody>({
         apType: 'isEsap',
-        specialistSupportCriteria: ['isSemiSpecialistMentalHealth'],
-        accessibilityCriteria: ['hasHearingLoop', 'hasTactileFlooring'],
+        specialistSupportCriteria: [],
+        accessibilityCriteria: [],
         isWheelchairDesignated: 'essential',
         isStepFreeDesignated: 'essential',
         isCatered: 'essential',
@@ -89,9 +89,6 @@ describe('placementRequestData', () => {
           'isWheelchairDesignated',
           'isStepFreeDesignated',
           'isCatered',
-          'isSemiSpecialistMentalHealth',
-          'hasHearingLoop',
-          'hasTactileFlooring',
           'acceptsSexOffenders',
           'acceptsChildSexOffenders',
           'acceptsNonSexualChildOffenders',
@@ -109,14 +106,21 @@ describe('placementRequestData', () => {
         isWheelchairDesignated: 'desirable',
         isStepFreeDesignated: 'desirable',
         isCatered: 'desirable',
-        specialistSupportCriteria: [],
-        accessibilityCriteria: [],
+        specialistSupportCriteria: ['isSemiSpecialistMentalHealth'],
+        accessibilityCriteria: ['hasHearingLoop', 'hasTactileFlooring'],
       })
 
       const result = criteriaFromMatchingInformation(matchingInformation)
 
       expect(result.desirableCriteria.sort()).toEqual(
-        ['isStepFreeDesignated', 'isWheelchairDesignated', 'isCatered'].sort(),
+        [
+          'isStepFreeDesignated',
+          'isWheelchairDesignated',
+          'isCatered',
+          'isSemiSpecialistMentalHealth',
+          'hasHearingLoop',
+          'hasTactileFlooring',
+        ].sort(),
       )
       expect(result.essentialCriteria).toEqual([])
     })

--- a/server/utils/assessments/placementRequestData.ts
+++ b/server/utils/assessments/placementRequestData.ts
@@ -90,8 +90,8 @@ export const criteriaFromMatchingInformation = (
     essentialCriteria.push(matchingInformation.apType)
   }
 
-  essentialCriteria.push(...matchingInformation.specialistSupportCriteria)
-  essentialCriteria.push(...matchingInformation.accessibilityCriteria)
+  desirableCriteria.push(...matchingInformation.specialistSupportCriteria)
+  desirableCriteria.push(...matchingInformation.accessibilityCriteria)
 
   Object.keys(placementRequirementOptions).forEach((requirement: PlacementRequirementCriteria) => {
     if (matchingInformation[requirement] === 'essential') {

--- a/server/utils/matchUtils.test.ts
+++ b/server/utils/matchUtils.test.ts
@@ -12,10 +12,12 @@ import {
   arrivalDateRow,
   bedCountRow,
   bedNameRow,
+  checkBoxesForCriteria,
   confirmationSummaryCardRows,
   decodeBedSearchResult,
   departureDateRow,
   encodeBedSearchResult,
+  groupedCheckboxes,
   mapApiParamsForUi,
   mapSearchParamCharacteristicsForUi,
   mapSearchResultCharacteristicsForUi,
@@ -26,7 +28,6 @@ import {
   placementLength,
   placementLengthRow,
   premisesNameRow,
-  searchFilter,
   startDateObjFromParams,
   summaryCardHeader,
   summaryCardRows,
@@ -34,18 +35,19 @@ import {
   translateApiCharacteristicForUi,
   unmatchedCharacteristics,
 } from './matchUtils'
-
-jest.mock('./placementCriteriaUtils', () => {
-  return {
-    placementCriteria: {
-      isESAP: 'ESAP',
-      isIAP: 'IAP',
-      isSemiSpecialistMentalHealth: 'Semi specialist mental health',
-    },
-  }
-})
+import {
+  accessibilityOptions,
+  apTypeOptions,
+  offenceAndRiskOptions,
+  placementRequirementOptions,
+  specialistSupportOptions,
+} from './placementCriteriaUtils'
 
 describe('matchUtils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe('matchedCharacteristics', () => {
     it('returns a list of the matched characteristics', () => {
       const actualCharacteristics = [
@@ -176,23 +178,42 @@ describe('matchUtils', () => {
     })
   })
 
-  describe('searchFilter', () => {
+  describe('checkBoxesForCriteria', () => {
     it('returns an array of checkboxes with the selectedValues selected and any empty values removed', () => {
-      const result = searchFilter(['isESAP', 'isIAP'])
+      const options = {
+        isESAP: 'ESAP',
+        isIAP: 'IAP',
+        isSemiSpecialistMentalHealth: 'Semi specialist mental health',
+      }
+      const result = checkBoxesForCriteria(options, ['isESAP', 'isIAP'])
 
       expect(result).toEqual([
         {
           checked: true,
+          id: 'isESAP',
           text: 'ESAP',
           value: 'isESAP',
         },
-        { text: 'IAP', value: 'isIAP', checked: true },
+        { text: 'IAP', value: 'isIAP', id: 'isIAP', checked: true },
         {
           checked: false,
+          id: 'isSemiSpecialistMentalHealth',
           text: 'Semi specialist mental health',
           value: 'isSemiSpecialistMentalHealth',
         },
       ])
+    })
+  })
+
+  describe('groupedCheckboxes', () => {
+    it('returns checkboxes grouped by category', () => {
+      expect(groupedCheckboxes([])).toEqual({
+        'Type of AP': checkBoxesForCriteria(apTypeOptions, []),
+        'Specialist AP': checkBoxesForCriteria(specialistSupportOptions, []),
+        'Placement Requirements': checkBoxesForCriteria(placementRequirementOptions, []),
+        'Risks and offences to consider': checkBoxesForCriteria(offenceAndRiskOptions, []),
+        'Would benefit from': checkBoxesForCriteria(accessibilityOptions, []),
+      })
     })
   })
 

--- a/server/utils/matchUtils.test.ts
+++ b/server/utils/matchUtils.test.ts
@@ -18,6 +18,7 @@ import {
   departureDateRow,
   encodeBedSearchResult,
   groupedCheckboxes,
+  groupedEssentialCriteria,
   mapApiParamsForUi,
   mapSearchParamCharacteristicsForUi,
   mapSearchResultCharacteristicsForUi,
@@ -28,6 +29,7 @@ import {
   placementLength,
   placementLengthRow,
   premisesNameRow,
+  selectedEssentialCriteria,
   startDateObjFromParams,
   summaryCardHeader,
   summaryCardRows,
@@ -39,6 +41,7 @@ import {
   accessibilityOptions,
   apTypeOptions,
   offenceAndRiskOptions,
+  placementCriteria,
   placementRequirementOptions,
   specialistSupportOptions,
 } from './placementCriteriaUtils'
@@ -213,6 +216,34 @@ describe('matchUtils', () => {
         'Placement Requirements': checkBoxesForCriteria(placementRequirementOptions, []),
         'Risks and offences to consider': checkBoxesForCriteria(offenceAndRiskOptions, []),
         'Would benefit from': checkBoxesForCriteria(accessibilityOptions, []),
+      })
+    })
+  })
+
+  describe('selectedEssentialCriteria', () => {
+    it('returns the translated selected essential criteria as an array', () => {
+      const criteria = {
+        foo: 'Foo',
+        bar: 'Bar',
+        baz: 'Baz',
+      }
+      expect(selectedEssentialCriteria(criteria, ['foo', 'fizz', 'buzz', 'bar'])).toEqual(['Foo', 'Bar'])
+    })
+  })
+
+  describe('groupedEssentialCriteria', () => {
+    it('groups criteria by their category, removing any empty criteria', () => {
+      const essentialCriteria = [
+        'isPipe',
+        'isSemiSpecialistMentalHealth',
+        'isRecoveryFocussed',
+        'isSuitableForVulnerable',
+      ]
+
+      expect(groupedEssentialCriteria(essentialCriteria)).toEqual({
+        'Type of AP': [placementCriteria.isPipe],
+        'Specialist AP': [placementCriteria.isSemiSpecialistMentalHealth, placementCriteria.isRecoveryFocussed],
+        'Risks and offences to consider': [placementCriteria.isSuitableForVulnerable],
       })
     })
   })

--- a/server/utils/matchUtils.ts
+++ b/server/utils/matchUtils.ts
@@ -8,7 +8,13 @@ import { BedSearchParametersUi, ObjectWithDateParts, SummaryListItem } from '../
 import { DateFormats } from './dateUtils'
 import { linkTo, sentenceCase } from './utils'
 import matchPaths from '../paths/match'
-import { placementCriteria } from './placementCriteriaUtils'
+import {
+  accessibilityOptions,
+  apTypeOptions,
+  offenceAndRiskOptions,
+  placementRequirementOptions,
+  specialistSupportOptions,
+} from './placementCriteriaUtils'
 
 type PlacementDates = {
   placementLength: number
@@ -17,6 +23,21 @@ type PlacementDates = {
 }
 
 export class InvalidBedSearchDataException extends Error {}
+
+export type SearchFilterCategories =
+  | 'accessibility'
+  | 'apType'
+  | 'offenceAndRisk'
+  | 'placementRequirements'
+  | 'specialistSupport'
+
+const groupedCriteria = {
+  apType: { title: 'Type of AP', options: apTypeOptions },
+  specialistSupport: { title: 'Specialist AP', options: specialistSupportOptions },
+  placementRequirements: { title: 'Placement Requirements', options: placementRequirementOptions },
+  offenceAndRisk: { title: 'Risks and offences to consider', options: offenceAndRiskOptions },
+  accessibility: { title: 'Would benefit from', options: accessibilityOptions },
+}
 
 export const mapUiParamsForApi = (query: BedSearchParametersUi): BedSearchParameters => ({
   ...query,
@@ -256,11 +277,22 @@ export const startDateObjFromParams = (params: { startDate: string } | ObjectWit
   return { startDate: params.startDate, ...DateFormats.isoDateToDateInputs(params.startDate, 'startDate') }
 }
 
-export const searchFilter = (selectedValues: Array<string>) =>
-  Object.keys(placementCriteria)
+export const groupedCheckboxes = (selectedValues: Array<string>) => {
+  return Object.keys(groupedCriteria).reduce((obj, k: SearchFilterCategories) => {
+    return {
+      ...obj,
+      [`${groupedCriteria[k].title}`]: checkBoxesForCriteria(groupedCriteria[k].options, selectedValues),
+    }
+  }, {})
+}
+
+export const checkBoxesForCriteria = (criteria: Record<string, string>, selectedValues: Array<string>) => {
+  return Object.keys(criteria)
     .map(criterion => ({
-      text: placementCriteria[criterion],
+      id: criterion,
+      text: criteria[criterion],
       value: criterion,
       checked: selectedValues.includes(criterion),
     }))
     .filter(item => item.text.length > 0)
+}

--- a/server/utils/matchUtils.ts
+++ b/server/utils/matchUtils.ts
@@ -277,6 +277,23 @@ export const startDateObjFromParams = (params: { startDate: string } | ObjectWit
   return { startDate: params.startDate, ...DateFormats.isoDateToDateInputs(params.startDate, 'startDate') }
 }
 
+export const groupedEssentialCriteria = (essentialCriteria: Array<string>) => {
+  return Object.keys(groupedCriteria).reduce((obj, k: SearchFilterCategories) => {
+    const selectedCriteria = selectedEssentialCriteria(groupedCriteria[k].options, essentialCriteria)
+    if (selectedCriteria.length) {
+      return {
+        ...obj,
+        [`${groupedCriteria[k].title}`]: selectedCriteria,
+      }
+    }
+    return obj
+  }, {})
+}
+
+export const selectedEssentialCriteria = (criteria: Record<string, string>, selectedCriteria: Array<string>) => {
+  return selectedCriteria.filter(key => key in criteria).map(key => criteria[key])
+}
+
 export const groupedCheckboxes = (selectedValues: Array<string>) => {
   return Object.keys(groupedCriteria).reduce((obj, k: SearchFilterCategories) => {
     return {

--- a/server/utils/placementRequests/utils.test.ts
+++ b/server/utils/placementRequests/utils.test.ts
@@ -42,7 +42,7 @@ describe('utils', () => {
         crn: person.crn,
         applicationId: placementRequest.applicationId,
         assessmentId: placementRequest.assessmentId,
-        requiredCharacteristics: placementRequest.essentialCriteria,
+        requiredCharacteristics: [...placementRequest.essentialCriteria, ...placementRequest.desirableCriteria],
       })
     })
   })

--- a/server/utils/placementRequests/utils.ts
+++ b/server/utils/placementRequests/utils.ts
@@ -10,6 +10,7 @@ import applyPaths from '../../paths/apply'
 export const mapPlacementRequestToBedSearchParams = ({
   duration,
   essentialCriteria,
+  desirableCriteria,
   expectedArrival,
   location,
   radius,
@@ -24,7 +25,7 @@ export const mapPlacementRequestToBedSearchParams = ({
   crn: person.crn,
   applicationId,
   assessmentId,
-  requiredCharacteristics: essentialCriteria,
+  requiredCharacteristics: [...essentialCriteria, ...desirableCriteria],
 })
 
 export const formatReleaseType = (placementRequest: PlacementRequest) => allReleaseTypes[placementRequest.releaseType]

--- a/server/views/match/search.njk
+++ b/server/views/match/search.njk
@@ -97,7 +97,7 @@
 							</div>
 						</div>
 
-						{% for title, items in MatchUtils.groupedCheckboxes(placementRequest.desirableCriteria) %}
+						{% for title, items in MatchUtils.groupedCheckboxes(selectedDesirableCriteria) %}
 							{{
 								govukCheckboxes({
 									name: 'requiredCharacteristics',

--- a/server/views/match/search.njk
+++ b/server/views/match/search.njk
@@ -65,15 +65,42 @@
 					<input type="hidden" name="startDate" value="{{startDate}}"/>
 					<input type="hidden" name="applicationId" value="{{applicationId}}"/>
 					<input type="hidden" name="assessmentId" value="{{assessmentId}}"/>
-					{% for requiredCharacteristic in requiredCharacteristics %}
+					{% for requiredCharacteristic in placementRequest.essentialCriteria %}
 						<input type="hidden" name="requiredCharacteristics[]" value="{{requiredCharacteristic}}"/>
 					{% endfor %}
 
 					<div class="govuk-grid-column-one-third">
+						<div class="moj-filter">
+							<div class="moj-filter__header">
+								<h2 class="govuk-heading-m">Filters</h2>
+							</div>
+							<div class="moj-filter__content">
+								<div class="moj-filter__selected">
+									<div class="moj-filter__selected-heading">
+										<div class="moj-filter__heading-title">
+											<h2 class="govuk-heading-m">Selected Filters</h2>
+										</div>
+									</div>
+									{% for title, items in MatchUtils.groupedEssentialCriteria(placementRequest.essentialCriteria) %}
+										<h3 class="govuk-heading-s govuk-!-margin-bottom-0">{{ title }}</h3>
+
+										<ul class="moj-filter-tags">
+											{% for item in items %}
+												<li>
+													<span class="moj-filter__tag">{{item}}</span>
+												</li>
+											{% endfor %}
+										</ul>
+									{% endfor %}
+
+								</div>
+							</div>
+						</div>
+
 						{% for title, items in MatchUtils.groupedCheckboxes(placementRequest.desirableCriteria) %}
 							{{
 								govukCheckboxes({
-									name: 'selectedRequiredCharacteristics',
+									name: 'requiredCharacteristics',
 									classes: "govuk-checkboxes--small",
 									fieldset: {
 										legend: {

--- a/server/views/match/search.njk
+++ b/server/views/match/search.njk
@@ -67,28 +67,32 @@
 					<input type="hidden" name="assessmentId" value="{{assessmentId}}"/>
 					{% for requiredCharacteristic in requiredCharacteristics %}
 						<input type="hidden" name="requiredCharacteristics[]" value="{{requiredCharacteristic}}"/>
-						{%endfor%}
+					{% endfor %}
 
-						<div class="govuk-grid-column-one-third">
-							{{govukCheckboxes({
-							name: 'selectedRequiredCharacteristics',
-							classes: "govuk-checkboxes--small",
-							fieldset: {
-								legend: {
-									text: 'Required characteristics',
-									isPageHeading: false,
-									classes: 'govuk-fieldset__legend--s'
-								}
-							},
-						items: MatchUtils.searchFilter(requiredCharacteristics)
-					})}}
-						</div>
+					<div class="govuk-grid-column-one-third">
+						{% for title, items in MatchUtils.groupedCheckboxes(placementRequest.desirableCriteria) %}
+							{{
+								govukCheckboxes({
+									name: 'selectedRequiredCharacteristics',
+									classes: "govuk-checkboxes--small",
+									fieldset: {
+										legend: {
+											text: title,
+											isPageHeading: false,
+											classes: 'govuk-fieldset__legend--s'
+										}
+									},
+									items: items
+								})
+							}}
+						{% endfor %}
+					</div>
 
-						<div class="govuk-grid-column-two-thirds">
+					<div class="govuk-grid-column-two-thirds">
 
-							<div class="bed-search-inputs">
+						<div class="bed-search-inputs">
 
-								{{ govukDateInput({
+							{{ govukDateInput({
 								id: "startDate",
 								namePrefix: "startDate",
 								fieldset: {
@@ -101,7 +105,7 @@
 								errorMessage: errors.startDate
 							}) }}
 
-								{{
+							{{
 								govukInput({
 								id: "durationWeeks",
 								name: "durationWeeks",
@@ -117,7 +121,7 @@
 								})
 							}}
 
-								{{ govukInput({
+							{{ govukInput({
 								id: "postcodeDistrict",
 								name: "postcodeDistrict",
 								value: postcodeDistrict,
@@ -127,7 +131,7 @@
 								classes: "govuk-input--width-3"
 							}) }}
 
-								{{ govukInput({
+							{{ govukInput({
 								id: "maxDistanceMiles",
 								name: "maxDistanceMiles",
 								value: maxDistanceMiles,
@@ -140,16 +144,16 @@
 								}
 							}) }}
 
-								<div class="button">
-									{{ govukButton({
+							<div class="button">
+								{{ govukButton({
 									text: "Update"
 								}) }}
-								</div>
 							</div>
-						</form>
+						</div>
+					</form>
 
-						{% for bedSearchResult in bedSearchResults.results %}
-							{{ govukSummaryList({
+					{% for bedSearchResult in bedSearchResults.results %}
+						{{ govukSummaryList({
 					card: {
 						title: {
 							html: MatchUtils.summaryCardHeader(bedSearchResult, placementRequest.id, startDate, durationWeeks)
@@ -157,9 +161,9 @@
 					},
 					rows: MatchUtils.summaryCardRows(bedSearchResult, requiredCharacteristics)
 				}) }}
-						{% endfor %}
-					</div>
+					{% endfor %}
 				</div>
 			</div>
+		</div>
 
-		{% endblock %}
+	{% endblock %}

--- a/server/views/match/search.njk
+++ b/server/views/match/search.njk
@@ -56,10 +56,15 @@
 		</div>
 		<div class="govuk-grid-row">
 			<div class="govuk-width-container">
+				<div class="govuk-grid-column-full">
+					<h2 class="govuk-heading-m">{{bedSearchResults.resultsBedCount}} matching beds in {{bedSearchResults.resultsRoomCount}} rooms in {{bedSearchResults.resultsPremisesCount}} premises</h2>
+				</div>
+			</div>
+		</div>
+		<div class="govuk-grid-row">
+			<div class="govuk-width-container">
 
 				<form action="{{formPath}}" method="post">
-					<h2 class="govuk-heading-m">{{bedSearchResults.resultsBedCount}} matching beds in {{bedSearchResults.resultsRoomCount}} rooms in {{bedSearchResults.resultsPremisesCount}} premises</h2>
-
 					<input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 					<input type="hidden" name="crn" value="{{crn}}"/>
 					<input type="hidden" name="startDate" value="{{startDate}}"/>


### PR DESCRIPTION
This updates the match screen to support both required and optional characteristics. If a characteristic is required, these are added in a hidden field and displayed in a Filter component similar to the MoJ component here - https://design-patterns.service.justice.gov.uk/components/filter/. I've had to tweak it a bit as our requirements are slightly different.

The characteristics are also broken up into categories to match the latest design changes.

## Screenshots

### Before

![Placement Requests -- shows a list of placementRequests](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/7ec1685c-83e5-4de1-a30f-7d5c60d9b36c)

### After

![Placement Requests -- allows me to make a booking](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/f1781857-df2a-402d-8569-12a262adfee3)

