### PR TITLE
(465) - Allow applications with a release date of today to be submitted

### DIFF
--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.test.ts
@@ -107,6 +107,19 @@ describe('ReleaseDate', () => {
         )
         expect(page.errors()).toEqual({ releaseDate: 'The release date must not be in the past' })
       })
+
+      it('should not return an error if the date is today', () => {
+        const releaseDate = new Date(new Date().setHours(0, 0, 0, 0))
+
+        const page = new ReleaseDate(
+          {
+            knowReleaseDate: 'yes',
+            ...DateFormats.dateObjectToDateInputs(releaseDate, 'releaseDate'),
+          },
+          application,
+        )
+        expect(page.errors()).toEqual({})
+      })
     })
 
     it('should return an empty object if the user does not know the release date', () => {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.ts
@@ -3,10 +3,16 @@ import type { ApprovedPremisesApplication } from '@approved-premises/api'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
-import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank, dateIsInThePast } from '../../../../utils/dateUtils'
 import { convertToTitleCase } from '../../../../utils/utils'
 import { dateBodyProperties } from '../../../utils/dateBodyProperties'
 import { adjacentPageFromSentenceType } from '../../../../utils/applications/adjacentPageFromSentenceType'
+import {
+  DateFormats,
+  dateAndTimeInputsAreValidDates,
+  dateIsBlank,
+  dateIsInThePast,
+  isToday,
+} from '../../../../utils/dateUtils'
 import { retrieveQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 import SentenceType from './sentenceType'
 
@@ -81,7 +87,7 @@ export default class ReleaseDate implements TasklistPage {
         errors.releaseDate = 'You must specify the release date'
       } else if (!dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'releaseDate'>, 'releaseDate')) {
         errors.releaseDate = 'The release date is an invalid date'
-      } else if (dateIsInThePast(this.body.releaseDate)) {
+      } else if (!isToday(this.body.releaseDate) && dateIsInThePast(this.body.releaseDate)) {
         errors.releaseDate = 'The release date must not be in the past'
       }
     }

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -4,6 +4,8 @@ import isPast from 'date-fns/isPast'
 import differenceInDays from 'date-fns/differenceInDays'
 import formatDistanceStrict from 'date-fns/formatDistanceStrict'
 import { subDays } from 'date-fns'
+import isTodayDateFns from 'date-fns/isToday'
+
 import type { ObjectWithDateParts } from '@approved-premises/ui'
 
 import {
@@ -14,12 +16,14 @@ import {
   dateAndTimeInputsAreValidDates,
   dateIsBlank,
   dateIsInThePast,
+  isToday,
   monthOptions,
   uiDateOrDateEmptyMessage,
   yearOptions,
 } from './dateUtils'
 
 jest.mock('date-fns/isPast')
+jest.mock('date-fns/isToday')
 jest.mock('date-fns/formatDistanceStrict')
 jest.mock('date-fns/differenceInDays')
 jest.mock('../data/bankHolidays/bank-holidays.json', () => {
@@ -400,6 +404,24 @@ describe('dateIsInThePast', () => {
     ;(isPast as jest.Mock).mockReturnValue(false)
 
     expect(dateIsInThePast('2020-01-01')).toEqual(false)
+  })
+})
+
+describe('isToday', () => {
+  it('returns true if the date is today', () => {
+    const dateString = '2020-01-01'
+    ;(isTodayDateFns as jest.Mock).mockReturnValue(true)
+
+    expect(isToday(dateString)).toEqual(true)
+    expect(isTodayDateFns).toHaveBeenCalledWith(DateFormats.isoToDateObj(dateString))
+  })
+
+  it('returns false if the date is not today', () => {
+    const dateString = '2020-01-01'
+    ;(isTodayDateFns as jest.Mock).mockReturnValue(false)
+
+    expect(isToday(dateString)).toEqual(false)
+    expect(isTodayDateFns).toHaveBeenCalledWith(DateFormats.isoToDateObj(dateString))
   })
 })
 

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -9,6 +9,7 @@ import {
   formatISO,
   isBefore,
   isPast,
+  isToday as isTodayDateFns,
   isValid,
   isWeekend,
   isWithinInterval,
@@ -17,6 +18,7 @@ import {
 } from 'date-fns'
 
 import type { ObjectWithDateParts } from '@approved-premises/ui'
+
 import rawBankHolidays from '../data/bankHolidays/bank-holidays.json'
 
 type DifferenceInDays = { ui: string; number: number }
@@ -265,6 +267,11 @@ export const dateIsBlank = <K extends string | number>(
 export const dateIsInThePast = (dateString: string): boolean => {
   const date = DateFormats.isoToDateObj(dateString)
   return isPast(date)
+}
+
+export const isToday = (date: string): boolean => {
+  const dateObj = DateFormats.isoToDateObj(date)
+  return isTodayDateFns(dateObj)
 }
 
 export const monthOptions = [


### PR DESCRIPTION
Previously we didn't allow dates where the release date is the same day to be submitted. Date-fns' 'isPast' returns 'true' if the date is that date.

Now we check if the date isn't today AND it is in the past before erroring

[Trello card](https://trello.com/c/B9NWWWKZ/465-allow-same-day-arrivals)