### PR TITLE
Fix/Correct Dates of Placement duration

### DIFF
--- a/integration_tests/fixtures/rotlPlacementApplicationData.json
+++ b/integration_tests/fixtures/rotlPlacementApplicationData.json
@@ -20,7 +20,9 @@
       "arrivalDate-day": "01",
       "arrivalDate-month": "8",
       "arrivalDate-year": "2023",
-      "duration": "28"
+      "duration": "5",
+      "durationDays": "5",
+      "durationWeeks": "0"
     },
     "updates-to-application": {
       "significantEvents": "yes",

--- a/server/form-pages/placement-application/request-a-placement/datesOfPlacement.test.ts
+++ b/server/form-pages/placement-application/request-a-placement/datesOfPlacement.test.ts
@@ -6,7 +6,7 @@ import DateOfPlacement, { Body } from './datesOfPlacement'
 describe('DateOfPlacement', () => {
   const body = {
     durationDays: '1',
-    durationWeeks: '1',
+    durationWeeks: '2',
     'arrivalDate-year': '2023',
     'arrivalDate-month': '12',
     'arrivalDate-day': '1',
@@ -17,9 +17,9 @@ describe('DateOfPlacement', () => {
       const page = new DateOfPlacement(body)
 
       expect(page.body).toEqual({
-        duration: '8',
+        duration: '15',
         durationDays: '1',
-        durationWeeks: '1',
+        durationWeeks: '2',
         'arrivalDate-year': '2023',
         'arrivalDate-month': '12',
         'arrivalDate-day': '1',
@@ -64,7 +64,7 @@ describe('DateOfPlacement', () => {
       const page = new DateOfPlacement(body)
 
       expect(page.response()).toEqual({
-        'How long should the Approved Premises placement last?': '1 week, 1 day',
+        'How long should the Approved Premises placement last?': '2 weeks, 1 day',
         'When will the person arrive?': 'Friday 1 December 2023',
       })
     })

--- a/server/form-pages/placement-application/request-a-placement/datesOfPlacement.ts
+++ b/server/form-pages/placement-application/request-a-placement/datesOfPlacement.ts
@@ -64,8 +64,8 @@ export default class DatesOfPlacement implements TasklistPage {
     return {
       [this.questions.arrivalDate]: DateFormats.isoDateToUIDate(this.body.arrivalDate),
       [this.questions.duration]: DateFormats.formatDuration({
-        weeks: this.body.durationDays,
-        days: this.body.durationWeeks,
+        weeks: this.body.durationWeeks,
+        days: this.body.durationDays,
       }),
     }
   }


### PR DESCRIPTION
The weeks and days were the wrong way around.
The reason we missed this was because in the unit test the integer for durationDays and durationWeeks were both '1' so it looks correct for both values.

