### PR TITLE
Allow CRN search to handle 500 errors for missing OASys and NOMS number

### DIFF
--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -53,6 +53,37 @@ export default {
         status: 403,
       },
     }),
+  stubFindPersonNoNomsNumber: (crn: string): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/people/search?crn=${crn}&checkCaseload=true`,
+      },
+      response: {
+        status: 500,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+
+        jsonBody: {
+          detail: 'No nomsNumber present for CRN',
+        },
+      },
+    }),
+
+  stubFindPersonNoOasysRecord: (crn: string): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/people/search?crn=${crn}&checkCaseload=true`,
+      },
+      response: {
+        status: 500,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+
+        jsonBody: {
+          detail: 'No OASys present for CRN',
+        },
+      },
+    }),
   stubPersonNotFound: (args: { person: Person }): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/pages/apply/enterCrn.ts
+++ b/integration_tests/pages/apply/enterCrn.ts
@@ -20,4 +20,26 @@ export default class EnterCRNPage extends Page {
     cy.get('.govuk-error-summary').should('contain', `The CRN '${person.crn}' is not in your caseload`)
     cy.get(`[data-cy-error-crn]`).should('contain', `The CRN '${person.crn}' is not in your caseload`)
   }
+
+  public shouldShowNoNomsRecordForPersonErrorMessage(person: Person): void {
+    cy.get('.govuk-error-summary').should(
+      'contain',
+      `The CRN '${person.crn}' does not have a NOMS number. Email AP Service Support (APServiceSupport@digital.justice.gov.uk) with the person's name and CRN for help starting an AP application.`,
+    )
+    cy.get(`[data-cy-error-crn]`).should(
+      'contain',
+      `The CRN '${person.crn}' does not have a NOMS number. Email AP Service Support (APServiceSupport@digital.justice.gov.uk) with the person's name and CRN for help starting an AP application.`,
+    )
+  }
+
+  public shouldShowNoOasysForPersonErrorMessage(person: Person): void {
+    cy.get('.govuk-error-summary').should(
+      'contain',
+      `The CRN '${person.crn}' does not have an OASys record. Email AP Service Support (APServiceSupport@digital.justice.gov.uk) with the person's name and CRN for help starting an AP application.`,
+    )
+    cy.get(`[data-cy-error-crn]`).should(
+      'contain',
+      `The CRN '${person.crn}' does not have an OASys record. Email AP Service Support (APServiceSupport@digital.justice.gov.uk) with the person's name and CRN for help starting an AP application.`,
+    )
+  }
 }

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -190,6 +190,40 @@ context('Apply', () => {
     new EnterCRNPage().shouldShowPersonNotInCaseLoadErrorMessage(this.person)
   })
 
+  it('shows an error message if the person does not have a NOMS number', function test() {
+    // And the person I am about to search does not have NOMS number
+    cy.task('stubFindPersonNoNomsNumber', this.person.crn)
+
+    // And I have started an application
+    const startPage = StartPage.visit()
+    startPage.startApplication()
+
+    // When I enter a CRN
+    const crnPage = new EnterCRNPage()
+    crnPage.enterCrn(this.person.crn)
+    crnPage.clickSubmit()
+
+    // Then I should see an error message
+    new EnterCRNPage().shouldShowNoNomsRecordForPersonErrorMessage(this.person)
+  })
+
+  it('shows an error message if the person does not have a OASYS record', function test() {
+    // And the person I am about to search for does not have an OASYS record
+    cy.task('stubFindPersonNoOasysRecord', this.person.crn)
+
+    // And I have started an application
+    const startPage = StartPage.visit()
+    startPage.startApplication()
+
+    // When I enter a CRN
+    const crnPage = new EnterCRNPage()
+    crnPage.enterCrn(this.person.crn)
+    crnPage.clickSubmit()
+
+    // Then I should see an error message
+    new EnterCRNPage().shouldShowNoOasysForPersonErrorMessage(this.person)
+  })
+
   it('allows completion of application emergency flow', function test() {
     // And I complete the application
     const uiRisks = mapApiPersonRisksForUi(this.application.risks)

--- a/server/controllers/peopleController.test.ts
+++ b/server/controllers/peopleController.test.ts
@@ -84,6 +84,62 @@ describe('PeopleController', () => {
       ])
     })
 
+    it('send an error to the flash if the error is a 500 and checkOasys is set', async () => {
+      const err = { status: 500, data: { detail: 'No OASys present for CRN' } }
+
+      personService.findByCrn.mockImplementation(() => {
+        throw err
+      })
+
+      const requestHandler = peopleController.find()
+
+      request.body.crn = 'CRN123'
+      request.body.checkOasys = '1'
+
+      await requestHandler(request, response, next)
+
+      expect(flashSpy).toHaveBeenCalledWith('errors', {
+        crn: errorMessage(
+          'crn',
+          "The CRN 'CRN123' does not have an OASys record. Email AP Service Support (APServiceSupport@digital.justice.gov.uk) with the person's name and CRN for help starting an AP application.",
+        ),
+      })
+      expect(flashSpy).toHaveBeenCalledWith('errorSummary', [
+        errorSummary(
+          'crn',
+          "The CRN 'CRN123' does not have an OASys record. Email AP Service Support (APServiceSupport@digital.justice.gov.uk) with the person's name and CRN for help starting an AP application.",
+        ),
+      ])
+    })
+
+    it('send an error to the flash if the error is a 500 and checkNoms is set', async () => {
+      const err = { status: 500, data: { detail: 'No nomsNumber present for CRN' } }
+
+      personService.findByCrn.mockImplementation(() => {
+        throw err
+      })
+
+      const requestHandler = peopleController.find()
+
+      request.body.crn = 'CRN123'
+      request.body.checkNoms = '1'
+
+      await requestHandler(request, response, next)
+
+      expect(flashSpy).toHaveBeenCalledWith('errors', {
+        crn: errorMessage(
+          'crn',
+          "The CRN 'CRN123' does not have a NOMS number. Email AP Service Support (APServiceSupport@digital.justice.gov.uk) with the person's name and CRN for help starting an AP application.",
+        ),
+      })
+      expect(flashSpy).toHaveBeenCalledWith('errorSummary', [
+        errorSummary(
+          'crn',
+          "The CRN 'CRN123' does not have a NOMS number. Email AP Service Support (APServiceSupport@digital.justice.gov.uk) with the person's name and CRN for help starting an AP application.",
+        ),
+      ])
+    })
+
     it('sends an error to the flash if a crn has not been provided', async () => {
       request.body = {}
 

--- a/server/controllers/peopleController.ts
+++ b/server/controllers/peopleController.ts
@@ -2,13 +2,14 @@ import type { Request, RequestHandler, Response } from 'express'
 
 import PersonService from '../services/personService'
 import { addErrorMessageToFlash } from '../utils/validation'
+import { supportEmail } from '../utils/phaseBannerUtils'
 
 export default class PeopleController {
   constructor(private readonly personService: PersonService) {}
 
   find(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { crn, checkCaseload } = req.body
+      const { crn, checkCaseload, checkOasys, checkNoms } = req.body
 
       if (crn) {
         try {
@@ -19,6 +20,20 @@ export default class PeopleController {
             addErrorMessageToFlash(req, `No person with an CRN of '${crn}' was found`, 'crn')
           } else if (checkCaseload && err.status === 403) {
             addErrorMessageToFlash(req, `The CRN '${crn}' is not in your caseload`, 'crn')
+          } else if (err.status === 500) {
+            if (err?.data?.detail === 'No OASys present for CRN' && checkOasys) {
+              addErrorMessageToFlash(
+                req,
+                `The CRN '${crn}' does not have an OASys record. Email AP Service Support (${supportEmail}) with the person's name and CRN for help starting an AP application.`,
+                'crn',
+              )
+            } else if (err?.data?.detail === 'No nomsNumber present for CRN' && checkNoms) {
+              addErrorMessageToFlash(
+                req,
+                `The CRN '${crn}' does not have a NOMS number. Email AP Service Support (${supportEmail}) with the person's name and CRN for help starting an AP application.`,
+                'crn',
+              )
+            }
           } else {
             throw err
           }

--- a/server/utils/phaseBannerUtils.ts
+++ b/server/utils/phaseBannerUtils.ts
@@ -3,6 +3,8 @@ import applyPaths from '../paths/apply'
 import managePaths from '../paths/manage'
 import matchPaths from '../paths/match'
 
+export const supportEmail = 'APServiceSupport@digital.justice.gov.uk'
+
 export const APPLY_FEEDBACK_LINK =
   'https://forms.office.com/Pages/ResponsePage.aspx?id=KEeHxuZx_kGp4S6MNndq2H0aht4jI_tEtV4d1X0VL3lUOEw5WlFaUVFEWTQwRUtSWURGRUtFNzRDTi4u'
 export const ASSESS_FEEDBACK_LINK =
@@ -16,8 +18,8 @@ export const getContent = (currentUrl: string) => {
   const feedbackLink = getFeedbackLink(currentUrl)
 
   return feedbackLink
-    ? `This is a new service. <a class="govuk-link" href="${feedbackLink}">Give us your feedback</a> or <a class="govuk-link" href="mailto:APServiceSupport@digital.justice.gov.uk">email us</a> to report a bug`
-    : 'This is a new service. <a class="govuk-link" href="mailto:APServiceSupport@digital.justice.gov.uk">Email us</a> to report a bug'
+    ? `This is a new service. <a class="govuk-link" href="${feedbackLink}">Give us your feedback</a> or <a class="govuk-link" href="mailto:${supportEmail}">email us</a> to report a bug`
+    : `This is a new service. <a class="govuk-link" href="mailto:${supportEmail}">Email us</a> to report a bug`
 }
 
 const getFeedbackLink = (currentUrl: string) => {

--- a/server/views/applications/new.njk
+++ b/server/views/applications/new.njk
@@ -15,6 +15,8 @@
       <form action="{{ paths.applications.people.find() }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
         <input type="hidden" name="checkCaseload" value="true"/>
+        <input type="hidden" name="checkOasys" value="true"/>
+        <input type="hidden" name="checkNoms" value="true"/>
 
         {{ showErrorSummary(errorSummary) }}
 


### PR DESCRIPTION
If we recieve a 500 error from the service in the controller we now check to see if it has a 'data.detail' property with the correct content and if so we add the error to the flash. We also send 'checkOasys' and 'checkNoms' from the view as this method is also called from a different view when booking someone into an AP where they might not be concerned if there is an OASys or NOMS present and they may not have time to contact support.


[Trello card](https://trello.com/c/w2aKx7CW/253-return-user-friendly-error-for-an-application-when-a-user-has-no-noms-number-or-oasys-entry)


## Screenshots of UI changes

![no-noms-record](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/097a7473-2b63-4888-b288-6ab1e62d0d35)
![no-oasys-record](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/149c1c51-42c3-4524-8332-a96e51e315bf)

