### PR TITLE
(210) List placement applications for a matcher

### DIFF
--- a/integration_tests/mockApis/tasks.ts
+++ b/integration_tests/mockApis/tasks.ts
@@ -7,11 +7,25 @@ import { errorStub } from '../../wiremock/utils'
 import { kebabCase } from '../../server/utils/utils'
 
 export default {
-  stubTasks: (tasks: Array<Task>): SuperAgentRequest =>
+  stubReallocatableTasks: (tasks: Array<Task>): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
         urlPattern: paths.tasks.reallocatable.index.pattern,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: tasks,
+      },
+    }),
+  stubTasks: (tasks: Array<Task>): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: paths.tasks.index.pattern,
       },
       response: {
         status: 200,

--- a/integration_tests/pages/match/listPlacementRequestsPage.ts
+++ b/integration_tests/pages/match/listPlacementRequestsPage.ts
@@ -2,8 +2,9 @@ import Page from '../page'
 import paths from '../../../server/paths/match'
 
 import { tableUtils } from '../../../server/utils/placementRequests'
+import { tableUtils as placementApplicationTableUtils } from '../../../server/utils/placementApplications'
 
-import { PlacementRequest, PlacementRequestTask } from '../../../server/@types/shared'
+import { PlacementApplicationTask, PlacementRequest, PlacementRequestTask } from '../../../server/@types/shared'
 import { shouldShowTableRows } from '../../helpers'
 
 export default class ListPage extends Page {
@@ -18,6 +19,14 @@ export default class ListPage extends Page {
 
   shouldShowTasks(placementRequests: Array<PlacementRequestTask>): void {
     shouldShowTableRows(placementRequests, tableUtils.tableRows)
+  }
+
+  shouldShowPlacementApplicationTasks(placementApplicationTasks: Array<PlacementApplicationTask>): void {
+    shouldShowTableRows(placementApplicationTasks, placementApplicationTableUtils.tableRows)
+  }
+
+  clickPlacementApplications(): void {
+    cy.get('a').contains('Placement Applications').click()
   }
 
   clickUnableToMatch(): void {

--- a/integration_tests/pages/match/listPlacementRequestsPage.ts
+++ b/integration_tests/pages/match/listPlacementRequestsPage.ts
@@ -3,7 +3,7 @@ import paths from '../../../server/paths/match'
 
 import { tableUtils } from '../../../server/utils/placementRequests'
 
-import { PlacementRequest } from '../../../server/@types/shared'
+import { PlacementRequest, PlacementRequestTask } from '../../../server/@types/shared'
 import { shouldShowTableRows } from '../../helpers'
 
 export default class ListPage extends Page {
@@ -16,7 +16,7 @@ export default class ListPage extends Page {
     return new ListPage()
   }
 
-  shouldShowPlacementRequests(placementRequests: Array<PlacementRequest>): void {
+  shouldShowTasks(placementRequests: Array<PlacementRequestTask>): void {
     shouldShowTableRows(placementRequests, tableUtils.tableRows)
   }
 

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -11,6 +11,7 @@ import {
   bedSearchResultsFactory,
   personFactory,
   placementRequestFactory,
+  placementRequestTaskFactory,
 } from '../../../server/testutils/factories'
 import Page from '../../pages/page'
 import { DateFormats } from '../../../server/utils/dateUtils'
@@ -28,40 +29,36 @@ context('Placement Requests', () => {
   })
 
   it('shows a list of placementRequests', () => {
-    // Given there placement requests in the database
-    const activePlacementRequests = placementRequestFactory.buildList(1, { status: 'notMatched' })
-    const unableToMatchPlacementRequests = placementRequestFactory.buildList(3, { status: 'unableToMatch' })
-    const matchedPlacementRequests = placementRequestFactory.buildList(5, { status: 'matched' })
+    // Given there placement request tasks in the database
+    const notMatchedTasks = placementRequestTaskFactory.buildList(1, { placementRequestStatus: 'notMatched' })
+    const unableToMatchTasks = placementRequestTaskFactory.buildList(1, { placementRequestStatus: 'unableToMatch' })
+    const matchedTasks = placementRequestTaskFactory.buildList(3, { placementRequestStatus: 'matched' })
 
-    cy.task('stubPlacementRequests', [
-      ...activePlacementRequests,
-      ...unableToMatchPlacementRequests,
-      ...matchedPlacementRequests,
-    ])
+    cy.task('stubTasks', [...notMatchedTasks, ...unableToMatchTasks, ...matchedTasks])
 
     // When I visit the placementRequests dashboard
     const listPage = ListPage.visit()
 
     // Then I should see the placement requests that are allocated to me
-    listPage.shouldShowPlacementRequests(activePlacementRequests)
+    listPage.shouldShowTasks(notMatchedTasks)
 
     // When I click on the unable to match tab
     listPage.clickUnableToMatch()
 
     // Then I should see the unable to match placement requests
-    listPage.shouldShowPlacementRequests(unableToMatchPlacementRequests)
+    listPage.shouldShowTasks(unableToMatchTasks)
 
     // When I click on the completed tab
     listPage.clickCompleted()
 
     // Then I should see the completed placement requests
-    listPage.shouldShowPlacementRequests(matchedPlacementRequests)
+    listPage.shouldShowTasks(matchedTasks)
 
     // When I click on the active cases tab
     listPage.clickActive()
 
     // Then I should see the placement requests that are allocated to me
-    listPage.shouldShowPlacementRequests(activePlacementRequests)
+    listPage.shouldShowTasks(notMatchedTasks)
   })
 
   it('allows me to search for available rooms', () => {
@@ -78,13 +75,18 @@ context('Placement Requests', () => {
       desirableCriteria,
     })
 
+    const placementRequestTask = placementRequestTaskFactory.build({
+      id: placementRequest.id,
+      placementRequestStatus: placementRequest.status,
+    })
+
     const firstBedSearchParameters = bedSearchParametersUiFactory.build({
       requiredCharacteristics: [...essentialCriteria, ...desirableCriteria],
     })
 
     const bedSearchResults = bedSearchResultsFactory.build()
 
-    cy.task('stubPlacementRequests', [placementRequest])
+    cy.task('stubTasks', [placementRequestTask])
     cy.task('stubBedSearch', { bedSearchResults })
     cy.task('stubPlacementRequest', placementRequest)
     cy.task('stubBookingFromPlacementRequest', placementRequest)
@@ -178,11 +180,15 @@ context('Placement Requests', () => {
   it('allows me to make a booking', () => {
     // Given there is a placement request waiting for me to match
     const placementRequest = placementRequestFactory.build({ status: 'notMatched' })
+    const placementRequestTask = placementRequestTaskFactory.build({
+      id: placementRequest.id,
+      placementRequestStatus: placementRequest.status,
+    })
     const bedSearchResults = bedSearchResultsFactory.build()
 
     const bedSearchParameters = mapPlacementRequestToBedSearchParams(placementRequest)
 
-    cy.task('stubPlacementRequests', [placementRequest])
+    cy.task('stubTasks', [placementRequestTask])
     cy.task('stubBedSearch', { bedSearchResults })
     cy.task('stubPlacementRequest', placementRequest)
     cy.task('stubBookingFromPlacementRequest', placementRequest)
@@ -232,9 +238,13 @@ context('Placement Requests', () => {
   it('allows me to mark a placement request as unable to match', () => {
     // Given there is a placement request waiting for me to match
     const placementRequest = placementRequestFactory.build({ status: 'notMatched' })
+    const placementRequestTask = placementRequestTaskFactory.build({
+      id: placementRequest.id,
+      placementRequestStatus: placementRequest.status,
+    })
     const bedSearchResults = bedSearchResultsFactory.build()
 
-    cy.task('stubPlacementRequests', [placementRequest])
+    cy.task('stubTasks', [placementRequestTask])
     cy.task('stubBedSearch', { bedSearchResults })
     cy.task('stubPlacementRequest', placementRequest)
     cy.task('stubBookingFromPlacementRequest', placementRequest)

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -10,6 +10,7 @@ import {
   bedSearchParametersUiFactory,
   bedSearchResultsFactory,
   personFactory,
+  placementApplicationTaskFactory,
   placementRequestFactory,
   placementRequestTaskFactory,
 } from '../../../server/testutils/factories'
@@ -28,19 +29,26 @@ context('Placement Requests', () => {
     cy.signIn()
   })
 
-  it('shows a list of placementRequests', () => {
+  it('shows a list of matcher tasks', () => {
     // Given there placement request tasks in the database
     const notMatchedTasks = placementRequestTaskFactory.buildList(1, { placementRequestStatus: 'notMatched' })
     const unableToMatchTasks = placementRequestTaskFactory.buildList(1, { placementRequestStatus: 'unableToMatch' })
-    const matchedTasks = placementRequestTaskFactory.buildList(3, { placementRequestStatus: 'matched' })
+    const matchedTasks = placementRequestTaskFactory.buildList(1, { placementRequestStatus: 'matched' })
+    const placementApplicationTasks = placementApplicationTaskFactory.buildList(1)
 
-    cy.task('stubTasks', [...notMatchedTasks, ...unableToMatchTasks, ...matchedTasks])
+    cy.task('stubTasks', [...notMatchedTasks, ...unableToMatchTasks, ...matchedTasks, ...placementApplicationTasks])
 
     // When I visit the placementRequests dashboard
     const listPage = ListPage.visit()
 
     // Then I should see the placement requests that are allocated to me
     listPage.shouldShowTasks(notMatchedTasks)
+
+    // When I click on the Placement Applications Tab
+    listPage.clickPlacementApplications()
+
+    // Then I should see the placement applications
+    listPage.shouldShowPlacementApplicationTasks(placementApplicationTasks)
 
     // When I click on the unable to match tab
     listPage.clickUnableToMatch()

--- a/integration_tests/tests/tasks/allocations.cy.ts
+++ b/integration_tests/tests/tasks/allocations.cy.ts
@@ -23,7 +23,7 @@ context('Tasks', () => {
       taskType: 'Assessment',
     })
 
-    cy.task('stubTasks', [task])
+    cy.task('stubReallocatableTasks', [task])
     cy.task('stubTaskGet', { application, task, users })
     cy.task('stubApplicationGet', { application })
 

--- a/integration_tests/tests/tasks/list.cy.ts
+++ b/integration_tests/tests/tasks/list.cy.ts
@@ -17,7 +17,7 @@ context('Tasks', () => {
     const allocatedTasks = taskFactory.buildList(5)
     const unallocatedTasks = taskFactory.buildList(5, { allocatedToStaffMember: undefined })
 
-    cy.task('stubTasks', [...allocatedTasks, ...unallocatedTasks])
+    cy.task('stubReallocatableTasks', [...allocatedTasks, ...unallocatedTasks])
 
     // When I visit the tasks dashboard
     const listPage = ListPage.visit(allocatedTasks, unallocatedTasks)

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -9,7 +9,9 @@ import {
   ArrayOfOASysRiskToSelfQuestions,
   ArrayOfOASysSupportingInformationQuestions,
   ApprovedPremisesAssessment as Assessment,
+  AssessmentTask,
   Booking,
+  BookingAppealTask,
   Document,
   FlagsEnvelope,
   Mappa,
@@ -17,9 +19,12 @@ import {
   Person,
   PersonAcctAlert,
   PlacementApplication,
+  PlacementApplicationTask,
+  PlacementApplicationTask,
   PlacementCriteria,
   PlacementRequest,
   PlacementRequestStatus,
+  PlacementRequestTask,
   ReleaseTypeOption,
   RiskTier,
   RoshRisks,
@@ -258,6 +263,8 @@ export interface GroupedApplications {
 }
 
 export type GroupedPlacementRequests = Record<PlacementRequestStatus, Array<PlacementRequest>>
+
+export type CategorisedTask = AssessmentTask | BookingAppealTask | PlacementApplicationTask | PlacementRequestTask
 
 export interface ApplicationWithRisks extends Application {
   person: PersonWithRisks

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -266,6 +266,10 @@ export type GroupedPlacementRequests = Record<PlacementRequestStatus, Array<Plac
 
 export type CategorisedTask = AssessmentTask | BookingAppealTask | PlacementApplicationTask | PlacementRequestTask
 
+export type GroupedMatchTasks = Record<PlacementRequestStatus, Array<PlacementRequestTask>> & {
+  placementApplications: Array<PlacementApplicationTask>
+}
+
 export interface ApplicationWithRisks extends Application {
   person: PersonWithRisks
 }

--- a/server/controllers/match/index.ts
+++ b/server/controllers/match/index.ts
@@ -7,11 +7,12 @@ import BookingsController from './placementRequests/bookingsController'
 import type { Services } from '../../services'
 
 export const controllers = (services: Services) => {
-  const { placementApplicationService, placementRequestService, bedService } = services
+  const { placementApplicationService, placementRequestService, bedService, taskService } = services
 
   const placementRequestController = new PlacementRequestController(
     placementRequestService,
     placementApplicationService,
+    taskService,
   )
   const bedController = new BedSearchController(bedService, placementRequestService)
   const placementRequestBookingsController = new BookingsController(placementRequestService)

--- a/server/controllers/match/placementRequestsController.test.ts
+++ b/server/controllers/match/placementRequestsController.test.ts
@@ -1,10 +1,10 @@
 import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
-import { GroupedPlacementRequests } from '@approved-premises/ui'
+import { GroupedMatchTasks } from '@approved-premises/ui'
 import PlacementRequestsController from './placementRequestsController'
 
-import { PlacementApplicationService, PlacementRequestService } from '../../services'
+import { PlacementApplicationService, PlacementRequestService, TaskService } from '../../services'
 import { personFactory, placementApplicationFactory, placementRequestFactory } from '../../testutils/factories'
 import paths from '../../paths/placementApplications'
 import { getResponses } from '../../utils/applications/utils'
@@ -20,19 +20,24 @@ describe('PlacementRequestsController', () => {
 
   const placementRequestService = createMock<PlacementRequestService>({})
   const placementApplicationService = createMock<PlacementApplicationService>({})
+  const taskService = createMock<TaskService>({})
 
   let placementRequestsController: PlacementRequestsController
 
   beforeEach(() => {
     jest.resetAllMocks()
-    placementRequestsController = new PlacementRequestsController(placementRequestService, placementApplicationService)
+    placementRequestsController = new PlacementRequestsController(
+      placementRequestService,
+      placementApplicationService,
+      taskService,
+    )
   })
 
   describe('index', () => {
     it('should render the placement requests template', async () => {
-      const placementRequests = createMock<GroupedPlacementRequests>()
+      const tasks = createMock<GroupedMatchTasks>()
 
-      placementRequestService.getAll.mockResolvedValue(placementRequests)
+      taskService.getMatchTasks.mockResolvedValue(tasks)
 
       const requestHandler = placementRequestsController.index()
 
@@ -40,9 +45,9 @@ describe('PlacementRequestsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('match/placementRequests/index', {
         pageHeading: 'My Cases',
-        placementRequests,
+        tasks,
       })
-      expect(placementRequestService.getAll).toHaveBeenCalledWith(token)
+      expect(taskService.getMatchTasks).toHaveBeenCalledWith(token)
     })
   })
 

--- a/server/controllers/match/placementRequestsController.ts
+++ b/server/controllers/match/placementRequestsController.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
-import { PlacementApplicationService, PlacementRequestService } from '../../services'
+import { PlacementApplicationService, PlacementRequestService, TaskService } from '../../services'
 import paths from '../../paths/placementApplications'
 import { addErrorMessageToFlash } from '../../utils/validation'
 import { getResponses } from '../../utils/applications/utils'
@@ -8,15 +8,16 @@ export default class PlacementRequestsController {
   constructor(
     private readonly placementRequestService: PlacementRequestService,
     private readonly placementApplicationService: PlacementApplicationService,
+    private readonly taskService: TaskService,
   ) {}
 
   index(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
-      const placementRequests = await this.placementRequestService.getAll(req.user.token)
+      const tasks = await this.taskService.getMatchTasks(req.user.token)
 
       res.render('match/placementRequests/index', {
         pageHeading: 'My Cases',
-        placementRequests,
+        tasks,
       })
     }
   }

--- a/server/data/taskClient.test.ts
+++ b/server/data/taskClient.test.ts
@@ -1,7 +1,14 @@
 import TaskClient from './taskClient'
 import paths from '../paths/api'
 
-import { taskFactory, taskWrapperFactory } from '../testutils/factories'
+import {
+  assessmentTaskFactory,
+  bookingAppealTask,
+  placementApplicationTaskFactory,
+  placementRequestTaskFactory,
+  taskFactory,
+  taskWrapperFactory,
+} from '../testutils/factories'
 import describeClient from '../testutils/describeClient'
 
 describeClient('taskClient', provider => {
@@ -34,6 +41,37 @@ describeClient('taskClient', provider => {
       })
 
       const result = await taskClient.allReallocatable()
+
+      expect(result).toEqual(tasks)
+    })
+  })
+
+  describe('allForUser', () => {
+    it('makes a get request to the tasks endpoint', async () => {
+      const tasks = [
+        placementApplicationTaskFactory.buildList(1),
+        placementRequestTaskFactory.buildList(1),
+        assessmentTaskFactory.buildList(1),
+        bookingAppealTask.buildList(1),
+      ].flat()
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: `A request to get a list of tasks`,
+        withRequest: {
+          method: 'GET',
+          path: paths.tasks.index.pattern,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: tasks,
+        },
+      })
+
+      const result = await taskClient.allForUser()
 
       expect(result).toEqual(tasks)
     })

--- a/server/data/taskClient.ts
+++ b/server/data/taskClient.ts
@@ -1,3 +1,4 @@
+import { CategorisedTask } from '@approved-premises/ui'
 import config, { ApiConfig } from '../config'
 import RestClient from './restClient'
 import paths from '../paths/api'
@@ -12,6 +13,10 @@ export default class TaskClient {
 
   async allReallocatable(): Promise<Array<Task>> {
     return (await this.restClient.get({ path: paths.tasks.reallocatable.index.pattern })) as Promise<Array<Task>>
+  }
+
+  async allForUser(): Promise<Array<CategorisedTask>> {
+    return (await this.restClient.get({ path: paths.tasks.index.pattern })) as Promise<Array<CategorisedTask>>
   }
 
   async find(applicationId: string, taskType: string): Promise<TaskWrapper> {

--- a/server/paths/placementApplications.ts
+++ b/server/paths/placementApplications.ts
@@ -14,5 +14,8 @@ export default {
       show: pagesPath,
       update: pagesPath,
     },
+    review: {
+      show: placementApplicationPath.path('review'),
+    },
   },
 }

--- a/server/services/taskService.ts
+++ b/server/services/taskService.ts
@@ -1,4 +1,5 @@
-import { Reallocation, Task, TaskWrapper } from '@approved-premises/api'
+import { PlacementApplicationTask, PlacementRequestTask, Reallocation, Task, TaskWrapper } from '@approved-premises/api'
+import { GroupedMatchTasks } from '@approved-premises/ui'
 import { RestClientBuilder } from '../data'
 import TaskClient from '../data/taskClient'
 
@@ -10,6 +11,36 @@ export default class TaskService {
 
     const tasks = await taskClient.allReallocatable()
     return tasks
+  }
+
+  async getMatchTasks(token: string): Promise<GroupedMatchTasks> {
+    const taskClient = this.taskClientFactory(token)
+
+    const tasks = await taskClient.allForUser()
+    const results = {
+      notMatched: [],
+      unableToMatch: [],
+      matched: [],
+      placementApplications: [],
+    } as GroupedMatchTasks
+
+    tasks.forEach(task => {
+      switch (task.taskType) {
+        case 'PlacementApplication': {
+          results.placementApplications.push(task as PlacementApplicationTask)
+          break
+        }
+        case 'PlacementRequest': {
+          const t = task as PlacementRequestTask
+          results[t.placementRequestStatus].push(t)
+          break
+        }
+        default:
+          break
+      }
+    })
+
+    return results
   }
 
   async find(token: string, premisesId: string, taskType: string): Promise<TaskWrapper> {

--- a/server/testutils/factories/assessmentTask.ts
+++ b/server/testutils/factories/assessmentTask.ts
@@ -1,0 +1,10 @@
+import { Factory } from 'fishery'
+
+import type { AssessmentTask } from '@approved-premises/api'
+
+import taskFactory from './task'
+
+export default Factory.define<AssessmentTask>(() => ({
+  ...taskFactory.build(),
+  taskType: 'Assessment',
+}))

--- a/server/testutils/factories/bookingAppealTask.ts
+++ b/server/testutils/factories/bookingAppealTask.ts
@@ -1,0 +1,10 @@
+import { Factory } from 'fishery'
+
+import type { BookingAppealTask } from '@approved-premises/api'
+
+import taskFactory from './task'
+
+export default Factory.define<BookingAppealTask>(() => ({
+  ...taskFactory.build(),
+  taskType: 'BookingAppeal',
+}))

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -6,12 +6,14 @@ import adjudicationFactory from './adjudication'
 import applicationFactory from './application'
 import applicationSummaryFactory from './applicationSummary'
 import arrivalFactory from './arrival'
+import assessmentTaskFactory from './assessmentTask'
 import assessmentFactory from './assessment'
 import assessmentSummaryFactory from './assessmentSummary'
 import { bedSearchParametersFactory, bedSearchParametersUiFactory } from './bedSearchParameters'
 import bedSummaryFactory from './bedSummary'
 import bedDetailFactory from './bedDetail'
 import { apCharacteristicPairFactory, bedSearchResultFactory, bedSearchResultsFactory } from './bedSearchResult'
+import bookingAppealTask from './bookingAppealTask'
 import bookingFactory from './booking'
 import bookingExtensionFactory from './bookingExtension'
 import bookingNotMadeFactory from './bookingNotMade'
@@ -38,7 +40,10 @@ import oasysSectionsFactory, { roshSummaryFactory } from './oasysSections'
 import oasysSelectionFactory from './oasysSelection'
 import personFactory from './person'
 import placementApplicationFactory from './placementApplication'
+import placementApplicationTaskFactory from './placementApplicationTask'
+import placementDatesFactory from './placementDates'
 import placementRequestFactory from './placementRequest'
+import placementRequestTaskFactory from './placementRequestTask'
 import premisesFactory from './premises'
 import prisonCaseNotesFactory from './prisonCaseNotes'
 import reallocationFactory from './reallocation'
@@ -59,6 +64,7 @@ export {
   applicationFactory,
   applicationSummaryFactory,
   arrivalFactory,
+  assessmentTaskFactory,
   assessmentFactory,
   assessmentSummaryFactory,
   bedSummaryFactory,
@@ -67,6 +73,7 @@ export {
   bedSearchParametersUiFactory,
   bedSearchResultFactory,
   bedSearchResultsFactory,
+  bookingAppealTask,
   bookingFactory,
   bookingExtensionFactory,
   bookingNotMadeFactory,
@@ -91,7 +98,10 @@ export {
   oasysSelectionFactory,
   personFactory,
   placementApplicationFactory,
+  placementApplicationTaskFactory,
+  placementDatesFactory,
   placementRequestFactory,
+  placementRequestTaskFactory,
   premisesFactory,
   prisonCaseNotesFactory,
   reallocationFactory,

--- a/server/testutils/factories/placementApplicationTask.ts
+++ b/server/testutils/factories/placementApplicationTask.ts
@@ -1,0 +1,18 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { PlacementApplicationTask } from '@approved-premises/api'
+
+import taskFactory from './task'
+import risksFactory from './risks'
+import placementDatesFactory from './placementDates'
+
+export default Factory.define<PlacementApplicationTask>(() => ({
+  ...taskFactory.build(),
+  taskType: 'PlacementApplication',
+  id: faker.string.uuid(),
+  risks: risksFactory.build(),
+  releaseType: 'rotl',
+  placementType: 'rotl',
+  placementDates: placementDatesFactory.buildList(1),
+}))

--- a/server/testutils/factories/placementDates.ts
+++ b/server/testutils/factories/placementDates.ts
@@ -1,0 +1,10 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { PlacementDates } from '@approved-premises/api'
+import { DateFormats } from '../../utils/dateUtils'
+
+export default Factory.define<PlacementDates>(() => ({
+  expectedArrival: DateFormats.dateObjToIsoDate(faker.date.soon()),
+  duration: faker.number.int({ min: 1, max: 12 }),
+}))

--- a/server/testutils/factories/placementRequestTask.ts
+++ b/server/testutils/factories/placementRequestTask.ts
@@ -1,0 +1,19 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { PlacementRequestTask } from '@approved-premises/api'
+
+import { DateFormats } from '../../utils/dateUtils'
+import taskFactory from './task'
+import risksFactory from './risks'
+
+export default Factory.define<PlacementRequestTask>(() => ({
+  ...taskFactory.build(),
+  taskType: 'PlacementRequest',
+  id: faker.string.uuid(),
+  risks: risksFactory.build(),
+  releaseType: 'rotl',
+  expectedArrival: DateFormats.dateObjToIsoDate(faker.date.soon()),
+  duration: faker.number.int({ min: 1, max: 12 }),
+  placementRequestStatus: faker.helpers.arrayElement(['notMatched', 'unableToMatch', 'matched']),
+}))

--- a/server/utils/assessments/tableUtils.test.ts
+++ b/server/utils/assessments/tableUtils.test.ts
@@ -1,6 +1,5 @@
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
 
-import * as personUtils from '../personUtils'
 import { assessmentSummaryFactory } from '../../testutils/factories'
 import {
   daysSinceInfoRequest,
@@ -17,9 +16,9 @@ import {
   requestedFurtherInformationTableRows,
 } from './tableUtils'
 import paths from '../../paths/assess'
+import { crnCell, tierCell } from '../tableUtils'
 
 jest.mock('../applications/arrivalDateFromApplication')
-jest.mock('../personUtils')
 
 describe('tableUtils', () => {
   describe('getStatus', () => {
@@ -80,21 +79,17 @@ describe('tableUtils', () => {
 
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
 
-      const tierBadgeSpy = jest.spyOn(personUtils, 'tierBadge').mockReturnValue('TIER_BADGE')
-
       expect(awaitingAssessmentTableRows([assessment])).toEqual([
         [
           { html: assessmentLink(assessment) },
-          { html: assessment.person.crn },
-          { html: 'TIER_BADGE' },
+          crnCell(assessment),
+          tierCell(assessment),
           { text: formattedArrivalDate(assessment) },
           { text: assessment.person.prisonName },
           { html: formatDaysUntilDueWithWarning(assessment) },
           { html: getStatus(assessment) },
         ],
       ])
-
-      expect(tierBadgeSpy).toHaveBeenCalledWith(assessment.risks.tier.value.level)
     })
   })
 
@@ -104,21 +99,17 @@ describe('tableUtils', () => {
 
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
 
-      const tierBadgeSpy = jest.spyOn(personUtils, 'tierBadge').mockReturnValue('TIER_BADGE')
-
       expect(requestedFurtherInformationTableRows([assessment])).toEqual([
         [
           { html: assessmentLink(assessment) },
-          { html: assessment.person.crn },
-          { html: 'TIER_BADGE' },
+          crnCell(assessment),
+          tierCell(assessment),
           { text: formattedArrivalDate(assessment) },
           { text: formatDays(daysSinceReceived(assessment)) },
           { text: formatDays(daysSinceInfoRequest(assessment)) },
           { html: `<strong class="govuk-tag govuk-tag--yellow">Info Request</strong>` },
         ],
       ])
-
-      expect(tierBadgeSpy).toHaveBeenCalledWith(assessment.risks.tier.value.level)
     })
   })
 
@@ -128,19 +119,15 @@ describe('tableUtils', () => {
 
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
 
-      const tierBadgeSpy = jest.spyOn(personUtils, 'tierBadge').mockReturnValue('TIER_BADGE')
-
       expect(completedTableRows([assessment])).toEqual([
         [
           { html: assessmentLink(assessment) },
-          { html: assessment.person.crn },
-          { html: 'TIER_BADGE' },
+          crnCell(assessment),
+          tierCell(assessment),
           { text: formattedArrivalDate(assessment) },
           { html: getStatus(assessment) },
         ],
       ])
-
-      expect(tierBadgeSpy).toHaveBeenCalledWith(assessment.risks.tier.value.level)
     })
   })
 })

--- a/server/utils/assessments/tableUtils.ts
+++ b/server/utils/assessments/tableUtils.ts
@@ -8,8 +8,8 @@ import {
   formatDaysUntilDueWithWarning,
   formattedArrivalDate,
 } from './dateUtils'
-import { tierBadge } from '../personUtils'
 import paths from '../../paths/assess'
+import { crnCell, tierCell } from '../tableUtils'
 
 const getStatus = (assessment: AssessmentSummary): string => {
   if (assessment.status === 'completed') {
@@ -36,12 +36,6 @@ const assessmentLink = (assessment: AssessmentSummary, linkText = '', hiddenText
   )
 }
 
-const crnCell = (assessment: AssessmentSummary) => {
-  return {
-    html: assessment.person.crn,
-  }
-}
-
 const arrivalDateCell = (assessment: AssessmentSummary) => {
   return {
     text: formattedArrivalDate(assessment),
@@ -63,12 +57,6 @@ const statusCell = (assessment: AssessmentSummary) => {
 const linkCell = (assessment: AssessmentSummary) => {
   return {
     html: assessmentLink(assessment),
-  }
-}
-
-const tierCell = (assessment: AssessmentSummary) => {
-  return {
-    html: tierBadge(assessment.risks.tier?.value?.level),
   }
 }
 

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -40,6 +40,7 @@ import * as PlacementRequestUtils from './placementRequests'
 import * as MatchUtils from './matchUtils'
 import * as SummaryListUtils from './applications/summaryListUtils'
 import * as BedUtils from './bedUtils'
+import * as PlacementApplicationUtils from './placementApplications'
 
 import managePaths from '../paths/manage'
 import applyPaths from '../paths/apply'
@@ -196,4 +197,5 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('MatchUtils', MatchUtils)
   njkEnv.addGlobal('SummaryListUtils', SummaryListUtils)
   njkEnv.addGlobal('BedUtils', BedUtils)
+  njkEnv.addGlobal('PlacementApplicationUtils', PlacementApplicationUtils)
 }

--- a/server/utils/placementApplications/index.ts
+++ b/server/utils/placementApplications/index.ts
@@ -1,0 +1,1 @@
+export * as tableUtils from './table'

--- a/server/utils/placementApplications/table.test.ts
+++ b/server/utils/placementApplications/table.test.ts
@@ -1,0 +1,39 @@
+import { placementApplicationTaskFactory } from '../../testutils/factories'
+import { nameCell, placementTypeCell, statusCell, tableRows } from './table'
+import { crnCell, tierCell } from '../tableUtils'
+
+describe('table', () => {
+  describe('nameCell', () => {
+    it('returns the name of the service user and a link', () => {
+      const task = placementApplicationTaskFactory.build()
+
+      expect(nameCell(task)).toEqual({
+        html: `<a href="/placement-applications/${task.id}/review" data-cy-placementApplicationId="${task.id}">${task.person.name}</a>`,
+      })
+    })
+  })
+
+  describe('placementTypeCell', () => {
+    it('returns the correct placement type', () => {
+      const task = placementApplicationTaskFactory.build({ placementType: 'rotl' })
+
+      expect(placementTypeCell(task)).toEqual({ text: 'ROTL' })
+    })
+  })
+
+  describe('statusCell', () => {
+    it('returns the correct placement type', () => {
+      const task = placementApplicationTaskFactory.build({ status: 'complete' })
+
+      expect(statusCell(task)).toEqual({ html: '<strong class="govuk-tag">Complete</strong>' })
+    })
+  })
+
+  describe('tableRows', () => {
+    const tasks = placementApplicationTaskFactory.buildList(1)
+
+    expect(tableRows(tasks)).toEqual([
+      [nameCell(tasks[0]), crnCell(tasks[0]), tierCell(tasks[0]), placementTypeCell(tasks[0]), statusCell(tasks[0])],
+    ])
+  })
+})

--- a/server/utils/placementApplications/table.ts
+++ b/server/utils/placementApplications/table.ts
@@ -1,0 +1,39 @@
+import { PlacementApplicationTask, PlacementType } from '../../@types/shared'
+import { TableCell, TableRow } from '../../@types/ui'
+import paths from '../../paths/placementApplications'
+import { linkTo, sentenceCase } from '../utils'
+import { crnCell, tierCell } from '../tableUtils'
+
+const placementTypes: Record<PlacementType, string> = {
+  rotl: 'ROTL',
+  release_following_decision: 'Release Following Decision',
+  additional_placement: 'Additional Placement',
+}
+
+export const tableRows = (tasks: Array<PlacementApplicationTask>): Array<TableRow> => {
+  return tasks.map((task: PlacementApplicationTask) => {
+    return [nameCell(task), crnCell(task), tierCell(task), placementTypeCell(task), statusCell(task)]
+  })
+}
+
+export const nameCell = (task: PlacementApplicationTask): TableCell => {
+  return {
+    html: linkTo(
+      paths.placementApplications.review.show,
+      { id: task.id },
+      { text: task.person.name, attributes: { 'data-cy-placementApplicationId': task.id } },
+    ),
+  }
+}
+
+export const placementTypeCell = (task: PlacementApplicationTask) => {
+  return {
+    text: placementTypes[task.placementType],
+  }
+}
+
+export const statusCell = (task: PlacementApplicationTask) => {
+  return {
+    html: `<strong class="govuk-tag">${sentenceCase(task.status)}</strong>`,
+  }
+}

--- a/server/utils/placementRequests/table.test.ts
+++ b/server/utils/placementRequests/table.test.ts
@@ -1,9 +1,9 @@
 import { add } from 'date-fns'
-import { placementRequestTaskFactory, tierEnvelopeFactory } from '../../testutils/factories'
-import { crnCell, dueDateCell, expectedArrivalDateCell, nameCell, releaseTypeCell, tableRows, tierCell } from './table'
-import { tierBadge } from '../personUtils'
+import { placementRequestTaskFactory } from '../../testutils/factories'
+import { dueDateCell, expectedArrivalDateCell, nameCell, releaseTypeCell, tableRows } from './table'
 import { DateFormats } from '../dateUtils'
 import { allReleaseTypes } from '../applications/releaseTypeUtils'
+import { crnCell, tierCell } from '../tableUtils'
 
 describe('tableUtils', () => {
   describe('nameCell', () => {
@@ -13,23 +13,6 @@ describe('tableUtils', () => {
       expect(nameCell(task)).toEqual({
         html: `<a href="/placement-requests/${task.id}" data-cy-placementRequestId="${task.id}">${task.person.name}</a>`,
       })
-    })
-  })
-
-  describe('crnCell', () => {
-    it('returns the CRN of the service user associated with the placement request', () => {
-      const task = placementRequestTaskFactory.build()
-
-      expect(crnCell(task)).toEqual({ text: task.person.crn })
-    })
-  })
-
-  describe('tierCell', () => {
-    it('returns the tier badge for the service user associated with the placement request', () => {
-      const tier = tierEnvelopeFactory.build({ value: { level: 'A1' } })
-      const task = placementRequestTaskFactory.build({ risks: { tier } })
-
-      expect(tierCell(task)).toEqual({ html: tierBadge('A1') })
     })
   })
 

--- a/server/utils/placementRequests/table.test.ts
+++ b/server/utils/placementRequests/table.test.ts
@@ -1,5 +1,5 @@
 import { add } from 'date-fns'
-import { placementRequestFactory, tierEnvelopeFactory } from '../../testutils/factories'
+import { placementRequestTaskFactory, tierEnvelopeFactory } from '../../testutils/factories'
 import { crnCell, dueDateCell, expectedArrivalDateCell, nameCell, releaseTypeCell, tableRows, tierCell } from './table'
 import { tierBadge } from '../personUtils'
 import { DateFormats } from '../dateUtils'
@@ -8,36 +8,36 @@ import { allReleaseTypes } from '../applications/releaseTypeUtils'
 describe('tableUtils', () => {
   describe('nameCell', () => {
     it('returns the name of the service user and a link', () => {
-      const placementRequest = placementRequestFactory.build()
+      const task = placementRequestTaskFactory.build()
 
-      expect(nameCell(placementRequest)).toEqual({
-        html: `<a href="/placement-requests/${placementRequest.id}" data-cy-placementRequestId="${placementRequest.id}">${placementRequest.person.name}</a>`,
+      expect(nameCell(task)).toEqual({
+        html: `<a href="/placement-requests/${task.id}" data-cy-placementRequestId="${task.id}">${task.person.name}</a>`,
       })
     })
   })
 
   describe('crnCell', () => {
     it('returns the CRN of the service user associated with the placement request', () => {
-      const placementRequest = placementRequestFactory.build()
+      const task = placementRequestTaskFactory.build()
 
-      expect(crnCell(placementRequest)).toEqual({ text: placementRequest.person.crn })
+      expect(crnCell(task)).toEqual({ text: task.person.crn })
     })
   })
 
   describe('tierCell', () => {
     it('returns the tier badge for the service user associated with the placement request', () => {
       const tier = tierEnvelopeFactory.build({ value: { level: 'A1' } })
-      const placementRequest = placementRequestFactory.build({ risks: { tier } })
+      const task = placementRequestTaskFactory.build({ risks: { tier } })
 
-      expect(tierCell(placementRequest)).toEqual({ html: tierBadge('A1') })
+      expect(tierCell(task)).toEqual({ html: tierBadge('A1') })
     })
   })
 
   describe('expectedArrivalDateCell', () => {
     it('returns a formatted arrival date', () => {
-      const placementRequest = placementRequestFactory.build({ expectedArrival: '2022-01-01' })
+      const task = placementRequestTaskFactory.build({ expectedArrival: '2022-01-01' })
 
-      expect(expectedArrivalDateCell(placementRequest)).toEqual({
+      expect(expectedArrivalDateCell(task)).toEqual({
         text: DateFormats.isoDateToUIDate('2022-01-01'),
       })
     })
@@ -46,11 +46,11 @@ describe('tableUtils', () => {
   describe('dueDateCell', () => {
     it('returns the difference in days between the arrival date and the due date', () => {
       const arrivalDate = add(new Date(), { days: 14 })
-      const placementRequest = placementRequestFactory.build({
+      const task = placementRequestTaskFactory.build({
         expectedArrival: DateFormats.dateObjToIsoDate(arrivalDate),
       })
 
-      expect(dueDateCell(placementRequest, 7)).toEqual({
+      expect(dueDateCell(task, 7)).toEqual({
         text: '7 days',
       })
     })
@@ -58,24 +58,24 @@ describe('tableUtils', () => {
 
   describe('releaseTypeCell', () => {
     it('returns the release type', () => {
-      const placementRequest = placementRequestFactory.build({ releaseType: 'rotl' })
+      const task = placementRequestTaskFactory.build({ releaseType: 'rotl' })
 
-      expect(releaseTypeCell(placementRequest)).toEqual({ text: allReleaseTypes.rotl })
+      expect(releaseTypeCell(task)).toEqual({ text: allReleaseTypes.rotl })
     })
   })
 
   describe('tableRows', () => {
     it('returns table rows for placement requests', () => {
-      const placementRequest = placementRequestFactory.build()
+      const task = placementRequestTaskFactory.build()
 
-      expect(tableRows([placementRequest])).toEqual([
+      expect(tableRows([task])).toEqual([
         [
-          nameCell(placementRequest),
-          crnCell(placementRequest),
-          tierCell(placementRequest),
-          expectedArrivalDateCell(placementRequest),
-          dueDateCell(placementRequest, 7),
-          releaseTypeCell(placementRequest),
+          nameCell(task),
+          crnCell(task),
+          tierCell(task),
+          expectedArrivalDateCell(task),
+          dueDateCell(task, 7),
+          releaseTypeCell(task),
         ],
       ])
     })

--- a/server/utils/placementRequests/table.ts
+++ b/server/utils/placementRequests/table.ts
@@ -1,5 +1,5 @@
 import { add } from 'date-fns'
-import { PlacementRequest } from '../../@types/shared'
+import { PlacementRequestTask } from '../../@types/shared'
 import { TableCell, TableRow } from '../../@types/ui'
 import paths from '../../paths/match'
 import { DateFormats } from '../dateUtils'
@@ -9,26 +9,23 @@ import { allReleaseTypes } from '../applications/releaseTypeUtils'
 
 export const DIFFERENCE_IN_DAYS_BETWEEN_DUE_DATE_AND_ARRIVAL_DATE = 7
 
-export const tableRows = (placementRequests: Array<PlacementRequest>): Array<TableRow> => {
-  return placementRequests.map((placementRequest: PlacementRequest) => {
+export const tableRows = (tasks: Array<PlacementRequestTask>): Array<TableRow> => {
+  return tasks.map((task: PlacementRequestTask) => {
     return [
-      nameCell(placementRequest),
-      crnCell(placementRequest),
-      tierCell(placementRequest),
-      expectedArrivalDateCell(placementRequest),
-      dueDateCell(placementRequest, DIFFERENCE_IN_DAYS_BETWEEN_DUE_DATE_AND_ARRIVAL_DATE),
-      releaseTypeCell(placementRequest),
+      nameCell(task),
+      crnCell(task),
+      tierCell(task),
+      expectedArrivalDateCell(task),
+      dueDateCell(task, DIFFERENCE_IN_DAYS_BETWEEN_DUE_DATE_AND_ARRIVAL_DATE),
+      releaseTypeCell(task),
     ]
   })
 }
 
-export const crnCell = (placementRequest: PlacementRequest): TableCell => ({ text: placementRequest.person.crn })
+export const crnCell = (task: PlacementRequestTask): TableCell => ({ text: task.person.crn })
 
-export const dueDateCell = (
-  placementRequest: PlacementRequest,
-  differenceBetweenDueDateAndArrivalDate: number,
-): TableCell => {
-  const dateAsObject = DateFormats.isoToDateObj(placementRequest.expectedArrival)
+export const dueDateCell = (task: PlacementRequestTask, differenceBetweenDueDateAndArrivalDate: number): TableCell => {
+  const dateAsObject = DateFormats.isoToDateObj(task.expectedArrival)
 
   return {
     text: DateFormats.differenceInDays(
@@ -38,28 +35,28 @@ export const dueDateCell = (
   }
 }
 
-export const expectedArrivalDateCell = (placementRequest: PlacementRequest): TableCell => ({
-  text: DateFormats.isoDateToUIDate(placementRequest.expectedArrival),
+export const expectedArrivalDateCell = (task: PlacementRequestTask): TableCell => ({
+  text: DateFormats.isoDateToUIDate(task.expectedArrival),
 })
 
-export const nameCell = (placementRequest: PlacementRequest): TableCell => {
+export const nameCell = (task: PlacementRequestTask): TableCell => {
   return {
     html: linkTo(
       paths.placementRequests.show,
-      { id: placementRequest.id },
-      { text: placementRequest.person.name, attributes: { 'data-cy-placementRequestId': placementRequest.id } },
+      { id: task.id },
+      { text: task.person.name, attributes: { 'data-cy-placementRequestId': task.id } },
     ),
   }
 }
 
-export const tierCell = (placementRequest: PlacementRequest) => {
+export const tierCell = (task: PlacementRequestTask) => {
   return {
-    html: tierBadge(placementRequest.risks.tier?.value?.level),
+    html: tierBadge(task.risks.tier?.value?.level),
   }
 }
 
-export const releaseTypeCell = (placementRequest: PlacementRequest) => {
+export const releaseTypeCell = (task: PlacementRequestTask) => {
   return {
-    text: allReleaseTypes[placementRequest.releaseType],
+    text: allReleaseTypes[task.releaseType],
   }
 }

--- a/server/utils/placementRequests/table.ts
+++ b/server/utils/placementRequests/table.ts
@@ -4,7 +4,7 @@ import { TableCell, TableRow } from '../../@types/ui'
 import paths from '../../paths/match'
 import { DateFormats } from '../dateUtils'
 import { linkTo } from '../utils'
-import { tierBadge } from '../personUtils'
+import { crnCell, tierCell } from '../tableUtils'
 import { allReleaseTypes } from '../applications/releaseTypeUtils'
 
 export const DIFFERENCE_IN_DAYS_BETWEEN_DUE_DATE_AND_ARRIVAL_DATE = 7
@@ -21,8 +21,6 @@ export const tableRows = (tasks: Array<PlacementRequestTask>): Array<TableRow> =
     ]
   })
 }
-
-export const crnCell = (task: PlacementRequestTask): TableCell => ({ text: task.person.crn })
 
 export const dueDateCell = (task: PlacementRequestTask, differenceBetweenDueDateAndArrivalDate: number): TableCell => {
   const dateAsObject = DateFormats.isoToDateObj(task.expectedArrival)
@@ -46,12 +44,6 @@ export const nameCell = (task: PlacementRequestTask): TableCell => {
       { id: task.id },
       { text: task.person.name, attributes: { 'data-cy-placementRequestId': task.id } },
     ),
-  }
-}
-
-export const tierCell = (task: PlacementRequestTask) => {
-  return {
-    html: tierBadge(task.risks.tier?.value?.level),
   }
 }
 

--- a/server/utils/tableUtils.test.ts
+++ b/server/utils/tableUtils.test.ts
@@ -1,17 +1,44 @@
-import { taskFactory } from '../testutils/factories'
-import { nameCell } from './tableUtils'
+import { placementRequestTaskFactory, taskFactory, tierEnvelopeFactory } from '../testutils/factories'
+import { tierBadge } from './personUtils'
+import { crnCell, nameCell, tierCell } from './tableUtils'
 
-describe('nameCell', () => {
-  it('returns the name of the person the task is assigned to as a TableCell object', () => {
-    const task = taskFactory.build()
-    expect(nameCell(task)).toEqual({ text: task.person.name })
+describe('tableUtils', () => {
+  describe('nameCell', () => {
+    it('returns the name of the person the task is assigned to as a TableCell object', () => {
+      const task = taskFactory.build()
+      expect(nameCell(task)).toEqual({ text: task.person.name })
+    })
+
+    it('returns an empty string as a TableCell object if the task doesnt have a person', () => {
+      const taskWithNoPersonName = taskFactory.build({ person: { name: undefined } })
+      const taskWithNoPerson = taskFactory.build({ person: undefined })
+
+      expect(nameCell(taskWithNoPersonName)).toEqual({ text: '' })
+      expect(nameCell(taskWithNoPerson)).toEqual({ text: '' })
+    })
   })
 
-  it('returns an empty string as a TableCell object if the task doesnt have a person', () => {
-    const taskWithNoPersonName = taskFactory.build({ person: { name: undefined } })
-    const taskWithNoPerson = taskFactory.build({ person: undefined })
+  describe('crnCell', () => {
+    it('returns the crn of the person the task is assigned to as a TableCell object', () => {
+      const task = taskFactory.build()
+      expect(crnCell(task)).toEqual({ text: task.person.crn })
+    })
 
-    expect(nameCell(taskWithNoPersonName)).toEqual({ text: '' })
-    expect(nameCell(taskWithNoPerson)).toEqual({ text: '' })
+    it('returns an empty string as a TableCell object if the task doesnt have a person', () => {
+      const taskWithNoPersonCrn = taskFactory.build({ person: { crn: undefined } })
+      const taskWithNoPerson = taskFactory.build({ person: undefined })
+
+      expect(crnCell(taskWithNoPersonCrn)).toEqual({ text: '' })
+      expect(crnCell(taskWithNoPerson)).toEqual({ text: '' })
+    })
+  })
+
+  describe('tierCell', () => {
+    it('returns the tier badge for the service user associated with the task', () => {
+      const tier = tierEnvelopeFactory.build({ value: { level: 'A1' } })
+      const task = placementRequestTaskFactory.build({ risks: { tier } })
+
+      expect(tierCell(task)).toEqual({ html: tierBadge('A1') })
+    })
   })
 })

--- a/server/utils/tableUtils.ts
+++ b/server/utils/tableUtils.ts
@@ -1,4 +1,13 @@
-import { Person } from '../@types/shared'
+import { Person, PersonRisks } from '../@types/shared'
 import { TableCell } from '../@types/ui'
+import { tierBadge } from './personUtils'
 
 export const nameCell = (item: { person?: Person }): TableCell => ({ text: item?.person?.name || '' })
+
+export const crnCell = (item: { person?: Person }): TableCell => ({ text: item?.person?.crn || '' })
+
+export const tierCell = (item: { risks?: PersonRisks }) => {
+  return {
+    html: tierBadge(item.risks.tier?.value?.level),
+  }
+}

--- a/server/views/match/placementRequests/_table.njk
+++ b/server/views/match/placementRequests/_table.njk
@@ -1,8 +1,8 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% macro placementRequestTable(title, rows) %}
-  {% if rows %}
-    {{
+    {% if rows %}
+        {{
       govukTable({
           attributes: {
               'data-module': 'moj-sortable-table'
@@ -37,5 +37,33 @@
           rows: rows
       })
     }}
-  {% endif %}
+    {% endif %}
+{% endmacro %}
+
+{% macro placementApplicationTable(title, rows) %}
+    {% if rows %}
+        {{
+      govukTable({
+          firstCellIsHeader: true,
+          head: [
+              {
+                  text: "Name"
+              },
+              {
+                  text: "CRN"
+              },
+              {
+                  text: "Tier"
+              },
+              {
+                  text: "Type of request"
+              },
+              {
+                  text: "Status"
+              }
+          ],
+          rows: rows
+        })
+    }}
+    {% endif %}
 {% endmacro %}

--- a/server/views/match/placementRequests/index.njk
+++ b/server/views/match/placementRequests/index.njk
@@ -3,19 +3,20 @@
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% from "./_table.njk" import placementRequestTable %}
+{% from "./_table.njk" import placementApplicationTable %}
 
 {% set pageTitle = applicationName + " - " + pageHeading  %}
 {% set mainClasses = "app-container govuk-body assessments--index" %}
 
 {% block content %}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
 
-      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-      {% include "../../_messages.njk" %}
+            <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+            {% include "../../_messages.njk" %}
 
-      {{ govukTabs({
+            {{ govukTabs({
                 items: [
                     {
                         label: "Active cases",
@@ -32,6 +33,13 @@
                         }
                     },
                     {
+                        label: "Placement Applications",
+                        id: "placement-applications",
+                        panel: {
+                            html: placementApplicationTable("Placement Applications", PlacementApplicationUtils.tableUtils.tableRows(tasks.placementApplications))
+                        }
+                    },
+                    {
                         label: "Completed",
                         id: "completed",
                         panel: {
@@ -41,14 +49,14 @@
                 ]
             }) }}
 
+        </div>
     </div>
-  </div>
 {% endblock %}
 
 {% block extraScripts %}
-  <script type="text/javascript" nonce="{{ cspNonce }}">
-    window
-      .MOJFrontend
-      .initAll()
-  </script>
+    <script type="text/javascript" nonce="{{ cspNonce }}">
+        window
+            .MOJFrontend
+            .initAll()
+    </script>
 {% endblock %}

--- a/server/views/match/placementRequests/index.njk
+++ b/server/views/match/placementRequests/index.njk
@@ -21,21 +21,21 @@
                         label: "Active cases",
                         id: "active-cases",
                         panel: {
-                            html: placementRequestTable("Placement Requests", PlacementRequestUtils.tableUtils.tableRows(placementRequests.notMatched))
+                            html: placementRequestTable("Placement Requests", PlacementRequestUtils.tableUtils.tableRows(tasks.notMatched))
                         }
                     },
                     {
                         label: "Unable to match",
                         id: "unable-to-match",
                         panel: {
-                            html: placementRequestTable("Placement Requests", PlacementRequestUtils.tableUtils.tableRows(placementRequests.unableToMatch))
+                            html: placementRequestTable("Placement Requests", PlacementRequestUtils.tableUtils.tableRows(tasks.unableToMatch))
                         }
                     },
                     {
                         label: "Completed",
                         id: "completed",
                         panel: {
-                            html: placementRequestTable("Placement Requests", PlacementRequestUtils.tableUtils.tableRows(placementRequests.matched))
+                            html: placementRequestTable("Placement Requests", PlacementRequestUtils.tableUtils.tableRows(tasks.matched))
                         }
                     }
                 ]


### PR DESCRIPTION
This updates the `/match` homepage to fetch the Placement Requests from the `/tasks` endpoint, and also fetch and display the Placement Applications. These do not currently link anywhere, but this will come in a future PR.

## Screenshot

![Placement Requests -- shows a list of matcher tasks](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/3c1a0df3-e4b5-4f3c-a898-ad6aec3b3b2d)
