### PR TITLE
Improve date handling in End Dates page

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -20,11 +20,7 @@
       "sedDate-year": "2022",
       "sedDate-month": "11",
       "sedDate-day": "14",
-      "sedDate": "2022-11-14",
-      "pssDate-year": "2022",
-      "pssDate-month": "11",
-      "pssDate-day": "14",
-      "pssDate": "2022-11-14"
+      "sedDate": "2022-11-14"
     },
     "sentence-type": {
       "sentenceType": "communityOrder"

--- a/integration_tests/pages/apply/endDates.ts
+++ b/integration_tests/pages/apply/endDates.ts
@@ -8,7 +8,6 @@ export default class EndDatesPage extends ApplyPage {
   }
 
   completeForm() {
-    this.completeDateInputsFromPageBody('pssDate')
     this.completeDateInputsFromPageBody('ledDate')
     this.completeDateInputsFromPageBody('sedDate')
   }

--- a/server/form-pages/apply/move-on/foreignNational.ts
+++ b/server/form-pages/apply/move-on/foreignNational.ts
@@ -4,6 +4,7 @@ import { sentenceCase } from '../../../utils/utils'
 import TasklistPage from '../../tasklistPage'
 import { DateFormats, dateIsBlank } from '../../../utils/dateUtils'
 import { Page } from '../../utils/decorators'
+import { dateBodyProperties } from '../../utils/dateBodyProperties'
 
 type ForeignNationalBody =
   | ({
@@ -11,7 +12,7 @@ type ForeignNationalBody =
     } & ObjectWithDateParts<'date'>)
   | { response: 'no' }
 
-@Page({ name: 'foreign-national', bodyProperties: ['response', 'date-year', 'date-month', 'date-day', 'date'] })
+@Page({ name: 'foreign-national', bodyProperties: ['response', ...dateBodyProperties('date')] })
 export default class ForeignNational implements TasklistPage {
   name = 'foreign-national'
 

--- a/server/form-pages/apply/move-on/foreignNational.ts
+++ b/server/form-pages/apply/move-on/foreignNational.ts
@@ -71,7 +71,7 @@ export default class ForeignNational implements TasklistPage {
       errors.response =
         'You must confirm whether you have informed the Home Office that accommodation will be required after placement'
 
-    if (this.body.response === 'yes' && dateIsBlank(this.body))
+    if (this.body.response === 'yes' && dateIsBlank(this.body, 'date'))
       errors.date = 'You must confirm the date of notification'
 
     return errors

--- a/server/form-pages/apply/reasons-for-placement/basic-information/endDates.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/endDates.test.ts
@@ -77,8 +77,29 @@ describe('EndDates', () => {
       const page = new EndDates(body, application)
       expect(page.errors()).toEqual({})
     })
-  })
 
+    it('should return an error if an invalid date is entered', () => {
+      const page = new EndDates(
+        {
+          'pssDate-day': '32',
+          'pssDate-month': '13',
+          'pssDate-year': '2023',
+          'sedDate-day': '32',
+          'sedDate-month': '13',
+          'sedDate-year': '2023',
+          'ledDate-day': '32',
+          'ledDate-month': '13',
+          'ledDate-year': '2023',
+        },
+        application,
+      )
+      expect(page.errors()).toEqual({
+        ledDate: 'Licence end date (LED) must be a valid date',
+        pssDate: 'Post-sentence supervision (PSS) must be a valid date',
+        sedDate: 'Sentence end date (SED) must be a valid date',
+      })
+    })
+  })
   describe('response', () => {
     it('should return a translated version of the response', () => {
       const page = new EndDates(body, application)

--- a/server/form-pages/apply/reasons-for-placement/basic-information/endDates.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/endDates.test.ts
@@ -15,25 +15,43 @@ describe('EndDates', () => {
     'pssDate-month': '12',
     'pssDate-day': '3',
   } as EndDatesBody
+
+  const emptyDateBody = {
+    'sedDate-day': '',
+    'sedDate-month': '',
+    'sedDate-year': '',
+    'ledDate-day': '',
+    'ledDate-month': '',
+    'ledDate-year': '',
+    'pssDate-day': '',
+    'pssDate-month': '',
+    'pssDate-year': '',
+  }
   const application = applicationFactory.build()
 
   describe('body', () => {
-    it('should set the body', () => {
+    it('should set the body when all the dates are present', () => {
       const page = new EndDates(body, application)
 
+      expect(page.body).toEqual(body)
+    })
+
+    it('should set the body when all the dates not present', () => {
+      const page = new EndDates(emptyDateBody, application)
+
       expect(page.body).toEqual({
-        sedDate: '2023-12-01',
-        'sedDate-day': '1',
-        'sedDate-month': '12',
-        'sedDate-year': '2023',
-        ledDate: '2023-12-02',
-        'ledDate-day': '2',
-        'ledDate-month': '12',
-        'ledDate-year': '2023',
-        pssDate: '2023-12-03',
-        'pssDate-day': '3',
-        'pssDate-month': '12',
-        'pssDate-year': '2023',
+        sedDate: undefined,
+        'sedDate-day': '',
+        'sedDate-month': '',
+        'sedDate-year': '',
+        ledDate: undefined,
+        'ledDate-day': '',
+        'ledDate-month': '',
+        'ledDate-year': '',
+        pssDate: undefined,
+        'pssDate-day': '',
+        'pssDate-month': '',
+        'pssDate-year': '',
       })
     })
   })

--- a/server/form-pages/apply/reasons-for-placement/basic-information/endDates.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/endDates.test.ts
@@ -110,5 +110,15 @@ describe('EndDates', () => {
         'Sentence end date (SED)': 'Friday 1 December 2023',
       })
     })
+
+    it('should return a translated version of the response when the dates are blank', () => {
+      const page = new EndDates(emptyDateBody, application)
+
+      expect(page.response()).toEqual({
+        'Licence end date (LED)': 'No date supplied',
+        'Post-sentence supervision (PSS)': 'No date supplied',
+        'Sentence end date (SED)': 'No date supplied',
+      })
+    })
   })
 })

--- a/server/form-pages/apply/reasons-for-placement/basic-information/endDates.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/endDates.ts
@@ -1,11 +1,16 @@
 import type { ObjectWithDateParts, TaskListErrors } from '@approved-premises/ui'
 
 import { Page } from '../../../utils/decorators'
-import { DateFormats, uiDateOrDateEmptyMessage } from '../../../../utils/dateUtils'
+import {
+  DateFormats,
+  dateAndTimeInputsAreValidDates,
+  dateIsBlank,
+  uiDateOrDateEmptyMessage,
+} from '../../../../utils/dateUtils'
 
 import TasklistPage from '../../../tasklistPage'
 import { ApprovedPremisesApplication } from '../../../../@types/shared'
-import { dateBodyProperties } from '../../../utils'
+import { dateBodyProperties } from '../../../utils/dateBodyProperties'
 
 export type EndDatesBody = ObjectWithDateParts<'sedDate'> &
   ObjectWithDateParts<'ledDate'> &
@@ -53,6 +58,14 @@ export default class EndDates implements TasklistPage {
 
   errors() {
     const errors: TaskListErrors<this> = {}
+
+    ;['sedDate', 'ledDate', 'pssDate'].forEach(date => {
+      if (!dateIsBlank(this.body, date)) {
+        if (!dateAndTimeInputsAreValidDates(this.body, date)) {
+          errors[date] = `${this.questions[date]} must be a valid date`
+        }
+      }
+    })
 
     return errors
   }

--- a/server/form-pages/apply/reasons-for-placement/basic-information/endDates.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/endDates.ts
@@ -1,12 +1,7 @@
 import type { ObjectWithDateParts, TaskListErrors } from '@approved-premises/ui'
 
 import { Page } from '../../../utils/decorators'
-import {
-  DateFormats,
-  dateAndTimeInputsAreValidDates,
-  dateIsBlank,
-  uiDateOrDateEmptyMessage,
-} from '../../../../utils/dateUtils'
+import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../../utils/dateUtils'
 
 import TasklistPage from '../../../tasklistPage'
 import { ApprovedPremisesApplication } from '../../../../@types/shared'
@@ -38,11 +33,15 @@ export default class EndDates implements TasklistPage {
   constructor(body: Partial<EndDatesBody>, private readonly application: ApprovedPremisesApplication) {}
 
   response() {
-    return {
-      [this.questions.sed]: uiDateOrDateEmptyMessage(this.body, 'sedDate', DateFormats.isoDateToUIDate),
-      [this.questions.led]: uiDateOrDateEmptyMessage(this.body, 'ledDate', DateFormats.isoDateToUIDate),
-      [this.questions.pss]: uiDateOrDateEmptyMessage(this.body, 'pssDate', DateFormats.isoDateToUIDate),
-    }
+    const response = {}
+
+    Object.keys(this.questions).forEach(key => {
+      response[this.questions[key]] = !dateIsBlank(this.body, key)
+        ? DateFormats.dateAndTimeInputsToUiDate(this.body, key)
+        : 'No date supplied'
+    })
+
+    return response
   }
 
   previous() {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/endDates.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/endDates.ts
@@ -30,22 +30,7 @@ export default class EndDates implements TasklistPage {
 
   body: EndDatesBody
 
-  constructor(_body: Partial<EndDatesBody>, private readonly application: ApprovedPremisesApplication) {
-    this.body = {
-      'sedDate-year': _body['sedDate-year'],
-      'sedDate-month': _body['sedDate-month'],
-      'sedDate-day': _body['sedDate-day'],
-      sedDate: DateFormats.dateAndTimeInputsToIsoString(_body as ObjectWithDateParts<'sedDate'>, 'sedDate').sedDate,
-      'ledDate-year': _body['ledDate-year'],
-      'ledDate-month': _body['ledDate-month'],
-      'ledDate-day': _body['ledDate-day'],
-      ledDate: DateFormats.dateAndTimeInputsToIsoString(_body as ObjectWithDateParts<'ledDate'>, 'ledDate').ledDate,
-      'pssDate-year': _body['pssDate-year'],
-      'pssDate-month': _body['pssDate-month'],
-      'pssDate-day': _body['pssDate-day'],
-      pssDate: DateFormats.dateAndTimeInputsToIsoString(_body as ObjectWithDateParts<'pssDate'>, 'pssDate').pssDate,
-    }
-  }
+  constructor(body: Partial<EndDatesBody>, private readonly application: ApprovedPremisesApplication) {}
 
   response() {
     return {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/endDates.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/endDates.ts
@@ -5,6 +5,7 @@ import { DateFormats, uiDateOrDateEmptyMessage } from '../../../../utils/dateUti
 
 import TasklistPage from '../../../tasklistPage'
 import { ApprovedPremisesApplication } from '../../../../@types/shared'
+import { dateBodyProperties } from '../../../utils'
 
 export type EndDatesBody = ObjectWithDateParts<'sedDate'> &
   ObjectWithDateParts<'ledDate'> &
@@ -13,18 +14,9 @@ export type EndDatesBody = ObjectWithDateParts<'sedDate'> &
 @Page({
   name: 'end-dates',
   bodyProperties: [
-    'sedDate',
-    'sedDate-year',
-    'sedDate-month',
-    'sedDate-day',
-    'ledDate',
-    'ledDate-year',
-    'ledDate-month',
-    'ledDate-day',
-    'pssDate',
-    'pssDate-year',
-    'pssDate-month',
-    'pssDate-day',
+    ...dateBodyProperties('sedDate'),
+    ...dateBodyProperties('ledDate'),
+    ...dateBodyProperties('pssDate'),
   ],
 })
 export default class EndDates implements TasklistPage {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/endDates.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/endDates.ts
@@ -23,9 +23,9 @@ export default class EndDates implements TasklistPage {
   title = 'Which of the following dates are relevant?'
 
   questions = {
-    sed: 'Sentence end date (SED)',
-    led: 'Licence end date (LED)',
-    pss: 'Post-sentence supervision (PSS)',
+    sedDate: 'Sentence end date (SED)',
+    ledDate: 'Licence end date (LED)',
+    pssDate: 'Post-sentence supervision (PSS)',
   }
 
   body: EndDatesBody

--- a/server/form-pages/apply/reasons-for-placement/basic-information/oralHearing.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/oralHearing.ts
@@ -5,6 +5,7 @@ import TasklistPage from '../../../tasklistPage'
 import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../../utils/dateUtils'
 import { convertToTitleCase } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
+import { dateBodyProperties } from '../../../utils/dateBodyProperties'
 
 type OralHearingBody = ObjectWithDateParts<'oralHearingDate'> & {
   knowOralHearingDate: YesOrNo
@@ -12,13 +13,7 @@ type OralHearingBody = ObjectWithDateParts<'oralHearingDate'> & {
 
 @Page({
   name: 'oral-hearing',
-  bodyProperties: [
-    'oralHearingDate',
-    'oralHearingDate-day',
-    'oralHearingDate-month',
-    'oralHearingDate-year',
-    'knowOralHearingDate',
-  ],
+  bodyProperties: [...dateBodyProperties('oralHearingDate'), 'knowOralHearingDate'],
 })
 export default class OralHearing implements TasklistPage {
   title = `Do you know ${this.application.person.name}’s oral hearing date?`

--- a/server/form-pages/apply/reasons-for-placement/basic-information/oralHearing.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/oralHearing.ts
@@ -75,7 +75,7 @@ export default class OralHearing implements TasklistPage {
     }
 
     if (this.body.knowOralHearingDate === 'yes') {
-      if (dateIsBlank(this.body)) {
+      if (dateIsBlank(this.body, 'oralHearingDate')) {
         errors.oralHearingDate = 'You must specify the oral hearing date'
       } else if (
         !dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'oralHearingDate'>, 'oralHearingDate')

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
@@ -8,6 +8,7 @@ import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank, dateIsInThePa
 import { Page } from '../../../utils/decorators'
 import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
 import ReleaseDate from './releaseDate'
+import { dateBodyProperties } from '../../../utils/dateBodyProperties'
 
 type PlacementDateBody = ObjectWithDateParts<'startDate'> & {
   startDateSameAsReleaseDate: YesOrNo
@@ -15,7 +16,7 @@ type PlacementDateBody = ObjectWithDateParts<'startDate'> & {
 
 @Page({
   name: 'placement-date',
-  bodyProperties: ['startDate', 'startDate-day', 'startDate-month', 'startDate-year', 'startDateSameAsReleaseDate'],
+  bodyProperties: [...dateBodyProperties('startDate'), 'startDateSameAsReleaseDate'],
 })
 export default class PlacementDate implements TasklistPage {
   title: string

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
@@ -80,7 +80,7 @@ export default class PlacementDate implements TasklistPage {
     }
 
     if (this.body.startDateSameAsReleaseDate === 'no') {
-      if (dateIsBlank(this.body)) {
+      if (dateIsBlank(this.body, 'startDate')) {
         errors.startDate = 'You must enter a start date'
       } else if (!dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'startDate'>, 'startDate')) {
         errors.startDate = 'The start date is an invalid date'

--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.ts
@@ -5,6 +5,7 @@ import { Page } from '../../../utils/decorators'
 import TasklistPage from '../../../tasklistPage'
 import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank, dateIsInThePast } from '../../../../utils/dateUtils'
 import { convertToTitleCase } from '../../../../utils/utils'
+import { dateBodyProperties } from '../../../utils'
 
 type ReleaseDateType = ObjectWithDateParts<'releaseDate'> & {
   knowReleaseDate: YesOrNo
@@ -12,7 +13,7 @@ type ReleaseDateType = ObjectWithDateParts<'releaseDate'> & {
 
 @Page({
   name: 'release-date',
-  bodyProperties: ['releaseDate', 'releaseDate-year', 'releaseDate-month', 'releaseDate-day', 'knowReleaseDate'],
+  bodyProperties: [...dateBodyProperties('releaseDate'), 'knowReleaseDate'],
 })
 export default class ReleaseDate implements TasklistPage {
   title = `Do you know ${this.application.person.name}’s release date?`
@@ -73,7 +74,7 @@ export default class ReleaseDate implements TasklistPage {
     }
 
     if (this.body.knowReleaseDate === 'yes') {
-      if (dateIsBlank(this.body)) {
+      if (dateIsBlank(this.body, 'releaseDate')) {
         errors.releaseDate = 'You must specify the release date'
       } else if (!dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'releaseDate'>, 'releaseDate')) {
         errors.releaseDate = 'The release date is an invalid date'

--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.ts
@@ -5,7 +5,7 @@ import { Page } from '../../../utils/decorators'
 import TasklistPage from '../../../tasklistPage'
 import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank, dateIsInThePast } from '../../../../utils/dateUtils'
 import { convertToTitleCase } from '../../../../utils/utils'
-import { dateBodyProperties } from '../../../utils'
+import { dateBodyProperties } from '../../../utils/dateBodyProperties'
 
 type ReleaseDateType = ObjectWithDateParts<'releaseDate'> & {
   knowReleaseDate: YesOrNo

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/pipeReferral.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/pipeReferral.ts
@@ -74,7 +74,7 @@ export default class PipeReferral implements TasklistPage {
     }
 
     if (this.body.opdPathway === 'yes') {
-      if (dateIsBlank(this.body)) {
+      if (dateIsBlank(this.body, 'opdPathwayDate')) {
         errors.opdPathwayDate = 'You must enter an OPD Pathway date'
       } else if (
         !dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'opdPathwayDate'>, 'opdPathwayDate')

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/pipeReferral.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/pipeReferral.ts
@@ -5,12 +5,13 @@ import { Page } from '../../../utils/decorators'
 import TasklistPage from '../../../tasklistPage'
 import { convertToTitleCase } from '../../../../utils/utils'
 import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../../utils/dateUtils'
+import { dateBodyProperties } from '../../../utils/dateBodyProperties'
 
 type PipeReferralBody = ObjectWithDateParts<'opdPathwayDate'> & { opdPathway: YesOrNo }
 
 @Page({
   name: 'pipe-referral',
-  bodyProperties: ['opdPathway', 'opdPathwayDate', 'opdPathwayDate-year', 'opdPathwayDate-month', 'opdPathwayDate-day'],
+  bodyProperties: ['opdPathway', ...dateBodyProperties('opdPathwayDate')],
 })
 export default class PipeReferral implements TasklistPage {
   name = 'pipe-referral'

--- a/server/form-pages/assess/assessApplication/requiredActions/requiredActions.ts
+++ b/server/form-pages/assess/assessApplication/requiredActions/requiredActions.ts
@@ -112,7 +112,7 @@ export default class RequiredActions implements TasklistPage {
         errors.additionalActionsComments =
           'You must state the additional recommendations due to there being concerns that the person poses a potentially unmanageable risk to staff and others'
 
-      if (dateIsBlank(this.body)) errors.dateOfDiscussion = 'You must state the date of discussion'
+      if (dateIsBlank(this.body, 'dateOfDiscussion')) errors.dateOfDiscussion = 'You must state the date of discussion'
       else if (
         !dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'dateOfDiscussion'>, 'dateOfDiscussion')
       ) {

--- a/server/form-pages/assess/assessApplication/requiredActions/requiredActions.ts
+++ b/server/form-pages/assess/assessApplication/requiredActions/requiredActions.ts
@@ -5,6 +5,7 @@ import { Page } from '../../../utils/decorators'
 import TasklistPage from '../../../tasklistPage'
 import { responsesForYesNoAndCommentsSections } from '../../../utils/index'
 import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../../utils/dateUtils'
+import { dateBodyProperties } from '../../../utils/dateBodyProperties'
 
 export type RequiredActionsSections = {
   additionalActions: string
@@ -25,10 +26,7 @@ export type RequiredActionsSections = {
     'additionalRecommendations',
     'additionalRecommendationsComments',
     'nameOfAreaManager',
-    'dateOfDiscussion',
-    'dateOfDiscussion-day',
-    'dateOfDiscussion-month',
-    'dateOfDiscussion-year',
+    ...dateBodyProperties('dateOfDiscussion'),
     'outlineOfDiscussion',
   ],
 })

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/informationReceived.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/informationReceived.ts
@@ -6,6 +6,7 @@ import { sentenceCase } from '../../../../utils/utils'
 import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../../utils/dateUtils'
 
 import TasklistPage from '../../../tasklistPage'
+import { dateBodyProperties } from '../../../utils/dateBodyProperties'
 
 type InformationReceivedBody = ObjectWithDateParts<'responseReceivedOn'> & {
   informationReceived?: YesOrNo
@@ -14,14 +15,7 @@ type InformationReceivedBody = ObjectWithDateParts<'responseReceivedOn'> & {
 
 @Page({
   name: 'information-received',
-  bodyProperties: [
-    'informationReceived',
-    'response',
-    'responseReceivedOn',
-    'responseReceivedOn-year',
-    'responseReceivedOn-month',
-    'responseReceivedOn-day',
-  ],
+  bodyProperties: ['informationReceived', 'response', ...dateBodyProperties('responseReceivedOn')],
   controllerActions: { update: 'updateInformationRecieved' },
 })
 export default class InformationReceived implements TasklistPage {

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/informationReceived.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/informationReceived.ts
@@ -80,7 +80,7 @@ export default class InformationReceived implements TasklistPage {
     }
 
     if (this.body.informationReceived === 'yes') {
-      if (dateIsBlank(this.body)) {
+      if (dateIsBlank(this.body, 'responseReceivedOn')) {
         errors.responseReceivedOn = 'You must specify when you received the information'
       } else if (
         !dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'responseReceivedOn'>, 'responseReceivedOn')

--- a/server/form-pages/utils/dateBodyProperties.test.ts
+++ b/server/form-pages/utils/dateBodyProperties.test.ts
@@ -1,0 +1,7 @@
+import { dateBodyProperties } from './dateBodyProperties'
+
+describe('dateBodyProperties', () => {
+  it('returns date field names for use in page body properties', () => {
+    expect(dateBodyProperties('someDate')).toEqual(['someDate', 'someDate-year', 'someDate-month', 'someDate-day'])
+  })
+})

--- a/server/form-pages/utils/dateBodyProperties.ts
+++ b/server/form-pages/utils/dateBodyProperties.ts
@@ -1,0 +1,3 @@
+export const dateBodyProperties = (root: string) => {
+  return [root, `${root}-year`, `${root}-month`, `${root}-day`]
+}

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -151,6 +151,18 @@ describe('DateFormats', () => {
 
       expect(result.date.toString()).toEqual('twothousandtwentytwo-20-oo')
     })
+
+    it('returns an invalid ISO string when given all 0s as inputs', () => {
+      const obj: ObjectWithDateParts<'date'> = {
+        'date-year': '0000',
+        'date-month': '00',
+        'date-day': '00',
+      }
+
+      const result = DateFormats.dateAndTimeInputsToIsoString(obj, 'date')
+
+      expect(result.date.toString()).toEqual('0000-00-00')
+    })
   })
 
   describe('differenceInDays', () => {
@@ -238,7 +250,7 @@ describe('dateIsBlank', () => {
       'field-year': '2022',
     }
 
-    expect(dateIsBlank(date)).toEqual(false)
+    expect(dateIsBlank(date, 'field')).toEqual(false)
   })
 
   it('returns true if the date is blank', () => {
@@ -248,7 +260,20 @@ describe('dateIsBlank', () => {
       'field-year': '',
     }
 
-    expect(dateIsBlank(date)).toEqual(true)
+    expect(dateIsBlank(date, 'field')).toEqual(true)
+  })
+
+  it('ignores irrelevant fields', () => {
+    const date: ObjectWithDateParts<'field'> & ObjectWithDateParts<'otherField'> = {
+      'field-day': '12',
+      'field-month': '1',
+      'field-year': '2022',
+      'otherField-day': undefined,
+      'otherField-month': undefined,
+      'otherField-year': undefined,
+    }
+
+    expect(dateIsBlank(date, 'field')).toEqual(false)
   })
 })
 

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -165,6 +165,18 @@ describe('DateFormats', () => {
     })
   })
 
+  describe('dateAndTimeInputsToUiDate', () => {
+    it('converts a date and time input object to a human readable date', () => {
+      const dateTimeInputs = DateFormats.dateObjectToDateInputs(new Date('2022-11-11T10:00:00.000Z'), 'key')
+
+      expect(DateFormats.dateAndTimeInputsToUiDate(dateTimeInputs, 'key')).toEqual('Friday 11 November 2022')
+    })
+
+    it('throws an error if an object without date inputs for the key is entered', () => {
+      expect(() => DateFormats.dateAndTimeInputsToUiDate({}, 'key')).toThrow(InvalidDateStringError)
+    })
+  })
+
   describe('differenceInDays', () => {
     it('calls the date-fns functions and returns the results as an object', () => {
       const date1 = new Date(2023, 3, 12)

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -226,6 +226,14 @@ describe('uiDateOrDateEmptyMessage', () => {
       DateFormats.dateObjtoUIDate(new Date(2023, 3, 12)),
     )
   })
+
+  it('returns the message if the key is present in the object but undefined', () => {
+    const object: Record<string, string> = {
+      aDate: undefined,
+    }
+
+    expect(uiDateOrDateEmptyMessage(object, 'aDate', DateFormats.isoDateToUIDate)).toEqual('No date supplied')
+  })
 })
 
 describe('dateAndTimeInputsAreValidDates', () => {

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -110,6 +110,19 @@ export class DateFormats {
     return dateInputObj
   }
 
+  /**
+   * Converts input for a GDS date input https://design-system.service.gov.uk/components/date-input/
+   * into a human readable date for the user
+   * @param dateInputObj an object with date parts (i.e. `-month` `-day` `-year`), which come from a `govukDateInput`.
+   * @param key the key that prefixes each item in the dateInputObj, also the name of the property which the date object will be returned in the return value.
+   * @returns a friendly date.
+   */
+  static dateAndTimeInputsToUiDate(dateInputObj: Record<string, string>, key: string | number) {
+    const iso8601Date = DateFormats.dateAndTimeInputsToIsoString(dateInputObj, key)[key]
+
+    return DateFormats.isoDateToUIDate(iso8601Date)
+  }
+
   static dateObjectToDateInputs<K extends string>(date: Date, key: K): ObjectWithDateParts<K> {
     return {
       [`${key}-year`]: String(date.getFullYear()),

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -174,9 +174,11 @@ export const dateAndTimeInputsAreValidDates = <K extends string | number>(
   return true
 }
 
-export const dateIsBlank = <T = ObjectWithDateParts<string | number>>(body: T): boolean => {
-  const fields = Object.keys(body).filter(key => key.match(/-[year|month|day]/))
-  return fields.every(field => !body[field])
+export const dateIsBlank = <K extends string | number>(
+  dateInputObj: Partial<ObjectWithDateParts<K>>,
+  key: K,
+): boolean => {
+  return !['year' as const, 'month' as const, 'day' as const].every(part => !!dateInputObj[`${key}-${part}`])
 }
 
 export const dateIsInThePast = (dateString: string): boolean => {

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -168,7 +168,7 @@ export const uiDateOrDateEmptyMessage = (
   key: string,
   dateFormFunc: (date: string) => string,
 ) => {
-  if (key in object && typeof object?.[key] === 'string') return dateFormFunc(object?.[key] as string)
+  if (key in object && object[key] && typeof object[key] === 'string') return dateFormFunc(object?.[key] as string)
 
   return 'No date supplied'
 }

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -88,9 +88,12 @@ export class DateFormats {
    * into an ISO8601 date string
    * @param dateInputObj an object with date parts (i.e. `-month` `-day` `-year`), which come from a `govukDateInput`.
    * @param key the key that prefixes each item in the dateInputObj, also the name of the property which the date object will be returned in the return value.
-   * @returns an ISO8601 date string.
+   * @returns an ISO8601 date string as part of an ObjectWithDateParts.
    */
-  static dateAndTimeInputsToIsoString<K extends string | number>(dateInputObj: ObjectWithDateParts<K>, key: K) {
+  static dateAndTimeInputsToIsoString<K extends string | number>(
+    dateInputObj: ObjectWithDateParts<K>,
+    key: K,
+  ): ObjectWithDateParts<K> {
     const day = `0${dateInputObj[`${key}-day`]}`.slice(-2)
     const month = `0${dateInputObj[`${key}-month`]}`.slice(-2)
     const year = dateInputObj[`${key}-year`]

--- a/server/views/applications/pages/basic-information/end-dates.njk
+++ b/server/views/applications/pages/basic-information/end-dates.njk
@@ -14,7 +14,7 @@
         fieldName: "sedDate",
         fieldset: {
           legend: {
-            text: page.questions.sed
+            text: page.questions.sedDate
           }
         },
         hint: {
@@ -32,7 +32,7 @@
         fieldName: "ledDate",
         fieldset: {
           legend: {
-            text: page.questions.led
+            text: page.questions.ledDate
           }
         },
         hint: {
@@ -50,7 +50,7 @@
         fieldName: "pssDate",
         fieldset: {
           legend: {
-            text: page.questions.pss
+            text: page.questions.pssDate
           }
         },
         hint: {


### PR DESCRIPTION
# Context
We have been seeing [this error in Sentry](https://ministryofjustice.sentry.io/issues/4295320203/?project=4503931667742720&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=2).
which looks to be coming from the 'End dates'  (#917) page. 
I have struggled to reproduce the error locally but I suspect has been caused by us not validating that the dates on the page properly. 
Thanks for @bryangaledxw's work we have been able to borrow some utilities from the [TA repo](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/) that make it easier to [check the date is not blank](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/435/commits/c2ef11a7d02993b22370a81c8f00c107194a9f2d) before validating it and also [reduce some boilerplate](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/435/commits/725d2f617e8ac0aa081a759f7fd0fd2dfe0d5295) in the `bodyProperties` argument of the [at]page decorator.

# Changes in this PR 
- We update the DateIsBlank function and update its call sites
- Add the bodyProperties and use it to reduce some boilerplate
- We improve the validation around dates in the EndDates page
- Add some test cases to the endDates page 
