### PR TITLE
(165) Apply - Add applicant and COM detail

### DIFF
--- a/integration_tests/.eslintrc
+++ b/integration_tests/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "plugins": ["cypress", "no-only-tests"],
+  "plugins": ["cypress"],
   "env": {
     "cypress/globals": true
   },

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -7,6 +7,11 @@
       "caseManagementResponsibility": "no",
       "detailsToUpdate[]": ["phoneNumber", "emailAddress", "name"]
     },
+    "case-manager-information": {
+      "emailAddress": "bob@test.com",
+      "name": "Bob Smith",
+      "phoneNumber": "01234567890"
+    },
     "transgender": {
       "transgenderOrHasTransgenderHistory": "yes"
     },

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -1,5 +1,12 @@
 {
   "basic-information": {
+    "confirm-your-details": {
+      "emailAddress": "bob@test.com",
+      "name": "Bob Smith",
+      "phoneNumber": "01234567890",
+      "caseManagementResponsibility": "no",
+      "detailsToUpdate[]": ["phoneNumber", "emailAddress", "name"]
+    },
     "transgender": {
       "transgenderOrHasTransgenderHistory": "yes"
     },

--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -423,6 +423,10 @@ export default class ApplyHelper {
     confirmYourDetails.completeForm()
     confirmYourDetails.clickSubmit()
 
+    const caseManagerInformation = new ApplyPages.CaseManagerInformationPage(this.application)
+    caseManagerInformation.completeForm()
+    caseManagerInformation.clickSubmit()
+
     const transgenderPage = new ApplyPages.TransgenderPage(this.application)
     transgenderPage.completeForm()
     transgenderPage.clickSubmit()
@@ -472,6 +476,7 @@ export default class ApplyHelper {
 
     this.pages.basicInformation = [
       confirmYourDetails,
+      caseManagerInformation,
       transgenderPage,
       complexCaseBoardPage,
       boardTakenPlacePage,

--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -13,6 +13,7 @@ import {
   Person,
   PersonAcctAlert,
   PrisonCaseNote,
+  ApprovedPremisesUser as User,
 } from '@approved-premises/api'
 import { ContingencyPlanQuestionsBody, PartnerAgencyDetails, PersonRisksUI } from '@approved-premises/ui'
 
@@ -37,6 +38,7 @@ import {
   oasysSelectionFactory,
   premisesFactory,
   prisonCaseNotesFactory,
+  userFactory,
 } from '../../server/testutils/factories'
 import { documentsFromApplication } from '../../server/utils/assessments/documentUtils'
 import oasysStubs from '../../server/data/stubs/oasysStubs.json'
@@ -88,6 +90,7 @@ export default class ApplyHelper {
     private readonly application: Application,
     private readonly person: Person,
     private readonly offences: Array<ActiveOffence>,
+    private readonly user: User = userFactory.build(),
   ) {}
 
   setupApplicationStubs(uiRisks?: PersonRisksUI, oasysMissing = false, nomisMissing = false) {
@@ -110,6 +113,7 @@ export default class ApplyHelper {
     }
     this.stubDocumentEndpoints()
     this.stubOffences()
+    this.stubUserEndpoint()
     this.addContingencyPlanDetails()
   }
 
@@ -189,6 +193,10 @@ export default class ApplyHelper {
 
   private stubOffences() {
     cy.task('stubPersonOffences', { person: this.person, offences: this.offences })
+  }
+
+  private stubUserEndpoint() {
+    cy.task('stubFindUser', { user: this.user, id: this.application.createdByUserId })
   }
 
   private stubApplicationEndpoints() {
@@ -411,6 +419,10 @@ export default class ApplyHelper {
   }
 
   completeBasicInformation(options: { isEmergencyApplication?: boolean } = {}) {
+    const confirmYourDetails = new ApplyPages.ConfirmYourDetailsPage(this.application)
+    confirmYourDetails.completeForm()
+    confirmYourDetails.clickSubmit()
+
     const transgenderPage = new ApplyPages.TransgenderPage(this.application)
     transgenderPage.completeForm()
     transgenderPage.clickSubmit()
@@ -459,6 +471,7 @@ export default class ApplyHelper {
     placementPurposePage.clickSubmit()
 
     this.pages.basicInformation = [
+      confirmYourDetails,
       transgenderPage,
       complexCaseBoardPage,
       boardTakenPlacePage,

--- a/integration_tests/pages/apply/caseManagerInformation.ts
+++ b/integration_tests/pages/apply/caseManagerInformation.ts
@@ -1,0 +1,26 @@
+import { ApprovedPremisesApplication } from '@approved-premises/api'
+
+import paths from '../../../server/paths/apply'
+import ApplyPage from './applyPage'
+
+export default class CaseManagerInformation extends ApplyPage {
+  constructor(application: ApprovedPremisesApplication) {
+    super(
+      'Add case manager information',
+      application,
+      'basic-information',
+      'case-manager-information',
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'basic-information',
+        page: 'confirm-your-details',
+      }),
+    )
+  }
+
+  completeForm(): void {
+    this.completeTextInputFromPageBody('name')
+    this.completeTextInputFromPageBody('emailAddress')
+    this.completeTextInputFromPageBody('phoneNumber')
+  }
+}

--- a/integration_tests/pages/apply/confirmYourDetails.ts
+++ b/integration_tests/pages/apply/confirmYourDetails.ts
@@ -1,0 +1,24 @@
+import { ApprovedPremisesApplication } from '@approved-premises/api'
+
+import paths from '../../../server/paths/apply'
+import ApplyPage from './applyPage'
+
+export default class ConfirmYourDetails extends ApplyPage {
+  constructor(application: ApprovedPremisesApplication) {
+    super(
+      'Confirm your details',
+      application,
+      'basic-information',
+      'confirm-your-details',
+      paths.applications.show({ id: application.id }),
+    )
+  }
+
+  completeForm(): void {
+    this.checkCheckboxesFromPageBody('detailsToUpdate[]')
+    this.completeTextInputFromPageBody('name')
+    this.completeTextInputFromPageBody('emailAddress')
+    this.completeTextInputFromPageBody('phoneNumber')
+    this.checkRadioButtonFromPageBody('caseManagementResponsibility')
+  }
+}

--- a/integration_tests/pages/apply/index.ts
+++ b/integration_tests/pages/apply/index.ts
@@ -8,6 +8,7 @@ import CaseNotesPage from './caseNotes'
 import CateringPage from './catering'
 import CheckYourAnswersPage from './checkYourAnswersPage'
 import ComplexCaseBoard from './complexCaseBoard'
+import ConfirmYourDetailsPage from './confirmYourDetails'
 import ConfirmDetailsPage from './confirmDetails'
 import ContingencyPlanPartnersPage from './contingencyPlanPartners'
 import ContingencyPlanQuestionsPage from './contingencyPlanQuestions'
@@ -74,6 +75,7 @@ export {
   CheckYourAnswersPage,
   ComplexCaseBoard,
   ConfirmDetailsPage,
+  ConfirmYourDetailsPage,
   ContingencyPlanPartnersPage,
   ContingencyPlanQuestionsPage,
   ConvictedOffences,

--- a/integration_tests/pages/apply/index.ts
+++ b/integration_tests/pages/apply/index.ts
@@ -4,6 +4,7 @@ import AdditionalCircumstancesPage from './additionalCircumstances'
 import ArsonPage from './arson'
 import AttachDocumentsPage from './attachDocumentsPage'
 import BoardTakenPlacePage from './boardTakenPlace'
+import CaseManagerInformationPage from './caseManagerInformation'
 import CaseNotesPage from './caseNotes'
 import CateringPage from './catering'
 import CheckYourAnswersPage from './checkYourAnswersPage'
@@ -70,6 +71,7 @@ export {
   ArsonPage,
   AttachDocumentsPage,
   BoardTakenPlacePage,
+  CaseManagerInformationPage,
   CaseNotesPage,
   CateringPage,
   CheckYourAnswersPage,

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -69,8 +69,8 @@ context('Apply', () => {
       expect(body.offenceId).equal(selectedOffence.offenceId)
     })
 
-    // Then I should be on the Sentence Type page
-    Page.verifyOnPage(TransgenderPage, this.application)
+    // Then I should be on the Confirm Your Details page
+    Page.verifyOnPage(ConfirmYourDetailsPage, this.application)
   })
 
   it(`allows the user to specify if the case is exceptional if the offender's tier is not eligible`, function test() {
@@ -88,8 +88,8 @@ context('Apply', () => {
     // Then I should be able to confirm that the case is exceptional
     apply.completeExceptionalCase()
 
-    // And I should be on the Sentence Type page
-    Page.verifyOnPage(TransgenderPage, this.application)
+    // And I should be on the Confirm Your Details page
+    Page.verifyOnPage(ConfirmYourDetailsPage, this.application)
   })
 
   it('tells the user that their application is not applicable if the tier is not eligible and it is not an exceptional case', function test() {

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -1,5 +1,4 @@
 import { addDays } from 'date-fns'
-import { EnterCRNPage, ListPage, SelectOffencePage, StartPage, TransgenderPage } from '../../pages/apply'
 import { addResponseToFormArtifact, addResponsesToFormArtifact } from '../../../server/testutils/addToApplication'
 import {
   activeOffenceFactory,
@@ -7,10 +6,11 @@ import {
   restrictedPersonFactory,
   risksFactory,
   tierEnvelopeFactory,
+  userFactory,
 } from '../../../server/testutils/factories'
-
 import ApplyHelper from '../../helpers/apply'
 import { DateFormats } from '../../../server/utils/dateUtils'
+import { ConfirmYourDetailsPage, EnterCRNPage, ListPage, SelectOffencePage, StartPage } from '../../pages/apply'
 import IsExceptionalCasePage from '../../pages/apply/isExceptionalCase'
 import NotEligiblePage from '../../pages/apply/notEligiblePage'
 import Page from '../../pages/page'
@@ -117,8 +117,10 @@ context('Apply', () => {
 
   it('allows completion of application emergency flow', function test() {
     // And I complete the application
+    const user = userFactory.build()
+    this.application.createdByUserId = user.id
     const uiRisks = mapApiPersonRisksForUi(this.application.risks)
-    const apply = new ApplyHelper(this.application, this.person, this.offences)
+    const apply = new ApplyHelper(this.application, this.person, this.offences, user)
     const tomorrow = addDays(new Date(), 1)
 
     this.application = addResponsesToFormArtifact(this.application, {

--- a/integration_tests/tests/apply/personSearch.cy.ts
+++ b/integration_tests/tests/apply/personSearch.cy.ts
@@ -1,7 +1,6 @@
-import { EnterCRNPage, StartPage } from '../../pages/apply'
 import { personFactory } from '../../../server/testutils/factories'
-
 import ApplyHelper from '../../helpers/apply'
+import { EnterCRNPage, StartPage } from '../../pages/apply'
 import { setup } from './setup'
 
 context('Apply - Person Search', () => {
@@ -33,8 +32,8 @@ context('Apply - Person Search', () => {
       const firstRequestData = JSON.parse(requests[0].body).data
       const secondRequestData = JSON.parse(requests[1].body).data
 
-      expect(firstRequestData['basic-information'].transgender.transgenderOrHasTransgenderHistory).equal('yes')
-      expect(secondRequestData['basic-information']['complex-case-board'].reviewRequired).equal('yes')
+      expect(firstRequestData['basic-information']['confirm-your-details'].emailAddress).equal('bob@test.com')
+      expect(secondRequestData['basic-information']['case-manager-information'].name).equal('Bob Smith')
     })
   })
 

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -26,7 +26,6 @@ import {
   PersonAcctAlert,
   PlacementApplication,
   PlacementApplicationTask,
-  PlacementApplicationTask,
   PlacementCriteria,
   PlacementRequest,
   PlacementRequestStatus,
@@ -34,6 +33,7 @@ import {
   ReleaseTypeOption,
   RiskTier,
   RoshRisks,
+  ApprovedPremisesUser as User,
   ApprovedPremisesUserRole as UserRole,
 } from '@approved-premises/api'
 

--- a/server/controllers/apply/index.ts
+++ b/server/controllers/apply/index.ts
@@ -9,12 +9,13 @@ import WithdrawalsController from './applications/withdrawalsController'
 import type { Services } from '../../services'
 
 export const controllers = (services: Services) => {
-  const { applicationService, personService, premisesService } = services
+  const { applicationService, personService, premisesService, userService } = services
   const applicationsController = new ApplicationsController(applicationService, personService)
   const pagesController = new PagesController(applicationService, {
     personService,
     applicationService,
     premisesService,
+    userService,
   })
   const offencesController = new OffencesController(personService)
   const documentsController = new DocumentsController(personService)

--- a/server/form-pages/apply/reasons-for-placement/basic-information/caseManagerInformation.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/caseManagerInformation.test.ts
@@ -1,0 +1,48 @@
+import { lowerCase } from '../../../../utils/utils'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import CaseManagerInformation, { CaseManagerDetails, fields } from './caseManagerInformation'
+
+describe('CaseMangerInformation', () => {
+  const body: CaseManagerDetails = {
+    name: 'Bob',
+    emailAddress: 'bob@test.com',
+    phoneNumber: '0123456789',
+  }
+
+  describe('body', () => {
+    it('should set the body', () => {
+      const page = new CaseManagerInformation(body)
+
+      expect(page.body).toEqual(body)
+    })
+  })
+
+  itShouldHaveNextValue(new CaseManagerInformation(body), 'transgender')
+
+  itShouldHavePreviousValue(new CaseManagerInformation(body), 'confirm-your-details')
+
+  describe('errors', () => {
+    describe.each(fields)('when the %s is not supplied', field => {
+      it('should return an error', () => {
+        const bodyWithoutField: Partial<CaseManagerDetails> = { ...body, [field]: undefined }
+        const page = new CaseManagerInformation(bodyWithoutField)
+
+        expect(page.errors()).toEqual({
+          [field]: `You must enter the case manager's ${lowerCase(field)}`,
+        })
+      })
+    })
+  })
+
+  describe('response', () => {
+    it('returns the response in human readable form', () => {
+      const page = new CaseManagerInformation(body)
+
+      expect(page.response()).toEqual({
+        'Case manager email': body.emailAddress,
+        'Case manager name': body.name,
+        'Case manager phone number': body.phoneNumber,
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/reasons-for-placement/basic-information/caseManagerInformation.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/caseManagerInformation.ts
@@ -1,0 +1,56 @@
+import type { TaskListErrors } from '@approved-premises/ui'
+
+import { lowerCase } from '../../../../utils/utils'
+import TasklistPage from '../../../tasklistPage'
+import { Page } from '../../../utils/decorators'
+
+export type CaseManagerDetails = {
+  name: string
+  emailAddress: string
+  phoneNumber: string
+}
+
+export const fields: ReadonlyArray<keyof CaseManagerDetails> = ['name', 'emailAddress', 'phoneNumber']
+
+@Page({ name: 'case-manager-information', bodyProperties: ['name', 'emailAddress', 'phoneNumber'] })
+export default class CaseManagerInformation implements TasklistPage {
+  title = 'Add case manager information'
+
+  caseManager: CaseManagerDetails
+
+  inputLabels: CaseManagerDetails = {
+    name: 'Case manager name',
+    emailAddress: 'Case manager email',
+    phoneNumber: 'Case manager phone number',
+  }
+
+  constructor(public body: Partial<CaseManagerDetails>) {}
+
+  previous() {
+    return 'confirm-your-details'
+  }
+
+  next() {
+    return 'transgender'
+  }
+
+  response() {
+    return {
+      'Case manager name': this.body.name,
+      'Case manager email': this.body.emailAddress,
+      'Case manager phone number': this.body.phoneNumber,
+    }
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    fields.forEach(field => {
+      if (!this.body[field]) {
+        errors[field] = `You must enter the case manager's ${lowerCase(field)}`
+      }
+    })
+
+    return errors
+  }
+}

--- a/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.test.ts
@@ -1,0 +1,141 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+
+import { ApprovedPremisesApplication as Application } from '../../../../@types/shared'
+import { UserService } from '../../../../services'
+import { applicationFactory } from '../../../../testutils/factories'
+import { RestrictedPersonError } from '../../../../utils/errors'
+import { isApplicableTier, isFullPerson } from '../../../../utils/personUtils'
+import { lowerCase } from '../../../../utils/utils'
+import ConfirmYourDetails, { Body, updatableDetails } from './confirmYourDetails'
+
+jest.mock('../../../../utils/personUtils')
+
+describe('ConfirmYourDetails', () => {
+  const application: Readonly<Application> = applicationFactory.build()
+
+  const body: Body = {
+    'detailsToUpdate[]': ['name', 'emailAddress', 'phoneNumber'],
+    name: 'Bob',
+    emailAddress: 'bob@test.com',
+    phoneNumber: '0123456789',
+    caseManagementResponsibility: 'yes',
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('body', () => {
+    it('should set the body', () => {
+      const page = new ConfirmYourDetails(body, application)
+
+      expect(page.body).toEqual(body)
+    })
+  })
+
+  describe('initialize', () => {
+    it('calls the userService.getUserById method and returns an instantiated ConfirmYourDetails page', async () => {
+      const actingUser = {
+        name: body.name,
+        emailAddress: body.emailAddress,
+        phoneNumber: body.phoneNumber,
+      }
+      const getUserByIdMock = jest.fn().mockResolvedValue(actingUser)
+
+      const userService: DeepMocked<UserService> = createMock<UserService>({
+        getUserById: getUserByIdMock,
+      })
+
+      const result = await ConfirmYourDetails.initialize(body, application, 'token', { userService })
+
+      expect(getUserByIdMock).toHaveBeenCalledWith('token', application.createdByUserId)
+
+      expect(result).toEqual({
+        ...new ConfirmYourDetails(body, application),
+        userDetailsFromDelius: actingUser,
+      })
+    })
+  })
+
+  describe('next', () => {
+    it('returns "transgender" if caseManagementResponsibility is "yes', () => {
+      expect(new ConfirmYourDetails({ ...body, caseManagementResponsibility: 'yes' }, application).next()).toBe(
+        'transgender',
+      )
+    })
+
+    it('returns "case-manager-information" if caseManagementResponsibility is "no', () => {
+      expect(new ConfirmYourDetails({ ...body, caseManagementResponsibility: 'no' }, application).next()).toBe(
+        'case-manager-information',
+      )
+    })
+  })
+
+  describe('previous', () => {
+    describe('if the PiP is a restricted person', () => {
+      it('throws a restricted person error', () => {
+        ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(false)
+
+        const page = new ConfirmYourDetails({}, application)
+
+        expect(() => page.previous()).toThrowError(RestrictedPersonError)
+      })
+    })
+
+    describe('if the PiP is a full person', () => {
+      it('returns "dashboard" if the person is the applicable tier', () => {
+        ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
+        ;(isApplicableTier as jest.MockedFunction<typeof isApplicableTier>).mockReturnValue(true)
+
+        expect(new ConfirmYourDetails(body, application).previous()).toBe('dashboard')
+      })
+
+      it('returns "exception-details" if the person is not in the applicable tier', () => {
+        ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
+        ;(isApplicableTier as jest.MockedFunction<typeof isApplicableTier>).mockReturnValue(true)
+
+        expect(new ConfirmYourDetails(body, application).previous()).toBe('dashboard')
+      })
+    })
+  })
+
+  describe('errors', () => {
+    it('should return an empty object if all the fields are populated', () => {
+      const page = new ConfirmYourDetails(body, application)
+      expect(page.errors()).toEqual({})
+    })
+
+    describe.each(updatableDetails)('when %s is in the detailsToUpdate array but the field is not populated', field => {
+      const bodyWithoutField: Readonly<Partial<Body>> = { ...body, 'detailsToUpdate[]': [field], [field]: undefined }
+      const page = new ConfirmYourDetails(bodyWithoutField, application)
+
+      it('should return an error', () => {
+        expect(page.errors()).toEqual({
+          [field]: `You must enter your updated ${lowerCase(field)}`,
+        })
+      })
+    })
+
+    it('should return an error if there is no response for caseManagementResponsibility', () => {
+      const page = new ConfirmYourDetails({ ...body, caseManagementResponsibility: undefined }, application)
+
+      expect(page.errors()).toEqual({
+        caseManagementResponsibility: 'You must enter whether you have case management responsibility',
+      })
+    })
+  })
+
+  describe('response', () => {
+    it('should return a translated version of the response', () => {
+      const page = new ConfirmYourDetails(body, application)
+
+      expect(page.response()).toEqual({
+        [page.questions.updateDetails.label]: ['Name', 'Email address', 'Phone number'].join(', '),
+        'Applicant name': 'Bob',
+        'Applicant email address': 'bob@test.com',
+        'Applicant phone number': '0123456789',
+        'Do you have case management responsibility?': 'Yes',
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.ts
@@ -1,0 +1,145 @@
+import { ApprovedPremisesApplication as Application, ApprovedPremisesUser as User } from '@approved-premises/api'
+import type { DataServices, TaskListErrors, YesOrNo } from '@approved-premises/ui'
+
+import { RestrictedPersonError } from '../../../../utils/errors'
+import { isApplicableTier, isFullPerson } from '../../../../utils/personUtils'
+import { lowerCase, sentenceCase } from '../../../../utils/utils'
+import TasklistPage from '../../../tasklistPage'
+import { Page } from '../../../utils/decorators'
+
+export const updatableDetails: ReadonlyArray<UpdatableDetails> = ['name', 'emailAddress', 'phoneNumber'] as const
+
+type UpdatableDetails = 'name' | 'emailAddress' | 'phoneNumber'
+
+export type Body = {
+  'detailsToUpdate[]'?: Array<UpdatableDetails>
+  emailAddress?: string
+  name?: string
+  phoneNumber?: string
+  caseManagementResponsibility?: YesOrNo
+  userDetailsFromDelius?: {
+    name?: string
+    emailAddress?: string
+    phoneNumber?: string
+  }
+}
+
+@Page({
+  name: 'confirm-your-details',
+  bodyProperties: [
+    'detailsToUpdate[]',
+    'emailAddress',
+    'name',
+    'phoneNumber',
+    'caseManagementResponsibility',
+    'userDetailsFromDelius',
+  ],
+})
+export default class ConfirmYourDetails implements TasklistPage {
+  title = 'Confirm your details'
+
+  questions = {
+    updateDetails: {
+      label: 'If you need to update your details, select the relevant box below',
+      hint: `<p class="govuk-hint">Select all that need to be changed.</p>
+      <p class="govuk-hint">This information will not be written back to Delius</p>`,
+      items: updatableDetails,
+    },
+
+    caseManagementResponsibility: {
+      label: 'Do you have case management responsibility?',
+    },
+    name: {
+      label: 'Name',
+    },
+    emailAddress: {
+      label: 'Email address',
+    },
+    phoneNumber: {
+      label: 'Phone number',
+    },
+  }
+
+  userDetailsFromDelius: User
+
+  detailsToUpdate: ReadonlyArray<UpdatableDetails>
+
+  constructor(
+    readonly body: Body,
+    readonly application: Application,
+  ) {
+    this.detailsToUpdate = body?.['detailsToUpdate[]'] ?? []
+  }
+
+  static async initialize(
+    body: Body,
+    application: Application,
+    token: string,
+    dataServices: DataServices,
+  ): Promise<ConfirmYourDetails> {
+    const user = await dataServices.userService.getUserById(token, application.createdByUserId)
+
+    const page = new ConfirmYourDetails(body, application)
+
+    page.userDetailsFromDelius = user
+
+    return page
+  }
+
+  response() {
+    const response: Record<string, string> = {}
+
+    const detailsToUpdate = this.body['detailsToUpdate[]']
+      .map(detail => {
+        return sentenceCase(detail)
+      })
+      .join(', ')
+
+    response[this.questions.updateDetails.label] = detailsToUpdate
+
+    updatableDetails.forEach(detail => {
+      if (this.body[detail]) {
+        response[`Applicant ${lowerCase(detail)}`] = this.body[detail]
+      }
+    })
+
+    response[this.questions.caseManagementResponsibility.label] = sentenceCase(this.body.caseManagementResponsibility)
+
+    return response
+  }
+
+  previous() {
+    // This shouldn't happen at this point in the journey as LAO checks are completed at the start of application but is preferable to casting
+    if (!isFullPerson(this.application.person)) {
+      throw new RestrictedPersonError(this.application.person.crn)
+    }
+
+    return isApplicableTier(this.application.person.sex, this.application.risks?.tier?.value?.level)
+      ? 'dashboard'
+      : 'exception-details'
+  }
+
+  next() {
+    return this.body.caseManagementResponsibility === 'yes' ? 'transgender' : 'case-manager-information'
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    updatableDetails.forEach(detail => {
+      if (
+        this.body?.['detailsToUpdate[]']?.length &&
+        this.body?.['detailsToUpdate[]'].includes(detail) &&
+        !this.body[detail]
+      ) {
+        errors[detail] = `You must enter your updated ${lowerCase(detail)}`
+      }
+    })
+
+    if (!this.body.caseManagementResponsibility) {
+      errors.caseManagementResponsibility = 'You must enter whether you have case management responsibility'
+    }
+
+    return errors
+  }
+}

--- a/server/form-pages/apply/reasons-for-placement/basic-information/exceptionDetails.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/exceptionDetails.test.ts
@@ -31,7 +31,7 @@ describe('ExceptionDetails', () => {
   itShouldHavePreviousValue(new ExceptionDetails({}), 'is-exceptional-case')
 
   describe('when agreedCaseWithManager is yes', () => {
-    itShouldHaveNextValue(new ExceptionDetails({ agreedCaseWithManager: 'yes' }), 'transgender')
+    itShouldHaveNextValue(new ExceptionDetails({ agreedCaseWithManager: 'yes' }), 'confirm-your-details')
   })
 
   describe('when agreedCaseWithManager is no', () => {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/exceptionDetails.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/exceptionDetails.ts
@@ -74,7 +74,7 @@ export default class ExceptionDetails implements TasklistPage {
       return 'not-eligible'
     }
 
-    return 'transgender'
+    return 'confirm-your-details'
   }
 
   errors() {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/index.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/index.ts
@@ -21,6 +21,7 @@ import NotEligible from './notEligible'
 import EndDates from './endDates'
 import ManagedByMappa from './managedByMappa'
 import { Task } from '../../../utils/decorators'
+import CaseManagerInformation from './caseManagerInformation'
 
 @Task({
   name: 'Basic Information',
@@ -28,6 +29,7 @@ import { Task } from '../../../utils/decorators'
   pages: [
     IsExceptionalCase,
     ConfirmYourDetails,
+    CaseManagerInformation,
     IsPersonTransgender,
     ComplexCaseBoard,
     BoardTakenPlace,

--- a/server/form-pages/apply/reasons-for-placement/basic-information/index.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/index.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 
 import IsExceptionalCase from './isExceptionalCase'
+import ConfirmYourDetails from './confirmYourDetails'
 import ExceptionDetails from './exceptionDetails'
 import SentenceType from './sentenceType'
 import ReleaseType from './releaseType'
@@ -26,6 +27,7 @@ import { Task } from '../../../utils/decorators'
   slug: 'basic-information',
   pages: [
     IsExceptionalCase,
+    ConfirmYourDetails,
     IsPersonTransgender,
     ComplexCaseBoard,
     BoardTakenPlace,

--- a/server/form-pages/apply/reasons-for-placement/basic-information/isPersonTransgender.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/isPersonTransgender.test.ts
@@ -24,7 +24,7 @@ describe('IsPersonTransgender', () => {
     itShouldHaveNextValue(new IsPersonTransgender({ transgenderOrHasTransgenderHistory: 'no' }), 'end-dates')
   })
 
-  itShouldHavePreviousValue(new IsPersonTransgender(body), 'exception-details')
+  itShouldHavePreviousValue(new IsPersonTransgender(body), 'confirm-your-details')
 
   describe('errors', () => {
     it('should return errors when yes/no questions are blank', () => {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/isPersonTransgender.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/isPersonTransgender.ts
@@ -13,7 +13,7 @@ export default class IsPersonTransgender implements TasklistPage {
   constructor(public body: { transgenderOrHasTransgenderHistory: YesOrNo }) {}
 
   previous() {
-    return 'exception-details'
+    return 'confirm-your-details'
   }
 
   next() {

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -32,6 +32,66 @@
             }
           }
         },
+        "confirm-your-details": {
+          "type": "object",
+          "properties": {
+            "detailsToUpdate[]": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "emailAddress",
+                  "name",
+                  "phoneNumber"
+                ],
+                "type": "string"
+              }
+            },
+            "emailAddress": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "phoneNumber": {
+              "type": "string"
+            },
+            "caseManagementResponsibility": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "userDetailsFromDelius": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "emailAddress": {
+                  "type": "string"
+                },
+                "phoneNumber": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "case-manager-information": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "emailAddress": {
+              "type": "string"
+            },
+            "phoneNumber": {
+              "type": "string"
+            }
+          }
+        },
         "transgender": {
           "type": "object",
           "properties": {

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -352,7 +352,7 @@ describe('utils', () => {
       const application = applicationFactory.withFullPerson().build()
 
       expect(firstPageOfApplicationJourney(application)).toEqual(
-        paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'transgender' }),
+        paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'confirm-your-details' }),
       )
     })
 

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -154,7 +154,11 @@ const firstPageOfApplicationJourney = (application: Application) => {
   if (!isFullPerson(application.person)) throw new RestrictedPersonError(application.person.crn)
 
   if (isApplicableTier(application.person.sex, application.risks?.tier?.value?.level)) {
-    return paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'transgender' })
+    return paths.applications.pages.show({
+      id: application.id,
+      task: 'basic-information',
+      page: 'confirm-your-details',
+    })
   }
 
   return paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'is-exceptional-case' })

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -2,6 +2,7 @@ import { createMock } from '@golevelup/ts-jest'
 
 import type { ErrorMessages } from '@approved-premises/ui'
 import {
+  convertArrayToCheckboxItems,
   convertArrayToRadioItems,
   convertKeyValuePairToCheckBoxItems,
   convertKeyValuePairToRadioItems,
@@ -375,6 +376,15 @@ describe('formUtils', () => {
       expect(convertArrayToRadioItems(['one', 'two'], 'two')).toEqual([
         { text: 'One', value: 'one', checked: false },
         { text: 'Two', value: 'two', checked: true },
+      ])
+    })
+  })
+
+  describe('convertArrayToCheckboxItems', () => {
+    it('returns the array as checkbox items with the value in sentence case and the correct conditional', () => {
+      expect(convertArrayToCheckboxItems(['one', 'two'], ['one', 'two'])).toEqual([
+        { text: 'One', value: 'one', conditional: { html: 'one' } },
+        { text: 'Two', value: 'two', conditional: { html: 'two' } },
       ])
     })
   })

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -1,4 +1,5 @@
 import * as nunjucks from 'nunjucks'
+
 import type {
   CheckBoxItem,
   ErrorMessages,
@@ -103,6 +104,19 @@ export function convertArrayToRadioItems(array: Array<string>, checkedItem: stri
       value: key,
       text: sentenceCase(key),
       checked: checkedItem === key,
+    }
+  })
+}
+
+export function convertArrayToCheckboxItems(
+  array: Array<string>,
+  conditionals: Array<string> = [],
+): Array<CheckBoxItem> {
+  return array.map((key, i) => {
+    return {
+      value: key,
+      text: sentenceCase(key),
+      conditional: { html: conditionals[i] },
     }
   })
 }

--- a/server/views/applications/pages/basic-information/case-manager-information.njk
+++ b/server/views/applications/pages/basic-information/case-manager-information.njk
@@ -1,0 +1,48 @@
+{% extends "../layout.njk" %}
+
+{% block questions %}
+
+    <h1 class="govuk-heading-l">
+
+        {{ page.title }}
+    </h1>
+
+    {{
+            formPageInput({
+            fieldName: 'name',
+            label: {
+                text: page.inputLabels.name,
+                classes: "govuk-label--m"
+                },
+            classes: "govuk-input--width-20"
+            },
+            fetchContext())
+        }}
+
+    {{
+            formPageInput({
+            fieldName: 'emailAddress',
+            label: {
+                text: page.inputLabels.emailAddress,
+                classes: "govuk-label--m"
+                },
+            classes: "govuk-input--width-20"
+            },
+            fetchContext())
+        }}
+
+    {{
+            formPageInput({
+            fieldName: 'phoneNumber',
+            label: {
+                text: page.inputLabels.phoneNumber,
+                classes: "govuk-label--m"
+                },
+            classes: "govuk-input--width-20",
+            inputmode: 'tel'
+            },
+            fetchContext())
+        }}
+
+
+{% endblock %}

--- a/server/views/applications/pages/basic-information/confirm-your-details.njk
+++ b/server/views/applications/pages/basic-information/confirm-your-details.njk
@@ -1,0 +1,129 @@
+{% extends "../layout.njk" %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+
+{% block questions %}
+
+    <h1 class="govuk-heading-l">
+        {{ page.title }}
+    </h1>
+    <p class="govuk-body">This information has been imported from Delius.</p>
+
+    {% set rows = ([
+        {
+            key: {
+                text: "Name"
+            },
+            value: {
+                text: page.userDetailsFromDelius.name
+            }
+        }, {
+            key: {
+                text: "Email"
+            },
+            value: {
+                text: page.userDetailsFromDelius.email
+            }
+        }, {
+            key: {
+                text: "Phone number"
+            },
+            value: {
+                text: page.userDetailsFromDelius.telephoneNumber
+            }
+        }
+    ])
+ %}
+
+   
+
+    {{ govukSummaryList({
+      rows: rows
+    }) }}
+
+
+ {% set nameHtml %}
+    {{
+            formPageInput({
+            fieldName: 'name',
+            label: {
+                text: page.questions.name.label,
+                classes: "govuk-visually-hidden"
+            },
+            classes: "govuk-input--width-20"
+            },
+            fetchContext())
+        }}
+    {%endset %}
+
+    {% set emailAddressHtml %}
+    {{
+            formPageInput({
+            fieldName: 'emailAddress',
+            label: {
+                text: page.questions.emailAddress.label,
+                classes: "govuk-visually-hidden"
+            },
+            classes: "govuk-input--width-25"
+            },
+            fetchContext())
+        }}
+    {%endset %}
+
+    {% set phoneNumberHtml %}
+    {{
+            formPageInput({
+            fieldName: 'phoneNumber',
+            label: {
+                text: page.questions.phoneNumber.label,
+                classes: "govuk-visually-hidden"
+            },
+            classes: "govuk-input--width-20",
+            inputmode: 'tel'
+            },
+            fetchContext())
+        }}
+    {%endset %}
+
+    {% set conditionalArray = [nameHtml, emailAddressHtml, phoneNumberHtml] %}
+
+    {{
+        formPageCheckboxes({
+            fieldName: 'detailsToUpdate[]',
+            fieldset: {
+                legend: { 
+                    text: page.questions.updateDetails.label,
+                    classes: "govuk-fieldset__legend--m"
+                }
+            },
+            hint: {
+                html: page.questions.updateDetails.hint
+            },
+            values: page.detailsToUpdate,
+            items: FormUtils.convertArrayToCheckboxItems(page.questions.updateDetails.items, conditionalArray)
+        },
+        fetchContext()
+        )
+    }}
+
+    {{
+        formPageRadios({
+            fieldName: 'caseManagementResponsibility',
+            fieldset: {
+                legend: { 
+                    text: page.questions.caseManagementResponsibility.label,
+                    classes: "govuk-fieldset__legend--m"
+                }
+            },
+            items: [{
+                value: 'yes',
+                text: 'Yes'
+            }, 
+            {
+                value: 'no',
+                text: 'No'}
+            ]
+        },
+        fetchContext()
+        )
+    }}
+{% endblock %}

--- a/server/views/applications/pages/layout.njk
+++ b/server/views/applications/pages/layout.njk
@@ -8,6 +8,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% from "../../components/formFields/form-page-radios/macro.njk" import formPageRadios %}
 {% from "../../components/formFields/form-page-date-input/macro.njk" import formPageDateInput %}

--- a/server/views/applications/pages/type-of-ap/ap-type.njk
+++ b/server/views/applications/pages/type-of-ap/ap-type.njk
@@ -11,7 +11,7 @@
       summaryText: "What are the different types of AP?",
       html: '<p><strong>Standard APs</strong> provide 24 hour staff support and monitoring, an overnight curfew, CCTV, room searches, rehabilitative activities, medication monitoring, and drug and alcohol testing.</p>
             <p><strong>Psychologically Informed Planned Environment (PIPE)</strong> AP are for people who screen into the Offender Personality Disorder (OPD) pathway. PIPE staff have additional training to manage individuals and create an enhanced safe and supportive environment. </p>
-            <p><strong>Enhanced Security AP (ESAP)</strong> offer additional security measures and are intended to individuals whose risk management plan and astrongility to manage in the community are reliant on those measures. </p>
+            <p><strong>Enhanced Security AP (ESAP)</strong> offer additional security measures and are intended to individuals whose risk management plan and ability to manage in the community are reliant on those measures. </p>
             <p><strong>Recovery Focused AP (RFAP)</strong> provide concentrated support for prison leavers who have begun to address their substance misuse in custody. RFAP work closely with key recovery partners and organisations within the local community to offer people on probation the best level of support available. RFAP staff will be trained as recovery coaches and take a personalised approach to rehabilitation, including committing a minimum of 10 hours to each individual to work on a recovery plan tailored to their needs. </p>'
     }) 
     }}

--- a/server/views/components/formFields/form-page-checkboxes/macro.njk
+++ b/server/views/components/formFields/form-page-checkboxes/macro.njk
@@ -4,9 +4,7 @@
   {% set checkboxItems = [] %}
 
   {% for item in params.items %}
-    {% set checkboxItems = (checkboxItems.push(mergeObjects(item, {
-      checked: (item.value in (context[params.fieldName] or[]))
-    })), checkboxItems) %}
+    {% set checkboxItems = (checkboxItems.push(item), checkboxItems) %}
   {% endfor %}
 
   {{


### PR DESCRIPTION
# Context
This PR adds a page at the beginning of the Apply journey asking for details of the person making the application.
If the user answers 'No' to the question asking if they have Case management responsibility they are taken to a further screen that asks for the details of the person that does have case management responsibility.

[Trello card](https://trello.com/c/RFr7a1Bo/165-add-applicant-com-details) 

## Screenshots of UI changes
![screenshot1](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/4bd9de9e-956c-4265-b876-ca7a20d7a0eb)

![screenshot2](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/9ef85091-75c1-4820-9ef7-643bb533b632)

