### PR TITLE
(404) Further information request responses don't show on Check Your Answers screen 

### DIFF
--- a/server/form-pages/assess/reviewApplication/sufficientInformation/informationReceived.test.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/informationReceived.test.ts
@@ -83,10 +83,19 @@ describe('InformationReceived', () => {
 
   describe('response', () => {
     it('returns the response', () => {
-      const page = new InformationReceived({ informationReceived: 'yes' })
+      const page = new InformationReceived({
+        informationReceived: 'yes',
+        'responseReceivedOn-year': '2022',
+        'responseReceivedOn-month': '3',
+        'responseReceivedOn-day': '3',
+        responseReceivedOn: '2022-03-03',
+        response: 'some text',
+      })
 
       expect(page.response()).toEqual({
         'Have you received additional information from the probation practitioner?': 'Yes',
+        'Provide the additional information received from the probation practitioner': 'some text',
+        'When did you receive this information?': 'Thursday 3 March 2022',
       })
     })
   })

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/informationReceived.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/informationReceived.ts
@@ -23,6 +23,11 @@ export default class InformationReceived implements TasklistPage {
 
   title = 'Have you received additional information from the probation practitioner?'
 
+  questions = {
+    date: 'When did you receive this information?',
+    details: 'Provide the additional information received from the probation practitioner',
+  }
+
   user: User
 
   constructor(private _body: Partial<InformationReceivedBody>) {}
@@ -57,9 +62,16 @@ export default class InformationReceived implements TasklistPage {
   }
 
   response() {
-    return {
+    const response = {
       [`${this.title}`]: sentenceCase(this.body.informationReceived),
     }
+
+    if (this.body.informationReceived === 'yes') {
+      response[this.questions.date] = DateFormats.isoDateToUIDate(this.body.responseReceivedOn)
+      response[this.questions.details] = this.body.response
+    }
+
+    return response
   }
 
   errors() {

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.test.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.test.ts
@@ -72,11 +72,21 @@ describe('SufficientInformation', () => {
   })
 
   describe('response', () => {
-    it('returns the response', () => {
+    it('returns the sufficientInformation response when the answer is yes and an empty string for the query', () => {
       const page = new SufficientInformation({ sufficientInformation: 'yes' })
 
       expect(page.response()).toEqual({
         'Is there enough information in the application to make a decision?': 'Yes',
+        'What additional information is required?': '',
+      })
+    })
+
+    it('returns both responses when the answer is no', () => {
+      const page = new SufficientInformation({ sufficientInformation: 'no', query: 'some query' })
+
+      expect(page.response()).toEqual({
+        'Is there enough information in the application to make a decision?': 'No',
+        'What additional information is required?': 'some query',
       })
     })
   })

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.ts
@@ -16,6 +16,8 @@ export default class SufficientInformation implements TasklistPage {
 
   title = 'Is there enough information in the application to make a decision?'
 
+  furtherInformationQuestion = 'What additional information is required?'
+
   user: User
 
   constructor(public body: { sufficientInformation?: YesOrNo; query?: string }) {}
@@ -45,6 +47,7 @@ export default class SufficientInformation implements TasklistPage {
   response() {
     return {
       [`${this.title}`]: sentenceCase(this.body.sufficientInformation),
+      [`${this.furtherInformationQuestion}`]: this.body?.query ?? '',
     }
   }
 

--- a/server/views/assessments/pages/sufficient-information/information-received.njk
+++ b/server/views/assessments/pages/sufficient-information/information-received.njk
@@ -11,7 +11,7 @@
   {{ formPageTextarea({
             fieldName: 'response',
             label: {
-              text: "Provide the additional information received from the probation practitioner"
+              text: page.questions.details
             }
           }, fetchContext()) }}
 
@@ -21,7 +21,7 @@
         fieldName: "responseReceivedOn",
         fieldset: {
           legend: {
-            text: "When did you receive this information?"
+            text: page.questions.date
           }
         },
         items: dateFieldValues('responseReceivedOn', errors)

--- a/server/views/assessments/pages/sufficient-information/sufficient-information.njk
+++ b/server/views/assessments/pages/sufficient-information/sufficient-information.njk
@@ -36,7 +36,7 @@
   {{ formPageTextarea({
             fieldName: 'query',
             label: {
-              text: "What additional information is required?"
+              text: page.furtherInformationQuestion
             }
           }, fetchContext()) }}
   {% endset -%}


### PR DESCRIPTION
# Context

We missed off adding this information from the response method the first time around. 
This PR corrects it.

[Trello](https://trello.com/c/YX7nLDqu/404-further-information-requests-responses-do-not-show-on-check-your-answers-screen)
