### PR TITLE
Make arrivalDate date nullable on placement-duration page

### DIFF
--- a/server/form-pages/apply/move-on/placementDuration.ts
+++ b/server/form-pages/apply/move-on/placementDuration.ts
@@ -95,9 +95,9 @@ export default class PlacementDuration implements TasklistPage {
     }
   }
 
-  private fetchDepartureDate(): Date {
+  private fetchDepartureDate(): Date | null {
     const standardPlacementDuration = getDefaultPlacementDurationInWeeks(this.application)
 
-    return addDays(this.arrivalDate, 7 * standardPlacementDuration)
+    return this.arrivalDate ? addDays(this.arrivalDate, 7 * standardPlacementDuration) : null
   }
 }

--- a/server/views/applications/pages/move-on/placement-duration.njk
+++ b/server/views/applications/pages/move-on/placement-duration.njk
@@ -6,15 +6,17 @@
 
   <h1 class="govuk-heading-l">{{ page.title }}</h2>
 
-  <h2 class="govuk-heading-m"> Expected dates of stay in Approved Premises:</h2>
+  {% if page.arrivalDate %}
+    <h2 class="govuk-heading-m"> Expected dates of stay in Approved Premises:</h2>
 
-  <p class="govuk-body">
-    <strong>Arrival date:</strong>
-    {{dateObjToUIDate(page.arrivalDate)}}</p>
+    <p class="govuk-body">
+      <strong>Arrival date:</strong>
+      {{dateObjToUIDate(page.arrivalDate)}}</p>
 
-  <p class="govuk-body">
-    <strong>Departure date:</strong>
-    {{dateObjToUIDate(page.departureDate)}}</p>
+    <p class="govuk-body">
+      <strong>Departure date:</strong>
+      {{dateObjToUIDate(page.departureDate)}}</p>
+  {% endif %}
 
   {{ govukDetails({
       summaryText: "View guidance on AP placement duration",


### PR DESCRIPTION
Now that applications can be submitted without arrival dates this page won’t work without an arrival date.
To ensure it will work we hide the expected stay and no longer calculate the departureDate if the arrivalDate is truthy

