### PR TITLE
Update copy of Parole info box on Placement Request page

### DIFF
--- a/integration_tests/pages/admin/placementApplications/showPage.ts
+++ b/integration_tests/pages/admin/placementApplications/showPage.ts
@@ -70,7 +70,7 @@ export default class ShowPage extends Page {
   }
 
   shouldShowParoleNotification() {
-    cy.get('.govuk-notification-banner').contains('This application is parole').should('exist')
+    cy.get('.govuk-notification-banner').contains('Parole board directed release').should('exist')
   }
 
   shouldShowPreferredAps(premises: Array<ApprovedPremises>) {

--- a/server/views/admin/placementRequests/show.njk
+++ b/server/views/admin/placementRequests/show.njk
@@ -22,14 +22,18 @@
           {% if placementRequest.isParole %}
             {% set html %}
             <p class="govuk-notification-banner__heading">
-                This application is parole
+                Parole board directed release
               </p>
             <p class="govuk-body">
-                The person can be placed in an Approved Premises six weeks after the boards date of decision. The release date has been calculated as {{ formatDate(placementRequest.expectedArrival) }}.
+                The person's arrival date has been calculated as {{ formatDate(placementRequest.expectedArrival) }}. 
+                This is 6 weeks after the parole board's date of decision.
               </p>
-            <p class="govuk-body">
-                You can change the placement arrival date by using the ‘Amend dates’ screen. Contact the PP for further details on the release date.
+            {% if placementRequest.booking %}
+              <p class="govuk-body">
+                If needed, you can <a href="{{paths.bookings.dateChanges.new({ premisesId: placementRequest.booking.premisesId, bookingId: placementRequest.booking.id })}}">change the arrival date</a> in the Approved Premises service.
               </p>
+            {% endif %}
+
             {% endset %}
 
             {{ govukNotificationBanner({


### PR DESCRIPTION
At this point the Placement Request *should* have a booking but just in case it doesn't we will hide the link.

[Updated copy](https://mojdt.slack.com/archives/C02SHKETZ7F/p1690450048128059?thread_ts=1690449537.398459&cid=C02SHKETZ7F) 

## Screenshots
### Before

![after (4)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/f0a5a0fb-cc3b-4771-9f74-df9321cd7492)



### After
![after (3)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/201f5333-f251-47cc-b44a-2193b2b58bea)




