### PR TITLE
Remove Standard AP option from Match

### DIFF
--- a/server/utils/matchUtils.test.ts
+++ b/server/utils/matchUtils.test.ts
@@ -39,10 +39,10 @@ import {
 } from './matchUtils'
 import {
   accessibilityOptions,
-  apTypeOptions,
   offenceAndRiskOptions,
   placementCriteria,
   placementRequirementOptions,
+  specialistApTypeOptions,
   specialistSupportOptions,
 } from './placementCriteriaUtils'
 
@@ -211,7 +211,7 @@ describe('matchUtils', () => {
   describe('groupedCheckboxes', () => {
     it('returns checkboxes grouped by category', () => {
       expect(groupedCheckboxes([])).toEqual({
-        'Type of AP': checkBoxesForCriteria(apTypeOptions, []),
+        'Type of AP': checkBoxesForCriteria(specialistApTypeOptions, []),
         'Specialist AP': checkBoxesForCriteria(specialistSupportOptions, []),
         'Placement Requirements': checkBoxesForCriteria(placementRequirementOptions, []),
         'Risks and offences to consider': checkBoxesForCriteria(offenceAndRiskOptions, []),

--- a/server/utils/matchUtils.ts
+++ b/server/utils/matchUtils.ts
@@ -10,9 +10,9 @@ import { linkTo, sentenceCase } from './utils'
 import matchPaths from '../paths/match'
 import {
   accessibilityOptions,
-  apTypeOptions,
   offenceAndRiskOptions,
   placementRequirementOptions,
+  specialistApTypeOptions,
   specialistSupportOptions,
 } from './placementCriteriaUtils'
 
@@ -32,7 +32,7 @@ export type SearchFilterCategories =
   | 'specialistSupport'
 
 const groupedCriteria = {
-  apType: { title: 'Type of AP', options: apTypeOptions },
+  apType: { title: 'Type of AP', options: specialistApTypeOptions },
   specialistSupport: { title: 'Specialist AP', options: specialistSupportOptions },
   placementRequirements: { title: 'Placement Requirements', options: placementRequirementOptions },
   offenceAndRisk: { title: 'Risks and offences to consider', options: offenceAndRiskOptions },

--- a/server/utils/placementCriteriaUtils.test.ts
+++ b/server/utils/placementCriteriaUtils.test.ts
@@ -2,6 +2,7 @@ import {
   apTypeOptions,
   offenceAndRiskOptions,
   placementRequirementOptions,
+  specialistApTypeOptions,
   specialistSupportOptions,
 } from './placementCriteriaUtils'
 
@@ -9,6 +10,12 @@ describe('placementCriteriaUtils', () => {
   describe('apTypeOptions', () => {
     it('should return all the AP Type options', () => {
       expect(Object.keys(apTypeOptions)).toEqual(['normal', 'isPIPE', 'isESAP'])
+    })
+  })
+
+  describe('specialistApTypeOptions', () => {
+    it('should return all the AP Type options without a `normal` AP type', () => {
+      expect(Object.keys(specialistApTypeOptions)).toEqual(['isPIPE', 'isESAP'])
     })
   })
 

--- a/server/utils/placementCriteriaUtils.ts
+++ b/server/utils/placementCriteriaUtils.ts
@@ -65,9 +65,10 @@ const filterByType = <T extends PlacementCriteriaCategory>(keys: Array<string>):
     .reduce((criteria, key) => ({ ...criteria, [key]: placementCriteria[key] }), {}) as Record<T, string>
 }
 
+export const specialistApTypeOptions = filterByType<ApTypeCriteria>(apTypes)
 export const apTypeOptions = {
   normal: 'Standard AP',
-  ...filterByType<ApTypeCriteria>(apTypes),
+  ...specialistApTypeOptions,
 } as Record<ApTypeCriteria & 'normal', string>
 export const specialistSupportOptions = filterByType<SpecialistSupportCriteria>(specialistSupportCriteria)
 export const accessibilityOptions = filterByType<AccessibilityCriteria>(accessibilityCriteria)


### PR DESCRIPTION
Checking the "Standard AP" option on Match throws a 400 error, as `standard` is not a recognised PlacementCriteria. We should remove this from the options, as all APs are "standard", unless they have a specialism.