### PR TITLE
(274) Assess - Contingency plans suitability screens

### DIFF
--- a/integration_tests/helpers/assess.ts
+++ b/integration_tests/helpers/assess.ts
@@ -27,6 +27,7 @@ import { updateAssessmentData } from '../../server/form-pages/utils'
 import AssessPage from '../pages/assess/assessPage'
 import { assessmentSummaryFactory } from '../../server/testutils/factories'
 import RfapSuitabilityPage from '../pages/assess/rfapSuitability'
+import ContingencyPlanSuitabilityPage from '../pages/assess/contingencyPlanSuitability'
 
 export default class AseessHelper {
   assessmentSummary: AssessmentSummary
@@ -220,7 +221,17 @@ export default class AseessHelper {
       applicationTimelinessPage.completeForm()
       applicationTimelinessPage.clickSubmit()
       this.updateAssessmentAndStub(applicationTimelinessPage)
-      this.pages.assessSuitability = [...this.pages.assessSuitability, applicationTimelinessPage]
+
+      const contingencyPlanSuitabilityPage = new ContingencyPlanSuitabilityPage(this.assessment)
+      contingencyPlanSuitabilityPage.completeForm()
+      contingencyPlanSuitabilityPage.clickSubmit()
+      this.updateAssessmentAndStub(contingencyPlanSuitabilityPage)
+
+      this.pages.assessSuitability = [
+        ...this.pages.assessSuitability,
+        applicationTimelinessPage,
+        contingencyPlanSuitabilityPage,
+      ]
     }
 
     // Then I should be taken to the task list

--- a/integration_tests/pages/assess/contingencyPlanSuitability.ts
+++ b/integration_tests/pages/assess/contingencyPlanSuitability.ts
@@ -1,0 +1,23 @@
+import type { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
+import type { YesOrNo } from '@approved-premises/ui'
+
+import AssessPage from './assessPage'
+
+import ContingencyPlanSuitability from '../../../server/form-pages/assess/assessApplication/suitablityAssessment/contingencyPlanSuitability'
+
+export default class ContingencyPlanSuitabilityPage extends AssessPage {
+  pageClass: ContingencyPlanSuitability
+
+  constructor(assessment: Assessment, sufficientAnswer: YesOrNo = 'no', detailAnswer = 'Some detail') {
+    super(assessment, 'Suitability assessment')
+    this.pageClass = new ContingencyPlanSuitability(
+      { contingencyPlanSufficient: sufficientAnswer, additionalComments: detailAnswer },
+      assessment,
+    )
+  }
+
+  completeForm() {
+    this.checkRadioByNameAndValue('contingencyPlanSufficient', this.pageClass.body.contingencyPlanSufficient)
+    this.clearAndCompleteTextInputById('additionalComments', this.pageClass.body.additionalComments)
+  }
+}

--- a/integration_tests/tests/assess/assess.cy.ts
+++ b/integration_tests/tests/assess/assess.cy.ts
@@ -208,14 +208,14 @@ context('Assess', () => {
 
         application.data = applicationData
 
-        const nextWeek = addDays(new Date(), 8)
+        const tomorrow = addDays(new Date(), 1)
 
         application = addResponsesToFormArtifact(application, {
           section: 'basic-information',
           page: 'release-date',
           keyValuePairs: {
-            ...DateFormats.dateObjectToDateInputs(nextWeek, 'releaseDate'),
-            releaseDate: DateFormats.dateObjToIsoDate(nextWeek),
+            ...DateFormats.dateObjectToDateInputs(tomorrow, 'releaseDate'),
+            releaseDate: DateFormats.dateObjToIsoDate(tomorrow),
             knowReleaseDate: 'yes',
           },
         }) as Application
@@ -238,7 +238,7 @@ context('Assess', () => {
         assessment.application.submittedAt = application.submittedAt
 
         assessment.data = {}
-        const documents = documentFactory.buildList(4)
+        const documents = documentFactory.buildList(1)
         assessment.application = overwriteApplicationDocuments(assessment.application, documents)
         const user = userFactory.build()
 
@@ -252,6 +252,7 @@ context('Assess', () => {
     it('allows me to assess a short notice application', function test() {
       // Given there is a short notice application awaiting assessment
       this.assessHelper.setupStubs()
+
       // And I start an assessment
       this.assessHelper.startAssessment()
 

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -1115,99 +1115,123 @@
       "type": "object",
       "properties": {
         "case-notes": {
-          "type": "object",
-          "properties": {
-            "caseNoteIds": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "selectedCaseNotes": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "caseNoteIds": {
+                  "type": "array",
+                  "items": {
                     "type": "string"
-                  },
-                  "sensitive": {
-                    "type": "boolean"
-                  },
-                  "createdAt": {
-                    "type": "string"
-                  },
-                  "occurredAt": {
-                    "type": "string"
-                  },
-                  "authorName": {
-                    "type": "string"
-                  },
-                  "type": {
-                    "type": "string"
-                  },
-                  "subType": {
-                    "type": "string"
-                  },
-                  "note": {
-                    "type": "string"
+                  }
+                },
+                "selectedCaseNotes": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "sensitive": {
+                        "type": "boolean"
+                      },
+                      "createdAt": {
+                        "type": "string"
+                      },
+                      "occurredAt": {
+                        "type": "string"
+                      },
+                      "authorName": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      },
+                      "subType": {
+                        "type": "string"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "adjudications": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "reportedAt": {
+                        "type": "string"
+                      },
+                      "establishment": {
+                        "type": "string"
+                      },
+                      "offenceDescription": {
+                        "type": "string"
+                      },
+                      "hearingHeld": {
+                        "type": "boolean"
+                      },
+                      "finding": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "acctAlerts": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "alertId": {
+                        "type": "number"
+                      },
+                      "comment": {
+                        "type": "string"
+                      },
+                      "dateCreated": {
+                        "type": "string"
+                      },
+                      "dateExpires": {
+                        "type": "string"
+                      },
+                      "expired": {
+                        "type": "boolean"
+                      },
+                      "active": {
+                        "type": "boolean"
+                      }
+                    }
                   }
                 }
               }
             },
-            "adjudications": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "number"
-                  },
-                  "reportedAt": {
-                    "type": "string"
-                  },
-                  "establishment": {
-                    "type": "string"
-                  },
-                  "offenceDescription": {
-                    "type": "string"
-                  },
-                  "hearingHeld": {
-                    "type": "boolean"
-                  },
-                  "finding": {
-                    "type": "string"
-                  }
+            {
+              "type": "object",
+              "properties": {
+                "informationFromPrison": {
+                  "enum": [
+                    "no",
+                    "yes"
+                  ],
+                  "type": "string"
                 }
               }
             },
-            "acctAlerts": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "alertId": {
-                    "type": "number"
-                  },
-                  "comment": {
-                    "type": "string"
-                  },
-                  "dateCreated": {
-                    "type": "string"
-                  },
-                  "dateExpires": {
-                    "type": "string"
-                  },
-                  "expired": {
-                    "type": "boolean"
-                  },
-                  "active": {
-                    "type": "boolean"
-                  }
+            {
+              "type": "object",
+              "properties": {
+                "informationFromPrisonDetail": {
+                  "type": "string"
                 }
               }
             }
-          }
+          ]
         }
       }
     },

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.test.ts
@@ -1,12 +1,13 @@
 import { DateFormats } from '../../../../utils/dateUtils'
 import { assessmentFactory } from '../../../../testutils/factories'
 import { YesOrNo } from '../../../../@types/ui'
-import { itShouldHaveNextValue } from '../../../shared-examples'
 import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 
 import ApplicationTimeliness from './applicationTimeliness'
+import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
 
 jest.mock('../../../../utils/retrieveQuestionResponseFromFormArtifact')
+jest.mock('../../../../utils/applications/noticeTypeFromApplication')
 jest.mock('../../../../utils/dateUtils')
 
 describe('ApplicationTimeliness', () => {
@@ -39,16 +40,32 @@ describe('ApplicationTimeliness', () => {
     })
   })
 
-  itShouldHaveNextValue(
-    new ApplicationTimeliness(
-      {
-        agreeWithShortNoticeReason: 'yes',
-        agreeWithShortNoticeReasonComments: 'some reasons',
-      },
-      assessment,
-    ),
-    '',
-  )
+  describe('next', () => {
+    it('returns an empty string if the application has a notice type other than emergency', () => {
+      expect(
+        new ApplicationTimeliness(
+          {
+            agreeWithShortNoticeReason: 'yes',
+            agreeWithShortNoticeReasonComments: 'some reasons',
+          },
+          assessment,
+        ).next(),
+      ).toEqual('')
+    })
+
+    it('returns contingency-plan-suitability if the application ahs a notice type of emergency', () => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('emergency')
+      expect(
+        new ApplicationTimeliness(
+          {
+            agreeWithShortNoticeReason: 'yes',
+            agreeWithShortNoticeReasonComments: 'some reasons',
+          },
+          assessment,
+        ).next(),
+      ).toEqual('contingency-plan-suitability')
+    })
+  })
 
   describe('previous', () => {
     it('returns rfap-suitability if the applicant requires an RFAP', () => {

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.ts
@@ -11,6 +11,7 @@ import TasklistPage from '../../../tasklistPage'
 import { responsesForYesNoAndCommentsSections } from '../../../utils/index'
 import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 import Rfap from '../../../apply/risk-and-need-factors/further-considerations/rfap'
+import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
 
 export type ApplicationTimelinessSection = {
   agreeWithShortNoticeReason: string
@@ -69,7 +70,7 @@ export default class ApplicationTimeliness implements TasklistPage {
   }
 
   next() {
-    return ''
+    return noticeTypeFromApplication(this.assessment.application) === 'emergency' ? 'contingency-plan-suitability' : ''
   }
 
   response() {

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/contingencyPlanSuitability.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/contingencyPlanSuitability.test.ts
@@ -1,0 +1,65 @@
+import { assessmentFactory } from '../../../../testutils/factories'
+import { itShouldHaveNextValue } from '../../../shared-examples'
+
+import ContingencyPlanSuitability, { ContingencyPlanSuitabilityBody } from './contingencyPlanSuitability'
+import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
+
+jest.mock('../../../../utils/applications/noticeTypeFromApplication')
+
+describe('ContingencyPlanSuitability', () => {
+  const body: ContingencyPlanSuitabilityBody = {
+    contingencyPlanSufficient: 'yes',
+    additionalComments: 'some comments',
+  }
+
+  const assessment = assessmentFactory.build()
+  describe('title', () => {
+    expect(new ContingencyPlanSuitability(body, assessment).title).toBe('Suitability assessment')
+  })
+
+  describe('body', () => {
+    it('should set the body', () => {
+      const page = new ContingencyPlanSuitability(body, assessment)
+      expect(page.body).toEqual({
+        contingencyPlanSufficient: 'yes',
+        additionalComments: 'some comments',
+      })
+    })
+  })
+
+  itShouldHaveNextValue(new ContingencyPlanSuitability(body, assessment), '')
+
+  describe('previous', () => {
+    it('returns application-timeliness if the notice type is emergency', () => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('emergency')
+      expect(new ContingencyPlanSuitability(body, assessment).previous()).toBe('application-timeliness')
+    })
+
+    it('returns application-timeliness if the notice type is emergency', () => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('standard')
+      expect(new ContingencyPlanSuitability(body, assessment).previous()).toBe('suitability-assessment')
+    })
+  })
+  describe('errors', () => {
+    it('should have an error if there are no answers', () => {
+      const page = new ContingencyPlanSuitability({} as ContingencyPlanSuitabilityBody, assessment)
+
+      expect(page.errors()).toEqual({
+        additionalComments: 'You must provide additional comments',
+        contingencyPlanSufficient:
+          'You must confirm if the contingency plan is sufficient to manage behaviour or a failure to return out of hours',
+      })
+    })
+  })
+
+  describe('response', () => {
+    it('returns the response', () => {
+      const page = new ContingencyPlanSuitability(body, assessment)
+
+      expect(page.response()).toEqual({
+        'Additional comments': 'some comments',
+        'Is the contingency plan sufficient to manage behaviour or a failure to return out of hours?': 'Yes',
+      })
+    })
+  })
+})

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/contingencyPlanSuitability.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/contingencyPlanSuitability.ts
@@ -1,0 +1,59 @@
+import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
+import { ApprovedPremisesAssessment as Assessment } from '../../../../@types/shared'
+
+import { Page } from '../../../utils/decorators'
+
+import TasklistPage from '../../../tasklistPage'
+import { sentenceCase } from '../../../../utils/utils'
+
+export type ContingencyPlanSuitabilityBody = {
+  contingencyPlanSufficient: YesOrNo
+  additionalComments: string
+}
+
+@Page({
+  name: 'contingency-plan-suitability',
+  bodyProperties: ['contingencyPlanSufficient', 'additionalComments'],
+})
+export default class ContingencyPlanSuitability implements TasklistPage {
+  title = 'Suitability assessment'
+
+  questions = {
+    contingencyPlanSufficient:
+      'Is the contingency plan sufficient to manage behaviour or a failure to return out of hours?',
+    additionalComments: 'Additional comments',
+  }
+
+  constructor(public body: ContingencyPlanSuitabilityBody, private readonly assessment: Assessment) {}
+
+  previous() {
+    if (noticeTypeFromApplication(this.assessment.application) === 'emergency') return 'application-timeliness'
+    return 'suitability-assessment'
+  }
+
+  next() {
+    return ''
+  }
+
+  response() {
+    const response = {}
+
+    response[this.questions.contingencyPlanSufficient] = sentenceCase(this.body.contingencyPlanSufficient)
+    response[this.questions.additionalComments] = this.body.additionalComments
+
+    return response
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.contingencyPlanSufficient)
+      errors.contingencyPlanSufficient =
+        'You must confirm if the contingency plan is sufficient to manage behaviour or a failure to return out of hours'
+
+    if (!this.body.additionalComments) errors.additionalComments = 'You must provide additional comments'
+
+    return errors
+  }
+}

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/index.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/index.ts
@@ -3,10 +3,11 @@ import { Task } from '../../../utils/decorators'
 import SuitabilityAssessmentPage from './suitabilityAssessment'
 import ApplicationTimeliness from './applicationTimeliness'
 import RfapSuitability from './rfapSuitability'
+import ContingencyPlanSuitability from './contingencyPlanSuitability'
 
 @Task({
   slug: 'suitability-assessment',
   name: 'Assess suitability of application',
-  pages: [SuitabilityAssessmentPage, RfapSuitability, ApplicationTimeliness],
+  pages: [SuitabilityAssessmentPage, RfapSuitability, ApplicationTimeliness, ContingencyPlanSuitability],
 })
 export default class SuitabilityAssessment {}

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.test.ts
@@ -52,7 +52,7 @@ describe('RfapSuitability', () => {
 
       expect(page.errors()).toEqual({
         rfapIdentifiedAsSuitable:
-          'You must confirm if a Recovery Focused Approved Premises (RAP) been identified as a suitable placement',
+          'You must confirm if a Recovery Focused Approved Premises (RFAP) been identified as a suitable placement',
       })
     })
   })
@@ -62,7 +62,7 @@ describe('RfapSuitability', () => {
       const page = new RfapSuitability(body, assessment)
 
       expect(page.response()).toEqual({
-        'Has a Recovery Focused Approved Premises (RAP) been identified as a suitable placement?': 'yes',
+        'Has a Recovery Focused Approved Premises (RFAP) been identified as a suitable placement?': 'yes',
         'If the person is unsuitable for a RFAP placement yet suitable for a standard placement, summarise the rationale for the decision':
           'some reasons',
       })

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.ts
@@ -19,7 +19,8 @@ export default class RfapSuitability implements TasklistPage {
   title = 'Suitability assessment'
 
   questions = {
-    rfapIdentifiedAsSuitable: 'Has a Recovery Focused Approved Premises (RAP) been identified as a suitable placement?',
+    rfapIdentifiedAsSuitable:
+      'Has a Recovery Focused Approved Premises (RFAP) been identified as a suitable placement?',
     unsuitabilityForRfapRationale:
       'If the person is unsuitable for a RFAP placement yet suitable for a standard placement, summarise the rationale for the decision',
   }
@@ -55,7 +56,7 @@ export default class RfapSuitability implements TasklistPage {
 
     if (!this.body.rfapIdentifiedAsSuitable)
       errors.rfapIdentifiedAsSuitable =
-        'You must confirm if a Recovery Focused Approved Premises (RAP) been identified as a suitable placement'
+        'You must confirm if a Recovery Focused Approved Premises (RFAP) been identified as a suitable placement'
 
     return errors
   }

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
@@ -4,11 +4,18 @@ import { YesOrNo } from '../../../../@types/ui'
 import { itShouldHavePreviousValue } from '../../../shared-examples'
 
 import SuitabilityAssessment from './suitabilityAssessment'
+import { shouldShowContingencyPlanPages } from '../../../../utils/applications/shouldShowContingencyPlanPages'
 
 jest.mock('../../../../utils/applications/noticeTypeFromApplication')
+jest.mock('../../../../utils/applications/shouldShowContingencyPlanPages')
 
 describe('SuitabilityAssessment', () => {
   const assessment = assessmentFactory.build()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
   describe('title', () => {
     expect(
       new SuitabilityAssessment(
@@ -74,8 +81,24 @@ describe('SuitabilityAssessment', () => {
       ).toEqual('application-timeliness')
     })
 
+    it('returns contingency-plan-suitability if shouldShowContingencyPlanPages returns true', () => {
+      ;(shouldShowContingencyPlanPages as jest.Mock).mockReturnValue(true)
+      expect(
+        new SuitabilityAssessment(
+          {
+            riskFactors: 'yes',
+            riskManagement: 'yes',
+            locationOfPlacement: 'yes',
+            moveOnPlan: 'yes',
+          },
+          assessment,
+        ).next(),
+      ).toEqual('contingency-plan-suitability')
+    })
+
     it('returns an empty string if the notice type is standard', () => {
       ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('standard')
+
       expect(
         new SuitabilityAssessment(
           {

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.ts
@@ -8,6 +8,7 @@ import TasklistPage from '../../../tasklistPage'
 import { responsesForYesNoAndCommentsSections } from '../../../utils/index'
 import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 import Rfap from '../../../apply/risk-and-need-factors/further-considerations/rfap'
+import { shouldShowContingencyPlanPages } from '../../../../utils/applications/shouldShowContingencyPlanPages'
 
 export type SuitabilityAssessmentSection = {
   riskFactors: string
@@ -75,6 +76,10 @@ export default class SuitabilityAssessment implements TasklistPage {
       noticeTypeFromApplication(this.assessment.application) === 'emergency'
     ) {
       return 'application-timeliness'
+    }
+
+    if (shouldShowContingencyPlanPages(this.assessment.application)) {
+      return 'contingency-plan-suitability'
     }
 
     return ''

--- a/server/testutils/mockQuestionResponse.ts
+++ b/server/testutils/mockQuestionResponse.ts
@@ -61,6 +61,7 @@ export const mockOptionalQuestionResponse = ({
   agreedCaseWithManager,
   lengthOfStay,
   cruInformation,
+  pssDate,
 }: {
   releaseType?: string
   duration?: string
@@ -73,6 +74,7 @@ export const mockOptionalQuestionResponse = ({
   agreedCaseWithManager?: string
   lengthOfStay?: string
   cruInformation?: string
+  pssDate?: string
 }) => {
   ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockImplementation(
     // eslint-disable-next-line consistent-return
@@ -119,6 +121,10 @@ export const mockOptionalQuestionResponse = ({
 
       if (question === 'cruInformation') {
         return cruInformation
+      }
+
+      if (question === 'pssDate') {
+        return pssDate
       }
     },
   )

--- a/server/utils/applications/shouldShowContingencyPlanPages.test.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.test.ts
@@ -1,6 +1,6 @@
 import { applicationFactory } from '../../testutils/factories'
 import { shouldShowContingencyPlanPages } from './shouldShowContingencyPlanPages'
-import { mockQuestionResponse } from '../../testutils/mockQuestionResponse'
+import { mockOptionalQuestionResponse, mockQuestionResponse } from '../../testutils/mockQuestionResponse'
 
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
 
@@ -26,6 +26,12 @@ describe('shouldShowContingencyPlanPages', () => {
 
   it('returns true if the application has a release type of "Post Sentence Supervision (PSS)"', () => {
     mockQuestionResponse({ sentenceType: 'ipp', releaseType: 'pss' })
+
+    expect(shouldShowContingencyPlanPages(application)).toEqual(true)
+  })
+
+  it('returns true if the application has a release type of "Post Sentence Supervision (PSS)"', () => {
+    mockOptionalQuestionResponse({ pssDate: '20/02/2023' })
 
     expect(shouldShowContingencyPlanPages(application)).toEqual(true)
   })

--- a/server/utils/applications/shouldShowContingencyPlanPages.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.ts
@@ -2,7 +2,11 @@ import SelectApType from '../../form-pages/apply/reasons-for-placement/type-of-a
 import ReleaseType from '../../form-pages/apply/reasons-for-placement/basic-information/releaseType'
 import SentenceType from '../../form-pages/apply/reasons-for-placement/basic-information/sentenceType'
 import { ApprovedPremisesApplication as Application, ReleaseTypeOption } from '../../@types/shared'
-import { retrieveQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
+import {
+  retrieveOptionalQuestionResponseFromApplicationOrAssessment,
+  retrieveQuestionResponseFromFormArtifact,
+} from '../retrieveQuestionResponseFromFormArtifact'
+import EndDates from '../../form-pages/apply/reasons-for-placement/basic-information/endDates'
 
 export const shouldShowContingencyPlanPages = (application: Application) => {
   let releaseType: ReleaseTypeOption
@@ -26,6 +30,10 @@ export const shouldShowContingencyPlanPages = (application: Application) => {
     apType === 'esap'
   )
     return true
+
+  const pssEndDate = retrieveOptionalQuestionResponseFromApplicationOrAssessment(application, EndDates, 'pssDate')
+
+  if (pssEndDate) return true
 
   return false
 }

--- a/server/views/assessments/pages/suitability-assessment/contingency-plan-suitability.njk
+++ b/server/views/assessments/pages/suitability-assessment/contingency-plan-suitability.njk
@@ -1,0 +1,74 @@
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+
+{% extends "../layout.njk" %}
+
+{% block questions %}
+    <h1 class="govuk-heading-l">{{page.title}}</h1>
+
+    {{
+            formPageRadios({
+                fieldName: "contingencyPlanSufficient",
+                fieldset: {
+                    legend: {
+                    text: page.questions.contingencyPlanSufficient,
+                    classes: "govuk-fieldset__legend--m"
+                    }
+                },
+                hint: {
+                    html: '<details class="govuk-details" data-module="govuk-details">
+                                <summary class="govuk-details__summary">
+                                    <span class="govuk-details__summary-text">
+                                    View guidance notes
+                                    </span>
+                                </summary>
+                                <div class="govuk-details__text">
+                                    <b><strong>Contingency plan requirements</strong></b>
+                                    <p>Contingency plans are required for people who are due to arrive within 28 days of application and/or are: </p>
+                                    <ul class="govuk-list govuk-list--bullet">
+                                    <li>on Post-Sentence Supervision</li>
+                                    <li>on Non-Statutory Supervision</li>
+                                    <li>on a community sentence where residence at an Approved Premises (AP) is not a requirement of the Order</li>
+                                    <li>in need of an Enhanced Security AP placement</li>
+                                    </ul>
+                                    <p>Probation practitioners should give assessors an indication of the type of actions that should be completed by AP staff and out of hours managers in the event of behavioural issues or a failure to return to the AP.</p>
+                                    <p>Asking AP staff to contact out of hours managers is not sufficient.</p>
+                                </div>
+
+                                <div class="govuk-details__text">
+                                <b><strong>Multi-agency questions</strong></b>
+                                    <p>The specific multi-agency questions are only mandatory for people who are: </p>
+                                    <ul class="govuk-list govuk-list--bullet">
+                                    <li>on Post-Sentence Supervision</li>
+                                    <li>on Non-Statutory Supervision</li>
+                                    <li>on a community sentence where residence at an AP is not a requirement of the Order</li>
+                                    <li>in need of an Enhanced Security AP placement</li>
+                                    </ul>
+                                    <p> This information should detail key partners, contact details and their role in managing situations out of hours.</p>
+                                </div>
+                            </details>'
+                },
+                    items: [
+                    {
+                        value: "yes",
+                        text: "Yes"
+                    },
+                    {
+                        value: "no",
+                        text: "No"
+                    }
+                    ]
+                }, fetchContext()
+            )
+        }}
+
+    {{
+            formPageTextarea({
+                fieldName: "additionalComments",
+                label: {
+                    text:page.questions.additionalComments,
+                    classes: "govuk-label--s"
+                }
+            }, fetchContext())
+        }}
+
+{% endblock %}


### PR DESCRIPTION
# Context
This adds a screen to ask about the suitability of the Contingency Plans - if they exist in the application 

[Trello](https://trello.com/c/scNWHRCW/274-add-contingency-plan-assessment-questions)


## Screenshots of UI changes
![Assess -- Short notice assessments -- allows me to assess a short notice application (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/a08772eb-1698-4b30-8d75-30917bc3fbf1)
