### PR TITLE
Remove deprecated SQS secrets from Preprod

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -20,8 +20,6 @@ generic-service:
 
   namespace_secrets:
     sqs-hmpps-audit-secret:
-      AUDIT_SQS_ACCESS_KEY_ID: 'access_key_id'
-      AUDIT_SQS_SECRET_ACCESS_KEY: 'secret_access_key'
       AUDIT_SQS_QUEUE_URL: 'sqs_queue_url'
       AUDIT_SQS_QUEUE_NAME: 'sqs_queue_name'
 


### PR DESCRIPTION
https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/1052 switched us over to IRSA, but we forgot to move the deprecated secrets from the preprod environment, which has means preprod hasn’t been able to deploy.