### PR TITLE
(337) User management design & content iterations

### DIFF
--- a/integration_tests/tests/admin/userManagement.cy.ts
+++ b/integration_tests/tests/admin/userManagement.cy.ts
@@ -74,7 +74,8 @@ context('User management', () => {
       const body = JSON.parse(requests[0].body)
 
       expect(body).to.deep.equal({
-        ...updatedUser,
+        roles: updatedUser.roles,
+        qualifications: updatedRoles.qualifications,
       })
     })
 

--- a/server/controllers/admin/userManagementController.test.ts
+++ b/server/controllers/admin/userManagementController.test.ts
@@ -147,8 +147,10 @@ describe('UserManagementController', () => {
         next,
       )
 
-      expect(userService.getUserById).toHaveBeenCalledWith(token, user.id)
-      expect(userService.updateUser).toHaveBeenCalledWith(token, updatedUser)
+      expect(userService.updateUser).toHaveBeenCalledWith(token, user.id, {
+        roles: [...updatedRoles.roles, ...updatedRoles.allocationRoles],
+        qualifications: updatedUser.qualifications,
+      })
       expect(response.redirect).toHaveBeenCalledWith(paths.admin.userManagement.edit({ id: user.id }))
       expect(flash).toHaveBeenCalledWith('success', 'User updated')
     })

--- a/server/controllers/admin/userManagementController.ts
+++ b/server/controllers/admin/userManagementController.ts
@@ -41,16 +41,13 @@ export default class UserController {
 
   update(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
-      const user = await this.userService.getUserById(req.user.token, req.params.id)
-
-      await this.userService.updateUser(req.user.token, {
-        ...user,
+      await this.userService.updateUser(req.user.token, req.params.id, {
         roles: [...flattenCheckboxInput(req.body.roles), ...flattenCheckboxInput(req.body.allocationPreferences)],
         qualifications: flattenCheckboxInput(req.body.qualifications),
       })
 
       req.flash('success', 'User updated')
-      res.redirect(paths.admin.userManagement.edit({ id: user.id }))
+      res.redirect(paths.admin.userManagement.edit({ id: req.params.id }))
     }
   }
 

--- a/server/data/userClient.test.ts
+++ b/server/data/userClient.test.ts
@@ -311,6 +311,8 @@ describeClient('UserClient', provider => {
     it('should update a user', async () => {
       const user = userFactory.build()
 
+      const rolesAndQualifications = { roles: user.roles, qualifications: user.qualifications }
+
       provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to update a user',
@@ -321,7 +323,7 @@ describeClient('UserClient', provider => {
             authorization: `Bearer ${token}`,
             'X-Service-Name': 'approved-premises',
           },
-          body: user,
+          body: rolesAndQualifications,
         },
         willRespondWith: {
           status: 200,
@@ -329,7 +331,7 @@ describeClient('UserClient', provider => {
         },
       })
 
-      const output = await userClient.updateUser(user)
+      const output = await userClient.updateUser(user.id, rolesAndQualifications)
       expect(output).toEqual(user)
     })
   })

--- a/server/data/userClient.ts
+++ b/server/data/userClient.ts
@@ -3,6 +3,7 @@ import type {
   ApprovedPremisesUser as User,
   UserQualification,
   ApprovedPremisesUserRole as UserRole,
+  UserRolesAndQualifications,
   UserSortField,
 } from '@approved-premises/api'
 
@@ -50,8 +51,11 @@ export default class UserClient {
     })
   }
 
-  async updateUser(user: User): Promise<User> {
-    return (await this.restClient.put({ path: paths.users.update({ id: user.id }), data: user })) as User
+  async updateUser(userId: string, rolesAndQualifications: UserRolesAndQualifications): Promise<User> {
+    return (await this.restClient.put({
+      path: paths.users.update({ id: userId }),
+      data: rolesAndQualifications,
+    })) as User
   }
 
   search(name: string): Promise<Array<User>> {

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -88,15 +88,22 @@ describe('User service', () => {
 
   describe('updateUser', () => {
     it('calls the client method and returns the updated user', async () => {
-      const user = userFactory.build()
+      const userId = 'SOME_ID'
+      const user = userFactory.build({ id: userId })
 
       userClient.updateUser.mockResolvedValue(user)
 
-      const result = await userService.updateUser(token, user)
+      const result = await userService.updateUser(token, user.id, {
+        roles: user.roles,
+        qualifications: user.qualifications,
+      })
 
       expect(result).toEqual(user)
 
-      expect(userClient.updateUser).toHaveBeenCalledWith(user)
+      expect(userClient.updateUser).toHaveBeenCalledWith(userId, {
+        roles: user.roles,
+        qualifications: user.qualifications,
+      })
     })
   })
 

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -3,6 +3,7 @@ import {
   ApprovedPremisesUser as User,
   UserQualification,
   ApprovedPremisesUserRole as UserRole,
+  UserRolesAndQualifications,
   UserSortField,
 } from '@approved-premises/api'
 import { PaginatedResponse, UserDetails } from '@approved-premises/ui'
@@ -42,10 +43,10 @@ export default class UserService {
     return client.getUsers(roles, qualifications, page, sortBy, sortDirection)
   }
 
-  async updateUser(token: string, user: User): Promise<User> {
+  async updateUser(token: string, userId: string, rolesAndQualifications: UserRolesAndQualifications): Promise<User> {
     const client = this.userClientFactory(token)
 
-    return client.updateUser(user)
+    return client.updateUser(userId, rolesAndQualifications)
   }
 
   async search(token: string, query: string): Promise<Array<User>> {

--- a/server/testutils/factories/user.ts
+++ b/server/testutils/factories/user.ts
@@ -1,7 +1,11 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
 
-import type { ApprovedPremisesUser as User, ApprovedPremisesUserRole as UserRole } from '@approved-premises/api'
+import type {
+  ApprovedPremisesUser as User,
+  UserQualification,
+  ApprovedPremisesUserRole as UserRole,
+} from '@approved-premises/api'
 
 export default Factory.define<User>(() => ({
   name: faker.person.fullName(),
@@ -9,7 +13,7 @@ export default Factory.define<User>(() => ({
   email: faker.internet.email(),
   telephoneNumber: faker.phone.number(),
   roles: roleFactory.buildList(Math.floor(Math.random() * 10)),
-  qualifications: [],
+  qualifications: qualificationFactory.buildList(Math.floor(Math.random() * 2)),
   id: faker.string.uuid(),
   region: faker.helpers.arrayElement([{ id: faker.string.uuid(), name: faker.location.county() }]),
   service: 'ApprovedPremises',
@@ -28,4 +32,8 @@ const roleFactory = Factory.define<UserRole>(() =>
     'excluded_from_match_allocation',
     'excluded_from_placement_application_allocation',
   ]),
+)
+
+const qualificationFactory = Factory.define<UserQualification>(() =>
+  faker.helpers.arrayElement(['pipe', 'emergency', 'esap', 'lao', 'womens']),
 )

--- a/server/utils/users/roleCheckboxes/index.ts
+++ b/server/utils/users/roleCheckboxes/index.ts
@@ -9,7 +9,10 @@ export const roleLabelDictionary: RoleLabelDictionary = {
     hint: 'Mark arrivals, departures, and manage placements at an AP',
   },
   matcher: { label: 'Matcher', hint: 'Match a person to a suitable AP for placement' },
-  workflow_manager: { label: 'Workflow manager', hint: 'Manage the allocation of assessments and matches to staff' },
+  workflow_manager: {
+    label: 'Workflow manager',
+    hint: 'Manage the allocation of assessments and matches to staff, and view reports',
+  },
 }
 
 export const allocationRoleLabelDictionary: AllocationRoleLabelDictionary = {

--- a/server/utils/users/roleCheckboxes/index.ts
+++ b/server/utils/users/roleCheckboxes/index.ts
@@ -53,7 +53,7 @@ export type AllocationRole = (typeof allocationRoles)[number]
 
 export const qualifications: ReadonlyArray<UserQualification> = ['pipe', 'emergency', 'esap']
 
-const qualificationDictionary: Record<UserQualification, string> = {
+export const qualificationDictionary: Record<UserQualification, string> = {
   lao: 'LAO',
   womens: "Women's AP's",
   emergency: 'Emergency APs',

--- a/server/utils/users/roleCheckboxes/index.ts
+++ b/server/utils/users/roleCheckboxes/index.ts
@@ -49,6 +49,8 @@ export const allocationRoles = [
   'excluded_from_placement_application_allocation',
 ] as const
 
+export const unusedRoles = ['applicant', 'report_viewer'] as const
+
 export type AllocationRole = (typeof allocationRoles)[number]
 
 export const qualifications: ReadonlyArray<UserQualification> = ['pipe', 'emergency', 'esap']
@@ -61,11 +63,16 @@ export const qualificationDictionary: Record<UserQualification, string> = {
   pipe: 'PIPE',
 }
 
+export const filterUnusedRoles = (allRoles: Array<UserRole>) =>
+  allRoles.filter(role => !(unusedRoles as ReadonlyArray<UserRole>).includes(role))
+
 export const filterAllocationRoles = (
   allRoles: Array<UserRole>,
   { returnOnlyAllocationRoles: includeAllocationRoles }: { returnOnlyAllocationRoles: boolean },
 ) => {
-  return allRoles.filter(role => (allocationRoles as ReadonlyArray<UserRole>).includes(role) === includeAllocationRoles)
+  return filterUnusedRoles(allRoles).filter(
+    role => (allocationRoles as ReadonlyArray<UserRole>).includes(role) === includeAllocationRoles,
+  )
 }
 
 export const roleCheckboxItem = (

--- a/server/utils/users/tableUtils.test.ts
+++ b/server/utils/users/tableUtils.test.ts
@@ -1,7 +1,12 @@
 import { userFactory } from '../../testutils/factories'
-import { managementDashboardTableHeader, managementDashboardTableRows } from './tableUtils'
+import {
+  managementDashboardTableHeader,
+  managementDashboardTableRows,
+  nameCell,
+  roleCell,
+} from './tableUtils'
 import paths from '../../paths/admin'
-import { linkTo, sentenceCase } from '../utils'
+import { linkTo } from '../utils'
 import { sortHeader } from '../sortHeader'
 import { UserSortField } from '../../@types/shared'
 
@@ -38,24 +43,70 @@ describe('tableUtils', () => {
 
   describe('managementDashboardTableRows', () => {
     it('returns the table rows', () => {
-      const users = userFactory.buildList(1)
+      const users = userFactory.buildList(1, { roles: [], qualifications: [] })
       const user = users[0]
       expect(managementDashboardTableRows(users)).toEqual([
         [
-          {
-            html: linkTo(paths.admin.userManagement.edit, { id: user.id }, { text: user.name }),
-          },
-          {
-            text: user.roles.map(role => sentenceCase(role)).join(', '),
-          },
-          {
-            text: user.email,
-          },
-          {
-            text: user.region.name,
-          },
+          { html: linkTo(paths.admin.userManagement.edit, { id: user.id }, { text: user.name }) },
+          { text: '' },
+          { text: 'Standard' },
+          { text: user.email },
+          { text: user.region.name },
         ],
       ])
+    })
+  })
+  describe('roleCell', () => {
+    it('returns a cell with the persons roles in sentence case, excluding the allocation roles', () => {
+      const user = userFactory.build({
+        roles: [
+          'assessor',
+          'matcher',
+          'manager',
+          'workflow_manager',
+          'role_admin',
+
+          'excluded_from_assess_allocation',
+          'excluded_from_match_allocation',
+          'excluded_from_placement_application_allocation',
+        ],
+      })
+      expect(roleCell(user)).toEqual({
+        text: 'Assessor, Matcher, Manage an Approved Premises (AP), Workflow manager, Administrator',
+      })
+    })
+  })
+
+  describe('allocations', () => {
+    it('returns a cell with the persons allocations: a combination of certain roles and all qualifications in sentence case when the user has roles', () => {
+      const user = userFactory.build({
+        roles: [
+          'assessor',
+          'matcher',
+          'manager',
+          'workflow_manager',
+          'applicant',
+          'role_admin',
+          'report_viewer',
+          'excluded_from_assess_allocation',
+          'excluded_from_match_allocation',
+          'excluded_from_placement_application_allocation',
+        ],
+        qualifications: ['emergency', 'esap', 'pipe', 'lao', 'womens'],
+      })
+      expect(allocationCell(user)).toEqual({
+        text: "Stop assessment allocations, Stop match allocations, Stop placement request allocations, Emergency APs, ESAP, PIPE, LAO, Women's AP's",
+      })
+    })
+
+    it('returns "standard" if the user doesnt have any specific allocations', () => {
+      const user = userFactory.build({
+        roles: [],
+        qualifications: [],
+      })
+      expect(allocationCell(user)).toEqual({
+        text: 'Standard',
+      })
     })
   })
 })

--- a/server/utils/users/tableUtils.test.ts
+++ b/server/utils/users/tableUtils.test.ts
@@ -1,8 +1,10 @@
 import { userFactory } from '../../testutils/factories'
 import {
+  allocationCell,
   managementDashboardTableHeader,
   managementDashboardTableRows,
   nameCell,
+  regionCell,
   roleCell,
 } from './tableUtils'
 import paths from '../../paths/admin'
@@ -21,6 +23,9 @@ describe('tableUtils', () => {
           text: 'Role',
         },
         {
+          text: 'Allocations',
+        },
+        {
           text: 'Email',
         },
         { text: 'Region' },
@@ -32,6 +37,9 @@ describe('tableUtils', () => {
         sortHeader<UserSortField>('Name', 'name', 'name', 'desc', 'http://example.com?'),
         {
           text: 'Role',
+        },
+        {
+          text: 'Allocations',
         },
         {
           text: 'Email',
@@ -56,6 +64,16 @@ describe('tableUtils', () => {
       ])
     })
   })
+
+  describe('nameCell', () => {
+    it('returns a cell with the persons name as a link to the edit page', () => {
+      const user = userFactory.build()
+      expect(nameCell(user)).toEqual({
+        html: linkTo(paths.admin.userManagement.edit, { id: user.id }, { text: user.name }),
+      })
+    })
+  })
+
   describe('roleCell', () => {
     it('returns a cell with the persons roles in sentence case, excluding the allocation roles', () => {
       const user = userFactory.build({
@@ -77,7 +95,7 @@ describe('tableUtils', () => {
     })
   })
 
-  describe('allocations', () => {
+  describe('allocationCell', () => {
     it('returns a cell with the persons allocations: a combination of certain roles and all qualifications in sentence case when the user has roles', () => {
       const user = userFactory.build({
         roles: [
@@ -106,6 +124,15 @@ describe('tableUtils', () => {
       })
       expect(allocationCell(user)).toEqual({
         text: 'Standard',
+      })
+    })
+  })
+
+  describe('regionCell', () => {
+    it('returns the region for the user', () => {
+      const user = userFactory.build()
+      expect(regionCell(user)).toEqual({
+        text: user.region.name,
       })
     })
   })

--- a/server/utils/users/tableUtils.ts
+++ b/server/utils/users/tableUtils.ts
@@ -3,7 +3,13 @@ import { TableCell } from '../../@types/ui'
 import paths from '../../paths/admin'
 import { sortHeader } from '../sortHeader'
 import { emailCell } from '../tableUtils'
-import { linkTo, sentenceCase } from '../utils'
+import { linkTo } from '../utils'
+import {
+  allocationRoleLabelDictionary,
+  filterAllocationRoles,
+  qualificationDictionary,
+  roleLabelDictionary,
+} from './roleCheckboxes'
 
 export const managementDashboardTableHeader = (
   sortBy: UserSortField | undefined = undefined,
@@ -19,6 +25,7 @@ export const managementDashboardTableHeader = (
     {
       text: 'Role',
     },
+    { text: 'Allocations' },
     {
       text: 'Email',
     },
@@ -27,7 +34,7 @@ export const managementDashboardTableHeader = (
 }
 
 export const managementDashboardTableRows = (users: Array<User>): Array<Array<TableCell>> => {
-  return users.map(user => [nameCell(user), roleCell(user), emailCell(user), regionCell(user)])
+  return users.map(user => [nameCell(user), roleCell(user), allocationCell(user), emailCell(user), regionCell(user)])
 }
 
 const nameCell = (user: User): TableCell => {
@@ -36,13 +43,28 @@ const nameCell = (user: User): TableCell => {
   }
 }
 
-const roleCell = (user: User): TableCell => {
+export const roleCell = (user: User): TableCell => {
   return {
-    text: user.roles.map(role => sentenceCase(role)).join(', '),
+    text: filterAllocationRoles(user.roles, { returnOnlyAllocationRoles: false })
+      .map(role => roleLabelDictionary[role].label)
+      .join(', '),
   }
 }
 
-const regionCell = (user: User): TableCell => {
+export const allocationCell = (user: User): TableCell => {
+  const allocations = [
+    ...filterAllocationRoles(user.roles, { returnOnlyAllocationRoles: true }).map(
+      role => allocationRoleLabelDictionary[role].label,
+    ),
+    ...user.qualifications.map(qualification => qualificationDictionary[qualification]),
+  ].join(', ')
+
+  return {
+    text: allocations.length > 0 ? allocations : 'Standard',
+  }
+}
+
+export const regionCell = (user: User): TableCell => {
   return {
     text: user.region.name,
   }

--- a/server/utils/users/tableUtils.ts
+++ b/server/utils/users/tableUtils.ts
@@ -37,7 +37,7 @@ export const managementDashboardTableRows = (users: Array<User>): Array<Array<Ta
   return users.map(user => [nameCell(user), roleCell(user), allocationCell(user), emailCell(user), regionCell(user)])
 }
 
-const nameCell = (user: User): TableCell => {
+export const nameCell = (user: User): TableCell => {
   return {
     html: linkTo(paths.admin.userManagement.edit, { id: user.id }, { text: user.name }),
   }

--- a/server/views/admin/users/confirmDelete.njk
+++ b/server/views/admin/users/confirmDelete.njk
@@ -32,8 +32,7 @@
                 {{
                 govukButton({
                     text: "Remove access",
-                    type: "submit",
-                    classes: "govuk-button--warning"
+                    type: "submit"
                 })
             }}
             </form>


### PR DESCRIPTION
# Context

Some miscellaneous design and content iterations on the User management screens.

[Trello card](https://trello.com/c/WTrXhGUP/337-user-management)

# Changes in this PR
- On the user index page we split the 'roles' column into 'roles' and 'allocations' and add 'qualifications' to the 'allocations' column (previously not displayed on the index page). This mirrors what we do on the 'Edit' page
- Update the hint text for workflow manager to indicate they can view reports
- Update the colour of the Deletion confirmation button on the edit page to be green instead of red



## Screenshots of UI changes

### Before
![befre 1](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/abccec44-33f2-4ff9-8efa-bce6014a774b)
![befre 2](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/2d81d8ec-3330-4a89-96a4-5e5e3dd4ca33)
![after (3)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/40ba7db2-c95c-4227-90bd-1403a74a248f)


### After
![after](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/9bd4eb7e-8a69-4196-b628-c0092dacc737)
![User management -- allows searching for users (2)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/67908631-ea79-409c-83a4-8fac58993df0)
![after (2)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/ec0cf7f7-c662-4f6e-890c-c4d3cfac8e21)

