### PR TITLE
Fix case note dates undefined

### DIFF
--- a/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
+++ b/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
@@ -4,7 +4,7 @@ import type { Adjudication, ApprovedPremisesApplication, PersonAcctAlert, Prison
 
 import { sentenceCase } from '../../../../utils/utils'
 import TasklistPage from '../../../tasklistPage'
-import { DateFormats } from '../../../../utils/dateUtils'
+import { DateFormats, uiDateOrDateEmptyMessage } from '../../../../utils/dateUtils'
 import { Page } from '../../../utils/decorators'
 
 type CaseNotesAdjudication = Omit<Adjudication, 'finding'> & {
@@ -21,8 +21,8 @@ type CaseNotesBody = {
 
 export const caseNoteResponse = (caseNote: PrisonCaseNote) => {
   return {
-    'Date created': DateFormats.isoDateToUIDate(caseNote.createdAt),
-    'Date occurred': DateFormats.isoDateToUIDate(caseNote.occurredAt),
+    'Date created': uiDateOrDateEmptyMessage(caseNote, 'createdAt', DateFormats.isoDateToUIDate),
+    'Date occurred': uiDateOrDateEmptyMessage(caseNote, 'occurredAt', DateFormats.isoDateToUIDate),
     'Is the case note sensitive?': caseNote.sensitive ? 'Yes' : 'No',
     'Name of author': caseNote.authorName,
     Type: caseNote.type,
@@ -34,7 +34,7 @@ export const caseNoteResponse = (caseNote: PrisonCaseNote) => {
 export const adjudicationResponse = (adjudication: Adjudication) => {
   return {
     'Adjudication number': adjudication.id,
-    'Report date and time': DateFormats.isoDateTimeToUIDateTime(adjudication.reportedAt),
+    'Report date and time': uiDateOrDateEmptyMessage(adjudication, 'reportedAt', DateFormats.isoDateTimeToUIDateTime),
     Establishment: adjudication.establishment,
     'Offence description': adjudication.offenceDescription,
     Finding: sentenceCase(adjudication.finding),
@@ -45,8 +45,8 @@ export const acctAlertResponse = (acctAlert: PersonAcctAlert) => {
   return {
     'Alert type': acctAlert.alertId,
     'ACCT description': acctAlert.comment ?? '',
-    'Date created': DateFormats.isoDateToUIDate(acctAlert.dateCreated),
-    'Expiry date': DateFormats.isoDateToUIDate(acctAlert.dateExpires),
+    'Date created': uiDateOrDateEmptyMessage(acctAlert, 'dateCreated', DateFormats.isoDateToUIDate),
+    'Expiry date': uiDateOrDateEmptyMessage(acctAlert, 'dateExpires', DateFormats.isoDateToUIDate),
   }
 }
 
@@ -58,8 +58,10 @@ export const caseNoteCheckbox = (caseNote: PrisonCaseNote, checked: boolean) => 
     caseNote.id
   }" ${checked ? 'checked' : ''}>
       <label class="govuk-label govuk-checkboxes__label" for="${caseNote.id}">
-        <span class="govuk-visually-hidden">Select case note from ${DateFormats.isoDateToUIDate(
-          caseNote.createdAt,
+        <span class="govuk-visually-hidden">Select case note from ${uiDateOrDateEmptyMessage(
+          caseNote,
+          'createdAt',
+          DateFormats.isoDateToUIDate,
         )}</span>
       </label>
     </div>

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -12,6 +12,7 @@ import {
   dateAndTimeInputsAreValidDates,
   dateIsBlank,
   dateIsInThePast,
+  uiDateOrDateEmptyMessage,
 } from './dateUtils'
 
 jest.mock('date-fns/isPast')
@@ -172,6 +173,26 @@ describe('DateFormats', () => {
     it('formats a duration with the given unit', () => {
       expect(DateFormats.formatDuration({ days: '4', weeks: '7' })).toEqual('7 weeks, 4 days')
     })
+  })
+})
+
+describe('uiDateOrDateEmptyMessage', () => {
+  it('if the date is undefined it returns the message', () => {
+    const object: Record<string, undefined> = {
+      shouldBeADate: undefined,
+    }
+
+    expect(uiDateOrDateEmptyMessage(object, 'shouldBeADate', () => 'string')).toEqual('No date supplied')
+  })
+
+  it('if the date is defined it returns the date formatted using the format function', () => {
+    const object: Record<string, string> = {
+      aDate: DateFormats.dateObjToIsoDate(new Date(2023, 3, 12)),
+    }
+
+    expect(uiDateOrDateEmptyMessage(object, 'aDate', DateFormats.isoDateToUIDate)).toEqual(
+      DateFormats.dateObjtoUIDate(new Date(2023, 3, 12)),
+    )
   })
 })
 

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -143,6 +143,16 @@ export class DateFormats {
   }
 }
 
+export const uiDateOrDateEmptyMessage = (
+  object: Record<string, unknown>,
+  key: string,
+  dateFormFunc: (date: string) => string,
+) => {
+  if (typeof object?.[key] === 'string') return dateFormFunc(object?.[key] as string)
+
+  return 'No date supplied'
+}
+
 export const dateAndTimeInputsAreValidDates = <K extends string | number>(
   dateInputObj: ObjectWithDateParts<K>,
   key: K,

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -25,7 +25,7 @@ import { dashboardTableRows } from './applications/utils'
 import { navigationItems } from './navigationItems'
 
 import { statusTag } from './personUtils'
-import { DateFormats } from './dateUtils'
+import { DateFormats, uiDateOrDateEmptyMessage } from './dateUtils'
 
 import * as AssessmentUtils from './assessments/utils'
 import * as OASysUtils from './assessments/oasysUtils'
@@ -111,6 +111,11 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('dateFieldValues', function sendContextToDateFieldValues(fieldName: string, errors: ErrorMessages) {
     return dateFieldValues(fieldName, this.ctx, errors)
   })
+  njkEnv.addGlobal(
+    'uiDateOrDateEmptyMessage',
+    (object: Record<string, string>, propertyName: string, dateFormFunc: (date: string) => string) =>
+      uiDateOrDateEmptyMessage(object, propertyName, dateFormFunc),
+  )
 
   njkEnv.addGlobal(
     'convertObjectsToRadioItems',

--- a/server/views/applications/pages/prison-information/case-notes.njk
+++ b/server/views/applications/pages/prison-information/case-notes.njk
@@ -24,7 +24,7 @@
     {% for caseNote in page.caseNotes %}
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">{{ page.checkBoxForCaseNoteId(caseNote.id) | safe }}</td>
-        <td class="govuk-table__cell">{{ formatDate(caseNote.createdAt) }}</td>
+        <td class="govuk-table__cell">{{ uiDateOrDateEmptyMessage(caseNote, 'createdAt', formatDate) }}</td>
         <td class="govuk-table__cell">
           <p>
             <strong>Type: {{caseNote.type}}: {{caseNote.subType}}</strong>


### PR DESCRIPTION
We have been sent some undefined properties where there should be dates. 
Whilst our API devs are busy (and for extra safety) I have introduced a function which we can pass an object that we expect to contain a date, a string we can use to find that date and the function we want to use to format that date if it exists. 
We can use this in a lot of places to avoid writing`object?.maybeDate ? formatDate(object?.maybeDate) : 'No date'` over and over. 

I have used it on all the dates on the case notes pages as I'm not sure we can trust this data