### PR TITLE
Chore/throw error object on unhandled API error

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -15,6 +15,7 @@ generic-service:
     HMPPS_AUTH_URL: 'https://sign-in.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api.prison.service.justice.gov.uk'
     COMMUNITY_ACCOMMODATION_API_SERVICE_NAME: approved-premises
+    COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 20000
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/server/config.ts
+++ b/server/config.ts
@@ -93,7 +93,7 @@ export default {
         response: 10000,
         deadline: 10000,
       },
-      agent: new AgentConfig(10000),
+      agent: new AgentConfig(Number(get('COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE', 10000))),
       serviceName: get('COMMUNITY_ACCOMMODATION_API_SERVICE_NAME', 'approved-premises', requiredInProduction),
     },
     audit: {

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -112,8 +112,20 @@ describe('catchValidationErrorOrPropogate', () => {
   })
 
   it('throws the error if the error is not the type we expect', () => {
-    const err = new Error()
-    expect(() => catchValidationErrorOrPropogate(request, response, err, 'some/url')).toThrowError(err)
+    const err = new Error('Some unhandled error')
+    err.name = 'SomeUnhandledError'
+    err.stack = 'STACK_GOES_HERE'
+
+    const result = () => catchValidationErrorOrPropogate(request, response, err, 'some/url')
+
+    expect(result).toThrowError(err)
+    expect(result).toThrowError(
+      expect.objectContaining({
+        message: 'Some unhandled error',
+        name: 'SomeUnhandledError',
+        stack: 'STACK_GOES_HERE',
+      }),
+    )
   })
 
   it('throws an error if the property is not found in the error lookup', () => {

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -110,7 +110,11 @@ const extractValidationErrors = (error: SanitisedError | Error): Record<string, 
     }
   }
 
-  throw error
+  const unsantisedError = new Error(error.message)
+  unsantisedError.name = 'name' in error ? error.name : undefined
+  unsantisedError.stack = error.stack
+
+  throw unsantisedError
 }
 
 const generateErrors = (params: Array<InvalidParams>): Record<string, string> => {


### PR DESCRIPTION
When a timeout or another unhanlded API error occurs, we get a message `Non-Error exception captured with keys: message, stack` sent to Sentry. This is because we’re throwing a plain object, rather than an error, and this makes it hard to see what’s going on. Rather than throwing the sanitised error, we recreate the Error object and throw that instead, which should make reviewing the errors easier.

We also increase the timeout value in prod and makes the number configurable to hopefully cut down on the number of  timeout errors. It’s by no means a fix, but will hopefully reduce user frustrations