### PR TITLE
(225) Apply - Withdraw application

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -7,6 +7,7 @@ import type {
 } from '@approved-premises/api'
 
 import { getMatchingRequests, stubFor } from '../../wiremock'
+import paths from '../../server/paths/api'
 
 export default {
   stubApplications: (applications: Array<ApprovedPremisesApplicationSummary>): SuperAgentRequest =>
@@ -103,6 +104,17 @@ export default {
       request: {
         method: 'POST',
         url: `/applications/${args.application.id}/submission`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      },
+    }),
+  stubApplicationWithdrawn: (args: { applicationId: string }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: paths.applications.withdrawal({ id: args.applicationId }),
       },
       response: {
         status: 200,

--- a/integration_tests/pages/apply/applyPage.ts
+++ b/integration_tests/pages/apply/applyPage.ts
@@ -50,8 +50,4 @@ export default class ApplyPage extends Page {
   selectSelectOptionFromPageBody(fieldName: string) {
     this.getSelectInputByIdAndSelectAnEntry(fieldName, this.tasklistPage.body[fieldName] as string)
   }
-
-  checkForBackButton(path: string) {
-    cy.get('.govuk-back-link').should('have.attr', 'href').and('include', path)
-  }
 }

--- a/integration_tests/pages/apply/list.ts
+++ b/integration_tests/pages/apply/list.ts
@@ -53,6 +53,14 @@ export default class ListPage extends Page {
     cy.get(`a[data-cy-id="${application.id}"]`).click()
   }
 
+  clickWithdraw() {
+    cy.get('a').contains('Withdraw').first().click()
+  }
+
+  showsWithdrawalConfirmationMessage() {
+    this.shouldShowBanner('Application withdrawn')
+  }
+
   private shouldShowApplications(applications: Array<ApprovedPremisesApplicationSummary>, status: string): void {
     applications.forEach(application => {
       cy.contains(application.person.name)

--- a/integration_tests/pages/apply/withdrawApplicationPage.ts
+++ b/integration_tests/pages/apply/withdrawApplicationPage.ts
@@ -1,0 +1,14 @@
+import paths from '../../../server/paths/apply'
+
+import Page from '../page'
+
+export default class WithdrawApplicationPage extends Page {
+  constructor() {
+    super('Do you want to withdraw this application?')
+    this.checkForBackButton(paths.applications.index.pattern)
+  }
+
+  clickYes() {
+    this.checkRadioByNameAndValue('confirmWithdrawal', 'yes')
+  }
+}

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -322,4 +322,8 @@ export default abstract class Page {
   checkPhaseBanner(copy: string): void {
     cy.get('[data-cy-phase-banner="phase-banner"]').contains(copy)
   }
+
+  checkForBackButton(path: string) {
+    cy.get('.govuk-back-link').should('have.attr', 'href').and('include', path)
+  }
 }

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -507,5 +507,7 @@ context('Apply', () => {
     withdrawConfirmationPage.clickYes()
     withdrawConfirmationPage.clickSubmit()
 
+    // Then I should see the list page and be shown confirmation of the withdrawal
+    listPage.showsWithdrawalConfirmationMessage()
   })
 })

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -344,4 +344,25 @@ describe('applicationsController', () => {
       })
     })
   })
+
+  describe('confirmWithdrawal', () => {
+    it('renders the template', async () => {
+      const applicationId = 'some-id'
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
+      request.params.id = applicationId
+
+      const requestHandler = applicationsController.confirmWithdrawal()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('applications/withdraw', {
+        pageHeading: 'Do you want to withdraw this application?',
+        applicationId,
+        errors: errorsAndUserInput.errors,
+        errorSummary: errorsAndUserInput.errorSummary,
+        ...errorsAndUserInput.userInput,
+      })
+    })
+  })
 })

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -5,7 +5,7 @@ import type { ErrorsAndUserInput, GroupedApplications } from '@approved-premises
 import TasklistService from '../../services/tasklistService'
 import ApplicationsController, { tasklistPageHeading } from './applicationsController'
 import { ApplicationService, PersonService } from '../../services'
-import { fetchErrorsAndUserInput } from '../../utils/validation'
+import { addErrorMessageToFlash, fetchErrorsAndUserInput } from '../../utils/validation'
 import { activeOffenceFactory, applicationFactory, personFactory } from '../../testutils/factories'
 import Apply from '../../form-pages/apply'
 
@@ -363,6 +363,53 @@ describe('applicationsController', () => {
         errorSummary: errorsAndUserInput.errorSummary,
         ...errorsAndUserInput.userInput,
       })
+    })
+  })
+
+  describe('withdraw', () => {
+    it('redirects to the confirmation screen with an error if there isnt any input', async () => {
+      const applicationId = 'some-id'
+
+      request.params.id = applicationId
+
+      const requestHandler = applicationsController.withdraw()
+
+      await requestHandler(request, response, next)
+
+      expect(addErrorMessageToFlash).toHaveBeenCalledWith(
+        request,
+        'You must confirm if you want to withdraw this application',
+        'confirmWithdrawal',
+      )
+      expect(response.redirect).toHaveBeenCalledWith(paths.applications.withdraw.confirm({ id: applicationId }))
+    })
+
+    it('redirects to the index screen if the user responds "no" to withdrawing the application', async () => {
+      const applicationId = 'some-id'
+
+      request.params.id = applicationId
+      request.body.confirmWithdrawal = 'no'
+
+      const requestHandler = applicationsController.withdraw()
+
+      await requestHandler(request, response, next)
+
+      expect(response.redirect).toHaveBeenCalledWith(paths.applications.index({}))
+    })
+
+    it('calls the service method, redirects to the index screen and shows a confirmation message if the user answers yes', async () => {
+      const applicationId = 'some-id'
+
+      request.params.id = applicationId
+      request.body.confirmWithdrawal = 'yes'
+
+      const requestHandler = applicationsController.withdraw()
+
+      await requestHandler(request, response, next)
+
+      expect(applicationService.withdraw).toHaveBeenCalledWith(token, applicationId)
+      expect(response.redirect).toHaveBeenCalledWith(paths.applications.index({}))
+      expect(request.flash).toHaveBeenCalledWith('success', 'Application withdrawn')
     })
   })
 })

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -127,4 +127,18 @@ export default class ApplicationsController {
       return res.render('applications/confirm', { pageHeading: 'Application confirmation' })
     }
   }
+
+  confirmWithdrawal(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
+
+      return res.render('applications/withdraw', {
+        pageHeading: 'Do you want to withdraw this application?',
+        applicationId: req.params.id,
+        errors,
+        errorSummary,
+        ...userInput,
+      })
+    }
+  }
 }

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -3,7 +3,7 @@ import type { Request, RequestHandler, Response } from 'express'
 import TasklistService from '../../services/tasklistService'
 import ApplicationService from '../../services/applicationService'
 import { PersonService } from '../../services'
-import { fetchErrorsAndUserInput } from '../../utils/validation'
+import { addErrorMessageToFlash, fetchErrorsAndUserInput } from '../../utils/validation'
 import paths from '../../paths/apply'
 import { DateFormats } from '../../utils/dateUtils'
 import Apply from '../../form-pages/apply'
@@ -139,6 +139,25 @@ export default class ApplicationsController {
         errorSummary,
         ...userInput,
       })
+    }
+  }
+
+  withdraw(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      if (!req.body.confirmWithdrawal) {
+        addErrorMessageToFlash(req, 'You must confirm if you want to withdraw this application', 'confirmWithdrawal')
+
+        return res.redirect(paths.applications.withdraw.confirm({ id: req.params.id }))
+      }
+
+      if (req.body.confirmWithdrawal === 'no') {
+        return res.redirect(paths.applications.index({}))
+      }
+
+      await this.applicationService.withdraw(req.user.token, req.params.id)
+
+      req.flash('success', 'Application withdrawn')
+      return res.redirect(paths.applications.index({}))
     }
   }
 }

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -272,4 +272,28 @@ describeClient('ApplicationClient', provider => {
       expect(result).toEqual(assessment)
     })
   })
+
+  describe('withdrawal', () => {
+    it('calls the withdrawal endpoint with the application ID', async () => {
+      const applicationId = 'applicationId'
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to withdraw an application',
+        withRequest: {
+          method: 'POST',
+          path: paths.applications.withdrawal({ id: applicationId }),
+
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+        },
+      })
+
+      await applicationClient.withdrawal(applicationId)
+    })
+  })
 })

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -64,4 +64,10 @@ export default class ApplicationClient {
       path: paths.applications.assessment({ id: applicationId }),
     })) as Assessment
   }
+
+  async withdrawal(applicationId: string): Promise<void> {
+    await this.restClient.post({
+      path: paths.applications.withdrawal({ id: applicationId }),
+    })
+  }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -113,6 +113,7 @@ export default {
     submission: applyPaths.applications.submission,
     documents: applyPaths.applications.show.path('documents'),
     assessment: applyPaths.applications.show.path('assessment'),
+    withdrawal: applyPaths.applications.show.path('withdrawal'),
   },
   assessments: {
     index: assessPaths.assessments,

--- a/server/paths/apply.ts
+++ b/server/paths/apply.ts
@@ -24,6 +24,7 @@ const paths = {
     submission: applicationPath.path('submission'),
     withdraw: {
       confirm: applicationPath.path('confirmWithdrawal'),
+      create: applicationPath.path('withdraw'),
     },
     pages: {
       show: pagesPath,

--- a/server/paths/apply.ts
+++ b/server/paths/apply.ts
@@ -22,6 +22,9 @@ const paths = {
     update: applicationPath,
     checkYourAnswers: applicationPath.path('check-your-answers'),
     submission: applicationPath.path('submission'),
+    withdraw: {
+      confirm: applicationPath.path('confirmWithdrawal'),
+    },
     pages: {
       show: pagesPath,
       update: pagesPath,

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -35,6 +35,9 @@ export default function routes(controllers: Controllers, router: Router, service
   get(paths.applications.withdraw.confirm.pattern, applicationsController.confirmWithdrawal(), {
     auditEvent: 'VIEW_CONFIRM_WITHDRAWAL_SCREEN',
   })
+  post(paths.applications.withdraw.create.pattern, applicationsController.withdraw(), {
+    auditEvent: 'WITHDRAW_APPLICATION',
+  })
 
   Object.keys(pages).forEach((taskKey: string) => {
     Object.keys(pages[taskKey]).forEach((pageKey: string) => {

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -32,6 +32,9 @@ export default function routes(controllers: Controllers, router: Router, service
     auditEvent: 'SELECT_OFFENCE',
   })
   get(paths.applications.people.documents.pattern, documentsController.show(), { auditEvent: 'SHOW_DOCUMENTS' })
+  get(paths.applications.withdraw.confirm.pattern, applicationsController.confirmWithdrawal(), {
+    auditEvent: 'VIEW_CONFIRM_WITHDRAWAL_SCREEN',
+  })
 
   Object.keys(pages).forEach((taskKey: string) => {
     Object.keys(pages[taskKey]).forEach((pageKey: string) => {

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -386,4 +386,16 @@ describe('ApplicationService', () => {
       expect(applicationClient.assessment).toHaveBeenCalledWith(id)
     })
   })
+
+  describe('withdraw', () => {
+    it('it calls the client with the ID and token', async () => {
+      const token = 'some-token'
+      const id = 'some-uuid'
+
+      await service.withdraw(token, id)
+
+      expect(applicationClientFactory).toHaveBeenCalledWith(token)
+      expect(applicationClient.withdrawal).toHaveBeenCalledWith(id)
+    })
+  })
 })

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -130,4 +130,10 @@ export default class ApplicationService {
 
     return assessment
   }
+
+  async withdraw(token: string, applicationId: string) {
+    const client = this.applicationClientFactory(token)
+
+    await client.withdrawal(applicationId)
+  }
 }

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -15,6 +15,7 @@ import { DateFormats } from '../dateUtils'
 import { isApplicableTier, tierBadge } from '../personUtils'
 
 import {
+  createWithdrawAnchorElement,
   dashboardTableRows,
   firstPageOfApplicationJourney,
   getApplicationType,
@@ -185,6 +186,7 @@ describe('utils', () => {
           {
             html: getStatus(applicationB),
           },
+          createWithdrawAnchorElement(applicationA.id),
         ],
         [
           {
@@ -204,6 +206,7 @@ describe('utils', () => {
           {
             html: getStatus(applicationB),
           },
+          createWithdrawAnchorElement(applicationB.id),
         ],
       ])
     })
@@ -243,6 +246,7 @@ describe('utils', () => {
           {
             html: getStatus(application),
           },
+          createWithdrawAnchorElement(application.id),
         ],
       ])
     })
@@ -282,6 +286,7 @@ describe('utils', () => {
           {
             html: getStatus(application),
           },
+          createWithdrawAnchorElement(application.id),
         ],
       ])
     })

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -39,6 +39,7 @@ const dashboardTableRows = (applications: Array<ApplicationSummary>): Array<Tabl
         application.arrivalDate ? DateFormats.isoDateToUIDate(application.arrivalDate, { format: 'short' }) : 'N/A',
       ),
       htmlValue(getStatus(application)),
+      createWithdrawAnchorElement(application.id),
     ]
   })
 }
@@ -71,6 +72,10 @@ const createNameAnchorElement = (name: string, applicationId: string) => {
   return htmlValue(
     `<a href=${paths.applications.show({ id: applicationId })} data-cy-id="${applicationId}">${name}</a>`,
   )
+}
+
+export const createWithdrawAnchorElement = (applicationId: string) => {
+  return htmlValue(`<a href=${paths.applications.withdraw.confirm({ id: applicationId })}>Withdraw</a>`)
 }
 
 export type ApplicationOrAssessmentResponse = Record<string, Array<PageResponse>>

--- a/server/views/applications/_table.njk
+++ b/server/views/applications/_table.njk
@@ -22,6 +22,9 @@
             },
             {
               text: "Status"
+            },
+            {
+              text: "Withdraw"
             }
           ],
           rows: rows

--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -10,6 +10,7 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
+    {% include "../_messages.njk" %}
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">

--- a/server/views/applications/withdraw.njk
+++ b/server/views/applications/withdraw.njk
@@ -1,0 +1,61 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+      text: "Back",
+      href: paths.applications.index({})
+    }) }}
+{% endblock %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="{{ paths.applications.withdraw.create({id: applicationId}) }}" method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+                {{ showErrorSummary(errorSummary) }}
+
+                {{ govukRadios({
+                        idPrefix: "confirmWithdrawal",
+                        name: "confirmWithdrawal",
+                        fieldset: {
+                            legend: {
+                                text: "Do you want to withdraw this application?",
+                                classes: "govuk-fieldset__legend--l",
+                                isPageHeading: true
+                            }
+                        },
+                        hint: {
+                            text: 'Withdrawing an application will remove the application data from the AP service. It cannot be undone.'
+                        },
+                        items: [
+                            {
+                            value: "yes",
+                            text: "Yes"
+                            },
+                            {
+                            value: "no",
+                            text: "No"
+                            }
+                        ],
+                        errorMessage: errors.confirmWithdrawal
+                     }) }}
+
+                {{ govukButton({
+                    name: 'submit',
+                    text: "Continue"
+                }) }}
+
+            </form>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
# Context
PPs need to be able to withdraw applications, this PR adds a button to the Applications table where they can do just that.

[Trello card](https://trello.com/c/ZSUZjskW/225-withdraw-application)

# Changes in this PR
- We add the button to the table
- We add the relevant client and service methods
- We add a controller method for confirming the withdrawal
- We add the 'confirmation' view
- We add a controller method for validating and performing the withdrawal

## Screenshots of UI changes

![withdrawal-without-selection](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/f6f5cba2-64d9-4313-a910-06c22930743d)
![withdraw-confirmation](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/39d23b3a-9ca7-4c94-b530-d838bfd4f8ef)
