### PR TITLE
(245) Change dates for bookings

### DIFF
--- a/integration_tests/mockApis/booking.ts
+++ b/integration_tests/mockApis/booking.ts
@@ -2,6 +2,7 @@ import type { Booking } from '@approved-premises/api'
 
 import { getMatchingRequests, stubFor } from '../../wiremock'
 import { bedspaceConflictResponseBody, errorStub } from '../../wiremock/utils'
+import paths from '../../server/paths/api'
 
 export default {
   stubBookingCreate: (args: { premisesId: string; booking: Booking }) =>
@@ -66,6 +67,33 @@ export default {
         body: JSON.stringify(args.bookings),
       },
     }),
+  stubDateChange: (args: { premisesId: string; bookingId: string }) =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: paths.premises.bookings.dateChange({ premisesId: args.premisesId, bookingId: args.bookingId }),
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+      },
+    }),
+  stubDateChangeErrors: (args: { premisesId: string; bookingId: string; params: Array<string> }) =>
+    stubFor(
+      errorStub(
+        args.params,
+        paths.premises.bookings.dateChange({ premisesId: args.premisesId, bookingId: args.bookingId }),
+      ),
+    ),
+  verifyDateChange: async (args: { premisesId: string; bookingId: string }) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: paths.premises.bookings.dateChange({ premisesId: args.premisesId, bookingId: args.bookingId }),
+      })
+    ).body.requests,
   verifyBookingCreate: async (args: { premisesId }) =>
     (await getMatchingRequests({ method: 'POST', url: `/premises/${args.premisesId}/bookings` })).body.requests,
 }

--- a/integration_tests/pages/manage/booking/dateChanges/new.ts
+++ b/integration_tests/pages/manage/booking/dateChanges/new.ts
@@ -1,0 +1,34 @@
+import Page from '../../../page'
+import paths from '../../../../../server/paths/manage'
+
+export default class NewDateChange extends Page {
+  constructor() {
+    super('Change placement date')
+  }
+
+  static visit(premisesId: string, bookingId: string): NewDateChange {
+    cy.visit(paths.bookings.dateChanges.new({ premisesId, bookingId }))
+    return new NewDateChange()
+  }
+
+  completeForm(newArrivalDate: string, newDepartureDate: string): void {
+    const arrivalDate = new Date(Date.parse(newArrivalDate))
+    const departureDate = new Date(Date.parse(newDepartureDate))
+
+    this.checkDatesToChangeOption('newArrivalDate')
+
+    cy.get('#newArrivalDate-day').type(arrivalDate.getDate().toString())
+    cy.get('#newArrivalDate-month').type(`${arrivalDate.getMonth() + 1}`)
+    cy.get('#newArrivalDate-year').type(arrivalDate.getFullYear().toString())
+
+    this.checkDatesToChangeOption('newDepartureDate')
+
+    cy.get('#newDepartureDate-day').type(departureDate.getDate().toString())
+    cy.get('#newDepartureDate-month').type(`${departureDate.getMonth() + 1}`)
+    cy.get('#newDepartureDate-year').type(departureDate.getFullYear().toString())
+  }
+
+  checkDatesToChangeOption(option: 'newArrivalDate' | 'newDepartureDate'): void {
+    cy.get(`input[name="datesToChange"][value="${option}"]`).click()
+  }
+}

--- a/integration_tests/pages/manage/index.ts
+++ b/integration_tests/pages/manage/index.ts
@@ -10,6 +10,8 @@ import PremisesShowPage from './premisesShow'
 import BedsListPage from './bed/bedsList'
 import BedShowPage from './bed/bedShow'
 
+import NewDateChangePage from './booking/dateChanges/new'
+
 import BookingConfirmationPage from './booking/confirmation'
 import BookingFindPage from './booking/find'
 import BookingNewPage from './booking/new'
@@ -37,4 +39,5 @@ export {
   BedsListPage,
   BedShowPage,
   CalendarPage,
+  NewDateChangePage,
 }

--- a/integration_tests/tests/manage/dateChanges.cy.ts
+++ b/integration_tests/tests/manage/dateChanges.cy.ts
@@ -1,0 +1,84 @@
+import { BookingShowPage, NewDateChangePage } from '../../pages/manage'
+import Page from '../../pages/page'
+import { bookingFactory, premisesFactory } from '../../../server/testutils/factories'
+
+context('Date Changes', () => {
+  const premises = premisesFactory.build()
+  const booking = bookingFactory.build()
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    // Given I am logged in
+    cy.signIn()
+    // And I have a booking for a premises
+    cy.task('stubBookingGet', { premisesId: premises.id, booking })
+  })
+
+  it('changes a date', () => {
+    cy.task('stubDateChange', { premisesId: premises.id, bookingId: booking.id })
+
+    // And I visit the date change page
+    const dateChangePage = NewDateChangePage.visit(premises.id, booking.id)
+
+    // And I change the date of my booking
+    dateChangePage.completeForm('2023-01-01', '2023-03-02')
+    dateChangePage.clickSubmit()
+
+    // Then I should see a confirmation message
+    const bookingPage = Page.verifyOnPage(BookingShowPage, [premises.id, booking])
+    bookingPage.shouldShowBanner('Booking changed successfully')
+
+    // And the change booking endpoint should have been called with the correct parameters
+    cy.task('verifyDateChange', {
+      premisesId: premises.id,
+      bookingId: booking.id,
+    }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+
+      expect(requestBody.newArrivalDate).equal('2023-01-01')
+      expect(requestBody.newDepartureDate).equal('2023-03-02')
+    })
+  })
+
+  it('show arrival errors when the user chooses to change a date, but does not enter dates', () => {
+    cy.task('stubDateChangeErrors', {
+      premisesId: premises.id,
+      bookingId: booking.id,
+      params: ['newArrivalDate', 'newDepartureDate'],
+    })
+
+    // And I visit the date change page
+    const dateChangePage = NewDateChangePage.visit(premises.id, booking.id)
+
+    // And I check the date change checkboxes, but don't add dates
+    dateChangePage.checkDatesToChangeOption('newArrivalDate')
+    dateChangePage.checkDatesToChangeOption('newDepartureDate')
+
+    // And I click submit
+    dateChangePage.clickSubmit()
+
+    // Then I should see errors
+    dateChangePage.shouldShowErrorMessagesForFields(['newArrivalDate', 'newDepartureDate'])
+  })
+
+  it('show arrival errors when the API returns an error', () => {
+    cy.task('stubDateChangeErrors', {
+      premisesId: premises.id,
+      bookingId: booking.id,
+      params: ['newArrivalDate', 'newDepartureDate'],
+    })
+
+    // And I visit the date change page
+    const dateChangePage = NewDateChangePage.visit(premises.id, booking.id)
+
+    // And I click submit
+    dateChangePage.clickSubmit()
+
+    // Then I should see errors
+    dateChangePage.shouldShowErrorMessagesForFields(['newArrivalDate', 'newDepartureDate'])
+  })
+})

--- a/server/controllers/manage/dateChangesController.test.ts
+++ b/server/controllers/manage/dateChangesController.test.ts
@@ -1,0 +1,179 @@
+import type { NextFunction, Request, Response } from 'express'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+
+import type { ErrorsAndUserInput } from '@approved-premises/ui'
+
+import { DateFormats } from '../../utils/dateUtils'
+import BookingService from '../../services/bookingService'
+import DateChangesController from './dateChangesController'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
+
+import { bookingFactory } from '../../testutils/factories'
+import paths from '../../paths/manage'
+
+jest.mock('../../utils/validation')
+
+describe('dateChangesController', () => {
+  const token = 'SOME_TOKEN'
+
+  let request: DeepMocked<Request>
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const premisesId = 'premisesId'
+  const bookingId = 'bookingId'
+  const requestParams = { user: { token }, params: { premisesId, bookingId } }
+
+  const booking = bookingFactory.build()
+
+  const bookingService = createMock<BookingService>({})
+
+  const controller = new DateChangesController(bookingService)
+
+  beforeEach(() => {
+    bookingService.find.mockResolvedValue(booking)
+  })
+
+  describe('new', () => {
+    request = createMock<Request>(requestParams)
+
+    it('should render the form', async () => {
+      ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
+        return { errors: {}, errorSummary: [], userInput: {} }
+      })
+
+      const requestHandler = controller.new()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('bookings/dateChanges/new', {
+        premisesId,
+        bookingId,
+        booking,
+        pageHeading: 'Change placement date',
+        errors: {},
+        errorSummary: [],
+      })
+
+      expect(bookingService.find).toHaveBeenCalledWith(token, premisesId, bookingId)
+    })
+
+    it('renders the form with errors and user input if an error has been sent to the flash', async () => {
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
+
+      const requestHandler = controller.new()
+
+      await requestHandler({ ...request, params: { premisesId, bookingId } }, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('bookings/dateChanges/new', {
+        premisesId,
+        bookingId,
+        booking,
+        pageHeading: 'Change placement date',
+        errors: errorsAndUserInput.errors,
+        errorSummary: errorsAndUserInput.errorSummary,
+        ...errorsAndUserInput.userInput,
+      })
+    })
+  })
+
+  describe('create', () => {
+    const bodies = {
+      'with new arrival date': {
+        body: {
+          datesToChange: 'newArrivalDate',
+          ...DateFormats.isoDateToDateInputs('2022-01-01', 'newArrivalDate'),
+        },
+        expectedPayload: {
+          newArrivalDate: '2022-01-01',
+        },
+      },
+      'with new departure date': {
+        body: {
+          datesToChange: 'newDepartureDate',
+          ...DateFormats.isoDateToDateInputs('2022-01-01', 'newDepartureDate'),
+        },
+        expectedPayload: {
+          newDepartureDate: '2022-01-01',
+        },
+      },
+      'with new departure date and arrival date': {
+        body: {
+          datesToChange: ['newArrivalDate', 'newDepartureDate'],
+          ...DateFormats.isoDateToDateInputs('2022-01-01', 'newDepartureDate'),
+          ...DateFormats.isoDateToDateInputs('2022-01-01', 'newArrivalDate'),
+        },
+        expectedPayload: {
+          newArrivalDate: '2022-01-01',
+          newDepartureDate: '2022-01-01',
+        },
+      },
+      'with departure date and arrival date specified, but change flags not selected': {
+        body: {
+          datesToChange: [] as Array<undefined>,
+          ...DateFormats.isoDateToDateInputs('2022-01-01', 'newDepartureDate'),
+          ...DateFormats.isoDateToDateInputs('2022-01-01', 'newArrivalDate'),
+        },
+        expectedPayload: {},
+      },
+      'with an unexpected body': {
+        body: {
+          datesToChange: ['someFakeDate'],
+          ...DateFormats.isoDateToDateInputs('2022-01-01', 'someFakeDate'),
+        },
+        expectedPayload: {},
+      },
+    }
+
+    it.each(Object.keys(bodies))('creates a Date Change and redirects to the confirmation page %s', async key => {
+      const { expectedPayload, body } = bodies[key]
+
+      bookingService.moveBooking.mockImplementationOnce(() => Promise.resolve())
+
+      const requestHandler = controller.create()
+
+      request = createMock<Request>({ ...requestParams, body })
+
+      await requestHandler(request, response, next)
+
+      expect(bookingService.changeDates).toHaveBeenCalledWith(
+        token,
+        request.params.premisesId,
+        request.params.bookingId,
+        expectedPayload,
+      )
+
+      expect(request.flash).toHaveBeenCalledWith('success', 'Booking changed successfully')
+
+      expect(response.redirect).toHaveBeenCalledWith(
+        paths.bookings.show({ premisesId: request.params.premisesId, bookingId: request.params.bookingId }),
+      )
+    })
+
+    it('should catch the validation errors when the API returns an error', async () => {
+      const requestHandler = controller.create()
+
+      request = createMock<Request>(requestParams)
+
+      const err = new Error()
+
+      bookingService.changeDates.mockImplementation(() => {
+        throw err
+      })
+
+      await requestHandler(request, response, next)
+
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+        request,
+        response,
+        err,
+        paths.bookings.dateChanges.new({
+          bookingId: request.params.bookingId,
+          premisesId: request.params.premisesId,
+        }),
+      )
+    })
+  })
+})

--- a/server/controllers/manage/dateChangesController.ts
+++ b/server/controllers/manage/dateChangesController.ts
@@ -1,0 +1,63 @@
+import type { Request, RequestHandler, Response } from 'express'
+
+import type { NewDateChange } from '@approved-premises/api'
+
+import { flattenCheckboxInput } from '../../utils/formUtils'
+import { BookingService } from '../../services'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
+import { DateFormats } from '../../utils/dateUtils'
+
+import paths from '../../paths/manage'
+
+export default class DateChangeController {
+  constructor(private readonly bookingService: BookingService) {}
+
+  new(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, bookingId } = req.params
+      const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
+
+      const booking = await this.bookingService.find(req.user.token, premisesId, bookingId)
+
+      res.render('bookings/dateChanges/new', {
+        premisesId,
+        bookingId,
+        booking,
+        pageHeading: 'Change placement date',
+        errors,
+        errorSummary,
+        ...userInput,
+      })
+    }
+  }
+
+  create(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, bookingId } = req.params
+
+      const payload: NewDateChange = {}
+      const datesToChange = flattenCheckboxInput(req.body.datesToChange)
+
+      datesToChange.forEach((itemKey: keyof NewDateChange) => {
+        payload[itemKey] = DateFormats.dateAndTimeInputsToIsoString(req.body, itemKey)[itemKey]
+      })
+
+      try {
+        await this.bookingService.changeDates(req.user.token, premisesId, bookingId, payload)
+
+        req.flash('success', 'Booking changed successfully')
+        res.redirect(paths.bookings.show({ premisesId, bookingId }))
+      } catch (err) {
+        catchValidationErrorOrPropogate(
+          req,
+          res,
+          err,
+          paths.bookings.dateChanges.new({
+            bookingId,
+            premisesId,
+          }),
+        )
+      }
+    }
+  }
+}

--- a/server/controllers/manage/index.ts
+++ b/server/controllers/manage/index.ts
@@ -11,6 +11,7 @@ import LostBedsController from './lostBedsController'
 import PeopleController from '../peopleController'
 import MoveBedsController from './moveBedsController'
 import BedsController from './premises/bedsController'
+import DateChangesController from './dateChangesController'
 
 import type { Services } from '../../services'
 
@@ -30,11 +31,13 @@ export const controllers = (services: Services) => {
   const peopleController = new PeopleController(services.personService)
   const bedsController = new BedsController(services.premisesService)
   const moveBedsController = new MoveBedsController(services.bookingService, services.premisesService)
+  const dateChangesController = new DateChangesController(services.bookingService)
 
   return {
     premisesController,
     bookingsController,
     bookingExtensionsController,
+    dateChangesController,
     arrivalsController,
     nonArrivalsController,
     departuresController,

--- a/server/data/bookingClient.test.ts
+++ b/server/data/bookingClient.test.ts
@@ -4,6 +4,7 @@ import {
   arrivalFactory,
   bookingFactory,
   cancellationFactory,
+  dateChangeFactory,
   departureFactory,
   newArrivalFactory,
   newBookingFactory,
@@ -291,6 +292,30 @@ describeClient('BookingClient', provider => {
       })
 
       await bookingClient.moveBooking('premisesId', 'bookingId', payload)
+    })
+  })
+
+  describe('changeDates', () => {
+    it('should change dates for a booking', async () => {
+      const dateChange = dateChangeFactory.build()
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to move a booking',
+        withRequest: {
+          method: 'POST',
+          path: paths.premises.bookings.dateChange({ premisesId: 'premisesId', bookingId: 'bookingId' }),
+          body: dateChange,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+        },
+      })
+
+      await bookingClient.changeDates('premisesId', 'bookingId', dateChange)
     })
   })
 })

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -8,6 +8,7 @@ import type {
   NewBedMove,
   NewBooking,
   NewCancellation,
+  NewDateChange,
   NewDeparture,
   NewExtension,
   NewNonarrival,
@@ -83,6 +84,13 @@ export default class BookingClient {
     await this.restClient.post({
       path: paths.premises.bookings.move({ premisesId, bookingId }),
       data: move,
+    })
+  }
+
+  async changeDates(premisesId: string, bookingId: string, dateChange: NewDateChange): Promise<void> {
+    await this.restClient.post({
+      path: paths.premises.bookings.dateChange({ premisesId, bookingId }),
+      data: dateChange,
     })
   }
 

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -66,7 +66,13 @@
   "newDepartureDate": {
     "empty": "You must enter a new departure date",
     "invalid": "The departure date is an invalid date",
-    "beforeExistingDepartureDate": "The new departure date must be after the Booking's current departure date"
+    "beforeExistingDepartureDate": "The new departure date must be after the Booking's current departure date",
+    "beforeBookingArrivalDate": "The departure date and time must be after the booking's arrival date",
+    "departureDateCannotBeExtendedOnArrivedBooking": "The departure date and cannot be changed after the booking has been marked as arrived"
+  },
+  "newArrivalDate": {
+    "empty": "You must enter a new arrival date",
+    "invalid": "The arrival date is an invalid date"
   },
   "startDate": {
     "empty": "You must enter a start date",

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -29,6 +29,7 @@ const managePaths = {
   room: singlePremisesPath.path('rooms/:roomId'),
   bookings: {
     move: bookingPath.path('moves'),
+    dateChange: bookingPath.path('date-changes'),
   },
 }
 
@@ -102,6 +103,7 @@ export default {
     room: managePaths.room,
     bookings: {
       move: managePaths.bookings.move,
+      dateChange: managePaths.bookings.dateChange,
     },
     calendar: managePaths.premises.show.path('calendar'),
   },

--- a/server/paths/manage.ts
+++ b/server/paths/manage.ts
@@ -25,6 +25,8 @@ const lostBedsPath = singlePremisesPath.path('beds/:bedId/lost-beds')
 
 const bedsPath = singlePremisesPath.path('beds')
 
+const dateChangesPath = bookingPath.path('date-changes')
+
 const paths = {
   premises: {
     index: premisesPath,
@@ -44,6 +46,10 @@ const paths = {
     show: bookingPath,
     create: newBookingPath,
     confirm: bookingPath.path('confirmation'),
+    dateChanges: {
+      new: dateChangesPath.path('new'),
+      create: dateChangesPath,
+    },
     extensions: {
       new: extensionsPath.path('new'),
       create: extensionsPath,

--- a/server/routes/manage.ts
+++ b/server/routes/manage.ts
@@ -12,6 +12,7 @@ export default function routes(controllers: Controllers, router: Router, service
   const { get, post } = actions(router, services.auditService)
 
   const {
+    dateChangesController,
     premisesController,
     bookingsController,
     bookingExtensionsController,
@@ -140,6 +141,17 @@ export default function routes(controllers: Controllers, router: Router, service
       {
         path: paths.bookings.moves.new.pattern,
         auditEvent: 'BED_MOVE_FAILURE',
+      },
+    ],
+  })
+
+  get(paths.bookings.dateChanges.new.pattern, dateChangesController.new(), { auditEvent: 'NEW_DATE_CHANGE' })
+  post(paths.bookings.dateChanges.create.pattern, dateChangesController.create(), {
+    auditEvent: 'DATE_CHANGE_SUCCESS',
+    redirectAuditEventSpecs: [
+      {
+        path: paths.bookings.dateChanges.new.pattern,
+        auditEvent: 'DATE_CHANGE_FAILURE',
       },
     ],
   })

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -3,7 +3,7 @@ import { DateFormats } from '../utils/dateUtils'
 import BookingService from './bookingService'
 import BookingClient from '../data/bookingClient'
 
-import { bookingExtensionFactory, bookingFactory, newBookingFactory } from '../testutils/factories'
+import { bookingExtensionFactory, bookingFactory, dateChangeFactory, newBookingFactory } from '../testutils/factories'
 import { Booking, NewBedMove } from '../@types/shared'
 
 jest.mock('../data/bookingClient.ts')
@@ -213,6 +213,17 @@ describe('BookingService', () => {
 
       expect(bookingClientFactory).toHaveBeenCalledWith(token)
       expect(bookingClient.moveBooking).toHaveBeenCalledWith('premisesID', 'bookingId', payload)
+    })
+  })
+
+  describe('changeDates', () => {
+    it('on success returns the arrival that has been posted', async () => {
+      const payload = dateChangeFactory.build()
+
+      await service.changeDates(token, 'premisesID', 'bookingId', payload)
+
+      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClient.changeDates).toHaveBeenCalledWith('premisesID', 'bookingId', payload)
     })
   })
 })

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -1,6 +1,6 @@
 import { addDays, isAfter, isBefore, isEqual, isWithinInterval } from 'date-fns'
 
-import type { Booking, Extension, NewBedMove, NewBooking, NewExtension } from '@approved-premises/api'
+import type { Booking, Extension, NewBedMove, NewBooking, NewDateChange, NewExtension } from '@approved-premises/api'
 import type { GroupedListofBookings } from '@approved-premises/ui'
 
 import type { RestClientBuilder } from '../data'
@@ -73,6 +73,12 @@ export default class BookingService {
     const bookingClient = this.bookingClientFactory(token)
 
     await bookingClient.moveBooking(premisesId, bookingId, move)
+  }
+
+  async changeDates(token: string, premisesId: string, bookingId: string, dateChange: NewDateChange): Promise<void> {
+    const bookingClient = this.bookingClientFactory(token)
+
+    await bookingClient.changeDates(premisesId, bookingId, dateChange)
   }
 
   bookingsArrivingTodayOrLate(bookings: Array<Booking>, today: Date): Array<Booking> {

--- a/server/testutils/factories/dateChange.ts
+++ b/server/testutils/factories/dateChange.ts
@@ -1,0 +1,10 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { NewDateChange } from '@approved-premises/api'
+import { DateFormats } from '../../utils/dateUtils'
+
+export default Factory.define<NewDateChange>(() => ({
+  newArrivalDate: DateFormats.dateObjToIsoDate(faker.date.soon()),
+  newDepartureDate: DateFormats.dateObjToIsoDate(faker.date.future()),
+}))

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -32,6 +32,7 @@ import clarificationNoteFactory from './clarificationNote'
 import contingencyPlanPartnerFactory from './contingencyPlanPartner'
 import contingencyPlanQuestionsBodyFactory from './contingencyPlanQuestionsBody'
 import dateCapacityFactory from './dateCapacity'
+import dateChangeFactory from './dateChange'
 import departureFactory from './departure'
 import documentFactory from './document'
 import lostBedFactory from './lostBed'
@@ -102,6 +103,7 @@ export {
   clarificationNoteFactory,
   contingencyPlanPartnerFactory,
   contingencyPlanQuestionsBodyFactory,
+  dateChangeFactory,
   dateCapacityFactory,
   departureFactory,
   documentFactory,

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -147,14 +147,14 @@ describe('bookingUtils', () => {
               href: paths.bookings.nonArrivals.new({ premisesId, bookingId: booking.id }),
             },
             {
-              text: 'Extend placement',
-              classes: 'govuk-button--secondary',
-              href: paths.bookings.extensions.new({ premisesId, bookingId: booking.id }),
-            },
-            {
               text: 'Cancel placement',
               classes: 'govuk-button--secondary',
               href: paths.bookings.cancellations.new({ premisesId, bookingId: booking.id }),
+            },
+            {
+              text: 'Change placement dates',
+              classes: 'govuk-button--secondary',
+              href: paths.bookings.dateChanges.new({ premisesId, bookingId: booking.id }),
             },
           ],
         },

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -64,14 +64,14 @@ export const bookingActions = (booking: Booking, premisesId: string): Array<Iden
         href: paths.bookings.nonArrivals.new({ premisesId, bookingId: booking.id }),
       })
       items.push({
-        text: 'Extend placement',
-        classes: 'govuk-button--secondary',
-        href: paths.bookings.extensions.new({ premisesId, bookingId: booking.id }),
-      })
-      items.push({
         text: 'Cancel placement',
         classes: 'govuk-button--secondary',
         href: paths.bookings.cancellations.new({ premisesId, bookingId: booking.id }),
+      })
+      items.push({
+        text: 'Change placement dates',
+        classes: 'govuk-button--secondary',
+        href: paths.bookings.dateChanges.new({ premisesId, bookingId: booking.id }),
       })
     }
 

--- a/server/utils/errors.ts
+++ b/server/utils/errors.ts
@@ -25,3 +25,9 @@ export class TasklistAPIError extends Error {
     this.field = field
   }
 }
+
+export class ErrorWithData extends Error {
+  constructor(private readonly data: Record<string, unknown>) {
+    super()
+  }
+}

--- a/server/views/bookings/dateChanges/new.njk
+++ b/server/views/bookings/dateChanges/new.njk
@@ -1,0 +1,147 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+		text: "Back",
+		href: paths.bookings.show({ premisesId: premisesId, bookingId: booking.id })
+	}) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form action="{{ paths.bookings.dateChanges.create({ premisesId: premisesId, bookingId: booking.id }) }}" method="post">
+
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+        <h1>{{ pageHeading }}</h1>
+
+        {{ govukSummaryList({
+                rows: [
+                   {
+                    key: {
+                        text: "Name"
+                    },
+                    value: {
+                        text: booking.person.name
+                    }
+                    },
+                    {
+                    key: {
+                        text: "CRN"
+                    },
+                    value: {
+                        text: booking.person.crn
+                    }
+                    },
+                    {
+                    key: {
+                        text: "Current arrival date"
+                    },
+                    value: {
+                        text: formatDate(booking.arrivalDate)
+                    }
+                    },
+                    {
+                    key: {
+                        text: "Current departure date"
+                    },
+                    value: {
+                        text: formatDate(booking.departureDate)
+                    }
+                    },
+                    {
+                    key: {
+                        text: "Bed"
+                    },
+                    value: {
+                        text: booking.bed.name
+                    }
+                    }
+                ]
+            }) }}
+        {{ showErrorSummary(errorSummary) }}
+
+        {% set newArrivalDateHtml %}
+        {{ govukDateInput({
+                    id: "newArrivalDate",
+                    namePrefix: "newArrivalDate",
+                    fieldset: {
+                    legend: {
+                        text: "What is the new arrival date?",
+                        classes: "govuk-fieldset__legend--s"
+                        }
+                    },
+                    hint: {
+                    text: "For example, 27 3 2007"
+                    },
+                    items: dateFieldValues('newArrivalDate', errors),
+                    errorMessage: errors.newArrivalDate
+                }) }}
+        {% endset -%}
+
+        {% set newDepartureDateHtml %}
+        {{ govukDateInput({
+                    id: "newDepartureDate",
+                    namePrefix: "newDepartureDate",
+                    fieldset: {
+                    legend: {
+                        text: "What is the new departure date?",
+                        classes: "govuk-fieldset__legend--s"
+                        }
+                    },
+                    hint: {
+                    text: "For example, 27 3 2007"
+                    },
+                    items: dateFieldValues('newDepartureDate', errors),
+                    errorMessage: errors.newDepartureDate
+                }) }}
+        {% endset -%}
+
+        {{ govukCheckboxes({
+          name: "datesToChange",
+          fieldset: {
+            legend: {
+              text: "What dates do you want to change?",
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          hint: {
+            text: "Select all options that are relevant to you."
+          },
+          items: [
+            {
+              value: "newArrivalDate",
+              text: "Arrival Date",
+              checked: ('newArrivalDate' in (datesToChange or [])),
+              conditional: {
+                html: newArrivalDateHtml
+              }
+            },
+            {
+              value: "newDepartureDate",
+              text: "Departure Date",
+              checked: ('newDepartureDate' in (datesToChange or [])),
+              conditional: {
+                html: newDepartureDateHtml
+              }
+            }
+          ]
+        }) }}
+
+        {{ govukButton({
+                    text: "Submit"
+                }) }}
+      </div>
+    </div>
+  {% endblock %}


### PR DESCRIPTION
This allows bookings that have not been marked as arrived yet to have their start and / or end dates changed.

# Screenshots

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/43feac38-99e8-4b0b-a184-7a0d986fbd24)

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/b100fca5-bf99-4b10-bcc8-66cab26f359f)


