### PR TITLE
Add LAO qualification to user management UI

### DIFF
--- a/integration_tests/tests/admin/userManagement.cy.ts
+++ b/integration_tests/tests/admin/userManagement.cy.ts
@@ -49,7 +49,7 @@ context('User management', () => {
         'excluded_from_match_allocation',
         'excluded_from_placement_application_allocation',
       ] as const,
-      qualifications: ['pipe', 'emergency', 'esap'] as const,
+      qualifications: ['pipe', 'emergency', 'esap', 'lao'] as const,
     }
     showPage.completeForm({
       roles: updatedRoles.roles,

--- a/server/utils/users/roleCheckboxes/index.ts
+++ b/server/utils/users/roleCheckboxes/index.ts
@@ -53,10 +53,10 @@ export const unusedRoles = ['applicant', 'report_viewer'] as const
 
 export type AllocationRole = (typeof allocationRoles)[number]
 
-export const qualifications: ReadonlyArray<UserQualification> = ['pipe', 'emergency', 'esap']
+export const qualifications: ReadonlyArray<UserQualification> = ['pipe', 'emergency', 'esap', 'lao']
 
 export const qualificationDictionary: Record<UserQualification, string> = {
-  lao: 'LAO',
+  lao: 'Limited access offenders',
   womens: "Women's AP's",
   emergency: 'Emergency APs',
   esap: 'ESAP',

--- a/server/utils/users/tableUtils.test.ts
+++ b/server/utils/users/tableUtils.test.ts
@@ -113,7 +113,7 @@ describe('tableUtils', () => {
         qualifications: ['emergency', 'esap', 'pipe', 'lao', 'womens'],
       })
       expect(allocationCell(user)).toEqual({
-        text: "Stop assessment allocations, Stop match allocations, Stop placement request allocations, Emergency APs, ESAP, PIPE, LAO, Women's AP's",
+        text: "Stop assessment allocations, Stop match allocations, Stop placement request allocations, Emergency APs, ESAP, PIPE, Limited access offenders, Women's AP's",
       })
     })
 


### PR DESCRIPTION
This is in addition to the other qualifications we already have to allow assessors (and others!) to see Limited Access Offenders
