### PR TITLE
Select index offence when creating a booking

### DIFF
--- a/integration_tests/pages/manage/booking/new.ts
+++ b/integration_tests/pages/manage/booking/new.ts
@@ -1,4 +1,4 @@
-import type { Booking, FullPerson, LostBed } from '@approved-premises/api'
+import type { ActiveOffence, Booking, FullPerson, LostBed } from '@approved-premises/api'
 import BedspaceConflictErrorComponent from '../../../components/bedspaceConflictErrorComponent'
 import Page, { PageElement } from '../../page'
 import paths from '../../../../server/paths/manage'
@@ -22,6 +22,12 @@ export default class BookingNewPage extends Page {
     cy.get('dl').within(() => {
       this.assertDefinition('Name', person.name)
       this.assertDefinition('CRN', person.crn)
+    })
+  }
+
+  shouldShowOffences(offences: Array<ActiveOffence>): void {
+    offences.forEach((offence: ActiveOffence) => {
+      cy.get(`input[name="eventNumber"][value="${offence.deliusEventNumber}"]`).should('exist')
     })
   }
 
@@ -65,6 +71,10 @@ export default class BookingNewPage extends Page {
     this.expectedDepartureDay().type(departureDate.getDate().toString())
     this.expectedDepartureMonth().type(`${departureDate.getMonth() + 1}`)
     this.expectedDepartureYear().type(departureDate.getFullYear().toString())
+  }
+
+  selectOffence(offence: ActiveOffence): void {
+    cy.get(`input[name="eventNumber"][value="${offence.deliusEventNumber}"]`).click()
   }
 
   shouldShowDateConflictErrorMessages(

--- a/server/controllers/manage/bookingsController.test.ts
+++ b/server/controllers/manage/bookingsController.test.ts
@@ -12,7 +12,13 @@ import {
   generateConflictErrorAndRedirect,
 } from '../../utils/validation'
 
-import { bookingFactory, newBookingFactory, personFactory, restrictedPersonFactory } from '../../testutils/factories'
+import {
+  activeOffenceFactory,
+  bookingFactory,
+  newBookingFactory,
+  personFactory,
+  restrictedPersonFactory,
+} from '../../testutils/factories'
 import paths from '../../paths/manage'
 
 jest.mock('../../utils/validation')
@@ -57,6 +63,7 @@ describe('bookingsController', () => {
   describe('new', () => {
     describe('If there is a CRN in the flash', () => {
       const person = personFactory.build()
+      const offence = activeOffenceFactory.build()
 
       beforeEach(() => {
         request = createMock<Request>({
@@ -66,6 +73,7 @@ describe('bookingsController', () => {
         })
 
         personService.findByCrn.mockResolvedValue(person)
+        personService.getOffences.mockResolvedValue([offence])
       })
 
       it('if the CRN is not restricted it should render the new booking form', async () => {
@@ -80,6 +88,7 @@ describe('bookingsController', () => {
         expect(response.render).toHaveBeenCalledWith('bookings/new', {
           premisesId,
           pageHeading: 'Create a placement',
+          offences: [offence],
           ...person,
           errors: {},
           errorSummary: [],
@@ -122,6 +131,7 @@ describe('bookingsController', () => {
         expect(response.render).toHaveBeenCalledWith('bookings/new', {
           premisesId,
           pageHeading: 'Create a placement',
+          offences: [offence],
           ...person,
           errors: errorsAndUserInput.errors,
           errorSummary: errorsAndUserInput.errorSummary,

--- a/server/controllers/manage/bookingsController.ts
+++ b/server/controllers/manage/bookingsController.ts
@@ -37,12 +37,14 @@ export default class BookingsController {
 
       if (crnArr.length) {
         const person = await this.personService.findByCrn(req.user.token, crnArr[0])
+        const offences = await this.personService.getOffences(req.user.token, person.crn)
 
         if (isFullPerson(person)) {
           return res.render(`bookings/new`, {
             pageHeading: 'Create a placement',
             premisesId,
             bedId,
+            offences,
             ...person,
             errorTitle,
             errors,

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -21,6 +21,9 @@
   "month": {
     "empty": "You must choose a month"
   },
+  "eventNumber": {
+    "empty": "You must select an index offence"
+  },
   "arrivalDateTime": {
     "empty": "You must enter an arrival date and time",
     "invalid": "The arrival date or time is invalid",

--- a/server/views/bookings/new.njk
+++ b/server/views/bookings/new.njk
@@ -6,6 +6,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -49,6 +50,28 @@
                     }
                 ]
                 }) }}
+
+                {% if offences | length == 1 %}
+                    <input type="hidden" name="eventNumber" value="{{ offences[0].deliusEventNumber }}"/>
+                {% else %}
+                    {{
+                        govukRadios({
+                            name: "eventNumber",
+                            id: "eventNumber",
+                            fieldset: {
+                                legend: {
+                                    text: "Select an index offence",
+                                    classes: "govuk-fieldset__legend--m"
+                                }
+                            },
+                            hint: {
+                                text: "This person has more than one index offence identified against their CRN. Select the most relevant index offence."
+                            },
+                            errorMessage: errors.eventNumber,
+                            items: convertObjectsToRadioItems(offences, 'offenceDescription', 'deliusEventNumber', 'eventNumber')
+                        })
+                    }}
+                {% endif %}
 
                 {{ govukDateInput({
                     id: "arrivalDate",


### PR DESCRIPTION
When creating an ad-hoc booking, if an offender has multiple index offences against their name, the user should be prompted to select the index offence. This is needed to ensure that domain events get created in Delius.

This needs to be deployed along with https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1084

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/65daa080-6482-4412-b85c-09c0bf0e257f)
