### PR TITLE
Handle null sections in OAsys

### DIFF
--- a/server/utils/oasysImportUtils.test.ts
+++ b/server/utils/oasysImportUtils.test.ts
@@ -260,6 +260,18 @@ describe('OASysImportUtils', () => {
 
       expect(fetchOptionalOasysSections(application)).toEqual([1, 2])
     })
+
+    it('filters out null sections', () => {
+      const application = applicationFactory.build()
+      application.data['oasys-import'] = {
+        'optional-oasys-sections': {
+          needsLinkedToReoffending: [null, null],
+          otherNeeds: [null],
+        },
+      }
+
+      expect(fetchOptionalOasysSections(application)).toEqual([])
+    })
   })
 
   describe('sortOasysImportSummaries', () => {

--- a/server/utils/oasysImportUtils.ts
+++ b/server/utils/oasysImportUtils.ts
@@ -124,9 +124,9 @@ export const fetchOptionalOasysSections = (application: Application): Array<numb
 
     if (!optionalOasysSections) throw new SessionDataError('No optional OASys imports')
 
-    return [...optionalOasysSections.needsLinkedToReoffending, ...optionalOasysSections.otherNeeds].map(
-      (oasysSection: OASysSection) => oasysSection.section,
-    )
+    return [...optionalOasysSections.needsLinkedToReoffending, ...optionalOasysSections.otherNeeds]
+      .map((oasysSection: OASysSection) => oasysSection?.section)
+      .filter(section => !!section)
   } catch (e) {
     throw new SessionDataError(`Oasys supporting information error: ${e}`)
   }


### PR DESCRIPTION
Addresses https://ministryofjustice.sentry.io/issues/4472012604/?alert_rule_id=14512560&alert_type=issue&notification_uuid=b0b0468e-cbf6-47c5-8e88-1fa936478480&project=4503931667742720&referrer=slack

We’ve seen an error in prod where for some reason the `otherNeeds` section is returning `null`, meaning the Optional Oasys Sections page returns a 500. In the interests of moving this on, and allowing the user to continue with the application, we should filter out any of these `null` sections.