### PR TITLE
(332, 345) Show Parole cases and Preferred APs

### DIFF
--- a/integration_tests/mockApis/placementRequests.ts
+++ b/integration_tests/mockApis/placementRequests.ts
@@ -21,18 +21,21 @@ export default {
       },
     }),
 
-  stubPlacementRequestsDashboard: (placementRequests: Array<PlacementRequest>): SuperAgentRequest =>
+  stubPlacementRequestsDashboard: (args: {
+    placementRequests: Array<PlacementRequest>
+    isParole: boolean
+  }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
-        urlPattern: paths.placementRequests.dashboard.pattern,
+        url: `${paths.placementRequests.dashboard.pattern}?isParole=${args.isParole}`,
       },
       response: {
         status: 200,
         headers: {
           'Content-Type': 'application/json;charset=UTF-8',
         },
-        jsonBody: placementRequests,
+        jsonBody: args.placementRequests,
       },
     }),
   stubPlacementRequest: (placementRequestDetail: PlacementRequestDetail): SuperAgentRequest =>

--- a/integration_tests/pages/admin/placementApplications/listPage.ts
+++ b/integration_tests/pages/admin/placementApplications/listPage.ts
@@ -6,20 +6,28 @@ import { shouldShowTableRows } from '../../../helpers'
 import { dashboardTableRows } from '../../../../server/utils/placementRequests/table'
 
 export default class ListPage extends Page {
-  constructor(private readonly placementRequests: Array<PlacementRequest>) {
+  constructor() {
     super('Placement requests')
   }
 
-  static visit(placementRequests: Array<PlacementRequest>): ListPage {
+  static visit(): ListPage {
     cy.visit(paths.admin.placementRequests.index({}))
-    return new ListPage(placementRequests)
+    return new ListPage()
   }
 
-  shouldShowPlacementRequests(): void {
-    shouldShowTableRows(this.placementRequests, dashboardTableRows)
+  shouldShowPlacementRequests(placementRequests: Array<PlacementRequest>): void {
+    shouldShowTableRows(placementRequests, dashboardTableRows)
   }
 
   clickPlacementRequest(placementRequest: PlacementRequest): void {
     cy.get(`[data-cy-placementRequestId="${placementRequest.id}"]`).click()
+  }
+
+  clickParoleOption(): void {
+    cy.get('a.moj-sub-navigation__link').contains('Parole').click()
+  }
+
+  clickNonParoleOption(): void {
+    cy.get('a.moj-sub-navigation__link').contains('Confirmed release date').click()
   }
 }

--- a/integration_tests/pages/admin/placementApplications/showPage.ts
+++ b/integration_tests/pages/admin/placementApplications/showPage.ts
@@ -69,6 +69,10 @@ export default class ShowPage extends Page {
     this.buttonShouldNotExist('Cance placement')
   }
 
+  shouldShowParoleNotification() {
+    cy.get('.govuk-notification-banner').contains('This application is parole').should('exist')
+  }
+
   private buttonShouldExist(text: string) {
     cy.contains('.moj-button-menu__item', text).should('exist')
   }

--- a/integration_tests/pages/admin/placementApplications/showPage.ts
+++ b/integration_tests/pages/admin/placementApplications/showPage.ts
@@ -1,6 +1,6 @@
 import Page from '../../page'
 
-import { PlacementRequest, PlacementRequestDetail } from '../../../../server/@types/shared'
+import { ApprovedPremises, PlacementRequest, PlacementRequestDetail } from '../../../../server/@types/shared'
 import { adminSummary, matchingInformationSummary } from '../../../../server/utils/placementRequests'
 import { bookingSummaryList } from '../../../../server/utils/bookingUtils'
 
@@ -71,6 +71,16 @@ export default class ShowPage extends Page {
 
   shouldShowParoleNotification() {
     cy.get('.govuk-notification-banner').contains('This application is parole').should('exist')
+  }
+
+  shouldShowPreferredAps(premises: Array<ApprovedPremises>) {
+    const apList = premises.map(p => `<li>${p.name}</li>`)
+    this.shouldContainSummaryListItems([
+      {
+        key: { text: 'Preferred APs' },
+        value: { html: `<ol class="govuk-list govuk-list--number">${apList.join('')}</ol>` },
+      },
+    ])
   }
 
   private buttonShouldExist(text: string) {

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -2,6 +2,7 @@ import ListPage from '../../pages/admin/placementApplications/listPage'
 import ShowPage from '../../pages/admin/placementApplications/showPage'
 
 import {
+  applicationFactory,
   cancellationFactory,
   placementRequestDetailFactory,
   placementRequestFactory,
@@ -10,6 +11,8 @@ import {
 import Page from '../../pages/page'
 import CreatePlacementPage from '../../pages/admin/placementApplications/createPlacementPage'
 import { CancellationCreatePage, NewDateChangePage } from '../../pages/manage'
+import { addResponseToFormArtifact } from '../../../server/testutils/addToApplication'
+import { ApprovedPremisesApplication as Application } from '../../../server/@types/shared'
 
 context('Placement Requests', () => {
   const placementRequests = placementRequestFactory.buildList(2)
@@ -20,6 +23,8 @@ context('Placement Requests', () => {
   })
   const placementRequestWithBooking = placementRequestDetailFactory.build({ ...placementRequests[1] })
   const parolePlacementRequest = placementRequestDetailFactory.build({ ...parolePlacementRequests[0] })
+  const preferredAps = premisesFactory.buildList(3)
+  let application = applicationFactory.build()
 
   beforeEach(() => {
     cy.task('reset')
@@ -28,6 +33,15 @@ context('Placement Requests', () => {
 
     // Given I am logged in
     cy.signIn()
+
+    application = addResponseToFormArtifact(application, {
+      section: 'location-factors',
+      page: 'preferred-aps',
+      key: 'selectedAps',
+      value: preferredAps,
+    }) as Application
+
+    placementRequestWithoutBooking.application = application
 
     cy.task('stubPlacementRequestsDashboard', { placementRequests, isParole: false })
     cy.task('stubPlacementRequestsDashboard', { placementRequests: parolePlacementRequests, isParole: true })
@@ -61,6 +75,7 @@ context('Placement Requests', () => {
     // And I should see the information about the placement request
     showPage.shouldShowSummary()
     showPage.shouldShowMatchingInformationSummary()
+    showPage.shouldShowPreferredAps(preferredAps)
 
     // And I should not see any booking information
     showPage.shouldNotShowBookingInformation()

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -13,6 +13,7 @@ import { CancellationCreatePage, NewDateChangePage } from '../../pages/manage'
 
 context('Placement Requests', () => {
   const placementRequests = placementRequestFactory.buildList(2)
+  const parolePlacementRequests = placementRequestFactory.buildList(2, { isParole: true })
   const placementRequestWithoutBooking = placementRequestDetailFactory.build({
     ...placementRequests[0],
     booking: undefined,
@@ -27,19 +28,29 @@ context('Placement Requests', () => {
     // Given I am logged in
     cy.signIn()
 
-    cy.task('stubPlacementRequestsDashboard', placementRequests)
+    cy.task('stubPlacementRequestsDashboard', { placementRequests, isParole: false })
+    cy.task('stubPlacementRequestsDashboard', { placementRequests: parolePlacementRequests, isParole: true })
     cy.task('stubPlacementRequest', placementRequestWithoutBooking)
     cy.task('stubPlacementRequest', placementRequestWithBooking)
   })
 
   it('allows me to view a placement request', () => {
     // When I visit the tasks dashboard
-    const listPage = ListPage.visit(placementRequests)
+    const listPage = ListPage.visit()
 
     // Then I should see a list of placement requests
-    listPage.shouldShowPlacementRequests()
+    listPage.shouldShowPlacementRequests(placementRequests)
 
-    // When I choose a placement request
+    // When I click the parole link
+    listPage.clickParoleOption()
+
+    // Then I should see the parole requests listed
+    listPage.shouldShowPlacementRequests(parolePlacementRequests)
+
+    // When I click the non-parole link
+    listPage.clickNonParoleOption()
+
+    // And I choose a placement request
     listPage.clickPlacementRequest(placementRequestWithoutBooking)
 
     // Then I should be taken to the placement request page
@@ -57,7 +68,7 @@ context('Placement Requests', () => {
     showPage.shouldNotShowCancelBookingOption()
 
     // When I go back to the dashboard
-    ListPage.visit(placementRequests)
+    ListPage.visit()
 
     // And I click the placement request with a booking
     listPage.clickPlacementRequest(placementRequestWithBooking)
@@ -83,7 +94,7 @@ context('Placement Requests', () => {
     cy.task('stubBookingFromPlacementRequest', placementRequestWithoutBooking)
 
     // When I visit the tasks dashboard
-    const listPage = ListPage.visit(placementRequests)
+    const listPage = ListPage.visit()
 
     // And I choose a placement request
     listPage.clickPlacementRequest(placementRequestWithoutBooking)
@@ -135,7 +146,7 @@ context('Placement Requests', () => {
     })
 
     // When I visit the tasks dashboard
-    const listPage = ListPage.visit(placementRequests)
+    const listPage = ListPage.visit()
 
     // And I choose a placement request
     listPage.clickPlacementRequest(placementRequestWithBooking)
@@ -187,7 +198,7 @@ context('Placement Requests', () => {
     cy.task('stubCancellationReferenceData')
 
     // When I visit the tasks dashboard
-    const listPage = ListPage.visit(placementRequests)
+    const listPage = ListPage.visit()
 
     // And I choose a placement request
     listPage.clickPlacementRequest(placementRequestWithBooking)

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -19,6 +19,7 @@ context('Placement Requests', () => {
     booking: undefined,
   })
   const placementRequestWithBooking = placementRequestDetailFactory.build({ ...placementRequests[1] })
+  const parolePlacementRequest = placementRequestDetailFactory.build({ ...parolePlacementRequests[0] })
 
   beforeEach(() => {
     cy.task('reset')
@@ -32,6 +33,7 @@ context('Placement Requests', () => {
     cy.task('stubPlacementRequestsDashboard', { placementRequests: parolePlacementRequests, isParole: true })
     cy.task('stubPlacementRequest', placementRequestWithoutBooking)
     cy.task('stubPlacementRequest', placementRequestWithBooking)
+    cy.task('stubPlacementRequest', parolePlacementRequest)
   })
 
   it('allows me to view a placement request', () => {
@@ -86,6 +88,21 @@ context('Placement Requests', () => {
 
     // And I should not see any booking information
     showPage.shouldShowBookingInformation()
+
+    // When I go back to the dashboard
+    ListPage.visit()
+
+    // And I click the parole link
+    listPage.clickParoleOption()
+
+    // And I click the parole placement request
+    listPage.clickPlacementRequest(parolePlacementRequest)
+
+    // Then I should be taken to the placement request page
+    showPage = Page.verifyOnPage(ShowPage, parolePlacementRequest)
+
+    // And I should see the parole notification banner
+    showPage.shouldShowParoleNotification()
   })
 
   it('allows me to create a booking', () => {

--- a/server/controllers/admin/placementRequestsController.test.ts
+++ b/server/controllers/admin/placementRequestsController.test.ts
@@ -38,8 +38,25 @@ describe('PlacementRequestsController', () => {
       expect(response.render).toHaveBeenCalledWith('admin/placementRequests/index', {
         pageHeading: 'Placement requests',
         placementRequests,
+        isParole: false,
       })
-      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token)
+      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, false)
+    })
+
+    it('should request parole placement requests', async () => {
+      const placementRequests = placementRequestFactory.buildList(2)
+      placementRequestService.getDashboard.mockResolvedValue(placementRequests)
+
+      const requestHandler = placementRequestsController.index()
+
+      await requestHandler({ ...request, query: { isParole: '1' } }, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('admin/placementRequests/index', {
+        pageHeading: 'Placement requests',
+        placementRequests,
+        isParole: true,
+      })
+      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, true)
     })
   })
 

--- a/server/controllers/admin/placementRequestsController.ts
+++ b/server/controllers/admin/placementRequestsController.ts
@@ -6,11 +6,13 @@ export default class PlacementRequestsController {
 
   index(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
-      const placementRequests = await this.placementRequestService.getDashboard(req.user.token)
+      const isParole = req.query.isParole === '1'
+      const placementRequests = await this.placementRequestService.getDashboard(req.user.token, isParole)
 
       res.render('admin/placementRequests/index', {
         pageHeading: 'Placement requests',
         placementRequests,
+        isParole,
       })
     }
   }

--- a/server/data/placementRequestClient.test.ts
+++ b/server/data/placementRequestClient.test.ts
@@ -46,15 +46,16 @@ describeClient('placementRequestClient', provider => {
   })
 
   describe('dashboard', () => {
-    it('makes a get request to the placementRequests dashboard endpoint', async () => {
-      const placementRequests = placementRequestFactory.buildList(2)
+    const placementRequests = placementRequestFactory.buildList(2)
 
+    it('makes a get request to the placementRequests dashboard endpoint for parole requests', async () => {
       provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get the placement requests dashboard view',
         withRequest: {
           method: 'GET',
           path: paths.placementRequests.dashboard.pattern,
+          query: { isParole: 'true' },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -65,7 +66,30 @@ describeClient('placementRequestClient', provider => {
         },
       })
 
-      const result = await placementRequestClient.dashboard()
+      const result = await placementRequestClient.dashboard(true)
+
+      expect(result).toEqual(placementRequests)
+    })
+
+    it('makes a get request to the placementRequests dashboard endpoint for non-parole requests', async () => {
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get the placement requests dashboard view',
+        withRequest: {
+          method: 'GET',
+          path: paths.placementRequests.dashboard.pattern,
+          query: { isParole: 'false' },
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: placementRequests,
+        },
+      })
+
+      const result = await placementRequestClient.dashboard(false)
 
       expect(result).toEqual(placementRequests)
     })

--- a/server/data/placementRequestClient.ts
+++ b/server/data/placementRequestClient.ts
@@ -9,6 +9,7 @@ import {
 import config, { ApiConfig } from '../config'
 import RestClient from './restClient'
 import paths from '../paths/api'
+import { createQueryString } from '../utils/utils'
 
 export default class PlacementRequestClient {
   restClient: RestClient
@@ -23,10 +24,11 @@ export default class PlacementRequestClient {
     >
   }
 
-  async dashboard(): Promise<Array<PlacementRequest>> {
-    return (await this.restClient.get({ path: paths.placementRequests.dashboard.pattern })) as Promise<
-      Array<PlacementRequest>
-    >
+  async dashboard(isParole: boolean): Promise<Array<PlacementRequest>> {
+    return (await this.restClient.get({
+      path: paths.placementRequests.dashboard.pattern,
+      query: createQueryString({ isParole }),
+    })) as Promise<Array<PlacementRequest>>
   }
 
   async find(id: string): Promise<PlacementRequestDetail> {

--- a/server/services/placementRequestService.test.ts
+++ b/server/services/placementRequestService.test.ts
@@ -51,12 +51,12 @@ describe('placementRequestService', () => {
       const placementRequests = placementRequestFactory.buildList(4, { status: 'notMatched' })
       placementRequestClient.dashboard.mockResolvedValue(placementRequests)
 
-      const result = await service.getDashboard(token)
+      const result = await service.getDashboard(token, false)
 
       expect(result).toEqual(placementRequests)
 
       expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
-      expect(placementRequestClient.dashboard).toHaveBeenCalled()
+      expect(placementRequestClient.dashboard).toHaveBeenCalledWith(false)
     })
   })
 

--- a/server/services/placementRequestService.ts
+++ b/server/services/placementRequestService.ts
@@ -30,10 +30,10 @@ export default class PlacementRequestService {
     return results
   }
 
-  async getDashboard(token: string): Promise<Array<PlacementRequest>> {
+  async getDashboard(token: string, isParole: boolean): Promise<Array<PlacementRequest>> {
     const placementRequestClient = this.placementRequestClientFactory(token)
 
-    return placementRequestClient.dashboard()
+    return placementRequestClient.dashboard(isParole)
   }
 
   async getPlacementRequest(token: string, id: string): Promise<PlacementRequestDetail> {

--- a/server/utils/placementRequests/adminSummary.test.ts
+++ b/server/utils/placementRequests/adminSummary.test.ts
@@ -11,6 +11,7 @@ describe('adminSummary', () => {
     const placementRequest = placementRequestDetailFactory.build({
       expectedArrival: '2022-01-01',
       duration: 16,
+      isParole: false,
     })
 
     expect(adminSummary(placementRequest)).toEqual({
@@ -34,6 +35,61 @@ describe('adminSummary', () => {
         {
           key: {
             text: 'Arrival Date',
+          },
+          value: {
+            text: DateFormats.isoDateToUIDate('2022-01-01'),
+          },
+        },
+        {
+          key: {
+            text: 'Departure Date',
+          },
+          value: {
+            text: DateFormats.isoDateToUIDate('2022-01-17'),
+          },
+        },
+        {
+          key: {
+            text: 'Length of stay',
+          },
+          value: {
+            text: placementLength(16),
+          },
+        },
+        apTypeCell(placementRequest),
+        releaseTypeCell(placementRequest),
+      ],
+    })
+  })
+
+  it('should return a summary of a parole placement request', () => {
+    const placementRequest = placementRequestDetailFactory.build({
+      expectedArrival: '2022-01-01',
+      duration: 16,
+      isParole: true,
+    })
+
+    expect(adminSummary(placementRequest)).toEqual({
+      rows: [
+        {
+          key: {
+            text: 'CRN',
+          },
+          value: {
+            text: placementRequest.person.crn,
+          },
+        },
+        {
+          key: {
+            text: 'Tier',
+          },
+          value: {
+            text: placementRequest.risks.tier.value.level,
+          },
+        },
+        {
+          key: {
+            text: 'Date of decision',
           },
           value: {
             text: DateFormats.isoDateToUIDate('2022-01-01'),

--- a/server/utils/placementRequests/adminSummary.ts
+++ b/server/utils/placementRequests/adminSummary.ts
@@ -27,7 +27,7 @@ export const adminSummary = (placementRequest: PlacementRequestDetail): SummaryL
       },
       {
         key: {
-          text: 'Arrival Date',
+          text: placementRequest.isParole ? 'Date of decision' : 'Arrival Date',
         },
         value: {
           text: DateFormats.isoDateToUIDate(dates.startDate),

--- a/server/utils/placementRequests/getPreferredApsFromApplication.test.ts
+++ b/server/utils/placementRequests/getPreferredApsFromApplication.test.ts
@@ -1,0 +1,35 @@
+import { placementRequestDetailFactory, premisesFactory } from '../../testutils/factories'
+import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromFormArtifact'
+import { getPreferredApsFromApplication } from './getPreferredApsFromApplication'
+import PreferredAps from '../../form-pages/apply/risk-and-need-factors/location-factors/preferredAps'
+
+jest.mock('../retrieveQuestionResponseFromFormArtifact')
+
+describe('getPreferredApsFromApplication', () => {
+  const placementRequestDetail = placementRequestDetailFactory.build()
+
+  it('should return a list of preferred APs', () => {
+    const preferredAps = premisesFactory.buildList(3)
+    ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue(preferredAps)
+
+    expect(getPreferredApsFromApplication(placementRequestDetail)).toEqual(preferredAps)
+
+    expect(retrieveOptionalQuestionResponseFromApplicationOrAssessment).toHaveBeenCalledWith(
+      placementRequestDetail.application,
+      PreferredAps,
+      'selectedAps',
+    )
+  })
+
+  it('should return an empty list if no APs are specified', () => {
+    ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue(undefined)
+
+    expect(getPreferredApsFromApplication(placementRequestDetail)).toEqual([])
+
+    expect(retrieveOptionalQuestionResponseFromApplicationOrAssessment).toHaveBeenCalledWith(
+      placementRequestDetail.application,
+      PreferredAps,
+      'selectedAps',
+    )
+  })
+})

--- a/server/utils/placementRequests/getPreferredApsFromApplication.ts
+++ b/server/utils/placementRequests/getPreferredApsFromApplication.ts
@@ -1,0 +1,8 @@
+import { ApprovedPremises, ApprovedPremisesApplication, PlacementRequestDetail } from '../../@types/shared'
+import PreferredAps from '../../form-pages/apply/risk-and-need-factors/location-factors/preferredAps'
+import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromFormArtifact'
+
+export const getPreferredApsFromApplication = (placementRequest: PlacementRequestDetail): Array<ApprovedPremises> => {
+  const application = placementRequest.application as ApprovedPremisesApplication
+  return retrieveOptionalQuestionResponseFromApplicationOrAssessment(application, PreferredAps, 'selectedAps') || []
+}

--- a/server/utils/placementRequests/matchingInformationSummaryList.test.ts
+++ b/server/utils/placementRequests/matchingInformationSummaryList.test.ts
@@ -1,11 +1,16 @@
-import { placementRequestFactory } from '../../testutils/factories'
+import { placementRequestDetailFactory, premisesFactory } from '../../testutils/factories'
 import { mapSearchParamCharacteristicsForUi } from '../matchUtils'
-import { matchingInformationSummary, placementRequirementsRow } from './matchingInformationSummaryList'
+import { matchingInformationSummary, placementRequirementsRow, preferredApsRow } from './matchingInformationSummaryList'
+import { getPreferredApsFromApplication } from './getPreferredApsFromApplication'
+import { HtmlItem } from '../../@types/ui'
+
+jest.mock('./getPreferredApsFromApplication')
 
 describe('matchingInformationSummaryList', () => {
   describe('matchingInformationSummary', () => {
     it('should return a summary of the matching information', () => {
-      const placementRequest = placementRequestFactory.build()
+      ;(getPreferredApsFromApplication as jest.Mock).mockReturnValue([])
+      const placementRequest = placementRequestDetailFactory.build()
 
       expect(matchingInformationSummary(placementRequest)).toEqual({
         card: {
@@ -21,7 +26,9 @@ describe('matchingInformationSummaryList', () => {
     })
 
     it('should add notes if provided', () => {
-      const placementRequest = placementRequestFactory.build({ notes: 'Some notes' })
+      ;(getPreferredApsFromApplication as jest.Mock).mockReturnValue([])
+
+      const placementRequest = placementRequestDetailFactory.build({ notes: 'Some notes' })
 
       expect(matchingInformationSummary(placementRequest)).toEqual({
         card: {
@@ -43,11 +50,29 @@ describe('matchingInformationSummaryList', () => {
         ],
       })
     })
+
+    it('should add preferred APs if provided', () => {
+      ;(getPreferredApsFromApplication as jest.Mock).mockReturnValue(premisesFactory.buildList(4))
+      const placementRequest = placementRequestDetailFactory.build({})
+
+      expect(matchingInformationSummary(placementRequest)).toEqual({
+        card: {
+          title: {
+            text: 'Information for Matching',
+          },
+        },
+        rows: [
+          preferredApsRow(placementRequest),
+          placementRequirementsRow(placementRequest, 'essential'),
+          placementRequirementsRow(placementRequest, 'desirable'),
+        ],
+      })
+    })
   })
 
   describe('placementRequirementsRow', () => {
     it('returns a list of desirable placement requirements in sentence case', () => {
-      const placementRequest = placementRequestFactory.build()
+      const placementRequest = placementRequestDetailFactory.build()
 
       expect(placementRequirementsRow(placementRequest, 'desirable')).toEqual({
         key: {
@@ -62,7 +87,7 @@ describe('matchingInformationSummaryList', () => {
 
   describe('placementRequirementsRow', () => {
     it('returns a list of essential placement requirements in sentence case', () => {
-      const placementRequest = placementRequestFactory.build()
+      const placementRequest = placementRequestDetailFactory.build()
 
       expect(placementRequirementsRow(placementRequest, 'essential')).toEqual({
         key: {
@@ -72,6 +97,33 @@ describe('matchingInformationSummaryList', () => {
           html: mapSearchParamCharacteristicsForUi(placementRequest.essentialCriteria),
         },
       })
+    })
+  })
+
+  describe('preferredApsRow', () => {
+    const placementRequest = placementRequestDetailFactory.build()
+
+    it('should return undefined if there are no preferred APs', () => {
+      ;(getPreferredApsFromApplication as jest.Mock).mockReturnValue([])
+
+      expect(preferredApsRow(placementRequest)).toEqual(undefined)
+    })
+
+    it('should return a list of premises if there are preferred APs', () => {
+      const premises = premisesFactory.buildList(4)
+      ;(getPreferredApsFromApplication as jest.Mock).mockReturnValue(premises)
+
+      const row = preferredApsRow(placementRequest)
+
+      expect(row.key).toEqual({ text: 'Preferred APs' })
+      expect((row.value as HtmlItem).html).toMatchStringIgnoringWhitespace(`
+      <ol class="govuk-list govuk-list--number">
+        <li>${premises[0].name}</li>
+        <li>${premises[1].name}</li>
+        <li>${premises[2].name}</li>
+        <li>${premises[3].name}</li>
+      </ol>
+      `)
     })
   })
 })

--- a/server/utils/placementRequests/matchingInformationSummaryList.ts
+++ b/server/utils/placementRequests/matchingInformationSummaryList.ts
@@ -1,13 +1,20 @@
-import { PlacementRequest } from '@approved-premises/api'
+import { PlacementRequest, PlacementRequestDetail } from '@approved-premises/api'
 import { SummaryListItem, SummaryListWithCard } from '@approved-premises/ui'
 import { sentenceCase } from '../utils'
 import { mapSearchParamCharacteristicsForUi } from '../matchUtils'
+import { getPreferredApsFromApplication } from './getPreferredApsFromApplication'
 
-export const matchingInformationSummary = (placementRequest: PlacementRequest): SummaryListWithCard => {
-  const rows = [
-    placementRequirementsRow(placementRequest, 'essential'),
-    placementRequirementsRow(placementRequest, 'desirable'),
-  ]
+export const matchingInformationSummary = (placementRequest: PlacementRequestDetail): SummaryListWithCard => {
+  const rows = []
+
+  const preferredAps = preferredApsRow(placementRequest)
+
+  if (preferredAps) {
+    rows.push(preferredAps)
+  }
+
+  rows.push(placementRequirementsRow(placementRequest, 'essential'))
+  rows.push(placementRequirementsRow(placementRequest, 'desirable'))
 
   if (placementRequest.notes) {
     rows.push({
@@ -28,6 +35,20 @@ export const matchingInformationSummary = (placementRequest: PlacementRequest): 
     },
     rows,
   }
+}
+
+export const preferredApsRow = (placementRequest: PlacementRequestDetail): SummaryListItem | undefined => {
+  const premises = getPreferredApsFromApplication(placementRequest)
+
+  if (premises.length) {
+    const apList = premises.map(p => `<li>${p.name}</li>`)
+    return {
+      key: { text: 'Preferred APs' },
+      value: { html: `<ol class="govuk-list govuk-list--number">${apList.join('')}</ol>` },
+    }
+  }
+
+  return undefined
 }
 
 export const placementRequirementsRow = (

--- a/server/views/admin/placementRequests/index.njk
+++ b/server/views/admin/placementRequests/index.njk
@@ -1,5 +1,6 @@
 {% extends "../../partials/layout.njk" %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 
 {% set pageTitle = applicationName + " - " + pageHeading  %}
 {% set mainClasses = "app-container govuk-body assessments--index" %}
@@ -11,6 +12,24 @@
 
       <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
       {% include "../../_messages.njk" %}
+
+      {{
+        mojSubNavigation({
+          label: 'Sub navigation',
+          items: [
+            {
+              text: 'Confirmed release date',
+              href: paths.admin.placementRequests.index({}),
+              active: (isParole === false)
+            },
+            {
+              text: 'Parole',
+              href: paths.admin.placementRequests.index({}) + "?isParole=1",
+              active: (isParole === true)
+            }
+        ]
+        })
+      }}
 
       {{
               govukTable({
@@ -26,7 +45,7 @@
                           text: "CRN"
                       },
                       {
-                          text: "Arrival Date",
+                          text: ("Date of decision" if isParole else "Arrival date"),
                           attributes: {
                             "aria-sort": "none"
                           }

--- a/server/views/admin/placementRequests/show.njk
+++ b/server/views/admin/placementRequests/show.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -18,6 +19,24 @@
     <div class="govuk-grid-row">
       <div class="govuk-width-container">
         <div class="govuk-grid-column-two-thirds">
+          {% if placementRequest.isParole %}
+            {% set html %}
+            <p class="govuk-notification-banner__heading">
+                This application is parole
+              </p>
+            <p class="govuk-body">
+                The person can be placed in an Approved Premises six weeks after the boards date of decision. The release date has been calculated as {{ formatDate(placementRequest.expectedArrival) }}.
+              </p>
+            <p class="govuk-body">
+                You can change the placement arrival date by using the ‘Amend dates’ screen. Contact the PP for further details on the release date.
+              </p>
+            {% endset %}
+
+            {{ govukNotificationBanner({
+              html: html
+            }) }}
+          {% endif %}
+
           <ul class="govuk-list govuk-!-padding-bottom-3">
             <li>
               <a href="{{paths.applications.show({id: placementRequest.applicationId})}}">View application</a>


### PR DESCRIPTION
This adds a filterable list of Placement Requests that are associated with Parole cases, as well as adding a list of Preferred APs to the matching summary.

## Screenshots

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/52a69dfa-07fc-4e27-ac98-e3ad96964f6a)

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/94ea1464-4349-442a-8ca7-84a923bc349a)

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/531879fe-541c-41f3-b333-8fdc869c300f)

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/03917667-c126-40e9-96e6-3aa07af6c75b)
