### PR TITLE
Fix: Show 'Withdraw' link for applications that haven't been submitted

### DIFF
--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -236,13 +236,18 @@ context('Apply', () => {
 
   it('allows me to withdraw an in progress application', function test() {
     // Given I have completed an application
-    const inProgressApplication: Application = { ...this.application, status: 'inProgress', createdByUserId: '123' }
+    const inProgressApplication: Application = {
+      ...this.application,
+      status: 'inProgress',
+      createdByUserId: '123',
+      submittedAt: undefined,
+    }
     cy.task('stubApplicationGet', { application: inProgressApplication })
     cy.task('stubApplications', [inProgressApplication])
     cy.task('stubApplicationWithdrawn', { applicationId: inProgressApplication.id })
 
     // And I visit the list page
-    const listPage = ListPage.visit([], [inProgressApplication], [])
+    const listPage = ListPage.visit([inProgressApplication], [], [])
 
     // When I click 'Withdraw' on an application
     listPage.clickWithdraw()

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -437,14 +437,14 @@ describe('utils', () => {
 
   describe('createWithdrawElement', () => {
     it('returns a link to withdraw the application if the application doesnt have a submittedAt property', () => {
-      const applicationSummary = applicationSummaryFactory.build()
+      const applicationSummary = applicationSummaryFactory.build({ submittedAt: undefined })
       expect(createWithdrawElement('1', applicationSummary)).toEqual({
         html: '<a href=/applications/1/confirmWithdrawal>Withdraw</a>',
       })
     })
 
     it('returns an empty string if the application has a submittedAt property', () => {
-      const applicationSummary = applicationSummaryFactory.build({ submittedAt: undefined })
+      const applicationSummary = applicationSummaryFactory.build()
 
       expect(createWithdrawElement('1', applicationSummary)).toEqual({
         text: '',

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -75,7 +75,7 @@ const createNameAnchorElement = (name: string, applicationId: string) => {
 }
 
 export const createWithdrawElement = (applicationId: string, application: ApplicationSummary) => {
-  if (application?.submittedAt)
+  if (!application?.submittedAt)
     return htmlValue(`<a href=${paths.applications.withdraw.confirm({ id: applicationId })}>Withdraw</a>`)
 
   return textValue('')


### PR DESCRIPTION
This logic was the opposite of what it should be