### PR TITLE
(324) Add a CRU dashboard to show all Placement Applications

### DIFF
--- a/integration_tests/mockApis/placementRequests.ts
+++ b/integration_tests/mockApis/placementRequests.ts
@@ -20,6 +20,21 @@ export default {
         jsonBody: placementRequests,
       },
     }),
+
+  stubPlacementRequestsDashboard: (placementRequests: Array<PlacementRequest>): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: paths.placementRequests.dashboard.pattern,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: placementRequests,
+      },
+    }),
   stubPlacementRequest: (placementRequestDetail: PlacementRequestDetail): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/pages/admin/placementApplications/listPage.ts
+++ b/integration_tests/pages/admin/placementApplications/listPage.ts
@@ -1,0 +1,21 @@
+import Page from '../../page'
+import paths from '../../../../server/paths/admin'
+
+import { PlacementRequest } from '../../../../server/@types/shared'
+import { shouldShowTableRows } from '../../../helpers'
+import { dashboardTableRows } from '../../../../server/utils/placementRequests/table'
+
+export default class ListPage extends Page {
+  constructor(private readonly placementRequests: Array<PlacementRequest>) {
+    super('Placement requests')
+  }
+
+  static visit(placementRequests: Array<PlacementRequest>): ListPage {
+    cy.visit(paths.admin.placementRequests.index({}))
+    return new ListPage(placementRequests)
+  }
+
+  shouldShowPlacementRequests(): void {
+    shouldShowTableRows(this.placementRequests, dashboardTableRows)
+  }
+}

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -1,0 +1,27 @@
+import ListPage from '../../pages/admin/placementApplications/listPage'
+
+import { placementRequestFactory } from '../../../server/testutils/factories'
+
+context('Placement Requests', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+  })
+
+  it('shows a list of placement requests', () => {
+    cy.task('stubAuthUser')
+
+    // Given I am logged in
+    cy.signIn()
+
+    const placementRequests = placementRequestFactory.buildList(2)
+
+    cy.task('stubPlacementRequestsDashboard', placementRequests)
+
+    // When I visit the tasks dashboard
+    const listPage = ListPage.visit(placementRequests)
+
+    // Then I should see a list of placement requests
+    listPage.shouldShowPlacementRequests()
+  })
+})

--- a/server/controllers/admin/index.ts
+++ b/server/controllers/admin/index.ts
@@ -1,0 +1,15 @@
+/* istanbul ignore file */
+
+import AdminPlacementRequestsController from './placementRequestsController'
+import type { Services } from '../../services'
+
+export const controllers = (services: Services) => {
+  const { placementRequestService } = services
+  const adminPlacementRequestsController = new AdminPlacementRequestsController(placementRequestService)
+
+  return {
+    adminPlacementRequestsController,
+  }
+}
+
+export { AdminPlacementRequestsController }

--- a/server/controllers/admin/placementRequestsController.test.ts
+++ b/server/controllers/admin/placementRequestsController.test.ts
@@ -1,0 +1,44 @@
+import type { NextFunction, Request, Response } from 'express'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+
+import PlacementRequestsController from './placementRequestsController'
+
+import { PlacementRequestService } from '../../services'
+import { placementRequestFactory } from '../../testutils/factories'
+
+jest.mock('../../utils/applications/utils')
+jest.mock('../../utils/applications/getResponses')
+
+describe('PlacementRequestsController', () => {
+  const token = 'SOME_TOKEN'
+
+  const request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const placementRequestService = createMock<PlacementRequestService>({})
+
+  let placementRequestsController: PlacementRequestsController
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    placementRequestsController = new PlacementRequestsController(placementRequestService)
+  })
+
+  describe('index', () => {
+    it('should render the placement requests template', async () => {
+      const placementRequests = placementRequestFactory.buildList(2)
+      placementRequestService.getDashboard.mockResolvedValue(placementRequests)
+
+      const requestHandler = placementRequestsController.index()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('admin/placementRequests/index', {
+        pageHeading: 'Placement requests',
+        placementRequests,
+      })
+      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token)
+    })
+  })
+})

--- a/server/controllers/admin/placementRequestsController.ts
+++ b/server/controllers/admin/placementRequestsController.ts
@@ -1,0 +1,17 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+import { PlacementRequestService } from '../../services'
+
+export default class PlacementRequestsController {
+  constructor(private readonly placementRequestService: PlacementRequestService) {}
+
+  index(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      const placementRequests = await this.placementRequestService.getDashboard(req.user.token)
+
+      res.render('admin/placementRequests/index', {
+        pageHeading: 'Placement requests',
+        placementRequests,
+      })
+    }
+  }
+}

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -4,6 +4,7 @@ import { controllers as applyControllers } from './apply'
 import { controllers as assessControllers } from './assess'
 import { controllers as matchControllers } from './match'
 import { controllers as manageControllers } from './manage'
+import { controllers as adminControllers } from './admin'
 import TasksController from './tasksController'
 import AllocationsController from './tasks/allocationsController'
 
@@ -32,6 +33,7 @@ export const controllers = (services: Services) => {
     ...assessControllers(services),
     ...matchControllers(services),
     ...manageControllers(services),
+    ...adminControllers(services),
   }
 }
 

--- a/server/data/placementRequestClient.test.ts
+++ b/server/data/placementRequestClient.test.ts
@@ -45,6 +45,32 @@ describeClient('placementRequestClient', provider => {
     })
   })
 
+  describe('dashboard', () => {
+    it('makes a get request to the placementRequests dashboard endpoint', async () => {
+      const placementRequests = placementRequestFactory.buildList(2)
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get the placement requests dashboard view',
+        withRequest: {
+          method: 'GET',
+          path: paths.placementRequests.dashboard.pattern,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: placementRequests,
+        },
+      })
+
+      const result = await placementRequestClient.dashboard()
+
+      expect(result).toEqual(placementRequests)
+    })
+  })
+
   describe('find', () => {
     it('makes a get request to the placementRequest endpoint', async () => {
       const placementRequestDetail = placementRequestDetailFactory.build()

--- a/server/data/placementRequestClient.ts
+++ b/server/data/placementRequestClient.ts
@@ -23,6 +23,12 @@ export default class PlacementRequestClient {
     >
   }
 
+  async dashboard(): Promise<Array<PlacementRequest>> {
+    return (await this.restClient.get({ path: paths.placementRequests.dashboard.pattern })) as Promise<
+      Array<PlacementRequest>
+    >
+  }
+
   async find(id: string): Promise<PlacementRequestDetail> {
     return (await this.restClient.get({
       path: paths.placementRequests.show({ id }),

--- a/server/paths/admin.ts
+++ b/server/paths/admin.ts
@@ -1,0 +1,12 @@
+import { path } from 'static-path'
+
+const adminPath = path('/admin')
+const placementRequestsPath = adminPath.path('placement-requests')
+
+export default {
+  admin: {
+    placementRequests: {
+      index: placementRequestsPath,
+    },
+  },
+}

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -144,6 +144,7 @@ export default {
   placementRequests: {
     index: placementRequestsPath,
     show: placementRequestPath,
+    dashboard: placementRequestsPath.path('dashboard'),
     booking: placementRequestPath.path('booking'),
     bookingNotMade: placementRequestPath.path('booking-not-made'),
   },

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -1,0 +1,20 @@
+/* istanbul ignore file */
+
+import { Router } from 'express'
+import { Controllers } from '../controllers'
+import type { Services } from '../services'
+
+import paths from '../paths/admin'
+import actions from './utils'
+
+export default function routes(controllers: Controllers, router: Router, services: Partial<Services>): Router {
+  const { get } = actions(router, services.auditService)
+
+  const { adminPlacementRequestsController } = controllers
+
+  get(paths.admin.placementRequests.index.pattern, adminPlacementRequestsController.index(), {
+    auditEvent: 'ADMIN_LIST_PLACEMENT_REQUESTS',
+  })
+
+  return router
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -12,6 +12,7 @@ import matchRoutes from './match'
 import manageRoutes from './manage'
 import tasksRoutes from './tasks'
 import placementApplicationRoutes from './placementApplications'
+import adminRoutes from './admin'
 
 export default function routes(controllers: Controllers, services: Partial<Services>): Router {
   const router = Router()
@@ -28,6 +29,7 @@ export default function routes(controllers: Controllers, services: Partial<Servi
   manageRoutes(controllers, router, services)
   tasksRoutes(controllers, router, services)
   placementApplicationRoutes(controllers, router, services)
+  adminRoutes(controllers, router, services)
 
   return router
 }

--- a/server/services/placementRequestService.test.ts
+++ b/server/services/placementRequestService.test.ts
@@ -46,6 +46,20 @@ describe('placementRequestService', () => {
     })
   })
 
+  describe('getDashboard', () => {
+    it('calls the find method on the placementRequest client', async () => {
+      const placementRequests = placementRequestFactory.buildList(4, { status: 'notMatched' })
+      placementRequestClient.dashboard.mockResolvedValue(placementRequests)
+
+      const result = await service.getDashboard(token)
+
+      expect(result).toEqual(placementRequests)
+
+      expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
+      expect(placementRequestClient.dashboard).toHaveBeenCalled()
+    })
+  })
+
   describe('getPlacementRequest', () => {
     it('calls the find method on the placementRequest client', async () => {
       const placementRequestDetail: PlacementRequestDetail = placementRequestDetailFactory.build()

--- a/server/services/placementRequestService.ts
+++ b/server/services/placementRequestService.ts
@@ -3,6 +3,7 @@ import {
   NewBookingNotMade,
   NewPlacementRequestBooking,
   NewPlacementRequestBookingConfirmation,
+  PlacementRequest,
   PlacementRequestDetail,
 } from '@approved-premises/api'
 import { RestClientBuilder } from '../data'
@@ -27,6 +28,12 @@ export default class PlacementRequestService {
     })
 
     return results
+  }
+
+  async getDashboard(token: string): Promise<Array<PlacementRequest>> {
+    const placementRequestClient = this.placementRequestClientFactory(token)
+
+    return placementRequestClient.dashboard()
   }
 
   async getPlacementRequest(token: string, id: string): Promise<PlacementRequestDetail> {

--- a/server/utils/placementRequests/table.test.ts
+++ b/server/utils/placementRequests/table.test.ts
@@ -1,27 +1,95 @@
 import { add } from 'date-fns'
-import { placementRequestTaskFactory } from '../../testutils/factories'
-import { dueDateCell, expectedArrivalDateCell, nameCell, releaseTypeCell, tableRows } from './table'
+import { placementRequestFactory, placementRequestTaskFactory } from '../../testutils/factories'
+import {
+  dashboardTableRows,
+  dueDateCell,
+  durationCell,
+  expectedArrivalDateCell,
+  nameCell,
+  releaseTypeCell,
+  statusCell,
+  tableRows,
+} from './table'
 import { DateFormats } from '../dateUtils'
 import { allReleaseTypes } from '../applications/releaseTypeUtils'
 import { crnCell, tierCell } from '../tableUtils'
+import { PlacementRequestStatus } from '../../@types/shared'
 
 describe('tableUtils', () => {
   describe('nameCell', () => {
-    it('returns the name of the service user and a link', () => {
+    it('returns the name of the service user and a link with a task', () => {
       const task = placementRequestTaskFactory.build()
 
       expect(nameCell(task)).toEqual({
         html: `<a href="/placement-requests/${task.id}" data-cy-placementRequestId="${task.id}">${task.personName}</a>`,
       })
     })
+
+    it('returns the name of the service user and a link with a placement request', () => {
+      const placementRequest = placementRequestFactory.build()
+
+      expect(nameCell(placementRequest)).toEqual({
+        html: `<a href="/placement-requests/${placementRequest.id}" data-cy-placementRequestId="${placementRequest.id}">${placementRequest.person.name}</a>`,
+      })
+    })
+
+    it('returns an empty cell if the personName is blank', () => {
+      const task = placementRequestTaskFactory.build({ personName: null })
+
+      expect(nameCell(task)).toEqual({
+        html: '',
+      })
+    })
+
+    it('returns an empty cell if the personName is not present', () => {
+      const task = placementRequestFactory.build({ person: null })
+
+      expect(nameCell(task)).toEqual({
+        html: '',
+      })
+    })
   })
 
   describe('expectedArrivalDateCell', () => {
-    it('returns a formatted arrival date', () => {
+    it('returns a formatted arrival date with a task', () => {
       const task = placementRequestTaskFactory.build({ expectedArrival: '2022-01-01' })
 
       expect(expectedArrivalDateCell(task)).toEqual({
         text: DateFormats.isoDateToUIDate('2022-01-01'),
+      })
+    })
+
+    it('returns a formatted arrival date with a placement request', () => {
+      const task = placementRequestFactory.build({ expectedArrival: '2022-01-01' })
+
+      expect(expectedArrivalDateCell(task)).toEqual({
+        text: DateFormats.isoDateToUIDate('2022-01-01'),
+      })
+    })
+  })
+
+  describe('durationCell', () => {
+    it('returns a formatted duration', () => {
+      const placementRequest = placementRequestFactory.build({ duration: 16 })
+
+      expect(durationCell(placementRequest)).toEqual({
+        text: '2 weeks, 2 days',
+      })
+    })
+  })
+
+  describe('statusCell', () => {
+    const statuses = {
+      notMatched: 'Not started',
+      unableToMatch: 'Unable to allocate',
+      matched: 'Booking allocated',
+    } as Record<PlacementRequestStatus, string>
+
+    it.each(Object.keys(statuses))('returns the correct status for %s', (key: PlacementRequestStatus) => {
+      const placementRequest = placementRequestFactory.build({ status: key })
+
+      expect(statusCell(placementRequest)).toEqual({
+        text: statuses[key],
       })
     })
   })
@@ -59,6 +127,22 @@ describe('tableUtils', () => {
           expectedArrivalDateCell(task),
           dueDateCell(task, 7),
           releaseTypeCell(task),
+        ],
+      ])
+    })
+  })
+
+  describe('dashboardTableRows', () => {
+    it('returns table rows for placement requests', () => {
+      const placementRequest = placementRequestFactory.build()
+
+      expect(dashboardTableRows([placementRequest])).toEqual([
+        [
+          nameCell(placementRequest),
+          crnCell(placementRequest.person),
+          expectedArrivalDateCell(placementRequest),
+          durationCell(placementRequest),
+          statusCell(placementRequest),
         ],
       ])
     })

--- a/server/utils/placementRequests/table.ts
+++ b/server/utils/placementRequests/table.ts
@@ -1,11 +1,12 @@
 import { add } from 'date-fns'
-import { PlacementRequestTask } from '../../@types/shared'
+import { PlacementRequest, PlacementRequestTask } from '../../@types/shared'
 import { TableCell, TableRow } from '../../@types/ui'
 import paths from '../../paths/match'
 import { DateFormats } from '../dateUtils'
 import { linkTo } from '../utils'
 import { crnCell, tierCell } from '../tableUtils'
 import { allReleaseTypes } from '../applications/releaseTypeUtils'
+import { daysToWeeksAndDays } from '../assessments/dateUtils'
 
 export const DIFFERENCE_IN_DAYS_BETWEEN_DUE_DATE_AND_ARRIVAL_DATE = 7
 
@@ -22,6 +23,32 @@ export const tableRows = (tasks: Array<PlacementRequestTask>): Array<TableRow> =
   })
 }
 
+export const dashboardTableRows = (placementRequests: Array<PlacementRequest>): Array<TableRow> => {
+  return placementRequests.map((placementRequest: PlacementRequest) => {
+    return [
+      nameCell(placementRequest),
+      crnCell(placementRequest.person),
+      expectedArrivalDateCell(placementRequest),
+      durationCell(placementRequest),
+      statusCell(placementRequest),
+    ]
+  })
+}
+
+export const statusCell = (placementRequest: PlacementRequest): TableCell => {
+  return {
+    text: {
+      notMatched: 'Not started',
+      unableToMatch: 'Unable to allocate',
+      matched: 'Booking allocated',
+    }[placementRequest.status],
+  }
+}
+
+export const durationCell = (placementRequest: PlacementRequest): TableCell => {
+  return { text: DateFormats.formatDuration(daysToWeeksAndDays(placementRequest.duration), ['weeks', 'days']) }
+}
+
 export const dueDateCell = (task: PlacementRequestTask, differenceBetweenDueDateAndArrivalDate: number): TableCell => {
   const dateAsObject = DateFormats.isoToDateObj(task.expectedArrival)
 
@@ -33,18 +60,30 @@ export const dueDateCell = (task: PlacementRequestTask, differenceBetweenDueDate
   }
 }
 
-export const expectedArrivalDateCell = (task: PlacementRequestTask): TableCell => ({
-  text: DateFormats.isoDateToUIDate(task.expectedArrival),
+export const expectedArrivalDateCell = (item: PlacementRequestTask | PlacementRequest): TableCell => ({
+  text: DateFormats.isoDateToUIDate(item.expectedArrival),
 })
 
-export const nameCell = (task: PlacementRequestTask): TableCell => {
-  return {
-    html: linkTo(
-      paths.placementRequests.show,
-      { id: task.id },
-      { text: task.personName, attributes: { 'data-cy-placementRequestId': task.id } },
-    ),
+export const nameCell = (item: PlacementRequestTask | PlacementRequest): TableCell => {
+  if ('personName' in item && item.personName) {
+    return {
+      html: linkTo(
+        paths.placementRequests.show,
+        { id: item.id },
+        { text: item.personName, attributes: { 'data-cy-placementRequestId': item.id } },
+      ),
+    }
   }
+  if ('person' in item && item.person) {
+    return {
+      html: linkTo(
+        paths.placementRequests.show,
+        { id: item.id },
+        { text: item.person.name, attributes: { 'data-cy-placementRequestId': item.id } },
+      ),
+    }
+  }
+  return { html: '' }
 }
 
 export const releaseTypeCell = (task: PlacementRequestTask) => {

--- a/server/views/admin/placementRequests/index.njk
+++ b/server/views/admin/placementRequests/index.njk
@@ -1,0 +1,58 @@
+{% extends "../../partials/layout.njk" %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set mainClasses = "app-container govuk-body assessments--index" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+
+      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+      {% include "../../_messages.njk" %}
+
+      {{
+              govukTable({
+                  firstCellIsHeader: true,
+                  attributes: {
+                    'data-module': 'moj-sortable-table'
+                  },
+                  head: [
+                      {
+                          text: "Name"
+                      },
+                      {
+                          text: "CRN"
+                      },
+                      {
+                          text: "Arrival Date",
+                          attributes: {
+                            "aria-sort": "none"
+                          }
+                      },
+                      {
+                          text: "Length of stay",
+                          attributes: {
+                            "aria-sort": "none"
+                          }
+                      },
+                      {
+                          text: "Status"
+                      }
+                  ],
+                  rows: PlacementRequestUtils.tableUtils.dashboardTableRows(placementRequests)
+                })
+            }}
+
+    </div>
+  </div>
+{% endblock %}
+
+{% block extraScripts %}
+  <script type="text/javascript" nonce="{{ cspNonce }}">
+    window
+      .MOJFrontend
+      .initAll()
+  </script>
+{% endblock %}


### PR DESCRIPTION
This adds a CRU dashboard to show all Placement Applications. There's currently no pagination or filtering, but we can add this later.

## Screenshot

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/6ec97bd3-bb04-4f70-8ee7-91ee0174a888)
