### PR TITLE
(228) Update week inputs to weeks and days

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -4,3 +4,8 @@
 .moj-identity-bar__title
   @include govuk-font($size: 19)
 
+.govuk-form-group
+  &--inline
+    float: left
+    @include govuk-responsive-margin(4, 'right')
+    @include govuk-responsive-margin(0, 'bottom')

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -392,7 +392,8 @@
   "move-on": {
     "placement-duration": {
       "differentDuration": "yes",
-      "duration": "6",
+      "durationDays": "0",
+      "durationWeeks": "6",
       "reason": "some reason"
     },
     "relocation-region": {

--- a/integration_tests/fixtures/existingApplicationPlacementApplication.json
+++ b/integration_tests/fixtures/existingApplicationPlacementApplication.json
@@ -8,7 +8,9 @@
       "arrivalDate-day": "01",
       "arrivalDate-month": "8",
       "arrivalDate-year": "2023",
-      "duration": "28",
+      "durationDays": "5",
+      "durationWeeks": "12",
+      "duration": "24",
       "reason": "Some reason"
     },
     "updates-to-application": {

--- a/integration_tests/pages/apply/placementDuration.ts
+++ b/integration_tests/pages/apply/placementDuration.ts
@@ -19,7 +19,8 @@ export default class PlacementDurationPage extends ApplyPage {
 
   completeForm() {
     this.checkRadioButtonFromPageBody('differentDuration')
-    this.completeTextInputFromPageBody('duration')
+    this.completeTextInputFromPageBody('durationDays')
+    this.completeTextInputFromPageBody('durationWeeks')
     this.completeTextInputFromPageBody('reason')
   }
 }

--- a/integration_tests/pages/assess/matchingInformationPage.ts
+++ b/integration_tests/pages/assess/matchingInformationPage.ts
@@ -23,7 +23,10 @@ export default class MatchingInformationPage extends AssessPage {
       acceptsHateCrimeOffenders: 'relevant',
       isArsonSuitable: 'relevant',
       isSuitedForSexOffenders: 'essential',
-      lengthOfStayAgreed: 'yes',
+      lengthOfStayAgreed: 'no',
+      lengthOfStayDays: '5',
+      lengthOfStayWeeks: '1',
+      lengthOfStay: '12',
       cruInformation: 'Some info',
     },
     this.assessment,
@@ -53,6 +56,9 @@ export default class MatchingInformationPage extends AssessPage {
     })
 
     this.checkRadioByNameAndValue('lengthOfStayAgreed', this.pageClass.body.lengthOfStayAgreed)
+
+    this.getTextInputByIdAndEnterDetails('lengthOfStayDays', this.pageClass.body.lengthOfStayDays)
+    this.getTextInputByIdAndEnterDetails('lengthOfStayWeeks', this.pageClass.body.lengthOfStayWeeks)
 
     this.completeTextArea('cruInformation', this.pageClass.body.cruInformation)
   }

--- a/integration_tests/pages/match/placementRequestForm/additionalPlacementDetails.ts
+++ b/integration_tests/pages/match/placementRequestForm/additionalPlacementDetails.ts
@@ -7,7 +7,8 @@ export default class AdditionalPlacementDetails extends Page {
 
   completeForm() {
     this.clearAndCompleteDateInputs('arrivalDate', '2023-08-01')
-    this.clearAndCompleteTextInputById('duration', '14')
+    this.clearAndCompleteTextInputById('durationWeeks', '12')
+    this.clearAndCompleteTextInputById('durationDays', '5')
     this.clearAndCompleteTextInputById('reason', 'Some reason')
   }
 }

--- a/integration_tests/pages/match/placementRequestForm/datesOfPlacement.ts
+++ b/integration_tests/pages/match/placementRequestForm/datesOfPlacement.ts
@@ -7,7 +7,7 @@ export default class DatesOfPlacement extends Page {
 
   completeForm() {
     this.clearAndCompleteDateInputs('arrivalDate', '2023-08-01')
-    this.clearAndCompleteTextInputById('durationDays', '5')
     this.clearAndCompleteTextInputById('durationWeeks', '12')
+    this.clearAndCompleteTextInputById('durationDays', '5')
   }
 }

--- a/integration_tests/pages/match/placementRequestForm/datesOfPlacement.ts
+++ b/integration_tests/pages/match/placementRequestForm/datesOfPlacement.ts
@@ -7,6 +7,7 @@ export default class DatesOfPlacement extends Page {
 
   completeForm() {
     this.clearAndCompleteDateInputs('arrivalDate', '2023-08-01')
-    this.clearAndCompleteTextInputById('duration', '14')
+    this.clearAndCompleteTextInputById('durationDays', '5')
+    this.clearAndCompleteTextInputById('durationWeeks', '12')
   }
 }

--- a/integration_tests/pages/match/searchPage.ts
+++ b/integration_tests/pages/match/searchPage.ts
@@ -50,10 +50,14 @@ export default class SearchPage extends Page {
   }
 
   changeSearchParameters(newSearchParameters: BedSearchParametersUi): void {
-    this.getTextInputByIdAndClear('durationWeeks')
-    this.getTextInputByIdAndEnterDetails('durationWeeks', newSearchParameters.durationWeeks.toString())
     this.clearDateInputs('startDate')
     this.completeDateInputs('startDate', newSearchParameters.startDate)
+
+    this.getTextInputByIdAndClear('durationDays')
+    this.getTextInputByIdAndEnterDetails('durationDays', newSearchParameters.durationDays.toString())
+    this.getTextInputByIdAndClear('durationWeeks')
+    this.getTextInputByIdAndEnterDetails('durationWeeks', newSearchParameters.durationWeeks.toString())
+
     this.getTextInputByIdAndClear('postcodeDistrict')
     this.getTextInputByIdAndEnterDetails('postcodeDistrict', newSearchParameters.postcodeDistrict)
     this.getTextInputByIdAndClear('maxDistanceMiles')

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -1,4 +1,4 @@
-import { addWeeks } from 'date-fns'
+import { addWeeks, weeksToDays } from 'date-fns'
 import SuccessPage from '../../pages/match/successPage'
 import ConfirmationPage from '../../pages/match/confirmationPage'
 import PlacementRequestPage from '../../pages/match/placementRequestPage'
@@ -79,6 +79,7 @@ context('Placement Requests', () => {
     const placementRequest = placementRequestFactory.build({
       person,
       status: 'notMatched',
+      duration: 15,
       essentialCriteria,
       desirableCriteria,
     })
@@ -157,7 +158,7 @@ context('Placement Requests', () => {
 
       // And the first request to the API should contain the criteria from the placement request
       expect(initialSearchRequestBody).to.contain({
-        durationDays: placementRequest.duration * 7,
+        durationDays: placementRequest.duration,
         startDate: placementRequest.expectedArrival,
         postcodeDistrict: placementRequest.location,
         maxDistanceMiles: placementRequest.radius,
@@ -169,7 +170,8 @@ context('Placement Requests', () => {
       ])
 
       // And the second request to the API should contain the new criteria I submitted
-      const durationDays = Number(newSearchParameters.durationWeeks) * 7
+      const durationDays =
+        weeksToDays(Number(newSearchParameters.durationWeeks)) + Number(newSearchParameters.durationDays)
 
       expect(secondSearchRequestBody).to.contain({
         durationDays,

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -335,6 +335,7 @@ type ContingencyPlanQuestion = {
 export type ContingencyPlanQuestionsRecord = Record<ContingencyPlanQuestionId, ContingencyPlanQuestion>
 
 export interface BedSearchParametersUi {
+  durationDays: string
   durationWeeks: string
   maxDistanceMiles: string
   startDate: string

--- a/server/form-pages/apply/move-on/placementDuration.test.ts
+++ b/server/form-pages/apply/move-on/placementDuration.test.ts
@@ -22,10 +22,28 @@ describe('PlacementDuration', () => {
   })
 
   describe('body', () => {
-    it('should set the body', () => {
-      const body = { differentDuration: 'yes' as const, duration: '4', reason: 'Some reason' }
+    it('should set the body and duration', () => {
+      const body = { differentDuration: 'yes' as const, durationDays: '4', durationWeeks: '7', reason: 'Some reason' }
       const page = new PlacementDuration(body, application)
 
+      expect(page.body).toEqual({ ...body, duration: '53' })
+    })
+
+    it('should not set the duration if differentDuration is not yes', () => {
+      const body = { differentDuration: 'no' as const }
+      const page = new PlacementDuration(body, application)
+      expect(page.body).toEqual(body)
+    })
+
+    it('should not set the duration if durationDays is not set', () => {
+      const body = { differentDuration: 'yes' as const, durationWeeks: '4' }
+      const page = new PlacementDuration(body, application)
+      expect(page.body).toEqual(body)
+    })
+
+    it('should not set the duration if durationWeeks is not set', () => {
+      const body = { differentDuration: 'yes' as const, durationDays: '4' }
+      const page = new PlacementDuration(body, application)
       expect(page.body).toEqual(body)
     })
   })
@@ -144,18 +162,35 @@ describe('PlacementDuration', () => {
         reason: 'You must specify the reason for the different placement duration',
       })
     })
+
+    it('returns an error if the different duration response is yes but both durations are not set', () => {
+      let page = new PlacementDuration(
+        { differentDuration: 'yes', durationWeeks: '1', reason: 'Some reason' },
+        application,
+      )
+
+      expect(page.errors()).toEqual({
+        duration: 'You must specify the duration of the placement',
+      })
+
+      page = new PlacementDuration({ differentDuration: 'yes', durationDays: '1', reason: 'Some reason' }, application)
+
+      expect(page.errors()).toEqual({
+        duration: 'You must specify the duration of the placement',
+      })
+    })
   })
 
   describe('response', () => {
     it('should return a translated version of the response', () => {
       const page = new PlacementDuration(
-        { differentDuration: 'yes' as const, duration: '4', reason: 'Some reason' },
+        { differentDuration: 'yes' as const, durationDays: '4', durationWeeks: '1', reason: 'Some reason' },
         application,
       )
 
       expect(page.response()).toEqual({
         'Does this application require a different placement duration?': 'Yes',
-        'How many weeks will the person stay at the AP?': '4 weeks',
+        'How many weeks will the person stay at the AP?': '1 week, 4 days',
         'Why does this person require a different placement duration?': 'Some reason',
       })
     })

--- a/server/form-pages/apply/move-on/placementDuration.ts
+++ b/server/form-pages/apply/move-on/placementDuration.ts
@@ -1,4 +1,4 @@
-import { addDays, formatDuration, weeksToDays } from 'date-fns'
+import { addDays, weeksToDays } from 'date-fns'
 import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
 import { ApprovedPremisesApplication } from '@approved-premises/api'
 import { SessionDataError } from '../../../utils/errors'
@@ -53,10 +53,7 @@ export default class PlacementDuration implements TasklistPage {
 
     if (this.body.differentDuration === 'yes') {
       response[this.questions.duration] = sentenceCase(
-        `${formatDuration(
-          { weeks: Number(this.body.durationWeeks), days: Number(this.body.durationDays) },
-          { delimiter: ', ' },
-        )}`,
+        `${DateFormats.formatDuration({ weeks: this.body.durationWeeks, days: this.body.durationDays })}`,
       )
       response[this.questions.reason] = this.body.reason
     }

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -1643,6 +1643,12 @@
               ],
               "type": "string"
             },
+            "durationDays": {
+              "type": "string"
+            },
+            "durationWeeks": {
+              "type": "string"
+            },
             "duration": {
               "type": "string"
             },
@@ -1666,9 +1672,7 @@
               "properties": {
                 "arePlansInPlace": {
                   "type": "string",
-                  "enum": [
-                    "yes"
-                  ]
+                  "const": "yes"
                 },
                 "plansInPlaceDetail": {
                   "type": "string"
@@ -1680,9 +1684,7 @@
               "properties": {
                 "arePlansInPlace": {
                   "type": "string",
-                  "enum": [
-                    "no"
-                  ]
+                  "const": "no"
                 },
                 "plansNotInPlaceDetail": {
                   "type": "string"
@@ -1723,9 +1725,7 @@
                   "properties": {
                     "response": {
                       "type": "string",
-                      "enum": [
-                        "yes"
-                      ]
+                      "const": "yes"
                     }
                   }
                 },
@@ -1766,9 +1766,7 @@
               "properties": {
                 "response": {
                   "type": "string",
-                  "enum": [
-                    "no"
-                  ]
+                  "const": "no"
                 }
               }
             }

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -219,7 +219,7 @@ describe('MatchingInformation', () => {
 
       ;(placementDurationFromApplication as jest.Mock).mockReturnValueOnce(12)
 
-      expect(page.suggestedLengthOfStay).toEqual(12)
+      expect(page.suggestedLengthOfStay).toEqual('1 week, 5 days')
 
       expect(placementDurationFromApplication).toHaveBeenCalledWith(assessment.application)
     })

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -42,6 +42,18 @@ describe('MatchingInformation', () => {
       expect(page.body).toEqual(defaultArguments)
     })
 
+    it('should set lengthOfStay if lengthOfStayAgreed is no and the days and weeks are set', () => {
+      const body = {
+        ...defaultArguments,
+        lengthOfStayAgreed: 'no' as const,
+        lengthOfStayDays: '1',
+        lengthOfStayWeeks: '4',
+      }
+      const page = new MatchingInformation(body, assessment)
+
+      expect(page.body).toEqual({ ...body, lengthOfStay: '29' })
+    })
+
     it('should return accessibilityCriteria and specialistSupportCriteria as arrays if strings are provided', () => {
       const page = new MatchingInformation(
         {
@@ -100,10 +112,13 @@ describe('MatchingInformation', () => {
     })
 
     it('should add an error if lengthOfStayAgreed is no and the details are not provided', () => {
-      const page = new MatchingInformation({ ...defaultArguments, lengthOfStayAgreed: 'no' }, assessment)
+      const page = new MatchingInformation(
+        { ...defaultArguments, lengthOfStayAgreed: 'no', lengthOfStayWeeks: null, lengthOfStayDays: null },
+        assessment,
+      )
 
       expect(page.errors()).toEqual({
-        lengthOfStayAgreedDetail: 'You must provide a recommended length of stay',
+        lengthOfStay: 'You must provide a recommended length of stay',
       })
     })
   })
@@ -156,7 +171,8 @@ describe('MatchingInformation', () => {
         {
           ...defaultArguments,
           lengthOfStayAgreed: 'no',
-          lengthOfStayAgreedDetail: '12',
+          lengthOfStayDays: '5',
+          lengthOfStayWeeks: '5',
         },
         assessment,
       )
@@ -164,7 +180,7 @@ describe('MatchingInformation', () => {
       const response = page.response()
 
       expect(response['Do you agree with the suggested length of stay?']).toEqual('No')
-      expect(response['Recommended length of stay']).toEqual('12 weeks')
+      expect(response['Recommended length of stay']).toEqual('5 weeks, 5 days')
     })
   })
 

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
@@ -67,9 +67,16 @@ export default class MatchingInformation implements TasklistPage {
 
   title = 'Matching information'
 
-  apTypeQuestion = 'What type of AP is required?'
-
   apTypes = apTypeOptions
+
+  questions = {
+    apType: 'What type of AP is required?',
+    specialistSupportCriteria: 'If this person would benefit from specialist support, select the relevant option below',
+    accessibilityCriteria: 'Would the person benefit from any of the following?',
+    lengthOfStayAgreed: 'Do you agree with the suggested length of stay?',
+    lengthOfStay: 'Provide recommended length of stay',
+    cruInformation: 'Information for Central Referral Unit (CRU) manager (optional)',
+  }
 
   placementRequirementTableHeadings = ['Specify placement requirements', 'Essential', 'Desirable', 'Not required']
 
@@ -113,7 +120,7 @@ export default class MatchingInformation implements TasklistPage {
 
   response() {
     const response = {
-      [this.apTypeQuestion]: this.apTypes[this.body.apType],
+      [this.questions.apType]: this.apTypes[this.body.apType],
     }
 
     response['Specialist support needs'] = this.selectedOptions('specialistSupport')

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
@@ -1,7 +1,8 @@
 import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
 
 import { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
-import { formatDuration, weeksToDays } from 'date-fns'
+import { weeksToDays } from 'date-fns'
+import { DateFormats } from '../../../../utils/dateUtils'
 import { daysToWeeksAndDays } from '../../../../utils/assessments/dateUtils'
 import { placementDurationFromApplication } from '../../../../utils/assessments/placementDurationFromApplication'
 import { Page } from '../../../utils/decorators'
@@ -139,16 +140,10 @@ export default class MatchingInformation implements TasklistPage {
     response['Do you agree with the suggested length of stay?'] = sentenceCase(this.body.lengthOfStayAgreed)
 
     if (this.body.lengthOfStayAgreed === 'no') {
-      response['Recommended length of stay'] = formatDuration(
-        {
-          weeks: Number(this.body.lengthOfStayWeeks),
-          days: Number(this.body.lengthOfStayDays),
-        },
-        {
-          format: ['weeks', 'days'],
-          delimiter: ', ',
-        },
-      )
+      response['Recommended length of stay'] = DateFormats.formatDuration({
+        weeks: this.body.lengthOfStayWeeks,
+        days: this.body.lengthOfStayDays,
+      })
     }
 
     if (this.body.cruInformation) {
@@ -191,10 +186,7 @@ export default class MatchingInformation implements TasklistPage {
   }
 
   get suggestedLengthOfStay() {
-    return formatDuration(daysToWeeksAndDays(placementDurationFromApplication(this.assessment.application)), {
-      format: ['weeks', 'days'],
-      delimiter: ', ',
-    })
+    return DateFormats.formatDuration(daysToWeeksAndDays(placementDurationFromApplication(this.assessment.application)))
   }
 
   get specialistSupportCheckboxes() {

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
@@ -1,6 +1,8 @@
 import type { TaskListErrors, YesOrNoWithDetail } from '@approved-premises/ui'
 
 import { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
+import { formatDuration } from 'date-fns'
+import { daysToWeeksAndDays } from '../../../../utils/assessments/dateUtils'
 import { placementDurationFromApplication } from '../../../../utils/assessments/placementDurationFromApplication'
 import { Page } from '../../../utils/decorators'
 
@@ -167,7 +169,10 @@ export default class MatchingInformation implements TasklistPage {
   }
 
   get suggestedLengthOfStay() {
-    return placementDurationFromApplication(this.assessment.application)
+    return formatDuration(daysToWeeksAndDays(placementDurationFromApplication(this.assessment.application)), {
+      format: ['weeks', 'days'],
+      delimiter: ', ',
+    })
   }
 
   get specialistSupportCheckboxes() {

--- a/server/form-pages/placement-application/request-a-placement/additionalPlacementDetails.test.ts
+++ b/server/form-pages/placement-application/request-a-placement/additionalPlacementDetails.test.ts
@@ -5,7 +5,8 @@ import AdditionalPlacementDetails, { Body } from './additionalPlacementDetails'
 
 describe('AdditionalPlacementDetails', () => {
   const body = {
-    duration: '12',
+    durationDays: '5',
+    durationWeeks: '1',
     'arrivalDate-year': '2023',
     'arrivalDate-month': '12',
     'arrivalDate-day': '1',
@@ -18,6 +19,8 @@ describe('AdditionalPlacementDetails', () => {
 
       expect(page.body).toEqual({
         duration: '12',
+        durationDays: '5',
+        durationWeeks: '1',
         'arrivalDate-year': '2023',
         'arrivalDate-month': '12',
         'arrivalDate-day': '1',
@@ -64,7 +67,7 @@ describe('AdditionalPlacementDetails', () => {
       const page = new AdditionalPlacementDetails(body)
 
       expect(page.response()).toEqual({
-        'How long should the Approved Premises placement last? (in weeks)': '12 weeks',
+        'How long should the Approved Premises placement last?': '5 weeks, 1 day',
         'When will the person arrive?': 'Friday 1 December 2023',
         'Why are you requesting this placement?': 'Some reason',
       })

--- a/server/form-pages/placement-application/request-a-placement/additionalPlacementDetails.ts
+++ b/server/form-pages/placement-application/request-a-placement/additionalPlacementDetails.ts
@@ -1,39 +1,59 @@
 import type { ObjectWithDateParts, TaskListErrors } from '@approved-premises/ui'
 
+import { formatDuration, weeksToDays } from 'date-fns'
 import TasklistPage from '../../tasklistPage'
 import { Page } from '../../utils/decorators'
 import { DateFormats, dateAndTimeInputsAreValidDates } from '../../../utils/dateUtils'
 
 export type Body = {
   duration: string
+  durationDays: string
+  durationWeeks: string
   reason: string
 } & ObjectWithDateParts<'arrivalDate'>
 
 @Page({
   name: 'additional-placement-details',
-  bodyProperties: ['arrivalDate', 'arrivalDate-day', 'arrivalDate-month', 'arrivalDate-year', 'duration', 'reason'],
+  bodyProperties: [
+    'arrivalDate',
+    'arrivalDate-day',
+    'arrivalDate-month',
+    'arrivalDate-year',
+    'duration',
+    'durationDays',
+    'durationWeeks',
+    'reason',
+  ],
 })
 export default class AdditionalPlacementDetails implements TasklistPage {
   title = 'Placement details'
 
-  body: Body
-
   questions = {
     arrivalDate: 'When will the person arrive?',
-    duration: 'How long should the Approved Premises placement last? (in weeks)',
+    duration: 'How long should the Approved Premises placement last?',
     reason: 'Why are you requesting this placement?',
   }
 
-  constructor(_body: Body) {
-    this.body = {
-      'arrivalDate-year': _body['arrivalDate-year'],
-      'arrivalDate-month': _body['arrivalDate-month'],
-      'arrivalDate-day': _body['arrivalDate-day'],
-      arrivalDate: DateFormats.dateAndTimeInputsToIsoString(_body as ObjectWithDateParts<'arrivalDate'>, 'arrivalDate')
-        .arrivalDate,
-      duration: _body.duration,
-      reason: _body.reason,
+  constructor(private _body: Body) {}
+
+  get body() {
+    return {
+      'arrivalDate-year': this._body['arrivalDate-year'],
+      'arrivalDate-month': this._body['arrivalDate-month'],
+      'arrivalDate-day': this._body['arrivalDate-day'],
+      arrivalDate: DateFormats.dateAndTimeInputsToIsoString(
+        this._body as ObjectWithDateParts<'arrivalDate'>,
+        'arrivalDate',
+      ).arrivalDate,
+      durationDays: this._body.durationDays,
+      durationWeeks: this._body.durationWeeks,
+      duration: this.lengthInDays(),
+      reason: this._body.reason,
     }
+  }
+
+  set body(value: Body) {
+    this._body = value
   }
 
   previous() {
@@ -47,7 +67,16 @@ export default class AdditionalPlacementDetails implements TasklistPage {
   response() {
     return {
       [this.questions.arrivalDate]: DateFormats.isoDateToUIDate(this.body.arrivalDate),
-      [this.questions.duration]: `${this.body.duration} weeks`,
+      [this.questions.duration]: formatDuration(
+        {
+          weeks: Number(this.body.durationDays),
+          days: Number(this.body.durationWeeks),
+        },
+        {
+          format: ['weeks', 'days'],
+          delimiter: ', ',
+        },
+      ),
       [this.questions.reason]: this.body.reason,
     }
   }
@@ -70,5 +99,16 @@ export default class AdditionalPlacementDetails implements TasklistPage {
     }
 
     return errors
+  }
+
+  private lengthInDays(): string {
+    if (this._body.durationWeeks && this._body.durationDays) {
+      const lengthOfStayWeeksInDays = weeksToDays(Number(this._body.durationWeeks))
+      const totalLengthInDays = lengthOfStayWeeksInDays + Number(this._body.durationDays)
+
+      return String(totalLengthInDays)
+    }
+
+    return undefined
   }
 }

--- a/server/form-pages/placement-application/request-a-placement/additionalPlacementDetails.ts
+++ b/server/form-pages/placement-application/request-a-placement/additionalPlacementDetails.ts
@@ -1,6 +1,6 @@
 import type { ObjectWithDateParts, TaskListErrors } from '@approved-premises/ui'
 
-import { formatDuration, weeksToDays } from 'date-fns'
+import { weeksToDays } from 'date-fns'
 import TasklistPage from '../../tasklistPage'
 import { Page } from '../../utils/decorators'
 import { DateFormats, dateAndTimeInputsAreValidDates } from '../../../utils/dateUtils'
@@ -67,16 +67,10 @@ export default class AdditionalPlacementDetails implements TasklistPage {
   response() {
     return {
       [this.questions.arrivalDate]: DateFormats.isoDateToUIDate(this.body.arrivalDate),
-      [this.questions.duration]: formatDuration(
-        {
-          weeks: Number(this.body.durationDays),
-          days: Number(this.body.durationWeeks),
-        },
-        {
-          format: ['weeks', 'days'],
-          delimiter: ', ',
-        },
-      ),
+      [this.questions.duration]: DateFormats.formatDuration({
+        weeks: this.body.durationDays,
+        days: this.body.durationWeeks,
+      }),
       [this.questions.reason]: this.body.reason,
     }
   }

--- a/server/form-pages/placement-application/request-a-placement/datesOfPlacement.test.ts
+++ b/server/form-pages/placement-application/request-a-placement/datesOfPlacement.test.ts
@@ -5,7 +5,8 @@ import DateOfPlacement, { Body } from './datesOfPlacement'
 
 describe('DateOfPlacement', () => {
   const body = {
-    duration: '12',
+    durationDays: '1',
+    durationWeeks: '1',
     'arrivalDate-year': '2023',
     'arrivalDate-month': '12',
     'arrivalDate-day': '1',
@@ -16,7 +17,9 @@ describe('DateOfPlacement', () => {
       const page = new DateOfPlacement(body)
 
       expect(page.body).toEqual({
-        duration: '12',
+        duration: '8',
+        durationDays: '1',
+        durationWeeks: '1',
         'arrivalDate-year': '2023',
         'arrivalDate-month': '12',
         'arrivalDate-day': '1',
@@ -61,7 +64,7 @@ describe('DateOfPlacement', () => {
       const page = new DateOfPlacement(body)
 
       expect(page.response()).toEqual({
-        'How long should the Approved Premises placement last? (in weeks)': '12 weeks',
+        'How long should the Approved Premises placement last?': '1 week, 1 day',
         'When will the person arrive?': 'Friday 1 December 2023',
       })
     })

--- a/server/form-pages/placement-application/request-a-placement/datesOfPlacement.ts
+++ b/server/form-pages/placement-application/request-a-placement/datesOfPlacement.ts
@@ -1,6 +1,6 @@
 import type { ObjectWithDateParts, TaskListErrors } from '@approved-premises/ui'
 
-import { formatDuration, weeksToDays } from 'date-fns'
+import { weeksToDays } from 'date-fns'
 import TasklistPage from '../../tasklistPage'
 import { Page } from '../../utils/decorators'
 import { DateFormats, dateAndTimeInputsAreValidDates } from '../../../utils/dateUtils'
@@ -63,16 +63,10 @@ export default class DatesOfPlacement implements TasklistPage {
   response() {
     return {
       [this.questions.arrivalDate]: DateFormats.isoDateToUIDate(this.body.arrivalDate),
-      [this.questions.duration]: formatDuration(
-        {
-          weeks: Number(this.body.durationDays),
-          days: Number(this.body.durationWeeks),
-        },
-        {
-          format: ['weeks', 'days'],
-          delimiter: ', ',
-        },
-      ),
+      [this.questions.duration]: DateFormats.formatDuration({
+        weeks: this.body.durationDays,
+        days: this.body.durationWeeks,
+      }),
     }
   }
 

--- a/server/form-pages/placement-application/request-a-placement/datesOfPlacement.ts
+++ b/server/form-pages/placement-application/request-a-placement/datesOfPlacement.ts
@@ -1,37 +1,55 @@
 import type { ObjectWithDateParts, TaskListErrors } from '@approved-premises/ui'
 
+import { formatDuration, weeksToDays } from 'date-fns'
 import TasklistPage from '../../tasklistPage'
 import { Page } from '../../utils/decorators'
-import { sentenceCase } from '../../../utils/utils'
 import { DateFormats, dateAndTimeInputsAreValidDates } from '../../../utils/dateUtils'
 
 export type Body = {
   duration: string
+  durationDays: string
+  durationWeeks: string
 } & ObjectWithDateParts<'arrivalDate'>
 
 @Page({
   name: 'dates-of-placement',
-  bodyProperties: ['arrivalDate', 'arrivalDate-day', 'arrivalDate-month', 'arrivalDate-year', 'duration'],
+  bodyProperties: [
+    'arrivalDate',
+    'arrivalDate-day',
+    'arrivalDate-month',
+    'arrivalDate-year',
+    'duration',
+    'durationDays',
+    'durationWeeks',
+  ],
 })
 export default class DatesOfPlacement implements TasklistPage {
   title = 'Dates of placement'
 
   questions = {
     arrivalDate: 'When will the person arrive?',
-    duration: 'How long should the Approved Premises placement last? (in weeks)',
+    duration: 'How long should the Approved Premises placement last?',
   }
 
-  body: Body
+  constructor(private _body: Body) {}
 
-  constructor(_body: Body) {
-    this.body = {
-      'arrivalDate-year': _body['arrivalDate-year'],
-      'arrivalDate-month': _body['arrivalDate-month'],
-      'arrivalDate-day': _body['arrivalDate-day'],
-      arrivalDate: DateFormats.dateAndTimeInputsToIsoString(_body as ObjectWithDateParts<'arrivalDate'>, 'arrivalDate')
-        .arrivalDate,
-      duration: _body.duration,
+  get body() {
+    return {
+      'arrivalDate-year': this._body['arrivalDate-year'],
+      'arrivalDate-month': this._body['arrivalDate-month'],
+      'arrivalDate-day': this._body['arrivalDate-day'],
+      arrivalDate: DateFormats.dateAndTimeInputsToIsoString(
+        this._body as ObjectWithDateParts<'arrivalDate'>,
+        'arrivalDate',
+      ).arrivalDate,
+      durationDays: this._body.durationDays,
+      durationWeeks: this._body.durationWeeks,
+      duration: this.lengthInDays(),
     }
+  }
+
+  set body(value: Body) {
+    this._body = value
   }
 
   previous() {
@@ -45,7 +63,16 @@ export default class DatesOfPlacement implements TasklistPage {
   response() {
     return {
       [this.questions.arrivalDate]: DateFormats.isoDateToUIDate(this.body.arrivalDate),
-      [this.questions.duration]: `${sentenceCase(this.body.duration)} weeks`,
+      [this.questions.duration]: formatDuration(
+        {
+          weeks: Number(this.body.durationDays),
+          days: Number(this.body.durationWeeks),
+        },
+        {
+          format: ['weeks', 'days'],
+          delimiter: ', ',
+        },
+      ),
     }
   }
 
@@ -61,5 +88,16 @@ export default class DatesOfPlacement implements TasklistPage {
     if (!this.body.duration) errors.duration = 'You must state the duration of the placement'
 
     return errors
+  }
+
+  private lengthInDays(): string {
+    if (this._body.durationWeeks && this._body.durationDays) {
+      const lengthOfStayWeeksInDays = weeksToDays(Number(this._body.durationWeeks))
+      const totalLengthInDays = lengthOfStayWeeksInDays + Number(this._body.durationDays)
+
+      return String(totalLengthInDays)
+    }
+
+    return undefined
   }
 }

--- a/server/testutils/factories/bedSearchParameters.ts
+++ b/server/testutils/factories/bedSearchParameters.ts
@@ -16,6 +16,7 @@ export const bedSearchParametersFactory = Factory.define<BedSearchParameters>(()
 
 export const bedSearchParametersUiFactory = Factory.define<BedSearchParametersUi>(() => ({
   durationWeeks: faker.number.int({ min: 12, max: 52 }).toString(),
+  durationDays: faker.number.int({ min: 0, max: 6 }).toString(),
   maxDistanceMiles: faker.number.int({ min: 1, max: 100 }).toString(),
   startDate: DateFormats.dateObjToIsoDate(faker.date.soon()),
   postcodeDistrict: 'SW11',

--- a/server/utils/assessments/dateUtils.test.ts
+++ b/server/utils/assessments/dateUtils.test.ts
@@ -1,6 +1,7 @@
 import {
   daysSinceInfoRequest,
   daysSinceReceived,
+  daysToWeeksAndDays,
   daysUntilDue,
   formatDays,
   formatDaysUntilDueWithWarning,
@@ -111,6 +112,24 @@ describe('dateUtils', () => {
       expect(formatDaysUntilDueWithWarning(assessment)).toEqual(
         '<strong class="assessments--index__warning">1 Day<span class="govuk-visually-hidden"> (Approaching due date)</span></strong>',
       )
+    })
+  })
+
+  describe('daysToWeeksAndDays', () => {
+    it('should return zero weeks when a day length is less than 7 days', () => {
+      expect(daysToWeeksAndDays(6)).toEqual({ days: 6, weeks: 0 })
+    })
+
+    it('should return one week when a day length is 7 days', () => {
+      expect(daysToWeeksAndDays(7)).toEqual({ days: 0, weeks: 1 })
+    })
+
+    it('should return week and days for a long length', () => {
+      expect(daysToWeeksAndDays(52)).toEqual({ days: 3, weeks: 7 })
+    })
+
+    it('should convert a string value to a number', () => {
+      expect(daysToWeeksAndDays('7')).toEqual({ days: 0, weeks: 1 })
     })
   })
 })

--- a/server/utils/assessments/dateUtils.ts
+++ b/server/utils/assessments/dateUtils.ts
@@ -38,6 +38,16 @@ const daysUntilDue = (assessment: AssessmentSummary): number => {
   return differenceInDays(dueDate, new Date())
 }
 
+const daysToWeeksAndDays = (days: string | number): { days: number; weeks: number } => {
+  const daysAsNumber = Number(days)
+  const durationWeeks = Math.floor(daysAsNumber / 7)
+
+  return {
+    days: daysAsNumber - durationWeeks * 7,
+    weeks: durationWeeks,
+  }
+}
+
 const formatDaysUntilDueWithWarning = (assessment: AssessmentSummary): string => {
   const days = daysUntilDue(assessment)
   if (days < DUE_DATE_APPROACHING_DAYS_WINDOW) {
@@ -76,4 +86,5 @@ export {
   assessmentsApproachingDue,
   formattedArrivalDate,
   daysUntilDue,
+  daysToWeeksAndDays,
 }

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -167,6 +167,12 @@ describe('DateFormats', () => {
       expect(differenceInDays).toHaveBeenCalledWith(date1, date2)
     })
   })
+
+  describe('formatDuration', () => {
+    it('formats a duration with the given unit', () => {
+      expect(DateFormats.formatDuration({ days: '4', weeks: '7' })).toEqual('7 weeks, 4 days')
+    })
+  })
 })
 
 describe('dateAndTimeInputsAreValidDates', () => {

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,9 +1,19 @@
 /* eslint-disable */
 import type { ObjectWithDateParts } from '@approved-premises/ui'
 
-import { differenceInDays, formatDistanceStrict, getUnixTime, formatISO, parseISO, format, isPast } from 'date-fns'
+import { differenceInDays, formatDistanceStrict, formatISO, parseISO, format, isPast, formatDuration } from 'date-fns'
 
 type DifferenceInDays = { ui: string; number: number }
+
+type DurationWithNumberOrString = {
+  years?: number | string
+  months?: number | string
+  weeks?: number | string
+  days?: number | string
+  hours?: number | string
+  minutes?: number | string
+  seconds?: number | string
+}
 export class DateFormats {
   /**
    * @param date JS Date object.
@@ -112,6 +122,16 @@ export class DateFormats {
 
   static isoDateToDateInputs<K extends string>(isoDate: string, key: string): ObjectWithDateParts<K> {
     return DateFormats.dateObjectToDateInputs(DateFormats.isoToDateObj(isoDate), key)
+  }
+
+  static formatDuration(duration: DurationWithNumberOrString, format: Array<string> = ['weeks', 'days']): string {
+    const formattedDuration = {} as Duration
+    Object.keys(duration).forEach(k => (formattedDuration[k] = Number(duration[k])))
+
+    return formatDuration(formattedDuration, {
+      format,
+      delimiter: ', ',
+    })
   }
 }
 

--- a/server/utils/matchUtils.test.ts
+++ b/server/utils/matchUtils.test.ts
@@ -19,7 +19,6 @@ import {
   encodeBedSearchResult,
   groupedCheckboxes,
   groupedEssentialCriteria,
-  mapApiParamsForUi,
   mapSearchParamCharacteristicsForUi,
   mapSearchResultCharacteristicsForUi,
   mapUiParamsForApi,
@@ -83,23 +82,13 @@ describe('matchUtils', () => {
 
   describe('mapUiParamsForApi', () => {
     it('converts string properties to numbers', () => {
-      const uiParams = bedSearchParametersUiFactory.build({ durationWeeks: '2' })
+      const uiParams = bedSearchParametersUiFactory.build({ durationWeeks: '2', durationDays: '1' })
 
       expect(mapUiParamsForApi(uiParams)).toEqual({
         ...uiParams,
-        durationDays: 14,
+        durationDays: 15,
         maxDistanceMiles: Number(uiParams.maxDistanceMiles),
       })
-    })
-  })
-
-  describe('mapApiParamsForUi', () => {
-    const apiParams = bedSearchParametersFactory.build({ durationDays: 14 })
-
-    expect(mapApiParamsForUi(apiParams)).toEqual({
-      ...apiParams,
-      durationWeeks: '2',
-      maxDistanceMiles: apiParams.maxDistanceMiles.toString(),
     })
   })
 

--- a/server/utils/matchUtils.ts
+++ b/server/utils/matchUtils.ts
@@ -1,4 +1,4 @@
-import { addWeeks, daysToWeeks, formatDuration, weeksToDays } from 'date-fns'
+import { addWeeks, formatDuration, weeksToDays } from 'date-fns'
 import {
   ApprovedPremisesBedSearchParameters as BedSearchParameters,
   BedSearchResult,
@@ -39,17 +39,14 @@ const groupedCriteria = {
   accessibility: { title: 'Would benefit from', options: accessibilityOptions },
 }
 
-export const mapUiParamsForApi = (query: BedSearchParametersUi): BedSearchParameters => ({
-  ...query,
-  durationDays: weeksToDays(Number(query.durationWeeks)),
-  maxDistanceMiles: Number(query.maxDistanceMiles),
-})
-
-export const mapApiParamsForUi = (apiParams: BedSearchParameters): Partial<BedSearchParametersUi> => ({
-  ...apiParams,
-  durationWeeks: daysToWeeks(apiParams.durationDays).toString(),
-  maxDistanceMiles: apiParams.maxDistanceMiles.toString(),
-})
+export const mapUiParamsForApi = (query: BedSearchParametersUi): BedSearchParameters => {
+  const durationDays = weeksToDays(Number(query.durationWeeks)) + Number(query.durationDays)
+  return {
+    ...query,
+    durationDays,
+    maxDistanceMiles: Number(query.maxDistanceMiles),
+  }
+}
 
 export const translateApiCharacteristicForUi = (characteristic: string) => {
   const result = characteristic.startsWith('is') ? characteristic.slice(2) : characteristic

--- a/server/utils/matchUtils.ts
+++ b/server/utils/matchUtils.ts
@@ -1,4 +1,4 @@
-import { addWeeks, formatDuration, weeksToDays } from 'date-fns'
+import { addWeeks, weeksToDays } from 'date-fns'
 import {
   ApprovedPremisesBedSearchParameters as BedSearchParameters,
   BedSearchResult,
@@ -105,7 +105,7 @@ export const decodeBedSearchResult = (string: string): BedSearchResult => {
 }
 
 export const placementLength = (lengthInWeeks: number): string => {
-  return formatDuration({ weeks: lengthInWeeks }, { format: ['weeks'] })
+  return DateFormats.formatDuration({ weeks: lengthInWeeks }, ['weeks'])
 }
 
 export const placementDates = (startDateString: string, lengthInWeeks: string): PlacementDates => {

--- a/server/utils/placementRequests/utils.test.ts
+++ b/server/utils/placementRequests/utils.test.ts
@@ -23,13 +23,14 @@ describe('utils', () => {
     it('transforms a placement request into bed search params', () => {
       const person = personFactory.build()
       const placementRequest = placementRequestFactory.build({
-        duration: 12,
+        duration: 15,
         radius: 100,
         person,
       })
 
       expect(mapPlacementRequestToBedSearchParams(placementRequest)).toEqual({
-        durationWeeks: '12',
+        durationWeeks: '2',
+        durationDays: '1',
         startDate: placementRequest.expectedArrival,
         postcodeDistrict: placementRequest.location,
         maxDistanceMiles: '100',

--- a/server/utils/placementRequests/utils.ts
+++ b/server/utils/placementRequests/utils.ts
@@ -5,6 +5,7 @@ import { linkTo } from '../utils'
 
 import paths from '../../paths/match'
 import assessPaths from '../../paths/assess'
+import { daysToWeeksAndDays } from '../assessments/dateUtils'
 
 export const mapPlacementRequestToBedSearchParams = ({
   duration,
@@ -16,16 +17,20 @@ export const mapPlacementRequestToBedSearchParams = ({
   person,
   applicationId,
   assessmentId,
-}: PlacementRequest): BedSearchParametersUi => ({
-  durationWeeks: duration.toString(),
-  startDate: expectedArrival,
-  postcodeDistrict: location,
-  maxDistanceMiles: radius.toString(),
-  crn: person.crn,
-  applicationId,
-  assessmentId,
-  requiredCharacteristics: [...essentialCriteria, ...desirableCriteria],
-})
+}: PlacementRequest): BedSearchParametersUi => {
+  const daysAndWeeks = daysToWeeksAndDays(duration)
+  return {
+    durationDays: String(daysAndWeeks.days),
+    durationWeeks: String(daysAndWeeks.weeks),
+    startDate: expectedArrival,
+    postcodeDistrict: location,
+    maxDistanceMiles: radius.toString(),
+    crn: person.crn,
+    applicationId,
+    assessmentId,
+    requiredCharacteristics: [...essentialCriteria, ...desirableCriteria],
+  }
+}
 
 export const formatReleaseType = (placementRequest: PlacementRequest) => allReleaseTypes[placementRequest.releaseType]
 

--- a/server/views/applications/pages/move-on/placement-duration.njk
+++ b/server/views/applications/pages/move-on/placement-duration.njk
@@ -1,4 +1,4 @@
-{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "../../../components/formFields/form-page-day-weeks-input/macro.njk" import formPageDaysAndWeeksInput %}
 
 {% extends "../layout.njk" %}
 
@@ -31,17 +31,9 @@
     }) }}
 
   {% set yesDetails %}
+
   {{
-    formPageInput(
-      {
-        label: {
-          text: page.questions.duration
-        },
-        classes: "govuk-input--width-2",
-        fieldName: "duration"
-      },
-      fetchContext()
-    )
+    formPageDaysAndWeeksInput("duration", "govuk-label", fetchContext())
   }}
 
   {{

--- a/server/views/assessments/pages/matching-information/matching-information.njk
+++ b/server/views/assessments/pages/matching-information/matching-information.njk
@@ -1,4 +1,5 @@
 {% extends "../layout.njk" %}
+{% from "../../../components/formFields/form-page-day-weeks-input/macro.njk" import formPageDaysAndWeeksInput %}
 
 {% block questions %}
 
@@ -9,7 +10,7 @@
       fieldName: "apType",
       fieldset: {
         legend: {
-          text: page.apTypeQuestion,
+          text: page.questions.apType,
           classes: "govuk-fieldset__legend--m"
         }
       },
@@ -22,7 +23,7 @@
         fieldName: "specialistSupportCriteria",
         fieldset: {
           legend: {
-            text: "If this person would benefit from specialist support, select the relevant option below",
+            text: page.questions.specialistSupportCriteria,
             classes: "govuk-fieldset__legend--m"
           }
         },
@@ -41,7 +42,7 @@
         fieldName: "accessibilityCriteria",
         fieldset: {
           legend: {
-            text: "Would the person benefit from any of the following?",
+            text: page.questions.accessibilityCriteria,
             classes: "govuk-fieldset__legend--m"
           }
         },
@@ -55,34 +56,14 @@
 
   {{placementRequirementsTable(page.placementRequirementTableHeadings, page.placementRequirements, page.placementRequirementPreferences, page.body) | safe}}
 
-  {{placementRequirementsTable(page.relevantInformationTableHeadings, page.offenceAndRiskInformationKeys, page.offenceAndRiskInformationRelevance, page.body) | safe}}
-
-  {% set noDetails %}
-  {{
-    formPageInput(
-      {
-        fieldName: "lengthOfStayAgreedDetail",
-        spellcheck: false,
-        inputmode: "numeric",
-        label: {
-          text: "Provide recommended length of stay"
-        },
-        suffix: {
-          text: "weeks"
-        },
-        classes: "govuk-input--width-2"
-      },
-      fetchContext()
-    )
-  }}
-  {% endset -%}
+  {{ placementRequirementsTable(page.relevantInformationTableHeadings, page.offenceAndRiskInformationKeys, page.offenceAndRiskInformationRelevance, page.body) | safe }}
 
   {{
     formPageRadios({
       fieldName: "lengthOfStayAgreed",
       fieldset: {
         legend: {
-          text: "Do you agree with the suggested length of stay?",
+          text: page.questions.lengthOfStayAgreed,
           classes: "govuk-fieldset__legend--m"
         }
       },
@@ -98,7 +79,7 @@
           value: "no",
           text: "No",
           conditional: {
-            html: noDetails
+            html: formPageDaysAndWeeksInput("lengthOfStay", "govuk-label--s", fetchContext())
           }
         }
       ]
@@ -114,7 +95,7 @@
         type: "textarea",
         spellcheck: false,
         label: {
-          text: "Information for Central Referral Unit (CRU) manager (optional)",
+          text: page.questions.cruInformation,
           classes: "govuk-label--m"
         },
         hint: {

--- a/server/views/assessments/pages/matching-information/matching-information.njk
+++ b/server/views/assessments/pages/matching-information/matching-information.njk
@@ -87,7 +87,7 @@
         }
       },
       hint: {
-        text: "Recommended length of stay: " + page.suggestedLengthOfStay + " weeks"
+        text: "Recommended length of stay: " + page.suggestedLengthOfStay
       },
       items: [
         {

--- a/server/views/components/formFields/form-page-day-weeks-input/macro.njk
+++ b/server/views/components/formFields/form-page-day-weeks-input/macro.njk
@@ -1,0 +1,66 @@
+{% from "../form-page-input/macro.njk" import formPageInput %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+
+{% macro formPageDaysAndWeeksInput(fieldName, legendClasses, context) %}
+  {% if context.errors[fieldName] %}
+    {% set wrapperClasses = "govuk-form-group govuk-form-group--error" %}
+    {% set inputClasses = "govuk-input--width-2 govuk-input--error" %}
+  {% else %}
+    {% set wrapperClasses = "govuk-form-group" %}
+    {% set inputClasses = "govuk-input--width-2" %}
+  {% endif %}
+
+  <div class="{{ wrapperClasses }}" id="{{ fieldName }}">
+    {% call govukFieldset({
+      legend: {
+        text: context
+          .page
+          .questions[fieldName],
+        classes: legendClasses
+      }
+    })
+ %}
+
+    {% if context.errors[fieldName] %}
+      <p id="{{ fieldname }}-error" class="govuk-error-message" data-cy-error-{{ fieldname }}="true">
+        <span class="govuk-visually-hidden">Error:</span>
+        {{ context.errors[fieldname].text }}
+      </p>
+    {% endif %}
+
+    {{
+      formPageInput(
+        {
+          classes: inputClasses,
+          fieldName: fieldName + "Weeks",
+          formGroup: {
+            classes: "govuk-form-group--inline"
+          },
+          label: {
+            text: "Weeks"
+          }
+        },
+        context
+      )
+    }}
+
+    {{
+      formPageInput(
+        {
+          classes: inputClasses,
+          fieldName: fieldName + "Days",
+          formGroup: {
+            classes: "govuk-form-group--inline"
+          },
+          label: {
+            text: "Days"
+          }
+        },
+        context
+      )
+    }}
+
+    {% endcall %}
+  </div>
+
+{% endmacro %}

--- a/server/views/match/search.njk
+++ b/server/views/match/search.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -137,21 +138,50 @@
 								errorMessage: errors.startDate
 							}) }}
 
-							{{
-								govukInput({
-								id: "durationWeeks",
-								name: "durationWeeks",
-								value: durationWeeks,
-								type: "number",
-								label: {
-								text: "Length of stay"
-								},
-								classes: "govuk-input--width-2",
-								suffix: {
-									text: "weeks"
+							{% call govukFieldset({
+								legend: {
+									text: "Length of stay",
+									classes: "govuk-fieldset__legend--s"
 								}
-								})
+							}) %}
+
+							{{
+								govukInput(
+									{
+										classes: "govuk-input--width-2",
+										id: "durationWeeks",
+       							name: "durationWeeks",
+										formGroup: {
+											classes: "govuk-form-group--inline"
+										},
+										label: {
+											text: "Weeks"
+										},
+										value: durationWeeks
+									},
+									context
+								)
 							}}
+
+							{{
+								govukInput(
+									{
+										classes: "govuk-input--width-2",
+										id: "durationDays",
+       							name: "durationDays",
+										formGroup: {
+											classes: "govuk-form-group--inline"
+										},
+										label: {
+											text: "Days"
+										},
+										value: durationDays
+									},
+									context
+								)
+							}}
+
+							{% endcall %}
 
 							{{ govukInput({
 								id: "postcodeDistrict",

--- a/server/views/placement-applications/pages/request-a-placement/additional-placement-details.njk
+++ b/server/views/placement-applications/pages/request-a-placement/additional-placement-details.njk
@@ -1,4 +1,6 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "../../../components/formFields/form-page-day-weeks-input/macro.njk" import formPageDaysAndWeeksInput %}
+
 {% extends "../../layout.njk" %}
 
 {% block questions %}
@@ -23,19 +25,7 @@
     )
   }}
 
-  {{
-    formPageInput(
-      {
-        label: {
-          text: page.questions.duration,
-          classes: "govuk-fieldset__legend--m"
-        },
-        classes: "govuk-input--width-2",
-        fieldName: "duration"
-      },
-      fetchContext()
-    )
-  }}
+  {{ formPageDaysAndWeeksInput("duration", "govuk-fieldset__legend--m", fetchContext()) }}
 
   {{ formPageTextarea({
         fieldName: "reason",

--- a/server/views/placement-applications/pages/request-a-placement/dates-of-placement.njk
+++ b/server/views/placement-applications/pages/request-a-placement/dates-of-placement.njk
@@ -1,4 +1,6 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "../../../components/formFields/form-page-day-weeks-input/macro.njk" import formPageDaysAndWeeksInput %}
+
 {% extends "../../layout.njk" %}
 
 {% block questions %}
@@ -23,18 +25,6 @@
     )
   }}
 
-  {{
-    formPageInput(
-      {
-        label: {
-          text: page.questions.duration,
-          classes: "govuk-fieldset__legend--m"
-        },
-        classes: "govuk-input--width-2",
-        fieldName: "duration"
-      },
-      fetchContext()
-    )
-  }}
+  {{ formPageDaysAndWeeksInput("duration", "govuk-fieldset__legend--m", fetchContext()) }}
 
 {% endblock %}


### PR DESCRIPTION
This updates all the places where we ask for and about placement length to ask for weeks and days. On all the form pages, rather than storing just the weeks and days, we gather them both up and add them together into a duration field, which we then send to the API as the "duration". The search already accepts duration in days, so we don't have to do anything API-side to make all this work correctly.

## Screenshots

![Apply -- allows completion of the form](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/ea631f69-eb6f-4f95-aa75-62526c57d07a)

![Assess -- allows me to assess an application](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/34b3eac6-dd97-43f5-92ad-78dba71e4be6)

![Placement Applications -- allows me to complete form if the reason for placement is an additional placement on an existing application](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/e7d0dbd4-d355-4515-a9c3-f3567c013617)

![Placement Applications -- allows me to complete form if the reason for placement is ROTL](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/9f84ca55-46fa-4c0a-8dd0-c8ed890e2257)

![Placement Requests -- allows me to search for available rooms (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/27edc49d-06cb-4dd7-8d37-87337dc1ac4b)




