### PR TITLE
(Fix) Authorisation issues

### DIFF
--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -139,7 +139,7 @@ const stubUser = (name: string) =>
     },
   })
 
-const stubProfile = (roles = [], userId = '70596333-63d4-4fb2-8acc-9ca55563d878') =>
+const stubProfile = (roles = [], userId = '70596333-63d4-4fb2-8acc-9ca55563d878', isActive = true) =>
   stubFor({
     request: {
       method: 'GET',
@@ -153,6 +153,7 @@ const stubProfile = (roles = [], userId = '70596333-63d4-4fb2-8acc-9ca55563d878'
       jsonBody: {
         id: userId,
         roles,
+        isActive,
       },
     },
   })

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -333,6 +333,7 @@ export type UserDetails = {
   name: string
   displayName: string
   roles: Array<UserRole>
+  active: boolean
 }
 
 export type PartnerAgencyDetails = {

--- a/server/middleware/populateCurrentUser.test.ts
+++ b/server/middleware/populateCurrentUser.test.ts
@@ -1,0 +1,109 @@
+import type { NextFunction, Request, Response } from 'express'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+
+import { UserService } from '../services'
+import populateCurrentUser from './populateCurrentUser'
+import { userDetailsFactory } from '../testutils/factories'
+import logger from '../../logger'
+
+jest.mock('../../logger')
+
+describe('populateCurrentUser', () => {
+  const token = 'SOME_TOKEN'
+
+  let userService: DeepMocked<UserService>
+
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  let next: DeepMocked<NextFunction>
+
+  const user = userDetailsFactory.build({ active: true })
+
+  beforeEach(() => {
+    userService = createMock<UserService>()
+
+    request = createMock<Request>({})
+    response = createMock<Response>({ locals: { user: { token } } })
+    next = jest.fn()
+
+    jest.resetAllMocks()
+  })
+
+  it('should populate the current user from the API if the user is not in the session', async () => {
+    ;(userService.getActingUser as jest.Mock).mockResolvedValue(user)
+
+    const middleware = populateCurrentUser(userService)
+
+    await middleware(request, response, next)
+
+    expect(request.session.user).toEqual(user)
+    expect(response.locals.user).toEqual({ ...response.locals.user, ...user })
+
+    expect(userService.getActingUser).toHaveBeenCalledWith(token)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should fetch the user from the session if present', async () => {
+    const middleware = populateCurrentUser(userService)
+
+    request.session.user = user
+
+    await middleware(request, response, next)
+
+    expect(request.session.user).toEqual(user)
+    expect(response.locals.user).toEqual({ ...response.locals.user, ...user })
+
+    expect(userService.getActingUser).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should redirect to an autherror if no user is available', async () => {
+    ;(userService.getActingUser as jest.Mock).mockResolvedValue(undefined)
+
+    const middleware = populateCurrentUser(userService)
+
+    await middleware(request, response, next)
+
+    expect(userService.getActingUser).toHaveBeenCalledWith(token)
+    expect(response.redirect).toHaveBeenCalledWith('/autherror')
+    expect(logger.info).toHaveBeenCalledWith('No user available')
+  })
+
+  it('should redirect to an autherror if the user is inactive', async () => {
+    user.active = false
+    ;(userService.getActingUser as jest.Mock).mockResolvedValue(user)
+
+    const middleware = populateCurrentUser(userService)
+
+    await middleware(request, response, next)
+
+    expect(userService.getActingUser).toHaveBeenCalledWith(token)
+    expect(response.redirect).toHaveBeenCalledWith('/autherror')
+    expect(logger.error).toHaveBeenCalledWith('User is inactive')
+  })
+
+  it('should catch an error when an error is raised', async () => {
+    const err = new Error()
+
+    ;(userService.getActingUser as jest.Mock).mockImplementation(() => {
+      throw err
+    })
+
+    const middleware = populateCurrentUser(userService)
+
+    await middleware(request, response, next)
+
+    expect(userService.getActingUser).toHaveBeenCalledWith(token)
+    expect(next).toHaveBeenCalledWith(err)
+  })
+
+  it('should call next when there is no token', async () => {
+    response.locals.user.token = null
+
+    const middleware = populateCurrentUser(userService)
+
+    await middleware(request, response, next)
+
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -12,12 +12,18 @@ export default function populateCurrentUser(userService: UserService): RequestHa
 
         if (!user) {
           logger.info('No user available')
+          return res.redirect('/autherror')
+        }
+
+        if (!req.session.user.active) {
+          logger.error('User is inactive')
+          return res.redirect('/autherror')
         }
       }
-      next()
+      return next()
     } catch (error) {
       logger.error(error, `Failed to retrieve user for: ${res.locals.user && res.locals.user.username}`)
-      next(error)
+      return next(error)
     }
   }
 }

--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -16,7 +16,7 @@ export default function setUpAuth(): Router {
 
   router.get('/autherror', (req, res) => {
     res.status(401)
-    return res.render('autherror')
+    return res.render('autherror', { hideNav: true })
   })
 
   router.get('/sign-in', passport.authenticate('oauth2'))

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -21,7 +21,13 @@ export default class UserService {
     const user = await this.hmppsAuthClient.getActingUser(token)
     const client = this.userClientFactory(token)
     const profile = await client.getUserProfile()
-    return { ...user, id: profile.id, displayName: convertToTitleCase(user.name), roles: profile.roles }
+    return {
+      ...user,
+      id: profile.id,
+      displayName: convertToTitleCase(user.name),
+      roles: profile.roles,
+      active: profile.isActive,
+    }
   }
 
   async getUserById(token: string, id: string): Promise<User> {

--- a/server/testutils/factories/user.ts
+++ b/server/testutils/factories/user.ts
@@ -17,6 +17,7 @@ export default Factory.define<User>(() => ({
   id: faker.string.uuid(),
   region: faker.helpers.arrayElement([{ id: faker.string.uuid(), name: faker.location.county() }]),
   service: 'ApprovedPremises',
+  isActive: true,
 }))
 
 const roleFactory = Factory.define<UserRole>(() =>

--- a/server/testutils/factories/userDetails.ts
+++ b/server/testutils/factories/userDetails.ts
@@ -7,5 +7,6 @@ export default Factory.define<UserDetails>(() => ({
   id: faker.string.uuid(),
   name: faker.internet.userName(),
   displayName: faker.person.fullName(),
+  active: true,
   roles: [],
 }))


### PR DESCRIPTION
This fixes when an unauthorised user tries to access the system - currently the autherror template tries to render the navigation, which requires a user to be present. As we don't get to that bit of middleware the user gets an error.

I've also added a check for if a user is active. If they are inactive, they see a authentication error, rather than the current (unexpected) behaviour of them being able to access the system, but without any of the roles.