### PR TITLE
(427) Apply navigation fixes and non-statutory sentence type changes

### DIFF
--- a/integration_tests/pages/apply/rehabilitativeInterventions.ts
+++ b/integration_tests/pages/apply/rehabilitativeInterventions.ts
@@ -1,6 +1,7 @@
 import { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
+import paths from '../../../server/paths/apply'
 
 export default class RehabilitativeInterventions extends ApplyPage {
   constructor(application: ApprovedPremisesApplication) {
@@ -9,6 +10,7 @@ export default class RehabilitativeInterventions extends ApplyPage {
       application,
       'risk-management-features',
       'rehabilitative-interventions',
+      paths.applications.pages.show({ id: application.id, task: 'risk-management-features', page: 'date-of-offence' }),
     )
   }
 

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -9,7 +9,6 @@ declare module 'express-session' {
     returnTo: string
     nowInMinutes: number
     application: ApprovedPremisesApplication
-    previousPage: string
     user: UserDetails
     placementApplicationDecisions: Record<string, Partial<PlacementApplicationDecisionEnvelope>>
   }

--- a/server/form-pages/apply/reasons-for-placement/basic-information/index.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/index.ts
@@ -18,6 +18,7 @@ import PauseApplication from './pauseApplication'
 import ReferToDelius from './referToDelius'
 import NotEligible from './notEligible'
 import EndDates from './endDates'
+import ManagedByMappa from './managedByMappa'
 import { Task } from '../../../utils/decorators'
 
 @Task({
@@ -34,6 +35,7 @@ import { Task } from '../../../utils/decorators'
     ReferToDelius,
     ExceptionDetails,
     SentenceType,
+    ManagedByMappa,
     ReleaseType,
     EndDates,
     Situation,

--- a/server/form-pages/apply/reasons-for-placement/basic-information/managedByMappa.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/managedByMappa.test.ts
@@ -1,0 +1,50 @@
+import { fromPartial } from '@total-typescript/shoehorn'
+import { itShouldHavePreviousValue } from '../../../shared-examples'
+
+import ManagedByMappa from './managedByMappa'
+
+describe('ManagedByMappa', () => {
+  const body = {
+    managedByMappa: 'yes' as const,
+  }
+
+  describe('body', () => {
+    it('should set the body', () => {
+      const page = new ManagedByMappa(body)
+
+      expect(page.body).toEqual(body)
+    })
+  })
+
+  describe('next', () => {
+    it('if the answer is "yes" it should be "release-date"', () => {
+      expect(new ManagedByMappa(fromPartial({ managedByMappa: 'yes' })).next()).toEqual('release-date')
+    })
+
+    it('if the answer is "no" it should be "sentence-type"', () => {
+      expect(new ManagedByMappa(fromPartial({ managedByMappa: 'no' })).next()).toEqual('sentence-type')
+    })
+  })
+
+  itShouldHavePreviousValue(new ManagedByMappa(body), 'sentence-type')
+
+  describe('errors', () => {
+    it('should return errors when yes/no questions are blank', () => {
+      const page = new ManagedByMappa(fromPartial({}))
+
+      expect(page.errors()).toEqual({
+        managedByMappa: 'You must specify if the person is managed by MAPPA',
+      })
+    })
+  })
+
+  describe('response', () => {
+    it('returns the response in human readable form', () => {
+      const page = new ManagedByMappa(body)
+
+      expect(page.response()).toEqual({
+        'Is the person managed by MAPPA?': 'Yes',
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/reasons-for-placement/basic-information/managedByMappa.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/managedByMappa.ts
@@ -1,0 +1,38 @@
+import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import { Page } from '../../../utils/decorators'
+
+import TasklistPage from '../../../tasklistPage'
+import { sentenceCase } from '../../../../utils/utils'
+
+@Page({ name: 'managed-by-mappa', bodyProperties: ['managedByMappa'] })
+export default class ManagedByMappa implements TasklistPage {
+  question = 'Is the person managed by MAPPA?'
+
+  title = this.question
+
+  constructor(public body: { managedByMappa: YesOrNo }) {}
+
+  previous() {
+    return 'sentence-type'
+  }
+
+  next() {
+    return this.body.managedByMappa === 'yes' ? 'release-date' : 'sentence-type'
+  }
+
+  response() {
+    return {
+      [this.question]: sentenceCase(this.body.managedByMappa),
+    }
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.managedByMappa) {
+      errors.managedByMappa = 'You must specify if the person is managed by MAPPA'
+    }
+
+    return errors
+  }
+}

--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.ts
@@ -6,6 +6,9 @@ import TasklistPage from '../../../tasklistPage'
 import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank, dateIsInThePast } from '../../../../utils/dateUtils'
 import { convertToTitleCase } from '../../../../utils/utils'
 import { dateBodyProperties } from '../../../utils/dateBodyProperties'
+import { adjacentPageFromSentenceType } from '../../../../utils/applications/adjacentPageFromSentenceType'
+import { retrieveQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
+import SentenceType from './sentenceType'
 
 type ReleaseDateType = ObjectWithDateParts<'releaseDate'> & {
   knowReleaseDate: YesOrNo
@@ -21,7 +24,6 @@ export default class ReleaseDate implements TasklistPage {
   constructor(
     private _body: Partial<ReleaseDateType>,
     readonly application: ApprovedPremisesApplication,
-    readonly previousPage: string,
   ) {}
 
   public set body(value: Partial<ReleaseDateType>) {
@@ -51,7 +53,8 @@ export default class ReleaseDate implements TasklistPage {
   }
 
   previous() {
-    return this.previousPage
+    const sentenceType = retrieveQuestionResponseFromFormArtifact(this.application, SentenceType)
+    return adjacentPageFromSentenceType(sentenceType)
   }
 
   response() {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseType.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseType.ts
@@ -4,9 +4,10 @@ import type { ReleaseTypeOptions, TaskListErrors } from '@approved-premises/ui'
 import { SessionDataError } from '../../../../utils/errors'
 import { retrieveQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 import TasklistPage from '../../../tasklistPage'
-import SentenceType, { SentenceTypesT } from './sentenceType'
+import SentenceType from './sentenceType'
 import { Page } from '../../../utils/decorators'
 import { allReleaseTypes } from '../../../../utils/applications/releaseTypeUtils'
+import { SentenceTypesT } from '../../../../utils/applications/adjacentPageFromSentenceType'
 
 type SelectableReleaseType = Exclude<ReleaseTypeOption, 'in_community'>
 type ReducedReleaseTypeOptions = Pick<ReleaseTypeOptions, 'rotl' | 'licence'>

--- a/server/form-pages/apply/reasons-for-placement/basic-information/sentenceType.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/sentenceType.test.ts
@@ -1,7 +1,10 @@
 import { applicationFactory } from '../../../../testutils/factories'
+import { adjacentPageFromSentenceType } from '../../../../utils/applications/adjacentPageFromSentenceType'
 import { itShouldHavePreviousValue } from '../../../shared-examples'
 
 import SentenceType from './sentenceType'
+
+jest.mock('../../../../utils/applications/adjacentPageFromSentenceType')
 
 describe('SentenceType', () => {
   const application = applicationFactory.build()
@@ -15,39 +18,15 @@ describe('SentenceType', () => {
   })
 
   describe('next', () => {
-    it('should return release-type for a standardDeterminate sentence', () => {
-      const page = new SentenceType({ sentenceType: 'standardDeterminate' }, application)
-      expect(page.next()).toEqual('release-type')
-    })
+    it('calls selectAdjacentPageFromSentenceType and returns the result', () => {
+      ;(adjacentPageFromSentenceType as jest.MockedFn<typeof adjacentPageFromSentenceType>).mockReturnValue(
+        'release-type',
+      )
 
-    it('should return situation for a communityOrder sentence', () => {
-      const page = new SentenceType({ sentenceType: 'communityOrder' }, application)
-      expect(page.next()).toEqual('situation')
-    })
+      const result = new SentenceType({ sentenceType: 'standardDeterminate' }, application).next()
 
-    it('should return situation for a bailPlacement sentence', () => {
-      const page = new SentenceType({ sentenceType: 'bailPlacement' }, application)
-      expect(page.next()).toEqual('situation')
-    })
-
-    it('should return release-type for an extendedDeterminate sentence', () => {
-      const page = new SentenceType({ sentenceType: 'extendedDeterminate' }, application)
-      expect(page.next()).toEqual('release-type')
-    })
-
-    it('should return release-type for an ipp sentence', () => {
-      const page = new SentenceType({ sentenceType: 'ipp' }, application)
-      expect(page.next()).toEqual('release-type')
-    })
-
-    it('should return release-type for a life sentence', () => {
-      const page = new SentenceType({ sentenceType: 'life' }, application)
-      expect(page.next()).toEqual('release-type')
-    })
-
-    it('should return release-date for a non-statutory / MAPPA sentence', () => {
-      const page = new SentenceType({ sentenceType: 'nonStatutory' }, application)
-      expect(page.next()).toEqual('release-date')
+      expect(result).toEqual('release-type')
+      expect(adjacentPageFromSentenceType).toHaveBeenCalledWith('standardDeterminate')
     })
   })
 

--- a/server/form-pages/apply/reasons-for-placement/basic-information/sentenceType.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/sentenceType.test.ts
@@ -48,7 +48,7 @@ describe('SentenceType', () => {
     it('marks an option as selected when the sentenceType is set', () => {
       const page = new SentenceType({ sentenceType: 'life' }, application)
 
-      const selectedOptions = page.items().filter(item => item.checked)
+      const selectedOptions = page.items('conditionalHTML').filter(item => item.checked)
 
       expect(selectedOptions.length).toEqual(1)
       expect(selectedOptions[0].value).toEqual('life')
@@ -57,9 +57,23 @@ describe('SentenceType', () => {
     it('marks no options selected when the sentenceType is not set', () => {
       const page = new SentenceType({}, application)
 
-      const selectedOptions = page.items().filter(item => item.checked)
+      const selectedOptions = page.items('conditionalHTML').filter(item => item.checked)
 
       expect(selectedOptions.length).toEqual(0)
+    })
+
+    it('returns the conditional text for the nonStatutory key', () => {
+      const page = new SentenceType({}, application)
+
+      const selectedOptions = page.items('conditionalHTML')
+
+      selectedOptions.forEach(item => {
+        if (item.value !== 'nonStatutory') {
+          expect(item.conditional).toEqual({ html: '' })
+        } else {
+          expect(item.conditional).toEqual({ html: 'conditionalHTML' })
+        }
+      })
     })
   })
 

--- a/server/form-pages/apply/reasons-for-placement/basic-information/sentenceType.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/sentenceType.ts
@@ -40,12 +40,13 @@ export default class SentenceType implements TasklistPage {
     return errors
   }
 
-  items() {
+  items(conditionalHtml: string) {
     return Object.keys(sentenceTypes).map(key => {
       return {
         value: key,
         text: sentenceTypes[key],
         checked: this.body.sentenceType === key,
+        conditional: { html: key === 'nonStatutory' ? conditionalHtml : '' },
       }
     })
   }

--- a/server/form-pages/apply/reasons-for-placement/basic-information/sentenceType.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/sentenceType.ts
@@ -3,18 +3,11 @@ import { ApprovedPremisesApplication as Application } from '@approved-premises/a
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
-
-export const sentenceTypes = {
-  standardDeterminate: 'Standard determinate custody',
-  life: 'Life sentence',
-  ipp: 'Indeterminate Public Protection (IPP)',
-  extendedDeterminate: 'Extended determinate custody',
-  communityOrder: 'Community Order (CO) / Suspended Sentence Order (SSO)',
-  bailPlacement: 'Bail placement',
-  nonStatutory: 'Non-statutory, MAPPA case',
-} as const
-
-export type SentenceTypesT = keyof typeof sentenceTypes
+import {
+  SentenceTypesT,
+  adjacentPageFromSentenceType,
+  sentenceTypes,
+} from '../../../../utils/applications/adjacentPageFromSentenceType'
 
 @Page({ name: 'sentence-type', bodyProperties: ['sentenceType'] })
 export default class SentenceType implements TasklistPage {
@@ -34,24 +27,7 @@ export default class SentenceType implements TasklistPage {
   }
 
   next() {
-    switch (this.body.sentenceType) {
-      case 'standardDeterminate':
-        return 'release-type'
-      case 'communityOrder':
-        return 'situation'
-      case 'bailPlacement':
-        return 'situation'
-      case 'extendedDeterminate':
-        return 'release-type'
-      case 'ipp':
-        return 'release-type'
-      case 'nonStatutory':
-        return 'release-date'
-      case 'life':
-        return 'release-type'
-      default:
-        throw new Error('The release type is invalid')
-    }
+    return adjacentPageFromSentenceType(this.body.sentenceType)
   }
 
   errors() {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/situation.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/situation.ts
@@ -5,7 +5,8 @@ import { Page } from '../../../utils/decorators'
 import { SessionDataError } from '../../../../utils/errors'
 import { retrieveQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 import TasklistPage from '../../../tasklistPage'
-import SentenceType, { SentenceTypesT } from './sentenceType'
+import SentenceType from './sentenceType'
+import { SentenceTypesT } from '../../../../utils/applications/adjacentPageFromSentenceType'
 
 const situations = {
   riskManagement: 'Application for risk management/public protection',

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.test.ts
@@ -44,7 +44,7 @@ describe('RehabilitativeInterventions', () => {
       })
       .build()
 
-    itShouldHavePreviousValue(new RehabilitativeInterventions(body, application), 'convicted-offences')
+    itShouldHavePreviousValue(new RehabilitativeInterventions(body, application), 'date-of-offence')
   })
 
   describe('if the user didnt answer "yes" to convictedOffences', () => {
@@ -57,7 +57,7 @@ describe('RehabilitativeInterventions', () => {
       })
       .build()
 
-    itShouldHavePreviousValue(new RehabilitativeInterventions(body, application), 'date-of-offence')
+    itShouldHavePreviousValue(new RehabilitativeInterventions(body, application), 'convicted-offences')
   })
 
   itShouldHaveNextValue(new RehabilitativeInterventions(body, application), '')

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/rehabilitativeInterventions.ts
@@ -66,9 +66,7 @@ export default class RehabilitativeInterventions implements TasklistPage {
   }
 
   previous() {
-    return convictedOffenceResponseFromApplication(this.application) === 'yes'
-      ? 'convicted-offences'
-      : 'date-of-offence'
+    return convictedOffenceResponseFromApplication(this.application) === 'no' ? 'convicted-offences' : 'date-of-offence'
   }
 
   next() {

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -158,6 +158,18 @@
             }
           }
         },
+        "managed-by-mappa": {
+          "type": "object",
+          "properties": {
+            "managedByMappa": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            }
+          }
+        },
         "release-type": {
           "type": "object",
           "properties": {

--- a/server/form-pages/tasklistPage.ts
+++ b/server/form-pages/tasklistPage.ts
@@ -3,7 +3,7 @@
 import type { DataServices, FormArtifact, PageResponse, TaskListErrors } from '@approved-premises/ui'
 
 export interface TasklistPageInterface {
-  new (body: Record<string, unknown>, document?: FormArtifact, previousPage?: string): TasklistPage
+  new (body: Record<string, unknown>, document?: FormArtifact): TasklistPage
   initialize?(
     body: Record<string, unknown>,
     document: FormArtifact,

--- a/server/form-pages/utils/decorators/page.decorator.test.ts
+++ b/server/form-pages/utils/decorators/page.decorator.test.ts
@@ -48,33 +48,12 @@ describe('tasklistPageDecorator', () => {
       ) {}
     }
 
-    @Page({
-      bodyProperties: ['foo', 'bar', 'baz'],
-      name: 'Some Name',
-    })
-    class ClassWithApplicationAndPreviousPage {
-      constructor(
-        readonly body: Record<string, unknown>,
-        readonly application: ApprovedPremisesApplication,
-        readonly previousPage: string,
-      ) {}
-    }
-
     const application = applicationFactory.build()
     const classWithApplication = new ClassWithApplication(
       { foo: '1', bar: '2', baz: '3', something: 'else' },
       application,
     )
 
-    const classWithApplicationAndPreviousPage = new ClassWithApplicationAndPreviousPage(
-      { foo: '1', bar: '2', baz: '3', something: 'else' },
-      application,
-      'previous',
-    )
-
     expect(classWithApplication.application).toEqual(application)
-
-    expect(classWithApplicationAndPreviousPage.application).toEqual(application)
-    expect(classWithApplicationAndPreviousPage.previousPage).toEqual('previous')
   })
 })

--- a/server/form-pages/utils/decorators/page.decorator.ts
+++ b/server/form-pages/utils/decorators/page.decorator.ts
@@ -13,16 +13,13 @@ const Page = (options: { bodyProperties: Array<string>; name: string; controller
 
       document: ApprovedPremisesApplication | ApprovedPremisesAssessment
 
-      previousPage: string
-
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       constructor(...args: Array<any>) {
         super(...args)
-        const [body, document, previousPage] = args
+        const [body, document] = args
 
         this.body = this.createBody(body, ...options.bodyProperties)
         this.document = document
-        this.previousPage = previousPage
       }
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -206,7 +206,6 @@ describe('ApplicationService', () => {
 
       request = createMock<Request>({
         params: { id: application.id, task: 'my-task', page: 'first' },
-        session: { previousPage: '' },
         user: { token: 'some-token' },
       })
     })
@@ -218,7 +217,7 @@ describe('ApplicationService', () => {
 
       expect(result).toBeInstanceOf(Page)
 
-      expect(Page).toHaveBeenCalledWith(request.body, application, '')
+      expect(Page).toHaveBeenCalledWith(request.body, application)
       expect(applicationClient.find).toHaveBeenCalledWith(request.params.id)
     })
 
@@ -229,7 +228,7 @@ describe('ApplicationService', () => {
 
       expect(result).toBeInstanceOf(Page)
 
-      expect(Page).toHaveBeenCalledWith(request.body, application, '')
+      expect(Page).toHaveBeenCalledWith(request.body, application)
     })
 
     it('should initialize the page with the session and the userInput if specified', async () => {
@@ -240,7 +239,7 @@ describe('ApplicationService', () => {
 
       expect(result).toBeInstanceOf(Page)
 
-      expect(Page).toHaveBeenCalledWith(userInput, application, '')
+      expect(Page).toHaveBeenCalledWith(userInput, application)
     })
 
     it('should load from the application if the body and userInput are blank', async () => {
@@ -257,7 +256,7 @@ describe('ApplicationService', () => {
 
       expect(result).toBeInstanceOf(Page)
 
-      expect(Page).toHaveBeenCalledWith({ foo: 'bar' }, applicationWithData, '')
+      expect(Page).toHaveBeenCalledWith({ foo: 'bar' }, applicationWithData)
     })
 
     it("should call a service's initialize method if it exists", async () => {
@@ -267,15 +266,6 @@ describe('ApplicationService', () => {
       await service.initializePage(OtherPage, request, dataServices)
 
       expect(OtherPage.initialize).toHaveBeenCalledWith(request.body, application, request.user.token, dataServices)
-    })
-
-    it("retrieve the 'previousPage' value from the session and call the Page object's constructor with that value", async () => {
-      ;(getBody as jest.Mock).mockReturnValue(request.body)
-
-      request.session.previousPage = 'previous-page-name'
-      await service.initializePage(Page, request, dataServices)
-
-      expect(Page).toHaveBeenCalledWith(request.body, application, 'previous-page-name')
     })
   })
 

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -87,7 +87,7 @@ export default class ApplicationService {
 
     const page = Page.initialize
       ? await Page.initialize(body, application, request.user.token, dataServices)
-      : new Page(body, application, request.session.previousPage)
+      : new Page(body, application)
 
     return page
   }

--- a/server/services/assessmentService.test.ts
+++ b/server/services/assessmentService.test.ts
@@ -70,7 +70,6 @@ describe('AssessmentService', () => {
     beforeEach(() => {
       request = createMock<Request>({
         params: { id: assessment.id, task: 'my-task', page: 'first' },
-        session: { previousPage: '' },
         user: { token: 'some-token' },
       })
     })
@@ -82,7 +81,7 @@ describe('AssessmentService', () => {
 
       expect(result).toBeInstanceOf(Page)
 
-      expect(Page).toHaveBeenCalledWith(request.body, assessment, '')
+      expect(Page).toHaveBeenCalledWith(request.body, assessment)
     })
 
     it("should call a page's initialize method if it exists", async () => {

--- a/server/services/assessmentService.ts
+++ b/server/services/assessmentService.ts
@@ -45,7 +45,7 @@ export default class AssessmentService {
 
     const page = Page.initialize
       ? await Page.initialize(body, assessment, request.user.token, dataServices)
-      : new Page(body, assessment, request.session.previousPage)
+      : new Page(body, assessment)
 
     return page
   }

--- a/server/services/placementApplicationService.test.ts
+++ b/server/services/placementApplicationService.test.ts
@@ -56,7 +56,6 @@ describe('placementApplicationService', () => {
 
       request = createMock<Request>({
         params: { id: placementApplication.id, task: 'my-task', page: 'first' },
-        session: { previousPage: '' },
         user: { token: 'some-token' },
       })
     })
@@ -68,7 +67,7 @@ describe('placementApplicationService', () => {
 
       expect(result).toBeInstanceOf(Page)
 
-      expect(Page).toHaveBeenCalledWith(request.body, placementApplication, '')
+      expect(Page).toHaveBeenCalledWith(request.body, placementApplication)
       expect(placementApplicationClient.find).toHaveBeenCalledWith(request.params.id)
     })
 
@@ -79,7 +78,7 @@ describe('placementApplicationService', () => {
 
       expect(result).toBeInstanceOf(Page)
 
-      expect(Page).toHaveBeenCalledWith(request.body, placementApplication, '')
+      expect(Page).toHaveBeenCalledWith(request.body, placementApplication)
     })
 
     it('should initialize the page with the session and the userInput if specified', async () => {
@@ -90,7 +89,7 @@ describe('placementApplicationService', () => {
 
       expect(result).toBeInstanceOf(Page)
 
-      expect(Page).toHaveBeenCalledWith(userInput, placementApplication, '')
+      expect(Page).toHaveBeenCalledWith(userInput, placementApplication)
     })
 
     it('should load from the application if the body and userInput are blank', async () => {
@@ -107,7 +106,7 @@ describe('placementApplicationService', () => {
 
       expect(result).toBeInstanceOf(Page)
 
-      expect(Page).toHaveBeenCalledWith({ foo: 'bar' }, applicationWithData, '')
+      expect(Page).toHaveBeenCalledWith({ foo: 'bar' }, applicationWithData)
     })
 
     it("should call a service's initialize method if it exists", async () => {
@@ -122,15 +121,6 @@ describe('placementApplicationService', () => {
         request.user.token,
         dataServices,
       )
-    })
-
-    it("retrieve the 'previousPage' value from the session and call the Page object's constructor with that value", async () => {
-      ;(getBody as jest.Mock).mockReturnValue(request.body)
-
-      request.session.previousPage = 'previous-page-name'
-      await service.initializePage(Page, request, dataServices)
-
-      expect(Page).toHaveBeenCalledWith(request.body, placementApplication, 'previous-page-name')
     })
   })
 

--- a/server/services/placementApplicationService.ts
+++ b/server/services/placementApplicationService.ts
@@ -38,7 +38,7 @@ export default class PlacementApplicationService {
 
     const page = Page.initialize
       ? await Page.initialize(body, placementApplication, request.user.token, dataServices)
-      : new Page(body, placementApplication, request.session.previousPage)
+      : new Page(body, placementApplication)
 
     return page
   }

--- a/server/testutils/addToApplication.ts
+++ b/server/testutils/addToApplication.ts
@@ -1,7 +1,7 @@
 import { FormArtifact } from '../@types/ui'
 
-export const addResponseToFormArtifact = (
-  formArtifact: FormArtifact,
+export const addResponseToFormArtifact = <T extends FormArtifact>(
+  formArtifact: T,
   { section, page, key, value }: { section: string; page: string; key?: string; value?: unknown },
 ) => {
   formArtifact.data = {
@@ -15,8 +15,8 @@ export const addResponseToFormArtifact = (
   return formArtifact
 }
 
-export const addResponsesToFormArtifact = (
-  formArtifact: FormArtifact,
+export const addResponsesToFormArtifact = <T extends FormArtifact>(
+  formArtifact: T,
   { section, page, keyValuePairs }: { section: string; page: string; keyValuePairs?: Record<string, unknown> },
 ) => {
   formArtifact.data = {

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -6,12 +6,12 @@ import { addDays } from 'date-fns'
 
 import type { ApprovedPremisesApplication, OASysSection, ReleaseTypeOption } from '@approved-premises/api'
 
-import { SentenceTypesT } from '../../form-pages/apply/reasons-for-placement/basic-information/sentenceType'
 import type { ApTypes } from '../../form-pages/apply/reasons-for-placement/type-of-ap/apType'
 import { fullPersonFactory, restrictedPersonFactory } from './person'
 import risksFactory from './risks'
 import { DateFormats } from '../../utils/dateUtils'
 import { PartnerAgencyDetails } from '../../@types/ui'
+import { SentenceTypesT } from '../../utils/applications/adjacentPageFromSentenceType'
 
 class ApplicationFactory extends Factory<ApprovedPremisesApplication> {
   withReleaseDate(releaseDate = DateFormats.dateObjToIsoDate(faker.date.soon())) {

--- a/server/utils/applications/adjacentPageFromSentenceType.test.ts
+++ b/server/utils/applications/adjacentPageFromSentenceType.test.ts
@@ -1,0 +1,31 @@
+import { adjacentPageFromSentenceType } from './adjacentPageFromSentenceType'
+
+describe('adjacentPageFromSentenceType', () => {
+  it('should return release-type for a standardDeterminate sentence', () => {
+    expect(adjacentPageFromSentenceType('standardDeterminate')).toEqual('release-type')
+  })
+
+  it('should return situation for a communityOrder sentence', () => {
+    expect(adjacentPageFromSentenceType('communityOrder')).toEqual('situation')
+  })
+
+  it('should return situation for a bailPlacement sentence', () => {
+    expect(adjacentPageFromSentenceType('bailPlacement')).toEqual('situation')
+  })
+
+  it('should return release-type for an extendedDeterminate sentence', () => {
+    expect(adjacentPageFromSentenceType('extendedDeterminate')).toEqual('release-type')
+  })
+
+  it('should return release-type for an ipp sentence', () => {
+    expect(adjacentPageFromSentenceType('ipp')).toEqual('release-type')
+  })
+
+  it('should return release-type for a life sentence', () => {
+    expect(adjacentPageFromSentenceType('life')).toEqual('release-type')
+  })
+
+  it('should return release-date for a non-statutory / MAPPA sentence', () => {
+    expect(adjacentPageFromSentenceType('nonStatutory')).toEqual('release-date')
+  })
+})

--- a/server/utils/applications/adjacentPageFromSentenceType.test.ts
+++ b/server/utils/applications/adjacentPageFromSentenceType.test.ts
@@ -26,6 +26,6 @@ describe('adjacentPageFromSentenceType', () => {
   })
 
   it('should return release-date for a non-statutory / MAPPA sentence', () => {
-    expect(adjacentPageFromSentenceType('nonStatutory')).toEqual('release-date')
+    expect(adjacentPageFromSentenceType('nonStatutory')).toEqual('managed-by-mappa')
   })
 })

--- a/server/utils/applications/adjacentPageFromSentenceType.ts
+++ b/server/utils/applications/adjacentPageFromSentenceType.ts
@@ -1,0 +1,32 @@
+export const sentenceTypes = {
+  standardDeterminate: 'Standard determinate custody',
+  life: 'Life sentence',
+  ipp: 'Indeterminate Public Protection (IPP)',
+  extendedDeterminate: 'Extended determinate custody',
+  communityOrder: 'Community Order (CO) / Suspended Sentence Order (SSO)',
+  bailPlacement: 'Bail placement',
+  nonStatutory: 'Non-statutory, MAPPA case',
+} as const
+
+export type SentenceTypesT = keyof typeof sentenceTypes
+
+export const adjacentPageFromSentenceType = (sentenceType: SentenceTypesT) => {
+  switch (sentenceType) {
+    case 'standardDeterminate':
+      return 'release-type'
+    case 'communityOrder':
+      return 'situation'
+    case 'bailPlacement':
+      return 'situation'
+    case 'extendedDeterminate':
+      return 'release-type'
+    case 'ipp':
+      return 'release-type'
+    case 'nonStatutory':
+      return 'release-date'
+    case 'life':
+      return 'release-type'
+    default:
+      throw new Error('The release type is invalid')
+  }
+}

--- a/server/utils/applications/adjacentPageFromSentenceType.ts
+++ b/server/utils/applications/adjacentPageFromSentenceType.ts
@@ -23,7 +23,7 @@ export const adjacentPageFromSentenceType = (sentenceType: SentenceTypesT) => {
     case 'ipp':
       return 'release-type'
     case 'nonStatutory':
-      return 'release-date'
+      return 'managed-by-mappa'
     case 'life':
       return 'release-type'
     default:

--- a/server/views/applications/pages/basic-information/managed-by-mappa.njk
+++ b/server/views/applications/pages/basic-information/managed-by-mappa.njk
@@ -1,0 +1,42 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{% extends "../layout.njk" %}
+
+{% set conditionalHtml %}
+{% set html %}
+<p class="govuk-body">A person on non-statutory sentence must be managed by MAPPA in order to be placed in an Approved Premises.</p>
+<p class="govuk-body">Check the person’s sentence type on nDelius and return to the sentence type question.</p>
+{% endset %}
+
+{{ govukNotificationBanner({
+        html: html
+    }) }}
+{% endset -%}
+
+{% block questions %}
+
+    <h1 class="govuk-heading-l">
+        {{ page.title }}
+    </h1>
+
+    {{
+        formPageRadios({
+            fieldName: 'managedByMappa',
+            items: [
+            {
+                value: "yes",
+                text: "Yes"
+            },
+            {
+                value: "no",
+                text: "No",
+                conditional: {
+                    html: conditionalHtml
+                }
+            }
+            ]
+        },
+        fetchContext()
+        )
+    }}
+{% endblock %}

--- a/server/views/applications/pages/basic-information/sentence-type.njk
+++ b/server/views/applications/pages/basic-information/sentence-type.njk
@@ -1,4 +1,18 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
 {% extends "../layout.njk" %}
+
+{% set conditionalHtml %}
+  {% set html %}
+  <p class="govuk-body">Non-statutory cases managed under MAPPA can be placed in Approved Premises.</p>
+  <p class="govuk-body">In a non-statutory case a person's management by the probation service continues after the end of their sentence or licence.</p>
+  <p class="govuk-body">If a person is or will be on post-sentence supervision (PSS) they cannot be a non-statutory case.</p>
+  {% endset %}
+
+{{ govukNotificationBanner({
+        html: html
+    }) }}
+{% endset -%}
 
 {% block questions %}
 
@@ -16,7 +30,7 @@
         hint: {
         text: "Select the option which best describes the situation"
       },
-        items: page.items()
+        items: page.items(conditionalHtml)
       },
       fetchContext()
     )


### PR DESCRIPTION
We have previously had a high number of applications where the sentence type was 'Non statutory'. 
This should be a very rare occurence and after post-hoc inspection each of these cases was not a valid non-statutory case. 
In order to better guide the user to the correct sentence type we add some guidance about what is a valid non-statutory case and if non-statutory is selected we take the user to a page where they're asked to confirmed if the user is managed by MAPPA (as they must be if it is a valid non-stat case).

With the current integration test setup we have this is quite hard to test as it would require adding a fair amount of logic to the 'completeBasicInformation' method in Apply helpers so intead I suggest we test this behavio

As well as this addition I have correct the behaviour of the 'Back' button on a couple of pages of the Apply journey.

[Trello card](https://trello.com/c/DmBrYFNZ/427-design-screens-for-non-stat-sentence-type)

## Screenshots of UI changes

### Before
![afte (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/9b3f43d7-7900-4331-be46-7a9d4005d836)

### After
![afte](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/9c9af6dd-14c3-4e85-a023-abca11d9be9a)

<img width="774" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/73ba4c1f-14c4-416a-8ed3-84ab8333676a">

