### PR TITLE
Update Playwright docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ jobs:
 
   e2e_environment_test:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.34.1-focal
+      - image: mcr.microsoft.com/playwright:v1.38.0-focal
     circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
     steps:
       - run:


### PR DESCRIPTION
1.34.1 is not compatible with the latest version of NPM CLI (> 10) so we need to update the docker image

