### PR TITLE
Use correct sort field for arrival date

### DIFF
--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -392,13 +392,13 @@ context('Placement Requests', () => {
     cy.task('stubPlacementRequestsDashboard', {
       placementRequests: unmatchedPlacementRequests,
       status: 'notMatched',
-      sortBy: 'expectedArrival',
+      sortBy: 'expected_arrival',
       sortDirection: 'asc',
     })
     cy.task('stubPlacementRequestsDashboard', {
       placementRequests: unmatchedPlacementRequests,
       status: 'notMatched',
-      sortBy: 'expectedArrival',
+      sortBy: 'expected_arrival',
       sortDirection: 'desc',
     })
 
@@ -409,30 +409,30 @@ context('Placement Requests', () => {
     listPage.shouldShowPlacementRequests(unmatchedPlacementRequests)
 
     // When I sort by expected arrival in ascending order
-    listPage.clickSortBy('expectedArrival')
+    listPage.clickSortBy('expected_arrival')
 
     // Then the dashboard should be sorted by expected arrival
-    listPage.shouldBeSortedByField('expectedArrival', 'ascending')
+    listPage.shouldBeSortedByField('expected_arrival', 'ascending')
 
     // And the API should have received a request for the correct sort order
     cy.task('verifyPlacementRequestsDashboard', {
       status: 'notMatched',
-      sortBy: 'expectedArrival',
+      sortBy: 'expected_arrival',
       sortDirection: 'asc',
     }).then(requests => {
       expect(requests).to.have.length(1)
     })
 
     // When I sort by expected arrival in descending order
-    listPage.clickSortBy('expectedArrival')
+    listPage.clickSortBy('expected_arrival')
 
     // Then the dashboard should be sorted by expected arrival in descending order
-    listPage.shouldBeSortedByField('expectedArrival', 'descending')
+    listPage.shouldBeSortedByField('expected_arrival', 'descending')
 
     // And the API should have received a request for the correct sort order
     cy.task('verifyPlacementRequestsDashboard', {
       status: 'notMatched',
-      sortBy: 'expectedArrival',
+      sortBy: 'expected_arrival',
       sortDirection: 'desc',
     }).then(requests => {
       expect(requests).to.have.length(1)

--- a/integration_tests/tests/admin/searchPlacementRequests.cy.ts
+++ b/integration_tests/tests/admin/searchPlacementRequests.cy.ts
@@ -87,13 +87,13 @@ context('Search placement Requests', () => {
     cy.task('stubPlacementRequestsSearch', {
       placementRequests,
       crn: 'CRN123',
-      sortBy: 'expectedArrival',
+      sortBy: 'expected_arrival',
       sortDirection: 'asc',
     })
     cy.task('stubPlacementRequestsSearch', {
       placementRequests,
       crn: 'CRN123',
-      sortBy: 'expectedArrival',
+      sortBy: 'expected_arrival',
       sortDirection: 'desc',
     })
 
@@ -107,30 +107,30 @@ context('Search placement Requests', () => {
     searchPage.enterSearchQuery(searchQuery)
 
     // When I sort by expected arrival in ascending order
-    searchPage.clickSortBy('expectedArrival')
+    searchPage.clickSortBy('expected_arrival')
 
     // Then the dashboard should be sorted by expected arrival
-    searchPage.shouldBeSortedByField('expectedArrival', 'ascending')
+    searchPage.shouldBeSortedByField('expected_arrival', 'ascending')
 
     // And the API should have received a request for the correct sort order
     cy.task('verifyPlacementRequestsSearch', {
       ...searchQuery,
-      sortBy: 'expectedArrival',
+      sortBy: 'expected_arrival',
       sortDirection: 'asc',
     }).then(requests => {
       expect(requests).to.have.length(1)
     })
 
     // When I sort by expected arrival in descending order
-    searchPage.clickSortBy('expectedArrival')
+    searchPage.clickSortBy('expected_arrival')
 
     // Then the dashboard should be sorted by expected arrival in descending order
-    searchPage.shouldBeSortedByField('expectedArrival', 'descending')
+    searchPage.shouldBeSortedByField('expected_arrival', 'descending')
 
     // And the API should have received a request for the correct sort order
     cy.task('verifyPlacementRequestsSearch', {
       ...searchQuery,
-      sortBy: 'expectedArrival',
+      sortBy: 'expected_arrival',
       sortDirection: 'desc',
     }).then(requests => {
       expect(requests).to.have.length(1)

--- a/server/utils/placementRequests/table.test.ts
+++ b/server/utils/placementRequests/table.test.ts
@@ -24,6 +24,7 @@ import { allReleaseTypes } from '../applications/releaseTypeUtils'
 import { crnCell, tierCell } from '../tableUtils'
 import { sortHeader } from '../sortHeader'
 import { isFullPerson } from '../personUtils'
+import { PlacementRequestSortField } from '../../@types/shared'
 
 describe('tableUtils', () => {
   describe('nameCell', () => {
@@ -238,7 +239,7 @@ describe('tableUtils', () => {
   })
 
   describe('dashboardTableHeader', () => {
-    const sortBy = 'sortBy'
+    const sortBy = 'duration'
     const sortDirection = 'asc'
     const hrefPrefix = 'http://example.com'
 
@@ -253,9 +254,15 @@ describe('tableUtils', () => {
         {
           text: 'Tier',
         },
-        sortHeader('Arrival date', 'expectedArrival', sortBy, sortDirection, hrefPrefix),
-        sortHeader('Application date', 'application_date', sortBy, sortDirection, hrefPrefix),
-        sortHeader('Length of stay', 'duration', sortBy, sortDirection, hrefPrefix),
+        sortHeader<PlacementRequestSortField>('Arrival date', 'expected_arrival', sortBy, sortDirection, hrefPrefix),
+        sortHeader<PlacementRequestSortField>(
+          'Application date',
+          'application_date',
+          sortBy,
+          sortDirection,
+          hrefPrefix,
+        ),
+        sortHeader<PlacementRequestSortField>('Length of stay', 'duration', sortBy, sortDirection, hrefPrefix),
         {
           text: 'Request type',
         },
@@ -273,8 +280,14 @@ describe('tableUtils', () => {
         {
           text: 'Tier',
         },
-        sortHeader('Arrival date', 'expectedArrival', sortBy, sortDirection, hrefPrefix),
-        sortHeader('Application date', 'application_date', sortBy, sortDirection, hrefPrefix),
+        sortHeader<PlacementRequestSortField>('Arrival date', 'expected_arrival', sortBy, sortDirection, hrefPrefix),
+        sortHeader<PlacementRequestSortField>(
+          'Application date',
+          'application_date',
+          sortBy,
+          sortDirection,
+          hrefPrefix,
+        ),
         {
           text: 'Approved Premises',
         },

--- a/server/utils/placementRequests/table.ts
+++ b/server/utils/placementRequests/table.ts
@@ -1,5 +1,11 @@
 import { addDays } from 'date-fns'
-import { PlacementRequest, PlacementRequestStatus, PlacementRequestTask, SortDirection } from '../../@types/shared'
+import {
+  PlacementRequest,
+  PlacementRequestSortField,
+  PlacementRequestStatus,
+  PlacementRequestTask,
+  SortDirection,
+} from '../../@types/shared'
 import { TableCell, TableRow } from '../../@types/ui'
 import matchPaths from '../../paths/match'
 import adminPaths from '../../paths/admin'
@@ -118,7 +124,7 @@ export const releaseTypeCell = (task: PlacementRequestTask) => {
 
 export const dashboardTableHeader = (
   status: PlacementRequestStatus,
-  sortBy: string,
+  sortBy: PlacementRequestSortField,
   sortDirection: SortDirection,
   hrefPrefix: string,
 ): Array<TableCell> => {
@@ -132,13 +138,13 @@ export const dashboardTableHeader = (
     {
       text: 'Tier',
     },
-    sortHeader('Arrival date', 'expectedArrival', sortBy, sortDirection, hrefPrefix),
-    sortHeader('Application date', 'application_date', sortBy, sortDirection, hrefPrefix),
+    sortHeader<PlacementRequestSortField>('Arrival date', 'expected_arrival', sortBy, sortDirection, hrefPrefix),
+    sortHeader<PlacementRequestSortField>('Application date', 'application_date', sortBy, sortDirection, hrefPrefix),
     status === 'matched'
       ? {
           text: 'Approved Premises',
         }
-      : sortHeader('Length of stay', 'duration', sortBy, sortDirection, hrefPrefix),
+      : sortHeader<PlacementRequestSortField>('Length of stay', 'duration', sortBy, sortDirection, hrefPrefix),
     {
       text: 'Request type',
     },

--- a/server/utils/sortHeader.test.ts
+++ b/server/utils/sortHeader.test.ts
@@ -1,11 +1,13 @@
 import { sortHeader } from './sortHeader'
 import { createQueryString } from './utils'
 
+type SortHeaders = 'myField' | 'otherField'
+
 describe('sortHeader', () => {
   const hrefPrefix = 'http://localhost/example?'
 
   it("should return a header when the current view is not sorted by the header's field`", () => {
-    expect(sortHeader('Some text', 'myField', 'otherField', 'asc', hrefPrefix)).toEqual({
+    expect(sortHeader<SortHeaders>('Some text', 'myField', 'otherField', 'asc', hrefPrefix)).toEqual({
       html: `<a href="${hrefPrefix}${createQueryString({ sortBy: 'myField' })}">Some text</a>`,
       attributes: {
         'aria-sort': 'none',
@@ -15,7 +17,7 @@ describe('sortHeader', () => {
   })
 
   it("should return a header when the current view is sorted in ascending order by the header's field`", () => {
-    expect(sortHeader('Some text', 'myField', 'myField', 'asc', hrefPrefix)).toEqual({
+    expect(sortHeader<SortHeaders>('Some text', 'myField', 'myField', 'asc', hrefPrefix)).toEqual({
       html: `<a href="${hrefPrefix}${createQueryString({ sortBy: 'myField', sortDirection: 'desc' })}">Some text</a>`,
       attributes: {
         'aria-sort': 'ascending',
@@ -25,7 +27,7 @@ describe('sortHeader', () => {
   })
 
   it("should return a header when the current view is sorted in descending order by the header's field`", () => {
-    expect(sortHeader('Some text', 'myField', 'myField', 'desc', hrefPrefix)).toEqual({
+    expect(sortHeader<SortHeaders>('Some text', 'myField', 'myField', 'desc', hrefPrefix)).toEqual({
       html: `<a href="${hrefPrefix}${createQueryString({ sortBy: 'myField', sortDirection: 'asc' })}">Some text</a>`,
       attributes: {
         'aria-sort': 'descending',
@@ -36,7 +38,7 @@ describe('sortHeader', () => {
 
   it('should override and replace the existing parameters in the hrefPrefix', () => {
     const prefixWithParams = `${hrefPrefix}?sortBy=myField&sortDirection=desc`
-    expect(sortHeader('Some text', 'myField', 'myField', 'desc', prefixWithParams)).toEqual({
+    expect(sortHeader<SortHeaders>('Some text', 'myField', 'myField', 'desc', prefixWithParams)).toEqual({
       html: `<a href="${hrefPrefix}${createQueryString({ sortBy: 'myField', sortDirection: 'asc' })}">Some text</a>`,
       attributes: {
         'aria-sort': 'descending',

--- a/server/utils/sortHeader.ts
+++ b/server/utils/sortHeader.ts
@@ -3,10 +3,10 @@ import { SortDirection } from '../@types/shared'
 import { TableCell } from '../@types/ui'
 import { createQueryString } from './utils'
 
-export const sortHeader = (
+export const sortHeader = <T extends string>(
   text: string,
-  targetField: string,
-  currentSortField: string,
+  targetField: T,
+  currentSortField: T,
   currentSortDirection: SortDirection,
   hrefPrefix: string,
 ): TableCell => {

--- a/server/utils/users/tableUtils.test.ts
+++ b/server/utils/users/tableUtils.test.ts
@@ -3,6 +3,7 @@ import { managementDashboardTableHeader, managementDashboardTableRows } from './
 import paths from '../../paths/admin'
 import { linkTo, sentenceCase } from '../utils'
 import { sortHeader } from '../sortHeader'
+import { UserSortField } from '../../@types/shared'
 
 describe('tableUtils', () => {
   describe('dashboardTableHeader', () => {
@@ -23,7 +24,7 @@ describe('tableUtils', () => {
 
     it('returns the table headers with sorting if hrefPrefix is present', () => {
       expect(managementDashboardTableHeader('name', 'desc', 'http://example.com?')).toEqual([
-        sortHeader('Name', 'name', 'name', 'desc', 'http://example.com?'),
+        sortHeader<UserSortField>('Name', 'name', 'name', 'desc', 'http://example.com?'),
         {
           text: 'Role',
         },

--- a/server/utils/users/tableUtils.ts
+++ b/server/utils/users/tableUtils.ts
@@ -1,4 +1,4 @@
-import { SortDirection, ApprovedPremisesUser as User } from '../../@types/shared'
+import { SortDirection, ApprovedPremisesUser as User, UserSortField } from '../../@types/shared'
 import { TableCell } from '../../@types/ui'
 import paths from '../../paths/admin'
 import { sortHeader } from '../sortHeader'
@@ -6,7 +6,7 @@ import { emailCell } from '../tableUtils'
 import { linkTo, sentenceCase } from '../utils'
 
 export const managementDashboardTableHeader = (
-  sortBy: string = undefined,
+  sortBy: UserSortField | undefined = undefined,
   sortDirection: SortDirection | undefined = undefined,
   hrefPrefix: string | undefined = undefined,
 ): Array<TableCell> => {
@@ -15,7 +15,7 @@ export const managementDashboardTableHeader = (
       ? {
           text: 'Name',
         }
-      : sortHeader('Name', 'name', sortBy, sortDirection, hrefPrefix),
+      : sortHeader<UserSortField>('Name', 'name', sortBy, sortDirection, hrefPrefix),
     {
       text: 'Role',
     },


### PR DESCRIPTION
I’ve also added a generic to ensure that the `targetField` and `currentSortField` arguments are typed correctly.