### PR TITLE
Tighten up application journey

### DIFF
--- a/integration_tests/fixtures/assessmentData.json
+++ b/integration_tests/fixtures/assessmentData.json
@@ -1,0 +1,60 @@
+{
+  "review-application": { "review": { "reviewed": "yes" } },
+  "sufficient-information": { "sufficient-information": { "sufficientInformation": "yes", "query": "" } },
+  "suitability-assessment": {
+    "suitability-assessment": {
+      "riskFactors": "yes",
+      "riskFactorsComments": "",
+      "riskManagement": "yes",
+      "riskManagementComments": "",
+      "locationOfPlacement": "yes",
+      "locationOfPlacementComments": "",
+      "moveOnPlan": "yes",
+      "moveOnPlanComments": ""
+    }
+  },
+  "required-actions": {
+    "required-actions": {
+      "additionalActions": "no",
+      "additionalActionsComments": "",
+      "curfewsOrSignIns": "no",
+      "curfewsOrSignInsComments": "",
+      "concernsOfUnmanagableRisk": "no",
+      "concernsOfUnmanagableRiskComments": "",
+      "additionalRecommendations": "no",
+      "additionalRecommendationsComments": "",
+      "nameOfAreaManager": "",
+      "dateOfDiscussion-day": "",
+      "dateOfDiscussion-month": "",
+      "dateOfDiscussion-year": "",
+      "outlineOfDiscussion": ""
+    }
+  },
+  "make-a-decision": { "make-a-decision": { "decision": "accept" } },
+  "matching-information": {
+    "matching-information": {
+      "apType": "normal",
+      "accessibilityCriteria": [],
+      "specialistSupportCriteria": [],
+      "lengthOfStayAgreed": "yes",
+      "lengthOfStayWeeks": "",
+      "lengthOfStayDays": "",
+      "cruInformation": "",
+      "isWheelchairDesignated": "notRelevant",
+      "isSingle": "notRelevant",
+      "isStepFreeDesignated": "notRelevant",
+      "isCatered": "notRelevant",
+      "isGroundFloor": "notRelevant",
+      "hasEnSuite": "notRelevant",
+      "isSuitedForSexOffenders": "notRelevant",
+      "isArsonDesignated": "notRelevant",
+      "isSuitableForVulnerable": "notRelevant",
+      "acceptsSexOffenders": "notRelevant",
+      "acceptsChildSexOffenders": "notRelevant",
+      "acceptsNonSexualChildOffenders": "notRelevant",
+      "acceptsHateCrimeOffenders": "notRelevant",
+      "isArsonSuitable": "notRelevant"
+    }
+  },
+  "check-your-answers": { "check-your-answers": { "reviewed": "1" } }
+}

--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -922,8 +922,11 @@ export default class ApplyHelper {
 
   private submitApplication() {
     const tasklistPage = Page.verifyOnPage(ApplyPages.TaskListPage)
-    tasklistPage.checkCheckboxByLabel('submit')
+    tasklistPage.clickSubmit()
 
+    tasklistPage.shouldShowMissingCheckboxErrorMessage()
+
+    tasklistPage.checkCheckboxByLabel('submit')
     tasklistPage.clickSubmit()
   }
 }

--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -468,6 +468,7 @@ export default class ApplyHelper {
 
     // And the next task should be marked as not started
     tasklistPage.shouldShowTaskStatus('type-of-ap', 'Not started')
+    tasklistPage.shouldNotShowSubmitComponents()
 
     // And the risk widgets should be visible
     if (this.uiRisks) {
@@ -496,6 +497,7 @@ export default class ApplyHelper {
 
     // And the OASys import task should show as not started
     tasklistPage.shouldShowTaskStatus('oasys-import', 'Not started')
+    tasklistPage.shouldNotShowSubmitComponents()
   }
 
   completeEsapFlow() {
@@ -635,6 +637,7 @@ export default class ApplyHelper {
 
     // And the Risk Management Features task should show as not started
     tasklistPage.shouldShowTaskStatus('risk-management-features', 'Not started')
+    tasklistPage.shouldNotShowSubmitComponents()
   }
 
   completeRiskManagementSection() {
@@ -675,6 +678,7 @@ export default class ApplyHelper {
 
     // And the risk management task should show a completed status
     tasklistPage.shouldShowTaskStatus('risk-management-features', 'Completed')
+    tasklistPage.shouldNotShowSubmitComponents()
   }
 
   completePrisonInformationSection(nomisMissing = false) {
@@ -704,6 +708,7 @@ export default class ApplyHelper {
 
     // And the location factors task should show a completed status
     tasklistPage.shouldShowTaskStatus('location-factors', 'Completed')
+    tasklistPage.shouldNotShowSubmitComponents()
   }
 
   private completeAccessAndHealthcareSection() {
@@ -730,6 +735,7 @@ export default class ApplyHelper {
 
     // And the access and healthcare task should show a completed status
     tasklistPage.shouldShowTaskStatus('access-and-healthcare', 'Completed')
+    tasklistPage.shouldNotShowSubmitComponents()
   }
 
   private completeFurtherConsiderationsSection() {
@@ -817,6 +823,7 @@ export default class ApplyHelper {
 
     // And the further considerations task should show a completed status
     tasklistPage.shouldShowTaskStatus('further-considerations', 'Completed')
+    tasklistPage.shouldNotShowSubmitComponents()
   }
 
   private completeMoveOnSection() {
@@ -860,6 +867,7 @@ export default class ApplyHelper {
 
     // And the move on information task should show a completed status
     tasklistPage.shouldShowTaskStatus('move-on', 'Completed')
+    tasklistPage.shouldNotShowSubmitComponents()
   }
 
   private completeDocumentsSection() {
@@ -884,6 +892,7 @@ export default class ApplyHelper {
 
     // And the Attach Documents task should show a completed status
     tasklistPage.shouldShowTaskStatus('attach-required-documents', 'Completed')
+    tasklistPage.shouldNotShowSubmitComponents()
   }
 
   private completeCheckYourAnswersSection() {

--- a/integration_tests/helpers/assess.ts
+++ b/integration_tests/helpers/assess.ts
@@ -23,11 +23,11 @@ import {
   TaskListPage,
 } from '../pages/assess'
 import Page from '../pages/page'
-import { updateAssessmentData } from '../../server/form-pages/utils'
 import AssessPage from '../pages/assess/assessPage'
 import { assessmentSummaryFactory } from '../../server/testutils/factories'
 import RfapSuitabilityPage from '../pages/assess/rfapSuitability'
 import ContingencyPlanSuitabilityPage from '../pages/assess/contingencyPlanSuitability'
+import { getPageName, getTaskName } from '../../server/form-pages/utils'
 
 export default class AseessHelper {
   assessmentSummary: AssessmentSummary
@@ -337,7 +337,16 @@ export default class AseessHelper {
   }
 
   updateAssessmentAndStub(pageObject: AssessPage) {
-    const updatedAssessement = updateAssessmentData(pageObject.pageClass, this.assessment)
-    return cy.task('stubAssessment', updatedAssessement)
+    const updatedAssessment = this.assessment
+    const page = pageObject.pageClass
+
+    const pageName = getPageName(page.constructor)
+    const taskName = getTaskName(page.constructor)
+
+    updatedAssessment.data = updatedAssessment.data || {}
+    updatedAssessment.data[taskName] = updatedAssessment.data[taskName] || {}
+    updatedAssessment.data[taskName][pageName] = page.body
+
+    return cy.task('stubAssessment', updatedAssessment)
   }
 }

--- a/integration_tests/helpers/assess.ts
+++ b/integration_tests/helpers/assess.ts
@@ -330,6 +330,9 @@ export default class AseessHelper {
 
   submitAssessment(isSuitable = true) {
     const tasklistPage = Page.verifyOnPage(TaskListPage)
+    tasklistPage.clickSubmit()
+
+    tasklistPage.shouldShowMissingCheckboxErrorMessage()
 
     tasklistPage.checkCheckboxByLabel('confirmed')
     tasklistPage.clickSubmit()

--- a/integration_tests/mockApis/assessments.ts
+++ b/integration_tests/mockApis/assessments.ts
@@ -151,4 +151,11 @@ export default {
         }),
       })
     ).body.requests,
+  verifyAssessmentUpdate: async (assessment: Assessment) =>
+    (
+      await getMatchingRequests({
+        method: 'PUT',
+        url: paths.assessments.show({ id: assessment.id }),
+      })
+    ).body.requests,
 }

--- a/integration_tests/pages/apply/taskListPage.ts
+++ b/integration_tests/pages/apply/taskListPage.ts
@@ -10,4 +10,10 @@ export default class TaskListPage extends TaskList {
     cy.visit(`/applications/${application.id}`)
     return new TaskListPage()
   }
+
+  shouldNotShowSubmitComponents(): void {
+    cy.get('input[value="submit"]').should('not.exist')
+    cy.get('input[name="confirmation"]').should('not.exist')
+    cy.get('button').should('not.exist')
+  }
 }

--- a/integration_tests/pages/apply/taskListPage.ts
+++ b/integration_tests/pages/apply/taskListPage.ts
@@ -1,7 +1,7 @@
 import { ApprovedPremisesApplication } from '@approved-premises/api'
 import TaskList from '../taskListPage'
 
-export default class TaskListPage extends Page {
+export default class TaskListPage extends TaskList {
   constructor() {
     super('Apply for an Approved Premises (AP) placement')
   }
@@ -9,9 +9,5 @@ export default class TaskListPage extends Page {
   static visit(application: ApprovedPremisesApplication) {
     cy.visit(`/applications/${application.id}`)
     return new TaskListPage()
-  }
-
-  shouldShowTaskStatus = (task: string, status: string): void => {
-    cy.get(`#${task}-status`).should('contain', status)
   }
 }

--- a/integration_tests/pages/apply/taskListPage.ts
+++ b/integration_tests/pages/apply/taskListPage.ts
@@ -1,8 +1,14 @@
-import Page from '../page'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
+import TaskList from '../taskListPage'
 
 export default class TaskListPage extends Page {
   constructor() {
     super('Apply for an Approved Premises (AP) placement')
+  }
+
+  static visit(application: ApprovedPremisesApplication) {
+    cy.visit(`/applications/${application.id}`)
+    return new TaskListPage()
   }
 
   shouldShowTaskStatus = (task: string, status: string): void => {

--- a/integration_tests/pages/assess/taskListPage.ts
+++ b/integration_tests/pages/assess/taskListPage.ts
@@ -1,7 +1,7 @@
 import { ApprovedPremisesAssessment } from '../../../server/@types/shared/models/ApprovedPremisesAssessment'
 import TaskList from '../taskListPage'
 
-export default class TaskListPage extends Page {
+export default class TaskListPage extends TaskList {
   constructor() {
     super('Assess an Approved Premises (AP) application')
   }
@@ -9,13 +9,5 @@ export default class TaskListPage extends Page {
   static visit(assessment: ApprovedPremisesAssessment) {
     cy.visit(`/assessments/${assessment.id}`)
     return new TaskListPage()
-  }
-
-  shouldShowTaskStatus = (task: string, status: string): void => {
-    cy.get(`#${task}-status`).should('contain', status)
-  }
-
-  shouldNotShowSection = (section: string): void => {
-    cy.get('.app-task-list').should('not.contain', section)
   }
 }

--- a/integration_tests/pages/assess/taskListPage.ts
+++ b/integration_tests/pages/assess/taskListPage.ts
@@ -1,8 +1,14 @@
-import Page from '../page'
+import { ApprovedPremisesAssessment } from '../../../server/@types/shared/models/ApprovedPremisesAssessment'
+import TaskList from '../taskListPage'
 
 export default class TaskListPage extends Page {
   constructor() {
     super('Assess an Approved Premises (AP) application')
+  }
+
+  static visit(assessment: ApprovedPremisesAssessment) {
+    cy.visit(`/assessments/${assessment.id}`)
+    return new TaskListPage()
   }
 
   shouldShowTaskStatus = (task: string, status: string): void => {

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -267,6 +267,11 @@ export default abstract class Page {
     })
   }
 
+  clearAllInputs() {
+    cy.get('input').filter(':visible').clear()
+    cy.get('textarea').clear()
+  }
+
   clearDateInputs(prefix: string): void {
     cy.get(`#${prefix}-day`).clear()
     cy.get(`#${prefix}-month`).clear()

--- a/integration_tests/pages/taskListPage.ts
+++ b/integration_tests/pages/taskListPage.ts
@@ -1,0 +1,22 @@
+import Page from './page'
+
+export default class TaskListPage extends Page {
+  shouldShowTaskStatus = (task: string, status: string): void => {
+    cy.get(`#${task}-status`).should('contain', status)
+  }
+
+  shouldNotShowSection = (section: string): void => {
+    cy.get('.app-task-list').should('not.contain', section)
+  }
+
+  shouldShowMissingCheckboxErrorMessage() {
+    cy.get('.govuk-error-summary').should(
+      'contain',
+      'You must confirm the information provided is complete, accurate and up to date.',
+    )
+    cy.get(`[data-cy-error-confirmation]`).should(
+      'contain',
+      'You must confirm the information provided is complete, accurate and up to date.',
+    )
+  }
+}

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../server/testutils/factories'
 
 import ApplyHelper from '../../helpers/apply'
+import * as ApplyPages from '../../pages/apply'
 import { DateFormats } from '../../../server/utils/dateUtils'
 import IsExceptionalCasePage from '../../pages/apply/isExceptionalCase'
 import NotEligiblePage from '../../pages/apply/notEligiblePage'
@@ -509,5 +510,88 @@ context('Apply', () => {
 
     // Then I should see the list page and be shown confirmation of the withdrawal
     listPage.showsWithdrawalConfirmationMessage()
+  })
+
+  it('invalidates the check your answers step if an answer is changed', function test() {
+    // Given there is a complete application in the database
+    const application = { ...this.application, status: 'inProgress' }
+    cy.task('stubApplicationGet', { application })
+
+    // And I visit the tasklist
+    ApplyPages.TaskListPage.visit(application)
+
+    // And I click on a task
+    cy.get('[data-cy-task-name="location-factors"]').click()
+
+    // And I change my response
+    this.application = addResponsesToFormArtifact(this.application, {
+      section: 'location-factors',
+      page: 'describe-location-factors',
+      keyValuePairs: {
+        ...this.application.data['location-factors']['describe-location-factors'],
+        postcodeArea: 'WS1',
+      },
+    })
+
+    const describeLocationFactorsPage = new ApplyPages.DescribeLocationFactors(this.application)
+    describeLocationFactorsPage.clearAllInputs()
+    describeLocationFactorsPage.completeForm()
+    describeLocationFactorsPage.clickSubmit()
+
+    // Then the application should be updated with the Check Your Answers section removed
+    cy.task('verifyApplicationUpdate', this.application.id).then((requests: Array<{ body: string }>) => {
+      expect(requests).to.have.length(1)
+      const body = JSON.parse(requests[0].body)
+
+      expect(body).to.have.keys(
+        'data',
+        'arrivalDate',
+        'isPipeApplication',
+        'isWomensApplication',
+        'targetLocation',
+        'releaseType',
+        'type',
+        'isInapplicable',
+        'isEsapApplication',
+        'isEmergencyApplication',
+      )
+      expect(body.data).not.to.have.keys(['check-your-answers'])
+    })
+  })
+
+  it('does not invalidate the check your answers step if an answer is reviewed and not changed', function test() {
+    // Given there is a complete application in the database
+    const application = { ...this.application, status: 'inProgress' }
+    cy.task('stubApplicationGet', { application })
+
+    // And I visit the tasklist
+    ApplyPages.TaskListPage.visit(application)
+
+    // And I click on a task
+    cy.get('[data-cy-task-name="location-factors"]').click()
+
+    // And I review a section
+    const describeLocationFactorsPage = new ApplyPages.DescribeLocationFactors(this.application)
+    describeLocationFactorsPage.clickSubmit()
+
+    // Then the application should be updated with the Check Your Answers section removed
+    cy.task('verifyApplicationUpdate', this.application.id).then((requests: Array<{ body: string }>) => {
+      expect(requests).to.have.length(1)
+      const body = JSON.parse(requests[0].body)
+
+      expect(body).to.have.keys(
+        'data',
+        'arrivalDate',
+        'isPipeApplication',
+        'isWomensApplication',
+        'targetLocation',
+        'releaseType',
+        'type',
+        'isInapplicable',
+        'isEsapApplication',
+        'isEmergencyApplication',
+      )
+      expect(body.data).to.have.any.keys(['check-your-answers'])
+    })
   })
 })

--- a/server/form-pages/utils/index.test.ts
+++ b/server/form-pages/utils/index.test.ts
@@ -4,10 +4,10 @@ import 'reflect-metadata'
 
 // Use a wildcard import to allow us to use jest.spyOn on functions within this module
 import * as utils from './index'
-import TasklistPage, { TasklistPageInterface } from '../tasklistPage'
+import { TasklistPageInterface } from '../tasklistPage'
 import { ApprovedPremisesApplication } from '../../@types/shared'
 
-import { applicationFactory, assessmentFactory } from '../../testutils/factories'
+import { applicationFactory } from '../../testutils/factories'
 
 describe('utils', () => {
   describe('applyYesOrNo', () => {
@@ -183,37 +183,6 @@ describe('utils', () => {
     })
   })
 
-  describe('updateAssessmentData', () => {
-    const page = createMock<TasklistPage>({
-      body: { foo: 'bar' },
-    })
-
-    beforeEach(() => {
-      ;(utils.getPageName as jest.Mock).mockReturnValue('some-page')
-      ;(utils.getTaskName as jest.Mock).mockReturnValue('some-task')
-    })
-
-    it('returns an assessment with an updated body', () => {
-      const assessment = assessmentFactory.build()
-      assessment.data = { 'first-task': { page: { foo: 'bar' } } }
-
-      const updatedAssessment = utils.updateAssessmentData(page, assessment)
-
-      expect(updatedAssessment.data).toEqual({
-        'first-task': {
-          page: {
-            foo: 'bar',
-          },
-        },
-        'some-task': {
-          'some-page': {
-            foo: 'bar',
-          },
-        },
-      })
-    })
-  })
-
   describe('generateResponsesForYesNoAndCommentsSections ', () => {
     it('generates the responses given the sections and body', () => {
       expect(
@@ -221,6 +190,67 @@ describe('utils', () => {
       ).toEqual({
         'question copy': 'Response',
       })
+    })
+  })
+
+  describe('pageBodyShallowEquals', () => {
+    it('returns true when the two parameters are equal', () => {
+      const value1 = {
+        'some-key': 'some-value',
+        'some-key-2': ['value1', 'value2'],
+      }
+
+      const value2 = {
+        'some-key': 'some-value',
+        'some-key-2': ['value1', 'value2'],
+      }
+
+      expect(utils.pageBodyShallowEquals(value1, value2)).toEqual(true)
+      expect(utils.pageBodyShallowEquals(value2, value1)).toEqual(true)
+    })
+
+    it('returns false when the one parameter is a subset of the other', () => {
+      const value1 = {
+        'some-key': 'some-value',
+        'some-key-2': ['value1', 'value2'],
+      }
+
+      const value2 = {
+        'some-key': 'some-value',
+      }
+
+      expect(utils.pageBodyShallowEquals(value1, value2)).toEqual(false)
+      expect(utils.pageBodyShallowEquals(value2, value1)).toEqual(false)
+    })
+
+    it('returns false when one parameter contains a different array to the other', () => {
+      const value1 = {
+        'some-key': 'some-value',
+        'some-key-2': ['value1', 'value2', 'value3'],
+      }
+
+      const value2 = {
+        'some-key': 'some-value',
+        'some-key-2': ['value1', 'value2'],
+      }
+
+      expect(utils.pageBodyShallowEquals(value1, value2)).toEqual(false)
+      expect(utils.pageBodyShallowEquals(value2, value1)).toEqual(false)
+    })
+
+    it('returns false when parameters contains an inner object', () => {
+      const value1 = {
+        'some-key': 'some-value',
+        'some-key-2': { 'inner-key': 'inner-value' },
+      }
+
+      const value2 = {
+        'some-key': 'some-value',
+        'some-key-2': { 'inner-key': 'inner-value' },
+      }
+
+      expect(utils.pageBodyShallowEquals(value1, value2)).toEqual(false)
+      expect(utils.pageBodyShallowEquals(value2, value1)).toEqual(false)
     })
   })
 })

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -1,7 +1,6 @@
 import type { FormArtifact, JourneyType, UiTask, YesOrNo, YesOrNoWithDetail } from '@approved-premises/ui'
 import type { Request } from 'express'
-import TasklistPage, { TasklistPageInterface } from '../tasklistPage'
-import { ApprovedPremisesAssessment } from '../../@types/shared'
+import { TasklistPageInterface } from '../tasklistPage'
 import { sentenceCase } from '../../utils/utils'
 
 export const applyYesOrNo = <K extends string>(key: K, body: Record<string, unknown>): YesOrNoWithDetail<K> => {
@@ -85,20 +84,6 @@ export const getTaskName = <T>(page: T) => {
   return Reflect.getMetadata('page:task', page)
 }
 
-export const updateAssessmentData = (
-  page: TasklistPage,
-  assessment: ApprovedPremisesAssessment,
-): ApprovedPremisesAssessment => {
-  const pageName = getPageName(page.constructor)
-  const taskName = getTaskName(page.constructor)
-
-  assessment.data = assessment.data || {}
-  assessment.data[taskName] = assessment.data[taskName] || {}
-  assessment.data[taskName][pageName] = page.body
-
-  return assessment
-}
-
 export function getBody(
   Page: TasklistPageInterface,
   application: FormArtifact,
@@ -137,4 +122,23 @@ export const responsesForYesNoAndCommentsSections = (
 
     return response
   }, {})
+}
+
+export const pageBodyShallowEquals = (body1: Record<string, unknown>, body2: Record<string, unknown>) => {
+  const body1Keys = Object.keys(body1)
+  const body2Keys = Object.keys(body2)
+
+  if (body1Keys.length !== body2Keys.length) {
+    return false
+  }
+
+  return body1Keys.every(key => {
+    const value1 = body1[key]
+    const value2 = body2[key]
+
+    if (Array.isArray(value1) && Array.isArray(value2)) {
+      return value1.length === value2.length && value1.every((arrayValue, index) => arrayValue === value2[index])
+    }
+    return value1 === value2
+  })
 }

--- a/server/form-pages/utils/updateFormArtifactData.test.ts
+++ b/server/form-pages/utils/updateFormArtifactData.test.ts
@@ -1,0 +1,125 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import { TaskListErrors } from '@approved-premises/ui'
+import { applicationFactory, assessmentFactory } from '../../testutils/factories'
+import TasklistPage from '../tasklistPage'
+import { getPageName, getTaskName, pageBodyShallowEquals } from './index'
+import { updateFormArtifactData } from './updateFormArtifactData'
+import AssessmentCheckYourAnswersPage from '../assess/checkYourAnswers/checkYourAnswersTask/checkYourAnswers'
+import ApplicationCheckYourAnswersPage from '../apply/check-your-answers/review'
+
+jest.mock('./index')
+
+const formArtifacts = {
+  assessment: {
+    factory: assessmentFactory,
+    pageClass: AssessmentCheckYourAnswersPage,
+  },
+  application: {
+    factory: applicationFactory,
+    pageClass: ApplicationCheckYourAnswersPage,
+  },
+}
+
+describe('updateFormArtifactData', () => {
+  describe.each([['assessment'], ['application']])('with an %s', artifactType => {
+    const artifact = formArtifacts[artifactType].factory.build()
+    const PageClass = formArtifacts[artifactType].pageClass
+
+    let page: DeepMocked<TasklistPage>
+
+    beforeEach(() => {
+      page = createMock<TasklistPage>({
+        body: { foo: 'bar' },
+      })
+      ;(getPageName as jest.Mock).mockImplementation(pageClass => (pageClass === PageClass ? 'review' : 'some-page'))
+      ;(getTaskName as jest.Mock).mockImplementation(pageClass =>
+        pageClass === PageClass ? 'check-your-answers' : 'some-task',
+      )
+      ;(pageBodyShallowEquals as jest.Mock).mockReturnValue(false)
+    })
+
+    it('returns an assessment with an updated body', () => {
+      artifact.data = { 'first-task': { page: { foo: 'bar' } } }
+
+      const updatedArtifact = updateFormArtifactData(page, artifact, PageClass)
+
+      expect(updatedArtifact.data).toEqual({
+        'first-task': {
+          page: {
+            foo: 'bar',
+          },
+        },
+        'some-task': {
+          'some-page': {
+            foo: 'bar',
+          },
+        },
+      })
+    })
+
+    it('invalidates the check your answers task when saving a new page', async () => {
+      artifact.data = {
+        'some-task': { 'other-page': { question: 'answer' } },
+        'check-your-answers': { review: { reviewed: '1' } },
+      }
+
+      const updatedArtifact = updateFormArtifactData(page, artifact, PageClass)
+
+      expect(updatedArtifact.data).toEqual({
+        'some-task': { 'other-page': { question: 'answer' }, 'some-page': { foo: 'bar' } },
+      })
+    })
+
+    it('invalidates the check your answers task when changing an existing page', async () => {
+      artifact.data = {
+        'some-task': { 'some-page': { foo: 'baz' }, 'other-page': { question: 'answer' } },
+        'check-your-answers': { review: { reviewed: '1' } },
+      }
+
+      const updatedArtifact = updateFormArtifactData(page, artifact, PageClass)
+
+      expect(updatedArtifact.data).toEqual({
+        'some-task': { 'other-page': { question: 'answer' }, 'some-page': { foo: 'bar' } },
+      })
+    })
+
+    it('does not invalidate the check your answers task when saving an existing page with unchanged data', async () => {
+      artifact.data = {
+        'some-task': { 'some-page': { foo: 'bar' } },
+        'check-your-answers': { review: { reviewed: '1' } },
+      }
+      ;(pageBodyShallowEquals as jest.Mock).mockReturnValue(true)
+
+      const updatedArtifact = updateFormArtifactData(page, artifact, PageClass)
+
+      expect(updatedArtifact.data).toEqual({
+        'some-task': { 'some-page': { foo: 'bar' } },
+        'check-your-answers': { review: { reviewed: '1' } },
+      })
+    })
+
+    it('does not invalidate the check your answers task when saving a check your answers page', async () => {
+      page = createMock<TasklistPage>({
+        errors: () => {
+          return {} as TaskListErrors<TasklistPage>
+        },
+        body: { reviewed: '1' },
+      })
+
+      artifact.data = {
+        'some-task': { 'other-page': { question: 'answer' } },
+      }
+      ;(getTaskName as jest.Mock).mockReturnValue('check-your-answers')
+      ;(getPageName as jest.Mock).mockReturnValue('review')
+
+      const updatedArtifact = updateFormArtifactData(page, artifact, PageClass)
+
+      expect(updatedArtifact.data).toEqual({
+        'some-task': {
+          'other-page': { question: 'answer' },
+        },
+        'check-your-answers': { review: { reviewed: '1' } },
+      })
+    })
+  })
+})

--- a/server/form-pages/utils/updateFormArtifactData.ts
+++ b/server/form-pages/utils/updateFormArtifactData.ts
@@ -1,0 +1,29 @@
+import { FormArtifact } from '@approved-premises/ui'
+import { getPageName, getTaskName, pageBodyShallowEquals } from '.'
+import TasklistPage from '../tasklistPage'
+
+export const updateFormArtifactData = <FormArtifactClass extends FormArtifact, CheckYourAnswersPageClass>(
+  page: TasklistPage,
+  formArtifact: FormArtifactClass,
+  checkYourAnswersPageClass: CheckYourAnswersPageClass,
+): FormArtifactClass => {
+  const pageName = getPageName(page.constructor)
+  const taskName = getTaskName(page.constructor)
+
+  const oldBody = formArtifact.data?.[taskName]?.[pageName]
+
+  formArtifact.data = formArtifact.data || {}
+  formArtifact.data[taskName] = formArtifact.data[taskName] || {}
+  formArtifact.data[taskName][pageName] = page.body
+
+  const reviewTaskName = getTaskName(checkYourAnswersPageClass)
+  const reviewPageName = getPageName(checkYourAnswersPageClass)
+
+  if (formArtifact.data[reviewTaskName] && !(taskName === reviewTaskName && pageName === reviewPageName)) {
+    if (!oldBody || !pageBodyShallowEquals(oldBody, page.body)) {
+      delete formArtifact.data[reviewTaskName]
+    }
+  }
+
+  return formArtifact
+}

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -7,12 +7,14 @@ import type {
   Document,
 } from '@approved-premises/api'
 
+import { updateFormArtifactData } from '../form-pages/utils/updateFormArtifactData'
 import { getApplicationSubmissionData, getApplicationUpdateData } from '../utils/applications/getApplicationData'
 import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
 import type { ApplicationClient, RestClientBuilder } from '../data'
 import { ValidationError } from '../utils/errors'
 
-import { getBody, getPageName, getTaskName } from '../form-pages/utils'
+import { getBody } from '../form-pages/utils'
+import Review from '../form-pages/apply/check-your-answers/review'
 
 export default class ApplicationService {
   constructor(private readonly applicationClientFactory: RestClientBuilder<ApplicationClient>) {}
@@ -96,16 +98,11 @@ export default class ApplicationService {
       throw new ValidationError<typeof page>(errors)
     } else {
       const application = await this.findApplication(request.user.token, request.params.id)
+      const updatedApplication = updateFormArtifactData(page, application, Review)
+
       const client = this.applicationClientFactory(request.user.token)
 
-      const pageName = getPageName(page.constructor)
-      const taskName = getTaskName(page.constructor)
-
-      application.data = application.data || {}
-      application.data[taskName] = application.data[taskName] || {}
-      application.data[taskName][pageName] = page.body
-
-      await client.update(application.id, getApplicationUpdateData(application))
+      await client.update(application.id, getApplicationUpdateData(updatedApplication))
     }
   }
 

--- a/server/services/assessmentService.test.ts
+++ b/server/services/assessmentService.test.ts
@@ -7,7 +7,8 @@ import AssessmentService from './assessmentService'
 import { assessmentFactory, assessmentSummaryFactory, clarificationNoteFactory } from '../testutils/factories'
 
 import { acceptanceData, placementRequestData } from '../utils/assessments/acceptanceData'
-import { getBody, updateAssessmentData } from '../form-pages/utils'
+import { getBody } from '../form-pages/utils'
+import { updateFormArtifactData } from '../form-pages/utils/updateFormArtifactData'
 import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
 import { DataServices, TaskListErrors } from '../@types/ui'
 import { ValidationError } from '../utils/errors'
@@ -18,6 +19,7 @@ import { getResponseForPage } from '../utils/applications/getResponseForPage'
 
 jest.mock('../data/assessmentClient.ts')
 jest.mock('../data/personClient.ts')
+jest.mock('../form-pages/utils/updateFormArtifactData')
 jest.mock('../form-pages/utils')
 jest.mock('../utils/applications/utils')
 jest.mock('../utils/applications/getResponses')
@@ -108,7 +110,7 @@ describe('AssessmentService', () => {
       let page: DeepMocked<TasklistPage>
 
       beforeEach(() => {
-        ;(updateAssessmentData as jest.Mock).mockReturnValue(assessment)
+        ;(updateFormArtifactData as jest.Mock).mockReturnValue(assessment)
 
         page = createMock<TasklistPage>({
           errors: () => {

--- a/server/services/assessmentService.ts
+++ b/server/services/assessmentService.ts
@@ -7,10 +7,12 @@ import {
 } from '@approved-premises/api'
 import type { DataServices } from '@approved-premises/ui'
 
+import { updateFormArtifactData } from '../form-pages/utils/updateFormArtifactData'
+import CheckYourAnswers from '../form-pages/assess/checkYourAnswers/checkYourAnswersTask/checkYourAnswers'
 import { acceptanceData } from '../utils/assessments/acceptanceData'
 import type { AssessmentClient, RestClientBuilder } from '../data'
 import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
-import { getBody, updateAssessmentData } from '../form-pages/utils'
+import { getBody } from '../form-pages/utils'
 import { ValidationError } from '../utils/errors'
 import { rejectionRationaleFromAssessmentResponses } from '../utils/assessments/utils'
 import { applicationAccepted } from '../utils/assessments/decisionUtils'
@@ -55,7 +57,7 @@ export default class AssessmentService {
       throw new ValidationError<typeof page>(errors)
     } else {
       const assessment = await this.findAssessment(request.user.token, request.params.id)
-      const updatedAssessment = updateAssessmentData(page, assessment)
+      const updatedAssessment = updateFormArtifactData(page, assessment, CheckYourAnswers)
 
       const client = this.assessmentClientFactory(request.user.token)
 

--- a/server/views/applications/tasklist.njk
+++ b/server/views/applications/tasklist.njk
@@ -32,15 +32,17 @@
           {% set applicationOrAssessment = application %}
           {% include '../partials/taskListItems.njk' %}
 
-          <li>
-            <h2 class="app-task-list__section">
-              <span class="app-task-list__section-number">
-                {{ (taskList.sections | length) + 1 }}.
+          {% if taskList.status === 'complete' %}
+
+            <li>
+              <h2 class="app-task-list__section">
+                <span class="app-task-list__section-number">
+                  {{ (taskList.sections | length) + 1 }}.
             </span>
             Submit your application
           </h2>
 
-            {{ govukCheckboxes({
+              {{ govukCheckboxes({
             idPrefix: "confirmation",
             name: "confirmation",
             errorMessage: errors.confirmation,
@@ -51,14 +53,21 @@
               }
             ]
           }) }}
-          </li>
+            </li>
+
+          {% endif %}
         </ol>
 
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+        {% if taskList.status === 'complete' %}
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-        {{ govukButton({
-          text: "Submit application"
-          }) }}
+          {{
+            govukButton({
+              text: "Submit application",
+              preventDoubleClick: true
+            })
+          }}
+        {% endif %}
       </form>
 
       {{ govukButton({

--- a/server/views/applications/tasklist.njk
+++ b/server/views/applications/tasklist.njk
@@ -19,10 +19,11 @@
         Apply for an Approved Premises (AP) placement
       </h1>
 
+      {{ showErrorSummary(errorSummary) }}
+
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2" data-cy-status>Application {{ taskList.status }}</h2>
       <p class="govuk-body govuk-!-margin-bottom-7">You have completed {{ taskList.completeSectionCount }} of {{ (taskList.sections | length) }} sections.</p>
     </div>
-    {{ showErrorSummary(errorSummary) }}
 
     <div class="govuk-grid-column-two-thirds">
       <form action="{{ paths.applications.submission({id: application.id}) }}" method="post">
@@ -42,7 +43,7 @@
             {{ govukCheckboxes({
             idPrefix: "confirmation",
             name: "confirmation",
-            errorMessage: errorObject,
+            errorMessage: errors.confirmation,
             items: [
               {
                 value: "submit",

--- a/server/views/assessments/tasklist.njk
+++ b/server/views/assessments/tasklist.njk
@@ -13,11 +13,11 @@
         {{ pageHeading }}
       </h1>
 
+      {{ showErrorSummary(errorSummary) }}
+
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2" data-cy-status>Assessment {{ taskList.status }}</h2>
       <p class="govuk-body govuk-!-margin-bottom-7">You have completed {{ taskList.completeSectionCount }} of {{ (taskList.sections | length) }} sections.</p>
     </div>
-
-    {{ showErrorSummary(errorSummary) }}
 
     <form action="{{ paths.assessments.submission({id: assessment.id}) }}" method="post">
 
@@ -37,7 +37,7 @@
             {{ govukCheckboxes({
             idPrefix: "confirmation",
             name: "confirmation",
-            errorMessage: errorObject,
+            errorMessage: errors.confirmation,
             items: [
               {
                 value: "confirmed",

--- a/server/views/assessments/tasklist.njk
+++ b/server/views/assessments/tasklist.njk
@@ -26,15 +26,16 @@
           {% set applicationOrAssessment = assessment %}
           {% include '../partials/taskListItems.njk' %}
 
-          <li>
-            <h2 class="app-task-list__section">
-              <span class="app-task-list__section-number">
-                {{ (taskList.sections | length) + 1 }}.
+          {% if taskList.status === 'complete' %}
+            <li>
+              <h2 class="app-task-list__section">
+                <span class="app-task-list__section-number">
+                  {{ (taskList.sections | length) + 1 }}.
             </span>
             Submit your assessment
           </h2>
 
-            {{ govukCheckboxes({
+              {{ govukCheckboxes({
             idPrefix: "confirmation",
             name: "confirmation",
             errorMessage: errors.confirmation,
@@ -45,14 +46,18 @@
               }
             ]
           }) }}
-          </li>
+            </li>
+          {% endif %}
         </ol>
 
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+        {% if taskList.status === 'complete' %}
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-        {{ govukButton({
-          text: "Submit application"
+          {{ govukButton({
+          text: "Submit application",
+          preventDoubleClick: true
           }) }}
+        {% endif %}
       </form>
 
       {{ govukButton({


### PR DESCRIPTION
This copies a bunch of work from CAS3 here https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/452 to: 

- invalidate the Check Your Answers screen
- fix the missing tasklist when a user does not check the confimation box
- hide the submit button until the form is complete

I've adapted some of it to work with both Apply and Assess, which hopefully makes it more portable too!