### PR TITLE
Handle missing Oasys and Nomis data

### DIFF
--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -139,6 +139,19 @@ export default {
       },
     }),
 
+  stubPrisonCaseNotes404: (args: { person: Person }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/people/${args.person.crn}/prison-case-notes`,
+      },
+      response: {
+        status: 404,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: { status: 404 },
+      },
+    }),
+
   stubAdjudications: (args: { person: Person; adjudications: Array<Adjudication> }) =>
     stubFor({
       request: {

--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -165,6 +165,19 @@ export default {
       },
     }),
 
+  stubOasysSelection404: (args: { person: Person }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/people/${args.person.crn}/oasys/selection`,
+      },
+      response: {
+        status: 404,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: { status: 404 },
+      },
+    }),
+
   stubOasysSelection: (args: { person: Person; oasysSelection: Array<OASysSection> }) =>
     stubFor({
       request: {
@@ -176,6 +189,19 @@ export default {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: args.oasysSelection,
+      },
+    }),
+
+  stubOasysSection404: (args: { person: Person }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPath: `/people/${args.person.crn}/oasys/sections`,
+      },
+      response: {
+        status: 404,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: { status: 404 },
       },
     }),
 

--- a/integration_tests/pages/apply/caseNotes.ts
+++ b/integration_tests/pages/apply/caseNotes.ts
@@ -20,13 +20,18 @@ export default class CaseNotesPage extends ApplyPage {
     this.prisonCaseNotes = prisonCaseNotes
   }
 
-  completeForm() {
-    cy.get('a').contains('Prison case notes').click()
+  completeForm(nomisMissing = false) {
+    if (nomisMissing) {
+      this.checkRadioButtonFromPageBody('informationFromPrison')
+      this.completeTextInputFromPageBody('informationFromPrisonDetail')
+    } else {
+      cy.get('a').contains('Prison case notes').click()
 
-    this.prisonCaseNotes.forEach(note => {
-      cy.contains('label', `Select case note from ${DateFormats.isoDateToUIDate(note.createdAt)}`)
-        .siblings('input')
-        .check()
-    })
+      this.prisonCaseNotes.forEach(note => {
+        cy.contains('label', `Select case note from ${DateFormats.isoDateToUIDate(note.createdAt)}`)
+          .siblings('input')
+          .check()
+      })
+    }
   }
 }

--- a/integration_tests/pages/apply/offenceDetails.ts
+++ b/integration_tests/pages/apply/offenceDetails.ts
@@ -7,9 +7,11 @@ export default class OffenceDetails extends ApplyPage {
   constructor(
     application: ApprovedPremisesApplication,
     private readonly offenceDetailSummaries: ArrayOfOASysOffenceDetailsQuestions,
+    private readonly oasysMissing: boolean,
   ) {
+    const title = oasysMissing ? 'Provide risk information' : 'Edit risk information'
     super(
-      'Edit risk information',
+      title,
       application,
       'oasys-import',
       'offence-details',
@@ -18,6 +20,6 @@ export default class OffenceDetails extends ApplyPage {
   }
 
   completeForm() {
-    this.completeOasysImportQuestions(this.offenceDetailSummaries, 'offenceDetailsAnswers')
+    this.completeOasysImportQuestions(this.offenceDetailSummaries, 'offenceDetailsAnswers', this.oasysMissing)
   }
 }

--- a/integration_tests/pages/apply/optionalOasysSections.ts
+++ b/integration_tests/pages/apply/optionalOasysSections.ts
@@ -4,9 +4,10 @@ import paths from '../../../server/paths/apply'
 import ApplyPage from './applyPage'
 
 export default class OptionalOasysSectionsPage extends ApplyPage {
-  constructor(application: ApprovedPremisesApplication) {
+  constructor(application: ApprovedPremisesApplication, oasysMissing = false) {
+    const title = oasysMissing ? 'Oasys Information' : 'Which of the following sections of OASys do you want to import?'
     super(
-      'Which of the following sections of OASys do you want to import?',
+      title,
       application,
       'oasys-import',
       'optional-oasys-sections',

--- a/integration_tests/pages/apply/riskManagementPlan.ts
+++ b/integration_tests/pages/apply/riskManagementPlan.ts
@@ -7,9 +7,12 @@ export default class RiskManagementPlan extends ApplyPage {
   constructor(
     application: ApprovedPremisesApplication,
     private readonly riskRiskManagementPlanSummaries: ArrayOfOASysRiskManagementPlanQuestions,
+    private readonly oasysMissing: boolean,
   ) {
+    const title = oasysMissing ? 'Provide risk information' : 'Edit risk information'
+
     super(
-      'Edit risk information',
+      title,
       application,
       'oasys-import',
       'offence-details',
@@ -18,6 +21,6 @@ export default class RiskManagementPlan extends ApplyPage {
   }
 
   completeForm() {
-    this.completeOasysImportQuestions(this.riskRiskManagementPlanSummaries, 'riskManagementAnswers')
+    this.completeOasysImportQuestions(this.riskRiskManagementPlanSummaries, 'riskManagementAnswers', this.oasysMissing)
   }
 }

--- a/integration_tests/pages/apply/riskToSelf.ts
+++ b/integration_tests/pages/apply/riskToSelf.ts
@@ -7,9 +7,12 @@ export default class RiskToSelf extends ApplyPage {
   constructor(
     application: ApprovedPremisesApplication,
     private readonly riskToSelfummaries: ArrayOfOASysRiskToSelfQuestions,
+    private readonly oasysMissing: boolean,
   ) {
+    const title = oasysMissing ? 'Provide risk information' : 'Edit risk information'
+
     super(
-      'Edit risk information',
+      title,
       application,
       'oasys-import',
       'offence-details',
@@ -18,6 +21,6 @@ export default class RiskToSelf extends ApplyPage {
   }
 
   completeForm() {
-    this.completeOasysImportQuestions(this.riskToSelfummaries, 'riskToSelfAnswers')
+    this.completeOasysImportQuestions(this.riskToSelfummaries, 'riskToSelfAnswers', this.oasysMissing)
   }
 }

--- a/integration_tests/pages/apply/roshSummary.ts
+++ b/integration_tests/pages/apply/roshSummary.ts
@@ -7,9 +7,12 @@ export default class RoshSummary extends ApplyPage {
   constructor(
     application: ApprovedPremisesApplication,
     private readonly roshSummary: ArrayOfOASysRiskOfSeriousHarmSummaryQuestions,
+    private readonly oasysMissing: boolean,
   ) {
+    const title = oasysMissing ? 'Provide risk information' : 'Edit risk information'
+
     super(
-      'Edit risk information',
+      title,
       application,
       'oasys-import',
       'rosh-summary',
@@ -18,6 +21,6 @@ export default class RoshSummary extends ApplyPage {
   }
 
   completeForm() {
-    this.completeOasysImportQuestions(this.roshSummary, 'roshAnswers')
+    this.completeOasysImportQuestions(this.roshSummary, 'roshAnswers', this.oasysMissing)
   }
 }

--- a/integration_tests/pages/apply/supportingInformation.ts
+++ b/integration_tests/pages/apply/supportingInformation.ts
@@ -7,9 +7,12 @@ export default class SupportingInformation extends ApplyPage {
   constructor(
     application: ApprovedPremisesApplication,
     private readonly supportingInformationSummaries: ArrayOfOASysSupportingInformationQuestions,
+    private readonly oasysMissing: boolean,
   ) {
+    const title = oasysMissing ? 'Provide risk information' : 'Edit risk information'
+
     super(
-      'Edit risk information',
+      title,
       application,
       'oasys-import',
       'offence-details',
@@ -18,6 +21,10 @@ export default class SupportingInformation extends ApplyPage {
   }
 
   completeForm() {
-    this.completeOasysImportQuestions(this.supportingInformationSummaries, 'supportingInformationAnswers')
+    this.completeOasysImportQuestions(
+      this.supportingInformationSummaries,
+      'supportingInformationAnswers',
+      this.oasysMissing,
+    )
   }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -177,12 +177,18 @@ export default abstract class Page {
     this.shouldShowDeliusRiskFlags(risks.flags)
   }
 
-  completeOasysImportQuestions(section, sectionName: string): void {
+  completeOasysImportQuestions(section, sectionName: string, oasysMissing: boolean): void {
     section.forEach(summary => {
       cy.get('.govuk-label').contains(summary.label)
-      cy.get(`textarea[name="${sectionName}[${summary.questionNumber}]"]`)
-        .should('contain', summary.answer)
-        .type(`. With an extra comment ${summary.questionNumber}`)
+      if (oasysMissing) {
+        cy.get(`textarea[name="${sectionName}[${summary.questionNumber}]"]`).type(
+          `${summary.questionNumber} content goes here`,
+        )
+      } else {
+        cy.get(`textarea[name="${sectionName}[${summary.questionNumber}]"]`)
+          .should('contain', summary.answer)
+          .type(`. With an extra comment ${summary.questionNumber}`)
+      }
     })
   }
 

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -343,6 +343,18 @@ context('Apply', () => {
     // Then I should be told I am ineligible for an ESAP placement
   })
 
+  it('handles missing Oasys information', function test() {
+    const uiRisks = mapApiPersonRisksForUi(this.application.risks)
+    const apply = new ApplyHelper(this.application, this.person, this.offences)
+    const oasysMissing = true
+
+    apply.setupApplicationStubs(uiRisks, oasysMissing)
+    apply.startApplication()
+    apply.completeBasicInformation({ isEmergencyApplication: false })
+    apply.completeTypeOfApSection()
+    apply.completeOasysSection(oasysMissing)
+  })
+
   it('allows completion of the form', function test() {
     // And I complete the application
     const uiRisks = mapApiPersonRisksForUi(this.application.risks)

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -355,6 +355,31 @@ context('Apply', () => {
     apply.completeOasysSection(oasysMissing)
   })
 
+  it('handles missing Nomis information', function test() {
+    const uiRisks = mapApiPersonRisksForUi(this.application.risks)
+
+    this.application = addResponsesToFormArtifact(this.application, {
+      section: 'prison-information',
+      page: 'case-notes',
+      keyValuePairs: {
+        informationFromPrison: 'yes',
+        informationFromPrisonDetail: 'Some Detail',
+        additionalConditionsDetail: 'some details',
+      },
+    })
+
+    const apply = new ApplyHelper(this.application, this.person, this.offences)
+    const nomisMissing = true
+
+    apply.setupApplicationStubs(uiRisks, false, nomisMissing)
+    apply.startApplication()
+    apply.completeBasicInformation({ isEmergencyApplication: false })
+    apply.completeTypeOfApSection()
+    apply.completeOasysSection()
+    apply.completeRiskManagementSection()
+    apply.completePrisonInformationSection(nomisMissing)
+  })
+
   it('allows completion of the form', function test() {
     // And I complete the application
     const uiRisks = mapApiPersonRisksForUi(this.application.risks)

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -391,3 +391,9 @@ export type BedOccupancyEntryUi = BedOccupancyEntryTypes & { type: BedOccupancyE
 export type BedOccupancyEntryCalendar = BedOccupancyEntryUi & { label: string }
 
 export type BedOccupancyRangeUi = Omit<BedOccupancyRange, 'schedule'> & { schedule: Array<BedOccupancyEntryUi> }
+
+export interface OasysPage extends TasklistPage {
+  oasysCompleted: string
+  risks: PersonRisksUI
+  oasysSuccess: boolean
+}

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.test.ts
@@ -6,6 +6,7 @@ import { mapApiPersonRisksForUi } from '../../../../utils/utils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
 import OffenceDetails from './offenceDetails'
+import { itShouldHandleErrors } from './sharedExamples'
 
 jest.mock('../../../../services/personService.ts')
 
@@ -55,12 +56,7 @@ describe('OffenceDetails', () => {
 
     itShouldHavePreviousValue(new OffenceDetails({}), 'rosh-summary')
 
-    describe('errors', () => {
-      it('should return an empty object', () => {
-        const page = new OffenceDetails({})
-        expect(page.errors()).toEqual({})
-      })
-    })
+    itShouldHandleErrors(OffenceDetails, { answerKey: 'offenceDetailsAnswers', summaryKey: 'offenceDetailsSummaries' })
 
     describe('response', () => {
       it('calls oasysImportReponse with the correct arguments', () => {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.test.ts
@@ -33,7 +33,7 @@ describe('OffenceDetails', () => {
     it('calls the getOasysSections  method on the client with a token and the persons CRN', async () => {
       await OffenceDetails.initialize({}, application, 'some-token', { personService })
 
-      expect(getOasysSectionsMock).toHaveBeenCalledWith('some-token', application.person.crn)
+      expect(getOasysSectionsMock).toHaveBeenCalledWith('some-token', application.person.crn, [])
     })
 
     it('adds the offenceDetailsSummaries and personRisks to the page object', async () => {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.ts
@@ -3,7 +3,7 @@ import type { DataServices, OasysPage, PersonRisksUI } from '@approved-premises/
 import type { ApprovedPremisesApplication, ArrayOfOASysOffenceDetailsQuestions } from '@approved-premises/api'
 
 import { Page } from '../../../utils/decorators'
-import { getOasysSections, oasysImportReponse } from '../../../../utils/oasysImportUtils'
+import { getOasysSections, oasysImportReponse, validateOasysEntries } from '../../../../utils/oasysImportUtils'
 
 type OffenceDetailsBody = {
   offenceDetailsAnswers: Record<string, string>
@@ -55,6 +55,6 @@ export default class OffenceDetails implements OasysPage {
   }
 
   errors() {
-    return {}
+    return validateOasysEntries<OffenceDetailsBody>(this.body, 'offenceDetailsSummaries', 'offenceDetailsAnswers')
   }
 }

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.test.ts
@@ -1,4 +1,5 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import { OasysNotFoundError } from '../../../../services/personService'
 import { ApplicationService, PersonService } from '../../../../services'
 import { applicationFactory, oasysSelectionFactory } from '../../../../testutils/factories'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
@@ -95,6 +96,21 @@ describe('OptionalOasysSections', () => {
 
       expect(page.body.needsLinkedToReoffending).toEqual([needsLinkedToReoffending[0]])
       expect(page.body.otherNeeds).toEqual([otherNeeds[0], otherNeeds[1]])
+    })
+
+    it('sets oasysSuccess to false if an OasysNotFoundError is thrown', async () => {
+      getOasysSelectionsMock.mockImplementation(() => {
+        throw new OasysNotFoundError('')
+      })
+
+      const page = await OptionalOasysSections.initialize({}, application, 'some-token', {
+        personService,
+        applicationService,
+      })
+
+      expect(page.oasysSuccess).toEqual(false)
+      expect(page.body.needsLinkedToReoffending).toEqual([])
+      expect(page.body.otherNeeds).toEqual([])
     })
   })
 

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.test.ts
@@ -5,6 +5,7 @@ import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../share
 import { oasysImportReponse } from '../../../../utils/oasysImportUtils'
 import RiskManagementPlan from './riskManagementPlan'
 import { mapApiPersonRisksForUi } from '../../../../utils/utils'
+import { itShouldHandleErrors } from './sharedExamples'
 
 jest.mock('../../../../services/personService.ts')
 
@@ -53,11 +54,9 @@ describe('RiskManagement', () => {
 
     itShouldHavePreviousValue(new RiskManagementPlan({}), 'supporting-information')
 
-    describe('errors', () => {
-      it('should return an empty object', () => {
-        const page = new RiskManagementPlan({})
-        expect(page.errors()).toEqual({})
-      })
+    itShouldHandleErrors(RiskManagementPlan, {
+      answerKey: 'riskManagementAnswers',
+      summaryKey: 'riskManagementSummaries',
     })
 
     describe('response', () => {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.test.ts
@@ -31,7 +31,7 @@ describe('RiskManagement', () => {
     it('calls the getOasysSections and getPersonRisks method on the client with a token and the persons CRN', async () => {
       await RiskManagementPlan.initialize({}, application, 'some-token', { personService })
 
-      expect(getOasysSectionsMock).toHaveBeenCalledWith('some-token', application.person.crn)
+      expect(getOasysSectionsMock).toHaveBeenCalledWith('some-token', application.person.crn, [])
     })
 
     it('adds the riskManagementSummaries and personRisks to the page object', async () => {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.ts
@@ -3,7 +3,7 @@ import type { DataServices, OasysPage, PersonRisksUI } from '@approved-premises/
 import type { ApprovedPremisesApplication, ArrayOfOASysRiskManagementQuestions } from '@approved-premises/api'
 
 import { Page } from '../../../utils/decorators'
-import { getOasysSections, oasysImportReponse } from '../../../../utils/oasysImportUtils'
+import { getOasysSections, oasysImportReponse, validateOasysEntries } from '../../../../utils/oasysImportUtils'
 
 type RiskManagementBody = {
   riskManagementAnswers: Record<string, string>
@@ -57,6 +57,6 @@ export default class RiskManagementPlan implements OasysPage {
   }
 
   errors() {
-    return {}
+    return validateOasysEntries<RiskManagementBody>(this.body, 'riskManagementSummaries', 'riskManagementAnswers')
   }
 }

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.ts
@@ -1,16 +1,9 @@
-import type { DataServices, PersonRisksUI } from '@approved-premises/ui'
+import type { DataServices, OasysPage, PersonRisksUI } from '@approved-premises/ui'
 
-import type {
-  ApprovedPremisesApplication,
-  ArrayOfOASysRiskManagementQuestions,
-  OASysSections,
-} from '@approved-premises/api'
-
-import TasklistPage from '../../../tasklistPage'
+import type { ApprovedPremisesApplication, ArrayOfOASysRiskManagementQuestions } from '@approved-premises/api'
 
 import { Page } from '../../../utils/decorators'
-import { oasysImportReponse, sortOasysImportSummaries } from '../../../../utils/oasysImportUtils'
-import { mapApiPersonRisksForUi } from '../../../../utils/utils'
+import { getOasysSections, oasysImportReponse } from '../../../../utils/oasysImportUtils'
 
 type RiskManagementBody = {
   riskManagementAnswers: Record<string, string>
@@ -21,7 +14,7 @@ type RiskManagementBody = {
   name: 'risk-management-plan',
   bodyProperties: ['riskManagementAnswers', 'riskManagementSummaries'],
 })
-export default class RiskManagementPlan implements TasklistPage {
+export default class RiskManagementPlan implements OasysPage {
   title = 'Edit risk information'
 
   riskManagementSummaries: RiskManagementBody['riskManagementSummaries']
@@ -32,6 +25,10 @@ export default class RiskManagementPlan implements TasklistPage {
 
   risks: PersonRisksUI
 
+  oasysSuccess: boolean
+
+  static sectionName = 'riskManagement'
+
   constructor(public body: Partial<RiskManagementBody>) {}
 
   static async initialize(
@@ -40,21 +37,11 @@ export default class RiskManagementPlan implements TasklistPage {
     token: string,
     dataServices: DataServices,
   ) {
-    const oasysSections: OASysSections = await dataServices.personService.getOasysSections(
-      token,
-      application.person.crn,
-    )
-
-    const riskManagement = sortOasysImportSummaries(oasysSections.riskManagementPlan)
-
-    body.riskManagementSummaries = riskManagement
-
-    const page = new RiskManagementPlan(body)
-    page.riskManagementSummaries = riskManagement
-    page.oasysCompleted = oasysSections?.dateCompleted || oasysSections?.dateStarted
-    page.risks = mapApiPersonRisksForUi(application.risks)
-
-    return page
+    return getOasysSections(body, application, token, dataServices, RiskManagementPlan, {
+      sectionName: 'riskManagementPlan',
+      summaryKey: 'riskManagementSummaries',
+      answerKey: 'riskManagementAnswers',
+    })
   }
 
   previous() {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.test.ts
@@ -6,6 +6,7 @@ import { mapApiPersonRisksForUi } from '../../../../utils/utils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
 import RiskToSelf from './riskToSelf'
+import { itShouldHandleErrors } from './sharedExamples'
 
 jest.mock('../../../../services/personService.ts')
 
@@ -50,11 +51,9 @@ describe('RiskToSelf', () => {
 
     itShouldHavePreviousValue(new RiskToSelf({}), 'risk-management-plan')
 
-    describe('errors', () => {
-      it('should return an empty object', () => {
-        const page = new RiskToSelf({})
-        expect(page.errors()).toEqual({})
-      })
+    itShouldHandleErrors(RiskToSelf, {
+      answerKey: 'riskToSelfAnswers',
+      summaryKey: 'riskToSelfSummaries',
     })
 
     describe('response', () => {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.test.ts
@@ -28,7 +28,7 @@ describe('RiskToSelf', () => {
     it('calls the getOasysSections  method on the client with a token and the persons CRN', async () => {
       await RiskToSelf.initialize({}, application, 'some-token', { personService })
 
-      expect(getOasysSectionsMock).toHaveBeenCalledWith('some-token', application.person.crn)
+      expect(getOasysSectionsMock).toHaveBeenCalledWith('some-token', application.person.crn, [])
     })
 
     it('adds the riskToSelfSummaries and personRisks to the page object', async () => {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.ts
@@ -1,16 +1,9 @@
-import type { DataServices, PersonRisksUI } from '@approved-premises/ui'
+import type { DataServices, OasysPage, PersonRisksUI } from '@approved-premises/ui'
 
-import type {
-  ApprovedPremisesApplication,
-  ArrayOfOASysRiskToSelfQuestions,
-  OASysSections,
-} from '@approved-premises/api'
-
-import TasklistPage from '../../../tasklistPage'
+import type { ApprovedPremisesApplication, ArrayOfOASysRiskToSelfQuestions } from '@approved-premises/api'
 
 import { Page } from '../../../utils/decorators'
-import { oasysImportReponse, sortOasysImportSummaries } from '../../../../utils/oasysImportUtils'
-import { mapApiPersonRisksForUi } from '../../../../utils/utils'
+import { getOasysSections, oasysImportReponse } from '../../../../utils/oasysImportUtils'
 
 type RiskToSelfBody = {
   riskToSelfAnswers: Record<string, string>
@@ -21,7 +14,7 @@ type RiskToSelfBody = {
   name: 'risk-to-self',
   bodyProperties: ['riskToSelfAnswers', 'riskToSelfSummaries'],
 })
-export default class RiskToSelf implements TasklistPage {
+export default class RiskToSelf implements OasysPage {
   title = 'Edit risk information'
 
   riskToSelfSummaries: RiskToSelfBody['riskToSelfSummaries']
@@ -32,6 +25,8 @@ export default class RiskToSelf implements TasklistPage {
 
   risks: PersonRisksUI
 
+  oasysSuccess: boolean
+
   constructor(public body: Partial<RiskToSelfBody>) {}
 
   static async initialize(
@@ -40,21 +35,11 @@ export default class RiskToSelf implements TasklistPage {
     token: string,
     dataServices: DataServices,
   ) {
-    const oasysSections: OASysSections = await dataServices.personService.getOasysSections(
-      token,
-      application.person.crn,
-    )
-
-    const riskToSelf = sortOasysImportSummaries(oasysSections.riskToSelf)
-
-    body.riskToSelfSummaries = riskToSelf
-
-    const page = new RiskToSelf(body)
-    page.riskToSelfSummaries = riskToSelf
-    page.oasysCompleted = oasysSections?.dateCompleted || oasysSections?.dateStarted
-    page.risks = mapApiPersonRisksForUi(application.risks)
-
-    return page
+    return getOasysSections(body, application, token, dataServices, RiskToSelf, {
+      sectionName: 'riskToSelf',
+      summaryKey: 'riskToSelfSummaries',
+      answerKey: 'riskToSelfAnswers',
+    })
   }
 
   previous() {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.ts
@@ -3,7 +3,7 @@ import type { DataServices, OasysPage, PersonRisksUI } from '@approved-premises/
 import type { ApprovedPremisesApplication, ArrayOfOASysRiskToSelfQuestions } from '@approved-premises/api'
 
 import { Page } from '../../../utils/decorators'
-import { getOasysSections, oasysImportReponse } from '../../../../utils/oasysImportUtils'
+import { getOasysSections, oasysImportReponse, validateOasysEntries } from '../../../../utils/oasysImportUtils'
 
 type RiskToSelfBody = {
   riskToSelfAnswers: Record<string, string>
@@ -55,6 +55,6 @@ export default class RiskToSelf implements OasysPage {
   }
 
   errors() {
-    return {}
+    return validateOasysEntries<RiskToSelfBody>(this.body, 'riskToSelfSummaries', 'riskToSelfAnswers')
   }
 }

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
@@ -5,6 +5,7 @@ import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../share
 import { oasysImportReponse } from '../../../../utils/oasysImportUtils'
 import RoshSummary from './roshSummary'
 import { mapApiPersonRisksForUi } from '../../../../utils/utils'
+import { itShouldHandleErrors } from './sharedExamples'
 
 jest.mock('../../../../services/personService.ts')
 
@@ -54,12 +55,7 @@ describe('RoshSummary', () => {
 
     itShouldHavePreviousValue(new RoshSummary({}), 'optional-oasys-sections')
 
-    describe('errors', () => {
-      it('should return an empty object', () => {
-        const page = new RoshSummary({})
-        expect(page.errors()).toEqual({})
-      })
-    })
+    itShouldHandleErrors(RoshSummary, { answerKey: 'roshAnswers', summaryKey: 'roshSummaries' })
 
     describe('response', () => {
       it('calls oasysImportReponse with the correct arguments', () => {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
@@ -32,13 +32,13 @@ describe('RoshSummary', () => {
     it('calls the getOasysSections method on the client with a token and the persons CRN', async () => {
       await RoshSummary.initialize({}, application, 'some-token', { personService })
 
-      expect(getOasysSectionsMock).toHaveBeenCalledWith('some-token', application.person.crn)
+      expect(getOasysSectionsMock).toHaveBeenCalledWith('some-token', application.person.crn, [])
     })
 
     it('adds the roshSummary and personRisks to the page object', async () => {
       const page = await RoshSummary.initialize({}, application, 'some-token', { personService })
 
-      expect(page.roshSummary).toEqual(oasysSections.roshSummary)
+      expect(page.roshSummaries).toEqual(oasysSections.roshSummary)
       expect(page.risks).toEqual(mapApiPersonRisksForUi(personRisks))
       expect(page.oasysCompleted).toEqual(oasysSections.dateCompleted)
     })

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
@@ -56,6 +56,6 @@ export default class RoshSummary implements OasysPage {
   }
 
   errors() {
-    return {}
+    return validateOasysEntries<RoshSummaryBody>(this.body, 'roshSummaries', 'roshAnswers')
   }
 }

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/sharedExamples.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/sharedExamples.ts
@@ -1,0 +1,48 @@
+import { Constructor } from '../../../../utils/oasysImportUtils'
+import type TasklistPage from '../../../tasklistPage'
+
+export const itShouldHandleErrors = <T extends TasklistPage>(
+  constructor: Constructor<T>,
+  { answerKey, summaryKey }: { answerKey: string; summaryKey: string },
+) => {
+  describe('errors', () => {
+    const summaries = [
+      {
+        questionNumber: '1',
+        label: 'The first question',
+        answer: 'Some answer for the first question',
+      },
+      {
+        questionNumber: '2',
+        label: 'The second question',
+        answer: 'Some answer for the second question',
+      },
+    ]
+
+    it(`should handle missing responses`, () => {
+      const answers = { '1': '', '2': 'Some response' }
+
+      const body = {
+        [`${answerKey}`]: answers,
+        [`${summaryKey}`]: summaries,
+      }
+
+      const page = new constructor(body)
+
+      expect(page.errors()).toEqual({
+        [`${answerKey}[1]`]: "You must enter a response for the 'The first question' question",
+      })
+    })
+
+    it('should return success when answers are populated', () => {
+      const answers = { '1': 'Some response', '2': 'Some response' }
+
+      const body = {
+        [`${answerKey}`]: answers,
+        [`${summaryKey}`]: summaries,
+      }
+      const page = new constructor(body)
+      expect(page.errors()).toEqual({})
+    })
+  })
+}

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.test.ts
@@ -11,6 +11,7 @@ import { mapApiPersonRisksForUi } from '../../../../utils/utils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
 import SupportingInformation from './supportingInformation'
+import { itShouldHandleErrors } from './sharedExamples'
 
 jest.mock('../../../../services/personService.ts')
 
@@ -66,11 +67,9 @@ describe('SupportingInformation', () => {
 
     itShouldHavePreviousValue(new SupportingInformation({}), 'offence-details')
 
-    describe('errors', () => {
-      it('should return an empty object', () => {
-        const page = new SupportingInformation({})
-        expect(page.errors()).toEqual({})
-      })
+    itShouldHandleErrors(SupportingInformation, {
+      answerKey: 'supportingInformationAnswers',
+      summaryKey: 'supportingInformationSummaries',
     })
 
     describe('response', () => {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.ts
@@ -3,7 +3,12 @@ import type { DataServices, OasysPage, PersonRisksUI } from '@approved-premises/
 import type { ApprovedPremisesApplication, ArrayOfOASysSupportingInformationQuestions } from '@approved-premises/api'
 
 import { Page } from '../../../utils/decorators'
-import { fetchOptionalOasysSections, getOasysSections, oasysImportReponse } from '../../../../utils/oasysImportUtils'
+import {
+  fetchOptionalOasysSections,
+  getOasysSections,
+  oasysImportReponse,
+  validateOasysEntries,
+} from '../../../../utils/oasysImportUtils'
 
 type SupportingInformationBody = {
   supportingInformationAnswers: Record<string, string>
@@ -56,6 +61,10 @@ export default class SupportingInformation implements OasysPage {
   }
 
   errors() {
-    return {}
+    return validateOasysEntries<SupportingInformationBody>(
+      this.body,
+      'supportingInformationSummaries',
+      'supportingInformationAnswers',
+    )
   }
 }

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.ts
@@ -1,20 +1,9 @@
-import type { DataServices, PersonRisksUI } from '@approved-premises/ui'
+import type { DataServices, OasysPage, PersonRisksUI } from '@approved-premises/ui'
 
-import type {
-  ApprovedPremisesApplication,
-  ArrayOfOASysSupportingInformationQuestions,
-  OASysSections,
-} from '@approved-premises/api'
-
-import TasklistPage from '../../../tasklistPage'
+import type { ApprovedPremisesApplication, ArrayOfOASysSupportingInformationQuestions } from '@approved-premises/api'
 
 import { Page } from '../../../utils/decorators'
-import {
-  fetchOptionalOasysSections,
-  oasysImportReponse,
-  sortOasysImportSummaries,
-} from '../../../../utils/oasysImportUtils'
-import { mapApiPersonRisksForUi } from '../../../../utils/utils'
+import { fetchOptionalOasysSections, getOasysSections, oasysImportReponse } from '../../../../utils/oasysImportUtils'
 
 type SupportingInformationBody = {
   supportingInformationAnswers: Record<string, string>
@@ -25,7 +14,7 @@ type SupportingInformationBody = {
   name: 'supporting-information',
   bodyProperties: ['supportingInformationAnswers', 'supportingInformationSummaries'],
 })
-export default class SupportingInformation implements TasklistPage {
+export default class SupportingInformation implements OasysPage {
   title = 'Edit risk information'
 
   supportingInformationSummaries: SupportingInformationBody['supportingInformationSummaries']
@@ -36,6 +25,8 @@ export default class SupportingInformation implements TasklistPage {
 
   risks: PersonRisksUI
 
+  oasysSuccess: boolean
+
   constructor(public body: Partial<SupportingInformationBody>) {}
 
   static async initialize(
@@ -44,22 +35,12 @@ export default class SupportingInformation implements TasklistPage {
     token: string,
     dataServices: DataServices,
   ) {
-    const oasysSections: OASysSections = await dataServices.personService.getOasysSections(
-      token,
-      application.person.crn,
-      fetchOptionalOasysSections(application),
-    )
-
-    const supportingInformation = sortOasysImportSummaries(oasysSections.supportingInformation)
-
-    body.supportingInformationSummaries = supportingInformation
-
-    const page = new SupportingInformation(body)
-    page.supportingInformationSummaries = supportingInformation
-    page.oasysCompleted = oasysSections?.dateCompleted || oasysSections?.dateStarted
-    page.risks = mapApiPersonRisksForUi(application.risks)
-
-    return page
+    return getOasysSections(body, application, token, dataServices, SupportingInformation, {
+      sectionName: 'supportingInformation',
+      summaryKey: 'supportingInformationSummaries',
+      answerKey: 'supportingInformationAnswers',
+      selectedSections: fetchOptionalOasysSections(application),
+    })
   }
 
   previous() {

--- a/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.test.ts
@@ -282,6 +282,18 @@ describe('CaseNotes', () => {
 
       expect(page.response()).toEqual({})
     })
+
+    it('returns the information from prison fields if provided', () => {
+      const page = new CaseNotes(
+        { informationFromPrison: 'yes', informationFromPrisonDetail: 'Some detail' },
+        application,
+      )
+
+      expect(page.response()).toEqual({
+        "Do you have any information from prison that will help with the person's risk management?":
+          'Yes - Some detail',
+      })
+    })
   })
 
   describe('checkBoxForCaseNoteId', () => {
@@ -305,6 +317,24 @@ describe('CaseNotes', () => {
   })
 
   describe('errors', () => {
-    expect(new CaseNotes({}, application).errors()).toEqual({})
+    it('returns an empty object if nomisFailed is false', () => {
+      const page = new CaseNotes({}, application)
+      page.nomisFailed = false
+      expect(page.errors()).toEqual({})
+    })
+
+    it('returns errors if nomisFailed is true and the informationFromPrison detail is invalid', () => {
+      const page = new CaseNotes({}, application)
+      page.nomisFailed = true
+      expect(page.errors()).toEqual({
+        informationFromPrison: 'You must state if you have any information from prison',
+      })
+
+      page.body.informationFromPrison = 'yes'
+
+      expect(page.errors()).toEqual({
+        informationFromPrisonDetail: 'You must provide detail of the information you have from prison',
+      })
+    })
   })
 })

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -13,6 +13,8 @@ import type { PersonClient, RestClientBuilder } from '../data'
 
 import { mapApiPersonRisksForUi } from '../utils/utils'
 
+export class OasysNotFoundError extends Error {}
+
 export default class PersonService {
   constructor(private readonly personClientFactory: RestClientBuilder<PersonClient>) {}
 
@@ -65,17 +67,31 @@ export default class PersonService {
   async getOasysSelections(token: string, crn: string): Promise<Array<OASysSection>> {
     const personClient = this.personClientFactory(token)
 
-    const oasysSections = await personClient.oasysSelections(crn)
+    try {
+      const oasysSections = await personClient.oasysSelections(crn)
 
-    return oasysSections
+      return oasysSections
+    } catch (e) {
+      if (e?.data?.status === 404) {
+        throw new OasysNotFoundError(`Oasys record not found for CRN: ${crn}`)
+      }
+      throw e
+    }
   }
 
   async getOasysSections(token: string, crn: string, selectedSections: Array<number> = []): Promise<OASysSections> {
     const personClient = this.personClientFactory(token)
 
-    const oasysSections = await personClient.oasysSections(crn, selectedSections)
+    try {
+      const oasysSections = await personClient.oasysSections(crn, selectedSections)
 
-    return oasysSections
+      return oasysSections
+    } catch (e) {
+      if (e?.data?.status === 404) {
+        throw new OasysNotFoundError(`Oasys record not found for CRN: ${crn}`)
+      }
+      throw e
+    }
   }
 
   async getDocument(token: string, crn: string, documentId: string, response: Response): Promise<void> {

--- a/server/utils/oasysImportUtils.test.ts
+++ b/server/utils/oasysImportUtils.test.ts
@@ -18,6 +18,7 @@ import {
   sectionCheckBoxes,
   sortOasysImportSummaries,
   textareas,
+  validateOasysEntries,
 } from './oasysImportUtils'
 import oasysStubs from '../data/stubs/oasysStubs.json'
 
@@ -120,6 +121,47 @@ describe('OASysImportUtils', () => {
           questionNumber: offenceDetails[1].questionNumber,
         },
       ])
+    })
+  })
+
+  describe('validateOasysEntries', () => {
+    const summaries = [
+      {
+        questionNumber: '1',
+        label: 'The first question',
+        answer: 'Some answer for the first question',
+      },
+      {
+        questionNumber: '2',
+        label: 'The second question',
+        answer: 'Some answer for the second question',
+      },
+    ]
+
+    it('should return errors for missing fields', () => {
+      const answers = { '1': '', '2': 'Some response' }
+      const body = {
+        summaries,
+        answers,
+      }
+
+      const errors = validateOasysEntries(body, 'summaries', 'answers')
+
+      expect(errors).toEqual({
+        'answers[1]': "You must enter a response for the 'The first question' question",
+      })
+    })
+
+    it('should return no errors when all fields are complete', () => {
+      const answers = { '1': 'Some response', '2': 'Some response' }
+      const body = {
+        summaries,
+        answers,
+      }
+
+      const errors = validateOasysEntries(body, 'summaries', 'answers')
+
+      expect(errors).toEqual({})
     })
   })
 

--- a/server/utils/oasysImportUtils.test.ts
+++ b/server/utils/oasysImportUtils.test.ts
@@ -1,14 +1,128 @@
-import { applicationFactory, oasysSelectionFactory, roshSummaryFactory } from '../testutils/factories'
-import { sentenceCase } from './utils'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import { OasysPage } from '@approved-premises/ui'
+import { offenceDetailsFactory } from '../testutils/factories/oasysSections'
+import PersonService, { OasysNotFoundError } from '../services/personService'
 import {
+  applicationFactory,
+  oasysSectionsFactory,
+  oasysSelectionFactory,
+  risksFactory,
+  roshSummaryFactory,
+} from '../testutils/factories'
+import { mapApiPersonRisksForUi, sentenceCase } from './utils'
+import {
+  Constructor,
   fetchOptionalOasysSections,
+  getOasysSections,
   oasysImportReponse,
   sectionCheckBoxes,
   sortOasysImportSummaries,
   textareas,
 } from './oasysImportUtils'
+import oasysStubs from '../data/stubs/oasysStubs.json'
 
 describe('OASysImportUtils', () => {
+  describe('getOasysSections', () => {
+    let getOasysSectionsMock: jest.Mock
+    let personService: DeepMocked<PersonService>
+    let constructor: DeepMocked<Constructor<OasysPage>>
+
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    beforeEach(() => {
+      constructor = createMock<Constructor<OasysPage>>(
+        jest.fn().mockImplementation(() => ({ body: {} } as unknown as OasysPage)),
+      )
+      getOasysSectionsMock = jest.fn()
+      personService = createMock<PersonService>({
+        getOasysSections: getOasysSectionsMock,
+      })
+    })
+
+    it('sets oasysSuccess to false along with the stubs if there is an OasysNotFoundError', async () => {
+      const personRisks = risksFactory.build()
+      const application = applicationFactory.build({ risks: personRisks })
+
+      getOasysSectionsMock.mockImplementation(() => {
+        throw new OasysNotFoundError()
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result: any = await getOasysSections({}, application, 'some-token', { personService }, constructor, {
+        sectionName: 'offenceDetails',
+        summaryKey: 'offenceDetailsSummary',
+        answerKey: 'offenceDetailsAnswers',
+      })
+
+      expect(result.oasysSuccess).toEqual(false)
+      expect(result.body.offenceDetailsSummary).toEqual(sortOasysImportSummaries(oasysStubs.offenceDetails))
+      expect(result.offenceDetailsSummary).toEqual(oasysStubs.offenceDetails)
+      expect(result.risks).toEqual(mapApiPersonRisksForUi(application.risks))
+    })
+
+    it('sets oasysSuccess to true along with the marshalled oasys data if there is not an OasysNotFoundError', async () => {
+      const personRisks = risksFactory.build()
+      const application = applicationFactory.build({ risks: personRisks })
+
+      const oasysSections = oasysSectionsFactory.build()
+
+      getOasysSectionsMock.mockResolvedValue(oasysSections)
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result: any = await getOasysSections({}, application, 'some-token', { personService }, constructor, {
+        sectionName: 'offenceDetails',
+        summaryKey: 'offenceDetailsSummary',
+        answerKey: 'offenceDetailsAnswers',
+      })
+
+      expect(result.oasysSuccess).toEqual(true)
+      expect(result.body.offenceDetailsSummary).toEqual(sortOasysImportSummaries(oasysSections.offenceDetails))
+      expect(result.offenceDetailsSummary).toEqual(oasysSections.offenceDetails)
+      expect(result.risks).toEqual(mapApiPersonRisksForUi(application.risks))
+    })
+
+    it('prioritises the body over the Oasys data if the body is provided', async () => {
+      const personRisks = risksFactory.build()
+      const application = applicationFactory.build({ risks: personRisks })
+
+      const offenceDetails = [
+        offenceDetailsFactory.build({ questionNumber: '1' }),
+        offenceDetailsFactory.build({ questionNumber: '2' }),
+      ]
+
+      const oasysSections = oasysSectionsFactory.build({
+        offenceDetails,
+      })
+
+      getOasysSectionsMock.mockResolvedValue(oasysSections)
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result: any = await getOasysSections(
+        { offenceDetailsAnswers: { '1': 'My Response' } },
+        application,
+        'some-token',
+        { personService },
+        constructor,
+        {
+          sectionName: 'offenceDetails',
+          summaryKey: 'offenceDetailsSummary',
+          answerKey: 'offenceDetailsAnswers',
+        },
+      )
+
+      expect(result.body.offenceDetailsSummary).toEqual([
+        { answer: 'My Response', label: offenceDetails[0].label, questionNumber: offenceDetails[0].questionNumber },
+        {
+          answer: offenceDetails[1].answer,
+          label: offenceDetails[1].label,
+          questionNumber: offenceDetails[1].questionNumber,
+        },
+      ])
+    })
+  })
+
   describe('textareas', () => {
     it('it returns reoffending needs as textareas', () => {
       const roshSummaries = roshSummaryFactory.buildList(2)

--- a/server/utils/oasysImportUtils.ts
+++ b/server/utils/oasysImportUtils.ts
@@ -1,8 +1,71 @@
-import { OasysImportArrays } from '../@types/ui'
-import { ApprovedPremisesApplication as Application, OASysQuestion, OASysSection } from '../@types/shared'
+import { DataServices, OasysImportArrays, OasysPage } from '../@types/ui'
+import {
+  ApprovedPremisesApplication as Application,
+  ApprovedPremisesApplication,
+  OASysQuestion,
+  OASysSection,
+  OASysSections,
+} from '../@types/shared'
 import { SessionDataError } from './errors'
 import { escape } from './formUtils'
-import { sentenceCase } from './utils'
+import { mapApiPersonRisksForUi, sentenceCase } from './utils'
+import { OasysNotFoundError } from '../services/personService'
+import oasysStubs from '../data/stubs/oasysStubs.json'
+
+export type Constructor<T> = new (body: unknown) => T
+
+export const getOasysSections = async <T extends OasysPage>(
+  body: Record<string, unknown>,
+  application: ApprovedPremisesApplication,
+  token: string,
+  dataServices: DataServices,
+  constructor: Constructor<T>,
+  {
+    sectionName,
+    summaryKey,
+    answerKey,
+    selectedSections = [],
+  }: {
+    sectionName: string
+    summaryKey: string
+    answerKey: string
+    selectedSections?: Array<number>
+  },
+): Promise<T> => {
+  let oasysSections: OASysSections
+  let oasysSuccess: boolean
+
+  try {
+    oasysSections = await dataServices.personService.getOasysSections(token, application.person.crn, selectedSections)
+    oasysSuccess = true
+  } catch (e) {
+    if (e instanceof OasysNotFoundError) {
+      oasysSections = oasysStubs
+      oasysSuccess = false
+    } else {
+      throw e
+    }
+  }
+
+  const summaries = sortOasysImportSummaries(oasysSections[sectionName]).map(question => {
+    const answer = body[answerKey]?.[question.questionNumber] || question.answer
+    return {
+      ...question,
+      answer,
+    }
+  })
+
+  const page = new constructor(body)
+
+  page.body[summaryKey] = summaries
+  page[summaryKey] = summaries
+  page.oasysCompleted = oasysSections?.dateCompleted || oasysSections?.dateStarted
+  page.oasysSuccess = oasysSuccess
+  page.risks = mapApiPersonRisksForUi(application.risks)
+
+  return page
+}
+
 
 export const textareas = (questions: OasysImportArrays, key: 'roshAnswers' | 'offenceDetails') => {
   return questions

--- a/server/utils/oasysImportUtils.ts
+++ b/server/utils/oasysImportUtils.ts
@@ -66,6 +66,22 @@ export const getOasysSections = async <T extends OasysPage>(
   return page
 }
 
+export const validateOasysEntries = <T>(body: Partial<T>, questionKey: string, answerKey: string) => {
+  const errors = {}
+  const questions = body[questionKey]
+  const answers = body[answerKey]
+
+  Object.keys(questions).forEach(key => {
+    const question = questions[key]
+    if (!answers[question.questionNumber]) {
+      errors[
+        `${answerKey}[${question.questionNumber}]`
+      ] = `You must enter a response for the '${question.label}' question`
+    }
+  })
+
+  return errors
+}
 
 export const textareas = (questions: OasysImportArrays, key: 'roshAnswers' | 'offenceDetails') => {
   return questions

--- a/server/views/applications/pages/oasys-import/_oasys-screen.njk
+++ b/server/views/applications/pages/oasys-import/_oasys-screen.njk
@@ -8,11 +8,15 @@
 {% block questions %}
   <div class="govuk-grid-row">
     <div>
-      {% if oasysDisabled %}
-        <h1 class="govuk-heading-l">Input risk information</h1>
+      {% if oasysDisabled or page.oasysSuccess == false %}
+        <h1 class="govuk-heading-l">Provide risk information</h1>
       {% else %}
         <h1 class="govuk-heading-l">{{page.title}}</h1>
         <p>OASys last updated: {{formatDate(page.oasysCompleted)}}</p>
+      {% endif %}
+
+      {% if page.oasysSuccess == false %}
+        <p class="govuk-body">This information will be used to help Approved Premises (AP) managers understand factors that may help with the person’s risk management in an AP.</p>
       {% endif %}
     </div>
 
@@ -49,13 +53,21 @@
   <div class="govuk-grid-row">
     {% if oasysDisabled %}
       <div class="govuk-grid-column-full" id="{{ pageName }}">
-         <p> {{ guidance }} </p>
-         {{OasysImportUtils.textareas(questions, key) | safe}}
+        <p>
+          {{ guidance }}
+        </p>
+        {{OasysImportUtils.textareas(questions, key) | safe}}
       </div>
     {% else %}
       <div class="govuk-grid-column-two-thirds" id="{{ pageName }}">
-         <h2 class="govuk-heading-m"> {{ heading }} </h2>
-         <p> {{ guidance }} </p>
+        {% if page.oasysSuccess == true %}
+          <h2 class="govuk-heading-m">
+            {{ heading }}
+          </h2>
+          <p>
+            {{ guidance }}
+          </p>
+        {% endif %}
         {{OasysImportUtils.textareas(questions, key) | safe}}
       </div>
 

--- a/server/views/applications/pages/oasys-import/optional-oasys-sections.njk
+++ b/server/views/applications/pages/oasys-import/optional-oasys-sections.njk
@@ -1,61 +1,92 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% extends "../layout.njk" %}
 
 {% block questions %}
 
-    <h1 class="govuk-heading-l">{{page.title}}</h1>
+    {% if page.oasysSuccess %}
+        <h1 class="govuk-heading-l">{{page.title}}</h1>
 
-    <p class="govuk-body">We'll automatically import:</p>
+        <p class="govuk-body">We'll automatically import:</p>
 
-    <ul class="govuk-list govuk-list--bullet">
-        <li>offence details</li>
-        <li>RoSH summary</li>
-        <li>any MAPPA or hate-based information</li>
-        <li>sections linked to RoSH</li>
-        <li>Risk Management Plan</li>
-        <li>Section 8 - Drug misuse</li>
-        <li>Section 9 - Alcohol misuse</li>
-    </ul>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>offence details</li>
+            <li>RoSH summary</li>
+            <li>any MAPPA or hate-based information</li>
+            <li>sections linked to RoSH</li>
+            <li>Risk Management Plan</li>
+            <li>Section 8 - Drug misuse</li>
+            <li>Section 9 - Alcohol misuse</li>
+        </ul>
 
-    <p>Select any sections that include information that's relevant to the risk an Approved Premises (AP) will help manage or the needs an AP can support.</p>
-    <p>You will be able to edit the information that is pulled in from OASys. Any new information that you provide as part of this application should be added to OASys.</p>
+        <p>Select any sections that include information that's relevant to the risk an Approved Premises (AP) will help manage or the needs an AP can support.</p>
+        <p>You will be able to edit the information that is pulled in from OASys. Any new information that you provide as part of this application should be added to OASys.</p>
 
-    <h2 class="govuk-heading-s">Needs linked to risk of serious harm are automatically imported</h2>
+        <h2 class="govuk-heading-s">Needs linked to risk of serious harm are automatically imported</h2>
 
-    {% if page.allNeedsLinkedToReoffending.length %}
+        {% if page.allNeedsLinkedToReoffending.length %}
+            {{
+            govukCheckboxes({
+                idPrefix: "needsLinkedToReoffending",
+                name: "needsLinkedToReoffending",
+                errorMessage: errors.needsLinkedToReoffending,
+                fieldset: {
+                    legend: {
+                        text: "Optional - Needs linked to reoffending",
+                        classes: "govuk-fieldset__legend--m"
+                    }
+                },
+                items: OasysImportUtils.sectionCheckBoxes(page.allNeedsLinkedToReoffending, page.body.needsLinkedToReoffending)
+            })
+        }}
+        {% endif %}
+
+        {% if page.allOtherNeeds.length %}
+            {{
+            govukCheckboxes({
+                idPrefix: "otherNeeds",
+                name: "otherNeeds",
+                errorMessage: errors.otherNeeds,
+                fieldset: {
+                    legend: {
+                        text: "Optional - Needs not linked to risk of serious harm or reoffending",
+                        classes: "govuk-fieldset__legend--m"
+                    }
+                },
+                items: OasysImportUtils.sectionCheckBoxes(page.allOtherNeeds, page.body.otherNeeds)
+            })
+        }}
+
+        {% endif %}
+    {% else %}
+        <h1 class="govuk-heading-l">Oasys Information</h1>
+
+        {% set html %}
+        <p class="govuk-body">
+            We are unable to import information from OASys as the person does not have a OASys record.
+        </p>
+        {% endset %}
+
         {{
-        govukCheckboxes({
-            idPrefix: "needsLinkedToReoffending",
-            name: "needsLinkedToReoffending",
-            errorMessage: errors.needsLinkedToReoffending,
-            fieldset: {
-                legend: {
-                    text: "Optional - Needs linked to reoffending",
-                    classes: "govuk-fieldset__legend--m"
-                }
-            },
-            items: OasysImportUtils.sectionCheckBoxes(page.allNeedsLinkedToReoffending, page.body.needsLinkedToReoffending)
-        })
-    }}
-    {% endif %}
+            govukNotificationBanner({
+                html: html
+            })
+        }}
 
-    {% if page.allOtherNeeds.length %}
-        {{
-        govukCheckboxes({
-            idPrefix: "otherNeeds",
-            name: "otherNeeds",
-            errorMessage: errors.otherNeeds,
-            fieldset: {
-                legend: {
-                    text: "Optional - Needs not linked to risk of serious harm or reoffending",
-                    classes: "govuk-fieldset__legend--m"
-                }
-            },
-            items: OasysImportUtils.sectionCheckBoxes(page.allOtherNeeds, page.body.otherNeeds)
-        })
-    }}
+        <p class="govuk-body">You will be asked to provide relevant information from OASys, including: </p>
 
+        <ul class="govuk-list govuk-list--bullet">
+            <li>offence details</li>
+            <li>RoSH summary</li>
+            <li>any MAPPA or hate-based information</li>
+            <li>sections linked to RoSH</li>
+            <li>issues contributing to risks of offending and harm  (Section 2 - 13)</li>
+            <li>Risk Management Plan</li>
+            <li>Risk to self</li>
+        </ul>
+
+        <p class="govuk-body">Any information that you provide as part of this application will not be written back to OASys.</p>
     {% endif %}
 
 {% endblock %}

--- a/server/views/applications/pages/oasys-import/rosh-summary.njk
+++ b/server/views/applications/pages/oasys-import/rosh-summary.njk
@@ -5,7 +5,7 @@
 
 {% set columnClasses = "govuk-grid-column-full" %}
 {% set pageName = "roshSummary" %}
-{% set questions = page.roshSummary %}
+{% set questions = page.roshSummaries %}
 {% set key = "roshAnswers" %}
 {% set heading = "RoSH summary" %}
 {% set guidance = "These questions have been imported from the Risk of Serious Harm Summary (Layer 3) section of OASys." %}

--- a/server/views/applications/pages/prison-information/case-notes.njk
+++ b/server/views/applications/pages/prison-information/case-notes.njk
@@ -6,7 +6,9 @@
 
 {% extends "../layout.njk" %}
 
-{% set columnClasses = "govuk-grid-column-full" %}
+{% if nomisFailed == false %}
+  {% set columnClasses = "govuk-grid-column-full" %}
+{% endif %}
 
 {% set caseNotes %}
 <table class="govuk-table">
@@ -39,14 +41,27 @@
 {% endset %}
 
 {% block questions %}
-  <div class="govuk-grid-row">
-    <div>
-      <h1 class="govuk-heading-l">{{page.title}}</h1>
-      <p>This information is imported from NOMIS</p>
-      <p>Select any prison case notes that will help Approved Premises (AP) managers understand factors that may help with the person's risk management in an AP. </p>
-      <p>Adjudications from the person's current sentence and ACCT (Assessment, Care in Custody and Teamwork) information will be sent automatically.</p>
-    </div>
+  {% if page.nomisFailed == true %}
+    <h1 class="govuk-heading-l">{{page.title}}</h1>
 
-    {{prisonInformationTable(caseNotes, page.body.adjudications, page.body.acctAlerts)}}
-  </div>
+    <p>We are unable to import information from NOMIS.</p>
+
+    <p>If you have any information from the prison provide it below. This includes case notes, adjudications and ACCT information. </p>
+
+    <p>These will be used to help Approved Premises (AP) managers understand factors that may help with the person's risk management in an AP. You may need to contact the persons prison to get this information</p>
+
+    {% set key = 'informationFromPrison' %}
+    {% include "./../../partials/_yes-no-with-detail.njk" %}
+  {% else %}
+    <div class="govuk-grid-row">
+      <div>
+        <h1 class="govuk-heading-l">{{page.title}}</h1>
+        <p>This information is imported from NOMIS</p>
+        <p>Select any prison case notes that will help Approved Premises (AP) managers understand factors that may help with the person's risk management in an AP. </p>
+        <p>Adjudications from the person's current sentence and ACCT (Assessment, Care in Custody and Teamwork) information will be sent automatically.</p>
+      </div>
+
+      {{prisonInformationTable(caseNotes, page.body.adjudications, page.body.acctAlerts)}}
+    </div>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
This builds on https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/767 to handle a 404 response from either Oasys or Nomis. If there are no Nomis details, the user is informed of the fact and then is prompted to add the detail manually.

If there are no case notes, they're prompted to speak to the person's prison and add any pertinent info.

## Screenshots

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/06544e75-a769-4bcc-b331-d5d3226cbc91)

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/03e7d23e-d334-4001-b8f8-3aa57179260e)

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/fcbe3d05-0050-4947-9501-16c716f591a1)
