### PR TITLE
(466) Information not received flow fix

### DIFF
--- a/server/utils/assessments/informationSetAsNotReceived.test.ts
+++ b/server/utils/assessments/informationSetAsNotReceived.test.ts
@@ -1,8 +1,11 @@
 import { applicationFactory, assessmentFactory } from '../../testutils/factories'
 import informationSetAsNotReceived from './informationSetAsNotReceived'
+import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromFormArtifact'
+
+jest.mock('../retrieveQuestionResponseFromFormArtifact')
 
 describe('informationSetAsNotReceived', () => {
-  const assessment = assessmentFactory.build({ status: 'awaiting_response' })
+  const assessment = assessmentFactory.build()
 
   it('returns false when there is no data', () => {
     assessment.data = {}
@@ -11,21 +14,23 @@ describe('informationSetAsNotReceived', () => {
   })
 
   it('returns false when informationReceived is set to yes', () => {
-    assessment.data = { 'sufficient-information': { 'information-received': { informationReceived: 'yes' } } }
+    ;(
+      retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.MockedFn<
+        typeof retrieveOptionalQuestionResponseFromApplicationOrAssessment
+      >
+    ).mockReturnValue('yes')
 
     expect(informationSetAsNotReceived(assessment)).toEqual(false)
   })
 
   it('returns true when informationReceived is set to no', () => {
-    assessment.data = { 'sufficient-information': { 'information-received': { informationReceived: 'no' } } }
+    ;(
+      retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.MockedFn<
+        typeof retrieveOptionalQuestionResponseFromApplicationOrAssessment
+      >
+    ).mockReturnValue('no')
 
     expect(informationSetAsNotReceived(assessment)).toEqual(true)
-  })
-
-  it('returns false when the application is not pending', () => {
-    assessment.status = 'in_progress'
-
-    expect(informationSetAsNotReceived(assessment)).toEqual(false)
   })
 
   it('returns false when the argument is an Application', () => {

--- a/server/utils/assessments/informationSetAsNotReceived.ts
+++ b/server/utils/assessments/informationSetAsNotReceived.ts
@@ -2,15 +2,22 @@ import {
   ApprovedPremisesApplication as Application,
   ApprovedPremisesAssessment as Assessment,
 } from '../../@types/shared'
+import InformationReceived from '../../form-pages/assess/reviewApplication/sufficientInformation/informationReceived'
+import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromFormArtifact'
 import isAssessment from './isAssessment'
 
 export default (applicationOrAssessment: Assessment | Application): boolean => {
   if (!isAssessment(applicationOrAssessment)) return false
 
-  if (applicationOrAssessment.status === 'awaiting_response' && applicationOrAssessment.data) {
-    const response =
-      applicationOrAssessment.data?.['sufficient-information']?.['information-received']?.informationReceived
+  if (applicationOrAssessment?.data) {
+    const response = retrieveOptionalQuestionResponseFromApplicationOrAssessment(
+      applicationOrAssessment,
+      InformationReceived,
+      'informationReceived',
+    )
+
     return response === 'no'
   }
+
   return false
 }

--- a/server/views/applications/start.njk
+++ b/server/views/applications/start.njk
@@ -42,7 +42,7 @@
 
         <ul>
           <li>
-            <a href="">eligibility requirements</a> - you'll need to demonstrate why an AP is necessary over other interventions and accommodation options</li>
+            <a href="https://equip-portal.equip.service.justice.gov.uk/CtrlWebIsapi.dll?__id=webMyTopics.searchOne&k=8722">eligibility requirements</a> - you'll need to demonstrate why an AP is necessary over other interventions and accommodation options</li>
           <li>factors impacting which location, type of AP, and type of room will be suitable</li>
           <li>how you'll prepare for move on after the AP</li>
         </ul>


### PR DESCRIPTION
This PR fixes the `informationSetAsNotReceived` function so that it works properly with the `filterSectionTasks` function. This means that a user will be able to mark that they have not received the information required for the assessment then go back and say that they have and see the 'Required Actions' task that they need to complete. Previously they would not have seen the 'Required Actions' task


Previously `informationSetAsNotReceived` checked if the response to the 'informationReceived' question was 'no' AND if the assessment status was 'awaiting_response'.
`informationSetAsNotReceived` is used in two places: a) in the assessmentsController.show method and, b)
in the filterSections function.
In a) we want to check the assessment status is 'awaiting_response' but we do this already in the controller
method so we don't need to do it again in the util.
In b) we don't care about the assessment status and checking that it is 'awaiting_response' before checking
the answer to the question means that if a user changes their mind about the whether they have received
sufficient information they won't be able to complete the 'required-actions' task.