### PR TITLE
(373) Add CRN search for Placement Requests

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -16,6 +16,7 @@ $path: "/assets/images/"
 @import './components/calendar'
 @import './components/withdrawal-reasons'
 @import './components/sortable-table'
+@import './components/placement-request-search'
 
 @import './pages/assessments-index'
 @import './pages/applications-pages-attach-document'

--- a/assets/sass/components/_placement-request-search.scss
+++ b/assets/sass/components/_placement-request-search.scss
@@ -1,0 +1,12 @@
+.placement-request-search {
+  .moj-search {
+    @include govuk-responsive-padding(6);
+    @include govuk-responsive-margin(6, "bottom");
+
+    background-color: govuk-colour("light-grey");
+
+    &__label {
+      @extend .govuk-heading-m;
+    }
+  }
+}

--- a/integration_tests/mockApis/placementRequests.ts
+++ b/integration_tests/mockApis/placementRequests.ts
@@ -50,6 +50,55 @@ export default {
         jsonBody: placementRequests,
       },
     }),
+  stubPlacementRequestsSearch: ({
+    placementRequests,
+    crn = '',
+    page = '1',
+    sortBy = 'created_at',
+    sortDirection = 'asc',
+  }: {
+    placementRequests: Array<PlacementRequest>
+    crn: string
+    page: string
+    sortBy: string
+    sortDirection: string
+  }): SuperAgentRequest => {
+    const queryParameters = {
+      page: {
+        equalTo: page,
+      },
+      sortBy: {
+        equalTo: sortBy,
+      },
+      sortDirection: {
+        equalTo: sortDirection,
+      },
+    } as Record<string, unknown>
+
+    if (crn) {
+      queryParameters.crn = {
+        equalTo: crn,
+      }
+    }
+
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPathPattern: paths.placementRequests.dashboard.pattern,
+        queryParameters,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+          'X-Pagination-TotalPages': '10',
+          'X-Pagination-TotalResults': '100',
+          'X-Pagination-PageSize': '10',
+        },
+        jsonBody: placementRequests,
+      },
+    })
+  },
   verifyPlacementRequestsDashboard: async ({
     status,
     page = '1',
@@ -65,6 +114,37 @@ export default {
       await getMatchingRequests({
         method: 'GET',
         url: `${paths.placementRequests.dashboard.pattern}?status=${status}&page=${page}&sortBy=${sortBy}&sortDirection=${sortDirection}`,
+      })
+    ).body.requests,
+  verifyPlacementRequestsSearch: async ({
+    crn,
+    page = '1',
+    sortBy = 'created_at',
+    sortDirection = 'asc',
+  }: {
+    crn: string
+    page: string
+    sortBy: string
+    sortDirection: string
+  }) =>
+    (
+      await getMatchingRequests({
+        method: 'GET',
+        urlPathPattern: paths.placementRequests.dashboard.pattern,
+        queryParameters: {
+          crn: {
+            equalTo: crn,
+          },
+          page: {
+            equalTo: page,
+          },
+          sortBy: {
+            equalTo: sortBy,
+          },
+          sortDirection: {
+            equalTo: sortDirection,
+          },
+        },
       })
     ).body.requests,
   stubPlacementRequest: (placementRequestDetail: PlacementRequestDetail): SuperAgentRequest =>

--- a/integration_tests/mockApis/placementRequests.ts
+++ b/integration_tests/mockApis/placementRequests.ts
@@ -33,11 +33,30 @@ export default {
     page: string
     sortBy: string
     sortDirection: string
-  }): SuperAgentRequest =>
-    stubFor({
+  }): SuperAgentRequest => {
+    const queryParameters = {
+      page: {
+        equalTo: page,
+      },
+      sortBy: {
+        equalTo: sortBy,
+      },
+      sortDirection: {
+        equalTo: sortDirection,
+      },
+    } as Record<string, unknown>
+
+    if (status) {
+      queryParameters.status = {
+        equalTo: status,
+      }
+    }
+
+    return stubFor({
       request: {
         method: 'GET',
-        url: `${paths.placementRequests.dashboard.pattern}?status=${status}&page=${page}&sortBy=${sortBy}&sortDirection=${sortDirection}`,
+        urlPathPattern: paths.placementRequests.dashboard.pattern,
+        queryParameters,
       },
       response: {
         status: 200,
@@ -49,7 +68,8 @@ export default {
         },
         jsonBody: placementRequests,
       },
-    }),
+    })
+  },
   stubPlacementRequestsSearch: ({
     placementRequests,
     crn = '',
@@ -113,7 +133,21 @@ export default {
     (
       await getMatchingRequests({
         method: 'GET',
-        url: `${paths.placementRequests.dashboard.pattern}?status=${status}&page=${page}&sortBy=${sortBy}&sortDirection=${sortDirection}`,
+        urlPathPattern: paths.placementRequests.dashboard.pattern,
+        queryParameters: {
+          page: {
+            equalTo: page,
+          },
+          sortBy: {
+            equalTo: sortBy,
+          },
+          sortDirection: {
+            equalTo: sortDirection,
+          },
+          status: {
+            equalTo: status,
+          },
+        },
       })
     ).body.requests,
   verifyPlacementRequestsSearch: async ({

--- a/integration_tests/pages/admin/placementApplications/searchPage.ts
+++ b/integration_tests/pages/admin/placementApplications/searchPage.ts
@@ -1,0 +1,15 @@
+import paths from '../../../../server/paths/admin'
+
+import ListPage from './listPage'
+
+export default class SearchPage extends ListPage {
+  static visit(): SearchPage {
+    cy.visit(paths.admin.placementRequests.search({}))
+    return new SearchPage()
+  }
+
+  searchForCrn(crn: string): void {
+    this.getTextInputByIdAndEnterDetails('crn', crn)
+    this.clickSubmit()
+  }
+}

--- a/integration_tests/tests/admin/searchPlacementRequests.cy.ts
+++ b/integration_tests/tests/admin/searchPlacementRequests.cy.ts
@@ -1,0 +1,135 @@
+import SearchPage from '../../pages/admin/placementApplications/searchPage'
+
+import { placementRequestFactory } from '../../../server/testutils/factories'
+
+context('Search placement Requests', () => {
+  const placementRequests = placementRequestFactory.buildList(3)
+  const searchResults = placementRequestFactory.buildList(2)
+
+  const crn = 'CRN123'
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    // Given I am logged in
+    cy.signIn()
+
+    cy.task('stubPlacementRequestsSearch', { placementRequests })
+    cy.task('stubPlacementRequestsSearch', { placementRequests: searchResults, crn })
+  })
+
+  it('allows me to search for placement requests', () => {
+    // When I visit the search page
+    const searchPage = SearchPage.visit()
+
+    // Then I should see a list of placement requests
+    searchPage.shouldShowPlacementRequests(placementRequests)
+
+    // When I search for a CRN
+    searchPage.searchForCrn('CRN123')
+
+    // Then I should see the search results
+    searchPage.shouldShowPlacementRequests(searchResults)
+
+    // And the API should have received a request for the CRN
+    cy.task('verifyPlacementRequestsSearch', { crn: 'CRN123' }).then(requests => {
+      expect(requests).to.have.length(1)
+    })
+  })
+
+  it('supports pagination', () => {
+    cy.task('stubPlacementRequestsSearch', {
+      placementRequests,
+      crn: 'CRN123',
+      status: 'notMatched',
+      page: '2',
+    })
+    cy.task('stubPlacementRequestsSearch', {
+      placementRequests,
+      crn: 'CRN123',
+      status: 'notMatched',
+      page: '9',
+    })
+
+    // When I visit the search page
+    const searchPage = SearchPage.visit()
+
+    // Then I should see a list of placement requests
+    searchPage.shouldShowPlacementRequests(placementRequests)
+
+    // And I search for a CRN
+    searchPage.searchForCrn('CRN123')
+
+    // When I click next
+    searchPage.clickNext()
+
+    // Then the API should have received a request for the next page
+    cy.task('verifyPlacementRequestsSearch', { page: '2', crn: 'CRN123' }).then(requests => {
+      expect(requests).to.have.length(1)
+    })
+
+    // When I click on a page number
+    searchPage.clickPageNumber('9')
+
+    // Then the API should have received a request for the that page number
+    cy.task('verifyPlacementRequestsSearch', { page: '9', crn: 'CRN123' }).then(requests => {
+      expect(requests).to.have.length(1)
+    })
+  })
+
+  it('supports sorting', () => {
+    cy.task('stubPlacementRequestsSearch', {
+      placementRequests,
+      crn: 'CRN123',
+      sortBy: 'expectedArrival',
+      sortDirection: 'asc',
+    })
+    cy.task('stubPlacementRequestsSearch', {
+      placementRequests,
+      crn: 'CRN123',
+      sortBy: 'expectedArrival',
+      sortDirection: 'desc',
+    })
+
+    // When I visit the search page
+    const searchPage = SearchPage.visit()
+
+    // Then I should see a list of placement requests
+    searchPage.shouldShowPlacementRequests(placementRequests)
+
+    // And I search for a CRN
+    searchPage.searchForCrn('CRN123')
+
+    // When I sort by expected arrival in ascending order
+    searchPage.clickSortBy('expectedArrival')
+
+    // Then the dashboard should be sorted by expected arrival
+    searchPage.shouldBeSortedByField('expectedArrival', 'ascending')
+
+    // And the API should have received a request for the correct sort order
+    cy.task('verifyPlacementRequestsSearch', {
+      crn: 'CRN123',
+      sortBy: 'expectedArrival',
+      sortDirection: 'asc',
+    }).then(requests => {
+      expect(requests).to.have.length(1)
+    })
+
+    // When I sort by expected arrival in descending order
+    searchPage.clickSortBy('expectedArrival')
+
+    // Then the dashboard should be sorted by expected arrival in descending order
+    searchPage.shouldBeSortedByField('expectedArrival', 'descending')
+
+    // And the API should have received a request for the correct sort order
+    cy.task('verifyPlacementRequestsSearch', {
+      crn: 'CRN123',
+      sortBy: 'expectedArrival',
+      sortDirection: 'desc',
+    }).then(requests => {
+      expect(requests).to.have.length(1)
+    })
+  })
+})

--- a/server/data/placementRequestClient.test.ts
+++ b/server/data/placementRequestClient.test.ts
@@ -105,7 +105,41 @@ describeClient('placementRequestClient', provider => {
         },
       })
 
-      const result = await placementRequestClient.dashboard('unableToMatch')
+      const result = await placementRequestClient.dashboard({ status: 'unableToMatch' })
+
+      expect(result).toEqual({
+        data: placementRequests,
+        pageNumber: '1',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
+    })
+
+    it('makes a get request to the placementRequests dashboard endpoint when searching by CRN', async () => {
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get the placement requests dashboard view',
+        withRequest: {
+          method: 'GET',
+          path: paths.placementRequests.dashboard.pattern,
+          query: { crn: 'CRN123', page: '1', sortBy: 'created_at', sortDirection: 'asc' },
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: placementRequests,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
+        },
+      })
+
+      const result = await placementRequestClient.dashboard({ crn: 'CRN123' })
 
       expect(result).toEqual({
         data: placementRequests,
@@ -139,7 +173,7 @@ describeClient('placementRequestClient', provider => {
         },
       })
 
-      const result = await placementRequestClient.dashboard('notMatched', 2)
+      const result = await placementRequestClient.dashboard({ status: 'notMatched' }, 2)
 
       expect(result).toEqual({
         data: placementRequests,
@@ -173,7 +207,7 @@ describeClient('placementRequestClient', provider => {
         },
       })
 
-      const result = await placementRequestClient.dashboard('notMatched', 1, 'duration', 'desc')
+      const result = await placementRequestClient.dashboard({ status: 'notMatched' }, 1, 'duration', 'desc')
 
       expect(result).toEqual({
         data: placementRequests,

--- a/server/data/placementRequestClient.ts
+++ b/server/data/placementRequestClient.ts
@@ -1,5 +1,3 @@
-import superagent from 'superagent'
-
 import {
   BookingNotMade,
   NewBookingNotMade,
@@ -14,7 +12,6 @@ import {
 import config, { ApiConfig } from '../config'
 import RestClient from './restClient'
 import paths from '../paths/api'
-import { createQueryString } from '../utils/utils'
 import { PaginatedResponse } from '../@types/ui'
 
 export default class PlacementRequestClient {
@@ -31,24 +28,16 @@ export default class PlacementRequestClient {
   }
 
   async dashboard(
-    status: PlacementRequestStatus = 'notMatched',
+    filters: { status: PlacementRequestStatus } | { crn: string } = { status: 'notMatched' },
     page = 1,
     sortBy: PlacementRequestSortField = 'created_at',
     sortDirection: SortDirection = 'asc',
   ): Promise<PaginatedResponse<PlacementRequest>> {
-    const response = (await this.restClient.get({
+    return this.restClient.getPaginatedResponse<PlacementRequest>({
       path: paths.placementRequests.dashboard.pattern,
-      query: createQueryString({ status, page, sortBy, sortDirection }),
-      raw: true,
-    })) as superagent.Response
-
-    return {
-      data: response.body,
-      pageNumber: page.toString(),
-      totalPages: response.headers['x-pagination-totalpages'],
-      totalResults: response.headers['x-pagination-totalresults'],
-      pageSize: response.headers['x-pagination-pagesize'],
-    }
+      page: page.toString(),
+      query: { ...filters, sortBy, sortDirection },
+    })
   }
 
   async find(id: string): Promise<PlacementRequestDetail> {

--- a/server/data/restClient.test.ts
+++ b/server/data/restClient.test.ts
@@ -163,4 +163,29 @@ describe('restClient', () => {
       nock.cleanAll()
     })
   })
+
+  describe('getPaginatedResponse', () => {
+    it('should make a GET request', async () => {
+      fakeApprovedPremisesApi.get(`/some/path?page=1&foo=bar`).reply(
+        200,
+        { some: 'data' },
+        {
+          'X-Pagination-TotalPages': '10',
+          'X-Pagination-TotalResults': '100',
+          'X-Pagination-PageSize': '10',
+        },
+      )
+
+      const result = await restClient.getPaginatedResponse({ path: '/some/path', page: '1', query: { foo: 'bar' } })
+
+      expect(result).toEqual({
+        data: { some: 'data' },
+        pageNumber: '1',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
 })

--- a/server/paths/admin.ts
+++ b/server/paths/admin.ts
@@ -12,6 +12,7 @@ export default {
   admin: {
     placementRequests: {
       index: placementRequestsPath,
+      search: placementRequestsPath.path('search'),
       show: placementRequestPath,
       bookings: {
         new: bookingsPath.path('new'),

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -20,6 +20,9 @@ export default function routes(controllers: Controllers, router: Router, service
   get(paths.admin.placementRequests.index.pattern, adminPlacementRequestsController.index(), {
     auditEvent: 'ADMIN_LIST_PLACEMENT_REQUESTS',
   })
+  get(paths.admin.placementRequests.search.pattern, adminPlacementRequestsController.search(), {
+    auditEvent: 'ADMIN_SEARCH_PLACEMENT_REQUESTS',
+  })
   get(paths.admin.placementRequests.show.pattern, adminPlacementRequestsController.show(), {
     auditEvent: 'ADMIN_SHOW_PLACEMENT_REQUEST',
   })

--- a/server/services/placementRequestService.test.ts
+++ b/server/services/placementRequestService.test.ts
@@ -80,6 +80,38 @@ describe('placementRequestService', () => {
     })
   })
 
+  describe('search', () => {
+    it('calls the dashboard method on the placementRequest client', async () => {
+      const response = paginatedResponseFactory.build({
+        data: placementRequestFactory.buildList(4),
+      }) as PaginatedResponse<PlacementRequest>
+
+      placementRequestClient.dashboard.mockResolvedValue(response)
+
+      const result = await service.search(token, 'CRN123')
+
+      expect(result).toEqual(response)
+
+      expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
+      expect(placementRequestClient.dashboard).toHaveBeenCalledWith({ crn: 'CRN123' }, 1, 'created_at', 'asc')
+    })
+
+    it('calls the dashboard method on the placementRequest client with page and sort options', async () => {
+      const response = paginatedResponseFactory.build({
+        data: placementRequestFactory.buildList(4),
+      }) as PaginatedResponse<PlacementRequest>
+
+      placementRequestClient.dashboard.mockResolvedValue(response)
+
+      const result = await service.search(token, 'CRN123', 2, 'duration', 'desc')
+
+      expect(result).toEqual(response)
+
+      expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
+      expect(placementRequestClient.dashboard).toHaveBeenCalledWith({ crn: 'CRN123' }, 2, 'duration', 'desc')
+    })
+  })
+
   describe('getPlacementRequest', () => {
     it('calls the find method on the placementRequest client', async () => {
       const placementRequestDetail: PlacementRequestDetail = placementRequestDetailFactory.build()

--- a/server/services/placementRequestService.test.ts
+++ b/server/services/placementRequestService.test.ts
@@ -61,7 +61,7 @@ describe('placementRequestService', () => {
       expect(result).toEqual(response)
 
       expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
-      expect(placementRequestClient.dashboard).toHaveBeenCalledWith('notMatched', 1, 'created_at', 'asc')
+      expect(placementRequestClient.dashboard).toHaveBeenCalledWith({ status: 'notMatched' }, 1, 'created_at', 'asc')
     })
 
     it('calls the find method on the placementRequest client with page and sort options', async () => {
@@ -76,7 +76,7 @@ describe('placementRequestService', () => {
       expect(result).toEqual(response)
 
       expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
-      expect(placementRequestClient.dashboard).toHaveBeenCalledWith('notMatched', 2, 'duration', 'desc')
+      expect(placementRequestClient.dashboard).toHaveBeenCalledWith({ status: 'notMatched' }, 2, 'duration', 'desc')
     })
   })
 

--- a/server/services/placementRequestService.ts
+++ b/server/services/placementRequestService.ts
@@ -45,6 +45,18 @@ export default class PlacementRequestService {
     return placementRequestClient.dashboard({ status }, page, sortBy, sortDirection)
   }
 
+  async search(
+    token: string,
+    crn: string,
+    page: number = 1,
+    sortBy: PlacementRequestSortField = 'created_at',
+    sortDirection: SortDirection = 'asc',
+  ): Promise<PaginatedResponse<PlacementRequest>> {
+    const placementRequestClient = this.placementRequestClientFactory(token)
+
+    return placementRequestClient.dashboard({ crn }, page, sortBy, sortDirection)
+  }
+
   async getPlacementRequest(token: string, id: string): Promise<PlacementRequestDetail> {
     const placementRequestClient = this.placementRequestClientFactory(token)
 

--- a/server/services/placementRequestService.ts
+++ b/server/services/placementRequestService.ts
@@ -42,7 +42,7 @@ export default class PlacementRequestService {
   ): Promise<PaginatedResponse<PlacementRequest>> {
     const placementRequestClient = this.placementRequestClientFactory(token)
 
-    return placementRequestClient.dashboard(status, page, sortBy, sortDirection)
+    return placementRequestClient.dashboard({ status }, page, sortBy, sortDirection)
   }
 
   async getPlacementRequest(token: string, id: string): Promise<PlacementRequestDetail> {

--- a/server/views/admin/placementRequests/_navigation.njk
+++ b/server/views/admin/placementRequests/_navigation.njk
@@ -1,0 +1,31 @@
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+
+{% macro navigation(activeTab) %}
+  {{
+    mojSubNavigation({
+      label: 'Sub navigation',
+      items: [
+        {
+          text: 'Ready to match',
+          href: paths.admin.placementRequests.index({}),
+          active: (activeTab === 'notMatched' or activeTab|length === 0)
+        },
+        {
+          text: 'Unable to match',
+          href: paths.admin.placementRequests.index({}) + "?status=unableToMatch",
+          active: (activeTab === 'unableToMatch')
+        },
+        {
+          text: 'Matched',
+          href: paths.admin.placementRequests.index({}) + "?status=matched",
+          active: (activeTab === 'matched')
+        },
+        {
+          text: 'Search',
+          href: paths.admin.placementRequests.search({}),
+          active: (activeTab === 'search')
+        }
+      ]
+    })
+  }}
+{% endmacro %}

--- a/server/views/admin/placementRequests/search.njk
+++ b/server/views/admin/placementRequests/search.njk
@@ -1,6 +1,7 @@
 {% extends "../../partials/layout.njk" %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
+{%- from "moj/components/search/macro.njk" import mojSearch -%}
 {% from "./_navigation.njk" import navigation %}
 
 {% set pageTitle = applicationName + " - " + pageHeading  %}
@@ -9,16 +10,32 @@
 {% block content %}
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+    <div class="govuk-grid-column-full placement-request-search">
       {% include "../../_messages.njk" %}
 
       <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
-      <p class="govuk-body">
-        All applications that have been assessed as suitable and require matching to an AP are listed below
-      </p>
+      {{ navigation("search") }}
 
-      {{ navigation(status) }}
+      {{
+        mojSearch({
+          action: paths.admin.placementRequests.search({}),
+          method: 'get',
+          input: {
+            id: 'crn',
+            name: 'crn'
+          },
+          label: {
+            text: 'Find a placement'
+          },
+          hint: {
+            text: 'You can search by CRN'
+          },
+          button: {
+            text: 'Search'
+          }
+        })
+      }}
 
       {{
         govukTable({


### PR DESCRIPTION
This adds an additional endpoint to allow Placement Requests to be filtered by CRN. 

## Screenshots

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/ad494c22-2923-4fcd-938a-7a6951456d70)
