### PR TITLE
Allow ARK/DOM1 IP addresses to access the service

### DIFF
--- a/helm_deploy/hmpps-approved-premises-ui/values.yaml
+++ b/helm_deploy/hmpps-approved-premises-ui/values.yaml
@@ -67,6 +67,11 @@ generic-service:
     cloudplatform-live1-1: '35.178.209.113/32'
     cloudplatform-live1-2: '3.8.51.207/32'
     cloudplatform-live1-3: '35.177.252.54/32'
+    ark-nps-hmcts-ttp1: '195.59.75.0/24'
+    ark-nps-hmcts-ttp2: '194.33.192.0/25'
+    ark-nps-hmcts-ttp3: '194.33.193.0/25'
+    ark-nps-hmcts-ttp4: '194.33.196.0/25'
+    ark-nps-hmcts-ttp5: '194.33.197.0/25'
 
 generic-prometheus-alerts:
   targetApplication: hmpps-approved-premises-ui


### PR DESCRIPTION
Users who are not using a MOJ VPN and so can't access production.

This borrows the [same allowlist that CAS3 use, which uses the same allowlist as Delius][1]

[1]: https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/commit/773b614834f8751ecd8f10b4ea09bb276527b1d4