### PR TITLE
Add Unable to Match functionality to search page

### DIFF
--- a/integration_tests/mockApis/placementRequests.ts
+++ b/integration_tests/mockApis/placementRequests.ts
@@ -3,7 +3,7 @@ import { SuperAgentRequest } from 'superagent'
 import type { PlacementRequest } from '@approved-premises/api'
 import { getMatchingRequests, stubFor } from '../../wiremock'
 import paths from '../../server/paths/api'
-import { newPlacementRequestBookingConfirmationFactory } from '../../server/testutils/factories'
+import { bookingNotMadeFactory, newPlacementRequestBookingConfirmationFactory } from '../../server/testutils/factories'
 
 export default {
   stubPlacementRequests: (placementRequests: Array<PlacementRequest>): SuperAgentRequest =>
@@ -55,4 +55,18 @@ export default {
         url: paths.placementRequests.booking({ id: placementRequest.id }),
       })
     ).body.requests,
+  stubUnableToMatchPlacementRequest: (placementRequest: PlacementRequest): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: paths.placementRequests.bookingNotMade({ id: placementRequest.id }),
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: bookingNotMadeFactory.build(),
+      },
+    }),
 }

--- a/integration_tests/pages/match/searchPage.ts
+++ b/integration_tests/pages/match/searchPage.ts
@@ -64,4 +64,8 @@ export default class SearchPage extends Page {
       this.checkCheckboxByNameAndValue('requiredCharacteristics', characteristic)
     })
   }
+
+  clickUnableToMatch(): void {
+    cy.get('.govuk-button').contains('Unable to match').click()
+  }
 }

--- a/integration_tests/pages/match/unableToMatchPage.ts
+++ b/integration_tests/pages/match/unableToMatchPage.ts
@@ -1,0 +1,11 @@
+import Page from '../page'
+
+export default class UnableToMatch extends Page {
+  constructor() {
+    super('Unable to match')
+  }
+
+  completeForm(): void {
+    this.completeTextArea('notes', 'I am unable to match this person')
+  }
+}

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -4,6 +4,7 @@ import ConfirmationPage from '../../pages/match/confirmationPage'
 import PlacementRequestPage from '../../pages/match/placementRequestPage'
 import ListPage from '../../pages/match/listPlacementRequestsPage'
 import SearchPage from '../../pages/match/searchPage'
+import UnableToMatchPage from '../../pages/match/unableToMatchPage'
 
 import {
   bedSearchParametersUiFactory,
@@ -252,5 +253,14 @@ context('Placement Requests', () => {
     // Given I am unable to match the placement request to a bed
     const searchPage = new SearchPage(placementRequest.person.name)
     searchPage.clickUnableToMatch()
+
+    // When I complete the form and click submit
+    const unableToMatchPage = new UnableToMatchPage()
+    unableToMatchPage.completeForm()
+    unableToMatchPage.clickSubmit()
+
+    // Then I should see a success message on the list page
+    Page.verifyOnPage(ListPage)
+    listPage.shouldShowBanner('Placement request marked unable to match')
   })
 })

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -227,4 +227,30 @@ context('Placement Requests', () => {
       })
     })
   })
+
+  it('allows me to mark a placement request as unable to match', () => {
+    // Given there is a placement request waiting for me to match
+    const placementRequest = placementRequestFactory.build({ status: 'notMatched' })
+    const bedSearchResults = bedSearchResultsFactory.build()
+
+    cy.task('stubPlacementRequests', [placementRequest])
+    cy.task('stubBedSearch', { bedSearchResults })
+    cy.task('stubPlacementRequest', placementRequest)
+    cy.task('stubBookingFromPlacementRequest', placementRequest)
+    cy.task('stubUnableToMatchPlacementRequest', placementRequest)
+
+    // When I visit the placementRequests dashboard
+    const listPage = ListPage.visit()
+
+    // And I click on a placement request
+    listPage.clickFindBed(placementRequest)
+
+    // And I click on the search button
+    const showPage = new PlacementRequestPage(placementRequest)
+    showPage.clickSearch()
+
+    // Given I am unable to match the placement request to a bed
+    const searchPage = new SearchPage(placementRequest.person.name)
+    searchPage.clickUnableToMatch()
+  })
 })

--- a/server/controllers/match/placementRequests/bookingsController.test.ts
+++ b/server/controllers/match/placementRequests/bookingsController.test.ts
@@ -99,4 +99,21 @@ describe('BookingsController', () => {
       })
     })
   })
+
+  describe('createBookingNotMade', () => {
+    it('should call the service and redirect to the index page', async () => {
+      const placementRequestId = '123'
+      const body: NewBookingNotMade = {
+        notes: 'Some notes',
+      }
+      const flash = jest.fn()
+
+      const requestHandler = bookingsController.createBookingNotMade()
+      await requestHandler({ ...request, params: { id: placementRequestId }, body, flash }, response, next)
+
+      expect(flash).toHaveBeenCalledWith('success', 'Placement request marked unable to match')
+      expect(response.redirect).toHaveBeenCalledWith(`${matchPaths.placementRequests.index.pattern}#unable-to-match`)
+      expect(placementRequestService.bookingNotMade).toHaveBeenCalledWith(token, placementRequestId, body)
+    })
+  })
 })

--- a/server/controllers/match/placementRequests/bookingsController.test.ts
+++ b/server/controllers/match/placementRequests/bookingsController.test.ts
@@ -11,6 +11,9 @@ import {
   placementRequestFactory,
 } from '../../../testutils/factories'
 import { encodeBedSearchResult, placementDates } from '../../../utils/matchUtils'
+import { NewBookingNotMade } from '../../../@types/shared'
+
+import matchPaths from '../../../paths/match'
 
 describe('BookingsController', () => {
   const token = 'SOME_TOKEN'
@@ -81,6 +84,19 @@ describe('BookingsController', () => {
         bookingConfirmation,
       })
       expect(placementRequestService.createBooking).toHaveBeenCalledWith(token, 'some-uuid', body)
+    })
+  })
+
+  describe('bookingNotMade', () => {
+    it('should render the booking not made confirmation template', async () => {
+      const placementRequestId = '123'
+      const requestHandler = bookingsController.bookingNotMade()
+      await requestHandler({ ...request, params: { id: placementRequestId } }, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('match/placementRequests/bookings/unable-to-match', {
+        pageHeading: 'Unable to match',
+        confirmPath: matchPaths.placementRequests.bookingNotMade.create({ id: placementRequestId }),
+      })
     })
   })
 })

--- a/server/controllers/match/placementRequests/bookingsController.ts
+++ b/server/controllers/match/placementRequests/bookingsController.ts
@@ -61,4 +61,13 @@ export default class BookingsController {
       })
     }
   }
+
+  createBookingNotMade(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      await this.placementRequestService.bookingNotMade(req.user.token, req.params.id, { notes: req.body.notes })
+      req.flash('success', 'Placement request marked unable to match')
+
+      return res.redirect(`${paths.placementRequests.index({})}#unable-to-match`)
+    }
+  }
 }

--- a/server/controllers/match/placementRequests/bookingsController.ts
+++ b/server/controllers/match/placementRequests/bookingsController.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 import { decodeBedSearchResult, placementDates } from '../../../utils/matchUtils'
 import { PlacementRequestService } from '../../../services'
+import paths from '../../../paths/match'
 
 interface ConfirmRequest extends Request {
   params: { id: string }
@@ -46,6 +47,17 @@ export default class BookingsController {
       res.render('match/placementRequests/bookings/success', {
         pageHeading: 'Your booking is complete',
         bookingConfirmation,
+      })
+    }
+  }
+
+  bookingNotMade(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      const confirmPath = paths.placementRequests.bookingNotMade.create({ id: req.params.id })
+
+      return res.render('match/placementRequests/bookings/unable-to-match', {
+        pageHeading: 'Unable to match',
+        confirmPath,
       })
     }
   }

--- a/server/data/placementRequestClient.test.ts
+++ b/server/data/placementRequestClient.test.ts
@@ -2,6 +2,7 @@ import PlacementRequestClient from './placementRequestClient'
 import paths from '../paths/api'
 
 import {
+  bookingNotMadeFactory,
   newPlacementRequestBookingConfirmationFactory,
   newPlacementRequestBookingFactory,
   placementRequestFactory,
@@ -95,6 +96,37 @@ describeClient('placementRequestClient', provider => {
       const result = await placementRequestClient.createBooking(placementRequest.id, newPlacementRequestBooking)
 
       expect(result).toEqual(bookingConfirmation)
+    })
+  })
+
+  describe('bookingNotMade', () => {
+    it('makes a POST request to the booking not made endpoint', async () => {
+      const placementRequestId = 'placement-request-id'
+      const body = {
+        notes: 'some notes',
+      }
+      const bookingNotMade = bookingNotMadeFactory.build()
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to mark a placement request as not booked',
+        withRequest: {
+          method: 'POST',
+          path: paths.placementRequests.bookingNotMade({ id: placementRequestId }),
+          body,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: bookingNotMade,
+        },
+      })
+
+      const result = await placementRequestClient.bookingNotMade(placementRequestId, body)
+
+      expect(result).toEqual(bookingNotMade)
     })
   })
 })

--- a/server/data/placementRequestClient.ts
+++ b/server/data/placementRequestClient.ts
@@ -1,4 +1,6 @@
 import {
+  BookingNotMade,
+  NewBookingNotMade,
   NewPlacementRequestBooking,
   NewPlacementRequestBookingConfirmation,
   PlacementRequest,
@@ -32,5 +34,12 @@ export default class PlacementRequestClient {
       path: paths.placementRequests.booking({ id }),
       data: newPlacementRequestBooking,
     })) as Promise<NewPlacementRequestBookingConfirmation>
+  }
+
+  async bookingNotMade(id: string, data: NewBookingNotMade): Promise<BookingNotMade> {
+    return (await this.restClient.post({
+      path: paths.placementRequests.bookingNotMade({ id }),
+      data,
+    })) as Promise<BookingNotMade>
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -133,6 +133,7 @@ export default {
     index: placementRequestsPath,
     show: placementRequestPath,
     booking: placementRequestPath.path('booking'),
+    bookingNotMade: placementRequestPath.path('booking-not-made'),
   },
   placementApplications: {
     update: placementApplicationPath,

--- a/server/paths/match.ts
+++ b/server/paths/match.ts
@@ -4,12 +4,13 @@ const placementRequestsPath = path('/placement-requests')
 const placementRequestPath = placementRequestsPath.path(':id')
 const placementRequestBookingsPath = placementRequestPath.path('bookings')
 const newPlacementRequestPath = placementRequestsPath.path('new')
-
+const bookingNotMadePath = placementRequestPath.path('booking-not-made')
 export default {
   placementRequests: {
     index: placementRequestsPath,
     show: placementRequestPath,
     create: newPlacementRequestPath,
+    bookingNotMade: { confirm: bookingNotMadePath.path('confirm'), create: bookingNotMadePath },
     bookings: {
       confirm: placementRequestBookingsPath.path('confirm'),
       create: placementRequestBookingsPath,

--- a/server/routes/match.ts
+++ b/server/routes/match.ts
@@ -14,6 +14,10 @@ export default function routes(controllers: Controllers, router: Router): Router
 
   get(paths.placementRequests.index.pattern, placementRequestController.index())
   get(paths.placementRequests.show.pattern, placementRequestController.show())
+
+  get(paths.placementRequests.bookingNotMade.confirm.pattern, placementRequestBookingsController.bookingNotMade())
+  post(paths.placementRequests.bookingNotMade.create.pattern, placementRequestBookingsController.createBookingNotMade())
+
   get(paths.placementRequests.beds.search.pattern, bedController.search())
   post(paths.placementRequests.beds.search.pattern, bedController.search())
 

--- a/server/services/placementRequestService.test.ts
+++ b/server/services/placementRequestService.test.ts
@@ -1,6 +1,10 @@
 import { PlacementRequest } from '@approved-premises/api'
 import PlacementRequestClient from '../data/placementRequestClient'
-import { newPlacementRequestBookingConfirmationFactory, placementRequestFactory } from '../testutils/factories'
+import {
+  bookingNotMadeFactory,
+  newPlacementRequestBookingConfirmationFactory,
+  placementRequestFactory,
+} from '../testutils/factories'
 import PlacementRequestService from './placementRequestService'
 
 jest.mock('../data/placementRequestClient.ts')
@@ -73,6 +77,25 @@ describe('placementRequestService', () => {
 
       expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
       expect(placementRequestClient.createBooking).toHaveBeenCalledWith(id, newBooking)
+    })
+  })
+
+  describe('bookingNotMade', () => {
+    it('it should call the service and return the booking not made object', async () => {
+      const bookingNotMade = bookingNotMadeFactory.build()
+      placementRequestClient.bookingNotMade.mockResolvedValue(bookingNotMade)
+
+      const id = 'some-uuid'
+      const body = {
+        notes: 'some notes',
+      }
+
+      const result = await service.bookingNotMade(token, id, body)
+
+      expect(result).toEqual(bookingNotMade)
+
+      expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
+      expect(placementRequestClient.bookingNotMade).toHaveBeenCalledWith(id, body)
     })
   })
 })

--- a/server/services/placementRequestService.ts
+++ b/server/services/placementRequestService.ts
@@ -1,5 +1,6 @@
 import { GroupedPlacementRequests } from '@approved-premises/ui'
 import {
+  NewBookingNotMade,
   NewPlacementRequestBooking,
   NewPlacementRequestBookingConfirmation,
   PlacementRequest,
@@ -42,5 +43,11 @@ export default class PlacementRequestService {
     const placementRequestClient = this.placementRequestClientFactory(token)
 
     return placementRequestClient.createBooking(id, newBooking)
+  }
+
+  async bookingNotMade(token: string, id: string, body: NewBookingNotMade) {
+    const placementRequestClient = this.placementRequestClientFactory(token)
+
+    return placementRequestClient.bookingNotMade(id, body)
   }
 }

--- a/server/testutils/factories/bookingNotMade.ts
+++ b/server/testutils/factories/bookingNotMade.ts
@@ -1,0 +1,12 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { BookingNotMade } from '@approved-premises/api'
+import { DateFormats } from '../../utils/dateUtils'
+
+export default Factory.define<BookingNotMade>(() => ({
+  createdAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
+  id: faker.string.uuid(),
+  placementRequestId: faker.string.uuid(),
+  notes: faker.lorem.paragraph(),
+}))

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -14,6 +14,7 @@ import bedDetailFactory from './bedDetail'
 import { apCharacteristicPairFactory, bedSearchResultFactory, bedSearchResultsFactory } from './bedSearchResult'
 import bookingFactory from './booking'
 import bookingExtensionFactory from './bookingExtension'
+import bookingNotMadeFactory from './bookingNotMade'
 import cancellationFactory from './cancellation'
 import clarificationNoteFactory from './clarificationNote'
 import contingencyPlanPartnerFactory from './contingencyPlanPartner'
@@ -68,6 +69,7 @@ export {
   bedSearchResultsFactory,
   bookingFactory,
   bookingExtensionFactory,
+  bookingNotMadeFactory,
   cancellationFactory,
   clarificationNoteFactory,
   contingencyPlanPartnerFactory,

--- a/server/views/match/placementRequests/bookings/unable-to-match.njk
+++ b/server/views/match/placementRequests/bookings/unable-to-match.njk
@@ -1,0 +1,37 @@
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-width-container">
+            <div class="govuk-grid-column-two-thirds">
+                <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+                <p class="govuk-body">We recommend that you continue to search for a placement weekly until a match is found.</p>
+                <p class="govuk-body">If the expected arrival date is less than 4 weeks away, consider the referral prioritisation approach or escalation to an AP Area Manager.</p>
+                <p class="govuk-body">This application will be added to to the 'unable to match' tab on your dashboard.</p>
+
+                <form action="{{confirmPath}}" method="post">
+                    <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+                    {{ govukTextarea({
+                        id: "notes",
+                        name: "notes",
+                        label: {
+                        text: "Provide detail about why you are unable to find a suitable bed in an Approved Premises",
+                        classes: "govuk-fieldset__legend--s"
+                        }
+                    }) }}
+
+                    {{ govukButton({
+                      text: "Continue"
+                    }) }}
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/server/views/match/search.njk
+++ b/server/views/match/search.njk
@@ -194,6 +194,13 @@
 					rows: MatchUtils.summaryCardRows(bedSearchResult, requiredCharacteristics)
 				}) }}
 					{% endfor %}
+
+					<h3 class="govuk-heading-m">Mark this case as unable to match</h3>
+					<p>If there are no suitable results for your search, mark this case as unable to match.</p>
+					{{ govukButton({
+						text: "Unable to match",
+						href: paths.placementRequests.bookingNotMade.confirm({id: placementRequest.id})
+					}) }}
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
# Context
In some circumstances matchers won't be able to match a placement request to a premises, they need to be able to record this. 

# Changes in this PR
- We add the client and service methods for marking a booking as unable to match in the API
- We add a button to the search page for the Matcher to click when they are unable to match. We also add a screen for the Matcher to confirm that they want to mark the case as unable to match
- We add a controller method to redirect the matcher to the Placement Request list view when they confirm they are unable to match with a flash showing that the operation was a success


## Screenshots of UI changes
![Placement Requests -- allows me to mark a placement request as unable to match (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/0c47f821-5881-44d8-8896-344f839a118d)
![Placement Requests -- allows me to mark a placement request as unable to match (2)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/28153b18-ea8a-46f8-9b28-5a79e9658a02)
![Placement Requests -- allows me to mark a placement request as unable to match](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/8f8cd29e-8af4-46a5-9767-2acef00da5e2)
