### PR TITLE
Show expected arrival/departure on booking page

### DIFF
--- a/integration_tests/pages/manage/booking/show.ts
+++ b/integration_tests/pages/manage/booking/show.ts
@@ -2,7 +2,7 @@ import type { Booking } from '@approved-premises/api'
 
 import Page from '../../page'
 import paths from '../../../../server/paths/manage'
-import { DateFormats } from '../../../../server/utils/dateUtils'
+import { bookingArrivalRows, bookingDepartureRows, bookingPersonRows } from '../../../../server/utils/bookingUtils'
 
 export default class BookingShowPage extends Page {
   constructor() {
@@ -25,26 +25,16 @@ export default class BookingShowPage extends Page {
   }
 
   shouldShowBookingDetails(booking: Booking): void {
-    cy.get('dl[data-cy-crn]').within(() => {
-      this.assertDefinition('CRN', booking.person.crn)
+    cy.get('dl[data-cy-person-info]').within(() => {
+      this.shouldContainSummaryListItems(bookingPersonRows(booking))
     })
 
     cy.get('dl[data-cy-arrival-information]').within(() => {
-      this.assertDefinition('Expected arrival date', DateFormats.isoDateToUIDate(booking.arrival.arrivalDate))
-      this.assertDefinition('Arrival date', DateFormats.isoDateToUIDate(booking.arrival.arrivalDate))
-      this.assertDefinition('Notes', booking.arrival.notes)
+      this.shouldContainSummaryListItems(bookingArrivalRows(booking))
     })
 
     cy.get('dl[data-cy-departure-information]').within(() => {
-      this.assertDefinition('Expected departure date', DateFormats.isoDateToUIDate(booking.departure.dateTime))
-      this.assertDefinition('Actual departure date', DateFormats.isoDateToUIDate(booking.departure.dateTime))
-      this.assertDefinition('Reason', booking.departure.reason.name)
-      this.assertDefinition('Notes', booking.departure.notes)
-    })
-
-    cy.get('dl[data-cy-documents]').within(() => {
-      this.assertDefinition('Application', 'View document')
-      this.assertDefinition('Assessment', 'View document')
+      this.shouldContainSummaryListItems(bookingDepartureRows(booking))
     })
   }
 }

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -2,6 +2,9 @@ import { SanitisedError } from '../sanitisedError'
 import {
   bedsAsSelectItems,
   bookingActions,
+  bookingArrivalRows,
+  bookingDepartureRows,
+  bookingPersonRows,
   bookingShowDocumentRows,
   bookingSummaryList,
   bookingsToTableRows,
@@ -10,9 +13,11 @@ import {
   nameCell,
 } from './bookingUtils'
 import {
+  arrivalFactory,
   bedSummaryFactory,
   bookingFactory,
   bookingSummaryFactory,
+  departureFactory,
   personFactory,
   restrictedPersonFactory,
 } from '../testutils/factories'
@@ -20,7 +25,7 @@ import paths from '../paths/manage'
 import assessPaths from '../paths/assess'
 import applyPaths from '../paths/apply'
 import { DateFormats } from './dateUtils'
-import { linkTo } from './utils'
+import { linebreaksToParagraphs, linkTo } from './utils'
 
 describe('bookingUtils', () => {
   const premisesId = 'e8f29a4a-dd4d-40a2-aa58-f3f60245c8fc'
@@ -412,6 +417,109 @@ describe('bookingUtils', () => {
           },
         ],
       })
+    })
+  })
+
+  describe('bookingPersonRows', () => {
+    it('returns the correct rows for a person', () => {
+      const booking = bookingFactory.build()
+
+      expect(bookingPersonRows(booking)).toEqual([
+        {
+          key: {
+            text: 'Name',
+          },
+          value: nameCell(booking),
+        },
+        {
+          key: {
+            text: 'CRN',
+          },
+          value: {
+            text: booking.person.crn,
+          },
+        },
+      ])
+    })
+  })
+
+  describe('bookingArrivalRows', () => {
+    it('returns the correct rows for a non-arrived booking', () => {
+      const booking = bookingFactory.build({ arrival: null })
+
+      expect(bookingArrivalRows(booking)).toEqual([
+        {
+          key: { text: 'Expected arrival date' },
+          value: { text: DateFormats.isoDateToUIDate(booking.arrivalDate) },
+        },
+      ])
+    })
+
+    it('returns the correct rows for an arrived booking', () => {
+      const booking = bookingFactory.build({ arrival: arrivalFactory.build() })
+
+      expect(bookingArrivalRows(booking)).toEqual([
+        {
+          key: { text: 'Actual arrival date' },
+          value: { text: DateFormats.isoDateToUIDate(booking.arrival.arrivalDate) },
+        },
+        {
+          key: {
+            text: 'Notes',
+          },
+          value: {
+            html: linebreaksToParagraphs(booking.arrival.notes),
+          },
+        },
+      ])
+    })
+  })
+
+  describe('bookingDepartureRows', () => {
+    it('returns the correct rows for a non=departed booking', () => {
+      const booking = bookingFactory.build({ departure: null })
+
+      expect(bookingDepartureRows(booking)).toEqual([
+        {
+          key: {
+            text: 'Expected departure date',
+          },
+          value: {
+            text: DateFormats.isoDateToUIDate(booking.departureDate),
+          },
+        },
+      ])
+    })
+
+    it('returns the correct rows for a departed booking', () => {
+      const booking = bookingFactory.build({ departure: departureFactory.build() })
+
+      expect(bookingDepartureRows(booking)).toEqual([
+        {
+          key: {
+            text: 'Actual departure date',
+          },
+          value: {
+            text: DateFormats.isoDateToUIDate(booking.departure.dateTime),
+          },
+        },
+        {
+          key: {
+            text: 'Reason',
+          },
+          value: {
+            text: booking.departure.reason.name,
+          },
+        },
+        {
+          key: {
+            text: 'Notes',
+          },
+          value: {
+            html: linebreaksToParagraphs(booking.departure.notes),
+          },
+        },
+      ])
     })
   })
 })

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -13,7 +13,7 @@ import applyPaths from '../paths/apply'
 import assessPaths from '../paths/assess'
 import { DateFormats } from './dateUtils'
 import { SanitisedError } from '../sanitisedError'
-import { linkTo } from './utils'
+import { linebreaksToParagraphs, linkTo } from './utils'
 import { isFullPerson } from './personUtils'
 
 type ParsedConflictError = {
@@ -205,6 +205,97 @@ export const bedsAsSelectItems = (beds: Array<BedSummary>, selectedId: string): 
     value: bed.id,
     selected: selectedId === bed.id,
   }))
+}
+
+export const bookingPersonRows = (booking: Booking): Array<SummaryListItem> => {
+  return [
+    {
+      key: {
+        text: 'Name',
+      },
+      value: nameCell(booking),
+    },
+    {
+      key: {
+        text: 'CRN',
+      },
+      value: {
+        text: booking.person.crn,
+      },
+    },
+  ]
+}
+
+export const bookingArrivalRows = (booking: Booking): Array<SummaryListItem> => {
+  const rows = []
+
+  if (booking.arrival) {
+    rows.push({
+      key: { text: 'Actual arrival date' },
+      value: { text: DateFormats.isoDateToUIDate(booking.arrival.arrivalDate) },
+    })
+
+    if (booking.arrival.notes) {
+      rows.push({
+        key: {
+          text: 'Notes',
+        },
+        value: {
+          html: linebreaksToParagraphs(booking.arrival.notes),
+        },
+      })
+    }
+  } else {
+    rows.push({
+      key: { text: 'Expected arrival date' },
+      value: { text: DateFormats.isoDateToUIDate(booking.arrivalDate) },
+    })
+  }
+
+  return rows
+}
+
+export const bookingDepartureRows = (booking: Booking): Array<SummaryListItem> => {
+  const rows = []
+
+  if (booking.departure) {
+    rows.push(
+      {
+        key: {
+          text: 'Actual departure date',
+        },
+        value: {
+          text: DateFormats.isoDateToUIDate(booking.departure.dateTime),
+        },
+      },
+      {
+        key: {
+          text: 'Reason',
+        },
+        value: {
+          text: booking.departure.reason.name,
+        },
+      },
+    )
+
+    if (booking.departure.notes) {
+      rows.push({
+        key: {
+          text: 'Notes',
+        },
+        value: {
+          html: linebreaksToParagraphs(booking.departure.notes),
+        },
+      })
+    }
+  } else {
+    rows.push({
+      key: { text: 'Expected departure date' },
+      value: { text: DateFormats.isoDateToUIDate(booking.departureDate) },
+    })
+  }
+
+  return rows
 }
 
 export const bookingShowDocumentRows = (booking: Booking): Array<SummaryListItem> => {

--- a/server/views/bookings/show.njk
+++ b/server/views/bookings/show.njk
@@ -38,116 +38,41 @@
         govukSummaryList({
           classes: 'govuk-summary-list--no-border',
           attributes: {
-            'data-cy-crn': true
+            'data-cy-person-info': true
           },
-          rows: [
-            {
-              key: {
-                text: "Name"
-              },
-              value: {
-                text: booking.person.name
-              }
-            },
-            {
-              key: {
-                text: "CRN"
-              },
-              value: {
-                text: booking.person.crn
-              }
-            }
-          ]
+          rows: BookingUtils.bookingPersonRows(booking)
         })
       }}
+
       <br>
-      {% if booking.arrival | length %}
-        <h2>Arrival information</h2>
 
-        {{
-          govukSummaryList({
-            classes: 'govuk-summary-list--no-border',
-            attributes: {
-              'data-cy-arrival-information': true
-            },
-            rows: [
-              {
-                key: {
-                  text: "Expected arrival date"
-                },
-                value: {
-                  text: formatDate(booking.arrivalDate)
-                }
-              },
-              {
-                key: {
-                  text: "Arrival date"
-                },
-                value: {
-                  text: formatDate(booking.arrival.arrivalDate)
-                }
-              },
-              {
-                key: {
-                  text: "Notes"
-                },
-                value: {
-                  text: booking.arrival.notes
-                }
-              }
-            ]
-          })
-        }}
+      <h2>Arrival information</h2>
 
-      {% endif %}
+      {{
+        govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          attributes: {
+            'data-cy-arrival-information': true
+          },
+          rows: BookingUtils.bookingArrivalRows(booking)
+        })
+      }}
+
       <br>
-      {% if booking.departure | length %}
-        <h2>Departure information</h2>
 
-        {{
+      <h2>Departure information</h2>
+
+      {{
           govukSummaryList({
             classes: 'govuk-summary-list--no-border',
             attributes: {
               'data-cy-departure-information': true
             },
-            rows: [
-              {
-                key: {
-                  text: "Expected departure date"
-                },
-                value: {
-                  text: formatDate(booking.arrival.expectedDepartureDate)
-                }
-              },
-              {
-                key: {
-                  text: "Actual departure date"
-                },
-                value: {
-                  text: formatDate(booking.departure.dateTime)
-                }
-              },
-              {
-                key: {
-                  text: "Reason"
-                },
-                value: {
-                  text: booking.departure.reason.name
-                }
-              },
-              {
-                key: {
-                  text: "Notes"
-                },
-                value: {
-                  text: booking.departure.notes
-                }
-              }
-            ]
+            rows: BookingUtils.bookingDepartureRows(booking)
           })
         }}
 
-      {% endif %}
+      <br>
 
       <h2>Documents</h2>
 


### PR DESCRIPTION
This adds a new `bookingInformationRows` helper which combines all the information about a booking into one definition list. If the booking has been marked as arrived, we show the actual arrival details, otherwise we show the expected arrival date. Similarly, if the booking has been marked as departed, we show the departure details, otherwise we show the expected departure date.

## Screenshots

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/4cd2b065-6b9f-44a1-9210-6ab26a514f6c)

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/62eb7baa-77ea-4e22-a426-0fa3a77663b9)

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/02a25220-b282-4af8-a43d-cb1b15917bc0)
