### PR TITLE
Make ACCT alert comment nullable

### DIFF
--- a/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.test.ts
@@ -77,6 +77,22 @@ describe('acctAlertResponse', () => {
       'Expiry date': 'Sunday 9 January 2022',
     })
   })
+
+  it('returns an empty string for the comment if it is undefined', () => {
+    const acctAlert = acctAlertFactory.build({
+      alertId: 123,
+      comment: undefined,
+      dateCreated: '2022-01-01T10:00:00Z',
+      dateExpires: '2022-01-09T10:00:00Z',
+    })
+
+    expect(acctAlertResponse(acctAlert)).toEqual({
+      'Alert type': 123,
+      'Date created': 'Saturday 1 January 2022',
+      'Expiry date': 'Sunday 9 January 2022',
+      'ACCT description': '',
+    })
+  })
 })
 
 describe('caseNoteCheckbox', () => {

--- a/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
+++ b/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
@@ -44,7 +44,7 @@ export const adjudicationResponse = (adjudication: Adjudication) => {
 export const acctAlertResponse = (acctAlert: PersonAcctAlert) => {
   return {
     'Alert type': acctAlert.alertId,
-    'ACCT description': acctAlert.comment,
+    'ACCT description': acctAlert.comment ?? '',
     'Date created': DateFormats.isoDateToUIDate(acctAlert.dateCreated),
     'Expiry date': DateFormats.isoDateToUIDate(acctAlert.dateExpires),
   }

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -257,6 +257,16 @@ describe('utils', () => {
       expect(acctAlertsFromAssessment(assessment)).toEqual(acctAlerts)
     })
 
+    it('if the comments property of an ACCT alert is undefined it returns an empty string', () => {
+      const acctAlert1 = acctAlertFactory.build()
+      const acctAlert2 = acctAlertFactory.build({ comment: undefined })
+
+      const assessment = assessmentFactory.build()
+      assessment.application.data['prison-information'] = { 'case-notes': { acctAlerts: [acctAlert1, acctAlert2] } }
+
+      expect(acctAlertsFromAssessment(assessment)).toEqual([acctAlert1, { ...acctAlert2, comment: '' }])
+    })
+
     it('returns an empty string if the case notes are empty', () => {
       const assessment = assessmentFactory.build()
       assessment.application.data['prison-information'] = {}

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -1,6 +1,6 @@
 import { ApplicationType, GroupedAssessments, SummaryListItem } from '@approved-premises/ui'
 
-import { ApprovedPremisesAssessment as Assessment, AssessmentSummary } from '@approved-premises/api'
+import { ApprovedPremisesAssessment as Assessment, AssessmentSummary, PersonAcctAlert } from '@approved-premises/api'
 import { TasklistPageInterface } from '../../form-pages/tasklistPage'
 import Assess from '../../form-pages/assess'
 import { UnknownPageError } from '../errors'
@@ -134,7 +134,9 @@ const caseNotesFromAssessment = (assessment: Assessment) =>
   assessment.application?.data?.['prison-information']?.['case-notes']?.selectedCaseNotes || []
 
 const acctAlertsFromAssessment = (assessment: Assessment) =>
-  assessment.application?.data?.['prison-information']?.['case-notes']?.acctAlerts || []
+  assessment.application?.data?.['prison-information']?.['case-notes']?.acctAlerts.map((acctAlert: PersonAcctAlert) => {
+    return { ...acctAlert, comment: acctAlert.comment ?? '' }
+  }) || []
 
 const rejectionRationaleFromAssessmentResponses = (assessment: Assessment): string => {
   const response = getResponseForPage(assessment, 'make-a-decision', 'make-a-decision')?.Decision || ''


### PR DESCRIPTION
Due to [this API change](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/741) we need to ensure ACCT Alert comments are nullable. 
This PR returns an empty string when the comments are undefined in both places they are used