### PR TITLE
APS 14 - Withdraw a Placement Application

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -134,6 +134,22 @@ export default {
         jsonBody: args.timeline,
       },
     }),
+  stubApplicationPlacementRequests: (args: {
+    applicationId: string
+    placementApplications: Array<TimelineEvent>
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: paths.applications.placementApplications({ id: args.applicationId }),
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.placementApplications,
+      },
+    }),
+
   verifyApplicationWithdrawn: async (args: { applicationId: string }) =>
     (
       await getMatchingRequests({

--- a/integration_tests/mockApis/placementApplication.ts
+++ b/integration_tests/mockApis/placementApplication.ts
@@ -75,6 +75,20 @@ export default {
         jsonBody: placementApplication,
       },
     }),
+  stubSubmitPlacementApplicationWithdraw: (placementApplication: PlacementApplication): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: paths.placementApplications.withdraw({ id: placementApplication.id }),
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: placementApplication,
+      },
+    }),
   verifyPlacementApplicationSubmit: async (applicationId: string) =>
     (
       await getMatchingRequests({

--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -75,6 +75,16 @@ export default class ShowPage extends Page {
     cy.get('a').contains('Timeline').click()
   }
 
+  clickRequestAPlacementTab() {
+    cy.get('a').contains('Request a placement').click()
+  }
+
+  clickWithdraw(placementRequestId: string) {
+    cy.get(`[data-cy-placement-application-id="${placementRequestId}"]`).within(() => {
+      cy.get('a').contains('Withdraw').click()
+    })
+  }
+
   shouldShowTimeline(timelineEvents: Array<TimelineEvent>) {
     const sortedTimelineEvents = timelineEvents.sort((a, b) => {
       return new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime()

--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -91,6 +91,10 @@ export default class ShowPage extends Page {
     })
   }
 
+  verifyOnTimelineTab() {
+    cy.get('a').contains('Request a placement').should('contain', '[aria-page="current"]')
+  }
+
   shouldShowTimeline(timelineEvents: Array<TimelineEvent>) {
     const sortedTimelineEvents = timelineEvents.sort((a, b) => {
       return new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime()
@@ -134,5 +138,9 @@ export default class ShowPage extends Page {
           })
       },
     )
+  }
+
+  showsWithdrawalConfirmationMessage() {
+    this.shouldShowBanner('Placement application withdrawn')
   }
 }

--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -1,17 +1,23 @@
-import type { ApprovedPremisesApplication, FullPerson, TimelineEvent } from '@approved-premises/api'
+import type {
+  ApprovedPremisesApplication as Application,
+  FullPerson,
+  PlacementApplication,
+  TimelineEvent,
+} from '@approved-premises/api'
 import { DateFormats } from '../../../server/utils/dateUtils'
 
 import { summaryListSections } from '../../../server/utils/applications/summaryListUtils'
 
 import Page from '../page'
-import { eventTypeTranslations } from '../../../server/utils/applications/utils'
+import { eventTypeTranslations, mapPlacementApplicationToSummaryCards } from '../../../server/utils/applications/utils'
+import { TextItem } from '../../../server/@types/ui'
 
 export default class ShowPage extends Page {
-  constructor(private readonly application: ApprovedPremisesApplication) {
+  constructor(private readonly application: Application) {
     super((application.person as FullPerson).name)
   }
 
-  static visit(application: ApprovedPremisesApplication) {
+  static visit(application: Application) {
     cy.visit(`/applications/${application.id}`)
     return new ShowPage(application)
   }
@@ -102,5 +108,31 @@ export default class ShowPage extends Page {
         })
       })
     })
+  }
+
+  shouldShowPlacementApplications(placementApplications: Array<PlacementApplication>, application: Application) {
+    mapPlacementApplicationToSummaryCards(placementApplications, application).forEach(
+      placementApplicationSummaryCard => {
+        cy.get(
+          `[data-cy-placement-application-id="${placementApplicationSummaryCard.card.attributes['data-cy-placement-application-id']}"]`,
+        )
+          .should('contain', placementApplicationSummaryCard.card.title.text)
+          .within(() => {
+            cy.get('.govuk-summary-list__row').should('have.length', placementApplicationSummaryCard.rows.length)
+            cy.get('.govuk-summary-list__row').each(($el, index) => {
+              cy.wrap($el).within(() => {
+                cy.get('.govuk-summary-list__key').should(
+                  'contain',
+                  (placementApplicationSummaryCard.rows[index].key as TextItem).text,
+                )
+                cy.get('.govuk-summary-list__value').should(
+                  'contain',
+                  (placementApplicationSummaryCard.rows[index].value as TextItem).text,
+                )
+              })
+            })
+          })
+      },
+    )
   }
 }

--- a/integration_tests/pages/match/placementApplicationWithdrawalConfirmationPage.ts
+++ b/integration_tests/pages/match/placementApplicationWithdrawalConfirmationPage.ts
@@ -1,0 +1,11 @@
+import Page from '../page'
+
+export default class ConfirmationPage extends Page {
+  constructor() {
+    super('Are you sure you want to withdraw this placement application?')
+  }
+
+  clickConfirm() {
+    cy.get('button').contains('Continue').click()
+  }
+}

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -43,7 +43,7 @@ context('Placement Requests', () => {
     signIn(['workflow_manager'])
 
     application = addResponseToFormArtifact(application, {
-      section: 'location-factors',
+      task: 'location-factors',
       page: 'preferred-aps',
       key: 'selectedAps',
       value: preferredAps,

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -151,7 +151,7 @@ context('Apply', () => {
     const tomorrow = addDays(new Date(), 1)
 
     this.application = addResponsesToFormArtifact(this.application, {
-      section: 'basic-information',
+      task: 'basic-information',
       page: 'release-date',
       keyValuePairs: {
         ...DateFormats.dateObjectToDateInputs(tomorrow, 'releaseDate'),
@@ -161,14 +161,14 @@ context('Apply', () => {
     })
 
     this.application = addResponseToFormArtifact(this.application, {
-      section: 'basic-information',
+      task: 'basic-information',
       page: 'reason-for-short-notice',
       key: 'reason',
       value: 'riskEscalated',
     })
 
     this.application = addResponsesToFormArtifact(this.application, {
-      section: 'further-considerations',
+      task: 'further-considerations',
       page: 'trigger-plan',
       keyValuePairs: {
         planInPlace: 'yes',
@@ -190,7 +190,7 @@ context('Apply', () => {
     // A release date in the past
     const releaseDate = subDays(new Date(), 1)
     this.application = addResponsesToFormArtifact(this.application, {
-      section: 'basic-information',
+      task: 'basic-information',
       page: 'placement-date',
       keyValuePairs: {
         ...DateFormats.dateObjectToDateInputs(placementDate, 'startDate'),
@@ -199,7 +199,7 @@ context('Apply', () => {
       },
     })
     this.application = addResponsesToFormArtifact(this.application, {
-      section: 'basic-information',
+      task: 'basic-information',
       page: 'release-date',
       keyValuePairs: {
         ...DateFormats.dateObjectToDateInputs(releaseDate, 'releaseDate'),

--- a/integration_tests/tests/apply/esap.cy.ts
+++ b/integration_tests/tests/apply/esap.cy.ts
@@ -15,21 +15,21 @@ context('Apply - ESAP', () => {
     const apply = new ApplyHelper(this.application, this.person, this.offences)
 
     this.application = addResponseToFormArtifact(this.application, {
-      section: 'type-of-ap',
+      task: 'type-of-ap',
       page: 'ap-type',
       key: 'type',
       value: 'esap',
     })
 
     this.application = addResponseToFormArtifact(this.application, {
-      section: 'type-of-ap',
+      task: 'type-of-ap',
       page: 'managed-by-national-security-division',
       key: 'managedByNationalSecurityDivision',
       value: 'no',
     })
 
     this.application = addResponsesToFormArtifact(this.application, {
-      section: 'type-of-ap',
+      task: 'type-of-ap',
       page: 'esap-exceptional-case',
       keyValuePairs: {
         ...DateFormats.isoDateToDateInputs('2023-07-01', 'agreementDate'),
@@ -40,7 +40,7 @@ context('Apply - ESAP', () => {
     })
 
     this.application = addResponsesToFormArtifact(this.application, {
-      section: 'type-of-ap',
+      task: 'type-of-ap',
       page: 'esap-placement-screening',
       keyValuePairs: {
         esapReasons: ['secreting', 'cctv'],
@@ -48,7 +48,7 @@ context('Apply - ESAP', () => {
     })
 
     this.application = addResponsesToFormArtifact(this.application, {
-      section: 'type-of-ap',
+      task: 'type-of-ap',
       page: 'esap-placement-cctv',
       keyValuePairs: {
         cctvHistory: ['appearance', 'networks'],
@@ -59,7 +59,7 @@ context('Apply - ESAP', () => {
     })
 
     this.application = addResponsesToFormArtifact(this.application, {
-      section: 'type-of-ap',
+      task: 'type-of-ap',
       page: 'esap-placement-secreting',
       keyValuePairs: {
         secretingHistory: ['radicalisationLiterature', 'drugs'],
@@ -91,21 +91,21 @@ context('Apply - ESAP', () => {
     const apply = new ApplyHelper(this.application, this.person, this.offences)
 
     this.application = addResponseToFormArtifact(this.application, {
-      section: 'type-of-ap',
+      task: 'type-of-ap',
       page: 'ap-type',
       key: 'type',
       value: 'esap',
     })
 
     this.application = addResponseToFormArtifact(this.application, {
-      section: 'type-of-ap',
+      task: 'type-of-ap',
       page: 'managed-by-national-security-division',
       key: 'managedByNationalSecurityDivision',
       value: 'no',
     })
 
     this.application = addResponsesToFormArtifact(this.application, {
-      section: 'type-of-ap',
+      task: 'type-of-ap',
       page: 'esap-exceptional-case',
       keyValuePairs: {
         agreedCaseWithCommunityHopp: 'no',

--- a/integration_tests/tests/apply/invalidations.cy.ts
+++ b/integration_tests/tests/apply/invalidations.cy.ts
@@ -18,7 +18,7 @@ context('Apply', () => {
 
     // And I change my response
     this.application = addResponsesToFormArtifact(this.application, {
-      section: 'location-factors',
+      task: 'location-factors',
       page: 'describe-location-factors',
       keyValuePairs: {
         ...this.application.data['location-factors']['describe-location-factors'],

--- a/integration_tests/tests/apply/missingInformation.cy.ts
+++ b/integration_tests/tests/apply/missingInformation.cy.ts
@@ -22,7 +22,7 @@ context('Apply - Missing information', () => {
     const uiRisks = mapApiPersonRisksForUi(this.application.risks)
 
     this.application = addResponsesToFormArtifact(this.application, {
-      section: 'prison-information',
+      task: 'prison-information',
       page: 'case-notes',
       keyValuePairs: {
         informationFromPrison: 'yes',

--- a/integration_tests/tests/apply/viewApplication.cy.ts
+++ b/integration_tests/tests/apply/viewApplication.cy.ts
@@ -94,4 +94,19 @@ context('show applications', () => {
     // And I should see the person information
     showPage.shouldShowPersonInformation()
   })
+
+  it('should show placement applications', function test() {
+    const application = { ...this.application, status: 'submitted' }
+
+    cy.task('stubApplicationGet', { application })
+
+    // Given I visit the application page
+    ShowPage.visit(application)
+    const showPage = Page.verifyOnPage(ShowPage, application)
+
+    // When I click the 'Request a placement' tab
+    showPage.clickRequestAPlacementTab()
+    cy.screenshot('after-1')
+    // Then I should see the placement requests
+  })
 })

--- a/integration_tests/tests/apply/viewApplication.cy.ts
+++ b/integration_tests/tests/apply/viewApplication.cy.ts
@@ -3,7 +3,10 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 import { ListPage, ShowPage } from '../../pages/apply'
 import Page from '../../pages/page'
 import { setup } from './setup'
-import { timelineEventFactory } from '../../../server/testutils/factories'
+import { timelineEventFactory, userFactory } from '../../../server/testutils/factories'
+import placementApplication from '../../../server/testutils/factories/placementApplication'
+import { addResponseToFormArtifact, addResponsesToFormArtifact } from '../../../server/testutils/addToApplication'
+import { ApprovedPremisesApplication as Application } from '../../../server/@types/shared'
 
 context('show applications', () => {
   beforeEach(setup)
@@ -96,10 +99,20 @@ context('show applications', () => {
   })
 
   it('should show placement applications', function test() {
-    const application = { ...this.application, status: 'submitted' }
-
+    const { application, placementApplication: releaseFollowingDecisionPlacementApplication } =
+      makeReleaseFollowingDecisionPlacementApplication(this.application)
+    const rotlPlacementApplication = makeRotlPlacementApplication(application.id)
+    const additionalPlacementApplication = makeAdditionalPlacementApplication(application.id)
+    const placementApplications = [
+      releaseFollowingDecisionPlacementApplication,
+      rotlPlacementApplication,
+      additionalPlacementApplication,
+    ]
     cy.task('stubApplicationGet', { application })
-
+    cy.task('stubApplicationPlacementRequests', {
+      applicationId: application.id,
+      placementApplications,
+    })
     // Given I visit the application page
     ShowPage.visit(application)
     const showPage = Page.verifyOnPage(ShowPage, application)
@@ -108,5 +121,92 @@ context('show applications', () => {
     showPage.clickRequestAPlacementTab()
     cy.screenshot('after-1')
     // Then I should see the placement requests
+    showPage.shouldShowPlacementApplications(placementApplications, application)
   })
 })
+
+const makeReleaseFollowingDecisionPlacementApplication = (application: Application) => {
+  let updatedApplication = addResponseToFormArtifact(application, {
+    task: 'move-on',
+    page: 'placement-duration',
+    key: 'duration',
+    value: '84',
+  })
+
+  updatedApplication = {
+    ...updatedApplication,
+    status: 'submitted',
+    createdByUserId: '',
+    assessmentDecision: 'accepted',
+    assessmentDecisionDate: '2023-01-01',
+    assessmentId: 'low',
+  }
+
+  let releaseFollowingDecisionPlacementApplication = placementApplication.build({ applicationId: application.id })
+
+  releaseFollowingDecisionPlacementApplication = addResponseToFormArtifact(
+    releaseFollowingDecisionPlacementApplication,
+    {
+      task: 'request-a-placement',
+      page: 'reason-for-placement',
+      key: 'reason',
+      value: 'release_following_decision',
+    },
+  )
+
+  releaseFollowingDecisionPlacementApplication = addResponseToFormArtifact(
+    releaseFollowingDecisionPlacementApplication,
+    {
+      task: 'request-a-placement',
+      page: 'decision-to-release',
+      key: 'decisionToReleaseDate',
+      value: '2024-01-01',
+    },
+  )
+
+  return { application: updatedApplication, placementApplication: releaseFollowingDecisionPlacementApplication }
+}
+
+const makeRotlPlacementApplication = (applicationId: string) => {
+  let rotlPlacementApplication = placementApplication.build({ applicationId })
+
+  rotlPlacementApplication = addResponseToFormArtifact(rotlPlacementApplication, {
+    task: 'request-a-placement',
+    page: 'reason-for-placement',
+    key: 'reason',
+    value: 'rotl',
+  })
+  rotlPlacementApplication = addResponsesToFormArtifact(rotlPlacementApplication, {
+    task: 'request-a-placement',
+    page: 'dates-of-placement',
+    keyValuePairs: {
+      arrivalDate: '2023-01-01',
+      durationDays: '20',
+      duration: '20',
+    },
+  })
+  return rotlPlacementApplication
+}
+
+const makeAdditionalPlacementApplication = (applicationId: string) => {
+  let additionalPlacementApplication = placementApplication.build({ applicationId })
+
+  additionalPlacementApplication = addResponseToFormArtifact(additionalPlacementApplication, {
+    task: 'request-a-placement',
+    page: 'reason-for-placement',
+    key: 'reason',
+    value: 'additional_placement',
+  })
+
+  additionalPlacementApplication = addResponsesToFormArtifact(additionalPlacementApplication, {
+    task: 'request-a-placement',
+    page: 'additional-placement-details',
+    keyValuePairs: {
+      arrivalDate: '2024-05-21',
+      durationDays: '10',
+      duration: '10',
+    },
+  })
+
+  return additionalPlacementApplication
+}

--- a/integration_tests/tests/assess/shortNoticeAssessments.cy.ts
+++ b/integration_tests/tests/assess/shortNoticeAssessments.cy.ts
@@ -36,7 +36,7 @@ describe('Short notice assessments', () => {
       const tomorrow = addDays(new Date(), 1)
 
       application = addResponsesToFormArtifact(application, {
-        section: 'basic-information',
+        task: 'basic-information',
         page: 'release-date',
         keyValuePairs: {
           ...DateFormats.dateObjectToDateInputs(tomorrow, 'releaseDate'),
@@ -46,7 +46,7 @@ describe('Short notice assessments', () => {
       }) as Application
 
       application = addResponseToFormArtifact(application, {
-        section: 'basic-information',
+        task: 'basic-information',
         page: 'reason-for-short-notice',
         key: 'reason',
         value: 'riskEscalated',

--- a/integration_tests/tests/match/placementApplications.cy.ts
+++ b/integration_tests/tests/match/placementApplications.cy.ts
@@ -179,7 +179,7 @@ context('Placement Applications', () => {
         person,
       })
       completedApplication = addResponseToFormArtifact(completedApplication, {
-        section: 'type-of-ap',
+        task: 'type-of-ap',
         page: 'ap-type',
         key: 'type',
         value: 'standard',

--- a/integration_tests/tests/match/placementApplications.cy.ts
+++ b/integration_tests/tests/match/placementApplications.cy.ts
@@ -59,9 +59,16 @@ context('Placement Applications', () => {
       cy.task('stubPlacementApplicationUpdate', placementApplication)
       cy.task('stubSubmitPlacementApplication', placementApplication)
       cy.task('stubPlacementApplication', placementApplication)
+      cy.task('stubApplicationPlacementRequests', {
+        applicationId: completedApplication.id,
+        placementApplications: [placementApplication],
+      })
 
-      // When I visit the readonly application view
+      // Given I am on the readonly application view
       const showPage = ShowPage.visit(completedApplication)
+
+      // When I click the Request Placement Application tab
+      showPage.clickRequestAPlacementTab()
 
       // Then I should be able to click submit
       showPage.clickSubmit()
@@ -129,9 +136,16 @@ context('Placement Applications', () => {
       cy.task('stubPlacementApplicationUpdate', placementApplication)
       cy.task('stubSubmitPlacementApplication', placementApplication)
       cy.task('stubPlacementApplication', placementApplication)
+      cy.task('stubApplicationPlacementRequests', {
+        applicationId: completedApplication.id,
+        placementApplications: [placementApplication],
+      })
 
-      // When I visit the readonly application view
+      // Given I am on the readonly application view
       const showPage = ShowPage.visit(completedApplication)
+
+      // When I click the Request Placement Application tab
+      showPage.clickRequestAPlacementTab()
 
       // Then I should be able to click submit
       showPage.clickSubmit()
@@ -204,9 +218,16 @@ context('Placement Applications', () => {
       cy.task('stubSubmitPlacementApplication', placementApplication)
       cy.task('stubPlacementApplication', placementApplication)
       cy.task('stubApplicationDocuments', { application: completedApplication, documents })
+      cy.task('stubApplicationPlacementRequests', {
+        applicationId: completedApplication.id,
+        placementApplications: [placementApplication],
+      })
 
-      // When I visit the readonly application view
+      // Given I am on the readonly application view
       const showPage = ShowPage.visit(completedApplication)
+
+      // When I click the Request Placement Application tab
+      showPage.clickRequestAPlacementTab()
 
       // Then I should be able to click submit
       showPage.clickSubmit()

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -152,7 +152,7 @@ export interface SummaryList {
 
 export type SummaryListWithCard = SummaryList & {
   card: {
-    title: { text: string }
+    title: { text: string; headingLevel?: string }
     actions?: SummaryListActions
     attributes?: HtmlAttributes
   }

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -42,18 +42,19 @@ export default class ApplicationsController {
 
       if (application.status !== 'inProgress') {
         const referrer = req.headers.referer
+        const defaultParams = { application, referrer }
 
         if (req.query.tab === 'timeline') {
           const timelineEvents = await this.applicationService.timeline(req.user.token, application.id)
 
-          return res.render('applications/show', { application, timelineEvents, referrer, tab: 'timeline' })
+          return res.render('applications/show', { ...defaultParams, timelineEvents, tab: 'timeline' })
         }
 
         if (req.query.tab === 'requestAPlacement') {
           return res.render('applications/show', { application, referrer, tab: 'requestAPlacement' })
         }
 
-        return res.render('applications/show', { application, referrer, tab: 'application' })
+        return res.render('applications/show', { ...defaultParams, tab: 'application' })
       }
       return res.render('applications/tasklist', { application, taskList, errorSummary, errors })
     }

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -49,6 +49,10 @@ export default class ApplicationsController {
           return res.render('applications/show', { application, timelineEvents, referrer, tab: 'timeline' })
         }
 
+        if (req.query.tab === 'requestAPlacement') {
+          return res.render('applications/show', { application, referrer, tab: 'requestAPlacement' })
+        }
+
         return res.render('applications/show', { application, referrer, tab: 'application' })
       }
       return res.render('applications/tasklist', { application, taskList, errorSummary, errors })

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -37,6 +37,7 @@ export default class ApplicationsController {
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
       const application = await this.applicationService.findApplication(req.user.token, req.params.id)
+
       const taskList = new TasklistService(application)
       const { errors, errorSummary } = fetchErrorsAndUserInput(req)
 
@@ -51,7 +52,16 @@ export default class ApplicationsController {
         }
 
         if (req.query.tab === 'requestAPlacement') {
-          return res.render('applications/show', { application, referrer, tab: 'requestAPlacement' })
+          const placementApplications = await this.applicationService.getPlacementApplications(
+            req.user.token,
+            application.id,
+          )
+
+          return res.render('applications/show', {
+            ...defaultParams,
+            placementApplications,
+            tab: 'requestAPlacement',
+          })
         }
 
         return res.render('applications/show', { ...defaultParams, tab: 'application' })

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -12,6 +12,7 @@ import type { Services } from '../services'
 import DashboardController from './dashboardController'
 import PagesController from './placementApplications/pagesController'
 import ReviewController from './placementApplications/reviewController'
+import WithdrawalsController from './placementApplications/withdrawalsController'
 
 export const controllers = (services: Services) => {
   const dashboardController = new DashboardController()
@@ -22,6 +23,7 @@ export const controllers = (services: Services) => {
     services.applicationService,
   )
   const placementApplicationReviewController = new ReviewController(services.placementApplicationService)
+  const placementApplicationWithdrawalsController = new WithdrawalsController(services.placementApplicationService)
 
   return {
     dashboardController,
@@ -29,6 +31,7 @@ export const controllers = (services: Services) => {
     allocationsController,
     placementApplicationPagesController,
     placementApplicationReviewController,
+    placementApplicationWithdrawalsController,
     ...applyControllers(services),
     ...assessControllers(services),
     ...matchControllers(services),

--- a/server/controllers/placementApplications/reviewController.test.ts
+++ b/server/controllers/placementApplications/reviewController.test.ts
@@ -73,7 +73,7 @@ describe('reviewController', () => {
       expect(response.render).toHaveBeenCalledWith('placement-applications/pages/review/review', {
         pageProps: {
           pageHeading: 'Review information',
-          backLink: `${matchPaths.placementRequests.index}#placement-applications`,
+          backLink: `${matchPaths.placementRequests.index({})}#placement-applications`,
         },
         placementApplication,
         errors: {},
@@ -122,7 +122,7 @@ describe('reviewController', () => {
       expect(response.render).toHaveBeenCalledWith('placement-applications/pages/review/review', {
         pageProps: {
           pageHeading: 'Review information',
-          backLink: `${matchPaths.placementRequests.index}#placement-applications`,
+          backLink: `${matchPaths.placementRequests.index({})}#placement-applications`,
         },
         placementApplication,
         errors: errorsAndUserInput.errors,

--- a/server/controllers/placementApplications/reviewController.ts
+++ b/server/controllers/placementApplications/reviewController.ts
@@ -28,7 +28,10 @@ export default class ReviewController {
 
       const pageProps =
         step === 'review'
-          ? { pageHeading: 'Review information', backLink: `${paths.placementRequests.index}#placement-applications` }
+          ? {
+              pageHeading: 'Review information',
+              backLink: `${paths.placementRequests.index({})}#placement-applications`,
+            }
           : {
               pageHeading: 'Make a decision',
               backLink: placementApplicationPaths.placementApplications.show({ id: review.applicationId }),

--- a/server/controllers/placementApplications/withdrawalsController.test.ts
+++ b/server/controllers/placementApplications/withdrawalsController.test.ts
@@ -1,0 +1,98 @@
+import type { NextFunction, Request, Response } from 'express'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+
+import type { ErrorsAndUserInput } from '@approved-premises/ui'
+
+import { PlacementApplicationService } from '../../services'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
+
+import placementApplicationPaths from '../../paths/placementApplications'
+import applyPaths from '../../paths/apply'
+import WithdrawalsController from './withdrawalsController'
+import { placementApplicationFactory } from '../../testutils/factories'
+
+jest.mock('../../utils/validation')
+
+describe('withdrawalsController', () => {
+  const token = 'SOME_TOKEN'
+
+  let request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  let response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = jest.fn()
+
+  const placementApplicationService = createMock<PlacementApplicationService>({})
+
+  let withdrawalsController: WithdrawalsController
+  const applicationId = 'app-id'
+  const placementApplicationId = 'place-app-id'
+
+  beforeEach(() => {
+    withdrawalsController = new WithdrawalsController(placementApplicationService)
+    request = createMock<Request>({ user: { token } })
+    response = createMock<Response>({})
+    jest.clearAllMocks()
+  })
+
+  describe('new', () => {
+    it('renders the template', async () => {
+      const placementApplication = placementApplicationFactory.build({ applicationId })
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
+      request.params.id = placementApplicationId
+
+      placementApplicationService.getPlacementApplication.mockResolvedValue(placementApplication)
+
+      const requestHandler = withdrawalsController.new()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('placement-applications/withdraw/new', {
+        pageHeading: 'Are you sure you want to withdraw this placement application?',
+        placementApplicationId: placementApplication.id,
+        applicationId,
+        errors: errorsAndUserInput.errors,
+        errorSummary: errorsAndUserInput.errorSummary,
+        ...errorsAndUserInput.userInput,
+      })
+      expect(placementApplicationService.getPlacementApplication).toHaveBeenCalledWith(token, placementApplicationId)
+    })
+  })
+
+  describe('create', () => {
+    it('calls the service method, redirects to the application screen and shows a confirmation message', async () => {
+      request.body.applicationId = applicationId
+      request.params.id = placementApplicationId
+
+      const requestHandler = withdrawalsController.create()
+
+      await requestHandler(request, response, next)
+
+      expect(placementApplicationService.withdraw).toHaveBeenCalledWith(token, placementApplicationId)
+      expect(response.redirect).toHaveBeenCalledWith(
+        `${applyPaths.applications.show({ id: applicationId })}?tab=requestAPlacement`,
+      )
+      expect(request.flash).toHaveBeenCalledWith('success', 'Placement application withdrawn')
+    })
+
+    it('redirects with errors if the API returns an error', async () => {
+      request.params.id = placementApplicationId
+
+      const requestHandler = withdrawalsController.create()
+
+      const err = new Error()
+
+      placementApplicationService.withdraw.mockImplementation(() => {
+        throw err
+      })
+
+      await requestHandler(request, response, next)
+
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+        request,
+        response,
+        err,
+        placementApplicationPaths.placementApplications.withdraw.new({ id: placementApplicationId }),
+      )
+    })
+  })
+})

--- a/server/controllers/placementApplications/withdrawalsController.ts
+++ b/server/controllers/placementApplications/withdrawalsController.ts
@@ -1,0 +1,50 @@
+import type { Request, RequestHandler, Response } from 'express'
+
+import { PlacementApplicationService } from '../../services'
+
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
+
+import applyPaths from '../../paths/apply'
+import placementApplicationPaths from '../../paths/placementApplications'
+
+export default class WithdrawlsController {
+  constructor(private readonly placementApplicationService: PlacementApplicationService) {}
+
+  new(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
+      const placementApplication = await this.placementApplicationService.getPlacementApplication(
+        req.user.token,
+        req.params.id,
+      )
+
+      return res.render('placement-applications/withdraw/new', {
+        pageHeading: 'Are you sure you want to withdraw this placement application?',
+        placementApplicationId: placementApplication.id,
+        applicationId: placementApplication.applicationId,
+        errors,
+        errorSummary,
+        ...userInput,
+      })
+    }
+  }
+
+  create(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      try {
+        await this.placementApplicationService.withdraw(req.user.token, req.params.id)
+        const { applicationId } = req.body
+        req.flash('success', 'Placement application withdrawn')
+
+        return res.redirect(`${applyPaths.applications.show({ id: applicationId })}?tab=requestAPlacement`)
+      } catch (err) {
+        return catchValidationErrorOrPropogate(
+          req,
+          res,
+          err,
+          placementApplicationPaths.placementApplications.withdraw.new({ id: req.params.id }),
+        )
+      }
+    }
+  }
+}

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -6,6 +6,7 @@ import {
   applicationSummaryFactory,
   assessmentFactory,
   documentFactory,
+  placementApplicationFactory,
   timelineEventFactory,
 } from '../testutils/factories'
 import paths from '../paths/api'
@@ -323,6 +324,32 @@ describeClient('ApplicationClient', provider => {
       })
 
       await applicationClient.timeline(applicationId)
+    })
+  })
+
+  describe('placementApplications', () => {
+    it('calls the placement applications endpoint with the application ID', async () => {
+      const applicationId = 'applicationId'
+      const placementApplications = placementApplicationFactory.buildList(1)
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request for the placement applications of an application',
+        withRequest: {
+          method: 'GET',
+          path: paths.applications.placementApplications({ id: applicationId }),
+          headers: {
+            authorization: `Bearer ${token}`,
+            'X-Service-Name': 'approved-premises',
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: placementApplications,
+        },
+      })
+
+      await applicationClient.placementApplications(applicationId)
     })
   })
 })

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -5,6 +5,7 @@ import type {
   ApprovedPremisesAssessment as Assessment,
   Document,
   NewWithdrawal,
+  PlacementApplication,
   SubmitApprovedPremisesApplication,
   TimelineEvent,
   UpdateApprovedPremisesApplication,
@@ -78,5 +79,11 @@ export default class ApplicationClient {
     return (await this.restClient.get({
       path: paths.applications.timeline({ id: applicationId }),
     })) as Array<TimelineEvent>
+  }
+
+  async placementApplications(applicationId: string): Promise<Array<PlacementApplication>> {
+    return (await this.restClient.get({
+      path: paths.applications.placementApplications({ id: applicationId }),
+    })) as Array<PlacementApplication>
   }
 }

--- a/server/data/placementApplicationClient.test.ts
+++ b/server/data/placementApplicationClient.test.ts
@@ -153,4 +153,30 @@ describeClient('placementApplicationClient', provider => {
       expect(result).toEqual(placementApplication)
     })
   })
+
+  describe('withdraw', () => {
+    it('withdraws a placement application and returns the result', async () => {
+      const placementApplication = placementApplicationFactory.build()
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to withdraw a placement application',
+        withRequest: {
+          method: 'POST',
+          path: paths.placementApplications.withdraw({ id: placementApplication.id }),
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: placementApplication,
+        },
+      })
+
+      const result = await placementApplicationClient.withdraw(placementApplication.id)
+
+      expect(result).toEqual(placementApplication)
+    })
+  })
 })

--- a/server/data/placementApplicationClient.ts
+++ b/server/data/placementApplicationClient.ts
@@ -53,4 +53,10 @@ export default class PlacementApplicationClient {
       data: decision,
     })) as Promise<PlacementApplication>
   }
+
+  async withdraw(placementApplicationId: string): Promise<PlacementApplication> {
+    return (await this.restClient.post({
+      path: paths.placementApplications.withdraw({ id: placementApplicationId }),
+    })) as Promise<PlacementApplication>
+  }
 }

--- a/server/form-pages/apply/move-on/placementDuration.test.ts
+++ b/server/form-pages/apply/move-on/placementDuration.test.ts
@@ -70,7 +70,7 @@ describe('PlacementDuration', () => {
   describe('the previous and next page are correct', () => {
     beforeEach(() => {
       application = addResponsesToFormArtifact(application, {
-        section: 'basic-information',
+        task: 'basic-information',
         page: 'placement-date',
         keyValuePairs: { startDateSameAsReleaseDate: 'no', startDate: '2022-11-11' },
       }) as ApprovedPremisesApplication

--- a/server/form-pages/placement-application/request-a-placement/reasonForPlacement.ts
+++ b/server/form-pages/placement-application/request-a-placement/reasonForPlacement.ts
@@ -4,7 +4,7 @@ import type { PlacementType } from '@approved-premises/api'
 import TasklistPage from '../../tasklistPage'
 import { Page } from '../../utils/decorators'
 
-const reasons: Record<PlacementType, string> = {
+export const reasons: Record<PlacementType, string> = {
   release_following_decision: 'Release directed following parole board or other hearing/decision',
   rotl: 'Release on Temporary Licence (ROTL)',
   additional_placement: 'An additional placement on an existing application',

--- a/server/form-pages/placement-application/request-a-placement/updatesToApplication.ts
+++ b/server/form-pages/placement-application/request-a-placement/updatesToApplication.ts
@@ -6,6 +6,8 @@ import { yesOrNoResponseWithDetailForYes } from '../../utils'
 import TasklistPage from '../../tasklistPage'
 import { PlacementApplication } from '../../../@types/shared'
 import { applicationLink } from '../../../utils/placementRequests/applicationLink'
+import { retrieveQuestionResponseFromFormArtifact } from '../../../utils/retrieveQuestionResponseFromFormArtifact'
+import ReasonForPlacement from './reasonForPlacement'
 
 export type Body = YesOrNoWithDetail<'significantEvents'> &
   YesOrNoWithDetail<'changedCirumstances'> &
@@ -48,15 +50,36 @@ export default class UpdatesToApplication implements TasklistPage {
 
   applicationLink: string
 
+  placementApplication: PlacementApplication
+
   constructor(
     public body: Partial<Body>,
     placementApplication: PlacementApplication,
   ) {
     this.applicationLink = applicationLink(placementApplication, 'View application', 'View application')
+    this.placementApplication = placementApplication
   }
 
   previous() {
-    return 'dates-of-placement'
+    const reasonForPlacement = retrieveQuestionResponseFromFormArtifact(
+      this.placementApplication,
+      ReasonForPlacement,
+      'reason',
+    )
+
+    if (reasonForPlacement === 'rotl') {
+      return 'dates-of-placement'
+    }
+
+    if (reasonForPlacement === 'additional_placement') {
+      return 'additional-placement-details'
+    }
+
+    if (reasonForPlacement === 'release_following_decision') {
+      return 'additional-documents'
+    }
+
+    throw new Error('Unknown reason for placement')
   }
 
   next() {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -120,6 +120,7 @@ export default {
     assessment: applyPaths.applications.show.path('assessment'),
     withdrawal: applyPaths.applications.show.path('withdrawal'),
     timeline: applyPaths.applications.show.path('timeline'),
+    placementApplications: applyPaths.applications.show.path('placement-applications'),
   },
   assessments: {
     index: assessPaths.assessments,

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -162,6 +162,7 @@ export default {
     show: placementApplicationPath,
     submit: placementApplicationPath.path('submission'),
     submitDecision: placementApplicationPath.path('decision'),
+    withdraw: placementApplicationPath.path('withdraw'),
   },
   people: {
     risks: {

--- a/server/paths/placementApplications.ts
+++ b/server/paths/placementApplications.ts
@@ -21,5 +21,9 @@ export default {
       submission: placementApplicationPath.path('submission'),
       confirm: placementApplicationPath.path('confirm'),
     },
+    withdraw: {
+      new: placementApplicationPath.path('withdrawals/new'),
+      create: placementApplicationPath.path('withdrawals/create'),
+    },
   },
 }

--- a/server/routes/placementApplications.ts
+++ b/server/routes/placementApplications.ts
@@ -14,8 +14,12 @@ export default function routes(controllers: Controllers, router: Router, service
   const { get, put, post } = actions(router, services.auditService)
   const { pages } = Match
 
-  const { placementApplicationPagesController, placementRequestController, placementApplicationReviewController } =
-    controllers
+  const {
+    placementApplicationPagesController,
+    placementRequestController,
+    placementApplicationReviewController,
+    placementApplicationWithdrawalsController,
+  } = controllers
 
   post(paths.placementApplications.create.pattern, placementRequestController.create(), {
     auditEvent: 'CREATE_PLACEMENT_APPLICATION',
@@ -73,6 +77,8 @@ export default function routes(controllers: Controllers, router: Router, service
     ],
   })
   get(paths.placementApplications.review.confirm.pattern, placementApplicationReviewController.confirm())
+  get(paths.placementApplications.withdraw.new.pattern, placementApplicationWithdrawalsController.new())
+  post(paths.placementApplications.withdraw.create.pattern, placementApplicationWithdrawalsController.create())
 
   return router
 }

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -23,6 +23,7 @@ import {
   applicationSummaryFactory,
   assessmentFactory,
   documentFactory,
+  placementApplicationFactory,
 } from '../testutils/factories'
 import { TasklistPageInterface } from '../form-pages/tasklistPage'
 import { getApplicationSubmissionData, getApplicationUpdateData } from '../utils/applications/getApplicationData'
@@ -364,7 +365,7 @@ describe('ApplicationService', () => {
   })
 
   describe('withdraw', () => {
-    it('it calls the client with the ID and token', async () => {
+    it('calls the client with the ID and token', async () => {
       const token = 'some-token'
       const id = 'some-uuid'
       const body = {
@@ -380,7 +381,7 @@ describe('ApplicationService', () => {
   })
 
   describe('timeline', () => {
-    it('it calls the client with the Id and token', async () => {
+    it('calls the client with the Id and token', async () => {
       const token = 'some-token'
       const id = 'some-uuid'
 
@@ -388,6 +389,22 @@ describe('ApplicationService', () => {
 
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
       expect(applicationClient.timeline).toHaveBeenCalledWith(id)
+    })
+  })
+
+  describe('getPlacementApplications', () => {
+    it('calls the client with the id and the token and returns the result', async () => {
+      const token = 'some-token'
+      const id = 'some-uuid'
+      const placementApplications = placementApplicationFactory.buildList(1)
+      applicationClient.placementApplications.mockResolvedValue(placementApplications)
+
+      const result = await service.getPlacementApplications(token, id)
+
+      expect(result).toEqual(placementApplications)
+
+      expect(applicationClientFactory).toHaveBeenCalledWith(token)
+      expect(applicationClient.placementApplications).toHaveBeenCalledWith(id)
     })
   })
 })

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -142,4 +142,12 @@ export default class ApplicationService {
 
     return timeline
   }
+
+  async getPlacementApplications(token: string, applicationId: string) {
+    const client = this.applicationClientFactory(token)
+
+    const placementApplications = await client.placementApplications(applicationId)
+
+    return placementApplications
+  }
 }

--- a/server/services/placementApplicationService.test.ts
+++ b/server/services/placementApplicationService.test.ts
@@ -202,4 +202,16 @@ describe('placementApplicationService', () => {
       expect(result).resolves.toEqual(placementApplication)
     })
   })
+
+  describe('withdraw', () => {
+    it('calls the client method and returns the result', async () => {
+      const placementApplication = placementApplicationFactory.build()
+
+      placementApplicationClient.withdraw.mockResolvedValue(placementApplication)
+
+      const result = await service.withdraw(token, placementApplication.id)
+
+      expect(result).toEqual(placementApplication)
+    })
+  })
 })

--- a/server/services/placementApplicationService.ts
+++ b/server/services/placementApplicationService.ts
@@ -84,4 +84,10 @@ export default class PlacementApplicationService {
 
     return placementApplicationClient.decisionSubmission(placementApplicationId, decisionEnvelope)
   }
+
+  async withdraw(token: string, placementApplicationId: string) {
+    const placementApplicationClient = this.placementApplicationClientFactory(token)
+
+    return placementApplicationClient.withdraw(placementApplicationId)
+  }
 }

--- a/server/testutils/addToApplication.test.ts
+++ b/server/testutils/addToApplication.test.ts
@@ -5,13 +5,13 @@ import { applicationFactory } from './factories'
 describe('addResponseToApplication', () => {
   it('adds a key and value to the application', () => {
     const application = applicationFactory.build()
-    const response = { section: 'section', page: 'page', key: 'key', value: 'value' }
+    const response = { task: 'task', page: 'page', key: 'key', value: 'value' }
 
     const updatedApplication = addResponseToFormArtifact(application, response)
 
     expect(updatedApplication.data).toEqual({
       ...application.data,
-      [response.section]: {
+      [response.task]: {
         [response.page]: {
           [response.key]: response.value,
         },
@@ -22,14 +22,14 @@ describe('addResponseToApplication', () => {
 
 describe('addResponsesToApplication', () => {
   it('adds an object to the application', () => {
-    const application = applicationFactory.build({ data: { section: { page: {} } } })
-    const response = { section: 'section', page: 'page', keyValuePairs: { key: 'value' } }
+    const application = applicationFactory.build({ data: { task: { page: {} } } })
+    const response = { task: 'task', page: 'page', keyValuePairs: { key: 'value' } }
 
     const updatedApplication = addResponsesToFormArtifact(application, response)
 
     expect(updatedApplication.data).toEqual({
       ...application.data,
-      [response.section]: {
+      [response.task]: {
         [response.page]: {
           key: response.keyValuePairs.key,
         },

--- a/server/testutils/addToApplication.ts
+++ b/server/testutils/addToApplication.ts
@@ -2,12 +2,12 @@ import { FormArtifact } from '../@types/ui'
 
 export const addResponseToFormArtifact = <T extends FormArtifact>(
   formArtifact: T,
-  { section, page, key, value }: { section: string; page: string; key?: string; value?: unknown },
+  { task, page, key, value }: { task: string; page: string; key?: string; value?: unknown },
 ) => {
   formArtifact.data = {
     ...formArtifact.data,
-    [section]: {
-      ...formArtifact.data[section],
+    [task]: {
+      ...formArtifact.data[task],
       [page]: key && { [key]: value },
     },
   }
@@ -17,13 +17,13 @@ export const addResponseToFormArtifact = <T extends FormArtifact>(
 
 export const addResponsesToFormArtifact = <T extends FormArtifact>(
   formArtifact: T,
-  { section, page, keyValuePairs }: { section: string; page: string; keyValuePairs?: Record<string, unknown> },
+  { task, page, keyValuePairs }: { task: string; page: string; keyValuePairs?: Record<string, unknown> },
 ) => {
   formArtifact.data = {
     ...formArtifact.data,
-    [section]: {
-      ...formArtifact.data[section],
-      [page]: { ...formArtifact.data[section][page], ...keyValuePairs },
+    [task]: {
+      ...formArtifact.data[task],
+      [page]: { ...formArtifact.data[task][page], ...keyValuePairs },
     },
   }
 

--- a/server/testutils/factories/placementApplication.ts
+++ b/server/testutils/factories/placementApplication.ts
@@ -16,4 +16,5 @@ export default Factory.define<PlacementApplication>(() => ({
   submittedAt: DateFormats.dateObjToIsoDateTime(faker.date.recent()),
   data: {},
   document: {},
+  canBeWithdrawn: true,
 }))

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -12,6 +12,7 @@ import {
   timelineEventFactory,
 } from '../../testutils/factories'
 import paths from '../../paths/apply'
+import placementApplicationPaths from '../../paths/placementApplications'
 import Apply from '../../form-pages/apply'
 import Assess from '../../form-pages/assess'
 import PlacementRequest from '../../form-pages/placement-application'
@@ -37,7 +38,6 @@ import { journeyTypeFromArtifact } from '../journeyTypeFromArtifact'
 import { RestrictedPersonError } from '../errors'
 import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromFormArtifact'
 import { durationAndArrivalDateFromPlacementApplication } from '../placementRequests/placementApplicationSubmissionData'
-import placementApplication from '../../testutils/factories/placementApplication'
 
 jest.mock('../placementRequests/placementApplicationSubmissionData')
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
@@ -573,7 +573,9 @@ describe('utils', () => {
             actions: {
               items: [
                 {
-                  href: '',
+                  href: placementApplicationPaths.placementApplications.withdraw.new({
+                    id: placementApplications[0].id,
+                  }),
                   text: 'Withdraw',
                 },
               ],
@@ -607,7 +609,7 @@ describe('utils', () => {
       ])
     })
 
-    it('returns a placement application mapped to SummaryCard including an action when the placement application can be withdrawn', () => {
+    it('returns a placement application mapped to SummaryCard including an action when the placement application cannot be withdrawn', () => {
       ;(
         retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.MockedFunction<
           typeof retrieveOptionalQuestionResponseFromApplicationOrAssessment

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -154,6 +154,9 @@ PlacementRequest.pages['placement-request-page'] = {
 }
 
 describe('utils', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
   describe('dashboardTableRows', () => {
     it('returns an array of applications as table rows', async () => {
       ;(tierBadge as jest.Mock).mockReturnValue('TIER_BADGE')
@@ -353,6 +356,7 @@ describe('utils', () => {
 
   describe('firstPageOfApplicationJourney', () => {
     it('returns the sentence type page for an applicable application', () => {
+      ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
       ;(isApplicableTier as jest.Mock).mockReturnValue(true)
       const application = applicationFactory.withFullPerson().build()
 
@@ -363,6 +367,8 @@ describe('utils', () => {
 
     it('returns the is exceptional case page for an unapplicable application', () => {
       ;(isApplicableTier as jest.Mock).mockReturnValue(false)
+      ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
+
       const application = applicationFactory.withFullPerson().build()
 
       expect(firstPageOfApplicationJourney(application)).toEqual(
@@ -372,6 +378,8 @@ describe('utils', () => {
 
     it('returns the "is exceptional case" page for an application for a person without a tier', () => {
       const application = applicationFactory.withFullPerson().build()
+      ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
+
       application.risks = undefined
 
       expect(firstPageOfApplicationJourney(application)).toEqual(

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -240,7 +240,9 @@ const mapPlacementApplicationToSummaryCards = (
 
     if (placementApplication?.canBeWithdrawn) {
       actionItems.push({
-        href: '',
+        href: placementApplicationPaths.placementApplications.withdraw.new({
+          id: placementApplications[0].id,
+        }),
         text: 'Withdraw',
       })
     }
@@ -255,12 +257,7 @@ const mapPlacementApplicationToSummaryCards = (
           'data-cy-placement-application-id': placementApplication.id,
         },
         actions: {
-          items: [
-            {
-              href: '',
-              text: 'Withdraw',
-            },
-          ],
+          items: actionItems,
         },
       },
       rows: [

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -208,6 +208,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
 
   njkEnv.addGlobal('ApplyUtils', ApplyUtils)
   njkEnv.addGlobal('AssessmentUtils', AssessmentUtils)
+  njkEnv.addGlobal('ApplyUtils', ApplyUtils)
   njkEnv.addGlobal('OASysUtils', OASysUtils)
   njkEnv.addGlobal('OffenceUtils', OffenceUtils)
   njkEnv.addGlobal('AttachDocumentsUtils', AttachDocumentsUtils)

--- a/server/utils/placementRequests/checkYourAnswersUtils.test.ts
+++ b/server/utils/placementRequests/checkYourAnswersUtils.test.ts
@@ -15,7 +15,7 @@ describe('checkYourAnswersUtils', () => {
   const application = applicationFactory.build()
   let placementApplication = placementApplicationFactory.build()
   placementApplication = addResponseToFormArtifact(placementApplication, {
-    section: 'request-a-placement',
+    task: 'request-a-placement',
     page: 'same-ap',
     key: 'sameAp',
     value: 'Yes',

--- a/server/utils/placementRequests/placementApplicationSubmissionData.test.ts
+++ b/server/utils/placementRequests/placementApplicationSubmissionData.test.ts
@@ -6,7 +6,10 @@ import { pageDataFromApplicationOrAssessment } from '../../form-pages/utils'
 import { addResponseToFormArtifact, addResponsesToFormArtifact } from '../../testutils/addToApplication'
 import { applicationFactory, placementApplicationFactory } from '../../testutils/factories'
 import { placementDurationFromApplication } from '../assessments/placementDurationFromApplication'
-import { mapPlacementDateForSubmission, placementApplicationSubmissionData } from './placementApplicationSubmissionData'
+import {
+  durationAndArrivalDateFromPlacementApplication,
+  placementApplicationSubmissionData,
+} from './placementApplicationSubmissionData'
 
 jest.mock('../../form-pages/utils')
 jest.mock('../../utils/assessments/placementDurationFromApplication')
@@ -48,7 +51,7 @@ describe('placementApplicationSubmissionData', () => {
   })
 })
 
-describe('mapPlacementDateForSubmission', () => {
+describe('durationAndArrivalDateFromPlacementApplication', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
@@ -70,7 +73,9 @@ describe('mapPlacementDateForSubmission', () => {
       duration: '1',
     })
 
-    expect(mapPlacementDateForSubmission(placementApplication, 'rotl', applicationFactory.build())).toEqual({
+    expect(
+      durationAndArrivalDateFromPlacementApplication(placementApplication, 'rotl', applicationFactory.build()),
+    ).toEqual({
       expectedArrival: '2023-01-01',
       duration: 1,
     })
@@ -88,7 +93,11 @@ describe('mapPlacementDateForSubmission', () => {
     })
 
     expect(
-      mapPlacementDateForSubmission(placementApplication, 'additional_placement', applicationFactory.build()),
+      durationAndArrivalDateFromPlacementApplication(
+        placementApplication,
+        'additional_placement',
+        applicationFactory.build(),
+      ),
     ).toEqual({
       expectedArrival: '2023-01-01',
       duration: 1,
@@ -108,7 +117,11 @@ describe('mapPlacementDateForSubmission', () => {
     ;(placementDurationFromApplication as jest.Mock).mockReturnValue('1')
 
     expect(
-      mapPlacementDateForSubmission(placementApplication, 'release_following_decision', applicationFactory.build()),
+      durationAndArrivalDateFromPlacementApplication(
+        placementApplication,
+        'release_following_decision',
+        applicationFactory.build(),
+      ),
     ).toEqual({
       duration: '1',
       expectedArrival: '2023-02-12',

--- a/server/utils/placementRequests/placementApplicationSubmissionData.test.ts
+++ b/server/utils/placementRequests/placementApplicationSubmissionData.test.ts
@@ -16,13 +16,13 @@ describe('placementApplicationSubmissionData', () => {
     let placementApplication = placementApplicationFactory.build()
 
     placementApplication = addResponseToFormArtifact(placementApplication, {
-      section: 'request-a-placement',
+      task: 'request-a-placement',
       page: 'reason-for-placement',
       key: 'reason',
       value: 'rotl',
     }) as PlacementApplication
     placementApplication = addResponsesToFormArtifact(placementApplication, {
-      section: 'request-a-placement',
+      task: 'request-a-placement',
       page: 'dates-of-placement',
       keyValuePairs: {
         arrivalDate: '2023-01-01',
@@ -58,7 +58,7 @@ describe('mapPlacementDateForSubmission', () => {
       data: { 'request-a-placement': { 'reason-for-placement': { reason: 'rotl' } } },
     })
     placementApplication = addResponsesToFormArtifact(placementApplication, {
-      section: 'request-a-placement',
+      task: 'request-a-placement',
       page: 'dates-of-placement',
       keyValuePairs: {
         arrivalDate: '2023-01-01',

--- a/server/utils/placementRequests/placementApplicationSubmissionData.ts
+++ b/server/utils/placementRequests/placementApplicationSubmissionData.ts
@@ -26,11 +26,13 @@ export const placementApplicationSubmissionData = (
     translatedDocument: placementApplication.document,
     placementType: reasonForPlacement,
     // At a later date we want to support multiple placement dates, but for now we will hard code the first one
-    placementDates: [mapPlacementDateForSubmission(placementApplication, reasonForPlacement, application)],
+    placementDates: [
+      durationAndArrivalDateFromPlacementApplication(placementApplication, reasonForPlacement, application),
+    ],
   }
 }
 
-export const mapPlacementDateForSubmission = (
+export const durationAndArrivalDateFromPlacementApplication = (
   placementApplication: PlacementApplication,
   reasonForPlacement: PlacementType,
   application: Application,

--- a/server/utils/placementRequests/placementApplicationSubmissionData.ts
+++ b/server/utils/placementRequests/placementApplicationSubmissionData.ts
@@ -72,7 +72,11 @@ export const durationAndArrivalDateFromPlacementApplication = (
         duration: placementDurationFromApplication(application),
       }
     }
+
     default:
-      throw new Error(`Unknown reason for placement: ${reasonForPlacement}`)
+      return {
+        expectedArrival: '',
+        duration: '',
+      }
   }
 }

--- a/server/utils/retrieveQuestionResponseFromFormArtifact.ts
+++ b/server/utils/retrieveQuestionResponseFromFormArtifact.ts
@@ -1,7 +1,3 @@
-import {
-  ApprovedPremisesApplication as Application,
-  ApprovedPremisesAssessment as Assessment,
-} from '@approved-premises/api'
 import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
 import { getPageName, pageDataFromApplicationOrAssessment } from '../form-pages/utils'
 import { SessionDataError } from './errors'
@@ -45,7 +41,7 @@ export const retrieveQuestionResponseFromFormArtifact = (
  * @returns the response for the given page/question.
  */
 export const retrieveOptionalQuestionResponseFromApplicationOrAssessment = (
-  applicationOrAssessment: Application | Assessment,
+  applicationOrAssessment: FormArtifact,
   Page: TasklistPageInterface,
   question?: string,
 ) => {

--- a/server/views/applications/partials/_request-a-placement.njk
+++ b/server/views/applications/partials/_request-a-placement.njk
@@ -1,0 +1,20 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% macro requestAPlacement(application, user, csrfToken) %}
+    <div class="moj-page-header-actions__actions">
+        <div class="moj-button-menu">
+            <div class="moj-button-menu__wrapper">
+                {% if application.createdByUserId === user.id and application.assessmentDecision === 'accepted' %}
+                    <form action="{{paths.placementApplications.create({}) }}" method="post">
+                        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+                        <input type="hidden" name="applicationId" value="{{ application.id }}"/>
+                        {{ govukButton({
+                    text: "Create placement request"
+                  }) }}
+                    </form>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+
+    {%endmacro%}

--- a/server/views/applications/partials/_request-a-placement.njk
+++ b/server/views/applications/partials/_request-a-placement.njk
@@ -1,6 +1,8 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% macro requestAPlacement(application, user, csrfToken) %}
+{% macro requestAPlacement(placementApplications, application, user, csrfToken) %}
+
     <div class="moj-page-header-actions__actions">
         <div class="moj-button-menu">
             <div class="moj-button-menu__wrapper">
@@ -17,4 +19,23 @@
         </div>
     </div>
 
-    {%endmacro%}
+    {% set placementApplications = ApplyUtils.mapPlacementApplicationToSummaryCards(placementApplications, application) %}
+
+    {% if placementApplications.length === 0 %}
+        <div class="govuk-warning-text">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text">
+                <span class="govuk-warning-text__assistive">Warning</span>
+                There are no placement requests for this application
+            </strong>
+        </div>
+
+    {% else %}
+
+        {% for placementApplication in placementApplications %}
+            {{govukSummaryList(placementApplication)}}
+            {%endfor%}
+
+        {% endif %}
+
+        {%endmacro%}

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -75,7 +75,7 @@
       {% if tab === 'timeline' %}
         {{ timeline(mapTimelineEventsForUi(timelineEvents)) }}
       {% elif tab === 'requestAPlacement'%}
-        {{ requestAPlacement(application, user, csrfToken) }}
+        {{ requestAPlacement(placementApplications, application, user, csrfToken) }}
       {% else %}
         {{ applicationReadonlyView(application) }}
       {% endif %}

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -41,6 +41,7 @@
           </h1>
         </div>
       </div>
+      {% include "../_messages.njk" %}
 
       {% if application.assessmentDecision %}
         {% set html %}

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -4,6 +4,7 @@
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% from "./partials/_readonly-application.njk" import applicationReadonlyView %}
 {% from "./partials/_timeline.njk" import timeline %}
+{% from "./partials/_request-a-placement.njk" import requestAPlacement %}
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
 
 {% extends "../partials/layout.njk" %}
@@ -39,21 +40,6 @@
             {% endif %}
           </h1>
         </div>
-        <div class="moj-page-header-actions__actions">
-          <div class="moj-button-menu">
-            <div class="moj-button-menu__wrapper">
-              {% if application.createdByUserId === user.id and application.assessmentDecision === 'accepted' %}
-                <form action="{{paths.placementApplications.create({}) }}" method="post">
-                  <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-                  <input type="hidden" name="applicationId" value="{{ application.id }}"/>
-                  {{ govukButton({
-                    text: "Create placement request"
-                  }) }}
-                </form>
-              {% endif %}
-            </div>
-          </div>
-        </div>
       </div>
 
       {% if application.assessmentDecision %}
@@ -78,11 +64,18 @@
           text: 'Timeline',
           href:  paths.applications.show({id: application.id}) + '?tab=timeline',
           active: tab === 'timeline'
+        },
+        {
+          text: 'Request a placement',
+          href: paths.applications.show({id: application.id}) + '?tab=requestAPlacement',
+          active: tab === 'requestAPlacement'
         }]
       }) }}
 
       {% if tab === 'timeline' %}
         {{ timeline(mapTimelineEventsForUi(timelineEvents)) }}
+      {% elif tab === 'requestAPlacement'%}
+        {{ requestAPlacement(application, user, csrfToken) }}
       {% else %}
         {{ applicationReadonlyView(application) }}
       {% endif %}

--- a/server/views/placement-applications/withdraw/new.njk
+++ b/server/views/placement-applications/withdraw/new.njk
@@ -1,0 +1,39 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+		text: "Back",
+		href: paths.applications.show({ id: applicationId }) + '?tab=requestAPlacement'
+	}) }}
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {% include "../../_messages.njk" %}
+
+            <form action="{{ paths.placementApplications.withdraw.create({ id: placementApplicationId }) }}" method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+                <input type="hidden" name="applicationId" value="{{ applicationId }}"/>
+
+                {{ showErrorSummary(errorSummary) }}
+
+                <h1>{{pageHeading}}</h1>
+
+                {{ govukButton({
+                    name: 'submit',
+                    text: "Continue"
+                }) }}
+
+            </form>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
# Context
Users need to be able to withdraw placement applications (PAs). 
To do this we need to list all PAs and add a 'Withdraw' link to each one.

[Jira ticket/card](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?selectedIssue=APS-14)

# Changes in this PR
- The majority of the commits in this PR are fixing bugs and issues I spotted along the way as well as refactoring to 'make the hard work easy'.
- The final two commits are where the bulk of the action happens

## Screenshots of UI changes

### Before
![before](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/31183675-44af-4bf7-95e5-f46e23d6927f)


### After
![after-1](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/11539f49-2164-4baa-9586-0a6277f34d3b)
![after-2](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/ec696f18-635e-46b3-acc1-bd63a386bbb1)
![after-3](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/83e0ebfc-44fe-4fb1-90e1-f4dbb9238415)
