### PR TITLE
(487) Application timeline

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -4,6 +4,7 @@ import type {
   ApprovedPremisesApplication,
   ApprovedPremisesApplicationSummary,
   ApprovedPremisesAssessment,
+  TimelineEvent,
 } from '@approved-premises/api'
 
 import { getMatchingRequests, stubFor } from '../../wiremock'
@@ -119,6 +120,18 @@ export default {
       response: {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      },
+    }),
+  stubApplicationTimeline: (args: { applicationId: string; timeline: Array<TimelineEvent> }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: paths.applications.timeline({ id: args.applicationId }),
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.timeline,
       },
     }),
   verifyApplicationWithdrawn: async (args: { applicationId: string }) =>

--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -7,7 +7,7 @@ import Page from '../page'
 
 export default class ShowPage extends Page {
   constructor(private readonly application: ApprovedPremisesApplication) {
-    super('View Application')
+    super((application.person as FullPerson).name)
   }
 
   static visit(application: ApprovedPremisesApplication) {

--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -1,9 +1,10 @@
-import type { ApprovedPremisesApplication, FullPerson } from '@approved-premises/api'
+import type { ApprovedPremisesApplication, FullPerson, TimelineEvent } from '@approved-premises/api'
 import { DateFormats } from '../../../server/utils/dateUtils'
 
 import { summaryListSections } from '../../../server/utils/applications/summaryListUtils'
 
 import Page from '../page'
+import { eventTypeTranslations } from '../../../server/utils/applications/utils'
 
 export default class ShowPage extends Page {
   constructor(private readonly application: ApprovedPremisesApplication) {
@@ -57,6 +58,29 @@ export default class ShowPage extends Page {
         cy.get(`[data-cy-section="${task.card.attributes['data-cy-section']}"]`).within(() => {
           cy.get('.govuk-summary-card__title').contains(task.card.title.text).should('exist')
           this.shouldContainSummaryListItems(task.rows)
+        })
+      })
+    })
+  }
+
+  clickTimelineTab() {
+    cy.get('a').contains('Timeline').click()
+  }
+
+  shouldShowTimeline(timelineEvents: Array<TimelineEvent>) {
+    const sortedTimelineEvents = timelineEvents.sort((a, b) => {
+      return new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime()
+    })
+
+    cy.get('h2').contains('Application history').should('exist')
+    cy.get('.moj-timeline').within(() => {
+      cy.get('.moj-timeline__item').should('have.length', timelineEvents.length)
+
+      cy.get('.moj-timeline__item').each(($el, index) => {
+        cy.wrap($el).within(() => {
+          cy.get('.moj-timeline__header').should('contain', eventTypeTranslations[sortedTimelineEvents[index].type])
+          cy.get('time').should('have.attr', { time: sortedTimelineEvents[index].occurredAt })
+          cy.get('time').should('contain', DateFormats.isoDateTimeToUIDateTime(timelineEvents[index].occurredAt))
         })
       })
     })

--- a/integration_tests/tests/apply/viewApplication.cy.ts
+++ b/integration_tests/tests/apply/viewApplication.cy.ts
@@ -3,14 +3,18 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 import { ListPage, ShowPage } from '../../pages/apply'
 import Page from '../../pages/page'
 import { setup } from './setup'
+import { timelineEventFactory } from '../../../server/testutils/factories'
 
 context('show applications', () => {
   beforeEach(setup)
 
   it('shows a read-only version of the application', function test() {
     // Given I have completed an application
+    const timeline = timelineEventFactory.buildList(10)
+
     const updatedApplication = { ...this.application, status: 'submitted' }
     cy.task('stubApplicationGet', { application: updatedApplication })
+    cy.task('stubApplicationTimeline', { applicationId: updatedApplication.id, timeline })
     cy.task('stubApplications', [updatedApplication])
 
     // And I visit the list page
@@ -28,8 +32,14 @@ context('show applications', () => {
     // Then I should see a read-only version of the application
     const showPage = Page.verifyOnPage(ShowPage, updatedApplication)
 
+    // And I should see the application details
     showPage.shouldShowPersonInformation()
     showPage.shouldShowResponses()
+
+    // When I click on the 'Timeline' tab
+    // Then I should see timeline page
+    showPage.clickTimelineTab()
+    showPage.shouldShowTimeline(timeline)
   })
 
   it('links to an assessment when an application has been assessed', function test() {

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -191,6 +191,8 @@ export interface IdentityBarMenuItem {
   text: string
 }
 
+export type UiTimelineEvent = { label: { text: string }; datetime: { timestamp: string; type?: 'datetime' } }
+
 export type RiskLevel = 'Low' | 'Medium' | 'High' | 'Very High'
 
 export type TierNumber = '1' | '2' | '3' | '4'

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -11,6 +11,7 @@ import {
   applicationFactory,
   personFactory,
   restrictedPersonFactory,
+  timelineEventFactory,
 } from '../../testutils/factories'
 
 import paths from '../../paths/apply'
@@ -117,6 +118,30 @@ describe('applicationsController', () => {
       expect(applicationService.findApplication).toHaveBeenCalledWith(token, application.id)
     })
 
+    describe('when the tab=timeline query param is present', () => {
+      it('calls the timeline method on the application service and passes the tab: "timeline" property', async () => {
+        const timelineEvents = timelineEventFactory.buildList(1)
+        application.status = 'submitted'
+
+        const requestHandler = applicationsController.show()
+
+        applicationService.findApplication.mockResolvedValue(application)
+        applicationService.timeline.mockResolvedValue(timelineEvents)
+
+        await requestHandler({ ...request, query: { tab: 'timeline' } }, response, next)
+
+        expect(response.render).toHaveBeenCalledWith('applications/show', {
+          application,
+          referrer,
+          tab: 'timeline',
+          timelineEvents,
+        })
+
+        expect(applicationService.findApplication).toHaveBeenCalledWith(token, application.id)
+        expect(applicationService.timeline).toHaveBeenCalledWith(token, application.id)
+      })
+    })
+
     it('fetches the application from the API and renders the read only view if the application is submitted', async () => {
       application.status = 'submitted'
 
@@ -132,6 +157,7 @@ describe('applicationsController', () => {
       expect(response.render).toHaveBeenCalledWith('applications/show', {
         application,
         referrer,
+        tab: 'application',
       })
 
       expect(applicationService.findApplication).toHaveBeenCalledWith(token, application.id)

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -42,10 +42,16 @@ export default class ApplicationsController {
 
       if (application.status !== 'inProgress') {
         const referrer = req.headers.referer
-        res.render('applications/show', { application, referrer })
-      } else {
-        res.render('applications/tasklist', { application, taskList, errorSummary, errors })
+
+        if (req.query.tab === 'timeline') {
+          const timelineEvents = await this.applicationService.timeline(req.user.token, application.id)
+
+          return res.render('applications/show', { application, timelineEvents, referrer, tab: 'timeline' })
+        }
+
+        return res.render('applications/show', { application, referrer, tab: 'application' })
       }
+      return res.render('applications/tasklist', { application, taskList, errorSummary, errors })
     }
   }
 

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -6,6 +6,7 @@ import {
   applicationSummaryFactory,
   assessmentFactory,
   documentFactory,
+  timelineEventFactory,
 } from '../testutils/factories'
 import paths from '../paths/api'
 import describeClient from '../testutils/describeClient'
@@ -296,6 +297,32 @@ describeClient('ApplicationClient', provider => {
       })
 
       await applicationClient.withdrawal(applicationId, newWithdrawal)
+    })
+  })
+
+  describe('timeline', () => {
+    it('calls the timeline endpoint with the application ID', async () => {
+      const applicationId = 'applicationId'
+      const timelineEvents = timelineEventFactory.buildList(1)
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request for the timeline of an application',
+        withRequest: {
+          method: 'GET',
+          path: paths.applications.timeline({ id: applicationId }),
+          headers: {
+            authorization: `Bearer ${token}`,
+            'X-Service-Name': 'approved-premises',
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: timelineEvents,
+        },
+      })
+
+      await applicationClient.timeline(applicationId)
     })
   })
 })

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -6,6 +6,7 @@ import type {
   Document,
   NewWithdrawal,
   SubmitApprovedPremisesApplication,
+  TimelineEvent,
   UpdateApprovedPremisesApplication,
 } from '@approved-premises/api'
 import RestClient from './restClient'
@@ -71,5 +72,11 @@ export default class ApplicationClient {
       path: paths.applications.withdrawal({ id: applicationId }),
       data: body,
     })
+  }
+
+  async timeline(applicationId: string): Promise<Array<TimelineEvent>> {
+    return (await this.restClient.get({
+      path: paths.applications.timeline({ id: applicationId }),
+    })) as Array<TimelineEvent>
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -119,6 +119,7 @@ export default {
     documents: applyPaths.applications.show.path('documents'),
     assessment: applyPaths.applications.show.path('assessment'),
     withdrawal: applyPaths.applications.show.path('withdrawal'),
+    timeline: applyPaths.applications.show.path('timeline'),
   },
   assessments: {
     index: assessPaths.assessments,

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -378,4 +378,16 @@ describe('ApplicationService', () => {
       expect(applicationClient.withdrawal).toHaveBeenCalledWith(id, body)
     })
   })
+
+  describe('timeline', () => {
+    it('it calls the client with the Id and token', async () => {
+      const token = 'some-token'
+      const id = 'some-uuid'
+
+      await service.timeline(token, id)
+
+      expect(applicationClientFactory).toHaveBeenCalledWith(token)
+      expect(applicationClient.timeline).toHaveBeenCalledWith(id)
+    })
+  })
 })

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -134,4 +134,12 @@ export default class ApplicationService {
 
     await client.withdrawal(applicationId, body)
   }
+
+  async timeline(token: string, applicationId: string) {
+    const client = this.applicationClientFactory(token)
+
+    const timeline = await client.timeline(applicationId)
+
+    return timeline
+  }
 }

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -70,6 +70,7 @@ import roomFactory from './room'
 import staffMemberFactory from './staffMember'
 import taskFactory from './task'
 import taskWrapperFactory from './taskWrapperFactory'
+import timelineEventFactory from './timelineEvent'
 import userFactory from './user'
 import userDetailsFactory from './userDetails'
 import placementApplicationDecisionEnvelopeFactory from './placementApplicationDecisionEnvelope'
@@ -151,6 +152,7 @@ export {
   taskFactory,
   taskWrapperFactory,
   tierEnvelopeFactory,
+  timelineEventFactory,
   userFactory,
   userDetailsFactory,
 }

--- a/server/testutils/factories/timelineEvent.ts
+++ b/server/testutils/factories/timelineEvent.ts
@@ -1,0 +1,24 @@
+import { Factory } from 'fishery'
+import { TimelineEvent } from '@approved-premises/api'
+import { faker } from '@faker-js/faker'
+import { DateFormats } from '../../utils/dateUtils'
+
+export default Factory.define<TimelineEvent>(() => ({
+  id: faker.string.uuid(),
+  occurredAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
+  type: faker.helpers.arrayElement([
+    'approved_premises_application_submitted',
+    'approved_premises_application_assessed',
+    'approved_premises_booking_made',
+    'approved_premises_person_arrived',
+    'approved_premises_person_not_arrived',
+    'approved_premises_person_departed',
+    'approved_premises_booking_not_made',
+    'approved_premises_booking_cancelled',
+    'approved_premises_booking_changed',
+    'approved_premises_application_withdrawn',
+    'approved_premises_information_request',
+    'cas3_person_arrived',
+    'cas3_person_departed',
+  ] as const),
+}))

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -6,12 +6,15 @@ import type {
   JourneyType,
   PageResponse,
   TableRow,
+  UiTimelineEvent,
 } from '@approved-premises/ui'
 import type {
   ApprovedPremisesApplication as Application,
   ApplicationStatus,
   ApprovedPremisesApplicationSummary as ApplicationSummary,
   Person,
+  TimelineEvent,
+  TimelineEventType,
 } from '@approved-premises/api'
 import MaleAp from '../../form-pages/apply/reasons-for-placement/basic-information/maleAp'
 import IsExceptionalCase from '../../form-pages/apply/reasons-for-placement/basic-information/isExceptionalCase'
@@ -171,6 +174,36 @@ const getApplicationType = (application: Application): ApplicationType => {
   return 'Standard'
 }
 
+export const eventTypeTranslations: Record<TimelineEventType, string> = {
+  approved_premises_application_submitted: 'Application submitted',
+  approved_premises_application_assessed: 'Application assessed',
+  approved_premises_booking_made: 'Booking made',
+  approved_premises_person_arrived: 'Person arrived',
+  approved_premises_person_not_arrived: 'Person not arrived',
+  approved_premises_person_departed: 'Person departed',
+  approved_premises_booking_not_made: 'Booking not made',
+  approved_premises_booking_cancelled: 'Booking cancelled',
+  approved_premises_booking_changed: 'Booking changed',
+  approved_premises_application_withdrawn: 'Application withdrawn',
+  approved_premises_information_request: 'Information request',
+  cas3_person_arrived: 'CAS3 person arrived',
+  cas3_person_departed: 'CAS3 person departed',
+}
+
+const mapTimelineEventsForUi = (timelineEvents: Array<TimelineEvent>): Array<UiTimelineEvent> => {
+  return timelineEvents
+    .sort((a, b) => Number(DateFormats.isoToDateObj(b.occurredAt)) - Number(DateFormats.isoToDateObj(a.occurredAt)))
+    .map(timelineEvent => {
+      return {
+        label: { text: eventTypeTranslations[timelineEvent.type] },
+        datetime: {
+          timestamp: timelineEvent.occurredAt,
+          date: DateFormats.isoDateTimeToUIDateTime(timelineEvent.occurredAt),
+        },
+      }
+    })
+}
+
 export {
   dashboardTableRows,
   firstPageOfApplicationJourney,
@@ -178,5 +211,6 @@ export {
   getApplicationType,
   getStatus,
   isInapplicable,
+  mapTimelineEventsForUi,
   statusTags,
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -21,7 +21,7 @@ import {
   convertObjectsToSelectOptions,
   dateFieldValues,
 } from './formUtils'
-import { dashboardTableRows } from './applications/utils'
+import { dashboardTableRows, mapTimelineEventsForUi } from './applications/utils'
 import { navigationItems } from './navigationItems'
 
 import { statusTag } from './personUtils'
@@ -198,6 +198,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
 
   njkEnv.addGlobal('numberToOrdinal', numberToOrdinal)
   njkEnv.addGlobal('dashboardTableRows', dashboardTableRows)
+  njkEnv.addGlobal('mapTimelineEventsForUi', mapTimelineEventsForUi)
   njkEnv.addGlobal('navigationItems', navigationItems)
   njkEnv.addGlobal('withdrawalRadioOptions', withdrawalRadioOptions)
   njkEnv.addGlobal('pagination', pagination)

--- a/server/views/applications/partials/_readonly-application.njk
+++ b/server/views/applications/partials/_readonly-application.njk
@@ -1,0 +1,17 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "../../partials/personDetails.njk" import personDetails %}
+
+{% macro applicationReadonlyView(application) %}
+
+      {{ personDetails(application.person) }}
+
+      {% for section in SummaryListUtils.summaryListSections(application, false) %}
+        <h2 class="govuk-heading-l">{{ section.title }}</h2>
+        {% for task in section.tasks %}
+          {{
+            govukSummaryList(task)
+          }}
+        {% endfor %}
+      {% endfor %}
+
+{% endmacro %}

--- a/server/views/applications/partials/_timeline.njk
+++ b/server/views/applications/partials/_timeline.njk
@@ -1,0 +1,26 @@
+
+{%- from "moj/components/timeline/macro.njk" import mojTimeline -%}
+
+{% macro timeline(timelineEvents) %}
+
+<h2 class="govuk-heading-m">Application history</h2>
+  <div class="moj-timeline">
+
+    {% for event in timelineEvents %}
+      <div class="moj-timeline__item">
+
+        <div class="moj-timeline__header">
+          <h3 class="moj-timeline__title">{{event.label.text}}</h3>
+        </div>
+
+        <p class="moj-timeline__date">
+          <time datetime="{{event.datetime.timestamp}}">{{event.datetime.date}}</time>
+        </p>
+
+      </div>
+    {% endfor %}
+</div>
+
+
+
+{% endmacro %}

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -1,12 +1,13 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "../partials/personDetails.njk" import personDetails %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+{% from "../partials/personDetails.njk" import personDetails %}
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageHeading = "View Application" %}
+{% set pageHeading = "Approved Premises application" %}
 {% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body" %}
 
@@ -24,7 +25,8 @@
     <div class="govuk-width-container">
       <div class="moj-page-header-actions">
         <div class="moj-page-header-actions__title">
-          <h1 class="govuk-heading-xl">{{ pageHeading }}</h1>
+          <span class="govuk-caption-l">{{ pageHeading }}</span>
+          <h1 class="govuk-heading-l">{{ application.person.name }}</h1>
         </div>
         <div class="moj-page-header-actions__actions">
           <div class="moj-button-menu">
@@ -55,6 +57,16 @@
           html: html
         }) }}
       {% endif %}
+
+
+
+      {{ mojSubNavigation({
+        items: [{
+          text: 'Application',
+          href: paths.applications.show({id: application.id}) + '?tab=application',
+          active: tab === 'application'
+        }]
+      }) }}
 
       {{ personDetails(application.person) }}
 

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -1,9 +1,9 @@
-{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
-{% from "../partials/personDetails.njk" import personDetails %}
+{% from "./partials/_readonly-application.njk" import applicationReadonlyView %}
+{% from "./partials/_timeline.njk" import timeline %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -65,19 +65,19 @@
           text: 'Application',
           href: paths.applications.show({id: application.id}) + '?tab=application',
           active: tab === 'application'
+        }, {
+          text: 'Timeline',
+          href:  paths.applications.show({id: application.id}) + '?tab=timeline',
+          active: tab === 'timeline'
         }]
       }) }}
 
-      {{ personDetails(application.person) }}
-
-      {% for section in SummaryListUtils.summaryListSections(application, false) %}
-        <h2 class="govuk-heading-l">{{ section.title }}</h2>
-        {% for task in section.tasks %}
-          {{
-            govukSummaryList(task)
-          }}
-        {% endfor %}
-      {% endfor %}
+    {% if tab === 'timeline' %}
+      {{ timeline(mapTimelineEventsForUi(timelineEvents)) }}
+    {% else %}
+      {{ applicationReadonlyView(application) }}
+    {% endif %}
+    
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
# Context

[Trello ticket](https://trello.com/c/YJKwQZKO/487-show-application-timeline) 

This PR adds a timeline of events to the 'readonly' application view.

# Changes in this PR
- First we enable the Application page to handle subnavigation
- Then we add the timeline view 
## Screenshots of UI changes
![before](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/d782a9ab-b2fd-4729-9b65-1535d5588886)

### Before

### After
![after](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/c0e1d783-e37d-4165-9e35-c233f3545d3d)


![2 (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/98a7314e-986b-48f0-afcf-074f65528f85)
