### PR TITLE
Add further offences to dateOfOffence page

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -205,7 +205,12 @@
     "date-of-offence": {
       "arsonOffence": ["current"],
       "hateCrime": ["previous"],
-      "inPersonSexualOffence": ["current", "previous"]
+      "offencesAgainstChildren": ["current", "previous"],
+      "contactSexualOffencesAgainstAdults": ["current", "previous"],
+      "nonContactSexualOffencesAgainstAdults": ["current", "previous"],
+      "contactSexualOffencesAgainstChildren": ["current", "previous"],
+      "nonContactSexualOffencesAgainstChildren": ["current", "previous"],
+      "otherSexualOffences": ["current", "previous"]
     },
     "rehabilitative-interventions": {
       "rehabilitativeInterventions": [

--- a/integration_tests/pages/apply/dateOfOffence.ts
+++ b/integration_tests/pages/apply/dateOfOffence.ts
@@ -10,6 +10,11 @@ export default class DateOfOffence extends ApplyPage {
   completeForm(): void {
     this.checkCheckboxesFromPageBody('arsonOffence')
     this.checkCheckboxesFromPageBody('hateCrime')
-    this.checkCheckboxesFromPageBody('inPersonSexualOffence')
+    this.checkCheckboxesFromPageBody('offencesAgainstChildren')
+    this.checkCheckboxesFromPageBody('contactSexualOffencesAgainstAdults')
+    this.checkCheckboxesFromPageBody('nonContactSexualOffencesAgainstAdults')
+    this.checkCheckboxesFromPageBody('contactSexualOffencesAgainstChildren')
+    this.checkCheckboxesFromPageBody('nonContactSexualOffencesAgainstChildren')
+    this.checkCheckboxesFromPageBody('otherSexualOffences')
   }
 }

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/dateOfOffence.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/dateOfOffence.test.ts
@@ -5,19 +5,22 @@ import DateOfOffence from './dateOfOffence'
 jest.mock('../../../../utils/formUtils')
 
 describe('DateOfOffence', () => {
+  const body = {
+    arsonOffence: 'current',
+    hateCrime: 'previous',
+    offencesAgainstChildren: ['current', 'previous'],
+    contactSexualOffencesAgainstAdults: ['current', 'previous'],
+    nonContactSexualOffencesAgainstAdults: ['current', 'previous'],
+    contactSexualOffencesAgainstChildren: ['current', 'previous'],
+    nonContactSexualOffencesAgainstChildren: ['current', 'previous'],
+    otherSexualOffences: ['current', 'previous'],
+  } as const
+
   describe('body', () => {
     it('should set the body', () => {
-      const page = new DateOfOffence({
-        arsonOffence: 'current',
-        onlineSexualOffence: ['previous', 'current'],
-        hateCrime: ['previous'],
-      })
+      const page = new DateOfOffence(body)
 
-      expect(page.body).toEqual({
-        arsonOffence: ['current'],
-        onlineSexualOffence: ['previous', 'current'],
-        hateCrime: ['previous'],
-      })
+      expect(page.body).toEqual({ ...body, arsonOffence: ['current'], hateCrime: ['previous'] })
     })
   })
 
@@ -38,17 +41,17 @@ describe('DateOfOffence', () => {
 
   describe('response', () => {
     it('should return a translated version of the response', () => {
-      const page = new DateOfOffence({
-        arsonOffence: 'current',
-        hateCrime: 'previous',
-        onlineSexualOffence: ['previous', 'current'],
-      })
+      const page = new DateOfOffence(body)
 
       expect(page.response()).toEqual({
         'Is the arson offence current or previous?': 'Current',
         'Is the hate crime current or previous?': 'Previous',
-        'Is the in person sexual offence current or previous?': 'Neither',
-        'Is the online sexual offence current or previous?': 'Current and previous',
+        'Is the contact sexual offences against adults current or previous?': 'Current and previous',
+        'Is the contact sexual offences against children current or previous?': 'Current and previous',
+        'Is the non contact sexual offences against adults current or previous?': 'Current and previous',
+        'Is the non contact sexual offences against children current or previous?': 'Current and previous',
+        'Is the offences against children current or previous?': 'Current and previous',
+        'Is the other sexual offences current or previous?': 'Current and previous',
       })
     })
   })
@@ -92,8 +95,12 @@ describe('DateOfOffence', () => {
       expect(result).toEqual([
         new DateOfOffence({}).renderTableRow('arsonOffence'),
         new DateOfOffence({}).renderTableRow('hateCrime'),
-        new DateOfOffence({}).renderTableRow('inPersonSexualOffence'),
-        new DateOfOffence({}).renderTableRow('onlineSexualOffence'),
+        new DateOfOffence({}).renderTableRow('offencesAgainstChildren'),
+        new DateOfOffence({}).renderTableRow('contactSexualOffencesAgainstAdults'),
+        new DateOfOffence({}).renderTableRow('nonContactSexualOffencesAgainstAdults'),
+        new DateOfOffence({}).renderTableRow('contactSexualOffencesAgainstChildren'),
+        new DateOfOffence({}).renderTableRow('nonContactSexualOffencesAgainstChildren'),
+        new DateOfOffence({}).renderTableRow('otherSexualOffences'),
       ])
     })
   })

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/dateOfOffence.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/dateOfOffence.ts
@@ -7,15 +7,19 @@ import TasklistPage from '../../../tasklistPage'
 const offences = {
   arsonOffence: 'Arson offence',
   hateCrime: 'Hate crime',
-  inPersonSexualOffence: 'Child sexual offence, in person',
-  onlineSexualOffence: 'Online sexual offence',
+  offencesAgainstChildren: 'Offences against children',
+  contactSexualOffencesAgainstAdults: 'Contact sexual offences against adults',
+  nonContactSexualOffencesAgainstAdults: 'Non-contact sexual offences against adults',
+  contactSexualOffencesAgainstChildren: 'Contact sexual offences against children',
+  nonContactSexualOffencesAgainstChildren: 'Non-contact sexual offences against children',
+  otherSexualOffences: 'Other sexual offence',
 } as const
 
 const offencesList = Object.keys(offences)
 
 type Offence = keyof typeof offences
 
-type Response = Array<'previous' | 'current'> | 'previous' | 'current'
+type Response = ReadonlyArray<'previous' | 'current'> | 'previous' | 'current'
 
 @Page({ name: 'date-of-offence', bodyProperties: Object.keys(offences) })
 export default class DateOfOffence implements TasklistPage {

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -991,7 +991,7 @@
                 }
               ]
             },
-            "inPersonSexualOffence": {
+            "offencesAgainstChildren": {
               "anyOf": [
                 {
                   "type": "array",
@@ -1012,7 +1012,91 @@
                 }
               ]
             },
-            "onlineSexualOffence": {
+            "contactSexualOffencesAgainstAdults": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "enum": [
+                      "current",
+                      "previous"
+                    ],
+                    "type": "string"
+                  }
+                },
+                {
+                  "enum": [
+                    "current",
+                    "previous"
+                  ],
+                  "type": "string"
+                }
+              ]
+            },
+            "nonContactSexualOffencesAgainstAdults": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "enum": [
+                      "current",
+                      "previous"
+                    ],
+                    "type": "string"
+                  }
+                },
+                {
+                  "enum": [
+                    "current",
+                    "previous"
+                  ],
+                  "type": "string"
+                }
+              ]
+            },
+            "contactSexualOffencesAgainstChildren": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "enum": [
+                      "current",
+                      "previous"
+                    ],
+                    "type": "string"
+                  }
+                },
+                {
+                  "enum": [
+                    "current",
+                    "previous"
+                  ],
+                  "type": "string"
+                }
+              ]
+            },
+            "nonContactSexualOffencesAgainstChildren": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "enum": [
+                      "current",
+                      "previous"
+                    ],
+                    "type": "string"
+                  }
+                },
+                {
+                  "enum": [
+                    "current",
+                    "previous"
+                  ],
+                  "type": "string"
+                }
+              ]
+            },
+            "otherSexualOffences": {
               "anyOf": [
                 {
                   "type": "array",


### PR DESCRIPTION
We need to add some extra offences to this page and remove 'onlineSexualOffence' because users need to be able to declare this information.

[Trello ticket](https://trello.com/c/xIj0sFxy/448-update-convicted-offences-screens-on-apply)


## Screenshots of UI changes

### Before
![bvefore](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/69b0203f-b2b5-4806-b398-bd1ca59fc997)

### After
![after (3)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/81de4ac2-46c8-472f-9c38-6164f33aa26c)

