### PR TITLE
(359) Ability to withdraw placement requests

### DIFF
--- a/integration_tests/mockApis/placementRequests.ts
+++ b/integration_tests/mockApis/placementRequests.ts
@@ -87,4 +87,24 @@ export default {
         jsonBody: bookingNotMadeFactory.build(),
       },
     }),
+  stubPlacementRequestWithdrawal: (placementRequest: PlacementRequest): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: paths.placementRequests.withdrawal.create({ id: placementRequest.id }),
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+      },
+    }),
+  verifyPlacementRequestWithdrawal: async (placementRequest: PlacementRequest) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: paths.placementRequests.withdrawal.create({ id: placementRequest.id }),
+      })
+    ).body.requests,
 }

--- a/integration_tests/pages/admin/placementApplications/showPage.ts
+++ b/integration_tests/pages/admin/placementApplications/showPage.ts
@@ -45,6 +45,11 @@ export default class ShowPage extends Page {
     cy.contains('.moj-button-menu__item', 'Cancel placement').click()
   }
 
+  clickWithdraw() {
+    cy.get('.moj-button-menu__toggle-button').click()
+    cy.contains('.moj-button-menu__item', 'Withdraw placement request').click()
+  }
+
   shouldShowCreateBookingOption() {
     this.buttonShouldExist('Create placement')
   }

--- a/integration_tests/pages/manage/withdrawConfirm.ts
+++ b/integration_tests/pages/manage/withdrawConfirm.ts
@@ -1,0 +1,11 @@
+import Page from '../page'
+
+export default class WithdrawConfirmPage extends Page {
+  constructor() {
+    super('Are you sure you want to withdraw this placement request?')
+  }
+
+  completeForm() {
+    this.checkRadioByNameAndValue('confirm', 'yes')
+  }
+}

--- a/server/controllers/admin/index.ts
+++ b/server/controllers/admin/index.ts
@@ -2,6 +2,7 @@
 
 import AdminPlacementRequestsController from './placementRequestsController'
 import PlacementRequestsBookingsController from './placementRequests/bookingsController'
+import PlacementRequestsWithdrawalsController from './placementRequests/withdrawalsController'
 
 import type { Services } from '../../services'
 
@@ -12,10 +13,12 @@ export const controllers = (services: Services) => {
     placementRequestService,
     premisesService,
   )
+  const placementRequestWithdrawalsController = new PlacementRequestsWithdrawalsController(placementRequestService)
 
   return {
     adminPlacementRequestsController,
     placementRequestsBookingsController,
+    placementRequestWithdrawalsController,
   }
 }
 

--- a/server/controllers/admin/placementRequests/withdrawalsController.test.ts
+++ b/server/controllers/admin/placementRequests/withdrawalsController.test.ts
@@ -1,0 +1,121 @@
+import type { NextFunction, Request, Response } from 'express'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+
+import type { ErrorsAndUserInput } from '@approved-premises/ui'
+import { PlacementRequestService } from '../../../services'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
+
+import paths from '../../../paths/admin'
+import WithdrawalsController from './withdrawalsController'
+import { ErrorWithData } from '../../../utils/errors'
+
+jest.mock('../../../utils/validation')
+
+describe('withdrawalsController', () => {
+  const token = 'SOME_TOKEN'
+
+  let request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  let response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = jest.fn()
+
+  const placementRequestService = createMock<PlacementRequestService>({})
+
+  let withdrawalsController: WithdrawalsController
+
+  beforeEach(() => {
+    withdrawalsController = new WithdrawalsController(placementRequestService)
+    request = createMock<Request>({ user: { token } })
+    response = createMock<Response>({})
+    jest.clearAllMocks()
+  })
+
+  describe('new', () => {
+    it('renders the template', async () => {
+      const applicationId = 'some-id'
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
+      request.params.id = applicationId
+
+      const requestHandler = withdrawalsController.new()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('admin/placementRequests/withdrawals/new', {
+        pageHeading: 'Are you sure you want to withdraw this placement request?',
+        id: request.params.id,
+        errors: errorsAndUserInput.errors,
+        errorSummary: errorsAndUserInput.errorSummary,
+      })
+    })
+  })
+
+  describe('create', () => {
+    const applicationId = 'some-id'
+
+    beforeEach(() => {
+      request.params.id = applicationId
+    })
+
+    it('calls the service method, redirects to the index screen and shows a confirmation message', async () => {
+      request.body.confirm = 'yes'
+
+      const requestHandler = withdrawalsController.create()
+
+      await requestHandler(request, response, next)
+
+      expect(placementRequestService.withdraw).toHaveBeenCalledWith(token, applicationId)
+      expect(response.redirect).toHaveBeenCalledWith(paths.admin.placementRequests.index({}))
+      expect(request.flash).toHaveBeenCalledWith('success', 'Placement request withdrawn successfully')
+    })
+
+    it('redirects with errors if the API returns an error', async () => {
+      const requestHandler = withdrawalsController.create()
+
+      const err = new Error()
+
+      placementRequestService.withdraw.mockImplementation(() => {
+        throw err
+      })
+
+      await requestHandler(request, response, next)
+
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+        request,
+        response,
+        err,
+        paths.admin.placementRequests.withdrawal.new({ id: request.params.id }),
+      )
+    })
+
+    it('redirects with errors if confirm is blank', async () => {
+      const requestHandler = withdrawalsController.create()
+
+      await requestHandler(request, response, next)
+
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+        request,
+        response,
+        new ErrorWithData({}),
+        paths.admin.placementRequests.withdrawal.new({ id: request.params.id }),
+      )
+
+      const errorData = (catchValidationErrorOrPropogate as jest.Mock).mock.lastCall[2].data
+
+      expect(errorData).toEqual({
+        'invalid-params': [{ propertyName: `$.confirm`, errorType: 'empty' }],
+      })
+    })
+
+    it('redirects to the placement request if confirm is no', async () => {
+      request.body.confirm = 'no'
+
+      const requestHandler = withdrawalsController.create()
+
+      await requestHandler(request, response, next)
+
+      expect(placementRequestService.withdraw).not.toHaveBeenCalled()
+      expect(response.redirect).toHaveBeenCalledWith(paths.admin.placementRequests.show({ id: request.params.id }))
+      expect(request.flash).toHaveBeenCalledWith('success', 'Placement request not withdrawn')
+    })
+  })
+})

--- a/server/controllers/admin/placementRequests/withdrawalsController.ts
+++ b/server/controllers/admin/placementRequests/withdrawalsController.ts
@@ -1,0 +1,52 @@
+import type { Request, RequestHandler, Response } from 'express'
+
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
+import paths from '../../../paths/admin'
+import { PlacementRequestService } from '../../../services'
+import { ErrorWithData } from '../../../utils/errors'
+
+export const tasklistPageHeading = 'Apply for an Approved Premises (AP) placement'
+
+export default class WithdrawlsController {
+  constructor(private readonly placementRequestService: PlacementRequestService) {}
+
+  new(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { errors, errorSummary } = fetchErrorsAndUserInput(req)
+
+      return res.render('admin/placementRequests/withdrawals/new', {
+        pageHeading: 'Are you sure you want to withdraw this placement request?',
+        id: req.params.id,
+        errors,
+        errorSummary,
+      })
+    }
+  }
+
+  create(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      try {
+        if (!req.body.confirm) {
+          throw new ErrorWithData({ 'invalid-params': [{ propertyName: `$.confirm`, errorType: 'empty' }] })
+        }
+
+        if (req.body.confirm === 'yes') {
+          await this.placementRequestService.withdraw(req.user.token, req.params.id)
+
+          req.flash('success', 'Placement request withdrawn successfully')
+          return res.redirect(paths.admin.placementRequests.index({}))
+        }
+
+        req.flash('success', 'Placement request not withdrawn')
+        return res.redirect(paths.admin.placementRequests.show({ id: req.params.id }))
+      } catch (err) {
+        return catchValidationErrorOrPropogate(
+          req,
+          res,
+          err,
+          paths.admin.placementRequests.withdrawal.new({ id: req.params.id }),
+        )
+      }
+    }
+  }
+}

--- a/server/data/placementRequestClient.test.ts
+++ b/server/data/placementRequestClient.test.ts
@@ -180,4 +180,27 @@ describeClient('placementRequestClient', provider => {
       expect(result).toEqual(bookingNotMade)
     })
   })
+
+  describe('withdraw', () => {
+    it('makes a POST request to the withdrawal endpoint', async () => {
+      const placementRequestId = 'placement-request-id'
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to mark a placement request as withdrawn',
+        withRequest: {
+          method: 'POST',
+          path: paths.placementRequests.withdrawal.create({ id: placementRequestId }),
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+        },
+      })
+
+      await placementRequestClient.withdraw(placementRequestId)
+    })
+  })
 })

--- a/server/data/placementRequestClient.ts
+++ b/server/data/placementRequestClient.ts
@@ -53,4 +53,10 @@ export default class PlacementRequestClient {
       data,
     })) as Promise<BookingNotMade>
   }
+
+  async withdraw(id: string): Promise<void> {
+    await this.restClient.post({
+      path: paths.placementRequests.withdrawal.create({ id }),
+    })
+  }
 }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -36,6 +36,9 @@
   "reason": {
     "empty": "You must choose a valid reason"
   },
+  "confirm": {
+    "empty": "You must confirm if you want to withdraw this placement request"
+  },
   "otherReason": {
     "empty": "You must enter the other reason"
   },

--- a/server/paths/admin.ts
+++ b/server/paths/admin.ts
@@ -6,6 +6,8 @@ const placementRequestPath = placementRequestsPath.path(':id')
 
 const bookingsPath = placementRequestPath.path('bookings')
 
+const withdrawalPath = placementRequestPath.path('withdrawal')
+
 export default {
   admin: {
     placementRequests: {
@@ -14,6 +16,10 @@ export default {
       bookings: {
         new: bookingsPath.path('new'),
         create: bookingsPath,
+      },
+      withdrawal: {
+        new: withdrawalPath.path('new'),
+        create: withdrawalPath,
       },
     },
   },

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -147,6 +147,9 @@ export default {
     dashboard: placementRequestsPath.path('dashboard'),
     booking: placementRequestPath.path('booking'),
     bookingNotMade: placementRequestPath.path('booking-not-made'),
+    withdrawal: {
+      create: placementRequestPath.path('withdrawal'),
+    },
   },
   placementApplications: {
     update: placementApplicationPath,

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -10,7 +10,11 @@ import actions from './utils'
 export default function routes(controllers: Controllers, router: Router, services: Partial<Services>): Router {
   const { get, post } = actions(router, services.auditService)
 
-  const { adminPlacementRequestsController, placementRequestsBookingsController } = controllers
+  const {
+    adminPlacementRequestsController,
+    placementRequestsBookingsController,
+    placementRequestWithdrawalsController,
+  } = controllers
 
   get(paths.admin.placementRequests.index.pattern, adminPlacementRequestsController.index(), {
     auditEvent: 'ADMIN_LIST_PLACEMENT_REQUESTS',
@@ -32,6 +36,26 @@ export default function routes(controllers: Controllers, router: Router, service
       {
         path: paths.admin.placementRequests.show.pattern,
         auditEvent: 'ADMIN_PLACEMENT_REQUEST_CREATE_BOOKING_SUCCESS',
+      },
+    ],
+  })
+
+  get(paths.admin.placementRequests.withdrawal.new.pattern, placementRequestWithdrawalsController.new(), {
+    auditEvent: 'ADMIN_NEW_PLACEMENT_REQUEST_WITHDRAWL',
+  })
+  post(paths.admin.placementRequests.withdrawal.create.pattern, placementRequestWithdrawalsController.create(), {
+    redirectAuditEventSpecs: [
+      {
+        path: paths.admin.placementRequests.withdrawal.new.pattern,
+        auditEvent: 'ADMIN_CREATE_PLACEMENT_REQUEST_WITHDRAWL_FAILURE',
+      },
+      {
+        path: paths.admin.placementRequests.show.pattern,
+        auditEvent: 'ADMIN_CREATE_PLACEMENT_REQUEST_WITHDRAWL_CANCELLATION',
+      },
+      {
+        path: paths.admin.placementRequests.index.pattern,
+        auditEvent: 'ADMIN_CREATE_PLACEMENT_REQUEST_WITHDRAWL_SUCCESS',
       },
     ],
   })

--- a/server/services/placementRequestService.test.ts
+++ b/server/services/placementRequestService.test.ts
@@ -113,4 +113,17 @@ describe('placementRequestService', () => {
       expect(placementRequestClient.bookingNotMade).toHaveBeenCalledWith(id, body)
     })
   })
+
+  describe('withdraw', () => {
+    it('it should call the service', async () => {
+      placementRequestClient.withdraw.mockResolvedValue()
+
+      const id = 'some-uuid'
+
+      await service.withdraw(token, id)
+
+      expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
+      expect(placementRequestClient.withdraw).toHaveBeenCalledWith(id)
+    })
+  })
 })

--- a/server/services/placementRequestService.ts
+++ b/server/services/placementRequestService.ts
@@ -57,4 +57,10 @@ export default class PlacementRequestService {
 
     return placementRequestClient.bookingNotMade(id, body)
   }
+
+  async withdraw(token: string, id: string) {
+    const placementRequestClient = this.placementRequestClientFactory(token)
+
+    return placementRequestClient.withdraw(id)
+  }
 }

--- a/server/utils/placementRequests/adminIdentityBar.test.ts
+++ b/server/utils/placementRequests/adminIdentityBar.test.ts
@@ -27,13 +27,17 @@ describe('adminIdentityBar', () => {
       ])
     })
 
-    it('should return actions to create a booking if there is a booking', () => {
+    it('should return actions to create a booking and withdraw a placement request if there is a booking', () => {
       const placementRequestDetail = placementRequestDetailFactory.build({ booking: undefined })
 
       expect(adminActions(placementRequestDetail)).toEqual([
         {
           href: adminPaths.admin.placementRequests.bookings.new({ id: placementRequestDetail.id }),
           text: 'Create placement',
+        },
+        {
+          href: adminPaths.admin.placementRequests.withdrawal.new({ id: placementRequestDetail.id }),
+          text: 'Withdraw placement request',
         },
       ])
     })

--- a/server/utils/placementRequests/adminIdentityBar.ts
+++ b/server/utils/placementRequests/adminIdentityBar.ts
@@ -35,6 +35,10 @@ export const adminActions = (placementRequest: PlacementRequestDetail): Array<Id
       href: adminPaths.admin.placementRequests.bookings.new({ id: placementRequest.id }),
       text: 'Create placement',
     },
+    {
+      href: adminPaths.admin.placementRequests.withdrawal.new({ id: placementRequest.id }),
+      text: 'Withdraw placement request',
+    },
   ]
 }
 

--- a/server/views/admin/placementRequests/withdrawals/new.njk
+++ b/server/views/admin/placementRequests/withdrawals/new.njk
@@ -1,0 +1,59 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+		text: "Back",
+		href: paths.admin.placementRequests.show({ id: id })
+	}) }}
+{% endblock %}
+
+{% block content %}
+  {% include "../../../_messages.njk" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form action="{{ paths.admin.placementRequests.withdrawal.create({ id: id }) }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {{ showErrorSummary(errorSummary) }}
+
+        {{ govukRadios({
+          idPrefix: "confirm",
+          name: "confirm",
+          fieldset: {
+              legend: {
+                  text: pageHeading,
+                  classes: "govuk-fieldset__legend--l",
+                  isPageHeading: true
+              }
+          },
+          items: [
+              {
+              value: "yes",
+              text: "Yes"
+              },
+              {
+              value: "no",
+              text: "No"
+              }
+          ],
+          errorMessage: errors.confirm
+        }) }}
+
+        {{ govukButton({
+            name: 'submit',
+            text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
This adds the ability to withdraw placement requests that have been created in error with a confirmation screen. This will only apply to placement requests that do not yet have an associated booking.

## Screenshots

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/38617192-4acf-4667-bd9a-803162aaf136)

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/41748cff-8b40-40d2-b7c1-caa1b383e8d9)

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/d71cba52-17cb-42bf-aebf-9a880709b97c)
