### PR TITLE
255 - Only allow withdrawing an application if the it has been submitted

### DIFF
--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -15,7 +15,7 @@ import { DateFormats } from '../dateUtils'
 import { isApplicableTier, tierBadge } from '../personUtils'
 
 import {
-  createWithdrawAnchorElement,
+  createWithdrawElement,
   dashboardTableRows,
   firstPageOfApplicationJourney,
   getApplicationType,
@@ -186,7 +186,7 @@ describe('utils', () => {
           {
             html: getStatus(applicationA),
           },
-          createWithdrawAnchorElement(applicationA.id),
+          createWithdrawElement(applicationA.id, applicationA),
         ],
         [
           {
@@ -206,7 +206,7 @@ describe('utils', () => {
           {
             html: getStatus(applicationB),
           },
-          createWithdrawAnchorElement(applicationB.id),
+          createWithdrawElement(applicationB.id, applicationB),
         ],
       ])
     })
@@ -221,6 +221,7 @@ describe('utils', () => {
         arrivalDate,
         person: { name: 'My Name' },
         risks: { tier: undefined },
+        status: 'inProgress',
       })
 
       const result = dashboardTableRows([application])
@@ -246,7 +247,7 @@ describe('utils', () => {
           {
             html: getStatus(application),
           },
-          createWithdrawAnchorElement(application.id),
+          createWithdrawElement(application.id, application),
         ],
       ])
     })
@@ -286,7 +287,7 @@ describe('utils', () => {
           {
             html: getStatus(application),
           },
-          createWithdrawAnchorElement(application.id),
+          createWithdrawElement(application.id, application),
         ],
       ])
     })
@@ -431,6 +432,23 @@ describe('utils', () => {
       })
 
       expect(getApplicationType(application)).toEqual('PIPE')
+    })
+  })
+
+  describe('createWithdrawElement', () => {
+    it('returns a link to withdraw the application if the application doesnt have a submittedAt property', () => {
+      const applicationSummary = applicationSummaryFactory.build()
+      expect(createWithdrawElement('1', applicationSummary)).toEqual({
+        html: '<a href=/applications/1/confirmWithdrawal>Withdraw</a>',
+      })
+    })
+
+    it('returns an empty string if the application has a submittedAt property', () => {
+      const applicationSummary = applicationSummaryFactory.build({ submittedAt: undefined })
+
+      expect(createWithdrawElement('1', applicationSummary)).toEqual({
+        text: '',
+      })
     })
   })
 })

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -184,7 +184,7 @@ describe('utils', () => {
             text: 'N/A',
           },
           {
-            html: getStatus(applicationB),
+            html: getStatus(applicationA),
           },
           createWithdrawAnchorElement(applicationA.id),
         ],

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -39,7 +39,7 @@ const dashboardTableRows = (applications: Array<ApplicationSummary>): Array<Tabl
         application.arrivalDate ? DateFormats.isoDateToUIDate(application.arrivalDate, { format: 'short' }) : 'N/A',
       ),
       htmlValue(getStatus(application)),
-      createWithdrawAnchorElement(application.id),
+      createWithdrawElement(application.id, application),
     ]
   })
 }
@@ -74,8 +74,11 @@ const createNameAnchorElement = (name: string, applicationId: string) => {
   )
 }
 
-export const createWithdrawAnchorElement = (applicationId: string) => {
-  return htmlValue(`<a href=${paths.applications.withdraw.confirm({ id: applicationId })}>Withdraw</a>`)
+export const createWithdrawElement = (applicationId: string, application: ApplicationSummary) => {
+  if (application?.submittedAt)
+    return htmlValue(`<a href=${paths.applications.withdraw.confirm({ id: applicationId })}>Withdraw</a>`)
+
+  return textValue('')
 }
 
 export type ApplicationOrAssessmentResponse = Record<string, Array<PageResponse>>

--- a/server/views/applications/_table.njk
+++ b/server/views/applications/_table.njk
@@ -24,7 +24,7 @@
               text: "Status"
             },
             {
-              text: "Withdraw"
+              text: "Actions"
             }
           ],
           rows: rows

--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -20,7 +20,7 @@
             {{ govukTabs({
                 items: [
                     {
-                        label: "In Progress",
+                        label: "In progress",
                         id: "applications",
                         panel: {
                             html: applicationsTable("Applications", dashboardTableRows(applications.inProgress))


### PR DESCRIPTION
Previously we showed the 'Withdraw' button for all applications but we would like to narrow this down to only applications that haven't been submitted. If the application has been submitted we will show a message stating 'Cannot withdraw' in the 'Withdraw' column 