### PR TITLE
Link to an assessment from an application page

### DIFF
--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -19,6 +19,18 @@ export default class ShowPage extends Page {
     cy.get('Create placement request').should('not.exist')
   }
 
+  shouldShowAssessmentDetails() {
+    cy.get('.govuk-inset-text')
+      .contains(
+        `Application was ${this.application.assessmentDecision} on ${DateFormats.isoDateToUIDate(
+          this.application.assessmentDecisionDate,
+        )}`,
+      )
+      .should('exist')
+
+    cy.get(`a[data-cy-assessmentId="${this.application.assessmentId}"]`).should('exist')
+  }
+
   shouldShowPersonInformation() {
     cy.get('[data-cy-section="person-details"]').within(() => {
       const person = this.application.person as FullPerson

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -1,5 +1,5 @@
 import { addDays } from 'date-fns'
-import { EnterCRNPage, ListPage, SelectOffencePage, ShowPage, StartPage, TransgenderPage } from '../../pages/apply'
+import { EnterCRNPage, ListPage, SelectOffencePage, StartPage, TransgenderPage } from '../../pages/apply'
 import { addResponseToFormArtifact, addResponsesToFormArtifact } from '../../../server/testutils/addToApplication'
 import {
   activeOffenceFactory,
@@ -223,30 +223,5 @@ context('Apply', () => {
 
     // Then I am taken back to the dashboard
     Page.verifyOnPage(ListPage)
-  })
-
-  it('shows a read-only version the application', function test() {
-    // Given I have completed an application
-    const updatedApplication = { ...this.application, status: 'submitted' }
-    cy.task('stubApplicationGet', { application: updatedApplication })
-    cy.task('stubApplications', [updatedApplication])
-
-    // And I visit the list page
-    const listPage = ListPage.visit([], [updatedApplication], [])
-
-    // When I click on the Submitted tab
-    listPage.clickSubmittedTab()
-
-    // Then I should see my application
-    listPage.shouldShowInProgressApplications()
-
-    // When I click on my application
-    listPage.clickApplication(this.application)
-
-    // Then I should see a read-only version of the application
-    const showPage = Page.verifyOnPage(ShowPage, updatedApplication)
-
-    showPage.shouldShowPersonInformation()
-    showPage.shouldShowResponses()
   })
 })

--- a/integration_tests/tests/apply/viewApplication.cy.ts
+++ b/integration_tests/tests/apply/viewApplication.cy.ts
@@ -1,0 +1,65 @@
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import { ListPage, ShowPage } from '../../pages/apply'
+import Page from '../../pages/page'
+import { setup } from './setup'
+
+context('show applications', () => {
+  beforeEach(setup)
+
+  it('shows a read-only version of the application', function test() {
+    // Given I have completed an application
+    const updatedApplication = { ...this.application, status: 'submitted' }
+    cy.task('stubApplicationGet', { application: updatedApplication })
+    cy.task('stubApplications', [updatedApplication])
+
+    // And I visit the list page
+    const listPage = ListPage.visit([], [updatedApplication], [])
+
+    // When I click on the Submitted tab
+    listPage.clickSubmittedTab()
+
+    // Then I should see my application
+    listPage.shouldShowInProgressApplications()
+
+    // When I click on my application
+    listPage.clickApplication(this.application)
+
+    // Then I should see a read-only version of the application
+    const showPage = Page.verifyOnPage(ShowPage, updatedApplication)
+
+    showPage.shouldShowPersonInformation()
+    showPage.shouldShowResponses()
+  })
+
+  it('links to an assessment when an application has been assessed', function test() {
+    // Given I have completed an application
+    const application = {
+      ...this.application,
+      status: 'submitted',
+      assessmentDecision: 'accepted',
+      assessmentDecisionDate: '2023-01-01',
+      assessmentId: faker.string.uuid(),
+    }
+    cy.task('stubApplicationGet', { application })
+    cy.task('stubApplications', [application])
+
+    // And I visit the list page
+    const listPage = ListPage.visit([], [], [application])
+
+    // When I click on the Submitted tab
+    listPage.clickSubmittedTab()
+
+    // Then I should see my application
+    listPage.shouldShowSubmittedApplications()
+
+    // When I click on my application
+    listPage.clickApplication(this.application)
+
+    // Then I should see a read-only version of the application
+    const showPage = Page.verifyOnPage(ShowPage, application)
+
+    // And I should see details of the assessment
+    showPage.shouldShowAssessmentDetails()
+  })
+})

--- a/integration_tests/tests/match/placementApplications.cy.ts
+++ b/integration_tests/tests/match/placementApplications.cy.ts
@@ -40,11 +40,9 @@ context('Placement Applications', () => {
   it('allows me to complete form if the reason for placement is ROTL', () => {
     cy.fixture('rotlPlacementApplicationData.json').then(placementApplicationData => {
       // Given I have completed an application I am viewing a completed application
-      const completedApplication = applicationFactory.build({
-        status: 'submitted',
+      const completedApplication = applicationFactory.completed('accepted').build({
         id: '123',
         createdByUserId: userId,
-        assessmentDecision: 'accepted',
         person: personFactory.build(),
       })
       cy.task('stubApplicationGet', { application: completedApplication })
@@ -112,11 +110,9 @@ context('Placement Applications', () => {
   it('allows me to complete form if the reason for placement is an additional placement on an existing application', () => {
     cy.fixture('existingApplicationPlacementApplication.json').then(placementApplicationData => {
       // Given I have completed an application I am viewing a completed application
-      const completedApplication = applicationFactory.build({
-        status: 'submitted',
+      const completedApplication = applicationFactory.completed('accepted').build({
         id: '123',
         createdByUserId: userId,
-        assessmentDecision: 'accepted',
         person: personFactory.build(),
       })
       cy.task('stubApplicationGet', { application: completedApplication })
@@ -177,12 +173,10 @@ context('Placement Applications', () => {
     cy.fixture('paroleBoardPlacementApplication.json').then(placementApplicationData => {
       // Given I have completed an application I am viewing a completed application
       const person = personFactory.build()
-      let completedApplication = applicationFactory.build({
-        status: 'submitted',
+      let completedApplication = applicationFactory.completed('accepted').build({
         id: '123',
-        person,
         createdByUserId: userId,
-        assessmentDecision: 'accepted',
+        person,
       })
       completedApplication = addResponseToFormArtifact(completedApplication, {
         section: 'type-of-ap',
@@ -367,10 +361,8 @@ context('Placement Applications', () => {
 
   it('does not allow me to create a placement application if I did not create the application', () => {
     // Given there is an accepted application that I did not create
-    const application = applicationFactory.build({
-      status: 'submitted',
+    const application = applicationFactory.completed('accepted').build({
       id: '123',
-      assessmentDecision: 'accepted',
       person: personFactory.build(),
     })
     cy.task('stubApplicationGet', { application })
@@ -384,11 +376,9 @@ context('Placement Applications', () => {
 
   it('does not allow me to create a placement application if the assessment was rejected', () => {
     // Given there is an rejected application that I created
-    const application = applicationFactory.build({
-      status: 'submitted',
+    const application = applicationFactory.completed('rejected').build({
       id: '123',
       createdByUserId: userId,
-      assessmentDecision: 'rejected',
       person: personFactory.build(),
     })
     cy.task('stubApplicationGet', { application })

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -4,7 +4,12 @@ import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { addDays } from 'date-fns'
 
-import type { ApprovedPremisesApplication, OASysSection, ReleaseTypeOption } from '@approved-premises/api'
+import type {
+  ApprovedPremisesApplication,
+  AssessmentDecision,
+  OASysSection,
+  ReleaseTypeOption,
+} from '@approved-premises/api'
 
 import type { ApTypes } from '../../form-pages/apply/reasons-for-placement/type-of-ap/apType'
 import { fullPersonFactory, restrictedPersonFactory } from './person'
@@ -104,6 +109,15 @@ class ApplicationFactory extends Factory<ApprovedPremisesApplication> {
   withFullPerson() {
     return this.params({
       person: fullPersonFactory.build(),
+    })
+  }
+
+  completed(assessmentDecision: AssessmentDecision) {
+    return this.params({
+      status: 'submitted',
+      assessmentDecision,
+      assessmentDecisionDate: DateFormats.dateObjToIsoDateTime(faker.date.past()),
+      assessmentId: faker.string.uuid(),
     })
   }
 }

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "../partials/personDetails.njk" import personDetails %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -41,6 +42,19 @@
           </div>
         </div>
       </div>
+
+      {% if application.assessmentDecision %}
+        {% set html %}
+        <p class="govuk-body">Application was {{ application.assessmentDecision }} on {{ formatDate(application.assessmentDecisionDate) }}</p>
+        <p class="govuk-body">
+          <a href="{{paths.assessments.show({id: application.assessmentId})}}" data-cy-assessmentId="{{ application.assessmentId }}">View assessment</a>
+        </p>
+        {% endset %}
+
+        {{ govukInsetText({
+          html: html
+        }) }}
+      {% endif %}
 
       {{ personDetails(application.person) }}
 


### PR DESCRIPTION
This allows users to quickly view an assessment when an application has been assessed.

I’ve also broken the apply tests up a bit for readability.

# Screenshot

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/e053c056-5409-44a6-b0f8-f2c614db6f32)
