### PR TITLE
Allow sorting by application date

### DIFF
--- a/server/utils/placementRequests/table.test.ts
+++ b/server/utils/placementRequests/table.test.ts
@@ -1,6 +1,7 @@
 import { add } from 'date-fns'
 import { bookingSummaryFactory, placementRequestFactory, placementRequestTaskFactory } from '../../testutils/factories'
 import {
+  applicationDateCell,
   dashboardTableHeader,
   dashboardTableRows,
   dueDateCell,
@@ -66,6 +67,24 @@ describe('tableUtils', () => {
 
       expect(expectedArrivalDateCell(task)).toEqual({
         text: DateFormats.isoDateToUIDate('2022-01-01'),
+      })
+    })
+
+    it('returns a formatted arrival date in short format', () => {
+      const task = placementRequestTaskFactory.build({ expectedArrival: '2022-01-01' })
+
+      expect(expectedArrivalDateCell(task, 'short')).toEqual({
+        text: DateFormats.isoDateToUIDate('2022-01-01', { format: 'short' }),
+      })
+    })
+  })
+
+  describe('applicationDateCell', () => {
+    it("returns the application's created at date", () => {
+      const task = placementRequestFactory.build({ applicationDate: '2022-01-01' })
+
+      expect(applicationDateCell(task)).toEqual({
+        text: DateFormats.isoDateToUIDate('2022-01-01', { format: 'short' }),
       })
     })
   })
@@ -157,7 +176,8 @@ describe('tableUtils', () => {
           nameCell(placementRequest),
           crnCell(placementRequest.person),
           tierCell(placementRequest.risks),
-          expectedArrivalDateCell(placementRequest),
+          expectedArrivalDateCell(placementRequest, 'short'),
+          applicationDateCell(placementRequest),
           durationCell(placementRequest),
           requestTypeCell(placementRequest),
         ],
@@ -172,7 +192,8 @@ describe('tableUtils', () => {
           nameCell(placementRequest),
           crnCell(placementRequest.person),
           tierCell(placementRequest.risks),
-          expectedArrivalDateCell(placementRequest),
+          expectedArrivalDateCell(placementRequest, 'short'),
+          applicationDateCell(placementRequest),
           premisesNameCell(placementRequest),
           requestTypeCell(placementRequest),
         ],
@@ -187,7 +208,8 @@ describe('tableUtils', () => {
           nameCell(placementRequest),
           crnCell(placementRequest.person),
           tierCell(placementRequest.risks),
-          expectedArrivalDateCell(placementRequest),
+          expectedArrivalDateCell(placementRequest, 'short'),
+          applicationDateCell(placementRequest),
           durationCell(placementRequest),
           requestTypeCell(placementRequest),
         ],
@@ -212,6 +234,7 @@ describe('tableUtils', () => {
           text: 'Tier',
         },
         sortHeader('Arrival date', 'expectedArrival', sortBy, sortDirection, hrefPrefix),
+        sortHeader('Application date', 'application_date', sortBy, sortDirection, hrefPrefix),
         sortHeader('Length of stay', 'duration', sortBy, sortDirection, hrefPrefix),
         {
           text: 'Request type',
@@ -231,6 +254,7 @@ describe('tableUtils', () => {
           text: 'Tier',
         },
         sortHeader('Arrival date', 'expectedArrival', sortBy, sortDirection, hrefPrefix),
+        sortHeader('Application date', 'application_date', sortBy, sortDirection, hrefPrefix),
         {
           text: 'Approved Premises',
         },

--- a/server/utils/placementRequests/table.ts
+++ b/server/utils/placementRequests/table.ts
@@ -34,7 +34,8 @@ export const dashboardTableRows = (
       nameCell(placementRequest),
       crnCell(placementRequest.person),
       tierCell(placementRequest.risks),
-      expectedArrivalDateCell(placementRequest),
+      expectedArrivalDateCell(placementRequest, 'short'),
+      applicationDateCell(placementRequest),
       status === 'matched' ? premisesNameCell(placementRequest) : durationCell(placementRequest),
       requestTypeCell(placementRequest),
     ]
@@ -68,8 +69,15 @@ export const dueDateCell = (task: PlacementRequestTask, differenceBetweenDueDate
   }
 }
 
-export const expectedArrivalDateCell = (item: PlacementRequestTask | PlacementRequest): TableCell => ({
-  text: DateFormats.isoDateToUIDate(item.expectedArrival),
+export const expectedArrivalDateCell = (
+  item: PlacementRequestTask | PlacementRequest,
+  format: 'short' | 'long' = 'long',
+): TableCell => ({
+  text: DateFormats.isoDateToUIDate(item.expectedArrival, { format }),
+})
+
+export const applicationDateCell = (item: PlacementRequest): TableCell => ({
+  text: DateFormats.isoDateToUIDate(item.applicationDate, { format: 'short' }),
 })
 
 export const nameCell = (item: PlacementRequestTask | PlacementRequest): TableCell => {
@@ -117,6 +125,7 @@ export const dashboardTableHeader = (
       text: 'Tier',
     },
     sortHeader('Arrival date', 'expectedArrival', sortBy, sortDirection, hrefPrefix),
+    sortHeader('Application date', 'application_date', sortBy, sortDirection, hrefPrefix),
     status === 'matched'
       ? {
           text: 'Approved Premises',


### PR DESCRIPTION
This allows placement dates to be ordered by the date the application was made. As there’s now another column, I’ve had to make these dates into short format dates to ensure it all fits neatly.

# Screenshot

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/66f21bab-6ea8-4a9e-81dd-ac174ece19ac)
