### PR TITLE
Update npm to v10.1.0 and node to 18.17 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ parameters:
 
   node-version:
     type: string
-    default: 18.16-browsers
+    default: 18.17-browsers
 
 executors:
   integration-tests:
@@ -38,7 +38,7 @@ jobs:
       - checkout
       - run:
           name: Update npm
-          command: 'sudo npm install -g npm@9.8.1'
+          command: 'sudo npm install -g npm@10.1.0'
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
@@ -191,7 +191,7 @@ jobs:
             git clone https://github.com/ministryofjustice/hmpps-approved-premises-e2e.git .
       - run:
           name: Update npm
-          command: 'npm install -g npm@9.8.1'
+          command: 'npm install -g npm@10.1.0'
       - node/install-packages
       - run:
           name: E2E Check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base image
-FROM node:18.16-bullseye-slim as base
+FROM node:18.17-bullseye-slim as base
 
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available


### PR DESCRIPTION
We previously pinned this https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/1087/commits/aba2d048ede9f27a10e1e259e5edd487babc638c but now it's safe to update as NPM have issued release notes for v10

