### PR TITLE
Add paragraphs to text with linebreaks

### DIFF
--- a/server/utils/applications/summaryListUtils.test.ts
+++ b/server/utils/applications/summaryListUtils.test.ts
@@ -12,6 +12,7 @@ import { documentsFromApplication } from '../assessments/documentUtils'
 import { getActionsForTaskId } from '../assessments/getActionsForTaskId'
 import { getResponseForPage } from './getResponseForPage'
 import TasklistPage from '../../form-pages/tasklistPage'
+import { linebreaksToParagraphs } from '../utils'
 
 jest.mock('../reviewUtils')
 jest.mock('./utils')
@@ -126,7 +127,7 @@ describe('summaryListUtils', () => {
               text: 'title',
             },
             value: {
-              text: 'response',
+              html: linebreaksToParagraphs('response'),
             },
           },
         ])
@@ -165,7 +166,7 @@ describe('summaryListUtils', () => {
               text: 'title',
             },
             value: {
-              text: 'response',
+              html: linebreaksToParagraphs('response'),
             },
           },
         ])
@@ -185,7 +186,7 @@ describe('summaryListUtils', () => {
             text: 'title',
           },
           value: {
-            text: 'response',
+            html: linebreaksToParagraphs('response'),
           },
         },
       ])

--- a/server/utils/applications/summaryListUtils.ts
+++ b/server/utils/applications/summaryListUtils.ts
@@ -14,6 +14,7 @@ import { getActionsForTaskId } from '../assessments/getActionsForTaskId'
 import { journeyTypeFromArtifact } from '../journeyTypeFromArtifact'
 import { getResponseForPage } from './getResponseForPage'
 import { forPagesInTask } from './forPagesInTask'
+import { linebreaksToParagraphs } from '../utils'
 
 const summaryListSections = (applicationOrAssessment: Application | Assessment, showActions = true) =>
   reviewSections(applicationOrAssessment, taskResponsesAsSummaryListItems, showActions)
@@ -37,8 +38,8 @@ const taskResponsesAsSummaryListItems = (
     Object.keys(response).forEach(key => {
       const value =
         typeof response[key] === 'string' || response[key] instanceof String
-          ? ({ text: response[key] } as TextItem)
-          : ({ html: embeddedSummaryListItem(response[key] as Array<Record<string, unknown>>) } as HtmlItem)
+          ? { html: linebreaksToParagraphs(response[key] as string) }
+          : { html: embeddedSummaryListItem(response[key] as Array<Record<string, unknown>>) }
 
       items.push(summaryListItemForResponse(key, value, task.id, pageName, applicationOrAssessment, showActions))
     })

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -5,6 +5,7 @@ import {
   camelCase,
   convertToTitleCase,
   initialiseName,
+  linebreaksToParagraphs,
   linkTo,
   mapApiPersonRisksForUi,
   numberToOrdinal,
@@ -330,5 +331,26 @@ describe('numberToOrdinal', () => {
   it('returns undefined if the number is >5 or <0', () => {
     expect(numberToOrdinal(6)).toBeUndefined()
     expect(numberToOrdinal(-1)).toBeUndefined()
+  })
+})
+
+describe('linebreaksToParagraphs', () => {
+  it('returns a single paragraph', () => {
+    expect(linebreaksToParagraphs('foo')).toEqual('<p class="govuk-body">foo</p>')
+  })
+
+  it('replaces single linebreaks with a line break element', () => {
+    expect(linebreaksToParagraphs('foo\nbar')).toEqual('<p class="govuk-body">foo<br />bar</p>')
+  })
+
+  it('adds new paragraphs when there are two line breaks', () => {
+    expect(linebreaksToParagraphs('foo\n\nbar')).toEqual('<p class="govuk-body">foo</p><p class="govuk-body">bar</p>')
+  })
+
+  it('handles Windows-style linebreaks', () => {
+    expect(linebreaksToParagraphs('foo\r\nbar')).toEqual('<p class="govuk-body">foo<br />bar</p>')
+    expect(linebreaksToParagraphs('foo\r\n\r\nbar')).toEqual(
+      '<p class="govuk-body">foo</p><p class="govuk-body">bar</p>',
+    )
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -162,3 +162,8 @@ export const objectIfNotEmpty = <T>(object: Record<string, unknown> | T | undefi
 
 export const numberToOrdinal = (number: number | string): string =>
   ['First', 'Second', 'Third', 'Fourth', 'Fifth'][Number(number)]
+
+export const linebreaksToParagraphs = (text: string) =>
+  `<p class="govuk-body">${text
+    .replace(/\r?\n([ \t]*\r?\n)+/g, '</p><p class="govuk-body">')
+    .replace(/\r?\n/g, '<br />')}</p>`


### PR DESCRIPTION
On some questions, particularly Oasys responses, text that has line breaks is played back to users as a single block of text, making it really hard to read. The adds a `linebreaksToParagraphs` helper which we use in the `taskResponsesAsSummaryListItems` helper to replace single linebreaks with `<br/>` HTML elements and double linebreaks with new `<p>` paragraph elements.

## Screenshots

### Before

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/ba44f501-7bd8-4916-bf15-236416d88688)

### After 

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/358bd321-2fb2-4116-9282-24d0610a2bfe)
