### PR TITLE
Check release date in relation to the created date

### DIFF
--- a/integration_tests/tests/apply/setup.ts
+++ b/integration_tests/tests/apply/setup.ts
@@ -6,6 +6,7 @@ import {
   risksFactory,
   tierEnvelopeFactory,
 } from '../../../server/testutils/factories'
+import { DateFormats } from '../../../server/utils/dateUtils'
 
 export const setup = () => {
   cy.task('reset')
@@ -17,7 +18,11 @@ export const setup = () => {
 
   cy.fixture('applicationData.json').then(applicationData => {
     const person = personFactory.build()
-    const application = applicationFactory.build({ person, status: 'inProgress' })
+    const application = applicationFactory.build({
+      person,
+      status: 'inProgress',
+      createdAt: DateFormats.dateObjToIsoDate(new Date()),
+    })
     const risks = risksFactory.build({
       crn: person.crn,
       tier: tierEnvelopeFactory.build({ value: { level: 'A3' } }),

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
@@ -1,10 +1,7 @@
 import type { ObjectWithDateParts, TaskListErrors, YesOrNo } from '@approved-premises/ui'
 import type { ApprovedPremisesApplication } from '@approved-premises/api'
 
-// eslint-disable-next-line import/no-duplicates
-import isFuture from 'date-fns/isFuture'
-// eslint-disable-next-line import/no-duplicates
-import isToday from 'date-fns/isToday'
+import { isAfter, isSameDay } from 'date-fns'
 import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 import TasklistPage from '../../../tasklistPage'
 import { convertToTitleCase } from '../../../../utils/utils'
@@ -35,7 +32,9 @@ export default class PlacementDate implements TasklistPage {
 
     if (releaseDate) {
       const releaseDateObj = DateFormats.isoToDateObj(releaseDate)
-      if (isToday(releaseDateObj) || isFuture(releaseDateObj)) {
+      const applicationDate = DateFormats.isoToDateObj(application.createdAt)
+
+      if (isAfter(releaseDateObj, applicationDate) || isSameDay(applicationDate, releaseDateObj)) {
         const formattedReleaseDate = DateFormats.isoDateToUIDate(releaseDate)
         this.title = `Is ${formattedReleaseDate} the date you want the placement to start?`
         this.releaseDatePast = false


### PR DESCRIPTION
Fixes https://ministryofjustice.sentry.io/issues/4595156572/?alert_rule_id=14512560&alert_type=issue&notification_uuid=ba2799d8-4dde-4071-b49a-34af020f6ef0&project=4503931667742720&referrer=slack

Because we run validations when showing the application, the release date will be in the past for applications where the release date has already passed, so we get inconsistent behaviour. We fix this by checking the release date in relation to when the application was created. There are still some edge cases where the user may go back and edit the repsonse, but this at least fixes the error in prod that we’re seeing.