### PR TITLE
(296) Github action for updating the bank holidays json

### DIFF
--- a/.github/workflows/fetch-bank-holidays.yml
+++ b/.github/workflows/fetch-bank-holidays.yml
@@ -1,0 +1,41 @@
+name: Fetch bank holidays JSON from the gov.uk API
+
+on:
+  schedule:
+    - cron: '55 8 * * *'
+
+jobs:
+  call_api:
+    name: Call API
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Call API
+        id: call_api
+        run: |
+          curl -o bank-holidays.json https://www.gov.uk/bank-holidays.json
+          mv bank-holidays.json ./server/data/bankHolidays/bank-holidays.json
+  create_pr:
+    name: Create Pull Request
+    needs: call_api
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          title: 'Bank holiday updates'
+          commit-message: 'Update bank holidays'
+          body: 'This PR updates the bank holidays JSON file from the gov.uk API.'
+          delete-branch: true
+          branch-suffix: timestamp
+          branch: bh-updates

--- a/server/data/bankHolidays/bank-holidays.json
+++ b/server/data/bankHolidays/bank-holidays.json
@@ -1,0 +1,22 @@
+{
+  "england-and-wales": {
+    "division": "england-and-wales",
+    "events": [
+      { "title": "New Year’s Day", "date": "2018-01-01", "notes": "", "bunting": true },
+      { "title": "Good Friday", "date": "2018-03-30", "notes": "", "bunting": false },
+      { "title": "Easter Monday", "date": "2018-04-02", "notes": "", "bunting": true },
+      { "title": "Early May bank holiday", "date": "2018-05-07", "notes": "", "bunting": true },
+      { "title": "Spring bank holiday", "date": "2018-05-28", "notes": "", "bunting": true },
+      { "title": "Summer bank holiday", "date": "2018-08-27", "notes": "", "bunting": true },
+      { "title": "Christmas Day", "date": "2018-12-25", "notes": "", "bunting": true },
+      { "title": "Boxing Day", "date": "2018-12-26", "notes": "", "bunting": true },
+      { "title": "New Year’s Day", "date": "2019-01-01", "notes": "", "bunting": true },
+      { "title": "Good Friday", "date": "2019-04-19", "notes": "", "bunting": false },
+      { "title": "Easter Monday", "date": "2019-04-22", "notes": "", "bunting": true },
+      { "title": "Early May bank holiday", "date": "2019-05-06", "notes": "", "bunting": true },
+      { "title": "Spring bank holiday", "date": "2019-05-27", "notes": "", "bunting": true },
+      { "title": "Summer bank holiday", "date": "2019-08-26", "notes": "", "bunting": true },
+      { "title": "Christmas Day", "date": "2019-12-25", "notes": "", "bunting": true }
+    ]
+  }
+}


### PR DESCRIPTION
[Trello card](https://trello.com/c/lRTWjnm3/390-create-date-change-option-should-appear-for-arrived-bookings)

We want to use 'working days' in the calendar (and potentially in future elsewhere).
In order for us to do this we need to be able to include bank holidays. As bank holidays are liable to change at short notice (EG last year) we need to make sure that these are kept up to date. 

This PR adds a Github action that calls the [gov.uk bank holidays API](https://www.api.gov.uk/gds/bank-holidays/#bank-holidays) and updates a file containing the bank holidays in this repo every night at midnight, if they have changed.