### PR TITLE
(438) Ensure assessment  due date is in working days

### DIFF
--- a/server/utils/assessments/dateUtils.test.ts
+++ b/server/utils/assessments/dateUtils.test.ts
@@ -1,4 +1,4 @@
-import { formatISO } from 'date-fns'
+import { addBusinessDays as addBusinessDaysDateFns, formatISO } from 'date-fns'
 import {
   daysSinceInfoRequest,
   daysSinceReceived,
@@ -20,6 +20,7 @@ jest.mock('../dateUtils', () => ({
     dateObjToIsoDateTime: jest.fn().mockImplementation(date => formatISO(date)),
     differenceInBusinessDays: jest.fn().mockReturnValue(1),
   },
+  addBusinessDays: jest.fn().mockImplementation((date, days) => addBusinessDaysDateFns(date, days)),
 }))
 
 describe('dateUtils', () => {

--- a/server/utils/assessments/dateUtils.ts
+++ b/server/utils/assessments/dateUtils.ts
@@ -1,10 +1,10 @@
-import { add, differenceInDays, format } from 'date-fns'
+import { differenceInDays, format } from 'date-fns'
 import {
   ApprovedPremisesApplication as Application,
   ApprovedPremisesAssessment as Assessment,
   AssessmentSummary,
 } from '@approved-premises/api'
-import { DateFormats } from '../dateUtils'
+import { DateFormats, addBusinessDays } from '../dateUtils'
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
 
 const DUE_DATE_APPROACHING_DAYS_WINDOW = 3
@@ -33,7 +33,7 @@ const formatDays = (days: number): string => {
 
 const daysUntilDue = (assessment: AssessmentSummary): number => {
   const receivedDate = DateFormats.isoToDateObj(assessment.createdAt)
-  const dueDate = add(receivedDate, { days: 10 })
+  const dueDate = addBusinessDays(receivedDate, 10)
 
   return DateFormats.differenceInBusinessDays(dueDate, new Date())
 }

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -133,10 +133,10 @@ describe('utils', () => {
   describe('assessmentsApproachingDue', () => {
     it('returns the number of assessments where the due date is less than DUE_DATE_APPROACHING_WINDOW away', () => {
       const assessments = [
-        assessmentSummaryFactory.createdXDaysAgo(1).build(),
-        assessmentSummaryFactory.createdXDaysAgo(2).build(),
-        assessmentSummaryFactory.createdXDaysAgo(9).build(),
         assessmentSummaryFactory.createdXDaysAgo(8).build(),
+        assessmentSummaryFactory.createdXDaysAgo(7).build(),
+        assessmentSummaryFactory.createdXDaysAgo(10).build(),
+        assessmentSummaryFactory.createdXDaysAgo(11).build(),
       ]
 
       expect(assessmentsApproachingDue(assessments)).toEqual(2)
@@ -153,7 +153,7 @@ describe('utils', () => {
     })
 
     it('returns a badge when there are assessments approaching the due date', () => {
-      const assessments = assessmentSummaryFactory.createdXDaysAgo(9).buildList(2)
+      const assessments = assessmentSummaryFactory.createdXDaysAgo(10).buildList(2)
 
       expect(assessmentsApproachingDueBadge(assessments)).toEqual(
         '<span id="notifications" class="moj-notification-badge">2<span class="govuk-visually-hidden"> assessments approaching due date</span></span>',

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -9,6 +9,7 @@ import type { ObjectWithDateParts } from '@approved-premises/ui'
 import {
   DateFormats,
   InvalidDateStringError,
+  addBusinessDays,
   bankHolidays,
   dateAndTimeInputsAreValidDates,
   dateIsBlank,
@@ -298,6 +299,20 @@ describe('uiDateOrDateEmptyMessage', () => {
     }
 
     expect(uiDateOrDateEmptyMessage(object, 'aDate', DateFormats.isoDateToUIDate)).toEqual('No date supplied')
+  })
+})
+
+describe('addBusinessDays', () => {
+  it('returns the correct date if the gap doesnt include business days', () => {
+    expect(addBusinessDays(new Date(2023, 10, 13), 1)).toEqual(new Date(2023, 10, 14))
+  })
+
+  it('returns the correct date if the gap includes a weekend', () => {
+    expect(addBusinessDays(new Date(2023, 10, 13), 7)).toEqual(new Date(2023, 10, 22))
+  })
+
+  it('returns the correct date if the gap includes a weekend and a bank holiday', () => {
+    expect(addBusinessDays(new Date(2023, 10, 13), 7, [new Date(2023, 10, 13)])).toEqual(new Date(2023, 10, 23))
   })
 })
 

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,4 +1,6 @@
 import {
+  addBusinessDays as addBusinsessDaysWithoutBankHolidays,
+  addDays,
   differenceInBusinessDays as differenceInBusinessDaysDateFns,
   differenceInDays,
   format,
@@ -207,6 +209,19 @@ export class DateFormats {
   static timeFromDate(date: Date): string {
     return format(date, 'HH:mm')
   }
+}
+
+export const addBusinessDays = (date: Date, days: number, holidays: Array<Date> = bankHolidays()): Date => {
+  const businsessDaysToAddWithoutBankHolidays = addBusinsessDaysWithoutBankHolidays(date, days)
+
+  const numberOfHolidayDays = holidays.filter(holiday => {
+    return isWithinInterval(holiday, {
+      start: date,
+      end: businsessDaysToAddWithoutBankHolidays,
+    })
+  })
+
+  return addDays(businsessDaysToAddWithoutBankHolidays, numberOfHolidayDays.length)
 }
 
 export const uiDateOrDateEmptyMessage = (


### PR DESCRIPTION
# Context
Previously (#1055) we did work to ensure that the due date shown on the assessment dashboard was in business days. 
However the due date was still calculated in calendar days meaning users had less time to complete assessments. 
This PR ensures that the due date is calculated in working days so that the due date is accurate.

[Trello card](https://trello.com/c/7GhcnItr/438-countdown-timer-allowing-less-then-the-10-working-days-for-assessments)