### PR TITLE
Fix date isses

### DIFF
--- a/server/form-pages/apply/reasons-for-placement/basic-information/reasonForShortNotice.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/reasonForShortNotice.test.ts
@@ -16,7 +16,7 @@ describe('ReasonForShortNotice', () => {
 
     expect(page.title).toEqual('Emergency application')
     expect(page.question).toEqual(
-      'What is the reason for submitting this application less than 7 days before the AP is needed?',
+      'What is the reason for submitting this application less than 28 days before the AP is needed?',
     )
   })
 

--- a/server/form-pages/apply/reasons-for-placement/basic-information/reasonForShortNotice.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/reasonForShortNotice.ts
@@ -33,7 +33,7 @@ export default class ReasonForShortNotice implements TasklistPage {
   ) {
     if (noticeTypeFromApplication(application) === 'emergency') {
       this.title = 'Emergency application'
-      this.question = 'What is the reason for submitting this application less than 7 days before the AP is needed?'
+      this.question = 'What is the reason for submitting this application less than 28 days before the AP is needed?'
     } else {
       this.title = 'Short notice application'
       this.question = 'Why is this application being submitted outside of National Standards timescales?'

--- a/server/views/applications/pages/move-on/placement-duration.njk
+++ b/server/views/applications/pages/move-on/placement-duration.njk
@@ -11,11 +11,13 @@
 
     <p class="govuk-body">
       <strong>Arrival date:</strong>
-      {{uiDateOrDateEmptyMessage(page,'arrivalDate', dateObjToUIDate)}}</p>
+      {{ page.arrivalDate }}
+    </p>
 
     <p class="govuk-body">
       <strong>Departure date:</strong>
-      {{uiDateOrDateEmptyMessage(page,'departureDate', dateObjToUIDate)}}</p>
+      {{ page.departureDate }}
+    </p>
   {% endif %}
 
   {{ govukDetails({


### PR DESCRIPTION
This fixes two dates issues that @adamhughes86 noticed, the first one was where the number of  days an application should be treated as an emergency was incorrect, and the second one was where arrival and departure dates were missing from the Placement Duration section.