### PR TITLE
(12) Add occupancy calendar

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -13,6 +13,7 @@ $path: "/assets/images/"
 @import './components/bed-search-identity'
 @import './components/bed-search-inputs'
 @import './components/filter'
+@import './components/calendar'
 
 @import './pages/assessments-index'
 @import './pages/applications-pages-attach-document'

--- a/assets/sass/components/_calendar.scss
+++ b/assets/sass/components/_calendar.scss
@@ -21,11 +21,31 @@ $calendarWidth: $roomHeaderWidth + (30 * ($colWidth + ($colPadding * 2)));
   }
 }
 
+.govuk-pagination {
+  &--calendar {
+    padding-bottom: govuk-spacing(6);
+
+    .govuk-pagination__prev {
+      float: left;
+    }
+
+    .govuk-pagination__next {
+      float: right;
+      border-top: none;
+    }
+
+    .govuk-pagination__prev + .govuk-pagination__next {
+      border-top: none;
+    }
+  }
+}
+
 .govuk-table {
   &--calendar {
     font-size: 0.9em;
     width: $calendarWidth;
     table-layout: fixed;
+    margin: 0 auto;
 
     @for $i from 1 through 31 {
       th[colspan="#{$i}"], td[colspan="#{$i}"] {

--- a/assets/sass/components/_calendar.scss
+++ b/assets/sass/components/_calendar.scss
@@ -1,0 +1,82 @@
+$colWidth: 22px;
+$colPadding: 2px;
+
+$roomHeaderWidth: 100px;
+
+$calendarWidth: $roomHeaderWidth + (30 * ($colWidth + ($colPadding * 2)));
+
+.govuk-link {
+  &--booking {
+    &:link, &:visited {
+      color: govuk-colour("black");
+      font-weight: bold;
+    }
+  }
+
+  &--overbooking {
+    &:link, &:visited {
+      color: govuk-colour("white");
+      font-weight: bold;
+    }
+  }
+}
+
+.govuk-table {
+  &--calendar {
+    font-size: 0.9em;
+    width: $calendarWidth;
+    table-layout: fixed;
+
+    @for $i from 1 through 31 {
+      th[colspan="#{$i}"], td[colspan="#{$i}"] {
+        width: ($i * ($colWidth + ($colPadding * 2)));
+      }
+    }
+  }
+
+  &__header {
+    &--calendar {
+      border: 1px solid $govuk-border-colour;
+      text-align: center;
+      width: $colWidth;
+      padding: $colPadding;
+    }
+
+    &--calendar-room-header {
+      text-align: center;
+      width: 100px;
+      vertical-align: middle;
+    }
+  }
+
+
+  &__cell {
+    white-space: nowrap;
+    overflow:hidden;
+    text-overflow: ellipsis;
+
+    &--calendar {
+      border: 1px solid $govuk-border-colour;
+      padding: $colPadding;
+    }
+
+    &--booking {
+      background-color: govuk-colour("light-blue");
+    }
+
+    &--lost_bed {
+      background-color: govuk-colour("light-grey");
+      font-weight: bold;
+    }
+
+    &--month {
+      text-align: center;
+    }
+
+    &--overbooking {
+      background-color: govuk-colour("black");
+      color: govuk-colour("white");
+      font-weight: bold;
+    }
+  }
+}

--- a/integration_tests/mockApis/premises.ts
+++ b/integration_tests/mockApis/premises.ts
@@ -1,9 +1,11 @@
 import type { Response, SuperAgentRequest } from 'superagent'
 
-import type { Booking, DateCapacity, Premises, StaffMember } from '@approved-premises/api'
+import type { BedOccupancyRange, Booking, DateCapacity, Premises, StaffMember } from '@approved-premises/api'
 
 import { stubFor } from '../../wiremock'
 import bookingStubs from './booking'
+import paths from '../../server/paths/api'
+import { createQueryString } from '../../server/utils/utils'
 
 const stubPremises = (premises: Array<Premises>) =>
   stubFor({
@@ -73,6 +75,26 @@ export default {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: args.staff,
+      },
+    }),
+  stubPremisesOccupancy: (args: {
+    premisesId: string
+    startDate: string
+    endDate: string
+    premisesOccupancy: Array<BedOccupancyRange>
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `${paths.premises.calendar({ premisesId: args.premisesId })}?${createQueryString({
+          startDate: args.startDate,
+          endDate: args.endDate,
+        })}`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.premisesOccupancy,
       },
     }),
 }

--- a/integration_tests/pages/manage/calendar.ts
+++ b/integration_tests/pages/manage/calendar.ts
@@ -1,0 +1,41 @@
+import { BedOccupancyRange, Premises } from '@approved-premises/api'
+import { differenceInDays } from 'date-fns'
+import Page from '../page'
+import { DateFormats } from '../../../server/utils/dateUtils'
+
+export default class Calendar extends Page {
+  constructor(premises: Premises) {
+    super(premises.name)
+  }
+
+  shouldShowOccupancy(occupancyRange: Array<BedOccupancyRange>) {
+    occupancyRange.forEach(occupancy => {
+      cy.get(`tr[data-cy-bedId="${occupancy.bedId}"]`).within(() => {
+        let columns = 0
+        occupancy.schedule.forEach(item => {
+          cy.get(`td[data-cy-startdate="${item.startDate}"]`)
+            .should('have.attr', 'colspan')
+            .and('contain', String(columns + item.length > 30 ? 31 - columns : item.length))
+          columns += item.length
+        })
+      })
+    })
+  }
+
+  shouldShowOverbookingsForPeriod(startDate: string, endDate: string) {
+    cy.get(`td.govuk-table__cell--overbooking[data-cy-startdate="${startDate}"]`)
+      .should('exist')
+      .should('have.attr', 'colspan')
+      .and(
+        'contain',
+        String(differenceInDays(DateFormats.isoToDateObj(endDate), DateFormats.isoToDateObj(startDate)) + 1),
+      )
+  }
+
+  shouldShowOccupancyForId(id: string, startDate: Date, length: string) {
+    cy.get(`td.govuk-table__cell[data-cy-id="${id}"][data-cy-startdate="${DateFormats.dateObjToIsoDate(startDate)}"]`)
+      .should('exist')
+      .should('have.attr', 'colspan')
+      .and('contain', length)
+  }
+}

--- a/integration_tests/pages/manage/index.ts
+++ b/integration_tests/pages/manage/index.ts
@@ -17,6 +17,8 @@ import BookingShowPage from './booking/show'
 import BookingExtensionConfirmationPage from './booking/extension/confirmation'
 import BookingExtensionCreatePage from './booking/extension/create'
 
+import CalendarPage from './calendar'
+
 export {
   ArrivalCreatePage,
   CancellationCreatePage,
@@ -34,4 +36,5 @@ export {
   BookingExtensionCreatePage,
   BedsListPage,
   BedShowPage,
+  CalendarPage,
 }

--- a/integration_tests/pages/manage/premisesShow.ts
+++ b/integration_tests/pages/manage/premisesShow.ts
@@ -14,6 +14,11 @@ export default class PremisesShowPage extends Page {
     return new PremisesShowPage(premises)
   }
 
+  clickViewCalendar() {
+    cy.get('.moj-button-menu__toggle-button').click()
+    cy.get('a').contains('View calendar').click()
+  }
+
   shouldShowPremisesDetail(): void {
     cy.get('.govuk-summary-list__key')
       .contains('Code')

--- a/integration_tests/pages/manage/premisesShow.ts
+++ b/integration_tests/pages/manage/premisesShow.ts
@@ -14,16 +14,6 @@ export default class PremisesShowPage extends Page {
     return new PremisesShowPage(premises)
   }
 
-  clickLostBedsOption() {
-    cy.get('.moj-button-menu__toggle-button').click()
-    cy.get('a').contains('Mark bed as out of service').click()
-  }
-
-  clickCreateBookingOption() {
-    cy.get('.moj-button-menu__toggle-button')
-    cy.get('a').contains('Create a placement').click()
-  }
-
   shouldShowPremisesDetail(): void {
     cy.get('.govuk-summary-list__key')
       .contains('Code')

--- a/integration_tests/support/helpers.ts
+++ b/integration_tests/support/helpers.ts
@@ -7,6 +7,14 @@ import {
   ArrayOfOASysSupportingInformationQuestions,
   Document,
 } from '@approved-premises/api'
+import { BedOccupancyEntryUiType } from '@approved-premises/ui'
+import { differenceInDays } from 'date-fns'
+import { bedOccupancyEntryBookingUiFactory } from '../../server/testutils/factories'
+import {
+  bedOccupancyEntryLostBedUiFactory,
+  bedOccupancyEntryOpenUiFactory,
+} from '../../server/testutils/factories/bedOccupancyRange'
+import { DateFormats } from '../../server/utils/dateUtils'
 
 const documentsFromApplication = (application: ApprovedPremisesApplication): Array<Document> => {
   return application.data['attach-required-documents']['attach-documents'].selectedDocuments as Array<Document>
@@ -45,6 +53,21 @@ const riskToSelfSummariesFromApplication = (
   return application.data['oasys-import']['risk-to-self'].riskToSelfSummaries as ArrayOfOASysRiskToSelfQuestions
 }
 
+const createOccupancyEntry = (startDate: Date, endDate: Date, type: BedOccupancyEntryUiType) => {
+  const factory = {
+    booking: bedOccupancyEntryBookingUiFactory,
+    lost_bed: bedOccupancyEntryLostBedUiFactory,
+    open: bedOccupancyEntryOpenUiFactory,
+  }[type]
+
+  return factory.build({
+    type,
+    startDate: DateFormats.dateObjToIsoDate(startDate),
+    endDate: DateFormats.dateObjToIsoDate(endDate),
+    length: differenceInDays(endDate, startDate) + 1,
+  })
+}
+
 export {
   documentsFromApplication,
   roshSummariesFromApplication,
@@ -52,4 +75,5 @@ export {
   supportInformationFromApplication,
   riskManagementPlanFromApplication,
   riskToSelfSummariesFromApplication,
+  createOccupancyEntry,
 }

--- a/integration_tests/tests/manage/premises.cy.ts
+++ b/integration_tests/tests/manage/premises.cy.ts
@@ -1,5 +1,10 @@
 import { addDays } from 'date-fns'
-import { bookingFactory, dateCapacityFactory, premisesFactory } from '../../../server/testutils/factories'
+import {
+  bedOccupancyRangeFactory,
+  bookingFactory,
+  dateCapacityFactory,
+  premisesFactory,
+} from '../../../server/testutils/factories'
 import { DateFormats } from '../../../server/utils/dateUtils'
 
 import { PremisesListPage, PremisesShowPage } from '../../pages/manage'
@@ -67,5 +72,29 @@ context('Premises', () => {
 
     // And I should see the overcapacity banner showing the dates that the AP is overcapacity
     page.shouldShowOvercapacityMessage(overcapacityStartDate.date, overcapacityEndDate.date)
+  })
+
+  it('should show the premises calendar', () => {
+    // Given there is a premises in the database
+    const premises = premisesFactory.build()
+
+    const premisesOccupancy = bedOccupancyRangeFactory.buildList(10)
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubPremisesCapacity', {
+      premisesId: premises.id,
+      dateCapacities: [],
+    })
+    cy.task('stubPremisesOccupancy', {
+      premisesId: premises.id,
+      startDate: DateFormats.dateObjToIsoDate(new Date()),
+      endDate: DateFormats.dateObjToIsoDate(addDays(new Date(), 30)),
+      premisesOccupancy,
+    })
+
+    // When I visit the premises page
+    const page = PremisesShowPage.visit(premises)
+
+    // Then I should be able to click to view the calendar
+    page.clickViewCalendar()
   })
 })

--- a/integration_tests/tests/manage/premises.cy.ts
+++ b/integration_tests/tests/manage/premises.cy.ts
@@ -1,13 +1,9 @@
 import { addDays } from 'date-fns'
-import {
-  bedOccupancyRangeFactory,
-  bookingFactory,
-  dateCapacityFactory,
-  premisesFactory,
-} from '../../../server/testutils/factories'
+import { createOccupancyEntry } from '../../support/helpers'
+import { bookingFactory, dateCapacityFactory, premisesFactory } from '../../../server/testutils/factories'
 import { DateFormats } from '../../../server/utils/dateUtils'
 
-import { PremisesListPage, PremisesShowPage } from '../../pages/manage'
+import { CalendarPage, PremisesListPage, PremisesShowPage } from '../../pages/manage'
 
 context('Premises', () => {
   beforeEach(() => {
@@ -78,16 +74,52 @@ context('Premises', () => {
     // Given there is a premises in the database
     const premises = premisesFactory.build()
 
-    const premisesOccupancy = bedOccupancyRangeFactory.buildList(10)
     cy.task('stubSinglePremises', premises)
     cy.task('stubPremisesCapacity', {
       premisesId: premises.id,
       dateCapacities: [],
     })
+
+    // And that premises has bookings for a bed
+    const startDate = new Date()
+    const premisesOccupancy = [
+      {
+        bedId: '1',
+        bedName: 'Bed 1',
+        schedule: [
+          createOccupancyEntry(startDate, addDays(startDate, 3), 'open'),
+          createOccupancyEntry(addDays(startDate, 4), addDays(startDate, 9), 'booking'),
+          createOccupancyEntry(addDays(startDate, 10), addDays(startDate, 19), 'lost_bed'),
+          createOccupancyEntry(addDays(startDate, 20), addDays(startDate, 35), 'booking'),
+        ],
+      },
+      {
+        bedId: '2',
+        bedName: 'Bed 2',
+        schedule: [
+          createOccupancyEntry(startDate, addDays(startDate, 7), 'open'),
+          createOccupancyEntry(addDays(startDate, 8), addDays(startDate, 30), 'booking'),
+        ],
+      },
+      {
+        bedId: '3',
+        bedName: 'Bed 3',
+        schedule: [createOccupancyEntry(startDate, addDays(startDate, 50), 'open')],
+      },
+      {
+        bedId: '4',
+        bedName: 'Bed 4',
+        schedule: [
+          createOccupancyEntry(startDate, addDays(startDate, 21), 'lost_bed'),
+          createOccupancyEntry(addDays(startDate, 22), addDays(startDate, 35), 'booking'),
+        ],
+      },
+    ]
+
     cy.task('stubPremisesOccupancy', {
       premisesId: premises.id,
-      startDate: DateFormats.dateObjToIsoDate(new Date()),
-      endDate: DateFormats.dateObjToIsoDate(addDays(new Date(), 30)),
+      startDate: DateFormats.dateObjToIsoDate(startDate),
+      endDate: DateFormats.dateObjToIsoDate(addDays(startDate, 30)),
       premisesOccupancy,
     })
 
@@ -96,5 +128,69 @@ context('Premises', () => {
 
     // Then I should be able to click to view the calendar
     page.clickViewCalendar()
+
+    // And the calendar should show the schedule
+    const calendar = new CalendarPage(premises)
+    calendar.shouldShowOccupancy(premisesOccupancy)
+  })
+
+  it('should show overbookings', () => {
+    // Given there is a premises in the database
+    const premises = premisesFactory.build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubPremisesCapacity', {
+      premisesId: premises.id,
+      dateCapacities: [],
+    })
+
+    // And that premises has bookings with overbookings for a bed
+    const startDate = new Date()
+
+    const firstEntry = createOccupancyEntry(startDate, addDays(startDate, 12), 'booking')
+    const secondEntry = createOccupancyEntry(addDays(startDate, 4), addDays(startDate, 15), 'booking')
+    const thirdEntry = createOccupancyEntry(addDays(startDate, 16), addDays(startDate, 25), 'lost_bed')
+    const fourthEntry = createOccupancyEntry(addDays(startDate, 21), addDays(startDate, 40), 'booking')
+
+    const premisesOccupancy = [
+      {
+        bedId: '1',
+        bedName: 'Bed 1',
+        schedule: [firstEntry, secondEntry, thirdEntry, fourthEntry],
+      },
+    ]
+
+    cy.task('stubPremisesOccupancy', {
+      premisesId: premises.id,
+      startDate: DateFormats.dateObjToIsoDate(startDate),
+      endDate: DateFormats.dateObjToIsoDate(addDays(startDate, 30)),
+      premisesOccupancy,
+    })
+
+    // When I visit the premises page
+    const page = PremisesShowPage.visit(premises)
+
+    // Then I should be able to click to view the calendar
+    page.clickViewCalendar()
+
+    // And the calendar should show the schedule
+    const calendar = new CalendarPage(premises)
+    // And the overbookings should be shown for the relevant dates
+    calendar.shouldShowOverbookingsForPeriod(secondEntry.startDate, firstEntry.endDate)
+    calendar.shouldShowOverbookingsForPeriod(fourthEntry.startDate, thirdEntry.endDate)
+
+    // And the overbooked bookings should be partially visible
+    calendar.shouldShowOccupancyForId(firstEntry.bookingId, DateFormats.isoToDateObj(firstEntry.startDate), '4')
+    calendar.shouldShowOccupancyForId(
+      secondEntry.bookingId,
+      addDays(DateFormats.isoToDateObj(firstEntry.endDate), 1),
+      '3',
+    )
+    calendar.shouldShowOccupancyForId(thirdEntry.lostBedId, DateFormats.isoToDateObj(thirdEntry.startDate), '5')
+    calendar.shouldShowOccupancyForId(
+      fourthEntry.bookingId,
+      addDays(DateFormats.isoToDateObj(thirdEntry.endDate), 1),
+      '5',
+    )
   })
 })

--- a/integration_tests/tests/manage/premises.cy.ts
+++ b/integration_tests/tests/manage/premises.cy.ts
@@ -1,4 +1,6 @@
+import { addDays } from 'date-fns'
 import { bookingFactory, dateCapacityFactory, premisesFactory } from '../../../server/testutils/factories'
+import { DateFormats } from '../../../server/utils/dateUtils'
 
 import { PremisesListPage, PremisesShowPage } from '../../pages/manage'
 
@@ -7,13 +9,11 @@ context('Premises', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+    cy.signIn()
   })
 
   it('should list all premises', () => {
-    // Given I am signed in
-    cy.signIn()
-
-    // And there are premises in the database
+    // Given there are premises in the database
     const premises = premisesFactory.buildList(5)
     cy.task('stubPremises', premises)
 
@@ -52,9 +52,6 @@ context('Premises', () => {
       premisesId: premises.id,
       dateCapacities: [overcapacityStartDate, overcapacityEndDate],
     })
-
-    // And I am signed in
-    cy.signIn()
 
     // When I visit the premises page
     const page = PremisesShowPage.visit(premises)

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -379,4 +379,6 @@ export type BedOccupancyEntryUiType = 'open' | 'lost_bed' | 'booking'
 
 export type BedOccupancyEntryUi = BedOccupancyEntryTypes & { type: BedOccupancyEntryUiType }
 
+export type BedOccupancyEntryCalendar = BedOccupancyEntryUi & { label: string }
+
 export type BedOccupancyRangeUi = Omit<BedOccupancyRange, 'schedule'> & { schedule: Array<BedOccupancyEntryUi> }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -10,6 +10,10 @@ import {
   ArrayOfOASysSupportingInformationQuestions,
   ApprovedPremisesAssessment as Assessment,
   AssessmentTask,
+  BedOccupancyBookingEntry,
+  BedOccupancyLostBedEntry,
+  BedOccupancyOpenEntry,
+  BedOccupancyRange,
   Booking,
   BookingAppealTask,
   Document,
@@ -349,3 +353,28 @@ export interface BedSearchParametersUi {
 export type ReleaseTypeOptions = Record<ReleaseTypeOption, string>
 
 export type FormArtifact = ApprovedPremisesApplication | ApprovedPremisesAssessment | PlacementApplication
+
+type RemoveStartAndEndDates<T> = Omit<T, 'startDate' | 'endDate'>
+
+interface StartAndEndDates {
+  startDate: Date
+  endDate: Date
+}
+
+export interface BedOccupancyBookingEntryUi extends RemoveStartAndEndDates<BedOccupancyBookingEntry>, StartAndEndDates {
+  type: 'booking'
+}
+
+export interface BedOccupancyLostBedEntryUi extends RemoveStartAndEndDates<BedOccupancyLostBedEntry>, StartAndEndDates {
+  type: 'lost_bed'
+}
+
+export interface BedOccupancyOpenEntryUi extends RemoveStartAndEndDates<BedOccupancyOpenEntry>, StartAndEndDates {
+  type: 'open'
+}
+
+export type BedOccupancyEntryTypes = BedOccupancyBookingEntryUi | BedOccupancyLostBedEntryUi | BedOccupancyOpenEntryUi
+
+export type BedOccupancyEntryUi = BedOccupancyEntryTypes & { type: 'open' | 'lost_bed' | 'booking' }
+
+export type BedOccupancyRangeUi = Omit<BedOccupancyRange, 'schedule'> & { schedule: Array<BedOccupancyEntryUi> }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -373,9 +373,18 @@ export interface BedOccupancyOpenEntryUi extends RemoveStartAndEndDates<BedOccup
   type: 'open'
 }
 
-export type BedOccupancyEntryTypes = BedOccupancyBookingEntryUi | BedOccupancyLostBedEntryUi | BedOccupancyOpenEntryUi
+export interface BedOccupancyOverbookingEntryUi extends StartAndEndDates {
+  length: number
+  type: 'overbooking'
+}
 
-export type BedOccupancyEntryUiType = 'open' | 'lost_bed' | 'booking'
+export type BedOccupancyEntryTypes =
+  | BedOccupancyBookingEntryUi
+  | BedOccupancyLostBedEntryUi
+  | BedOccupancyOpenEntryUi
+  | BedOccupancyOverbookingEntryUi
+
+export type BedOccupancyEntryUiType = 'open' | 'lost_bed' | 'booking' | 'overbooking'
 
 export type BedOccupancyEntryUi = BedOccupancyEntryTypes & { type: BedOccupancyEntryUiType }
 

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -375,6 +375,8 @@ export interface BedOccupancyOpenEntryUi extends RemoveStartAndEndDates<BedOccup
 
 export type BedOccupancyEntryTypes = BedOccupancyBookingEntryUi | BedOccupancyLostBedEntryUi | BedOccupancyOpenEntryUi
 
-export type BedOccupancyEntryUi = BedOccupancyEntryTypes & { type: 'open' | 'lost_bed' | 'booking' }
+export type BedOccupancyEntryUiType = 'open' | 'lost_bed' | 'booking'
+
+export type BedOccupancyEntryUi = BedOccupancyEntryTypes & { type: BedOccupancyEntryUiType }
 
 export type BedOccupancyRangeUi = Omit<BedOccupancyRange, 'schedule'> & { schedule: Array<BedOccupancyEntryUi> }

--- a/server/controllers/manage/premises/premisesController.test.ts
+++ b/server/controllers/manage/premises/premisesController.test.ts
@@ -83,6 +83,7 @@ describe('PremisesController', () => {
       expect(response.render).toHaveBeenCalledWith('premises/calendar', {
         bedOccupancyRangeList: occupancy,
         premisesId: request.params.premisesId,
+        startDate: new Date(),
       })
     })
   })

--- a/server/controllers/manage/premises/premisesController.test.ts
+++ b/server/controllers/manage/premises/premisesController.test.ts
@@ -1,4 +1,4 @@
-import { addDays } from 'date-fns'
+import { addDays, subDays } from 'date-fns'
 import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
@@ -13,14 +13,19 @@ import { DateFormats } from '../../../utils/dateUtils'
 
 describe('PremisesController', () => {
   const token = 'SOME_TOKEN'
+  const premisesId = 'some-uuid'
 
-  const request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  let request: DeepMocked<Request>
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
   const premisesService = createMock<PremisesService>({})
   const bookingService = createMock<BookingService>({})
   const premisesController = new PremisesController(premisesService, bookingService)
+
+  beforeEach(() => {
+    request = createMock<Request>({ user: { token }, params: { premisesId } })
+  })
 
   describe('index', () => {
     it('should return the table rows to the template', async () => {
@@ -46,47 +51,78 @@ describe('PremisesController', () => {
       bookingService.groupedListOfBookingsForPremisesId.mockResolvedValue(bookings)
       bookingService.currentResidents.mockResolvedValue(currentResidents)
 
-      request.params.premisesId = 'some-uuid'
-
       const requestHandler = premisesController.show()
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('premises/show', {
-        premisesId: 'some-uuid',
+        premisesId,
         premises,
         bookings,
         currentResidents,
         infoMessages: [overcapacityMessage],
       })
 
-      expect(premisesService.getPremisesDetails).toHaveBeenCalledWith(token, 'some-uuid')
-      expect(bookingService.groupedListOfBookingsForPremisesId).toHaveBeenCalledWith(token, 'some-uuid')
-      expect(bookingService.currentResidents).toHaveBeenCalledWith(token, 'some-uuid')
+      expect(premisesService.getPremisesDetails).toHaveBeenCalledWith(token, premisesId)
+      expect(bookingService.groupedListOfBookingsForPremisesId).toHaveBeenCalledWith(token, premisesId)
+      expect(bookingService.currentResidents).toHaveBeenCalledWith(token, premisesId)
     })
   })
 
   describe('calendar', () => {
-    it('renders the calendar view', async () => {
-      const occupancy = bedOccupancyRangeFactoryUi.buildList(2)
-      const premises = premisesFactory.build()
+    const occupancy = bedOccupancyRangeFactoryUi.buildList(2)
+    const premises = premisesFactory.build()
+    const requestHandler = premisesController.calendar()
 
+    beforeEach(() => {
       premisesService.getOccupancy.mockResolvedValue(occupancy)
       premisesService.find.mockResolvedValue(premises)
+    })
 
-      const requestHandler = premisesController.calendar()
+    it('renders the calendar view', async () => {
       await requestHandler(request, response, next)
+
+      const startDate = new Date()
+      const nextDate = DateFormats.dateObjToIsoDate(addDays(startDate, 14))
+      const previousDate = DateFormats.dateObjToIsoDate(subDays(startDate, 14))
 
       expect(premisesService.getOccupancy).toHaveBeenCalledWith(
         token,
-        'some-uuid',
-        DateFormats.dateObjToIsoDate(new Date()),
-        DateFormats.dateObjToIsoDate(addDays(new Date(), 30)),
+        premisesId,
+        DateFormats.dateObjToIsoDate(startDate),
+        DateFormats.dateObjToIsoDate(addDays(startDate, 30)),
       )
       expect(response.render).toHaveBeenCalledWith('premises/calendar', {
         bedOccupancyRangeList: occupancy,
         premisesId: request.params.premisesId,
         premises,
-        startDate: new Date(),
+        startDate,
+        nextDate,
+        previousDate,
+      })
+    })
+
+    it('allows a startDate to be passed in', async () => {
+      request.query = { startDate: '2023-01-15' }
+      await requestHandler(request, response, next)
+
+      const startDate = new Date(2023, 0, 15)
+      const nextDate = DateFormats.dateObjToIsoDate(new Date(2023, 0, 29))
+      const previousDate = DateFormats.dateObjToIsoDate(new Date(2023, 0, 1))
+
+      expect(premisesService.getOccupancy).toHaveBeenCalledWith(
+        token,
+        premisesId,
+        DateFormats.dateObjToIsoDate(startDate),
+        DateFormats.dateObjToIsoDate(addDays(startDate, 30)),
+      )
+
+      expect(response.render).toHaveBeenCalledWith('premises/calendar', {
+        bedOccupancyRangeList: occupancy,
+        premisesId: request.params.premisesId,
+        premises,
+        startDate,
+        nextDate,
+        previousDate,
       })
     })
   })

--- a/server/controllers/manage/premises/premisesController.test.ts
+++ b/server/controllers/manage/premises/premisesController.test.ts
@@ -8,7 +8,7 @@ import PremisesService from '../../../services/premisesService'
 import BookingService from '../../../services/bookingService'
 import PremisesController from './premisesController'
 
-import { bedOccupancyRangeFactoryUi } from '../../../testutils/factories'
+import { bedOccupancyRangeFactoryUi, premisesFactory } from '../../../testutils/factories'
 import { DateFormats } from '../../../utils/dateUtils'
 
 describe('PremisesController', () => {
@@ -68,8 +68,10 @@ describe('PremisesController', () => {
   describe('calendar', () => {
     it('renders the calendar view', async () => {
       const occupancy = bedOccupancyRangeFactoryUi.buildList(2)
+      const premises = premisesFactory.build()
 
       premisesService.getOccupancy.mockResolvedValue(occupancy)
+      premisesService.find.mockResolvedValue(premises)
 
       const requestHandler = premisesController.calendar()
       await requestHandler(request, response, next)
@@ -83,6 +85,7 @@ describe('PremisesController', () => {
       expect(response.render).toHaveBeenCalledWith('premises/calendar', {
         bedOccupancyRangeList: occupancy,
         premisesId: request.params.premisesId,
+        premises,
         startDate: new Date(),
       })
     })

--- a/server/controllers/manage/premises/premisesController.ts
+++ b/server/controllers/manage/premises/premisesController.ts
@@ -1,7 +1,9 @@
 import type { Request, RequestHandler, Response } from 'express'
+import { addDays } from 'date-fns'
 
 import PremisesService from '../../../services/premisesService'
 import BookingService from '../../../services/bookingService'
+import { DateFormats } from '../../../utils/dateUtils'
 
 export default class PremisesController {
   constructor(private readonly premisesService: PremisesService, private readonly bookingService: BookingService) {}
@@ -34,6 +36,19 @@ export default class PremisesController {
         currentResidents,
         infoMessages: overcapacityMessage,
       })
+    }
+  }
+
+  calendar(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const bedOccupancyRangeList = await this.premisesService.getOccupancy(
+        req.user.token,
+        req.params.premisesId,
+        DateFormats.dateObjToIsoDate(new Date()),
+        DateFormats.dateObjToIsoDate(addDays(new Date(), 30)),
+      )
+
+      return res.render('premises/calendar', { bedOccupancyRangeList, premisesId: req.params.premisesId })
     }
   }
 }

--- a/server/controllers/manage/premises/premisesController.ts
+++ b/server/controllers/manage/premises/premisesController.ts
@@ -41,6 +41,8 @@ export default class PremisesController {
 
   calendar(): RequestHandler {
     return async (req: Request, res: Response) => {
+      const premises = await this.premisesService.find(req.user.token, req.params.premisesId)
+
       const startDate = new Date()
       const endDate = addDays(new Date(), 30)
 
@@ -51,7 +53,12 @@ export default class PremisesController {
         DateFormats.dateObjToIsoDate(endDate),
       )
 
-      return res.render('premises/calendar', { bedOccupancyRangeList, premisesId: req.params.premisesId, startDate })
+      return res.render('premises/calendar', {
+        bedOccupancyRangeList,
+        premisesId: req.params.premisesId,
+        startDate,
+        premises,
+      })
     }
   }
 }

--- a/server/controllers/manage/premises/premisesController.ts
+++ b/server/controllers/manage/premises/premisesController.ts
@@ -41,14 +41,17 @@ export default class PremisesController {
 
   calendar(): RequestHandler {
     return async (req: Request, res: Response) => {
+      const startDate = new Date()
+      const endDate = addDays(new Date(), 30)
+
       const bedOccupancyRangeList = await this.premisesService.getOccupancy(
         req.user.token,
         req.params.premisesId,
-        DateFormats.dateObjToIsoDate(new Date()),
-        DateFormats.dateObjToIsoDate(addDays(new Date(), 30)),
+        DateFormats.dateObjToIsoDate(startDate),
+        DateFormats.dateObjToIsoDate(endDate),
       )
 
-      return res.render('premises/calendar', { bedOccupancyRangeList, premisesId: req.params.premisesId })
+      return res.render('premises/calendar', { bedOccupancyRangeList, premisesId: req.params.premisesId, startDate })
     }
   }
 }

--- a/server/controllers/manage/premises/premisesController.ts
+++ b/server/controllers/manage/premises/premisesController.ts
@@ -1,5 +1,5 @@
 import type { Request, RequestHandler, Response } from 'express'
-import { addDays } from 'date-fns'
+import { addDays, subDays } from 'date-fns'
 
 import PremisesService from '../../../services/premisesService'
 import BookingService from '../../../services/bookingService'
@@ -43,8 +43,11 @@ export default class PremisesController {
     return async (req: Request, res: Response) => {
       const premises = await this.premisesService.find(req.user.token, req.params.premisesId)
 
-      const startDate = new Date()
-      const endDate = addDays(new Date(), 30)
+      const startDate = req.query.startDate ? DateFormats.isoToDateObj(req.query.startDate as string) : new Date()
+      const endDate = addDays(startDate, 30)
+
+      const nextDate = DateFormats.dateObjToIsoDate(addDays(startDate, 14))
+      const previousDate = DateFormats.dateObjToIsoDate(subDays(startDate, 14))
 
       const bedOccupancyRangeList = await this.premisesService.getOccupancy(
         req.user.token,
@@ -58,6 +61,8 @@ export default class PremisesController {
         premisesId: req.params.premisesId,
         startDate,
         premises,
+        nextDate,
+        previousDate,
       })
     }
   }

--- a/server/data/premisesClient.test.ts
+++ b/server/data/premisesClient.test.ts
@@ -1,5 +1,6 @@
 import {
   bedDetailFactory,
+  bedOccupancyRangeFactory,
   bedSummaryFactory,
   dateCapacityFactory,
   premisesFactory,
@@ -222,6 +223,36 @@ describeClient('PremisesClient', provider => {
 
       const output = await premisesClient.getBed(premises.id, bed.id)
       expect(output).toEqual(bed)
+    })
+  })
+
+  describe('calendar', () => {
+    it('should return the occupancy of the premises for a given date range', async () => {
+      const premises = premisesFactory.build()
+      const startDate = '2020-01-01'
+      const endDate = '2020-01-31'
+
+      const result = bedOccupancyRangeFactory.buildList(1)
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get a calendar for a premises',
+        withRequest: {
+          method: 'GET',
+          path: paths.premises.calendar({ premisesId: premises.id }),
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+          query: { endDate, startDate },
+        },
+        willRespondWith: {
+          status: 200,
+          body: result,
+        },
+      })
+
+      const output = await premisesClient.calendar(premises.id, startDate, endDate)
+      expect(output).toEqual(result)
     })
   })
 })

--- a/server/data/premisesClient.ts
+++ b/server/data/premisesClient.ts
@@ -1,4 +1,12 @@
-import type { ApprovedPremises, BedDetail, BedSummary, DateCapacity, Room, StaffMember } from '@approved-premises/api'
+import type {
+  ApprovedPremises,
+  BedDetail,
+  BedOccupancyRange,
+  BedSummary,
+  DateCapacity,
+  Room,
+  StaffMember,
+} from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -42,5 +50,13 @@ export default class PremisesClient {
 
   async getRoom(premisesId: string, roomId: string): Promise<Room> {
     return (await this.restClient.get({ path: paths.premises.room({ premisesId, roomId }) })) as Room
+  }
+
+  async calendar(premisesId: string, startDate: string, endDate: string): Promise<Array<BedOccupancyRange>> {
+    const path = paths.premises.calendar({ premisesId })
+    return (await this.restClient.get({
+      path,
+      query: { startDate, endDate },
+    })) as Array<BedOccupancyRange>
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -105,6 +105,7 @@ export default {
     bookings: {
       move: managePaths.bookings.move,
     },
+    calendar: managePaths.premises.show.path('calendar'),
   },
   applications: {
     show: applyPaths.applications.show,

--- a/server/paths/manage.ts
+++ b/server/paths/manage.ts
@@ -30,6 +30,7 @@ const paths = {
     index: premisesPath,
     show: singlePremisesPath,
     capacity: singlePremisesPath.path('capacity'),
+    calendar: singlePremisesPath.path('calendar'),
     beds: {
       index: bedsPath,
       show: bedsPath.path(':bedId'),

--- a/server/routes/manage.ts
+++ b/server/routes/manage.ts
@@ -26,6 +26,7 @@ export default function routes(controllers: Controllers, router: Router): Router
 
   get(paths.premises.index.pattern, premisesController.index())
   get(paths.premises.show.pattern, premisesController.show())
+  get(paths.premises.calendar.pattern, premisesController.calendar())
 
   get(paths.premises.beds.index.pattern, bedsController.index())
   get(paths.premises.beds.show.pattern, bedsController.show())

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -186,6 +186,16 @@ describe('PremisesService', () => {
     })
   })
 
+  describe('find', () => {
+    it('fetches the premises from the client', async () => {
+      const premises = premisesFactory.build()
+      premisesClient.find.mockResolvedValue(premises)
+
+      const result = await service.find(token, premises.id)
+      expect(result).toEqual(premises)
+    })
+  })
+
   describe('getPremisesDetails', () => {
     it('returns a title and a summary list for a given Premises ID', async () => {
       const premises = premisesFactory.build({

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -2,13 +2,14 @@ import PremisesService from './premisesService'
 import PremisesClient from '../data/premisesClient'
 import {
   bedDetailFactory,
+  bedOccupancyRangeFactory,
   bedSummaryFactory,
   dateCapacityFactory,
   premisesFactory,
   roomFactory,
   staffMemberFactory,
 } from '../testutils/factories'
-import getDateRangesWithNegativeBeds from '../utils/premisesUtils'
+import getDateRangesWithNegativeBeds, { mapApiOccupancyToUiOccupancy } from '../utils/premisesUtils'
 import paths from '../paths/manage'
 
 jest.mock('../data/premisesClient')
@@ -347,6 +348,24 @@ describe('PremisesService', () => {
         `<h3 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity for the periods:</h3>
         <ul class="govuk-list govuk-list--bullet"><li>Sunday 1 January 2023</li><li>Thursday 2 March 2023 to Sunday 2 April 2023</li></ul>`,
       ])
+    })
+  })
+
+  describe('getOccupancy', () => {
+    it('returns the premises occupancy from the client', async () => {
+      const occupancy = bedOccupancyRangeFactory.buildList(1)
+      const startDate = '2020-01-01'
+      const endDate = '2020-01-31'
+
+      premisesClient.calendar.mockResolvedValue(occupancy)
+      ;(mapApiOccupancyToUiOccupancy as jest.Mock).mockReturnValue(occupancy)
+
+      const result = await service.getOccupancy(token, premisesId, startDate, endDate)
+
+      expect(result).toEqual(occupancy)
+
+      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClient.calendar).toHaveBeenCalledWith(premisesId, startDate, endDate)
     })
   })
 })

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -1,5 +1,5 @@
 import type { SummaryList, TableRow } from '@approved-premises/ui'
-import type { ApprovedPremises, BedDetail, BedSummary, Room, StaffMember } from '@approved-premises/api'
+import type { ApprovedPremises, BedDetail, BedSummary, Premises, Room, StaffMember } from '@approved-premises/api'
 import type { PremisesClient, RestClientBuilder } from '../data'
 import paths from '../paths/manage'
 
@@ -63,6 +63,13 @@ export default class PremisesService {
           ),
         ]
       })
+  }
+
+  async find(token: string, id: string): Promise<Premises> {
+    const premisesClient = this.premisesClientFactory(token)
+    const premises = await premisesClient.find(id)
+
+    return premises
   }
 
   async getPremisesDetails(token: string, id: string): Promise<{ name: string; summaryList: SummaryList }> {

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -4,7 +4,7 @@ import type { PremisesClient, RestClientBuilder } from '../data'
 import paths from '../paths/manage'
 
 import { DateFormats } from '../utils/dateUtils'
-import getDateRangesWithNegativeBeds, { NegativeDateRange } from '../utils/premisesUtils'
+import getDateRangesWithNegativeBeds, { NegativeDateRange, mapApiOccupancyToUiOccupancy } from '../utils/premisesUtils'
 
 export default class PremisesService {
   constructor(private readonly premisesClientFactory: RestClientBuilder<PremisesClient>) {}
@@ -82,6 +82,14 @@ export default class PremisesService {
     const overcapacityMessage = this.generateOvercapacityMessage(overcapacityDateRanges)
 
     return overcapacityMessage ? [overcapacityMessage] : ''
+  }
+
+  async getOccupancy(token: string, premisesId: string, startDate: string, endDate: string) {
+    const premisesClient = this.premisesClientFactory(token)
+    const apiOccupancy = await premisesClient.calendar(premisesId, startDate, endDate)
+    const occupancyForUi = await mapApiOccupancyToUiOccupancy(apiOccupancy)
+
+    return occupancyForUi
   }
 
   private generateOvercapacityMessage(overcapacityDateRanges: Array<NegativeDateRange>) {

--- a/server/testutils/factories/bedOccupancyRange.ts
+++ b/server/testutils/factories/bedOccupancyRange.ts
@@ -1,0 +1,57 @@
+import { addDays, differenceInDays } from 'date-fns'
+import type { BedOccupancyEntry, BedOccupancyRange } from '@approved-premises/api'
+
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import { DateFormats } from '../../utils/dateUtils'
+
+export default Factory.define<BedOccupancyRange>(generator => ({
+  bedId: faker.string.uuid(),
+  bedName: `bed ${generator.sequence}`,
+  schedule: faker.helpers.arrayElements(
+    [
+      bedOccupancyEntryBookingFactory.build(),
+      bedOccupancyEntryLostBedFactory.build(),
+      bedOccupancyEntryOpenFactory.build(),
+    ],
+    10,
+  ),
+}))
+
+const generateStay = () => {
+  const startDate = addDays(new Date(), Math.floor(Math.random() * 10))
+  const endDate = addDays(startDate, Math.floor(Math.random() * 20))
+  const length = differenceInDays(endDate, startDate)
+
+  return { startDate, endDate, length }
+}
+
+export const bedOccupancyEntryFactory = Factory.define<BedOccupancyEntry>(() => {
+  const { startDate, endDate, length } = generateStay()
+
+  return {
+    startDate: DateFormats.dateObjToIsoDate(startDate),
+    endDate: DateFormats.dateObjToIsoDate(endDate),
+    length,
+    type: 'booking',
+  }
+})
+
+const bedOccupancyEntryBookingFactory = Factory.define<BedOccupancyBookingEntryUi>(() => ({
+  ...bedOccupancyEntryFactory.build(),
+  type: 'booking',
+  personName: faker.person.firstName(),
+  bookingId: faker.string.uuid(),
+}))
+
+const bedOccupancyEntryLostBedFactory = Factory.define<BedOccupancyLostBedEntryUi>(() => ({
+  ...bedOccupancyEntryFactory.build(),
+  type: 'lost_bed',
+  lostBedId: faker.string.uuid(),
+}))
+
+const bedOccupancyEntryOpenFactory = Factory.define<BedOccupancyOpenEntryUi>(() => ({
+  ...bedOccupancyEntryFactory.build(),
+  type: 'open',
+}))

--- a/server/testutils/factories/bedOccupancyRange.ts
+++ b/server/testutils/factories/bedOccupancyRange.ts
@@ -12,6 +12,7 @@ import type {
 } from '@approved-premises/api'
 import {
   BedOccupancyBookingEntryUi,
+  BedOccupancyEntryCalendar,
   BedOccupancyEntryUi,
   BedOccupancyLostBedEntryUi,
   BedOccupancyOpenEntryUi,
@@ -91,6 +92,17 @@ export const bedOccupancyEntryUiFactory = Factory.define<BedOccupancyEntryUi>(()
     length,
     type: 'booking',
   } as BedOccupancyEntryUi
+})
+
+export const bedOccupancyEntryCalendarFactory = Factory.define<BedOccupancyEntryCalendar>(() => {
+  const { startDate, endDate, length } = generateStay()
+  return {
+    startDate,
+    endDate,
+    length,
+    type: 'booking',
+    label: 'Some text goes here',
+  } as BedOccupancyEntryCalendar
 })
 
 export const bedOccupancyEntryBookingUiFactory = Factory.define<BedOccupancyBookingEntryUi>(

--- a/server/testutils/factories/bedOccupancyRange.ts
+++ b/server/testutils/factories/bedOccupancyRange.ts
@@ -20,7 +20,7 @@ import {
 
 import { DateFormats } from '../../utils/dateUtils'
 
-export default Factory.define<BedOccupancyRange>(generator => ({
+export const bedOccupancyRangeFactory = Factory.define<BedOccupancyRange>(generator => ({
   bedId: faker.string.uuid(),
   bedName: `bed ${generator.sequence}`,
   schedule: faker.helpers.arrayElements(
@@ -52,20 +52,20 @@ export const bedOccupancyEntryFactory = Factory.define<BedOccupancyEntry>(() => 
   }
 })
 
-const bedOccupancyEntryBookingFactory = Factory.define<BedOccupancyBookingEntryUi>(() => ({
+const bedOccupancyEntryBookingFactory = Factory.define<BedOccupancyBookingEntry>(() => ({
   ...bedOccupancyEntryFactory.build(),
   type: 'booking',
   personName: faker.person.firstName(),
   bookingId: faker.string.uuid(),
 }))
 
-const bedOccupancyEntryLostBedFactory = Factory.define<BedOccupancyLostBedEntryUi>(() => ({
+const bedOccupancyEntryLostBedFactory = Factory.define<BedOccupancyLostBedEntry>(() => ({
   ...bedOccupancyEntryFactory.build(),
   type: 'lost_bed',
   lostBedId: faker.string.uuid(),
 }))
 
-const bedOccupancyEntryOpenFactory = Factory.define<BedOccupancyOpenEntryUi>(() => ({
+const bedOccupancyEntryOpenFactory = Factory.define<BedOccupancyOpenEntry>(() => ({
   ...bedOccupancyEntryFactory.build(),
   type: 'open',
 }))

--- a/server/testutils/factories/bedOccupancyRange.ts
+++ b/server/testutils/factories/bedOccupancyRange.ts
@@ -1,8 +1,22 @@
 import { addDays, differenceInDays } from 'date-fns'
-import type { BedOccupancyEntry, BedOccupancyRange } from '@approved-premises/api'
 
-import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
+
+import type {
+  BedOccupancyBookingEntry,
+  BedOccupancyEntry,
+  BedOccupancyLostBedEntry,
+  BedOccupancyOpenEntry,
+  BedOccupancyRange,
+} from '@approved-premises/api'
+import {
+  BedOccupancyBookingEntryUi,
+  BedOccupancyEntryUi,
+  BedOccupancyLostBedEntryUi,
+  BedOccupancyOpenEntryUi,
+  BedOccupancyRangeUi,
+} from '../../@types/ui'
 
 import { DateFormats } from '../../utils/dateUtils'
 
@@ -55,3 +69,53 @@ const bedOccupancyEntryOpenFactory = Factory.define<BedOccupancyOpenEntryUi>(() 
   ...bedOccupancyEntryFactory.build(),
   type: 'open',
 }))
+
+export const bedOccupancyRangeFactoryUi = Factory.define<BedOccupancyRangeUi>(generator => ({
+  bedId: faker.string.uuid(),
+  bedName: `bed ${generator.sequence}`,
+  schedule: faker.helpers.arrayElements(
+    [
+      bedOccupancyEntryBookingUiFactory.build(),
+      bedOccupancyEntryLostBedUiFactory.build(),
+      bedOccupancyEntryOpenUiFactory.build(),
+    ],
+    10,
+  ),
+}))
+
+export const bedOccupancyEntryUiFactory = Factory.define<BedOccupancyEntryUi>(() => {
+  const { startDate, endDate, length } = generateStay()
+  return {
+    startDate,
+    endDate,
+    length,
+    type: 'booking',
+  } as BedOccupancyEntryUi
+})
+
+export const bedOccupancyEntryBookingUiFactory = Factory.define<BedOccupancyBookingEntryUi>(
+  () =>
+    ({
+      ...bedOccupancyEntryUiFactory.build(),
+      type: 'booking',
+      personName: faker.person.firstName(),
+      bookingId: faker.string.uuid(),
+    } as BedOccupancyBookingEntryUi),
+)
+
+export const bedOccupancyEntryLostBedUiFactory = Factory.define<BedOccupancyLostBedEntryUi>(
+  () =>
+    ({
+      ...bedOccupancyEntryUiFactory.build(),
+      type: 'lost_bed',
+      lostBedId: faker.string.uuid(),
+    } as BedOccupancyLostBedEntryUi),
+)
+
+export const bedOccupancyEntryOpenUiFactory = Factory.define<BedOccupancyOpenEntryUi>(
+  () =>
+    ({
+      ...bedOccupancyEntryUiFactory.build(),
+      type: 'open',
+    } as BedOccupancyOpenEntryUi),
+)

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -12,6 +12,7 @@ import assessmentSummaryFactory from './assessmentSummary'
 import { bedSearchParametersFactory, bedSearchParametersUiFactory } from './bedSearchParameters'
 import bedSummaryFactory from './bedSummary'
 import bedDetailFactory from './bedDetail'
+import { bedOccupancyEntryFactory, bedOccupancyRangeFactory, bedOccupancyRangeFactoryUi } from './bedOccupancyRange'
 import { apCharacteristicPairFactory, bedSearchResultFactory, bedSearchResultsFactory } from './bedSearchResult'
 import bookingAppealTask from './bookingAppealTask'
 import bookingFactory from './booking'
@@ -70,6 +71,9 @@ export {
   assessmentSummaryFactory,
   bedSummaryFactory,
   bedDetailFactory,
+  bedOccupancyEntryFactory,
+  bedOccupancyRangeFactory,
+  bedOccupancyRangeFactoryUi,
   bedSearchParametersFactory,
   bedSearchParametersUiFactory,
   bedSearchResultFactory,

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -12,7 +12,13 @@ import assessmentSummaryFactory from './assessmentSummary'
 import { bedSearchParametersFactory, bedSearchParametersUiFactory } from './bedSearchParameters'
 import bedSummaryFactory from './bedSummary'
 import bedDetailFactory from './bedDetail'
-import { bedOccupancyEntryFactory, bedOccupancyRangeFactory, bedOccupancyRangeFactoryUi } from './bedOccupancyRange'
+import {
+  bedOccupancyEntryBookingUiFactory,
+  bedOccupancyEntryFactory,
+  bedOccupancyEntryUiFactory,
+  bedOccupancyRangeFactory,
+  bedOccupancyRangeFactoryUi,
+} from './bedOccupancyRange'
 import { apCharacteristicPairFactory, bedSearchResultFactory, bedSearchResultsFactory } from './bedSearchResult'
 import bookingAppealTask from './bookingAppealTask'
 import bookingFactory from './booking'
@@ -72,8 +78,10 @@ export {
   bedSummaryFactory,
   bedDetailFactory,
   bedOccupancyEntryFactory,
-  bedOccupancyRangeFactory,
+  bedOccupancyEntryBookingUiFactory,
+  bedOccupancyEntryUiFactory,
   bedOccupancyRangeFactoryUi,
+  bedOccupancyRangeFactory,
   bedSearchParametersFactory,
   bedSearchParametersUiFactory,
   bedSearchResultFactory,

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -14,6 +14,7 @@ import bedSummaryFactory from './bedSummary'
 import bedDetailFactory from './bedDetail'
 import {
   bedOccupancyEntryBookingUiFactory,
+  bedOccupancyEntryCalendarFactory,
   bedOccupancyEntryFactory,
   bedOccupancyEntryUiFactory,
   bedOccupancyRangeFactory,
@@ -77,6 +78,7 @@ export {
   assessmentSummaryFactory,
   bedSummaryFactory,
   bedDetailFactory,
+  bedOccupancyEntryCalendarFactory,
   bedOccupancyEntryFactory,
   bedOccupancyEntryBookingUiFactory,
   bedOccupancyEntryUiFactory,

--- a/server/utils/addOverbookingsToSchedule.test.ts
+++ b/server/utils/addOverbookingsToSchedule.test.ts
@@ -1,0 +1,34 @@
+import { differenceInDays } from 'date-fns'
+import { BedOccupancyEntryUiType } from '@approved-premises/ui'
+import { bedOccupancyEntryUiFactory } from '../testutils/factories'
+import { DateFormats } from './dateUtils'
+import { addOverbookingsToSchedule } from './addOverbookingsToSchedule'
+
+const createOccupancyEntry = (startDate: string, endDate: string, type: BedOccupancyEntryUiType) => {
+  return bedOccupancyEntryUiFactory.build({
+    type,
+    startDate: DateFormats.isoToDateObj(startDate),
+    endDate: DateFormats.isoToDateObj(endDate),
+    length: differenceInDays(DateFormats.isoToDateObj(endDate), DateFormats.isoToDateObj(startDate)) + 1,
+  })
+}
+
+describe('addOverbookingsToSchedule', () => {
+  it('should add overbookings and change the booking dates', () => {
+    const entry1 = createOccupancyEntry('2023-04-01', '2023-06-01', 'booking')
+    const entry2 = createOccupancyEntry('2023-04-21', '2023-07-01', 'booking')
+    const entry3 = createOccupancyEntry('2023-08-01', '2023-08-12', 'open')
+    const entry4 = createOccupancyEntry('2023-08-13', '2023-09-23', 'lost_bed')
+    const entry5 = createOccupancyEntry('2023-09-10', '2023-09-25', 'booking')
+
+    const result = addOverbookingsToSchedule([entry1, entry2, entry3, entry4, entry5])
+
+    expect(result[0]).toEqual(createOccupancyEntry('2023-04-01', '2023-04-20', 'booking'))
+    expect(result[1]).toEqual(createOccupancyEntry('2023-04-21', '2023-06-01', 'overbooking'))
+    expect(result[2]).toEqual(createOccupancyEntry('2023-06-02', '2023-07-01', 'booking'))
+    expect(result[3]).toEqual(createOccupancyEntry('2023-08-01', '2023-08-12', 'open'))
+    expect(result[4]).toEqual(createOccupancyEntry('2023-08-13', '2023-09-09', 'lost_bed'))
+    expect(result[5]).toEqual(createOccupancyEntry('2023-09-10', '2023-09-23', 'overbooking'))
+    expect(result[6]).toEqual(createOccupancyEntry('2023-09-24', '2023-09-25', 'booking'))
+  })
+})

--- a/server/utils/addOverbookingsToSchedule.ts
+++ b/server/utils/addOverbookingsToSchedule.ts
@@ -1,0 +1,41 @@
+import { BedOccupancyEntryUi } from '@approved-premises/ui'
+import { addDays, differenceInDays, isBefore, subDays } from 'date-fns'
+
+export const addOverbookingsToSchedule = (schedule: Array<BedOccupancyEntryUi>): Array<BedOccupancyEntryUi> => {
+  const overbookings: Array<BedOccupancyEntryUi> = []
+
+  // Ensure the schedule is ordered by date
+  const orderedSchedule = schedule.sort((a, b) => a.startDate.getTime() - b.startDate.getTime())
+
+  // Loop through each schedule item and check for overbookings
+  const newSchedule = orderedSchedule.map((item, index) => {
+    const nextItem = orderedSchedule[index + 1]
+    // Is the next item a lost bed or booking?
+    if (nextItem && ['booking', 'lost_bed'].includes(nextItem.type)) {
+      // If it is, is the start date before our end date?
+      if (isBefore(nextItem.startDate, item.endDate)) {
+        // If it is, we have an overbooking
+        const overlapStartDate = nextItem.startDate
+        const overlapEndDate = item.endDate
+        // Change our end date to the day before overbooking's start date
+        item.endDate = subDays(overlapStartDate, 1)
+        item.length = differenceInDays(item.endDate, item.startDate) + 1
+        // Change the next booking's start date to the day after the overbooking's end date
+        nextItem.startDate = addDays(overlapEndDate, 1)
+        nextItem.length = differenceInDays(nextItem.endDate, nextItem.startDate) + 1
+        // We then create an overbooking with the start and end dates of each booking
+        overbookings.push({
+          startDate: overlapStartDate,
+          endDate: overlapEndDate,
+          type: 'overbooking',
+          length: differenceInDays(overlapEndDate, overlapStartDate) + 1,
+        })
+      }
+    }
+
+    return item
+  })
+
+  // Combine the overbookings with the new schedule and sort by date
+  return [...newSchedule, ...overbookings].sort((a, b) => a.startDate.getTime() - b.startDate.getTime())
+}

--- a/server/utils/calendarUtils.test.ts
+++ b/server/utils/calendarUtils.test.ts
@@ -30,6 +30,7 @@ import {
   wrapCellContentInTableCellMarkup,
 } from './calendarUtils'
 import { bedOccupancyEntryCalendarFactory } from '../testutils/factories/bedOccupancyRange'
+import { DateFormats } from './dateUtils'
 
 describe('calendarUtils', () => {
   const premisesId = 'some-uuid'
@@ -134,7 +135,7 @@ describe('calendarUtils', () => {
       const bedOccupancyRange = bedOccupancyRangeFactoryUi.build()
 
       expect(bedRow(bedOccupancyRange, startDate, premisesId)).toMatchStringIgnoringWhitespace(
-        `<tr class="${rowClass}">
+        `<tr class="${rowClass}" data-cy-bedId="${bedOccupancyRange.bedId}">
         <th scope="row" class="${headerClass}">${bedOccupancyRange.bedName}</th>
         ${generateRowCells(bedOccupancyRange, startDate, premisesId)}</tr>`,
       )
@@ -295,7 +296,59 @@ describe('calendarUtils', () => {
       const bedOccupancyEntry = bedOccupancyEntryCalendarFactory.build({ startDate: new Date() })
 
       expect(cell(new Date(), bedOccupancyEntry)).toMatchStringIgnoringWhitespace(
-        wrapCellContentInTableCellMarkup(bedOccupancyEntry.length, bedOccupancyEntry.label, bedOccupancyEntry.type),
+        wrapCellContentInTableCellMarkup(bedOccupancyEntry),
+      )
+    })
+  })
+
+  describe('wrapCellContentInTableCellMarkup', () => {
+    it('should return the cell content for a booking', () => {
+      const bedOccupancyEntry = bedOccupancyEntryCalendarFactory.build({
+        startDate: DateFormats.isoToDateObj('2023-06-22'),
+        type: 'booking',
+        length: 4,
+        bookingId: '123',
+      })
+
+      expect(wrapCellContentInTableCellMarkup(bedOccupancyEntry)).toMatchStringIgnoringWhitespace(
+        `<td class="govuk-table__cell govuk-table__cell--calendar govuk-table__cell--booking" colspan="4" data-cy-startdate="2023-06-22" data-cy-id="123">Some text goes here</td>`,
+      )
+    })
+
+    it('should return the cell content for a lost bed', () => {
+      const bedOccupancyEntry = bedOccupancyEntryCalendarFactory.build({
+        startDate: DateFormats.isoToDateObj('2023-06-22'),
+        type: 'lost_bed',
+        length: 4,
+        lostBedId: '123',
+      })
+
+      expect(wrapCellContentInTableCellMarkup(bedOccupancyEntry)).toMatchStringIgnoringWhitespace(
+        `<td class="govuk-table__cell govuk-table__cell--calendar govuk-table__cell--lost_bed" colspan="4" data-cy-startdate="2023-06-22" data-cy-id="123">Some text goes here</td>`,
+      )
+    })
+
+    it('should return the cell content for an open entry', () => {
+      const bedOccupancyEntry = bedOccupancyEntryCalendarFactory.build({
+        startDate: DateFormats.isoToDateObj('2023-06-22'),
+        type: 'open',
+        length: 4,
+      })
+
+      expect(wrapCellContentInTableCellMarkup(bedOccupancyEntry)).toMatchStringIgnoringWhitespace(
+        `<td class="govuk-table__cell govuk-table__cell--calendar govuk-table__cell--open" colspan="4" data-cy-startdate="2023-06-22" data-cy-id="">Some text goes here</td>`,
+      )
+    })
+
+    it('should return the cell content for an overbooked entry', () => {
+      const bedOccupancyEntry = bedOccupancyEntryCalendarFactory.build({
+        startDate: DateFormats.isoToDateObj('2023-06-22'),
+        type: 'overbooking',
+        length: 4,
+      })
+
+      expect(wrapCellContentInTableCellMarkup(bedOccupancyEntry)).toMatchStringIgnoringWhitespace(
+        `<td class="govuk-table__cell govuk-table__cell--calendar govuk-table__cell--overbooking" colspan="4" data-cy-startdate="2023-06-22" data-cy-id="">Some text goes here</td>`,
       )
     })
   })

--- a/server/utils/calendarUtils.test.ts
+++ b/server/utils/calendarUtils.test.ts
@@ -1,4 +1,4 @@
-import { addDays, getDaysInMonth, subDays } from 'date-fns'
+import { addDays, differenceInDays, getDaysInMonth, subDays } from 'date-fns'
 import {
   bedOccupancyEntryBookingUiFactory,
   bedOccupancyEntryUiFactory,
@@ -180,21 +180,21 @@ describe('calendarUtils', () => {
         {
           startDate: scheduleItems[0].startDate,
           endDate: scheduleItems[0].endDate,
-          length: scheduleItems[0].length,
+          length: scheduleItems[0].length + 1,
           label: labelForScheduleItem(scheduleItems[0]),
           type: scheduleItems[0].type,
         },
         {
           startDate: scheduleItems[1].startDate,
           endDate: scheduleItems[1].endDate,
-          length: scheduleItems[1].length,
+          length: scheduleItems[1].length + 1,
           label: labelForScheduleItem(scheduleItems[1]),
           type: scheduleItems[1].type,
         },
         {
           startDate: scheduleItems[2].startDate,
           endDate: scheduleItems[2].endDate,
-          length: scheduleItems[2].length,
+          length: scheduleItems[2].length + 1,
           label: labelForScheduleItem(scheduleItems[2]),
           type: scheduleItems[2].type,
         },
@@ -203,13 +203,33 @@ describe('calendarUtils', () => {
 
     it('changes the start dates to today if any start dates are before the start date', () => {
       const startDate = new Date()
-      const scheduleItems = [bedOccupancyEntryUiFactory.build({ startDate: subDays(startDate, 2) })]
+      const scheduleItems = [
+        bedOccupancyEntryUiFactory.build({ startDate: subDays(startDate, 2), endDate: addDays(startDate, 5) }),
+      ]
 
       expect(scheduleForCalendar(scheduleItems, startDate)).toEqual([
         {
           startDate,
           endDate: scheduleItems[0].endDate,
-          length: scheduleItems[0].length,
+          length: 6,
+          label: labelForScheduleItem(scheduleItems[0]),
+          type: scheduleItems[0].type,
+        },
+      ])
+    })
+
+    it('changes the end dates to the end of the calendar if any end dates are after 30 days after the start date', () => {
+      const startDate = new Date()
+      const endDate = addDays(startDate, 30)
+      const scheduleItems = [
+        bedOccupancyEntryUiFactory.build({ startDate: addDays(startDate, 10), endDate: addDays(endDate, 2) }),
+      ]
+
+      expect(scheduleForCalendar(scheduleItems, startDate)).toEqual([
+        {
+          startDate: scheduleItems[0].startDate,
+          endDate: addDays(startDate, 30),
+          length: differenceInDays(endDate, scheduleItems[0].startDate) + 1,
           label: labelForScheduleItem(scheduleItems[0]),
           type: scheduleItems[0].type,
         },

--- a/server/utils/calendarUtils.test.ts
+++ b/server/utils/calendarUtils.test.ts
@@ -8,15 +8,23 @@ import {
 import {
   bedRow,
   bedRows,
+  bodyClass,
   bookingCellContent,
   calendar,
+  calendarTableClass,
   cell,
   dateRow,
   formatDaysForDateRow,
   generateDays,
   generateRowCells,
+  headClass,
+  headerClass,
   monthRow,
   occupierName,
+  roomHeaderClass,
+  rowClass,
+  scheduleForCalendar,
+  tableClass,
   wrapCellContentInTableCellMarkup,
 } from './calendarUtils'
 import {} from '../testutils/factories/bedOccupancyRange'
@@ -28,10 +36,10 @@ describe('calendarUtils', () => {
       const startDate = new Date()
 
       expect(calendar(bedOccupancyRangeList, startDate)).toMatchStringIgnoringWhitespace(
-        `<table cellspacing="0">
-        <thead>${dateRow()}</thead>
-        <tr>${monthRow(startDate)}</tr>
-        <tbody>${bedRows(bedOccupancyRangeList)}</tbody>
+        `<table class="${calendarTableClass}" cellspacing="0">
+        <thead class="${headClass}">${dateRow()}</thead>
+        <tr class="${rowClass}">${monthRow(startDate)}</tr>
+        <tbody class="${bodyClass}">${bedRows(bedOccupancyRangeList)}</tbody>
       </table>`,
       )
     })
@@ -39,7 +47,7 @@ describe('calendarUtils', () => {
 
   describe('dateRow', () => {
     it('should return dateRow', () => {
-      expect(dateRow()).toMatchStringIgnoringWhitespace(`<th>Room/Bed</th>
+      expect(dateRow()).toMatchStringIgnoringWhitespace(`<th class="${roomHeaderClass}">Room/Bed</th>
       ${formatDaysForDateRow(new Date())}`)
     })
   })
@@ -48,7 +56,9 @@ describe('calendarUtils', () => {
     it('should return cells for each month in the date range that span all the dates of that month prefixed by an empty cell', () => {
       const startDate = new Date(2023, 5, 1)
       const colspan = getDaysInMonth(startDate)
-      expect(monthRow(startDate)).toBe(`<td></td><th colspan="${colspan}">June</th>`)
+      expect(monthRow(startDate)).toBe(
+        `<td class="${cellClass}"></td><th colspan="${colspan}" class="${cellClass} ${tableClass}__cell--month">June</th>`,
+      )
     })
   })
 
@@ -104,8 +114,8 @@ describe('calendarUtils', () => {
     it('returns the markup for a row and calls generateRowCells', () => {
       const bedOccupancyRange = bedOccupancyRangeFactoryUi.build()
       expect(bedRow(bedOccupancyRange)).toMatchStringIgnoringWhitespace(
-        `<tr>
-        <th scope="row">${bedOccupancyRange.bedName}</th>
+        `<tr class="${rowClass}">
+        <th scope="row" class="${headerClass}">${bedOccupancyRange.bedName}</th>
         ${generateRowCells(bedOccupancyRange)}</tr>`,
       )
     })
@@ -134,7 +144,11 @@ describe('calendarUtils', () => {
       const openBedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'open', startDate: new Date() })
 
       expect(cell(new Date(), openBedOccupancyEntry)).toMatchStringIgnoringWhitespace(
-        wrapCellContentInTableCellMarkup(openBedOccupancyEntry.length, 'open'),
+        wrapCellContentInTableCellMarkup(
+          openBedOccupancyEntry.length,
+          '<span class="govuk-visually-hidden">open</span>',
+          'open',
+        ),
       )
     })
 
@@ -142,7 +156,7 @@ describe('calendarUtils', () => {
       const lostBedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'lost_bed', startDate: new Date() })
 
       expect(cell(new Date(), lostBedOccupancyEntry)).toMatchStringIgnoringWhitespace(
-        wrapCellContentInTableCellMarkup(lostBedOccupancyEntry.length, 'lost'),
+        wrapCellContentInTableCellMarkup(lostBedOccupancyEntry.length, 'lost', 'lost_bed'),
       )
     })
 
@@ -154,7 +168,11 @@ describe('calendarUtils', () => {
       })
 
       expect(cell(new Date(), bookingBedOccupancyEntry)).toEqual(
-        wrapCellContentInTableCellMarkup(bookingBedOccupancyEntry.length, occupierName(bookingBedOccupancyEntry)),
+        wrapCellContentInTableCellMarkup(
+          bookingBedOccupancyEntry.length,
+          occupierName(bookingBedOccupancyEntry),
+          'booking',
+        ),
       )
     })
   })

--- a/server/utils/calendarUtils.test.ts
+++ b/server/utils/calendarUtils.test.ts
@@ -391,12 +391,12 @@ describe('calendarUtils', () => {
     it('returns the occupiers name, length of stay in words and the start and end date if the booking length is more than 10 days', () => {
       const bookingBedOccupancyEntry = bedOccupancyEntryBookingUiFactory.build({
         length: 10,
-        startDate: new Date(2023, 5, 21),
-        endDate: addDays(new Date(), 11),
+        startDate: DateFormats.isoToDateObj('2023-01-01'),
+        endDate: addDays(DateFormats.isoToDateObj('2023-01-01'), 12),
       })
 
       expect(bookingCellContent(bookingBedOccupancyEntry, premisesId)).toBe(
-        `<a href="/premises/some-uuid/bookings/${bookingBedOccupancyEntry.bookingId}" data-cy-bookingId="${bookingBedOccupancyEntry.bookingId}" class="govuk-link govuk-link--booking">${bookingBedOccupancyEntry.personName}</a> (12 days 21/06/2023 - 02/07/2023)`,
+        `<a href="/premises/some-uuid/bookings/${bookingBedOccupancyEntry.bookingId}" data-cy-bookingId="${bookingBedOccupancyEntry.bookingId}" class="govuk-link govuk-link--booking">${bookingBedOccupancyEntry.personName}</a> (12 days 01/01/2023 - 13/01/2023)`,
       )
     })
   })

--- a/server/utils/calendarUtils.test.ts
+++ b/server/utils/calendarUtils.test.ts
@@ -157,7 +157,7 @@ describe('calendarUtils', () => {
     it('if the bedOccupancyEntry.type is lost it returns the markup for a lost bed cell', () => {
       const lostBedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'lost_bed' })
 
-      expect(labelForScheduleItem(lostBedOccupancyEntry)).toEqual('lost')
+      expect(labelForScheduleItem(lostBedOccupancyEntry)).toEqual('Out of Service')
     })
 
     it('if the bedOccupancyEntry.type is booking it returns the markup for a booking cell', () => {

--- a/server/utils/calendarUtils.test.ts
+++ b/server/utils/calendarUtils.test.ts
@@ -22,6 +22,7 @@ import {
   labelForScheduleItem,
   monthRow,
   occupierName,
+  overbookedCellContent,
   roomHeaderClass,
   rowClass,
   scheduleForCalendar,
@@ -142,8 +143,9 @@ describe('calendarUtils', () => {
     it('for each day from generateDays, calls cellText on every entry of the bedOccupancyRange.schedule array', () => {
       const startDate = new Date()
       const bedOccupancyRange = bedOccupancyRangeFactoryUi.build()
+      const bedId = 'some-uuid'
 
-      const schedule = scheduleForCalendar(bedOccupancyRange.schedule, startDate, premisesId)
+      const schedule = scheduleForCalendar(bedOccupancyRange.schedule, startDate, premisesId, bedId)
 
       expect(generateRowCells(bedOccupancyRange, startDate, premisesId)).toMatchStringIgnoringWhitespace(
         `${generateDays(new Date())
@@ -154,10 +156,12 @@ describe('calendarUtils', () => {
   })
 
   describe('labelForScheduleItem', () => {
+    const bedId = 'some-uuid'
+
     it('if the bedOccupancyEntry.type is open it returns the markup for an open cell', () => {
       const openBedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'open' })
 
-      expect(labelForScheduleItem(openBedOccupancyEntry, premisesId)).toEqual(
+      expect(labelForScheduleItem(openBedOccupancyEntry, premisesId, bedId)).toEqual(
         '<span class="govuk-visually-hidden">open</span>',
       )
     })
@@ -165,13 +169,13 @@ describe('calendarUtils', () => {
     it('if the bedOccupancyEntry.type is lost it returns the markup for a lost bed cell', () => {
       const lostBedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'lost_bed' })
 
-      expect(labelForScheduleItem(lostBedOccupancyEntry, premisesId)).toEqual('Out of Service')
+      expect(labelForScheduleItem(lostBedOccupancyEntry, premisesId, bedId)).toEqual('Out of Service')
     })
 
     it('if the bedOccupancyEntry.type is booking it returns the markup for a booking cell', () => {
       const bedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'booking', bookingId: '123' })
 
-      expect(labelForScheduleItem(bedOccupancyEntry, premisesId)).toEqual(
+      expect(labelForScheduleItem(bedOccupancyEntry, premisesId, bedId)).toEqual(
         bookingCellContent(bedOccupancyEntry, premisesId),
       )
     })
@@ -179,11 +183,23 @@ describe('calendarUtils', () => {
     it('if the bedOccupancyEntry.type is booking it returns the markup for an overbooked cell', () => {
       const bedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'overbooking' })
 
-      expect(labelForScheduleItem(bedOccupancyEntry, premisesId)).toEqual('Overbooked')
+      expect(labelForScheduleItem(bedOccupancyEntry, premisesId, bedId)).toEqual(
+        overbookedCellContent(premisesId, bedId),
+      )
+    })
+  })
+
+  describe('overbookedCellContent', () => {
+    it('returns a link to the bed', () => {
+      expect(overbookedCellContent('premises-uuid', 'bed-uuid')).toEqual(
+        '<a href="/premises/premises-uuid/beds/bed-uuid" data-cy-bedId="bed-uuid" class="govuk-link govuk-link--overbooking">Overbooked</a>',
+      )
     })
   })
 
   describe('scheduleForCalendar', () => {
+    const bedId = 'some-uuid'
+
     it('adds labels to all the schedule items', () => {
       const startDate = new Date()
       const scheduleItems = [
@@ -192,26 +208,26 @@ describe('calendarUtils', () => {
         bedOccupancyEntryUiFactory.build({ type: 'booking', bookingId: '123' }),
       ]
 
-      expect(scheduleForCalendar(scheduleItems, startDate, premisesId)).toEqual([
+      expect(scheduleForCalendar(scheduleItems, startDate, premisesId, bedId)).toEqual([
         {
           startDate: scheduleItems[0].startDate,
           endDate: scheduleItems[0].endDate,
           length: scheduleItems[0].length + 1,
-          label: labelForScheduleItem(scheduleItems[0], premisesId),
+          label: labelForScheduleItem(scheduleItems[0], premisesId, bedId),
           type: scheduleItems[0].type,
         },
         {
           startDate: scheduleItems[1].startDate,
           endDate: scheduleItems[1].endDate,
           length: scheduleItems[1].length + 1,
-          label: labelForScheduleItem(scheduleItems[1], premisesId),
+          label: labelForScheduleItem(scheduleItems[1], premisesId, bedId),
           type: scheduleItems[1].type,
         },
         {
           startDate: scheduleItems[2].startDate,
           endDate: scheduleItems[2].endDate,
           length: scheduleItems[2].length + 1,
-          label: labelForScheduleItem(scheduleItems[2], premisesId),
+          label: labelForScheduleItem(scheduleItems[2], premisesId, bedId),
           bookingId: '123',
           type: scheduleItems[2].type,
         },
@@ -229,12 +245,12 @@ describe('calendarUtils', () => {
         }),
       ]
 
-      expect(scheduleForCalendar(scheduleItems, startDate, premisesId)).toEqual([
+      expect(scheduleForCalendar(scheduleItems, startDate, premisesId, bedId)).toEqual([
         {
           startDate,
           endDate: scheduleItems[0].endDate,
           length: 6,
-          label: labelForScheduleItem(scheduleItems[0], premisesId),
+          label: labelForScheduleItem(scheduleItems[0], premisesId, bedId),
           type: scheduleItems[0].type,
           bookingId: '123',
         },
@@ -253,12 +269,12 @@ describe('calendarUtils', () => {
         }),
       ]
 
-      expect(scheduleForCalendar(scheduleItems, startDate, premisesId)).toEqual([
+      expect(scheduleForCalendar(scheduleItems, startDate, premisesId, bedId)).toEqual([
         {
           startDate: scheduleItems[0].startDate,
           endDate: addDays(startDate, 30),
           length: differenceInDays(endDate, scheduleItems[0].startDate) + 1,
-          label: labelForScheduleItem(scheduleItems[0], premisesId),
+          label: labelForScheduleItem(scheduleItems[0], premisesId, bedId),
           type: scheduleItems[0].type,
           bookingId: '123',
         },

--- a/server/utils/calendarUtils.test.ts
+++ b/server/utils/calendarUtils.test.ts
@@ -1,4 +1,4 @@
-import { addDays, getDaysInMonth } from 'date-fns'
+import { addDays, getDaysInMonth, subDays } from 'date-fns'
 import {
   bedOccupancyEntryBookingUiFactory,
   bedOccupancyEntryUiFactory,
@@ -19,6 +19,7 @@ import {
   generateRowCells,
   headClass,
   headerClass,
+  labelForScheduleItem,
   monthRow,
   occupierName,
   roomHeaderClass,
@@ -27,7 +28,7 @@ import {
   tableClass,
   wrapCellContentInTableCellMarkup,
 } from './calendarUtils'
-import {} from '../testutils/factories/bedOccupancyRange'
+import { bedOccupancyEntryCalendarFactory } from '../testutils/factories/bedOccupancyRange'
 
 describe('calendarUtils', () => {
   describe('calendar', () => {
@@ -39,7 +40,7 @@ describe('calendarUtils', () => {
         `<table class="${calendarTableClass}" cellspacing="0">
         <thead class="${headClass}">${dateRow()}</thead>
         <tr class="${rowClass}">${monthRow(startDate)}</tr>
-        <tbody class="${bodyClass}">${bedRows(bedOccupancyRangeList)}</tbody>
+        <tbody class="${bodyClass}">${bedRows(bedOccupancyRangeList, startDate)}</tbody>
       </table>`,
       )
     })
@@ -103,76 +104,125 @@ describe('calendarUtils', () => {
 
   describe('bedRows', () => {
     it('calls bedRow func for each item in the param array', () => {
+      const startDate = new Date()
       const bedOccupancyRangeList = bedOccupancyRangeFactoryUi.buildList(2)
-      expect(bedRows(bedOccupancyRangeList)).toMatchStringIgnoringWhitespace(
-        `${bedRow(bedOccupancyRangeList[0])}${bedRow(bedOccupancyRangeList[1])}`,
+
+      expect(bedRows(bedOccupancyRangeList, startDate)).toMatchStringIgnoringWhitespace(
+        `${bedRow(bedOccupancyRangeList[0], startDate)}${bedRow(bedOccupancyRangeList[1], startDate)}`,
       )
     })
   })
 
   describe('bedRow', () => {
     it('returns the markup for a row and calls generateRowCells', () => {
+      const startDate = new Date()
       const bedOccupancyRange = bedOccupancyRangeFactoryUi.build()
-      expect(bedRow(bedOccupancyRange)).toMatchStringIgnoringWhitespace(
+
+      expect(bedRow(bedOccupancyRange, startDate)).toMatchStringIgnoringWhitespace(
         `<tr class="${rowClass}">
         <th scope="row" class="${headerClass}">${bedOccupancyRange.bedName}</th>
-        ${generateRowCells(bedOccupancyRange)}</tr>`,
+        ${generateRowCells(bedOccupancyRange, startDate)}</tr>`,
       )
     })
   })
 
   describe('generateRowCells', () => {
     it('for each day from generateDays, calls cellText on every entry of the bedOccupancyRange.schedule array', () => {
+      const startDate = new Date()
       const bedOccupancyRange = bedOccupancyRangeFactoryUi.build()
 
-      expect(generateRowCells(bedOccupancyRange)).toMatchStringIgnoringWhitespace(
+      const schedule = scheduleForCalendar(bedOccupancyRange.schedule, startDate)
+
+      expect(generateRowCells(bedOccupancyRange, startDate)).toMatchStringIgnoringWhitespace(
         `${generateDays(new Date())
-          .map(day => bedOccupancyRange.schedule.map(entry => cell(day, entry)).join(''))
+          .map(day => schedule.map(entry => cell(day, entry)).join(''))
           .join('')}`,
       )
     })
   })
 
+  describe('labelForScheduleItem', () => {
+    it('if the bedOccupancyEntry.type is open it returns the markup for an open cell', () => {
+      const openBedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'open' })
+
+      expect(labelForScheduleItem(openBedOccupancyEntry)).toEqual('<span class="govuk-visually-hidden">open</span>')
+    })
+
+    it('if the bedOccupancyEntry.type is lost it returns the markup for a lost bed cell', () => {
+      const lostBedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'lost_bed' })
+
+      expect(labelForScheduleItem(lostBedOccupancyEntry)).toEqual('lost')
+    })
+
+    it('if the bedOccupancyEntry.type is booking it returns the markup for a booking cell', () => {
+      const bedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'booking' })
+
+      expect(labelForScheduleItem(bedOccupancyEntry)).toEqual(bookingCellContent(bedOccupancyEntry))
+    })
+  })
+
+  describe('scheduleForCalendar', () => {
+    it('adds labels to all the schedule items', () => {
+      const startDate = new Date()
+      const scheduleItems = [
+        bedOccupancyEntryUiFactory.build({ type: 'open' }),
+        bedOccupancyEntryUiFactory.build({ type: 'lost_bed' }),
+        bedOccupancyEntryUiFactory.build({ type: 'booking' }),
+      ]
+
+      expect(scheduleForCalendar(scheduleItems, startDate)).toEqual([
+        {
+          startDate: scheduleItems[0].startDate,
+          endDate: scheduleItems[0].endDate,
+          length: scheduleItems[0].length,
+          label: labelForScheduleItem(scheduleItems[0]),
+          type: scheduleItems[0].type,
+        },
+        {
+          startDate: scheduleItems[1].startDate,
+          endDate: scheduleItems[1].endDate,
+          length: scheduleItems[1].length,
+          label: labelForScheduleItem(scheduleItems[1]),
+          type: scheduleItems[1].type,
+        },
+        {
+          startDate: scheduleItems[2].startDate,
+          endDate: scheduleItems[2].endDate,
+          length: scheduleItems[2].length,
+          label: labelForScheduleItem(scheduleItems[2]),
+          type: scheduleItems[2].type,
+        },
+      ])
+    })
+
+    it('changes the start dates to today if any start dates are before the start date', () => {
+      const startDate = new Date()
+      const scheduleItems = [bedOccupancyEntryUiFactory.build({ startDate: subDays(startDate, 2) })]
+
+      expect(scheduleForCalendar(scheduleItems, startDate)).toEqual([
+        {
+          startDate,
+          endDate: scheduleItems[0].endDate,
+          length: scheduleItems[0].length,
+          label: labelForScheduleItem(scheduleItems[0]),
+          type: scheduleItems[0].type,
+        },
+      ])
+    })
+  })
+
   describe('cell', () => {
     it('the start date is not the same as the cell date it returns an empty string', () => {
-      const bedOccupancyEntry = bedOccupancyEntryUiFactory.build({ startDate: addDays(new Date(), 1) })
+      const bedOccupancyEntry = bedOccupancyEntryCalendarFactory.build({ startDate: addDays(new Date(), 1) })
 
       expect(cell(new Date(), bedOccupancyEntry)).toEqual('')
     })
 
-    it('if the bedOccupancyEntry.type is open and the start date is the same as the cell date it returns the markup for an open cell', () => {
-      const openBedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'open', startDate: new Date() })
+    it('if the start date is the same as the cell date it returns the markup for a cell', () => {
+      const bedOccupancyEntry = bedOccupancyEntryCalendarFactory.build({ startDate: new Date() })
 
-      expect(cell(new Date(), openBedOccupancyEntry)).toMatchStringIgnoringWhitespace(
-        wrapCellContentInTableCellMarkup(
-          openBedOccupancyEntry.length,
-          '<span class="govuk-visually-hidden">open</span>',
-          'open',
-        ),
-      )
-    })
-
-    it('if the bedOccupancyEntry.type is lost it returns the markup for a lost bed cell', () => {
-      const lostBedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'lost_bed', startDate: new Date() })
-
-      expect(cell(new Date(), lostBedOccupancyEntry)).toMatchStringIgnoringWhitespace(
-        wrapCellContentInTableCellMarkup(lostBedOccupancyEntry.length, 'lost', 'lost_bed'),
-      )
-    })
-
-    it('if the bedOccupancyEntry.type is booking and the start date is the same as the cell date it returns the markup for a booked bed cell', () => {
-      const bookingBedOccupancyEntry = bedOccupancyEntryBookingUiFactory.build({
-        type: 'booking',
-        startDate: new Date(),
-        length: 1,
-      })
-
-      expect(cell(new Date(), bookingBedOccupancyEntry)).toEqual(
-        wrapCellContentInTableCellMarkup(
-          bookingBedOccupancyEntry.length,
-          occupierName(bookingBedOccupancyEntry),
-          'booking',
-        ),
+      expect(cell(new Date(), bedOccupancyEntry)).toMatchStringIgnoringWhitespace(
+        wrapCellContentInTableCellMarkup(bedOccupancyEntry.length, bedOccupancyEntry.label, bedOccupancyEntry.type),
       )
     })
   })

--- a/server/utils/calendarUtils.test.ts
+++ b/server/utils/calendarUtils.test.ts
@@ -37,19 +37,25 @@ describe('calendarUtils', () => {
       const startDate = new Date()
 
       expect(calendar(bedOccupancyRangeList, startDate)).toMatchStringIgnoringWhitespace(
-        `<table class="${calendarTableClass}" cellspacing="0">
-        <thead class="${headClass}">${dateRow()}</thead>
-        <tr class="${rowClass}">${monthRow(startDate)}</tr>
-        <tbody class="${bodyClass}">${bedRows(bedOccupancyRangeList, startDate)}</tbody>
-      </table>`,
+        `
+        <table class="${calendarTableClass}" cellspacing="0">
+          <thead class="${headClass}">
+            <tr class="${rowClass} ${tableClass}__row--months">${monthRow(startDate)}</tr>
+            ${dateRow()}
+          </thead>
+          <tbody class="${bodyClass}">${bedRows(bedOccupancyRangeList, startDate)}</tbody>
+        </table>
+      `,
       )
     })
   })
 
   describe('dateRow', () => {
     it('should return dateRow', () => {
-      expect(dateRow()).toMatchStringIgnoringWhitespace(`<th class="${roomHeaderClass}">Room/Bed</th>
-      ${formatDaysForDateRow(new Date())}`)
+      expect(dateRow()).toMatchStringIgnoringWhitespace(`
+          <tr class="${rowClass}">
+            ${formatDaysForDateRow(new Date())}
+          </tr>`)
     })
   })
 
@@ -58,7 +64,7 @@ describe('calendarUtils', () => {
       const startDate = new Date(2023, 5, 1)
       const colspan = getDaysInMonth(startDate)
       expect(monthRow(startDate)).toBe(
-        `<td class="${cellClass}"></td><th colspan="${colspan}" class="${cellClass} ${tableClass}__cell--month">June</th>`,
+        `<th class="${roomHeaderClass}" rowspan="2">Room/Bed</th><th colspan="${colspan}" class="${headerClass} ${tableClass}__head--month">June</th>`,
       )
     })
   })

--- a/server/utils/calendarUtils.test.ts
+++ b/server/utils/calendarUtils.test.ts
@@ -31,19 +31,21 @@ import {
 import { bedOccupancyEntryCalendarFactory } from '../testutils/factories/bedOccupancyRange'
 
 describe('calendarUtils', () => {
+  const premisesId = 'some-uuid'
+
   describe('calendar', () => {
     it('should return calendar', () => {
       const bedOccupancyRangeList = bedOccupancyRangeFactoryUi.buildList(1)
       const startDate = new Date()
 
-      expect(calendar(bedOccupancyRangeList, startDate)).toMatchStringIgnoringWhitespace(
+      expect(calendar(bedOccupancyRangeList, startDate, premisesId)).toMatchStringIgnoringWhitespace(
         `
         <table class="${calendarTableClass}" cellspacing="0">
           <thead class="${headClass}">
             <tr class="${rowClass} ${tableClass}__row--months">${monthRow(startDate)}</tr>
             ${dateRow()}
           </thead>
-          <tbody class="${bodyClass}">${bedRows(bedOccupancyRangeList, startDate)}</tbody>
+          <tbody class="${bodyClass}">${bedRows(bedOccupancyRangeList, startDate, premisesId)}</tbody>
         </table>
       `,
       )
@@ -113,8 +115,12 @@ describe('calendarUtils', () => {
       const startDate = new Date()
       const bedOccupancyRangeList = bedOccupancyRangeFactoryUi.buildList(2)
 
-      expect(bedRows(bedOccupancyRangeList, startDate)).toMatchStringIgnoringWhitespace(
-        `${bedRow(bedOccupancyRangeList[0], startDate)}${bedRow(bedOccupancyRangeList[1], startDate)}`,
+      expect(bedRows(bedOccupancyRangeList, startDate, premisesId)).toMatchStringIgnoringWhitespace(
+        `${bedRow(bedOccupancyRangeList[0], startDate, premisesId)}${bedRow(
+          bedOccupancyRangeList[1],
+          startDate,
+          premisesId,
+        )}`,
       )
     })
   })
@@ -124,10 +130,10 @@ describe('calendarUtils', () => {
       const startDate = new Date()
       const bedOccupancyRange = bedOccupancyRangeFactoryUi.build()
 
-      expect(bedRow(bedOccupancyRange, startDate)).toMatchStringIgnoringWhitespace(
+      expect(bedRow(bedOccupancyRange, startDate, premisesId)).toMatchStringIgnoringWhitespace(
         `<tr class="${rowClass}">
         <th scope="row" class="${headerClass}">${bedOccupancyRange.bedName}</th>
-        ${generateRowCells(bedOccupancyRange, startDate)}</tr>`,
+        ${generateRowCells(bedOccupancyRange, startDate, premisesId)}</tr>`,
       )
     })
   })
@@ -137,9 +143,9 @@ describe('calendarUtils', () => {
       const startDate = new Date()
       const bedOccupancyRange = bedOccupancyRangeFactoryUi.build()
 
-      const schedule = scheduleForCalendar(bedOccupancyRange.schedule, startDate)
+      const schedule = scheduleForCalendar(bedOccupancyRange.schedule, startDate, premisesId)
 
-      expect(generateRowCells(bedOccupancyRange, startDate)).toMatchStringIgnoringWhitespace(
+      expect(generateRowCells(bedOccupancyRange, startDate, premisesId)).toMatchStringIgnoringWhitespace(
         `${generateDays(new Date())
           .map(day => schedule.map(entry => cell(day, entry)).join(''))
           .join('')}`,
@@ -151,25 +157,29 @@ describe('calendarUtils', () => {
     it('if the bedOccupancyEntry.type is open it returns the markup for an open cell', () => {
       const openBedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'open' })
 
-      expect(labelForScheduleItem(openBedOccupancyEntry)).toEqual('<span class="govuk-visually-hidden">open</span>')
+      expect(labelForScheduleItem(openBedOccupancyEntry, premisesId)).toEqual(
+        '<span class="govuk-visually-hidden">open</span>',
+      )
     })
 
     it('if the bedOccupancyEntry.type is lost it returns the markup for a lost bed cell', () => {
       const lostBedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'lost_bed' })
 
-      expect(labelForScheduleItem(lostBedOccupancyEntry)).toEqual('Out of Service')
+      expect(labelForScheduleItem(lostBedOccupancyEntry, premisesId)).toEqual('Out of Service')
     })
 
     it('if the bedOccupancyEntry.type is booking it returns the markup for a booking cell', () => {
-      const bedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'booking' })
+      const bedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'booking', bookingId: '123' })
 
-      expect(labelForScheduleItem(bedOccupancyEntry)).toEqual(bookingCellContent(bedOccupancyEntry))
+      expect(labelForScheduleItem(bedOccupancyEntry, premisesId)).toEqual(
+        bookingCellContent(bedOccupancyEntry, premisesId),
+      )
     })
 
     it('if the bedOccupancyEntry.type is booking it returns the markup for an overbooked cell', () => {
       const bedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'overbooking' })
 
-      expect(labelForScheduleItem(bedOccupancyEntry)).toEqual('Overbooked')
+      expect(labelForScheduleItem(bedOccupancyEntry, premisesId)).toEqual('Overbooked')
     })
   })
 
@@ -179,29 +189,30 @@ describe('calendarUtils', () => {
       const scheduleItems = [
         bedOccupancyEntryUiFactory.build({ type: 'open' }),
         bedOccupancyEntryUiFactory.build({ type: 'lost_bed' }),
-        bedOccupancyEntryUiFactory.build({ type: 'booking' }),
+        bedOccupancyEntryUiFactory.build({ type: 'booking', bookingId: '123' }),
       ]
 
-      expect(scheduleForCalendar(scheduleItems, startDate)).toEqual([
+      expect(scheduleForCalendar(scheduleItems, startDate, premisesId)).toEqual([
         {
           startDate: scheduleItems[0].startDate,
           endDate: scheduleItems[0].endDate,
           length: scheduleItems[0].length + 1,
-          label: labelForScheduleItem(scheduleItems[0]),
+          label: labelForScheduleItem(scheduleItems[0], premisesId),
           type: scheduleItems[0].type,
         },
         {
           startDate: scheduleItems[1].startDate,
           endDate: scheduleItems[1].endDate,
           length: scheduleItems[1].length + 1,
-          label: labelForScheduleItem(scheduleItems[1]),
+          label: labelForScheduleItem(scheduleItems[1], premisesId),
           type: scheduleItems[1].type,
         },
         {
           startDate: scheduleItems[2].startDate,
           endDate: scheduleItems[2].endDate,
           length: scheduleItems[2].length + 1,
-          label: labelForScheduleItem(scheduleItems[2]),
+          label: labelForScheduleItem(scheduleItems[2], premisesId),
+          bookingId: '123',
           type: scheduleItems[2].type,
         },
       ])
@@ -210,16 +221,22 @@ describe('calendarUtils', () => {
     it('changes the start dates to today if any start dates are before the start date', () => {
       const startDate = new Date()
       const scheduleItems = [
-        bedOccupancyEntryUiFactory.build({ startDate: subDays(startDate, 2), endDate: addDays(startDate, 5) }),
+        bedOccupancyEntryUiFactory.build({
+          startDate: subDays(startDate, 2),
+          endDate: addDays(startDate, 5),
+          type: 'booking',
+          bookingId: '123',
+        }),
       ]
 
-      expect(scheduleForCalendar(scheduleItems, startDate)).toEqual([
+      expect(scheduleForCalendar(scheduleItems, startDate, premisesId)).toEqual([
         {
           startDate,
           endDate: scheduleItems[0].endDate,
           length: 6,
-          label: labelForScheduleItem(scheduleItems[0]),
+          label: labelForScheduleItem(scheduleItems[0], premisesId),
           type: scheduleItems[0].type,
+          bookingId: '123',
         },
       ])
     })
@@ -228,16 +245,22 @@ describe('calendarUtils', () => {
       const startDate = new Date()
       const endDate = addDays(startDate, 30)
       const scheduleItems = [
-        bedOccupancyEntryUiFactory.build({ startDate: addDays(startDate, 10), endDate: addDays(endDate, 2) }),
+        bedOccupancyEntryUiFactory.build({
+          startDate: addDays(startDate, 10),
+          endDate: addDays(endDate, 2),
+          type: 'booking',
+          bookingId: '123',
+        }),
       ]
 
-      expect(scheduleForCalendar(scheduleItems, startDate)).toEqual([
+      expect(scheduleForCalendar(scheduleItems, startDate, premisesId)).toEqual([
         {
           startDate: scheduleItems[0].startDate,
           endDate: addDays(startDate, 30),
           length: differenceInDays(endDate, scheduleItems[0].startDate) + 1,
-          label: labelForScheduleItem(scheduleItems[0]),
+          label: labelForScheduleItem(scheduleItems[0], premisesId),
           type: scheduleItems[0].type,
+          bookingId: '123',
         },
       ])
     })
@@ -261,9 +284,11 @@ describe('calendarUtils', () => {
 
   describe('occupierName', () => {
     it('returns the markup for a booked bed cell', () => {
-      const bookedBedOccupancyEntry = bedOccupancyEntryBookingUiFactory.build()
+      const bookedBedOccupancyEntry = bedOccupancyEntryBookingUiFactory.build({ bookingId: '123' })
 
-      expect(occupierName(bookedBedOccupancyEntry)).toBe(bookedBedOccupancyEntry.personName)
+      expect(occupierName(bookedBedOccupancyEntry, premisesId)).toBe(
+        `<a href="/premises/some-uuid/bookings/123" data-cy-bookingId="123" class="govuk-link govuk-link--booking">${bookedBedOccupancyEntry.personName}</a>`,
+      )
     })
   })
 
@@ -275,7 +300,9 @@ describe('calendarUtils', () => {
         endDate: addDays(new Date(), 4),
       })
 
-      expect(bookingCellContent(bookingBedOccupancyEntry)).toBe(bookingBedOccupancyEntry.personName)
+      expect(bookingCellContent(bookingBedOccupancyEntry, premisesId)).toBe(
+        `<a href="/premises/some-uuid/bookings/${bookingBedOccupancyEntry.bookingId}" data-cy-bookingId="${bookingBedOccupancyEntry.bookingId}" class="govuk-link govuk-link--booking">${bookingBedOccupancyEntry.personName}</a>`,
+      )
     })
 
     it('returns the occupiers name and length of stay in words if the booking length is 5 or more days and less than 10 days', () => {
@@ -285,7 +312,9 @@ describe('calendarUtils', () => {
         endDate: addDays(new Date(), 5),
       })
 
-      expect(bookingCellContent(bookingBedOccupancyEntry)).toBe(`${bookingBedOccupancyEntry.personName} (5 days)`)
+      expect(bookingCellContent(bookingBedOccupancyEntry, premisesId)).toBe(
+        `<a href="/premises/some-uuid/bookings/${bookingBedOccupancyEntry.bookingId}" data-cy-bookingId="${bookingBedOccupancyEntry.bookingId}" class="govuk-link govuk-link--booking">${bookingBedOccupancyEntry.personName}</a> (5 days)`,
+      )
     })
 
     it('returns the occupiers name, length of stay in words and the start and end date if the booking length is more than 10 days', () => {
@@ -295,8 +324,8 @@ describe('calendarUtils', () => {
         endDate: addDays(new Date(), 11),
       })
 
-      expect(bookingCellContent(bookingBedOccupancyEntry)).toBe(
-        `${bookingBedOccupancyEntry.personName} (11 days 21/06/2023 - 01/07/2023)`,
+      expect(bookingCellContent(bookingBedOccupancyEntry, premisesId)).toBe(
+        `<a href="/premises/some-uuid/bookings/${bookingBedOccupancyEntry.bookingId}" data-cy-bookingId="${bookingBedOccupancyEntry.bookingId}" class="govuk-link govuk-link--booking">${bookingBedOccupancyEntry.personName}</a> (12 days 21/06/2023 - 02/07/2023)`,
       )
     })
   })

--- a/server/utils/calendarUtils.test.ts
+++ b/server/utils/calendarUtils.test.ts
@@ -1,12 +1,32 @@
-import { calendar, dateRow, formatDaysForDateRow, generateDays } from './calendarUtils'
+import { addDays } from 'date-fns'
+import {
+  bedOccupancyEntryBookingUiFactory,
+  bedOccupancyEntryUiFactory,
+  bedOccupancyRangeFactoryUi,
+} from '../testutils/factories'
+
+import {
+  bedRow,
+  bedRows,
+  calendar,
+  cell,
+  dateRow,
+  formatDaysForDateRow,
+  generateDays,
+  generateRowCells,
+  occupierName,
+  wrapCellContentInTableCellMarkup,
+} from './calendarUtils'
 import {} from '../testutils/factories/bedOccupancyRange'
 
 describe('calendarUtils', () => {
   describe('calendar', () => {
     it('should return calendar', () => {
-      expect(calendar()).toMatchStringIgnoringWhitespace(
+      const bedOccupancyRangeList = bedOccupancyRangeFactoryUi.buildList(1)
+      expect(calendar(bedOccupancyRangeList)).toMatchStringIgnoringWhitespace(
         `<table cellspacing="0">
         <thead>${dateRow()}</thead>
+        <tbody>${bedRows(bedOccupancyRangeList)}</tbody>
       </table>`,
       )
     })
@@ -55,6 +75,82 @@ describe('calendarUtils', () => {
         new Date(2023, 6, 12),
         new Date(2023, 6, 13),
       ])
+    })
+  })
+
+  describe('bedRows', () => {
+    it('calls bedRow func for each item in the param array', () => {
+      const bedOccupancyRangeList = bedOccupancyRangeFactoryUi.buildList(2)
+      expect(bedRows(bedOccupancyRangeList)).toMatchStringIgnoringWhitespace(
+        `${bedRow(bedOccupancyRangeList[0])}${bedRow(bedOccupancyRangeList[1])}`,
+      )
+    })
+  })
+
+  describe('bedRow', () => {
+    it('returns the markup for a row and calls generateRowCells', () => {
+      const bedOccupancyRange = bedOccupancyRangeFactoryUi.build()
+      expect(bedRow(bedOccupancyRange)).toMatchStringIgnoringWhitespace(
+        `<tr>
+        <th scope="row">${bedOccupancyRange.bedName}</th>
+        ${generateRowCells(bedOccupancyRange)}</tr>`,
+      )
+    })
+  })
+
+  describe('generateRowCells', () => {
+    it('for each day from generateDays, calls cellText on every entry of the bedOccupancyRange.schedule array', () => {
+      const bedOccupancyRange = bedOccupancyRangeFactoryUi.build()
+
+      expect(generateRowCells(bedOccupancyRange)).toMatchStringIgnoringWhitespace(
+        `${generateDays(new Date())
+          .map(day => bedOccupancyRange.schedule.map(entry => cell(day, entry)).join(''))
+          .join('')}`,
+      )
+    })
+  })
+
+  describe('cell', () => {
+    it('the start date is not the same as the cell date it returns an empty string', () => {
+      const bedOccupancyEntry = bedOccupancyEntryUiFactory.build({ startDate: addDays(new Date(), 1) })
+
+      expect(cell(new Date(), bedOccupancyEntry)).toEqual('')
+    })
+
+    it('if the bedOccupancyEntry.type is open and the start date is the same as the cell date it returns the markup for an open cell', () => {
+      const openBedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'open', startDate: new Date() })
+
+      expect(cell(new Date(), openBedOccupancyEntry)).toMatchStringIgnoringWhitespace(
+        wrapCellContentInTableCellMarkup(openBedOccupancyEntry.length, 'open'),
+      )
+    })
+
+    it('if the bedOccupancyEntry.type is lost it returns the markup for a lost bed cell', () => {
+      const lostBedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'lost_bed', startDate: new Date() })
+
+      expect(cell(new Date(), lostBedOccupancyEntry)).toMatchStringIgnoringWhitespace(
+        wrapCellContentInTableCellMarkup(lostBedOccupancyEntry.length, 'lost'),
+      )
+    })
+
+    it('if the bedOccupancyEntry.type is booking and the start date is the same as the cell date it returns the markup for a booked bed cell', () => {
+      const bookingBedOccupancyEntry = bedOccupancyEntryBookingUiFactory.build({
+        type: 'booking',
+        startDate: new Date(),
+        length: 1,
+      })
+
+      expect(cell(new Date(), bookingBedOccupancyEntry)).toEqual(
+        wrapCellContentInTableCellMarkup(bookingBedOccupancyEntry.length, occupierName(bookingBedOccupancyEntry)),
+      )
+    })
+  })
+
+  describe('occupierName', () => {
+    it('returns the markup for a booked bed cell', () => {
+      const bookedBedOccupancyEntry = bedOccupancyEntryBookingUiFactory.build()
+
+      expect(occupierName(bookedBedOccupancyEntry)).toBe(bookedBedOccupancyEntry.personName)
     })
   })
 })

--- a/server/utils/calendarUtils.test.ts
+++ b/server/utils/calendarUtils.test.ts
@@ -1,0 +1,60 @@
+import { calendar, dateRow, formatDaysForDateRow, generateDays } from './calendarUtils'
+import {} from '../testutils/factories/bedOccupancyRange'
+
+describe('calendarUtils', () => {
+  describe('calendar', () => {
+    it('should return calendar', () => {
+      expect(calendar()).toMatchStringIgnoringWhitespace(
+        `<table cellspacing="0">
+        <thead>${dateRow()}</thead>
+      </table>`,
+      )
+    })
+  })
+
+  describe('dateRow', () => {
+    it('should return dateRow', () => {
+      expect(dateRow()).toMatchStringIgnoringWhitespace(`<th>Room/Bed</th>
+      ${formatDaysForDateRow(new Date())}`)
+    })
+  })
+
+  describe('generateDays', () => {
+    it('should return a string of the date for the next 30 days', () => {
+      const days = generateDays(new Date(2023, 5, 14))
+      expect(days).toHaveLength(30)
+      expect(days).toEqual([
+        new Date(2023, 5, 14),
+        new Date(2023, 5, 15),
+        new Date(2023, 5, 16),
+        new Date(2023, 5, 17),
+        new Date(2023, 5, 18),
+        new Date(2023, 5, 19),
+        new Date(2023, 5, 20),
+        new Date(2023, 5, 21),
+        new Date(2023, 5, 22),
+        new Date(2023, 5, 23),
+        new Date(2023, 5, 24),
+        new Date(2023, 5, 25),
+        new Date(2023, 5, 26),
+        new Date(2023, 5, 27),
+        new Date(2023, 5, 28),
+        new Date(2023, 5, 29),
+        new Date(2023, 5, 30),
+        new Date(2023, 6, 1),
+        new Date(2023, 6, 2),
+        new Date(2023, 6, 3),
+        new Date(2023, 6, 4),
+        new Date(2023, 6, 5),
+        new Date(2023, 6, 6),
+        new Date(2023, 6, 7),
+        new Date(2023, 6, 8),
+        new Date(2023, 6, 9),
+        new Date(2023, 6, 10),
+        new Date(2023, 6, 11),
+        new Date(2023, 6, 12),
+        new Date(2023, 6, 13),
+      ])
+    })
+  })
+})

--- a/server/utils/calendarUtils.test.ts
+++ b/server/utils/calendarUtils.test.ts
@@ -1,4 +1,4 @@
-import { addDays } from 'date-fns'
+import { addDays, getDaysInMonth } from 'date-fns'
 import {
   bedOccupancyEntryBookingUiFactory,
   bedOccupancyEntryUiFactory,
@@ -15,6 +15,7 @@ import {
   formatDaysForDateRow,
   generateDays,
   generateRowCells,
+  monthRow,
   occupierName,
   wrapCellContentInTableCellMarkup,
 } from './calendarUtils'
@@ -24,9 +25,12 @@ describe('calendarUtils', () => {
   describe('calendar', () => {
     it('should return calendar', () => {
       const bedOccupancyRangeList = bedOccupancyRangeFactoryUi.buildList(1)
-      expect(calendar(bedOccupancyRangeList)).toMatchStringIgnoringWhitespace(
+      const startDate = new Date()
+
+      expect(calendar(bedOccupancyRangeList, startDate)).toMatchStringIgnoringWhitespace(
         `<table cellspacing="0">
         <thead>${dateRow()}</thead>
+        <tr>${monthRow(startDate)}</tr>
         <tbody>${bedRows(bedOccupancyRangeList)}</tbody>
       </table>`,
       )
@@ -37,6 +41,14 @@ describe('calendarUtils', () => {
     it('should return dateRow', () => {
       expect(dateRow()).toMatchStringIgnoringWhitespace(`<th>Room/Bed</th>
       ${formatDaysForDateRow(new Date())}`)
+    })
+  })
+
+  describe('monthRow', () => {
+    it('should return cells for each month in the date range that span all the dates of that month prefixed by an empty cell', () => {
+      const startDate = new Date(2023, 5, 1)
+      const colspan = getDaysInMonth(startDate)
+      expect(monthRow(startDate)).toBe(`<td></td><th colspan="${colspan}">June</th>`)
     })
   })
 
@@ -184,7 +196,7 @@ describe('calendarUtils', () => {
       })
 
       expect(bookingCellContent(bookingBedOccupancyEntry)).toBe(
-        `${bookingBedOccupancyEntry.personName} (10 days 21/06/2023 - 01/07/2023)`,
+        `${bookingBedOccupancyEntry.personName} (11 days 21/06/2023 - 01/07/2023)`,
       )
     })
   })

--- a/server/utils/calendarUtils.test.ts
+++ b/server/utils/calendarUtils.test.ts
@@ -165,6 +165,12 @@ describe('calendarUtils', () => {
 
       expect(labelForScheduleItem(bedOccupancyEntry)).toEqual(bookingCellContent(bedOccupancyEntry))
     })
+
+    it('if the bedOccupancyEntry.type is booking it returns the markup for an overbooked cell', () => {
+      const bedOccupancyEntry = bedOccupancyEntryUiFactory.build({ type: 'overbooking' })
+
+      expect(labelForScheduleItem(bedOccupancyEntry)).toEqual('Overbooked')
+    })
   })
 
   describe('scheduleForCalendar', () => {

--- a/server/utils/calendarUtils.test.ts
+++ b/server/utils/calendarUtils.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   bedRow,
   bedRows,
+  bookingCellContent,
   calendar,
   cell,
   dateRow,
@@ -151,6 +152,40 @@ describe('calendarUtils', () => {
       const bookedBedOccupancyEntry = bedOccupancyEntryBookingUiFactory.build()
 
       expect(occupierName(bookedBedOccupancyEntry)).toBe(bookedBedOccupancyEntry.personName)
+    })
+  })
+
+  describe('bookingCellContent', () => {
+    it('returns the occupiers name if the booking length is less than 5 days', () => {
+      const bookingBedOccupancyEntry = bedOccupancyEntryBookingUiFactory.build({
+        length: 4,
+        startDate: new Date(),
+        endDate: addDays(new Date(), 4),
+      })
+
+      expect(bookingCellContent(bookingBedOccupancyEntry)).toBe(bookingBedOccupancyEntry.personName)
+    })
+
+    it('returns the occupiers name and length of stay in words if the booking length is 5 or more days and less than 10 days', () => {
+      const bookingBedOccupancyEntry = bedOccupancyEntryBookingUiFactory.build({
+        length: 5,
+        startDate: new Date(),
+        endDate: addDays(new Date(), 5),
+      })
+
+      expect(bookingCellContent(bookingBedOccupancyEntry)).toBe(`${bookingBedOccupancyEntry.personName} (5 days)`)
+    })
+
+    it('returns the occupiers name, length of stay in words and the start and end date if the booking length is more than 10 days', () => {
+      const bookingBedOccupancyEntry = bedOccupancyEntryBookingUiFactory.build({
+        length: 10,
+        startDate: new Date(2023, 5, 21),
+        endDate: addDays(new Date(), 11),
+      })
+
+      expect(bookingCellContent(bookingBedOccupancyEntry)).toBe(
+        `${bookingBedOccupancyEntry.personName} (10 days 21/06/2023 - 01/07/2023)`,
+      )
     })
   })
 })

--- a/server/utils/calendarUtils.test.ts
+++ b/server/utils/calendarUtils.test.ts
@@ -44,7 +44,7 @@ describe('calendarUtils', () => {
         <table class="${calendarTableClass}" cellspacing="0">
           <thead class="${headClass}">
             <tr class="${rowClass} ${tableClass}__row--months">${monthRow(startDate)}</tr>
-            ${dateRow()}
+            ${dateRow(startDate)}
           </thead>
           <tbody class="${bodyClass}">${bedRows(bedOccupancyRangeList, startDate, premisesId)}</tbody>
         </table>
@@ -55,9 +55,11 @@ describe('calendarUtils', () => {
 
   describe('dateRow', () => {
     it('should return dateRow', () => {
-      expect(dateRow()).toMatchStringIgnoringWhitespace(`
+      const startDate = new Date()
+
+      expect(dateRow(startDate)).toMatchStringIgnoringWhitespace(`
           <tr class="${rowClass}">
-            ${formatDaysForDateRow(new Date())}
+            ${formatDaysForDateRow(startDate)}
           </tr>`)
     })
   })

--- a/server/utils/calendarUtils.ts
+++ b/server/utils/calendarUtils.ts
@@ -1,10 +1,11 @@
-import { addDays, formatDistanceStrict, isSameDay } from 'date-fns'
+import { addDays, format, formatDistanceStrict, isSameDay, isSameMonth } from 'date-fns'
 import { DateFormats } from './dateUtils'
 
 import { BedOccupancyEntryUi, BedOccupancyRangeUi } from '../@types/ui'
 
-export const calendar = (bedOccupancyRangeList: Array<BedOccupancyRangeUi>) => `<table cellspacing="0">
+export const calendar = (bedOccupancyRangeList: Array<BedOccupancyRangeUi>, startDate: Date) => `<table cellspacing="0">
   <thead>${dateRow()}</thead>
+  <tr>${monthRow(startDate)}</tr>
   <tbody>${bedRows(bedOccupancyRangeList)}</tbody>
 </table>`
 
@@ -26,6 +27,23 @@ export const generateDays = (date: Date) => {
     days.push(newDate)
   }
   return days
+}
+
+export const monthRow = (startDate: Date) => {
+  const monthRowArr = [`<td></td>`]
+  const days = generateDays(startDate)
+
+  for (let i = 0; i < days.length; i += 1) {
+    if (!isSameMonth(days[i], days[i - 1]) || i === 0) {
+      const month = format(days[i], 'MMMM')
+
+      const colspan = days.slice(i).filter(d => isSameMonth(d, days[i])).length
+
+      monthRowArr.push(`<th colspan="${colspan}">${month}</th>`)
+    }
+  }
+
+  return monthRowArr.join('')
 }
 
 export const bedRows = (bedOccupancyRangeList: Array<BedOccupancyRangeUi>) => {

--- a/server/utils/calendarUtils.ts
+++ b/server/utils/calendarUtils.ts
@@ -93,6 +93,8 @@ export const labelForScheduleItem = (bedOccupancyEntry: BedOccupancyEntryUi): st
       return '<span class="govuk-visually-hidden">open</span>'
     case 'lost_bed':
       return 'Out of Service'
+    case 'overbooking':
+      return 'Overbooked'
     default:
       return ''
   }

--- a/server/utils/calendarUtils.ts
+++ b/server/utils/calendarUtils.ts
@@ -11,12 +11,7 @@ import {
 import paths from '../paths/manage'
 import { DateFormats } from './dateUtils'
 
-import {
-  BedOccupancyEntryCalendar,
-  BedOccupancyEntryUi,
-  BedOccupancyEntryUiType,
-  BedOccupancyRangeUi,
-} from '../@types/ui'
+import { BedOccupancyEntryCalendar, BedOccupancyEntryUi, BedOccupancyRangeUi } from '../@types/ui'
 import { linkTo } from './utils'
 
 export const tableClass = 'govuk-table'
@@ -83,7 +78,7 @@ export const bedRows = (bedOccupancyRangeList: Array<BedOccupancyRangeUi>, start
 }
 
 export const bedRow = (bedOccupancyRange: BedOccupancyRangeUi, startDate: Date, premisesId: string) => {
-  return `<tr class="${rowClass}">
+  return `<tr class="${rowClass}" data-cy-bedId="${bedOccupancyRange.bedId}">
     <th scope="row" class="${headerClass}">${bedOccupancyRange.bedName}</th>
     ${generateRowCells(bedOccupancyRange, startDate, premisesId)}</tr>`
 }
@@ -181,11 +176,22 @@ export const bookingCellContent = (bedOccupancyEntry: BedOccupancyEntryUi, premi
 export const cell = (cellDate: Date, bedOccupancyEntry: BedOccupancyEntryCalendar) => {
   if (!isSameDay(bedOccupancyEntry.startDate, cellDate)) return ''
 
-  return wrapCellContentInTableCellMarkup(bedOccupancyEntry.length, bedOccupancyEntry.label, bedOccupancyEntry.type)
+  return wrapCellContentInTableCellMarkup(bedOccupancyEntry)
 }
 
-export const wrapCellContentInTableCellMarkup = (
-  lengthOfOccupancy: number,
-  cellText: string,
-  type: BedOccupancyEntryUiType,
-) => `<td class="${cellClass} ${tableClass}__cell--${type}" colspan="${lengthOfOccupancy}">${cellText}</td>`
+export const wrapCellContentInTableCellMarkup = (bedOccupancyEntry: BedOccupancyEntryCalendar) =>
+  `<td class="${cellClass} ${tableClass}__cell--${bedOccupancyEntry.type}" colspan="${
+    bedOccupancyEntry.length
+  }" data-cy-startdate="${DateFormats.dateObjToIsoDate(bedOccupancyEntry.startDate)}" data-cy-id="${entryId(
+    bedOccupancyEntry,
+  )}">${bedOccupancyEntry.label}</td>`
+
+const entryId = (bedOccupancyEntry: BedOccupancyEntryCalendar) => {
+  if ('bookingId' in bedOccupancyEntry) {
+    return bedOccupancyEntry.bookingId
+  }
+  if ('lostBedId' in bedOccupancyEntry) {
+    return bedOccupancyEntry.lostBedId
+  }
+  return ''
+}

--- a/server/utils/calendarUtils.ts
+++ b/server/utils/calendarUtils.ts
@@ -21,14 +21,17 @@ export const calendar = (
   bedOccupancyRangeList: Array<BedOccupancyRangeUi>,
   startDate: Date,
 ) => `<table class="${calendarTableClass}" cellspacing="0">
-  <thead class="${headClass}">${dateRow()}</thead>
-  <tr class="${rowClass}">${monthRow(startDate)}</tr>
+  <thead class="${headClass}">
+    <tr class="${rowClass} ${tableClass}__row--months">${monthRow(startDate)}</tr>
+    ${dateRow()}
+  </thead>
   <tbody class="${bodyClass}">${bedRows(bedOccupancyRangeList, startDate)}</tbody>
 </table>`
 
 export const dateRow = () => `
-<th class="${roomHeaderClass}">Room/Bed</th>
-${formatDaysForDateRow(new Date())}
+<tr class="${rowClass}">
+  ${formatDaysForDateRow(new Date())}
+</tr>
 `
 
 export const formatDaysForDateRow = (date: Date) => {
@@ -47,7 +50,7 @@ export const generateDays = (date: Date) => {
 }
 
 export const monthRow = (startDate: Date) => {
-  const monthRowArr = [`<td class="${cellClass}"></td>`]
+  const monthRowArr = [`<th class="${roomHeaderClass}" rowspan="2">Room/Bed</th>`]
   const days = generateDays(startDate)
 
   for (let i = 0; i < days.length; i += 1) {
@@ -56,7 +59,7 @@ export const monthRow = (startDate: Date) => {
 
       const colspan = days.slice(i).filter(d => isSameMonth(d, days[i])).length
 
-      monthRowArr.push(`<th colspan="${colspan}" class="${cellClass} ${tableClass}__cell--month">${month}</th>`)
+      monthRowArr.push(`<th colspan="${colspan}" class="${headerClass} ${tableClass}__head--month">${month}</th>`)
     }
   }
 

--- a/server/utils/calendarUtils.ts
+++ b/server/utils/calendarUtils.ts
@@ -35,14 +35,14 @@ export const calendar = (
 ) => `<table class="${calendarTableClass}" cellspacing="0">
   <thead class="${headClass}">
     <tr class="${rowClass} ${tableClass}__row--months">${monthRow(startDate)}</tr>
-    ${dateRow()}
+    ${dateRow(startDate)}
   </thead>
   <tbody class="${bodyClass}">${bedRows(bedOccupancyRangeList, startDate, premisesId)}</tbody>
 </table>`
 
-export const dateRow = () => `
+export const dateRow = (startDate: Date) => `
 <tr class="${rowClass}">
-  ${formatDaysForDateRow(new Date())}
+  ${formatDaysForDateRow(startDate)}
 </tr>
 `
 
@@ -128,7 +128,7 @@ export const scheduleForCalendar = (
 }
 
 export const generateRowCells = (bedOccupancyRange: BedOccupancyRangeUi, startDate: Date, premisesId: string) => {
-  return generateDays(new Date())
+  return generateDays(startDate)
     .map(day =>
       scheduleForCalendar(bedOccupancyRange.schedule, startDate, premisesId, bedOccupancyRange.bedId)
         .map(entry => cell(day, entry))

--- a/server/utils/calendarUtils.ts
+++ b/server/utils/calendarUtils.ts
@@ -1,4 +1,13 @@
-import { addDays, format, formatDistanceStrict, isBefore, isSameDay, isSameMonth } from 'date-fns'
+import {
+  addDays,
+  differenceInDays,
+  format,
+  formatDistanceStrict,
+  isAfter,
+  isBefore,
+  isSameDay,
+  isSameMonth,
+} from 'date-fns'
 import { DateFormats } from './dateUtils'
 
 import {
@@ -94,10 +103,15 @@ export const scheduleForCalendar = (
   startDate: Date,
 ): Array<BedOccupancyEntryCalendar> => {
   return schedule.map(bedOccupancyEntry => {
+    const endDate = addDays(startDate, 30)
+    const scheduleStartDate = isBefore(bedOccupancyEntry.startDate, startDate) ? startDate : bedOccupancyEntry.startDate
+    const scheduleEndDate = isAfter(bedOccupancyEntry.endDate, endDate) ? endDate : bedOccupancyEntry.endDate
     return {
       ...bedOccupancyEntry,
       label: labelForScheduleItem(bedOccupancyEntry),
-      startDate: isBefore(bedOccupancyEntry.startDate, startDate) ? startDate : bedOccupancyEntry.startDate,
+      startDate: scheduleStartDate,
+      endDate: scheduleEndDate,
+      length: differenceInDays(scheduleEndDate, scheduleStartDate) + 1,
     }
   })
 }

--- a/server/utils/calendarUtils.ts
+++ b/server/utils/calendarUtils.ts
@@ -1,22 +1,34 @@
 import { addDays, format, formatDistanceStrict, isSameDay, isSameMonth } from 'date-fns'
 import { DateFormats } from './dateUtils'
 
-import { BedOccupancyEntryUi, BedOccupancyRangeUi } from '../@types/ui'
+import { BedOccupancyEntryUi, BedOccupancyEntryUiType, BedOccupancyRangeUi } from '../@types/ui'
 
-export const calendar = (bedOccupancyRangeList: Array<BedOccupancyRangeUi>, startDate: Date) => `<table cellspacing="0">
-  <thead>${dateRow()}</thead>
-  <tr>${monthRow(startDate)}</tr>
-  <tbody>${bedRows(bedOccupancyRangeList)}</tbody>
+export const tableClass = 'govuk-table'
+export const calendarTableClass = `${tableClass} ${tableClass}--calendar`
+export const headClass = `${tableClass}__head ${tableClass}__head--calendar`
+export const bodyClass = `${tableClass}__body ${tableClass}__body--calendar`
+export const headerClass = `${tableClass}__header ${tableClass}__header--calendar`
+export const roomHeaderClass = `${headerClass} ${tableClass}__header--calendar-room-header`
+export const rowClass = `${tableClass}__row ${tableClass}__row--calendar`
+export const cellClass = `${tableClass}__cell ${tableClass}__cell--calendar`
+
+export const calendar = (
+  bedOccupancyRangeList: Array<BedOccupancyRangeUi>,
+  startDate: Date,
+) => `<table class="${calendarTableClass}" cellspacing="0">
+  <thead class="${headClass}">${dateRow()}</thead>
+  <tr class="${rowClass}">${monthRow(startDate)}</tr>
+  <tbody class="${bodyClass}">${bedRows(bedOccupancyRangeList)}</tbody>
 </table>`
 
 export const dateRow = () => `
-<th>Room/Bed</th>
+<th class="${roomHeaderClass}">Room/Bed</th>
 ${formatDaysForDateRow(new Date())}
 `
 
 export const formatDaysForDateRow = (date: Date) => {
   const days = generateDays(date)
-  return days.map(day => `<th>${DateFormats.calendarDate(day)}</th>`).join('')
+  return days.map(day => `<th class="${headerClass}">${DateFormats.calendarDate(day)}</th>`).join('')
 }
 
 export const generateDays = (date: Date) => {
@@ -30,7 +42,7 @@ export const generateDays = (date: Date) => {
 }
 
 export const monthRow = (startDate: Date) => {
-  const monthRowArr = [`<td></td>`]
+  const monthRowArr = [`<td class="${cellClass}"></td>`]
   const days = generateDays(startDate)
 
   for (let i = 0; i < days.length; i += 1) {
@@ -39,7 +51,7 @@ export const monthRow = (startDate: Date) => {
 
       const colspan = days.slice(i).filter(d => isSameMonth(d, days[i])).length
 
-      monthRowArr.push(`<th colspan="${colspan}">${month}</th>`)
+      monthRowArr.push(`<th colspan="${colspan}" class="${cellClass} ${tableClass}__cell--month">${month}</th>`)
     }
   }
 
@@ -51,8 +63,8 @@ export const bedRows = (bedOccupancyRangeList: Array<BedOccupancyRangeUi>) => {
 }
 
 export const bedRow = (bedOccupancyRange: BedOccupancyRangeUi) => {
-  return `<tr>
-    <th scope="row">${bedOccupancyRange.bedName}</th>
+  return `<tr class="${rowClass}">
+    <th scope="row" class="${headerClass}">${bedOccupancyRange.bedName}</th>
     ${generateRowCells(bedOccupancyRange)}</tr>`
 }
 
@@ -94,7 +106,7 @@ export const cell = (cellDate: Date, bedOccupancyEntry: BedOccupancyEntryUi) => 
       cellContent = bookingCellContent(bedOccupancyEntry)
       break
     case 'open':
-      cellContent = 'open'
+      cellContent = '<span class="govuk-visually-hidden">open</span>'
       break
     case 'lost_bed':
       cellContent = 'lost'
@@ -103,8 +115,11 @@ export const cell = (cellDate: Date, bedOccupancyEntry: BedOccupancyEntryUi) => 
       cellContent = ''
   }
 
-  return wrapCellContentInTableCellMarkup(bedOccupancyEntry.length, cellContent)
+  return wrapCellContentInTableCellMarkup(bedOccupancyEntry.length, cellContent, bedOccupancyEntry.type)
 }
 
-export const wrapCellContentInTableCellMarkup = (lengthOfOccupancy: number, cellText: string) =>
-  `<td colspan="${lengthOfOccupancy}">${cellText}</td>`
+export const wrapCellContentInTableCellMarkup = (
+  lengthOfOccupancy: number,
+  cellText: string,
+  type: BedOccupancyEntryUiType,
+) => `<td class="${cellClass} ${tableClass}__cell--${type}" colspan="${lengthOfOccupancy}">${cellText}</td>`

--- a/server/utils/calendarUtils.ts
+++ b/server/utils/calendarUtils.ts
@@ -92,7 +92,7 @@ export const labelForScheduleItem = (bedOccupancyEntry: BedOccupancyEntryUi): st
     case 'open':
       return '<span class="govuk-visually-hidden">open</span>'
     case 'lost_bed':
-      return 'lost'
+      return 'Out of Service'
     default:
       return ''
   }

--- a/server/utils/calendarUtils.ts
+++ b/server/utils/calendarUtils.ts
@@ -88,7 +88,11 @@ export const bedRow = (bedOccupancyRange: BedOccupancyRangeUi, startDate: Date, 
     ${generateRowCells(bedOccupancyRange, startDate, premisesId)}</tr>`
 }
 
-export const labelForScheduleItem = (bedOccupancyEntry: BedOccupancyEntryUi, premisesId: string): string => {
+export const labelForScheduleItem = (
+  bedOccupancyEntry: BedOccupancyEntryUi,
+  premisesId: string,
+  bedId: string,
+): string => {
   switch (bedOccupancyEntry.type) {
     case 'booking':
       return bookingCellContent(bedOccupancyEntry, premisesId)
@@ -97,7 +101,7 @@ export const labelForScheduleItem = (bedOccupancyEntry: BedOccupancyEntryUi, pre
     case 'lost_bed':
       return 'Out of Service'
     case 'overbooking':
-      return 'Overbooked'
+      return overbookedCellContent(premisesId, bedId)
     default:
       return ''
   }
@@ -107,6 +111,7 @@ export const scheduleForCalendar = (
   schedule: Array<BedOccupancyEntryUi>,
   startDate: Date,
   premisesId: string,
+  bedId: string,
 ): Array<BedOccupancyEntryCalendar> => {
   return schedule.map(bedOccupancyEntry => {
     const endDate = addDays(startDate, 30)
@@ -114,7 +119,7 @@ export const scheduleForCalendar = (
     const scheduleEndDate = isAfter(bedOccupancyEntry.endDate, endDate) ? endDate : bedOccupancyEntry.endDate
     return {
       ...bedOccupancyEntry,
-      label: labelForScheduleItem(bedOccupancyEntry, premisesId),
+      label: labelForScheduleItem(bedOccupancyEntry, premisesId, bedId),
       startDate: scheduleStartDate,
       endDate: scheduleEndDate,
       length: differenceInDays(scheduleEndDate, scheduleStartDate) + 1,
@@ -125,11 +130,22 @@ export const scheduleForCalendar = (
 export const generateRowCells = (bedOccupancyRange: BedOccupancyRangeUi, startDate: Date, premisesId: string) => {
   return generateDays(new Date())
     .map(day =>
-      scheduleForCalendar(bedOccupancyRange.schedule, startDate, premisesId)
+      scheduleForCalendar(bedOccupancyRange.schedule, startDate, premisesId, bedOccupancyRange.bedId)
         .map(entry => cell(day, entry))
         .join(''),
     )
     .join('')
+}
+
+export const overbookedCellContent = (premisesId: string, bedId: string) => {
+  return linkTo(
+    paths.premises.beds.show,
+    { bedId, premisesId },
+    {
+      text: 'Overbooked',
+      attributes: { 'data-cy-bedId': bedId, class: 'govuk-link govuk-link--overbooking' },
+    },
+  )
 }
 
 export const occupierName = (bedOccupancyEntry: BedOccupancyEntryUi, premisesId: string) => {

--- a/server/utils/calendarUtils.ts
+++ b/server/utils/calendarUtils.ts
@@ -1,4 +1,4 @@
-import { addDays, isSameDay } from 'date-fns'
+import { addDays, formatDistanceStrict, isSameDay } from 'date-fns'
 import { DateFormats } from './dateUtils'
 
 import { BedOccupancyEntryUi, BedOccupancyRangeUi } from '../@types/ui'
@@ -49,6 +49,23 @@ export const occupierName = (bedOccupancyEntry: BedOccupancyEntryUi) => {
   return ''
 }
 
+export const bookingCellContent = (bedOccupancyEntry: BedOccupancyEntryUi) => {
+  const name = occupierName(bedOccupancyEntry)
+  const lengthOfStay = bedOccupancyEntry.length
+  const lengthOfStayInWords = formatDistanceStrict(bedOccupancyEntry.startDate, bedOccupancyEntry.endDate)
+  const startAndEndDates = `${DateFormats.dateObjtoUIDate(bedOccupancyEntry.startDate, {
+    format: 'short',
+  })} - ${DateFormats.dateObjtoUIDate(bedOccupancyEntry.endDate, { format: 'short' })}`
+
+  if (lengthOfStay < 5) return name
+
+  if (lengthOfStay >= 5 && lengthOfStay < 10) return `${name} (${lengthOfStayInWords})`
+
+  if (lengthOfStay >= 10) return `${name} (${lengthOfStayInWords} ${startAndEndDates})`
+
+  return ''
+}
+
 export const cell = (cellDate: Date, bedOccupancyEntry: BedOccupancyEntryUi) => {
   if (!isSameDay(bedOccupancyEntry.startDate, cellDate)) return ''
 
@@ -56,7 +73,7 @@ export const cell = (cellDate: Date, bedOccupancyEntry: BedOccupancyEntryUi) => 
 
   switch (bedOccupancyEntry.type) {
     case 'booking':
-      cellContent = occupierName(bedOccupancyEntry)
+      cellContent = bookingCellContent(bedOccupancyEntry)
       break
     case 'open':
       cellContent = 'open'

--- a/server/utils/calendarUtils.ts
+++ b/server/utils/calendarUtils.ts
@@ -1,0 +1,26 @@
+import { addDays } from 'date-fns'
+import { DateFormats } from './dateUtils'
+
+export const calendar = () => `<table cellspacing="0">
+  <thead>${dateRow()}</thead>
+</table>`
+
+export const dateRow = () => `
+<th>Room/Bed</th>
+${formatDaysForDateRow(new Date())}
+`
+
+export const formatDaysForDateRow = (date: Date) => {
+  const days = generateDays(date)
+  return days.map(day => `<th>${DateFormats.calendarDate(day)}</th>`).join('')
+}
+
+export const generateDays = (date: Date) => {
+  date.setHours(0, 0, 0, 0)
+  const days = []
+  for (let i = 0; i < 30; i += 1) {
+    const newDate = addDays(date, i)
+    days.push(newDate)
+  }
+  return days
+}

--- a/server/utils/calendarUtils.ts
+++ b/server/utils/calendarUtils.ts
@@ -1,8 +1,11 @@
-import { addDays } from 'date-fns'
+import { addDays, isSameDay } from 'date-fns'
 import { DateFormats } from './dateUtils'
 
-export const calendar = () => `<table cellspacing="0">
+import { BedOccupancyEntryUi, BedOccupancyRangeUi } from '../@types/ui'
+
+export const calendar = (bedOccupancyRangeList: Array<BedOccupancyRangeUi>) => `<table cellspacing="0">
   <thead>${dateRow()}</thead>
+  <tbody>${bedRows(bedOccupancyRangeList)}</tbody>
 </table>`
 
 export const dateRow = () => `
@@ -24,3 +27,49 @@ export const generateDays = (date: Date) => {
   }
   return days
 }
+
+export const bedRows = (bedOccupancyRangeList: Array<BedOccupancyRangeUi>) => {
+  return bedOccupancyRangeList.map(range => bedRow(range)).join('')
+}
+
+export const bedRow = (bedOccupancyRange: BedOccupancyRangeUi) => {
+  return `<tr>
+    <th scope="row">${bedOccupancyRange.bedName}</th>
+    ${generateRowCells(bedOccupancyRange)}</tr>`
+}
+
+export const generateRowCells = (bedOccupancyRange: BedOccupancyRangeUi) => {
+  return generateDays(new Date())
+    .map(day => bedOccupancyRange.schedule.map(entry => cell(day, entry)).join(''))
+    .join('')
+}
+
+export const occupierName = (bedOccupancyEntry: BedOccupancyEntryUi) => {
+  if (bedOccupancyEntry.type === 'booking') return bedOccupancyEntry.personName
+  return ''
+}
+
+export const cell = (cellDate: Date, bedOccupancyEntry: BedOccupancyEntryUi) => {
+  if (!isSameDay(bedOccupancyEntry.startDate, cellDate)) return ''
+
+  let cellContent: string
+
+  switch (bedOccupancyEntry.type) {
+    case 'booking':
+      cellContent = occupierName(bedOccupancyEntry)
+      break
+    case 'open':
+      cellContent = 'open'
+      break
+    case 'lost_bed':
+      cellContent = 'lost'
+      break
+    default:
+      cellContent = ''
+  }
+
+  return wrapCellContentInTableCellMarkup(bedOccupancyEntry.length, cellContent)
+}
+
+export const wrapCellContentInTableCellMarkup = (lengthOfOccupancy: number, cellText: string) =>
+  `<td colspan="${lengthOfOccupancy}">${cellText}</td>`

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -44,6 +44,14 @@ export class DateFormats {
   }
 
   /**
+   * @param date JS Date object.
+   * @returns the date in the to be shown in the heading row of the calendar: "20 ".
+   */
+  static calendarDate(date: Date) {
+    return format(date, 'd')
+  }
+
+  /**
    * Converts an ISO8601 datetime string into a Javascript Date object.
    * @param date An ISO8601 datetime string
    * @returns A Date object

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -45,7 +45,7 @@ export class DateFormats {
 
   /**
    * @param date JS Date object.
-   * @returns the date in the to be shown in the heading row of the calendar: "20 ".
+   * @returns the date in the to be shown in the heading row of the calendar: "20".
    */
   static calendarDate(date: Date) {
     return format(date, 'd')

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -44,6 +44,7 @@ import * as BedUtils from './bedUtils'
 import * as LostBedUtils from './lostBedUtils'
 import * as PhaseBannerUtils from './phaseBannerUtils'
 import * as PlacementApplicationUtils from './placementApplications'
+import * as CalendarUtils from './calendarUtils'
 
 import managePaths from '../paths/manage'
 import applyPaths from '../paths/apply'
@@ -210,4 +211,5 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('LostBedUtils', LostBedUtils)
   njkEnv.addGlobal('PhaseBannerUtils', PhaseBannerUtils)
   njkEnv.addGlobal('PlacementApplicationUtils', PlacementApplicationUtils)
+  njkEnv.addGlobal('CalendarUtils', CalendarUtils)
 }

--- a/server/utils/premisesUtils.test.ts
+++ b/server/utils/premisesUtils.test.ts
@@ -1,4 +1,8 @@
-import getDateRangesWithNegativeBeds from './premisesUtils'
+import { bedOccupancyEntryFactory, bedOccupancyRangeFactory } from '../testutils/factories'
+import getDateRangesWithNegativeBeds, {
+  mapApiOccupancyEntryToUiOccupancyEntry,
+  mapApiOccupancyToUiOccupancy,
+} from './premisesUtils'
 
 describe('premisesUtils', () => {
   describe('getDateRangeWithNegativeBeds', () => {
@@ -82,6 +86,50 @@ describe('premisesUtils', () => {
         { start: dateCapacities[0].date },
         { start: dateCapacities[2].date, end: dateCapacities[3].date },
       ])
+    })
+  })
+
+  describe('mapApiOccupancyToUiOccupancy', () => {
+    it('converts dates from strings to dates objects', async () => {
+      const bedOccupancyEntry = bedOccupancyEntryFactory.build({ startDate: '2023-01-02', endDate: '2023-01-03' })
+      const bedOccupancyRange = bedOccupancyRangeFactory.build({
+        schedule: [bedOccupancyEntry],
+      })
+      expect(await mapApiOccupancyToUiOccupancy([bedOccupancyRange])).toEqual([
+        {
+          bedId: bedOccupancyRange.bedId,
+          bedName: bedOccupancyRange.bedName,
+          schedule: [
+            {
+              endDate: new Date(2023, 0, 3),
+              length: bedOccupancyEntry.length,
+              startDate: new Date(2023, 0, 2),
+              type: bedOccupancyEntry.type,
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  describe('mapApiOccupancyEntryToUiOccupancyEntry', () => {
+    it('converts dates from strings to dates objects', async () => {
+      const bedOccupancyEntry = bedOccupancyEntryFactory.build({ startDate: '2023-01-02', endDate: '2023-01-03' })
+      const bedOccupancyRange = bedOccupancyRangeFactory.build({
+        schedule: [bedOccupancyEntry],
+      })
+      expect(await mapApiOccupancyEntryToUiOccupancyEntry(bedOccupancyRange)).toEqual({
+        bedId: bedOccupancyRange.bedId,
+        bedName: bedOccupancyRange.bedName,
+        schedule: [
+          {
+            endDate: new Date(2023, 0, 3),
+            length: bedOccupancyEntry.length,
+            startDate: new Date(2023, 0, 2),
+            type: bedOccupancyEntry.type,
+          },
+        ],
+      })
     })
   })
 })

--- a/server/utils/premisesUtils.ts
+++ b/server/utils/premisesUtils.ts
@@ -1,6 +1,7 @@
 import type { BedOccupancyRange, DateCapacity } from '@approved-premises/api'
+import { BedOccupancyRangeUi } from '@approved-premises/ui'
 import { DateFormats } from './dateUtils'
-import { BedOccupancyRangeUi } from '../@types/ui'
+import { addOverbookingsToSchedule } from './addOverbookingsToSchedule'
 
 export type NegativeDateRange = { start?: string; end?: string }
 
@@ -33,7 +34,12 @@ export async function mapApiOccupancyToUiOccupancy(bedOccupancyRangeList: Array<
     }),
   )
 
-  return mappedOccupancyList
+  const occupancyListWithOverBookings = mappedOccupancyList.map(item => ({
+    ...item,
+    schedule: addOverbookingsToSchedule(item.schedule),
+  }))
+
+  return occupancyListWithOverBookings
 }
 
 export async function mapApiOccupancyEntryToUiOccupancyEntry(

--- a/server/utils/premisesUtils.ts
+++ b/server/utils/premisesUtils.ts
@@ -1,4 +1,6 @@
-import type { DateCapacity } from '@approved-premises/api'
+import type { BedOccupancyRange, DateCapacity } from '@approved-premises/api'
+import { DateFormats } from './dateUtils'
+import { BedOccupancyRangeUi } from '../@types/ui'
 
 export type NegativeDateRange = { start?: string; end?: string }
 
@@ -21,4 +23,30 @@ export default function getDateRangesWithNegativeBeds(premisesCapacity: Array<Da
   })
 
   return result
+}
+
+export async function mapApiOccupancyToUiOccupancy(bedOccupancyRangeList: Array<BedOccupancyRange>) {
+  const mappedOccupancyList = await Promise.all(
+    bedOccupancyRangeList.map(async occupancyRange => {
+      const mappedEntry = await mapApiOccupancyEntryToUiOccupancyEntry(occupancyRange)
+      return mappedEntry
+    }),
+  )
+
+  return mappedOccupancyList
+}
+
+export async function mapApiOccupancyEntryToUiOccupancyEntry(
+  bedOccupancyRangeList: BedOccupancyRange,
+): Promise<BedOccupancyRangeUi> {
+  return {
+    ...bedOccupancyRangeList,
+    schedule: bedOccupancyRangeList.schedule.map(scheduleEntry => {
+      return {
+        ...scheduleEntry,
+        startDate: DateFormats.isoToDateObj(scheduleEntry.startDate),
+        endDate: DateFormats.isoToDateObj(scheduleEntry.endDate),
+      }
+    }),
+  } as BedOccupancyRangeUi
 }

--- a/server/views/premises/calendar.njk
+++ b/server/views/premises/calendar.njk
@@ -1,0 +1,18 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + premises.name %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+
+	{{ govukBackLink({
+		text: "Back",
+		href: paths.premises.show({ premisesId: premisesId })
+	}) }}
+{% endblock %}
+
+{% block content %}
+	{{CalendarUtils.calendar(bedOccupancyRangeList) | safe}}
+{% endblock %}

--- a/server/views/premises/calendar.njk
+++ b/server/views/premises/calendar.njk
@@ -14,5 +14,5 @@
 {% endblock %}
 
 {% block content %}
-	{{CalendarUtils.calendar(bedOccupancyRangeList, startDate) | safe}}
+	{{CalendarUtils.calendar(bedOccupancyRangeList, startDate, premisesId) | safe}}
 {% endblock %}

--- a/server/views/premises/calendar.njk
+++ b/server/views/premises/calendar.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -15,5 +16,46 @@
 {% endblock %}
 
 {% block content %}
+	<h1 class="govuk-heading-l">{{ premises.name }}</h1>
+
+	<div class="govuk-grid-row">
+		<div class="govuk-grid-column-two-thirds">
+			{{
+					govukSummaryList({
+						rows: [
+							{
+								key: {
+									text: "Total number of beds"
+								},
+								value: {
+									text: premises.bedCount
+								}
+							}
+						]
+					})
+				}}
+		</div>
+	</div>
+
+	<h2 class="govuk-heading-m">{{ dateObjToUIDate(startDate) }}</h2>
+
+	<p class="govuk-body">
+		Showing occupancy for the next 30 days
+	</p>
+
+	{{
+		govukPagination({
+			classes: "govuk-pagination--calendar",
+			previous: {
+				text: "Previous 14 Days",
+				href: paths.premises.calendar({premisesId: premisesId}) + "?startDate=" + previousDate
+			},
+			next: {
+				text: "Next 14 Days",
+				href: paths.premises.calendar({premisesId: premisesId}) + "?startDate=" + nextDate
+			}
+		})
+	}}
+
 	{{CalendarUtils.calendar(bedOccupancyRangeList, startDate, premisesId) | safe}}
 {% endblock %}

--- a/server/views/premises/calendar.njk
+++ b/server/views/premises/calendar.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% extends "../partials/layout.njk" %}
 

--- a/server/views/premises/calendar.njk
+++ b/server/views/premises/calendar.njk
@@ -14,5 +14,5 @@
 {% endblock %}
 
 {% block content %}
-	{{CalendarUtils.calendar(bedOccupancyRangeList) | safe}}
+	{{CalendarUtils.calendar(bedOccupancyRangeList, startDate) | safe}}
 {% endblock %}

--- a/server/views/premises/show.njk
+++ b/server/views/premises/show.njk
@@ -35,7 +35,13 @@
             text: "Manage beds",
             classes: "govuk-button--secondary",
             href: paths.premises.beds.index({premisesId: premisesId})
-          }]
+          },
+           {
+            text: "View calendar",
+            classes: "govuk-button--secondary",
+            href: paths.premises.calendar({premisesId: premisesId})
+          }
+          ]
         }]
         })
       }}


### PR DESCRIPTION
This adds an occupancy calendar to the Manage view, allowing users to see bookings at a glance. If any beds are overbooking, we show and "Overbooked" cell for the period and link through to the bed. In future, we'll show the booking details on this page, together with details of the overbooking.

## Screenshot

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/8bde8f55-042c-41e8-b047-91a46140022c)
