### PR TITLE
Call the reallocatable tasks endpoint for workflow

### DIFF
--- a/integration_tests/mockApis/tasks.ts
+++ b/integration_tests/mockApis/tasks.ts
@@ -11,7 +11,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        urlPattern: paths.tasks.index.pattern,
+        urlPattern: paths.tasks.reallocatable.index.pattern,
       },
       response: {
         status: 200,

--- a/server/controllers/tasksController.test.ts
+++ b/server/controllers/tasksController.test.ts
@@ -30,7 +30,7 @@ describe('TasksController', () => {
   describe('index', () => {
     it('should render the tasks template', async () => {
       const tasks = taskFactory.buildList(1)
-      taskService.getAll.mockResolvedValue(tasks)
+      taskService.getAllReallocatable.mockResolvedValue(tasks)
 
       const requestHandler = tasksController.index()
 
@@ -40,7 +40,7 @@ describe('TasksController', () => {
         pageHeading: 'Tasks',
         tasks: groupByAllocation(tasks),
       })
-      expect(taskService.getAll).toHaveBeenCalledWith(token)
+      expect(taskService.getAllReallocatable).toHaveBeenCalledWith(token)
     })
   })
 

--- a/server/controllers/tasksController.ts
+++ b/server/controllers/tasksController.ts
@@ -9,7 +9,7 @@ export default class TasksController {
 
   index(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
-      const tasks = await this.taskService.getAll(req.user.token)
+      const tasks = await this.taskService.getAllReallocatable(req.user.token)
 
       res.render('tasks/index', { pageHeading: 'Tasks', tasks: groupByAllocation(tasks) })
     }

--- a/server/data/taskClient.test.ts
+++ b/server/data/taskClient.test.ts
@@ -13,8 +13,8 @@ describeClient('taskClient', provider => {
     taskClient = new TaskClient(token)
   })
 
-  describe('all', () => {
-    it('makes a get request to the tasks endpoint', async () => {
+  describe('allReallocatable', () => {
+    it('makes a get request to the reallocatable tasks endpoint', async () => {
       const tasks = taskFactory.buildList(2)
 
       provider.addInteraction({
@@ -22,7 +22,7 @@ describeClient('taskClient', provider => {
         uponReceiving: `A request to get a list of tasks`,
         withRequest: {
           method: 'GET',
-          path: paths.tasks.index.pattern,
+          path: paths.tasks.reallocatable.index.pattern,
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -33,7 +33,7 @@ describeClient('taskClient', provider => {
         },
       })
 
-      const result = await taskClient.all()
+      const result = await taskClient.allReallocatable()
 
       expect(result).toEqual(tasks)
     })

--- a/server/data/taskClient.ts
+++ b/server/data/taskClient.ts
@@ -10,8 +10,8 @@ export default class TaskClient {
     this.restClient = new RestClient('taskClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
-  async all(): Promise<Array<Task>> {
-    return (await this.restClient.get({ path: paths.tasks.index.pattern })) as Promise<Array<Task>>
+  async allReallocatable(): Promise<Array<Task>> {
+    return (await this.restClient.get({ path: paths.tasks.reallocatable.index.pattern })) as Promise<Array<Task>>
   }
 
   async find(applicationId: string, taskType: string): Promise<TaskWrapper> {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -125,6 +125,9 @@ export default {
   },
   tasks: {
     index: tasksPaths.index,
+    reallocatable: {
+      index: tasksPaths.index.path('reallocatable'),
+    },
   },
   placementRequests: {
     index: placementRequestsPath,

--- a/server/services/taskService.test.ts
+++ b/server/services/taskService.test.ts
@@ -18,17 +18,17 @@ describe('taskService', () => {
     taskClientFactory.mockReturnValue(taskClient)
   })
 
-  describe('getAll', () => {
+  describe('getAllReallocatable', () => {
     it('calls the all method on the task client', async () => {
       const tasks: Array<Task> = taskFactory.buildList(2)
-      taskClient.all.mockResolvedValue(tasks)
+      taskClient.allReallocatable.mockResolvedValue(tasks)
 
-      const result = await service.getAll(token)
+      const result = await service.getAllReallocatable(token)
 
       expect(result).toEqual(tasks)
 
       expect(taskClientFactory).toHaveBeenCalledWith(token)
-      expect(taskClient.all).toHaveBeenCalled()
+      expect(taskClient.allReallocatable).toHaveBeenCalled()
     })
   })
 

--- a/server/services/taskService.ts
+++ b/server/services/taskService.ts
@@ -5,10 +5,10 @@ import TaskClient from '../data/taskClient'
 export default class TaskService {
   constructor(private readonly taskClientFactory: RestClientBuilder<TaskClient>) {}
 
-  async getAll(token: string): Promise<Array<Task>> {
+  async getAllReallocatable(token: string): Promise<Array<Task>> {
     const taskClient = this.taskClientFactory(token)
 
-    const tasks = await taskClient.all()
+    const tasks = await taskClient.allReallocatable()
     return tasks
   }
 


### PR DESCRIPTION
For workflow managers, we now need to call the `tasks/reallocatable` endpoint, which returns all tasks that can be reallocated.