### PR TITLE
Safely navigate the data object

### DIFF
--- a/server/utils/taskListUtils.test.ts
+++ b/server/utils/taskListUtils.test.ts
@@ -55,6 +55,19 @@ describe('taskListUtils', () => {
 
         expect(taskLink(task, application)).toEqual(`Second Task`)
       })
+
+      it('should handle when data is undefined', () => {
+        task.status = 'in_progress'
+        application.data = undefined
+
+        expect(taskLink(task, application)).toEqual(
+          `<a href="${applyPaths.applications.pages.show({
+            id: 'some-uuid',
+            task: 'second-task',
+            page: 'foo',
+          })}" aria-describedby="eligibility-second-task" data-cy-task-name="second-task">Second Task</a>`,
+        )
+      })
     })
 
     describe('with an assessment', () => {

--- a/server/utils/taskListUtils.ts
+++ b/server/utils/taskListUtils.ts
@@ -19,7 +19,7 @@ export const statusTag = (task: TaskWithStatus): string => {
 
 export const taskLink = (task: TaskWithStatus, applicationOrAssessment: Application | Assessment): string => {
   if (task.status !== 'cannot_start') {
-    const firstPage = Object.keys(applicationOrAssessment.data[task.id] || task.pages)[0]
+    const firstPage = Object.keys(applicationOrAssessment?.data?.[task.id] || task.pages)[0]
 
     const link = isAssessment(applicationOrAssessment)
       ? assessPaths.assessments.pages.show({


### PR DESCRIPTION
At the moment, if we call `taskLink` and the `data` object is `undefined` or `null` we get an error. We can fix this with safe navigation