### PR TITLE
Throw error if date doesn't have a 4 digit year

### DIFF
--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -260,6 +260,18 @@ describe('dateAndTimeInputsAreValidDates', () => {
 
     expect(result).toEqual(false)
   })
+
+  it('returns false when the year is not 4 digits', () => {
+    const obj: ObjectWithDateParts<'date'> = {
+      'date-year': '22',
+      'date-month': '12',
+      'date-day': '11',
+    }
+
+    const result = dateAndTimeInputsAreValidDates(obj, 'date')
+
+    expect(result).toEqual(false)
+  })
 })
 
 describe('dateIsBlank', () => {

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -177,6 +177,10 @@ export const dateAndTimeInputsAreValidDates = <K extends string | number>(
   dateInputObj: ObjectWithDateParts<K>,
   key: K,
 ): boolean => {
+  const inputYear = dateInputObj?.[`${key}-year`] as string
+
+  if (inputYear && inputYear.length !== 4) return false
+
   const dateString = DateFormats.dateAndTimeInputsToIsoString(dateInputObj, key)
 
   try {


### PR DESCRIPTION
Users have been entering 2 digits in the year inputs which causes certain date functions to blow up, lets throw a validation error when they do.