### PR TITLE
(165) Apply - Use Delius details if the user doesnt update fields

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -4,8 +4,13 @@
       "emailAddress": "bob@test.com",
       "name": "Bob Smith",
       "phoneNumber": "01234567890",
+      "detailsToUpdate": ["phoneNumber", "emailAddress", "name"],
       "caseManagementResponsibility": "no",
-      "detailsToUpdate": ["phoneNumber", "emailAddress", "name"]
+      "userDetailsFromDelius": {
+        "name": "Frank",
+        "emailAddress": "frank@test.com",
+        "phoneNumber": "01234567890"
+      }
     },
     "case-manager-information": {
       "emailAddress": "bob@test.com",

--- a/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.test.ts
@@ -1,6 +1,6 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
-import { ApprovedPremisesApplication as Application } from '../../../../@types/shared'
+import { ApprovedPremisesApplication as Application, FullPerson } from '../../../../@types/shared'
 import { UserService } from '../../../../services'
 import { applicationFactory } from '../../../../testutils/factories'
 import { RestrictedPersonError } from '../../../../utils/errors'
@@ -100,6 +100,7 @@ describe('ConfirmYourDetails', () => {
         const page = new ConfirmYourDetails({}, application)
 
         expect(() => page.previous()).toThrowError(RestrictedPersonError)
+        expect(isApplicableTier).not.toHaveBeenCalled()
       })
     })
 
@@ -109,6 +110,10 @@ describe('ConfirmYourDetails', () => {
         ;(isApplicableTier as jest.MockedFunction<typeof isApplicableTier>).mockReturnValue(true)
 
         expect(new ConfirmYourDetails(body, application).previous()).toBe('dashboard')
+        expect(isApplicableTier).toHaveBeenCalledWith(
+          (application.person as FullPerson).sex,
+          application.risks?.tier?.value?.level,
+        )
       })
 
       it('returns "exception-details" if the person is not in the applicable tier', () => {
@@ -116,6 +121,10 @@ describe('ConfirmYourDetails', () => {
         ;(isApplicableTier as jest.MockedFunction<typeof isApplicableTier>).mockReturnValue(true)
 
         expect(new ConfirmYourDetails(body, application).previous()).toBe('dashboard')
+        expect(isApplicableTier).toHaveBeenCalledWith(
+          (application.person as FullPerson).sex,
+          application.risks?.tier?.value?.level,
+        )
       })
     })
   })

--- a/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.ts
@@ -93,13 +93,13 @@ export default class ConfirmYourDetails implements TasklistPage {
   response() {
     const response: Record<string, string> = {}
 
-    const detailsToUpdate = this.body?.detailsToUpdate
+    const detailsToUpdate = (this.body?.detailsToUpdate || [])
       .map(detail => {
         return sentenceCase(detail)
       })
       .join(', ')
 
-    response[this.questions.updateDetails.label] = detailsToUpdate
+    response[this.questions.updateDetails.label] = detailsToUpdate.length ? detailsToUpdate : 'None'
 
     updatableDetails.forEach(detail => {
       response[`Applicant ${lowerCase(detail)}`] =

--- a/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesApplication as Application, ApprovedPremisesUser as User } from '@approved-premises/api'
+import { ApprovedPremisesApplication as Application } from '@approved-premises/api'
 import type { DataServices, TaskListErrors, YesOrNo } from '@approved-premises/ui'
 
 import { RestrictedPersonError } from '../../../../utils/errors'
@@ -11,17 +11,19 @@ export const updatableDetails: ReadonlyArray<UpdatableDetails> = ['name', 'email
 
 type UpdatableDetails = 'name' | 'emailAddress' | 'phoneNumber'
 
+type UserDetailsFromDelius = {
+  name?: string
+  emailAddress?: string
+  phoneNumber?: string
+}
+
 export type Body = {
   detailsToUpdate?: Array<UpdatableDetails>
   emailAddress?: string
   name?: string
   phoneNumber?: string
   caseManagementResponsibility?: YesOrNo
-  userDetailsFromDelius?: {
-    name?: string
-    emailAddress?: string
-    phoneNumber?: string
-  }
+  userDetailsFromDelius?: UserDetailsFromDelius
 }
 
 @Page({
@@ -60,7 +62,7 @@ export default class ConfirmYourDetails implements TasklistPage {
     },
   }
 
-  userDetailsFromDelius: User
+  userDetailsFromDelius: UserDetailsFromDelius
 
   detailsToUpdate: ReadonlyArray<UpdatableDetails>
 
@@ -79,9 +81,11 @@ export default class ConfirmYourDetails implements TasklistPage {
   ): Promise<ConfirmYourDetails> {
     const user = await dataServices.userService.getUserById(token, application.createdByUserId)
 
-    const page = new ConfirmYourDetails(body, application)
+    const userForUi = { name: user.name, emailAddress: user.email, phoneNumber: user.telephoneNumber }
 
-    page.userDetailsFromDelius = user
+    const page = new ConfirmYourDetails({ ...body, userDetailsFromDelius: userForUi }, application)
+
+    page.userDetailsFromDelius = userForUi
 
     return page
   }
@@ -98,9 +102,10 @@ export default class ConfirmYourDetails implements TasklistPage {
     response[this.questions.updateDetails.label] = detailsToUpdate
 
     updatableDetails.forEach(detail => {
-      if (this.body?.[detail]) {
-        response[`Applicant ${lowerCase(detail)}`] = this.body[detail]
-      }
+      response[`Applicant ${lowerCase(detail)}`] =
+        this.body?.[detail] && this.body?.detailsToUpdate?.includes(detail)
+          ? this.body[detail]
+          : this.body.userDetailsFromDelius?.[detail]
     })
 
     response[this.questions.caseManagementResponsibility.label] = sentenceCase(this.body.caseManagementResponsibility)

--- a/server/views/applications/pages/basic-information/confirm-your-details.njk
+++ b/server/views/applications/pages/basic-information/confirm-your-details.njk
@@ -8,6 +8,10 @@
     </h1>
     <p class="govuk-body">This information has been imported from Delius.</p>
 
+    <input type="hidden" name="userDetailsFromDelius[name]" value="{{ page.userDetailsFromDelius.name }}"/>
+    <input type="hidden" name="userDetailsFromDelius[emailAddress]" value="{{ page.userDetailsFromDelius.emailAddress }}"/>
+    <input type="hidden" name="userDetailsFromDelius[phoneNumber]" value="{{ page.userDetailsFromDelius.phoneNumber }}"/>
+
     {% set rows = ([
         {
             key: {
@@ -28,7 +32,7 @@
                 text: "Phone number"
             },
             value: {
-                text: page.userDetailsFromDelius.telephoneNumber
+                text: page.userDetailsFromDelius.phoneNumber
             }
         }
     ])


### PR DESCRIPTION
Previously if the user said they didn't want to update any of the details then we didn't pull through the email, name and phoneNumber from Delius. Now we do.
We have to map from the Delius names for fields to ones we can easily lowercase and still have them make sense.
We also do a check to make sure the detailsToUpdate array exists before we map over it. We also return 'None' for the fields the user would like to update if there aren't any they would like to update so that when someone reads the CYA or read-only version it's a bit more explicit.
 
 This should allow this PR to pass (once this PR is deployed to dev): https://github.com/ministryofjustice/hmpps-approved-premises-e2e/pull/45