### PR TITLE
Pin e2e node version to 9.8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,7 @@ jobs:
             git clone https://github.com/ministryofjustice/hmpps-approved-premises-e2e.git .
       - run:
           name: Update npm
-          command: 'npm install -g npm@latest'
+          command: 'npm install -g npm@9.8.1'
       - node/install-packages
       - run:
           name: E2E Check


### PR DESCRIPTION
Following on from https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/1078, we also pin of the version NPM we use in the e2e tests too as NPM 10 isn't compatible with the current version of Node