### PR TITLE
(466) Information not received flow 

### DIFF
--- a/integration_tests/pages/taskListPage.ts
+++ b/integration_tests/pages/taskListPage.ts
@@ -9,6 +9,10 @@ export default class TaskListPage extends Page {
     cy.get('.app-task-list').should('not.contain', section)
   }
 
+  shouldNotShowTask = (task: string): void => {
+    cy.get('.app-task-list__items').should('not.contain', task)
+  }
+
   shouldShowMissingCheckboxErrorMessage() {
     cy.get('.govuk-error-summary').should(
       'contain',

--- a/integration_tests/tests/assess/assess.cy.ts
+++ b/integration_tests/tests/assess/assess.cy.ts
@@ -158,6 +158,9 @@ context('Assess', () => {
         // Then I should not see the MatchingInformation section
         tasklistPage.shouldNotShowSection('Information for matching')
 
+        // And I should not see the Further actions section
+        tasklistPage.shouldNotShowSection('Provide any requirements to support placement')
+
         // When I check my answers
         this.assessHelper.completeCheckYourAnswersPage()
 

--- a/integration_tests/tests/assess/assess.cy.ts
+++ b/integration_tests/tests/assess/assess.cy.ts
@@ -149,8 +149,8 @@ context('Assess', () => {
         // And the sufficient information task should show a completed status
         tasklistPage.shouldShowTaskStatus('review-application', 'Completed')
 
-        // And I should not see the AssessApplication section
-        tasklistPage.shouldNotShowSection('Assess application')
+        // And I should see the AssessApplication section
+        this.assessHelper.completeSuitabilityOfAssessmentQuestion()
 
         // When I make a decision
         this.assessHelper.completeMakeADecisionPage('otherReasons')

--- a/server/utils/assessments/filterSectionTasks.test.ts
+++ b/server/utils/assessments/filterSectionTasks.test.ts
@@ -1,0 +1,48 @@
+import { FormSection, UiTask } from '../../@types/ui'
+import { assessmentFactory } from '../../testutils/factories'
+import informationSetAsNotReceived from './informationSetAsNotReceived'
+import { filterSectionTasks } from './filterSectionTasks'
+import AssessApplication from '../../form-pages/assess/assessApplication'
+
+jest.mock('./informationSetAsNotReceived')
+
+describe('filterSectionTasks', () => {
+  const assessment = assessmentFactory.build()
+  const task: UiTask = { id: 'task-id', title: 'task-title', pages: { page1: 'response' } }
+  const section: FormSection = { name: 'section-name', title: 'section-title', tasks: [task] }
+  const requiredActionsTask: UiTask = {
+    id: 'required-actions',
+    title: 'Provide any requirements to support placement',
+    pages: { page1: 'response' },
+  }
+  const sectionWithRequiredActionsTask: FormSection = {
+    name: AssessApplication.name,
+    title: 'section-title',
+    tasks: [requiredActionsTask],
+  }
+
+  beforeEach(() => {
+    ;(informationSetAsNotReceived as jest.MockedFn<typeof informationSetAsNotReceived>).mockReset()
+  })
+
+  it('it returns the section without modification if it doesnt contain the RequiredActions task', () => {
+    ;(informationSetAsNotReceived as jest.MockedFn<typeof informationSetAsNotReceived>).mockReturnValue(false)
+
+    expect(filterSectionTasks(section, assessment)).toEqual(section)
+  })
+
+  it('returns the section with the RequiredActions task unchanged if informationSetAsNotReceived returns false', () => {
+    ;(informationSetAsNotReceived as jest.MockedFn<typeof informationSetAsNotReceived>).mockReturnValue(false)
+
+    expect(filterSectionTasks(sectionWithRequiredActionsTask, assessment)).toEqual(sectionWithRequiredActionsTask)
+  })
+
+  it('returns the section with the RequiredActions task removed if informationSetAsNotReceived returns true', () => {
+    ;(informationSetAsNotReceived as jest.MockedFn<typeof informationSetAsNotReceived>).mockReturnValue(true)
+
+    expect(filterSectionTasks(sectionWithRequiredActionsTask, assessment)).toEqual({
+      ...sectionWithRequiredActionsTask,
+      tasks: [],
+    })
+  })
+})

--- a/server/utils/assessments/filterSectionTasks.ts
+++ b/server/utils/assessments/filterSectionTasks.ts
@@ -1,0 +1,18 @@
+import {
+  ApprovedPremisesApplication as Application,
+  ApprovedPremisesAssessment as Assessment,
+} from '../../@types/shared'
+import { FormSection } from '../../@types/ui'
+import AssessApplication from '../../form-pages/assess/assessApplication'
+import informationSetAsNotReceived from './informationSetAsNotReceived'
+import isAssessment from './isAssessment'
+
+export const filterSectionTasks = (section: FormSection, applicationOrAssessment: Assessment | Application) => {
+  if (!isAssessment(applicationOrAssessment) || section.name !== AssessApplication.name) return section
+
+  if (informationSetAsNotReceived(applicationOrAssessment)) {
+    return { ...section, tasks: section.tasks.filter(t => t.id !== 'required-actions') }
+  }
+
+  return section
+}

--- a/server/utils/assessments/getSections.test.ts
+++ b/server/utils/assessments/getSections.test.ts
@@ -20,16 +20,6 @@ describe('getSections', () => {
     expect(sectionNames).toContain('AssessApplication')
   })
 
-  it('removes the assess section if informationSetAsNotReceived is true', () => {
-    ;(informationSetAsNotReceived as jest.Mock).mockReturnValue(true)
-
-    const sections = getSections(assessment)
-    const sectionNames = sections.map(s => s.name)
-
-    expect(sections.length).toEqual(Assess.sections.length - 1)
-    expect(sectionNames).not.toContain('AssessApplication')
-  })
-
   it('removes the matching information section if the application has not been accepted', () => {
     ;(informationSetAsNotReceived as jest.Mock).mockReturnValue(false)
     ;(decisionFromAssessment as jest.Mock).mockReturnValue('decision')
@@ -54,7 +44,7 @@ describe('getSections', () => {
     expect(sectionNames).toContain('MatchingInformation')
   })
 
-  it('removes the assess and matching information section if informationSetAsNotReceived is true and the application has not been accepted', () => {
+  it('removes the matching information section if informationSetAsNotReceived is true and the application has not been accepted', () => {
     ;(informationSetAsNotReceived as jest.Mock).mockReturnValue(true)
     ;(decisionFromAssessment as jest.Mock).mockReturnValue('decision')
     ;(applicationAccepted as jest.Mock).mockReturnValue(false)
@@ -62,8 +52,7 @@ describe('getSections', () => {
     const sections = getSections(assessment)
     const sectionNames = sections.map(s => s.name)
 
-    expect(sections.length).toEqual(Assess.sections.length - 2)
+    expect(sections.length).toEqual(Assess.sections.length - 1)
     expect(sectionNames).not.toContain('MatchingInformation')
-    expect(sectionNames).not.toContain('AssessApplication')
   })
 })

--- a/server/utils/assessments/getSections.ts
+++ b/server/utils/assessments/getSections.ts
@@ -2,6 +2,7 @@ import { ApprovedPremisesAssessment as Assessment } from '../../@types/shared'
 import Assess from '../../form-pages/assess'
 import MatchingInformation from '../../form-pages/assess/matchingInformation'
 import { applicationAccepted, decisionFromAssessment } from './decisionUtils'
+import { filterSectionTasks } from './filterSectionTasks'
 
 export default (assessment: Assessment) => {
   let { sections } = Assess
@@ -10,5 +11,5 @@ export default (assessment: Assessment) => {
     sections = sections.filter(section => section.name !== MatchingInformation.name)
   }
 
-  return sections
+  return sections.map(section => filterSectionTasks(section, assessment))
 }

--- a/server/utils/assessments/getSections.ts
+++ b/server/utils/assessments/getSections.ts
@@ -1,16 +1,10 @@
 import { ApprovedPremisesAssessment as Assessment } from '../../@types/shared'
 import Assess from '../../form-pages/assess'
-import informationSetAsNotReceived from './informationSetAsNotReceived'
-import AssessApplication from '../../form-pages/assess/assessApplication'
 import MatchingInformation from '../../form-pages/assess/matchingInformation'
 import { applicationAccepted, decisionFromAssessment } from './decisionUtils'
 
 export default (assessment: Assessment) => {
   let { sections } = Assess
-
-  if (informationSetAsNotReceived(assessment)) {
-    sections = sections.filter(section => section.name !== AssessApplication.name)
-  }
 
   if (decisionFromAssessment(assessment) && !applicationAccepted(assessment)) {
     sections = sections.filter(section => section.name !== MatchingInformation.name)

--- a/server/utils/assessments/informationSetAsNotReceived.test.ts
+++ b/server/utils/assessments/informationSetAsNotReceived.test.ts
@@ -1,4 +1,4 @@
-import { assessmentFactory } from '../../testutils/factories'
+import { applicationFactory, assessmentFactory } from '../../testutils/factories'
 import informationSetAsNotReceived from './informationSetAsNotReceived'
 
 describe('informationSetAsNotReceived', () => {
@@ -26,5 +26,11 @@ describe('informationSetAsNotReceived', () => {
     assessment.status = 'in_progress'
 
     expect(informationSetAsNotReceived(assessment)).toEqual(false)
+  })
+
+  it('returns false when the argument is an Application', () => {
+    const application = applicationFactory.build()
+
+    expect(informationSetAsNotReceived(application)).toEqual(false)
   })
 })

--- a/server/utils/assessments/informationSetAsNotReceived.ts
+++ b/server/utils/assessments/informationSetAsNotReceived.ts
@@ -1,8 +1,15 @@
-import { ApprovedPremisesAssessment as Assessment } from '../../@types/shared'
+import {
+  ApprovedPremisesApplication as Application,
+  ApprovedPremisesAssessment as Assessment,
+} from '../../@types/shared'
+import isAssessment from './isAssessment'
 
-export default (assessment: Assessment): boolean => {
-  if (assessment.status === 'awaiting_response' && assessment.data) {
-    const response = assessment.data?.['sufficient-information']?.['information-received']?.informationReceived
+export default (applicationOrAssessment: Assessment | Application): boolean => {
+  if (!isAssessment(applicationOrAssessment)) return false
+
+  if (applicationOrAssessment.status === 'awaiting_response' && applicationOrAssessment.data) {
+    const response =
+      applicationOrAssessment.data?.['sufficient-information']?.['information-received']?.informationReceived
     return response === 'no'
   }
   return false


### PR DESCRIPTION
# Context

Previously if a user marked that they did not receive the information they requested from the probation practicioner then are not asked the Suitability Assessment questions. 
We need to ask these questions in order to have more detail on why the case has been rejected. 
However it doesn't make sense to ask the user questions about 'Required Actions' needed to support the PiP in an AP as they haven't been accepted into an AP and these questions are part of the 'Assess Application' section. Therefore we only want to show the first task for this section and not the second.


[Trello card](https://trello.com/c/xOGF8miz/466-user-flow-following-information-not-received-to-go-straight-to-reject-the-application)




## Screenshots of UI changes

### Before
![after (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/e3fd5248-2320-4ec3-be33-17ed60a15a90)

### After
![after](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/4a3b4470-e4d4-4310-b491-dbcafb1ae78c)
