### PR TITLE
Send correct placement duration

### DIFF
--- a/server/form-pages/apply/move-on/placementDuration.test.ts
+++ b/server/form-pages/apply/move-on/placementDuration.test.ts
@@ -91,12 +91,12 @@ describe('PlacementDuration', () => {
       )
     })
 
-    it('returns null if the "placement-date" object is not present', () => {
+    it('returns undefined if the "placement-date" object is not present', () => {
       application = applicationFactory.build({ data: { 'basic-information': {} } })
 
       const page = new PlacementDuration({}, application)
 
-      expect(page.arrivalDate).toBeNull()
+      expect(page.arrivalDate).toBeUndefined()
     })
 
     it('returns null if the start date is the same as the release date and the "release-date" object is not present', () => {
@@ -112,7 +112,7 @@ describe('PlacementDuration', () => {
 
       const page = new PlacementDuration({}, application)
 
-      expect(page.arrivalDate).toBeNull()
+      expect(page.arrivalDate).toBeUndefined()
     })
   })
 

--- a/server/form-pages/apply/move-on/placementDuration.ts
+++ b/server/form-pages/apply/move-on/placementDuration.ts
@@ -24,9 +24,9 @@ type PlacementDurationBody = {
 export default class PlacementDuration implements TasklistPage {
   title = 'Placement duration and move on'
 
-  arrivalDate: Date | null = this.fetchArrivalDate()
+  arrivalDate: Date = this.fetchArrivalDate()
 
-  departureDate: Date | null = this.fetchDepartureDate()
+  departureDate: Date = this.fetchDepartureDate()
 
   questions = {
     differentDuration: 'Does this application require a different placement duration?',
@@ -35,7 +35,7 @@ export default class PlacementDuration implements TasklistPage {
   }
 
   constructor(public body: Partial<PlacementDurationBody>, private readonly application: ApprovedPremisesApplication) {
-    this.body.duration = String(this.lengthInDays())
+    this.body.duration = this.lengthInDays()
   }
 
   previous() {
@@ -85,19 +85,15 @@ export default class PlacementDuration implements TasklistPage {
     return errors
   }
 
-  private lengthInDays(): number | null {
-    if (this.body.differentDuration === 'yes') {
-      if (this.body.durationDays && this.body.durationWeeks) {
-        return weeksToDays(Number(this.body.durationWeeks)) + Number(this.body.durationDays)
-      }
-
-      return null
+  private lengthInDays(): string {
+    if (this.body.differentDuration === 'yes' && this.body.durationDays && this.body.durationWeeks) {
+      return String(weeksToDays(Number(this.body.durationWeeks)) + Number(this.body.durationDays))
     }
 
-    return null
+    return undefined
   }
 
-  private fetchArrivalDate(): Date | null {
+  private fetchArrivalDate(): Date {
     try {
       const basicInformation = this.application.data['basic-information']
 
@@ -105,17 +101,17 @@ export default class PlacementDuration implements TasklistPage {
 
       const placementDate = basicInformation['placement-date']
 
-      if (!placementDate) return null
+      if (!placementDate) return undefined
 
       if (placementDate && placementDate.startDateSameAsReleaseDate === 'yes') {
         const releaseDate = basicInformation['release-date']
 
-        if (!releaseDate) return null
+        if (!releaseDate) return undefined
 
         return DateFormats.isoToDateObj(releaseDate.releaseDate)
       }
 
-      return placementDate?.startDate ? DateFormats.isoToDateObj(placementDate.startDate) : null
+      return placementDate?.startDate ? DateFormats.isoToDateObj(placementDate.startDate) : undefined
     } catch (e) {
       throw new SessionDataError(`Move on information placement duration error: ${e}`)
     }

--- a/server/form-pages/apply/move-on/placementDuration.ts
+++ b/server/form-pages/apply/move-on/placementDuration.ts
@@ -85,7 +85,7 @@ export default class PlacementDuration implements TasklistPage {
     return errors
   }
 
-  private lengthInDays(): string {
+  private lengthInDays(): string | undefined {
     if (this.body.differentDuration === 'yes' && this.body.durationDays && this.body.durationWeeks) {
       return String(weeksToDays(Number(this.body.durationWeeks)) + Number(this.body.durationDays))
     }
@@ -93,7 +93,7 @@ export default class PlacementDuration implements TasklistPage {
     return undefined
   }
 
-  private fetchArrivalDate(): Date {
+  private fetchArrivalDate(): Date | undefined {
     try {
       const basicInformation = this.application.data['basic-information']
 
@@ -117,9 +117,9 @@ export default class PlacementDuration implements TasklistPage {
     }
   }
 
-  private fetchDepartureDate(): Date | null {
+  private fetchDepartureDate(): Date | undefined {
     const standardPlacementDuration = getDefaultPlacementDurationInWeeks(this.application)
 
-    return this.arrivalDate ? addDays(this.arrivalDate, 7 * standardPlacementDuration) : null
+    return this.arrivalDate ? addDays(this.arrivalDate, 7 * standardPlacementDuration) : undefined
   }
 }

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
@@ -215,7 +215,7 @@ export default class MatchingInformation implements TasklistPage {
     return selectedOptions.length ? selectedOptions.map((k: string) => this[`${key}Options`][k]).join(', ') : 'None'
   }
 
-  private lengthInDays(): string {
+  private lengthInDays(): string | undefined {
     if (this.body.lengthOfStayAgreed === 'no') {
       if (this.body.lengthOfStayDays && this.body.lengthOfStayWeeks) {
         const lengthOfStayWeeksInDays = weeksToDays(Number(this.body.lengthOfStayWeeks))

--- a/server/form-pages/placement-application/request-a-placement/additionalPlacementDetails.ts
+++ b/server/form-pages/placement-application/request-a-placement/additionalPlacementDetails.ts
@@ -95,7 +95,7 @@ export default class AdditionalPlacementDetails implements TasklistPage {
     return errors
   }
 
-  private lengthInDays(): string {
+  private lengthInDays(): string | undefined {
     if (this._body.durationWeeks && this._body.durationDays) {
       const lengthOfStayWeeksInDays = weeksToDays(Number(this._body.durationWeeks))
       const totalLengthInDays = lengthOfStayWeeksInDays + Number(this._body.durationDays)

--- a/server/form-pages/placement-application/request-a-placement/datesOfPlacement.ts
+++ b/server/form-pages/placement-application/request-a-placement/datesOfPlacement.ts
@@ -84,7 +84,7 @@ export default class DatesOfPlacement implements TasklistPage {
     return errors
   }
 
-  private lengthInDays(): string {
+  private lengthInDays(): string | undefined {
     if (this._body.durationWeeks && this._body.durationDays) {
       const lengthOfStayWeeksInDays = weeksToDays(Number(this._body.durationWeeks))
       const totalLengthInDays = lengthOfStayWeeksInDays + Number(this._body.durationDays)

--- a/server/testutils/mockQuestionResponse.ts
+++ b/server/testutils/mockQuestionResponse.ts
@@ -59,7 +59,7 @@ export const mockOptionalQuestionResponse = ({
   isExceptionalCase,
   shouldPersonBePlacedInMaleAp,
   agreedCaseWithManager,
-  lengthOfStayAgreedDetail,
+  lengthOfStay,
   cruInformation,
 }: {
   releaseType?: string
@@ -71,7 +71,7 @@ export const mockOptionalQuestionResponse = ({
   isExceptionalCase?: string
   shouldPersonBePlacedInMaleAp?: string
   agreedCaseWithManager?: string
-  lengthOfStayAgreedDetail?: string
+  lengthOfStay?: string
   cruInformation?: string
 }) => {
   ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockImplementation(
@@ -113,8 +113,8 @@ export const mockOptionalQuestionResponse = ({
         return agreedCaseWithManager
       }
 
-      if (question === 'lengthOfStayAgreedDetail') {
-        return lengthOfStayAgreedDetail
+      if (question === 'lengthOfStay') {
+        return lengthOfStay
       }
 
       if (question === 'cruInformation') {

--- a/server/utils/assessments/acceptanceData.test.ts
+++ b/server/utils/assessments/acceptanceData.test.ts
@@ -35,7 +35,7 @@ describe('acceptanceData', () => {
     it('should return the placement dates if an arrival date is provided', () => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(expectedArrival)
 
-      mockOptionalQuestionResponse({ lengthOfStayAgreedDetail: '12' })
+      mockOptionalQuestionResponse({ lengthOfStay: '12' })
 
       const result = placementDates(assessment)
 
@@ -47,7 +47,7 @@ describe('acceptanceData', () => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(expectedArrival)
       ;(placementDurationFromApplication as jest.Mock).mockReturnValueOnce('52')
 
-      mockOptionalQuestionResponse({ lengthOfStayAgreedDetail: undefined })
+      mockOptionalQuestionResponse({ lengthOfStay: undefined })
 
       const result = placementDates(assessment)
 
@@ -76,7 +76,7 @@ describe('acceptanceData', () => {
     it('converts matching data into a placement request', () => {
       mockQuestionResponse({ postcodeArea: 'ABC123', type: 'normal', duration: '12' })
       mockOptionalQuestionResponse({
-        lengthOfStayAgreedDetail: '12',
+        lengthOfStay: '12',
         alternativeRadius: '100',
       })
 
@@ -91,7 +91,7 @@ describe('acceptanceData', () => {
     })
 
     it('returns a default radius if one is not present', () => {
-      mockOptionalQuestionResponse({ lengthOfStayAgreedDetail: '12', alternativeRadius: undefined })
+      mockOptionalQuestionResponse({ lengthOfStay: '12', alternativeRadius: undefined })
 
       const result = placementRequestData(assessment)
 

--- a/server/utils/assessments/acceptanceData.ts
+++ b/server/utils/assessments/acceptanceData.ts
@@ -50,11 +50,8 @@ export const placementDates = (assessment: Assessment): PlacementDates | null =>
   }
 
   const placementDuration =
-    retrieveOptionalQuestionResponseFromApplicationOrAssessment(
-      assessment,
-      MatchingInformation,
-      'lengthOfStayAgreedDetail',
-    ) || placementDurationFromApplication(assessment.application)
+    retrieveOptionalQuestionResponseFromApplicationOrAssessment(assessment, MatchingInformation, 'lengthOfStay') ||
+    placementDurationFromApplication(assessment.application)
 
   return {
     expectedArrival: arrivalDate,


### PR DESCRIPTION
If the placement durations were not set, we were sending a literal value of `'null'`, a string, which was then getting cast as a zero, causing the placement requests to have a length of zero days, meaning the API would error. 

Javascript is fun sometimes isn't it? 😆 