### PR TITLE
Fix: Date of Offence checkboxes

### DIFF
--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/dateOfOffence.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/dateOfOffence.test.ts
@@ -80,22 +80,8 @@ describe('DateOfOffence', () => {
       const result = new DateOfOffence({ arsonOffence: ['previous'] }).renderTableRow('arsonOffence')
       expect(result).toEqual([
         { text: 'Arson offence' },
-        {
-          html: `<div class="govuk-checkboxes" data-module="govuk-checkboxes">
-            <div class="govuk-checkboxes__item">
-                <label class="govuk-label govuk-checkboxes__label" for="arsonOffence-current">
-                  <span class="govuk-visually-hidden">Arson offence: current</span></label>
-                <input class="govuk-checkboxes__input" id="arsonOffence-current" name="arsonOffence" type="checkbox" value="current" >
-            </div>`,
-        },
-        {
-          html: `<div class="govuk-checkboxes" data-module="govuk-checkboxes">
-            <div class="govuk-checkboxes__item">
-                <label class="govuk-label govuk-checkboxes__label" for="arsonOffence-previous">
-                  <span class="govuk-visually-hidden">Arson offence: previous</span></label>
-                <input class="govuk-checkboxes__input" id="arsonOffence-previous" name="arsonOffence" type="checkbox" value="previous" checked>
-            </div>`,
-        },
+        DateOfOffence.checkbox('arsonOffence', 'current', false),
+        DateOfOffence.checkbox('arsonOffence', 'previous', true),
       ])
     })
   })
@@ -109,6 +95,34 @@ describe('DateOfOffence', () => {
         new DateOfOffence({}).renderTableRow('inPersonSexualOffence'),
         new DateOfOffence({}).renderTableRow('onlineSexualOffence'),
       ])
+    })
+  })
+
+  describe('checkbox', () => {
+    it('it renders the markup for a unselected checkbox', () => {
+      expect(DateOfOffence.checkbox('arsonOffence', 'current', false)).toEqual({
+        html: `<div class="govuk-checkboxes" data-module="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="arsonOffence-current" name="arsonOffence" type="checkbox" value="current" >
+              <label class="govuk-label govuk-checkboxes__label" for="arsonOffence-current">
+                <span class="govuk-visually-hidden">Arson offence: current</span>
+              </label>
+          </div>
+        </div>`,
+      })
+    })
+
+    it('it renders the markup for a selected checkbox', () => {
+      expect(DateOfOffence.checkbox('arsonOffence', 'previous', true)).toEqual({
+        html: `<div class="govuk-checkboxes" data-module="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="arsonOffence-previous" name="arsonOffence" type="checkbox" value="previous" checked>
+              <label class="govuk-label govuk-checkboxes__label" for="arsonOffence-previous">
+                <span class="govuk-visually-hidden">Arson offence: previous</span>
+              </label>
+          </div>
+        </div>`,
+      })
     })
   })
 })

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/dateOfOffence.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/dateOfOffence.ts
@@ -82,8 +82,8 @@ export default class DateOfOffence implements TasklistPage {
   renderTableRow(offence: string) {
     return [
       this.textValue(sentenceCase(offence)),
-      this.checkbox(offence, 'current', this.isSelected(offence, 'current')),
-      this.checkbox(offence, 'previous', this.isSelected(offence, 'previous')),
+      DateOfOffence.checkbox(offence, 'current', this.isSelected(offence, 'current')),
+      DateOfOffence.checkbox(offence, 'previous', this.isSelected(offence, 'previous')),
     ]
   }
 
@@ -91,26 +91,29 @@ export default class DateOfOffence implements TasklistPage {
     return Object.keys(offences).map(offence => this.renderTableRow(offence))
   }
 
+  static checkbox(offence: string, date: 'current' | 'previous', checked: boolean) {
+    const id = `${offence}-${date}`
+
+    return this.htmlValue(
+      `<div class="govuk-checkboxes" data-module="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="${id}" name="${offence}" type="checkbox" value="${date}" ${
+            checked ? 'checked' : ''
+          }>
+              <label class="govuk-label govuk-checkboxes__label" for="${id}">
+                <span class="govuk-visually-hidden">${sentenceCase(offence)}: ${date}</span>
+              </label>
+          </div>
+        </div>`,
+    )
+  }
+
   private textValue(value: string) {
     return { text: value }
   }
 
-  private htmlValue(value: string) {
+  private static htmlValue(value: string) {
     return { html: value }
-  }
-
-  private checkbox(offence: string, date: 'current' | 'previous', checked: boolean) {
-    const id = `${offence}-${date}`
-    return this.htmlValue(
-      `<div class="govuk-checkboxes" data-module="govuk-checkboxes">
-            <div class="govuk-checkboxes__item">
-                <label class="govuk-label govuk-checkboxes__label" for="${id}">
-                  <span class="govuk-visually-hidden">${sentenceCase(offence)}: ${date}</span></label>
-                <input class="govuk-checkboxes__input" id="${id}" name="${offence}" type="checkbox" value="${date}" ${
-                  checked ? 'checked' : ''
-                }>
-            </div>`,
-    )
   }
 
   private isSelected(offence: string, timePeriod: string) {


### PR DESCRIPTION
A misordering of the `<input>`/`<label>` elements were causing the checks not to show. 