### PR TITLE
Update Playwright Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ jobs:
 
   e2e_environment_test:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.32.1-focal
+      - image: mcr.microsoft.com/playwright:v1.34.1-focal
     circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
     steps:
       - run:


### PR DESCRIPTION
The e2es are erroring with:

```
Error: browserType.launch: Executable doesn't exist at /ms-playwright/chromium-1064/chrome-linux/chrome
    ╔══════════════════════════════════════════════════════════════════════╗
    ║ Looks like Playwright Test or Playwright was just updated to 1.34.1. ║
    ║ Please update docker image as well.                                  ║
    ║ -  current: mcr.microsoft.com/playwright:v1.32.1-focal               ║
    ║ - required: mcr.microsoft.com/playwright:v1.34.1-focal               ║
    ║                                                                      ║
    ║ <3 Playwright Team
```

It’s a bit annoying that we can’t keep the image in sync with the version, but this unblocks us for now
