### PR TITLE
Fix - ESAP - Ensure the response method returns a string for each question

### DIFF
--- a/integration_tests/tests/admin/userManagement.cy.ts
+++ b/integration_tests/tests/admin/userManagement.cy.ts
@@ -134,7 +134,7 @@ context('User management', () => {
 
     // Then I should be taken to the confirm details of the new user page
     const confirmationPage = Page.verifyOnPage(ConfirmUserDetailsPage)
-    confirmationPage.checkForBackButton(paths.admin.userManagement.searchDelius({}))
+    confirmationPage.checkForBackButton(paths.admin.userManagement.new({}))
     confirmationPage.shouldShowUserDetails(newUser)
 
     // When I click 'continue'

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -96,7 +96,7 @@ export type FormSections = Array<FormSection>
 
 export type FormPages = { [key in TaskNames]: Record<string, unknown> }
 
-export type PageResponse = Record<string, string | Array<string> | Array<Record<string, unknown>>>
+export type PageResponse = Record<string, string | Array<Record<string, unknown>>>
 
 export interface HtmlAttributes {
   [key: string]: string | number

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementCCTV.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementCCTV.test.ts
@@ -52,9 +52,8 @@ describe('EsapPlacementCCTV', () => {
       )
 
       expect(page.response()).toEqual({
-        'Which behaviours has the person demonstrated that require enhanced CCTV provision to monitor?': [
+        'Which behaviours has the person demonstrated that require enhanced CCTV provision to monitor?':
           'Physically assaulted other people in prison',
-        ],
         'Have partnership agencies requested the sharing of intelligence captured via enhanced CCTV?': 'Yes',
         'Provide details': 'Some detail',
         'Provide any supporting information about why the person requires enhanced CCTV provision': 'notes',

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementCCTV.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementCCTV.ts
@@ -66,7 +66,7 @@ export default class EsapPlacementCCTV implements TasklistPage {
 
   response() {
     return {
-      [this.questions.cctvHistory]: this.body.cctvHistory.map(response => cctvHistory[response]),
+      [this.questions.cctvHistory]: this.body.cctvHistory.map(response => cctvHistory[response]).join(', '),
       [this.questions.cctvIntelligence]: convertToTitleCase(this.body.cctvIntelligence),
       [this.questions.cctvIntelligenceDetails]: this.body.cctvIntelligenceDetails,
       [this.questions.cctvNotes]: this.body.cctvNotes,

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementScreening.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementScreening.test.ts
@@ -58,14 +58,9 @@ describe('EsapPlacementScreening', () => {
       )
 
       expect(page.response()).toEqual({
-        'Why does the person require an enhanced security placement?': [
-          'History of secreting items relevant to risk and re-offending in their room - requires enhanced room search through the use of body worn technology',
-          'History of engaging in behaviours which are most effectively monitored via enhanced CCTV technology - requires enhanced CCTV provision',
-        ],
-        'Do any of the following factors also apply?': [
-          'A diagnosis of autism or neurodiverse traits',
-          'A complex personality presentation which has created challenges in the prison and where an AP PIPE is deemed unsuitable',
-        ],
+        'Do any of the following factors also apply?': `A diagnosis of autism or neurodiverse traits, A complex personality presentation which has created challenges in the prison and where an AP PIPE is deemed unsuitable`,
+        'Why does the person require an enhanced security placement?':
+          'History of secreting items relevant to risk and re-offending in their room - requires enhanced room search through the use of body worn technology, History of engaging in behaviours which are most effectively monitored via enhanced CCTV technology - requires enhanced CCTV provision',
       })
     })
 
@@ -73,10 +68,9 @@ describe('EsapPlacementScreening', () => {
       const page = new EsapPlacementScreening({ esapReasons: ['secreting', 'cctv'] }, application)
 
       expect(page.response()).toEqual({
-        'Why does the person require an enhanced security placement?': [
-          'History of secreting items relevant to risk and re-offending in their room - requires enhanced room search through the use of body worn technology',
-          'History of engaging in behaviours which are most effectively monitored via enhanced CCTV technology - requires enhanced CCTV provision',
-        ],
+        'Why does the person require an enhanced security placement?':
+          'History of secreting items relevant to risk and re-offending in their room - requires enhanced room search through the use of body worn technology, History of engaging in behaviours which are most effectively monitored via enhanced CCTV technology - requires enhanced CCTV provision',
+        'Do any of the following factors also apply?': '',
       })
     })
   })

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementScreening.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementScreening.ts
@@ -63,8 +63,8 @@ export default class EsapPlacementScreening implements TasklistPage {
 
   response() {
     return {
-      [`${this.questions.esapReasons}`]: this.body.esapReasons.map(reason => esapReasons[reason]),
-      [`${this.questions.esapFactors}`]: this.body.esapFactors?.map(factor => esapFactors[factor]),
+      [this.questions.esapReasons]: this.body.esapReasons.map(reason => esapReasons[reason]).join(', '),
+      [this.questions.esapFactors]: this.body.esapFactors?.map(factor => esapFactors[factor]).join(', ') || '',
     }
   }
 

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementSecreting.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementSecreting.test.ts
@@ -71,9 +71,8 @@ describe('EsapPlacementSecreting', () => {
       )
 
       expect(page.response()).toEqual({
-        'Which items does the person have a history of secreting?': [
+        'Which items does the person have a history of secreting?':
           'Literature and materials supporting radicalisation ideals',
-        ],
         'Have partnership agencies requested the sharing of intelligence captured via body worn technology?': 'Yes',
         'Provide details': 'Some detail',
         'Provide any supporting information about why the person requires enhanced room searches': 'notes',

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementSecreting.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapPlacementSecreting.ts
@@ -67,7 +67,9 @@ export default class EsapPlacementSecreting implements TasklistPage {
 
   response() {
     return {
-      [this.questions.secretingHistory]: this.body.secretingHistory.map(response => secretingHistory[response]),
+      [this.questions.secretingHistory]: this.body.secretingHistory
+        .map(response => secretingHistory[response])
+        .join(', '),
       [this.questions.secretingIntelligence]: convertToTitleCase(this.body.secretingIntelligence),
       [this.questions.secretingIntelligenceDetails]: this.body.secretingIntelligenceDetails,
       [this.questions.secretingNotes]: this.body.secretingNotes,

--- a/server/views/admin/users/confirm.njk
+++ b/server/views/admin/users/confirm.njk
@@ -9,7 +9,7 @@
 {% block beforeContent %}
     {{ govukBackLink({
 		text: "Back",
-		href: paths.admin.userManagement.searchDelius()
+		href: paths.admin.userManagement.new({})
 	}) }}
 {% endblock %}
 


### PR DESCRIPTION
Previously this returned an array which was allowed in the PageResponse type but it fell apart when it came to generating the response in embeddedSummaryListItem because embeddedSummaryListItem assumed it was dealing with an object. As these recently changed `response` methods were the only places returning an array I decided it is best to remove the Array<string> type from the PageResponse union.

# Context
[Trello card](https://trello.com/c/nvg2Grm6/431-esap-application-vertical-text)

