### PR TITLE
Show offline applications

### DIFF
--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -20,6 +20,14 @@ export default class ShowPage extends Page {
     cy.get('Create placement request').should('not.exist')
   }
 
+  shouldNotShowOfflineStatus() {
+    cy.get('.govuk-tag').contains('Offline application').should('not.exist')
+  }
+
+  shouldShowOfflineStatus() {
+    cy.get('.govuk-tag').contains('Offline application').should('exist')
+  }
+
   shouldShowAssessmentDetails() {
     cy.get('.govuk-inset-text')
       .contains(

--- a/integration_tests/tests/apply/viewApplication.cy.ts
+++ b/integration_tests/tests/apply/viewApplication.cy.ts
@@ -33,6 +33,7 @@ context('show applications', () => {
     const showPage = Page.verifyOnPage(ShowPage, updatedApplication)
 
     // And I should see the application details
+    showPage.shouldNotShowOfflineStatus()
     showPage.shouldShowPersonInformation()
     showPage.shouldShowResponses()
 
@@ -71,5 +72,26 @@ context('show applications', () => {
 
     // And I should see details of the assessment
     showPage.shouldShowAssessmentDetails()
+  })
+
+  it('should show an offline application', function test() {
+    const application = {
+      ...this.application,
+      type: 'Offline',
+      status: undefined,
+    }
+    cy.task('stubApplicationGet', { application })
+
+    // And I visit the application page
+    ShowPage.visit(application)
+
+    // Then I should see a stub application
+    const showPage = Page.verifyOnPage(ShowPage, application)
+
+    // And the application should show as offline
+    showPage.shouldShowOfflineStatus()
+
+    // And I should see the person information
+    showPage.shouldShowPersonInformation()
   })
 })

--- a/server/views/applications/partials/_readonly-application.njk
+++ b/server/views/applications/partials/_readonly-application.njk
@@ -3,15 +3,17 @@
 
 {% macro applicationReadonlyView(application) %}
 
-      {{ personDetails(application.person) }}
+  {{ personDetails(application.person) }}
 
-      {% for section in SummaryListUtils.summaryListSections(application, false) %}
-        <h2 class="govuk-heading-l">{{ section.title }}</h2>
-        {% for task in section.tasks %}
-          {{
-            govukSummaryList(task)
-          }}
-        {% endfor %}
+  {% if application.type !== 'Offline' %}
+    {% for section in SummaryListUtils.summaryListSections(application, false) %}
+      <h2 class="govuk-heading-l">{{ section.title }}</h2>
+      {% for task in section.tasks %}
+        {{
+              govukSummaryList(task)
+            }}
       {% endfor %}
+    {% endfor %}
+  {% endif %}
 
 {% endmacro %}

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -4,6 +4,7 @@
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% from "./partials/_readonly-application.njk" import applicationReadonlyView %}
 {% from "./partials/_timeline.njk" import timeline %}
+{%- from "govuk/components/tag/macro.njk" import govukTag -%}
 
 {% extends "../partials/layout.njk" %}
 
@@ -26,7 +27,17 @@
       <div class="moj-page-header-actions">
         <div class="moj-page-header-actions__title">
           <span class="govuk-caption-l">{{ pageHeading }}</span>
-          <h1 class="govuk-heading-l">{{ application.person.name }}</h1>
+          <h1 class="govuk-heading-l">
+            {{ application.person.name }}
+            {% if application.type == 'Offline' %}
+              {{
+                govukTag({
+                  text: "Offline application",
+                  classes: "govuk-tag--grey govuk-!-margin-5"
+                })
+              }}
+            {% endif %}
+          </h1>
         </div>
         <div class="moj-page-header-actions__actions">
           <div class="moj-button-menu">
@@ -58,8 +69,6 @@
         }) }}
       {% endif %}
 
-
-
       {{ mojSubNavigation({
         items: [{
           text: 'Application',
@@ -72,12 +81,12 @@
         }]
       }) }}
 
-    {% if tab === 'timeline' %}
-      {{ timeline(mapTimelineEventsForUi(timelineEvents)) }}
-    {% else %}
-      {{ applicationReadonlyView(application) }}
-    {% endif %}
-    
+      {% if tab === 'timeline' %}
+        {{ timeline(mapTimelineEventsForUi(timelineEvents)) }}
+      {% else %}
+        {{ applicationReadonlyView(application) }}
+      {% endif %}
+
     </div>
   </div>
 {% endblock %}

--- a/server/views/partials/personDetails.njk
+++ b/server/views/partials/personDetails.njk
@@ -21,7 +21,8 @@
         text: "Date of Birth"
       },
       value: {
-        text: formatDate(person.dateOfBirth, {format: 'short'})
+        text: formatDate(person.dateOfBirth, {format: 'short'})if person.dateOfBirth else 
+          ''
       }
     }, {
       key: {


### PR DESCRIPTION
This hides all the irrelevant page furniture for offline applications, together with a small tag showing the status of the application.

## Screenshot

### Before

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/b09cc20f-5b58-4567-9575-dec958ff5a2d)

### After

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/ad49e5f4-317a-43d1-8560-4cafdecf4b45)
