### PR TITLE
(165) Apply - Confirm Your Details - Handle cases where data is missing from Delius

### DIFF
--- a/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.test.ts
@@ -191,5 +191,24 @@ describe('ConfirmYourDetails', () => {
         'Do you have case management responsibility?': 'Yes',
       })
     })
+
+    it('should return an empty field if the field name is not in the detailsToUpdate[] and it is not present in Delius', () => {
+      const page = new ConfirmYourDetails(
+        {
+          ...body,
+          detailsToUpdate: [],
+          userDetailsFromDelius: { ...body.userDetailsFromDelius, phoneNumber: undefined, emailAddress: undefined },
+        },
+        application,
+      )
+
+      expect(page.response()).toEqual({
+        [page.questions.updateDetails.label]: 'None',
+        'Applicant name': body.userDetailsFromDelius.name,
+        'Applicant email address': '',
+        'Applicant phone number': '',
+        'Do you have case management responsibility?': 'Yes',
+      })
+    })
   })
 })

--- a/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.ts
@@ -102,10 +102,13 @@ export default class ConfirmYourDetails implements TasklistPage {
     response[this.questions.updateDetails.label] = detailsToUpdate.length ? detailsToUpdate : 'None'
 
     updatableDetails.forEach(detail => {
-      response[`Applicant ${lowerCase(detail)}`] =
-        this.body?.[detail] && this.body?.detailsToUpdate?.includes(detail)
-          ? this.body[detail]
-          : this.body.userDetailsFromDelius?.[detail]
+      if (this.body?.[detail] && this.body?.detailsToUpdate?.includes(detail)) {
+        response[`Applicant ${lowerCase(detail)}`] = this.body[detail]
+      } else if (this.body.userDetailsFromDelius?.[detail]) {
+        response[`Applicant ${lowerCase(detail)}`] = this.body.userDetailsFromDelius?.[detail]
+      } else {
+        response[`Applicant ${lowerCase(detail)}`] = ''
+      }
     })
 
     response[this.questions.caseManagementResponsibility.label] = sentenceCase(this.body.caseManagementResponsibility)


### PR DESCRIPTION
Sometimes a user might not have an email address or phone number in Delius but we assumed that they would which may break the CYA page
