### PR TITLE
(373) Filter placement requests by type

### DIFF
--- a/integration_tests/mockApis/placementRequests.ts
+++ b/integration_tests/mockApis/placementRequests.ts
@@ -1,6 +1,6 @@
 import { SuperAgentRequest } from 'superagent'
 
-import type { PlacementRequest, PlacementRequestDetail } from '@approved-premises/api'
+import type { PlacementRequest, PlacementRequestDetail, PlacementRequestStatus } from '@approved-premises/api'
 import { getMatchingRequests, stubFor } from '../../wiremock'
 import paths from '../../server/paths/api'
 import { bookingNotMadeFactory, newPlacementRequestBookingConfirmationFactory } from '../../server/testutils/factories'
@@ -23,13 +23,13 @@ export default {
 
   stubPlacementRequestsDashboard: ({
     placementRequests,
-    isParole,
+    status,
     page = '1',
-    sortBy = 'createdAt',
+    sortBy = 'created_at',
     sortDirection = 'asc',
   }: {
     placementRequests: Array<PlacementRequest>
-    isParole: boolean
+    status: PlacementRequestStatus
     page: string
     sortBy: string
     sortDirection: string
@@ -37,7 +37,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `${paths.placementRequests.dashboard.pattern}?isParole=${isParole}&page=${page}&sortBy=${sortBy}&sortDirection=${sortDirection}`,
+        url: `${paths.placementRequests.dashboard.pattern}?status=${status}&page=${page}&sortBy=${sortBy}&sortDirection=${sortDirection}`,
       },
       response: {
         status: 200,
@@ -51,12 +51,12 @@ export default {
       },
     }),
   verifyPlacementRequestsDashboard: async ({
-    isParole,
+    status,
     page = '1',
-    sortBy = 'createdAt',
+    sortBy = 'created_at',
     sortDirection = 'asc',
   }: {
-    isParole: boolean
+    status: PlacementRequestStatus
     page: string
     sortBy: string
     sortDirection: string
@@ -64,7 +64,7 @@ export default {
     (
       await getMatchingRequests({
         method: 'GET',
-        url: `${paths.placementRequests.dashboard.pattern}?isParole=${isParole}&page=${page}&sortBy=${sortBy}&sortDirection=${sortDirection}`,
+        url: `${paths.placementRequests.dashboard.pattern}?status=${status}&page=${page}&sortBy=${sortBy}&sortDirection=${sortDirection}`,
       })
     ).body.requests,
   stubPlacementRequest: (placementRequestDetail: PlacementRequestDetail): SuperAgentRequest =>

--- a/integration_tests/pages/admin/placementApplications/listPage.ts
+++ b/integration_tests/pages/admin/placementApplications/listPage.ts
@@ -23,12 +23,16 @@ export default class ListPage extends Page {
     cy.get(`[data-cy-placementRequestId="${placementRequest.id}"]`).click()
   }
 
-  clickParoleOption(): void {
-    cy.get('a.moj-sub-navigation__link').contains('Parole').click()
+  clickReadyToMatch(): void {
+    cy.get('a.moj-sub-navigation__link').contains('Ready to match').click()
   }
 
-  clickNonParoleOption(): void {
-    cy.get('a.moj-sub-navigation__link').contains('Confirmed release date').click()
+  clickMatched(): void {
+    cy.get('a.moj-sub-navigation__link').contains('Matched').click()
+  }
+
+  clickUnableToMatch(): void {
+    cy.get('a.moj-sub-navigation__link').contains('Unable to match').click()
   }
 
   clickNext(): void {

--- a/server/@types/shared/models/PlacementRequest.ts
+++ b/server/@types/shared/models/PlacementRequest.ts
@@ -5,6 +5,7 @@
 
 import type { ApprovedPremisesUser } from './ApprovedPremisesUser';
 import type { AssessmentDecision } from './AssessmentDecision';
+import type { BookingSummary } from './BookingSummary';
 import type { Person } from './Person';
 import type { PersonRisks } from './PersonRisks';
 import type { PlacementDates } from './PlacementDates';
@@ -26,5 +27,6 @@ export type PlacementRequest = (PlacementRequirements & PlacementDates & {
     assessor: ApprovedPremisesUser;
     isParole: boolean;
     notes?: string;
+    booking?: BookingSummary;
 });
 

--- a/server/@types/shared/models/PlacementRequestDetail.ts
+++ b/server/@types/shared/models/PlacementRequestDetail.ts
@@ -4,13 +4,11 @@
 /* eslint-disable */
 
 import type { Application } from './Application';
-import type { BookingSummary } from './BookingSummary';
 import type { Cancellation } from './Cancellation';
 import type { PlacementRequest } from './PlacementRequest';
 
 export type PlacementRequestDetail = (PlacementRequest & {
     cancellations: Array<Cancellation>;
-    booking?: BookingSummary;
     application: Application;
 });
 

--- a/server/@types/shared/models/PlacementRequestSortField.ts
+++ b/server/@types/shared/models/PlacementRequestSortField.ts
@@ -3,4 +3,4 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type PlacementRequestSortField = 'duration' | 'expectedArrival' | 'createdAt';
+export type PlacementRequestSortField = 'duration' | 'expected_arrival' | 'created_at';

--- a/server/controllers/admin/placementRequestsController.test.ts
+++ b/server/controllers/admin/placementRequestsController.test.ts
@@ -40,7 +40,7 @@ describe('PlacementRequestsController', () => {
     })
 
     it('should render the placement requests template', async () => {
-      const hrefPrefix = `${paths.admin.placementRequests.index({})}?${createQueryString({ isParole: false })}&`
+      const hrefPrefix = `${paths.admin.placementRequests.index({})}?status=notMatched&`
 
       const requestHandler = placementRequestsController.index()
 
@@ -49,39 +49,51 @@ describe('PlacementRequestsController', () => {
       expect(response.render).toHaveBeenCalledWith('admin/placementRequests/index', {
         pageHeading: 'Record and update placement details',
         placementRequests: paginatedResponse.data,
-        isParole: false,
+        status: 'notMatched',
         pageNumber: Number(paginatedResponse.pageNumber),
         totalPages: Number(paginatedResponse.totalPages),
         hrefPrefix,
       })
-      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, false, undefined, undefined, undefined)
+      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(
+        token,
+        'notMatched',
+        undefined,
+        undefined,
+        undefined,
+      )
     })
 
     it('should request parole placement requests', async () => {
-      const hrefPrefix = `${paths.admin.placementRequests.index({})}?${createQueryString({ isParole: true })}&`
+      const hrefPrefix = `${paths.admin.placementRequests.index({})}?${createQueryString({ status: 'notMatched' })}&`
 
       const requestHandler = placementRequestsController.index()
 
-      await requestHandler({ ...request, query: { isParole: '1' } }, response, next)
+      await requestHandler({ ...request, query: { status: 'notMatched' } }, response, next)
 
       expect(response.render).toHaveBeenCalledWith('admin/placementRequests/index', {
         pageHeading: 'Record and update placement details',
         placementRequests: paginatedResponse.data,
-        isParole: true,
+        status: 'notMatched',
         pageNumber: Number(paginatedResponse.pageNumber),
         totalPages: Number(paginatedResponse.totalPages),
         hrefPrefix,
       })
-      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, true, undefined, undefined, undefined)
+      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(
+        token,
+        'notMatched',
+        undefined,
+        undefined,
+        undefined,
+      )
     })
 
     it('should request page numbers and sort options', async () => {
-      const hrefPrefix = `${paths.admin.placementRequests.index({})}?${createQueryString({ isParole: true })}&`
+      const hrefPrefix = `${paths.admin.placementRequests.index({})}?${createQueryString({ status: 'notMatched' })}&`
 
       const requestHandler = placementRequestsController.index()
 
       await requestHandler(
-        { ...request, query: { isParole: '1', page: '2', sortBy: 'expectedArrival', sortDirection: 'desc' } },
+        { ...request, query: { status: 'notMatched', page: '2', sortBy: 'expectedArrival', sortDirection: 'desc' } },
         response,
         next,
       )
@@ -89,14 +101,20 @@ describe('PlacementRequestsController', () => {
       expect(response.render).toHaveBeenCalledWith('admin/placementRequests/index', {
         pageHeading: 'Record and update placement details',
         placementRequests: paginatedResponse.data,
-        isParole: true,
+        status: 'notMatched',
         pageNumber: Number(paginatedResponse.pageNumber),
         totalPages: Number(paginatedResponse.totalPages),
         hrefPrefix,
         sortBy: 'expectedArrival',
         sortDirection: 'desc',
       })
-      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(token, true, 2, 'expectedArrival', 'desc')
+      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(
+        token,
+        'notMatched',
+        2,
+        'expectedArrival',
+        'desc',
+      )
     })
   })
 

--- a/server/controllers/admin/placementRequestsController.ts
+++ b/server/controllers/admin/placementRequestsController.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 import { PlacementRequestService } from '../../services'
-import { PlacementRequestSortField, SortDirection } from '../../@types/shared'
+import { PlacementRequestSortField, PlacementRequestStatus, SortDirection } from '../../@types/shared'
 import paths from '../../paths/admin'
 import { createQueryString } from '../../utils/utils'
 
@@ -9,16 +9,19 @@ export default class PlacementRequestsController {
 
   index(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
-      const isParole = req.query.isParole === '1'
+      const status = (req.query.status as PlacementRequestStatus) || 'notMatched'
       const pageNumber = req.query.page ? Number(req.query.page) : undefined
       const sortBy = req.query.sortBy as PlacementRequestSortField
       const sortDirection = req.query.sortDirection as SortDirection
 
-      const hrefPrefix = `${paths.admin.placementRequests.index({})}?${createQueryString({ isParole })}&`
+      const hrefPrefix = `${paths.admin.placementRequests.index({})}${createQueryString(
+        { status },
+        { addQueryPrefix: true },
+      )}&`
 
       const dashboard = await this.placementRequestService.getDashboard(
         req.user.token,
-        isParole,
+        status,
         pageNumber,
         sortBy,
         sortDirection,
@@ -27,7 +30,7 @@ export default class PlacementRequestsController {
       res.render('admin/placementRequests/index', {
         pageHeading: 'Record and update placement details',
         placementRequests: dashboard.data,
-        isParole,
+        status,
         pageNumber: Number(dashboard.pageNumber),
         totalPages: Number(dashboard.totalPages),
         hrefPrefix,

--- a/server/data/placementRequestClient.test.ts
+++ b/server/data/placementRequestClient.test.ts
@@ -55,7 +55,7 @@ describeClient('placementRequestClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.placementRequests.dashboard.pattern,
-          query: { isParole: 'true', page: '1', sortBy: 'createdAt', sortDirection: 'asc' },
+          query: { isParole: 'true', page: '1', sortBy: 'created_at', sortDirection: 'asc' },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -89,7 +89,7 @@ describeClient('placementRequestClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.placementRequests.dashboard.pattern,
-          query: { isParole: 'false', page: '1', sortBy: 'createdAt', sortDirection: 'asc' },
+          query: { isParole: 'false', page: '1', sortBy: 'created_at', sortDirection: 'asc' },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -123,7 +123,7 @@ describeClient('placementRequestClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.placementRequests.dashboard.pattern,
-          query: { isParole: 'true', page: '2', sortBy: 'createdAt', sortDirection: 'asc' },
+          query: { isParole: 'true', page: '2', sortBy: 'created_at', sortDirection: 'asc' },
           headers: {
             authorization: `Bearer ${token}`,
           },

--- a/server/data/placementRequestClient.test.ts
+++ b/server/data/placementRequestClient.test.ts
@@ -48,14 +48,14 @@ describeClient('placementRequestClient', provider => {
   describe('dashboard', () => {
     const placementRequests = placementRequestFactory.buildList(2)
 
-    it('makes a get request to the placementRequests dashboard endpoint for parole requests', async () => {
+    it('makes a get request to the placementRequests dashboard endpoint for unmatched requests', async () => {
       provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get the placement requests dashboard view',
         withRequest: {
           method: 'GET',
           path: paths.placementRequests.dashboard.pattern,
-          query: { isParole: 'true', page: '1', sortBy: 'created_at', sortDirection: 'asc' },
+          query: { status: 'notMatched', page: '1', sortBy: 'created_at', sortDirection: 'asc' },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -71,7 +71,7 @@ describeClient('placementRequestClient', provider => {
         },
       })
 
-      const result = await placementRequestClient.dashboard(true)
+      const result = await placementRequestClient.dashboard()
 
       expect(result).toEqual({
         data: placementRequests,
@@ -82,14 +82,14 @@ describeClient('placementRequestClient', provider => {
       })
     })
 
-    it('makes a get request to the placementRequests dashboard endpoint for non-parole requests', async () => {
+    it('makes a get request to the placementRequests dashboard endpoint for requests of another type', async () => {
       provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get the placement requests dashboard view',
         withRequest: {
           method: 'GET',
           path: paths.placementRequests.dashboard.pattern,
-          query: { isParole: 'false', page: '1', sortBy: 'created_at', sortDirection: 'asc' },
+          query: { status: 'unableToMatch', page: '1', sortBy: 'created_at', sortDirection: 'asc' },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -105,7 +105,7 @@ describeClient('placementRequestClient', provider => {
         },
       })
 
-      const result = await placementRequestClient.dashboard(false)
+      const result = await placementRequestClient.dashboard('unableToMatch')
 
       expect(result).toEqual({
         data: placementRequests,
@@ -116,14 +116,14 @@ describeClient('placementRequestClient', provider => {
       })
     })
 
-    it('makes a get request to the placementRequests dashboard endpoint for parole requests with a page number', async () => {
+    it('makes a get request to the placementRequests dashboard endpoint with a page number', async () => {
       provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get the placement requests dashboard view',
         withRequest: {
           method: 'GET',
           path: paths.placementRequests.dashboard.pattern,
-          query: { isParole: 'true', page: '2', sortBy: 'created_at', sortDirection: 'asc' },
+          query: { status: 'notMatched', page: '2', sortBy: 'created_at', sortDirection: 'asc' },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -139,7 +139,7 @@ describeClient('placementRequestClient', provider => {
         },
       })
 
-      const result = await placementRequestClient.dashboard(true, 2)
+      const result = await placementRequestClient.dashboard('notMatched', 2)
 
       expect(result).toEqual({
         data: placementRequests,
@@ -150,14 +150,14 @@ describeClient('placementRequestClient', provider => {
       })
     })
 
-    it('makes a get request to the placementRequests dashboard endpoint for parole requests with a sortBy option', async () => {
+    it('makes a get request to the placementRequests dashboard endpoint with a sortBy option', async () => {
       provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get the placement requests dashboard view',
         withRequest: {
           method: 'GET',
           path: paths.placementRequests.dashboard.pattern,
-          query: { isParole: 'true', page: '1', sortBy: 'duration', sortDirection: 'desc' },
+          query: { status: 'notMatched', page: '1', sortBy: 'duration', sortDirection: 'desc' },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -173,7 +173,7 @@ describeClient('placementRequestClient', provider => {
         },
       })
 
-      const result = await placementRequestClient.dashboard(true, 1, 'duration', 'desc')
+      const result = await placementRequestClient.dashboard('notMatched', 1, 'duration', 'desc')
 
       expect(result).toEqual({
         data: placementRequests,

--- a/server/data/placementRequestClient.ts
+++ b/server/data/placementRequestClient.ts
@@ -32,7 +32,7 @@ export default class PlacementRequestClient {
   async dashboard(
     isParole: boolean,
     page = 1,
-    sortBy: PlacementRequestSortField = 'createdAt',
+    sortBy: PlacementRequestSortField = 'created_at',
     sortDirection: SortDirection = 'asc',
   ): Promise<PaginatedResponse<PlacementRequest>> {
     const response = (await this.restClient.get({

--- a/server/data/placementRequestClient.ts
+++ b/server/data/placementRequestClient.ts
@@ -8,6 +8,7 @@ import {
   PlacementRequest,
   PlacementRequestDetail,
   PlacementRequestSortField,
+  PlacementRequestStatus,
   SortDirection,
 } from '@approved-premises/api'
 import config, { ApiConfig } from '../config'
@@ -30,14 +31,14 @@ export default class PlacementRequestClient {
   }
 
   async dashboard(
-    isParole: boolean,
+    status: PlacementRequestStatus = 'notMatched',
     page = 1,
     sortBy: PlacementRequestSortField = 'created_at',
     sortDirection: SortDirection = 'asc',
   ): Promise<PaginatedResponse<PlacementRequest>> {
     const response = (await this.restClient.get({
       path: paths.placementRequests.dashboard.pattern,
-      query: createQueryString({ isParole, page, sortBy, sortDirection }),
+      query: createQueryString({ status, page, sortBy, sortDirection }),
       raw: true,
     })) as superagent.Response
 

--- a/server/services/placementRequestService.test.ts
+++ b/server/services/placementRequestService.test.ts
@@ -61,7 +61,7 @@ describe('placementRequestService', () => {
       expect(result).toEqual(response)
 
       expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
-      expect(placementRequestClient.dashboard).toHaveBeenCalledWith(false, 1, 'createdAt', 'asc')
+      expect(placementRequestClient.dashboard).toHaveBeenCalledWith(false, 1, 'created_at', 'asc')
     })
 
     it('calls the find method on the placementRequest client with page and sort options', async () => {

--- a/server/services/placementRequestService.test.ts
+++ b/server/services/placementRequestService.test.ts
@@ -56,12 +56,12 @@ describe('placementRequestService', () => {
 
       placementRequestClient.dashboard.mockResolvedValue(response)
 
-      const result = await service.getDashboard(token, false)
+      const result = await service.getDashboard(token, 'notMatched')
 
       expect(result).toEqual(response)
 
       expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
-      expect(placementRequestClient.dashboard).toHaveBeenCalledWith(false, 1, 'created_at', 'asc')
+      expect(placementRequestClient.dashboard).toHaveBeenCalledWith('notMatched', 1, 'created_at', 'asc')
     })
 
     it('calls the find method on the placementRequest client with page and sort options', async () => {
@@ -71,12 +71,12 @@ describe('placementRequestService', () => {
 
       placementRequestClient.dashboard.mockResolvedValue(response)
 
-      const result = await service.getDashboard(token, false, 2, 'duration', 'desc')
+      const result = await service.getDashboard(token, 'notMatched', 2, 'duration', 'desc')
 
       expect(result).toEqual(response)
 
       expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
-      expect(placementRequestClient.dashboard).toHaveBeenCalledWith(false, 2, 'duration', 'desc')
+      expect(placementRequestClient.dashboard).toHaveBeenCalledWith('notMatched', 2, 'duration', 'desc')
     })
   })
 

--- a/server/services/placementRequestService.ts
+++ b/server/services/placementRequestService.ts
@@ -6,6 +6,7 @@ import {
   PlacementRequest,
   PlacementRequestDetail,
   PlacementRequestSortField,
+  PlacementRequestStatus,
   SortDirection,
 } from '@approved-premises/api'
 import { RestClientBuilder } from '../data'
@@ -34,14 +35,14 @@ export default class PlacementRequestService {
 
   async getDashboard(
     token: string,
-    isParole: boolean,
+    status: PlacementRequestStatus,
     page: number = 1,
     sortBy: PlacementRequestSortField = 'created_at',
     sortDirection: SortDirection = 'asc',
   ): Promise<PaginatedResponse<PlacementRequest>> {
     const placementRequestClient = this.placementRequestClientFactory(token)
 
-    return placementRequestClient.dashboard(isParole, page, sortBy, sortDirection)
+    return placementRequestClient.dashboard(status, page, sortBy, sortDirection)
   }
 
   async getPlacementRequest(token: string, id: string): Promise<PlacementRequestDetail> {

--- a/server/services/placementRequestService.ts
+++ b/server/services/placementRequestService.ts
@@ -36,7 +36,7 @@ export default class PlacementRequestService {
     token: string,
     isParole: boolean,
     page: number = 1,
-    sortBy: PlacementRequestSortField = 'createdAt',
+    sortBy: PlacementRequestSortField = 'created_at',
     sortDirection: SortDirection = 'asc',
   ): Promise<PaginatedResponse<PlacementRequest>> {
     const placementRequestClient = this.placementRequestClientFactory(token)

--- a/server/testutils/factories/placementRequest.ts
+++ b/server/testutils/factories/placementRequest.ts
@@ -5,6 +5,7 @@ import { DateFormats } from '../../utils/dateUtils'
 import personFactory from './person'
 import risksFactory from './risks'
 import userFactory from './user'
+import bookingSummary from './bookingSummary'
 
 export default Factory.define<PlacementRequest>(() => {
   const essentialCriteria = faker.helpers.arrayElements(placementCriteria)
@@ -31,6 +32,7 @@ export default Factory.define<PlacementRequest>(() => {
     assessmentDate: DateFormats.dateObjToIsoDateTime(faker.date.soon()),
     assessor: userFactory.build(),
     isParole: false,
+    booking: bookingSummary.build({}),
   }
 })
 

--- a/server/utils/placementRequests/table.test.ts
+++ b/server/utils/placementRequests/table.test.ts
@@ -7,13 +7,12 @@ import {
   expectedArrivalDateCell,
   nameCell,
   releaseTypeCell,
-  statusCell,
+  requestTypeCell,
   tableRows,
 } from './table'
 import { DateFormats } from '../dateUtils'
 import { allReleaseTypes } from '../applications/releaseTypeUtils'
 import { crnCell, tierCell } from '../tableUtils'
-import { PlacementRequestStatus } from '../../@types/shared'
 
 describe('tableUtils', () => {
   describe('nameCell', () => {
@@ -78,18 +77,20 @@ describe('tableUtils', () => {
     })
   })
 
-  describe('statusCell', () => {
-    const statuses = {
-      notMatched: 'Not matched',
-      unableToMatch: 'Unable to allocate',
-      matched: 'Booking confirmed',
-    } as Record<PlacementRequestStatus, string>
+  describe('requestTypeCell', () => {
+    it('returns parole if isParole is true', () => {
+      const placementRequest = placementRequestFactory.build({ isParole: true })
 
-    it.each(Object.keys(statuses))('returns the correct status for %s', (key: PlacementRequestStatus) => {
-      const placementRequest = placementRequestFactory.build({ status: key })
+      expect(requestTypeCell(placementRequest)).toEqual({
+        text: 'Parole',
+      })
+    })
 
-      expect(statusCell(placementRequest)).toEqual({
-        text: statuses[key],
+    it('returns standard if isParole is false', () => {
+      const placementRequest = placementRequestFactory.build({ isParole: false })
+
+      expect(requestTypeCell(placementRequest)).toEqual({
+        text: 'Standard release',
       })
     })
   })
@@ -143,7 +144,7 @@ describe('tableUtils', () => {
           tierCell(placementRequest.risks),
           expectedArrivalDateCell(placementRequest),
           durationCell(placementRequest),
-          statusCell(placementRequest),
+          requestTypeCell(placementRequest),
         ],
       ])
     })

--- a/server/utils/placementRequests/table.ts
+++ b/server/utils/placementRequests/table.ts
@@ -32,18 +32,14 @@ export const dashboardTableRows = (placementRequests: Array<PlacementRequest>): 
       tierCell(placementRequest.risks),
       expectedArrivalDateCell(placementRequest),
       durationCell(placementRequest),
-      statusCell(placementRequest),
+      requestTypeCell(placementRequest),
     ]
   })
 }
 
-export const statusCell = (placementRequest: PlacementRequest): TableCell => {
+export const requestTypeCell = (placementRequest: PlacementRequest): TableCell => {
   return {
-    text: {
-      notMatched: 'Not matched',
-      unableToMatch: 'Unable to allocate',
-      matched: 'Booking confirmed',
-    }[placementRequest.status],
+    text: placementRequest.isParole ? 'Parole' : 'Standard release',
   }
 }
 

--- a/server/utils/placementRequests/table.ts
+++ b/server/utils/placementRequests/table.ts
@@ -1,5 +1,5 @@
 import { add } from 'date-fns'
-import { PlacementRequest, PlacementRequestTask } from '../../@types/shared'
+import { PlacementRequest, PlacementRequestStatus, PlacementRequestTask, SortDirection } from '../../@types/shared'
 import { TableCell, TableRow } from '../../@types/ui'
 import matchPaths from '../../paths/match'
 import adminPaths from '../../paths/admin'
@@ -8,6 +8,7 @@ import { linkTo } from '../utils'
 import { crnCell, tierCell } from '../tableUtils'
 import { allReleaseTypes } from '../applications/releaseTypeUtils'
 import { daysToWeeksAndDays } from '../assessments/dateUtils'
+import { sortHeader } from '../sortHeader'
 
 export const DIFFERENCE_IN_DAYS_BETWEEN_DUE_DATE_AND_ARRIVAL_DATE = 7
 
@@ -31,7 +32,7 @@ export const dashboardTableRows = (placementRequests: Array<PlacementRequest>): 
       crnCell(placementRequest.person),
       tierCell(placementRequest.risks),
       expectedArrivalDateCell(placementRequest),
-      durationCell(placementRequest),
+      placementRequest.status === 'matched' ? premisesNameCell(placementRequest) : durationCell(placementRequest),
       requestTypeCell(placementRequest),
     ]
   })
@@ -40,6 +41,12 @@ export const dashboardTableRows = (placementRequests: Array<PlacementRequest>): 
 export const requestTypeCell = (placementRequest: PlacementRequest): TableCell => {
   return {
     text: placementRequest.isParole ? 'Parole' : 'Standard release',
+  }
+}
+
+export const premisesNameCell = (placementRequest: PlacementRequest): TableCell => {
+  return {
+    text: placementRequest.booking?.premisesName,
   }
 }
 
@@ -88,4 +95,32 @@ export const releaseTypeCell = (task: PlacementRequestTask) => {
   return {
     text: allReleaseTypes[task.releaseType],
   }
+}
+
+export const dashboardTableHeader = (
+  status: PlacementRequestStatus,
+  sortBy: string,
+  sortDirection: SortDirection,
+  hrefPrefix: string,
+): Array<TableCell> => {
+  return [
+    {
+      text: 'Name',
+    },
+    {
+      text: 'CRN',
+    },
+    {
+      text: 'Tier',
+    },
+    sortHeader('Arrival date', 'expectedArrival', sortBy, sortDirection, hrefPrefix),
+    status === 'matched'
+      ? {
+          text: 'Approved Premises',
+        }
+      : sortHeader('Length of stay', 'duration', sortBy, sortDirection, hrefPrefix),
+    {
+      text: 'Request type',
+    },
+  ]
 }

--- a/server/views/admin/placementRequests/index.njk
+++ b/server/views/admin/placementRequests/index.njk
@@ -44,22 +44,7 @@
       {{
               govukTable({
                   firstCellIsHeader: true,
-                  head: [
-                      {
-                          text: "Name"
-                      },
-                      {
-                          text: "CRN"
-                      },
-                      {
-                          text: "Tier"
-                      },
-                      sortHeader(("Date of decision" if isParole else "Arrival date"), 'expectedArrival', sortBy, sortDirection, hrefPrefix),
-                      sortHeader("Length of stay", 'duration', sortBy, sortDirection, hrefPrefix),
-                      {
-                          text: "Request type"
-                      }
-                  ],
+                  head: PlacementRequestUtils.tableUtils.dashboardTableHeader(status, sortBy, sortDirection, hrefPrefix),
                   rows: PlacementRequestUtils.tableUtils.dashboardTableRows(placementRequests)
                 })
             }}

--- a/server/views/admin/placementRequests/index.njk
+++ b/server/views/admin/placementRequests/index.njk
@@ -57,7 +57,7 @@
                       sortHeader(("Date of decision" if isParole else "Arrival date"), 'expectedArrival', sortBy, sortDirection, hrefPrefix),
                       sortHeader("Length of stay", 'duration', sortBy, sortDirection, hrefPrefix),
                       {
-                          text: "Status"
+                          text: "Request type"
                       }
                   ],
                   rows: PlacementRequestUtils.tableUtils.dashboardTableRows(placementRequests)

--- a/server/views/admin/placementRequests/index.njk
+++ b/server/views/admin/placementRequests/index.njk
@@ -23,16 +23,21 @@
           label: 'Sub navigation',
           items: [
             {
-              text: 'Confirmed release date',
+              text: 'Ready to match',
               href: paths.admin.placementRequests.index({}),
-              active: (isParole === false)
+              active: (status === 'notMatched' or status|length === 0)
             },
             {
-              text: 'Parole',
-              href: paths.admin.placementRequests.index({}) + "?isParole=1",
-              active: (isParole === true)
+              text: 'Unable to match',
+              href: paths.admin.placementRequests.index({}) + "?status=unableToMatch",
+              active: (status === 'unableToMatch')
+            },
+            {
+              text: 'Matched',
+              href: paths.admin.placementRequests.index({}) + "?status=matched",
+              active: (status === 'matched')
             }
-        ]
+          ]
         })
       }}
 


### PR DESCRIPTION
This follows on from https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/869 to change the filtering to the placement request type, rather than Parole status.

## Screenshots

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/df021a32-dc65-4554-aa1e-6e6416b6fb8b)

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/b551ce1a-6e88-40b8-b8d5-27882553c1aa)
