### PR TITLE
(488) Tasklist link returns the first completed section

### DIFF
--- a/server/utils/taskListUtils.test.ts
+++ b/server/utils/taskListUtils.test.ts
@@ -28,6 +28,28 @@ describe('taskListUtils', () => {
         )
       })
 
+      it('should return a link to the first completed question page if it exists', () => {
+        task.status = 'in_progress'
+        application.data = { 'second-task': { foo: { some: 'response' } } }
+
+        expect(taskLink(task, application)).toEqual(
+          `<a href="${applyPaths.applications.pages.show({
+            id: 'some-uuid',
+            task: 'second-task',
+            page: 'foo',
+          })}" aria-describedby="eligibility-second-task" data-cy-task-name="second-task">Second Task</a>`,
+        )
+
+        application.data = { 'second-task': { bar: { some: 'response' } } }
+        expect(taskLink(task, application)).toEqual(
+          `<a href="${applyPaths.applications.pages.show({
+            id: 'some-uuid',
+            task: 'second-task',
+            page: 'bar',
+          })}" aria-describedby="eligibility-second-task" data-cy-task-name="second-task">Second Task</a>`,
+        )
+      })
+
       it('should return the task name when the task cannot be started', () => {
         task.status = 'cannot_start'
 

--- a/server/utils/taskListUtils.ts
+++ b/server/utils/taskListUtils.ts
@@ -19,7 +19,7 @@ export const statusTag = (task: TaskWithStatus): string => {
 
 export const taskLink = (task: TaskWithStatus, applicationOrAssessment: Application | Assessment): string => {
   if (task.status !== 'cannot_start') {
-    const firstPage = Object.keys(task.pages)[0]
+    const firstPage = Object.keys(applicationOrAssessment.data[task.id] || task.pages)[0]
 
     const link = isAssessment(applicationOrAssessment)
       ? assessPaths.assessments.pages.show({


### PR DESCRIPTION
Currently the `taskLink` helper returns the first question in the task. This is causing users some confusion, as the first question in the Basic Information task is telling the user that the Tier is not applicable, which is only shown when the user has an ineligible tier.

To get around this, rather than blindly returning the first question in the task, and the user has started the task, we return the first question they have completed within that task.

This is not ideal, and we’ll need to iterate on this, for example if we add a mandatory question to the start of a section, but this will at least resolve some of the confusion.