### PR TITLE
(382) Use Premises summary endpoint

### DIFF
--- a/integration_tests/helpers/assess.ts
+++ b/integration_tests/helpers/assess.ts
@@ -1,6 +1,6 @@
 import {
   ApprovedPremisesAssessment as Assessment,
-  AssessmentStatus,
+  ApprovedPremisesAssessmentStatus as AssessmentStatus,
   ApprovedPremisesAssessmentSummary as AssessmentSummary,
   ClarificationNote,
   Document,

--- a/integration_tests/mockApis/premises.ts
+++ b/integration_tests/mockApis/premises.ts
@@ -1,17 +1,24 @@
 import type { Response, SuperAgentRequest } from 'superagent'
 
-import type { BedOccupancyRange, Booking, DateCapacity, Premises, StaffMember } from '@approved-premises/api'
+import type {
+  BedOccupancyRange,
+  Booking,
+  DateCapacity,
+  Premises,
+  PremisesSummary,
+  StaffMember,
+} from '@approved-premises/api'
 
 import { stubFor } from '../../wiremock'
 import bookingStubs from './booking'
 import paths from '../../server/paths/api'
 import { createQueryString } from '../../server/utils/utils'
 
-const stubPremises = (premises: Array<Premises>) =>
+const stubPremises = (premises: Array<PremisesSummary>) =>
   stubFor({
     request: {
       method: 'GET',
-      urlPattern: '/premises',
+      urlPattern: '/premises/summary',
     },
     response: {
       status: 200,

--- a/integration_tests/pages/admin/placementApplications/listPage.ts
+++ b/integration_tests/pages/admin/placementApplications/listPage.ts
@@ -15,10 +15,7 @@ export default class ListPage extends Page {
     return new ListPage()
   }
 
-  shouldShowPlacementRequests(
-    placementRequests: Array<PlacementRequest>,
-    status: PlacementRequestStatus | undefined,
-  ): void {
+  shouldShowPlacementRequests(placementRequests: Array<PlacementRequest>, status?: PlacementRequestStatus): void {
     const tableRows = dashboardTableRows(placementRequests, status)
     const rowItems = tableRowsToArrays(tableRows)
 

--- a/server/data/premisesClient.test.ts
+++ b/server/data/premisesClient.test.ts
@@ -4,6 +4,7 @@ import {
   bedSummaryFactory,
   dateCapacityFactory,
   premisesFactory,
+  premisesSummaryFactory,
   roomFactory,
   staffMemberFactory,
 } from '../testutils/factories'
@@ -21,9 +22,9 @@ describeClient('PremisesClient', provider => {
   })
 
   describe('all', () => {
-    const premises = premisesFactory.buildList(5)
-
     it('should get all premises', async () => {
+      const premisesSummaries = premisesSummaryFactory.buildList(5)
+
       provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get all premises',
@@ -32,16 +33,17 @@ describeClient('PremisesClient', provider => {
           path: paths.premises.index({}),
           headers: {
             authorization: `Bearer ${token}`,
+            'X-Service-Name': 'approved-premises',
           },
         },
         willRespondWith: {
           status: 200,
-          body: premises,
+          body: premisesSummaries,
         },
       })
 
       const output = await premisesClient.all()
-      expect(output).toEqual(premises)
+      expect(output).toEqual(premisesSummaries)
     })
   })
 

--- a/server/data/premisesClient.ts
+++ b/server/data/premisesClient.ts
@@ -4,6 +4,7 @@ import type {
   BedOccupancyRange,
   BedSummary,
   DateCapacity,
+  ApprovedPremisesSummary as PremisesSummary,
   Room,
   StaffMember,
 } from '@approved-premises/api'
@@ -18,8 +19,8 @@ export default class PremisesClient {
     this.restClient = new RestClient('premisesClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
-  async all(): Promise<Array<ApprovedPremises>> {
-    return (await this.restClient.get({ path: paths.premises.index({}) })) as Array<ApprovedPremises>
+  async all(): Promise<Array<PremisesSummary>> {
+    return (await this.restClient.get({ path: paths.premises.index({}) })) as Array<PremisesSummary>
   }
 
   async find(id: string): Promise<ApprovedPremises> {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -11,7 +11,7 @@ const bookingPath = singlePremisesPath.path('bookings/:bookingId')
 
 const managePaths = {
   premises: {
-    index: premisesPath,
+    index: premisesPath.path('summary'),
     show: singlePremisesPath,
   },
   lostBeds: {

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -1,5 +1,13 @@
 import type { SummaryList, TableRow } from '@approved-premises/ui'
-import type { ApprovedPremises, BedDetail, BedSummary, Premises, Room, StaffMember } from '@approved-premises/api'
+import type {
+  ApprovedPremises,
+  BedDetail,
+  BedSummary,
+  Premises,
+  PremisesSummary,
+  Room,
+  StaffMember,
+} from '@approved-premises/api'
 import type { PremisesClient, RestClientBuilder } from '../data'
 import paths from '../paths/manage'
 
@@ -9,7 +17,7 @@ import getDateRangesWithNegativeBeds, { NegativeDateRange, mapApiOccupancyToUiOc
 export default class PremisesService {
   constructor(private readonly premisesClientFactory: RestClientBuilder<PremisesClient>) {}
 
-  async getAll(token: string): Promise<Array<ApprovedPremises>> {
+  async getAll(token: string): Promise<Array<PremisesSummary>> {
     const premisesClient = this.premisesClientFactory(token)
     const premises = await premisesClient.all()
 

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -60,6 +60,7 @@ import placementRequestFactory from './placementRequest'
 import placementRequestDetailFactory from './placementRequestDetail'
 import placementRequestTaskFactory from './placementRequestTask'
 import premisesFactory from './premises'
+import premisesSummaryFactory from './premisesSummary'
 import prisonCaseNotesFactory from './prisonCaseNotes'
 import reallocationFactory from './reallocation'
 import referenceDataFactory from './referenceData'
@@ -133,6 +134,7 @@ export {
   placementRequestDetailFactory,
   placementRequestTaskFactory,
   premisesFactory,
+  premisesSummaryFactory,
   prisonCaseNotesFactory,
   reallocationFactory,
   referenceDataFactory,

--- a/server/testutils/factories/premisesSummary.ts
+++ b/server/testutils/factories/premisesSummary.ts
@@ -1,0 +1,16 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { ApprovedPremisesSummary } from '@approved-premises/api'
+
+export default Factory.define<ApprovedPremisesSummary>(() => ({
+  id: faker.string.uuid(),
+  service: 'approved-premises',
+  name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
+  status: faker.helpers.arrayElement(['pending', 'active', 'archived']),
+  postcode: faker.location.zipCode(),
+  apCode: `${faker.string.alpha(2)}`,
+  bedCount: 50,
+  addressLine1: faker.location.streetAddress(),
+  addressLine2: faker.location.city(),
+}))


### PR DESCRIPTION
# Context
The new `premises/summary` endpoint has performance benefits over the `premises` endpoint. 
We should use it when we're listing all premises.

[Trello](https://trello.com/c/E9mQB0ZY/382-removing-the-static-number-of-beds-value-from-dashboards)
# Changes in this PR
- First we address some linting errors in the E2E tests
- We update the endpoint for premises to use the new `summary` endpoint
- We update the mockApis for the integration tests
