### PR TITLE
(381) Add pagination and sorting to CRU dashboard

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -15,6 +15,7 @@ $path: "/assets/images/"
 @import './components/filter'
 @import './components/calendar'
 @import './components/withdrawal-reasons'
+@import './components/sortable-table'
 
 @import './pages/assessments-index'
 @import './pages/applications-pages-attach-document'

--- a/assets/sass/components/_sortable-table.scss
+++ b/assets/sass/components/_sortable-table.scss
@@ -1,0 +1,66 @@
+[aria-sort] a,
+[aria-sort] a:hover {
+  background-color: transparent;
+  border-width: 0;
+  -webkit-box-shadow: 0 0 0 0;
+  -moz-box-shadow: 0 0 0 0;
+  box-shadow: 0 0 0 0;
+  color: #005ea5;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  padding: 0 10px 0 0;
+  position: relative;
+  text-align: inherit;
+  font-size: 1em;
+  margin: 0;
+}
+
+[aria-sort] a:focus {
+  background-color: $govuk-focus-colour;
+  color: $govuk-focus-text-colour;
+  box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
+  outline: none;
+}
+
+[aria-sort]:first-child a {
+  right: auto;
+}
+
+[aria-sort] a:before {
+  content: " \25bc";
+  position: absolute;
+  right: -1px;
+  top: 9px;
+  font-size: 0.5em;
+}
+
+[aria-sort] a:after {
+  content: " \25b2";
+  position: absolute;
+  right: -1px;
+  top: 1px;
+  font-size: 0.5em;
+}
+
+[aria-sort="ascending"] a:before,
+[aria-sort="descending"] a:before {
+  content: none;
+}
+
+[aria-sort="ascending"] a:after {
+  content: " \25b2";
+  font-size: .8em;
+  position: absolute;
+  right: -5px;
+  top: 2px;
+}
+
+[aria-sort="descending"] a:after {
+  content: " \25bc";
+  font-size: .8em;
+  position: absolute;
+  right: -5px;
+  top: 2px;
+}

--- a/integration_tests/mockApis/placementRequests.ts
+++ b/integration_tests/mockApis/placementRequests.ts
@@ -21,23 +21,38 @@ export default {
       },
     }),
 
-  stubPlacementRequestsDashboard: (args: {
+  stubPlacementRequestsDashboard: ({
+    placementRequests,
+    isParole,
+    page = '1',
+  }: {
     placementRequests: Array<PlacementRequest>
     isParole: boolean
+    page: string
   }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
-        url: `${paths.placementRequests.dashboard.pattern}?isParole=${args.isParole}`,
+        url: `${paths.placementRequests.dashboard.pattern}?isParole=${isParole}&page=${page}&sortBy=createdAt`,
       },
       response: {
         status: 200,
         headers: {
           'Content-Type': 'application/json;charset=UTF-8',
+          'X-Pagination-TotalPages': '10',
+          'X-Pagination-TotalResults': '100',
+          'X-Pagination-PageSize': '10',
         },
-        jsonBody: args.placementRequests,
+        jsonBody: placementRequests,
       },
     }),
+  verifyPlacementRequestsDashboard: async ({ isParole, page = '1' }: { isParole: boolean; page: string }) =>
+    (
+      await getMatchingRequests({
+        method: 'GET',
+        url: `${paths.placementRequests.dashboard.pattern}?isParole=${isParole}&page=${page}&sortBy=createdAt`,
+      })
+    ).body.requests,
   stubPlacementRequest: (placementRequestDetail: PlacementRequestDetail): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/mockApis/placementRequests.ts
+++ b/integration_tests/mockApis/placementRequests.ts
@@ -25,15 +25,19 @@ export default {
     placementRequests,
     isParole,
     page = '1',
+    sortBy = 'createdAt',
+    sortDirection = 'asc',
   }: {
     placementRequests: Array<PlacementRequest>
     isParole: boolean
     page: string
+    sortBy: string
+    sortDirection: string
   }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
-        url: `${paths.placementRequests.dashboard.pattern}?isParole=${isParole}&page=${page}&sortBy=createdAt`,
+        url: `${paths.placementRequests.dashboard.pattern}?isParole=${isParole}&page=${page}&sortBy=${sortBy}&sortDirection=${sortDirection}`,
       },
       response: {
         status: 200,
@@ -46,11 +50,21 @@ export default {
         jsonBody: placementRequests,
       },
     }),
-  verifyPlacementRequestsDashboard: async ({ isParole, page = '1' }: { isParole: boolean; page: string }) =>
+  verifyPlacementRequestsDashboard: async ({
+    isParole,
+    page = '1',
+    sortBy = 'createdAt',
+    sortDirection = 'asc',
+  }: {
+    isParole: boolean
+    page: string
+    sortBy: string
+    sortDirection: string
+  }) =>
     (
       await getMatchingRequests({
         method: 'GET',
-        url: `${paths.placementRequests.dashboard.pattern}?isParole=${isParole}&page=${page}&sortBy=createdAt`,
+        url: `${paths.placementRequests.dashboard.pattern}?isParole=${isParole}&page=${page}&sortBy=${sortBy}&sortDirection=${sortDirection}`,
       })
     ).body.requests,
   stubPlacementRequest: (placementRequestDetail: PlacementRequestDetail): SuperAgentRequest =>

--- a/integration_tests/pages/admin/placementApplications/listPage.ts
+++ b/integration_tests/pages/admin/placementApplications/listPage.ts
@@ -38,4 +38,12 @@ export default class ListPage extends Page {
   clickPageNumber(pageNumber: string): void {
     cy.get('.govuk-pagination__link').contains(pageNumber).click()
   }
+
+  clickSortBy(field: string): void {
+    cy.get(`th[data-cy-sort-field="${field}"] a`).click()
+  }
+
+  shouldBeSortedByField(field: string, order: string): void {
+    cy.get(`th[data-cy-sort-field="${field}"]`).should('have.attr', 'aria-sort', order)
+  }
 }

--- a/integration_tests/pages/admin/placementApplications/listPage.ts
+++ b/integration_tests/pages/admin/placementApplications/listPage.ts
@@ -30,4 +30,12 @@ export default class ListPage extends Page {
   clickNonParoleOption(): void {
     cy.get('a.moj-sub-navigation__link').contains('Confirmed release date').click()
   }
+
+  clickNext(): void {
+    cy.get('a[rel="next"]').click()
+  }
+
+  clickPageNumber(pageNumber: string): void {
+    cy.get('.govuk-pagination__link').contains(pageNumber).click()
+  }
 }

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -297,4 +297,31 @@ context('Placement Requests', () => {
       expect(requests).to.have.length(1)
     })
   })
+
+  it('supports pagination', () => {
+    cy.task('stubPlacementRequestsDashboard', { placementRequests, isParole: false, page: '2' })
+    cy.task('stubPlacementRequestsDashboard', { placementRequests, isParole: false, page: '9' })
+
+    // When I visit the tasks dashboard
+    const listPage = ListPage.visit()
+
+    // Then I should see a list of placement requests
+    listPage.shouldShowPlacementRequests(placementRequests)
+
+    // When I click next
+    listPage.clickNext()
+
+    // Then the API should have received a request for the next page
+    cy.task('verifyPlacementRequestsDashboard', { page: '2', isParole: false }).then(requests => {
+      expect(requests).to.have.length(1)
+    })
+
+    // When I click on a page number
+    listPage.clickPageNumber('9')
+
+    // Then the API should have received a request for the that page number
+    cy.task('verifyPlacementRequestsDashboard', { page: '9', isParole: false }).then(requests => {
+      expect(requests).to.have.length(1)
+    })
+  })
 })

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -324,4 +324,55 @@ context('Placement Requests', () => {
       expect(requests).to.have.length(1)
     })
   })
+
+  it('supports sorting', () => {
+    cy.task('stubPlacementRequestsDashboard', {
+      placementRequests,
+      isParole: false,
+      sortBy: 'expectedArrival',
+      sortDirection: 'asc',
+    })
+    cy.task('stubPlacementRequestsDashboard', {
+      placementRequests,
+      isParole: false,
+      sortBy: 'expectedArrival',
+      sortDirection: 'desc',
+    })
+
+    // When I visit the tasks dashboard
+    const listPage = ListPage.visit()
+
+    // Then I should see a list of placement requests
+    listPage.shouldShowPlacementRequests(placementRequests)
+
+    // When I sort by expected arrival in ascending order
+    listPage.clickSortBy('expectedArrival')
+
+    // Then the dashboard should be sorted by expected arrival
+    listPage.shouldBeSortedByField('expectedArrival', 'ascending')
+
+    // And the API should have received a request for the correct sort order
+    cy.task('verifyPlacementRequestsDashboard', {
+      isParole: false,
+      sortBy: 'expectedArrival',
+      sortDirection: 'asc',
+    }).then(requests => {
+      expect(requests).to.have.length(1)
+    })
+
+    // When I sort by expected arrival in descending order
+    listPage.clickSortBy('expectedArrival')
+
+    // Then the dashboard should be sorted by expected arrival in descending order
+    listPage.shouldBeSortedByField('expectedArrival', 'descending')
+
+    // And the API should have received a request for the correct sort order
+    cy.task('verifyPlacementRequestsDashboard', {
+      isParole: false,
+      sortBy: 'expectedArrival',
+      sortDirection: 'desc',
+    }).then(requests => {
+      expect(requests).to.have.length(1)
+    })
+  })
 })

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -109,7 +109,9 @@ export interface HtmlItem {
   html: string
 }
 
-export type TableCell = { text: string; attributes?: HtmlAttributes; classes?: string } | { html: string }
+export type TableCell =
+  | { text: string; attributes?: HtmlAttributes; classes?: string }
+  | { html: string; attributes?: HtmlAttributes }
 
 export type TableRow = Array<TableCell>
 

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -415,3 +415,11 @@ export interface OasysPage extends TasklistPage {
   risks: PersonRisksUI
   oasysSuccess: boolean
 }
+
+export type PaginatedResponse<T> = {
+  data: Array<T>
+  pageNumber: string
+  totalPages: string
+  totalResults: string
+  pageSize: string
+}

--- a/server/controllers/admin/placementRequestsController.test.ts
+++ b/server/controllers/admin/placementRequestsController.test.ts
@@ -4,8 +4,10 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import PlacementRequestsController from './placementRequestsController'
 
 import { PlacementRequestService } from '../../services'
-import { placementRequestFactory } from '../../testutils/factories'
+import { paginatedResponseFactory, placementRequestFactory } from '../../testutils/factories'
 import placementRequestDetail from '../../testutils/factories/placementRequestDetail'
+import { PaginatedResponse } from '../../@types/ui'
+import { PlacementRequest } from '../../@types/shared'
 
 jest.mock('../../utils/applications/utils')
 jest.mock('../../utils/applications/getResponses')
@@ -28,8 +30,10 @@ describe('PlacementRequestsController', () => {
 
   describe('index', () => {
     it('should render the placement requests template', async () => {
-      const placementRequests = placementRequestFactory.buildList(2)
-      placementRequestService.getDashboard.mockResolvedValue(placementRequests)
+      const paginatedResponse = paginatedResponseFactory.build({
+        data: placementRequestFactory.buildList(2),
+      }) as PaginatedResponse<PlacementRequest>
+      placementRequestService.getDashboard.mockResolvedValue(paginatedResponse)
 
       const requestHandler = placementRequestsController.index()
 
@@ -37,15 +41,19 @@ describe('PlacementRequestsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('admin/placementRequests/index', {
         pageHeading: 'Record and update placement details',
-        placementRequests,
+        placementRequests: paginatedResponse.data,
         isParole: false,
+        pageNumber: Number(paginatedResponse.pageNumber),
+        totalPages: Number(paginatedResponse.totalPages),
       })
       expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, false, undefined, undefined)
     })
 
     it('should request parole placement requests', async () => {
-      const placementRequests = placementRequestFactory.buildList(2)
-      placementRequestService.getDashboard.mockResolvedValue(placementRequests)
+      const paginatedResponse = paginatedResponseFactory.build({
+        data: placementRequestFactory.buildList(2),
+      }) as PaginatedResponse<PlacementRequest>
+      placementRequestService.getDashboard.mockResolvedValue(paginatedResponse)
 
       const requestHandler = placementRequestsController.index()
 
@@ -53,15 +61,19 @@ describe('PlacementRequestsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('admin/placementRequests/index', {
         pageHeading: 'Record and update placement details',
-        placementRequests,
+        placementRequests: paginatedResponse.data,
         isParole: true,
+        pageNumber: Number(paginatedResponse.pageNumber),
+        totalPages: Number(paginatedResponse.totalPages),
       })
       expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, true, undefined, undefined)
     })
 
     it('should request page numbers and sort options', async () => {
-      const placementRequests = placementRequestFactory.buildList(2)
-      placementRequestService.getDashboard.mockResolvedValue(placementRequests)
+      const paginatedResponse = paginatedResponseFactory.build({
+        data: placementRequestFactory.buildList(2),
+      }) as PaginatedResponse<PlacementRequest>
+      placementRequestService.getDashboard.mockResolvedValue(paginatedResponse)
 
       const requestHandler = placementRequestsController.index()
 
@@ -73,8 +85,10 @@ describe('PlacementRequestsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('admin/placementRequests/index', {
         pageHeading: 'Record and update placement details',
-        placementRequests,
+        placementRequests: paginatedResponse.data,
         isParole: true,
+        pageNumber: Number(paginatedResponse.pageNumber),
+        totalPages: Number(paginatedResponse.totalPages),
       })
       expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, true, 2, 'expectedArrival')
     })

--- a/server/controllers/admin/placementRequestsController.test.ts
+++ b/server/controllers/admin/placementRequestsController.test.ts
@@ -8,6 +8,8 @@ import { paginatedResponseFactory, placementRequestFactory } from '../../testuti
 import placementRequestDetail from '../../testutils/factories/placementRequestDetail'
 import { PaginatedResponse } from '../../@types/ui'
 import { PlacementRequest } from '../../@types/shared'
+import paths from '../../paths/admin'
+import { createQueryString } from '../../utils/utils'
 
 jest.mock('../../utils/applications/utils')
 jest.mock('../../utils/applications/getResponses')
@@ -29,11 +31,16 @@ describe('PlacementRequestsController', () => {
   })
 
   describe('index', () => {
-    it('should render the placement requests template', async () => {
-      const paginatedResponse = paginatedResponseFactory.build({
-        data: placementRequestFactory.buildList(2),
-      }) as PaginatedResponse<PlacementRequest>
+    const paginatedResponse = paginatedResponseFactory.build({
+      data: placementRequestFactory.buildList(2),
+    }) as PaginatedResponse<PlacementRequest>
+
+    beforeEach(() => {
       placementRequestService.getDashboard.mockResolvedValue(paginatedResponse)
+    })
+
+    it('should render the placement requests template', async () => {
+      const hrefPrefix = `${paths.admin.placementRequests.index({})}?${createQueryString({ isParole: false })}&`
 
       const requestHandler = placementRequestsController.index()
 
@@ -45,15 +52,13 @@ describe('PlacementRequestsController', () => {
         isParole: false,
         pageNumber: Number(paginatedResponse.pageNumber),
         totalPages: Number(paginatedResponse.totalPages),
+        hrefPrefix,
       })
       expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, false, undefined, undefined)
     })
 
     it('should request parole placement requests', async () => {
-      const paginatedResponse = paginatedResponseFactory.build({
-        data: placementRequestFactory.buildList(2),
-      }) as PaginatedResponse<PlacementRequest>
-      placementRequestService.getDashboard.mockResolvedValue(paginatedResponse)
+      const hrefPrefix = `${paths.admin.placementRequests.index({})}?${createQueryString({ isParole: true })}&`
 
       const requestHandler = placementRequestsController.index()
 
@@ -65,15 +70,13 @@ describe('PlacementRequestsController', () => {
         isParole: true,
         pageNumber: Number(paginatedResponse.pageNumber),
         totalPages: Number(paginatedResponse.totalPages),
+        hrefPrefix,
       })
       expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, true, undefined, undefined)
     })
 
     it('should request page numbers and sort options', async () => {
-      const paginatedResponse = paginatedResponseFactory.build({
-        data: placementRequestFactory.buildList(2),
-      }) as PaginatedResponse<PlacementRequest>
-      placementRequestService.getDashboard.mockResolvedValue(paginatedResponse)
+      const hrefPrefix = `${paths.admin.placementRequests.index({})}?${createQueryString({ isParole: true })}&`
 
       const requestHandler = placementRequestsController.index()
 
@@ -89,6 +92,7 @@ describe('PlacementRequestsController', () => {
         isParole: true,
         pageNumber: Number(paginatedResponse.pageNumber),
         totalPages: Number(paginatedResponse.totalPages),
+        hrefPrefix,
       })
       expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, true, 2, 'expectedArrival')
     })

--- a/server/controllers/admin/placementRequestsController.test.ts
+++ b/server/controllers/admin/placementRequestsController.test.ts
@@ -40,7 +40,7 @@ describe('PlacementRequestsController', () => {
         placementRequests,
         isParole: false,
       })
-      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, false)
+      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, false, undefined, undefined)
     })
 
     it('should request parole placement requests', async () => {
@@ -56,7 +56,27 @@ describe('PlacementRequestsController', () => {
         placementRequests,
         isParole: true,
       })
-      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, true)
+      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, true, undefined, undefined)
+    })
+
+    it('should request page numbers and sort options', async () => {
+      const placementRequests = placementRequestFactory.buildList(2)
+      placementRequestService.getDashboard.mockResolvedValue(placementRequests)
+
+      const requestHandler = placementRequestsController.index()
+
+      await requestHandler(
+        { ...request, query: { isParole: '1', page: '2', sortBy: 'expectedArrival' } },
+        response,
+        next,
+      )
+
+      expect(response.render).toHaveBeenCalledWith('admin/placementRequests/index', {
+        pageHeading: 'Record and update placement details',
+        placementRequests,
+        isParole: true,
+      })
+      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, true, 2, 'expectedArrival')
     })
   })
 

--- a/server/controllers/admin/placementRequestsController.test.ts
+++ b/server/controllers/admin/placementRequestsController.test.ts
@@ -54,7 +54,7 @@ describe('PlacementRequestsController', () => {
         totalPages: Number(paginatedResponse.totalPages),
         hrefPrefix,
       })
-      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, false, undefined, undefined)
+      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, false, undefined, undefined, undefined)
     })
 
     it('should request parole placement requests', async () => {
@@ -72,7 +72,7 @@ describe('PlacementRequestsController', () => {
         totalPages: Number(paginatedResponse.totalPages),
         hrefPrefix,
       })
-      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, true, undefined, undefined)
+      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, true, undefined, undefined, undefined)
     })
 
     it('should request page numbers and sort options', async () => {
@@ -81,7 +81,7 @@ describe('PlacementRequestsController', () => {
       const requestHandler = placementRequestsController.index()
 
       await requestHandler(
-        { ...request, query: { isParole: '1', page: '2', sortBy: 'expectedArrival' } },
+        { ...request, query: { isParole: '1', page: '2', sortBy: 'expectedArrival', sortDirection: 'desc' } },
         response,
         next,
       )
@@ -93,8 +93,10 @@ describe('PlacementRequestsController', () => {
         pageNumber: Number(paginatedResponse.pageNumber),
         totalPages: Number(paginatedResponse.totalPages),
         hrefPrefix,
+        sortBy: 'expectedArrival',
+        sortDirection: 'desc',
       })
-      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, true, 2, 'expectedArrival')
+      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, true, 2, 'expectedArrival', 'desc')
     })
   })
 

--- a/server/controllers/admin/placementRequestsController.ts
+++ b/server/controllers/admin/placementRequestsController.ts
@@ -1,6 +1,8 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 import { PlacementRequestService } from '../../services'
 import { PlacementRequestSortField } from '../../@types/shared'
+import paths from '../../paths/admin'
+import { createQueryString } from '../../utils/utils'
 
 export default class PlacementRequestsController {
   constructor(private readonly placementRequestService: PlacementRequestService) {}
@@ -11,6 +13,7 @@ export default class PlacementRequestsController {
       const pageNumber = req.query.page ? Number(req.query.page) : undefined
       const sortBy = req.query.sortBy as PlacementRequestSortField
       const dashboard = await this.placementRequestService.getDashboard(req.user.token, isParole, pageNumber, sortBy)
+      const hrefPrefix = `${paths.admin.placementRequests.index({})}?${createQueryString({ isParole })}&`
 
       res.render('admin/placementRequests/index', {
         pageHeading: 'Record and update placement details',
@@ -18,6 +21,7 @@ export default class PlacementRequestsController {
         isParole,
         pageNumber: Number(dashboard.pageNumber),
         totalPages: Number(dashboard.totalPages),
+        hrefPrefix,
       })
     }
   }

--- a/server/controllers/admin/placementRequestsController.ts
+++ b/server/controllers/admin/placementRequestsController.ts
@@ -10,17 +10,14 @@ export default class PlacementRequestsController {
       const isParole = req.query.isParole === '1'
       const pageNumber = req.query.page ? Number(req.query.page) : undefined
       const sortBy = req.query.sortBy as PlacementRequestSortField
-      const placementRequests = await this.placementRequestService.getDashboard(
-        req.user.token,
-        isParole,
-        pageNumber,
-        sortBy,
-      )
+      const dashboard = await this.placementRequestService.getDashboard(req.user.token, isParole, pageNumber, sortBy)
 
       res.render('admin/placementRequests/index', {
         pageHeading: 'Record and update placement details',
-        placementRequests,
+        placementRequests: dashboard.data,
         isParole,
+        pageNumber: Number(dashboard.pageNumber),
+        totalPages: Number(dashboard.totalPages),
       })
     }
   }

--- a/server/controllers/admin/placementRequestsController.ts
+++ b/server/controllers/admin/placementRequestsController.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 import { PlacementRequestService } from '../../services'
-import { PlacementRequestSortField } from '../../@types/shared'
+import { PlacementRequestSortField, SortDirection } from '../../@types/shared'
 import paths from '../../paths/admin'
 import { createQueryString } from '../../utils/utils'
 
@@ -12,8 +12,17 @@ export default class PlacementRequestsController {
       const isParole = req.query.isParole === '1'
       const pageNumber = req.query.page ? Number(req.query.page) : undefined
       const sortBy = req.query.sortBy as PlacementRequestSortField
-      const dashboard = await this.placementRequestService.getDashboard(req.user.token, isParole, pageNumber, sortBy)
+      const sortDirection = req.query.sortDirection as SortDirection
+
       const hrefPrefix = `${paths.admin.placementRequests.index({})}?${createQueryString({ isParole })}&`
+
+      const dashboard = await this.placementRequestService.getDashboard(
+        req.user.token,
+        isParole,
+        pageNumber,
+        sortBy,
+        sortDirection,
+      )
 
       res.render('admin/placementRequests/index', {
         pageHeading: 'Record and update placement details',
@@ -22,6 +31,8 @@ export default class PlacementRequestsController {
         pageNumber: Number(dashboard.pageNumber),
         totalPages: Number(dashboard.totalPages),
         hrefPrefix,
+        sortBy,
+        sortDirection,
       })
     }
   }

--- a/server/controllers/admin/placementRequestsController.ts
+++ b/server/controllers/admin/placementRequestsController.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 import { PlacementRequestService } from '../../services'
+import { PlacementRequestSortField } from '../../@types/shared'
 
 export default class PlacementRequestsController {
   constructor(private readonly placementRequestService: PlacementRequestService) {}
@@ -7,7 +8,14 @@ export default class PlacementRequestsController {
   index(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       const isParole = req.query.isParole === '1'
-      const placementRequests = await this.placementRequestService.getDashboard(req.user.token, isParole)
+      const pageNumber = req.query.page ? Number(req.query.page) : undefined
+      const sortBy = req.query.sortBy as PlacementRequestSortField
+      const placementRequests = await this.placementRequestService.getDashboard(
+        req.user.token,
+        isParole,
+        pageNumber,
+        sortBy,
+      )
 
       res.render('admin/placementRequests/index', {
         pageHeading: 'Record and update placement details',

--- a/server/data/placementRequestClient.test.ts
+++ b/server/data/placementRequestClient.test.ts
@@ -55,7 +55,7 @@ describeClient('placementRequestClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.placementRequests.dashboard.pattern,
-          query: { isParole: 'true' },
+          query: { isParole: 'true', page: '1', sortBy: 'createdAt' },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -78,7 +78,7 @@ describeClient('placementRequestClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.placementRequests.dashboard.pattern,
-          query: { isParole: 'false' },
+          query: { isParole: 'false', page: '1', sortBy: 'createdAt' },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -90,6 +90,52 @@ describeClient('placementRequestClient', provider => {
       })
 
       const result = await placementRequestClient.dashboard(false)
+
+      expect(result).toEqual(placementRequests)
+    })
+
+    it('makes a get request to the placementRequests dashboard endpoint for parole requests with a page number', async () => {
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get the placement requests dashboard view',
+        withRequest: {
+          method: 'GET',
+          path: paths.placementRequests.dashboard.pattern,
+          query: { isParole: 'true', page: '2', sortBy: 'createdAt' },
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: placementRequests,
+        },
+      })
+
+      const result = await placementRequestClient.dashboard(true, 2)
+
+      expect(result).toEqual(placementRequests)
+    })
+
+    it('makes a get request to the placementRequests dashboard endpoint for parole requests with a sortBy option', async () => {
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get the placement requests dashboard view',
+        withRequest: {
+          method: 'GET',
+          path: paths.placementRequests.dashboard.pattern,
+          query: { isParole: 'true', page: '1', sortBy: 'duration' },
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: placementRequests,
+        },
+      })
+
+      const result = await placementRequestClient.dashboard(true, 1, 'duration')
 
       expect(result).toEqual(placementRequests)
     })

--- a/server/data/placementRequestClient.test.ts
+++ b/server/data/placementRequestClient.test.ts
@@ -55,7 +55,7 @@ describeClient('placementRequestClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.placementRequests.dashboard.pattern,
-          query: { isParole: 'true', page: '1', sortBy: 'createdAt' },
+          query: { isParole: 'true', page: '1', sortBy: 'createdAt', sortDirection: 'asc' },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -89,7 +89,7 @@ describeClient('placementRequestClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.placementRequests.dashboard.pattern,
-          query: { isParole: 'false', page: '1', sortBy: 'createdAt' },
+          query: { isParole: 'false', page: '1', sortBy: 'createdAt', sortDirection: 'asc' },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -123,7 +123,7 @@ describeClient('placementRequestClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.placementRequests.dashboard.pattern,
-          query: { isParole: 'true', page: '2', sortBy: 'createdAt' },
+          query: { isParole: 'true', page: '2', sortBy: 'createdAt', sortDirection: 'asc' },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -157,7 +157,7 @@ describeClient('placementRequestClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.placementRequests.dashboard.pattern,
-          query: { isParole: 'true', page: '1', sortBy: 'duration' },
+          query: { isParole: 'true', page: '1', sortBy: 'duration', sortDirection: 'desc' },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -173,7 +173,7 @@ describeClient('placementRequestClient', provider => {
         },
       })
 
-      const result = await placementRequestClient.dashboard(true, 1, 'duration')
+      const result = await placementRequestClient.dashboard(true, 1, 'duration', 'desc')
 
       expect(result).toEqual({
         data: placementRequests,

--- a/server/data/placementRequestClient.test.ts
+++ b/server/data/placementRequestClient.test.ts
@@ -63,12 +63,23 @@ describeClient('placementRequestClient', provider => {
         willRespondWith: {
           status: 200,
           body: placementRequests,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
         },
       })
 
       const result = await placementRequestClient.dashboard(true)
 
-      expect(result).toEqual(placementRequests)
+      expect(result).toEqual({
+        data: placementRequests,
+        pageNumber: '1',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
     })
 
     it('makes a get request to the placementRequests dashboard endpoint for non-parole requests', async () => {
@@ -86,12 +97,23 @@ describeClient('placementRequestClient', provider => {
         willRespondWith: {
           status: 200,
           body: placementRequests,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
         },
       })
 
       const result = await placementRequestClient.dashboard(false)
 
-      expect(result).toEqual(placementRequests)
+      expect(result).toEqual({
+        data: placementRequests,
+        pageNumber: '1',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
     })
 
     it('makes a get request to the placementRequests dashboard endpoint for parole requests with a page number', async () => {
@@ -109,12 +131,23 @@ describeClient('placementRequestClient', provider => {
         willRespondWith: {
           status: 200,
           body: placementRequests,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
         },
       })
 
       const result = await placementRequestClient.dashboard(true, 2)
 
-      expect(result).toEqual(placementRequests)
+      expect(result).toEqual({
+        data: placementRequests,
+        pageNumber: '2',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
     })
 
     it('makes a get request to the placementRequests dashboard endpoint for parole requests with a sortBy option', async () => {
@@ -132,12 +165,23 @@ describeClient('placementRequestClient', provider => {
         willRespondWith: {
           status: 200,
           body: placementRequests,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
         },
       })
 
       const result = await placementRequestClient.dashboard(true, 1, 'duration')
 
-      expect(result).toEqual(placementRequests)
+      expect(result).toEqual({
+        data: placementRequests,
+        pageNumber: '1',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
     })
   })
 

--- a/server/data/placementRequestClient.ts
+++ b/server/data/placementRequestClient.ts
@@ -8,6 +8,7 @@ import {
   PlacementRequest,
   PlacementRequestDetail,
   PlacementRequestSortField,
+  SortDirection,
 } from '@approved-premises/api'
 import config, { ApiConfig } from '../config'
 import RestClient from './restClient'
@@ -32,10 +33,11 @@ export default class PlacementRequestClient {
     isParole: boolean,
     page = 1,
     sortBy: PlacementRequestSortField = 'createdAt',
+    sortDirection: SortDirection = 'asc',
   ): Promise<PaginatedResponse<PlacementRequest>> {
     const response = (await this.restClient.get({
       path: paths.placementRequests.dashboard.pattern,
-      query: createQueryString({ isParole, page, sortBy }),
+      query: createQueryString({ isParole, page, sortBy, sortDirection }),
       raw: true,
     })) as superagent.Response
 

--- a/server/data/placementRequestClient.ts
+++ b/server/data/placementRequestClient.ts
@@ -5,6 +5,7 @@ import {
   NewPlacementRequestBookingConfirmation,
   PlacementRequest,
   PlacementRequestDetail,
+  PlacementRequestSortField,
 } from '@approved-premises/api'
 import config, { ApiConfig } from '../config'
 import RestClient from './restClient'
@@ -24,10 +25,14 @@ export default class PlacementRequestClient {
     >
   }
 
-  async dashboard(isParole: boolean): Promise<Array<PlacementRequest>> {
+  async dashboard(
+    isParole: boolean,
+    page = 1,
+    sortBy: PlacementRequestSortField = 'createdAt',
+  ): Promise<Array<PlacementRequest>> {
     return (await this.restClient.get({
       path: paths.placementRequests.dashboard.pattern,
-      query: createQueryString({ isParole }),
+      query: createQueryString({ isParole, page, sortBy }),
     })) as Promise<Array<PlacementRequest>>
   }
 

--- a/server/data/placementRequestClient.ts
+++ b/server/data/placementRequestClient.ts
@@ -1,3 +1,5 @@
+import superagent from 'superagent'
+
 import {
   BookingNotMade,
   NewBookingNotMade,
@@ -11,6 +13,7 @@ import config, { ApiConfig } from '../config'
 import RestClient from './restClient'
 import paths from '../paths/api'
 import { createQueryString } from '../utils/utils'
+import { PaginatedResponse } from '../@types/ui'
 
 export default class PlacementRequestClient {
   restClient: RestClient
@@ -29,11 +32,20 @@ export default class PlacementRequestClient {
     isParole: boolean,
     page = 1,
     sortBy: PlacementRequestSortField = 'createdAt',
-  ): Promise<Array<PlacementRequest>> {
-    return (await this.restClient.get({
+  ): Promise<PaginatedResponse<PlacementRequest>> {
+    const response = (await this.restClient.get({
       path: paths.placementRequests.dashboard.pattern,
       query: createQueryString({ isParole, page, sortBy }),
-    })) as Promise<Array<PlacementRequest>>
+      raw: true,
+    })) as superagent.Response
+
+    return {
+      data: response.body,
+      pageNumber: page.toString(),
+      totalPages: response.headers['x-pagination-totalpages'],
+      totalResults: response.headers['x-pagination-totalresults'],
+      pageSize: response.headers['x-pagination-pagesize'],
+    }
   }
 
   async find(id: string): Promise<PlacementRequestDetail> {

--- a/server/services/placementRequestService.test.ts
+++ b/server/services/placementRequestService.test.ts
@@ -61,7 +61,7 @@ describe('placementRequestService', () => {
       expect(result).toEqual(response)
 
       expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
-      expect(placementRequestClient.dashboard).toHaveBeenCalledWith(false, 1, 'createdAt')
+      expect(placementRequestClient.dashboard).toHaveBeenCalledWith(false, 1, 'createdAt', 'asc')
     })
 
     it('calls the find method on the placementRequest client with page and sort options', async () => {
@@ -71,12 +71,12 @@ describe('placementRequestService', () => {
 
       placementRequestClient.dashboard.mockResolvedValue(response)
 
-      const result = await service.getDashboard(token, false, 2, 'duration')
+      const result = await service.getDashboard(token, false, 2, 'duration', 'desc')
 
       expect(result).toEqual(response)
 
       expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
-      expect(placementRequestClient.dashboard).toHaveBeenCalledWith(false, 2, 'duration')
+      expect(placementRequestClient.dashboard).toHaveBeenCalledWith(false, 2, 'duration', 'desc')
     })
   })
 

--- a/server/services/placementRequestService.test.ts
+++ b/server/services/placementRequestService.test.ts
@@ -56,7 +56,19 @@ describe('placementRequestService', () => {
       expect(result).toEqual(placementRequests)
 
       expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
-      expect(placementRequestClient.dashboard).toHaveBeenCalledWith(false)
+      expect(placementRequestClient.dashboard).toHaveBeenCalledWith(false, 1, 'createdAt')
+    })
+
+    it('calls the find method on the placementRequest client with page and sort options', async () => {
+      const placementRequests = placementRequestFactory.buildList(4, { status: 'notMatched' })
+      placementRequestClient.dashboard.mockResolvedValue(placementRequests)
+
+      const result = await service.getDashboard(token, false, 2, 'duration')
+
+      expect(result).toEqual(placementRequests)
+
+      expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
+      expect(placementRequestClient.dashboard).toHaveBeenCalledWith(false, 2, 'duration')
     })
   })
 

--- a/server/services/placementRequestService.test.ts
+++ b/server/services/placementRequestService.test.ts
@@ -1,12 +1,14 @@
-import { PlacementRequestDetail } from '@approved-premises/api'
+import { PlacementRequest, PlacementRequestDetail } from '@approved-premises/api'
 import PlacementRequestClient from '../data/placementRequestClient'
 import {
   bookingNotMadeFactory,
   newPlacementRequestBookingConfirmationFactory,
+  paginatedResponseFactory,
   placementRequestDetailFactory,
   placementRequestFactory,
 } from '../testutils/factories'
 import PlacementRequestService from './placementRequestService'
+import { PaginatedResponse } from '../@types/ui'
 
 jest.mock('../data/placementRequestClient.ts')
 
@@ -48,24 +50,30 @@ describe('placementRequestService', () => {
 
   describe('getDashboard', () => {
     it('calls the find method on the placementRequest client', async () => {
-      const placementRequests = placementRequestFactory.buildList(4, { status: 'notMatched' })
-      placementRequestClient.dashboard.mockResolvedValue(placementRequests)
+      const response = paginatedResponseFactory.build({
+        data: placementRequestFactory.buildList(4, { status: 'notMatched' }),
+      }) as PaginatedResponse<PlacementRequest>
+
+      placementRequestClient.dashboard.mockResolvedValue(response)
 
       const result = await service.getDashboard(token, false)
 
-      expect(result).toEqual(placementRequests)
+      expect(result).toEqual(response)
 
       expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
       expect(placementRequestClient.dashboard).toHaveBeenCalledWith(false, 1, 'createdAt')
     })
 
     it('calls the find method on the placementRequest client with page and sort options', async () => {
-      const placementRequests = placementRequestFactory.buildList(4, { status: 'notMatched' })
-      placementRequestClient.dashboard.mockResolvedValue(placementRequests)
+      const response = paginatedResponseFactory.build({
+        data: placementRequestFactory.buildList(4, { status: 'notMatched' }),
+      }) as PaginatedResponse<PlacementRequest>
+
+      placementRequestClient.dashboard.mockResolvedValue(response)
 
       const result = await service.getDashboard(token, false, 2, 'duration')
 
-      expect(result).toEqual(placementRequests)
+      expect(result).toEqual(response)
 
       expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
       expect(placementRequestClient.dashboard).toHaveBeenCalledWith(false, 2, 'duration')

--- a/server/services/placementRequestService.ts
+++ b/server/services/placementRequestService.ts
@@ -5,6 +5,7 @@ import {
   NewPlacementRequestBookingConfirmation,
   PlacementRequest,
   PlacementRequestDetail,
+  PlacementRequestSortField,
 } from '@approved-premises/api'
 import { RestClientBuilder } from '../data'
 import PlacementRequestClient from '../data/placementRequestClient'
@@ -30,10 +31,15 @@ export default class PlacementRequestService {
     return results
   }
 
-  async getDashboard(token: string, isParole: boolean): Promise<Array<PlacementRequest>> {
+  async getDashboard(
+    token: string,
+    isParole: boolean,
+    page: number = 1,
+    sortBy: PlacementRequestSortField = 'createdAt',
+  ): Promise<Array<PlacementRequest>> {
     const placementRequestClient = this.placementRequestClientFactory(token)
 
-    return placementRequestClient.dashboard(isParole)
+    return placementRequestClient.dashboard(isParole, page, sortBy)
   }
 
   async getPlacementRequest(token: string, id: string): Promise<PlacementRequestDetail> {

--- a/server/services/placementRequestService.ts
+++ b/server/services/placementRequestService.ts
@@ -1,4 +1,4 @@
-import { GroupedPlacementRequests } from '@approved-premises/ui'
+import { GroupedPlacementRequests, PaginatedResponse } from '@approved-premises/ui'
 import {
   NewBookingNotMade,
   NewPlacementRequestBooking,
@@ -36,7 +36,7 @@ export default class PlacementRequestService {
     isParole: boolean,
     page: number = 1,
     sortBy: PlacementRequestSortField = 'createdAt',
-  ): Promise<Array<PlacementRequest>> {
+  ): Promise<PaginatedResponse<PlacementRequest>> {
     const placementRequestClient = this.placementRequestClientFactory(token)
 
     return placementRequestClient.dashboard(isParole, page, sortBy)

--- a/server/services/placementRequestService.ts
+++ b/server/services/placementRequestService.ts
@@ -6,6 +6,7 @@ import {
   PlacementRequest,
   PlacementRequestDetail,
   PlacementRequestSortField,
+  SortDirection,
 } from '@approved-premises/api'
 import { RestClientBuilder } from '../data'
 import PlacementRequestClient from '../data/placementRequestClient'
@@ -36,10 +37,11 @@ export default class PlacementRequestService {
     isParole: boolean,
     page: number = 1,
     sortBy: PlacementRequestSortField = 'createdAt',
+    sortDirection: SortDirection = 'asc',
   ): Promise<PaginatedResponse<PlacementRequest>> {
     const placementRequestClient = this.placementRequestClientFactory(token)
 
-    return placementRequestClient.dashboard(isParole, page, sortBy)
+    return placementRequestClient.dashboard(isParole, page, sortBy, sortDirection)
   }
 
   async getPlacementRequest(token: string, id: string): Promise<PlacementRequestDetail> {

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -51,6 +51,7 @@ import {
 import nonArrivalFactory from './nonArrival'
 import oasysSectionsFactory, { roshSummaryFactory } from './oasysSections'
 import oasysSelectionFactory from './oasysSelection'
+import paginatedResponseFactory from './paginatedResponse'
 import personFactory from './person'
 import placementApplicationFactory from './placementApplication'
 import placementApplicationTaskFactory from './placementApplicationTask'
@@ -122,6 +123,7 @@ export {
   nonArrivalFactory,
   oasysSectionsFactory,
   oasysSelectionFactory,
+  paginatedResponseFactory,
   personFactory,
   placementApplicationFactory,
   placementApplicationTaskFactory,

--- a/server/testutils/factories/paginatedResponse.ts
+++ b/server/testutils/factories/paginatedResponse.ts
@@ -1,0 +1,10 @@
+import { Factory } from 'fishery'
+import { PaginatedResponse } from '../../@types/ui'
+
+export default Factory.define<PaginatedResponse<unknown>>(() => ({
+  data: [] as Array<unknown>,
+  pageNumber: '1',
+  totalPages: '10',
+  totalResults: '100',
+  pageSize: '10',
+}))

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -28,6 +28,7 @@ import { navigationItems } from './navigationItems'
 import { statusTag } from './personUtils'
 import { DateFormats, uiDateOrDateEmptyMessage } from './dateUtils'
 import { pagination } from './pagination'
+import { sortHeader } from './sortHeader'
 
 import * as AssessmentUtils from './assessments/utils'
 import * as OASysUtils from './assessments/oasysUtils'
@@ -206,6 +207,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('navigationItems', navigationItems)
   njkEnv.addGlobal('withdrawalRadioOptions', withdrawalRadioOptions)
   njkEnv.addGlobal('pagination', pagination)
+  njkEnv.addGlobal('sortHeader', sortHeader)
 
   njkEnv.addGlobal('AssessmentUtils', AssessmentUtils)
   njkEnv.addGlobal('OASysUtils', OASysUtils)

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -27,6 +27,7 @@ import { navigationItems } from './navigationItems'
 
 import { statusTag } from './personUtils'
 import { DateFormats, uiDateOrDateEmptyMessage } from './dateUtils'
+import { pagination } from './pagination'
 
 import * as AssessmentUtils from './assessments/utils'
 import * as OASysUtils from './assessments/oasysUtils'
@@ -204,6 +205,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('dashboardTableRows', dashboardTableRows)
   njkEnv.addGlobal('navigationItems', navigationItems)
   njkEnv.addGlobal('withdrawalRadioOptions', withdrawalRadioOptions)
+  njkEnv.addGlobal('pagination', pagination)
 
   njkEnv.addGlobal('AssessmentUtils', AssessmentUtils)
   njkEnv.addGlobal('OASysUtils', OASysUtils)

--- a/server/utils/pagination.test.ts
+++ b/server/utils/pagination.test.ts
@@ -1,0 +1,121 @@
+import { type Pagination, pagination } from './pagination'
+
+describe('pagination', () => {
+  it('should be empty when there are no pages', () => {
+    expect(pagination(1, 0, '?a=b&')).toEqual<Pagination>({})
+  })
+
+  it('should be empty when there’s only 1 page', () => {
+    expect(pagination(1, 1, '?a=b&')).toEqual<Pagination>({})
+  })
+
+  it('should work on page 1 of 2', () => {
+    expect(pagination(1, 2, '?a=b&')).toEqual<Pagination>({
+      next: { href: '?a=b&page=2' },
+      items: [
+        { number: 1, href: '?a=b&page=1', current: true },
+        { number: 2, href: '?a=b&page=2' },
+      ],
+    })
+  })
+
+  it('should work on page 2 of 2', () => {
+    expect(pagination(2, 2, '?a=b&')).toEqual<Pagination>({
+      previous: { href: '?a=b&page=1' },
+      items: [
+        { number: 1, href: '?a=b&page=1' },
+        { number: 2, href: '?a=b&page=2', current: true },
+      ],
+    })
+  })
+
+  it('should work on page 2 of 3', () => {
+    expect(pagination(2, 3, '?a=b&')).toEqual<Pagination>({
+      previous: { href: '?a=b&page=1' },
+      next: { href: '?a=b&page=3' },
+      items: [
+        { number: 1, href: '?a=b&page=1' },
+        { number: 2, href: '?a=b&page=2', current: true },
+        { number: 3, href: '?a=b&page=3' },
+      ],
+    })
+  })
+
+  it('should work on page 1 of 7', () => {
+    expect(pagination(1, 7, '?a=b&')).toHaveProperty('items', [
+      { number: 1, href: '?a=b&page=1', current: true },
+      { number: 2, href: '?a=b&page=2' },
+      { ellipsis: true },
+      { number: 6, href: '?a=b&page=6' },
+      { number: 7, href: '?a=b&page=7' },
+    ])
+  })
+
+  it('should work on page 2 of 7', () => {
+    expect(pagination(2, 7, '?a=b&')).toHaveProperty('items', [
+      { number: 1, href: '?a=b&page=1' },
+      { number: 2, href: '?a=b&page=2', current: true },
+      { number: 3, href: '?a=b&page=3' },
+      { ellipsis: true },
+      { number: 6, href: '?a=b&page=6' },
+      { number: 7, href: '?a=b&page=7' },
+    ])
+  })
+
+  it('should work on page 3 of 7', () => {
+    expect(pagination(3, 7, '?a=b&')).toHaveProperty('items', [
+      { number: 1, href: '?a=b&page=1' },
+      { number: 2, href: '?a=b&page=2' },
+      { number: 3, href: '?a=b&page=3', current: true },
+      { number: 4, href: '?a=b&page=4' },
+      { ellipsis: true },
+      { number: 6, href: '?a=b&page=6' },
+      { number: 7, href: '?a=b&page=7' },
+    ])
+  })
+
+  it('should work on page 4 of 7', () => {
+    expect(pagination(4, 7, '?a=b&')).toHaveProperty('items', [
+      { number: 1, href: '?a=b&page=1' },
+      { number: 2, href: '?a=b&page=2' },
+      { number: 3, href: '?a=b&page=3' },
+      { number: 4, href: '?a=b&page=4', current: true },
+      { number: 5, href: '?a=b&page=5' },
+      { number: 6, href: '?a=b&page=6' },
+      { number: 7, href: '?a=b&page=7' },
+    ])
+  })
+
+  it('should work on page 5 of 7', () => {
+    expect(pagination(5, 7, '?a=b&')).toHaveProperty('items', [
+      { number: 1, href: '?a=b&page=1' },
+      { number: 2, href: '?a=b&page=2' },
+      { ellipsis: true },
+      { number: 4, href: '?a=b&page=4' },
+      { number: 5, href: '?a=b&page=5', current: true },
+      { number: 6, href: '?a=b&page=6' },
+      { number: 7, href: '?a=b&page=7' },
+    ])
+  })
+
+  it('should work on page 6 of 7', () => {
+    expect(pagination(6, 7, '?a=b&')).toHaveProperty('items', [
+      { number: 1, href: '?a=b&page=1' },
+      { number: 2, href: '?a=b&page=2' },
+      { ellipsis: true },
+      { number: 5, href: '?a=b&page=5' },
+      { number: 6, href: '?a=b&page=6', current: true },
+      { number: 7, href: '?a=b&page=7' },
+    ])
+  })
+
+  it('should work on page 7 of 7', () => {
+    expect(pagination(7, 7, '?a=b&')).toHaveProperty('items', [
+      { number: 1, href: '?a=b&page=1' },
+      { number: 2, href: '?a=b&page=2' },
+      { ellipsis: true },
+      { number: 6, href: '?a=b&page=6' },
+      { number: 7, href: '?a=b&page=7', current: true },
+    ])
+  })
+})

--- a/server/utils/pagination.ts
+++ b/server/utils/pagination.ts
@@ -1,0 +1,82 @@
+export type PaginationPreviousOrNext = {
+  href: string
+  text?: string
+  attributes?: Record<string, string>
+}
+
+export type PaginationItem =
+  | {
+      number: number
+      href: string
+      current?: boolean
+    }
+  | {
+      ellipsis: true
+    }
+
+export type Pagination = {
+  previous?: PaginationPreviousOrNext
+  items?: Array<PaginationItem>
+  next?: PaginationPreviousOrNext
+  landmarkLabel?: string
+}
+
+/**
+ * Produces parameters for GOV.UK Pagination component macro
+ * NB: `page` starts at 1
+ *
+ * Accessibility notes:
+ * - set `landmarkLabel` on the returned object otherwise the navigation box is announced as "results"
+ * - set `previous.attributes.aria-label` and `next.attributes.aria-label` on the returned object if "Previous" and "Next" are not clear enough
+ */
+export function pagination(currentPage: number, pageCount: number, hrefPrefix: string): Pagination {
+  const params: Pagination = {}
+
+  if (!pageCount || pageCount <= 1) {
+    return params
+  }
+
+  if (currentPage !== 1) {
+    params.previous = {
+      href: `${hrefPrefix}page=${currentPage - 1}`,
+    }
+  }
+  if (currentPage < pageCount) {
+    params.next = {
+      href: `${hrefPrefix}page=${currentPage + 1}`,
+    }
+  }
+
+  let pages: Array<number | null>
+  if (currentPage >= 5) {
+    pages = [1, 2, null, currentPage - 1, currentPage]
+  } else {
+    pages = [1, 2, 3, 4].slice(0, currentPage)
+  }
+  const maxPage = Math.max(currentPage, pages.at(-1))
+  if (maxPage === pageCount - 1) {
+    pages.push(pageCount)
+  } else if (maxPage === pageCount - 2) {
+    pages.push(pageCount - 1, pageCount)
+  } else if (maxPage === pageCount - 3) {
+    pages.push(maxPage + 1, pageCount - 1, pageCount)
+  } else if (maxPage <= pageCount - 4) {
+    pages.push(maxPage + 1, null, pageCount - 1, pageCount)
+  }
+
+  params.items = pages.map((somePage: number | null): PaginationItem => {
+    if (somePage) {
+      const item: PaginationItem = {
+        number: somePage,
+        href: `${hrefPrefix}page=${somePage}`,
+      }
+      if (somePage === currentPage) {
+        item.current = true
+      }
+      return item
+    }
+    return { ellipsis: true }
+  })
+
+  return params
+}

--- a/server/utils/sortHeader.test.ts
+++ b/server/utils/sortHeader.test.ts
@@ -1,0 +1,33 @@
+import { sortHeader } from './sortHeader'
+import { createQueryString } from './utils'
+
+describe('sortHeader', () => {
+  const hrefPrefix = 'http://localhost/example?'
+
+  it("should return a header when the current view is not sorted by the header's field`", () => {
+    expect(sortHeader('Some text', 'myField', 'otherField', 'asc', hrefPrefix)).toEqual({
+      html: `<a href="${hrefPrefix}${createQueryString({ sortBy: 'myField' })}">Some text</a>`,
+      attributes: {
+        'aria-sort': 'none',
+      },
+    })
+  })
+
+  it("should return a header when the current view is sorted in ascending order by the header's field`", () => {
+    expect(sortHeader('Some text', 'myField', 'myField', 'asc', hrefPrefix)).toEqual({
+      html: `<a href="${hrefPrefix}${createQueryString({ sortBy: 'myField', sortDirection: 'desc' })}">Some text</a>`,
+      attributes: {
+        'aria-sort': 'ascending',
+      },
+    })
+  })
+
+  it("should return a header when the current view is sorted in descending order by the header's field`", () => {
+    expect(sortHeader('Some text', 'myField', 'myField', 'desc', hrefPrefix)).toEqual({
+      html: `<a href="${hrefPrefix}${createQueryString({ sortBy: 'myField', sortDirection: 'asc' })}">Some text</a>`,
+      attributes: {
+        'aria-sort': 'descending',
+      },
+    })
+  })
+})

--- a/server/utils/sortHeader.test.ts
+++ b/server/utils/sortHeader.test.ts
@@ -9,6 +9,7 @@ describe('sortHeader', () => {
       html: `<a href="${hrefPrefix}${createQueryString({ sortBy: 'myField' })}">Some text</a>`,
       attributes: {
         'aria-sort': 'none',
+        'data-cy-sort-field': 'myField',
       },
     })
   })
@@ -18,6 +19,7 @@ describe('sortHeader', () => {
       html: `<a href="${hrefPrefix}${createQueryString({ sortBy: 'myField', sortDirection: 'desc' })}">Some text</a>`,
       attributes: {
         'aria-sort': 'ascending',
+        'data-cy-sort-field': 'myField',
       },
     })
   })
@@ -27,6 +29,7 @@ describe('sortHeader', () => {
       html: `<a href="${hrefPrefix}${createQueryString({ sortBy: 'myField', sortDirection: 'asc' })}">Some text</a>`,
       attributes: {
         'aria-sort': 'descending',
+        'data-cy-sort-field': 'myField',
       },
     })
   })

--- a/server/utils/sortHeader.ts
+++ b/server/utils/sortHeader.ts
@@ -1,0 +1,31 @@
+import { SortDirection } from '../@types/shared'
+import { TableCell } from '../@types/ui'
+import { createQueryString } from './utils'
+
+export const sortHeader = (
+  text: string,
+  targetField: string,
+  currentSortField: string,
+  currentSortDirection: SortDirection,
+  hrefPrefix: string,
+): TableCell => {
+  let sortDirection: SortDirection
+  let ariaSort = 'none'
+
+  if (targetField === currentSortField) {
+    if (currentSortDirection === 'desc') {
+      sortDirection = 'asc'
+      ariaSort = 'descending'
+    } else {
+      sortDirection = 'desc'
+      ariaSort = 'ascending'
+    }
+  }
+
+  return {
+    html: `<a href="${hrefPrefix}${createQueryString({ sortBy: targetField, sortDirection })}">${text}</a>`,
+    attributes: {
+      'aria-sort': ariaSort,
+    },
+  }
+}

--- a/server/utils/sortHeader.ts
+++ b/server/utils/sortHeader.ts
@@ -26,6 +26,7 @@ export const sortHeader = (
     html: `<a href="${hrefPrefix}${createQueryString({ sortBy: targetField, sortDirection })}">${text}</a>`,
     attributes: {
       'aria-sort': ariaSort,
+      'data-cy-sort-field': targetField,
     },
   }
 }

--- a/server/views/admin/placementRequests/index.njk
+++ b/server/views/admin/placementRequests/index.njk
@@ -39,9 +39,6 @@
       {{
               govukTable({
                   firstCellIsHeader: true,
-                  attributes: {
-                    'data-module': 'moj-sortable-table'
-                  },
                   head: [
                       {
                           text: "Name"
@@ -52,18 +49,8 @@
                       {
                           text: "Tier"
                       },
-                      {
-                          text: ("Date of decision" if isParole else "Arrival date"),
-                          attributes: {
-                            "aria-sort": "none"
-                          }
-                      },
-                      {
-                          text: "Length of stay",
-                          attributes: {
-                            "aria-sort": "none"
-                          }
-                      },
+                      sortHeader(("Date of decision" if isParole else "Arrival date"), 'expectedArrival', sortBy, sortDirection, hrefPrefix),
+                      sortHeader("Length of stay", 'duration', sortBy, sortDirection, hrefPrefix),
                       {
                           text: "Status"
                       }
@@ -76,12 +63,4 @@
 
     </div>
   </div>
-{% endblock %}
-
-{% block extraScripts %}
-  <script type="text/javascript" nonce="{{ cspNonce }}">
-    window
-      .MOJFrontend
-      .initAll()
-  </script>
 {% endblock %}

--- a/server/views/admin/placementRequests/index.njk
+++ b/server/views/admin/placementRequests/index.njk
@@ -1,6 +1,7 @@
 {% extends "../../partials/layout.njk" %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
 
 {% set pageTitle = applicationName + " - " + pageHeading  %}
 {% set mainClasses = "app-container govuk-body assessments--index" %}
@@ -70,6 +71,8 @@
                   rows: PlacementRequestUtils.tableUtils.dashboardTableRows(placementRequests)
                 })
             }}
+
+      {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
 
     </div>
   </div>


### PR DESCRIPTION
This adds server-side pagination and sorting to the CRU dashboard, using the functionality added in https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/859

## Screenshot

![Placement Requests -- supports sorting](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/bdcfa94d-bd7f-4c98-b588-16650b0ba350)