### PR TITLE
(373) Add tier and date options to CRU dashboard

### DIFF
--- a/assets/sass/components/_placement-request-search.scss
+++ b/assets/sass/components/_placement-request-search.scss
@@ -1,12 +1,16 @@
 .placement-request-search {
-  .moj-search {
+  &__wrapper {
     @include govuk-responsive-padding(6);
     @include govuk-responsive-margin(6, "bottom");
 
     background-color: govuk-colour("light-grey");
+  }
 
-    &__label {
-      @extend .govuk-heading-m;
-    }
+  &__crn-label {
+    @extend .govuk-heading-m;
+  }
+
+  &__submit {
+    @include govuk-responsive-margin(6, "top");
   }
 }

--- a/integration_tests/mockApis/placementRequests.ts
+++ b/integration_tests/mockApis/placementRequests.ts
@@ -1,6 +1,11 @@
 import { SuperAgentRequest } from 'superagent'
 
-import type { PlacementRequest, PlacementRequestDetail, PlacementRequestStatus } from '@approved-premises/api'
+import type {
+  PlacementRequest,
+  PlacementRequestDetail,
+  PlacementRequestStatus,
+  RiskTierLevel,
+} from '@approved-premises/api'
 import { getMatchingRequests, stubFor } from '../../wiremock'
 import paths from '../../server/paths/api'
 import { bookingNotMadeFactory, newPlacementRequestBookingConfirmationFactory } from '../../server/testutils/factories'
@@ -152,11 +157,17 @@ export default {
     ).body.requests,
   verifyPlacementRequestsSearch: async ({
     crn,
+    tier,
+    arrivalDateStart,
+    arrivalDateEnd,
     page = '1',
     sortBy = 'created_at',
     sortDirection = 'asc',
   }: {
     crn: string
+    tier: RiskTierLevel
+    arrivalDateStart: string
+    arrivalDateEnd: string
     page: string
     sortBy: string
     sortDirection: string
@@ -168,6 +179,15 @@ export default {
         queryParameters: {
           crn: {
             equalTo: crn,
+          },
+          tier: {
+            equalTo: tier,
+          },
+          arrivalDateStart: {
+            equalTo: arrivalDateStart,
+          },
+          arrivalDateEnd: {
+            equalTo: arrivalDateEnd,
           },
           page: {
             equalTo: page,

--- a/integration_tests/pages/admin/placementApplications/listPage.ts
+++ b/integration_tests/pages/admin/placementApplications/listPage.ts
@@ -1,8 +1,8 @@
 import Page from '../../page'
 import paths from '../../../../server/paths/admin'
 
-import { PlacementRequest } from '../../../../server/@types/shared'
-import { shouldShowTableRows } from '../../../helpers'
+import { PlacementRequest, PlacementRequestStatus } from '../../../../server/@types/shared'
+import { tableRowsToArrays } from '../../../helpers'
 import { dashboardTableRows } from '../../../../server/utils/placementRequests/table'
 
 export default class ListPage extends Page {
@@ -15,8 +15,23 @@ export default class ListPage extends Page {
     return new ListPage()
   }
 
-  shouldShowPlacementRequests(placementRequests: Array<PlacementRequest>): void {
-    shouldShowTableRows(placementRequests, dashboardTableRows)
+  shouldShowPlacementRequests(
+    placementRequests: Array<PlacementRequest>,
+    status: PlacementRequestStatus | undefined,
+  ): void {
+    const tableRows = dashboardTableRows(placementRequests, status)
+    const rowItems = tableRowsToArrays(tableRows)
+
+    rowItems.forEach(columns => {
+      const headerCell = columns.shift()
+      cy.contains('th', headerCell)
+        .parent('tr')
+        .within(() => {
+          columns.forEach((e, i) => {
+            cy.get('td').eq(i).invoke('text').should('contain', e)
+          })
+        })
+    })
   }
 
   clickPlacementRequest(placementRequest: PlacementRequest): void {

--- a/integration_tests/pages/admin/placementApplications/searchPage.ts
+++ b/integration_tests/pages/admin/placementApplications/searchPage.ts
@@ -1,3 +1,4 @@
+import { PlacementRequestDashboardSearchOptions } from '../../../../server/@types/ui'
 import paths from '../../../../server/paths/admin'
 
 import ListPage from './listPage'
@@ -8,8 +9,11 @@ export default class SearchPage extends ListPage {
     return new SearchPage()
   }
 
-  searchForCrn(crn: string): void {
-    this.getTextInputByIdAndEnterDetails('crn', crn)
+  enterSearchQuery(searchOptions: PlacementRequestDashboardSearchOptions): void {
+    this.getTextInputByIdAndEnterDetails('crn', searchOptions.crn)
+    this.getSelectInputByIdAndSelectAnEntry('tier', searchOptions.tier)
+    this.getTextInputByIdAndEnterDetails('arrivalDateStart', searchOptions.arrivalDateStart)
+    this.getTextInputByIdAndEnterDetails('arrivalDateEnd', searchOptions.arrivalDateEnd)
     this.clickSubmit()
   }
 }

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -69,19 +69,19 @@ context('Placement Requests', () => {
     const listPage = ListPage.visit()
 
     // Then I should see a list of placement requests
-    listPage.shouldShowPlacementRequests(unmatchedPlacementRequests)
+    listPage.shouldShowPlacementRequests(unmatchedPlacementRequests, 'notMatched')
 
     // When I click the unable to match link
     listPage.clickUnableToMatch()
 
     // Then I should see the unable to match requests listed
-    listPage.shouldShowPlacementRequests(unableToMatchPlacementRequests)
+    listPage.shouldShowPlacementRequests(unableToMatchPlacementRequests, 'unableToMatch')
 
     // When I click the matched link
     listPage.clickMatched()
 
     // Then I should see the matched requests listed
-    listPage.shouldShowPlacementRequests(matchedPlacementRequests)
+    listPage.shouldShowPlacementRequests(matchedPlacementRequests, 'matched')
 
     // When I click the awaiting match link
     listPage.clickReadyToMatch()

--- a/integration_tests/tests/admin/searchPlacementRequests.cy.ts
+++ b/integration_tests/tests/admin/searchPlacementRequests.cy.ts
@@ -1,12 +1,18 @@
 import SearchPage from '../../pages/admin/placementApplications/searchPage'
 
 import { placementRequestFactory } from '../../../server/testutils/factories'
+import { PlacementRequestDashboardSearchOptions } from '../../../server/@types/ui'
 
 context('Search placement Requests', () => {
   const placementRequests = placementRequestFactory.buildList(3)
   const searchResults = placementRequestFactory.buildList(2)
 
-  const crn = 'CRN123'
+  const searchQuery = {
+    crn: 'CRN123',
+    tier: 'D2',
+    arrivalDateStart: '2022-01-01',
+    arrivalDateEnd: '2022-01-03',
+  } as PlacementRequestDashboardSearchOptions
 
   beforeEach(() => {
     cy.task('reset')
@@ -17,7 +23,7 @@ context('Search placement Requests', () => {
     cy.signIn()
 
     cy.task('stubPlacementRequestsSearch', { placementRequests })
-    cy.task('stubPlacementRequestsSearch', { placementRequests: searchResults, crn })
+    cy.task('stubPlacementRequestsSearch', { placementRequests: searchResults, ...searchQuery })
   })
 
   it('allows me to search for placement requests', () => {
@@ -28,13 +34,13 @@ context('Search placement Requests', () => {
     searchPage.shouldShowPlacementRequests(placementRequests)
 
     // When I search for a CRN
-    searchPage.searchForCrn('CRN123')
+    searchPage.enterSearchQuery(searchQuery)
 
     // Then I should see the search results
     searchPage.shouldShowPlacementRequests(searchResults)
 
     // And the API should have received a request for the CRN
-    cy.task('verifyPlacementRequestsSearch', { crn: 'CRN123' }).then(requests => {
+    cy.task('verifyPlacementRequestsSearch', searchQuery).then(requests => {
       expect(requests).to.have.length(1)
     })
   })
@@ -42,14 +48,12 @@ context('Search placement Requests', () => {
   it('supports pagination', () => {
     cy.task('stubPlacementRequestsSearch', {
       placementRequests,
-      crn: 'CRN123',
-      status: 'notMatched',
+      ...searchQuery,
       page: '2',
     })
     cy.task('stubPlacementRequestsSearch', {
       placementRequests,
-      crn: 'CRN123',
-      status: 'notMatched',
+      ...searchQuery,
       page: '9',
     })
 
@@ -60,13 +64,13 @@ context('Search placement Requests', () => {
     searchPage.shouldShowPlacementRequests(placementRequests)
 
     // And I search for a CRN
-    searchPage.searchForCrn('CRN123')
+    searchPage.enterSearchQuery(searchQuery)
 
     // When I click next
     searchPage.clickNext()
 
     // Then the API should have received a request for the next page
-    cy.task('verifyPlacementRequestsSearch', { page: '2', crn: 'CRN123' }).then(requests => {
+    cy.task('verifyPlacementRequestsSearch', { page: '2', ...searchQuery }).then(requests => {
       expect(requests).to.have.length(1)
     })
 
@@ -74,7 +78,7 @@ context('Search placement Requests', () => {
     searchPage.clickPageNumber('9')
 
     // Then the API should have received a request for the that page number
-    cy.task('verifyPlacementRequestsSearch', { page: '9', crn: 'CRN123' }).then(requests => {
+    cy.task('verifyPlacementRequestsSearch', { page: '9', ...searchQuery }).then(requests => {
       expect(requests).to.have.length(1)
     })
   })
@@ -100,7 +104,7 @@ context('Search placement Requests', () => {
     searchPage.shouldShowPlacementRequests(placementRequests)
 
     // And I search for a CRN
-    searchPage.searchForCrn('CRN123')
+    searchPage.enterSearchQuery(searchQuery)
 
     // When I sort by expected arrival in ascending order
     searchPage.clickSortBy('expectedArrival')
@@ -110,7 +114,7 @@ context('Search placement Requests', () => {
 
     // And the API should have received a request for the correct sort order
     cy.task('verifyPlacementRequestsSearch', {
-      crn: 'CRN123',
+      ...searchQuery,
       sortBy: 'expectedArrival',
       sortDirection: 'asc',
     }).then(requests => {
@@ -125,7 +129,7 @@ context('Search placement Requests', () => {
 
     // And the API should have received a request for the correct sort order
     cy.task('verifyPlacementRequestsSearch', {
-      crn: 'CRN123',
+      ...searchQuery,
       sortBy: 'expectedArrival',
       sortDirection: 'desc',
     }).then(requests => {

--- a/integration_tests/tests/admin/searchPlacementRequests.cy.ts
+++ b/integration_tests/tests/admin/searchPlacementRequests.cy.ts
@@ -31,13 +31,13 @@ context('Search placement Requests', () => {
     const searchPage = SearchPage.visit()
 
     // Then I should see a list of placement requests
-    searchPage.shouldShowPlacementRequests(placementRequests)
+    searchPage.shouldShowPlacementRequests(placementRequests, undefined)
 
     // When I search for a CRN
     searchPage.enterSearchQuery(searchQuery)
 
     // Then I should see the search results
-    searchPage.shouldShowPlacementRequests(searchResults)
+    searchPage.shouldShowPlacementRequests(searchResults, undefined)
 
     // And the API should have received a request for the CRN
     cy.task('verifyPlacementRequestsSearch', searchQuery).then(requests => {
@@ -61,7 +61,7 @@ context('Search placement Requests', () => {
     const searchPage = SearchPage.visit()
 
     // Then I should see a list of placement requests
-    searchPage.shouldShowPlacementRequests(placementRequests)
+    searchPage.shouldShowPlacementRequests(placementRequests, undefined)
 
     // And I search for a CRN
     searchPage.enterSearchQuery(searchQuery)
@@ -101,7 +101,7 @@ context('Search placement Requests', () => {
     const searchPage = SearchPage.visit()
 
     // Then I should see a list of placement requests
-    searchPage.shouldShowPlacementRequests(placementRequests)
+    searchPage.shouldShowPlacementRequests(placementRequests, undefined)
 
     // And I search for a CRN
     searchPage.enterSearchQuery(searchQuery)

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -436,3 +436,10 @@ export type MiddlewareSpec = {
   additionalMetadata?: Record<string, string>
   allowedRoles?: Array<ApprovedPremisesUserRole>
 }
+
+export type PlacementRequestDashboardSearchOptions = {
+  crn?: string
+  tier?: RiskTierLevel
+  arrivalDateStart?: string
+  arrivalDateEnd?: string
+}

--- a/server/controllers/admin/placementRequestsController.test.ts
+++ b/server/controllers/admin/placementRequestsController.test.ts
@@ -161,7 +161,7 @@ describe('PlacementRequestsController', () => {
         hrefPrefix,
       })
 
-      expect(placementRequestService.search).toHaveBeenCalledWith(token, undefined, undefined, undefined, undefined)
+      expect(placementRequestService.search).toHaveBeenCalledWith(token, {}, undefined, undefined, undefined)
     })
 
     it('should search for placement requests by CRN', async () => {
@@ -179,7 +179,83 @@ describe('PlacementRequestsController', () => {
         totalPages: Number(paginatedResponse.totalPages),
         hrefPrefix,
       })
-      expect(placementRequestService.search).toHaveBeenCalledWith(token, 'CRN123', undefined, undefined, undefined)
+      expect(placementRequestService.search).toHaveBeenCalledWith(
+        token,
+        { crn: 'CRN123' },
+        undefined,
+        undefined,
+        undefined,
+      )
+    })
+
+    it('should search for placement requests by tier and dates', async () => {
+      const hrefPrefix = `${paths.admin.placementRequests.search({})}?${createQueryString({
+        tier: 'A1',
+        arrivalDateStart: '2022-01-01',
+        arrivalDateEnd: '2022-01-03',
+      })}&`
+
+      const requestHandler = placementRequestsController.search()
+
+      await requestHandler(
+        { ...request, query: { tier: 'A1', arrivalDateStart: '2022-01-01', arrivalDateEnd: '2022-01-03' } },
+        response,
+        next,
+      )
+
+      expect(response.render).toHaveBeenCalledWith('admin/placementRequests/search', {
+        pageHeading: 'Record and update placement details',
+        placementRequests: paginatedResponse.data,
+        crn: undefined,
+        tier: 'A1',
+        arrivalDateStart: '2022-01-01',
+        arrivalDateEnd: '2022-01-03',
+        pageNumber: Number(paginatedResponse.pageNumber),
+        totalPages: Number(paginatedResponse.totalPages),
+        hrefPrefix,
+      })
+      expect(placementRequestService.search).toHaveBeenCalledWith(
+        token,
+        { tier: 'A1', arrivalDateStart: '2022-01-01', arrivalDateEnd: '2022-01-03' },
+        undefined,
+        undefined,
+        undefined,
+      )
+    })
+
+    it('should remove empty queries from the search request', async () => {
+      const hrefPrefix = `${paths.admin.placementRequests.search({})}?${createQueryString({
+        tier: 'A1',
+        arrivalDateStart: '2022-01-01',
+        arrivalDateEnd: '2022-01-03',
+      })}&`
+
+      const requestHandler = placementRequestsController.search()
+
+      await requestHandler(
+        { ...request, query: { crn: '', tier: 'A1', arrivalDateStart: '2022-01-01', arrivalDateEnd: '2022-01-03' } },
+        response,
+        next,
+      )
+
+      expect(response.render).toHaveBeenCalledWith('admin/placementRequests/search', {
+        pageHeading: 'Record and update placement details',
+        placementRequests: paginatedResponse.data,
+        crn: undefined,
+        tier: 'A1',
+        arrivalDateStart: '2022-01-01',
+        arrivalDateEnd: '2022-01-03',
+        pageNumber: Number(paginatedResponse.pageNumber),
+        totalPages: Number(paginatedResponse.totalPages),
+        hrefPrefix,
+      })
+      expect(placementRequestService.search).toHaveBeenCalledWith(
+        token,
+        { tier: 'A1', arrivalDateStart: '2022-01-01', arrivalDateEnd: '2022-01-03' },
+        undefined,
+        undefined,
+        undefined,
+      )
     })
 
     it('should request page numbers and sort options', async () => {
@@ -203,7 +279,13 @@ describe('PlacementRequestsController', () => {
         sortBy: 'expectedArrival',
         sortDirection: 'desc',
       })
-      expect(placementRequestService.search).toHaveBeenCalledWith(token, 'CRN123', 2, 'expectedArrival', 'desc')
+      expect(placementRequestService.search).toHaveBeenCalledWith(
+        token,
+        { crn: 'CRN123' },
+        2,
+        'expectedArrival',
+        'desc',
+      )
     })
   })
 })

--- a/server/data/placementRequestClient.test.ts
+++ b/server/data/placementRequestClient.test.ts
@@ -150,6 +150,51 @@ describeClient('placementRequestClient', provider => {
       })
     })
 
+    it('makes a get request to the placementRequests dashboard endpoint when searching by tier and start/end dates', async () => {
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get the placement requests dashboard view',
+        withRequest: {
+          method: 'GET',
+          path: paths.placementRequests.dashboard.pattern,
+          query: {
+            tier: 'A1',
+            arrivalDateStart: '2020-01-01',
+            arrivalDateEnd: '2020-03-01',
+            page: '1',
+            sortBy: 'created_at',
+            sortDirection: 'asc',
+          },
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: placementRequests,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
+        },
+      })
+
+      const result = await placementRequestClient.dashboard({
+        tier: 'A1',
+        arrivalDateStart: '2020-01-01',
+        arrivalDateEnd: '2020-03-01',
+      })
+
+      expect(result).toEqual({
+        data: placementRequests,
+        pageNumber: '1',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
+    })
+
     it('makes a get request to the placementRequests dashboard endpoint with a page number', async () => {
       provider.addInteraction({
         state: 'Server is healthy',

--- a/server/data/placementRequestClient.ts
+++ b/server/data/placementRequestClient.ts
@@ -12,7 +12,7 @@ import {
 import config, { ApiConfig } from '../config'
 import RestClient from './restClient'
 import paths from '../paths/api'
-import { PaginatedResponse } from '../@types/ui'
+import { PaginatedResponse, PlacementRequestDashboardSearchOptions } from '../@types/ui'
 
 export default class PlacementRequestClient {
   restClient: RestClient
@@ -28,7 +28,9 @@ export default class PlacementRequestClient {
   }
 
   async dashboard(
-    filters: { status: PlacementRequestStatus } | { crn: string } = { status: 'notMatched' },
+    filters: { status: PlacementRequestStatus } | PlacementRequestDashboardSearchOptions = {
+      status: 'notMatched',
+    },
     page = 1,
     sortBy: PlacementRequestSortField = 'created_at',
     sortDirection: SortDirection = 'asc',

--- a/server/services/placementRequestService.test.ts
+++ b/server/services/placementRequestService.test.ts
@@ -88,12 +88,37 @@ describe('placementRequestService', () => {
 
       placementRequestClient.dashboard.mockResolvedValue(response)
 
-      const result = await service.search(token, 'CRN123')
+      const result = await service.search(token, { crn: 'CRN123' })
 
       expect(result).toEqual(response)
 
       expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
       expect(placementRequestClient.dashboard).toHaveBeenCalledWith({ crn: 'CRN123' }, 1, 'created_at', 'asc')
+    })
+
+    it('calls the dashboard method on the placementRequest client with optional search params', async () => {
+      const response = paginatedResponseFactory.build({
+        data: placementRequestFactory.buildList(4),
+      }) as PaginatedResponse<PlacementRequest>
+
+      placementRequestClient.dashboard.mockResolvedValue(response)
+
+      const result = await service.search(token, {
+        crn: 'CRN123',
+        tier: 'A1',
+        arrivalDateStart: '2022-01-01',
+        arrivalDateEnd: '2022-01-02',
+      })
+
+      expect(result).toEqual(response)
+
+      expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
+      expect(placementRequestClient.dashboard).toHaveBeenCalledWith(
+        { crn: 'CRN123', tier: 'A1', arrivalDateStart: '2022-01-01', arrivalDateEnd: '2022-01-02' },
+        1,
+        'created_at',
+        'asc',
+      )
     })
 
     it('calls the dashboard method on the placementRequest client with page and sort options', async () => {
@@ -103,7 +128,7 @@ describe('placementRequestService', () => {
 
       placementRequestClient.dashboard.mockResolvedValue(response)
 
-      const result = await service.search(token, 'CRN123', 2, 'duration', 'desc')
+      const result = await service.search(token, { crn: 'CRN123' }, 2, 'duration', 'desc')
 
       expect(result).toEqual(response)
 

--- a/server/services/placementRequestService.ts
+++ b/server/services/placementRequestService.ts
@@ -1,4 +1,8 @@
-import { GroupedPlacementRequests, PaginatedResponse } from '@approved-premises/ui'
+import {
+  GroupedPlacementRequests,
+  PaginatedResponse,
+  PlacementRequestDashboardSearchOptions,
+} from '@approved-premises/ui'
 import {
   NewBookingNotMade,
   NewPlacementRequestBooking,
@@ -47,14 +51,14 @@ export default class PlacementRequestService {
 
   async search(
     token: string,
-    crn: string,
+    searchParams: PlacementRequestDashboardSearchOptions,
     page: number = 1,
     sortBy: PlacementRequestSortField = 'created_at',
     sortDirection: SortDirection = 'asc',
   ): Promise<PaginatedResponse<PlacementRequest>> {
     const placementRequestClient = this.placementRequestClientFactory(token)
 
-    return placementRequestClient.dashboard({ crn }, page, sortBy, sortDirection)
+    return placementRequestClient.dashboard(searchParams, page, sortBy, sortDirection)
   }
 
   async getPlacementRequest(token: string, id: string): Promise<PlacementRequestDetail> {

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -13,6 +13,7 @@ import {
   escape,
   flattenCheckboxInput,
   isStringOrArrayOfStrings,
+  tierSelectOptions,
   validPostcodeArea,
 } from './formUtils'
 
@@ -423,6 +424,52 @@ describe('formUtils', () => {
             text: 'someValue',
           },
         },
+      ])
+    })
+  })
+
+  describe('tierSelectOptions', () => {
+    it('returns a list of tiers as select options', () => {
+      expect(tierSelectOptions(undefined)).toEqual([
+        { text: 'Please select', value: '', selected: true },
+        { text: 'D0', value: 'D0', selected: false },
+        { text: 'D1', value: 'D1', selected: false },
+        { text: 'D2', value: 'D2', selected: false },
+        { text: 'D3', value: 'D3', selected: false },
+        { text: 'C0', value: 'C0', selected: false },
+        { text: 'C1', value: 'C1', selected: false },
+        { text: 'C2', value: 'C2', selected: false },
+        { text: 'C3', value: 'C3', selected: false },
+        { text: 'B0', value: 'B0', selected: false },
+        { text: 'B1', value: 'B1', selected: false },
+        { text: 'B2', value: 'B2', selected: false },
+        { text: 'B3', value: 'B3', selected: false },
+        { text: 'A0', value: 'A0', selected: false },
+        { text: 'A1', value: 'A1', selected: false },
+        { text: 'A2', value: 'A2', selected: false },
+        { text: 'A3', value: 'A3', selected: false },
+      ])
+    })
+
+    it('return the selected tier if specified', () => {
+      expect(tierSelectOptions('C1')).toEqual([
+        { text: 'Please select', value: '', selected: false },
+        { text: 'D0', value: 'D0', selected: false },
+        { text: 'D1', value: 'D1', selected: false },
+        { text: 'D2', value: 'D2', selected: false },
+        { text: 'D3', value: 'D3', selected: false },
+        { text: 'C0', value: 'C0', selected: false },
+        { text: 'C1', value: 'C1', selected: true },
+        { text: 'C2', value: 'C2', selected: false },
+        { text: 'C3', value: 'C3', selected: false },
+        { text: 'B0', value: 'B0', selected: false },
+        { text: 'B1', value: 'B1', selected: false },
+        { text: 'B2', value: 'B2', selected: false },
+        { text: 'B3', value: 'B3', selected: false },
+        { text: 'A0', value: 'A0', selected: false },
+        { text: 'A1', value: 'A1', selected: false },
+        { text: 'A2', value: 'A2', selected: false },
+        { text: 'A3', value: 'A3', selected: false },
       ])
     })
   })

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -1,5 +1,12 @@
 import * as nunjucks from 'nunjucks'
-import type { CheckBoxItem, ErrorMessages, RadioItem, SelectOption, SummaryListItem } from '@approved-premises/ui'
+import type {
+  CheckBoxItem,
+  ErrorMessages,
+  RadioItem,
+  RiskTierLevel,
+  SelectOption,
+  SummaryListItem,
+} from '@approved-premises/ui'
 import { resolvePath, sentenceCase } from './utils'
 import postcodeAreas from '../etc/postcodeAreas.json'
 
@@ -171,4 +178,22 @@ export function isStringOrArrayOfStrings(input: unknown) {
 export const escape = (text: string): string => {
   const escapeFilter = new nunjucks.Environment().getFilter('escape')
   return escapeFilter(text).val
+}
+
+export const tierSelectOptions = (selectedOption: RiskTierLevel | undefined): Array<SelectOption> => {
+  const tiers = ['D0', 'D1', 'D2', 'D3', 'C0', 'C1', 'C2', 'C3', 'B0', 'B1', 'B2', 'B3', 'A0', 'A1', 'A2', 'A3']
+
+  const options = tiers.map(tier => ({
+    text: tier,
+    value: tier,
+    selected: tier === selectedOption,
+  }))
+
+  options.unshift({
+    text: 'Please select',
+    value: '',
+    selected: selectedOption === undefined,
+  })
+
+  return options
 }

--- a/server/utils/placementRequests/table.test.ts
+++ b/server/utils/placementRequests/table.test.ts
@@ -150,9 +150,9 @@ describe('tableUtils', () => {
 
   describe('dashboardTableRows', () => {
     it('returns table rows for non matched placement requests', () => {
-      const placementRequest = placementRequestFactory.build({ status: 'notMatched' })
+      const placementRequest = placementRequestFactory.build()
 
-      expect(dashboardTableRows([placementRequest])).toEqual([
+      expect(dashboardTableRows([placementRequest], 'notMatched')).toEqual([
         [
           nameCell(placementRequest),
           crnCell(placementRequest.person),
@@ -165,15 +165,30 @@ describe('tableUtils', () => {
     })
 
     it('returns table rows for matched placement requests', () => {
-      const placementRequest = placementRequestFactory.build({ status: 'matched' })
+      const placementRequest = placementRequestFactory.build()
 
-      expect(dashboardTableRows([placementRequest])).toEqual([
+      expect(dashboardTableRows([placementRequest], 'matched')).toEqual([
         [
           nameCell(placementRequest),
           crnCell(placementRequest.person),
           tierCell(placementRequest.risks),
           expectedArrivalDateCell(placementRequest),
           premisesNameCell(placementRequest),
+          requestTypeCell(placementRequest),
+        ],
+      ])
+    })
+
+    it('returns table rows when the status is undefined', () => {
+      const placementRequest = placementRequestFactory.build()
+
+      expect(dashboardTableRows([placementRequest], undefined)).toEqual([
+        [
+          nameCell(placementRequest),
+          crnCell(placementRequest.person),
+          tierCell(placementRequest.risks),
+          expectedArrivalDateCell(placementRequest),
+          durationCell(placementRequest),
           requestTypeCell(placementRequest),
         ],
       ])

--- a/server/utils/placementRequests/table.ts
+++ b/server/utils/placementRequests/table.ts
@@ -25,14 +25,17 @@ export const tableRows = (tasks: Array<PlacementRequestTask>): Array<TableRow> =
   })
 }
 
-export const dashboardTableRows = (placementRequests: Array<PlacementRequest>): Array<TableRow> => {
+export const dashboardTableRows = (
+  placementRequests: Array<PlacementRequest>,
+  status: PlacementRequestStatus | undefined,
+): Array<TableRow> => {
   return placementRequests.map((placementRequest: PlacementRequest) => {
     return [
       nameCell(placementRequest),
       crnCell(placementRequest.person),
       tierCell(placementRequest.risks),
       expectedArrivalDateCell(placementRequest),
-      placementRequest.status === 'matched' ? premisesNameCell(placementRequest) : durationCell(placementRequest),
+      status === 'matched' ? premisesNameCell(placementRequest) : durationCell(placementRequest),
       requestTypeCell(placementRequest),
     ]
   })

--- a/server/views/admin/placementRequests/index.njk
+++ b/server/views/admin/placementRequests/index.njk
@@ -24,7 +24,7 @@
         govukTable({
             firstCellIsHeader: true,
             head: PlacementRequestUtils.tableUtils.dashboardTableHeader(status, sortBy, sortDirection, hrefPrefix),
-            rows: PlacementRequestUtils.tableUtils.dashboardTableRows(placementRequests)
+            rows: PlacementRequestUtils.tableUtils.dashboardTableRows(placementRequests, status)
           })
       }}
 

--- a/server/views/admin/placementRequests/search.njk
+++ b/server/views/admin/placementRequests/search.njk
@@ -1,7 +1,13 @@
 {% extends "../../partials/layout.njk" %}
+
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+
 {%- from "moj/components/search/macro.njk" import mojSearch -%}
+
 {% from "./_navigation.njk" import navigation %}
 
 {% set pageTitle = applicationName + " - " + pageHeading  %}
@@ -17,25 +23,77 @@
 
       {{ navigation("search") }}
 
-      {{
-        mojSearch({
-          action: paths.admin.placementRequests.search({}),
-          method: 'get',
-          input: {
-            id: 'crn',
-            name: 'crn'
-          },
-          label: {
-            text: 'Find a placement'
-          },
-          hint: {
-            text: 'You can search by CRN'
-          },
-          button: {
-            text: 'Search'
-          }
-        })
-      }}
+      <div class="placement-request-search__wrapper">
+
+        <form action="{{ paths.admin.placementRequests.search({}) }}" method="get">
+
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+              <div class="govuk-form-group">
+                <label class="placement-request-search__crn-label" for="crn">
+                 Find a placement
+                </label>
+
+                <div id="crn-hint" class="govuk-hint moj-crn__hint ">
+                  You can search by CRN
+                </div>
+
+                <input class="govuk-input moj-search__input" id="crn" name="crn" type="search" aria-describedby="crn-hint">
+              </div>
+            </div>
+          </div>
+
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-quarter">
+              <h2 class="govuk-heading-m">Filters</h2>
+            </div>
+          </div>
+
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-quarter">
+              {{
+                govukSelect({
+                  label: {
+                      text: "Tier",
+                      classes: "govuk-label--s"
+                  },
+                  id: "tier",
+                  name: "tier",
+                  items: FormUtils.tierSelectOptions(tier)
+                })
+              }}
+            </div>
+            <div class="govuk-grid-column-one-quarter">
+              <div class="govuk-form-group">
+                <label class="govuk-label govuk-label--s" for="arrivalDateStart">
+                  Arrival date from
+                </label>
+
+                <input type="date" id="arrivalDateStart" class="govuk-input" name="arrivalDateStart" placeholder="Date from" value="{{ arrivalDateStart }}"/>
+              </div>
+            </div>
+            <div class="govuk-grid-column-one-quarter">
+              <div class="govuk-form-group">
+                <label class="govuk-label govuk-label--s" for="arrivalDateEnd">
+                  Arrival date to
+                </label>
+
+                <input type="date" id="arrivalDateEnd" class="govuk-input" name="arrivalDateEnd" placeholder="Date to" value="{{ arrivalDateEnd }}"/>
+              </div>
+            </div>
+            <div class="govuk-grid-column-one-quarter">
+              {{
+                govukButton({
+                  name: 'submit',
+                  text: 'Apply filters',
+                  classes: 'placement-request-search__submit'
+                })
+              }}
+            </div>
+          </div>
+
+        </form>
+      </div>
 
       {{
         govukTable({


### PR DESCRIPTION
This adds some new search options to the CRU dashboard, allowing filter by Tier and Start / End date

## Screenshot

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/dece6d6e-ccad-4d34-942b-c91f160d0abd)
