### PR TITLE
(237) Add guidance when the user selects an appeal

### DIFF
--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -112,6 +112,9 @@ export interface RadioItem {
   text: string
   value: string
   checked?: boolean
+  conditional?: {
+    html?: string
+  }
 }
 
 export type CheckBoxItem =

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -2,6 +2,7 @@ import { createMock } from '@golevelup/ts-jest'
 
 import type { ErrorMessages } from '@approved-premises/ui'
 import {
+  cancellationReasonRadioItems,
   convertArrayToRadioItems,
   convertKeyValuePairToCheckBoxItems,
   convertKeyValuePairToRadioItems,
@@ -120,6 +121,39 @@ describe('formUtils', () => {
           text: 'abc',
           value: '123',
           checked: true,
+        },
+        {
+          text: 'def',
+          value: '345',
+          checked: false,
+        },
+      ])
+    })
+  })
+
+  describe('cancellationReasonRadioItems', () => {
+    const objects = [
+      {
+        id: '123',
+        name: 'Booking successfully appealed',
+      },
+      {
+        id: '345',
+        name: 'def',
+      },
+    ]
+
+    it('converts objects to an array of radio items', () => {
+      const result = cancellationReasonRadioItems(objects, 'somehtml', {})
+
+      expect(result).toEqual([
+        {
+          text: 'Appealed placement approved by AP area manager (APAM)',
+          value: '123',
+          checked: false,
+          conditional: {
+            html: 'somehtml',
+          },
         },
         {
           text: 'def',

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -40,6 +40,25 @@ export const convertObjectsToRadioItems = (
   })
 }
 
+export const cancellationReasonRadioItems = (
+  cancellationReasons: Array<Record<string, string>>,
+  appealHtml: string,
+  context: Record<string, unknown>,
+): Array<RadioItem> => {
+  const items = convertObjectsToRadioItems(cancellationReasons, 'name', 'id', 'cancellation[reason]', context)
+
+  return items.map(item => {
+    if (item.text === 'Booking successfully appealed') {
+      item.text = 'Appealed placement approved by AP area manager (APAM)'
+      item.conditional = {
+        html: appealHtml,
+      }
+    }
+
+    return item
+  })
+}
+
 export const convertObjectsToSelectOptions = (
   items: Array<Record<string, string>>,
   prompt: string,

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -15,6 +15,7 @@ import {
   sentenceCase,
 } from './utils'
 import {
+  cancellationReasonRadioItems,
   convertKeyValuePairToRadioItems,
   convertObjectsToRadioItems,
   convertObjectsToSelectOptions,
@@ -117,6 +118,13 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
       fieldName: string,
     ) {
       return convertObjectsToRadioItems(items, textKey, valueKey, fieldName, this.ctx)
+    },
+  )
+
+  njkEnv.addGlobal(
+    'cancellationReasonRadioItems',
+    function sendContextToCancellationReasonRadioItems(items: Array<Record<string, string>>, appealHtml: string) {
+      return cancellationReasonRadioItems(items, appealHtml, this.ctx)
     },
   )
 

--- a/server/views/cancellations/new.njk
+++ b/server/views/cancellations/new.njk
@@ -5,6 +5,8 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -85,6 +87,33 @@
             items: dateFieldValues('date', errors)
         }) }}
 
+        {% set appealHtml %}
+
+        {% set appealBody %}
+        <p class="govuk-body">You must receive approval from your APAM to appeal a placement before cancelling it.</p>
+
+        <p class="govuk-body">Reasons for appealing a placement may include:</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>an overlap with a person who is co-accused</li>
+          <li>gang / rival members in the AP</li>
+          <li>an unmanageable mix of offence and behaviour types in the AP</li>
+          <li>staff conflict of interest</li>
+        </ul>
+
+        <p class="govuk-body">You will need to provide the name of the APAM, their contact details, an outline of the discussion and when it took place.</p>
+
+        <p class="govuk-body">Appealed placements will be returned to the central referral unit to be matched to another AP.</p>
+        {% endset %}
+
+        {{
+          govukNotificationBanner({
+            html: appealBody
+          })
+        }}
+
+        {% endset %}
+
         {{ govukRadios({
           name: "cancellation[reason]",
           id: "reason",
@@ -95,7 +124,7 @@
               }
           },
           errorMessage: errors.reason,
-          items: convertObjectsToRadioItems(cancellationReasons, 'name', 'id', 'cancellation[reason]')
+          items: cancellationReasonRadioItems(cancellationReasons, appealHtml)
           }) }}
 
         {{ govukTextarea({


### PR DESCRIPTION
This adds a big obvious warning with guidance when a placement gets cancelled through the appeals process. It’s a bit of a hack, but it is enough to see us through until we have a proper online process

# Screenshot

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/c5bed1dd-be6d-40ed-bdd5-31b72a9de44c)
