### PR TITLE
(296) Github action for updating the bank holidays json

### DIFF
--- a/.github/workflows/fetch-bank-holidays.yml
+++ b/.github/workflows/fetch-bank-holidays.yml
@@ -2,7 +2,7 @@ name: Fetch bank holidays JSON from the gov.uk API
 
 on:
   schedule:
-    - cron: '55 8 * * *'
+    - cron: '30 10 * * *'
 
 jobs:
   call_api:
@@ -16,11 +16,6 @@ jobs:
         run: |
           curl -o bank-holidays.json https://www.gov.uk/bank-holidays.json
           mv bank-holidays.json ./server/data/bankHolidays/bank-holidays.json
-  create_pr:
-    name: Create Pull Request
-    needs: call_api
-    runs-on: ubuntu-latest
-    steps:
       - name: Generate Token
         uses: tibdex/github-app-token@v1
         id: generate-token


### PR DESCRIPTION
The previous job failed when creating a branch because the state is lost between jobs. 
Here we consolidate the two jobs into one to retain state