### PR TITLE
(375) User needs to mark a placement request as unable to match

### DIFF
--- a/integration_tests/mockApis/placementRequests.ts
+++ b/integration_tests/mockApis/placementRequests.ts
@@ -263,11 +263,32 @@ export default {
         },
       },
     }),
+
+  stubPlacementRequestUnableToMatch: (placementRequest: PlacementRequest): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: paths.placementRequests.bookingNotMade({ id: placementRequest.id }),
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+      },
+    }),
   verifyPlacementRequestWithdrawal: async (placementRequest: PlacementRequest) =>
     (
       await getMatchingRequests({
         method: 'POST',
         url: paths.placementRequests.withdrawal.create({ id: placementRequest.id }),
+      })
+    ).body.requests,
+  verifyPlacementRequestedMarkedUnableToMatch: async (placementRequest: PlacementRequest) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: paths.placementRequests.bookingNotMade({ id: placementRequest.id }),
       })
     ).body.requests,
 }

--- a/integration_tests/pages/admin/placementApplications/showPage.ts
+++ b/integration_tests/pages/admin/placementApplications/showPage.ts
@@ -50,6 +50,11 @@ export default class ShowPage extends Page {
     cy.contains('.moj-button-menu__item', 'Withdraw placement request').click()
   }
 
+  clickUnableToMatch() {
+    cy.get('.moj-button-menu__toggle-button').click()
+    cy.contains('.moj-button-menu__item', 'Mark as unable to match').click()
+  }
+
   shouldShowCreateBookingOption() {
     this.buttonShouldExist('Create placement')
   }

--- a/integration_tests/pages/manage/index.ts
+++ b/integration_tests/pages/manage/index.ts
@@ -6,6 +6,8 @@ import LostBedListPage from './lostBedList'
 import LostBedShowPage from './lostBedShow'
 import PremisesListPage from './premisesList'
 import PremisesShowPage from './premisesShow'
+import WithdrawConfirmPage from './withdrawConfirm'
+import UnableToMatchPage from './unableToMatch'
 
 import BedsListPage from './bed/bedsList'
 import BedShowPage from './bed/bedShow'
@@ -40,4 +42,6 @@ export {
   BedShowPage,
   CalendarPage,
   NewDateChangePage,
+  WithdrawConfirmPage,
+  UnableToMatchPage,
 }

--- a/integration_tests/pages/manage/unableToMatch.ts
+++ b/integration_tests/pages/manage/unableToMatch.ts
@@ -1,0 +1,7 @@
+import Page from '../page'
+
+export default class UnableToMatchPage extends Page {
+  constructor() {
+    super('Mark as unable to match')
+  }
+}

--- a/server/controllers/admin/index.ts
+++ b/server/controllers/admin/index.ts
@@ -3,6 +3,7 @@
 import AdminPlacementRequestsController from './placementRequestsController'
 import PlacementRequestsBookingsController from './placementRequests/bookingsController'
 import PlacementRequestsWithdrawalsController from './placementRequests/withdrawalsController'
+import PlacementRequestUnableToMatchController from './placementRequests/unableToMatchController'
 import ReportsController from './reportsController'
 
 import type { Services } from '../../services'
@@ -16,13 +17,21 @@ export const controllers = (services: Services) => {
   )
   const placementRequestWithdrawalsController = new PlacementRequestsWithdrawalsController(placementRequestService)
   const reportsController = new ReportsController(reportService)
+  const placementRequestUnableToMatchController = new PlacementRequestUnableToMatchController(placementRequestService)
 
   return {
     adminPlacementRequestsController,
     placementRequestsBookingsController,
     placementRequestWithdrawalsController,
     reportsController,
+    placementRequestUnableToMatchController,
   }
 }
 
-export { AdminPlacementRequestsController, PlacementRequestsBookingsController, ReportsController }
+export {
+  AdminPlacementRequestsController,
+  PlacementRequestsBookingsController,
+  PlacementRequestUnableToMatchController,
+  PlacementRequestsWithdrawalsController,
+  ReportsController,
+}

--- a/server/controllers/admin/placementRequests/unableToMatchController.test.ts
+++ b/server/controllers/admin/placementRequests/unableToMatchController.test.ts
@@ -3,6 +3,7 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
 import { PlacementRequestService } from '../../../services'
 
+import paths from '../../../paths/admin'
 import UnableToMatchController from './unableToMatchController'
 
 jest.mock('../../../utils/validation')
@@ -39,6 +40,26 @@ describe('unableToMatchController', () => {
         pageHeading: 'Mark as unable to match',
         id: request.params.id,
       })
+    })
+  })
+
+  describe('create', () => {
+    const prId = 'some-id'
+
+    beforeEach(() => {
+      request.params.id = prId
+    })
+
+    it('calls the service method, redirects to the index screen and shows a confirmation message', async () => {
+      request.body.confirm = 'yes'
+
+      const requestHandler = unableToMatchController.create()
+
+      await requestHandler(request, response, next)
+
+      expect(placementRequestService.bookingNotMade).toHaveBeenCalledWith(token, prId, { notes: '' })
+      expect(response.redirect).toHaveBeenCalledWith(paths.admin.placementRequests.show({ id: prId }))
+      expect(request.flash).toHaveBeenCalledWith('success', 'Placement request has been marked unable to match')
     })
   })
 })

--- a/server/controllers/admin/placementRequests/unableToMatchController.test.ts
+++ b/server/controllers/admin/placementRequests/unableToMatchController.test.ts
@@ -1,0 +1,44 @@
+import type { NextFunction, Request, Response } from 'express'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+
+import { PlacementRequestService } from '../../../services'
+
+import UnableToMatchController from './unableToMatchController'
+
+jest.mock('../../../utils/validation')
+
+describe('unableToMatchController', () => {
+  const token = 'SOME_TOKEN'
+
+  let request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  let response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = jest.fn()
+
+  const placementRequestService = createMock<PlacementRequestService>({})
+
+  let unableToMatchController: UnableToMatchController
+
+  beforeEach(() => {
+    unableToMatchController = new UnableToMatchController(placementRequestService)
+    request = createMock<Request>({ user: { token } })
+    response = createMock<Response>({})
+    jest.clearAllMocks()
+  })
+
+  describe('new', () => {
+    it('renders the template', async () => {
+      const applicationId = 'some-id'
+
+      request.params.id = applicationId
+
+      const requestHandler = unableToMatchController.new()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('admin/placementRequests/unableToMatch/new', {
+        pageHeading: 'Mark as unable to match',
+        id: request.params.id,
+      })
+    })
+  })
+})

--- a/server/controllers/admin/placementRequests/unableToMatchController.ts
+++ b/server/controllers/admin/placementRequests/unableToMatchController.ts
@@ -1,6 +1,7 @@
 import type { Request, RequestHandler, Response } from 'express'
 
 import { PlacementRequestService } from '../../../services'
+import paths from '../../../paths/admin'
 
 export const tasklistPageHeading = 'Apply for an Approved Premises (AP) placement'
 
@@ -13,6 +14,16 @@ export default class UnableToMatchController {
         pageHeading: 'Mark as unable to match',
         id: req.params.id,
       })
+    }
+  }
+
+  create(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      await this.placementRequestService.bookingNotMade(req.user.token, req.params.id, { notes: '' })
+
+      req.flash('success', 'Placement request has been marked unable to match')
+
+      res.redirect(paths.admin.placementRequests.show({ id: req.params.id }))
     }
   }
 }

--- a/server/controllers/admin/placementRequests/unableToMatchController.ts
+++ b/server/controllers/admin/placementRequests/unableToMatchController.ts
@@ -1,0 +1,18 @@
+import type { Request, RequestHandler, Response } from 'express'
+
+import { PlacementRequestService } from '../../../services'
+
+export const tasklistPageHeading = 'Apply for an Approved Premises (AP) placement'
+
+export default class UnableToMatchController {
+  constructor(private readonly placementRequestService: PlacementRequestService) {}
+
+  new(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      return res.render('admin/placementRequests/unableToMatch/new', {
+        pageHeading: 'Mark as unable to match',
+        id: req.params.id,
+      })
+    }
+  }
+}

--- a/server/paths/admin.ts
+++ b/server/paths/admin.ts
@@ -22,6 +22,10 @@ export default {
         new: withdrawalPath.path('new'),
         create: withdrawalPath,
       },
+      unableToMatch: {
+        new: unableToMatchPath.path('new'),
+        create: unableToMatchPath,
+      },
     },
     reports: {
       new: adminPath.path('reports'),

--- a/server/paths/admin.ts
+++ b/server/paths/admin.ts
@@ -8,6 +8,8 @@ const bookingsPath = placementRequestPath.path('bookings')
 
 const withdrawalPath = placementRequestPath.path('withdrawal')
 
+const unableToMatchPath = placementRequestPath.path('unable-to-match')
+
 export default {
   admin: {
     placementRequests: {

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -68,6 +68,9 @@ export default function routes(controllers: Controllers, router: Router, service
   get(paths.admin.placementRequests.unableToMatch.new.pattern, placementRequestUnableToMatchController.new(), {
     auditEvent: 'ADMIN_NEW_PLACEMENT_REQUEST_UNABLE_TO_MATCH',
   })
+  post(paths.admin.placementRequests.unableToMatch.create.pattern, placementRequestUnableToMatchController.create(), {
+    auditEvent: 'ADMIN_NEW_PLACEMENT_REQUEST_UNABLE_TO_MATCH_SUCCESS',
+  })
 
   get(paths.admin.reports.new.pattern, reportsController.new(), {
     auditEvent: 'ADMIN_ACCESS_REPORTS_SECTION',

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -14,6 +14,7 @@ export default function routes(controllers: Controllers, router: Router, service
     adminPlacementRequestsController,
     placementRequestsBookingsController,
     placementRequestWithdrawalsController,
+    placementRequestUnableToMatchController,
     reportsController,
   } = controllers
 
@@ -62,6 +63,10 @@ export default function routes(controllers: Controllers, router: Router, service
         auditEvent: 'ADMIN_CREATE_PLACEMENT_REQUEST_WITHDRAWL_SUCCESS',
       },
     ],
+  })
+
+  get(paths.admin.placementRequests.unableToMatch.new.pattern, placementRequestUnableToMatchController.new(), {
+    auditEvent: 'ADMIN_NEW_PLACEMENT_REQUEST_UNABLE_TO_MATCH',
   })
 
   get(paths.admin.reports.new.pattern, reportsController.new(), {

--- a/server/utils/placementRequests/adminIdentityBar.test.ts
+++ b/server/utils/placementRequests/adminIdentityBar.test.ts
@@ -39,6 +39,10 @@ describe('adminIdentityBar', () => {
           href: adminPaths.admin.placementRequests.withdrawal.new({ id: placementRequestDetail.id }),
           text: 'Withdraw placement request',
         },
+        {
+          href: adminPaths.admin.placementRequests.unableToMatch.new({ id: placementRequestDetail.id }),
+          text: 'Mark as unable to match',
+        },
       ])
     })
   })

--- a/server/utils/placementRequests/adminIdentityBar.ts
+++ b/server/utils/placementRequests/adminIdentityBar.ts
@@ -39,6 +39,10 @@ export const adminActions = (placementRequest: PlacementRequestDetail): Array<Id
       href: adminPaths.admin.placementRequests.withdrawal.new({ id: placementRequest.id }),
       text: 'Withdraw placement request',
     },
+    {
+      href: adminPaths.admin.placementRequests.unableToMatch.new({ id: placementRequest.id }),
+      text: 'Mark as unable to match',
+    },
   ]
 }
 

--- a/server/views/admin/placementRequests/unableToMatch/new.njk
+++ b/server/views/admin/placementRequests/unableToMatch/new.njk
@@ -1,0 +1,39 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+		text: "Back",
+		href: paths.admin.placementRequests.show({ id: id })
+	}) }}
+{% endblock %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="{{ paths.admin.placementRequests.unableToMatch.create({ id: id }) }}" method="post">
+                <h1 class="govuk-heading-xl">{{ pageHeading }}</h1>
+
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+                <p class="govuk-body">We recommend that you continue to search for a placement weekly until a match is found.</p>
+                <p class="govuk-body">If the expected arrival date is less than 4 weeks away, consider the referral prioritisation approach or escalation to an AP Area Manager.</p>
+                <p class="govuk-body">This placement request will be added to your dashboard</p>
+
+                <div class="govuk-button-group">
+                    {{ govukButton({
+                        name: 'submit',
+                        text: "Continue"
+                    }) }}
+                    <a class="govuk-link" href="{{paths.admin.placementRequests.show({ id: id })}}">Back to placement details</a>
+                </div>
+            </form>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
[Trello](https://trello.com/c/d8bith7k/375-user-needs-to-mark-a-placement-request-as-unable-to-match)

# Changes in this PR
- We add a controller with  'new' and 'create' methods to allow an admin user to mark a Placement Request as unable to match
- We add the view
## Screenshots of UI changes
![1](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/1c35b81c-3dd4-4462-b457-e1b5f2801d61)
![2](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/e1e1cb2f-d45b-4aab-b5eb-7b8f9c13f75d)

