### PR TITLE
(415) Allow searching placement requests by name

### DIFF
--- a/integration_tests/mockApis/placementRequests.ts
+++ b/integration_tests/mockApis/placementRequests.ts
@@ -77,13 +77,13 @@ export default {
   },
   stubPlacementRequestsSearch: ({
     placementRequests,
-    crn = '',
+    crnOrName = '',
     page = '1',
     sortBy = 'created_at',
     sortDirection = 'asc',
   }: {
     placementRequests: Array<PlacementRequest>
-    crn: string
+    crnOrName: string
     page: string
     sortBy: string
     sortDirection: string
@@ -100,9 +100,9 @@ export default {
       },
     } as Record<string, unknown>
 
-    if (crn) {
-      queryParameters.crn = {
-        equalTo: crn,
+    if (crnOrName) {
+      queryParameters.crnOrName = {
+        equalTo: crnOrName,
       }
     }
 
@@ -156,7 +156,7 @@ export default {
       })
     ).body.requests,
   verifyPlacementRequestsSearch: async ({
-    crn,
+    crnOrName,
     tier,
     arrivalDateStart,
     arrivalDateEnd,
@@ -164,7 +164,7 @@ export default {
     sortBy = 'created_at',
     sortDirection = 'asc',
   }: {
-    crn: string
+    crnOrName: string
     tier: RiskTierLevel
     arrivalDateStart: string
     arrivalDateEnd: string
@@ -177,8 +177,8 @@ export default {
         method: 'GET',
         urlPathPattern: paths.placementRequests.dashboard.pattern,
         queryParameters: {
-          crn: {
-            equalTo: crn,
+          crnOrName: {
+            equalTo: crnOrName,
           },
           tier: {
             equalTo: tier,

--- a/integration_tests/pages/admin/placementApplications/searchPage.ts
+++ b/integration_tests/pages/admin/placementApplications/searchPage.ts
@@ -10,7 +10,7 @@ export default class SearchPage extends ListPage {
   }
 
   enterSearchQuery(searchOptions: PlacementRequestDashboardSearchOptions): void {
-    this.getTextInputByIdAndEnterDetails('crn', searchOptions.crn)
+    this.getTextInputByIdAndEnterDetails('crnOrName', searchOptions.crnOrName)
     this.getSelectInputByIdAndSelectAnEntry('tier', searchOptions.tier)
     this.getTextInputByIdAndEnterDetails('arrivalDateStart', searchOptions.arrivalDateStart)
     this.getTextInputByIdAndEnterDetails('arrivalDateEnd', searchOptions.arrivalDateEnd)

--- a/integration_tests/tests/admin/searchPlacementRequests.cy.ts
+++ b/integration_tests/tests/admin/searchPlacementRequests.cy.ts
@@ -8,7 +8,7 @@ context('Search placement Requests', () => {
   const searchResults = placementRequestFactory.buildList(2)
 
   const searchQuery = {
-    crn: 'CRN123',
+    crnOrName: 'CRN123',
     tier: 'D2',
     arrivalDateStart: '2022-01-01',
     arrivalDateEnd: '2022-01-03',

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -438,7 +438,7 @@ export type MiddlewareSpec = {
 }
 
 export type PlacementRequestDashboardSearchOptions = {
-  crn?: string
+  crnOrName?: string
   tier?: RiskTierLevel
   arrivalDateStart?: string
   arrivalDateEnd?: string

--- a/server/controllers/admin/placementRequestsController.test.ts
+++ b/server/controllers/admin/placementRequestsController.test.ts
@@ -155,7 +155,7 @@ describe('PlacementRequestsController', () => {
       expect(response.render).toHaveBeenCalledWith('admin/placementRequests/search', {
         pageHeading: 'Record and update placement details',
         placementRequests: paginatedResponse.data,
-        crn: undefined,
+        crnOrName: undefined,
         pageNumber: Number(paginatedResponse.pageNumber),
         totalPages: Number(paginatedResponse.totalPages),
         hrefPrefix,
@@ -165,23 +165,23 @@ describe('PlacementRequestsController', () => {
     })
 
     it('should search for placement requests by CRN', async () => {
-      const hrefPrefix = `${paths.admin.placementRequests.search({})}?${createQueryString({ crn: 'CRN123' })}&`
+      const hrefPrefix = `${paths.admin.placementRequests.search({})}?${createQueryString({ crnOrName: 'CRN123' })}&`
 
       const requestHandler = placementRequestsController.search()
 
-      await requestHandler({ ...request, query: { crn: 'CRN123' } }, response, next)
+      await requestHandler({ ...request, query: { crnOrName: 'CRN123' } }, response, next)
 
       expect(response.render).toHaveBeenCalledWith('admin/placementRequests/search', {
         pageHeading: 'Record and update placement details',
         placementRequests: paginatedResponse.data,
-        crn: 'CRN123',
+        crnOrName: 'CRN123',
         pageNumber: Number(paginatedResponse.pageNumber),
         totalPages: Number(paginatedResponse.totalPages),
         hrefPrefix,
       })
       expect(placementRequestService.search).toHaveBeenCalledWith(
         token,
-        { crn: 'CRN123' },
+        { crnOrName: 'CRN123' },
         undefined,
         undefined,
         undefined,
@@ -206,7 +206,7 @@ describe('PlacementRequestsController', () => {
       expect(response.render).toHaveBeenCalledWith('admin/placementRequests/search', {
         pageHeading: 'Record and update placement details',
         placementRequests: paginatedResponse.data,
-        crn: undefined,
+        crnOrName: undefined,
         tier: 'A1',
         arrivalDateStart: '2022-01-01',
         arrivalDateEnd: '2022-01-03',
@@ -233,7 +233,10 @@ describe('PlacementRequestsController', () => {
       const requestHandler = placementRequestsController.search()
 
       await requestHandler(
-        { ...request, query: { crn: '', tier: 'A1', arrivalDateStart: '2022-01-01', arrivalDateEnd: '2022-01-03' } },
+        {
+          ...request,
+          query: { crnOrName: '', tier: 'A1', arrivalDateStart: '2022-01-01', arrivalDateEnd: '2022-01-03' },
+        },
         response,
         next,
       )
@@ -241,7 +244,7 @@ describe('PlacementRequestsController', () => {
       expect(response.render).toHaveBeenCalledWith('admin/placementRequests/search', {
         pageHeading: 'Record and update placement details',
         placementRequests: paginatedResponse.data,
-        crn: undefined,
+        crnOrName: undefined,
         tier: 'A1',
         arrivalDateStart: '2022-01-01',
         arrivalDateEnd: '2022-01-03',
@@ -259,12 +262,12 @@ describe('PlacementRequestsController', () => {
     })
 
     it('should request page numbers and sort options', async () => {
-      const hrefPrefix = `${paths.admin.placementRequests.search({})}?${createQueryString({ crn: 'CRN123' })}&`
+      const hrefPrefix = `${paths.admin.placementRequests.search({})}?${createQueryString({ crnOrName: 'CRN123' })}&`
 
       const requestHandler = placementRequestsController.search()
 
       await requestHandler(
-        { ...request, query: { crn: 'CRN123', page: '2', sortBy: 'expectedArrival', sortDirection: 'desc' } },
+        { ...request, query: { crnOrName: 'CRN123', page: '2', sortBy: 'expectedArrival', sortDirection: 'desc' } },
         response,
         next,
       )
@@ -272,7 +275,7 @@ describe('PlacementRequestsController', () => {
       expect(response.render).toHaveBeenCalledWith('admin/placementRequests/search', {
         pageHeading: 'Record and update placement details',
         placementRequests: paginatedResponse.data,
-        crn: 'CRN123',
+        crnOrName: 'CRN123',
         pageNumber: Number(paginatedResponse.pageNumber),
         totalPages: Number(paginatedResponse.totalPages),
         hrefPrefix,
@@ -281,7 +284,7 @@ describe('PlacementRequestsController', () => {
       })
       expect(placementRequestService.search).toHaveBeenCalledWith(
         token,
-        { crn: 'CRN123' },
+        { crnOrName: 'CRN123' },
         2,
         'expectedArrival',
         'desc',

--- a/server/controllers/admin/placementRequestsController.ts
+++ b/server/controllers/admin/placementRequestsController.ts
@@ -53,7 +53,7 @@ export default class PlacementRequestsController {
     return async (req: Request, res: Response) => {
       const searchOptions = {} as PlacementRequestDashboardSearchOptions
 
-      searchOptions.crn = req.query.crn as string
+      searchOptions.crnOrName = req.query.crnOrName as string
       searchOptions.tier = req.query.tier as RiskTierLevel
       searchOptions.arrivalDateStart = req.query.arrivalDateStart as string
       searchOptions.arrivalDateEnd = req.query.arrivalDateEnd as string

--- a/server/data/placementRequestClient.test.ts
+++ b/server/data/placementRequestClient.test.ts
@@ -123,7 +123,7 @@ describeClient('placementRequestClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.placementRequests.dashboard.pattern,
-          query: { crn: 'CRN123', page: '1', sortBy: 'created_at', sortDirection: 'asc' },
+          query: { crnOrName: 'CRN123', page: '1', sortBy: 'created_at', sortDirection: 'asc' },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -139,7 +139,7 @@ describeClient('placementRequestClient', provider => {
         },
       })
 
-      const result = await placementRequestClient.dashboard({ crn: 'CRN123' })
+      const result = await placementRequestClient.dashboard({ crnOrName: 'CRN123' })
 
       expect(result).toEqual({
         data: placementRequests,

--- a/server/services/placementRequestService.test.ts
+++ b/server/services/placementRequestService.test.ts
@@ -88,12 +88,12 @@ describe('placementRequestService', () => {
 
       placementRequestClient.dashboard.mockResolvedValue(response)
 
-      const result = await service.search(token, { crn: 'CRN123' })
+      const result = await service.search(token, { crnOrName: 'CRN123' })
 
       expect(result).toEqual(response)
 
       expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
-      expect(placementRequestClient.dashboard).toHaveBeenCalledWith({ crn: 'CRN123' }, 1, 'created_at', 'asc')
+      expect(placementRequestClient.dashboard).toHaveBeenCalledWith({ crnOrName: 'CRN123' }, 1, 'created_at', 'asc')
     })
 
     it('calls the dashboard method on the placementRequest client with optional search params', async () => {
@@ -104,7 +104,7 @@ describe('placementRequestService', () => {
       placementRequestClient.dashboard.mockResolvedValue(response)
 
       const result = await service.search(token, {
-        crn: 'CRN123',
+        crnOrName: 'CRN123',
         tier: 'A1',
         arrivalDateStart: '2022-01-01',
         arrivalDateEnd: '2022-01-02',
@@ -114,7 +114,7 @@ describe('placementRequestService', () => {
 
       expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
       expect(placementRequestClient.dashboard).toHaveBeenCalledWith(
-        { crn: 'CRN123', tier: 'A1', arrivalDateStart: '2022-01-01', arrivalDateEnd: '2022-01-02' },
+        { crnOrName: 'CRN123', tier: 'A1', arrivalDateStart: '2022-01-01', arrivalDateEnd: '2022-01-02' },
         1,
         'created_at',
         'asc',
@@ -128,12 +128,12 @@ describe('placementRequestService', () => {
 
       placementRequestClient.dashboard.mockResolvedValue(response)
 
-      const result = await service.search(token, { crn: 'CRN123' }, 2, 'duration', 'desc')
+      const result = await service.search(token, { crnOrName: 'CRN123' }, 2, 'duration', 'desc')
 
       expect(result).toEqual(response)
 
       expect(placementRequestClientFactory).toHaveBeenCalledWith(token)
-      expect(placementRequestClient.dashboard).toHaveBeenCalledWith({ crn: 'CRN123' }, 2, 'duration', 'desc')
+      expect(placementRequestClient.dashboard).toHaveBeenCalledWith({ crnOrName: 'CRN123' }, 2, 'duration', 'desc')
     })
   })
 

--- a/server/views/admin/placementRequests/search.njk
+++ b/server/views/admin/placementRequests/search.njk
@@ -30,15 +30,15 @@
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
               <div class="govuk-form-group">
-                <label class="placement-request-search__crn-label" for="crn">
+                <label class="placement-request-search__crn-label" for="crnOrName">
                  Find a placement
                 </label>
 
                 <div id="crn-hint" class="govuk-hint moj-crn__hint ">
-                  You can search by CRN
+                  You can search by CRN or name
                 </div>
 
-                <input class="govuk-input moj-search__input" id="crn" name="crn" type="search" aria-describedby="crn-hint">
+                <input class="govuk-input moj-search__input" id="crnOrName" name="crnOrName" type="search" aria-describedby="crn-hint">
               </div>
             </div>
           </div>

--- a/server/views/admin/placementRequests/search.njk
+++ b/server/views/admin/placementRequests/search.njk
@@ -38,7 +38,7 @@
                   You can search by CRN or name
                 </div>
 
-                <input class="govuk-input moj-search__input" id="crnOrName" name="crnOrName" type="search" aria-describedby="crn-hint">
+                <input class="govuk-input moj-search__input" id="crnOrName" name="crnOrName" type="search" aria-describedby="crn-hint" value="{{ crnOrName }}">
               </div>
             </div>
           </div>


### PR DESCRIPTION
This updates the `crn` param to `crnOrName`, so users can search by either CRN or partial name. ~~We need to get https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/929 deployed before this can be deployed.~~