### PR TITLE
(10) Moving beds

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -19,6 +19,7 @@ import tasks from './integration_tests/mockApis/tasks'
 import placementRequests from './integration_tests/mockApis/placementRequests'
 import placementApplication from './integration_tests/mockApis/placementApplication'
 import bedSearch from './integration_tests/mockApis/beds'
+import moveBooking from './integration_tests/mockApis/moveBooking'
 
 import schemaValidator from './integration_tests/tasks/schemaValidator'
 
@@ -58,6 +59,7 @@ export default defineConfig({
         ...placementRequests,
         ...placementApplication,
         ...bedSearch,
+        ...moveBooking,
         stubApplicationJourney,
       })
     },

--- a/integration_tests/mockApis/moveBooking.ts
+++ b/integration_tests/mockApis/moveBooking.ts
@@ -1,0 +1,19 @@
+import { SuperAgentRequest } from 'superagent'
+import { NewBedMove } from '../../server/@types/shared'
+import { stubFor } from '../../wiremock'
+import paths from '../../server/paths/manage'
+
+export default {
+  stubMoveBooking: (args: { bedMove: NewBedMove; bookingId: string; premisesId: string }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: paths.bookings.moves.create({ bookingId: args.bookingId, premisesId: args.premisesId }),
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.bedMove,
+      },
+    }),
+}

--- a/integration_tests/pages/manage/bed/moveBed.ts
+++ b/integration_tests/pages/manage/bed/moveBed.ts
@@ -1,0 +1,20 @@
+import { BedDetail } from '../../../../server/@types/shared'
+
+import Page from '../../page'
+import paths from '../../../../server/paths/manage'
+
+export default class MoveBedPage extends Page {
+  constructor() {
+    super('Move person to a new bed')
+  }
+
+  static visit(premisesId: string, bookingId: string): MoveBedPage {
+    cy.visit(paths.bookings.moves.new({ premisesId, bookingId }))
+    return new MoveBedPage()
+  }
+
+  completeForm(bed: BedDetail): void {
+    this.getSelectInputByIdAndSelectAnEntry('bed', bed.id)
+    this.completeTextArea('notes', 'Test notes')
+  }
+}

--- a/integration_tests/pages/manage/booking/show.ts
+++ b/integration_tests/pages/manage/booking/show.ts
@@ -19,6 +19,11 @@ export default class BookingShowPage extends Page {
     cy.get('a').contains('Extend placement').click()
   }
 
+  clickMoveBooking() {
+    cy.get('.moj-button-menu__toggle-button').click()
+    cy.get('a').contains('Move person to a new bed').click()
+  }
+
   shouldShowBookingDetails(booking: Booking): void {
     cy.get('dl[data-cy-crn]').within(() => {
       this.assertDefinition('CRN', booking.person.crn)

--- a/integration_tests/pages/manage/premisesShow.ts
+++ b/integration_tests/pages/manage/premisesShow.ts
@@ -104,4 +104,8 @@ export default class PremisesShowPage extends Page {
       )} to ${DateFormats.isoDateToUIDate(overcapacityEndDate)}`,
     )
   }
+
+  shouldShowMoveConfirmation() {
+    this.shouldShowBanner('Bed move logged')
+  }
 }

--- a/integration_tests/tests/manage/booking.cy.ts
+++ b/integration_tests/tests/manage/booking.cy.ts
@@ -17,6 +17,7 @@ context('Booking', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+    cy.signIn()
   })
 
   it('should show the CRN form followed by the booking form', () => {
@@ -63,13 +64,10 @@ context('Booking', () => {
     })
     cy.task('stubFindPerson', { person })
 
-    // Given I am signed in
-    cy.signIn()
-
-    // When I visit the first new booking page
+    // Given I visit the first new booking page
     const bookingNewPage = BookingFindPage.visit(premises.id, booking.bed.id)
 
-    // And I enter the CRN to the form
+    // When I enter the CRN to the form
     bookingNewPage.enterCrn(person.crn)
     bookingNewPage.clickSubmit()
 
@@ -113,13 +111,10 @@ context('Booking', () => {
     const bedId = bedFactory.build().id
     cy.task('stubSinglePremises', premises)
 
-    // Given I am signed in
-    cy.signIn()
-
-    // When I visit the find page
+    // Given I visit the find page
     const page = BookingFindPage.visit(premises.id, bedId)
 
-    // And I miss a required field
+    // When I miss a required field
     cy.task('stubPersonNotFound', {
       person,
     })
@@ -167,13 +162,10 @@ context('Booking', () => {
       departureDate: '2022-06-01',
     })
 
-    // Given I am signed in
-    cy.signIn()
-
-    // When I visit the find page
+    // Given I visit the find page
     const page = BookingFindPage.visit(premises.id, bedId)
 
-    // And I enter the CRN to the form
+    // When I enter the CRN to the form
     page.completeForm(person.crn)
 
     // And I fill in the booking form
@@ -186,10 +178,7 @@ context('Booking', () => {
   })
 
   it('should allow me to see a booking', () => {
-    // Given I am signed in
-    cy.signIn()
-
-    // And a booking is available
+    // Given a booking is available
     const premises = premisesFactory.build()
     const booking = bookingFactory.build()
     cy.task('stubBookingGet', { premisesId: premises.id, booking })

--- a/server/controllers/manage/index.ts
+++ b/server/controllers/manage/index.ts
@@ -9,6 +9,7 @@ import DeparturesController from './departuresController'
 import CancellationsController from './cancellationsController'
 import LostBedsController from './lostBedsController'
 import PeopleController from '../peopleController'
+import MoveBedsController from './moveBedsController'
 import BedsController from './premises/bedsController'
 
 import type { Services } from '../../services'
@@ -28,6 +29,7 @@ export const controllers = (services: Services) => {
   const lostBedsController = new LostBedsController(services.lostBedService)
   const peopleController = new PeopleController(services.personService)
   const bedsController = new BedsController(services.premisesService)
+  const moveBedsController = new MoveBedsController(services.bookingService, services.premisesService)
 
   return {
     premisesController,
@@ -40,6 +42,7 @@ export const controllers = (services: Services) => {
     lostBedsController,
     peopleController,
     bedsController,
+    moveBedsController,
   }
 }
 
@@ -51,4 +54,5 @@ export {
   NonArrivalsController,
   DeparturesController,
   PeopleController,
+  MoveBedsController,
 }

--- a/server/controllers/manage/moveBedsController.test.ts
+++ b/server/controllers/manage/moveBedsController.test.ts
@@ -1,0 +1,90 @@
+import type { NextFunction, Request, Response } from 'express'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+
+import type { ErrorsAndUserInput } from '@approved-premises/ui'
+import BookingService from '../../services/bookingService'
+import PremisesService from '../../services/premisesService'
+import MoveBedsController from './moveBedsController'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
+import paths from '../../paths/manage'
+import { bedSummaryFactory, bookingFactory } from '../../testutils/factories'
+
+import { NewBedMove } from '../../@types/shared'
+
+jest.mock('../../utils/validation')
+
+describe('MoveBedsController', () => {
+  const token = 'SOME_TOKEN'
+
+  const request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const bookingService = createMock<BookingService>({})
+  const premisesService = createMock<PremisesService>({})
+
+  const moveBedsController = new MoveBedsController(bookingService, premisesService)
+
+  const premisesId = 'premisesId'
+  const bookingId = 'bookingId'
+
+  describe('new', () => {
+    it('renders the form', async () => {
+      const requestHandler = moveBedsController.new()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [], userInput: {} })
+
+      const beds = bedSummaryFactory.buildList(1)
+      premisesService.getBeds.mockResolvedValue(beds)
+
+      const booking = bookingFactory.build()
+      bookingService.find.mockResolvedValue(booking)
+
+      request.params = {
+        bookingId,
+        premisesId,
+      }
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('premises/beds/move/new', {
+        premisesId,
+        booking,
+        beds,
+        pageHeading: 'Move person to a new bed',
+        errors: {},
+        errorSummary: [],
+      })
+    })
+
+    it('renders the form with errors and user input if an error has been sent to the flash', async () => {
+      const requestHandler = moveBedsController.new()
+
+      const beds = bedSummaryFactory.buildList(1)
+      premisesService.getBeds.mockResolvedValue(beds)
+
+      const booking = bookingFactory.build()
+      bookingService.find.mockResolvedValue(booking)
+
+      request.params = {
+        bookingId,
+        premisesId,
+      }
+
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('premises/beds/move/new', {
+        premisesId,
+        booking,
+        beds,
+        pageHeading: 'Move person to a new bed',
+        errors: errorsAndUserInput.errors,
+        errorSummary: errorsAndUserInput.errorSummary,
+        ...errorsAndUserInput.userInput,
+      })
+    })
+  })
+})

--- a/server/controllers/manage/moveBedsController.ts
+++ b/server/controllers/manage/moveBedsController.ts
@@ -1,0 +1,29 @@
+import { Request, RequestHandler, Response } from 'express'
+
+import { fetchErrorsAndUserInput } from '../../utils/validation'
+
+import { BookingService, PremisesService } from '../../services'
+
+export default class MoveBedsController {
+  constructor(private readonly bookingService: BookingService, private readonly premisesService: PremisesService) {}
+
+  new(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, bookingId } = req.params
+      const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
+
+      const booking = await this.bookingService.find(req.user.token, premisesId, bookingId)
+      const beds = await this.premisesService.getBeds(req.user.token, premisesId)
+
+      res.render('premises/beds/move/new', {
+        premisesId,
+        booking,
+        beds,
+        errors,
+        errorSummary,
+        pageHeading: 'Move person to a new bed',
+        ...userInput,
+      })
+    }
+  }
+}

--- a/server/data/bookingClient.test.ts
+++ b/server/data/bookingClient.test.ts
@@ -16,6 +16,7 @@ import describeClient from '../testutils/describeClient'
 import BookingClient from './bookingClient'
 
 import { DateFormats } from '../utils/dateUtils'
+import paths from '../paths/api'
 
 describeClient('BookingClient', provider => {
   let bookingClient: BookingClient
@@ -267,6 +268,33 @@ describeClient('BookingClient', provider => {
 
       expect(result).toEqual(nonArrival)
       expect(nock.isDone()).toBeTruthy()
+    })
+  })
+
+  describe('moveBooking', () => {
+    it('should move a booking', async () => {
+      const payload = {
+        bedId: 'bedId',
+        notes: 'Some notes',
+      }
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to move a booking',
+        withRequest: {
+          method: 'POST',
+          path: paths.premises.bookings.move({ premisesId: 'premisesId', bookingId: 'bookingId' }),
+          body: payload,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+        },
+      })
+
+      await bookingClient.moveBooking('premisesId', 'bookingId', payload)
     })
   })
 })

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -5,6 +5,7 @@ import type {
   Departure,
   Extension,
   NewArrival,
+  NewBedMove,
   NewBooking,
   NewCancellation,
   NewDeparture,
@@ -14,6 +15,7 @@ import type {
 } from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
+import paths from '../paths/api'
 
 export default class BookingClient {
   restClient: RestClient
@@ -75,6 +77,13 @@ export default class BookingClient {
     })
 
     return response as Nonarrival
+  }
+
+  async moveBooking(premisesId: string, bookingId: string, move: NewBedMove): Promise<void> {
+    await this.restClient.post({
+      path: paths.premises.bookings.move({ premisesId, bookingId }),
+      data: move,
+    })
   }
 
   private bookingsPath(premisesId: string): string {

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -71,5 +71,6 @@
   },
   "referenceNumber": { "empty": "You must enter a reference number" },
   "query": { "empty": "You must enter a query" },
-  "userId": { "empty": "You must choose a user to allocate the application to" }
+  "userId": { "empty": "You must choose a user to allocate the application to" },
+  "moveBed": { "empty": "You must select a bed to move the person to" }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -7,6 +7,8 @@ const lostBedsPath = singlePremisesPath.path('lost-beds')
 
 const bedsPath = singlePremisesPath.path('beds')
 
+const bookingPath = singlePremisesPath.path('bookings/:bookingId')
+
 const managePaths = {
   premises: {
     index: premisesPath,
@@ -24,6 +26,9 @@ const managePaths = {
   },
   rooms: singlePremisesPath.path('rooms'),
   room: singlePremisesPath.path('rooms/:roomId'),
+  bookings: {
+    move: bookingPath.path('moves'),
+  },
 }
 
 const applicationsPath = path('/applications')
@@ -97,6 +102,9 @@ export default {
     },
     rooms: managePaths.rooms,
     room: managePaths.room,
+    bookings: {
+      move: managePaths.bookings.move,
+    },
   },
   applications: {
     show: applyPaths.applications.show,

--- a/server/paths/manage.ts
+++ b/server/paths/manage.ts
@@ -19,6 +19,8 @@ const cancellationsPath = bookingPath.path('cancellations')
 
 const departuresPath = bookingPath.path('departures')
 
+const movesPath = bookingPath.path('moves')
+
 const lostBedsPath = singlePremisesPath.path('beds/:bedId/lost-beds')
 
 const bedsPath = singlePremisesPath.path('beds')
@@ -58,6 +60,10 @@ const paths = {
     departures: {
       new: departuresPath.path('new'),
       create: departuresPath,
+    },
+    moves: {
+      new: movesPath.path('new'),
+      create: movesPath,
     },
   },
   people: {

--- a/server/routes/manage.ts
+++ b/server/routes/manage.ts
@@ -21,6 +21,7 @@ export default function routes(controllers: Controllers, router: Router): Router
     lostBedsController,
     peopleController,
     bedsController,
+    moveBedsController,
   } = controllers
 
   get(paths.premises.index.pattern, premisesController.index())
@@ -57,6 +58,8 @@ export default function routes(controllers: Controllers, router: Router): Router
   get(paths.lostBeds.index.pattern, lostBedsController.index())
   get(paths.lostBeds.show.pattern, lostBedsController.show())
   post(paths.lostBeds.update.pattern, lostBedsController.update())
+
+  get(paths.bookings.moves.new.pattern, moveBedsController.new())
 
   return router
 }

--- a/server/routes/manage.ts
+++ b/server/routes/manage.ts
@@ -60,6 +60,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   post(paths.lostBeds.update.pattern, lostBedsController.update())
 
   get(paths.bookings.moves.new.pattern, moveBedsController.new())
+  post(paths.bookings.moves.create.pattern, moveBedsController.create())
 
   return router
 }

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -2,7 +2,7 @@ import BookingService from './bookingService'
 import BookingClient from '../data/bookingClient'
 
 import { bookingExtensionFactory, bookingFactory, newBookingFactory } from '../testutils/factories'
-import { Booking } from '../@types/shared'
+import { Booking, NewBedMove } from '../@types/shared'
 
 jest.mock('../data/bookingClient.ts')
 jest.mock('../data/referenceDataClient.ts')
@@ -153,6 +153,20 @@ describe('BookingService', () => {
 
       expect(bookingClientFactory).toHaveBeenCalledWith(token)
       expect(bookingClient.allBookingsForPremisesId).toHaveBeenCalledWith(premisesId)
+    })
+  })
+
+  describe('createMoveBooking', () => {
+    it('on success returns the arrival that has been posted', async () => {
+      const payload: NewBedMove = {
+        bedId: 'bedId',
+        notes: 'notes',
+      }
+
+      await service.moveBooking(token, 'premisesID', 'bookingId', payload)
+
+      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClient.moveBooking).toHaveBeenCalledWith('premisesID', 'bookingId', payload)
     })
   })
 })

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -1,7 +1,7 @@
 /* istanbul ignore file: The tests for this are flaky and likely to be removed soon */
 import { addDays, isSameDay, isWithinInterval } from 'date-fns'
 
-import type { Booking, Extension, NewBooking, NewExtension } from '@approved-premises/api'
+import type { Booking, Extension, NewBedMove, NewBooking, NewExtension } from '@approved-premises/api'
 import type { GroupedListofBookings } from '@approved-premises/ui'
 
 import type { RestClientBuilder } from '../data'
@@ -68,6 +68,12 @@ export default class BookingService {
     const bookings = await bookingClient.allBookingsForPremisesId(premisesId)
 
     return this.arrivedBookings(bookings)
+  }
+
+  async moveBooking(token: string, premisesId: string, bookingId: string, move: NewBedMove): Promise<void> {
+    const bookingClient = this.bookingClientFactory(token)
+
+    await bookingClient.moveBooking(premisesId, bookingId, move)
   }
 
   private bookingsArrivingToday(bookings: Array<Booking>, today: Date): Array<Booking> {

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -1,6 +1,12 @@
 import { SanitisedError } from '../sanitisedError'
-import { bookingActions, bookingsToTableRows, generateConflictBespokeError, manageBookingLink } from './bookingUtils'
-import { bookingFactory, personFactory } from '../testutils/factories'
+import {
+  bedsAsSelectItems,
+  bookingActions,
+  bookingsToTableRows,
+  generateConflictBespokeError,
+  manageBookingLink,
+} from './bookingUtils'
+import { bedSummaryFactory, bookingFactory, personFactory } from '../testutils/factories'
 import paths from '../paths/manage'
 import { DateFormats } from './dateUtils'
 
@@ -118,33 +124,33 @@ describe('bookingUtils', () => {
     it('should return arrival, non-arrival and cancellation actions if a booking is awaiting arrival', () => {
       const booking = bookingFactory.arrivingToday().build()
 
-      expect(bookingActions(booking, 'premisesId')).toEqual([
+      expect(bookingActions(booking, premisesId)).toEqual([
         {
           items: [
             {
               text: 'Move person to a new bed',
               classes: 'govuk-button--secondary',
-              href: paths.bookings.moves.new({ premisesId: 'premisesId', bookingId: booking.id }),
+              href: paths.bookings.moves.new({ premisesId, bookingId: booking.id }),
             },
             {
               text: 'Mark as arrived',
               classes: 'govuk-button--secondary',
-              href: paths.bookings.arrivals.new({ premisesId: 'premisesId', bookingId: booking.id }),
+              href: paths.bookings.arrivals.new({ premisesId, bookingId: booking.id }),
             },
             {
               text: 'Mark as not arrived',
               classes: 'govuk-button--secondary',
-              href: paths.bookings.nonArrivals.new({ premisesId: 'premisesId', bookingId: booking.id }),
+              href: paths.bookings.nonArrivals.new({ premisesId, bookingId: booking.id }),
             },
             {
               text: 'Extend placement',
               classes: 'govuk-button--secondary',
-              href: paths.bookings.extensions.new({ premisesId: 'premisesId', bookingId: booking.id }),
+              href: paths.bookings.extensions.new({ premisesId, bookingId: booking.id }),
             },
             {
               text: 'Cancel placement',
               classes: 'govuk-button--secondary',
-              href: paths.bookings.cancellations.new({ premisesId: 'premisesId', bookingId: booking.id }),
+              href: paths.bookings.cancellations.new({ premisesId, bookingId: booking.id }),
             },
           ],
         },
@@ -154,28 +160,28 @@ describe('bookingUtils', () => {
     it('should return a departure action if a booking is arrived', () => {
       const booking = bookingFactory.arrived().build()
 
-      expect(bookingActions(booking, 'premisesId')).toEqual([
+      expect(bookingActions(booking, premisesId)).toEqual([
         {
           items: [
             {
               text: 'Move person to a new bed',
               classes: 'govuk-button--secondary',
-              href: paths.bookings.moves.new({ premisesId: 'premisesId', bookingId: booking.id }),
+              href: paths.bookings.moves.new({ premisesId, bookingId: booking.id }),
             },
             {
               text: 'Log departure',
               classes: 'govuk-button--secondary',
-              href: paths.bookings.departures.new({ premisesId: 'premisesId', bookingId: booking.id }),
+              href: paths.bookings.departures.new({ premisesId, bookingId: booking.id }),
             },
             {
               text: 'Extend placement',
               classes: 'govuk-button--secondary',
-              href: paths.bookings.extensions.new({ premisesId: 'premisesId', bookingId: booking.id }),
+              href: paths.bookings.extensions.new({ premisesId, bookingId: booking.id }),
             },
             {
               text: 'Cancel placement',
               classes: 'govuk-button--secondary',
-              href: paths.bookings.cancellations.new({ premisesId: 'premisesId', bookingId: booking.id }),
+              href: paths.bookings.cancellations.new({ premisesId, bookingId: booking.id }),
             },
           ],
         },
@@ -247,6 +253,17 @@ describe('bookingUtils', () => {
           },
         ],
       })
+    })
+  })
+
+  describe('bedsAsSelectItems', () => {
+    it('should return an array of select items', () => {
+      const beds = bedSummaryFactory.buildList(2)
+
+      expect(bedsAsSelectItems(beds, beds[0].id)).toEqual([
+        { text: `Bed name: ${beds[0].name}, room name: ${beds[0].roomName}`, value: beds[0].id, selected: true },
+        { text: `Bed name: ${beds[1].name}, room name: ${beds[1].roomName}`, value: beds[1].id, selected: false },
+      ])
     })
   })
 })

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -122,6 +122,11 @@ describe('bookingUtils', () => {
         {
           items: [
             {
+              text: 'Move person to a new bed',
+              classes: 'govuk-button--secondary',
+              href: paths.bookings.moves.new({ premisesId: 'premisesId', bookingId: booking.id }),
+            },
+            {
               text: 'Mark as arrived',
               classes: 'govuk-button--secondary',
               href: paths.bookings.arrivals.new({ premisesId: 'premisesId', bookingId: booking.id }),
@@ -152,6 +157,11 @@ describe('bookingUtils', () => {
       expect(bookingActions(booking, 'premisesId')).toEqual([
         {
           items: [
+            {
+              text: 'Move person to a new bed',
+              classes: 'govuk-button--secondary',
+              href: paths.bookings.moves.new({ premisesId: 'premisesId', bookingId: booking.id }),
+            },
             {
               text: 'Log departure',
               classes: 'govuk-button--secondary',

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -41,7 +41,13 @@ export const bookingsToTableRows = (
 
 export const bookingActions = (booking: Booking, premisesId: string): Array<IdentityBarMenu> => {
   if (booking.status === 'awaiting-arrival' || booking.status === 'arrived') {
-    const items = []
+    const items = [
+      {
+        text: 'Move person to a new bed',
+        classes: 'govuk-button--secondary',
+        href: paths.bookings.moves.new({ premisesId, bookingId: booking.id }),
+      },
+    ]
 
     if (booking.status === 'awaiting-arrival') {
       items.push({

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -1,5 +1,5 @@
-import type { BespokeError, IdentityBarMenu, TableRow } from '@approved-premises/ui'
-import type { Booking } from '@approved-premises/api'
+import type { BespokeError, IdentityBarMenu, SelectOption, TableRow } from '@approved-premises/ui'
+import type { BedSummary, Booking } from '@approved-premises/api'
 import paths from '../paths/manage'
 import { DateFormats } from './dateUtils'
 import { SanitisedError } from '../sanitisedError'
@@ -137,4 +137,12 @@ const parseConflictError = (detail: string): ParsedConflictError => {
   const conflictingEntityType = detail.includes('Lost Bed') ? 'lost-bed' : 'booking'
 
   return { conflictingEntityId, conflictingEntityType }
+}
+
+export const bedsAsSelectItems = (beds: Array<BedSummary>, selectedId: string): Array<SelectOption> => {
+  return beds.map(bed => ({
+    text: `Bed name: ${bed.name}, room name: ${bed.roomName}`,
+    value: bed.id,
+    selected: selectedId === bed.id,
+  }))
 }

--- a/server/views/premises/beds/move/new.njk
+++ b/server/views/premises/beds/move/new.njk
@@ -1,0 +1,105 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+		text: "Back",
+		href: paths.bookings.show({ premisesId: premisesId, bookingId: booking.id })
+	}) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1>{{pageHeading}}</h1>
+
+      {{ govukSummaryList({
+                rows: [
+                   {
+                    key: {
+                        text: "Name"
+                    },
+                    value: {
+                        text: booking.person.name
+                    }
+                    },
+                    {
+                    key: {
+                        text: "CRN"
+                    },
+                    value: {
+                        text: booking.person.crn
+                    }
+                    },
+                    {
+                    key: {
+                        text: "Arrival date"
+                    },
+                    value: {
+                        text: formatDate(booking.arrival.arrivalDate)
+                    }
+                    },
+                     {
+                    key: {
+                        text: "Departure date"
+                    },
+                    value: {
+                        text: formatDate(booking.departure.dateTime)
+                    }
+                    },
+                       {
+                    key: {
+                        text: "Bed"
+                    },
+                    value: {
+                        text: booking.bed.name
+                    }
+                    }
+                ]
+            }) }}
+      {# TODO once calendar is in #}
+      {# <a href="{{paths.premises.calendar({premisesId: premisesId})}}" class="govuk-link">View Calendar</a> #}
+
+      <form action="{{ paths.bookings.moves.create({ premisesId: premisesId, bookingId: booking.id }) }}" method="post">
+        {{ showErrorSummary(errorSummary) }}
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {{ govukSelect({
+          label: {
+              text: "Which bed do you want to move " + booking.person.name + " to?",
+              classes: "govuk-label--m"
+          },
+          classes: "govuk-input--width-20",
+          id: "bed",
+          name: "bed",
+          items: BookingUtils.bedsAsSelectItems(beds, bed),
+          errorMessage: errors.moveBed.empty
+        }) }}
+
+        {{ govukTextarea({
+          name: "notes",
+          id: "notes",
+          value: notes,
+          label: {
+            text: "Any other information"
+          }
+        }) }}
+
+        {{ govukButton({
+          name: 'submit',
+          text: "Submit"
+        }) }}
+      </form>
+
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
# Context
AP managers need to be able to move bookings between beds. This PR adds this functionality. 

[Prototype](https://approved-premises-prototype-main.apps.live.cloud-platform.service.justice.gov.uk/manage/move-residents-room)
[Trello card](https://trello.com/c/wUylP1WA/10-moving-beds)

# Changes in this PR
- We add a method to the booking client to post to the `moves` endpoint
- We add a method to the booking service to call the client method created previously
- We add a MoveBedsController with a method to render the form
- We add a `create` method to the previously create controller to post to the service method create in step 2
- We add a link from the Booking `show` page to the `new` method create in step 3
- Some refactoring/util function creating
- We add the view 

## Screenshots of UI changes

![move-booking](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/53329ba9-1c0e-4853-89b0-9c31e180f798)
![move-booking-confirmation](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/308dd58b-3505-4eb8-a731-8fcb847f2d81)


