### PR TITLE
Change Placement Request actions based on Booking Status

### DIFF
--- a/server/utils/placementRequests/adminIdentityBar.test.ts
+++ b/server/utils/placementRequests/adminIdentityBar.test.ts
@@ -6,8 +6,8 @@ import adminPaths from '../../paths/admin'
 
 describe('adminIdentityBar', () => {
   describe('adminActions', () => {
-    it('should return actions to amend a booking if there is a booking', () => {
-      const placementRequestDetail = placementRequestDetailFactory.build()
+    it('should return actions to amend a booking if the status is `matched`', () => {
+      const placementRequestDetail = placementRequestDetailFactory.build({ status: 'matched' })
 
       expect(adminActions(placementRequestDetail)).toEqual([
         {
@@ -27,8 +27,8 @@ describe('adminIdentityBar', () => {
       ])
     })
 
-    it('should return actions to create a booking and withdraw a placement request if there is a booking', () => {
-      const placementRequestDetail = placementRequestDetailFactory.build({ booking: undefined })
+    it('should return actions to create a booking and withdraw a placement request if the status is not `matched`', () => {
+      const placementRequestDetail = placementRequestDetailFactory.build({ status: 'notMatched' })
 
       expect(adminActions(placementRequestDetail)).toEqual([
         {

--- a/server/utils/placementRequests/adminIdentityBar.ts
+++ b/server/utils/placementRequests/adminIdentityBar.ts
@@ -12,7 +12,7 @@ export const adminIdentityBar = (placementRequest: PlacementRequestDetail): Iden
 })
 
 export const adminActions = (placementRequest: PlacementRequestDetail): Array<IdentityBarMenuItem> => {
-  if (placementRequest.booking) {
+  if (placementRequest.status === 'matched') {
     return [
       {
         href: managePaths.bookings.dateChanges.new({

--- a/server/views/admin/placementRequests/show.njk
+++ b/server/views/admin/placementRequests/show.njk
@@ -60,7 +60,7 @@
             govukSummaryList(PlacementRequestUtils.matchingInformationSummary(placementRequest))
           }}
 
-          {% if placementRequest.booking %}
+          {% if placementRequest.status === 'matched' %}
             <h2 class="govuk-heading-m">Booked Placement</h2>
             {{
               govukSummaryList(BookingUtils.bookingSummaryList(placementRequest.booking))

--- a/server/views/admin/placementRequests/show.njk
+++ b/server/views/admin/placementRequests/show.njk
@@ -5,7 +5,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - " + pageHeading %}
+{% set pageTitle = applicationName + " - View Placement Request" %}
 
 {% block content %}
   {% include "../../_messages.njk" %}
@@ -25,7 +25,7 @@
                 Parole board directed release
               </p>
             <p class="govuk-body">
-                The person's arrival date has been calculated as {{ formatDate(placementRequest.expectedArrival) }}. 
+                The person's arrival date has been calculated as {{ formatDate(placementRequest.expectedArrival) }}.
                 This is 6 weeks after the parole board's date of decision.
               </p>
             {% if placementRequest.booking %}


### PR DESCRIPTION
Before, if a placement request had a booking that was cancelled, users would still see the option to cancel it, even though it was already cancelled. This has caused some confusion as when a user is trying to withdraw the request, they're trying to cancel the booking, and getting an error.

This fixes the issue by matching on the placement request status, rather than the presence / absence of a booking. 