### PR TITLE
Pin npm version to 9.8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - checkout
       - run:
           name: Update npm
-          command: 'sudo npm install -g npm@latest'
+          command: 'sudo npm install -g npm@9.8.1'
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:


### PR DESCRIPTION
Following the lead of the 'Create and vary a licence' team (https://github.com/ministryofjustice/create-and-vary-a-licence/pull/644/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R43) we should temporarily pin the version of NPM we use as NPM 10 isn't compatible with the current version of Node and NPM are yet to update their CHANGELOG to acknowledge version 10 or communicate about its release. If we don't do this we are unable to run our CI pipelines.
