### PR TITLE
Add Cancel Lost Bed button

### DIFF
--- a/integration_tests/mockApis/lostBed.ts
+++ b/integration_tests/mockApis/lostBed.ts
@@ -101,12 +101,25 @@ export default {
         jsonBody: bedspaceConflictResponseBody(args.conflictingEntityId, args.conflictingEntityType),
       },
     }),
+
+  stubCancelLostBed: (args: { lostBedId: string; premisesId: string; lostBedCancellation }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: paths.premises.lostBeds.cancel({ premisesId: args.premisesId, id: args.lostBedId }),
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.lostBedCancellation,
+      },
+    }),
   stubLostBedErrors: (args: { premisesId: string; params: Array<string> }): SuperAgentRequest =>
     stubFor(errorStub(args.params, `/premises/${args.premisesId}/lost-beds`)),
 
   stubLostBedReferenceData: (): Promise<Response> => stubFor(lostBedReasons),
 
-  verifyLostBedCreate: async (args: { premisesId: string; bookingId: string }) =>
+  verifyLostBedCreate: async (args: { premisesId: string }) =>
     (
       await getMatchingRequests({
         method: 'POST',
@@ -119,6 +132,14 @@ export default {
       await getMatchingRequests({
         method: 'PUT',
         url: `/premises/${args.premisesId}/lost-beds/${args.lostBed.id}`,
+      })
+    ).body.requests,
+
+  verifyLostBedCancel: async (args: { premisesId: string; lostBedId: string }) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: paths.premises.lostBeds.cancel({ premisesId: args.premisesId, id: args.lostBedId }),
       })
     ).body.requests,
 }

--- a/integration_tests/mockApis/placementApplication.ts
+++ b/integration_tests/mockApis/placementApplication.ts
@@ -82,4 +82,12 @@ export default {
         url: paths.placementApplications.submit({ id: applicationId }),
       })
     ).body.requests,
+
+  verifyPlacementApplicationReviewSubmit: async (applicationId: string) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: paths.placementApplications.submitDecision({ id: applicationId }),
+      })
+    ).body.requests,
 }

--- a/integration_tests/pages/manage/lostBedShow.ts
+++ b/integration_tests/pages/manage/lostBedShow.ts
@@ -28,4 +28,12 @@ export default class LostBedShowPage extends Page {
 
     cy.get('textarea[name="notes"]').type(String(notes))
   }
+
+  clickSubmit(): void {
+    cy.get('button[name="submit"]').click()
+  }
+
+  clickCancel(): void {
+    cy.get('button').contains('Cancel lost bed').click()
+  }
 }

--- a/integration_tests/tests/match/placementApplications.cy.ts
+++ b/integration_tests/tests/match/placementApplications.cy.ts
@@ -282,6 +282,14 @@ context('Placement Applications', () => {
     decisionPage.clickSubmit()
 
     // Then I should be taken to the confirm submission page
+    cy.task('verifyPlacementApplicationReviewSubmit', placementApplication.id).then(requests => {
+      expect(requests).to.have.length(1)
+      expect(requests[0].url).to.equal(paths.placementApplications.submitDecision({ id: placementApplication.id }))
+
+      const body = JSON.parse(requests[0].body)
+
+      expect(body).to.contain.keys('decision', 'decisionSummary', 'summaryOfChanges')
+    })
 
     Page.verifyOnPage(ReviewApplicationConfirmPage)
   })

--- a/server/controllers/manage/lostBedsController.ts
+++ b/server/controllers/manage/lostBedsController.ts
@@ -115,6 +115,14 @@ export default class LostBedsController {
       req.body.endDate = endDate
 
       try {
+        if (req.body.cancel === '1') {
+          await this.lostBedService.cancelLostBed(req.user.token, id, premisesId, { notes: req.body.notes })
+
+          req.flash('success', 'Bed cancelled')
+
+          return res.redirect(paths.lostBeds.index({ premisesId }))
+        }
+
         await this.lostBedService.updateLostBed(req.user.token, id, premisesId, req.body as UpdateLostBed)
 
         req.flash('success', 'Bed updated')
@@ -124,6 +132,23 @@ export default class LostBedsController {
         const redirectPath = req.headers.referer
 
         return catchValidationErrorOrPropogate(req, res, err, redirectPath)
+      }
+    }
+  }
+
+  cancel(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, bedId, id } = req.params
+      const { notes = '' } = req.body
+
+      try {
+        await this.lostBedService.cancelLostBed(req.user.token, id, premisesId, { notes })
+
+        req.flash('success', 'Bed cancelled')
+
+        return res.redirect(paths.lostBeds.index({ premisesId }))
+      } catch (err) {
+        return catchValidationErrorOrPropogate(req, res, err, paths.lostBeds.show({ premisesId, bedId, id }))
       }
     }
   }

--- a/server/data/lostBedClient.test.ts
+++ b/server/data/lostBedClient.test.ts
@@ -1,7 +1,8 @@
 import LostBedClient from './lostBedClient'
-import { lostBedFactory, newLostBedFactory } from '../testutils/factories'
+import { lostBedCancellationFactory, lostBedFactory, newLostBedFactory } from '../testutils/factories'
 import paths from '../paths/api'
 import describeClient from '../testutils/describeClient'
+import { NewLostBedCancellation } from '../@types/shared'
 
 describeClient('LostBedClient', provider => {
   let lostBedClient: LostBedClient
@@ -132,6 +133,38 @@ describeClient('LostBedClient', provider => {
       const result = await lostBedClient.update(lostBed.id, lostBedUpdateData, 'premisesId')
 
       expect(result).toEqual(lostBed)
+    })
+  })
+
+  describe('cancel', () => {
+    it('cancels a lost bed', async () => {
+      const lostBedCancellation = lostBedCancellationFactory.build()
+      const notes = 'note'
+
+      const lostBedCancellationData: NewLostBedCancellation = {
+        notes,
+      }
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to cancel a lost bed',
+        withRequest: {
+          method: 'POST',
+          path: paths.premises.lostBeds.cancel({ premisesId, id: lostBedCancellation.id }),
+          body: lostBedCancellationData,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: lostBedCancellation,
+        },
+      })
+
+      const result = await lostBedClient.cancel(lostBedCancellation.id, 'premisesId', lostBedCancellationData)
+
+      expect(result).toEqual(lostBedCancellation)
     })
   })
 })

--- a/server/data/lostBedClient.ts
+++ b/server/data/lostBedClient.ts
@@ -1,4 +1,10 @@
-import type { LostBed, NewLostBed, UpdateLostBed } from '@approved-premises/api'
+import type {
+  LostBed,
+  LostBedCancellation,
+  NewLostBed,
+  NewLostBedCancellation,
+  UpdateLostBed,
+} from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -34,5 +40,14 @@ export default class LostBedClient {
     })
 
     return response as LostBed
+  }
+
+  async cancel(id: string, premisesId: string, lostBedData: NewLostBedCancellation): Promise<LostBedCancellation> {
+    const response = await this.restClient.post({
+      path: paths.premises.lostBeds.cancel({ id, premisesId }),
+      data: { ...lostBedData },
+    })
+
+    return response as LostBedCancellation
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -19,6 +19,7 @@ const managePaths = {
     index: lostBedsPath,
     show: lostBedsPath.path(':id'),
     update: lostBedsPath.path(':id'),
+    cancel: lostBedsPath.path(':id/cancellations'),
   },
   beds: {
     index: bedsPath,
@@ -88,6 +89,7 @@ export default {
       index: managePaths.lostBeds.index,
       update: managePaths.lostBeds.update,
       show: managePaths.lostBeds.show,
+      cancel: managePaths.lostBeds.cancel,
     },
     staffMembers: {
       index: managePaths.premises.show.path('staff'),

--- a/server/paths/manage.ts
+++ b/server/paths/manage.ts
@@ -76,6 +76,7 @@ const paths = {
     index: singlePremisesPath.path('lost-beds'),
     show: lostBedsPath.path(':id'),
     update: singlePremisesPath.path('lost-beds').path(':id'),
+    cancel: singlePremisesPath.path('lost-beds').path(':id').path('cancellations'),
   },
 }
 

--- a/server/routes/manage.ts
+++ b/server/routes/manage.ts
@@ -123,6 +123,7 @@ export default function routes(controllers: Controllers, router: Router, service
   get(paths.lostBeds.show.pattern, lostBedsController.show(), { auditEvent: 'SHOW_LOST_BED' })
   post(paths.lostBeds.update.pattern, lostBedsController.update(), {
     auditEvent: 'UPDATE_LOST_BED_SUCCESS',
+    auditBodyParams: ['cancel'],
     redirectAuditEventSpecs: [
       {
         path: paths.lostBeds.show.pattern,

--- a/server/services/lostBedService.test.ts
+++ b/server/services/lostBedService.test.ts
@@ -1,10 +1,15 @@
-import type { LostBed, NewLostBed } from '@approved-premises/api'
+import type { LostBed, NewLostBed, NewLostBedCancellation } from '@approved-premises/api'
 
 import LostBedService from './lostBedService'
 import LostBedClient from '../data/lostBedClient'
 import ReferenceDataClient from '../data/referenceDataClient'
 
-import { lostBedFactory, newLostBedFactory, referenceDataFactory } from '../testutils/factories'
+import {
+  lostBedCancellationFactory,
+  lostBedFactory,
+  newLostBedFactory,
+  referenceDataFactory,
+} from '../testutils/factories'
 
 jest.mock('../data/lostBedClient.ts')
 jest.mock('../data/referenceDataClient.ts')
@@ -115,6 +120,25 @@ describe('LostBedService', () => {
       expect(updatedLostBed).toEqual(lostBed)
       expect(LostBedClientFactory).toHaveBeenCalledWith(token)
       expect(lostBedClient.update).toHaveBeenCalledWith(lostBed.id, lostBedUpdateData, premisesId)
+    })
+  })
+
+  describe('cancelLostBed', () => {
+    it('cancels and returns the cancelled lost bed', async () => {
+      const lostBedId = 'lostBedId'
+      const newLostBedCancellation: NewLostBedCancellation = {
+        notes: 'some notes',
+      }
+      const lostBedCancellation = lostBedCancellationFactory.build()
+      const token = 'SOME_TOKEN'
+
+      lostBedClient.cancel.mockResolvedValue(lostBedCancellation)
+
+      const cancelledLostBed = await service.cancelLostBed(token, lostBedId, premisesId, newLostBedCancellation)
+
+      expect(cancelledLostBed).toEqual(lostBedCancellation)
+      expect(LostBedClientFactory).toHaveBeenCalledWith(token)
+      expect(lostBedClient.cancel).toHaveBeenCalledWith(lostBedId, premisesId, newLostBedCancellation)
     })
   })
 })

--- a/server/services/lostBedService.ts
+++ b/server/services/lostBedService.ts
@@ -1,5 +1,5 @@
 import type { ReferenceData } from '@approved-premises/ui'
-import type { LostBed, NewLostBed, UpdateLostBed } from '@approved-premises/api'
+import type { LostBed, NewLostBed, NewLostBedCancellation, UpdateLostBed } from '@approved-premises/api'
 import type { LostBedClient, ReferenceDataClient, RestClientBuilder } from '../data'
 
 export type LostBedReferenceData = Array<ReferenceData>
@@ -46,5 +46,18 @@ export default class LostBedService {
     const reasons = await referenceDataClient.getReferenceData('lost-bed-reasons')
 
     return reasons
+  }
+
+  async cancelLostBed(
+    token: string,
+    premisesId: string,
+    lostBedId: string,
+    data: NewLostBedCancellation,
+  ): Promise<NewLostBedCancellation> {
+    const lostBedService = this.lostBedClientFactory(token)
+
+    const cancellation = await lostBedService.cancel(premisesId, lostBedId, data)
+
+    return cancellation
   }
 }

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -34,6 +34,7 @@ import dateCapacityFactory from './dateCapacity'
 import departureFactory from './departure'
 import documentFactory from './document'
 import lostBedFactory from './lostBed'
+import lostBedCancellationFactory from './lostBedCancellation'
 import newArrivalFactory from './newArrival'
 import newBookingFactory from './newBooking'
 import newCancellationFactory from './newCancellation'
@@ -103,6 +104,7 @@ export {
   departureFactory,
   documentFactory,
   lostBedFactory,
+  lostBedCancellationFactory,
   newArrivalFactory,
   newBookingFactory,
   newPlacementRequestBookingFactory,

--- a/server/testutils/factories/lostBedCancellation.ts
+++ b/server/testutils/factories/lostBedCancellation.ts
@@ -1,0 +1,13 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { LostBedCancellation } from '@approved-premises/api'
+import { DateFormats } from '../../utils/dateUtils'
+
+export default Factory.define<LostBedCancellation>(() => {
+  return {
+    createdAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
+    id: faker.string.uuid(),
+    notes: faker.lorem.sentence(),
+  }
+})

--- a/server/views/lostBeds/show.njk
+++ b/server/views/lostBeds/show.njk
@@ -125,7 +125,16 @@
           text: "Save and continue",
           name: "submit"
         }) }}
+
+        {{ govukButton({
+          text: "Cancel lost bed",
+          name: "cancel",
+          value: '1',
+          classes: "govuk-button--secondary govuk-!-margin-left-3"
+        }) }}
+
       </form>
+
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
# Context

Users need to be able to cancel a lost bed. 
This PR adds a 'Cancel lost bed' button to the Lost Bed show template

# Changes in this PR
First we add the client and service methods. 
We then add a controller method.
This is followed by the view changes

## Screenshots of UI changes

### Before
![befooree](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/baedb8ae-1adc-4325-9ab9-5dc629675423)


### After

![LostBed -- managing lost beds -- should allow me to cancel a lost bed](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/ed929ec1-28cc-4cbc-b8cf-59e39af59197)

