### PR TITLE
Update OpenAPI spec url

### DIFF
--- a/script/generate-types
+++ b/script/generate-types
@@ -14,7 +14,7 @@ fi
 
 echo "==> Generating types for $branch branch..."
 
-npx openapi-typescript-codegen -i "https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/$branch/src/main/resources/static/api.yml" -o ./server/@types/shared -c axios --exportServices false --exportCore false --useUnionTypes true
+npx openapi-typescript-codegen -i "https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/$branch/src/main/resources/static/codegen/built-api-spec.yml" -o ./server/@types/shared -c axios --exportServices false --exportCore false --useUnionTypes true
 
 echo "==> Renaming the declaration file..."
 

--- a/server/testutils/jest.setup.ts
+++ b/server/testutils/jest.setup.ts
@@ -28,7 +28,7 @@ expect.extend({
   },
   toMatchOpenAPISpec(pactPath) {
     const openAPIUrl =
-      'https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/main/src/main/resources/static/api.yml'
+      'https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/main/src/main/resources/static/codegen/built-api-spec.yml'
 
     const openAPIPath = path.join(__dirname, '..', '..', 'tmp', 'api.yml')
 


### PR DESCRIPTION
https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1009 updates the OpenAPI spec to be a built spec depending on the service, so we need to update the generator to use the new URL