### PR TITLE
Handle generic api errors

### DIFF
--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -3,7 +3,8 @@
     "empty": "You must enter a CRN",
     "doesNotExist": "This CRN does not exist",
     "userPermission": "You do not have permission to access this CRN",
-    "doesNotHaveApplication": "This CRN does not have an application"
+    "doesNotHaveApplication": "This CRN does not have an application",
+    "notInCaseload": "This CRN is not in your caseload"
   },
   "data": {
     "invalid": "This data does not conform to the newest application schema"
@@ -48,6 +49,9 @@
   },
   "keyWorkerStaffCode": {
     "empty": "You must choose a keyworker"
+  },
+  "keyWorkerStaffId": {
+    "notFound": "The keyworker cannot be found"
   },
   "dateTime": {
     "empty": "You must enter a departure date and time",

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -78,6 +78,22 @@ describe('catchValidationErrorOrPropogate', () => {
     expect(response.redirect).toHaveBeenCalledWith('some/url')
   })
 
+  it('sets a generic error and redirects back to the form', () => {
+    const error = createMock<SanitisedError>({
+      data: {
+        detail: 'Some generic error',
+        'invalid-params': [],
+      },
+    })
+
+    catchValidationErrorOrPropogate(request, response, error, 'some/url')
+
+    expect(request.flash).toHaveBeenCalledWith('errorSummary', { text: 'Some generic error' })
+    expect(request.flash).toHaveBeenCalledWith('userInput', request.body)
+
+    expect(response.redirect).toHaveBeenCalledWith('some/url')
+  })
+
   it('gets errors from a ValidationError type', () => {
     const error = new ValidationError<TaskListPage>({
       data: {


### PR DESCRIPTION
At the moment, when we catch a generic error from the API, the frontend doesn't know what to do with it and we get a 500. This fixes the problem by updating the `catchValidationErrorOrPropogate` method - If there are no `invalid-params` in the problem response from the API, but there is a `detail` response, then we return the error detail as a string, and send it to the `errorSummary` without a href attribute (as it doesn’t refer to a field).

### Screenshot

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/d49146e3-946c-46d8-b22e-3b3fd90db25a)
