### PR TITLE
Update Circle CI paths

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,8 +195,8 @@ jobs:
           command: |
             npm run test
       - store_artifacts:
-          path: test-results
-          destination: test-results
+          path: playwright-report
+          destination: playwright-report
 workflows:
   version: 2
   build-test-and-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
           command: |
             mv ./coverage/coverage-final.json ./coverage/coverage_${CIRCLE_NODE_INDEX}.json
       - store_test_results:
-          path: test_results
+          path: test_results/jest
       - store_artifacts:
           path: test_results/unit-test-reports.html
       - persist_to_workspace:
@@ -149,7 +149,7 @@ jobs:
             TESTS=$(circleci tests glob "integration_tests/tests/**/*.cy.ts" | circleci tests split --split-by=timings | paste -sd ',')
             npm run int-test -- --spec $TESTS
       - store_test_results:
-          path: test_results
+          path: test_results/cypress
       - store_artifacts:
           path: integration_tests/videos
       - store_artifacts:
@@ -278,7 +278,7 @@ workflows:
             - deploy_preprod
       - hmpps/deploy_env:
           name: deploy_prod
-          env: "prod"
+          env: 'prod'
           slack_notification: true
           slack_channel_name: << pipeline.parameters.releases-slack-channel >>
           context:


### PR DESCRIPTION
There's a couple of places where artifact paths were pointing to the wrong place, meaning we weren't getting accurate timing data for test splitting, as well as missing videos and screenshots for failed e2e tests.