### PR TITLE
(Fix) Fetch `esapReasons` from `EsapPlacementScreening`

### DIFF
--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -536,7 +536,25 @@ export default class ApplyHelper {
     exceptionalCase.clickSubmit()
 
     // Then I should be taken to the rest of the Esap flow
-    Page.verifyOnPage(ApplyPages.EsapPlacementScreening, this.application)
+    const esapPlacementScreeningPage = Page.verifyOnPage(ApplyPages.EsapPlacementScreening, this.application)
+
+    // When I complete the screening page
+    esapPlacementScreeningPage.completeForm()
+    esapPlacementScreeningPage.clickSubmit()
+
+    // Then I should be taken to the Room Searches page
+    const roomSearchesPage = Page.verifyOnPage(ApplyPages.EsapRoomSearches, this.application)
+
+    // And I complete the room searches page
+    roomSearchesPage.completeForm()
+    roomSearchesPage.clickSubmit()
+
+    // Then I should be taken to the CCTV page
+    const esapCCTVPage = Page.verifyOnPage(ApplyPages.EsapCCTV, this.application)
+
+    // When I complete the CCTV page
+    esapCCTVPage.completeForm()
+    esapCCTVPage.clickSubmit()
   }
 
   completeIneligibleEsapFlow() {

--- a/integration_tests/pages/apply/esapCCTV.ts
+++ b/integration_tests/pages/apply/esapCCTV.ts
@@ -1,0 +1,15 @@
+import { ApprovedPremisesApplication } from '../../../server/@types/shared'
+import ApplyPage from './applyPage'
+
+export default class EsapCCTV extends ApplyPage {
+  constructor(application: ApprovedPremisesApplication) {
+    super('Enhanced CCTV Provision', application, 'type-of-ap', 'esap-placement-cctv')
+  }
+
+  completeForm() {
+    this.checkCheckboxesFromPageBody('cctvHistory')
+    this.checkRadioButtonFromPageBody('cctvIntelligence')
+    this.completeTextInputFromPageBody('cctvIntelligenceDetails')
+    this.completeTextInputFromPageBody('cctvNotes')
+  }
+}

--- a/integration_tests/pages/apply/esapPlacementScreening.ts
+++ b/integration_tests/pages/apply/esapPlacementScreening.ts
@@ -1,8 +1,17 @@
 import { ApprovedPremisesApplication } from '@approved-premises/api'
-import Page from '../page'
+import ApplyPage from './applyPage'
 
-export default class EsapPlacementScreening extends Page {
+export default class EsapPlacementScreening extends ApplyPage {
   constructor(application: ApprovedPremisesApplication) {
-    super(`Why does ${application.person.name} require an enhanced security placement?`)
+    super(
+      `Why does ${application.person.name} require an enhanced security placement?`,
+      application,
+      'type-of-ap',
+      'esap-placement-screening',
+    )
+  }
+
+  completeForm() {
+    this.checkCheckboxesFromPageBody('esapReasons')
   }
 }

--- a/integration_tests/pages/apply/esapRoomSearches.ts
+++ b/integration_tests/pages/apply/esapRoomSearches.ts
@@ -1,0 +1,15 @@
+import { ApprovedPremisesApplication } from '../../../server/@types/shared'
+import ApplyPage from './applyPage'
+
+export default class EsapRoomSearches extends ApplyPage {
+  constructor(application: ApprovedPremisesApplication) {
+    super('Enhanced room searches using body worn technology', application, 'type-of-ap', 'esap-placement-secreting')
+  }
+
+  completeForm() {
+    this.checkCheckboxesFromPageBody('secretingHistory')
+    this.checkRadioButtonFromPageBody('secretingIntelligence')
+    this.completeTextInputFromPageBody('secretingIntelligenceDetails')
+    this.completeTextInputFromPageBody('secretingNotes')
+  }
+}

--- a/integration_tests/pages/apply/index.ts
+++ b/integration_tests/pages/apply/index.ts
@@ -18,8 +18,10 @@ import DescribeLocationFactors from './describeLocationFactors'
 import EnterCRNPage from './enterCrn'
 import EndDatesPage from './endDates'
 import ExceptionDetailsPage from './ExceptionDetails'
+import EsapCCTV from './esapCCTV'
 import EsapExceptionalCase from './esapExceptionalCase'
 import EsapPlacementScreening from './esapPlacementScreening'
+import EsapRoomSearches from './esapRoomSearches'
 import EsapNotEligible from './esapNotEligible'
 import ForeignNationalPage from './foreignNational'
 import IsExceptionalCasePage from './isExceptionalCase'
@@ -81,9 +83,11 @@ export {
   EnterCRNPage,
   EndDatesPage,
   ExceptionDetailsPage,
+  EsapCCTV,
   EsapExceptionalCase,
   EsapPlacementScreening,
   EsapNotEligible,
+  EsapRoomSearches,
   ForeignNationalPage,
   IsExceptionalCasePage,
   ListPage,

--- a/integration_tests/tests/apply/esap.cy.ts
+++ b/integration_tests/tests/apply/esap.cy.ts
@@ -3,6 +3,8 @@ import ApplyHelper from '../../helpers/apply'
 import { DateFormats } from '../../../server/utils/dateUtils'
 import { mapApiPersonRisksForUi } from '../../../server/utils/utils'
 import { setup } from './setup'
+import Page from '../../pages/page'
+import TaskListPage from '../../pages/apply/taskListPage'
 
 context('Apply - ESAP', () => {
   beforeEach(setup)
@@ -37,6 +39,36 @@ context('Apply - ESAP', () => {
       },
     })
 
+    this.application = addResponsesToFormArtifact(this.application, {
+      section: 'type-of-ap',
+      page: 'esap-placement-screening',
+      keyValuePairs: {
+        esapReasons: ['secreting', 'cctv'],
+      },
+    })
+
+    this.application = addResponsesToFormArtifact(this.application, {
+      section: 'type-of-ap',
+      page: 'esap-placement-cctv',
+      keyValuePairs: {
+        cctvHistory: ['appearance', 'networks'],
+        cctvIntelligence: 'yes',
+        cctvIntelligenceDetails: 'Some Details',
+        cctvNotes: 'Some notes',
+      },
+    })
+
+    this.application = addResponsesToFormArtifact(this.application, {
+      section: 'type-of-ap',
+      page: 'esap-placement-secreting',
+      keyValuePairs: {
+        secretingHistory: ['radicalisationLiterature', 'drugs'],
+        secretingIntelligence: 'yes',
+        secretingIntelligenceDetails: 'Some Details',
+        secretingNotes: 'Some notes',
+      },
+    })
+
     apply.setupApplicationStubs(uiRisks)
 
     // And I start the application
@@ -46,7 +78,11 @@ context('Apply - ESAP', () => {
     // And I complete the Esap flow
     apply.completeEsapFlow()
 
-    // Then I should be asked if the person is managed by the National Security division
+    // Then I should be redirected to the task list
+    const tasklistPage = Page.verifyOnPage(TaskListPage)
+
+    // And the type-of-ap task should show as completed
+    tasklistPage.shouldShowTaskStatus('type-of-ap', 'Completed')
   })
 
   it('Tells me I am ineligible for ESAP', function test() {

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementCCTV.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementCCTV.ts
@@ -6,8 +6,7 @@ import TasklistPage from '../../../tasklistPage'
 import { convertToTitleCase } from '../../../../utils/utils'
 import { retrieveQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
-import { EsapReasons } from './esapPlacementScreening'
-import SelectApType from './apType'
+import EsapPlacementScreening, { EsapReasons } from './esapPlacementScreening'
 
 export const cctvHistory = {
   appearance: 'Changed their appearance or clothing to offend',
@@ -48,7 +47,7 @@ export default class EsapPlacementCCTV implements TasklistPage {
   previous() {
     const esapReasons = retrieveQuestionResponseFromFormArtifact(
       this.application,
-      SelectApType,
+      EsapPlacementScreening,
       'esapReasons',
     ) as Array<keyof EsapReasons>
 

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementSecreting.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementSecreting.ts
@@ -6,8 +6,7 @@ import TasklistPage from '../../../tasklistPage'
 import { convertToTitleCase } from '../../../../utils/utils'
 import { retrieveQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
-import { EsapReasons } from './esapPlacementScreening'
-import SelectApType from './apType'
+import EsapPlacementScreening, { EsapReasons } from './esapPlacementScreening'
 
 export const secretingHistory = {
   radicalisationLiterature: 'Literature and materials supporting radicalisation ideals',
@@ -53,7 +52,7 @@ export default class EsapPlacementSecreting implements TasklistPage {
   next() {
     const esapReasons = retrieveQuestionResponseFromFormArtifact(
       this.application,
-      SelectApType,
+      EsapPlacementScreening,
       'esapReasons',
     ) as Array<keyof EsapReasons>
 

--- a/server/views/applications/pages/type-of-ap/esap-placement-cctv.njk
+++ b/server/views/applications/pages/type-of-ap/esap-placement-cctv.njk
@@ -67,12 +67,14 @@
     )
   }}
 
-  <h2 class="govuk-heading-s">{{ page.questions.cctvNotes }}</h2>
-
   {{
     formPageTextarea(
       {
-        fieldName: "cctvNotes"
+        fieldName: "cctvNotes",
+        label: {
+          text: page.questions.cctvNotes,
+          classes: "govuk-label--m"
+        }
       },
       fetchContext()
     )

--- a/server/views/applications/pages/type-of-ap/esap-placement-secreting.njk
+++ b/server/views/applications/pages/type-of-ap/esap-placement-secreting.njk
@@ -67,12 +67,14 @@
     )
   }}
 
-  <h2 class="govuk-heading-s">{{ page.questions.secretingNotes }}</h2>
-
   {{
     formPageTextarea(
       {
-        fieldName: "secretingNotes"
+        fieldName: "secretingNotes",
+        label: {
+          text: page.questions.secretingNotes,
+          classes: "govuk-label--m"
+        }
       },
       fetchContext()
     )


### PR DESCRIPTION
This was fetching from the wrong page and wasn’t getting caught because these pages weren’t in the integration tests, so the ESAP flow was completely broken! I’ve fixed the bug, and also improved the ESAP tests (as well as fixing some accessiblity issues that the tests picked up!)