### PR TITLE
Disable caseload check in dev and preprod

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,6 +17,7 @@ generic-service:
     HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
     COMMUNITY_ACCOMMODATION_API_SERVICE_NAME: approved-premises
+    DISABLE_CASELOAD_CHECK: 1
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,6 +15,7 @@ generic-service:
     HMPPS_AUTH_URL: 'https://sign-in-preprod.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-preprod.prison.service.justice.gov.uk'
     COMMUNITY_ACCOMMODATION_API_SERVICE_NAME: approved-premises
+    DISABLE_CASELOAD_CHECK: 1
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -101,6 +101,8 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
     return safeFilter(html)
   }
 
+  njkEnv.addGlobal('checkCaseloadForApplications', !process.env.DISABLE_CASELOAD_CHECK)
+
   njkEnv.addFilter('initialiseName', initialiseName)
   njkEnv.addGlobal('dateFieldValues', dateFieldValues)
   njkEnv.addGlobal('formatDate', (date: string, options: { format: 'short' | 'long' } = { format: 'long' }) =>

--- a/server/views/applications/new.njk
+++ b/server/views/applications/new.njk
@@ -14,7 +14,7 @@
     <div class="govuk-grid-column-two-thirds">
       <form action="{{ paths.applications.people.find() }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-        <input type="hidden" name="checkCaseload" value="true"/>
+        <input type="hidden" name="checkCaseload" value="{{ checkCaseloadForApplications }}"/>
         <input type="hidden" name="checkOasys" value="true"/>
         <input type="hidden" name="checkNoms" value="true"/>
 


### PR DESCRIPTION
This adds a `DISABLE_CASELOAD_CHECK` env var. If it is set, then we pass `checkCaseload=false` to the person search. This allows us to bypass the caseload check, making verification of data issues much easier