### PR TITLE
(317) Apply -  Select preferred APs

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -303,6 +303,19 @@
       "restrictionDetail": "Restrictions go here",
       "alternativeRadiusAccepted": "yes",
       "alternativeRadius": "70"
+    },
+    "preferred-aps": {
+      "preferredAp1": "1",
+      "preferredAp2": "2",
+      "preferredAp3": "3",
+      "preferredAp4": "",
+      "preferredAp5": "",
+      "selectedAps": [
+        { "text": "Ap One", "value": "1" },
+        { "text": "Ap Two", "value": "2" },
+        { "text": "Ap Three", "value": "3" },
+        { "text": "No preference", "value": "" }
+      ]
     }
   },
   "access-and-healthcare": {

--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -34,6 +34,7 @@ import {
   documentFactory,
   oasysSectionsFactory,
   oasysSelectionFactory,
+  premisesFactory,
   prisonCaseNotesFactory,
 } from '../../server/testutils/factories'
 import { documentsFromApplication } from '../../server/utils/assessments/documentUtils'
@@ -92,6 +93,7 @@ export default class ApplyHelper {
     this.uiRisks = uiRisks
     this.stubPersonEndpoints()
     this.stubApplicationEndpoints()
+    this.stubPremisesEndpoint()
     if (oasysMissing) {
       this.stubOasys404()
     } else {
@@ -169,6 +171,13 @@ export default class ApplyHelper {
       ...this.pages.moveOn,
       ...this.selectedDocuments,
     ].length
+  }
+
+  private stubPremisesEndpoint() {
+    const premises1 = premisesFactory.build({ id: '1' })
+    const premises2 = premisesFactory.build({ id: '2' })
+    const premises3 = premisesFactory.build({ id: '3' })
+    cy.task('stubPremises', [premises1, premises2, premises3])
   }
 
   private stubPersonEndpoints() {
@@ -701,7 +710,12 @@ export default class ApplyHelper {
     describeLocationFactorsPage.completeForm()
     describeLocationFactorsPage.clickSubmit()
 
-    this.pages.locationFactors = [describeLocationFactorsPage]
+    const preferredApsPage = new ApplyPages.PreferredAps(this.application)
+
+    preferredApsPage.completeForm()
+    preferredApsPage.clickSubmit()
+
+    this.pages.locationFactors = [describeLocationFactorsPage, preferredApsPage]
 
     // Then I should be taken back to the task list
     const tasklistPage = Page.verifyOnPage(ApplyPages.TaskListPage)

--- a/integration_tests/pages/apply/index.ts
+++ b/integration_tests/pages/apply/index.ts
@@ -32,6 +32,7 @@ import PlacementDurationPage from './placementDuration'
 import PlacementPurposePage from './placementPurpose'
 import PlacementStartPage from './placementDate'
 import PlansInPlacePage from './plansInPlace'
+import PreferredAps from './preferredAps'
 import PreviousPlacements from './previousPlacements'
 import ReasonForShortNoticePage from './reasonForShortNoticePage'
 import RehabilitativeInterventions from './rehabilitativeInterventions'
@@ -94,6 +95,7 @@ export {
   PlacementPurposePage,
   PlacementStartPage,
   PlansInPlacePage,
+  PreferredAps,
   PreviousPlacements,
   ReasonForShortNoticePage,
   RehabilitativeInterventions,

--- a/integration_tests/pages/apply/preferredAps.ts
+++ b/integration_tests/pages/apply/preferredAps.ts
@@ -1,0 +1,26 @@
+import { ApprovedPremisesApplication } from '@approved-premises/api'
+import paths from '../../../server/paths/apply'
+
+import ApplyPage from './applyPage'
+
+export default class PreferredAps extends ApplyPage {
+  constructor(application: ApprovedPremisesApplication) {
+    super(
+      'Select a preferred AP',
+      application,
+      'location-factors',
+      'preferred-aps',
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'location-factors',
+        page: 'describe-location-factors',
+      }),
+    )
+  }
+
+  completeForm() {
+    this.selectSelectOptionFromPageBody('preferredAp1')
+    this.selectSelectOptionFromPageBody('preferredAp2')
+    this.selectSelectOptionFromPageBody('preferredAp3')
+  }
+}

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -262,6 +262,9 @@ export type DataServices = Partial<{
   userService: {
     getUserById: (token: string, id: string) => Promise<User>
   }
+  premisesService: {
+    getAll: (token: string) => Promise<Array<Premises>>
+  }
 }>
 
 export type AssessmentGroupingCategory = 'status' | 'allocation'

--- a/server/controllers/apply/index.ts
+++ b/server/controllers/apply/index.ts
@@ -8,9 +8,13 @@ import DocumentsController from './people/documentsController'
 import type { Services } from '../../services'
 
 export const controllers = (services: Services) => {
-  const { applicationService, personService } = services
+  const { applicationService, personService, premisesService } = services
   const applicationsController = new ApplicationsController(applicationService, personService)
-  const pagesController = new PagesController(applicationService, { personService, applicationService })
+  const pagesController = new PagesController(applicationService, {
+    personService,
+    applicationService,
+    premisesService,
+  })
   const offencesController = new OffencesController(personService)
   const documentsController = new DocumentsController(personService)
 

--- a/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.test.ts
@@ -33,7 +33,7 @@ describe('DescribeLocationFactors', () => {
   })
 
   itShouldHavePreviousValue(new DescribeLocationFactors({}), 'dashboard')
-  itShouldHaveNextValue(new DescribeLocationFactors({}), '')
+  itShouldHaveNextValue(new DescribeLocationFactors({}), 'preferred-aps')
 
   describe('errors', () => {
     it('should ensure all required attributes are specified', () => {

--- a/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.test.ts
@@ -3,7 +3,7 @@ import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../share
 
 import DescribeLocationFactors from './describeLocationFactors'
 
-describe('ConvictedOffences', () => {
+describe('DescribeLocationFactors', () => {
   describe('body', () => {
     it('should set the body and uppercase the postcode', () => {
       const page = new DescribeLocationFactors({ postcodeArea: 'e17' })

--- a/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.ts
@@ -58,7 +58,7 @@ export default class DescribeLocationFactors implements TasklistPage {
   }
 
   next() {
-    return ''
+    return 'preferred-aps'
   }
 
   errors() {

--- a/server/form-pages/apply/risk-and-need-factors/location-factors/index.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/index.ts
@@ -2,10 +2,11 @@
 import { Task } from '../../../utils/decorators'
 
 import DescribeLocationFactors from './describeLocationFactors'
+import PreferredAps from './preferredAps'
 
 @Task({
   slug: 'location-factors',
   name: 'Describe location factors',
-  pages: [DescribeLocationFactors],
+  pages: [DescribeLocationFactors, PreferredAps],
 })
 export default class LocationFactors {}

--- a/server/form-pages/apply/risk-and-need-factors/location-factors/preferredAps.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/preferredAps.test.ts
@@ -1,0 +1,106 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+
+import PreferredAps from './preferredAps'
+import { PremisesService } from '../../../../services'
+import { applicationFactory, premisesFactory } from '../../../../testutils/factories'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+
+describe('PreferredAps', () => {
+  let premisesService: DeepMocked<PremisesService>
+  const application = applicationFactory.build()
+
+  const ap1 = premisesFactory.build({ id: '1', name: 'AP 1' })
+  const ap2 = premisesFactory.build({ id: '2', name: 'AP 2' })
+  const ap3 = premisesFactory.build({ id: '3', name: 'AP 3' })
+  const ap4 = premisesFactory.build({ id: '4', name: 'AP 4' })
+  const ap5 = premisesFactory.build({ id: '5', name: 'AP 5' })
+
+  const aps = [ap1, ap2, ap3, ap4, ap5, { name: 'No preference', id: 'no-preference' }]
+
+  const body = {
+    preferredAp1: '1',
+    preferredAp2: '2',
+    preferredAp3: '3',
+    preferredAp4: '4',
+    preferredAp5: '5',
+    selectedAps: aps.map(ap => ({ value: ap.id, text: ap.name })),
+  }
+
+  describe('body', () => {
+    it('should set the body and uppercase the postcode', () => {
+      const page = new PreferredAps(body)
+
+      expect(page.body).toEqual(body)
+    })
+  })
+
+  describe('initialize', () => {
+    const getAll = jest.fn().mockResolvedValue([{ value: '1', text: 'Premises 1' }])
+    const token = 'token'
+
+    beforeEach(() => {
+      premisesService = createMock<PremisesService>({
+        getAll,
+      })
+    })
+
+    it('should call the Premises service and set the list of Premises on the page class', async () => {
+      const page = await PreferredAps.initialize(body, application, token, { premisesService })
+
+      expect(page.allPremises).toEqual([{ value: '1', text: 'Premises 1' }])
+      expect(getAll).toHaveBeenCalledWith(token)
+    })
+
+    it('should convert the selectedAps from strings to objects containing text and value properties', async () => {
+      const page = await PreferredAps.initialize({ ...body, selectedAps: ['1'] }, application, token, {
+        premisesService,
+      })
+
+      expect(page.selectedAps).toEqual([{ value: '1', text: 'Premises 1' }])
+    })
+  })
+
+  itShouldHaveNextValue(new PreferredAps(body), '')
+  itShouldHavePreviousValue(new PreferredAps(body), 'describe-location-factors')
+
+  describe('response', () => {
+    it('returns a human readable response for the selected 5 selected APs', () => {
+      const page = new PreferredAps(body)
+
+      page.allPremises = aps
+      expect(page.response()).toEqual({
+        'First choice AP': 'AP 1',
+        'Second choice AP': 'AP 2',
+        'Third choice AP': 'AP 3',
+        'Fourth choice AP': 'AP 4',
+        'Fifth choice AP': 'AP 5',
+      })
+    })
+
+    it('returns a human readable response for the selected APs when only 1 is selected', () => {
+      const page = new PreferredAps({
+        ...body,
+        preferredAp1: '1',
+        preferredAp2: 'no-preference',
+        preferredAp3: 'no-preference',
+        preferredAp4: 'no-preference',
+        preferredAp5: 'no-preference',
+      })
+
+      page.allPremises = aps
+      expect(page.response()).toEqual({
+        'First choice AP': 'AP 1',
+        'Second choice AP': 'No preference',
+        'Third choice AP': 'No preference',
+        'Fourth choice AP': 'No preference',
+        'Fifth choice AP': 'No preference',
+      })
+    })
+  })
+
+  describe('errors', () => {
+    it('should return an error if there isnt a first preference AP selected', () => {
+      expect(new PreferredAps({}).errors()).toEqual({ preferredAp1: 'You must select one preferred Approved Premises' })
+    })
+  })
+})

--- a/server/form-pages/apply/risk-and-need-factors/location-factors/preferredAps.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/preferredAps.ts
@@ -1,0 +1,96 @@
+import type { DataServices, SelectOption, TaskListErrors } from '@approved-premises/ui'
+import { ApprovedPremisesApplication as Application, ApprovedPremises } from '../../../../@types/shared'
+
+import { Page } from '../../../utils/decorators'
+
+import TasklistPage from '../../../tasklistPage'
+import { numberToOrdinal } from '../../../../utils/utils'
+
+export type PreferredApsBody = {
+  preferredAp1: string
+  preferredAp2: string
+  preferredAp3: string
+  preferredAp4: string
+  preferredAp5: string
+  selectedAps: Array<SelectOption>
+}
+
+const preferredAps = new Array(5).fill('').map((_, i) => `preferredAp${i + 1}`)
+
+@Page({
+  name: 'preferred-aps',
+  bodyProperties: [...preferredAps, 'selectedAps'],
+})
+export default class PreferredAps implements TasklistPage {
+  title = 'Select a preferred AP'
+
+  allPremises: Array<ApprovedPremises | { name: string; id: string }> = []
+
+  preferredApOptions = preferredAps
+
+  preferredApLabels = this.preferredApOptions.map((_, i) => `${numberToOrdinal(i)} choice AP`)
+
+  selectedAps: Array<SelectOption>
+
+  body: PreferredApsBody
+
+  constructor(private _: Partial<PreferredApsBody>) {}
+
+  static async initialize(
+    body: Record<string, unknown>,
+    _: Application,
+    token: string,
+    { premisesService }: DataServices,
+  ) {
+    const allPremises = await premisesService.getAll(token)
+
+    const selectedAps: Array<SelectOption> = []
+
+    preferredAps.forEach(id => {
+      const selectedAp = allPremises.find(premises => {
+        return premises.value === body[id]
+      })
+
+      if (selectedAp) {
+        selectedAps.push(selectedAp)
+      }
+    })
+
+    const page = new PreferredAps({ selectedAps, ...body })
+
+    page.selectedAps = selectedAps
+    page.allPremises = allPremises
+
+    return page
+  }
+
+  previous() {
+    return 'describe-location-factors'
+  }
+
+  next() {
+    return ''
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.preferredAp1) {
+      errors.preferredAp1 = 'You must select one preferred Approved Premises'
+    }
+
+    return errors
+  }
+
+  response() {
+    const response = {}
+
+    this.preferredApOptions.forEach((key, i) => {
+      const apName = this.body.selectedAps.find(premises => premises.value === this.body[key])?.text
+
+      response[this.preferredApLabels[i]] = apName ?? 'No preference'
+    })
+
+    return response
+  }
+}

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -1280,6 +1280,43 @@
               "type": "string"
             }
           }
+        },
+        "preferred-aps": {
+          "type": "object",
+          "properties": {
+            "preferredAp1": {
+              "type": "string"
+            },
+            "preferredAp2": {
+              "type": "string"
+            },
+            "preferredAp3": {
+              "type": "string"
+            },
+            "preferredAp4": {
+              "type": "string"
+            },
+            "preferredAp5": {
+              "type": "string"
+            },
+            "selectedAps": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  },
+                  "selected": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -29,6 +29,30 @@ describe('PremisesService', () => {
     premisesClientFactory.mockReturnValue(premisesClient)
   })
 
+  describe('getAll', () => {
+    it('calls the all method of the premises client and returns the response', async () => {
+      const premises = premisesFactory.buildList(2)
+      premisesClient.all.mockResolvedValue(premises)
+
+      const result = await service.getAll(token)
+
+      expect(result).toEqual(premises)
+      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClient.all).toHaveBeenCalled()
+    })
+
+    it('sorts the premises returned by name', async () => {
+      const premisesA = premisesFactory.build({ name: 'A' })
+      const premisesB = premisesFactory.build({ name: 'B' })
+
+      premisesClient.all.mockResolvedValue([premisesB, premisesA])
+
+      const result = await service.getAll(token)
+
+      expect(result).toEqual([premisesA, premisesB])
+    })
+  })
+
   describe('getStaffMembers', () => {
     it('on success returns the person given their CRN', async () => {
       const staffMembers = staffMemberFactory.buildList(5)

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -127,6 +127,10 @@ export default class PremisesService {
     return ''
   }
 
+  /**
+   * getPremisesSelectList
+   * @deprecated per ADR-0008: manipulation of view data should happen in the views
+   */
   async getPremisesSelectList(token: string): Promise<Array<{ text: string; value: string }>> {
     const premisesClient = this.premisesClientFactory(token)
     const premises = await premisesClient.all()

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -9,6 +9,21 @@ import getDateRangesWithNegativeBeds, { NegativeDateRange, mapApiOccupancyToUiOc
 export default class PremisesService {
   constructor(private readonly premisesClientFactory: RestClientBuilder<PremisesClient>) {}
 
+  async getAll(token: string): Promise<Array<ApprovedPremises>> {
+    const premisesClient = this.premisesClientFactory(token)
+    const premises = await premisesClient.all()
+
+    return premises.sort((a, b) => {
+      if (a.name < b.name) {
+        return -1
+      }
+      if (a.name > b.name) {
+        return 1
+      }
+      return 0
+    })
+  }
+
   async getStaffMembers(token: string, premisesId: string): Promise<Array<StaffMember>> {
     const premisesClient = this.premisesClientFactory(token)
 

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -11,6 +11,7 @@ import {
   kebabCase,
   linkTo,
   mapApiPersonRisksForUi,
+  numberToOrdinal,
   removeBlankSummaryListItems,
   sentenceCase,
 } from './utils'
@@ -196,6 +197,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addFilter('sentenceCase', sentenceCase)
   njkEnv.addFilter('kebabCase', kebabCase)
 
+  njkEnv.addGlobal('numberToOrdinal', numberToOrdinal)
   njkEnv.addGlobal('dashboardTableRows', dashboardTableRows)
   njkEnv.addGlobal('navigationItems', navigationItems)
 

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -7,6 +7,7 @@ import {
   initialiseName,
   linkTo,
   mapApiPersonRisksForUi,
+  numberToOrdinal,
   objectIfNotEmpty,
   pascalCase,
   removeBlankSummaryListItems,
@@ -314,5 +315,20 @@ describe('resolvePath', () => {
     it('returns the object if it does have keys', () => {
       expect(objectIfNotEmpty({ key: 'value' })).toEqual({ key: 'value' })
     })
+  })
+})
+
+describe('numberToOrdinal', () => {
+  it('returns the ordinal for a number', () => {
+    expect(numberToOrdinal(0)).toEqual('First')
+    expect(numberToOrdinal(1)).toEqual('Second')
+    expect(numberToOrdinal(2)).toEqual('Third')
+    expect(numberToOrdinal(3)).toEqual('Fourth')
+    expect(numberToOrdinal(4)).toEqual('Fifth')
+  })
+
+  it('returns undefined if the number is >5 or <0', () => {
+    expect(numberToOrdinal(6)).toBeUndefined()
+    expect(numberToOrdinal(-1)).toBeUndefined()
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -159,3 +159,6 @@ export const objectIfNotEmpty = <T>(object: Record<string, unknown> | T | undefi
   }
   return undefined
 }
+
+export const numberToOrdinal = (number: number | string): string =>
+  ['First', 'Second', 'Third', 'Fourth', 'Fifth'][Number(number)]

--- a/server/views/applications/pages/layout.njk
+++ b/server/views/applications/pages/layout.njk
@@ -14,6 +14,7 @@
 {% from "../../components/formFields/form-page-input/macro.njk" import formPageInput %}
 {% from "../../components/formFields/form-page-checkboxes/macro.njk" import formPageCheckboxes %}
 {% from "../../components/formFields/form-page-textarea/macro.njk" import formPageTextarea %}
+{% from "../../components/formFields/form-page-select/macro.njk" import formPageSelect %}
 
 {% extends "../../partials/layout.njk" %}
 

--- a/server/views/applications/pages/location-factors/preferred-aps.njk
+++ b/server/views/applications/pages/location-factors/preferred-aps.njk
@@ -1,0 +1,24 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+  <h1 class="govuk-heading-l">
+    {{ page.title }}
+  </h1>
+
+  {% for preferredAp in page.preferredApOptions %}
+
+    {{ formPageSelect({
+      fieldName: preferredAp,
+      label: {
+        text: page.preferredApLabels[loop.index0], 
+        classes: "govuk-label--m"
+      },
+      items: convertObjectsToSelectOptions(page.allPremises, 'No preference', 'name', 'id', preferredAp)
+    }, fetchContext()) }}
+
+    {%endfor%}
+
+  {% endblock %}

--- a/server/views/components/formFields/form-page-select/macro.njk
+++ b/server/views/components/formFields/form-page-select/macro.njk
@@ -1,0 +1,20 @@
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+
+{% macro formPageSelect(params, context) %}
+    {% set selectItems = [] %}
+
+    {% for item in params.items %}
+        {% set selectItems = (selectItems.push(mergeObjects(item, {
+            selected: context[params.fieldName] == item.value
+        })), selectItems) %}
+    {% endfor %}
+
+    {{
+      govukSelect(
+        mergeObjects(
+          mergeObjects(params, { items: selectItems }),
+          { id: params.fieldName, name: params.fieldName, errorMessage: context.errors[params.fieldName] }
+        )
+      )
+  }}
+{% endmacro %}


### PR DESCRIPTION
# Context
PPs need to be able to select a list of their top 5 APs. 
This screen allows for that. Initially they can use 5 select boxes but in future this could be augmented with autocompletes and only adding further inputs if the user requests them via javascript. Consider it MVP.
[Trello card](https://trello.com/c/PkFQW3p2/317-select-preferred-ap-screen)

# Changes in this PR
- There is some arranging and refactoring before we add the main changes:
- Add the Page Class for the Preferred APs screen. This is slightly complicated by the need to lookup APs from the AP
- Add the view for the Preferred APs screen.
## Screenshots of UI changes
![Apply -- allows completion of application emergency flow (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/04f0ce8e-03b4-4eb3-8bc1-9d7090b83551)
![Apply -- allows completion of application emergency flow](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/ba084fda-5b5e-46b6-89ab-e90cb0368ea0)

