### PR TITLE
Ensure correct hrefPrefix gets passed

### DIFF
--- a/server/controllers/admin/userManagementController.ts
+++ b/server/controllers/admin/userManagementController.ts
@@ -4,16 +4,18 @@ import { qualifications, roles } from '../../utils/users'
 import { UserService } from '../../services'
 import paths from '../../paths/admin'
 import { flattenCheckboxInput } from '../../utils/formUtils'
-import { SortDirection, UserSortField } from '../../@types/shared'
+import { UserSortField } from '../../@types/shared'
+import { getPaginationDetails } from '../../utils/getPaginationDetails'
 
 export default class UserController {
   constructor(private readonly userService: UserService) {}
 
   index(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
-      const pageNumber = req.query?.page ? Number(req.query.page) : undefined
-      const sortBy = req.query?.sortBy as UserSortField
-      const sortDirection = req.query?.sortDirection as SortDirection
+      const { pageNumber, sortBy, sortDirection, hrefPrefix } = getPaginationDetails<UserSortField>(
+        req,
+        paths.admin.userManagement.index({}),
+      )
 
       const usersResponse = await this.userService.getUsers(req.user.token, [], [], pageNumber, sortBy, sortDirection)
 
@@ -22,7 +24,7 @@ export default class UserController {
         users: usersResponse.data,
         pageNumber: Number(usersResponse.pageNumber),
         totalPages: Number(usersResponse.totalPages),
-        hrefPrefix: `${paths.admin.userManagement.index({})}?`,
+        hrefPrefix,
         sortBy,
         sortDirection,
       })

--- a/server/utils/getPaginationDetails.test.ts
+++ b/server/utils/getPaginationDetails.test.ts
@@ -1,0 +1,40 @@
+import { createMock } from '@golevelup/ts-jest'
+import type { Request } from 'express'
+import { getPaginationDetails } from './getPaginationDetails'
+
+describe('getPaginationDetails', () => {
+  const hrefPrefix = 'http://localhost/example'
+
+  it('should return the hrefPrefix with a query string prefix if there are no query parameters', () => {
+    const request = createMock<Request>({})
+
+    expect(getPaginationDetails(request, hrefPrefix)).toEqual({
+      pageNumber: undefined,
+      sortBy: undefined,
+      sortDirection: undefined,
+      hrefPrefix: `${hrefPrefix}?`,
+    })
+  })
+
+  it('should fetch the pagination query string options and append them to the hrefPrefix', () => {
+    const request = createMock<Request>({ query: { page: '1', sortBy: 'something', sortDirection: 'asc' } })
+
+    expect(getPaginationDetails(request, hrefPrefix)).toEqual({
+      pageNumber: 1,
+      sortBy: 'something',
+      sortDirection: 'asc',
+      hrefPrefix: `${hrefPrefix}?sortBy=something&sortDirection=asc&`,
+    })
+  })
+
+  it('should append additonal parameters to the hrefPrefix', () => {
+    const request = createMock<Request>({ query: { page: '1', sortBy: 'something', sortDirection: 'asc' } })
+
+    expect(getPaginationDetails(request, hrefPrefix, { foo: 'bar' })).toEqual({
+      pageNumber: 1,
+      sortBy: 'something',
+      sortDirection: 'asc',
+      hrefPrefix: `${hrefPrefix}?foo=bar&sortBy=something&sortDirection=asc&`,
+    })
+  })
+})

--- a/server/utils/getPaginationDetails.ts
+++ b/server/utils/getPaginationDetails.ts
@@ -1,0 +1,19 @@
+import type { Request } from 'express'
+import { SortDirection } from '../@types/shared'
+import { createQueryString } from './utils'
+
+export const getPaginationDetails = <T>(
+  request: Request,
+  basePath: string,
+  additionalParams: Record<string, unknown> = {},
+) => {
+  const pageNumber = request.query.page ? Number(request.query.page) : undefined
+  const sortBy = request.query.sortBy as T
+  const sortDirection = request.query.sortDirection as SortDirection
+
+  const queryString = createQueryString({ ...additionalParams, sortBy, sortDirection }, { addQueryPrefix: true })
+  const queryStringSuffix = queryString.length > 0 ? '&' : '?'
+  const hrefPrefix = `${basePath}${queryString}${queryStringSuffix}`
+
+  return { pageNumber, sortBy, sortDirection, hrefPrefix }
+}

--- a/server/utils/sortHeader.test.ts
+++ b/server/utils/sortHeader.test.ts
@@ -33,4 +33,15 @@ describe('sortHeader', () => {
       },
     })
   })
+
+  it('should override and replace the existing parameters in the hrefPrefix', () => {
+    const prefixWithParams = `${hrefPrefix}?sortBy=myField&sortDirection=desc`
+    expect(sortHeader('Some text', 'myField', 'myField', 'desc', prefixWithParams)).toEqual({
+      html: `<a href="${hrefPrefix}${createQueryString({ sortBy: 'myField', sortDirection: 'asc' })}">Some text</a>`,
+      attributes: {
+        'aria-sort': 'descending',
+        'data-cy-sort-field': 'myField',
+      },
+    })
+  })
 })

--- a/server/utils/sortHeader.ts
+++ b/server/utils/sortHeader.ts
@@ -1,3 +1,4 @@
+import qs from 'qs'
 import { SortDirection } from '../@types/shared'
 import { TableCell } from '../@types/ui'
 import { createQueryString } from './utils'
@@ -12,6 +13,9 @@ export const sortHeader = (
   let sortDirection: SortDirection
   let ariaSort = 'none'
 
+  const [basePath, queryString] = hrefPrefix.split('?')
+  const qsArgs = qs.parse(queryString)
+
   if (targetField === currentSortField) {
     if (currentSortDirection === 'desc') {
       sortDirection = 'asc'
@@ -23,7 +27,7 @@ export const sortHeader = (
   }
 
   return {
-    html: `<a href="${hrefPrefix}${createQueryString({ sortBy: targetField, sortDirection })}">${text}</a>`,
+    html: `<a href="${basePath}?${createQueryString({ ...qsArgs, sortBy: targetField, sortDirection })}">${text}</a>`,
     attributes: {
       'aria-sort': ariaSort,
       'data-cy-sort-field': targetField,


### PR DESCRIPTION
This adds a new `getPaginationDetails` to fetch pagination details from a request, and create a `hrefPrefix` with the appropriate suffix (`?` if there are no query strings, or `&` if we need to add more query string items to an existing query.

This will allow us to keep the sorting information around when paging through sorted results.

I’ve also updated the `sortHeader` helper to make sure existing params aren’t repeated.