### PR TITLE
Fix confirmationPageMessage

### DIFF
--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -182,23 +182,14 @@ describe('utils', () => {
     const assessment = assessmentFactory.build()
 
     it('returns the release date copy if the decision is "releaseDate"', () => {
-      ;(decisionFromAssessment as jest.Mock).mockReturnValue('releaseDate')
+      ;(decisionFromAssessment as jest.Mock).mockReturnValue('accept')
 
       expect(confirmationPageMessage(assessment)).toMatchStringIgnoringWhitespace(
         "<p>We've notified the Probation practitioner that this application has been assessed as suitable.</p>",
       )
     })
 
-    it('returns the hold copy if the decision is "hold"', () => {
-      ;(decisionFromAssessment as jest.Mock).mockReturnValue('hold')
-
-      expect(confirmationPageMessage(assessment))
-        .toMatchStringIgnoringWhitespace(`<p>We've notified the Probation practitioner that this application has been assessed as suitable.</p>
-        <p>This case is now paused until the oral hearing outcome has been provided by the Probation practitioner and a release date is confirmed.</p>
-        <p>It will be added to the matching queue if the oral hearing is successful.</p>`)
-    })
-
-    it('returns the rejection copy if the decision isnt "hold" or "releaseDate" ', () => {
+    it('returns the rejection copy if the decision isnt "accept"', () => {
       ;(decisionFromAssessment as jest.Mock).mockReturnValue('')
 
       expect(confirmationPageMessage(assessment))

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -109,17 +109,13 @@ const getReviewNavigationItems = () => {
 }
 
 const confirmationPageMessage = (assessment: Assessment) => {
-  switch (decisionFromAssessment(assessment)) {
-    case 'releaseDate':
-      return "<p>We've notified the Probation practitioner that this application has been assessed as suitable.</p>"
-    case 'hold':
-      return `<p>We've notified the Probation practitioner that this application has been assessed as suitable.</p>
-      <p>This case is now paused until the oral hearing outcome has been provided by the Probation practitioner and a release date is confirmed.</p>
-      <p>It will be added to the matching queue if the oral hearing is successful.</p>`
-    default:
-      return `<p>We've sent you a confirmation email.</p>
-      <p>We've notified the Probation practitioner that this application has been rejected as unsuitable for an Approved Premises.</p>`
+  const decision = decisionFromAssessment(assessment)
+
+  if (decision === 'accept') {
+    return "<p>We've notified the Probation practitioner that this application has been assessed as suitable.</p>"
   }
+  return `<p>We've sent you a confirmation email.</p>
+    <p>We've notified the Probation practitioner that this application has been rejected as unsuitable for an Approved Premises.</p>`
 }
 
 const confirmationPageResult = (assessment: Assessment) => {


### PR DESCRIPTION
Since the decision was changed to a single `Accept` option, the confirmation page message was showing as though it had been rejected.

We may need to update the copy if there is no release date, but this ensures the copy is correct for now