### PR TITLE
Make offence date nullable

### DIFF
--- a/server/@types/shared/models/ActiveOffence.ts
+++ b/server/@types/shared/models/ActiveOffence.ts
@@ -7,6 +7,6 @@ export type ActiveOffence = {
     offenceDescription: string;
     offenceId: string;
     convictionId: number;
-    offenceDate: string;
+    offenceDate?: string;
 };
 

--- a/server/utils/offenceUtils.test.ts
+++ b/server/utils/offenceUtils.test.ts
@@ -63,5 +63,29 @@ describe('offenceUtils', () => {
         ],
       ])
     })
+
+    it('returns table rows for the index offences when the offenceDate is missing', () => {
+      const offence = activeOffenceFactory.build({ offenceDate: undefined })
+
+      expect(offenceTableRows([offence])).toEqual([
+        [
+          {
+            html: offenceRadioButton(offence),
+          },
+          {
+            text: offence.offenceId,
+          },
+          {
+            text: offence.offenceDescription,
+          },
+          {
+            text: 'No offence date available',
+          },
+          {
+            text: String(offence.convictionId),
+          },
+        ],
+      ])
+    })
   })
 })

--- a/server/utils/offenceUtils.ts
+++ b/server/utils/offenceUtils.ts
@@ -6,6 +6,10 @@ const offenceTableRows = (offences: Array<ActiveOffence>): Array<TableRow> => {
   const rows = [] as Array<TableRow>
 
   offences.forEach(offence => {
+    const offenceDate = offence?.offenceDate
+      ? DateFormats.isoDateToUIDate(offence.offenceDate)
+      : 'No offence date available'
+
     rows.push([
       {
         html: offenceRadioButton(offence),
@@ -17,7 +21,7 @@ const offenceTableRows = (offences: Array<ActiveOffence>): Array<TableRow> => {
         text: offence.offenceDescription,
       },
       {
-        text: DateFormats.isoDateToUIDate(offence.offenceDate),
+        text: offenceDate,
       },
       {
         text: String(offence.convictionId),


### PR DESCRIPTION
Due to an [API change](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/760) we need to ensure the offenceDate is nullable 