### PR TITLE
(430) Add pagination to user response

### DIFF
--- a/integration_tests/pages/admin/placementApplications/listPage.ts
+++ b/integration_tests/pages/admin/placementApplications/listPage.ts
@@ -46,20 +46,4 @@ export default class ListPage extends Page {
   clickUnableToMatch(): void {
     cy.get('a.moj-sub-navigation__link').contains('Unable to match').click()
   }
-
-  clickNext(): void {
-    cy.get('a[rel="next"]').click()
-  }
-
-  clickPageNumber(pageNumber: string): void {
-    cy.get('.govuk-pagination__link').contains(pageNumber).click()
-  }
-
-  clickSortBy(field: string): void {
-    cy.get(`th[data-cy-sort-field="${field}"] a`).click()
-  }
-
-  shouldBeSortedByField(field: string, order: string): void {
-    cy.get(`th[data-cy-sort-field="${field}"]`).should('have.attr', 'aria-sort', order)
-  }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -362,4 +362,20 @@ export default abstract class Page {
     cy.get('.govuk-error-summary').should('contain', `CRN: ${person.crn} is restricted`)
     cy.get(`[data-cy-error-crn]`).should('contain', `CRN: ${person.crn} is restricted`)
   }
+
+  clickNext(): void {
+    cy.get('a[rel="next"]').click()
+  }
+
+  clickPageNumber(pageNumber: string): void {
+    cy.get('.govuk-pagination__link').contains(pageNumber).click()
+  }
+
+  clickSortBy(field: string): void {
+    cy.get(`th[data-cy-sort-field="${field}"] a`).click()
+  }
+
+  shouldBeSortedByField(field: string, order: string): void {
+    cy.get(`th[data-cy-sort-field="${field}"]`).should('have.attr', 'aria-sort', order)
+  }
 }

--- a/server/controllers/admin/userManagementController.ts
+++ b/server/controllers/admin/userManagementController.ts
@@ -4,15 +4,28 @@ import { qualifications, roles } from '../../utils/users'
 import { UserService } from '../../services'
 import paths from '../../paths/admin'
 import { flattenCheckboxInput } from '../../utils/formUtils'
+import { SortDirection, UserSortField } from '../../@types/shared'
 
 export default class UserController {
   constructor(private readonly userService: UserService) {}
 
   index(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
-      const users = await this.userService.getUsers(req.user.token)
+      const pageNumber = req.query?.page ? Number(req.query.page) : undefined
+      const sortBy = req.query?.sortBy as UserSortField
+      const sortDirection = req.query?.sortDirection as SortDirection
 
-      res.render('admin/users/index', { pageHeading: 'User management dashboard', users })
+      const usersResponse = await this.userService.getUsers(req.user.token, [], [], pageNumber, sortBy, sortDirection)
+
+      res.render('admin/users/index', {
+        pageHeading: 'User management dashboard',
+        users: usersResponse.data,
+        pageNumber: Number(usersResponse.pageNumber),
+        totalPages: Number(usersResponse.totalPages),
+        hrefPrefix: `${paths.admin.userManagement.index({})}?`,
+        sortBy,
+        sortDirection,
+      })
     }
   }
 

--- a/server/data/userClient.test.ts
+++ b/server/data/userClient.test.ts
@@ -75,6 +75,11 @@ describeClient('UserClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.users.index({}),
+          query: {
+            page: '1',
+            sortBy: 'name',
+            sortDirection: 'asc',
+          },
           headers: {
             authorization: `Bearer ${token}`,
             'X-Service-Name': 'approved-premises',
@@ -83,11 +88,101 @@ describeClient('UserClient', provider => {
         willRespondWith: {
           status: 200,
           body: users,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
         },
       })
 
       const output = await userClient.getUsers()
-      expect(output).toEqual(users)
+
+      expect(output).toEqual({
+        data: users,
+        pageNumber: '1',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
+    })
+
+    it('should return all users when a specific page number specified', async () => {
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get a list of users',
+        withRequest: {
+          method: 'GET',
+          path: paths.users.index({}),
+          query: {
+            page: '2',
+            sortBy: 'name',
+            sortDirection: 'asc',
+          },
+          headers: {
+            authorization: `Bearer ${token}`,
+            'X-Service-Name': 'approved-premises',
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: users,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
+        },
+      })
+
+      const output = await userClient.getUsers([], [], 2)
+
+      expect(output).toEqual({
+        data: users,
+        pageNumber: '2',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
+    })
+
+    it('should return all users when a specific sort direction specified', async () => {
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get a list of users',
+        withRequest: {
+          method: 'GET',
+          path: paths.users.index({}),
+          query: {
+            page: '1',
+            sortBy: 'name',
+            sortDirection: 'asc',
+          },
+          headers: {
+            authorization: `Bearer ${token}`,
+            'X-Service-Name': 'approved-premises',
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: users,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
+        },
+      })
+
+      const output = await userClient.getUsers([], [], 1, 'name', 'asc')
+
+      expect(output).toEqual({
+        data: users,
+        pageNumber: '1',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
     })
 
     it('should query by role', async () => {
@@ -99,6 +194,9 @@ describeClient('UserClient', provider => {
           path: paths.users.index({}),
           query: {
             roles: 'assessor,matcher',
+            page: '1',
+            sortBy: 'name',
+            sortDirection: 'asc',
           },
           headers: {
             authorization: `Bearer ${token}`,
@@ -108,11 +206,23 @@ describeClient('UserClient', provider => {
         willRespondWith: {
           status: 200,
           body: users,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
         },
       })
 
       const output = await userClient.getUsers(['assessor', 'matcher'])
-      expect(output).toEqual(users)
+
+      expect(output).toEqual({
+        data: users,
+        pageNumber: '1',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
     })
 
     it('should query by qualifications', async () => {
@@ -124,6 +234,9 @@ describeClient('UserClient', provider => {
           path: paths.users.index({}),
           query: {
             qualifications: 'pipe,womens',
+            page: '1',
+            sortBy: 'name',
+            sortDirection: 'asc',
           },
           headers: {
             authorization: `Bearer ${token}`,
@@ -133,11 +246,23 @@ describeClient('UserClient', provider => {
         willRespondWith: {
           status: 200,
           body: users,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
         },
       })
 
       const output = await userClient.getUsers([], ['pipe', 'womens'])
-      expect(output).toEqual(users)
+
+      expect(output).toEqual({
+        data: users,
+        pageNumber: '1',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
     })
 
     it('should query by qualifications and roles', async () => {
@@ -150,6 +275,9 @@ describeClient('UserClient', provider => {
           query: {
             roles: 'assessor,matcher',
             qualifications: 'pipe,womens',
+            page: '1',
+            sortBy: 'name',
+            sortDirection: 'asc',
           },
           headers: {
             authorization: `Bearer ${token}`,
@@ -159,11 +287,23 @@ describeClient('UserClient', provider => {
         willRespondWith: {
           status: 200,
           body: users,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
         },
       })
 
       const output = await userClient.getUsers(['assessor', 'matcher'], ['pipe', 'womens'])
-      expect(output).toEqual(users)
+
+      expect(output).toEqual({
+        data: users,
+        pageNumber: '1',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
     })
   })
 

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -2,7 +2,9 @@ import UserService from './userService'
 import HmppsAuthClient, { User } from '../data/hmppsAuthClient'
 import { UserClient } from '../data'
 
-import { userFactory } from '../testutils/factories'
+import { paginatedResponseFactory, userFactory } from '../testutils/factories'
+import { PaginatedResponse } from '../@types/ui'
+import { ApprovedPremisesUser } from '../@types/shared'
 
 jest.mock('../data/hmppsAuthClient')
 jest.mock('../data/userClient')
@@ -70,15 +72,17 @@ describe('User service', () => {
 
   describe('getUsers', () => {
     it('returns users by role and qualification', async () => {
-      const users = userFactory.buildList(4)
+      const response = paginatedResponseFactory.build({
+        data: userFactory.buildList(4),
+      }) as PaginatedResponse<ApprovedPremisesUser>
 
-      userClient.getUsers.mockResolvedValue(users)
+      userClient.getUsers.mockResolvedValue(response)
 
-      const result = await userService.getUsers(token, ['applicant', 'assessor'], ['pipe'])
+      const result = await userService.getUsers(token, ['applicant', 'assessor'], ['pipe'], 1, 'name', 'asc')
 
-      expect(result).toEqual(users)
+      expect(result).toEqual(response)
 
-      expect(userClient.getUsers).toHaveBeenCalledWith(['applicant', 'assessor'], ['pipe'])
+      expect(userClient.getUsers).toHaveBeenCalledWith(['applicant', 'assessor'], ['pipe'], 1, 'name', 'asc')
     })
   })
 

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,9 +1,11 @@
 import {
+  SortDirection,
   ApprovedPremisesUser as User,
   UserQualification,
   ApprovedPremisesUserRole as UserRole,
+  UserSortField,
 } from '@approved-premises/api'
-import { UserDetails } from '@approved-premises/ui'
+import { PaginatedResponse, UserDetails } from '@approved-premises/ui'
 import { RestClientBuilder, UserClient } from '../data'
 import { convertToTitleCase } from '../utils/utils'
 import type HmppsAuthClient from '../data/hmppsAuthClient'
@@ -31,10 +33,13 @@ export default class UserService {
     token: string,
     roles: Array<UserRole> = [],
     qualifications: Array<UserQualification> = [],
-  ): Promise<Array<User>> {
+    page: number = 1,
+    sortBy: UserSortField = 'name',
+    sortDirection: SortDirection = 'asc',
+  ): Promise<PaginatedResponse<User>> {
     const client = this.userClientFactory(token)
 
-    return client.getUsers(roles, qualifications)
+    return client.getUsers(roles, qualifications, page, sortBy, sortDirection)
   }
 
   async updateUser(token: string, user: User): Promise<User> {

--- a/server/utils/users/tableUtils.test.ts
+++ b/server/utils/users/tableUtils.test.ts
@@ -2,17 +2,28 @@ import { userFactory } from '../../testutils/factories'
 import { managementDashboardTableHeader, managementDashboardTableRows } from './tableUtils'
 import paths from '../../paths/admin'
 import { linkTo, sentenceCase } from '../utils'
+import { sortHeader } from '../sortHeader'
 
 describe('tableUtils', () => {
   describe('dashboardTableHeader', () => {
-    it('returns the table headers', () => {
+    it('returns the table headers without sorting by default', () => {
       expect(managementDashboardTableHeader()).toEqual([
         {
           text: 'Name',
-          attributes: {
-            'aria-sort': 'descending',
-          },
         },
+        {
+          text: 'Role',
+        },
+        {
+          text: 'Email',
+        },
+        { text: 'Region' },
+      ])
+    })
+
+    it('returns the table headers with sorting if hrefPrefix is present', () => {
+      expect(managementDashboardTableHeader('name', 'desc', 'http://example.com?')).toEqual([
+        sortHeader('Name', 'name', 'name', 'desc', 'http://example.com?'),
         {
           text: 'Role',
         },

--- a/server/utils/users/tableUtils.ts
+++ b/server/utils/users/tableUtils.ts
@@ -1,17 +1,21 @@
-import { ApprovedPremisesUser as User } from '../../@types/shared'
+import { SortDirection, ApprovedPremisesUser as User } from '../../@types/shared'
 import { TableCell } from '../../@types/ui'
 import paths from '../../paths/admin'
+import { sortHeader } from '../sortHeader'
 import { emailCell } from '../tableUtils'
 import { linkTo, sentenceCase } from '../utils'
 
-export const managementDashboardTableHeader = (): Array<TableCell> => {
+export const managementDashboardTableHeader = (
+  sortBy: string = undefined,
+  sortDirection: SortDirection | undefined = undefined,
+  hrefPrefix: string | undefined = undefined,
+): Array<TableCell> => {
   return [
-    {
-      text: 'Name',
-      attributes: {
-        'aria-sort': 'descending',
-      },
-    },
+    hrefPrefix === undefined
+      ? {
+          text: 'Name',
+        }
+      : sortHeader('Name', 'name', sortBy, sortDirection, hrefPrefix),
     {
       text: 'Role',
     },

--- a/server/views/admin/users/index.njk
+++ b/server/views/admin/users/index.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
 
 {% set pageTitle = applicationName + " - " + pageHeading  %}
 {% set mainClasses = "app-container govuk-body assessments--index" %}
@@ -56,24 +57,16 @@
                             }) }}
                 </div>
             </form>
-            {{ govukTable({
-                attributes: {
-                    'data-module': 'moj-sortable-table'
-                },
-                firstCellIsHeader: true,
-                head: UserUtils.tableUtils.managementDashboardTableHeader(),
-                rows: UserUtils.tableUtils.managementDashboardTableRows(users)
-            })
+
+            {{
+                govukTable({
+                    firstCellIsHeader: true,
+                    head: UserUtils.tableUtils.managementDashboardTableHeader(sortBy, sortDirection, hrefPrefix),
+                    rows: UserUtils.tableUtils.managementDashboardTableRows(users)
+                })
             }}
 
+            {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
         </div>
     </div>
-{% endblock %}
-
-{% block extraScripts %}
-    <script type="text/javascript" nonce="{{ cspNonce }}">
-        window
-            .MOJFrontend
-            .initAll()
-    </script>
 {% endblock %}


### PR DESCRIPTION
This builds on https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/956 to support the new pagination arguments for users, which should speed up the response times, as well as fix the strange sorting issues we had when using the client side sort.

## Screenshot
![User management -- supports sorting (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/d17d9101-364e-4c9c-9051-51d54f40c385)


