### PR TITLE
(390) Allow arrived bookings to reduce length of stay

### DIFF
--- a/integration_tests/pages/manage/booking/dateChanges/confirmation.ts
+++ b/integration_tests/pages/manage/booking/dateChanges/confirmation.ts
@@ -4,14 +4,14 @@ import Page from '../../../page'
 import paths from '../../../../../server/paths/manage'
 import { DateFormats } from '../../../../../server/utils/dateUtils'
 
-export default class BookingExtensionConfirmationPage extends Page {
+export default class DepartureDateChangeConfirmationPage extends Page {
   constructor() {
-    super('Booking extension complete')
+    super('Departure date changed')
   }
 
-  static visit(premisesId: string, bookingId: string): BookingExtensionConfirmationPage {
+  static visit(premisesId: string, bookingId: string): DepartureDateChangeConfirmationPage {
     cy.visit(paths.bookings.extensions.confirm({ premisesId, bookingId }))
-    return new BookingExtensionConfirmationPage()
+    return new DepartureDateChangeConfirmationPage()
   }
 
   verifyBookingIsVisible(booking: Booking): void {

--- a/integration_tests/pages/manage/booking/dateChanges/create.ts
+++ b/integration_tests/pages/manage/booking/dateChanges/create.ts
@@ -1,14 +1,14 @@
 import Page, { PageElement } from '../../../page'
 import paths from '../../../../../server/paths/manage'
 
-export default class BookingExtensionCreatePage extends Page {
+export default class DepartureDateChangePage extends Page {
   constructor() {
-    super('Extend placement')
+    super('Change departure date')
   }
 
-  static visit(premisesId: string, bookingId: string): BookingExtensionCreatePage {
+  static visit(premisesId: string, bookingId: string): DepartureDateChangePage {
     cy.visit(paths.bookings.extensions.new({ premisesId, bookingId }))
-    return new BookingExtensionCreatePage()
+    return new DepartureDateChangePage()
   }
 
   newDepartureDay(): PageElement {

--- a/integration_tests/pages/manage/index.ts
+++ b/integration_tests/pages/manage/index.ts
@@ -16,8 +16,8 @@ import BookingConfirmationPage from './booking/confirmation'
 import BookingFindPage from './booking/find'
 import BookingNewPage from './booking/new'
 import BookingShowPage from './booking/show'
-import BookingExtensionConfirmationPage from './booking/extension/confirmation'
-import BookingExtensionCreatePage from './booking/extension/create'
+import DepartureDateChangeConfirmationPage from './booking/dateChanges/confirmation'
+import DepartureDateChangePage from './booking/dateChanges/create'
 
 import CalendarPage from './calendar'
 
@@ -34,8 +34,8 @@ export {
   BookingFindPage,
   BookingNewPage,
   BookingShowPage,
-  BookingExtensionConfirmationPage,
-  BookingExtensionCreatePage,
+  DepartureDateChangeConfirmationPage,
+  DepartureDateChangePage,
   BedsListPage,
   BedShowPage,
   CalendarPage,

--- a/integration_tests/tests/manage/changeDepartureDate.cy.ts
+++ b/integration_tests/tests/manage/changeDepartureDate.cy.ts
@@ -1,9 +1,9 @@
 import { bookingFactory, premisesFactory } from '../../../server/testutils/factories'
 
-import { BookingExtensionConfirmationPage, BookingExtensionCreatePage } from '../../pages/manage'
+import { DepartureDateChangeConfirmationPage, DepartureDateChangePage } from '../../pages/manage'
 import { signIn } from '../signIn'
 
-context('BookingExtension', () => {
+context('Departure date', () => {
   beforeEach(() => {
     cy.task('reset')
 
@@ -11,7 +11,7 @@ context('BookingExtension', () => {
     signIn(['workflow_manager'])
   })
 
-  it('should show booking extension form', () => {
+  it('should show a form to change a bookings departure date', () => {
     const booking = bookingFactory.build({
       departureDate: '2022-06-03',
     })
@@ -23,14 +23,15 @@ context('BookingExtension', () => {
     cy.task('stubSinglePremises', { premisesId: premises.id, booking })
 
     // When I visit the booking extension page
-    const page = BookingExtensionCreatePage.visit(premises.id, booking.id)
+    const page = DepartureDateChangePage.visit(premises.id, booking.id)
 
     // And I fill in the extension form
     page.completeForm(newDepartureDate)
     page.clickSubmit()
 
     // Then I should be redirected to the confirmation page
-    const bookingConfirmationPage = new BookingExtensionConfirmationPage()
+    const bookingConfirmationPage = new DepartureDateChangeConfirmationPage()
+
     bookingConfirmationPage.verifyBookingIsVisible(booking)
 
     // And the extension should be created in the API
@@ -52,7 +53,7 @@ context('BookingExtension', () => {
     cy.task('stubBookingGet', { premisesId: premises.id, booking })
 
     // When I visit the booking extension page
-    const page = BookingExtensionCreatePage.visit(premises.id, booking.id)
+    const page = DepartureDateChangePage.visit(premises.id, booking.id)
 
     // And I don't enter details into the field
     cy.task('stubBookingExtensionErrors', {

--- a/server/controllers/manage/bookingExtensionsController.test.ts
+++ b/server/controllers/manage/bookingExtensionsController.test.ts
@@ -37,6 +37,7 @@ describe('bookingExtensionsController', () => {
       await requestHandler({ ...request, params: { premisesId, bookingId: booking.id } }, response, next)
 
       expect(response.render).toHaveBeenCalledWith('bookings/extensions/new', {
+        pageHeading: 'Change departure date',
         premisesId,
         booking,
         errors: {},
@@ -55,6 +56,7 @@ describe('bookingExtensionsController', () => {
       await requestHandler({ ...request, params: { premisesId, bookingId: booking.id } }, response, next)
 
       expect(response.render).toHaveBeenCalledWith('bookings/extensions/new', {
+        pageHeading: 'Change departure date',
         premisesId,
         booking,
         errors: errorsAndUserInput.errors,
@@ -144,7 +146,11 @@ describe('bookingExtensionsController', () => {
       await requestHandler(request, response, next)
 
       expect(bookingService.find).toHaveBeenCalledWith(token, premisesId, booking.id)
-      expect(response.render).toHaveBeenCalledWith('bookings/extensions/confirm', { premisesId, ...booking })
+      expect(response.render).toHaveBeenCalledWith('bookings/extensions/confirm', {
+        pageHeading: 'Departure date changed',
+        premisesId,
+        ...booking,
+      })
     })
   })
 })

--- a/server/controllers/manage/bookingExtensionsController.test.ts
+++ b/server/controllers/manage/bookingExtensionsController.test.ts
@@ -69,7 +69,7 @@ describe('bookingExtensionsController', () => {
     const bookingExtension = bookingExtensionFactory.build({ bookingId: booking.id })
 
     it('given the expected form data, the posting of the booking is successful should redirect to the "confirmation" page', async () => {
-      bookingService.extendBooking.mockResolvedValue(bookingExtension)
+      bookingService.changeDepartureDate.mockResolvedValue(bookingExtension)
 
       const requestHandler = bookingExtensionsController.create()
 
@@ -85,7 +85,7 @@ describe('bookingExtensionsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bookingService.extendBooking).toHaveBeenCalledWith(token, premisesId, bookingExtension.bookingId, {
+      expect(bookingService.changeDepartureDate).toHaveBeenCalledWith(token, premisesId, bookingExtension.bookingId, {
         ...request.body,
         newDepartureDate: '2022-02-01',
       })
@@ -99,7 +99,7 @@ describe('bookingExtensionsController', () => {
     })
 
     it('should render the page with errors when the API returns an error', async () => {
-      bookingService.extendBooking.mockResolvedValue(bookingExtension)
+      bookingService.changeDepartureDate.mockResolvedValue(bookingExtension)
       const requestHandler = bookingExtensionsController.create()
 
       request = {
@@ -109,7 +109,7 @@ describe('bookingExtensionsController', () => {
 
       const err = new Error()
 
-      bookingService.extendBooking.mockImplementation(() => {
+      bookingService.changeDepartureDate.mockImplementation(() => {
         throw err
       })
 

--- a/server/controllers/manage/bookingExtensionsController.ts
+++ b/server/controllers/manage/bookingExtensionsController.ts
@@ -31,7 +31,7 @@ export default class BookingExtensionsController {
       }
 
       try {
-        await this.bookingService.extendBooking(req.user.token, premisesId, bookingId, bookingExtension)
+        await this.bookingService.changeDepartureDate(req.user.token, premisesId, bookingId, bookingExtension)
 
         res.redirect(
           paths.bookings.extensions.confirm({

--- a/server/controllers/manage/bookingExtensionsController.ts
+++ b/server/controllers/manage/bookingExtensionsController.ts
@@ -17,7 +17,14 @@ export default class BookingExtensionsController {
       const booking = await this.bookingService.find(req.user.token, premisesId, bookingId)
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
-      return res.render('bookings/extensions/new', { premisesId, booking, errors, errorSummary, ...userInput })
+      return res.render('bookings/extensions/new', {
+        pageHeading: 'Change departure date',
+        premisesId,
+        booking,
+        errors,
+        errorSummary,
+        ...userInput,
+      })
     }
   }
 
@@ -58,7 +65,11 @@ export default class BookingExtensionsController {
       const { premisesId, bookingId } = req.params
       const booking = await this.bookingService.find(req.user.token, premisesId, bookingId)
 
-      return res.render('bookings/extensions/confirm', { premisesId, ...booking })
+      return res.render('bookings/extensions/confirm', {
+        pageHeading: 'Departure date changed',
+        premisesId,
+        ...booking,
+      })
     }
   }
 }

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -175,7 +175,7 @@ describe('BookingService', () => {
         notes: 'Some notes',
       }
 
-      const extendedBooking = await service.extendBooking(token, 'premisesId', booking.id, newDepartureDateObj)
+      const extendedBooking = await service.changeDepartureDate(token, 'premisesId', booking.id, newDepartureDateObj)
 
       expect(extendedBooking).toEqual(booking)
       expect(bookingClientFactory).toHaveBeenCalledWith(token)

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -48,7 +48,7 @@ export default class BookingService {
     }
   }
 
-  async extendBooking(
+  async changeDepartureDate(
     token: string,
     premisesId: string,
     bookingId: string,

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -190,26 +190,6 @@ describe('PremisesService', () => {
     })
   })
 
-  describe('premisesSelectList', () => {
-    it('returns the list mapped into the format required by the nunjucks macro and sorted alphabetically', async () => {
-      const premisesA = premisesFactory.build({ name: 'a' })
-      const premisesB = premisesFactory.build({ name: 'b' })
-      const premisesC = premisesFactory.build({ name: 'c' })
-      premisesClient.all.mockResolvedValue([premisesC, premisesB, premisesA])
-
-      const result = await service.getPremisesSelectList(token)
-
-      expect(result).toEqual([
-        { text: premisesA.name, value: premisesA.id },
-        { text: premisesB.name, value: premisesB.id },
-        { text: premisesC.name, value: premisesC.id },
-      ])
-
-      expect(premisesClientFactory).toHaveBeenCalledWith(token)
-      expect(premisesClient.all).toHaveBeenCalled()
-    })
-  })
-
   describe('find', () => {
     it('fetches the premises from the client', async () => {
       const premises = premisesFactory.build()

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -150,29 +150,6 @@ export default class PremisesService {
     return ''
   }
 
-  /**
-   * getPremisesSelectList
-   * @deprecated per ADR-0008: manipulation of view data should happen in the views
-   */
-  async getPremisesSelectList(token: string): Promise<Array<{ text: string; value: string }>> {
-    const premisesClient = this.premisesClientFactory(token)
-    const premises = await premisesClient.all()
-
-    return premises
-      .map(singlePremises => {
-        return { text: `${singlePremises.name}`, value: `${singlePremises.id}` }
-      })
-      .sort((a, b) => {
-        if (a.text < b.text) {
-          return -1
-        }
-        if (a.text > b.text) {
-          return 1
-        }
-        return 0
-      })
-  }
-
   async summaryListForPremises(premises: ApprovedPremises): Promise<SummaryList> {
     return {
       rows: [

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -196,7 +196,7 @@ describe('bookingUtils', () => {
               href: paths.bookings.departures.new({ premisesId, bookingId: booking.id }),
             },
             {
-              text: 'Extend placement',
+              text: 'Change departure date',
               classes: 'govuk-button--secondary',
               href: paths.bookings.extensions.new({ premisesId, bookingId: booking.id }),
             },

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -136,7 +136,7 @@ export const bookingActions = (booking: Booking, premisesId: string): Array<Iden
         href: paths.bookings.departures.new({ premisesId, bookingId: booking.id }),
       })
       items.push({
-        text: 'Extend placement',
+        text: 'Change departure date',
         classes: 'govuk-button--secondary',
         href: paths.bookings.extensions.new({ premisesId, bookingId: booking.id }),
       })

--- a/server/views/bookings/extensions/confirm.njk
+++ b/server/views/bookings/extensions/confirm.njk
@@ -3,14 +3,14 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Extension confirmed" %}
+{% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             {{ govukPanel({
-            titleText: "Booking extension complete"
+            titleText: pageHeading
             }) }}
             {{ govukSummaryList({
                 rows: [

--- a/server/views/bookings/extensions/new.njk
+++ b/server/views/bookings/extensions/new.njk
@@ -6,7 +6,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Extend placement" %}
+{% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
@@ -23,7 +23,7 @@
             <form action="{{ paths.bookings.extensions.create({ premisesId: premisesId, bookingId: booking.id }) }}" method="post">
 
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-                <h1>Extend placement</h1>
+                <h1>{{pageHeading}}</h1>
 
                 {{ govukSummaryList({
                 rows: [


### PR DESCRIPTION
# Context

As well as extending a booking, users need to be able to reduce the time that a PoP will stay in an AP.
Therefore we need to change the copy on and around the 'extend a booking' screen.

# Changes in this PR
1. We delete an unused method on the Premises service - unrelated to these changes.
2. We update the copy and filenames around the Booking Extension change
3. We update the service name from 'extendBooking' to 'changeDepartureDate'


## Screenshots of UI changes

### Before
![bfore 1](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/28b26a08-7878-4d6d-a298-caf321fd33f2)
![bfore 2](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/fe33d4f9-8b31-49c0-a7e6-ce6f573926ff)

### After
![booking-extension-create-page-after](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/bdf5009b-44ef-4fb6-8c76-1fe9e8b5cdf6)
![booking-extension-confirmation-page-after](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/be21fd8d-46c4-4579-b487-152d6b655998)


