### PR TITLE
(176) Add submit placement request flow

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -17,6 +17,7 @@ import assessments from './integration_tests/mockApis/assessments'
 import users from './integration_tests/mockApis/users'
 import tasks from './integration_tests/mockApis/tasks'
 import placementRequests from './integration_tests/mockApis/placementRequests'
+import placementApplication from './integration_tests/mockApis/placementApplication'
 import bedSearch from './integration_tests/mockApis/beds'
 
 import schemaValidator from './integration_tests/tasks/schemaValidator'
@@ -55,6 +56,7 @@ export default defineConfig({
         ...users,
         ...tasks,
         ...placementRequests,
+        ...placementApplication,
         ...bedSearch,
         stubApplicationJourney,
       })

--- a/integration_tests/mockApis/placementApplication.ts
+++ b/integration_tests/mockApis/placementApplication.ts
@@ -1,0 +1,50 @@
+import { SuperAgentRequest } from 'superagent'
+
+import type { PlacementApplication } from '@approved-premises/api'
+import { stubFor } from '../../wiremock'
+import paths from '../../server/paths/api'
+
+export default {
+  stubPlacementApplication: (placementApplication: PlacementApplication): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: paths.placementApplications.show({ id: placementApplication.id }),
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: placementApplication,
+      },
+    }),
+  stubPlacementApplicationUpdate: (args: { placementApplication: PlacementApplication }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'PUT',
+        url: paths.placementApplications.update({
+          id: args.placementApplication.id,
+        }),
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.placementApplication,
+      },
+    }),
+  stubCreatePlacementApplication: (placementApplication: PlacementApplication): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: paths.placementApplications.create.pattern,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: placementApplication,
+      },
+    }),
+}

--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -10,6 +10,11 @@ export default class ShowPage extends Page {
     super('View Application')
   }
 
+  static visit(application: ApprovedPremisesApplication) {
+    cy.visit(`/applications/${application.id}`)
+    return new ShowPage(application)
+  }
+
   shouldShowPersonInformation() {
     cy.get('[data-cy-section="person-details"]').within(() => {
       this.assertDefinition('Name', this.application.person.name)

--- a/integration_tests/pages/match/placementRequestForm/reasonForPlacement.ts
+++ b/integration_tests/pages/match/placementRequestForm/reasonForPlacement.ts
@@ -1,0 +1,24 @@
+import paths from '../../../../server/paths/placementApplications'
+
+import Page from '../../page'
+
+export default class ReasonForPlacementPage extends Page {
+  constructor() {
+    super('Request a placement')
+  }
+
+  static visit(placementRequestId: string): ReasonForPlacementPage {
+    cy.visit(
+      paths.placementApplications.pages.show({
+        id: placementRequestId,
+        task: 'request-a-placement',
+        page: 'reason-for-placement',
+      }),
+    )
+    return new ReasonForPlacementPage()
+  }
+
+  completeForm() {
+    this.checkRadioByNameAndValue('reason', 'paroleBoard')
+  }
+}

--- a/integration_tests/tests/match/placementApplications.cy.ts
+++ b/integration_tests/tests/match/placementApplications.cy.ts
@@ -1,0 +1,43 @@
+import { applicationFactory, placementApplicationFactory } from '../../../server/testutils/factories'
+import { ShowPage } from '../../pages/apply'
+import ReasonForPlacementPage from '../../pages/match/placementRequestForm/reasonForPlacement'
+
+context('Placement Applications', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+  })
+
+  beforeEach(() => {
+    cy.signIn()
+  })
+
+  it('allows me to complete form', () => {
+    // Given I have completed an application I am viewing a completed application
+    const completedApplication = applicationFactory.build({ status: 'submitted', id: '123' })
+    cy.task('stubApplicationGet', { application: completedApplication })
+    cy.task('stubApplications', [completedApplication])
+
+    // And there is a placement application in the DB
+    const placementApplicationId = '123'
+    const placementApplication = placementApplicationFactory.build({ id: placementApplicationId })
+    cy.task('stubCreatePlacementApplication', placementApplication)
+    cy.task('stubPlacementApplication', placementApplication)
+
+    // When I visit the readonly application view
+    const showPage = ShowPage.visit(completedApplication)
+
+    // Then I should be able to click submit
+    showPage.clickSubmit()
+
+    // When I visit the placement request page
+    const placementReasonPage = ReasonForPlacementPage.visit(placementApplicationId)
+
+    // Then I can complete the form
+    placementReasonPage.completeForm()
+
+    // And submit it
+    placementReasonPage.clickSubmit()
+  })
+})

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -2,6 +2,7 @@ import {
   Application,
   ApprovedPremisesApplicationSummary as ApplicationSummary,
   ApprovedPremisesApplication,
+  ApprovedPremisesAssessment,
   ArrayOfOASysOffenceDetailsQuestions,
   ArrayOfOASysRiskManagementPlanQuestions,
   ArrayOfOASysRiskOfSeriousHarmSummaryQuestions,
@@ -15,6 +16,7 @@ import {
   OASysSection,
   Person,
   PersonAcctAlert,
+  PlacementApplication,
   PlacementCriteria,
   PlacementRequest,
   PlacementRequestStatus,
@@ -274,7 +276,7 @@ export type OasysImportArrays =
 
 export type OasysSummariesSection = { [index: string]: OasysImportArrays }
 
-export type JourneyType = 'applications' | 'assessments'
+export type JourneyType = 'applications' | 'assessments' | 'placement-applications'
 
 export type ServiceSection = {
   id: string
@@ -329,3 +331,5 @@ export interface BedSearchParametersUi {
 }
 
 export type ReleaseTypeOptions = Record<ReleaseTypeOption, string>
+
+export type FormArtifact = ApprovedPremisesApplication | ApprovedPremisesAssessment | PlacementApplication

--- a/server/controllers/apply/applications/pagesController.test.ts
+++ b/server/controllers/apply/applications/pagesController.test.ts
@@ -65,7 +65,7 @@ describe('pagesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(getPage).toHaveBeenCalledWith('some-task', 'some-page')
+      expect(getPage).toHaveBeenCalledWith('some-task', 'some-page', 'applications')
       expect(applicationService.initializePage).toHaveBeenCalledWith(PageConstructor, request, dataServices, {})
 
       expect(response.render).toHaveBeenCalledWith('applications/pages/some/view', {

--- a/server/controllers/apply/applications/pagesController.ts
+++ b/server/controllers/apply/applications/pagesController.ts
@@ -20,7 +20,7 @@ export default class PagesController {
   show(taskName: string, pageName: string): RequestHandler {
     return async (req: Request, res: Response, next: NextFunction) => {
       try {
-        const Page = getPage(taskName, pageName)
+        const Page = getPage(taskName, pageName, 'applications')
 
         const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
         const page = await this.applicationService.initializePage(Page, req, this.dataServices, userInput)
@@ -45,7 +45,7 @@ export default class PagesController {
 
   update(taskName: string, pageName: string) {
     return async (req: Request, res: Response) => {
-      const Page = getPage(taskName, pageName)
+      const Page = getPage(taskName, pageName, 'applications')
       const page = await this.applicationService.initializePage(Page, req, this.dataServices)
 
       try {

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -9,15 +9,19 @@ import AllocationsController from './tasks/allocationsController'
 
 import type { Services } from '../services'
 import DashboardController from './dashboardController'
+import PagesController from './placementApplications/pagesController'
 
 export const controllers = (services: Services) => {
   const dashboardController = new DashboardController()
   const tasksController = new TasksController(services.taskService, services.applicationService)
   const allocationsController = new AllocationsController(services.taskService)
+  const placementApplicationPagesController = new PagesController(services.placementApplicationService)
+
   return {
     dashboardController,
     tasksController,
     allocationsController,
+    placementApplicationPagesController,
     ...applyControllers(services),
     ...assessControllers(services),
     ...matchControllers(services),

--- a/server/controllers/match/index.ts
+++ b/server/controllers/match/index.ts
@@ -7,9 +7,12 @@ import BookingsController from './placementRequests/bookingsController'
 import type { Services } from '../../services'
 
 export const controllers = (services: Services) => {
-  const { placementRequestService, bedService } = services
+  const { placementApplicationService, placementRequestService, bedService } = services
 
-  const placementRequestController = new PlacementRequestController(placementRequestService)
+  const placementRequestController = new PlacementRequestController(
+    placementRequestService,
+    placementApplicationService,
+  )
   const bedController = new BedSearchController(bedService, placementRequestService)
   const placementRequestBookingsController = new BookingsController(placementRequestService)
 

--- a/server/controllers/match/placementRequestsController.ts
+++ b/server/controllers/match/placementRequestsController.ts
@@ -1,8 +1,12 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
-import { PlacementRequestService } from '../../services'
+import { PlacementApplicationService, PlacementRequestService } from '../../services'
+import paths from '../../paths/placementApplications'
 
 export default class PlacementRequestsController {
-  constructor(private readonly placementRequestService: PlacementRequestService) {}
+  constructor(
+    private readonly placementRequestService: PlacementRequestService,
+    private readonly placementApplicationService: PlacementApplicationService,
+  ) {}
 
   index(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
@@ -23,6 +27,20 @@ export default class PlacementRequestsController {
         pageHeading: `Matching information for ${placementRequest.person.name}`,
         placementRequest,
       })
+    }
+  }
+
+  create(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      const application = await this.placementApplicationService.create(req.user.token, req.body.applicationId)
+
+      return res.redirect(
+        paths.placementApplications.pages.show({
+          id: application.id,
+          task: 'request-a-placement',
+          page: 'reason-for-placement',
+        }),
+      )
     }
   }
 }

--- a/server/controllers/placementApplications/pagesController.test.ts
+++ b/server/controllers/placementApplications/pagesController.test.ts
@@ -1,0 +1,183 @@
+import type { NextFunction, Request, Response } from 'express'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import createError from 'http-errors'
+
+import type { DataServices, ErrorsAndUserInput, FormPages } from '@approved-premises/ui'
+import PagesController from './pagesController'
+import { PlacementApplicationService } from '../../services'
+import TasklistPage from '../../form-pages/tasklistPage'
+import PlacementRequest from '../../form-pages/placement-application'
+import { getPage } from '../../utils/applications/utils'
+
+import {
+  catchAPIErrorOrPropogate,
+  catchValidationErrorOrPropogate,
+  fetchErrorsAndUserInput,
+} from '../../utils/validation'
+import { UnknownPageError } from '../../utils/errors'
+import paths from '../../paths/placementApplications'
+import { viewPath } from '../../form-pages/utils'
+
+jest.mock('../../utils/validation')
+jest.mock('../../form-pages/utils')
+jest.mock('../../utils/applications/utils')
+jest.mock('../../form-pages/placement-application', () => {
+  return {
+    pages: { 'my-task': {} },
+  }
+})
+
+PlacementRequest.pages = {} as FormPages
+
+describe('pagesController', () => {
+  const request: DeepMocked<Request> = createMock<Request>({})
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = jest.fn()
+
+  const placementApplicationService = createMock<PlacementApplicationService>({})
+  const dataServices = createMock<DataServices>({}) as DataServices
+
+  const PageConstructor = jest.fn()
+  const page = createMock<TasklistPage>({})
+
+  let pagesController: PagesController
+
+  beforeEach(() => {
+    pagesController = new PagesController(placementApplicationService)
+    placementApplicationService.initializePage.mockResolvedValue(page)
+    ;(getPage as jest.Mock).mockReturnValue(PageConstructor)
+  })
+
+  describe('show', () => {
+    beforeEach(() => {
+      request.params = {
+        id: 'some-uuid',
+      }
+      ;(viewPath as jest.Mock).mockReturnValue('placement-application/pages/some/view')
+    })
+
+    it('renders a page', async () => {
+      ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
+        return { errors: {}, errorSummary: [], userInput: {} }
+      })
+
+      const requestHandler = pagesController.show('some-task', 'some-page')
+
+      await requestHandler(request, response, next)
+
+      expect(getPage).toHaveBeenCalledWith('some-task', 'some-page', 'placement-applications')
+      expect(placementApplicationService.initializePage).toHaveBeenCalledWith(
+        PageConstructor,
+        request,
+        dataServices,
+        {},
+      )
+
+      expect(response.render).toHaveBeenCalledWith('placement-application/pages/some/view', {
+        placementRequestId: request.params.id,
+        task: 'some-task',
+        page,
+        errors: {},
+        errorSummary: [],
+        ...page.body,
+      })
+    })
+
+    it('shows errors and user input when returning from an error state', async () => {
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
+
+      const requestHandler = pagesController.show('some-task', 'some-page')
+
+      await requestHandler(request, response, next)
+
+      expect(placementApplicationService.initializePage).toHaveBeenCalledWith(
+        PageConstructor,
+        request,
+        dataServices,
+        errorsAndUserInput.userInput,
+      )
+
+      expect(response.render).toHaveBeenCalledWith('placement-application/pages/some/view', {
+        placementRequestId: request.params.id,
+        task: 'some-task',
+        page,
+        errors: errorsAndUserInput.errors,
+        errorSummary: errorsAndUserInput.errorSummary,
+        ...page.body,
+      })
+    })
+
+    it('returns a 404 when the page cannot be found', async () => {
+      placementApplicationService.initializePage.mockImplementation(() => {
+        throw new UnknownPageError('some-page')
+      })
+
+      const requestHandler = pagesController.show('some-task', 'some-page')
+
+      await requestHandler(request, response, next)
+
+      expect(next).toHaveBeenCalledWith(createError(404, 'Not found'))
+    })
+
+    it('calls catchAPIErrorOrPropogate if the error is not an unknown page error', async () => {
+      const genericError = new Error()
+
+      placementApplicationService.initializePage.mockImplementation(() => {
+        throw genericError
+      })
+
+      const requestHandler = pagesController.show('some-task', 'some-page')
+
+      await requestHandler(request, response, next)
+
+      expect(catchAPIErrorOrPropogate).toHaveBeenCalledWith(request, response, genericError)
+    })
+  })
+
+  describe('update', () => {
+    beforeEach(() => {
+      request.params = {
+        id: 'some-uuid',
+      }
+
+      placementApplicationService.initializePage.mockResolvedValue(page)
+    })
+
+    it('updates an placement request and redirects to the next page', async () => {
+      page.next.mockReturnValue('next-page')
+
+      placementApplicationService.save.mockResolvedValue()
+
+      const requestHandler = pagesController.update('some-task', 'page-name')
+
+      await requestHandler({ ...request }, response)
+
+      expect(placementApplicationService.save).toHaveBeenCalledWith(page, request)
+
+      expect(response.redirect).toHaveBeenCalledWith(
+        paths.placementApplications.pages.show({ id: request.params.id, task: 'some-task', page: 'next-page' }),
+      )
+    })
+
+    it('sets a flash and redirects if there are errors', async () => {
+      const err = new Error()
+      placementApplicationService.save.mockImplementation(() => {
+        throw err
+      })
+
+      const requestHandler = pagesController.update('some-task', 'page-name')
+
+      await requestHandler(request, response)
+
+      expect(placementApplicationService.save).toHaveBeenCalledWith(page, request)
+
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+        request,
+        response,
+        err,
+        paths.placementApplications.pages.show({ id: request.params.id, task: 'some-task', page: 'page-name' }),
+      )
+    })
+  })
+})

--- a/server/controllers/placementApplications/pagesController.ts
+++ b/server/controllers/placementApplications/pagesController.ts
@@ -1,0 +1,64 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express'
+import createError from 'http-errors'
+
+import { getPage } from '../../utils/applications/utils'
+import { PlacementApplicationService } from '../../services'
+
+import {
+  catchAPIErrorOrPropogate,
+  catchValidationErrorOrPropogate,
+  fetchErrorsAndUserInput,
+} from '../../utils/validation'
+import paths from '../../paths/placementApplications'
+import { UnknownPageError } from '../../utils/errors'
+import { viewPath } from '../../form-pages/utils'
+
+export default class PagesController {
+  constructor(private readonly placementApplicationService: PlacementApplicationService) {}
+
+  show(taskName: string, pageName: string): RequestHandler {
+    return async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const Page = getPage(taskName, pageName, 'placement-applications')
+
+        const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
+        const page = await this.placementApplicationService.initializePage(Page, req, {}, userInput)
+
+        res.render(viewPath(page, 'placement-applications'), {
+          placementRequestId: req.params.id,
+          errors,
+          errorSummary,
+          task: taskName,
+          page,
+          ...page.body,
+        })
+      } catch (e) {
+        if (e instanceof UnknownPageError) {
+          next(createError(404, 'Not found'))
+        } else {
+          catchAPIErrorOrPropogate(req, res, e)
+        }
+      }
+    }
+  }
+
+  update(taskName: string, pageName: string) {
+    return async (req: Request, res: Response) => {
+      const Page = getPage(taskName, pageName, 'placement-applications')
+      const page = await this.placementApplicationService.initializePage(Page, req, {})
+
+      try {
+        await this.placementApplicationService.save(page, req)
+
+        res.redirect(paths.placementApplications.pages.show({ id: req.params.id, task: taskName, page: page.next() }))
+      } catch (err) {
+        catchValidationErrorOrPropogate(
+          req,
+          res,
+          err,
+          paths.placementApplications.pages.show({ id: req.params.id, task: taskName, page: pageName }),
+        )
+      }
+    }
+  }
+}

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -24,6 +24,7 @@ import ApplicationClient from './applicationClient'
 import AssessmentClient from './assessmentClient'
 import TaskClient from './taskClient'
 import PlacementRequestClient from './placementRequestClient'
+import PlacementApplicationClient from './placementApplicationClient'
 import BedClient from './bedClient'
 
 type RestClientBuilder<T> = (token: string) => T
@@ -42,6 +43,8 @@ export const dataAccess = () => ({
   taskClientBuilder: ((token: string) => new TaskClient(token)) as RestClientBuilder<TaskClient>,
   placementRequestClientBuilder: ((token: string) =>
     new PlacementRequestClient(token)) as RestClientBuilder<PlacementRequestClient>,
+  placementApplicationClientBuilder: ((token: string) =>
+    new PlacementApplicationClient(token)) as RestClientBuilder<PlacementApplicationClient>,
   bedClientBuilder: ((token: string) => new BedClient(token)) as RestClientBuilder<BedClient>,
 })
 

--- a/server/data/placementApplicationClient.test.ts
+++ b/server/data/placementApplicationClient.test.ts
@@ -1,0 +1,96 @@
+import PlacementApplicationClient from './placementApplicationClient'
+import paths from '../paths/api'
+
+import { placementApplicationFactory } from '../testutils/factories'
+import describeClient from '../testutils/describeClient'
+
+describeClient('placementApplicationClient', provider => {
+  let placementApplicationClient: PlacementApplicationClient
+
+  const token = 'token-1'
+
+  beforeEach(() => {
+    placementApplicationClient = new PlacementApplicationClient(token)
+  })
+
+  describe('find', () => {
+    it('makes a get request to the placementApplication endpoint', async () => {
+      const placementApplication = placementApplicationFactory.build()
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get a placement application',
+        withRequest: {
+          method: 'GET',
+          path: paths.placementApplications.show({ id: placementApplication.id }),
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: placementApplication,
+        },
+      })
+
+      const result = await placementApplicationClient.find(placementApplication.id)
+
+      expect(result).toEqual(placementApplication)
+    })
+  })
+  describe('create', () => {
+    it('should return a placement application when a application ID is posted', async () => {
+      const applicationId = '123'
+      const placementApplication = placementApplicationFactory.build()
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to create a placement application',
+        withRequest: {
+          method: 'POST',
+          path: paths.placementApplications.create({ id: applicationId }),
+          body: {
+            applicationId,
+          },
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: placementApplication,
+        },
+      })
+
+      const result = await placementApplicationClient.create(applicationId)
+      expect(result).toEqual(placementApplication)
+    })
+  })
+
+  describe('update', () => {
+    it('updates and returns a placement application', async () => {
+      const placementApplication = placementApplicationFactory.build()
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to update a placement application',
+        withRequest: {
+          method: 'PUT',
+          path: paths.placementApplications.update({ id: placementApplication.id }),
+          body: placementApplication,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: placementApplication,
+        },
+      })
+
+      const result = await placementApplicationClient.update(placementApplication)
+
+      expect(result).toEqual(placementApplication)
+    })
+  })
+})

--- a/server/data/placementApplicationClient.ts
+++ b/server/data/placementApplicationClient.ts
@@ -1,0 +1,32 @@
+import { PlacementApplication } from '@approved-premises/api'
+import config, { ApiConfig } from '../config'
+import RestClient from './restClient'
+import paths from '../paths/api'
+
+export default class PlacementApplicationClient {
+  restClient: RestClient
+
+  constructor(token: string) {
+    this.restClient = new RestClient('placementApplicationClient', config.apis.approvedPremises as ApiConfig, token)
+  }
+
+  async find(id: string): Promise<PlacementApplication> {
+    return (await this.restClient.get({
+      path: paths.placementApplications.show({ id }),
+    })) as Promise<PlacementApplication>
+  }
+
+  async create(applicationId: string): Promise<PlacementApplication> {
+    return (await this.restClient.post({
+      path: paths.placementApplications.create({}),
+      data: { applicationId },
+    })) as Promise<PlacementApplication>
+  }
+
+  async update(placementApplication: PlacementApplication): Promise<PlacementApplication> {
+    return (await this.restClient.put({
+      path: paths.placementApplications.update({ id: placementApplication.id }),
+      data: placementApplication,
+    })) as Promise<PlacementApplication>
+  }
+}

--- a/server/form-pages/placement-application/index.ts
+++ b/server/form-pages/placement-application/index.ts
@@ -1,0 +1,8 @@
+/* istanbul ignore file */
+
+import { Form } from '../utils/decorators'
+import BaseForm from '../baseForm'
+import RequestAPlacement from './request-a-placement'
+
+@Form({ sections: [RequestAPlacement] })
+export default class PlacementRequest extends BaseForm {}

--- a/server/form-pages/placement-application/request-a-placement/index.ts
+++ b/server/form-pages/placement-application/request-a-placement/index.ts
@@ -1,0 +1,15 @@
+/* istanbul ignore file */
+
+import ReasonsForPlacement from './reason-for-placement'
+import { Section, Task } from '../../utils/decorators'
+
+@Task({
+  name: 'Request a placement',
+  slug: 'request-a-placement',
+  pages: [ReasonsForPlacement],
+})
+@Section({
+  title: 'Request a Placement',
+  tasks: [RequestAPlacement],
+})
+export default class RequestAPlacement {}

--- a/server/form-pages/placement-application/request-a-placement/reason-for-placement.test.ts
+++ b/server/form-pages/placement-application/request-a-placement/reason-for-placement.test.ts
@@ -1,0 +1,43 @@
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+
+import ReasonForPlacement from './reason-for-placement'
+
+describe('ReasonForPlacement', () => {
+  describe('title', () => {
+    expect(new ReasonForPlacement({}).title).toBe('Request a placement')
+  })
+
+  describe('body', () => {
+    it('should set the body', () => {
+      const page = new ReasonForPlacement({
+        reason: 'rotl',
+      })
+      expect(page.body).toEqual({
+        reason: 'rotl',
+      })
+    })
+  })
+
+  itShouldHaveNextValue(new ReasonForPlacement({}), '')
+  itShouldHavePreviousValue(new ReasonForPlacement({}), '')
+
+  describe('errors', () => {
+    it('if no response is given an error is returned', () => {
+      expect(new ReasonForPlacement({}).errors()).toEqual({
+        reason: 'You must state the reason for placement',
+      })
+    })
+  })
+
+  describe('response', () => {
+    it("If the response is 'no' only the response is returned", () => {
+      expect(
+        new ReasonForPlacement({
+          reason: 'rotl',
+        }).response(),
+      ).toEqual({
+        'Why are you requesting a placement?': 'Release on Temporary Licence (ROTL)',
+      })
+    })
+  })
+})

--- a/server/form-pages/placement-application/request-a-placement/reason-for-placement.ts
+++ b/server/form-pages/placement-application/request-a-placement/reason-for-placement.ts
@@ -1,0 +1,43 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+
+import TasklistPage from '../../tasklistPage'
+import { Page } from '../../utils/decorators'
+
+const reasons = {
+  paroleBoard: 'Release directed following parole board or other hearing/decision',
+  rotl: 'Release on Temporary Licence (ROTL)',
+  existingApplication: 'An additional placement on an existing application',
+} as const
+
+type Reason = keyof typeof reasons
+
+@Page({ name: 'reason-for-placement', bodyProperties: ['reason'] })
+export default class ReasonForPlacement implements TasklistPage {
+  title = 'Request a placement'
+
+  question = 'Why are you requesting a placement?'
+
+  reasons = reasons
+
+  constructor(public body: { reason?: Reason }) {}
+
+  previous() {
+    return ''
+  }
+
+  next() {
+    return ''
+  }
+
+  response() {
+    return { [this.question]: this.reasons[this.body.reason] }
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.reason) errors.reason = 'You must state the reason for placement'
+
+    return errors
+  }
+}

--- a/server/form-pages/tasklistPage.ts
+++ b/server/form-pages/tasklistPage.ts
@@ -1,17 +1,12 @@
 /* istanbul ignore file */
 
-import type { DataServices, PageResponse, TaskListErrors } from '@approved-premises/ui'
-import { ApprovedPremisesApplication, ApprovedPremisesAssessment } from '@approved-premises/api'
+import type { DataServices, FormArtifact, PageResponse, TaskListErrors } from '@approved-premises/ui'
 
 export interface TasklistPageInterface {
-  new (
-    body: Record<string, unknown>,
-    document?: ApprovedPremisesApplication | ApprovedPremisesAssessment,
-    previousPage?: string,
-  ): TasklistPage
+  new (body: Record<string, unknown>, document?: FormArtifact, previousPage?: string): TasklistPage
   initialize?(
     body: Record<string, unknown>,
-    document: ApprovedPremisesApplication | ApprovedPremisesAssessment,
+    document: FormArtifact,
     token: string,
     dataServices: DataServices,
   ): Promise<TasklistPage>

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -1,7 +1,7 @@
-import type { JourneyType, UiTask, YesOrNo, YesOrNoWithDetail } from '@approved-premises/ui'
+import type { FormArtifact, JourneyType, UiTask, YesOrNo, YesOrNoWithDetail } from '@approved-premises/ui'
 import type { Request } from 'express'
 import TasklistPage, { TasklistPageInterface } from '../tasklistPage'
-import { ApprovedPremisesApplication, ApprovedPremisesAssessment } from '../../@types/shared'
+import { ApprovedPremisesAssessment } from '../../@types/shared'
 import { sentenceCase } from '../../utils/utils'
 
 export const applyYesOrNo = <K extends string>(key: K, body: Record<string, unknown>): YesOrNoWithDetail<K> => {
@@ -97,7 +97,7 @@ export const updateAssessmentData = (
 
 export function getBody(
   Page: TasklistPageInterface,
-  application: ApprovedPremisesApplication | ApprovedPremisesAssessment,
+  application: FormArtifact,
   request: Request,
   userInput: Record<string, unknown>,
 ) {
@@ -110,10 +110,7 @@ export function getBody(
   return pageDataFromApplicationOrAssessment(Page, application)
 }
 
-export function pageDataFromApplicationOrAssessment(
-  Page: TasklistPageInterface,
-  application: ApprovedPremisesApplication | ApprovedPremisesAssessment,
-) {
+export function pageDataFromApplicationOrAssessment(Page: TasklistPageInterface, application: FormArtifact) {
   const pageName = getPageName(Page)
   const taskName = getTaskName(Page)
 

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -38,6 +38,9 @@ const tasksPath = path('/tasks')
 const placementRequestsPath = path('/placement-requests')
 const placementRequestPath = placementRequestsPath.path(':id')
 
+const placementApplicationsPath = path('/placement-applications')
+const placementApplicationPath = placementApplicationsPath.path(':id')
+
 const tasksPaths = {
   index: tasksPath,
   allocations: {
@@ -127,6 +130,11 @@ export default {
     index: placementRequestsPath,
     show: placementRequestPath,
     booking: placementRequestPath.path('booking'),
+  },
+  placementApplications: {
+    update: placementApplicationPath,
+    create: placementApplicationsPath,
+    show: placementApplicationPath,
   },
   people: {
     risks: {

--- a/server/paths/match.ts
+++ b/server/paths/match.ts
@@ -3,11 +3,13 @@ import { path } from 'static-path'
 const placementRequestsPath = path('/placement-requests')
 const placementRequestPath = placementRequestsPath.path(':id')
 const placementRequestBookingsPath = placementRequestPath.path('bookings')
+const newPlacementRequestPath = placementRequestsPath.path('new')
 
 export default {
   placementRequests: {
     index: placementRequestsPath,
     show: placementRequestPath,
+    create: newPlacementRequestPath,
     bookings: {
       confirm: placementRequestBookingsPath.path('confirm'),
       create: placementRequestBookingsPath,

--- a/server/paths/placementApplications.ts
+++ b/server/paths/placementApplications.ts
@@ -1,0 +1,16 @@
+import { path } from 'static-path'
+
+const placementApplicationsPath = path('/placement-applications')
+const placementApplicationPath = placementApplicationsPath.path(':id')
+const pagesPath = placementApplicationPath.path('tasks/:task/pages/:page')
+
+export default {
+  placementApplications: {
+    create: placementApplicationsPath,
+    show: placementApplicationPath,
+    pages: {
+      show: pagesPath,
+      update: pagesPath,
+    },
+  },
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -10,6 +10,7 @@ import assessRoutes from './assess'
 import matchRoutes from './match'
 import manageRoutes from './manage'
 import tasksRoutes from './tasks'
+import placementApplicationRoutes from './placementApplications'
 
 export default function routes(controllers: Controllers): Router {
   const router = Router()
@@ -25,6 +26,7 @@ export default function routes(controllers: Controllers): Router {
   matchRoutes(controllers, router)
   manageRoutes(controllers, router)
   tasksRoutes(controllers, router)
+  placementApplicationRoutes(controllers, router)
 
   return router
 }

--- a/server/routes/placementApplications.ts
+++ b/server/routes/placementApplications.ts
@@ -1,0 +1,28 @@
+/* istanbul ignore file */
+
+import type { Router } from 'express'
+
+import type { Controllers } from '../controllers'
+import paths from '../paths/placementApplications'
+import Match from '../form-pages/placement-application'
+
+import actions from './utils'
+
+export default function routes(controllers: Controllers, router: Router): Router {
+  const { get, put, post } = actions(router)
+  const { pages } = Match
+
+  const { placementApplicationPagesController, placementRequestController } = controllers
+
+  post(paths.placementApplications.create.pattern, placementRequestController.create())
+
+  Object.keys(pages).forEach((taskKey: string) => {
+    Object.keys(pages[taskKey]).forEach((pageKey: string) => {
+      const { pattern } = paths.placementApplications.show.path(`tasks/${taskKey}/pages/${pageKey}`)
+      get(pattern, placementApplicationPagesController.show(taskKey, pageKey))
+      put(pattern, placementApplicationPagesController.update(taskKey, pageKey))
+    })
+  })
+
+  return router
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -15,6 +15,7 @@ import ApplicationService from './applicationService'
 import AssessmentService from './assessmentService'
 import TaskService from './taskService'
 import PlacementRequestService from './placementRequestService'
+import PlacementApplicationService from './placementApplicationService'
 import BedService from './bedService'
 
 export const services = () => {
@@ -30,6 +31,7 @@ export const services = () => {
     userClientBuilder,
     taskClientBuilder,
     placementRequestClientBuilder,
+    placementApplicationClientBuilder,
     bedClientBuilder,
   } = dataAccess()
 
@@ -46,6 +48,7 @@ export const services = () => {
   const assessmentService = new AssessmentService(assessmentClientBuilder)
   const taskService = new TaskService(taskClientBuilder)
   const placementRequestService = new PlacementRequestService(placementRequestClientBuilder)
+  const placementApplicationService = new PlacementApplicationService(placementApplicationClientBuilder)
   const bedService = new BedService(bedClientBuilder)
 
   return {
@@ -62,6 +65,7 @@ export const services = () => {
     assessmentService,
     taskService,
     placementRequestService,
+    placementApplicationService,
     bedService,
   }
 }
@@ -82,5 +86,6 @@ export {
   AssessmentService,
   TaskService,
   PlacementRequestService,
+  PlacementApplicationService,
   BedService,
 }

--- a/server/services/placementApplicationService.ts
+++ b/server/services/placementApplicationService.ts
@@ -1,0 +1,63 @@
+import { DataServices } from '@approved-premises/ui'
+import type { Request } from 'express'
+import { PlacementApplication } from '@approved-premises/api'
+import { RestClientBuilder } from '../data'
+import PlacementApplicationClient from '../data/placementApplicationClient'
+import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
+import { getBody, getPageName, getTaskName } from '../form-pages/utils'
+import { ValidationError } from '../utils/errors'
+
+export default class PlacementApplicationService {
+  constructor(private readonly placementApplicationClientFactory: RestClientBuilder<PlacementApplicationClient>) {}
+
+  async getPlacementApplication(token: string, id: string): Promise<PlacementApplication> {
+    const placementApplicationClient = this.placementApplicationClientFactory(token)
+
+    return placementApplicationClient.find(id)
+  }
+
+  async create(token: string, applicationId: string): Promise<PlacementApplication> {
+    const placementApplicationClient = this.placementApplicationClientFactory(token)
+    return placementApplicationClient.create(applicationId)
+  }
+
+  async initializePage(
+    Page: TasklistPageInterface,
+    request: Request,
+    dataServices: DataServices,
+    userInput?: Record<string, unknown>,
+  ): Promise<TasklistPage> {
+    const placementApplication = await this.getPlacementApplication(request.user.token, request.params.id)
+
+    const body = getBody(Page, placementApplication, request, userInput)
+
+    const page = Page.initialize
+      ? await Page.initialize(body, placementApplication, request.user.token, dataServices)
+      : new Page(body, placementApplication, request.session.previousPage)
+
+    return page
+  }
+
+  async save(page: TasklistPage, request: Request) {
+    const errors = page.errors()
+
+    if (Object.keys(errors).length) {
+      throw new ValidationError<typeof page>(errors)
+    } else {
+      const placementApplication = (await this.getPlacementApplication(
+        request.user.token,
+        request.params.id,
+      )) as PlacementApplication
+      const client = this.placementApplicationClientFactory(request.user.token)
+
+      const pageName = getPageName(page.constructor)
+      const taskName = getTaskName(page.constructor)
+
+      placementApplication.data = placementApplication.data || {}
+      placementApplication.data[taskName] = placementApplication.data[taskName] || {}
+      placementApplication.data[taskName][pageName] = page.body
+
+      await client.update(placementApplication)
+    }
+  }
+}

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -36,6 +36,7 @@ import nonArrivalFactory from './nonArrival'
 import oasysSectionsFactory, { roshSummaryFactory } from './oasysSections'
 import oasysSelectionFactory from './oasysSelection'
 import personFactory from './person'
+import placementApplicationFactory from './placementApplication'
 import placementRequestFactory from './placementRequest'
 import premisesFactory from './premises'
 import prisonCaseNotesFactory from './prisonCaseNotes'
@@ -87,6 +88,7 @@ export {
   oasysSectionsFactory,
   oasysSelectionFactory,
   personFactory,
+  placementApplicationFactory,
   placementRequestFactory,
   premisesFactory,
   prisonCaseNotesFactory,

--- a/server/testutils/factories/placementApplication.ts
+++ b/server/testutils/factories/placementApplication.ts
@@ -1,0 +1,16 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { PlacementApplication } from '../../@types/shared'
+import { DateFormats } from '../../utils/dateUtils'
+
+export default Factory.define<PlacementApplication>(() => ({
+  id: faker.string.uuid(),
+  applicationId: faker.string.uuid(),
+  createdByUserId: faker.string.uuid(),
+  schemaVersion: faker.string.uuid(),
+  outdatedSchema: false,
+  createdAt: DateFormats.dateObjToIsoDateTime(faker.date.recent()),
+  submittedAt: DateFormats.dateObjToIsoDateTime(faker.date.recent()),
+  data: {},
+  document: {},
+}))

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -3,6 +3,7 @@ import { applicationFactory, applicationSummaryFactory, tierEnvelopeFactory } fr
 import paths from '../../paths/apply'
 import Apply from '../../form-pages/apply'
 import Assess from '../../form-pages/assess'
+import PlacementRequest from '../../form-pages/placement-application'
 import { DateFormats } from '../dateUtils'
 import { isApplicableTier, tierBadge } from '../personUtils'
 
@@ -17,9 +18,13 @@ import {
 } from './utils'
 import { UnknownPageError } from '../errors'
 
+jest.mock('../personUtils')
+jest.mock('../retrieveQuestionResponseFromApplicationOrAssessment')
+
 const FirstApplyPage = jest.fn()
 const SecondApplyPage = jest.fn()
 const AssessPage = jest.fn()
+const PlacementRequestPage = jest.fn()
 
 jest.mock('../../form-pages/apply', () => {
   return {
@@ -34,8 +39,11 @@ jest.mock('../../form-pages/assess', () => {
   }
 })
 
-jest.mock('../personUtils')
-jest.mock('../retrieveQuestionResponseFromApplicationOrAssessment')
+jest.mock('../../form-pages/placement-application', () => {
+  return {
+    pages: { 'placement-request-page': {} },
+  }
+})
 
 Apply.pages['basic-information'] = {
   first: FirstApplyPage,
@@ -44,6 +52,10 @@ Apply.pages['basic-information'] = {
 
 Assess.pages['assess-page'] = {
   first: AssessPage,
+}
+
+PlacementRequest.pages['placement-request-page'] = {
+  first: PlacementRequestPage,
 }
 
 describe('utils', () => {
@@ -70,17 +82,21 @@ describe('utils', () => {
 
   describe('getPage', () => {
     it('should return a page from Apply if it exists', () => {
-      expect(getPage('basic-information', 'first')).toEqual(FirstApplyPage)
-      expect(getPage('basic-information', 'second')).toEqual(SecondApplyPage)
+      expect(getPage('basic-information', 'first', 'applications')).toEqual(FirstApplyPage)
+      expect(getPage('basic-information', 'second', 'applications')).toEqual(SecondApplyPage)
     })
 
-    it('should return a page from assess if passed the option', () => {
-      expect(getPage('assess-page', 'first', true)).toEqual(AssessPage)
+    it('should return a page from assess if passed the an assessment', () => {
+      expect(getPage('assess-page', 'first', 'assessments')).toEqual(AssessPage)
+    })
+
+    it('should return a page from the placement request journey if passed the placement requests', () => {
+      expect(getPage('placement-request-page', 'first', 'placement-applications')).toEqual(PlacementRequestPage)
     })
 
     it('should raise an error if the page is not found', async () => {
       expect(() => {
-        getPage('basic-information', 'bar')
+        getPage('basic-information', 'bar', 'applications')
       }).toThrow(UnknownPageError)
     })
   })

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -1,4 +1,11 @@
-import type { ApplicationType, PageResponse, TableRow } from '@approved-premises/ui'
+import type {
+  ApplicationType,
+  FormArtifact,
+  FormPages,
+  JourneyType,
+  PageResponse,
+  TableRow,
+} from '@approved-premises/ui'
 import type {
   ApprovedPremisesApplication as Application,
   ApprovedPremisesApplicationSummary as ApplicationSummary,
@@ -13,7 +20,6 @@ import { isApplicableTier, tierBadge } from '../personUtils'
 import { DateFormats } from '../dateUtils'
 import { TasklistPageInterface } from '../../form-pages/tasklistPage'
 import Assess from '../../form-pages/assess'
-import isAssessment from '../assessments/isAssessment'
 import { arrivalDateFromApplication } from './arrivalDateFromApplication'
 import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromApplicationOrAssessment'
 import ExceptionDetails from '../../form-pages/apply/reasons-for-placement/basic-information/exceptionDetails'
@@ -91,8 +97,8 @@ const getResponseForPage = (formArtifact: FormArtifact, taskName: string, pageNa
   return page.response()
 }
 
-const getPage = (taskName: string, pageName: string, isAnAssessment?: boolean): TasklistPageInterface => {
-  const pageList = isAnAssessment ? Assess.pages[taskName] : Apply.pages[taskName]
+const getPage = (taskName: string, pageName: string, journeyType: JourneyType): TasklistPageInterface => {
+  const pageList = journeyPages(journeyType)[taskName]
 
   const Page = pageList[pageName]
 

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -17,6 +17,8 @@ import isAssessment from '../assessments/isAssessment'
 import { arrivalDateFromApplication } from './arrivalDateFromApplication'
 import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromApplicationOrAssessment'
 import ExceptionDetails from '../../form-pages/apply/reasons-for-placement/basic-information/exceptionDetails'
+import { journeyTypeFromArtifact } from '../journeyTypeFromArtifact'
+import PlacementRequest from '../../form-pages/placement-application'
 
 const dashboardTableRows = (applications: Array<ApplicationSummary>): Array<TableRow> => {
   return applications.map(application => {
@@ -99,6 +101,19 @@ const getPage = (taskName: string, pageName: string, isAnAssessment?: boolean): 
   }
 
   return Page as TasklistPageInterface
+}
+
+const journeyPages = (journeyType: JourneyType): FormPages => {
+  switch (journeyType) {
+    case 'applications':
+      return Apply.pages
+    case 'assessments':
+      return Assess.pages
+    case 'placement-applications':
+      return PlacementRequest.pages
+    default:
+      throw new Error(`Unknown journey type: ${journeyType}`)
+  }
 }
 
 const isInapplicable = (application: Application): boolean => {

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -80,15 +80,11 @@ const getResponsesForTask = (
   return responsesForPages
 }
 
-const getResponseForPage = (
-  applicationOrAssessment: Application | Assessment,
-  taskName: string,
-  pageName: string,
-): PageResponse => {
-  const Page = getPage(taskName, pageName, isAssessment(applicationOrAssessment))
+const getResponseForPage = (formArtifact: FormArtifact, taskName: string, pageName: string): PageResponse => {
+  const Page = getPage(taskName, pageName, journeyTypeFromArtifact(formArtifact))
 
-  const body = applicationOrAssessment?.data?.[taskName]?.[pageName]
-  const page = new Page(body, applicationOrAssessment)
+  const body = formArtifact?.data?.[taskName]?.[pageName]
+  const page = new Page(body, formArtifact)
 
   return page.response()
 }

--- a/server/utils/assessments/isAssessment.ts
+++ b/server/utils/assessments/isAssessment.ts
@@ -1,7 +1,5 @@
-import {
-  ApprovedPremisesApplication as Application,
-  ApprovedPremisesAssessment as Assessment,
-} from '../../@types/shared'
+import { ApprovedPremisesAssessment as Assessment } from '../../@types/shared'
+import { FormArtifact } from '../../@types/ui'
 
-export default (applicationOrAssessment: Application | Assessment): applicationOrAssessment is Assessment =>
-  (applicationOrAssessment as Assessment)?.allocatedAt !== undefined
+export default (formArtifact: FormArtifact): formArtifact is Assessment =>
+  (formArtifact as Assessment)?.allocatedAt !== undefined

--- a/server/utils/journeyTypeFromArtifact.test.ts
+++ b/server/utils/journeyTypeFromArtifact.test.ts
@@ -1,0 +1,22 @@
+import { applicationFactory, assessmentFactory, placementApplicationFactory } from '../testutils/factories'
+import { journeyTypeFromArtifact } from './journeyTypeFromArtifact'
+
+describe('journeyTypeFromArtifact', () => {
+  it('returns "placementRequest" if the artifact is a placement request', () => {
+    const placementApplication = placementApplicationFactory.build()
+
+    expect(journeyTypeFromArtifact(placementApplication)).toEqual('placement-applications')
+  })
+
+  it('returns "application" if the artifact is an application', () => {
+    const application = applicationFactory.build()
+
+    expect(journeyTypeFromArtifact(application)).toEqual('applications')
+  })
+
+  it('returns "assessment" if the artifact is an assessment', () => {
+    const assessment = assessmentFactory.build()
+
+    expect(journeyTypeFromArtifact(assessment)).toEqual('assessments')
+  })
+})

--- a/server/utils/journeyTypeFromArtifact.ts
+++ b/server/utils/journeyTypeFromArtifact.ts
@@ -1,0 +1,9 @@
+import { FormArtifact, JourneyType } from '../@types/ui'
+import isAssessment from './assessments/isAssessment'
+import { isPlacementApplication } from './placementRequests/isPlacementApplication'
+
+export const journeyTypeFromArtifact = (artifact: FormArtifact): JourneyType => {
+  if (isAssessment(artifact)) return 'assessments'
+  if (isPlacementApplication(artifact)) return 'placement-applications'
+  return 'applications'
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -46,6 +46,7 @@ import applyPaths from '../paths/apply'
 import assessPaths from '../paths/assess'
 import tasksPaths from '../paths/tasks'
 import matchPaths from '../paths/match'
+import placementApplicationsPaths from '../paths/placementApplications'
 import { radioMatrixTable } from './radioMatrixTable'
 
 import config from '../config'
@@ -149,7 +150,14 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
     },
   )
 
-  njkEnv.addGlobal('paths', { ...managePaths, ...applyPaths, ...assessPaths, ...tasksPaths, ...matchPaths })
+  njkEnv.addGlobal('paths', {
+    ...managePaths,
+    ...applyPaths,
+    ...assessPaths,
+    ...tasksPaths,
+    ...matchPaths,
+    ...placementApplicationsPaths,
+  })
 
   njkEnv.addGlobal('linkTo', linkTo)
 

--- a/server/utils/placementRequests/isPlacementApplication.test.ts
+++ b/server/utils/placementRequests/isPlacementApplication.test.ts
@@ -1,0 +1,19 @@
+import { applicationFactory, assessmentFactory, placementApplicationFactory } from '../../testutils/factories'
+import { isPlacementApplication } from './isPlacementApplication'
+
+describe('isPlacementApplication', () => {
+  it('returns true if the document is an placementRequest', () => {
+    const placementApplication = placementApplicationFactory.build()
+    expect(isPlacementApplication(placementApplication)).toBe(true)
+  })
+
+  it('returns false if the document is an application', () => {
+    const application = applicationFactory.build()
+    expect(isPlacementApplication(application)).toBe(false)
+  })
+
+  it('returns false if the document is an assessment', () => {
+    const assessment = assessmentFactory.build()
+    expect(isPlacementApplication(assessment)).toBe(false)
+  })
+})

--- a/server/utils/placementRequests/isPlacementApplication.ts
+++ b/server/utils/placementRequests/isPlacementApplication.ts
@@ -1,0 +1,6 @@
+import { PlacementApplication } from '../../@types/shared'
+import { FormArtifact } from '../../@types/ui'
+
+export const isPlacementApplication = (formArtifact: FormArtifact): formArtifact is PlacementApplication => {
+  return (formArtifact as PlacementApplication)?.applicationId !== undefined
+}

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -36,6 +36,13 @@
         {% endfor %}
       {% endfor %}
 
+      <form action="{{paths.placementApplications.create({}) }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+        <input type="hidden" name="applicationId" value="{{ application.id }}"/>
+        {{ govukButton({
+          text: "Create placement request"
+        }) }}
+      </form>
     </div>
   </div>
 {% endblock %}

--- a/server/views/placement-applications/layout.njk
+++ b/server/views/placement-applications/layout.njk
@@ -1,0 +1,48 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% from "../components/formFields/form-page-radios/macro.njk" import formPageRadios %}
+{% from "../components/formFields/form-page-date-input/macro.njk" import formPageDateInput %}
+{% from "../components/formFields/form-page-input/macro.njk" import formPageInput %}
+{% from "../components/formFields/form-page-checkboxes/macro.njk" import formPageCheckboxes %}
+{% from "../components/formFields/form-page-textarea/macro.njk" import formPageTextarea %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + page.title %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+    {% if page.previous() %}
+        {{ govukBackLink({
+      text: "Back",
+      href: paths.placementRequests.pages.show({ id: placementRequestId, task: task, page: page.previous() })
+    }) }}
+    {% endif %}
+{% endblock %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="{{ columnClasses | default("govuk-grid-column-two-thirds") }}">
+            <form action="{{ paths.placementApplications.pages.update({ id: placementRequestId, task: task, page: page.name }) }}?_method=PUT" method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+                {{ showErrorSummary(errorSummary) }}
+
+                {% block questions %}{% endblock %}
+
+                {{ govukButton({
+                    text: "Submit"
+                }) }}
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/server/views/placement-applications/pages/request-a-placement/reason-for-placement.njk
+++ b/server/views/placement-applications/pages/request-a-placement/reason-for-placement.njk
@@ -1,0 +1,17 @@
+{% extends "../../layout.njk" %}
+
+{% block questions %}
+    <h1 class="govuk-heading-l">{{page.title}}</h1>
+
+    {{ formPageRadios({
+      fieldName: "reason",
+      fieldset: {
+        legend: {
+          text: page.question,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items:convertKeyValuePairToRadioItems(page.reasons, page.reason)
+    }, fetchContext()) }}
+
+{% endblock %}


### PR DESCRIPTION
# Context
[Trello card](https://trello.com/c/ncPgE6LL/176-add-a-flow-to-create-and-submit-a-placement-request)

Users need to be able to create Placement Requests from completed Applications.
This be in the form of a form completed via the read-only view of applications.
This PR is the first step towards having that form and does a lot of the behind-the-scenes heavy lifting to enable it.

# Changes in this PR
Following the approach used for assessments in #469 we add new client and service methods for creating and saving Placement Requests. 
We then add a 'pages controller' which allows the user to navigate through the form. 
Following this we add the first page of the form in order to prove it works through E2E tests. 
We then add the button to start this form journey from the read-only application view.

## Screenshots of UI changes
![placementReasonPage](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/37435716-6350-488d-bc91-db3be6afd11a)

![Placement Requests -- allows me to complete form](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/bf9eb904-12ae-4900-bd23-54f0f680a903)

