### PR TITLE
(281) Add PIPE screen

### DIFF
--- a/integration_tests/pages/assess/rfapSuitability.ts
+++ b/integration_tests/pages/assess/rfapSuitability.ts
@@ -8,16 +8,22 @@ import RfapSuitability from '../../../server/form-pages/assess/assessApplication
 export default class RfapSuitabilityPage extends AssessPage {
   pageClass: RfapSuitability
 
-  constructor(assessment: Assessment, suitableAnswer: YesOrNo = 'no', detailAnswer = 'Some detail') {
+  constructor(
+    assessment: Assessment,
+    suitableAnswer: YesOrNo = 'no',
+    detailAnswer = 'Some detail',
+    noDetail = 'No detail',
+  ) {
     super(assessment, 'Suitability assessment')
     this.pageClass = new RfapSuitability(
-      { rfapIdentifiedAsSuitable: suitableAnswer, unsuitabilityForRfapRationale: detailAnswer },
+      { rfapIdentifiedAsSuitable: suitableAnswer, unsuitabilityForRfapRationale: detailAnswer, noDetail },
       assessment,
     )
   }
 
   completeForm() {
     this.checkRadioByNameAndValue('rfapIdentifiedAsSuitable', this.pageClass.body.rfapIdentifiedAsSuitable)
+    this.clearAndCompleteTextInputById('noDetail', this.pageClass.body.noDetail)
     this.clearAndCompleteTextInputById('unsuitabilityForRfapRationale', this.pageClass.body.rfapIdentifiedAsSuitable)
   }
 }

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/index.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/index.ts
@@ -4,10 +4,17 @@ import SuitabilityAssessmentPage from './suitabilityAssessment'
 import ApplicationTimeliness from './applicationTimeliness'
 import RfapSuitability from './rfapSuitability'
 import ContingencyPlanSuitability from './contingencyPlanSuitability'
+import PipeSuitability from './pipeSuitability'
 
 @Task({
   slug: 'suitability-assessment',
   name: 'Assess suitability of application',
-  pages: [SuitabilityAssessmentPage, RfapSuitability, ApplicationTimeliness, ContingencyPlanSuitability],
+  pages: [
+    SuitabilityAssessmentPage,
+    RfapSuitability,
+    PipeSuitability,
+    ApplicationTimeliness,
+    ContingencyPlanSuitability,
+  ],
 })
 export default class SuitabilityAssessment {}

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/pipeSuitability.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/pipeSuitability.test.ts
@@ -1,0 +1,102 @@
+import { assessmentFactory } from '../../../../testutils/factories'
+import { itShouldHavePreviousValue } from '../../../shared-examples'
+
+import PipeSuitability, { PipeSuitabilityBody } from './pipeSuitability'
+import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
+
+jest.mock('../../../../utils/applications/noticeTypeFromApplication')
+
+describe('PipeSuitability', () => {
+  const body: PipeSuitabilityBody = {
+    pipeIdentifiedAsSuitable: 'yes',
+    yesDetail: 'Some yes detail',
+    unsuitabilityForPipeRationale: 'some reasons',
+  }
+
+  const assessment = assessmentFactory.build()
+  describe('title', () => {
+    expect(new PipeSuitability(body, assessment).title).toBe('Suitability assessment')
+  })
+
+  describe('body', () => {
+    it('should set the body', () => {
+      const page = new PipeSuitability(body, assessment)
+      expect(page.body).toEqual(body)
+    })
+  })
+
+  describe('next', () => {
+    it('returns application-timeliness if the notice type is short_notice', () => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('short_notice')
+      expect(new PipeSuitability(body, assessment).next()).toEqual('application-timeliness')
+    })
+
+    it('returns application-timeliness if the notice type is emergency', () => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('emergency')
+      expect(new PipeSuitability(body, assessment).next()).toEqual('application-timeliness')
+    })
+
+    it('returns an empty string if the notice type is standard', () => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('standard')
+      expect(new PipeSuitability(body, assessment).next()).toEqual('')
+    })
+  })
+
+  itShouldHavePreviousValue(new PipeSuitability(body, assessment), 'suitability-assessment')
+
+  describe('errors', () => {
+    it('should have an error if there are no answers', () => {
+      const page = new PipeSuitability({} as PipeSuitabilityBody, assessment)
+
+      expect(page.errors()).toEqual({
+        pipeIdentifiedAsSuitable:
+          'You must confirm if Psychologically Informed Planned Environment (PIPE) been identified as a viable pathway',
+      })
+    })
+
+    it('should have an error if there is a yes answer but no details given', () => {
+      const page = new PipeSuitability({ pipeIdentifiedAsSuitable: 'yes' } as PipeSuitabilityBody, assessment)
+
+      expect(page.errors()).toEqual({
+        yesDetail: 'You must provide details to support the decision',
+      })
+    })
+
+    it('should have two errors if there is a no answer but no details given', () => {
+      const page = new PipeSuitability({ pipeIdentifiedAsSuitable: 'no' } as PipeSuitabilityBody, assessment)
+
+      expect(page.errors()).toEqual({
+        noDetail: 'You must provide details to support the decision',
+        unsuitabilityForPipeRationale:
+          'You must summarise why the person is unsuitable for a PIPE placement yet suitable for a standard placement',
+      })
+    })
+  })
+
+  describe('response', () => {
+    it('returns the response when the answer is "yes"', () => {
+      const page = new PipeSuitability({ ...body, pipeIdentifiedAsSuitable: 'yes' }, assessment)
+
+      expect(page.response()).toEqual({
+        'Has Psychologically Informed Planned Environment (PIPE) been identified as a viable pathway?':
+          'Yes - Some yes detail',
+        'If the person is unsuitable for a PIPE placement yet suitable for a standard placement, summarise the rationale for the decision.':
+          'some reasons',
+      })
+    })
+
+    it('returns the response when the answer is "no"', () => {
+      const page = new PipeSuitability(
+        { ...body, pipeIdentifiedAsSuitable: 'no', noDetail: 'Some no detail' },
+        assessment,
+      )
+
+      expect(page.response()).toEqual({
+        'Has Psychologically Informed Planned Environment (PIPE) been identified as a viable pathway?':
+          'No - Some no detail',
+        'If the person is unsuitable for a PIPE placement yet suitable for a standard placement, summarise the rationale for the decision.':
+          'some reasons',
+      })
+    })
+  })
+})

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/pipeSuitability.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/pipeSuitability.ts
@@ -1,0 +1,84 @@
+import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
+import { ApprovedPremisesAssessment as Assessment } from '../../../../@types/shared'
+
+import { Page } from '../../../utils/decorators'
+
+import TasklistPage from '../../../tasklistPage'
+
+export type PipeSuitabilityBody = {
+  pipeIdentifiedAsSuitable: YesOrNo
+  unsuitabilityForPipeRationale: string
+  yesDetail?: string
+  noDetail?: string
+}
+
+@Page({
+  name: 'pipe-suitability',
+  bodyProperties: ['pipeIdentifiedAsSuitable', 'unsuitabilityForPipeRationale', 'yesDetail', 'noDetail'],
+})
+export default class PipeSuitability implements TasklistPage {
+  title = 'Suitability assessment'
+
+  questions = {
+    pipeIdentifiedAsSuitable:
+      'Has Psychologically Informed Planned Environment (PIPE) been identified as a viable pathway?',
+    unsuitabilityForPipeRationale:
+      'If the person is unsuitable for a PIPE placement yet suitable for a standard placement, summarise the rationale for the decision.',
+    detail: 'Provide details to support the decision',
+  }
+
+  constructor(
+    public body: PipeSuitabilityBody,
+    private readonly assessment: Assessment,
+  ) {}
+
+  previous() {
+    return 'suitability-assessment'
+  }
+
+  next() {
+    if (
+      noticeTypeFromApplication(this.assessment.application) === 'short_notice' ||
+      noticeTypeFromApplication(this.assessment.application) === 'emergency'
+    ) {
+      return 'application-timeliness'
+    }
+
+    return ''
+  }
+
+  response() {
+    const response = {}
+
+    if (this.body.pipeIdentifiedAsSuitable === 'yes') {
+      response[this.questions.pipeIdentifiedAsSuitable] = `Yes - ${this.body.yesDetail}`
+    }
+    if (this.body.pipeIdentifiedAsSuitable === 'no') {
+      response[this.questions.pipeIdentifiedAsSuitable] = `No - ${this.body.noDetail}`
+    }
+    response[this.questions.unsuitabilityForPipeRationale] = this.body.unsuitabilityForPipeRationale
+
+    return response
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.pipeIdentifiedAsSuitable)
+      errors.pipeIdentifiedAsSuitable =
+        'You must confirm if Psychologically Informed Planned Environment (PIPE) been identified as a viable pathway'
+
+    if (this.body.pipeIdentifiedAsSuitable === 'yes' && !this.body.yesDetail)
+      errors.yesDetail = 'You must provide details to support the decision'
+
+    if (this.body.pipeIdentifiedAsSuitable === 'no' && !this.body.noDetail)
+      errors.noDetail = 'You must provide details to support the decision'
+
+    if (this.body.pipeIdentifiedAsSuitable === 'no' && !this.body.unsuitabilityForPipeRationale)
+      errors.unsuitabilityForPipeRationale =
+        'You must summarise why the person is unsuitable for a PIPE placement yet suitable for a standard placement'
+
+    return errors
+  }
+}

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.test.ts
@@ -10,6 +10,7 @@ describe('RfapSuitability', () => {
   const body: RfapSuitabilityBody = {
     rfapIdentifiedAsSuitable: 'yes',
     unsuitabilityForRfapRationale: 'some reasons',
+    yesDetail: 'Some yes detail',
   }
 
   const assessment = assessmentFactory.build()
@@ -20,10 +21,7 @@ describe('RfapSuitability', () => {
   describe('body', () => {
     it('should set the body', () => {
       const page = new RfapSuitability(body, assessment)
-      expect(page.body).toEqual({
-        rfapIdentifiedAsSuitable: 'yes',
-        unsuitabilityForRfapRationale: 'some reasons',
-      })
+      expect(page.body).toEqual(body)
     })
   })
 
@@ -58,11 +56,26 @@ describe('RfapSuitability', () => {
   })
 
   describe('response', () => {
-    it('returns the response', () => {
+    it('returns the response when the asnwer is yes', () => {
       const page = new RfapSuitability(body, assessment)
 
       expect(page.response()).toEqual({
-        'Has a Recovery Focused Approved Premises (RFAP) been identified as a suitable placement?': 'yes',
+        'Has a Recovery Focused Approved Premises (RFAP) been identified as a suitable placement?':
+          'Yes - Some yes detail',
+        'If the person is unsuitable for a RFAP placement yet suitable for a standard placement, summarise the rationale for the decision':
+          'some reasons',
+      })
+    })
+
+    it('returns the response when the asnwer is no', () => {
+      const page = new RfapSuitability(
+        { ...body, rfapIdentifiedAsSuitable: 'no', noDetail: 'Some no detail' },
+        assessment,
+      )
+
+      expect(page.response()).toEqual({
+        'Has a Recovery Focused Approved Premises (RFAP) been identified as a suitable placement?':
+          'No - Some no detail',
         'If the person is unsuitable for a RFAP placement yet suitable for a standard placement, summarise the rationale for the decision':
           'some reasons',
       })

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.ts
@@ -9,11 +9,13 @@ import TasklistPage from '../../../tasklistPage'
 export type RfapSuitabilityBody = {
   rfapIdentifiedAsSuitable: YesOrNo
   unsuitabilityForRfapRationale: string
+  yesDetail?: string
+  noDetail?: string
 }
 
 @Page({
   name: 'rfap-suitability',
-  bodyProperties: ['rfapIdentifiedAsSuitable', 'unsuitabilityForRfapRationale'],
+  bodyProperties: ['rfapIdentifiedAsSuitable', 'unsuitabilityForRfapRationale', 'yesDetail', 'noDetail'],
 })
 export default class RfapSuitability implements TasklistPage {
   title = 'Suitability assessment'
@@ -23,6 +25,7 @@ export default class RfapSuitability implements TasklistPage {
       'Has a Recovery Focused Approved Premises (RFAP) been identified as a suitable placement?',
     unsuitabilityForRfapRationale:
       'If the person is unsuitable for a RFAP placement yet suitable for a standard placement, summarise the rationale for the decision',
+    detail: 'Provide details to support the decision',
   }
 
   constructor(
@@ -48,7 +51,13 @@ export default class RfapSuitability implements TasklistPage {
   response() {
     const response = {}
 
-    response[this.questions.rfapIdentifiedAsSuitable] = this.body.rfapIdentifiedAsSuitable
+    if (this.body.rfapIdentifiedAsSuitable === 'yes') {
+      response[this.questions.rfapIdentifiedAsSuitable] = `Yes - ${this.body.yesDetail}`
+    }
+    if (this.body.rfapIdentifiedAsSuitable === 'no') {
+      response[this.questions.rfapIdentifiedAsSuitable] = `No - ${this.body.noDetail}`
+    }
+
     response[this.questions.unsuitabilityForRfapRationale] = this.body.unsuitabilityForRfapRationale
 
     return response
@@ -56,6 +65,12 @@ export default class RfapSuitability implements TasklistPage {
 
   errors() {
     const errors: TaskListErrors<this> = {}
+
+    if (this.body.rfapIdentifiedAsSuitable === 'yes' && !this.body.yesDetail)
+      errors.yesDetail = 'You must provide details to support the decision'
+
+    if (this.body.rfapIdentifiedAsSuitable === 'no' && !this.body.noDetail)
+      errors.noDetail = 'You must provide details to support the decision'
 
     if (!this.body.rfapIdentifiedAsSuitable)
       errors.rfapIdentifiedAsSuitable =

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
@@ -5,9 +5,11 @@ import { itShouldHavePreviousValue } from '../../../shared-examples'
 
 import SuitabilityAssessment from './suitabilityAssessment'
 import { shouldShowContingencyPlanPartnersPages } from '../../../../utils/applications/shouldShowContingencyPlanPages'
+import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 
 jest.mock('../../../../utils/applications/noticeTypeFromApplication')
 jest.mock('../../../../utils/applications/shouldShowContingencyPlanPages')
+jest.mock('../../../../utils/retrieveQuestionResponseFromFormArtifact')
 
 describe('SuitabilityAssessment', () => {
   const assessment = assessmentFactory.build()
@@ -51,6 +53,20 @@ describe('SuitabilityAssessment', () => {
   })
 
   describe('next', () => {
+    it('returns rfap-suitability if the application needs an RFAP', () => {
+      ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue('yes')
+      expect(
+        new SuitabilityAssessment(
+          {
+            riskFactors: 'yes',
+            riskManagement: 'yes',
+            locationOfPlacement: 'yes',
+            moveOnPlan: 'yes',
+          },
+          assessment,
+        ).next(),
+      ).toEqual('rfap-suitability')
+    })
     it('returns application-timeliness if the notice type is short_notice', () => {
       ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('short_notice')
       expect(

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
@@ -67,6 +67,22 @@ describe('SuitabilityAssessment', () => {
         ).next(),
       ).toEqual('rfap-suitability')
     })
+
+    it('returns pipe-suitability if the application needs a PIPE', () => {
+      ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue('pipe')
+      expect(
+        new SuitabilityAssessment(
+          {
+            riskFactors: 'yes',
+            riskManagement: 'yes',
+            locationOfPlacement: 'yes',
+            moveOnPlan: 'yes',
+          },
+          assessment,
+        ).next(),
+      ).toEqual('pipe-suitability')
+    })
+
     it('returns application-timeliness if the notice type is short_notice', () => {
       ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('short_notice')
       expect(

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.ts
@@ -9,6 +9,7 @@ import { responsesForYesNoAndCommentsSections } from '../../../utils/index'
 import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 import Rfap from '../../../apply/risk-and-need-factors/further-considerations/rfap'
 import { shouldShowContingencyPlanPartnersPages } from '../../../../utils/applications/shouldShowContingencyPlanPages'
+import SelectApType from '../../../apply/reasons-for-placement/type-of-ap/apType'
 
 export type SuitabilityAssessmentSection = {
   riskFactors: string
@@ -70,6 +71,12 @@ export default class SuitabilityAssessment implements TasklistPage {
     if (needsRfap === 'yes') {
       return 'rfap-suitability'
     }
+
+    if (
+      retrieveOptionalQuestionResponseFromApplicationOrAssessment(this.assessment.application, SelectApType, 'type') ===
+      'pipe'
+    )
+      return 'pipe-suitability'
 
     if (
       noticeTypeFromApplication(this.assessment.application) === 'short_notice' ||

--- a/server/views/assessments/pages/suitability-assessment/pipe-suitability.njk
+++ b/server/views/assessments/pages/suitability-assessment/pipe-suitability.njk
@@ -1,0 +1,66 @@
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+
+{% extends "../layout.njk" %}
+
+{% block questions %}
+    <h1 class="govuk-heading-l">
+        {{page.title}}</h1>
+
+    {% set yesDetail %}
+    {{ formPageTextarea({
+        fieldName: "yesDetail",
+        label: {
+          text: page.questions.detail
+        }
+    }, fetchContext()) }}
+    {% endset -%}
+
+    {% set noDetail %}
+    {{ formPageTextarea({
+        fieldName: "noDetail",
+        label: {
+          text: page.questions.detail
+        }
+    }, fetchContext()) }}
+    {% endset -%}
+
+    {{
+            formPageRadios({
+                fieldset: {
+                    legend: {
+                    text: page.questions.pipeIdentifiedAsSuitable,
+                    classes: "govuk-fieldset__legend--m"
+                    }
+                },
+                fieldName: "pipeIdentifiedAsSuitable",
+                    items: [
+                    {
+                        value: "yes",
+                        text: "Yes",
+                        conditional: {
+                            html: yesDetail
+                    }
+                    },
+                    {
+                        value: "no",
+                        text: "No",
+                        conditional: {
+                            html: noDetail
+                    }
+                    }
+                    ]
+                }, fetchContext()
+            )
+        }}
+
+    {{
+            formPageTextarea({
+                fieldName: "unsuitabilityForPipeRationale",
+                label: {
+                    text: page.questions.unsuitabilityForPipeRationale,
+                    classes: "govuk-label--s"
+                }
+            }, fetchContext())
+        }}
+
+{% endblock %}

--- a/server/views/assessments/pages/suitability-assessment/rfap-suitability.njk
+++ b/server/views/assessments/pages/suitability-assessment/rfap-suitability.njk
@@ -6,6 +6,24 @@
     <h1 class="govuk-heading-l">
         {{page.title}}</h1>
 
+    {% set yesDetail %}
+    {{ formPageTextarea({
+        fieldName: "yesDetail",
+        label: {
+          text: page.questions.detail
+        }
+    }, fetchContext()) }}
+    {% endset -%}
+
+    {% set noDetail %}
+    {{ formPageTextarea({
+        fieldName: "noDetail",
+        label: {
+          text: page.questions.detail
+        }
+    }, fetchContext()) }}
+    {% endset -%}
+
     {{
             formPageRadios({
                 fieldset: {
@@ -16,13 +34,19 @@
                 },
                 fieldName: "rfapIdentifiedAsSuitable",
                     items: [
-                    {
+                  {
                         value: "yes",
-                        text: "Yes"
+                        text: "Yes",
+                        conditional: {
+                            html: yesDetail
+                    }
                     },
                     {
                         value: "no",
-                        text: "No"
+                        text: "No",
+                        conditional: {
+                            html: noDetail
+                    }
                     }
                     ]
                 }, fetchContext()


### PR DESCRIPTION
# Context
We need to ask the user some more questions if the application is for PIPE. 
[Trello card](https://trello.com/c/xxAAUogk/281-add-pipe-assess-screen)

# Changes in this PR
- We add some 'more details' boxes to the RFAP page that were missed the first time
- We add the PIPE screen

RFAP and PIPE are exclusive and it seemed overkill to run through the Assess journey twice just to test both pages so there isn't an intergration test for this page. 
## Screenshots of UI changes
![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/eb5407a0-9fa6-4922-989a-db3374de4ffa)
