### PR TITLE
Setup prod / preprod for auditing

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -16,5 +16,12 @@ generic-service:
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-preprod.prison.service.justice.gov.uk'
     COMMUNITY_ACCOMMODATION_API_SERVICE_NAME: approved-premises
 
+  namespace_secrets:
+    sqs-hmpps-audit-secret:
+      AUDIT_SQS_ACCESS_KEY_ID: 'access_key_id'
+      AUDIT_SQS_SECRET_ACCESS_KEY: 'secret_access_key'
+      AUDIT_SQS_QUEUE_URL: 'sqs_queue_url'
+      AUDIT_SQS_QUEUE_NAME: 'sqs_queue_name'
+
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -16,5 +16,12 @@ generic-service:
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api.prison.service.justice.gov.uk'
     COMMUNITY_ACCOMMODATION_API_SERVICE_NAME: approved-premises
 
+  namespace_secrets:
+    sqs-hmpps-audit-secret:
+      AUDIT_SQS_ACCESS_KEY_ID: 'access_key_id'
+      AUDIT_SQS_SECRET_ACCESS_KEY: 'secret_access_key'
+      AUDIT_SQS_QUEUE_URL: 'sqs_queue_url'
+      AUDIT_SQS_QUEUE_NAME: 'sqs_queue_name'
+
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service


### PR DESCRIPTION
This adds the relevant secrets to our prod/preprod environments. The secrets already exist in the our shared namespace and are in use by CAS3, so we can use the same ones.