### PR TITLE
Set case notes column class correctly

### DIFF
--- a/server/views/applications/pages/prison-information/case-notes.njk
+++ b/server/views/applications/pages/prison-information/case-notes.njk
@@ -6,7 +6,7 @@
 
 {% extends "../layout.njk" %}
 
-{% if nomisFailed == false %}
+{% if page.nomisFailed == false %}
   {% set columnClasses = "govuk-grid-column-full" %}
 {% endif %}
 


### PR DESCRIPTION
We want the page to be full-width if `nomisFailed` is false