### PR TITLE
Allow arrival date to be null in application summary

### DIFF
--- a/server/utils/tasks/index.test.ts
+++ b/server/utils/tasks/index.test.ts
@@ -21,39 +21,77 @@ describe('index', () => {
   })
 
   describe('applicationSummary', () => {
-    beforeEach(() => {
-      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
+    describe('when the application contains an arrival date', () => {
+      beforeEach(() => {
+        ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
+      })
+
+      it('returns the summary list when the assessment has a staff member allocated', () => {
+        const application = applicationFactory.build()
+
+        expect(applicationSummary(application)).toEqual([
+          {
+            key: {
+              text: 'CRN',
+            },
+            value: {
+              text: application.person.crn,
+            },
+          },
+          {
+            key: {
+              text: 'Arrival date',
+            },
+            value: {
+              text: DateFormats.isoDateToUIDate(arrivalDateFromApplication(application)),
+            },
+          },
+          {
+            key: {
+              text: 'Application Type',
+            },
+            value: {
+              text: getApplicationType(application),
+            },
+          },
+        ])
+      })
     })
+    describe('when the application doesnt have an arrival date', () => {
+      beforeEach(() => {
+        ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(null)
+      })
 
-    it('returns the summary list when the assessment has a staff member allocated', () => {
-      const application = applicationFactory.build()
+      it('returns the summary list when the assessment has a staff member allocated', () => {
+        const application = applicationFactory.build()
 
-      expect(applicationSummary(application)).toEqual([
-        {
-          key: {
-            text: 'CRN',
+        expect(applicationSummary(application)).toEqual([
+          {
+            key: {
+              text: 'CRN',
+            },
+            value: {
+              text: application.person.crn,
+            },
           },
-          value: {
-            text: application.person.crn,
+          {
+            key: {
+              text: 'Arrival date',
+            },
+            value: {
+              text: 'Not provided',
+            },
           },
-        },
-        {
-          key: {
-            text: 'Arrival date',
+          {
+            key: {
+              text: 'Application Type',
+            },
+            value: {
+              text: getApplicationType(application),
+            },
           },
-          value: {
-            text: DateFormats.isoDateToUIDate(arrivalDateFromApplication(application)),
-          },
-        },
-        {
-          key: {
-            text: 'Application Type',
-          },
-          value: {
-            text: getApplicationType(application),
-          },
-        },
-      ])
+        ])
+      })
     })
   })
 })

--- a/server/utils/tasks/index.ts
+++ b/server/utils/tasks/index.ts
@@ -27,6 +27,8 @@ const groupByAllocation = (tasks: Array<Task>) => {
 }
 
 const applicationSummary = (application: Application): Array<SummaryListItem> => {
+  const arrivalDate = arrivalDateFromApplication(application)
+
   const summary = [
     {
       key: {
@@ -41,7 +43,7 @@ const applicationSummary = (application: Application): Array<SummaryListItem> =>
         text: 'Arrival date',
       },
       value: {
-        text: DateFormats.isoDateToUIDate(arrivalDateFromApplication(application)),
+        text: arrivalDate ? DateFormats.isoDateToUIDate(arrivalDate) : 'Not provided',
       },
     },
     {


### PR DESCRIPTION
This was causing an error when trying to Reallocate an Assessment