### PR TITLE
Emergency Applications should be 28 days or less

### DIFF
--- a/server/utils/applications/noticeTypeFromApplication.test.ts
+++ b/server/utils/applications/noticeTypeFromApplication.test.ts
@@ -11,8 +11,8 @@ jest.mock('./arrivalDateFromApplication')
 describe('noticeTypeFromApplication', () => {
   const application = applicationFactory.build({})
 
-  it('returns emergency if the arrival date is less than seven days away', () => {
-    const date = add(new Date(), { days: 4 })
+  it('returns emergency if the arrival date is less than 28 days away', () => {
+    const date = add(new Date(), { days: 14 })
     const arrivalDate = DateFormats.dateObjToIsoDate(date)
 
     ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(arrivalDate)

--- a/server/utils/applications/noticeTypeFromApplication.ts
+++ b/server/utils/applications/noticeTypeFromApplication.ts
@@ -13,7 +13,7 @@ export const noticeTypeFromApplication = (application: Application): Application
   const arrivalDateObj = DateFormats.isoToDateObj(arrivalDateString)
 
   switch (true) {
-    case differenceInDays(arrivalDateObj, new Date()) < 7:
+    case differenceInDays(arrivalDateObj, new Date()) <= 28:
       return 'emergency'
     case differenceInCalendarMonths(arrivalDateObj, new Date()) < 4:
       return 'short_notice'

--- a/server/utils/applications/shouldShowContingencyPlanPages.test.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.test.ts
@@ -1,15 +1,14 @@
-import { addDays } from 'date-fns'
 import { applicationFactory } from '../../testutils/factories'
 import {
   shouldShowContingencyPlanPartnersPages,
   shouldShowContingencyPlanQuestionsPage,
 } from './shouldShowContingencyPlanPages'
 import { mockOptionalQuestionResponse, mockQuestionResponse } from '../../testutils/mockQuestionResponse'
-import { arrivalDateFromApplication } from './arrivalDateFromApplication'
-import { DateFormats } from '../dateUtils'
+import { noticeTypeFromApplication } from './noticeTypeFromApplication'
 
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
 jest.mock('./arrivalDateFromApplication')
+jest.mock('./noticeTypeFromApplication')
 
 const application = applicationFactory.build()
 
@@ -61,16 +60,21 @@ describe('shouldShowContingencyPlanQuestionsScreen', () => {
     jest.clearAllMocks()
   })
 
-  it('returns true if the application arrival date is in less than or equal to 28 days"', () => {
-    ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(DateFormats.dateObjToIsoDate(new Date()))
+  it('returns true if the application notice type is emergency"', () => {
+    ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('emergency')
 
     expect(shouldShowContingencyPlanQuestionsPage(application)).toEqual(true)
   })
 
-  it('returns true if the application arrival date is in less than 28 days"', () => {
-    const today = new Date()
-    ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(DateFormats.dateObjToIsoDate(addDays(today, 28)))
+  it('returns false if the application notice type is standard"', () => {
+    ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('standard')
 
-    expect(shouldShowContingencyPlanQuestionsPage(application)).toEqual(true)
+    expect(shouldShowContingencyPlanQuestionsPage(application)).toEqual(false)
+  })
+
+  it('returns false if the application notice type is standard"', () => {
+    ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('short_notice')
+
+    expect(shouldShowContingencyPlanQuestionsPage(application)).toEqual(false)
   })
 })

--- a/server/utils/applications/shouldShowContingencyPlanPages.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.ts
@@ -1,4 +1,3 @@
-import { differenceInDays } from 'date-fns'
 import SelectApType from '../../form-pages/apply/reasons-for-placement/type-of-ap/apType'
 import ReleaseType from '../../form-pages/apply/reasons-for-placement/basic-information/releaseType'
 import SentenceType from '../../form-pages/apply/reasons-for-placement/basic-information/sentenceType'
@@ -8,8 +7,7 @@ import {
   retrieveQuestionResponseFromFormArtifact,
 } from '../retrieveQuestionResponseFromFormArtifact'
 import EndDates from '../../form-pages/apply/reasons-for-placement/basic-information/endDates'
-import { DateFormats } from '../dateUtils'
-import { arrivalDateFromApplication } from './arrivalDateFromApplication'
+import { noticeTypeFromApplication } from './noticeTypeFromApplication'
 
 export const shouldShowContingencyPlanPartnersPages = (application: Application) => {
   let releaseType: ReleaseTypeOption
@@ -41,14 +39,5 @@ export const shouldShowContingencyPlanPartnersPages = (application: Application)
   return false
 }
 
-export const shouldShowContingencyPlanQuestionsPage = (application: Application) => {
-  const arrivalDateString = arrivalDateFromApplication(application)
-
-  if (!arrivalDateString) return false
-
-  const arrivalDateObj = DateFormats.isoToDateObj(arrivalDateString)
-
-  if (differenceInDays(arrivalDateObj, new Date()) <= 28) return true
-
-  return false
-}
+export const shouldShowContingencyPlanQuestionsPage = (application: Application) =>
+  noticeTypeFromApplication(application) === 'emergency'


### PR DESCRIPTION
We've since discovered, that, instead of 7 days, an application should be treated as emergency if it is 28 days or less away. This has resulted in confusion with people getting assigned applications they assume to be emergency applications, even though they are not supposed to be getting sent emergency applications.  This is a small change that changes the `noticeTypeFromApplication` rule to 28 days.
