### PR TITLE
(296) Show working days until assessment of application is due

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "connect-flash": "^0.1.1",
         "connect-redis": "^7.0.0",
         "csurf": "^1.11.0",
-        "date-fns": "^2.29.3",
+        "date-fns": "^2.30.0",
         "dotenv": "^16.0.3",
         "express": "^4.18.1",
         "express-prom-bundle": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "connect-flash": "^0.1.1",
     "connect-redis": "^7.0.0",
     "csurf": "^1.11.0",
-    "date-fns": "^2.29.3",
+    "date-fns": "^2.30.0",
     "dotenv": "^16.0.3",
     "express": "^4.18.1",
     "express-prom-bundle": "^6.5.0",

--- a/server/utils/assessments/dateUtils.ts
+++ b/server/utils/assessments/dateUtils.ts
@@ -4,7 +4,7 @@ import {
   ApprovedPremisesAssessment as Assessment,
   AssessmentSummary,
 } from '@approved-premises/api'
-import { DateFormats } from '../dateUtils'
+import { DateFormats, differenceInBusinessDays } from '../dateUtils'
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
 
 const DUE_DATE_APPROACHING_DAYS_WINDOW = 3
@@ -35,7 +35,7 @@ const daysUntilDue = (assessment: AssessmentSummary): number => {
   const receivedDate = DateFormats.isoToDateObj(assessment.createdAt)
   const dueDate = add(receivedDate, { days: 10 })
 
-  return differenceInDays(dueDate, new Date())
+  return differenceInBusinessDays(dueDate, new Date())
 }
 
 const daysToWeeksAndDays = (days: string | number): { days: number; weeks: number } => {

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -136,7 +136,7 @@ describe('utils', () => {
         assessmentSummaryFactory.createdXDaysAgo(1).build(),
         assessmentSummaryFactory.createdXDaysAgo(2).build(),
         assessmentSummaryFactory.createdXDaysAgo(9).build(),
-        assessmentSummaryFactory.createdXDaysAgo(7).build(),
+        assessmentSummaryFactory.createdXDaysAgo(8).build(),
       ]
 
       expect(assessmentsApproachingDue(assessments)).toEqual(2)

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -8,6 +8,7 @@ import type { ObjectWithDateParts } from '@approved-premises/ui'
 import {
   DateFormats,
   InvalidDateStringError,
+  bankHolidays,
   dateAndTimeInputsAreValidDates,
   dateIsBlank,
   dateIsInThePast,
@@ -19,6 +20,19 @@ import {
 jest.mock('date-fns/isPast')
 jest.mock('date-fns/formatDistanceStrict')
 jest.mock('date-fns/differenceInDays')
+jest.mock('../data/bankHolidays/bank-holidays.json', () => {
+  return {
+    'england-and-wales': {
+      division: 'england-and-wales',
+      events: [
+        { title: 'New Year’s Day', date: '2018-01-01', notes: '', bunting: true },
+        { title: 'Good Friday', date: '2018-03-30', notes: '', bunting: false },
+        { title: 'Easter Monday', date: '2018-04-02', notes: '', bunting: true },
+        { title: 'Early May bank holiday', date: '2018-05-07', notes: '', bunting: true },
+      ],
+    },
+  }
+})
 
 describe('DateFormats', () => {
   describe('convertIsoToDateObj', () => {
@@ -357,6 +371,16 @@ describe('monthOptions', () => {
       { name: 'October', value: '10' },
       { name: 'November', value: '11' },
       { name: 'December', value: '12' },
+    ])
+  })
+})
+describe('bankHolidays', () => {
+  it('maps the bank-holidays.json an array of dates', () => {
+    expect(bankHolidays()).toEqual([
+      new Date('2018-01-01'),
+      new Date('2018-03-30'),
+      new Date('2018-04-02'),
+      new Date('2018-05-07'),
     ])
   })
 })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import type { ObjectWithDateParts } from '@approved-premises/ui'
 
 import { differenceInDays, formatDistanceStrict, formatISO, parseISO, format, isPast, formatDuration } from 'date-fns'
@@ -38,9 +37,8 @@ export class DateFormats {
   static dateObjtoUIDate(date: Date, options: { format: 'short' | 'long' } = { format: 'long' }) {
     if (options.format === 'long') {
       return format(date, 'cccc d MMMM y')
-    } else {
-      return format(date, 'dd/LL/y')
     }
+    return format(date, 'dd/LL/y')
   }
 
   /**
@@ -148,12 +146,18 @@ export class DateFormats {
     return DateFormats.dateObjectToDateInputs(DateFormats.isoToDateObj(isoDate), key)
   }
 
-  static formatDuration(duration: DurationWithNumberOrString, format: Array<string> = ['weeks', 'days']): string {
+  static formatDuration(
+    duration: DurationWithNumberOrString,
+    durationFormat: Array<string> = ['weeks', 'days'],
+  ): string {
     const formattedDuration = {} as Duration
-    Object.keys(duration).forEach(k => (formattedDuration[k] = Number(duration[k])))
+
+    Object.keys(duration).forEach(k => {
+      formattedDuration[k] = Number(duration[k])
+    })
 
     return formatDuration(formattedDuration, {
-      format,
+      format: durationFormat,
       delimiter: ', ',
     })
   }
@@ -223,8 +227,9 @@ export const monthOptions = [
 
 export const yearOptions = (startYear: number) => getYearsSince(startYear).map(year => ({ name: year, value: year }))
 
+/* eslint-disable */
 export const getYearsSince = (startYear: number): Array<string> => {
-  let years = []
+  const years: Array<string> = []
   const thisYear = new Date().getFullYear()
   while (startYear <= thisYear) {
     years.push((startYear++).toString())

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,7 +1,21 @@
+import {
+  differenceInBusinessDays as differenceInBusinessDaysDateFns,
+  differenceInDays,
+  format,
+  formatDistanceStrict,
+  formatDuration,
+  formatISO,
+  isBefore,
+  isPast,
+  isValid,
+  isWeekend,
+  isWithinInterval,
+  parseISO,
+  toDate,
+} from 'date-fns'
+
 import type { ObjectWithDateParts } from '@approved-premises/ui'
 import rawBankHolidays from '../data/bankHolidays/bank-holidays.json'
-
-import { differenceInDays, formatDistanceStrict, formatISO, parseISO, format, isPast, formatDuration } from 'date-fns'
 
 type DifferenceInDays = { ui: string; number: number }
 
@@ -236,6 +250,35 @@ export const getYearsSince = (startYear: number): Array<string> => {
     years.push((startYear++).toString())
   }
   return years
+}
+
+/**
+ * differenceInBusinessDays returns the number of business days between two dates excluding holidays.
+ * This is the same as date-fns' differenceInBusinessDays, but with the addition of a holidays parameter.
+ * We hope to be able to remove this once this PR is merged: https://github.com/date-fns/date-fns/pull/3475
+ * @param {Date} dateLeft
+ * @param {Date} dateRight
+ * @param {Array<Date>} holidays
+ * @returns {number}
+ */
+export function differenceInBusinessDays(
+  dateLeft: Date,
+  dateRight: Date,
+  holidays: Array<Date> = bankHolidays(),
+): number {
+  if (!isValid(dateLeft) || !isValid(dateRight)) return NaN
+
+  const { earlierDate, laterDate } = isBefore(dateLeft, dateRight)
+    ? { earlierDate: dateLeft, laterDate: dateRight }
+    : { earlierDate: dateRight, laterDate: dateLeft }
+
+  const holidaysLength = holidays
+    .map(holiday => toDate(holiday))
+    .filter(holiday => isWithinInterval(holiday, { start: earlierDate, end: laterDate }) && !isWeekend(holiday)).length
+
+  const differenceInBusinessDaysWithoutHolidays = differenceInBusinessDaysDateFns(dateLeft, dateRight)
+
+  return differenceInBusinessDaysWithoutHolidays - holidaysLength
 }
 
 type RawBankHolidays = {

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,4 +1,5 @@
 import type { ObjectWithDateParts } from '@approved-premises/ui'
+import rawBankHolidays from '../data/bankHolidays/bank-holidays.json'
 
 import { differenceInDays, formatDistanceStrict, formatISO, parseISO, format, isPast, formatDuration } from 'date-fns'
 
@@ -235,6 +236,20 @@ export const getYearsSince = (startYear: number): Array<string> => {
     years.push((startYear++).toString())
   }
   return years
+}
+
+type RawBankHolidays = {
+  'england-and-wales': {
+    division: 'england-and-wales'
+    events: Array<{
+      title: string
+      date: string
+    }>
+  }
+}
+
+export const bankHolidays = () => {
+  return (rawBankHolidays as RawBankHolidays)['england-and-wales'].events.map(event => new Date(event.date))
 }
 
 export class InvalidDateStringError extends Error {}


### PR DESCRIPTION
# Context
Previously the assessment dashboard showed calendar days until an assessment's due date. This is misleading as  the time until the assessment is due should be counted in working days. [date-fns' business days function](https://date-fns.org/v2.29.2/docs/differenceInBusinessDays) simply removes weekends from the calculation of business days but doesn't take into account holidays. 
@pezholio opened a PR to add an optional parameter of an array of holiday days to this function via [this PR](https://github.com/date-fns/date-fns/pull/3475) but it is yet to be merged or even acknowledged. 
In the meantime we can borrow most of his work for this PR and build on #1048 to calculate working days with weekends *and* bank holidays substracted. 

# Changes in this PR
- We reinstate linting of the dateUtils.ts file to make it easier to work with 
- We add the function to calculate difference in business days including UK bank holidays
- We use the function in the assessment dashboard 
- We correct some tests that fail because of complications introduced by using business days instead of calendar days. 
