### PR TITLE
Remove upcomming arrivals and departures window

### DIFF
--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -9,7 +9,7 @@ import BookingClient from '../data/bookingClient'
 import { DateFormats } from '../utils/dateUtils'
 
 export default class BookingService {
-  UPCOMING_WINDOW_IN_DAYS = 40
+  UPCOMING_WINDOW_IN_DAYS = 365 * 10
 
   constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
 


### PR DESCRIPTION
We thought that it may be useful to limit upcomming departures and arrivals to the next 40 days. However AP managers need to be able to see all upcomming arrivals. I can imagine this being adjusted in future so I think it's best to leave the filtering mechanism in place and set the window to a very high number (~10 years).
