### PR TITLE
Flatten checkbox inputs

### DIFF
--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementCCTV.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementCCTV.test.ts
@@ -1,11 +1,16 @@
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
-import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
+import { convertKeyValuePairToCheckBoxItems, flattenCheckboxInput } from '../../../../utils/formUtils'
 
 import EsapPlacementCCTV, { cctvHistory } from './esapPlacementCCTV'
 import { applicationFactory, personFactory } from '../../../../testutils/factories'
 import { retrieveQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 
-jest.mock('../../../../utils/formUtils')
+jest.mock('../../../../utils/formUtils', () => {
+  return {
+    flattenCheckboxInput: jest.fn(arg => arg),
+    convertKeyValuePairToCheckBoxItems: jest.fn(),
+  }
+})
 jest.mock('../../../../utils/retrieveQuestionResponseFromFormArtifact', () => {
   return { retrieveQuestionResponseFromFormArtifact: jest.fn(() => []) }
 })
@@ -113,6 +118,8 @@ describe('EsapPlacementCCTV', () => {
 
   describe('cctvHistoryItems', () => {
     it('it calls convertKeyValuePairToCheckBoxItems with the correct values', () => {
+      ;(flattenCheckboxInput as jest.MockedFunction<typeof flattenCheckboxInput>).mockReturnValue(['prisonerAssualt'])
+
       const page = new EsapPlacementCCTV({ cctvHistory: ['prisonerAssualt'] }, application)
       page.cctvHistoryItems()
 

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementCCTV.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementCCTV.ts
@@ -5,7 +5,7 @@ import { Page } from '../../../utils/decorators'
 import TasklistPage from '../../../tasklistPage'
 import { convertToTitleCase } from '../../../../utils/utils'
 import { retrieveQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
-import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
+import { convertKeyValuePairToCheckBoxItems, flattenCheckboxInput } from '../../../../utils/formUtils'
 import EsapPlacementScreening, { EsapReasons } from './esapPlacementScreening'
 import { nameOrPlaceholderCopy } from '../../../../utils/personUtils'
 
@@ -47,7 +47,9 @@ export default class EsapPlacementCCTV implements TasklistPage {
       cctvNotes: string
     }>,
     private readonly application: ApprovedPremisesApplication,
-  ) {}
+  ) {
+    this.body.cctvHistory = flattenCheckboxInput(body.cctvHistory)
+  }
 
   previous() {
     const esapReasons = retrieveQuestionResponseFromFormArtifact(

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementScreening.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementScreening.test.ts
@@ -1,5 +1,5 @@
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
-import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
+import { convertKeyValuePairToCheckBoxItems, flattenCheckboxInput } from '../../../../utils/formUtils'
 
 import EsapPlacementScreening, { esapFactors, esapReasons } from './esapPlacementScreening'
 import { applicationFactory, personFactory } from '../../../../testutils/factories'
@@ -7,6 +7,9 @@ import { pageDataFromApplicationOrAssessment } from '../../../utils'
 
 jest.mock('../../../../utils/formUtils')
 jest.mock('../../../utils')
+;(flattenCheckboxInput as jest.MockedFunction<typeof flattenCheckboxInput>).mockImplementation(
+  input => input as Array<string>,
+)
 
 describe('EsapPlacementScreening', () => {
   const person = personFactory.build({ name: 'John Wayne' })

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementScreening.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementScreening.ts
@@ -2,7 +2,7 @@ import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import type { TaskListErrors } from '@approved-premises/ui'
 
 import TasklistPage from '../../../tasklistPage'
-import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
+import { convertKeyValuePairToCheckBoxItems, flattenCheckboxInput } from '../../../../utils/formUtils'
 import { Page } from '../../../utils/decorators'
 import EsapExceptionalCase from './esapExceptionalCase'
 import { pageDataFromApplicationOrAssessment } from '../../../utils'
@@ -42,7 +42,10 @@ export default class EsapPlacementScreening implements TasklistPage {
   constructor(
     public body: Partial<{ esapReasons: Array<keyof EsapReasons>; esapFactors: Array<keyof EsapFactors> }>,
     private readonly application: ApprovedPremisesApplication,
-  ) {}
+  ) {
+    this.body.esapFactors = flattenCheckboxInput(body.esapFactors)
+    this.body.esapReasons = flattenCheckboxInput(body.esapReasons)
+  }
 
   previous() {
     if (Object.keys(pageDataFromApplicationOrAssessment(EsapExceptionalCase, this.application)).length) {

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementSecreting.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementSecreting.test.ts
@@ -1,11 +1,16 @@
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
-import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
+import { convertKeyValuePairToCheckBoxItems, flattenCheckboxInput } from '../../../../utils/formUtils'
 
 import EsapPlacementSecreting, { secretingHistory } from './esapPlacementSecreting'
 import { applicationFactory, personFactory } from '../../../../testutils/factories'
 import { retrieveQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 
-jest.mock('../../../../utils/formUtils')
+jest.mock('../../../../utils/formUtils', () => {
+  return {
+    flattenCheckboxInput: jest.fn(arg => arg),
+    convertKeyValuePairToCheckBoxItems: jest.fn(),
+  }
+})
 jest.mock('../../../../utils/retrieveQuestionResponseFromFormArtifact', () => {
   return { retrieveQuestionResponseFromFormArtifact: jest.fn(() => []) }
 })
@@ -24,6 +29,7 @@ describe('EsapPlacementSecreting', () => {
         application,
       )
 
+      expect(flattenCheckboxInput).toHaveBeenCalledWith(['radicalisationLiterature'])
       expect(page.body).toEqual({
         secretingHistory: ['radicalisationLiterature'],
         secretingIntelligence: 'yes',

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementSecreting.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementSecreting.ts
@@ -5,7 +5,7 @@ import { Page } from '../../../utils/decorators'
 import TasklistPage from '../../../tasklistPage'
 import { convertToTitleCase } from '../../../../utils/utils'
 import { retrieveQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
-import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
+import { convertKeyValuePairToCheckBoxItems, flattenCheckboxInput } from '../../../../utils/formUtils'
 import EsapPlacementScreening, { EsapReasons } from './esapPlacementScreening'
 import { nameOrPlaceholderCopy } from '../../../../utils/personUtils'
 
@@ -46,7 +46,9 @@ export default class EsapPlacementSecreting implements TasklistPage {
       secretingNotes: string
     }>,
     private readonly application: ApprovedPremisesApplication,
-  ) {}
+  ) {
+    this.body.secretingHistory = flattenCheckboxInput(body.secretingHistory)
+  }
 
   previous() {
     return 'esap-placement-screening'


### PR DESCRIPTION
When express receives a single response from a checkbox input it 'helpfully' sends it as a string as opposed to the usual array. This means array methods can't be used and causes errors (EG https://ministryofjustice.sentry.io/issues/4395174101/events/f1d83babeea64b809e5b320b1884e2bb/?project=4503931667742720) on the Check Your Answers screen.
