### PR TITLE
(171) Allow placement requests to be created without a start date

### DIFF
--- a/integration_tests/tests/assess/assess.cy.ts
+++ b/integration_tests/tests/assess/assess.cy.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../server/testutils/factories'
 
 import { overwriteApplicationDocuments } from '../../../server/utils/assessments/documentUtils'
-import { placementRequestData } from '../../../server/utils/assessments/placementRequestData'
+import { acceptanceData } from '../../../server/utils/assessments/acceptanceData'
 
 import AssessHelper from '../../helpers/assess'
 import { ListPage, ShowPage, TaskListPage } from '../../pages/assess'
@@ -58,8 +58,7 @@ context('Assess', () => {
       expect(requests).to.have.length(1)
 
       const body = JSON.parse(requests[0].body)
-      expect(body).to.have.keys('document', 'requirements')
-      expect(body.requirements).to.deep.equal(placementRequestData(this.assessHelper.assessment))
+      expect(body).to.deep.equal(acceptanceData(this.assessHelper.assessment))
     })
   })
 

--- a/server/@types/shared/index.d.ts
+++ b/server/@types/shared/index.d.ts
@@ -115,6 +115,7 @@ export type { Person } from './models/Person';
 export type { PersonAcctAlert } from './models/PersonAcctAlert';
 export type { PersonRisks } from './models/PersonRisks';
 export type { PlacementCriteria } from './models/PlacementCriteria';
+export type { PlacementDates } from './models/PlacementDates';
 export type { PlacementRequest } from './models/PlacementRequest';
 export type { PlacementRequestStatus } from './models/PlacementRequestStatus';
 export type { PlacementRequirements } from './models/PlacementRequirements';

--- a/server/@types/shared/models/AssessmentAcceptance.ts
+++ b/server/@types/shared/models/AssessmentAcceptance.ts
@@ -3,10 +3,13 @@
 /* eslint-disable */
 
 import type { AnyValue } from './AnyValue';
+import type { PlacementDates } from './PlacementDates';
 import type { PlacementRequirements } from './PlacementRequirements';
 
 export type AssessmentAcceptance = {
     document: AnyValue;
-    requirements?: PlacementRequirements;
+    requirements: PlacementRequirements;
+    placementDates?: PlacementDates;
+    notes?: string;
 };
 

--- a/server/@types/shared/models/PlacementDates.ts
+++ b/server/@types/shared/models/PlacementDates.ts
@@ -1,0 +1,9 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type PlacementDates = {
+    expectedArrival: string;
+    duration: number;
+};
+

--- a/server/@types/shared/models/PlacementRequest.ts
+++ b/server/@types/shared/models/PlacementRequest.ts
@@ -6,11 +6,12 @@ import type { ApprovedPremisesUser } from './ApprovedPremisesUser';
 import type { AssessmentDecision } from './AssessmentDecision';
 import type { Person } from './Person';
 import type { PersonRisks } from './PersonRisks';
+import type { PlacementDates } from './PlacementDates';
 import type { PlacementRequestStatus } from './PlacementRequestStatus';
 import type { PlacementRequirements } from './PlacementRequirements';
 import type { ReleaseTypeOption } from './ReleaseTypeOption';
 
-export type PlacementRequest = (PlacementRequirements & {
+export type PlacementRequest = (PlacementRequirements & PlacementDates & {
     id: string;
     person: Person;
     risks: PersonRisks;
@@ -21,5 +22,6 @@ export type PlacementRequest = (PlacementRequirements & {
     assessmentDecision: AssessmentDecision;
     assessmentDate: string;
     assessor: ApprovedPremisesUser;
+    notes?: string;
 });
 

--- a/server/@types/shared/models/PlacementRequirements.ts
+++ b/server/@types/shared/models/PlacementRequirements.ts
@@ -9,12 +9,9 @@ import type { PlacementCriteria } from './PlacementCriteria';
 export type PlacementRequirements = {
     gender: Gender;
     type: ApType;
-    expectedArrival: string;
-    duration: number;
     location: string;
     radius: number;
     essentialCriteria: Array<PlacementCriteria>;
     desirableCriteria: Array<PlacementCriteria>;
-    notes?: string;
 };
 

--- a/server/services/assessmentService.test.ts
+++ b/server/services/assessmentService.test.ts
@@ -1,12 +1,12 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import { Request } from 'express'
-import { PlacementRequest } from '@approved-premises/api'
+import { AssessmentAcceptance } from '@approved-premises/api'
 
 import { AssessmentClient } from '../data'
 import AssessmentService from './assessmentService'
 import { assessmentFactory, assessmentSummaryFactory, clarificationNoteFactory } from '../testutils/factories'
 
-import { placementRequestData } from '../utils/assessments/placementRequestData'
+import { acceptanceData, placementRequestData } from '../utils/assessments/acceptanceData'
 import { getBody, updateAssessmentData } from '../form-pages/utils'
 import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
 import { DataServices, TaskListErrors } from '../@types/ui'
@@ -18,7 +18,7 @@ jest.mock('../data/assessmentClient.ts')
 jest.mock('../data/personClient.ts')
 jest.mock('../form-pages/utils')
 jest.mock('../utils/applications/utils')
-jest.mock('../utils/assessments/placementRequestData')
+jest.mock('../utils/assessments/acceptanceData')
 jest.mock('../utils/assessments/decisionUtils')
 
 describe('AssessmentService', () => {
@@ -150,18 +150,17 @@ describe('AssessmentService', () => {
   describe('submit', () => {
     const token = 'some-token'
     let document = { foo: [{ bar: 'baz' }] } as ApplicationOrAssessmentResponse
-    const requirements = createMock<PlacementRequest>()
+    const assessmentAcceptance = createMock<AssessmentAcceptance>()
     const assessment = assessmentFactory.build()
 
     it('if the assessment is accepted the accept client method is called', async () => {
       ;(applicationAccepted as jest.Mock).mockReturnValue(true)
-      ;(getResponses as jest.Mock).mockReturnValue(document)
-      ;(placementRequestData as jest.Mock).mockReturnValue(requirements)
+      ;(acceptanceData as jest.Mock).mockReturnValue(assessmentAcceptance)
 
       await service.submit(token, assessment)
 
       expect(assessmentClientFactory).toHaveBeenCalledWith(token)
-      expect(assessmentClient.acceptance).toHaveBeenCalledWith(assessment.id, { document, requirements })
+      expect(assessmentClient.acceptance).toHaveBeenCalledWith(assessment.id, assessmentAcceptance)
     })
 
     it('if the assessment is rejected the rejection client method is called with the rejectionRationale', async () => {

--- a/server/services/assessmentService.ts
+++ b/server/services/assessmentService.ts
@@ -7,7 +7,7 @@ import {
 } from '@approved-premises/api'
 import type { DataServices } from '@approved-premises/ui'
 
-import { placementRequestData } from '../utils/assessments/placementRequestData'
+import { acceptanceData } from '../utils/assessments/acceptanceData'
 import type { AssessmentClient, RestClientBuilder } from '../data'
 import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
 import { getBody, updateAssessmentData } from '../form-pages/utils'
@@ -66,15 +66,12 @@ export default class AssessmentService {
   async submit(token: string, assessment: Assessment) {
     const client = this.assessmentClientFactory(token)
 
-    const document = getResponses(assessment)
-
     if (!applicationAccepted(assessment)) {
+      const document = getResponses(assessment)
       return client.rejection(assessment.id, document, rejectionRationaleFromAssessmentResponses(assessment))
     }
 
-    const requirements = placementRequestData(assessment)
-
-    return client.acceptance(assessment.id, { document, requirements })
+    return client.acceptance(assessment.id, acceptanceData(assessment))
   }
 
   async createClarificationNote(token: string, assessmentId: string, clarificationNote: NewClarificationNote) {

--- a/server/utils/assessments/acceptanceData.test.ts
+++ b/server/utils/assessments/acceptanceData.test.ts
@@ -1,71 +1,107 @@
 import { createMock } from '@golevelup/ts-jest'
 import { mockOptionalQuestionResponse, mockQuestionResponse } from '../../testutils/mockQuestionResponse'
 import { MatchingInformationBody } from '../../form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation'
-import { criteriaFromMatchingInformation, placementRequestData } from './placementRequestData'
+import { acceptanceData, criteriaFromMatchingInformation, placementDates, placementRequestData } from './acceptanceData'
 import { assessmentFactory } from '../../testutils/factories'
 import { pageDataFromApplicationOrAssessment } from '../../form-pages/utils'
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
 import { placementDurationFromApplication } from './placementDurationFromApplication'
+import { getResponses } from '../applications/utils'
 
 jest.mock('../../form-pages/utils')
 jest.mock('../retrieveQuestionResponseFromApplicationOrAssessment')
 jest.mock('../applications/arrivalDateFromApplication')
 jest.mock('./placementDurationFromApplication')
 
-describe('placementRequestData', () => {
+describe('acceptanceData', () => {
   const assessment = assessmentFactory.build()
-  const expectedArrival = '2020-01-01'
 
-  let matchingInformation = createMock<MatchingInformationBody>({
-    apType: 'isESAP',
-    specialistSupportCriteria: [],
-    accessibilityCriteria: [],
-  })
+  describe('acceptanceData', () => {
+    it('should return the acceptance data for the assessment', () => {
+      mockOptionalQuestionResponse({ cruInformation: 'Some notes' })
 
-  ;(pageDataFromApplicationOrAssessment as jest.Mock).mockReturnValue(matchingInformation)
-  ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2020-01-01')
-
-  it('converts matching data into a placement request', () => {
-    mockQuestionResponse({ postcodeArea: 'ABC123', type: 'normal', duration: '12' })
-    mockOptionalQuestionResponse({
-      lengthOfStayAgreedDetail: '12',
-      alternativeRadius: '100',
-      cruInformation: 'Some notes',
-    })
-
-    expect(placementRequestData(assessment)).toEqual({
-      gender: 'male',
-      type: 'esap',
-      expectedArrival,
-      duration: '12',
-      location: 'ABC123',
-      radius: '100',
-      essentialCriteria: criteriaFromMatchingInformation(matchingInformation).essentialCriteria,
-      desirableCriteria: criteriaFromMatchingInformation(matchingInformation).desirableCriteria,
-      notes: 'Some notes',
+      expect(acceptanceData(assessment)).toEqual({
+        document: getResponses(assessment),
+        requirements: placementRequestData(assessment),
+        placementDates: placementDates(assessment),
+        notes: 'Some notes',
+      })
     })
   })
 
-  it('returns a default radius if one is not present', () => {
-    mockOptionalQuestionResponse({ lengthOfStayAgreedDetail: '12', alternativeRadius: undefined })
+  describe('placementDates', () => {
+    const expectedArrival = '2020-01-01'
 
-    const result = placementRequestData(assessment)
+    it('should return the placement dates if an arrival date is provided', () => {
+      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(expectedArrival)
 
-    expect(result.radius).toEqual(50)
+      mockOptionalQuestionResponse({ lengthOfStayAgreedDetail: '12' })
+
+      const result = placementDates(assessment)
+
+      expect(result.expectedArrival).toEqual(expectedArrival)
+      expect(result.duration).toEqual(12)
+    })
+
+    it('should return the default duration if a duration is not provided', () => {
+      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(expectedArrival)
+      ;(placementDurationFromApplication as jest.Mock).mockReturnValueOnce('52')
+
+      mockOptionalQuestionResponse({ lengthOfStayAgreedDetail: undefined })
+
+      const result = placementDates(assessment)
+
+      expect(result.expectedArrival).toEqual(expectedArrival)
+      expect(result.duration).toEqual(52)
+    })
+
+    it('should return null if the arrival date is not provided', () => {
+      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(undefined)
+
+      const result = placementDates(assessment)
+
+      expect(result).toBeNull()
+    })
   })
 
-  it('returns the default placement duration if one is not present', () => {
-    ;(placementDurationFromApplication as jest.Mock).mockReturnValueOnce(52)
-    mockOptionalQuestionResponse({ duration: undefined, alternativeRadius: '100' })
+  describe('placementRequestData', () => {
+    const matchingInformation = createMock<MatchingInformationBody>({
+      apType: 'isESAP',
+      specialistSupportCriteria: [],
+      accessibilityCriteria: [],
+    })
 
-    const result = placementRequestData(assessment)
+    ;(pageDataFromApplicationOrAssessment as jest.Mock).mockReturnValue(matchingInformation)
 
-    expect(result.duration).toEqual(52)
+    it('converts matching data into a placement request', () => {
+      mockQuestionResponse({ postcodeArea: 'ABC123', type: 'normal', duration: '12' })
+      mockOptionalQuestionResponse({
+        lengthOfStayAgreedDetail: '12',
+        alternativeRadius: '100',
+      })
+
+      expect(placementRequestData(assessment)).toEqual({
+        gender: 'male',
+        type: 'esap',
+        location: 'ABC123',
+        radius: '100',
+        essentialCriteria: criteriaFromMatchingInformation(matchingInformation).essentialCriteria,
+        desirableCriteria: criteriaFromMatchingInformation(matchingInformation).desirableCriteria,
+      })
+    })
+
+    it('returns a default radius if one is not present', () => {
+      mockOptionalQuestionResponse({ lengthOfStayAgreedDetail: '12', alternativeRadius: undefined })
+
+      const result = placementRequestData(assessment)
+
+      expect(result.radius).toEqual(50)
+    })
   })
 
   describe('criteriaFromMatchingInformation', () => {
     it('returns all essential criteria for essential and relevant matching information', () => {
-      matchingInformation = createMock<MatchingInformationBody>({
+      const matchingInformation = createMock<MatchingInformationBody>({
         apType: 'isESAP',
         specialistSupportCriteria: [],
         accessibilityCriteria: [],
@@ -101,7 +137,7 @@ describe('placementRequestData', () => {
     })
 
     it('returns all desirable criteria for desirable matching information', () => {
-      matchingInformation = createMock<MatchingInformationBody>({
+      const matchingInformation = createMock<MatchingInformationBody>({
         apType: 'normal',
         isWheelchairDesignated: 'desirable',
         isStepFreeDesignated: 'desirable',
@@ -126,7 +162,7 @@ describe('placementRequestData', () => {
     })
 
     it('returns empty objects for not relevant matching information', () => {
-      matchingInformation = createMock<MatchingInformationBody>({
+      const matchingInformation = createMock<MatchingInformationBody>({
         apType: 'normal',
         isWheelchairDesignated: 'notRelevant',
         isStepFreeDesignated: 'notRelevant',


### PR DESCRIPTION
This updates the placement requests acceptance functionality to only send placement date information if we know when a placement starts. If there is no placement date information, a placement request is not created by the API