### PR TITLE
(275) Assess - Add RFAP questions

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -34,10 +34,10 @@
       "situation": "riskManagement"
     },
     "release-date": {
-      "releaseDate-year": "2022",
+      "releaseDate-year": "2024",
       "releaseDate-month": "11",
       "releaseDate-day": "14",
-      "releaseDate": "2022-11-14",
+      "releaseDate": "2024-11-14",
       "knowReleaseDate": "yes"
     },
     "placement-date": {

--- a/integration_tests/helpers/assess.ts
+++ b/integration_tests/helpers/assess.ts
@@ -26,6 +26,7 @@ import Page from '../pages/page'
 import { updateAssessmentData } from '../../server/form-pages/utils'
 import AssessPage from '../pages/assess/assessPage'
 import { assessmentSummaryFactory } from '../../server/testutils/factories'
+import RfapSuitabilityPage from '../pages/assess/rfapSuitability'
 
 export default class AseessHelper {
   assessmentSummary: AssessmentSummary
@@ -200,11 +201,18 @@ export default class AseessHelper {
     cy.get('[data-cy-task-name="suitability-assessment"]').click()
 
     // Then I should be taken to the suitability assessment page
-    const page = new SuitabilityAssessmentPage(this.assessment)
-    page.completeForm()
-    page.clickSubmit()
-    this.updateAssessmentAndStub(page)
-    this.pages.assessSuitability = [page]
+    const suitabilityAssessmentPage = new SuitabilityAssessmentPage(this.assessment)
+    suitabilityAssessmentPage.completeForm()
+    suitabilityAssessmentPage.clickSubmit()
+    this.updateAssessmentAndStub(suitabilityAssessmentPage)
+
+    const rfapSuitabilityPage = new RfapSuitabilityPage(this.assessment)
+    rfapSuitabilityPage.completeForm()
+    rfapSuitabilityPage.clickSubmit()
+
+    this.updateAssessmentAndStub(rfapSuitabilityPage)
+
+    this.pages.assessSuitability = [suitabilityAssessmentPage, rfapSuitabilityPage]
 
     if (options.isShortNoticeApplication) {
       // Then I should be taken to the application timeliness page

--- a/integration_tests/pages/assess/rfapSuitability.ts
+++ b/integration_tests/pages/assess/rfapSuitability.ts
@@ -1,0 +1,23 @@
+import type { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
+import type { YesOrNo } from '@approved-premises/ui'
+
+import AssessPage from './assessPage'
+
+import RfapSuitability from '../../../server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability'
+
+export default class RfapSuitabilityPage extends AssessPage {
+  pageClass: RfapSuitability
+
+  constructor(assessment: Assessment, suitableAnswer: YesOrNo = 'no', detailAnswer = 'Some detail') {
+    super(assessment, 'Suitability assessment')
+    this.pageClass = new RfapSuitability(
+      { rfapIdentifiedAsSuitable: suitableAnswer, unsuitabilityForRfapRationale: detailAnswer },
+      assessment,
+    )
+  }
+
+  completeForm() {
+    this.checkRadioByNameAndValue('rfapIdentifiedAsSuitable', this.pageClass.body.rfapIdentifiedAsSuitable)
+    this.clearAndCompleteTextInputById('unsuitabilityForRfapRationale', this.pageClass.body.rfapIdentifiedAsSuitable)
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.359.0",
         "@faker-js/faker": "^8.0.0",
-        "@ministryofjustice/frontend": "^1.6.6",
+        "@ministryofjustice/frontend": "^1.8.0",
         "@sentry/node": "^7.14.1",
         "@sentry/tracing": "^7.14.1",
         "@total-typescript/shoehorn": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.359.0",
     "@faker-js/faker": "^8.0.0",
-    "@ministryofjustice/frontend": "^1.6.6",
+    "@ministryofjustice/frontend": "^1.8.0",
     "@sentry/node": "^7.14.1",
     "@sentry/tracing": "^7.14.1",
     "@total-typescript/shoehorn": "^0.1.0",

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -172,6 +172,100 @@
             }
           }
         },
+        "end-dates": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "sedDate-year": {
+                  "type": "string"
+                },
+                "sedDate-month": {
+                  "type": "string"
+                },
+                "sedDate-day": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "sedDate-time": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "sedDate": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ledDate-year": {
+                  "type": "string"
+                },
+                "ledDate-month": {
+                  "type": "string"
+                },
+                "ledDate-day": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ledDate-time": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ledDate": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "pssDate-year": {
+                  "type": "string"
+                },
+                "pssDate-month": {
+                  "type": "string"
+                },
+                "pssDate-day": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "pssDate-time": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "pssDate": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        },
         "situation": {
           "type": "object",
           "properties": {

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.test.ts
@@ -1,8 +1,11 @@
 import { DateFormats } from '../../../../utils/dateUtils'
 import { assessmentFactory } from '../../../../testutils/factories'
 import { YesOrNo } from '../../../../@types/ui'
-import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
-import { retrieveQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
+import { itShouldHaveNextValue } from '../../../shared-examples'
+import {
+  retrieveOptionalQuestionResponseFromApplicationOrAssessment,
+  retrieveQuestionResponseFromFormArtifact,
+} from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 
 import ApplicationTimeliness from './applicationTimeliness'
 
@@ -50,16 +53,35 @@ describe('ApplicationTimeliness', () => {
     '',
   )
 
-  itShouldHavePreviousValue(
-    new ApplicationTimeliness(
-      {
-        agreeWithShortNoticeReason: 'yes',
-        agreeWithShortNoticeReasonComments: 'some reasons',
-      },
-      assessment,
-    ),
-    'suitability-assessment',
-  )
+  describe('previous', () => {
+    it('returns rfap-suitability if the applicant requires an RFAP', () => {
+      ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue('yes')
+
+      expect(
+        new ApplicationTimeliness(
+          {
+            agreeWithShortNoticeReason: 'yes',
+            agreeWithShortNoticeReasonComments: 'some reasons',
+          },
+          assessment,
+        ).previous(),
+      ).toEqual('rfap-suitability')
+    })
+
+    it('returns suitability-assessment if the applicant doesnt require an RFAP', () => {
+      ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue(undefined)
+
+      expect(
+        new ApplicationTimeliness(
+          {
+            agreeWithShortNoticeReason: 'yes',
+            agreeWithShortNoticeReasonComments: 'some reasons',
+          },
+          assessment,
+        ).previous(),
+      ).toEqual('suitability-assessment')
+    })
+  })
 
   describe('errors', () => {
     it('should have an error if there are no answers', () => {

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.test.ts
@@ -2,10 +2,7 @@ import { DateFormats } from '../../../../utils/dateUtils'
 import { assessmentFactory } from '../../../../testutils/factories'
 import { YesOrNo } from '../../../../@types/ui'
 import { itShouldHaveNextValue } from '../../../shared-examples'
-import {
-  retrieveOptionalQuestionResponseFromApplicationOrAssessment,
-  retrieveQuestionResponseFromFormArtifact,
-} from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
+import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 
 import ApplicationTimeliness from './applicationTimeliness'
 
@@ -134,7 +131,7 @@ describe('ApplicationTimeliness', () => {
   describe('retrieveShortNoticeApplicationDetails', () => {
     const applicationDate = '30/06/2023'
     ;(DateFormats.isoDateToUIDate as jest.Mock).mockReturnValue(applicationDate)
-    ;(retrieveQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue('onBail')
+    ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue('onBail')
 
     const page = new ApplicationTimeliness(
       {

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.ts
@@ -9,10 +9,7 @@ import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
 import { responsesForYesNoAndCommentsSections } from '../../../utils/index'
-import {
-  retrieveOptionalQuestionResponseFromApplicationOrAssessment,
-  retrieveQuestionResponseFromFormArtifact,
-} from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
+import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 import Rfap from '../../../apply/risk-and-need-factors/further-considerations/rfap'
 
 export type ApplicationTimelinessSection = {
@@ -44,12 +41,15 @@ export default class ApplicationTimeliness implements TasklistPage {
 
   retrieveShortNoticeApplicationDetails() {
     const applicationDate = DateFormats.isoDateToUIDate(this.assessment.application.submittedAt, { format: 'short' })
-    const lateApplicationReasonId = retrieveQuestionResponseFromFormArtifact(
+    const lateApplicationReasonId = retrieveOptionalQuestionResponseFromApplicationOrAssessment(
       this.assessment.application,
       ReasonForShortNotice,
       'reason',
     )
-    const lateApplicationReason = shortNoticeReasons[lateApplicationReasonId]
+
+    const lateApplicationReason = lateApplicationReasonId
+      ? shortNoticeReasons[lateApplicationReasonId]
+      : 'None supplied'
 
     return { applicationDate, lateApplicationReason }
   }

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.ts
@@ -9,7 +9,11 @@ import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
 import { responsesForYesNoAndCommentsSections } from '../../../utils/index'
-import { retrieveQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
+import {
+  retrieveOptionalQuestionResponseFromApplicationOrAssessment,
+  retrieveQuestionResponseFromFormArtifact,
+} from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
+import Rfap from '../../../apply/risk-and-need-factors/further-considerations/rfap'
 
 export type ApplicationTimelinessSection = {
   agreeWithShortNoticeReason: string
@@ -51,6 +55,16 @@ export default class ApplicationTimeliness implements TasklistPage {
   }
 
   previous() {
+    const needsRfap = retrieveOptionalQuestionResponseFromApplicationOrAssessment(
+      this.assessment.application,
+      Rfap,
+      'needARfap',
+    )
+
+    if (needsRfap === 'yes') {
+      return 'rfap-suitability'
+    }
+
     return 'suitability-assessment'
   }
 

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/index.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/index.ts
@@ -2,10 +2,11 @@ import { Task } from '../../../utils/decorators'
 
 import SuitabilityAssessmentPage from './suitabilityAssessment'
 import ApplicationTimeliness from './applicationTimeliness'
+import RfapSuitability from './rfapSuitability'
 
 @Task({
   slug: 'suitability-assessment',
   name: 'Assess suitability of application',
-  pages: [SuitabilityAssessmentPage, ApplicationTimeliness],
+  pages: [SuitabilityAssessmentPage, RfapSuitability, ApplicationTimeliness],
 })
 export default class SuitabilityAssessment {}

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.test.ts
@@ -1,0 +1,71 @@
+import { assessmentFactory } from '../../../../testutils/factories'
+import { itShouldHavePreviousValue } from '../../../shared-examples'
+
+import RfapSuitability, { RfapSuitabilityBody } from './rfapSuitability'
+import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
+
+jest.mock('../../../../utils/applications/noticeTypeFromApplication')
+
+describe('RfapSuitability', () => {
+  const body: RfapSuitabilityBody = {
+    rfapIdentifiedAsSuitable: 'yes',
+    unsuitabilityForRfapRationale: 'some reasons',
+  }
+
+  const assessment = assessmentFactory.build()
+  describe('title', () => {
+    expect(new RfapSuitability(body, assessment).title).toBe('Suitability assessment')
+  })
+
+  describe('body', () => {
+    it('should set the body', () => {
+      const page = new RfapSuitability(body, assessment)
+      expect(page.body).toEqual({
+        rfapIdentifiedAsSuitable: 'yes',
+        unsuitabilityForRfapRationale: 'some reasons',
+      })
+    })
+  })
+
+  describe('next', () => {
+    it('returns application-timeliness if the notice type is short_notice', () => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('short_notice')
+      expect(new RfapSuitability(body, assessment).next()).toEqual('application-timeliness')
+    })
+
+    it('returns application-timeliness if the notice type is emergency', () => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('emergency')
+      expect(new RfapSuitability(body, assessment).next()).toEqual('application-timeliness')
+    })
+
+    it('returns an empty string if the notice type is standard', () => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('standard')
+      expect(new RfapSuitability(body, assessment).next()).toEqual('')
+    })
+  })
+
+  itShouldHavePreviousValue(new RfapSuitability(body, assessment), 'suitability-assessment')
+
+  describe('errors', () => {
+    it('should have an error if there are no answers', () => {
+      const page = new RfapSuitability({} as RfapSuitabilityBody, assessment)
+
+      expect(page.errors()).toEqual({
+        rfapIdentifiedAsSuitable:
+          'You must confirm if a Recovery Focused Approved Premises (RAP) been identified as a suitable placement',
+      })
+    })
+  })
+
+  describe('response', () => {
+    it('returns the response', () => {
+      const page = new RfapSuitability(body, assessment)
+
+      expect(page.response()).toEqual({
+        'Has a Recovery Focused Approved Premises (RAP) been identified as a suitable placement?': 'yes',
+        'If the person is unsuitable for a RFAP placement yet suitable for a standard placement, summarise the rationale for the decision':
+          'some reasons',
+      })
+    })
+  })
+})

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.ts
@@ -1,0 +1,62 @@
+import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
+import { ApprovedPremisesAssessment as Assessment } from '../../../../@types/shared'
+
+import { Page } from '../../../utils/decorators'
+
+import TasklistPage from '../../../tasklistPage'
+
+export type RfapSuitabilityBody = {
+  rfapIdentifiedAsSuitable: YesOrNo
+  unsuitabilityForRfapRationale: string
+}
+
+@Page({
+  name: 'rfap-suitability',
+  bodyProperties: ['rfapIdentifiedAsSuitable', 'unsuitabilityForRfapRationale'],
+})
+export default class RfapSuitability implements TasklistPage {
+  title = 'Suitability assessment'
+
+  questions = {
+    rfapIdentifiedAsSuitable: 'Has a Recovery Focused Approved Premises (RAP) been identified as a suitable placement?',
+    unsuitabilityForRfapRationale:
+      'If the person is unsuitable for a RFAP placement yet suitable for a standard placement, summarise the rationale for the decision',
+  }
+
+  constructor(public body: RfapSuitabilityBody, private readonly assessment: Assessment) {}
+
+  previous() {
+    return 'suitability-assessment'
+  }
+
+  next() {
+    if (
+      noticeTypeFromApplication(this.assessment.application) === 'short_notice' ||
+      noticeTypeFromApplication(this.assessment.application) === 'emergency'
+    ) {
+      return 'application-timeliness'
+    }
+
+    return ''
+  }
+
+  response() {
+    const response = {}
+
+    response[this.questions.rfapIdentifiedAsSuitable] = this.body.rfapIdentifiedAsSuitable
+    response[this.questions.unsuitabilityForRfapRationale] = this.body.unsuitabilityForRfapRationale
+
+    return response
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.rfapIdentifiedAsSuitable)
+      errors.rfapIdentifiedAsSuitable =
+        'You must confirm if a Recovery Focused Approved Premises (RAP) been identified as a suitable placement'
+
+    return errors
+  }
+}

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
@@ -1,7 +1,7 @@
 import { assessmentFactory } from '../../../../testutils/factories'
 import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
 import { YesOrNo } from '../../../../@types/ui'
-import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { itShouldHavePreviousValue } from '../../../shared-examples'
 
 import SuitabilityAssessment from './suitabilityAssessment'
 
@@ -43,18 +43,52 @@ describe('SuitabilityAssessment', () => {
     })
   })
 
-  itShouldHaveNextValue(
-    new SuitabilityAssessment(
-      {
-        riskFactors: 'yes',
-        riskManagement: 'yes',
-        locationOfPlacement: 'yes',
-        moveOnPlan: 'yes',
-      },
-      assessment,
-    ),
-    '',
-  )
+  describe('next', () => {
+    it('returns application-timeliness if the notice type is short_notice', () => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('short_notice')
+      expect(
+        new SuitabilityAssessment(
+          {
+            riskFactors: 'yes',
+            riskManagement: 'yes',
+            locationOfPlacement: 'yes',
+            moveOnPlan: 'yes',
+          },
+          assessment,
+        ).next(),
+      ).toEqual('application-timeliness')
+    })
+
+    it('returns application-timeliness if the notice type is emergency', () => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('emergency')
+      expect(
+        new SuitabilityAssessment(
+          {
+            riskFactors: 'yes',
+            riskManagement: 'yes',
+            locationOfPlacement: 'yes',
+            moveOnPlan: 'yes',
+          },
+          assessment,
+        ).next(),
+      ).toEqual('application-timeliness')
+    })
+
+    it('returns an empty string if the notice type is standard', () => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('standard')
+      expect(
+        new SuitabilityAssessment(
+          {
+            riskFactors: 'yes',
+            riskManagement: 'yes',
+            locationOfPlacement: 'yes',
+            moveOnPlan: 'yes',
+          },
+          assessment,
+        ).next(),
+      ).toEqual('')
+    })
+  })
 
   itShouldHavePreviousValue(
     new SuitabilityAssessment(

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.ts
@@ -6,6 +6,8 @@ import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
 import { responsesForYesNoAndCommentsSections } from '../../../utils/index'
+import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
+import Rfap from '../../../apply/risk-and-need-factors/further-considerations/rfap'
 
 export type SuitabilityAssessmentSection = {
   riskFactors: string
@@ -58,7 +60,20 @@ export default class SuitabilityAssessment implements TasklistPage {
   }
 
   next() {
-    if (noticeTypeFromApplication(this.assessment.application) === 'short_notice') {
+    const needsRfap = retrieveOptionalQuestionResponseFromApplicationOrAssessment(
+      this.assessment.application,
+      Rfap,
+      'needARfap',
+    )
+
+    if (needsRfap === 'yes') {
+      return 'rfap-suitability'
+    }
+
+    if (
+      noticeTypeFromApplication(this.assessment.application) === 'short_notice' ||
+      noticeTypeFromApplication(this.assessment.application) === 'emergency'
+    ) {
       return 'application-timeliness'
     }
 

--- a/server/views/assessments/pages/suitability-assessment/rfap-suitability.njk
+++ b/server/views/assessments/pages/suitability-assessment/rfap-suitability.njk
@@ -1,0 +1,42 @@
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+
+{% extends "../layout.njk" %}
+
+{% block questions %}
+    <h1 class="govuk-heading-l">
+        {{page.title}}</h1>
+
+    {{
+            formPageRadios({
+                fieldset: {
+                    legend: {
+                    text: page.questions.rfapIdentifiedAsSuitable,
+                    classes: "govuk-fieldset__legend--m"
+                    }
+                },
+                fieldName: "rfapIdentifiedAsSuitable",
+                    items: [
+                    {
+                        value: "yes",
+                        text: "Yes"
+                    },
+                    {
+                        value: "no",
+                        text: "No"
+                    }
+                    ]
+                }, fetchContext()
+            )
+        }}
+
+    {{
+            formPageTextarea({
+                fieldName: "unsuitabilityForRfapRationale",
+                label: {
+                    text:page.questions.unsuitabilityForRfapRationale,
+                    classes: "govuk-label--s"
+                }
+            }, fetchContext())
+        }}
+
+{% endblock %}


### PR DESCRIPTION
# Context
[Trello card](https://trello.com/c/mduEkYnq/275-add-rfap-assessment-questions)
We need to ask the user some questions about suitability for a RFAP if the user has applied to one. 
This PR also corrects some logic to correctly show the Application Timeliness page if the notice type of the application is emergency

## Screenshots of UI changes
![Assess -- Standard assessments -- allows me to assess an application](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/4d48a651-b10f-48f5-b08d-8cce38bab480)
