### PR TITLE
Capitalize 'type' property when marking an arrival

### DIFF
--- a/server/controllers/manage/arrivalsController.test.ts
+++ b/server/controllers/manage/arrivalsController.test.ts
@@ -118,7 +118,7 @@ describe('ArrivalsController', () => {
         keyWorkerStaffCode: request.body.arrival.keyWorkerStaffCode,
         arrivalDateTime: new Date(2022, 11, 11, 12, 35).toISOString(),
         expectedDepartureDate: '2022-11-12',
-        type: 'cas1',
+        type: 'CAS1',
       }
 
       expect(arrivalService.createArrival).toHaveBeenCalledWith(

--- a/server/controllers/manage/arrivalsController.ts
+++ b/server/controllers/manage/arrivalsController.ts
@@ -44,7 +44,7 @@ export default class ArrivalsController {
         notes: body.arrival.notes,
         arrivalDateTime,
         expectedDepartureDate,
-        type: 'cas1',
+        type: 'CAS1',
       }
 
       try {


### PR DESCRIPTION
I'm seeing ``` JSON parse error: Could not resolve type id 'cas1' as a subtype of `uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.NewArrival`: known type ids = [CAS1, CAS2, CAS3]; ``` in the logs so assuming we need to capatilize the type