### PR TITLE
(264) Apply - update contingency plans questions logic

### DIFF
--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/additionalCircumstances.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/additionalCircumstances.test.ts
@@ -3,7 +3,10 @@ import { itShouldHavePreviousValue } from '../../../shared-examples'
 
 import AdditionalCircumstances from './additionalCircumstances'
 import { applicationFactory, personFactory } from '../../../../testutils/factories'
-import { shouldShowContingencyPlanPages } from '../../../../utils/applications/shouldShowContingencyPlanPages'
+import {
+  shouldShowContingencyPlanPartnersPages,
+  shouldShowContingencyPlanQuestionsPage,
+} from '../../../../utils/applications/shouldShowContingencyPlanPages'
 
 jest.mock('../../../../utils/applications/shouldShowContingencyPlanPages')
 
@@ -15,6 +18,10 @@ describe('AdditionalCircumstances', () => {
     additionalCircumstances: 'yes' as YesOrNo,
     additionalCircumstancesDetail: 'Additional circumstances detail',
   }
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
 
   describe('title', () => {
     it("adds the person's name to the question titles", () => {
@@ -37,12 +44,22 @@ describe('AdditionalCircumstances', () => {
 
   describe('next', () => {
     describe('if the contingency-plan-partners page should be shown', () => {
-      ;(shouldShowContingencyPlanPages as jest.Mock).mockReturnValue(true)
+      ;(shouldShowContingencyPlanPartnersPages as jest.Mock).mockReturnValue(true)
+
       expect(new AdditionalCircumstances(body, application).next()).toBe('contingency-plan-partners')
     })
 
+    describe('if the contingency-plan-questions page should be shown', () => {
+      ;(shouldShowContingencyPlanPartnersPages as jest.Mock).mockReturnValue(false)
+      ;(shouldShowContingencyPlanQuestionsPage as jest.Mock).mockReturnValue(true)
+
+      expect(new AdditionalCircumstances(body, application).next()).toBe('contingency-plan-questions')
+    })
+
     describe('if the contingency-plan-partners page should not be shown', () => {
-      ;(shouldShowContingencyPlanPages as jest.Mock).mockReturnValue(false)
+      ;(shouldShowContingencyPlanPartnersPages as jest.Mock).mockReturnValue(false)
+      ;(shouldShowContingencyPlanQuestionsPage as jest.Mock).mockReturnValue(false)
+
       expect(new AdditionalCircumstances(body, application).next()).toBe('')
     })
   })

--- a/server/form-pages/apply/risk-and-need-factors/further-considerations/additionalCircumstances.ts
+++ b/server/form-pages/apply/risk-and-need-factors/further-considerations/additionalCircumstances.ts
@@ -4,7 +4,10 @@ import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
 import { yesOrNoResponseWithDetailForYes } from '../../../utils'
-import { shouldShowContingencyPlanPages } from '../../../../utils/applications/shouldShowContingencyPlanPages'
+import {
+  shouldShowContingencyPlanPartnersPages,
+  shouldShowContingencyPlanQuestionsPage,
+} from '../../../../utils/applications/shouldShowContingencyPlanPages'
 
 export const questionKeys = ['additionalCircumstances'] as const
 
@@ -35,7 +38,10 @@ export default class AdditionalCircumstances implements TasklistPage {
   }
 
   next() {
-    return shouldShowContingencyPlanPages(this.application) ? 'contingency-plan-partners' : ''
+    if (shouldShowContingencyPlanPartnersPages(this.application)) return 'contingency-plan-partners'
+    if (shouldShowContingencyPlanQuestionsPage(this.application)) return 'contingency-plan-questions'
+
+    return ''
   }
 
   response() {

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
@@ -4,7 +4,7 @@ import { YesOrNo } from '../../../../@types/ui'
 import { itShouldHavePreviousValue } from '../../../shared-examples'
 
 import SuitabilityAssessment from './suitabilityAssessment'
-import { shouldShowContingencyPlanPages } from '../../../../utils/applications/shouldShowContingencyPlanPages'
+import { shouldShowContingencyPlanPartnersPages } from '../../../../utils/applications/shouldShowContingencyPlanPages'
 
 jest.mock('../../../../utils/applications/noticeTypeFromApplication')
 jest.mock('../../../../utils/applications/shouldShowContingencyPlanPages')
@@ -81,8 +81,8 @@ describe('SuitabilityAssessment', () => {
       ).toEqual('application-timeliness')
     })
 
-    it('returns contingency-plan-suitability if shouldShowContingencyPlanPages returns true', () => {
-      ;(shouldShowContingencyPlanPages as jest.Mock).mockReturnValue(true)
+    it('returns contingency-plan-suitability if shouldShowContingencyPlanPartnerPages returns true', () => {
+      ;(shouldShowContingencyPlanPartnersPages as jest.Mock).mockReturnValue(true)
       expect(
         new SuitabilityAssessment(
           {

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.ts
@@ -8,7 +8,7 @@ import TasklistPage from '../../../tasklistPage'
 import { responsesForYesNoAndCommentsSections } from '../../../utils/index'
 import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 import Rfap from '../../../apply/risk-and-need-factors/further-considerations/rfap'
-import { shouldShowContingencyPlanPages } from '../../../../utils/applications/shouldShowContingencyPlanPages'
+import { shouldShowContingencyPlanPartnersPages } from '../../../../utils/applications/shouldShowContingencyPlanPages'
 
 export type SuitabilityAssessmentSection = {
   riskFactors: string
@@ -78,7 +78,7 @@ export default class SuitabilityAssessment implements TasklistPage {
       return 'application-timeliness'
     }
 
-    if (shouldShowContingencyPlanPages(this.assessment.application)) {
+    if (shouldShowContingencyPlanPartnersPages(this.assessment.application)) {
       return 'contingency-plan-suitability'
     }
 

--- a/server/utils/applications/shouldShowContingencyPlanPages.test.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.test.ts
@@ -1,12 +1,24 @@
+import { addDays } from 'date-fns'
 import { applicationFactory } from '../../testutils/factories'
-import { shouldShowContingencyPlanPartnersPages } from './shouldShowContingencyPlanPages'
+import {
+  shouldShowContingencyPlanPartnersPages,
+  shouldShowContingencyPlanQuestionsPage,
+} from './shouldShowContingencyPlanPages'
 import { mockOptionalQuestionResponse, mockQuestionResponse } from '../../testutils/mockQuestionResponse'
+import { arrivalDateFromApplication } from './arrivalDateFromApplication'
+import { DateFormats } from '../dateUtils'
 
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
+jest.mock('./arrivalDateFromApplication')
 
-  const application = applicationFactory.build()
+const application = applicationFactory.build()
 
 describe('shouldShowContingencyPlanPartnersPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+  })
+
   it('returns false if none of the conditions are met', () => {
     mockQuestionResponse({ sentenceType: 'ipp', type: 'other' })
 
@@ -43,5 +55,22 @@ describe('shouldShowContingencyPlanPartnersPage', () => {
     expect(shouldShowContingencyPlanPartnersPages(application)).toEqual(true)
   })
 })
+
+describe('shouldShowContingencyPlanQuestionsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns true if the application arrival date is in less than or equal to 28 days"', () => {
+    ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(DateFormats.dateObjToIsoDate(new Date()))
+
+    expect(shouldShowContingencyPlanQuestionsPage(application)).toEqual(true)
+  })
+
+  it('returns true if the application arrival date is in less than 28 days"', () => {
+    const today = new Date()
+    ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(DateFormats.dateObjToIsoDate(addDays(today, 28)))
+
+    expect(shouldShowContingencyPlanQuestionsPage(application)).toEqual(true)
   })
 })

--- a/server/utils/applications/shouldShowContingencyPlanPages.test.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.test.ts
@@ -30,13 +30,13 @@ describe('shouldShowContingencyPlanPages', () => {
     expect(shouldShowContingencyPlanPages(application)).toEqual(true)
   })
 
-  it('returns true if the application has a release type of "Post Sentence Supervision (PSS)"', () => {
+  it('returns true if the application has an end date for "Post Sentence Supervision (PSS)"', () => {
     mockOptionalQuestionResponse({ pssDate: '20/02/2023' })
 
     expect(shouldShowContingencyPlanPages(application)).toEqual(true)
   })
 
-  it('returns false if the application has a AP type of "ESAP"', () => {
+  it('returns true if the application has a AP type of "ESAP"', () => {
     mockQuestionResponse({ type: 'esap' })
 
     expect(shouldShowContingencyPlanPages(application)).toEqual(true)

--- a/server/utils/applications/shouldShowContingencyPlanPages.test.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.test.ts
@@ -1,44 +1,47 @@
 import { applicationFactory } from '../../testutils/factories'
-import { shouldShowContingencyPlanPages } from './shouldShowContingencyPlanPages'
+import { shouldShowContingencyPlanPartnersPages } from './shouldShowContingencyPlanPages'
 import { mockOptionalQuestionResponse, mockQuestionResponse } from '../../testutils/mockQuestionResponse'
 
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
 
-describe('shouldShowContingencyPlanPages', () => {
   const application = applicationFactory.build()
 
+describe('shouldShowContingencyPlanPartnersPage', () => {
   it('returns false if none of the conditions are met', () => {
     mockQuestionResponse({ sentenceType: 'ipp', type: 'other' })
-    expect(shouldShowContingencyPlanPages(application)).toEqual(false)
+
+    expect(shouldShowContingencyPlanPartnersPages(application)).toEqual(false)
   })
 
   it('returns true if the application has a sentence type of "Community Order/SSO"', () => {
     mockQuestionResponse({ sentenceType: 'communityOrder' })
 
-    expect(shouldShowContingencyPlanPages(application)).toEqual(true)
+    expect(shouldShowContingencyPlanPartnersPages(application)).toEqual(true)
   })
 
   it('returns true if the application has a sentence type of "Non-statutory, MAPPA case"', () => {
     mockQuestionResponse({ sentenceType: 'nonStatutory' })
 
-    expect(shouldShowContingencyPlanPages(application)).toEqual(true)
+    expect(shouldShowContingencyPlanPartnersPages(application)).toEqual(true)
   })
 
   it('returns true if the application has a release type of "Post Sentence Supervision (PSS)"', () => {
     mockQuestionResponse({ sentenceType: 'ipp', releaseType: 'pss' })
 
-    expect(shouldShowContingencyPlanPages(application)).toEqual(true)
+    expect(shouldShowContingencyPlanPartnersPages(application)).toEqual(true)
   })
 
   it('returns true if the application has an end date for "Post Sentence Supervision (PSS)"', () => {
     mockOptionalQuestionResponse({ pssDate: '20/02/2023' })
 
-    expect(shouldShowContingencyPlanPages(application)).toEqual(true)
+    expect(shouldShowContingencyPlanPartnersPages(application)).toEqual(true)
   })
 
   it('returns true if the application has a AP type of "ESAP"', () => {
     mockQuestionResponse({ type: 'esap' })
 
-    expect(shouldShowContingencyPlanPages(application)).toEqual(true)
+    expect(shouldShowContingencyPlanPartnersPages(application)).toEqual(true)
+  })
+})
   })
 })

--- a/server/utils/applications/shouldShowContingencyPlanPages.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.ts
@@ -8,7 +8,7 @@ import {
 } from '../retrieveQuestionResponseFromFormArtifact'
 import EndDates from '../../form-pages/apply/reasons-for-placement/basic-information/endDates'
 
-export const shouldShowContingencyPlanPages = (application: Application) => {
+export const shouldShowContingencyPlanPartnersPages = (application: Application) => {
   let releaseType: ReleaseTypeOption
   const sentenceType = retrieveQuestionResponseFromFormArtifact(application, SentenceType, 'sentenceType')
 

--- a/server/utils/applications/shouldShowContingencyPlanPages.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.ts
@@ -1,3 +1,4 @@
+import { differenceInDays } from 'date-fns'
 import SelectApType from '../../form-pages/apply/reasons-for-placement/type-of-ap/apType'
 import ReleaseType from '../../form-pages/apply/reasons-for-placement/basic-information/releaseType'
 import SentenceType from '../../form-pages/apply/reasons-for-placement/basic-information/sentenceType'
@@ -7,6 +8,8 @@ import {
   retrieveQuestionResponseFromFormArtifact,
 } from '../retrieveQuestionResponseFromFormArtifact'
 import EndDates from '../../form-pages/apply/reasons-for-placement/basic-information/endDates'
+import { DateFormats } from '../dateUtils'
+import { arrivalDateFromApplication } from './arrivalDateFromApplication'
 
 export const shouldShowContingencyPlanPartnersPages = (application: Application) => {
   let releaseType: ReleaseTypeOption
@@ -34,6 +37,18 @@ export const shouldShowContingencyPlanPartnersPages = (application: Application)
   const pssEndDate = retrieveOptionalQuestionResponseFromApplicationOrAssessment(application, EndDates, 'pssDate')
 
   if (pssEndDate) return true
+
+  return false
+}
+
+export const shouldShowContingencyPlanQuestionsPage = (application: Application) => {
+  const arrivalDateString = arrivalDateFromApplication(application)
+
+  if (!arrivalDateString) return false
+
+  const arrivalDateObj = DateFormats.isoToDateObj(arrivalDateString)
+
+  if (differenceInDays(arrivalDateObj, new Date()) <= 28) return true
 
   return false
 }


### PR DESCRIPTION
# Context

There was a bug in the Contingency Plan Apply questions logic which meant that Emergency cases weren't being shown the Contingency Plan screens.
After speaking to Dan I have discovered that we should be showing the Contingency Plan questions to all cases that will arrive within 28 days of the application being made.
Now if the case is emergency from the 'Additional circumstances' screen the user is taken to the 'Contingency Plan Questions' screen and then to the Trigger Plan questions

[Trello card](https://trello.com/c/hqOCJnRr/264-check-contingency-plan-questions)
