### PR TITLE
Update cypress to v13

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -35,7 +35,6 @@ export default defineConfig({
   reporterOptions: {
     configFile: 'reporter-config.json',
   },
-  videoUploadOnPasses: false,
   taskTimeout: 70000,
   e2e: {
     setupNodeEvents(on) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "axe-core": "^4.7.0",
         "concurrently": "^8.0.0",
         "cookie-session": "^2.0.0",
-        "cypress": "^12.10.0",
+        "cypress": "^13.1.0",
         "cypress-axe": "^1.4.0",
         "cypress-multi-reporters": "^1.6.1",
         "eslint": "^8.24.0",
@@ -1591,9 +1591,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "2.88.12",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
+      "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
       "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -1609,7 +1609,7 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.10.3",
+        "qs": "6.10.4",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
@@ -5871,13 +5871,13 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.17.4",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
-      "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "2.88.12",
+        "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^16.18.39",
         "@types/sinonjs__fake-timers": "8.1.1",
@@ -5925,7 +5925,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/cypress-axe": {

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "axe-core": "^4.7.0",
     "concurrently": "^8.0.0",
     "cookie-session": "^2.0.0",
-    "cypress": "^12.10.0",
+    "cypress": "^13.1.0",
     "cypress-axe": "^1.4.0",
     "cypress-multi-reporters": "^1.6.1",
     "eslint": "^8.24.0",


### PR DESCRIPTION
We previously ignored the updated to V13 as `cypress-axe` hadn't upgraded but now it has we can update Cypress