### PR TITLE
Fix expected placement dates

### DIFF
--- a/server/form-pages/apply/move-on/placementDuration.test.ts
+++ b/server/form-pages/apply/move-on/placementDuration.test.ts
@@ -124,7 +124,7 @@ describe('PlacementDuration', () => {
 
       application = applicationFactory.withReleaseDate(DateFormats.dateObjToIsoDate(releaseDate)).build()
 
-      expect(new PlacementDuration({}, application).departureDate).toEqual(addDays(releaseDate, 7 * 12))
+      expect(new PlacementDuration({}, application).departureDate).toEqual(addDays(releaseDate, 12))
     })
   })
 

--- a/server/form-pages/apply/move-on/placementDuration.ts
+++ b/server/form-pages/apply/move-on/placementDuration.ts
@@ -120,6 +120,6 @@ export default class PlacementDuration implements TasklistPage {
   private fetchDepartureDate(): Date | undefined {
     const standardPlacementDuration = getDefaultPlacementDurationInDays(this.application)
 
-    return this.arrivalDate ? addDays(this.arrivalDate, 7 * standardPlacementDuration) : undefined
+    return this.arrivalDate ? addDays(this.arrivalDate, standardPlacementDuration) : undefined
   }
 }


### PR DESCRIPTION
Now the default duration is returned in days, we don’t need to multiply the result by 7