### PR TITLE
Fix backlinks when amending cancelling bookings from admin screen

### DIFF
--- a/integration_tests/pages/admin/placementApplications/showPage.ts
+++ b/integration_tests/pages/admin/placementApplications/showPage.ts
@@ -35,6 +35,16 @@ export default class ShowPage extends Page {
     cy.contains('.moj-button-menu__item', 'Create placement').click()
   }
 
+  clickAmendBooking() {
+    cy.get('.moj-button-menu__toggle-button').click()
+    cy.contains('.moj-button-menu__item', 'Amend placement').click()
+  }
+
+  clickCancelBooking() {
+    cy.get('.moj-button-menu__toggle-button').click()
+    cy.contains('.moj-button-menu__item', 'Cancel placement').click()
+  }
+
   shouldShowCreateBookingOption() {
     this.buttonShouldExist('Create placement')
   }

--- a/integration_tests/pages/manage/booking/dateChanges/new.ts
+++ b/integration_tests/pages/manage/booking/dateChanges/new.ts
@@ -2,13 +2,16 @@ import Page from '../../../page'
 import paths from '../../../../../server/paths/manage'
 
 export default class NewDateChange extends Page {
-  constructor() {
+  constructor(
+    public readonly premisesId: string,
+    public readonly bookingId: string,
+  ) {
     super('Change placement date')
   }
 
   static visit(premisesId: string, bookingId: string): NewDateChange {
     cy.visit(paths.bookings.dateChanges.new({ premisesId, bookingId }))
-    return new NewDateChange()
+    return new NewDateChange(premisesId, bookingId)
   }
 
   completeForm(newArrivalDate: string, newDepartureDate: string): void {
@@ -30,5 +33,11 @@ export default class NewDateChange extends Page {
 
   checkDatesToChangeOption(option: 'newArrivalDate' | 'newDepartureDate'): void {
     cy.get(`input[name="datesToChange"][value="${option}"]`).click()
+  }
+
+  shouldHaveCorrectBacklink(): void {
+    cy.get('.govuk-back-link')
+      .should('have.attr', 'href')
+      .and('include', paths.bookings.show({ premisesId: this.premisesId, bookingId: this.bookingId }))
   }
 }

--- a/integration_tests/pages/manage/cancellationCreate.ts
+++ b/integration_tests/pages/manage/cancellationCreate.ts
@@ -3,14 +3,17 @@ import Page from '../page'
 import paths from '../../../server/paths/manage'
 
 export default class CancellationCreatePage extends Page {
-  constructor() {
+  constructor(
+    public readonly premisesId: string,
+    public readonly bookingId: string,
+  ) {
     super('Cancel this placement')
   }
 
   static visit(premisesId: string, bookingId: string): CancellationCreatePage {
     cy.visit(paths.bookings.cancellations.new({ premisesId, bookingId }))
 
-    return new CancellationCreatePage()
+    return new CancellationCreatePage(premisesId, bookingId)
   }
 
   completeForm(cancellation: Cancellation): void {
@@ -24,5 +27,11 @@ export default class CancellationCreatePage extends Page {
     this.completeTextArea('cancellation[notes]', cancellation.notes)
 
     this.clickSubmit()
+  }
+
+  shouldHaveCorrectBacklink(): void {
+    cy.get('.govuk-back-link')
+      .should('have.attr', 'href')
+      .and('include', paths.bookings.show({ premisesId: this.premisesId, bookingId: this.bookingId }))
   }
 }

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -2,12 +2,14 @@ import ListPage from '../../pages/admin/placementApplications/listPage'
 import ShowPage from '../../pages/admin/placementApplications/showPage'
 
 import {
+  cancellationFactory,
   placementRequestDetailFactory,
   placementRequestFactory,
   premisesFactory,
 } from '../../../server/testutils/factories'
 import Page from '../../pages/page'
 import CreatePlacementPage from '../../pages/admin/placementApplications/createPlacementPage'
+import { CancellationCreatePage, NewDateChangePage } from '../../pages/manage'
 
 context('Placement Requests', () => {
   const placementRequests = placementRequestFactory.buildList(2)
@@ -116,6 +118,108 @@ context('Placement Requests', () => {
         arrivalDate: '2022-01-01',
         departureDate: '2022-02-01',
       })
+    })
+  })
+
+  it('allows me to amend a booking', () => {
+    const premises = premisesFactory.buildList(3)
+    cy.task('stubPremises', premises)
+    cy.task('stubBookingFromPlacementRequest', placementRequestWithBooking)
+    cy.task('stubDateChange', {
+      premisesId: placementRequestWithBooking.booking.premisesId,
+      bookingId: placementRequestWithBooking.booking.id,
+    })
+    cy.task('stubBookingGet', {
+      premisesId: placementRequestWithBooking.booking.premisesId,
+      booking: placementRequestWithBooking.booking,
+    })
+
+    // When I visit the tasks dashboard
+    const listPage = ListPage.visit(placementRequests)
+
+    // And I choose a placement request
+    listPage.clickPlacementRequest(placementRequestWithBooking)
+
+    // Then I should be taken to the placement request page
+    const showPage = Page.verifyOnPage(ShowPage, placementRequestWithBooking)
+
+    // When I click on the create booking button
+    showPage.clickAmendBooking()
+
+    // Then I should be on the amend a booking page
+    const dateChangePage = Page.verifyOnPage(NewDateChangePage, placementRequestWithBooking)
+
+    // And I change the date of my booking
+    dateChangePage.completeForm('2023-01-01', '2023-03-02')
+    dateChangePage.clickSubmit()
+
+    // Then I should see a confirmation message
+    showPage.shouldShowBanner('Booking changed successfully')
+
+    // And the change booking endpoint should have been called with the correct parameters
+    cy.task('verifyDateChange', {
+      premisesId: placementRequestWithBooking.booking.premisesId,
+      bookingId: placementRequestWithBooking.booking.id,
+    }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+
+      expect(requestBody.newArrivalDate).equal('2023-01-01')
+      expect(requestBody.newDepartureDate).equal('2023-03-02')
+    })
+  })
+
+  it('allows me to cancel a booking', () => {
+    const premises = premisesFactory.buildList(3)
+    const cancellation = cancellationFactory.build({ date: '2022-06-01' })
+
+    cy.task('stubPremises', premises)
+    cy.task('stubBookingFromPlacementRequest', placementRequestWithBooking)
+    cy.task('stubCancellationCreate', {
+      premisesId: placementRequestWithBooking.booking.premisesId,
+      bookingId: placementRequestWithBooking.booking.id,
+      cancellation,
+    })
+    cy.task('stubBookingGet', {
+      premisesId: placementRequestWithBooking.booking.premisesId,
+      booking: placementRequestWithBooking.booking,
+    })
+    cy.task('stubCancellationReferenceData')
+
+    // When I visit the tasks dashboard
+    const listPage = ListPage.visit(placementRequests)
+
+    // And I choose a placement request
+    listPage.clickPlacementRequest(placementRequestWithBooking)
+
+    // Then I should be taken to the placement request page
+    const showPage = Page.verifyOnPage(ShowPage, placementRequestWithBooking)
+
+    // When I click on the create booking button
+    showPage.clickCancelBooking()
+
+    // Then I should be on the cancel a booking page
+    const cancellationPage = Page.verifyOnPage(CancellationCreatePage, placementRequestWithBooking)
+
+    // And I cancel my booking
+    cancellationPage.completeForm(cancellation)
+    cancellationPage.clickSubmit()
+
+    // Then I should see a confirmation message
+    showPage.shouldShowBanner('Booking cancelled')
+
+    // And a cancellation should have been created in the API
+    cy.task('verifyCancellationCreate', {
+      premisesId: placementRequestWithBooking.booking.premisesId,
+      bookingId: placementRequestWithBooking.booking.id,
+      cancellation,
+    }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+
+      expect(requestBody.date).equal(cancellation.date)
+      expect(requestBody.notes).equal(cancellation.notes)
+      expect(requestBody.reason).equal(cancellation.reason.id)
     })
   })
 })

--- a/integration_tests/tests/manage/cancellation.cy.ts
+++ b/integration_tests/tests/manage/cancellation.cy.ts
@@ -74,5 +74,8 @@ context('Cancellation', () => {
 
     // Then I should see error messages relating to that field
     page.shouldShowErrorMessagesForFields(['date', 'reason'])
+
+    // And the back link should be populated correctly
+    page.shouldHaveCorrectBacklink()
   })
 })

--- a/integration_tests/tests/manage/dateChanges.cy.ts
+++ b/integration_tests/tests/manage/dateChanges.cy.ts
@@ -80,5 +80,8 @@ context('Date Changes', () => {
 
     // Then I should see errors
     dateChangePage.shouldShowErrorMessagesForFields(['newArrivalDate', 'newDepartureDate'])
+
+    // And the back link should be populated correctly
+    dateChangePage.shouldHaveCorrectBacklink()
   })
 })

--- a/server/controllers/manage/cancellationsController.test.ts
+++ b/server/controllers/manage/cancellationsController.test.ts
@@ -63,7 +63,7 @@ describe('cancellationsController', () => {
     })
 
     it('renders the form with errors and user input if an error has been sent to the flash', async () => {
-      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>({ userInput: { backLink: 'http://foo.com' } })
 
       ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
 
@@ -75,12 +75,33 @@ describe('cancellationsController', () => {
         premisesId,
         bookingId,
         booking,
-        backLink,
+        backLink: 'http://foo.com',
         cancellationReasons,
         pageHeading: 'Cancel this placement',
         errors: errorsAndUserInput.errors,
         errorSummary: errorsAndUserInput.errorSummary,
         ...errorsAndUserInput.userInput,
+      })
+    })
+
+    it('sets a default backlink if the referrer is not present', async () => {
+      ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
+        return { errors: {}, errorSummary: [], userInput: {} }
+      })
+
+      const requestHandler = cancellationsController.new()
+
+      await requestHandler({ ...request, params: { premisesId, bookingId }, headers: {} }, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('cancellations/new', {
+        premisesId,
+        bookingId,
+        booking,
+        backLink: paths.bookings.show({ premisesId, bookingId }),
+        cancellationReasons,
+        pageHeading: 'Cancel this placement',
+        errors: {},
+        errorSummary: [],
       })
     })
   })

--- a/server/controllers/manage/cancellationsController.test.ts
+++ b/server/controllers/manage/cancellationsController.test.ts
@@ -15,8 +15,9 @@ jest.mock('../../utils/validation')
 
 describe('cancellationsController', () => {
   const token = 'SOME_TOKEN'
+  const backLink = 'http://localhost/some-path'
 
-  const request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  const request: DeepMocked<Request> = createMock<Request>({ user: { token }, headers: { referer: backLink } })
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
@@ -50,6 +51,7 @@ describe('cancellationsController', () => {
         premisesId,
         bookingId,
         booking,
+        backLink,
         cancellationReasons,
         pageHeading: 'Cancel this placement',
         errors: {},
@@ -73,6 +75,7 @@ describe('cancellationsController', () => {
         premisesId,
         bookingId,
         booking,
+        backLink,
         cancellationReasons,
         pageHeading: 'Cancel this placement',
         errors: errorsAndUserInput.errors,
@@ -99,6 +102,7 @@ describe('cancellationsController', () => {
         'date-year': 2022,
         'date-month': 12,
         'date-day': 11,
+        backLink,
         cancellation: {
           notes: 'Some notes',
           reason: '8b2677dd-e5d4-407a-a8f8-e2035aec9227',
@@ -121,9 +125,7 @@ describe('cancellationsController', () => {
 
       expect(request.flash).toHaveBeenCalledWith('success', 'Booking cancelled')
 
-      expect(response.redirect).toHaveBeenCalledWith(
-        paths.bookings.show({ premisesId: request.params.premisesId, bookingId: request.params.bookingId }),
-      )
+      expect(response.redirect).toHaveBeenCalledWith(backLink)
     })
 
     it('should catch the validation errors when the API returns an error', async () => {

--- a/server/controllers/manage/cancellationsController.ts
+++ b/server/controllers/manage/cancellationsController.ts
@@ -21,11 +21,13 @@ export default class CancellationsController {
 
       const booking = await this.bookingService.find(req.user.token, premisesId, bookingId)
       const cancellationReasons = await this.cancellationService.getCancellationReasons(req.user.token)
+      const backLink = req.headers.referer
 
       res.render('cancellations/new', {
         premisesId,
         bookingId,
         booking,
+        backLink,
         cancellationReasons,
         pageHeading: 'Cancel this placement',
         errors,
@@ -49,7 +51,7 @@ export default class CancellationsController {
         await this.cancellationService.createCancellation(req.user.token, premisesId, bookingId, cancellation)
 
         req.flash('success', 'Booking cancelled')
-        res.redirect(paths.bookings.show({ premisesId, bookingId }))
+        res.redirect(req.body.backLink)
       } catch (err) {
         catchValidationErrorOrPropogate(
           req,

--- a/server/controllers/manage/cancellationsController.ts
+++ b/server/controllers/manage/cancellationsController.ts
@@ -21,7 +21,15 @@ export default class CancellationsController {
 
       const booking = await this.bookingService.find(req.user.token, premisesId, bookingId)
       const cancellationReasons = await this.cancellationService.getCancellationReasons(req.user.token)
-      const backLink = req.headers.referer
+      let backLink: string
+
+      if (userInput.backLink) {
+        backLink = userInput.backLink as string
+      } else if (req.headers.referer) {
+        backLink = req.headers.referer
+      } else {
+        backLink = paths.bookings.show({ premisesId, bookingId })
+      }
 
       res.render('cancellations/new', {
         premisesId,

--- a/server/controllers/manage/dateChangesController.test.ts
+++ b/server/controllers/manage/dateChangesController.test.ts
@@ -62,7 +62,7 @@ describe('dateChangesController', () => {
     })
 
     it('renders the form with errors and user input if an error has been sent to the flash', async () => {
-      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>({ userInput: { backLink: 'http://foo.com' } })
 
       ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
 
@@ -74,12 +74,34 @@ describe('dateChangesController', () => {
         premisesId,
         bookingId,
         booking,
-        backLink,
+        backLink: 'http://foo.com',
         pageHeading: 'Change placement date',
         errors: errorsAndUserInput.errors,
         errorSummary: errorsAndUserInput.errorSummary,
         ...errorsAndUserInput.userInput,
       })
+    })
+
+    it('sets a default backlink if the referrer is not present', async () => {
+      ;(fetchErrorsAndUserInput as jest.Mock).mockImplementation(() => {
+        return { errors: {}, errorSummary: [], userInput: {} }
+      })
+
+      const requestHandler = controller.new()
+
+      await requestHandler({ ...request, headers: {} }, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('bookings/dateChanges/new', {
+        premisesId,
+        bookingId,
+        booking,
+        backLink: paths.bookings.show({ premisesId, bookingId }),
+        pageHeading: 'Change placement date',
+        errors: {},
+        errorSummary: [],
+      })
+
+      expect(bookingService.find).toHaveBeenCalledWith(token, premisesId, bookingId)
     })
   })
 

--- a/server/controllers/manage/dateChangesController.test.ts
+++ b/server/controllers/manage/dateChangesController.test.ts
@@ -16,6 +16,7 @@ jest.mock('../../utils/validation')
 
 describe('dateChangesController', () => {
   const token = 'SOME_TOKEN'
+  const backLink = 'http://localhost/some-path'
 
   let request: DeepMocked<Request>
   const response: DeepMocked<Response> = createMock<Response>({})
@@ -23,7 +24,7 @@ describe('dateChangesController', () => {
 
   const premisesId = 'premisesId'
   const bookingId = 'bookingId'
-  const requestParams = { user: { token }, params: { premisesId, bookingId } }
+  const requestParams = { user: { token }, params: { premisesId, bookingId }, headers: { referer: backLink } }
 
   const booking = bookingFactory.build()
 
@@ -51,6 +52,7 @@ describe('dateChangesController', () => {
         premisesId,
         bookingId,
         booking,
+        backLink,
         pageHeading: 'Change placement date',
         errors: {},
         errorSummary: [],
@@ -72,6 +74,7 @@ describe('dateChangesController', () => {
         premisesId,
         bookingId,
         booking,
+        backLink,
         pageHeading: 'Change placement date',
         errors: errorsAndUserInput.errors,
         errorSummary: errorsAndUserInput.errorSummary,
@@ -135,6 +138,8 @@ describe('dateChangesController', () => {
 
       const requestHandler = controller.create()
 
+      body.backLink = backLink
+
       request = createMock<Request>({ ...requestParams, body })
 
       await requestHandler(request, response, next)
@@ -148,9 +153,7 @@ describe('dateChangesController', () => {
 
       expect(request.flash).toHaveBeenCalledWith('success', 'Booking changed successfully')
 
-      expect(response.redirect).toHaveBeenCalledWith(
-        paths.bookings.show({ premisesId: request.params.premisesId, bookingId: request.params.bookingId }),
-      )
+      expect(response.redirect).toHaveBeenCalledWith(backLink)
     })
 
     describe('errors', () => {

--- a/server/controllers/manage/dateChangesController.ts
+++ b/server/controllers/manage/dateChangesController.ts
@@ -19,11 +19,13 @@ export default class DateChangeController {
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
       const booking = await this.bookingService.find(req.user.token, premisesId, bookingId)
+      const backLink = req.headers.referer
 
       res.render('bookings/dateChanges/new', {
         premisesId,
         bookingId,
         booking,
+        backLink,
         pageHeading: 'Change placement date',
         errors,
         errorSummary,
@@ -37,6 +39,7 @@ export default class DateChangeController {
       const { premisesId, bookingId } = req.params
 
       try {
+        const { backLink } = req.body
         const payload: NewDateChange = {}
         const emptyDates: Array<keyof NewDateChange> = []
         const datesToChange = flattenCheckboxInput(req.body.datesToChange)
@@ -61,7 +64,7 @@ export default class DateChangeController {
         await this.bookingService.changeDates(req.user.token, premisesId, bookingId, payload)
 
         req.flash('success', 'Booking changed successfully')
-        res.redirect(paths.bookings.show({ premisesId, bookingId }))
+        res.redirect(backLink)
       } catch (err) {
         catchValidationErrorOrPropogate(
           req,

--- a/server/controllers/manage/dateChangesController.ts
+++ b/server/controllers/manage/dateChangesController.ts
@@ -19,7 +19,15 @@ export default class DateChangeController {
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
       const booking = await this.bookingService.find(req.user.token, premisesId, bookingId)
-      const backLink = req.headers.referer
+      let backLink: string
+
+      if (userInput.backLink) {
+        backLink = userInput.backLink as string
+      } else if (req.headers.referer) {
+        backLink = req.headers.referer
+      } else {
+        backLink = paths.bookings.show({ premisesId, bookingId })
+      }
 
       res.render('bookings/dateChanges/new', {
         premisesId,

--- a/server/views/bookings/dateChanges/new.njk
+++ b/server/views/bookings/dateChanges/new.njk
@@ -13,7 +13,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
 		text: "Back",
-		href: paths.bookings.show({ premisesId: premisesId, bookingId: booking.id })
+		href: backLink
 	}) }}
 {% endblock %}
 
@@ -24,6 +24,8 @@
       <form action="{{ paths.bookings.dateChanges.create({ premisesId: premisesId, bookingId: booking.id }) }}" method="post">
 
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+        <input type="hidden" name="backLink" value="{{ backLink }}"/>
+
         <h1>{{ pageHeading }}</h1>
 
         {{ govukSummaryList({

--- a/server/views/cancellations/new.njk
+++ b/server/views/cancellations/new.njk
@@ -16,7 +16,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-	  href: paths.bookings.show({ premisesId: premisesId, bookingId: booking.id })
+	  href: backLink
   }) }}
 {% endblock %}
 
@@ -29,6 +29,7 @@
 
       <form action="{{ paths.bookings.cancellations.create({ premisesId: premisesId, bookingId: booking.id }) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+        <input type="hidden" name="backLink" value="{{ backLink }}"/>
 
         {{ govukSummaryList({
             rows: [


### PR DESCRIPTION
To support two possible routes for cancelling and amending bookings, we set the `backLink` in the Cancellation and Date Change controllers to be the referrer. We then also add the original referrer as a hidden field, so we know where to take the user back to when successful.

## Screenshots

![Placement Requests -- allows me to amend a booking](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/560f9124-c480-43af-8794-d21829aaf4ae)

![Placement Requests -- allows me to cancel a booking](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/625ea656-6a77-4765-ab76-0175b4ec47bb)

