### PR TITLE
Only ask HMPPS Auth for the user on a new session

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -10,6 +10,7 @@ declare module 'express-session' {
     nowInMinutes: number
     application: ApprovedPremisesApplication
     previousPage: string
+    user: UserDetails
   }
 }
 

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -6,10 +6,11 @@ export default function populateCurrentUser(userService: UserService): RequestHa
   return async (req, res, next) => {
     try {
       if (res.locals.user) {
-        const user = res.locals.user && (await userService.getActingUser(res.locals.user.token))
-        if (user) {
-          res.locals.user = { ...user, ...res.locals.user }
-        } else {
+        const user = req.session.user || (await userService.getActingUser(res.locals.user.token))
+        req.session.user = user
+        res.locals.user = { ...user, ...res.locals.user }
+
+        if (!user) {
           logger.info('No user available')
         }
       }


### PR DESCRIPTION
Previously we were calling `GET /auth/api/user/me` to get a user’s details on every request. This stores the user details in the session, so we only have to get the user details once. CAS3 have implemented a similar solution here https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/405 and this has significantly reduced performance alerts in prod, so I think this is worth trying too.