### PR TITLE
Correct rejection reasons

### DIFF
--- a/server/form-pages/assess/makeADecision/makeADecisionTask/makeADecision.test.ts
+++ b/server/form-pages/assess/makeADecision/makeADecisionTask/makeADecision.test.ts
@@ -49,12 +49,11 @@ describe('MakeADecision', () => {
   describe('response', () => {
     it('returns the response', () => {
       const page = new MakeADecision({
-        decision: 'riskTooHigh',
+        decision: 'informationNotProvided',
       })
 
       expect(page.response()).toEqual({
-        Decision:
-          'Requested information not provided by probation practitioner: Reject, risk too high (must be approved by an AP Area Manager (APAM)',
+        Decision: 'Reject, insufficient information: Requested information not provided by probation practitioner',
       })
     })
   })

--- a/server/form-pages/assess/makeADecision/makeADecisionTask/makeADecision.ts
+++ b/server/form-pages/assess/makeADecision/makeADecisionTask/makeADecision.ts
@@ -30,8 +30,7 @@ export default class MakeADecision implements TasklistPage {
       insufficientContingencyPlan: 'Insufficient contingency plan',
       informationNotProvided: 'Requested information not provided by probation practitioner',
     },
-    'Requested information not provided by probation practitioner': {
-      riskTooHigh: 'Reject, risk too high (must be approved by an AP Area Manager (APAM)',
+    'Reject, risk too high (must be approved by an AP Area Manager (APAM)': {
       riskToCommunity: 'Risk to community',
       riskToOthersInAP: 'Risk to other people in AP',
       riskToStaff: 'Risk to staff',


### PR DESCRIPTION
We had previously added 'Requested information...' as a heading when it should be a radio option and 'Reject, risk too high...' as an option when it should be heading

### Before
![Assess -- should allow me to reject an application where I have not received the correct information (3)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/7af6c3e7-9508-49ee-9e9b-2889f33b7875)


### After 
![Assess -- should allow me to reject an application where I have not received the correct information (2)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/5f321399-b709-496c-931f-d7fc7eed6921)
