### PR TITLE
Mock response from DaysUntilDue

### DIFF
--- a/server/utils/assessments/dateUtils.test.ts
+++ b/server/utils/assessments/dateUtils.test.ts
@@ -3,7 +3,6 @@ import {
   daysSinceInfoRequest,
   daysSinceReceived,
   daysToWeeksAndDays,
-  daysUntilDue,
   formatDays,
   formatDaysUntilDueWithWarning,
   formattedArrivalDate,
@@ -62,14 +61,6 @@ describe('dateUtils', () => {
 
     it('returns N/A if the day in undefined', () => {
       expect(formatDays(undefined)).toEqual('N/A')
-    })
-  })
-
-  describe('daysUntilDue', () => {
-    it('returns the days until the assessment is due', () => {
-      const assessment = assessmentSummaryFactory.createdXDaysAgo(1).build()
-
-      expect(daysUntilDue(assessment)).toEqual(1)
     })
   })
 

--- a/server/utils/assessments/dateUtils.ts
+++ b/server/utils/assessments/dateUtils.ts
@@ -4,8 +4,9 @@ import {
   ApprovedPremisesAssessment as Assessment,
   AssessmentSummary,
 } from '@approved-premises/api'
-import { DateFormats, addBusinessDays } from '../dateUtils'
+import { DateFormats } from '../dateUtils'
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
+import { daysUntilDue } from './daysUntilDue'
 
 const DUE_DATE_APPROACHING_DAYS_WINDOW = 3
 
@@ -29,13 +30,6 @@ const formatDays = (days: number): string => {
     return 'N/A'
   }
   return `${days} Day${days > 1 ? 's' : ''}`
-}
-
-const daysUntilDue = (assessment: AssessmentSummary): number => {
-  const receivedDate = DateFormats.isoToDateObj(assessment.createdAt)
-  const dueDate = addBusinessDays(receivedDate, 10)
-
-  return DateFormats.differenceInBusinessDays(dueDate, new Date())
 }
 
 const daysToWeeksAndDays = (days: string | number): { days: number; weeks: number } => {

--- a/server/utils/assessments/daysUntilDue.test.ts
+++ b/server/utils/assessments/daysUntilDue.test.ts
@@ -1,0 +1,35 @@
+import { addDays, formatISO } from 'date-fns'
+import { assessmentSummaryFactory } from '../../testutils/factories'
+import { daysUntilDue } from './dateUtils'
+import { DateFormats, addBusinessDays } from '../dateUtils'
+
+jest.mock('../dateUtils')
+
+describe('daysUntilDue', () => {
+  it('calls the functions it contains with the correct arguments and returns the result of differenceInBusinessDays', () => {
+    const newDate = new Date()
+    const receivedDate = new Date()
+    const dueDate = addDays(receivedDate, 10)
+    ;(DateFormats.isoToDateObj as jest.MockedFunction<typeof DateFormats.isoToDateObj>).mockReturnValue(receivedDate)
+    ;(DateFormats.dateObjToIsoDate as jest.MockedFunction<typeof DateFormats.dateObjToIsoDate>).mockImplementation(
+      date => formatISO(date, { representation: 'date' }),
+    )
+    ;(
+      DateFormats.dateObjToIsoDateTime as jest.MockedFunction<typeof DateFormats.dateObjToIsoDateTime>
+    ).mockImplementation(date => formatISO(date, { representation: 'time' }))
+    ;(
+      DateFormats.differenceInBusinessDays as jest.MockedFunction<typeof DateFormats.differenceInBusinessDays>
+    ).mockReturnValue(1)
+    ;(addBusinessDays as jest.MockedFunction<typeof addBusinessDays>).mockReturnValue(addDays(receivedDate, 10))
+
+    const assessment = assessmentSummaryFactory.build({
+      createdAt: formatISO(receivedDate, { representation: 'date' }),
+    })
+
+    expect(daysUntilDue(assessment, newDate)).toEqual(1)
+
+    expect(DateFormats.isoToDateObj).toHaveBeenCalledWith(assessment.createdAt)
+    expect(addBusinessDays).toHaveBeenCalledWith(receivedDate, 10)
+    expect(DateFormats.differenceInBusinessDays).toHaveBeenCalledWith(dueDate, newDate)
+  })
+})

--- a/server/utils/assessments/daysUntilDue.ts
+++ b/server/utils/assessments/daysUntilDue.ts
@@ -1,0 +1,9 @@
+import { AssessmentSummary } from '../../@types/shared'
+import { DateFormats, addBusinessDays } from '../dateUtils'
+
+export const daysUntilDue = (assessment: AssessmentSummary, todaysDate: Date = new Date()): number => {
+  const receivedDate = DateFormats.isoToDateObj(assessment.createdAt)
+  const dueDate = addBusinessDays(receivedDate, 10)
+
+  return DateFormats.differenceInBusinessDays(dueDate, todaysDate)
+}

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -14,7 +14,6 @@ import {
   groupAssessmements,
   rejectionRationaleFromAssessmentResponses,
 } from './utils'
-import { DateFormats } from '../dateUtils'
 
 import * as applicationUtils from '../applications/utils'
 
@@ -33,6 +32,7 @@ import {
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
 import { applicationAccepted, decisionFromAssessment } from './decisionUtils'
 import { getResponseForPage } from '../applications/getResponseForPage'
+import { daysUntilDue } from './daysUntilDue'
 
 const FirstPage = jest.fn()
 const SecondPage = jest.fn()
@@ -44,6 +44,7 @@ jest.mock('./documentUtils')
 jest.mock('../applications/arrivalDateFromApplication')
 jest.mock('./decisionUtils')
 jest.mock('./getActionsForTaskId')
+jest.mock('./daysUntilDue')
 
 jest.mock('../../form-pages/assess', () => {
   return {
@@ -132,12 +133,9 @@ describe('utils', () => {
 
   describe('assessmentsApproachingDue', () => {
     it('returns the number of assessments where the due date is less than DUE_DATE_APPROACHING_WINDOW away', () => {
-      const assessments = [
-        assessmentSummaryFactory.createdXDaysAgo(8).build(),
-        assessmentSummaryFactory.createdXDaysAgo(7).build(),
-        assessmentSummaryFactory.createdXDaysAgo(10).build(),
-        assessmentSummaryFactory.createdXDaysAgo(11).build(),
-      ]
+      ;(daysUntilDue as jest.MockedFunction<typeof daysUntilDue>).mockReturnValue(2)
+
+      const assessments = assessmentSummaryFactory.buildList(2)
 
       expect(assessmentsApproachingDue(assessments)).toEqual(2)
     })
@@ -145,15 +143,15 @@ describe('utils', () => {
 
   describe('assessmentsApproachingDueBadge', () => {
     it('returns blank when there are no assessments approaching the due date', () => {
-      const assessments = assessmentSummaryFactory.buildList(2, {
-        createdAt: DateFormats.dateObjToIsoDate(new Date()),
-      })
+      const assessments = assessmentSummaryFactory.buildList(2)
+      ;(daysUntilDue as jest.MockedFunction<typeof daysUntilDue>).mockReturnValue(20)
 
       expect(assessmentsApproachingDueBadge(assessments)).toEqual('')
     })
 
     it('returns a badge when there are assessments approaching the due date', () => {
-      const assessments = assessmentSummaryFactory.createdXDaysAgo(10).buildList(2)
+      ;(daysUntilDue as jest.MockedFunction<typeof daysUntilDue>).mockReturnValue(2)
+      const assessments = assessmentSummaryFactory.buildList(2)
 
       expect(assessmentsApproachingDueBadge(assessments)).toEqual(
         '<span id="notifications" class="moj-notification-badge">2<span class="govuk-visually-hidden"> assessments approaching due date</span></span>',


### PR DESCRIPTION
Now that we're using business days in the daysUntilDue function we can no longer predict how many days an assessment will have until it is due as there is an unknown number of working days between the current date and the due date. So, for test purposes, we have to mock the response from daysUntilDue. To make this easier we'll put it in its own file.
