### PR TITLE
APS-36 - Allow past release dates 

### DIFF
--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -135,11 +135,11 @@ export default class ApplyHelper {
     confirmDetailsPage.clickSubmit()
   }
 
-  completeApplication(isExceptionalCase?: boolean) {
+  completeApplication(isExceptionalCase?: boolean, isInComunity?: boolean) {
     if (isExceptionalCase) {
       this.completeExceptionalCase()
     }
-    this.completeBasicInformation({ isEmergencyApplication: false })
+    this.completeBasicInformation({ isEmergencyApplication: false, isInComunity })
     this.completeTypeOfApSection()
     this.completeOasysSection()
     this.completeRiskManagementSection()
@@ -418,7 +418,7 @@ export default class ApplyHelper {
     exceptionDetailsPage.clickSubmit()
   }
 
-  completeBasicInformation(options: { isEmergencyApplication?: boolean } = {}) {
+  completeBasicInformation(options: { isEmergencyApplication?: boolean; isInComunity?: boolean } = {}) {
     const confirmYourDetails = new ApplyPages.ConfirmYourDetailsPage(this.application)
     confirmYourDetails.completeForm()
     confirmYourDetails.clickSubmit()
@@ -459,7 +459,7 @@ export default class ApplyHelper {
     releaseDatePage.completeForm()
     releaseDatePage.clickSubmit()
 
-    const placementStartPage = new ApplyPages.PlacementStartPage(this.application)
+    const placementStartPage = new ApplyPages.PlacementStartPage(this.application, options.isInComunity)
     placementStartPage.completeForm()
     placementStartPage.clickSubmit()
 

--- a/integration_tests/pages/apply/placementDate.ts
+++ b/integration_tests/pages/apply/placementDate.ts
@@ -1,22 +1,36 @@
 import { ApprovedPremisesApplication } from '@approved-premises/api'
 import ApplyPage from './applyPage'
 import { DateFormats } from '../../../server/utils/dateUtils'
-import { retrieveQuestionResponseFromFormArtifact } from '../../../server/utils/retrieveQuestionResponseFromFormArtifact'
+import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../../../server/utils/retrieveQuestionResponseFromFormArtifact'
 import ReleaseDate from '../../../server/form-pages/apply/reasons-for-placement/basic-information/releaseDate'
+import paths from '../../../server/paths/apply'
 
 export default class PlacementStartPage extends ApplyPage {
-  constructor(application: ApprovedPremisesApplication) {
-    const releaseDate = retrieveQuestionResponseFromFormArtifact(application, ReleaseDate) as string
+  constructor(
+    application: ApprovedPremisesApplication,
+    private readonly releaseDatePast: boolean,
+  ) {
+    const releaseDate = retrieveOptionalQuestionResponseFromApplicationOrAssessment(application, ReleaseDate) as string
+    const title = releaseDatePast
+      ? 'What date you want the placement to start?'
+      : `Is ${DateFormats.isoDateToUIDate(releaseDate)} the date you want the placement to start?`
+
+    const newApplication = application
 
     super(
-      `Is ${DateFormats.isoDateToUIDate(releaseDate)} the date you want the placement to start?`,
-      application,
+      title,
+      newApplication,
       'basic-information',
       'placement-date',
+      paths.applications.pages.show({ id: application.id, page: 'release-date', task: 'basic-information' }),
     )
   }
 
   completeForm() {
-    this.checkRadioButtonFromPageBody('startDateSameAsReleaseDate')
+    if (this.releaseDatePast && this.tasklistPage.body.startDate) {
+      this.completeDateInputsFromPageBody('startDate')
+    } else {
+      this.checkRadioButtonFromPageBody('startDateSameAsReleaseDate')
+    }
   }
 }

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
@@ -1,7 +1,11 @@
 import type { ObjectWithDateParts, TaskListErrors, YesOrNo } from '@approved-premises/ui'
 import type { ApprovedPremisesApplication } from '@approved-premises/api'
 
-import { retrieveQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
+// eslint-disable-next-line import/no-duplicates
+import isFuture from 'date-fns/isFuture'
+// eslint-disable-next-line import/no-duplicates
+import isToday from 'date-fns/isToday'
+import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 import TasklistPage from '../../../tasklistPage'
 import { convertToTitleCase } from '../../../../utils/utils'
 import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank, dateIsInThePast } from '../../../../utils/dateUtils'
@@ -21,29 +25,54 @@ type PlacementDateBody = ObjectWithDateParts<'startDate'> & {
 export default class PlacementDate implements TasklistPage {
   title: string
 
+  private releaseDatePast: boolean
+
   constructor(
     private _body: Partial<PlacementDateBody>,
     public application: ApprovedPremisesApplication,
   ) {
-    const formattedReleaseDate = DateFormats.isoDateToUIDate(
-      retrieveQuestionResponseFromFormArtifact(application, ReleaseDate),
-    )
+    const releaseDate = retrieveOptionalQuestionResponseFromApplicationOrAssessment(application, ReleaseDate)
 
-    this.title = `Is ${formattedReleaseDate} the date you want the placement to start?`
+    if (releaseDate) {
+      const releaseDateObj = DateFormats.isoToDateObj(releaseDate)
+      if (isToday(releaseDateObj) || isFuture(releaseDateObj)) {
+        const formattedReleaseDate = DateFormats.isoDateToUIDate(releaseDate)
+        this.title = `Is ${formattedReleaseDate} the date you want the placement to start?`
+        this.releaseDatePast = false
+      } else {
+        this.releaseDatePast = true
+      }
+    }
+
+    if (!releaseDate || this.releaseDatePast) {
+      this.title = 'What date you want the placement to start?'
+      this.releaseDatePast = true
+    }
   }
 
   public set body(value: Partial<PlacementDateBody>) {
-    this._body = {
-      startDateSameAsReleaseDate: value.startDateSameAsReleaseDate as YesOrNo,
-    }
-    if (value.startDateSameAsReleaseDate === 'no') {
+    if (this.releaseDatePast) {
       this._body = {
-        startDateSameAsReleaseDate: value.startDateSameAsReleaseDate as YesOrNo,
+        startDateSameAsReleaseDate: 'no',
         'startDate-year': value['startDate-year'] as string,
         'startDate-month': value['startDate-month'] as string,
         'startDate-day': value['startDate-day'] as string,
         startDate: DateFormats.dateAndTimeInputsToIsoString(value as ObjectWithDateParts<'startDate'>, 'startDate')
           .startDate,
+      }
+    } else {
+      this._body = {
+        startDateSameAsReleaseDate: value.startDateSameAsReleaseDate as YesOrNo,
+      }
+      if (value.startDateSameAsReleaseDate === 'no') {
+        this._body = {
+          startDateSameAsReleaseDate: 'no',
+          'startDate-year': value['startDate-year'] as string,
+          'startDate-month': value['startDate-month'] as string,
+          'startDate-day': value['startDate-day'] as string,
+          startDate: DateFormats.dateAndTimeInputsToIsoString(value as ObjectWithDateParts<'startDate'>, 'startDate')
+            .startDate,
+        }
       }
     }
   }
@@ -65,12 +94,16 @@ export default class PlacementDate implements TasklistPage {
   }
 
   response() {
-    const response = {
-      [this.title]: convertToTitleCase(this.body.startDateSameAsReleaseDate),
-    } as Record<string, string>
+    let response: Record<string, string>
 
-    if (this.body.startDateSameAsReleaseDate === 'no') {
-      response['Placement Start Date'] = DateFormats.isoDateToUIDate(this.body.startDate)
+    if (this.releaseDatePast) {
+      response = { [this.title]: DateFormats.isoDateToUIDate(this.body.startDate) }
+    } else {
+      response = { [this.title]: convertToTitleCase(this.body.startDateSameAsReleaseDate) }
+
+      if (this.body.startDateSameAsReleaseDate === 'no') {
+        response['Placement Start Date'] = DateFormats.isoDateToUIDate(this.body.startDate)
+      }
     }
 
     return response
@@ -79,11 +112,11 @@ export default class PlacementDate implements TasklistPage {
   errors() {
     const errors: TaskListErrors<this> = {}
 
-    if (!this.body.startDateSameAsReleaseDate) {
+    if (!this.releaseDatePast && !this.body.startDateSameAsReleaseDate) {
       errors.startDateSameAsReleaseDate = 'You must specify if the start date is the same as the release date'
     }
 
-    if (this.body.startDateSameAsReleaseDate === 'no') {
+    if (this.releaseDatePast || this.body.startDateSameAsReleaseDate === 'no') {
       if (dateIsBlank(this.body, 'startDate')) {
         errors.startDate = 'You must enter a start date'
       } else if (!dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'startDate'>, 'startDate')) {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.test.ts
@@ -1,4 +1,4 @@
-import { add, sub } from 'date-fns'
+import { add } from 'date-fns'
 import { DateFormats } from '../../../../utils/dateUtils'
 import { itShouldHaveNextValue } from '../../../shared-examples'
 
@@ -94,18 +94,6 @@ describe('ReleaseDate', () => {
           application,
         )
         expect(page.errors()).toEqual({ releaseDate: 'The release date is an invalid date' })
-      })
-
-      it('should return an error if the date is in the past', () => {
-        const releaseDate = sub(new Date(), { days: 5 })
-        const page = new ReleaseDate(
-          {
-            knowReleaseDate: 'yes',
-            ...DateFormats.dateObjectToDateInputs(releaseDate, 'releaseDate'),
-          },
-          application,
-        )
-        expect(page.errors()).toEqual({ releaseDate: 'The release date must not be in the past' })
       })
 
       it('should not return an error if the date is today', () => {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.ts
@@ -6,13 +6,7 @@ import TasklistPage from '../../../tasklistPage'
 import { convertToTitleCase } from '../../../../utils/utils'
 import { dateBodyProperties } from '../../../utils/dateBodyProperties'
 import { adjacentPageFromSentenceType } from '../../../../utils/applications/adjacentPageFromSentenceType'
-import {
-  DateFormats,
-  dateAndTimeInputsAreValidDates,
-  dateIsBlank,
-  dateIsInThePast,
-  isToday,
-} from '../../../../utils/dateUtils'
+import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../../utils/dateUtils'
 import { retrieveQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 import SentenceType from './sentenceType'
 
@@ -87,8 +81,6 @@ export default class ReleaseDate implements TasklistPage {
         errors.releaseDate = 'You must specify the release date'
       } else if (!dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'releaseDate'>, 'releaseDate')) {
         errors.releaseDate = 'The release date is an invalid date'
-      } else if (!isToday(this.body.releaseDate) && dateIsInThePast(this.body.releaseDate)) {
-        errors.releaseDate = 'The release date must not be in the past'
       }
     }
 

--- a/server/views/applications/pages/basic-information/placement-date.njk
+++ b/server/views/applications/pages/basic-information/placement-date.njk
@@ -4,53 +4,75 @@
 
 {% block questions %}
 
-  {% set startDateHTML %}
-  {{
-    formPageDateInput(
-      {
-        fieldName: "startDate",
-        fieldset: {
-          legend: {
-            text: "Expected arrival date"
-          }
-        },
-        hint: {
-          text: "For example, 27 3 2007"
-        },
-        items: dateFieldValues('startDate', errors)
-      },
-      fetchContext()
-    )
-  }}
-  {% endset -%}
-
-  {{
-    formPageRadios(
-      {
-        fieldName: "startDateSameAsReleaseDate",
-        fieldset: {
-          legend: {
-            text: page.title,
-            isPageHeading: true,
-            classes: "govuk-fieldset__legend--l"
-          }
-        },
-        items: [
-          {
-            value: "yes",
-            text: "Yes"
-          },
-          {
-            text: "No",
-            value: "no",
-            conditional: {
-              html: startDateHTML
+  {% if page.releaseDatePast %}
+    {{
+      formPageDateInput(
+        {
+          fieldName: "startDate",
+          fieldset: {
+            legend: {
+              text: page.title,
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
             }
-          }
-        ]
-      },
-      fetchContext()
-    )
-  }}
+          },
+          hint: {
+            text: "For example, 27 3 2007"
+          },
+          items: dateFieldValues('startDate', errors)
+        },
+        fetchContext()
+      )
+    }}
+  {% else %}
+    {% set startDateHTML %}
+    {{
+        formPageDateInput(
+          {
+            fieldName: "startDate",
+            fieldset: {
+              legend: {
+                text: "Expected arrival date"
+              }
+            },
+            hint: {
+              text: "For example, 27 3 2007"
+            },
+            items: dateFieldValues('startDate', errors)
+          },
+          fetchContext()
+        )
+      }}
+    {% endset -%}
+
+    {{
+      formPageRadios(
+        {
+          fieldName: "startDateSameAsReleaseDate",
+          fieldset: {
+            legend: {
+              text: page.title,
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [
+            {
+              value: "yes",
+              text: "Yes"
+            },
+            {
+              text: "No",
+              value: "no",
+              conditional: {
+                html: startDateHTML
+              }
+            }
+          ]
+        },
+        fetchContext()
+      )
+    }}
+  {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
# Context
We have recently learned applications to APs can be made for people who are 'in the community' - this means they have already been released from custody. However we performed validation on the Release Date to ensure that it wasn't in the past to avoid user error. 

In order for applications to be made for people in the community we need to remove this validation. We then ask users what date they would like the placement to start.
[JIRA Card](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?selectedIssue=APS-36)

## Screenshots of UI changes

### Before
![placement-start-page](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/88d357ab-b000-4b71-9a27-01f8b7f01b3e)

### After
![this (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/847be700-2528-4af5-8c6c-ca170fbc6891)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
