### PR TITLE
Add tab role to Prison Info tabs

### DIFF
--- a/assets/tabPanelTableScript.js
+++ b/assets/tabPanelTableScript.js
@@ -1,12 +1,12 @@
 function hidePanels() {
   for (var i = 0; i < panels.length; i++) {
-    panels[i].setAttribute('hidden', 'true')
+    panels[i].classList.add('govuk-visually-hidden')
   }
 }
 
 function showPanel(panel) {
   hidePanels()
-  panel.removeAttribute('hidden')
+  panel.classList.remove('govuk-visually-hidden')
 }
 
 function setCurrent(current) {
@@ -17,7 +17,7 @@ function setCurrent(current) {
   current.setAttribute('aria-selected', 'true')
 }
 
-var navLinks = document.querySelectorAll('[role="tab"]')
+var navLinks = document.querySelectorAll('.moj-sub-navigation__item a')
 var panels = document.querySelectorAll('[role="tabpanel"]')
 
 showPanel(panels[0])

--- a/server/utils/assessments/oasysUtils.test.ts
+++ b/server/utils/assessments/oasysUtils.test.ts
@@ -33,7 +33,7 @@ describe('oasysTableTabs', () => {
     const roshSummaries = roshSummaryFactory.buildList(2)
 
     expect(oasysTableTabs({ roshSummaries })).toMatchStringIgnoringWhitespace(
-      `<div class="govuk-grid-column-full" role="tabpanel" id="roshSummaries" aria-labelledby="roshSummariesTab" hidden>
+      `<div class="govuk-grid-column-full" role="tabpanel" id="roshSummaries" aria-labelledby="roshSummariesTab" class="govuk-visually-hidden">
               ${oasysQuestions(roshSummaries)}
               </div>`,
     )

--- a/server/utils/assessments/oasysUtils.ts
+++ b/server/utils/assessments/oasysUtils.ts
@@ -15,7 +15,7 @@ const oasysQuestions = (section: Array<OASysQuestion>) =>
 const oasysTableTabs = (oasysSections: { [index: string]: OasysImportArrays }) =>
   Object.entries(oasysSections)
     .map(([sectionName, oasysSection]) => {
-      return `<div class="govuk-grid-column-full" role="tabpanel" id="${sectionName}" aria-labelledby="${sectionName}Tab" hidden>
+      return `<div class="govuk-grid-column-full" role="tabpanel" id="${sectionName}" aria-labelledby="${sectionName}Tab" class="govuk-visually-hidden">
       ${oasysQuestions(oasysSection)}
       </div>`
     })

--- a/server/views/partials/prisonInformationTable.njk
+++ b/server/views/partials/prisonInformationTable.njk
@@ -31,11 +31,11 @@
                 }]
             }) }}
 
-    <div class="govuk-column-full-width" id="caseNotes" role="tabpanel" aria-labelledby="caseNotesTab" hidden>
+    <div class="govuk-column-full-width" id="caseNotes" role="tabpanel" aria-labelledby="caseNotesTab" class="govuk-visually-hidden">
         {{caseNotes | safe}}
     </div>
 
-    <div class="govuk-column-full-width" id="adjudications" role="tabpanel" aria-labelledby="adjudicationsTab" hidden>
+    <div class="govuk-column-full-width" id="adjudications" role="tabpanel" aria-labelledby="adjudicationsTab" class="govuk-visually-hidden">
         <table class="govuk-table">
             <caption class="govuk-table__caption govuk-table__caption--m">Adjudications</caption>
 
@@ -63,7 +63,7 @@
         </table>
     </div>
 
-    <div class="govuk-column-full-width" id="acct" role="tabpanel" aria-labelledby="acctTab" hidden>
+    <div class="govuk-column-full-width" id="acct" role="tabpanel" aria-labelledby="acctTab" class="govuk-visually-hidden">
         <table class="govuk-table">
             <caption class="govuk-table__caption govuk-table__caption--m">ACCT</caption>
             <thead class="govuk-table__head">


### PR DESCRIPTION
Event listeners not being attached by `tabPanelTableScript` because selector is based on role attribute which is missing.