### PR TITLE
Restore e2e tests to the pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,6 +249,7 @@ workflows:
       - request-preprod-approval:
           type: approval
           requires:
+            - e2e_environment_test
             - deploy_dev
       - hmpps/deploy_env:
           name: deploy_preprod


### PR DESCRIPTION
This reverts https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/979 as the e2e tests are more stable now.
