### PR TITLE
(350) Cancellation reasons to be updated

### DIFF
--- a/server/services/cancellationService.test.ts
+++ b/server/services/cancellationService.test.ts
@@ -41,13 +41,16 @@ describe('DepartureService', () => {
 
   describe('getCancellationReasons', () => {
     it('should return the cancellation reasons', async () => {
-      const cancellationReasons = referenceDataFactory.buildList(2)
+      const activeReasons = referenceDataFactory.buildList(2, { isActive: true })
+      const inactiveReasons = referenceDataFactory.buildList(2, { isActive: false })
+
+      const cancellationReasons = [...inactiveReasons, ...activeReasons]
 
       referenceDataClient.getReferenceData.mockResolvedValue(cancellationReasons)
 
       const result = await service.getCancellationReasons(token)
 
-      expect(result).toEqual(cancellationReasons)
+      expect(result).toEqual(activeReasons)
 
       expect(ReferenceDataClientFactory).toHaveBeenCalledWith(token)
       expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('cancellation-reasons')

--- a/server/services/cancellationService.ts
+++ b/server/services/cancellationService.ts
@@ -26,6 +26,6 @@ export default class CancellationService {
 
     const reasons = await referenceDataClient.getReferenceData('cancellation-reasons')
 
-    return reasons as Array<ReferenceData>
+    return reasons.filter(r => r.isActive) as Array<ReferenceData>
   }
 }

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -2,7 +2,6 @@ import { createMock } from '@golevelup/ts-jest'
 
 import type { ErrorMessages } from '@approved-premises/ui'
 import {
-  cancellationReasonRadioItems,
   convertArrayToRadioItems,
   convertKeyValuePairToCheckBoxItems,
   convertKeyValuePairToRadioItems,
@@ -122,39 +121,6 @@ describe('formUtils', () => {
           text: 'abc',
           value: '123',
           checked: true,
-        },
-        {
-          text: 'def',
-          value: '345',
-          checked: false,
-        },
-      ])
-    })
-  })
-
-  describe('cancellationReasonRadioItems', () => {
-    const objects = [
-      {
-        id: '123',
-        name: 'Booking successfully appealed',
-      },
-      {
-        id: '345',
-        name: 'def',
-      },
-    ]
-
-    it('converts objects to an array of radio items', () => {
-      const result = cancellationReasonRadioItems(objects, 'somehtml', {})
-
-      expect(result).toEqual([
-        {
-          text: 'Appealed placement approved by AP area manager (APAM)',
-          value: '123',
-          checked: false,
-          conditional: {
-            html: 'somehtml',
-          },
         },
         {
           text: 'def',

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -47,25 +47,6 @@ export const convertObjectsToRadioItems = (
   })
 }
 
-export const cancellationReasonRadioItems = (
-  cancellationReasons: Array<Record<string, string>>,
-  appealHtml: string,
-  context: Record<string, unknown>,
-): Array<RadioItem> => {
-  const items = convertObjectsToRadioItems(cancellationReasons, 'name', 'id', 'cancellation[reason]', context)
-
-  return items.map(item => {
-    if (item.text === 'Booking successfully appealed') {
-      item.text = 'Appealed placement approved by AP area manager (APAM)'
-      item.conditional = {
-        html: appealHtml,
-      }
-    }
-
-    return item
-  })
-}
-
 export const convertObjectsToSelectOptions = (
   items: Array<Record<string, string>>,
   prompt: string,

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -16,7 +16,6 @@ import {
   sentenceCase,
 } from './utils'
 import {
-  cancellationReasonRadioItems,
   convertKeyValuePairToRadioItems,
   convertObjectsToRadioItems,
   convertObjectsToSelectOptions,
@@ -131,13 +130,6 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
       fieldName: string,
     ) {
       return convertObjectsToRadioItems(items, textKey, valueKey, fieldName, this.ctx)
-    },
-  )
-
-  njkEnv.addGlobal(
-    'cancellationReasonRadioItems',
-    function sendContextToCancellationReasonRadioItems(items: Array<Record<string, string>>, appealHtml: string) {
-      return cancellationReasonRadioItems(items, appealHtml, this.ctx)
     },
   )
 

--- a/server/views/cancellations/new.njk
+++ b/server/views/cancellations/new.njk
@@ -87,33 +87,6 @@
             items: dateFieldValues('date', errors)
         }) }}
 
-        {% set appealHtml %}
-
-        {% set appealBody %}
-        <p class="govuk-body">You must receive approval from your APAM to appeal a placement before cancelling it.</p>
-
-        <p class="govuk-body">Reasons for appealing a placement may include:</p>
-
-        <ul class="govuk-list govuk-list--bullet">
-          <li>an overlap with a person who is co-accused</li>
-          <li>gang / rival members in the AP</li>
-          <li>an unmanageable mix of offence and behaviour types in the AP</li>
-          <li>staff conflict of interest</li>
-        </ul>
-
-        <p class="govuk-body">You will need to provide the name of the APAM, their contact details, an outline of the discussion and when it took place.</p>
-
-        <p class="govuk-body">Appealed placements will be returned to the central referral unit to be matched to another AP.</p>
-        {% endset %}
-
-        {{
-          govukNotificationBanner({
-            html: appealBody
-          })
-        }}
-
-        {% endset %}
-
         {{ govukRadios({
           name: "cancellation[reason]",
           id: "reason",
@@ -124,7 +97,7 @@
               }
           },
           errorMessage: errors.reason,
-          items: cancellationReasonRadioItems(cancellationReasons, appealHtml)
+          items: convertObjectsToRadioItems(cancellationReasons, 'name', 'id', 'cancellation[reason]')
           }) }}
 
         {{ govukTextarea({

--- a/wiremock/stubs/cancellation-reasons.json
+++ b/wiremock/stubs/cancellation-reasons.json
@@ -1,18 +1,22 @@
 [
   {
     "id": "78b9c1a4-1d60-11ed-861d-0242ac120002",
-    "name": "Recall"
+    "name": "Recall",
+    "isActive": true
   },
   {
     "id": "51b44b8c-f7f3-415d-90c3-61bb7fb96286",
-    "name": "Death"
+    "name": "Death",
+    "isActive": true
   },
   {
     "id": "9ddc9bfc-72fa-4a25-88c0-cc0ff8c6c00e",
-    "name": "Request from probabtion practictioner"
+    "name": "Request from probabtion practictioner",
+    "isActive": true
   },
   {
     "id": "7f3eb6cd-b3fc-4a8d-b9ce-5959918ffbe8",
-    "name": "Non-arrival"
+    "name": "Non-arrival",
+    "isActive": true
   }
 ]


### PR DESCRIPTION
Now the "Booking successfully appealed" reason has been retired (https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/890), we don't need to show a warning. We also update the service to ensure only active reasons are returned.