### PR TITLE
(309) Handle LAO in backward compatible manner

### DIFF
--- a/server/form-pages/apply/move-on/relocationRegion.test.ts
+++ b/server/form-pages/apply/move-on/relocationRegion.test.ts
@@ -26,7 +26,9 @@ describe('RelocationRegion', () => {
     })
 
     it('returns the question without the persons name if they are a restricted person', () => {
-      const page = new RelocationRegion({}, applicationFactory.build({ person: restrictedPersonFactory.build() }))
+      const restrictedPersonApplication = applicationFactory.build({ person: restrictedPersonFactory.build() })
+      restrictedPersonApplication.person = restrictedPersonFactory.build()
+      const page = new RelocationRegion({}, restrictedPersonApplication)
 
       expect(page.question).toEqual('Where is the person most likely to live when they move on from the AP?')
     })

--- a/server/utils/assessments/tableUtils.test.ts
+++ b/server/utils/assessments/tableUtils.test.ts
@@ -19,6 +19,7 @@ import {
 } from './tableUtils'
 import paths from '../../paths/assess'
 import { crnCell, tierCell } from '../tableUtils'
+import { ApprovedPremisesAssessmentSummary as AssessmentSummary } from '../../@types/shared'
 
 jest.mock('../applications/arrivalDateFromApplication')
 
@@ -88,8 +89,8 @@ describe('tableUtils', () => {
 
   describe('awaitingAssessmentTableRows', () => {
     it('returns table rows for the assessments', () => {
-      const assessment = assessmentSummaryFactory.build({ person })
-
+      const assessment = assessmentSummaryFactory.build()
+      assessment.person = person
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
 
       expect(awaitingAssessmentTableRows([assessment])).toEqual([
@@ -106,8 +107,9 @@ describe('tableUtils', () => {
     })
 
     it('returns table rows for the assessments for a RestrictedPerson', () => {
-      const assessment = assessmentSummaryFactory.build({ status: 'awaiting_response', person: restrictedPerson })
+      const assessment = assessmentSummaryFactory.build({ status: 'awaiting_response' })
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
+      assessment.person = restrictedPerson
 
       expect(awaitingAssessmentTableRows([assessment])).toEqual([
         [
@@ -124,9 +126,14 @@ describe('tableUtils', () => {
   })
 
   describe('requestedInformationTableRows', () => {
-    it('returns table rows for the assessments for a FullPerson', () => {
-      const assessment = assessmentSummaryFactory.build({ status: 'awaiting_response', person })
+    let assessment: AssessmentSummary
+    beforeEach(() => {
+      assessment = assessmentSummaryFactory.build()
+    })
 
+    it('returns table rows for the assessments for a FullPerson', () => {
+      assessment = assessmentSummaryFactory.build({ status: 'awaiting_response' })
+      assessment.person = person
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
 
       expect(requestedFurtherInformationTableRows([assessment])).toEqual([
@@ -143,7 +150,8 @@ describe('tableUtils', () => {
     })
 
     it('returns table rows for the assessments for a RestrictedPerson', () => {
-      const assessment = assessmentSummaryFactory.build({ status: 'awaiting_response', person: restrictedPerson })
+      assessment = assessmentSummaryFactory.build({ status: 'awaiting_response' })
+      assessment.person = restrictedPerson
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-01-01')
 
       expect(requestedFurtherInformationTableRows([assessment])).toEqual([

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -138,9 +138,10 @@ describe('bookingUtils', () => {
     })
 
     it('returns "Limited access offender" if they are a restricted person', () => {
-      const restrictedPerson = restrictedPersonFactory.build()
-      expect(nameCell(bookingFactory.build({ person: restrictedPerson }))).toEqual({
-        text: `LAO: ${restrictedPerson.crn}`,
+      const booking = bookingFactory.build()
+      booking.person = restrictedPersonFactory.build()
+      expect(nameCell(booking)).toEqual({
+        text: `LAO: ${booking.person.crn}`,
       })
     })
   })

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -26,7 +26,7 @@ const isApplicableTier = (sex: string, tier: string): boolean => {
   return applicableTiers.includes(tier)
 }
 
-const isFullPerson = (person: Person): person is FullPerson => person.type === 'FullPerson'
+const isFullPerson = (person: Person): person is FullPerson => (person as FullPerson)?.name !== undefined
 
 /**
  * Returns the person's name if they are a FullPerson, otherwise returns 'the person'

--- a/server/utils/placementRequests/adminIdentityBar.test.ts
+++ b/server/utils/placementRequests/adminIdentityBar.test.ts
@@ -59,9 +59,8 @@ describe('adminIdentityBar', () => {
     })
 
     it('should return Limited Access Offender if the person has no name', () => {
-      const placementRequestDetailWithRestrictedAccessOffender = placementRequestDetailFactory.build({
-        person: restrictedPersonFactory.build(),
-      })
+      const placementRequestDetailWithRestrictedAccessOffender = placementRequestDetailFactory.build()
+      placementRequestDetailWithRestrictedAccessOffender.person = restrictedPersonFactory.build()
 
       expect(title(placementRequestDetailWithRestrictedAccessOffender)).toMatchStringIgnoringWhitespace(`
       <span class="govuk-caption-l">Placement request</span>

--- a/server/utils/placementRequests/table.test.ts
+++ b/server/utils/placementRequests/table.test.ts
@@ -62,7 +62,8 @@ describe('tableUtils', () => {
     })
 
     it('returns the crn cell if the person is a restrictedPerson', () => {
-      const restrictedPersonTask = placementRequestFactory.build({ person: restrictedPersonFactory.build() })
+      const restrictedPersonTask = placementRequestFactory.build()
+      restrictedPersonTask.person = restrictedPersonFactory.build()
 
       expect(nameCell(restrictedPersonTask)).toEqual({
         text: `LAO: ${restrictedPersonTask.person.crn}`,


### PR DESCRIPTION
# Context
#974 allowed the UI to handle LAOs but it depended on the `person` object having a `type` property which it won't have until [this API PR is merged](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/804). 
To avoid having to deploy the API and UI changes at exactly the same time I have made the UI changes compatible with the current API.

# Changes in this PR
- We change the `isFullPerson` check from asserting the `person.type === FullPerson` to checking if the `person` has a name. LAOs won't have a name so the original behaviour is retained.
- We update some tests
