### PR TITLE
Improve types

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -7,7 +7,7 @@ const production = process.env.NODE_ENV === 'production'
 
 function get<T>(name: string, fallback: T, options = { requireInProduction: false }): T | string {
   if (process.env[name]) {
-    return process.env[name]
+    return process.env[name] as string
   }
   if (fallback !== undefined && (!production || !options.requireInProduction)) {
     return fallback
@@ -54,7 +54,7 @@ export default {
   },
   redis: {
     host: get('REDIS_HOST', 'localhost', requiredInProduction),
-    port: parseInt(process.env.REDIS_PORT, 10) || 6379,
+    port: parseInt(process.env.REDIS_PORT as string, 10) || 6379,
     password: process.env.REDIS_AUTH_TOKEN,
     tls_enabled: get('REDIS_TLS_ENABLED', 'false'),
   },

--- a/server/controllers/assess/index.ts
+++ b/server/controllers/assess/index.ts
@@ -6,6 +6,7 @@ import ClarificationNotesController from './assessments/clarificationNotesContro
 import SupportingInformationController from './supportingInformationController'
 
 import type { Services } from '../../services'
+import { DataServices } from '../../@types/ui'
 
 export const controllers = (services: Services) => {
   const { assessmentService, applicationService, userService } = services
@@ -14,7 +15,7 @@ export const controllers = (services: Services) => {
   const assessmentPagesController = new AssessmentPagesController(assessmentService, {
     applicationService,
     userService,
-  })
+  } as unknown as DataServices)
   const clarificationNotesController = new ClarificationNotesController(assessmentService, userService)
   const supportingInformationController = new SupportingInformationController(assessmentService)
 

--- a/server/controllers/assess/supportingInformationController.test.ts
+++ b/server/controllers/assess/supportingInformationController.test.ts
@@ -74,7 +74,7 @@ describe('supportingInformationController', () => {
 
         expect(response.render).toBeCalledWith('assessments/pages/risk-information/oasys-information', {
           assessmentId: assessment.id,
-          dateOfImport: DateFormats.isoDateToUIDate(assessment.application.submittedAt),
+          dateOfImport: DateFormats.isoDateToUIDate(assessment.application?.submittedAt || ''),
           oasysSections: {
             roshSummary: oasysImport['rosh-summary'].roshSummaries,
             offenceDetails: oasysImport['offence-details'].offenceDetailsSummaries,
@@ -107,7 +107,7 @@ describe('supportingInformationController', () => {
         caseNotes,
         acctAlerts,
         assessmentId: assessment.id,
-        dateOfImport: DateFormats.isoDateToUIDate(assessment.application.submittedAt),
+        dateOfImport: DateFormats.isoDateToUIDate(assessment.application?.submittedAt || ''),
         pageHeading: 'Prison information',
       })
       expect(assessmentService.findAssessment).toBeCalledWith(token, request.params.id)

--- a/server/form-pages/apply/add-documents/attachDocuments.test.ts
+++ b/server/form-pages/apply/add-documents/attachDocuments.test.ts
@@ -1,4 +1,5 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { ApplicationService, PersonService } from '../../../services'
 import { applicationFactory, documentFactory } from '../../../testutils/factories'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
@@ -23,7 +24,12 @@ describe('attachDocuments', () => {
     })
 
     it('calls the getDocuments method on the client with a token and the application', async () => {
-      await AttachDocuments.initialize({}, application, 'some-token', { personService, applicationService })
+      await AttachDocuments.initialize(
+        {},
+        application,
+        'some-token',
+        fromPartial({ personService, applicationService }),
+      )
 
       expect(getDocumentsMock).toHaveBeenCalledWith('some-token', application)
     })
@@ -39,7 +45,7 @@ describe('attachDocuments', () => {
         },
         application,
         'SOME_TOKEN',
-        { applicationService, personService },
+        fromPartial({ applicationService, personService }),
       )
 
       expect(page.body).toEqual({
@@ -53,13 +59,16 @@ describe('attachDocuments', () => {
 
     it('assigns the selected documents if the selection is not an array', async () => {
       const page = await AttachDocuments.initialize(
-        { documentIds: documents[0].id, documentDescriptions: { [documents[0].id]: documents[0].description } },
+        {
+          documentIds: documents[0].id,
+          documentDescriptions: { [documents[0].id]: documents[0].description } as Record<string, string>,
+        },
         application,
         'SOME_TOKEN',
-        {
+        fromPartial({
           applicationService,
           personService,
-        },
+        }),
       )
 
       expect(page.body).toEqual({ selectedDocuments: [documents[0]] })
@@ -72,7 +81,7 @@ describe('attachDocuments', () => {
         },
         application,
         'SOME_TOKEN',
-        { applicationService, personService },
+        fromPartial({ applicationService, personService }),
       )
 
       expect(page.body).toEqual({

--- a/server/form-pages/apply/add-documents/attachDocuments.test.ts
+++ b/server/form-pages/apply/add-documents/attachDocuments.test.ts
@@ -99,7 +99,7 @@ describe('attachDocuments', () => {
     it('should return an error if a document does not have a description', () => {
       const selectedDocuments = [
         documentFactory.build({ fileName: 'file1.pdf', description: 'Description goes here' }),
-        documentFactory.build({ fileName: 'file2.pdf', description: null }),
+        documentFactory.build({ fileName: 'file2.pdf', description: undefined }),
       ]
 
       const page = new AttachDocuments({ selectedDocuments }, application)
@@ -113,7 +113,7 @@ describe('attachDocuments', () => {
     it('should return a record with the document filename as the key and the description as the value', () => {
       const selectedDocuments = [
         documentFactory.build({ fileName: 'file1.pdf', description: 'Description goes here' }),
-        documentFactory.build({ fileName: 'file2.pdf', description: null }),
+        documentFactory.build({ fileName: 'file2.pdf', description: undefined }),
       ]
 
       const page = new AttachDocuments({ selectedDocuments }, application)

--- a/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.test.ts
@@ -1,5 +1,6 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
+import { fromPartial } from '@total-typescript/shoehorn'
 import { ApprovedPremisesApplication as Application, FullPerson } from '../../../../@types/shared'
 import { UserService } from '../../../../services'
 import { applicationFactory } from '../../../../testutils/factories'
@@ -58,7 +59,7 @@ describe('ConfirmYourDetails', () => {
         getUserById: getUserByIdMock,
       })
 
-      const result = await ConfirmYourDetails.initialize({}, application, 'token', { userService })
+      const result = await ConfirmYourDetails.initialize({}, application, 'token', fromPartial({ userService }))
       const expected = new ConfirmYourDetails(
         {
           userDetailsFromDelius: deliusUserMappedForUi,

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/apType.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/apType.test.ts
@@ -18,7 +18,7 @@ describe('ApType', () => {
   })
 
   describe('when type is set to standard', () => {
-    itShouldHaveNextValue(new ApType({ type: 'standard' }), null)
+    itShouldHaveNextValue(new ApType({ type: 'standard' }), '')
   })
 
   describe('errors', () => {

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/apType.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/apType.ts
@@ -31,7 +31,7 @@ export default class SelectApType implements TasklistPage {
       return 'managed-by-national-security-division'
     }
 
-    return null
+    return ''
   }
 
   response() {

--- a/server/form-pages/apply/risk-and-need-factors/location-factors/preferredAps.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/preferredAps.test.ts
@@ -1,5 +1,6 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
+import { fromPartial } from '@total-typescript/shoehorn'
 import PreferredAps from './preferredAps'
 import { PremisesService } from '../../../../services'
 import { applicationFactory, premisesFactory } from '../../../../testutils/factories'
@@ -45,16 +46,21 @@ describe('PreferredAps', () => {
     })
 
     it('should call the Premises service and set the list of Premises on the page class', async () => {
-      const page = await PreferredAps.initialize(body, application, token, { premisesService })
+      const page = await PreferredAps.initialize(body, application, token, fromPartial({ premisesService }))
 
       expect(page.allPremises).toEqual(allAps)
       expect(getAll).toHaveBeenCalledWith(token)
     })
 
     it('should convert the selectedAps from strings to objects containing text and value properties', async () => {
-      const page = await PreferredAps.initialize({ preferredAp1: '1', preferredAp2: '2' }, application, token, {
-        premisesService,
-      })
+      const page = await PreferredAps.initialize(
+        { preferredAp1: '1', preferredAp2: '2' },
+        application,
+        token,
+        fromPartial({
+          premisesService,
+        }),
+      )
 
       expect(page.body.selectedAps).toEqual([ap1, ap2])
     })

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.test.ts
@@ -1,4 +1,5 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { PersonService } from '../../../../services'
 import { applicationFactory, oasysSectionsFactory, risksFactory } from '../../../../testutils/factories'
 import { oasysImportReponse } from '../../../../utils/oasysImportUtils'
@@ -31,13 +32,13 @@ describe('OffenceDetails', () => {
     })
 
     it('calls the getOasysSections  method on the client with a token and the persons CRN', async () => {
-      await OffenceDetails.initialize({}, application, 'some-token', { personService })
+      await OffenceDetails.initialize({}, application, 'some-token', fromPartial({ personService }))
 
       expect(getOasysSectionsMock).toHaveBeenCalledWith('some-token', application.person.crn, [])
     })
 
     it('adds the offenceDetailsSummaries and personRisks to the page object', async () => {
-      const page = await OffenceDetails.initialize({}, application, 'some-token', { personService })
+      const page = await OffenceDetails.initialize({}, application, 'some-token', fromPartial({ personService }))
 
       expect(page.offenceDetailsSummaries).toEqual(oasysSections.offenceDetails)
       expect(page.risks).toEqual(mapApiPersonRisksForUi(personRisks))
@@ -47,7 +48,7 @@ describe('OffenceDetails', () => {
     it('sets dateCompleted to dateStarted if dateCompleted is null', async () => {
       getOasysSectionsMock.mockResolvedValue({ ...oasysSections, dateCompleted: null })
 
-      const page = await OffenceDetails.initialize({}, application, 'some-token', { personService })
+      const page = await OffenceDetails.initialize({}, application, 'some-token', fromPartial({ personService }))
       expect(page.oasysCompleted).toEqual(oasysSections.dateStarted)
     })
 

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.test.ts
@@ -1,4 +1,5 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { OasysNotFoundError } from '../../../../services/personService'
 import { ApplicationService, PersonService } from '../../../../services'
 import { applicationFactory, oasysSelectionFactory } from '../../../../testutils/factories'
@@ -40,26 +41,41 @@ describe('OptionalOasysSections', () => {
     })
 
     it('calls the getOasysSelections method on the client with a token and the persons CRN', async () => {
-      await OptionalOasysSections.initialize({}, application, 'some-token', { personService, applicationService })
+      await OptionalOasysSections.initialize(
+        {},
+        application,
+        'some-token',
+        fromPartial({ personService, applicationService }),
+      )
 
       expect(getOasysSelectionsMock).toHaveBeenCalledWith('some-token', application.person.crn)
     })
 
     it('filters the OASys sections into needs linked to reoffending and other needs not linked to reoffending or harm', async () => {
-      const page = await OptionalOasysSections.initialize({}, application, 'some-token', {
-        personService,
-        applicationService,
-      })
+      const page = await OptionalOasysSections.initialize(
+        {},
+        application,
+        'some-token',
+        fromPartial({
+          personService,
+          applicationService,
+        }),
+      )
 
       expect(page.allNeedsLinkedToReoffending).toEqual(needsLinkedToReoffending)
       expect(page.allOtherNeeds).toEqual(otherNeeds)
     })
 
     it('returns an empty array for the selected needs if the body is empty', async () => {
-      const page = await OptionalOasysSections.initialize({}, application, 'some-token', {
-        personService,
-        applicationService,
-      })
+      const page = await OptionalOasysSections.initialize(
+        {},
+        application,
+        'some-token',
+        fromPartial({
+          personService,
+          applicationService,
+        }),
+      )
 
       expect(page.body.needsLinkedToReoffending).toEqual([])
       expect(page.body.otherNeeds).toEqual([])
@@ -73,10 +89,10 @@ describe('OptionalOasysSections', () => {
         },
         application,
         'some-token',
-        {
+        fromPartial({
           personService,
           applicationService,
-        },
+        }),
       )
 
       expect(page.body.needsLinkedToReoffending).toEqual([needsLinkedToReoffending[0]])
@@ -88,10 +104,10 @@ describe('OptionalOasysSections', () => {
         { needsLinkedToReoffending: [needsLinkedToReoffending[0]], otherNeeds: [otherNeeds[0], otherNeeds[1]] },
         application,
         'some-token',
-        {
+        fromPartial({
           personService,
           applicationService,
-        },
+        }),
       )
 
       expect(page.body.needsLinkedToReoffending).toEqual([needsLinkedToReoffending[0]])
@@ -103,10 +119,15 @@ describe('OptionalOasysSections', () => {
         throw new OasysNotFoundError('')
       })
 
-      const page = await OptionalOasysSections.initialize({}, application, 'some-token', {
-        personService,
-        applicationService,
-      })
+      const page = await OptionalOasysSections.initialize(
+        {},
+        application,
+        'some-token',
+        fromPartial({
+          personService,
+          applicationService,
+        }),
+      )
 
       expect(page.oasysSuccess).toEqual(false)
       expect(page.body.needsLinkedToReoffending).toEqual([])

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
@@ -26,13 +26,13 @@ export default class OptionalOasysSections implements TasklistPage {
 
   needsLinkedToReoffendingHeading = 'Needs linked to reoffending'
 
-  allNeedsLinkedToReoffending: Array<OASysSection>
+  allNeedsLinkedToReoffending: Array<OASysSection> = []
 
   otherNeedsHeading = 'Needs not linked to risk of serious harm or reoffending'
 
-  allOtherNeeds: Array<OASysSection>
+  allOtherNeeds: Array<OASysSection> = []
 
-  oasysSuccess: boolean
+  oasysSuccess: boolean = false
 
   constructor(public body: Partial<Body>) {}
 
@@ -52,11 +52,20 @@ export default class OptionalOasysSections implements TasklistPage {
       )
       const allOtherNeeds = oasysSelections.filter(section => !section.linkedToHarm && !section.linkedToReOffending)
 
-      page.body.needsLinkedToReoffending = OptionalOasysSections.getSelectedNeeds(
-        body.needsLinkedToReoffending,
-        allNeedsLinkedToReoffending,
-      )
-      page.body.otherNeeds = OptionalOasysSections.getSelectedNeeds(body.otherNeeds, allOtherNeeds)
+      if (body.needsLinkedToReoffending) {
+        page.body.needsLinkedToReoffending = OptionalOasysSections.getSelectedNeeds(
+          body.needsLinkedToReoffending,
+          allNeedsLinkedToReoffending,
+        )
+      } else {
+        page.body.needsLinkedToReoffending = []
+      }
+
+      if (body.otherNeeds) {
+        page.body.otherNeeds = OptionalOasysSections.getSelectedNeeds(body.otherNeeds, allOtherNeeds)
+      } else {
+        page.body.otherNeeds = []
+      }
 
       page.allNeedsLinkedToReoffending = allNeedsLinkedToReoffending
       page.allOtherNeeds = allOtherNeeds
@@ -85,7 +94,9 @@ export default class OptionalOasysSections implements TasklistPage {
     if (isStringOrArrayOfStrings(selectedSections)) {
       const sectionIds = flattenCheckboxInput(selectedSections as string | Array<string>) || []
 
-      return sectionIds.map((need: string) => allSections.find((n: OASysSection) => need === n.section.toString()))
+      return sectionIds.map(
+        (need: string) => allSections.find((n: OASysSection) => need === n.section.toString()) as OASysSection,
+      )
     }
 
     return selectedSections as Array<OASysSection>
@@ -102,10 +113,10 @@ export default class OptionalOasysSections implements TasklistPage {
   response() {
     const response = {}
 
-    if (this.getResponseForTypeOfNeed(this.body.needsLinkedToReoffending))
+    if (this.body.needsLinkedToReoffending && this.getResponseForTypeOfNeed(this.body.needsLinkedToReoffending))
       response[this.needsLinkedToReoffendingHeading] = this.getResponseForTypeOfNeed(this.body.needsLinkedToReoffending)
 
-    if (this.getResponseForTypeOfNeed(this.body.otherNeeds))
+    if (this.body.otherNeeds && this.getResponseForTypeOfNeed(this.body.otherNeeds))
       response[this.otherNeedsHeading] = this.getResponseForTypeOfNeed(this.body.otherNeeds)
 
     return response

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.test.ts
@@ -1,4 +1,5 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { PersonService } from '../../../../services'
 import { applicationFactory, oasysSectionsFactory, risksFactory } from '../../../../testutils/factories'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
@@ -29,13 +30,13 @@ describe('RiskManagement', () => {
     })
 
     it('calls the getOasysSections and getPersonRisks method on the client with a token and the persons CRN', async () => {
-      await RiskManagementPlan.initialize({}, application, 'some-token', { personService })
+      await RiskManagementPlan.initialize({}, application, 'some-token', fromPartial({ personService }))
 
       expect(getOasysSectionsMock).toHaveBeenCalledWith('some-token', application.person.crn, [])
     })
 
     it('adds the riskManagementSummaries and personRisks to the page object', async () => {
-      const page = await RiskManagementPlan.initialize({}, application, 'some-token', { personService })
+      const page = await RiskManagementPlan.initialize({}, application, 'some-token', fromPartial({ personService }))
 
       expect(page.riskManagementSummaries).toEqual(oasysSections.riskManagementPlan)
       expect(page.risks).toEqual(mapApiPersonRisksForUi(personRisks))
@@ -45,7 +46,7 @@ describe('RiskManagement', () => {
     it('sets dateCompleted to dateStarted if dateCompleted is null', async () => {
       getOasysSectionsMock.mockResolvedValue({ ...oasysSections, dateCompleted: null })
 
-      const page = await RiskManagementPlan.initialize({}, application, 'some-token', { personService })
+      const page = await RiskManagementPlan.initialize({}, application, 'some-token', fromPartial({ personService }))
       expect(page.oasysCompleted).toEqual(oasysSections.dateStarted)
     })
 

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.ts
@@ -17,15 +17,15 @@ type RiskManagementBody = {
 export default class RiskManagementPlan implements OasysPage {
   title = 'Edit risk information'
 
-  riskManagementSummaries: RiskManagementBody['riskManagementSummaries']
+  riskManagementSummaries: RiskManagementBody['riskManagementSummaries'] = []
 
-  riskManagementAnswers: RiskManagementBody['riskManagementAnswers']
+  riskManagementAnswers: RiskManagementBody['riskManagementAnswers'] = {}
 
-  oasysCompleted: string
+  oasysCompleted: string = ''
 
-  risks: PersonRisksUI
+  risks: PersonRisksUI = {} as PersonRisksUI
 
-  oasysSuccess: boolean
+  oasysSuccess: boolean = false
 
   static sectionName = 'riskManagement'
 
@@ -53,7 +53,7 @@ export default class RiskManagementPlan implements OasysPage {
   }
 
   response() {
-    return oasysImportReponse(this.body.riskManagementAnswers, this.body.riskManagementSummaries)
+    return oasysImportReponse(this.body?.riskManagementAnswers || {}, this.body?.riskManagementSummaries || [])
   }
 
   errors() {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.test.ts
@@ -1,4 +1,5 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { PersonService } from '../../../../services'
 import { applicationFactory, oasysSectionsFactory, risksFactory } from '../../../../testutils/factories'
 import { oasysImportReponse } from '../../../../utils/oasysImportUtils'
@@ -26,13 +27,13 @@ describe('RiskToSelf', () => {
     })
 
     it('calls the getOasysSections  method on the client with a token and the persons CRN', async () => {
-      await RiskToSelf.initialize({}, application, 'some-token', { personService })
+      await RiskToSelf.initialize({}, application, 'some-token', fromPartial({ personService }))
 
       expect(getOasysSectionsMock).toHaveBeenCalledWith('some-token', application.person.crn, [])
     })
 
     it('adds the riskToSelfSummaries and personRisks to the page object', async () => {
-      const page = await RiskToSelf.initialize({}, application, 'some-token', { personService })
+      const page = await RiskToSelf.initialize({}, application, 'some-token', fromPartial({ personService }))
 
       expect(page.riskToSelfSummaries).toEqual(oasysSections.riskToSelf)
       expect(page.risks).toEqual(mapApiPersonRisksForUi(personRisks))
@@ -42,7 +43,7 @@ describe('RiskToSelf', () => {
     it('sets dateCompleted to dateStarted if dateCompleted is null', async () => {
       getOasysSectionsMock.mockResolvedValue({ ...oasysSections, dateCompleted: null })
 
-      const page = await RiskToSelf.initialize({}, application, 'some-token', { personService })
+      const page = await RiskToSelf.initialize({}, application, 'some-token', fromPartial({ personService }))
       expect(page.oasysCompleted).toEqual(oasysSections.dateStarted)
     })
 

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
@@ -1,4 +1,5 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { PersonService } from '../../../../services'
 import { applicationFactory, oasysSectionsFactory, risksFactory } from '../../../../testutils/factories'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
@@ -30,13 +31,13 @@ describe('RoshSummary', () => {
     })
 
     it('calls the getOasysSections method on the client with a token and the persons CRN', async () => {
-      await RoshSummary.initialize({}, application, 'some-token', { personService })
+      await RoshSummary.initialize({}, application, 'some-token', fromPartial({ personService }))
 
       expect(getOasysSectionsMock).toHaveBeenCalledWith('some-token', application.person.crn, [])
     })
 
     it('adds the roshSummary and personRisks to the page object', async () => {
-      const page = await RoshSummary.initialize({}, application, 'some-token', { personService })
+      const page = await RoshSummary.initialize({}, application, 'some-token', fromPartial({ personService }))
 
       expect(page.roshSummaries).toEqual(oasysSections.roshSummary)
       expect(page.risks).toEqual(mapApiPersonRisksForUi(personRisks))
@@ -46,7 +47,7 @@ describe('RoshSummary', () => {
     it('sets dateCompleted to dateStarted if dateCompleted is null', async () => {
       getOasysSectionsMock.mockResolvedValue({ ...oasysSections, dateCompleted: null })
 
-      const page = await RoshSummary.initialize({}, application, 'some-token', { personService })
+      const page = await RoshSummary.initialize({}, application, 'some-token', fromPartial({ personService }))
       expect(page.oasysCompleted).toEqual(oasysSections.dateStarted)
     })
 

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.test.ts
@@ -1,4 +1,5 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { PersonService } from '../../../../services'
 import {
   applicationFactory,
@@ -42,13 +43,13 @@ describe('SupportingInformation', () => {
         .withOptionalOasysSectionsSelected([needsLinkedToReoffending], [otherNeeds])
         .build({ risks: personRisks })
 
-      await SupportingInformation.initialize({}, application, 'some-token', { personService })
+      await SupportingInformation.initialize({}, application, 'some-token', fromPartial({ personService }))
 
       expect(getOasysSectionsMock).toHaveBeenCalledWith('some-token', application.person.crn, [1, 2])
     })
 
     it('adds the supportingInformationSummaries and personRisks to the page object', async () => {
-      const page = await SupportingInformation.initialize({}, application, 'some-token', { personService })
+      const page = await SupportingInformation.initialize({}, application, 'some-token', fromPartial({ personService }))
 
       expect(page.supportingInformationSummaries).toEqual(oasysSections.supportingInformation)
       expect(page.risks).toEqual(mapApiPersonRisksForUi(personRisks))
@@ -58,7 +59,7 @@ describe('SupportingInformation', () => {
     it('sets dateCompleted to dateStarted if dateCompleted is null', async () => {
       getOasysSectionsMock.mockResolvedValue({ ...oasysSections, dateCompleted: null })
 
-      const page = await SupportingInformation.initialize({}, application, 'some-token', { personService })
+      const page = await SupportingInformation.initialize({}, application, 'some-token', fromPartial({ personService }))
       expect(page.oasysCompleted).toEqual(oasysSections.dateStarted)
     })
 

--- a/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.test.ts
@@ -1,4 +1,5 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { SanitisedError } from '../../../../sanitisedError'
 import { ApplicationService, PersonService } from '../../../../services'
 
@@ -179,7 +180,12 @@ describe('CaseNotes', () => {
     })
 
     it('calls the getPrisonCaseNotes method on the with a token and the persons CRN', async () => {
-      const page = await CaseNotes.initialize({}, application, 'some-token', { personService, applicationService })
+      const page = await CaseNotes.initialize(
+        {},
+        application,
+        'some-token',
+        fromPartial({ personService, applicationService }),
+      )
 
       expect(page.caseNotes).toEqual(caseNotes)
 
@@ -187,7 +193,12 @@ describe('CaseNotes', () => {
     })
 
     it('calls the getAdjudications method on the with a token and the persons CRN', async () => {
-      const page = await CaseNotes.initialize({}, application, 'some-token', { personService, applicationService })
+      const page = await CaseNotes.initialize(
+        {},
+        application,
+        'some-token',
+        fromPartial({ personService, applicationService }),
+      )
 
       expect(page.caseNotes).toEqual(caseNotes)
 
@@ -195,10 +206,15 @@ describe('CaseNotes', () => {
     })
 
     it('initializes the caseNotes class with the selected case notes and adjudications', async () => {
-      const page = await CaseNotes.initialize({ caseNoteIds: [caseNotes[0].id] }, application, 'some-token', {
-        personService,
-        applicationService,
-      })
+      const page = await CaseNotes.initialize(
+        { caseNoteIds: [caseNotes[0].id] },
+        application,
+        'some-token',
+        fromPartial({
+          personService,
+          applicationService,
+        }),
+      )
 
       expect(page.body).toEqual({
         caseNoteIds: [caseNotes[0].id],
@@ -208,10 +224,15 @@ describe('CaseNotes', () => {
     })
 
     it('initializes the caseNotes class correctly when caseNoteIds is a string', async () => {
-      const page = await CaseNotes.initialize({ caseNoteIds: caseNotes[0].id }, application, 'some-token', {
-        personService,
-        applicationService,
-      })
+      const page = await CaseNotes.initialize(
+        { caseNoteIds: caseNotes[0].id },
+        application,
+        'some-token',
+        fromPartial({
+          personService,
+          applicationService,
+        }),
+      )
 
       expect(page.body).toEqual({
         caseNoteIds: [caseNotes[0].id],
@@ -221,7 +242,12 @@ describe('CaseNotes', () => {
     })
 
     it('initializes correctly when caseNoteIds is not present', async () => {
-      const page = await CaseNotes.initialize({}, application, 'some-token', { personService, applicationService })
+      const page = await CaseNotes.initialize(
+        {},
+        application,
+        'some-token',
+        fromPartial({ personService, applicationService }),
+      )
 
       expect(page.body).toEqual({
         caseNoteIds: [],
@@ -236,7 +262,12 @@ describe('CaseNotes', () => {
         throw err
       })
 
-      const page = await CaseNotes.initialize({}, application, 'some-token', { personService, applicationService })
+      const page = await CaseNotes.initialize(
+        {},
+        application,
+        'some-token',
+        fromPartial({ personService, applicationService }),
+      )
 
       expect(page.nomisFailed).toEqual(true)
     })
@@ -248,7 +279,7 @@ describe('CaseNotes', () => {
       })
 
       await expect(() =>
-        CaseNotes.initialize({}, application, 'some-token', { personService, applicationService }),
+        CaseNotes.initialize({}, application, 'some-token', fromPartial({ personService, applicationService })),
       ).rejects.toThrowError(genericError)
     })
   })

--- a/server/form-pages/assess/reviewApplication/reviewApplicationAndDocuments/review.test.ts
+++ b/server/form-pages/assess/reviewApplication/reviewApplicationAndDocuments/review.test.ts
@@ -1,4 +1,5 @@
 import { createMock } from '@golevelup/ts-jest'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { assessmentFactory, documentFactory } from '../../../../testutils/factories'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
@@ -30,7 +31,7 @@ describe('Review', () => {
       const getDocumentsMock = jest.fn().mockResolvedValue(documentFactory.buildList(3))
       const applicationService = createMock<ApplicationService>({ getDocuments: getDocumentsMock })
 
-      await Review.initialize({}, assessment, token, { applicationService })
+      await Review.initialize({}, assessment, token, fromPartial({ applicationService }))
 
       expect(applicationService.getDocuments).toHaveBeenCalledWith(token, assessment.application)
     })
@@ -51,7 +52,7 @@ describe('Review', () => {
 
       const applicationService = createMock<ApplicationService>({ getDocuments: getDocumentsMock })
 
-      const page = await Review.initialize({}, assessment, token, { applicationService })
+      const page = await Review.initialize({}, assessment, token, fromPartial({ applicationService }))
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const actualDocuments = documentsFromApplication((page as any).document.application)

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.test.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.test.ts
@@ -1,5 +1,6 @@
 import { createMock } from '@golevelup/ts-jest'
 
+import { fromPartial } from '@total-typescript/shoehorn'
 import { UserService } from '../../../../services'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
@@ -34,7 +35,7 @@ describe('SufficientInformation', () => {
 
       getUserByIdMock.mockResolvedValue(user)
 
-      const page = await SufficientInformation.initialize({}, assessment, 'some-token', { userService })
+      const page = await SufficientInformation.initialize({}, assessment, 'some-token', fromPartial({ userService }))
 
       expect(page).toBeInstanceOf(SufficientInformation)
       expect(page.user).toEqual(user)

--- a/server/form-pages/placement-application/request-a-placement/additionalDocuments.test.ts
+++ b/server/form-pages/placement-application/request-a-placement/additionalDocuments.test.ts
@@ -1,4 +1,5 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { ApplicationService, PersonService } from '../../../services'
 import { applicationFactory, documentFactory, placementApplicationFactory } from '../../../testutils/factories'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
@@ -24,10 +25,15 @@ describe('additionalDocuments', () => {
     })
 
     it('calls the getDocuments method on the client with a token and the application', async () => {
-      await AdditionalDocuments.initialize({}, placementApplication, 'some-token', {
-        personService,
-        applicationService,
-      })
+      await AdditionalDocuments.initialize(
+        {},
+        placementApplication,
+        'some-token',
+        fromPartial({
+          personService,
+          applicationService,
+        }),
+      )
 
       expect(getDocumentsMock).toHaveBeenCalledWith('some-token', application)
     })
@@ -43,7 +49,7 @@ describe('additionalDocuments', () => {
         },
         placementApplication,
         'SOME_TOKEN',
-        { applicationService, personService },
+        fromPartial({ applicationService, personService }),
       )
 
       expect(page.body).toEqual({
@@ -57,13 +63,16 @@ describe('additionalDocuments', () => {
 
     it('assigns the selected documents if the selection is not an array', async () => {
       const page = await AdditionalDocuments.initialize(
-        { documentIds: documents[0].id, documentDescriptions: { [documents[0].id]: documents[0].description } },
+        {
+          documentIds: documents[0].id,
+          documentDescriptions: { [documents[0].id]: documents[0].description as string },
+        },
         placementApplication,
         'SOME_TOKEN',
-        {
+        fromPartial({
           applicationService,
           personService,
-        },
+        }),
       )
 
       expect(page.body).toEqual({ selectedDocuments: [documents[0]] })
@@ -76,7 +85,7 @@ describe('additionalDocuments', () => {
         },
         placementApplication,
         'SOME_TOKEN',
-        { applicationService, personService },
+        fromPartial({ applicationService, personService }),
       )
 
       expect(page.body).toEqual({
@@ -94,7 +103,7 @@ describe('additionalDocuments', () => {
     it('should return an error if a document does not have a description', () => {
       const selectedDocuments = [
         documentFactory.build({ fileName: 'file1.pdf', description: 'Description goes here' }),
-        documentFactory.build({ fileName: 'file2.pdf', description: null }),
+        documentFactory.build({ fileName: 'file2.pdf', description: undefined }),
       ]
 
       const page = new AdditionalDocuments({ selectedDocuments }, placementApplication)
@@ -108,7 +117,7 @@ describe('additionalDocuments', () => {
     it('should return a record with the document filename as the key and the description as the value', () => {
       const selectedDocuments = [
         documentFactory.build({ fileName: 'file1.pdf', description: 'Description goes here' }),
-        documentFactory.build({ fileName: 'file2.pdf', description: null }),
+        documentFactory.build({ fileName: 'file2.pdf', description: undefined }),
       ]
 
       const page = new AdditionalDocuments({ selectedDocuments }, placementApplication)

--- a/server/form-pages/placement-application/request-a-placement/checkYourAnswers.test.ts
+++ b/server/form-pages/placement-application/request-a-placement/checkYourAnswers.test.ts
@@ -1,4 +1,5 @@
 import { createMock } from '@golevelup/ts-jest'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { ApplicationService } from '../../../services'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
 import { applicationFactory, placementApplicationFactory } from '../../../testutils/factories'
@@ -22,7 +23,12 @@ describe('CheckYourAnswers', () => {
 
       findApplicationMock.mockResolvedValue(application)
 
-      const page = await CheckYourAnswers.initialize(body, placementApplication, 'some-token', { applicationService })
+      const page = await CheckYourAnswers.initialize(
+        body,
+        placementApplication,
+        'some-token',
+        fromPartial({ applicationService }),
+      )
 
       expect(page).toBeInstanceOf(CheckYourAnswers)
       expect(page.application).toEqual(application)

--- a/server/form-pages/tasklistPage.ts
+++ b/server/form-pages/tasklistPage.ts
@@ -8,7 +8,7 @@ export interface TasklistPageInterface {
     body: Record<string, unknown>,
     document: FormArtifact,
     token: string,
-    dataServices: DataServices,
+    dataServices: Partial<DataServices>,
   ): Promise<TasklistPage>
 }
 

--- a/server/form-pages/utils/decorators/form.decorator.ts
+++ b/server/form-pages/utils/decorators/form.decorator.ts
@@ -8,9 +8,9 @@ type Constructor = new (...args: Array<any>) => {}
 const Form = (options: { sections: Array<unknown> }) => {
   return <T extends Constructor>(constructor: T) => {
     const FormClass = class extends constructor {
-      static pages = getPagesForSections(options.sections)
+      static pages = getPagesForSections(options.sections as Array<Record<string, unknown>>)
 
-      static sections = options.sections.map(s => getSection(s))
+      static sections = options.sections.map(s => getSection(s as Record<string, unknown>))
     }
 
     return FormClass

--- a/server/form-pages/utils/index.test.ts
+++ b/server/form-pages/utils/index.test.ts
@@ -4,7 +4,7 @@ import 'reflect-metadata'
 
 // Use a wildcard import to allow us to use jest.spyOn on functions within this module
 import * as utils from './index'
-import { TasklistPageInterface } from '../tasklistPage'
+import TasklistPage, { TasklistPageInterface } from '../tasklistPage'
 import { ApprovedPremisesApplication } from '../../@types/shared'
 
 import { applicationFactory } from '../../testutils/factories'
@@ -83,15 +83,19 @@ describe('utils', () => {
 
     describe('getTask', () => {
       it('fetches metadata for a specific task and pages', () => {
-        expect(utils.getTask(Task)).toEqual({ id: 'slug', title: 'Name', pages: { 'page-1': Page1, 'page-2': Page2 } })
+        expect(utils.getTask(Task as unknown as Record<string, unknown>)).toEqual({
+          id: 'slug',
+          title: 'Name',
+          pages: { 'page-1': Page1, 'page-2': Page2 },
+        })
       })
     })
 
     describe('getSection', () => {
       it('fetches metadata for a specific section and tasks', () => {
-        expect(utils.getSection(Section)).toEqual({
+        expect(utils.getSection(Section as unknown as Record<string, unknown>)).toEqual({
           title: 'Section',
-          tasks: [utils.getTask(Task)],
+          tasks: [utils.getTask(Task as unknown as Record<string, unknown>)],
         })
       })
     })
@@ -116,7 +120,12 @@ describe('utils', () => {
           }
         })
 
-        expect(utils.getPagesForSections([Section1, Section2])).toEqual({
+        expect(
+          utils.getPagesForSections([
+            Section1 as unknown as Record<string, unknown>,
+            Section2 as unknown as Record<string, unknown>,
+          ]),
+        ).toEqual({
           foo: {
             'page-1': Page1,
             'page-2': Page2,
@@ -134,8 +143,8 @@ describe('utils', () => {
         const page1 = new Page1()
         const page2 = new Page2()
 
-        expect(utils.viewPath(page1, 'applications')).toEqual('applications/pages/task-1/page-1')
-        expect(utils.viewPath(page2, 'assessments')).toEqual('assessments/pages/task-2/page-2')
+        expect(utils.viewPath(page1 as TasklistPage, 'applications')).toEqual('applications/pages/task-1/page-1')
+        expect(utils.viewPath(page2 as TasklistPage, 'assessments')).toEqual('assessments/pages/task-2/page-2')
       })
     })
 

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -1,6 +1,6 @@
 import type { Request } from 'express'
 import type { FormArtifact, JourneyType, UiTask, YesOrNo, YesOrNoWithDetail } from '@approved-premises/ui'
-import { TasklistPageInterface } from '../tasklistPage'
+import TasklistPage, { TasklistPageInterface } from '../tasklistPage'
 import { sentenceCase } from '../../utils/utils'
 
 export const applyYesOrNo = <K extends string>(key: K, body: Record<string, unknown>): YesOrNoWithDetail<K> => {
@@ -22,13 +22,13 @@ export const yesNoOrDontKnowResponseWithDetail = <K extends string>(key: K, body
   return body[key] === 'iDontKnow' ? "Don't know" : yesOrNoResponseWithDetailForYes<K>(key, body)
 }
 
-export const getTask = <T>(task: T) => {
+export const getTask = <T extends Record<string, unknown>>(task: T) => {
   const taskPages = {}
   const slug = Reflect.getMetadata('task:slug', task)
   const name = Reflect.getMetadata('task:name', task)
   const pageClasses = Reflect.getMetadata('task:pages', task)
 
-  pageClasses.forEach(<PageType>(page: PageType) => {
+  pageClasses.forEach(<PageType extends Record<string, unknown>>(page: PageType) => {
     const pageName = Reflect.getMetadata('page:name', page)
     taskPages[pageName] = page
   })
@@ -40,13 +40,13 @@ export const getTask = <T>(task: T) => {
   }
 }
 
-export const getSection = <T>(section: T) => {
+export const getSection = <T extends Record<string, unknown>>(section: T) => {
   const tasks: Array<UiTask> = []
   const title = Reflect.getMetadata('section:title', section)
   const name = Reflect.getMetadata('section:name', section)
   const taskClasses = Reflect.getMetadata('section:tasks', section)
 
-  taskClasses.forEach(<PageType>(task: PageType) => {
+  taskClasses.forEach(<PageType extends Record<string, unknown>>(task: PageType) => {
     tasks.push(getTask(task))
   })
 
@@ -57,7 +57,7 @@ export const getSection = <T>(section: T) => {
   }
 }
 
-export const getPagesForSections = <T>(sections: Array<T>) => {
+export const getPagesForSections = <T extends Record<string, unknown>>(sections: Array<T>) => {
   const pages = {}
   sections.forEach(sectionClass => {
     const section = getSection(sectionClass)
@@ -69,18 +69,18 @@ export const getPagesForSections = <T>(sections: Array<T>) => {
   return pages
 }
 
-export const viewPath = <T>(page: T, journeyType: JourneyType) => {
+export const viewPath = <T extends TasklistPage>(page: T, journeyType: JourneyType) => {
   const pageName = getPageName(page.constructor)
   const taskName = getTaskName(page.constructor)
 
   return `${journeyType}/pages/${taskName}/${pageName}`
 }
 
-export const getPageName = <T>(page: T) => {
+export const getPageName = <T extends TasklistPageInterface['constructor']>(page: T) => {
   return Reflect.getMetadata('page:name', page)
 }
 
-export const getTaskName = <T>(page: T) => {
+export const getTaskName = <T extends TasklistPageInterface['constructor']>(page: T) => {
   return Reflect.getMetadata('page:task', page)
 }
 

--- a/server/form-pages/utils/updateFormArtifactData.ts
+++ b/server/form-pages/utils/updateFormArtifactData.ts
@@ -1,8 +1,11 @@
 import { FormArtifact } from '@approved-premises/ui'
 import { getPageName, getTaskName, pageBodyShallowEquals } from '.'
-import TasklistPage from '../tasklistPage'
+import TasklistPage, { TasklistPageInterface } from '../tasklistPage'
 
-export const updateFormArtifactData = <FormArtifactClass extends FormArtifact, CheckYourAnswersPageClass>(
+export const updateFormArtifactData = <
+  FormArtifactClass extends FormArtifact,
+  CheckYourAnswersPageClass extends TasklistPageInterface['constructor'],
+>(
   page: TasklistPage,
   formArtifact: FormArtifactClass,
   checkYourAnswersPageClass: CheckYourAnswersPageClass,

--- a/server/services/assessmentService.test.ts
+++ b/server/services/assessmentService.test.ts
@@ -1,7 +1,8 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import { Request } from 'express'
-import { AssessmentAcceptance } from '@approved-premises/api'
+import { AssessmentAcceptance, UpdatedClarificationNote } from '@approved-premises/api'
 
+import { fromPartial } from '@total-typescript/shoehorn'
 import { AssessmentClient } from '../data'
 import AssessmentService from './assessmentService'
 import { assessmentFactory, assessmentSummaryFactory, clarificationNoteFactory } from '../testutils/factories'
@@ -77,7 +78,7 @@ describe('AssessmentService', () => {
     it('should return a page', async () => {
       ;(getBody as jest.Mock).mockReturnValue(request.body)
 
-      const result = await service.initializePage(Page, assessment, request, {})
+      const result = await service.initializePage(Page, assessment, request, fromPartial({}))
 
       expect(result).toBeInstanceOf(Page)
 
@@ -92,7 +93,12 @@ describe('AssessmentService', () => {
 
       await service.initializePage(TestPage, assessment, request, dataServices)
 
-      expect(TestPage.initialize).toHaveBeenCalledWith(request.body, assessment, request.user.token, dataServices)
+      expect(TestPage.initialize).toHaveBeenCalledWith(
+        request.body,
+        assessment,
+        (request.user as { token: string }).token,
+        dataServices,
+      )
     })
   })
 
@@ -210,9 +216,9 @@ describe('AssessmentService', () => {
       const token = 'token'
       const id = 'some-uuid'
       const clarificationNote = clarificationNoteFactory.build()
-      const updatedNote = {
-        response: clarificationNote.response,
-        responseReceivedOn: clarificationNote.responseReceivedOn,
+      const updatedNote: UpdatedClarificationNote = {
+        response: clarificationNote.response || '',
+        responseReceivedOn: clarificationNote.responseReceivedOn || '',
       }
 
       assessmentClient.updateClarificationNote.mockResolvedValue(clarificationNote)

--- a/server/services/placementApplicationService.ts
+++ b/server/services/placementApplicationService.ts
@@ -29,7 +29,7 @@ export default class PlacementApplicationService {
   async initializePage(
     Page: TasklistPageInterface,
     request: Request,
-    dataServices: DataServices,
+    dataServices: Partial<DataServices>,
     userInput?: Record<string, unknown>,
   ): Promise<TasklistPage> {
     const placementApplication = await this.getPlacementApplication(request.user.token, request.params.id)

--- a/server/testutils/factories/placementRequest.ts
+++ b/server/testutils/factories/placementRequest.ts
@@ -27,7 +27,7 @@ export const placementRequestFactory = Factory.define<PlacementRequest>(() => {
     assessmentId: faker.string.uuid(),
     releaseType: faker.helpers.arrayElement(['licence', 'rotl', 'hdc', 'pss', 'in_community']),
     status: faker.helpers.arrayElement(['notMatched', 'unableToMatch', 'matched']),
-    assessmentDecision: faker.helpers.arrayElement(['accepted' as const, 'rejected' as const, undefined]),
+    assessmentDecision: faker.helpers.arrayElement(['accepted' as const, 'rejected' as const]),
     applicationDate: DateFormats.dateObjToIsoDateTime(faker.date.soon()),
     assessmentDate: DateFormats.dateObjToIsoDateTime(faker.date.soon()),
     assessor: userFactory.build(),

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -218,13 +218,17 @@ describe('utils', () => {
     it('returns the adjudications from the assessment', () => {
       const adjudications = adjudicationFactory.buildList(2)
       const assessment = assessmentFactory.build()
-      assessment.application.data['prison-information'] = { 'case-notes': { adjudications } }
+      assessment.data = {}
+      assessment.application.data['prison-information'] = {
+        'case-notes': { adjudications },
+      }
 
       expect(adjudicationsFromAssessment(assessment)).toEqual(adjudications)
     })
 
     it('returns an empty string if the case notes are empty', () => {
       const assessment = assessmentFactory.build()
+      assessment.data = {}
       assessment.application.data['prison-information'] = {}
 
       expect(adjudicationsFromAssessment(assessment)).toEqual([])
@@ -235,13 +239,17 @@ describe('utils', () => {
     it('returns the caseNotes from the assessment', () => {
       const selectedCaseNotes = prisonCaseNotesFactory.buildList(2)
       const assessment = assessmentFactory.build()
-      assessment.application.data['prison-information'] = { 'case-notes': { selectedCaseNotes } }
+      assessment.data = {}
+      assessment.application.data['prison-information'] = {
+        'case-notes': { selectedCaseNotes },
+      }
 
       expect(caseNotesFromAssessment(assessment)).toEqual(selectedCaseNotes)
     })
 
     it('returns an empty string if the case notes are empty', () => {
       const assessment = assessmentFactory.build()
+      assessment.data = {}
       assessment.application.data['prison-information'] = {}
 
       expect(caseNotesFromAssessment(assessment)).toEqual([])
@@ -252,6 +260,7 @@ describe('utils', () => {
     it('returns the acctAlerts from the assessment', () => {
       const acctAlerts = acctAlertFactory.buildList(2)
       const assessment = assessmentFactory.build()
+      assessment.data = {}
       assessment.application.data['prison-information'] = { 'case-notes': { acctAlerts } }
 
       expect(acctAlertsFromAssessment(assessment)).toEqual(acctAlerts)
@@ -260,15 +269,18 @@ describe('utils', () => {
     it('if the comments property of an ACCT alert is undefined it returns an empty string', () => {
       const acctAlert1 = acctAlertFactory.build()
       const acctAlert2 = acctAlertFactory.build({ comment: undefined })
-
       const assessment = assessmentFactory.build()
-      assessment.application.data['prison-information'] = { 'case-notes': { acctAlerts: [acctAlert1, acctAlert2] } }
+      assessment.data = {}
+      assessment.application.data['prison-information'] = {
+        'case-notes': { acctAlerts: [acctAlert1, acctAlert2] },
+      }
 
       expect(acctAlertsFromAssessment(assessment)).toEqual([acctAlert1, { ...acctAlert2, comment: '' }])
     })
 
     it('returns an empty string if the case notes are empty', () => {
       const assessment = assessmentFactory.build()
+      assessment.data = {}
       assessment.application.data['prison-information'] = {}
 
       expect(acctAlertsFromAssessment(assessment)).toEqual([])
@@ -316,7 +328,7 @@ describe('utils', () => {
             text: 'Allocated To',
           },
           value: {
-            text: assessment.allocatedToStaffMember.name,
+            text: assessment.allocatedToStaffMember?.name,
           },
         },
       ])
@@ -324,7 +336,7 @@ describe('utils', () => {
 
     it('returns the summary list when the assessment does not have a staff member allocated', () => {
       const assessment = assessmentFactory.build({
-        allocatedToStaffMember: null,
+        allocatedToStaffMember: undefined,
       })
 
       expect(allocationSummary(assessment)).toEqual([

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -69,12 +69,14 @@ export const bookingSummaryList = (booking: BookingSummary): SummaryListWithCard
 }
 
 export const manageBookingLink = (premisesId: string, booking: Booking | PremisesBooking): string => {
-  return `<a href="${paths.bookings.show({ premisesId, bookingId: booking.id })}">
+  return booking.id && booking.person
+    ? `<a href="${paths.bookings.show({ premisesId, bookingId: booking.id })}">
     Manage
     <span class="govuk-visually-hidden">
       booking for ${booking.person.crn}
     </span>
   </a>`
+    : 'Unable to manage booking'
 }
 
 export const arrivingTodayOrLate = (bookings: Array<PremisesBooking>, premisesId: string): Array<TableRow> => {

--- a/server/utils/oasysImportUtils.test.ts
+++ b/server/utils/oasysImportUtils.test.ts
@@ -1,5 +1,6 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import { OasysPage } from '@approved-premises/ui'
+import { fromPartial } from '@total-typescript/shoehorn'
 import { offenceDetailsFactory } from '../testutils/factories/oasysSections'
 import PersonService, { OasysNotFoundError } from '../services/personService'
 import {
@@ -51,16 +52,23 @@ describe('OASysImportUtils', () => {
       })
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result: any = await getOasysSections({}, application, 'some-token', { personService }, constructor, {
-        sectionName: 'offenceDetails',
-        summaryKey: 'offenceDetailsSummary',
-        answerKey: 'offenceDetailsAnswers',
-      })
+      const result: any = await getOasysSections(
+        {},
+        application,
+        'some-token',
+        fromPartial({ personService }),
+        constructor,
+        {
+          sectionName: 'offenceDetails',
+          summaryKey: 'offenceDetailsSummary',
+          answerKey: 'offenceDetailsAnswers',
+        },
+      )
 
       expect(result.oasysSuccess).toEqual(false)
       expect(result.body.offenceDetailsSummary).toEqual(sortOasysImportSummaries(oasysStubs.offenceDetails))
       expect(result.offenceDetailsSummary).toEqual(oasysStubs.offenceDetails)
-      expect(result.risks).toEqual(mapApiPersonRisksForUi(application.risks))
+      expect(result.risks).toEqual(mapApiPersonRisksForUi(application.risks as PersonRisks))
     })
 
     it('sets oasysSuccess to true along with the marshalled oasys data if there is not an OasysNotFoundError', async () => {
@@ -72,16 +80,23 @@ describe('OASysImportUtils', () => {
       getOasysSectionsMock.mockResolvedValue(oasysSections)
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result: any = await getOasysSections({}, application, 'some-token', { personService }, constructor, {
-        sectionName: 'offenceDetails',
-        summaryKey: 'offenceDetailsSummary',
-        answerKey: 'offenceDetailsAnswers',
-      })
+      const result: any = await getOasysSections(
+        {},
+        application,
+        'some-token',
+        fromPartial({ personService }),
+        constructor,
+        {
+          sectionName: 'offenceDetails',
+          summaryKey: 'offenceDetailsSummary',
+          answerKey: 'offenceDetailsAnswers',
+        },
+      )
 
       expect(result.oasysSuccess).toEqual(true)
       expect(result.body.offenceDetailsSummary).toEqual(sortOasysImportSummaries(oasysSections.offenceDetails))
       expect(result.offenceDetailsSummary).toEqual(oasysSections.offenceDetails)
-      expect(result.risks).toEqual(mapApiPersonRisksForUi(application.risks))
+      expect(result.risks).toEqual(mapApiPersonRisksForUi(application.risks as PersonRisks))
     })
 
     it('prioritises the body over the Oasys data if the body is provided', async () => {
@@ -104,7 +119,7 @@ describe('OASysImportUtils', () => {
         { offenceDetailsAnswers: { '1': 'My Response' } },
         application,
         'some-token',
-        { personService },
+        fromPartial({ personService }),
         constructor,
         {
           sectionName: 'offenceDetails',

--- a/server/utils/oasysImportUtils.test.ts
+++ b/server/utils/oasysImportUtils.test.ts
@@ -22,6 +22,7 @@ import {
   validateOasysEntries,
 } from './oasysImportUtils'
 import oasysStubs from '../data/stubs/oasysStubs.json'
+import { PersonRisks } from '../@types/shared'
 
 describe('OASysImportUtils', () => {
   describe('getOasysSections', () => {
@@ -278,6 +279,7 @@ describe('OASysImportUtils', () => {
 
     it('filters out null sections', () => {
       const application = applicationFactory.build()
+      application.data = {}
       application.data['oasys-import'] = {
         'optional-oasys-sections': {
           needsLinkedToReoffending: [null, null],

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -26,7 +26,7 @@ const isApplicableTier = (sex: string, tier: string): boolean => {
   return applicableTiers.includes(tier)
 }
 
-const isFullPerson = (person: Person): person is FullPerson => (person as FullPerson)?.name !== undefined
+const isFullPerson = (person?: Person): person is FullPerson => (person as FullPerson)?.name !== undefined
 
 const laoName = (person: FullPerson) => (person.isRestricted ? `LAO: ${person.name}` : person.name)
 

--- a/server/utils/placementApplications/review.test.ts
+++ b/server/utils/placementApplications/review.test.ts
@@ -93,7 +93,7 @@ describe('PlacementApplicationReview', () => {
 
       review.update()
 
-      expect(request.session.placementApplicationDecisions[id]).toEqual({
+      expect(request?.session?.placementApplicationDecisions?.[id] || '').toEqual({
         summaryOfChanges: 'some changes',
         decision: 'accepted',
         decisionSummary: 'a summary',

--- a/server/utils/placementRequests/adminIdentityBar.test.ts
+++ b/server/utils/placementRequests/adminIdentityBar.test.ts
@@ -13,15 +13,15 @@ describe('adminIdentityBar', () => {
       expect(adminActions(placementRequestDetail)).toEqual([
         {
           href: managePaths.bookings.dateChanges.new({
-            premisesId: placementRequestDetail.booking.premisesId,
-            bookingId: placementRequestDetail.booking.id,
+            premisesId: placementRequestDetail.booking?.premisesId || '',
+            bookingId: placementRequestDetail.booking?.id || '',
           }),
           text: 'Amend placement',
         },
         {
           href: managePaths.bookings.cancellations.new({
-            premisesId: placementRequestDetail.booking.premisesId,
-            bookingId: placementRequestDetail.booking.id,
+            premisesId: placementRequestDetail.booking?.premisesId || '',
+            bookingId: placementRequestDetail.booking?.id || '',
           }),
           text: 'Cancel placement',
         },

--- a/server/utils/placementRequests/adminIdentityBar.ts
+++ b/server/utils/placementRequests/adminIdentityBar.ts
@@ -17,15 +17,15 @@ export const adminActions = (placementRequest: PlacementRequestDetail): Array<Id
     return [
       {
         href: managePaths.bookings.dateChanges.new({
-          premisesId: placementRequest.booking.premisesId,
-          bookingId: placementRequest.booking.id,
+          premisesId: placementRequest?.booking?.premisesId || '',
+          bookingId: placementRequest?.booking?.id || '',
         }),
         text: 'Amend placement',
       },
       {
         href: managePaths.bookings.cancellations.new({
-          premisesId: placementRequest.booking.premisesId,
-          bookingId: placementRequest.booking.id,
+          premisesId: placementRequest?.booking?.premisesId || '',
+          bookingId: placementRequest?.booking?.id || '',
         }),
         text: 'Cancel placement',
       },

--- a/server/utils/placementRequests/adminSummary.test.ts
+++ b/server/utils/placementRequests/adminSummary.test.ts
@@ -173,24 +173,27 @@ describe('adminSummary', () => {
   })
 
   describe('apTypeCell', () => {
-    it.each(Object.keys(allApTypes))('should return the correct type for AP Type %s', (apType: ApType) => {
-      const placementRequest = placementRequestDetailFactory.build({
-        type: apType,
-      })
+    it.each(Object.keys(allApTypes) as Array<ApType>)(
+      'should return the correct type for AP Type %s',
+      (apType: ApType) => {
+        const placementRequest = placementRequestDetailFactory.build({
+          type: apType,
+        })
 
-      expect(apTypeCell(placementRequest)).toEqual({
-        key: {
-          text: 'Type of AP',
-        },
-        value: {
-          text: allApTypes[apType],
-        },
-      })
-    })
+        expect(apTypeCell(placementRequest)).toEqual({
+          key: {
+            text: 'Type of AP',
+          },
+          value: {
+            text: allApTypes[apType],
+          },
+        })
+      },
+    )
   })
 
   describe('releaseTypeCell', () => {
-    it.each(Object.keys(allReleaseTypes))(
+    it.each(Object.keys(allReleaseTypes) as Array<ReleaseTypeOption>)(
       'should return the correct type for release type %s',
       (releaseType: ReleaseTypeOption) => {
         const placementRequest = placementRequestDetailFactory.build({

--- a/server/utils/placementRequests/adminSummary.test.ts
+++ b/server/utils/placementRequests/adminSummary.test.ts
@@ -29,7 +29,7 @@ describe('adminSummary', () => {
             text: 'Tier',
           },
           value: {
-            text: placementRequest.risks.tier.value.level,
+            text: placementRequest.risks.tier.value?.level,
           },
         },
         {
@@ -84,7 +84,7 @@ describe('adminSummary', () => {
             text: 'Tier',
           },
           value: {
-            text: placementRequest.risks.tier.value.level,
+            text: placementRequest.risks.tier.value?.level,
           },
         },
         {

--- a/server/utils/placementRequests/assessmentSummaryList.test.ts
+++ b/server/utils/placementRequests/assessmentSummaryList.test.ts
@@ -74,7 +74,7 @@ describe('assessmentSummaryList', () => {
     it('filters out any empty values', () => {
       const assessor = userFactory.build({
         name: 'Bruce Wayne',
-        telephoneNumber: null,
+        telephoneNumber: undefined,
         email: 'bruce@example.com',
       })
       const placementRequest = placementRequestFactory.build({ assessor })

--- a/server/utils/placementRequests/cancellationSummaryList.test.ts
+++ b/server/utils/placementRequests/cancellationSummaryList.test.ts
@@ -16,7 +16,7 @@ describe('cancellationSummaryList', () => {
           cancellationRow('Approved Premises', cancellation.premisesName),
           cancellationRow('Date', cancellation.date),
           cancellationRow('Reason', cancellation.reason.name),
-          cancellationRow('Notes', cancellation.notes),
+          cancellationRow('Notes', cancellation.notes as string),
         ],
       })
     })

--- a/server/utils/placementRequests/checkYourAnswersUtils.test.ts
+++ b/server/utils/placementRequests/checkYourAnswersUtils.test.ts
@@ -59,7 +59,7 @@ describe('checkYourAnswersUtils', () => {
   it('if the page name is "additional-documents"', () => {
     const documents = documentFactory.buildList(1)
 
-    placementApplication.data['request-a-placement'] = {
+    ;(placementApplication.data as Record<string, unknown>)['request-a-placement'] = {
       'additional-documents': {
         selectedDocuments: documents,
       },

--- a/server/utils/placementRequests/matchingInformationSummaryList.test.ts
+++ b/server/utils/placementRequests/matchingInformationSummaryList.test.ts
@@ -2,7 +2,7 @@ import { placementRequestDetailFactory, premisesFactory } from '../../testutils/
 import { mapSearchParamCharacteristicsForUi } from '../matchUtils'
 import { matchingInformationSummary, placementRequirementsRow, preferredApsRow } from './matchingInformationSummaryList'
 import { getPreferredApsFromApplication } from './getPreferredApsFromApplication'
-import { HtmlItem } from '../../@types/ui'
+import { HtmlItem, SummaryListItem } from '../../@types/ui'
 
 jest.mock('./getPreferredApsFromApplication')
 
@@ -113,7 +113,7 @@ describe('matchingInformationSummaryList', () => {
       const premises = premisesFactory.buildList(4)
       ;(getPreferredApsFromApplication as jest.Mock).mockReturnValue(premises)
 
-      const row = preferredApsRow(placementRequest)
+      const row = preferredApsRow(placementRequest) as SummaryListItem
 
       expect(row.key).toEqual({ text: 'Preferred APs' })
       expect((row.value as HtmlItem).html).toMatchStringIgnoringWhitespace(`

--- a/server/utils/placementRequests/table.test.ts
+++ b/server/utils/placementRequests/table.test.ts
@@ -48,7 +48,7 @@ describe('tableUtils', () => {
     })
 
     it('returns an empty cell if the personName is blank', () => {
-      const task = placementRequestTaskFactory.build({ personName: null })
+      const task = placementRequestTaskFactory.build({ personName: undefined })
 
       expect(nameCell(task)).toEqual({
         html: '',
@@ -56,7 +56,7 @@ describe('tableUtils', () => {
     })
 
     it('returns an empty cell if the personName is not present', () => {
-      const task = placementRequestFactory.build({ person: null })
+      const task = placementRequestFactory.build({ person: undefined })
 
       expect(nameCell(task)).toEqual({
         html: '',

--- a/server/utils/retrieveQuestionResponseFromFormArtifact.ts
+++ b/server/utils/retrieveQuestionResponseFromFormArtifact.ts
@@ -2,7 +2,7 @@ import {
   ApprovedPremisesApplication as Application,
   ApprovedPremisesAssessment as Assessment,
 } from '@approved-premises/api'
-import { TasklistPageInterface } from '../form-pages/tasklistPage'
+import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
 import { getPageName, pageDataFromApplicationOrAssessment } from '../form-pages/utils'
 import { SessionDataError } from './errors'
 import { camelCase } from './utils'
@@ -21,7 +21,7 @@ export const retrieveQuestionResponseFromFormArtifact = (
   question?: string,
 ) => {
   const pageData = pageDataFromApplicationOrAssessment(Page as TasklistPageInterface, formArtifact)
-  const pageName = getPageName(Page)
+  const pageName = getPageName(Page as TasklistPage['constructor'])
   const q = question || camelCase(pageName)
 
   if (!pageData) {

--- a/server/utils/tasks/index.test.ts
+++ b/server/utils/tasks/index.test.ts
@@ -43,7 +43,7 @@ describe('index', () => {
               text: 'Arrival date',
             },
             value: {
-              text: DateFormats.isoDateToUIDate(arrivalDateFromApplication(application)),
+              text: DateFormats.isoDateToUIDate(arrivalDateFromApplication(application) as string),
             },
           },
           {

--- a/server/utils/tasks/table.test.ts
+++ b/server/utils/tasks/table.test.ts
@@ -102,7 +102,7 @@ describe('table', () => {
   describe('allocationCell', () => {
     it('returns the name of the staff member the task is allocated to as a TableCell object', () => {
       const task = taskFactory.build()
-      expect(allocationCell(task)).toEqual({ text: task.allocatedToStaffMember.name })
+      expect(allocationCell(task)).toEqual({ text: task.allocatedToStaffMember?.name })
     })
   })
 

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -145,20 +145,23 @@ describe('mapApiPersonRiskForUI', () => {
       crn: risks.crn,
       flags: risks.flags.value,
       mappa: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks.mappa.value.lastUpdated),
+        lastUpdated: risks?.mappa?.value?.lastUpdated
+          ? DateFormats.isoDateToUIDate(risks?.mappa?.value?.lastUpdated)
+          : '',
         level: 'CAT 2 / LEVEL 1',
       },
       roshRisks: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks.roshRisks.value.lastUpdated),
-        overallRisk: risks.roshRisks.value.overallRisk,
-        riskToChildren: risks.roshRisks.value.riskToChildren,
-        riskToKnownAdult: risks.roshRisks.value.riskToKnownAdult,
-        riskToPublic: risks.roshRisks.value.riskToPublic,
-        riskToStaff: risks.roshRisks.value.riskToStaff,
+        lastUpdated:
+          risks?.roshRisks?.value?.lastUpdated && DateFormats.isoDateToUIDate(risks.roshRisks.value.lastUpdated),
+        overallRisk: risks?.roshRisks?.value?.overallRisk ?? '',
+        riskToChildren: risks?.roshRisks?.value?.riskToChildren ?? '',
+        riskToKnownAdult: risks?.roshRisks?.value?.riskToKnownAdult ?? '',
+        riskToPublic: risks?.roshRisks?.value?.riskToPublic ?? '',
+        riskToStaff: risks?.roshRisks?.value?.riskToStaff ?? '',
       },
       tier: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks.tier.value.lastUpdated),
-        level: risks.tier.value.level,
+        lastUpdated: DateFormats.isoDateToUIDate(risks?.tier?.value?.lastUpdated ?? ''),
+        level: risks?.tier?.value?.level || '',
       },
     })
   })
@@ -172,15 +175,15 @@ describe('mapApiPersonRiskForUI', () => {
       crn: risks.crn,
       flags: risks.flags.value,
       mappa: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks.mappa.value.lastUpdated),
+        lastUpdated: DateFormats.isoDateToUIDate(risks?.mappa?.value?.lastUpdated || ''),
         level: 'CAT 2 / LEVEL 1',
       },
       roshRisks: {
         lastUpdated: '',
       },
       tier: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks.tier.value.lastUpdated),
-        level: risks.tier.value.level,
+        lastUpdated: DateFormats.isoDateToUIDate(risks?.tier?.value?.lastUpdated || ''),
+        level: risks?.tier?.value?.level,
       },
     })
   })
@@ -197,16 +200,16 @@ describe('mapApiPersonRiskForUI', () => {
         lastUpdated: '',
       },
       roshRisks: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks.roshRisks.value.lastUpdated),
-        overallRisk: risks.roshRisks.value.overallRisk,
-        riskToChildren: risks.roshRisks.value.riskToChildren,
-        riskToKnownAdult: risks.roshRisks.value.riskToKnownAdult,
-        riskToPublic: risks.roshRisks.value.riskToPublic,
-        riskToStaff: risks.roshRisks.value.riskToStaff,
+        lastUpdated: DateFormats.isoDateToUIDate(risks?.roshRisks?.value?.lastUpdated || ''),
+        overallRisk: risks.roshRisks.value?.overallRisk,
+        riskToChildren: risks.roshRisks.value?.riskToChildren,
+        riskToKnownAdult: risks.roshRisks.value?.riskToKnownAdult,
+        riskToPublic: risks.roshRisks.value?.riskToPublic,
+        riskToStaff: risks.roshRisks.value?.riskToStaff,
       },
       tier: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks.tier.value.lastUpdated),
-        level: risks.tier.value.level,
+        lastUpdated: DateFormats.isoDateToUIDate(risks.tier?.value?.lastUpdated || ''),
+        level: risks.tier.value?.level,
       },
     })
   })
@@ -220,16 +223,16 @@ describe('mapApiPersonRiskForUI', () => {
       crn: risks.crn,
       flags: risks.flags.value,
       mappa: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks.mappa.value.lastUpdated),
+        lastUpdated: DateFormats.isoDateToUIDate(risks?.mappa?.value?.lastUpdated || ''),
         level: 'CAT 2 / LEVEL 1',
       },
       roshRisks: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks.roshRisks.value.lastUpdated),
-        overallRisk: risks.roshRisks.value.overallRisk,
-        riskToChildren: risks.roshRisks.value.riskToChildren,
-        riskToKnownAdult: risks.roshRisks.value.riskToKnownAdult,
-        riskToPublic: risks.roshRisks.value.riskToPublic,
-        riskToStaff: risks.roshRisks.value.riskToStaff,
+        lastUpdated: DateFormats.isoDateToUIDate(risks?.roshRisks?.value?.lastUpdated || ''),
+        overallRisk: risks.roshRisks.value?.overallRisk,
+        riskToChildren: risks.roshRisks.value?.riskToChildren,
+        riskToKnownAdult: risks.roshRisks.value?.riskToKnownAdult,
+        riskToPublic: risks.roshRisks.value?.riskToPublic,
+        riskToStaff: risks.roshRisks.value?.riskToStaff,
       },
       tier: {
         lastUpdated: '',
@@ -246,20 +249,20 @@ describe('mapApiPersonRiskForUI', () => {
       crn: risks.crn,
       flags: null,
       mappa: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks.mappa.value.lastUpdated),
+        lastUpdated: DateFormats.isoDateToUIDate(risks.mappa?.value?.lastUpdated || ''),
         level: 'CAT 2 / LEVEL 1',
       },
       roshRisks: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks.roshRisks.value.lastUpdated),
-        overallRisk: risks.roshRisks.value.overallRisk,
-        riskToChildren: risks.roshRisks.value.riskToChildren,
-        riskToKnownAdult: risks.roshRisks.value.riskToKnownAdult,
-        riskToPublic: risks.roshRisks.value.riskToPublic,
-        riskToStaff: risks.roshRisks.value.riskToStaff,
+        lastUpdated: DateFormats.isoDateToUIDate(risks?.roshRisks?.value?.lastUpdated || ''),
+        overallRisk: risks.roshRisks.value?.overallRisk,
+        riskToChildren: risks.roshRisks.value?.riskToChildren,
+        riskToKnownAdult: risks.roshRisks.value?.riskToKnownAdult,
+        riskToPublic: risks.roshRisks.value?.riskToPublic,
+        riskToStaff: risks.roshRisks.value?.riskToStaff,
       },
       tier: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks.tier.value.lastUpdated),
-        level: risks.tier.value.level,
+        lastUpdated: DateFormats.isoDateToUIDate(risks.tier.value?.lastUpdated || ''),
+        level: risks.tier.value?.level,
       },
     })
   })

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -19,7 +19,7 @@ import { DateFormats } from './dateUtils'
 
 describe('convert to title case', () => {
   it.each([
-    [null, null, ''],
+    [null, null, ''] as unknown as Array<string>,
     ['empty string', '', ''],
     ['Lower case', 'robert', 'Robert'],
     ['Upper case', 'ROBERT', 'Robert'],
@@ -47,8 +47,8 @@ describe('camelCase', () => {
 
 describe('initialise name', () => {
   it.each([
-    [null, null, null],
-    ['Empty string', '', null],
+    [null, null, null] as unknown as Array<string>,
+    ['Empty string', '', null] as unknown as Array<string>,
     ['One word', 'robert', 'r. robert'],
     ['Two words', 'Robert James', 'R. James'],
     ['Three words', 'Robert James Smith', 'R. Smith'],
@@ -164,7 +164,7 @@ describe('mapApiPersonRiskForUI', () => {
   })
 
   it('handles the case where roshRisks is null', () => {
-    risks.roshRisks = null
+    risks.roshRisks = null as unknown as PersonRisks['roshRisks']
 
     const actual = mapApiPersonRisksForUi(risks)
 
@@ -186,7 +186,7 @@ describe('mapApiPersonRiskForUI', () => {
   })
 
   it('handles the case where mappa is null', () => {
-    risks.mappa = null
+    risks.mappa = null as unknown as PersonRisks['mappa']
 
     const actual = mapApiPersonRisksForUi(risks)
 
@@ -212,7 +212,7 @@ describe('mapApiPersonRiskForUI', () => {
   })
 
   it('handles the case where tier is null', () => {
-    risks.tier = null
+    risks.tier = null as unknown as PersonRisks['tier']
 
     const actual = mapApiPersonRisksForUi(risks)
 
@@ -238,7 +238,7 @@ describe('mapApiPersonRiskForUI', () => {
   })
 
   it('handles the case where flags is null', () => {
-    risks.flags.value = null
+    risks.flags.value = null as unknown as PersonRisks['flags']['value']
 
     const actual = mapApiPersonRisksForUi(risks)
 

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -66,7 +66,7 @@ export const catchAPIErrorOrPropogate = (request: Request, response: Response, e
     })
     request.flash('errorSummary', [errorSummary(error.field, error.message)])
 
-    response.redirect(request.headers.referer)
+    response.redirect(request.headers.referer || '')
   } else {
     throw error
   }
@@ -98,7 +98,7 @@ export const errorMessage = (field: string, text: string): ErrorMessage => {
 }
 
 const extractValidationErrors = (error: SanitisedError | Error): Record<string, string> | string => {
-  if ('data' in error) {
+  if ('data' in error && error.data) {
     if (Array.isArray(error.data['invalid-params']) && error.data['invalid-params'].length) {
       return generateErrors(error.data['invalid-params'])
     }
@@ -111,7 +111,7 @@ const extractValidationErrors = (error: SanitisedError | Error): Record<string, 
   }
 
   const unsantisedError = new Error(error.message)
-  unsantisedError.name = 'name' in error ? error.name : undefined
+  unsantisedError.name = 'name' in error ? error.name : ''
   unsantisedError.stack = error.stack
 
   throw unsantisedError


### PR DESCRIPTION
# Context

[The template that this repo builds on](https://github.com/ministryofjustice/hmpps-template-typescript) does not have [typescript strict mode](https://www.typescriptlang.org/tsconfig#strict) enabled. A lot of the benefit of typechecking is lost without this but unfortunately we realised too late in the development process to turn it on without causing a lot of extra work. Running the TS compiler with strict mode now results in >700 violations compared to running it without strict mode. Despite this I think it would be worthwhile to enable it.

There are a few approaches I can think of to enable it: 
1. Turn it on, fix all the errors. Given an infinite amount of time this is option I would choose. The downsides of this option are: we don't have enough time and it would generate a PR so unwieldy that it would be difficult to review. 
2. Incrementally increase our typesafety. We can run TS in strict mode when we have time to fix some errors and hopefully get to a point where we can turn on strict mode permanently. The downside to this is that new changes would not be tested in strict mode and we would have to remember to find the time to improve the typesafety. 
3. Use [typescript-strict-plugin](https://www.npmjs.com/package/typescript-strict-plugin) or similar to gradually introduce strictness. Currently TS only supports having strict mode on for all files or none. typescript-strict-plugin allows you to gradually introduce strictness by commenting which files the compiler should not check in strict mode. This seems like a good option but it involves adding an additional dependency, commenting on every file to be ignored and running the plugin as well as running the usual typescript compiler. 

Of the options 2 and 3 seem most viable. I suggest we opt for 2 for the time being but if we don't make progress towards being able to turn strict mode on *or* we introduce bugs that would have been caught by strict mode being on then we should progress with 3.  


# Changes in this PR 
This PR contains various fixes that error when TS is run with `strict: true`. The behaviour should be largely unchanged except:
 - some places where we were returning a falsy value that is better implemented by a more accurate falsy value. For instance we use `null`s in a lot of places that makes `strict` error whereas `undefined` doesn't. 
- some places we assumed a value would exist when this might not be the case so we need to handle the cases where the value doesn't exist