### PR TITLE
Fix `arrivingToday`

### DIFF
--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -1,3 +1,5 @@
+import { subDays } from 'date-fns'
+import { DateFormats } from '../utils/dateUtils'
 import BookingService from './bookingService'
 import BookingClient from '../data/bookingClient'
 
@@ -76,37 +78,39 @@ describe('BookingService', () => {
     })
   })
 
-  describe('bookingsArrivingTodayOrLater', () => {
-    it('should return bookings arriving after today', async () => {
+  describe('bookingsArrivingTodayOrLate', () => {
+    it('should return bookings due to arrive today or earlier', async () => {
       const bookingsArrivingToday = bookingFactory.arrivingToday().buildList(1)
       const arrivedBookings = bookingFactory.arrivedToday().buildList(1)
-      const bookingsArrivingSoon = bookingFactory.arrivingSoon().buildList(1)
+      const bookingsArrivingYesterday = bookingFactory.buildList(1, {
+        arrivalDate: DateFormats.dateObjToIsoDate(subDays(new Date(), 1)),
+      })
       const cancelledBookingsWithFutureArrivalDate = bookingFactory.cancelledWithFutureArrivalDate().buildList(1)
       const today = new Date(new Date().setHours(0, 0, 0, 0))
 
-      const results = service.bookingsArrivingTodayOrLater(
+      const results = service.bookingsArrivingTodayOrLate(
         [
           ...bookingsArrivingToday,
           ...arrivedBookings,
-          ...bookingsArrivingSoon,
+          ...bookingsArrivingYesterday,
           ...cancelledBookingsWithFutureArrivalDate,
         ],
         today,
       )
 
-      expect(results).toEqual([...bookingsArrivingToday, ...bookingsArrivingSoon])
+      expect(results).toEqual([...bookingsArrivingToday, ...bookingsArrivingYesterday])
     })
   })
 
-  describe('bookingsDepartingTodayOrLater', () => {
-    it('should return bookings departing today or later', async () => {
+  describe('bookingsDepartingTodayOrLate', () => {
+    it('should return bookings due to depart today or after', async () => {
       const bookingsDepartingToday = bookingFactory.departingToday().buildList(1)
       const departedBookings = bookingFactory.departedToday().buildList(1)
       const bookingsDepartingSoon = bookingFactory.departingSoon().buildList(2)
 
       const today = new Date(new Date().setHours(0, 0, 0, 0))
 
-      const results = service.bookingsDepartingTodayOrLater(
+      const results = service.bookingsDepartingTodayOrLate(
         [...bookingsDepartingToday, ...departedBookings, ...bookingsDepartingSoon],
         today,
       )
@@ -146,8 +150,8 @@ describe('BookingService', () => {
 
       const results = await service.groupedListOfBookingsForPremisesId(token, 'some-uuid')
 
-      expect(results.arrivingToday).toEqual(service.bookingsArrivingTodayOrLater(bookings, today))
-      expect(results.departingToday).toEqual(service.bookingsDepartingTodayOrLater(bookings, today))
+      expect(results.arrivingToday).toEqual(service.bookingsArrivingTodayOrLate(bookings, today))
+      expect(results.departingToday).toEqual(service.bookingsDepartingTodayOrLate(bookings, today))
       expect(results.upcomingArrivals).toEqual(bookingsArrivingSoon)
 
       expect(results.upcomingDepartures).toEqual([...arrivedBookings, ...bookingsDepartingSoon])

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -1,4 +1,4 @@
-import { addDays, isAfter, isEqual, isWithinInterval } from 'date-fns'
+import { addDays, isAfter, isBefore, isEqual, isWithinInterval } from 'date-fns'
 
 import type { Booking, Extension, NewBedMove, NewBooking, NewExtension } from '@approved-premises/api'
 import type { GroupedListofBookings } from '@approved-premises/ui'
@@ -41,8 +41,8 @@ export default class BookingService {
     const today = new Date(new Date().setHours(0, 0, 0, 0))
 
     return {
-      arrivingToday: this.bookingsArrivingTodayOrLater(bookings, today),
-      departingToday: this.bookingsDepartingTodayOrLater(bookings, today),
+      arrivingToday: this.bookingsArrivingTodayOrLate(bookings, today),
+      departingToday: this.bookingsDepartingTodayOrLate(bookings, today),
       upcomingArrivals: this.upcomingArrivals(bookings, today),
       upcomingDepartures: this.upcomingDepartures(bookings, today),
     }
@@ -75,15 +75,15 @@ export default class BookingService {
     await bookingClient.moveBooking(premisesId, bookingId, move)
   }
 
-  bookingsArrivingTodayOrLater(bookings: Array<Booking>, today: Date): Array<Booking> {
+  bookingsArrivingTodayOrLate(bookings: Array<Booking>, today: Date): Array<Booking> {
     return this.bookingsAwaitingArrival(bookings).filter(
       booking =>
         isEqual(DateFormats.isoToDateObj(booking.arrivalDate), today) ||
-        isAfter(DateFormats.isoToDateObj(booking.arrivalDate), today),
+        isBefore(DateFormats.isoToDateObj(booking.arrivalDate), today),
     )
   }
 
-  bookingsDepartingTodayOrLater(bookings: Array<Booking>, today: Date): Array<Booking> {
+  bookingsDepartingTodayOrLate(bookings: Array<Booking>, today: Date): Array<Booking> {
     return this.arrivedBookings(bookings).filter(
       booking =>
         isEqual(DateFormats.isoToDateObj(booking.departureDate), today) ||


### PR DESCRIPTION
We should be displaying bookings that are late to arrive (i.e with an arrivalDate of today or earlier), not bookings that are awaiting arrival (i.e. with an arrivalDate of today or after)