### PR TITLE
(176) Request a placement - Parole flow

### DIFF
--- a/integration_tests/.eslintrc
+++ b/integration_tests/.eslintrc
@@ -1,11 +1,12 @@
 {
-  "plugins": ["cypress"],
+  "plugins": ["cypress", "no-only-tests"],
   "env": {
     "cypress/globals": true
   },
   "extends": ["plugin:cypress/recommended"],
   "rules": {
-    "import/no-extraneous-dependencies": ["error", { "devDependencies": true }]
+    "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
+    "no-only-tests/no-only-tests": "error"
   },
   "settings": {
     "import/resolver": {

--- a/integration_tests/fixtures/paroleBoardPlacementApplication.json
+++ b/integration_tests/fixtures/paroleBoardPlacementApplication.json
@@ -1,0 +1,48 @@
+{
+  "request-a-placement": {
+    "reason-for-placement": {
+      "reason": "release_following_decision"
+    },
+    "decision-to-release": {
+      "decisionToReleaseDate": "2023-08-01",
+      "decisionToReleaseDate-day": "01",
+      "decisionToReleaseDate-month": "8",
+      "decisionToReleaseDate-year": "2023",
+      "informationFromDirectionToRelease": "Some info"
+    },
+    "additional-documents": {
+      "selectedDocuments": [
+        {
+          "id": "aeb43e06-a4a1-460f-9acf-e2495de84604",
+          "level": "Offender",
+          "fileName": "Random offender document1.pdf",
+          "createdAt": "2019-09-10T00:00:00Z",
+          "typeCode": "OFFENDER_DOCUMENT",
+          "typeDescription": "Offender related",
+          "description": "Some Description 1"
+        },
+        {
+          "id": "5f8a2288-0a17-4e45-afd5-5e57794a7b53",
+          "level": "Conviction",
+          "fileName": "national.asm",
+          "createdAt": "2022-09-13",
+          "typeCode": "serenade",
+          "typeDescription": "porter",
+          "description": "Some Description 2"
+        }
+      ]
+    },
+    "updates-to-application": {
+      "significantEvents": "yes",
+      "significantEventsDetail": "Some details",
+      "changedCirumstances": "yes",
+      "changedCirumstancesDetail": "Some details",
+      "riskFactors": "yes",
+      "riskFactorsDetail": "Some details",
+      "accessOrHealthcareNeeds": "yes",
+      "accessOrHealthcareNeedsDetail": "Some details",
+      "locationFactors": "yes",
+      "locationFactorsDetail": "Some details"
+    }
+  }
+}

--- a/integration_tests/pages/match/placementRequestForm/additionalDocuments.ts
+++ b/integration_tests/pages/match/placementRequestForm/additionalDocuments.ts
@@ -1,0 +1,39 @@
+import { Document } from '@approved-premises/api'
+import { DateFormats } from '../../../../server/utils/dateUtils'
+import Page from '../../page'
+
+export default class AdditionalDocuments extends Page {
+  documents: Array<Document>
+
+  selectedDocuments: Array<Document>
+
+  constructor(documents: Array<Document>, selectedDocuments: Array<Document>) {
+    super('Select any additional documents that are required to support your application')
+
+    this.documents = documents
+    this.selectedDocuments = selectedDocuments
+  }
+
+  shouldDisplayDocuments() {
+    this.documents.forEach(document => {
+      cy.get('tr')
+        .contains(document.fileName)
+        .parent()
+        .parent()
+        .parent()
+        .within(() => {
+          cy.get('td').eq(0).contains(DateFormats.isoDateToUIDate(document.createdAt))
+        })
+    })
+  }
+
+  completeForm() {
+    this.selectedDocuments.forEach(d => {
+      const textareaSelector = `textarea[name="documentDescriptions[${d.id}]"]`
+
+      cy.get('label').contains(d.fileName).click()
+      cy.get(textareaSelector).clear()
+      cy.get(textareaSelector).type(d.description)
+    })
+  }
+}

--- a/integration_tests/pages/match/placementRequestForm/decisionToRelease.ts
+++ b/integration_tests/pages/match/placementRequestForm/decisionToRelease.ts
@@ -1,0 +1,12 @@
+import Page from '../../page'
+
+export default class DecisionToRelease extends Page {
+  constructor() {
+    super('Release details')
+  }
+
+  completeForm() {
+    this.clearAndCompleteDateInputs('decisionToReleaseDate', '2023-08-01')
+    this.clearAndCompleteTextInputById('informationFromDirectionToRelease', 'Some information')
+  }
+}

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -237,6 +237,7 @@ export type DataServices = Partial<{
   }
   applicationService: {
     getDocuments: (token: string, application: ApprovedPremisesApplication) => Promise<Array<Document>>
+    findApplication: (token: string, id: string) => Promise<ApprovedPremisesApplication>
   }
   userService: {
     getUserById: (token: string, id: string) => Promise<User>

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -15,7 +15,10 @@ export const controllers = (services: Services) => {
   const dashboardController = new DashboardController()
   const tasksController = new TasksController(services.taskService, services.applicationService)
   const allocationsController = new AllocationsController(services.taskService)
-  const placementApplicationPagesController = new PagesController(services.placementApplicationService)
+  const placementApplicationPagesController = new PagesController(
+    services.placementApplicationService,
+    services.applicationService,
+  )
 
   return {
     dashboardController,

--- a/server/controllers/match/index.ts
+++ b/server/controllers/match/index.ts
@@ -7,12 +7,13 @@ import BookingsController from './placementRequests/bookingsController'
 import type { Services } from '../../services'
 
 export const controllers = (services: Services) => {
-  const { placementApplicationService, placementRequestService, bedService, taskService } = services
+  const { placementApplicationService, placementRequestService, bedService, taskService, applicationService } = services
 
   const placementRequestController = new PlacementRequestController(
     placementRequestService,
     placementApplicationService,
     taskService,
+    applicationService,
   )
   const bedController = new BedSearchController(bedService, placementRequestService)
   const placementRequestBookingsController = new BookingsController(placementRequestService)

--- a/server/controllers/match/placementRequestsController.test.ts
+++ b/server/controllers/match/placementRequestsController.test.ts
@@ -4,8 +4,13 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import { GroupedMatchTasks } from '@approved-premises/ui'
 import PlacementRequestsController from './placementRequestsController'
 
-import { PlacementApplicationService, PlacementRequestService, TaskService } from '../../services'
-import { personFactory, placementApplicationFactory, placementRequestFactory } from '../../testutils/factories'
+import { ApplicationService, PlacementApplicationService, PlacementRequestService, TaskService } from '../../services'
+import {
+  applicationFactory,
+  personFactory,
+  placementApplicationFactory,
+  placementRequestFactory,
+} from '../../testutils/factories'
 import paths from '../../paths/placementApplications'
 import { getResponses } from '../../utils/applications/utils'
 
@@ -21,6 +26,7 @@ describe('PlacementRequestsController', () => {
   const placementRequestService = createMock<PlacementRequestService>({})
   const placementApplicationService = createMock<PlacementApplicationService>({})
   const taskService = createMock<TaskService>({})
+  const applicationService = createMock<ApplicationService>({})
 
   let placementRequestsController: PlacementRequestsController
 
@@ -30,6 +36,7 @@ describe('PlacementRequestsController', () => {
       placementRequestService,
       placementApplicationService,
       taskService,
+      applicationService,
     )
   })
 
@@ -95,7 +102,9 @@ describe('PlacementRequestsController', () => {
     describe('when confirmation is "1"', () => {
       it('should POST to the service and redirect to the confirmation page', async () => {
         const placementApplication = placementApplicationFactory.build()
+        const application = applicationFactory.build()
         placementApplicationService.submit.mockResolvedValue(placementApplication)
+        applicationService.findApplication.mockResolvedValue(application)
 
         const requestHandler = placementRequestsController.submit()
 
@@ -109,7 +118,7 @@ describe('PlacementRequestsController', () => {
         expect(response.render).toHaveBeenCalledWith('placement-applications/confirm', {
           pageHeading: 'Request for placement confirmed',
         })
-        expect(placementApplicationService.submit).toHaveBeenCalledWith(token, placementApplication.id)
+        expect(placementApplicationService.submit).toHaveBeenCalledWith(token, placementApplication.id, application)
       })
     })
 

--- a/server/controllers/match/placementRequestsController.ts
+++ b/server/controllers/match/placementRequestsController.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
-import { PlacementApplicationService, PlacementRequestService, TaskService } from '../../services'
+import { ApplicationService, PlacementApplicationService, PlacementRequestService, TaskService } from '../../services'
 import paths from '../../paths/placementApplications'
 import { addErrorMessageToFlash } from '../../utils/validation'
 import { getResponses } from '../../utils/applications/utils'
@@ -9,6 +9,7 @@ export default class PlacementRequestsController {
     private readonly placementRequestService: PlacementRequestService,
     private readonly placementApplicationService: PlacementApplicationService,
     private readonly taskService: TaskService,
+    private readonly applicationService: ApplicationService,
   ) {}
 
   index(): TypedRequestHandler<Request, Response> {
@@ -65,8 +66,11 @@ export default class PlacementRequestsController {
 
       const placementApplication = await this.placementApplicationService.getPlacementApplication(req.user.token, id)
       placementApplication.document = getResponses(placementApplication)
-
-      await this.placementApplicationService.submit(req.user.token, placementApplication)
+      const application = await this.applicationService.findApplication(
+        req.user.token,
+        placementApplication.applicationId,
+      )
+      await this.placementApplicationService.submit(req.user.token, placementApplication, application)
 
       return res.render('placement-applications/confirm', {
         pageHeading: 'Request for placement confirmed',

--- a/server/controllers/placementApplications/pagesController.test.ts
+++ b/server/controllers/placementApplications/pagesController.test.ts
@@ -4,7 +4,7 @@ import createError from 'http-errors'
 
 import type { DataServices, ErrorsAndUserInput, FormPages } from '@approved-premises/ui'
 import PagesController from './pagesController'
-import { PlacementApplicationService } from '../../services'
+import { ApplicationService, PlacementApplicationService } from '../../services'
 import TasklistPage from '../../form-pages/tasklistPage'
 import PlacementRequest from '../../form-pages/placement-application'
 import { getPage } from '../../utils/applications/utils'
@@ -35,6 +35,7 @@ describe('pagesController', () => {
   const next: DeepMocked<NextFunction> = jest.fn()
 
   const placementApplicationService = createMock<PlacementApplicationService>({})
+  const applicationService = createMock<ApplicationService>({})
   const dataServices = createMock<DataServices>({}) as DataServices
 
   const PageConstructor = jest.fn()
@@ -43,7 +44,7 @@ describe('pagesController', () => {
   let pagesController: PagesController
 
   beforeEach(() => {
-    pagesController = new PagesController(placementApplicationService)
+    pagesController = new PagesController(placementApplicationService, applicationService)
     placementApplicationService.initializePage.mockResolvedValue(page)
     ;(getPage as jest.Mock).mockReturnValue(PageConstructor)
   })

--- a/server/form-pages/placement-application/request-a-placement/additionalDocuments.test.ts
+++ b/server/form-pages/placement-application/request-a-placement/additionalDocuments.test.ts
@@ -1,0 +1,119 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import { ApplicationService, PersonService } from '../../../services'
+import { applicationFactory, documentFactory, placementApplicationFactory } from '../../../testutils/factories'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+
+import AdditionalDocuments from './additionalDocuments'
+
+jest.mock('../../../services/applicationService.ts')
+
+describe('additionalDocuments', () => {
+  const placementApplication = placementApplicationFactory.build()
+  const application = applicationFactory.build()
+  const documents = documentFactory.buildList(3)
+
+  describe('initialize', () => {
+    const getDocumentsMock = jest.fn().mockResolvedValue(documents)
+    let applicationService: DeepMocked<ApplicationService>
+    const personService = createMock<PersonService>({})
+
+    beforeEach(() => {
+      applicationService = createMock<ApplicationService>({
+        getDocuments: getDocumentsMock,
+      })
+    })
+
+    it('calls the getDocuments method on the client with a token and the application', async () => {
+      await AdditionalDocuments.initialize({}, placementApplication, 'some-token', {
+        personService,
+        applicationService,
+      })
+
+      expect(getDocumentsMock).toHaveBeenCalledWith('some-token', application)
+    })
+
+    it('assigns the selected documents', async () => {
+      const page = await AdditionalDocuments.initialize(
+        {
+          documentIds: [documents[0].id, documents[1].id],
+          documentDescriptions: {
+            [documents[0].id]: 'Document 1 Description',
+            [documents[1].id]: 'Document 2 Description',
+          },
+        },
+        placementApplication,
+        'SOME_TOKEN',
+        { applicationService, personService },
+      )
+
+      expect(page.body).toEqual({
+        selectedDocuments: [
+          { ...documents[0], description: 'Document 1 Description' },
+          { ...documents[1], description: 'Document 2 Description' },
+        ],
+      })
+      expect(page.documents).toEqual(documents)
+    })
+
+    it('assigns the selected documents if the selection is not an array', async () => {
+      const page = await AdditionalDocuments.initialize(
+        { documentIds: documents[0].id, documentDescriptions: { [documents[0].id]: documents[0].description } },
+        placementApplication,
+        'SOME_TOKEN',
+        {
+          applicationService,
+          personService,
+        },
+      )
+
+      expect(page.body).toEqual({ selectedDocuments: [documents[0]] })
+    })
+
+    it('returns the selected documents if they are already defined', async () => {
+      const page = await AdditionalDocuments.initialize(
+        {
+          selectedDocuments: [documents[0]],
+        },
+        placementApplication,
+        'SOME_TOKEN',
+        { applicationService, personService },
+      )
+
+      expect(page.body).toEqual({
+        selectedDocuments: [documents[0]],
+      })
+      expect(page.documents).toEqual(documents)
+    })
+  })
+
+  itShouldHaveNextValue(new AdditionalDocuments({}, placementApplication), 'updates-to-application')
+
+  itShouldHavePreviousValue(new AdditionalDocuments({}, placementApplication), 'decision-to-release')
+
+  describe('errors', () => {
+    it('should return an error if a document does not have a description', () => {
+      const selectedDocuments = [
+        documentFactory.build({ fileName: 'file1.pdf', description: 'Description goes here' }),
+        documentFactory.build({ fileName: 'file2.pdf', description: null }),
+      ]
+
+      const page = new AdditionalDocuments({ selectedDocuments }, placementApplication)
+      expect(page.errors()).toEqual({
+        [`selectedDocuments_${selectedDocuments[1].id}`]: `You must enter a description for the document '${selectedDocuments[1].fileName}'`,
+      })
+    })
+  })
+
+  describe('response', () => {
+    it('should return a record with the document filename as the key and the description as the value', () => {
+      const selectedDocuments = [
+        documentFactory.build({ fileName: 'file1.pdf', description: 'Description goes here' }),
+        documentFactory.build({ fileName: 'file2.pdf', description: null }),
+      ]
+
+      const page = new AdditionalDocuments({ selectedDocuments }, placementApplication)
+
+      expect(page.response()).toEqual({ 'file1.pdf': 'Description goes here', 'file2.pdf': 'No description' })
+    })
+  })
+})

--- a/server/form-pages/placement-application/request-a-placement/additionalDocuments.ts
+++ b/server/form-pages/placement-application/request-a-placement/additionalDocuments.ts
@@ -1,0 +1,87 @@
+import type { ApprovedPremisesApplication, Document, PlacementApplication } from '@approved-premises/api'
+import { DataServices, TaskListErrors } from '@approved-premises/ui'
+import { Page } from '../../utils/decorators'
+
+import TasklistPage from '../../tasklistPage'
+
+type AdditionalDocumentsBody = {
+  selectedDocuments?: Array<Document>
+}
+
+type AdditionalDocumentsResponse = {
+  selectedDocuments?: Array<Document>
+  documentIds?: Array<string> | string
+  documentDescriptions?: Record<string, string>
+}
+
+@Page({ name: 'additional-documents', bodyProperties: ['selectedDocuments'] })
+export default class AdditionalDocuments implements TasklistPage {
+  title = 'Select any additional documents that are required to support your application'
+
+  documents: Array<Document> | undefined
+
+  application: ApprovedPremisesApplication
+
+  constructor(public body: AdditionalDocumentsBody, public readonly placementApplication: PlacementApplication) {}
+
+  static async initialize(
+    body: AdditionalDocumentsResponse,
+    placementApplication: PlacementApplication,
+    token: string,
+    dataServices: DataServices,
+  ): Promise<AdditionalDocuments> {
+    const application = await dataServices.applicationService.findApplication(token, placementApplication.applicationId)
+    const documents = await dataServices.applicationService.getDocuments(token, application)
+    const documentIds = [body.documentIds].flat()
+    const documentDescriptions = body.documentDescriptions || {}
+
+    const selectedDocuments = body.selectedDocuments
+      ? body.selectedDocuments
+      : documents
+          .filter((d: Document) => documentIds.includes(d.id))
+          .map(document => {
+            return {
+              ...document,
+              description: documentDescriptions[document.id],
+            }
+          })
+
+    const page = new AdditionalDocuments({ selectedDocuments }, placementApplication)
+    page.documents = documents
+    page.application = application
+
+    return page
+  }
+
+  previous() {
+    return 'decision-to-release'
+  }
+
+  next() {
+    return 'updates-to-application'
+  }
+
+  response() {
+    const response = {}
+
+    this.body.selectedDocuments.forEach(d => {
+      response[d.fileName] = d.description || 'No description'
+    })
+
+    return response
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    this.body.selectedDocuments.forEach(document => {
+      if (!document.description) {
+        errors[
+          `selectedDocuments_${document.id}`
+        ] = `You must enter a description for the document '${document.fileName}'`
+      }
+    })
+
+    return errors
+  }
+}

--- a/server/form-pages/placement-application/request-a-placement/checkYourAnswers.ts
+++ b/server/form-pages/placement-application/request-a-placement/checkYourAnswers.ts
@@ -1,8 +1,10 @@
-import type { TaskListErrors } from '@approved-premises/ui'
+import type { DataServices, TaskListErrors } from '@approved-premises/ui'
 import { Page } from '../../utils/decorators'
 
 import TasklistPage from '../../tasklistPage'
-import { PlacementApplication } from '../../../@types/shared'
+import { ApprovedPremisesApplication as Application, PlacementApplication } from '../../../@types/shared'
+
+type Body = { reviewed?: string }
 
 @Page({ name: 'check-your-answers', bodyProperties: ['reviewed'] })
 export default class Review implements TasklistPage {
@@ -12,7 +14,24 @@ export default class Review implements TasklistPage {
 
   placementApplication: PlacementApplication
 
-  constructor(public body: { reviewed?: string }, placementApplication: PlacementApplication) {
+  application: Application
+
+  static async initialize(
+    body: Body,
+    placementApplication: PlacementApplication,
+    token: string,
+    dataServices: DataServices,
+  ): Promise<Review> {
+    const application = await dataServices.applicationService.findApplication(token, placementApplication.applicationId)
+
+    const page = new Review(body, placementApplication)
+
+    page.application = application
+
+    return page
+  }
+
+  constructor(public body: Body, placementApplication: PlacementApplication) {
     this.placementApplication = placementApplication
   }
 

--- a/server/form-pages/placement-application/request-a-placement/decisionToRelease.test.ts
+++ b/server/form-pages/placement-application/request-a-placement/decisionToRelease.test.ts
@@ -1,0 +1,70 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+
+import DecisionToRelease, { Body } from './decisionToRelease'
+
+describe('DecisionToRelease', () => {
+  const body = {
+    duration: '12',
+    informationFromDirectionToRelease: 'Some information',
+    'decisionToReleaseDate-year': '2023',
+    'decisionToReleaseDate-month': '12',
+    'decisionToReleaseDate-day': '1',
+  } as Body
+
+  describe('body', () => {
+    it('should set the body', () => {
+      const page = new DecisionToRelease(body)
+
+      expect(page.body).toEqual({
+        'decisionToReleaseDate-year': '2023',
+        'decisionToReleaseDate-month': '12',
+        'decisionToReleaseDate-day': '1',
+        decisionToReleaseDate: '2023-12-01',
+        informationFromDirectionToRelease: 'Some information',
+      })
+    })
+  })
+
+  itShouldHavePreviousValue(new DecisionToRelease(body), 'reason-for-placement')
+
+  itShouldHaveNextValue(new DecisionToRelease(body), 'additional-documents')
+
+  describe('errors', () => {
+    it('should return an empty object if the body is provided correctly', () => {
+      const page = new DecisionToRelease(body)
+      expect(page.errors()).toEqual({})
+    })
+
+    it('should return errors if decisionToRelease is blank', () => {
+      const page = new DecisionToRelease(fromPartial({}))
+      expect(page.errors()).toEqual({
+        decisionToReleaseDate: 'You must state the date of the decision to release',
+        informationFromDirectionToRelease: 'You must state the relevant information from the direction to release',
+      })
+    })
+
+    it('should return errors if the last decision to release date is invalid', () => {
+      const page = new DecisionToRelease({
+        ...body,
+        'decisionToReleaseDate-year': '99999',
+        'decisionToReleaseDate-month': '99999',
+        'decisionToReleaseDate-day': '199999',
+      })
+      expect(page.errors()).toEqual({
+        decisionToReleaseDate: 'The decision to release date is invalid',
+      })
+    })
+  })
+
+  describe('response', () => {
+    it('should return a translated version of the response', () => {
+      const page = new DecisionToRelease(body)
+
+      expect(page.response()).toEqual({
+        'When will the person arrive?': 'Friday 1 December 2023',
+        'Provide relevant information from the direction to release that will impact the placement': 'Some information',
+      })
+    })
+  })
+})

--- a/server/form-pages/placement-application/request-a-placement/decisionToRelease.ts
+++ b/server/form-pages/placement-application/request-a-placement/decisionToRelease.ts
@@ -1,0 +1,80 @@
+import type { ObjectWithDateParts, TaskListErrors } from '@approved-premises/ui'
+
+import TasklistPage from '../../tasklistPage'
+import { Page } from '../../utils/decorators'
+import { DateFormats, dateAndTimeInputsAreValidDates } from '../../../utils/dateUtils'
+
+export type Body = {
+  informationFromDirectionToRelease: string
+} & ObjectWithDateParts<'decisionToReleaseDate'>
+
+@Page({
+  name: 'decision-to-release',
+  bodyProperties: [
+    'decisionToReleaseDate',
+    'decisionToReleaseDate-day',
+    'decisionToReleaseDate-month',
+    'decisionToReleaseDate-year',
+    'informationFromDirectionToRelease',
+  ],
+})
+export default class DecisionToRelease implements TasklistPage {
+  title = 'Release details'
+
+  questions = {
+    decisionToReleaseDate: 'When will the person arrive?',
+    informationFromDirectionToRelease:
+      'Provide relevant information from the direction to release that will impact the placement',
+  }
+
+  body: Body
+
+  constructor(_body: Body) {
+    this.body = {
+      'decisionToReleaseDate-year': _body['decisionToReleaseDate-year'],
+      'decisionToReleaseDate-month': _body['decisionToReleaseDate-month'],
+      'decisionToReleaseDate-day': _body['decisionToReleaseDate-day'],
+      decisionToReleaseDate: DateFormats.dateAndTimeInputsToIsoString(
+        _body as ObjectWithDateParts<'decisionToReleaseDate'>,
+        'decisionToReleaseDate',
+      ).decisionToReleaseDate,
+
+      informationFromDirectionToRelease: _body.informationFromDirectionToRelease,
+    }
+  }
+
+  previous() {
+    return 'reason-for-placement'
+  }
+
+  next() {
+    return 'additional-documents'
+  }
+
+  response() {
+    return {
+      [this.questions.decisionToReleaseDate]: DateFormats.isoDateToUIDate(this.body.decisionToReleaseDate),
+      [this.questions.informationFromDirectionToRelease]: this.body.informationFromDirectionToRelease,
+    }
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.decisionToReleaseDate) {
+      errors.decisionToReleaseDate = 'You must state the date of the decision to release'
+    } else if (
+      !dateAndTimeInputsAreValidDates(
+        this.body as ObjectWithDateParts<'decisionToReleaseDate'>,
+        'decisionToReleaseDate',
+      )
+    ) {
+      errors.decisionToReleaseDate = 'The decision to release date is invalid'
+    }
+
+    if (!this.body.informationFromDirectionToRelease)
+      errors.informationFromDirectionToRelease = 'You must state the relevant information from the direction to release'
+
+    return errors
+  }
+}

--- a/server/form-pages/placement-application/request-a-placement/index.ts
+++ b/server/form-pages/placement-application/request-a-placement/index.ts
@@ -9,6 +9,7 @@ import UpdatesToApplication from './updatesToApplication'
 import CheckYourAnswers from './checkYourAnswers'
 import AdditionalPlacementDetails from './additionalPlacementDetails'
 import DecisionToRelease from './decisionToRelease'
+import AdditionalDocuments from './additionalDocuments'
 
 @Task({
   name: 'Request a placement',
@@ -22,6 +23,7 @@ import DecisionToRelease from './decisionToRelease'
     UpdatesToApplication,
     CheckYourAnswers,
     DecisionToRelease,
+    AdditionalDocuments,
   ],
 })
 @Section({

--- a/server/form-pages/placement-application/request-a-placement/index.ts
+++ b/server/form-pages/placement-application/request-a-placement/index.ts
@@ -8,6 +8,7 @@ import DatesOfPlacement from './datesOfPlacement'
 import UpdatesToApplication from './updatesToApplication'
 import CheckYourAnswers from './checkYourAnswers'
 import AdditionalPlacementDetails from './additionalPlacementDetails'
+import DecisionToRelease from './decisionToRelease'
 
 @Task({
   name: 'Request a placement',
@@ -20,6 +21,7 @@ import AdditionalPlacementDetails from './additionalPlacementDetails'
     DatesOfPlacement,
     UpdatesToApplication,
     CheckYourAnswers,
+    DecisionToRelease,
   ],
 })
 @Section({

--- a/server/form-pages/placement-application/request-a-placement/reasonForPlacement.test.ts
+++ b/server/form-pages/placement-application/request-a-placement/reasonForPlacement.test.ts
@@ -1,3 +1,4 @@
+import { PlacementType } from '../../../@types/shared'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
 
 import ReasonForPlacement from './reasonForPlacement'
@@ -24,6 +25,14 @@ describe('ReasonForPlacement', () => {
 
   describe('if the reason is additional_placement', () => {
     itShouldHaveNextValue(new ReasonForPlacement({ reason: 'additional_placement' }), 'additional-placement-details')
+  })
+
+  describe('if the reason is release_following_decision', () => {
+    itShouldHaveNextValue(new ReasonForPlacement({ reason: 'release_following_decision' }), 'decision-to-release')
+  })
+
+  describe('if the reason is not one of the prescribed reasons', () => {
+    expect(() => new ReasonForPlacement({ reason: 'a made up reason' as PlacementType }).next()).toThrowError()
   })
 
   itShouldHavePreviousValue(new ReasonForPlacement({}), '')

--- a/server/form-pages/placement-application/request-a-placement/reasonForPlacement.ts
+++ b/server/form-pages/placement-application/request-a-placement/reasonForPlacement.ts
@@ -25,7 +25,17 @@ export default class ReasonForPlacement implements TasklistPage {
   }
 
   next() {
-    return this.body.reason === 'rotl' ? 'previous-rotl-placement' : 'additional-placement-details'
+    if (this.body.reason === 'rotl') {
+      return 'previous-rotl-placement'
+    }
+    if (this.body.reason === 'additional_placement') {
+      return 'additional-placement-details'
+    }
+    if (this.body.reason === 'release_following_decision') {
+      return 'decision-to-release'
+    }
+
+    throw new Error('Unknown reason for placement')
   }
 
   response() {

--- a/server/services/placementApplicationService.test.ts
+++ b/server/services/placementApplicationService.test.ts
@@ -2,7 +2,7 @@ import { Request } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
 import PlacementApplicationClient from '../data/placementApplicationClient'
-import { placementApplicationFactory } from '../testutils/factories'
+import { applicationFactory, placementApplicationFactory } from '../testutils/factories'
 import PlacementApplicationService from './placementApplicationService'
 import { DataServices, TaskListErrors } from '../@types/ui'
 import { getBody } from '../form-pages/utils'
@@ -185,11 +185,12 @@ describe('placementApplicationService', () => {
   describe('submit', () => {
     it('calls the client method and returns the resulting placement application', () => {
       const placementApplication = placementApplicationFactory.build()
+      const application = applicationFactory.build()
       ;(placementApplicationSubmissionData as jest.Mock).mockReturnValue({})
 
       placementApplicationClient.submission.mockResolvedValue(placementApplication)
 
-      const result = service.submit(token, placementApplication)
+      const result = service.submit(token, placementApplication, application)
 
       expect(result).resolves.toEqual(placementApplication)
     })

--- a/server/services/placementApplicationService.ts
+++ b/server/services/placementApplicationService.ts
@@ -1,6 +1,6 @@
 import { DataServices } from '@approved-premises/ui'
 import type { Request } from 'express'
-import { PlacementApplication } from '@approved-premises/api'
+import { ApprovedPremisesApplication as Application, PlacementApplication } from '@approved-premises/api'
 import { RestClientBuilder } from '../data'
 import PlacementApplicationClient from '../data/placementApplicationClient'
 import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
@@ -62,12 +62,12 @@ export default class PlacementApplicationService {
     }
   }
 
-  async submit(token: string, placementApplication: PlacementApplication) {
+  async submit(token: string, placementApplication: PlacementApplication, application: Application) {
     const placementApplicationClient = this.placementApplicationClientFactory(token)
 
     return placementApplicationClient.submission(
       placementApplication.id,
-      placementApplicationSubmissionData(placementApplication),
+      placementApplicationSubmissionData(placementApplication, application),
     )
   }
 }

--- a/server/utils/placementRequests/checkYourAnswersUtils.test.ts
+++ b/server/utils/placementRequests/checkYourAnswersUtils.test.ts
@@ -1,7 +1,7 @@
 import { PlacementApplication } from '../../@types/shared'
 import paths from '../../paths/placementApplications'
 import { addResponseToFormArtifact } from '../../testutils/addToApplication'
-import { placementApplicationFactory } from '../../testutils/factories'
+import { applicationFactory, documentFactory, placementApplicationFactory } from '../../testutils/factories'
 import {
   getPageTitle,
   mapPageForSummaryList,
@@ -10,6 +10,7 @@ import {
 } from './checkYourAnswersUtils'
 
 describe('checkYourAnswersUtils', () => {
+  const application = applicationFactory.build()
   let placementApplication = placementApplicationFactory.build()
   placementApplication = addResponseToFormArtifact(placementApplication, {
     section: 'request-a-placement',
@@ -20,47 +21,79 @@ describe('checkYourAnswersUtils', () => {
 
   describe('mapPageForSummaryList', () => {
     it('should return the correct object for the summary card', () => {
-      expect(mapPageForSummaryList(placementApplication, 'same-ap')).toEqual({
+      expect(mapPageForSummaryList(placementApplication, 'same-ap', application)).toEqual({
         card: {
           title: { text: getPageTitle(placementApplication, 'same-ap') },
         },
-        rows: pageResponsesAsSummaryListItems(placementApplication, 'same-ap'),
+        rows: pageResponsesAsSummaryListItems(placementApplication, 'same-ap', application),
       })
     })
-    describe('pagesForReview', () => {
-      it('should return all of the pages except the check-your-answers page', () => {
-        placementApplication = addResponseToFormArtifact(placementApplication, {
-          section: 'request-a-placement',
-          page: 'check-your-answers',
-          key: 'reviwed',
-          value: '1',
-        }) as PlacementApplication
-        expect(pagesForReview(placementApplication)).toEqual(['same-ap'])
-      })
-    })
+  })
 
-    describe('pageResponsesAsSummaryListItems', () => {
-      it('should return the correct object for the summary card', () => {
-        expect(pageResponsesAsSummaryListItems(placementApplication, 'same-ap')).toEqual([
-          {
-            key: { text: 'Do you want this person to stay in the same Approved Premises (AP)?' },
-            value: { text: 'Yes' },
-            actions: {
-              items: [
-                {
-                  href: paths.placementApplications.pages.show({
-                    task: 'request-a-placement',
-                    page: 'same-ap',
-                    id: placementApplication.id,
-                  }),
-                  text: 'Change',
-                  visuallyHiddenText: 'Do you want this person to stay in the same Approved Premises (AP)?',
-                },
-              ],
-            },
-          },
-        ])
-      })
+  describe('pagesForReview', () => {
+    it('should return all of the pages except the check-your-answers page', () => {
+      placementApplication = addResponseToFormArtifact(placementApplication, {
+        section: 'request-a-placement',
+        page: 'check-your-answers',
+        key: 'reviwed',
+        value: '1',
+      }) as PlacementApplication
+      expect(pagesForReview(placementApplication)).toEqual(['same-ap'])
     })
+  })
+
+  describe('pageResponsesAsSummaryListItems', () => {
+    it('should return the correct object for the summary card', () => {
+      expect(pageResponsesAsSummaryListItems(placementApplication, 'same-ap', application)).toEqual([
+        {
+          key: { text: 'Do you want this person to stay in the same Approved Premises (AP)?' },
+          value: { text: 'Yes' },
+          actions: {
+            items: [
+              {
+                href: paths.placementApplications.pages.show({
+                  task: 'request-a-placement',
+                  page: 'same-ap',
+                  id: placementApplication.id,
+                }),
+                text: 'Change',
+                visuallyHiddenText: 'Do you want this person to stay in the same Approved Premises (AP)?',
+              },
+            ],
+          },
+        },
+      ])
+    })
+  })
+
+  it('if the page name is "additional-documents"', () => {
+    const documents = documentFactory.buildList(1)
+
+    placementApplication.data['request-a-placement'] = {
+      'additional-documents': {
+        selectedDocuments: documents,
+      },
+    }
+
+    expect(pageResponsesAsSummaryListItems(placementApplication, 'additional-documents', application)).toEqual([
+      {
+        key: {
+          html: `<a href="/applications/people/${application.person.crn}/documents/${documents[0].id}" data-cy-documentId="${documents[0].id}">${documents[0].fileName}</a>`,
+        },
+        value: {
+          text: documents[0].description,
+        },
+
+        actions: {
+          items: [
+            {
+              href: `/placement-applications/${application.id}/tasks/request-a-placement/pages/additional-documents`,
+              text: 'Change',
+              visuallyHiddenText: documents[0].fileName,
+            },
+          ],
+        },
+      },
+    ])
   })
 })

--- a/server/utils/placementRequests/checkYourAnswersUtils.ts
+++ b/server/utils/placementRequests/checkYourAnswersUtils.ts
@@ -1,15 +1,21 @@
-import { PlacementApplication } from '../../@types/shared'
-import { HtmlItem, TextItem } from '../../@types/ui'
+import { ApprovedPremisesApplication as Application, Document, PlacementApplication } from '../../@types/shared'
+import { HtmlItem, SummaryListItem, TextItem } from '../../@types/ui'
+import AdditionalDocuments from '../../form-pages/placement-application/request-a-placement/additionalDocuments'
+import paths from '../../paths/placementApplications'
 import { embeddedSummaryListItem, summaryListItemForResponse } from '../applications/summaryListUtils'
-
 import { getPage, getResponseForPage } from '../applications/utils'
+import { retrieveQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
 
-export const mapPageForSummaryList = (placementApplication: PlacementApplication, pageName: string) => {
+export const mapPageForSummaryList = (
+  placementApplication: PlacementApplication,
+  pageName: string,
+  application: Application,
+) => {
   return {
     card: {
       title: { text: getPageTitle(placementApplication, pageName) },
     },
-    rows: pageResponsesAsSummaryListItems(placementApplication, pageName),
+    rows: pageResponsesAsSummaryListItems(placementApplication, pageName, application),
   }
 }
 
@@ -24,7 +30,15 @@ export const pagesForReview = (placementApplication: PlacementApplication) => {
   return pageNames.filter(page => page !== 'check-your-answers')
 }
 
-export const pageResponsesAsSummaryListItems = (placementApplication: PlacementApplication, pageName: string) => {
+export const pageResponsesAsSummaryListItems = (
+  placementApplication: PlacementApplication,
+  pageName: string,
+  application: Application,
+) => {
+  if (pageName === 'additional-documents') {
+    return attachDocumentsSummaryListItems(placementApplication, application, 'request-a-placement', pageName, true)
+  }
+
   const response = getResponseForPage(placementApplication, 'request-a-placement', pageName)
   return Object.keys(response).map(key => {
     const value =
@@ -34,4 +48,43 @@ export const pageResponsesAsSummaryListItems = (placementApplication: PlacementA
 
     return summaryListItemForResponse(key, value, 'request-a-placement', pageName, placementApplication, true)
   })
+}
+
+export const attachDocumentsSummaryListItems = (
+  placementApplication: PlacementApplication,
+  application: Application,
+  taskName: string,
+  pageName: string,
+  showActions: boolean,
+) => {
+  const items: Array<SummaryListItem> = []
+
+  const documents = retrieveQuestionResponseFromFormArtifact(
+    placementApplication,
+    AdditionalDocuments,
+    'selectedDocuments',
+  ) as Array<Document>
+
+  documents.forEach(document => {
+    const item: SummaryListItem = {
+      key: {
+        html: `<a href="/applications/people/${application.person.crn}/documents/${document.id}" data-cy-documentId="${document.id}">${document.fileName}</a>`,
+      },
+      value: { text: document?.description || '' },
+    }
+    if (showActions) {
+      item.actions = {
+        items: [
+          {
+            href: paths.placementApplications.pages.show({ task: taskName, page: pageName, id: application.id }),
+            text: 'Change',
+            visuallyHiddenText: document.fileName,
+          },
+        ],
+      }
+    }
+    items.push(item)
+  })
+
+  return items
 }

--- a/server/utils/placementRequests/placementApplicationSubmissionData.test.ts
+++ b/server/utils/placementRequests/placementApplicationSubmissionData.test.ts
@@ -1,16 +1,20 @@
 import { PlacementApplication } from '../../@types/shared'
 import AdditionalPlacementDetails from '../../form-pages/placement-application/request-a-placement/additionalPlacementDetails'
 import DatesOfPlacement from '../../form-pages/placement-application/request-a-placement/datesOfPlacement'
+import DecisionToRelease from '../../form-pages/placement-application/request-a-placement/decisionToRelease'
 import { pageDataFromApplicationOrAssessment } from '../../form-pages/utils'
 import { addResponseToFormArtifact, addResponsesToFormArtifact } from '../../testutils/addToApplication'
-import { placementApplicationFactory } from '../../testutils/factories'
+import { applicationFactory, placementApplicationFactory } from '../../testutils/factories'
+import { placementDurationFromApplication } from '../assessments/placementDurationFromApplication'
 import { mapPlacementDateForSubmission, placementApplicationSubmissionData } from './placementApplicationSubmissionData'
 
 jest.mock('../../form-pages/utils')
+jest.mock('../../utils/assessments/placementDurationFromApplication')
 
 describe('placementApplicationSubmissionData', () => {
   it('returns the data in the correct format for submission', () => {
     let placementApplication = placementApplicationFactory.build()
+
     placementApplication = addResponseToFormArtifact(placementApplication, {
       section: 'request-a-placement',
       page: 'reason-for-placement',
@@ -31,7 +35,7 @@ describe('placementApplicationSubmissionData', () => {
       arrivalDate: '2023-01-01',
     })
 
-    expect(placementApplicationSubmissionData(placementApplication)).toEqual({
+    expect(placementApplicationSubmissionData(placementApplication, applicationFactory.build())).toEqual({
       placementType: 'rotl',
       translatedDocument: {},
       placementDates: [
@@ -45,6 +49,10 @@ describe('placementApplicationSubmissionData', () => {
 })
 
 describe('mapPlacementDateForSubmission', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('returns the arrivalDate and duration from the dates-of-placement page if the "reason" is "rotl"', () => {
     let placementApplication = placementApplicationFactory.build({
       data: { 'request-a-placement': { 'reason-for-placement': { reason: 'rotl' } } },
@@ -62,7 +70,7 @@ describe('mapPlacementDateForSubmission', () => {
       duration: '1',
     })
 
-    expect(mapPlacementDateForSubmission(placementApplication, 'rotl')).toEqual({
+    expect(mapPlacementDateForSubmission(placementApplication, 'rotl', applicationFactory.build())).toEqual({
       expectedArrival: '2023-01-01',
       duration: 1,
     })
@@ -79,10 +87,32 @@ describe('mapPlacementDateForSubmission', () => {
       duration: '1',
     })
 
-    expect(mapPlacementDateForSubmission(placementApplication, 'additional_placement')).toEqual({
+    expect(
+      mapPlacementDateForSubmission(placementApplication, 'additional_placement', applicationFactory.build()),
+    ).toEqual({
       expectedArrival: '2023-01-01',
       duration: 1,
     })
     expect(pageDataFromApplicationOrAssessment).toHaveBeenCalledWith(AdditionalPlacementDetails, placementApplication)
+  })
+
+  it('calculates the release date to be decision to release date + 6 weeks and retrieves the placement duration from the application if the "reason" is "release_following_decision"', () => {
+    const placementApplication = placementApplicationFactory.build({
+      data: { 'request-a-placement': { 'reason-for-placement': { reason: 'release_following_decision' } } },
+    })
+
+    ;(pageDataFromApplicationOrAssessment as jest.Mock).mockReturnValue({
+      decisionToReleaseDate: '2023-01-01',
+      duration: '1',
+    })
+    ;(placementDurationFromApplication as jest.Mock).mockReturnValue('1')
+
+    expect(
+      mapPlacementDateForSubmission(placementApplication, 'release_following_decision', applicationFactory.build()),
+    ).toEqual({
+      duration: '1',
+      expectedArrival: '2023-02-12',
+    })
+    expect(pageDataFromApplicationOrAssessment).toHaveBeenCalledWith(DecisionToRelease, placementApplication)
   })
 })

--- a/server/views/partials/personDetails.njk
+++ b/server/views/partials/personDetails.njk
@@ -81,7 +81,7 @@
         title: {
           text: "Person Details",
           headingLevel: "2",
-          class: "govuk-heading-m"
+          classes: "govuk-heading-m"
         },
         attributes: {
           'data-cy-section': "person-details"

--- a/server/views/placement-applications/pages/request-a-placement/additional-documents.njk
+++ b/server/views/placement-applications/pages/request-a-placement/additional-documents.njk
@@ -1,0 +1,40 @@
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% extends "../../layout.njk" %}
+
+{% set columnClasses = "govuk-grid-column-full applications--pages--attach-documents" %}
+
+{% block questions %}
+  <h1 class="govuk-heading-l">{{page.title}}</h1>
+
+  <p>These documents are imported from NDelius. </p>
+  <p>Select the parole report and any additional documents to support your request for a placement.</p>
+
+  <p class="applications--pages--attach-document__results">Showing <b>{{ page.documents | length }}</b> documents</p>
+
+  {{ govukTable({
+    firstCellIsHeader: true,
+    classes: "applications--pages--attach-document__table",
+    head: [
+      {
+        html: "Document name",
+        classes: "applications--pages--attach-document__header-name"
+      },
+      {
+        text: "Date uploaded to Delius",
+        classes: "applications--pages--attach-document__header-date"
+      },
+      {
+        text: "Download",
+        classes: "applications--pages--attach-document__header-download"
+      },
+      {
+        text: "Provide description",
+        classes: "applications--pages--attach-document__header-description"
+      }
+    ],
+    rows: AttachDocumentsUtils.tableRows(page.documents, page.body.selectedDocuments, page.application, errors)
+  }) }}
+
+{% endblock %}

--- a/server/views/placement-applications/pages/request-a-placement/additional-placement-details.njk
+++ b/server/views/placement-applications/pages/request-a-placement/additional-placement-details.njk
@@ -3,17 +3,17 @@
 
 {% block questions %}
 
-    <h1 class="govuk-heading-l">
-        {{ page.title }}
-    </h1>
+  <h1 class="govuk-heading-l">
+    {{ page.title }}
+  </h1>
 
-    {{
+  {{
     formPageDateInput(
       {
         fieldName: "arrivalDate",
         fieldset: {
           legend: {
-            class: "govuk-fieldset__legend--m",
+            classes: "govuk-fieldset__legend--m",
             text: page.questions.arrivalDate
           }
         },
@@ -23,12 +23,12 @@
     )
   }}
 
-    {{
+  {{
     formPageInput(
       {
         label: {
           text: page.questions.duration,
-          class: "govuk-fieldset__legend--m"
+          classes: "govuk-fieldset__legend--m"
         },
         classes: "govuk-input--width-2",
         fieldName: "duration"
@@ -37,7 +37,7 @@
     )
   }}
 
-    {{ formPageTextarea({
+  {{ formPageTextarea({
         fieldName: "reason",
         label: {
           text: page.questions.reason

--- a/server/views/placement-applications/pages/request-a-placement/check-your-answers.njk
+++ b/server/views/placement-applications/pages/request-a-placement/check-your-answers.njk
@@ -26,7 +26,7 @@
             {{ showErrorSummary(errorSummary) }}
 
             {% for pageForReview in PlacementRequestUtils.pagesForReview(page.placementApplication) %}
-                {{ govukSummaryList(PlacementRequestUtils.mapPageForSummaryList(page.placementApplication, pageForReview)) }}
+                {{ govukSummaryList(PlacementRequestUtils.mapPageForSummaryList(page.placementApplication, pageForReview, page.application)) }}
             {% endfor %}
 
             <form action="{{paths.placementApplications.submit({id: placementApplicationId })}}" method="post">

--- a/server/views/placement-applications/pages/request-a-placement/dates-of-placement.njk
+++ b/server/views/placement-applications/pages/request-a-placement/dates-of-placement.njk
@@ -13,7 +13,7 @@
         fieldName: "arrivalDate",
         fieldset: {
           legend: {
-            class: "govuk-fieldset__legend--m",
+            classes: "govuk-fieldset__legend--m",
             text: page.questions.arrivalDate
           }
         },
@@ -28,7 +28,7 @@
       {
         label: {
           text: page.questions.duration,
-          class: "govuk-fieldset__legend--m"
+          classes: "govuk-fieldset__legend--m"
         },
         classes: "govuk-input--width-2",
         fieldName: "duration"

--- a/server/views/placement-applications/pages/request-a-placement/decision-to-release.njk
+++ b/server/views/placement-applications/pages/request-a-placement/decision-to-release.njk
@@ -1,0 +1,48 @@
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% extends "../../layout.njk" %}
+
+{% block questions %}
+
+  <h1 class="govuk-heading-l">
+    {{ page.title }}
+  </h1>
+
+  {{
+    formPageDateInput(
+      {
+        fieldName: "decisionToReleaseDate",
+        fieldset: {
+          legend: {
+            classes: "govuk-fieldset__legend--m",
+            text: page.questions.decisionToReleaseDate
+          }
+        },
+        items: dateFieldValues('decisionToReleaseDate', errors)
+      },
+      fetchContext()
+    )
+  }}
+  <p class="govuk-body">The central referral unit will aim to place the person in a suitable Approved Premises (AP) within 6 weeks of this date.</p>
+  {{
+    formPageTextarea(
+      {
+        label: {
+          text: page.questions.informationFromDirectionToRelease,
+          classes: "govuk-label--m"
+        },
+        hint: {
+            html: 
+            'This should include:
+            <ul class="govuk-list govuk-list--bullet govuk-hint">
+                <li>the type of AP placement</li>
+                <li>the placement location</li>
+                <li>any factors that may affect the release date</li>
+            </ul>'
+        },
+        fieldName: "informationFromDirectionToRelease"
+      },
+      fetchContext()
+    )
+  }}
+
+{% endblock %}


### PR DESCRIPTION
# Context
This adds the third and final flow to the 'Request a placement' form. 
We add 2 screens, one asking about the decision to release and another requesting the user add additional relevant documents.
[Trello card](https:/trello.com/c/ncPgE6LL/176-add-a-flow-to-create-and-submit-a-placement-request)

![updates-to-applicatiosn](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/ec14c82b-156a-437b-b827-de65011615d0)
![updates-to-application](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/f4b007d2-2e32-4aab-8f35-63a1029f14f9)
