### PR TITLE
Managing lost beds

### DIFF
--- a/integration_tests/mockApis/lostBed.ts
+++ b/integration_tests/mockApis/lostBed.ts
@@ -21,6 +21,55 @@ export default {
       },
     }),
 
+  stubLostBedUpdate: (args: { lostBed: LostBed; premisesId: string }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'PUT',
+        url: `/premises/${args.premisesId}/lost-beds/${args.lostBed.id}`,
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.lostBed,
+      },
+    }),
+
+  stubLostBedUpdateErrors: (args: { lostBed: LostBed; premisesId: string; params: Array<string> }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'PUT',
+        url: `/premises/${args.premisesId}/lost-beds/${args.lostBed.id}`,
+      },
+      response: {
+        status: 400,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          type: 'https://example.net/validation-error',
+          title: 'Invalid request parameters',
+          code: 400,
+          'invalid-params': [
+            {
+              propertyName: `$.endDate`,
+              errorType: 'empty',
+            },
+          ],
+        },
+      },
+    }),
+
+  stubLostBedsList: (args: { premisesId: string; lostBeds: Array<LostBed> }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/premises/${args.premisesId}/lost-beds`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.lostBeds,
+      },
+    }),
+
   stubLostBed: (args: { premisesId: string; lostBed: LostBed }): SuperAgentRequest =>
     stubFor({
       request: {
@@ -62,6 +111,14 @@ export default {
       await getMatchingRequests({
         method: 'POST',
         url: `/premises/${args.premisesId}/lost-beds`,
+      })
+    ).body.requests,
+
+  verifyLostBedUpdate: async (args: { premisesId: string; lostBed: LostBed }) =>
+    (
+      await getMatchingRequests({
+        method: 'PUT',
+        url: `/premises/${args.premisesId}/lost-beds/${args.lostBed.id}`,
       })
     ).body.requests,
 }

--- a/integration_tests/pages/manage/bed/bedsList.ts
+++ b/integration_tests/pages/manage/bed/bedsList.ts
@@ -23,4 +23,9 @@ export default class BedsListPage extends Page {
   clickBed(bed: BedDetail): void {
     cy.get(`a[data-cy-bedid="${bed.id}"]`).click()
   }
+
+  clickManageLostBeds(): void {
+    cy.get('.moj-button-menu__toggle-button').click()
+    cy.get('a').contains('Manage out of service beds').click()
+  }
 }

--- a/integration_tests/pages/manage/index.ts
+++ b/integration_tests/pages/manage/index.ts
@@ -2,6 +2,7 @@ import ArrivalCreatePage from './arrivalCreate'
 import CancellationCreatePage from './cancellationCreate'
 import DepartureCreatePage from './departureCreate'
 import LostBedCreatePage from './lostBedCreate'
+import LostBedListPage from './lostBedList'
 import LostBedShowPage from './lostBedShow'
 import PremisesListPage from './premisesList'
 import PremisesShowPage from './premisesShow'
@@ -21,6 +22,7 @@ export {
   CancellationCreatePage,
   DepartureCreatePage,
   LostBedCreatePage,
+  LostBedListPage,
   LostBedShowPage,
   PremisesListPage,
   PremisesShowPage,

--- a/integration_tests/pages/manage/lostBedList.ts
+++ b/integration_tests/pages/manage/lostBedList.ts
@@ -1,0 +1,40 @@
+import type { LostBed } from '@approved-premises/api'
+import paths from '../../../server/paths/manage'
+
+import Page from '../page'
+
+export default class LostBedListPage extends Page {
+  constructor() {
+    super('Manage out of service beds')
+  }
+
+  static visit(premisesId: string): LostBedListPage {
+    cy.visit(paths.lostBeds.index({ premisesId }))
+    return new LostBedListPage()
+  }
+
+  shouldShowLostBeds(lostBeds: Array<LostBed>): void {
+    lostBeds.forEach((item: LostBed) => {
+      cy.get(`[data-cy-lostBedId="${item.id}"]`)
+        .parent()
+        .parent()
+        .within(() => {
+          cy.get('td').eq(0).contains(item.bedName)
+          cy.get('td').eq(1).contains(item.roomName)
+          cy.get('td').eq(2).contains(item.startDate)
+          cy.get('td').eq(3).contains(item.endDate)
+          cy.get('td').eq(4).contains(item.reason.name)
+          cy.get('td').eq(5).contains(item.referenceNumber)
+        })
+    })
+  }
+
+  clickManageBed(lostBed): void {
+    cy.get(`[data-cy-lostBedId="${lostBed.id}"]`)
+      .parent()
+      .parent()
+      .within(() => {
+        cy.get('td').eq(6).contains('Manage').click()
+      })
+  }
+}

--- a/integration_tests/pages/manage/lostBedShow.ts
+++ b/integration_tests/pages/manage/lostBedShow.ts
@@ -6,7 +6,7 @@ import { DateFormats } from '../../../server/utils/dateUtils'
 
 export default class LostBedShowPage extends Page {
   constructor(private readonly lostBed: LostBed) {
-    super('Lost bed details')
+    super('Manage out of service bed')
   }
 
   static visit(premisesId: string, lostBed: LostBed): LostBedShowPage {
@@ -15,8 +15,17 @@ export default class LostBedShowPage extends Page {
   }
 
   shouldShowLostBedDetail(): void {
-    this.assertDefinition('Start date', DateFormats.isoDateToUIDate(this.lostBed.startDate, { format: 'short' }))
-    this.assertDefinition('End date', DateFormats.isoDateToUIDate(this.lostBed.startDate, { format: 'short' }))
-    this.assertDefinition('Reason', this.lostBed.reason.name)
+    this.assertDefinition('Room number', this.lostBed.roomName)
+    this.assertDefinition('Bed number', this.lostBed.bedName)
+    this.assertDefinition('Start date', DateFormats.isoDateToUIDate(this.lostBed.startDate, { format: 'long' }))
+    this.assertDefinition('End date', DateFormats.isoDateToUIDate(this.lostBed.startDate, { format: 'long' }))
+    this.assertDefinition('Reason for bed being marked as lost', this.lostBed.reason.name)
+    this.assertDefinition('Reference number', this.lostBed.referenceNumber)
+  }
+
+  public completeForm(endDateString: string, notes: string): void {
+    super.completeDateInputs('endDate', endDateString)
+
+    cy.get('textarea[name="notes"]').type(String(notes))
   }
 }

--- a/integration_tests/tests/manage/beds.cy.ts
+++ b/integration_tests/tests/manage/beds.cy.ts
@@ -1,6 +1,6 @@
-import { bedDetailFactory, bedSummaryFactory } from '../../../server/testutils/factories'
+import { bedDetailFactory, bedSummaryFactory, lostBedFactory } from '../../../server/testutils/factories'
 
-import { BedShowPage, BedsListPage, BookingFindPage, LostBedCreatePage } from '../../pages/manage'
+import { BedShowPage, BedsListPage, BookingFindPage, LostBedCreatePage, LostBedListPage } from '../../pages/manage'
 import Page from '../../pages/page'
 
 context('Beds', () => {
@@ -9,13 +9,13 @@ context('Beds', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubLostBedReferenceData')
+
+    // Given I am signed in
+    cy.signIn()
   })
 
   it('should allow me to visit a bed from the bed list page', () => {
     const premisesId = 'premisesId'
-
-    // Given I am signed in
-    cy.signIn()
 
     // And there are bed in the database
     const bedSummaries = bedSummaryFactory.buildList(5)
@@ -55,5 +55,29 @@ context('Beds', () => {
 
     // Then I am taken to the mark bed out of service page
     Page.verifyOnPage(LostBedCreatePage)
+  })
+
+  it('should allow me to manage out of service beds from the bed list page', () => {
+    const premisesId = 'premisesId'
+
+    // And there are beds and a lost bed in the database
+    const bedSummaries = bedSummaryFactory.buildList(5)
+    const bedDetail = bedDetailFactory.build({ ...bedSummaries[0] })
+    cy.task('stubBeds', { premisesId, bedSummaries })
+    cy.task('stubBed', { premisesId, bedDetail })
+
+    const lostBed = lostBedFactory.build()
+    cy.task('stubLostBed', { premisesId, lostBed })
+    cy.task('stubLostBedsList', { premisesId, lostBeds: [lostBed] })
+    cy.task('stubLostBedUpdate', { premisesId, lostBed })
+
+    // When I visit the rooms page
+    const bedsPage = BedsListPage.visit(premisesId)
+
+    // And I click on manage out of service beds
+    bedsPage.clickManageLostBeds()
+
+    // Then I should see the list of out of service beds
+    Page.verifyOnPage(LostBedListPage)
   })
 })

--- a/integration_tests/tests/manage/lostBeds.cy.ts
+++ b/integration_tests/tests/manage/lostBeds.cy.ts
@@ -5,7 +5,8 @@ import {
   premisesFactory,
 } from '../../../server/testutils/factories'
 
-import { LostBedCreatePage, LostBedShowPage } from '../../pages/manage'
+import { LostBedCreatePage, LostBedListPage, LostBedShowPage } from '../../pages/manage'
+import Page from '../../pages/page'
 
 context('LostBed', () => {
   beforeEach(() => {
@@ -13,12 +14,12 @@ context('LostBed', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubLostBedReferenceData')
+
+    // Given I am signed in
+    cy.signIn()
   })
 
   it('should allow me to create a lost bed', () => {
-    // Given I am signed in
-    cy.signIn()
-
     const premises = premisesFactory.build()
     cy.task('stubSinglePremises', premises)
 
@@ -60,9 +61,6 @@ context('LostBed', () => {
   })
 
   it('should show errors', () => {
-    // Given I am signed in
-    cy.signIn()
-
     // And a lost bed is available
     const premises = premisesFactory.build()
 
@@ -82,9 +80,6 @@ context('LostBed', () => {
   })
 
   it('should show an error when there are booking conflicts', () => {
-    // Given I am signed in
-    cy.signIn()
-
     const premises = premisesFactory.build()
     const conflictingBooking = bookingFactory.build()
     cy.task('stubSinglePremises', premises)
@@ -117,9 +112,6 @@ context('LostBed', () => {
   })
 
   it('should show a lost bed', () => {
-    // Given I am signed in
-    cy.signIn()
-
     // And I have created a lost bed
     const premises = premisesFactory.build()
     const lostBed = lostBedFactory.build()
@@ -131,5 +123,84 @@ context('LostBed', () => {
 
     // Then I should see the details of that lost bed
     page.shouldShowLostBedDetail()
+  })
+
+  describe('managing lost beds', () => {
+    it('should allow me to update a lost bed', () => {
+      const premisesId = 'premisesId'
+
+      // And there is a lost bed in the database
+      const lostBed = lostBedFactory.build()
+      cy.task('stubLostBed', { premisesId, lostBed })
+      cy.task('stubLostBedsList', { premisesId, lostBeds: [lostBed] })
+      cy.task('stubLostBedUpdate', { premisesId, lostBed })
+
+      // When I visit the Lost Bed index page
+      const lostBedListPage = LostBedListPage.visit(premisesId)
+
+      // Then I see the lost beds for that premises
+      lostBedListPage.shouldShowLostBeds([lostBed])
+
+      // When I click manage on a bed
+      lostBedListPage.clickManageBed(lostBed)
+
+      // Then I should see the out of service bed manage form
+      Page.verifyOnPage(LostBedShowPage)
+      const lostBedShowPage = LostBedShowPage.visit(premisesId, lostBed)
+      lostBedShowPage.shouldShowLostBedDetail()
+
+      // When I fill in the form and submit
+      const newEndDate = '2023-10-12'
+      const newNote = 'example'
+      lostBedShowPage.completeForm(newEndDate, newNote)
+      lostBedShowPage.clickSubmit()
+
+      // Then I am taken back to the list of out of service beds
+      Page.verifyOnPage(LostBedListPage)
+
+      // Then a lost bed should have been updated in the API
+      cy.task('verifyLostBedUpdate', {
+        premisesId,
+        lostBed,
+      }).then(requests => {
+        expect(requests).to.have.length(1)
+        const requestBody = JSON.parse(requests[0].body)
+
+        expect(requestBody.startDate).equal(lostBed.startDate)
+        expect(requestBody.endDate).equal(newEndDate)
+        expect(requestBody.notes).equal(newNote)
+        expect(requestBody.reason).equal(lostBed.reason.id)
+        expect(requestBody.referenceNumber).equal(lostBed.referenceNumber)
+      })
+
+      // And I should be navigated to the premises detail page and see the confirmation message
+      lostBedShowPage.shouldShowBanner('Bed updated')
+    })
+
+    it('should show an error when there are validation errors', () => {
+      const premisesId = 'premisesId'
+
+      // And there is a lost bed in the database
+      const lostBed = lostBedFactory.build()
+      cy.task('stubLostBed', { premisesId, lostBed })
+      cy.task('stubLostBedsList', { premisesId, lostBeds: [lostBed] })
+
+      // And I miss required fields
+      cy.task('stubLostBedUpdateErrors', {
+        lostBed,
+        premisesId,
+        params: ['endDate'],
+      })
+
+      // When I visit the Lost Bed show page
+      const lostBedShowPage = LostBedShowPage.visit(premisesId, lostBed)
+      lostBedShowPage.shouldShowLostBedDetail()
+
+      // When I try to submit
+      lostBedShowPage.clickSubmit()
+
+      // Then I should see an error message
+      lostBedShowPage.shouldShowErrorMessagesForFields(['endDate'])
+    })
   })
 })

--- a/server/controllers/manage/lostBedsController.test.ts
+++ b/server/controllers/manage/lostBedsController.test.ts
@@ -18,8 +18,9 @@ jest.mock('../../utils/bookingUtils')
 
 describe('LostBedsController', () => {
   const token = 'SOME_TOKEN'
+  const referrer = 'http://localhost/foo/bar'
 
-  const request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  let request: DeepMocked<Request>
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
@@ -31,6 +32,7 @@ describe('LostBedsController', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    request = createMock<Request>({ user: { token }, headers: { referer: referrer } })
   })
 
   describe('new', () => {
@@ -123,11 +125,12 @@ describe('LostBedsController', () => {
     })
 
     describe('when errors are raised', () => {
-      request.params = {
-        premisesId,
-        bedId,
-      }
-
+      beforeEach(() => {
+        request.params = {
+          premisesId,
+          bedId,
+        }
+      })
       const requestHandler = lostBedController.create()
 
       it('should call catchValidationErrorOrPropogate with a standard error', async () => {
@@ -172,17 +175,95 @@ describe('LostBedsController', () => {
   describe('show', () => {
     it('shows the lost bed', async () => {
       const lostBed = lostBedFactory.build()
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+
       lostBedService.getLostBed.mockResolvedValue(lostBed)
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
 
       const requestHandler = lostBedController.show()
 
       await requestHandler({ ...request, params: { premisesId, id: lostBed.id } }, response, next)
 
       expect(response.render).toHaveBeenCalledWith('lostBeds/show', {
-        premisesId,
+        errors: errorsAndUserInput.errors,
+        errorSummary: errorsAndUserInput.errorSummary,
         lostBed,
+        premisesId,
+        referrer,
+        ...errorsAndUserInput.userInput,
       })
       expect(lostBedService.getLostBed).toHaveBeenCalledWith(token, premisesId, lostBed.id)
+    })
+  })
+
+  describe('index', () => {
+    it('shows a list of lost beds', async () => {
+      const lostBed = lostBedFactory.build()
+
+      lostBedService.getLostBeds.mockResolvedValue([lostBed])
+
+      const requestHandler = lostBedController.index()
+
+      await requestHandler({ ...request, params: { premisesId } }, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('lostBeds/index', {
+        lostBeds: [lostBed],
+        numberOfLostBeds: 1,
+        pageHeading: 'Manage out of service beds',
+        premisesId,
+      })
+      expect(lostBedService.getLostBeds).toHaveBeenCalledWith(token, premisesId)
+    })
+  })
+
+  describe('update', () => {
+    it('updates a lost bed and redirects to the lost beds index page', async () => {
+      const lostBed = lostBedFactory.build()
+      lostBedService.updateLostBed.mockResolvedValue(lostBed)
+
+      const requestHandler = lostBedController.update()
+
+      request.params = {
+        premisesId,
+        id: lostBed.id,
+      }
+
+      request.body = {
+        'endDate-year': 2022,
+        'endDate-month': 9,
+        'endDate-day': 22,
+        notes: 'a note',
+        startDate: lostBed.startDate,
+        reason: lostBed.reason.id,
+        referenceNumber: lostBed.referenceNumber,
+        submit: '',
+      }
+
+      await requestHandler(request, response, next)
+
+      expect(lostBedService.updateLostBed).toHaveBeenCalledWith(
+        token,
+        lostBed.id,
+        request.params.premisesId,
+        request.body,
+      )
+      expect(request.flash).toHaveBeenCalledWith('success', 'Bed updated')
+      expect(response.redirect).toHaveBeenCalledWith(paths.lostBeds.index({ premisesId: request.params.premisesId }))
+    })
+
+    describe('when there are errors', () => {
+      it('should call catchValidationErrorOrPropogate with a standard error', async () => {
+        const err = new Error()
+        lostBedService.updateLostBed.mockImplementation(() => {
+          throw err
+        })
+
+        const requestHandler = lostBedController.update()
+
+        await requestHandler(request, response, next)
+
+        expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, referrer)
+      })
     })
   })
 })

--- a/server/controllers/manage/lostBedsController.ts
+++ b/server/controllers/manage/lostBedsController.ts
@@ -1,6 +1,6 @@
 import type { Request, RequestHandler, Response } from 'express'
 
-import type { NewLostBed } from '@approved-premises/api'
+import type { NewLostBed, UpdateLostBed } from '@approved-premises/api'
 import LostBedService from '../../services/lostBedService'
 import {
   catchValidationErrorOrPropogate,
@@ -72,16 +72,59 @@ export default class LostBedsController {
     }
   }
 
+  index(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId } = req.params
+
+      const lostBeds = await this.lostBedService.getLostBeds(req.user.token, premisesId)
+
+      res.render('lostBeds/index', {
+        lostBeds,
+        numberOfLostBeds: lostBeds.length,
+        pageHeading: 'Manage out of service beds',
+        premisesId,
+      })
+    }
+  }
+
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, id } = req.params
+      const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
+
+      const referrer = req.headers.referer
 
       const lostBed = await this.lostBedService.getLostBed(req.user.token, premisesId, id)
 
       res.render('lostBeds/show', {
-        premisesId,
+        errors,
+        errorSummary,
         lostBed,
+        premisesId,
+        referrer,
+        ...userInput,
       })
+    }
+  }
+
+  update(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, id } = req.params
+
+      const { endDate } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'endDate')
+      req.body.endDate = endDate
+
+      try {
+        await this.lostBedService.updateLostBed(req.user.token, id, premisesId, req.body as UpdateLostBed)
+
+        req.flash('success', 'Bed updated')
+
+        return res.redirect(paths.lostBeds.index({ premisesId }))
+      } catch (err) {
+        const redirectPath = req.headers.referer
+
+        return catchValidationErrorOrPropogate(req, res, err, redirectPath)
+      }
     }
   }
 }

--- a/server/data/lostBedClient.ts
+++ b/server/data/lostBedClient.ts
@@ -1,4 +1,4 @@
-import type { LostBed, NewLostBed } from '@approved-premises/api'
+import type { LostBed, NewLostBed, UpdateLostBed } from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -21,5 +21,18 @@ export default class LostBedClient {
 
   async find(premisesId: string, id: string): Promise<LostBed> {
     return (await this.restClient.get({ path: paths.premises.lostBeds.show({ premisesId, id }) })) as LostBed
+  }
+
+  async get(premisesId: string): Promise<Array<LostBed>> {
+    return (await this.restClient.get({ path: paths.premises.lostBeds.index({ premisesId }) })) as Array<LostBed>
+  }
+
+  async update(id: string, lostBedData: UpdateLostBed, premisesId: string): Promise<LostBed> {
+    const response = await this.restClient.put({
+      path: paths.premises.lostBeds.update({ id, premisesId }),
+      data: { ...lostBedData },
+    })
+
+    return response as LostBed
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -14,7 +14,9 @@ const managePaths = {
   },
   lostBeds: {
     create: lostBedsPath,
+    index: lostBedsPath,
     show: lostBedsPath.path(':id'),
+    update: lostBedsPath.path(':id'),
   },
   beds: {
     index: bedsPath,
@@ -82,6 +84,8 @@ export default {
     capacity: managePaths.premises.show.path('capacity'),
     lostBeds: {
       create: managePaths.lostBeds.create,
+      index: managePaths.lostBeds.index,
+      update: managePaths.lostBeds.update,
       show: managePaths.lostBeds.show,
     },
     staffMembers: {

--- a/server/paths/manage.ts
+++ b/server/paths/manage.ts
@@ -66,7 +66,9 @@ const paths = {
   lostBeds: {
     new: lostBedsPath.path('new'),
     create: lostBedsPath,
+    index: singlePremisesPath.path('lost-beds'),
     show: lostBedsPath.path(':id'),
+    update: singlePremisesPath.path('lost-beds').path(':id'),
   },
 }
 

--- a/server/routes/manage.ts
+++ b/server/routes/manage.ts
@@ -54,7 +54,9 @@ export default function routes(controllers: Controllers, router: Router): Router
 
   get(paths.lostBeds.new.pattern, lostBedsController.new())
   post(paths.lostBeds.create.pattern, lostBedsController.create())
+  get(paths.lostBeds.index.pattern, lostBedsController.index())
   get(paths.lostBeds.show.pattern, lostBedsController.show())
+  post(paths.lostBeds.update.pattern, lostBedsController.update())
 
   return router
 }

--- a/server/services/lostBedService.test.ts
+++ b/server/services/lostBedService.test.ts
@@ -18,6 +18,8 @@ describe('LostBedService', () => {
 
   const service = new LostBedService(LostBedClientFactory, ReferenceDataClientFactory)
 
+  const premisesId = 'premisesId'
+
   beforeEach(() => {
     jest.resetAllMocks()
     LostBedClientFactory.mockReturnValue(lostBedClient)
@@ -32,11 +34,11 @@ describe('LostBedService', () => {
       const token = 'SOME_TOKEN'
       lostBedClient.create.mockResolvedValue(lostBed)
 
-      const postedLostBed = await service.createLostBed(token, 'premisesID', newLostBed)
+      const postedLostBed = await service.createLostBed(token, premisesId, newLostBed)
 
       expect(postedLostBed).toEqual(lostBed)
       expect(LostBedClientFactory).toHaveBeenCalledWith(token)
-      expect(lostBedClient.create).toHaveBeenCalledWith('premisesID', newLostBed)
+      expect(lostBedClient.create).toHaveBeenCalledWith(premisesId, newLostBed)
     })
   })
 
@@ -47,11 +49,26 @@ describe('LostBedService', () => {
       const token = 'SOME_TOKEN'
       lostBedClient.find.mockResolvedValue(lostBed)
 
-      const postedLostBed = await service.getLostBed(token, 'premisesID', 'id')
+      const postedLostBed = await service.getLostBed(token, premisesId, 'id')
 
       expect(postedLostBed).toEqual(lostBed)
       expect(LostBedClientFactory).toHaveBeenCalledWith(token)
-      expect(lostBedClient.find).toHaveBeenCalledWith('premisesID', 'id')
+      expect(lostBedClient.find).toHaveBeenCalledWith(premisesId, 'id')
+    })
+  })
+
+  describe('getLostBeds', () => {
+    it('on success returns the lostBeds for a premises', async () => {
+      const expectedLostBeds: Array<LostBed> = lostBedFactory.buildList(2)
+
+      const token = 'SOME_TOKEN'
+      lostBedClient.get.mockResolvedValue(expectedLostBeds)
+
+      const lostBeds = await service.getLostBeds(token, premisesId)
+
+      expect(lostBeds).toEqual(expectedLostBeds)
+      expect(LostBedClientFactory).toHaveBeenCalledWith(token)
+      expect(lostBedClient.get).toHaveBeenCalledWith(premisesId)
     })
   })
 
@@ -73,6 +90,31 @@ describe('LostBedService', () => {
       expect(result).toEqual(lostBedReasons)
       expect(ReferenceDataClientFactory).toHaveBeenCalledWith(token)
       expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('lost-bed-reasons')
+    })
+  })
+
+  describe('updateLostBed', () => {
+    it('updates and returns the specified lost bed', async () => {
+      const lostBed: LostBed = lostBedFactory.build()
+      const endDate = '2022-09-22'
+      const notes = 'note'
+
+      const token = 'SOME_TOKEN'
+      lostBedClient.update.mockResolvedValue(lostBed)
+
+      const lostBedUpdateData = {
+        startDate: lostBed.startDate,
+        endDate,
+        reason: lostBed.reason.id,
+        referenceNumber: lostBed.referenceNumber,
+        notes,
+      }
+
+      const updatedLostBed = await service.updateLostBed(token, lostBed.id, premisesId, lostBedUpdateData)
+
+      expect(updatedLostBed).toEqual(lostBed)
+      expect(LostBedClientFactory).toHaveBeenCalledWith(token)
+      expect(lostBedClient.update).toHaveBeenCalledWith(lostBed.id, lostBedUpdateData, premisesId)
     })
   })
 })

--- a/server/services/lostBedService.ts
+++ b/server/services/lostBedService.ts
@@ -1,5 +1,5 @@
 import type { ReferenceData } from '@approved-premises/ui'
-import type { LostBed, NewLostBed } from '@approved-premises/api'
+import type { LostBed, NewLostBed, UpdateLostBed } from '@approved-premises/api'
 import type { LostBedClient, ReferenceDataClient, RestClientBuilder } from '../data'
 
 export type LostBedReferenceData = Array<ReferenceData>
@@ -23,6 +23,21 @@ export default class LostBedService {
     const lostBed = await lostBedClient.find(premisesId, id)
 
     return lostBed
+  }
+
+  async updateLostBed(token: string, id: string, premisesId: string, updateLostBed: UpdateLostBed): Promise<LostBed> {
+    const lostBedClient = this.lostBedClientFactory(token)
+
+    const updatedLostBed = await lostBedClient.update(id, updateLostBed, premisesId)
+
+    return updatedLostBed
+  }
+
+  async getLostBeds(token: string, premisesId: string): Promise<Array<LostBed>> {
+    const lostBedClient = this.lostBedClientFactory(token)
+    const lostBeds = await lostBedClient.get(premisesId)
+
+    return lostBeds
   }
 
   async getReferenceData(token: string): Promise<LostBedReferenceData> {

--- a/server/testutils/factories/lostBed.ts
+++ b/server/testutils/factories/lostBed.ts
@@ -16,5 +16,5 @@ export default Factory.define<LostBed>(() => ({
   referenceNumber: faker.string.uuid(),
   reason: referenceDataFactory.lostBedReasons().build(),
   status: 'active',
-  cancellation: null,
+  cancellation: { id: faker.string.uuid(), createdAt: DateFormats.dateObjToIsoDateTime(faker.date.past()) },
 }))

--- a/server/utils/lostBedUtils.test.ts
+++ b/server/utils/lostBedUtils.test.ts
@@ -1,0 +1,36 @@
+import { lostBedFactory } from '../testutils/factories'
+import { lostBedTableRows, referenceNumberCell } from './lostBedUtils'
+
+describe('lostBedUtils', () => {
+  describe('referenceNumberCell', () => {
+    it('returns ref number', () => {
+      const refNumber = '123'
+      expect(referenceNumberCell(refNumber)).toEqual({ text: refNumber })
+    })
+    it('returns text if no ref number', () => {
+      expect(referenceNumberCell(undefined)).toEqual({ text: 'Not provided' })
+    })
+  })
+
+  describe('lostBedTableRows', () => {
+    it('returns table rows', () => {
+      const lostBed = lostBedFactory.build()
+      const premisesId = 'premisesId'
+      const expectedRows = [
+        [
+          { text: lostBed.bedName },
+          { text: lostBed.roomName },
+          { text: lostBed.startDate },
+          { text: lostBed.endDate },
+          { text: lostBed.reason.name },
+          { text: lostBed.referenceNumber },
+          {
+            html: `<a href="/premises/${premisesId}/beds/${lostBed.bedId}/lost-beds/${lostBed.id}" data-cy-lostBedId="${lostBed.id}">Manage <span class="govuk-visually-hidden">lost bed ${lostBed.bedName}</span></a>`,
+          },
+        ],
+      ]
+      const rows = lostBedTableRows([lostBed], premisesId)
+      expect(rows).toEqual(expectedRows)
+    })
+  })
+})

--- a/server/utils/lostBedUtils.ts
+++ b/server/utils/lostBedUtils.ts
@@ -1,0 +1,34 @@
+import { LostBed } from '@approved-premises/api'
+import { TableCell } from '@approved-premises/ui'
+
+import paths from '../paths/manage'
+import { linkTo } from './utils'
+
+export const lostBedTableRows = (beds: Array<LostBed>, premisesId: string) => {
+  return beds.map(bed => [
+    textCell(bed.bedName),
+    textCell(bed.roomName),
+    textCell(bed.startDate),
+    textCell(bed.endDate),
+    textCell(bed.reason.name),
+    referenceNumberCell(bed.referenceNumber),
+    actionCell(bed, premisesId),
+  ])
+}
+
+export const textCell = (value: string): TableCell => ({ text: value })
+export const referenceNumberCell = (value: string): TableCell => ({ text: value || 'Not provided' })
+export const actionCell = (bed: LostBed, premisesId: string): TableCell => ({
+  html: bedLink(bed, premisesId),
+})
+
+const bedLink = (bed: LostBed, premisesId: string): string =>
+  linkTo(
+    paths.lostBeds.show,
+    { id: bed.id, bedId: bed.bedId, premisesId },
+    {
+      text: 'Manage',
+      hiddenText: `lost bed ${bed.bedName}`,
+      attributes: { 'data-cy-lostBedId': bed.id },
+    },
+  )

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -41,6 +41,7 @@ import * as PlacementRequestUtils from './placementRequests'
 import * as MatchUtils from './matchUtils'
 import * as SummaryListUtils from './applications/summaryListUtils'
 import * as BedUtils from './bedUtils'
+import * as LostBedUtils from './lostBedUtils'
 import * as PlacementApplicationUtils from './placementApplications'
 
 import managePaths from '../paths/manage'
@@ -205,5 +206,6 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('MatchUtils', MatchUtils)
   njkEnv.addGlobal('SummaryListUtils', SummaryListUtils)
   njkEnv.addGlobal('BedUtils', BedUtils)
+  njkEnv.addGlobal('LostBedUtils', LostBedUtils)
   njkEnv.addGlobal('PlacementApplicationUtils', PlacementApplicationUtils)
 }

--- a/server/views/lostBeds/index.njk
+++ b/server/views/lostBeds/index.njk
@@ -1,0 +1,76 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+		text: "Back",
+		href: paths.premises.beds.index({ premisesId: premisesId })
+	}) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      {% include "../_messages.njk" %}
+
+      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+      {{
+        govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          rows: [            {
+              key: {
+                text: "Out of service"
+              },
+              value: {
+                text: numberOfLostBeds
+              }
+            }
+          ]
+        })
+      }}
+
+      {% if lostBeds %}
+
+        {{
+          govukTable({
+            caption: "Out of service",
+            captionClasses: "govuk-table__caption--m",
+            head: [
+              {
+                text: "Bed"
+              },
+              {
+                text: "Room"
+              },
+              {
+                text: "Out of service from"
+              },
+              {
+                text: "Out of service until"
+              },
+              {
+                text: "Reason"
+              },
+              {
+                text: "Ref number"
+              },
+              { 
+                text: "Manage"
+              }
+            ],
+            rows: LostBedUtils.lostBedTableRows(lostBeds, premisesId)
+          })
+        }}
+
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/lostBeds/show.njk
+++ b/server/views/lostBeds/show.njk
@@ -1,7 +1,13 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 
-{%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+{% from "../partials/showErrorSummary.njk" import showErrorSummary %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -9,29 +15,46 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
-  {{ govukBackLink({
-    text: "Back",
-    href: paths.premises.show({premisesId: premisesId})
-  }) }}
+  {% if referrer %}
+    {{ govukBackLink({
+      text: "Back",
+      href: referrer
+    }) }}
+  {% endif %}
 {% endblock %}
 
 {% block content %}
-  {% include "../_messages.njk" %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+    <div class="govuk-grid-column-two-thirds">
 
-      <h1>Lost bed details</h1>
+      <h1 class="govuk-heading-l">Manage out of service bed</h1>
 
       {{
         govukSummaryList({
-          classes: 'govuk-summary-list',
+          classes: 'govuk-summary-list--no-border',
           rows: [
+            {
+              key: {
+                text: "Room number"
+              },
+              value: {
+                text: lostBed.roomName
+              }
+            },
+            {
+              key: {
+                text: "Bed number"
+              },
+              value: {
+                text: lostBed.bedName
+              }
+            },
             {
               key: {
                 text: "Start date"
               },
               value: {
-                text: formatDate(lostBed.startDate, {format: 'short'})
+                text: formatDate(lostBed.startDate, {format: 'long'})
               }
             },
             {
@@ -39,21 +62,70 @@
                 text: "End date"
               },
               value: {
-                text: formatDate(lostBed.endDate, {format: 'short'})
+                text: formatDate(lostBed.endDate, {format: 'long'})
               }
             },
             {
               key: {
-                text: "Reason"
+                text: "Reason for bed being marked as lost"
               },
               value: {
                 text: lostBed.reason.name
+              }
+            },
+                        {
+              key: {
+                text: "Reference number"
+              },
+              value: {
+                text: lostBed.referenceNumber
               }
             }
           ]
         })
       }}
 
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+      <form action="{{ paths.lostBeds.update({ id: lostBed.id, bedId: lostBed.bedId, premisesId: premisesId }) }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+        <input type="hidden" name="startDate" value="{{ lostBed.startDate }}"/>
+        <input type="hidden" name="reason" value="{{ lostBed.reason.id }}"/>
+        <input type="hidden" name="referenceNumber" value="{{ lostBed.referenceNumber }}"/>
+
+        {{ showErrorSummary(errorSummary, errorTitle) }}
+
+        {{ govukDateInput({
+        id: "endDate",
+        namePrefix: "endDate",
+        items: dateFieldValues('endDate', errors),
+        errorMessage: errors.endDate,
+        hint: {
+        text: "For example, 27 3 2007"
+        },
+        fieldset: {
+          legend: {
+            text: "End date",
+            classes: "govuk-fieldset__legend--s"
+          }
+        }
+        }) }}
+
+        {{ govukTextarea({
+        id: "notes",
+        name: "notes",
+        label: {
+          text: "Can you provide more detail?",
+          classes: "govuk-fieldset__legend--s"
+        },
+        errorMessage: errors.notes
+        }) }}
+
+        {{ govukButton({
+          text: "Save and continue",
+          name: "submit"
+        }) }}
+      </form>
     </div>
   </div>
 {% endblock %}

--- a/server/views/premises/beds/index.njk
+++ b/server/views/premises/beds/index.njk
@@ -1,6 +1,8 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
+{%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+
 {% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - " + pageHeading %}
@@ -15,7 +17,20 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-width">
-      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+      {{
+        mojIdentityBar({
+          title: {
+            html: "<h1>" + pageHeading + "</h1>"
+          },
+        menus: [{
+          items: [ {
+            text: "Manage out of service beds",
+            classes: "govuk-button--secondary",
+            href: paths.lostBeds.index({premisesId: premisesId})
+          }]
+        }]
+        })
+      }}
 
       {{
         govukTable({
@@ -40,4 +55,10 @@
       }}
     </div>
   </div>
+{% endblock %}
+
+{% block extraScripts %}
+  <script type="text/javascript" nonce="{{ cspNonce }}">
+    new MOJFrontend.ButtonMenu({container: $('.moj-button-menu'), mq: "(min-width: 200em)", buttonText: "Actions", menuClasses: "moj-button-menu__wrapper--right"});
+  </script>
 {% endblock %}


### PR DESCRIPTION
# Context

[Trello card](https://trello.com/c/jTauQPuo/207-edit-a-lost-bed-entry)
[Prototype](https://approved-premises-prototype-main.apps.live.cloud-platform.service.justice.gov.uk/manage/out-of-service-beds-board)

We would like users to be able to edit out of service/lost beds - initially just to update their end date and notes. 
When a user is on the list of all beds for a premises, 
Then they will be able to click an action menu item to manage out of service beds, 
Then they will be shown a list of all lost beds for a premises and be able to click to update one.

# Changes in this PR

**Not included from prototype designs:**
* A table showing Closed/Active lost beds. They are all just shown in list for expediency atm.
* Room updates on Manage a Lost Bed page. They don't exist yet.

This PR adds the views, routes, paths, controller, service and client methods to make the user journey possible - to update a single lost bed and view a list of lost beds for a premise.
 
## Screenshots of UI changes

### After
![Screenshot 2023-06-19 at 10 12 13](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/16647486/1c309849-1003-49bd-b5ea-1625bbe900a3)

![Screenshot 2023-06-19 at 10 12 19](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/16647486/23b6d645-366c-415a-9ff1-882d2485d2fa)

![Screenshot 2023-06-19 at 10 12 31](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/16647486/fc244440-147d-4a37-b615-14c02d5aee3f)


![Screenshot 2023-06-19 at 10 12 41](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/16647486/6819bf92-79a4-4f8e-b4c4-ab334ee25315)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
