### PR TITLE
Disable API retries

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,6 +15,7 @@ generic-service:
     HMPPS_AUTH_URL: 'https://sign-in-preprod.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-preprod.prison.service.justice.gov.uk'
     COMMUNITY_ACCOMMODATION_API_SERVICE_NAME: approved-premises
+    COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -15,7 +15,7 @@ generic-service:
     HMPPS_AUTH_URL: 'https://sign-in.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api.prison.service.justice.gov.uk'
     COMMUNITY_ACCOMMODATION_API_SERVICE_NAME: approved-premises
-    COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 20000
+    COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -17,6 +17,7 @@ generic-service:
     HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
     COMMUNITY_ACCOMMODATION_API_SERVICE_NAME: approved-premises
+    COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
 
   allowlist: null
 

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -174,10 +174,6 @@ export default class RestClient {
         .send(this.filterBlanksFromData(data))
         .agent(this.agent)
         .use(restClientMetricsMiddleware)
-        .retry(2, (err, res) => {
-          if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
-          return undefined // retry handler only for logging retries, not to influence retry logic
-        })
         .auth(this.token, { type: 'bearer' })
         .set({ ...this.defaultHeaders, ...headers })
         .responseType(responseType)


### PR DESCRIPTION
This disables the API retries and increases the timeout to 30s. If a POST / PUT times out on the frontend, this can result in multiple queries succeeding.