### PR TITLE
Use `useFakeTimers` in premisesController tests

### DIFF
--- a/server/controllers/manage/premises/premisesController.test.ts
+++ b/server/controllers/manage/premises/premisesController.test.ts
@@ -25,6 +25,7 @@ describe('PremisesController', () => {
 
   beforeEach(() => {
     request = createMock<Request>({ user: { token }, params: { premisesId } })
+    jest.useFakeTimers()
   })
 
   describe('index', () => {


### PR DESCRIPTION
Because we’re using `new Date()` in these tests, we’re getting situations where there’s a short (microseconds) delay between running our tests and getting the expectations, so the tests can occassionally fail. This uses `jest.useFakeTimers()` to “freeze” time, allowing our expectations to pass conistently.