### PR TITLE
Correct next page from oral hearing page

### DIFF
--- a/server/form-pages/apply/reasons-for-placement/basic-information/oralHearing.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/oralHearing.test.ts
@@ -37,7 +37,7 @@ describe('OralHearing', () => {
     })
   })
 
-  itShouldHaveNextValue(new OralHearing({}, application), '')
+  itShouldHaveNextValue(new OralHearing({}, application), 'placement-purpose')
   itShouldHavePreviousValue(new OralHearing({}, application), 'release-date')
 
   describe('errors', () => {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/oralHearing.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/oralHearing.ts
@@ -48,7 +48,7 @@ export default class OralHearing implements TasklistPage {
   }
 
   next() {
-    return ''
+    return 'placement-purpose'
   }
 
   previous() {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.test.ts
@@ -4,8 +4,10 @@ import { noticeTypeFromApplication } from '../../../../utils/applications/notice
 import { applicationFactory } from '../../../../testutils/factories'
 
 import PlacementPurpose from './placementPurpose'
+import { retrieveQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromApplicationOrAssessment'
 
 jest.mock('../../../../utils/applications/noticeTypeFromApplication')
+jest.mock('../../../../utils/retrieveQuestionResponseFromApplicationOrAssessment')
 
 describe('PlacementPurpose', () => {
   const application = applicationFactory.build()
@@ -70,11 +72,19 @@ describe('PlacementPurpose', () => {
   itShouldHaveNextValue(new PlacementPurpose({ placementPurposes: ['publicProtection'] }, application), '')
 
   describe('when the notice type is standard', () => {
-    beforeEach(() => {
+    describe('when the applicant knows the release date', () => {
       ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('standard')
+      ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue('yes')
+
+      expect(new PlacementPurpose({}, application).previous()).toBe('placement-date')
     })
 
-    itShouldHavePreviousValue(new PlacementPurpose({}, application), 'placement-purpose')
+    describe('when the applicant doesnt know the release date', () => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('standard')
+      ;(retrieveQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue('no')
+
+      expect(new PlacementPurpose({}, application).previous()).toBe('oral-hearing')
+    })
   })
 
   describe('when the notice type is emergency', () => {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.ts
@@ -5,6 +5,8 @@ import { Page } from '../../../utils/decorators'
 import TasklistPage from '../../../tasklistPage'
 import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
 import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
+import { retrieveQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromApplicationOrAssessment'
+import ReleaseDate from './releaseDate'
 
 export const placementPurposes = {
   publicProtection: 'Public protection',
@@ -49,7 +51,17 @@ export default class PlacementPurpose implements TasklistPage {
 
   previous() {
     if (noticeTypeFromApplication(this.application) === 'standard') {
-      return 'placement-purpose'
+      const knowReleaseDate = retrieveQuestionResponseFromApplicationOrAssessment(
+        this.application,
+        ReleaseDate,
+        'knowReleaseDate',
+      )
+
+      if (knowReleaseDate === 'no') {
+        return 'oral-hearing'
+      }
+
+      return 'placement-date'
     }
 
     return 'reason-for-short-notice'


### PR DESCRIPTION
Previously we weren't showing the placement purpose page if the person selected that they don't know when the oral hearing date is.
This PR corrects this and ensures that the 'previous' function returns correctly from the placement purpose page.