### PR TITLE
(378) Add link to beds from calendar

### DIFF
--- a/server/controllers/manage/premises/bedsController.test.ts
+++ b/server/controllers/manage/premises/bedsController.test.ts
@@ -9,6 +9,7 @@ import {
   bedOccupancyEntryOverbookingUiFactory,
   bedSummaryFactory,
 } from '../../../testutils/factories'
+import paths from '../../../paths/manage'
 
 describe('BedsController', () => {
   const token = 'SOME_TOKEN'
@@ -42,22 +43,45 @@ describe('BedsController', () => {
   })
 
   describe('show', () => {
-    it('should return the bed to the template', async () => {
-      const bed = bedDetailFactory.build()
-      const premisesId = 'premisesId'
+    const bed = bedDetailFactory.build()
+    const premisesId = 'premisesId'
+    const bedId = 'bedId'
+
+    beforeEach(() => {
       request.params.premisesId = premisesId
-      const bedId = 'bedId'
       request.params.bedId = bedId
-
       premisesService.getBed.mockResolvedValue(bed)
+    })
 
+    it('should return the bed to the template', async () => {
       const requestHandler = bedsController.show()
+
+      request.headers.referer = 'http://localhost/'
+
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('premises/beds/show', {
         bed,
         premisesId,
         pageHeading: 'Manage beds',
+        backLink: paths.premises.beds.index({ premisesId }),
+      })
+
+      expect(premisesService.getBed).toHaveBeenCalledWith(token, premisesId, bedId)
+    })
+
+    it('should return the bed to the template with a link back to the calendar', async () => {
+      const requestHandler = bedsController.show()
+
+      request.headers.referer = 'http://localhost/calendar'
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('premises/beds/show', {
+        bed,
+        premisesId,
+        pageHeading: 'Manage beds',
+        backLink: paths.premises.calendar({ premisesId }),
       })
 
       expect(premisesService.getBed).toHaveBeenCalledWith(token, premisesId, bedId)

--- a/server/controllers/manage/premises/bedsController.ts
+++ b/server/controllers/manage/premises/bedsController.ts
@@ -2,6 +2,7 @@ import type { Request, RequestHandler, Response } from 'express'
 
 import { decodeOverbooking } from '../../../utils/bedUtils'
 import PremisesService from '../../../services/premisesService'
+import paths from '../../../paths/manage'
 
 export default class BedsController {
   constructor(private readonly premisesService: PremisesService) {}
@@ -20,12 +21,21 @@ export default class BedsController {
 
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
+      let backLink: string
+
+      if (req.headers.referer?.match(/calendar/)) {
+        backLink = paths.premises.calendar({ premisesId: req.params.premisesId })
+      } else {
+        backLink = paths.premises.beds.index({ premisesId: req.params.premisesId })
+      }
+
       const bed = await this.premisesService.getBed(req.user.token, req.params.premisesId, req.params.bedId)
 
       return res.render('premises/beds/show', {
         bed,
         premisesId: req.params.premisesId,
         pageHeading: 'Manage beds',
+        backLink,
       })
     }
   }

--- a/server/utils/calendarUtils.test.ts
+++ b/server/utils/calendarUtils.test.ts
@@ -1,5 +1,6 @@
 import { addDays, differenceInDays, getDaysInMonth, subDays } from 'date-fns'
 import { bedOccupancyEntryUiFactory, bedOccupancyRangeFactoryUi } from '../testutils/factories'
+import paths from '../paths/manage'
 
 import {
   bedRow,
@@ -135,7 +136,10 @@ describe('calendarUtils', () => {
 
       expect(bedRow(bedOccupancyRange, startDate, premisesId)).toMatchStringIgnoringWhitespace(
         `<tr class="${rowClass}" data-cy-bedId="${bedOccupancyRange.bedId}">
-        <th scope="row" class="${headerClass}">${bedOccupancyRange.bedName}</th>
+        <th scope="row" class="${headerClass}"><a href="${paths.premises.beds.show({
+          premisesId,
+          bedId: bedOccupancyRange.bedId,
+        })}" class="govuk-link">${bedOccupancyRange.bedName}</a></th>
         ${generateRowCells(bedOccupancyRange, startDate, premisesId)}</tr>`,
       )
     })

--- a/server/utils/calendarUtils.ts
+++ b/server/utils/calendarUtils.ts
@@ -80,7 +80,10 @@ export const bedRows = (bedOccupancyRangeList: Array<BedOccupancyRangeUi>, start
 
 export const bedRow = (bedOccupancyRange: BedOccupancyRangeUi, startDate: Date, premisesId: string) => {
   return `<tr class="${rowClass}" data-cy-bedId="${bedOccupancyRange.bedId}">
-    <th scope="row" class="${headerClass}">${bedOccupancyRange.bedName}</th>
+    <th scope="row" class="${headerClass}"><a href="${paths.premises.beds.show({
+      premisesId,
+      bedId: bedOccupancyRange.bedId,
+    })}" class="govuk-link">${bedOccupancyRange.bedName}</a></th>
     ${generateRowCells(bedOccupancyRange, startDate, premisesId)}</tr>`
 }
 

--- a/server/views/premises/beds/show.njk
+++ b/server/views/premises/beds/show.njk
@@ -11,7 +11,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
 		text: "Back",
-		href: paths.premises.beds.index({ premisesId: premisesId })
+		href: backLink
 	}) }}
 {% endblock %}
 


### PR DESCRIPTION
🎆  PR 1000! 🎆 

Users have requested a way of being able to see the bed details from the calendar view. As a quick fix, we’re adding a link to each bed, allowing users to be able to quickly see if an available bed has the necessary characteristics.

# Screenshot

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/8ff4d4f1-180f-4b8c-9c4f-45618b3bac34)
