### PR TITLE
Show due date in business days on CRU dashboard

### DIFF
--- a/server/utils/assessments/dateUtils.test.ts
+++ b/server/utils/assessments/dateUtils.test.ts
@@ -8,17 +8,17 @@ import {
   formatDaysUntilDueWithWarning,
   formattedArrivalDate,
 } from './dateUtils'
-import { DateFormats, differenceInBusinessDays } from '../dateUtils'
+import { DateFormats } from '../dateUtils'
 import { assessmentFactory, assessmentSummaryFactory } from '../../testutils/factories'
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
 
 jest.mock('../applications/arrivalDateFromApplication')
 jest.mock('../dateUtils', () => ({
-  differenceInBusinessDays: jest.fn().mockImplementation(() => 1),
   DateFormats: {
     isoToDateObj: jest.fn().mockImplementation(date => new Date(date)),
     dateObjToIsoDate: jest.fn().mockImplementation(date => formatISO(date)),
     dateObjToIsoDateTime: jest.fn().mockImplementation(date => formatISO(date)),
+    differenceInBusinessDays: jest.fn().mockReturnValue(1),
   },
 }))
 
@@ -108,7 +108,7 @@ describe('dateUtils', () => {
 
   describe('formatDaysUntilDueWithWarning', () => {
     it('returns the number of days without a warning if the due date is not soon', () => {
-      ;(differenceInBusinessDays as jest.Mock).mockReturnValue(9)
+      DateFormats.differenceInBusinessDays = jest.fn().mockReturnValue(9)
       const assessment = assessmentSummaryFactory.build({
         createdAt: DateFormats.dateObjToIsoDate(new Date()),
       })
@@ -117,7 +117,7 @@ describe('dateUtils', () => {
     })
 
     it('returns the number of days with a warning if the due date is soon', () => {
-      ;(differenceInBusinessDays as jest.Mock).mockReturnValue(1)
+      DateFormats.differenceInBusinessDays = jest.fn().mockReturnValue(1)
       const assessment = assessmentSummaryFactory.createdXDaysAgo(1).build()
 
       expect(formatDaysUntilDueWithWarning(assessment)).toEqual(

--- a/server/utils/assessments/dateUtils.ts
+++ b/server/utils/assessments/dateUtils.ts
@@ -4,7 +4,7 @@ import {
   ApprovedPremisesAssessment as Assessment,
   AssessmentSummary,
 } from '@approved-premises/api'
-import { DateFormats, differenceInBusinessDays } from '../dateUtils'
+import { DateFormats } from '../dateUtils'
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
 
 const DUE_DATE_APPROACHING_DAYS_WINDOW = 3
@@ -35,7 +35,7 @@ const daysUntilDue = (assessment: AssessmentSummary): number => {
   const receivedDate = DateFormats.isoToDateObj(assessment.createdAt)
   const dueDate = add(receivedDate, { days: 10 })
 
-  return differenceInBusinessDays(dueDate, new Date())
+  return DateFormats.differenceInBusinessDays(dueDate, new Date())
 }
 
 const daysToWeeksAndDays = (days: string | number): { days: number; weeks: number } => {

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -13,7 +13,6 @@ import {
   dateAndTimeInputsAreValidDates,
   dateIsBlank,
   dateIsInThePast,
-  differenceInBusinessDays,
   monthOptions,
   uiDateOrDateEmptyMessage,
   yearOptions,
@@ -210,6 +209,55 @@ describe('DateFormats', () => {
     })
   })
 
+  describe('differenceInBusinessDays', () => {
+    it('should return NaN if either date is invalid', () => {
+      const date1InvalidResult = DateFormats.differenceInBusinessDays(new Date('invalid date'), new Date('2022-01-10'))
+      const date2InvalidResult = DateFormats.differenceInBusinessDays(new Date('2022-01-10'), new Date('invalid date'))
+
+      expect(date1InvalidResult).toBeNaN()
+      expect(date2InvalidResult).toBeNaN()
+    })
+
+    it('returns the number of business days between the given dates, excluding weekends and holidays', () => {
+      const holidays = [
+        new Date(2023, 7 /* Aug */, 28),
+        new Date(2023, 11 /* Dec */, 25),
+        new Date(2023, 11 /* Dec */, 26),
+      ]
+
+      expect(DateFormats.differenceInBusinessDays(new Date(2024, 0, 10), new Date(2023, 6, 18), holidays)).toBe(123)
+    })
+
+    it('ignores holidays the are not in the range', () => {
+      const holidays = [
+        new Date(2023, 7 /* Aug */, 28),
+        new Date(2023, 11 /* Dec */, 25),
+        new Date(2023, 11 /* Dec */, 26),
+      ]
+
+      expect(DateFormats.differenceInBusinessDays(new Date(2024, 0, 10), new Date(2023, 9, 18), holidays)).toBe(58)
+    })
+
+    it('ignores holidays that are at the weekend', () => {
+      const holidays = [
+        new Date(2023, 7 /* Aug */, 28),
+        new Date(2023, 11 /* Dec */, 24),
+        new Date(2023, 11 /* Dec */, 25),
+        new Date(2023, 11 /* Dec */, 26),
+      ]
+
+      expect(DateFormats.differenceInBusinessDays(new Date(2024, 0, 10), new Date(2023, 9, 18), holidays)).toBe(58)
+    })
+
+    it('returns the number of business days between the given dates if no holidays are provided', () => {
+      expect(DateFormats.differenceInBusinessDays(new Date(2024, 0, 10), new Date(2023, 6, 18))).toBe(126)
+    })
+
+    it('returns the correct number of business days if the leftDate is earlier than the rightDate', () => {
+      expect(DateFormats.differenceInBusinessDays(subDays(new Date(), 7), new Date())).toBe(-5)
+    })
+  })
+
   describe('formatDuration', () => {
     it('formats a duration with the given unit', () => {
       expect(DateFormats.formatDuration({ days: '4', weeks: '7' })).toEqual('7 weeks, 4 days')
@@ -374,55 +422,6 @@ describe('monthOptions', () => {
       { name: 'November', value: '11' },
       { name: 'December', value: '12' },
     ])
-  })
-})
-
-describe('differenceInBusinessDays', () => {
-  it('should return NaN if either date is invalid', () => {
-    const date1InvalidResult = differenceInBusinessDays(new Date('invalid date'), new Date('2022-01-10'))
-    const date2InvalidResult = differenceInBusinessDays(new Date('2022-01-10'), new Date('invalid date'))
-
-    expect(date1InvalidResult).toBeNaN()
-    expect(date2InvalidResult).toBeNaN()
-  })
-
-  it('returns the number of business days between the given dates, excluding weekends and holidays', () => {
-    const holidays = [
-      new Date(2023, 7 /* Aug */, 28),
-      new Date(2023, 11 /* Dec */, 25),
-      new Date(2023, 11 /* Dec */, 26),
-    ]
-
-    expect(differenceInBusinessDays(new Date(2024, 0, 10), new Date(2023, 6, 18), holidays)).toBe(123)
-  })
-
-  it('ignores holidays the are not in the range', () => {
-    const holidays = [
-      new Date(2023, 7 /* Aug */, 28),
-      new Date(2023, 11 /* Dec */, 25),
-      new Date(2023, 11 /* Dec */, 26),
-    ]
-
-    expect(differenceInBusinessDays(new Date(2024, 0, 10), new Date(2023, 9, 18), holidays)).toBe(58)
-  })
-
-  it('ignores holidays that are at the weekend', () => {
-    const holidays = [
-      new Date(2023, 7 /* Aug */, 28),
-      new Date(2023, 11 /* Dec */, 24),
-      new Date(2023, 11 /* Dec */, 25),
-      new Date(2023, 11 /* Dec */, 26),
-    ]
-
-    expect(differenceInBusinessDays(new Date(2024, 0, 10), new Date(2023, 9, 18), holidays)).toBe(58)
-  })
-
-  it('returns the number of business days between the given dates if no holidays are provided', () => {
-    expect(differenceInBusinessDays(new Date(2024, 0, 10), new Date(2023, 6, 18))).toBe(126)
-  })
-
-  it('returns the correct number of business days if the leftDate is earlier than the rightDate', () => {
-    expect(differenceInBusinessDays(subDays(new Date(), 7), new Date())).toBe(-5)
   })
 })
 

--- a/server/utils/placementRequests/table.test.ts
+++ b/server/utils/placementRequests/table.test.ts
@@ -137,6 +137,8 @@ describe('tableUtils', () => {
 
   describe('dueDateCell', () => {
     it('returns the difference in days between the arrival date and the due date', () => {
+      DateFormats.differenceInBusinessDays = jest.fn().mockReturnValue(7)
+
       const arrivalDate = add(new Date(), { days: 14 })
       const task = placementRequestTaskFactory.build({
         expectedArrival: DateFormats.dateObjToIsoDate(arrivalDate),

--- a/server/utils/placementRequests/table.ts
+++ b/server/utils/placementRequests/table.ts
@@ -1,4 +1,4 @@
-import { add } from 'date-fns'
+import { addDays } from 'date-fns'
 import { PlacementRequest, PlacementRequestStatus, PlacementRequestTask, SortDirection } from '../../@types/shared'
 import { TableCell, TableRow } from '../../@types/ui'
 import matchPaths from '../../paths/match'
@@ -63,10 +63,10 @@ export const dueDateCell = (task: PlacementRequestTask, differenceBetweenDueDate
   const dateAsObject = DateFormats.isoToDateObj(task.expectedArrival)
 
   return {
-    text: DateFormats.differenceInDays(
+    text: `${DateFormats.differenceInBusinessDays(
       dateAsObject,
-      add(dateAsObject, { days: differenceBetweenDueDateAndArrivalDate }),
-    ).ui,
+      addDays(dateAsObject, differenceBetweenDueDateAndArrivalDate),
+    )} days`,
   }
 }
 


### PR DESCRIPTION
# Context
As well as showing working days for the due date on the assessment dashboard (#1055) we also need to show the due date in working days on the CRU dashboard.

# Changes in this PR
- We move the `differenceInBusinessDays` function to the DateFormats class
- We change the difference in days function to use the `differenceInBusisnessDays` function instead of just difference in days 
