### PR TITLE
Fix `getTaskStatus`

### DIFF
--- a/integration_tests/pages/assess/requiredActionsPage.ts
+++ b/integration_tests/pages/assess/requiredActionsPage.ts
@@ -1,4 +1,3 @@
-import { faker } from '@faker-js/faker/locale/en_GB'
 import type { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
 
 import AssessPage from './assessPage'
@@ -8,18 +7,18 @@ import RequiredActions from '../../../server/form-pages/assess/assessApplication
 export default class RequiredActionsPage extends AssessPage {
   pageClass = new RequiredActions({
     additionalActions: 'yes',
-    additionalActionsComments: '',
+    additionalActionsComments: 'Additional actions',
     curfewsOrSignIns: 'yes',
     curfewsOrSignInsComments: '',
     concernsOfUnmanagableRisk: 'yes',
     concernsOfUnmanagableRiskComments: '',
     additionalRecommendations: 'yes',
     additionalRecommendationsComments: '',
-    nameOfAreaManager: faker.person.fullName(),
+    nameOfAreaManager: 'Frank',
     'dateOfDiscussion-day': '1',
     'dateOfDiscussion-month': '2',
     'dateOfDiscussion-year': '2022',
-    outlineOfDiscussion: '',
+    outlineOfDiscussion: 'Outline of discussion',
   })
 
   constructor(assessment: Assessment) {
@@ -28,15 +27,15 @@ export default class RequiredActionsPage extends AssessPage {
 
   completeForm() {
     this.checkRadioByNameAndValue('additionalActions', this.pageClass.body.additionalActions)
-    this.completeTextArea('additionalActionsComments', 'One')
+    this.clearAndCompleteTextInputById('additionalActionsComments', 'One')
 
     this.checkRadioByNameAndValue('curfewsOrSignIns', this.pageClass.body.curfewsOrSignIns)
     this.completeTextArea('curfewsOrSignInsComments', 'Two')
 
     this.checkRadioByNameAndValue('concernsOfUnmanagableRisk', this.pageClass.body.concernsOfUnmanagableRisk)
-    this.getTextInputByIdAndEnterDetails('nameOfAreaManager', 'Frank')
+    this.clearAndCompleteTextInputById('nameOfAreaManager', this.pageClass.body.nameOfAreaManager)
 
-    this.completeTextArea('outlineOfDiscussion', 'foo bar baz')
+    this.clearAndCompleteTextInputById('outlineOfDiscussion', this.pageClass.body.outlineOfDiscussion)
 
     this.completeTextArea('concernsOfUnmanagableRiskComments', 'Three')
     this.checkRadioByNameAndValue('additionalRecommendations', this.pageClass.body.additionalActions)

--- a/server/form-pages/utils/getTaskStatus.test.ts
+++ b/server/form-pages/utils/getTaskStatus.test.ts
@@ -56,6 +56,7 @@ describe('getTaskStatus', () => {
       data: { 'my-task': { 'page-1': { foo: 'bar' }, 'page-2': { foo: 'bar' } } },
     })
 
+    page1Instance.next.mockReturnValue('')
     page1Instance.errors.mockReturnValue({ some: 'errors' })
 
     expect(getTaskStatus(task, application)).toEqual('in_progress')

--- a/server/form-pages/utils/getTaskStatus.ts
+++ b/server/form-pages/utils/getTaskStatus.ts
@@ -41,7 +41,7 @@ const getTaskStatus = (task: UiTask, applicationOrAssessment: Application | Asse
     // And the next page ID
     pageId = page.next()
 
-    if (errors.length) {
+    if (Object.keys(errors).length) {
       // Are there any errors? Then the task is incomplete
       status = 'in_progress'
       break


### PR DESCRIPTION
This was not picking up errors correctly, so if a page has errors the helper was erroneously thinking the page was in progress.