### PR TITLE
(APS 16) View all applications

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -1,9 +1,11 @@
 import { SuperAgentRequest } from 'superagent'
 
 import type {
+  ApplicationSortField,
   ApprovedPremisesApplication,
   ApprovedPremisesApplicationSummary,
   ApprovedPremisesAssessment,
+  SortDirection,
   TimelineEvent,
 } from '@approved-premises/api'
 
@@ -26,15 +28,25 @@ export default {
   stubAllApplications: ({
     applications,
     page = '1',
+    sortBy = 'createdAt',
+    sortDirection = 'asc',
   }: {
     applications: Array<ApprovedPremisesApplicationSummary>
     page: string
+    sortBy: ApplicationSortField
+    sortDirection: SortDirection
   }): SuperAgentRequest => {
     const queryParameters = {
       page: {
         equalTo: page,
       },
-    } as Record<string, unknown>
+      sortBy: {
+        equalTo: sortBy,
+      },
+      sortDirection: {
+        equalTo: sortDirection,
+      },
+    }
 
     return stubFor({
       request: {
@@ -54,7 +66,15 @@ export default {
       },
     })
   },
-  verifyDashboardRequest: async ({ page = '1' }: { page: string }) =>
+  verifyDashboardRequest: async ({
+    page = '1',
+    sortBy = 'createdAt',
+    sortDirection = 'asc',
+  }: {
+    page: string
+    sortBy: ApplicationSortField
+    sortDirection: SortDirection
+  }) =>
     (
       await getMatchingRequests({
         method: 'GET',
@@ -62,6 +82,12 @@ export default {
         queryParameters: {
           page: {
             equalTo: page,
+          },
+          sortBy: {
+            equalTo: sortBy,
+          },
+          sortDirection: {
+            equalTo: sortDirection,
           },
         },
       })

--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -23,6 +23,49 @@ export default {
         jsonBody: applications,
       },
     }),
+  stubAllApplications: ({
+    applications,
+    page = '1',
+  }: {
+    applications: Array<ApprovedPremisesApplicationSummary>
+    page: string
+  }): SuperAgentRequest => {
+    const queryParameters = {
+      page: {
+        equalTo: page,
+      },
+    } as Record<string, unknown>
+
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPathPattern: paths.applications.all.pattern,
+        queryParameters,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+          'X-Pagination-TotalPages': '10',
+          'X-Pagination-TotalResults': '100',
+          'X-Pagination-PageSize': '10',
+        },
+        jsonBody: applications,
+      },
+    })
+  },
+  verifyDashboardRequest: async ({ page = '1' }: { page: string }) =>
+    (
+      await getMatchingRequests({
+        method: 'GET',
+        urlPathPattern: paths.applications.all.pattern,
+        queryParameters: {
+          page: {
+            equalTo: page,
+          },
+        },
+      })
+    ).body.requests,
   stubApplicationCreate: (args: { application: ApprovedPremisesApplication }): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/pages/apply/dashboard.ts
+++ b/integration_tests/pages/apply/dashboard.ts
@@ -1,0 +1,21 @@
+import Page from '../page'
+import paths from '../../../server/paths/apply'
+import { ApprovedPremisesApplicationSummary } from '../../../server/@types/shared'
+import { dashboardTableRows } from '../../../server/utils/applications/utils'
+import { shouldShowTableRows } from '../../helpers'
+
+export default class DashboardPage extends Page {
+  constructor(private readonly applications: Array<ApprovedPremisesApplicationSummary>) {
+    super('Approved Premises applications')
+  }
+
+  static visit(applications: Array<ApprovedPremisesApplicationSummary>): DashboardPage {
+    cy.visit(paths.applications.dashboard.pattern)
+
+    return new DashboardPage(applications)
+  }
+
+  shouldShowApplications(): void {
+    shouldShowTableRows(this.applications, dashboardTableRows)
+  }
+}

--- a/integration_tests/tests/apply/dashboard.cy.ts
+++ b/integration_tests/tests/apply/dashboard.cy.ts
@@ -1,0 +1,54 @@
+import { applicationSummaryFactory } from '../../../server/testutils/factories'
+import DashboardPage from '../../pages/apply/dashboard'
+
+context('All applications', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+  })
+
+  it('lists all applications with pagination', () => {
+    // Given I am logged in
+    cy.signIn()
+
+    // Given there are multiple pages of applications
+    const page1Applications = applicationSummaryFactory.buildList(10)
+    const page2Applications = applicationSummaryFactory.buildList(10)
+    const page3Applications = applicationSummaryFactory.buildList(10)
+
+    cy.task('stubAllApplications', { applications: page1Applications, page: '1' })
+    cy.task('stubAllApplications', { applications: page2Applications, page: '2' })
+    cy.task('stubAllApplications', { applications: page3Applications, page: '3' })
+
+    // When I access the applications dashboard
+    const page1 = DashboardPage.visit(page1Applications)
+
+    // Then I should see the first result
+    page1.shouldShowApplications()
+
+    // When I click to see the next page
+    page1.clickNext()
+    const page2 = new DashboardPage(page2Applications)
+
+    // Then the API should have received a request for the next page
+    cy.task('verifyDashboardRequest', { page: '2' }).then(requests => {
+      expect(requests).to.have.length(1)
+    })
+
+    // And I should see the next page of applications
+    page2.shouldShowApplications()
+
+    // When I click on a page number
+    page2.clickPageNumber('3')
+    const page3 = new DashboardPage(page3Applications)
+
+    // Then the API should have received a request for the next page
+    cy.task('verifyDashboardRequest', { page: '3' }).then(requests => {
+      expect(requests).to.have.length(1)
+    })
+
+    // Then I should see the applications for that page
+    page3.shouldShowApplications()
+  })
+})

--- a/integration_tests/tests/apply/dashboard.cy.ts
+++ b/integration_tests/tests/apply/dashboard.cy.ts
@@ -51,4 +51,66 @@ context('All applications', () => {
     // Then I should see the applications for that page
     page3.shouldShowApplications()
   })
+
+  it('supports sorting by tier', () => {
+    shouldSortByField('tier')
+  })
+
+  it('supports sorting by createdAt', () => {
+    shouldSortByField('createdAt')
+  })
+
+  it('supports sorting by arrivalDate', () => {
+    shouldSortByField('arrivalDate')
+  })
+
+  const shouldSortByField = (field: string) => {
+    // Given I am logged in
+    cy.signIn()
+
+    // And there is a page of applications
+    const applications = applicationSummaryFactory.buildList(10)
+
+    cy.task('stubAllApplications', { applications, page: '1' })
+    cy.task('stubAllApplications', {
+      applications,
+      page: '1',
+      sortBy: field,
+      sortDirection: 'asc',
+    })
+    cy.task('stubAllApplications', {
+      applications,
+      page: '1',
+      sortBy: field,
+      sortDirection: 'desc',
+    })
+
+    // When I access the applications dashboard
+    const page = DashboardPage.visit(applications)
+
+    // Then I should see the first result
+    page.shouldShowApplications()
+
+    // When I sort by Tier
+    page.clickSortBy(field)
+
+    // Then the API should have received a request for the sort
+    cy.task('verifyDashboardRequest', { page: '1', sortBy: field, sortDirection: 'asc' }).then(requests => {
+      expect(requests).to.have.length.greaterThan(0)
+    })
+
+    // And the page should show the sorted items
+    page.shouldBeSortedByField(field, 'ascending')
+
+    // When I click the sort button again
+    page.clickSortBy(field)
+
+    // Then the API should have received a request for the sort
+    cy.task('verifyDashboardRequest', { page: '1', sortBy: field, sortDirection: 'desc' }).then(requests => {
+      expect(requests).to.have.length.greaterThan(0)
+    })
+
+    // And the page should show the sorted items
+    page.shouldBeSortedByField(field, 'descending')
+  }
 })

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -86,7 +86,7 @@ describe('applicationsController', () => {
       const paginationDetails = {
         hrefPrefix: paths.applications.dashboard({}),
         pageNumber: 1,
-        sortBy: 'name',
+        sortBy: 'arrivalDate',
         sortDirection: 'desc',
       }
 
@@ -103,9 +103,16 @@ describe('applicationsController', () => {
         pageNumber: Number(paginationDetails.pageNumber),
         totalPages: Number(paginatedResponse.totalPages),
         hrefPrefix: paginationDetails.hrefPrefix,
+        sortBy: paginationDetails.sortBy,
+        sortDirection: paginationDetails.sortDirection,
       })
 
-      expect(applicationService.dashboard).toHaveBeenCalledWith(token, paginationDetails.pageNumber)
+      expect(applicationService.dashboard).toHaveBeenCalledWith(
+        token,
+        paginationDetails.pageNumber,
+        paginationDetails.sortBy,
+        paginationDetails.sortDirection,
+      )
       expect(getPaginationDetails).toHaveBeenCalledWith(request, paths.applications.dashboard({}))
     })
   })

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -1,7 +1,7 @@
 import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
-import type { ErrorsAndUserInput, GroupedApplications } from '@approved-premises/ui'
+import type { ErrorsAndUserInput, GroupedApplications, PaginatedResponse } from '@approved-premises/ui'
 import TasklistService from '../../services/tasklistService'
 import ApplicationsController from './applicationsController'
 import { ApplicationService, PersonService } from '../../services'
@@ -9,6 +9,7 @@ import { addErrorMessageToFlash, fetchErrorsAndUserInput } from '../../utils/val
 import {
   activeOffenceFactory,
   applicationFactory,
+  paginatedResponseFactory,
   personFactory,
   restrictedPersonFactory,
   timelineEventFactory,
@@ -18,11 +19,14 @@ import paths from '../../paths/apply'
 import { DateFormats } from '../../utils/dateUtils'
 import { firstPageOfApplicationJourney } from '../../utils/applications/utils'
 import { getResponses } from '../../utils/applications/getResponses'
+import { ApprovedPremisesApplication } from '../../@types/shared'
+import { getPaginationDetails } from '../../utils/getPaginationDetails'
 
 jest.mock('../../utils/validation')
 jest.mock('../../utils/applications/utils')
 jest.mock('../../utils/applications/getResponses')
 jest.mock('../../services/tasklistService')
+jest.mock('../../utils/getPaginationDetails')
 
 describe('applicationsController', () => {
   const token = 'SOME_TOKEN'
@@ -70,6 +74,39 @@ describe('applicationsController', () => {
       expect(response.render).toHaveBeenCalledWith('applications/start', {
         pageHeading: 'Apply for an Approved Premises (AP) placement',
       })
+    })
+  })
+
+  describe('dashboard', () => {
+    it('calls the dashboard service with the page number and renders the results', async () => {
+      const paginatedResponse = paginatedResponseFactory.build({
+        data: applicationFactory.buildList(2),
+      }) as PaginatedResponse<ApprovedPremisesApplication>
+
+      const paginationDetails = {
+        hrefPrefix: paths.applications.dashboard({}),
+        pageNumber: 1,
+        sortBy: 'name',
+        sortDirection: 'desc',
+      }
+
+      applicationService.dashboard.mockResolvedValue(paginatedResponse)
+      ;(getPaginationDetails as jest.Mock).mockReturnValue(paginationDetails)
+
+      const requestHandler = applicationsController.dashboard()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('applications/dashboard', {
+        pageHeading: 'Approved Premises applications',
+        applications: paginatedResponse.data,
+        pageNumber: Number(paginationDetails.pageNumber),
+        totalPages: Number(paginatedResponse.totalPages),
+        hrefPrefix: paginationDetails.hrefPrefix,
+      })
+
+      expect(applicationService.dashboard).toHaveBeenCalledWith(token, paginationDetails.pageNumber)
+      expect(getPaginationDetails).toHaveBeenCalledWith(request, paths.applications.dashboard({}))
     })
   })
 

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -9,6 +9,7 @@ import { DateFormats } from '../../utils/dateUtils'
 import { firstPageOfApplicationJourney } from '../../utils/applications/utils'
 import { getResponses } from '../../utils/applications/getResponses'
 import { isFullPerson } from '../../utils/personUtils'
+import { getPaginationDetails } from '../../utils/getPaginationDetails'
 
 export const tasklistPageHeading = 'Apply for an Approved Premises (AP) placement'
 
@@ -23,6 +24,21 @@ export default class ApplicationsController {
       const applications = await this.applicationService.getAllForLoggedInUser(req.user.token)
 
       res.render('applications/index', { pageHeading: 'Approved Premises applications', applications })
+    }
+  }
+
+  dashboard(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { pageNumber, hrefPrefix } = getPaginationDetails(req, paths.applications.dashboard({}))
+      const result = await this.applicationService.dashboard(req.user.token, pageNumber)
+
+      res.render('applications/dashboard', {
+        pageHeading: 'Approved Premises applications',
+        applications: result.data,
+        pageNumber: Number(result.pageNumber),
+        totalPages: Number(result.totalPages),
+        hrefPrefix,
+      })
     }
   }
 

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -10,6 +10,7 @@ import { firstPageOfApplicationJourney } from '../../utils/applications/utils'
 import { getResponses } from '../../utils/applications/getResponses'
 import { isFullPerson } from '../../utils/personUtils'
 import { getPaginationDetails } from '../../utils/getPaginationDetails'
+import { ApplicationSortField } from '../../@types/shared'
 
 export const tasklistPageHeading = 'Apply for an Approved Premises (AP) placement'
 
@@ -29,8 +30,11 @@ export default class ApplicationsController {
 
   dashboard(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { pageNumber, hrefPrefix } = getPaginationDetails(req, paths.applications.dashboard({}))
-      const result = await this.applicationService.dashboard(req.user.token, pageNumber)
+      const { pageNumber, hrefPrefix, sortBy, sortDirection } = getPaginationDetails<ApplicationSortField>(
+        req,
+        paths.applications.dashboard({}),
+      )
+      const result = await this.applicationService.dashboard(req.user.token, pageNumber, sortBy, sortDirection)
 
       res.render('applications/dashboard', {
         pageHeading: 'Approved Premises applications',
@@ -38,6 +42,8 @@ export default class ApplicationsController {
         pageNumber: Number(result.pageNumber),
         totalPages: Number(result.totalPages),
         hrefPrefix,
+        sortBy,
+        sortDirection,
       })
     }
   }

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -168,7 +168,7 @@ describeClient('ApplicationClient', provider => {
 
       provider.addInteraction({
         state: 'Server is healthy',
-        uponReceiving: 'A request for all applications',
+        uponReceiving: 'A request for all applications for a user',
         withRequest: {
           method: 'GET',
           path: paths.applications.index.pattern,
@@ -185,6 +185,82 @@ describeClient('ApplicationClient', provider => {
       const result = await applicationClient.all()
 
       expect(result).toEqual(previousApplications)
+    })
+  })
+
+  describe('dashboard', () => {
+    it('should get all previous applications', async () => {
+      const allApplications = applicationSummaryFactory.buildList(5)
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request for all applications',
+        withRequest: {
+          method: 'GET',
+          path: paths.applications.all.pattern,
+          query: { page: '1' },
+          headers: {
+            authorization: `Bearer ${token}`,
+            'X-Service-Name': 'approved-premises',
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: allApplications,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
+        },
+      })
+
+      const result = await applicationClient.dashboard()
+
+      expect(result).toEqual({
+        data: allApplications,
+        pageNumber: '1',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
+    })
+
+    it('should pass a page number', async () => {
+      const allApplications = applicationSummaryFactory.buildList(5)
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request for all applications',
+        withRequest: {
+          method: 'GET',
+          path: paths.applications.all.pattern,
+          query: { page: '2' },
+          headers: {
+            authorization: `Bearer ${token}`,
+            'X-Service-Name': 'approved-premises',
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: allApplications,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
+        },
+      })
+
+      const result = await applicationClient.dashboard(2)
+
+      expect(result).toEqual({
+        data: allApplications,
+        pageNumber: '2',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
     })
   })
 

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -198,7 +198,7 @@ describeClient('ApplicationClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.applications.all.pattern,
-          query: { page: '1' },
+          query: { page: '1', sortBy: 'arrivalDate', sortDirection: 'asc' },
           headers: {
             authorization: `Bearer ${token}`,
             'X-Service-Name': 'approved-premises',
@@ -215,7 +215,7 @@ describeClient('ApplicationClient', provider => {
         },
       })
 
-      const result = await applicationClient.dashboard()
+      const result = await applicationClient.dashboard(1, 'arrivalDate', 'asc')
 
       expect(result).toEqual({
         data: allApplications,
@@ -235,7 +235,7 @@ describeClient('ApplicationClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.applications.all.pattern,
-          query: { page: '2' },
+          query: { page: '2', sortBy: 'createdAt', sortDirection: 'desc' },
           headers: {
             authorization: `Bearer ${token}`,
             'X-Service-Name': 'approved-premises',
@@ -252,7 +252,7 @@ describeClient('ApplicationClient', provider => {
         },
       })
 
-      const result = await applicationClient.dashboard(2)
+      const result = await applicationClient.dashboard(2, 'createdAt', 'desc')
 
       expect(result).toEqual({
         data: allApplications,

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -1,12 +1,14 @@
 import type {
   ActiveOffence,
   ApprovedPremisesApplication as Application,
+  ApplicationSortField,
   ApprovedPremisesApplicationSummary as ApplicationSummary,
   ApprovedPremisesApplicationSummary,
   ApprovedPremisesAssessment as Assessment,
   Document,
   NewWithdrawal,
   PlacementApplication,
+  SortDirection,
   SubmitApprovedPremisesApplication,
   TimelineEvent,
   UpdateApprovedPremisesApplication,
@@ -51,11 +53,15 @@ export default class ApplicationClient {
     })) as Array<ApplicationSummary>
   }
 
-  async dashboard(page = 1): Promise<PaginatedResponse<ApprovedPremisesApplicationSummary>> {
+  async dashboard(
+    page: number,
+    sortBy: ApplicationSortField,
+    sortDirection: SortDirection,
+  ): Promise<PaginatedResponse<ApprovedPremisesApplicationSummary>> {
     return this.restClient.getPaginatedResponse<ApprovedPremisesApplicationSummary>({
       path: paths.applications.all.pattern,
       page: page.toString(),
-      query: {},
+      query: { sortBy, sortDirection },
     })
   }
 

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -2,6 +2,7 @@ import type {
   ActiveOffence,
   ApprovedPremisesApplication as Application,
   ApprovedPremisesApplicationSummary as ApplicationSummary,
+  ApprovedPremisesApplicationSummary,
   ApprovedPremisesAssessment as Assessment,
   Document,
   NewWithdrawal,
@@ -13,6 +14,7 @@ import type {
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
+import { PaginatedResponse } from '../@types/ui'
 
 export default class ApplicationClient {
   restClient: RestClient
@@ -47,6 +49,14 @@ export default class ApplicationClient {
     return (await this.restClient.get({
       path: paths.applications.index.pattern,
     })) as Array<ApplicationSummary>
+  }
+
+  async dashboard(page = 1): Promise<PaginatedResponse<ApprovedPremisesApplicationSummary>> {
+    return this.restClient.getPaginatedResponse<ApprovedPremisesApplicationSummary>({
+      path: paths.applications.all.pattern,
+      page: page.toString(),
+      query: {},
+    })
   }
 
   async submit(applicationId: string, submissionData: SubmitApprovedPremisesApplication): Promise<void> {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -113,6 +113,7 @@ export default {
   applications: {
     show: applyPaths.applications.show,
     index: applyPaths.applications.index,
+    all: applyPaths.applications.index.path('all'),
     update: applyPaths.applications.update,
     new: applyPaths.applications.create,
     submission: applyPaths.applications.submission,

--- a/server/paths/apply.ts
+++ b/server/paths/apply.ts
@@ -12,6 +12,7 @@ const paths = {
   applications: {
     new: applicationsPath.path('new'),
     start: applicationsPath.path('start'),
+    dashboard: applicationsPath.path('dashboard'),
     people: {
       find: peoplePath.path('find'),
       selectOffence: personPath.path('select-offence'),

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -23,6 +23,9 @@ export default function routes(controllers: Controllers, router: Router, service
 
   get(paths.applications.start.pattern, applicationsController.start(), { auditEvent: 'START_APPLICATION' })
   get(paths.applications.index.pattern, applicationsController.index(), { auditEvent: 'LIST_APPLICATIONS' })
+  get(paths.applications.dashboard.pattern, applicationsController.dashboard(), {
+    auditEvent: 'LIST_APPLICATIONS_DASHBOARD',
+  })
   get(paths.applications.new.pattern, applicationsController.new(), { auditEvent: 'NEW_APPLICATION' })
   get(paths.applications.show.pattern, applicationsController.show(), { auditEvent: 'VIEW_APPLICATION' })
   post(paths.applications.create.pattern, applicationsController.create(), {

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -1,6 +1,6 @@
 import type { Request } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
-import type { DataServices, TaskListErrors } from '@approved-premises/ui'
+import type { DataServices, PaginatedResponse, TaskListErrors } from '@approved-premises/ui'
 import type {
   ApplicationStatus,
   ApprovedPremisesApplicationSummary,
@@ -23,6 +23,7 @@ import {
   applicationSummaryFactory,
   assessmentFactory,
   documentFactory,
+  paginatedResponseFactory,
   placementApplicationFactory,
 } from '../testutils/factories'
 import { TasklistPageInterface } from '../form-pages/tasklistPage'
@@ -361,6 +362,36 @@ describe('ApplicationService', () => {
 
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
       expect(applicationClient.assessment).toHaveBeenCalledWith(id)
+    })
+  })
+
+  describe('dashboard', () => {
+    const token = 'some-token'
+    const applications = applicationSummaryFactory.buildList(5)
+    const paginatedResponse = paginatedResponseFactory.build({
+      data: applications,
+    }) as PaginatedResponse<ApprovedPremisesApplicationSummary>
+
+    beforeEach(() => {
+      applicationClient.dashboard.mockResolvedValue(paginatedResponse)
+    })
+
+    it('calls the dashboard client method', async () => {
+      const result = await service.dashboard(token)
+
+      expect(result).toEqual(paginatedResponse)
+
+      expect(applicationClientFactory).toHaveBeenCalledWith(token)
+      expect(applicationClient.dashboard).toHaveBeenCalledWith(1)
+    })
+
+    it('passes a page number', async () => {
+      const result = await service.dashboard(token, 2)
+
+      expect(result).toEqual(paginatedResponse)
+
+      expect(applicationClientFactory).toHaveBeenCalledWith(token)
+      expect(applicationClient.dashboard).toHaveBeenCalledWith(2)
     })
   })
 

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -382,16 +382,16 @@ describe('ApplicationService', () => {
       expect(result).toEqual(paginatedResponse)
 
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
-      expect(applicationClient.dashboard).toHaveBeenCalledWith(1)
+      expect(applicationClient.dashboard).toHaveBeenCalledWith(1, 'createdAt', 'asc')
     })
 
-    it('passes a page number', async () => {
-      const result = await service.dashboard(token, 2)
+    it('passes a page number and sort options', async () => {
+      const result = await service.dashboard(token, 2, 'arrivalDate', 'desc')
 
       expect(result).toEqual(paginatedResponse)
 
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
-      expect(applicationClient.dashboard).toHaveBeenCalledWith(2)
+      expect(applicationClient.dashboard).toHaveBeenCalledWith(2, 'arrivalDate', 'desc')
     })
   })
 

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -1,8 +1,9 @@
 import type { Request } from 'express'
-import type { DataServices, GroupedApplications } from '@approved-premises/ui'
+import type { DataServices, GroupedApplications, PaginatedResponse } from '@approved-premises/ui'
 import type {
   ActiveOffence,
   ApprovedPremisesApplication,
+  ApprovedPremisesApplicationSummary,
   ApprovedPremisesAssessment as Assessment,
   Document,
   NewWithdrawal,
@@ -38,6 +39,12 @@ export default class ApplicationService {
     const application = await applicationClient.find(id)
 
     return application
+  }
+
+  async dashboard(token: string, page: number = 1): Promise<PaginatedResponse<ApprovedPremisesApplicationSummary>> {
+    const applicationClient = this.applicationClientFactory(token)
+
+    return applicationClient.dashboard(page)
   }
 
   async getAllForLoggedInUser(token: string): Promise<GroupedApplications> {

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -2,11 +2,13 @@ import type { Request } from 'express'
 import type { DataServices, GroupedApplications, PaginatedResponse } from '@approved-premises/ui'
 import type {
   ActiveOffence,
+  ApplicationSortField,
   ApprovedPremisesApplication,
   ApprovedPremisesApplicationSummary,
   ApprovedPremisesAssessment as Assessment,
   Document,
   NewWithdrawal,
+  SortDirection,
 } from '@approved-premises/api'
 
 import { updateFormArtifactData } from '../form-pages/utils/updateFormArtifactData'
@@ -41,10 +43,15 @@ export default class ApplicationService {
     return application
   }
 
-  async dashboard(token: string, page: number = 1): Promise<PaginatedResponse<ApprovedPremisesApplicationSummary>> {
+  async dashboard(
+    token: string,
+    page: number = 1,
+    sortBy: ApplicationSortField = 'createdAt',
+    sortDirection: SortDirection = 'asc',
+  ): Promise<PaginatedResponse<ApprovedPremisesApplicationSummary>> {
     const applicationClient = this.applicationClientFactory(token)
 
-    return applicationClient.dashboard(page)
+    return applicationClient.dashboard(page, sortBy, sortDirection)
   }
 
   async getAllForLoggedInUser(token: string): Promise<GroupedApplications> {

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -1,4 +1,4 @@
-import { ApplicationStatus } from '@approved-premises/api'
+import { ApplicationSortField, ApplicationStatus } from '@approved-premises/api'
 import { isAfter } from 'date-fns'
 import { mockOptionalQuestionResponse } from '../../testutils/mockQuestionResponse'
 import {
@@ -22,6 +22,7 @@ import { isApplicableTier, isFullPerson, tierBadge } from '../personUtils'
 import {
   applicationTableRows,
   createWithdrawElement,
+  dashboardTableHeader,
   dashboardTableRows,
   eventTypeTranslations,
   firstPageOfApplicationJourney,
@@ -39,6 +40,7 @@ import { journeyTypeFromArtifact } from '../journeyTypeFromArtifact'
 import { RestrictedPersonError } from '../errors'
 import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../retrieveQuestionResponseFromFormArtifact'
 import { durationAndArrivalDateFromPlacementApplication } from '../placementRequests/placementApplicationSubmissionData'
+import { sortHeader } from '../sortHeader'
 
 jest.mock('../placementRequests/placementApplicationSubmissionData')
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
@@ -274,6 +276,29 @@ describe('utils', () => {
           html: '',
         })
       })
+    })
+  })
+
+  describe('dashboardTableHeader', () => {
+    const sortBy = 'createdAt'
+    const sortDirection = 'asc'
+    const hrefPrefix = 'http://example.com'
+
+    it('returns header values', () => {
+      expect(dashboardTableHeader(sortBy, sortDirection, hrefPrefix)).toEqual([
+        {
+          text: 'Name',
+        },
+        {
+          text: 'CRN',
+        },
+        sortHeader<ApplicationSortField>('Tier', 'tier', sortBy, sortDirection, hrefPrefix),
+        sortHeader<ApplicationSortField>('Arrival Date', 'arrivalDate', sortBy, sortDirection, hrefPrefix),
+        sortHeader<ApplicationSortField>('Date of application', 'createdAt', sortBy, sortDirection, hrefPrefix),
+        {
+          text: 'Status',
+        },
+      ])
     })
   })
 

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -20,8 +20,8 @@ import { DateFormats } from '../dateUtils'
 import { isApplicableTier, isFullPerson, tierBadge } from '../personUtils'
 
 import {
+  applicationTableRows,
   createWithdrawElement,
-  dashboardTableRows,
   eventTypeTranslations,
   firstPageOfApplicationJourney,
   getApplicationType,
@@ -163,7 +163,7 @@ describe('utils', () => {
   beforeEach(() => {
     jest.resetAllMocks()
   })
-  describe('dashboardTableRows', () => {
+  describe('applicationTableRows', () => {
     it('returns an array of applications as table rows', async () => {
       ;(tierBadge as jest.Mock).mockReturnValue('TIER_BADGE')
       ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
@@ -182,7 +182,7 @@ describe('utils', () => {
         risks: { tier: tierEnvelopeFactory.build({ value: { level: null } }) },
       })
 
-      const result = dashboardTableRows([applicationA, applicationB])
+      const result = applicationTableRows([applicationA, applicationB])
 
       expect(tierBadge).toHaveBeenCalledWith('A1')
 
@@ -231,7 +231,7 @@ describe('utils', () => {
     })
   })
 
-  describe('dashboardTableRows when tier is undefined', () => {
+  describe('applicationTableRows when tier is undefined', () => {
     it('returns a blank tier badge', async () => {
       ;(tierBadge as jest.Mock).mockClear()
       ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
@@ -245,7 +245,7 @@ describe('utils', () => {
         status: 'inProgress',
       })
 
-      const result = dashboardTableRows([application])
+      const result = applicationTableRows([application])
 
       expect(tierBadge).not.toHaveBeenCalled()
 
@@ -274,7 +274,7 @@ describe('utils', () => {
     })
   })
 
-  describe('dashboardTableRows when risks is undefined', () => {
+  describe('applicationTableRows when risks is undefined', () => {
     it('returns a blank tier badge', async () => {
       ;(tierBadge as jest.Mock).mockClear()
       ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
@@ -288,7 +288,7 @@ describe('utils', () => {
         risks: undefined,
       })
 
-      const result = dashboardTableRows([application])
+      const result = applicationTableRows([application])
 
       expect(tierBadge).not.toHaveBeenCalled()
 

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -6,16 +6,19 @@ import type {
   JourneyType,
   PageResponse,
   SummaryListWithCard,
+  TableCell,
   TableRow,
   UiTimelineEvent,
 } from '@approved-premises/ui'
 import type {
   ApprovedPremisesApplication as Application,
+  ApplicationSortField,
   ApplicationStatus,
   ApprovedPremisesApplicationSummary as ApplicationSummary,
   Person,
   PlacementApplication,
   PlacementType,
+  SortDirection,
   TimelineEvent,
   TimelineEventType,
 } from '@approved-premises/api'
@@ -39,6 +42,7 @@ import ReasonForPlacement, {
   reasons as reasonsDictionary,
 } from '../../form-pages/placement-application/request-a-placement/reasonForPlacement'
 import { durationAndArrivalDateFromPlacementApplication } from '../placementRequests/placementApplicationSubmissionData'
+import { sortHeader } from '../sortHeader'
 
 const applicationTableRows = (applications: Array<ApplicationSummary>): Array<TableRow> => {
   return applications.map(application => [
@@ -49,6 +53,27 @@ const applicationTableRows = (applications: Array<ApplicationSummary>): Array<Ta
     htmlValue(getStatus(application)),
     createWithdrawElement(application.id, application),
   ])
+}
+
+const dashboardTableHeader = (
+  sortBy: ApplicationSortField,
+  sortDirection: SortDirection,
+  hrefPrefix: string,
+): Array<TableCell> => {
+  return [
+    {
+      text: 'Name',
+    },
+    {
+      text: 'CRN',
+    },
+    sortHeader<ApplicationSortField>('Tier', 'tier', sortBy, sortDirection, hrefPrefix),
+    sortHeader<ApplicationSortField>('Arrival Date', 'arrivalDate', sortBy, sortDirection, hrefPrefix),
+    sortHeader<ApplicationSortField>('Date of application', 'createdAt', sortBy, sortDirection, hrefPrefix),
+    {
+      text: 'Status',
+    },
+  ]
 }
 
 const dashboardTableRows = (applications: Array<ApplicationSummary>): Array<TableRow> => {
@@ -307,6 +332,7 @@ const lengthOfStayForUI = (duration: string) => {
 export {
   applicationTableRows,
   dashboardTableRows,
+  dashboardTableHeader,
   firstPageOfApplicationJourney,
   arrivalDateFromApplication,
   getApplicationType,

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -40,7 +40,7 @@ import ReasonForPlacement, {
 } from '../../form-pages/placement-application/request-a-placement/reasonForPlacement'
 import { durationAndArrivalDateFromPlacementApplication } from '../placementRequests/placementApplicationSubmissionData'
 
-const dashboardTableRows = (applications: Array<ApplicationSummary>): Array<TableRow> => {
+const applicationTableRows = (applications: Array<ApplicationSummary>): Array<TableRow> => {
   return applications.map(application => {
     const tier = application.risks?.tier?.value?.level
 
@@ -295,7 +295,7 @@ const lengthOfStayForUI = (duration: string) => {
 }
 
 export {
-  dashboardTableRows,
+  applicationTableRows,
   firstPageOfApplicationJourney,
   arrivalDateFromApplication,
   getApplicationType,

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -41,21 +41,31 @@ import ReasonForPlacement, {
 import { durationAndArrivalDateFromPlacementApplication } from '../placementRequests/placementApplicationSubmissionData'
 
 const applicationTableRows = (applications: Array<ApplicationSummary>): Array<TableRow> => {
-  return applications.map(application => {
-    const tier = application.risks?.tier?.value?.level
-
-    return [
-      createNameAnchorElement(application.person, application.id),
-      textValue(application.person.crn),
-      htmlValue(tier == null ? '' : tierBadge(tier)),
-      textValue(
-        application.arrivalDate ? DateFormats.isoDateToUIDate(application.arrivalDate, { format: 'short' }) : 'N/A',
-      ),
-      htmlValue(getStatus(application)),
-      createWithdrawElement(application.id, application),
-    ]
-  })
+  return applications.map(application => [
+    createNameAnchorElement(application.person, application.id),
+    textValue(application.person.crn),
+    htmlValue(getTierOrBlank(application.risks?.tier?.value?.level)),
+    textValue(getArrivalDateorNA(application.arrivalDate)),
+    htmlValue(getStatus(application)),
+    createWithdrawElement(application.id, application),
+  ])
 }
+
+const dashboardTableRows = (applications: Array<ApplicationSummary>): Array<TableRow> => {
+  return applications.map(application => [
+    createNameAnchorElement(application.person, application.id),
+    textValue(application.person.crn),
+    htmlValue(getTierOrBlank(application.risks?.tier?.value?.level)),
+    textValue(getArrivalDateorNA(application.arrivalDate)),
+    textValue(DateFormats.isoDateToUIDate(application.createdAt, { format: 'short' })),
+    htmlValue(getStatus(application)),
+  ])
+}
+
+const getTierOrBlank = (tier: string | null | undefined) => (tier ? tierBadge(tier) : '')
+
+const getArrivalDateorNA = (arrivalDate: string | null | undefined) =>
+  arrivalDate ? DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' }) : 'N/A'
 
 const statusTags: Record<ApplicationStatus, string> = {
   inProgress: `<strong class="govuk-tag govuk-tag--blue">In Progress</strong>`,
@@ -296,6 +306,7 @@ const lengthOfStayForUI = (duration: string) => {
 
 export {
   applicationTableRows,
+  dashboardTableRows,
   firstPageOfApplicationJourney,
   arrivalDateFromApplication,
   getApplicationType,

--- a/server/views/applications/_navigation.njk
+++ b/server/views/applications/_navigation.njk
@@ -1,0 +1,21 @@
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+
+{% macro navigation(activeTab) %}
+  {{
+    mojSubNavigation({
+      label: 'Sub navigation',
+      items: [
+        {
+          text: 'My Applications',
+          href: paths.applications.index({}),
+          active: (activeTab === 'myApplications' or activeTab|length === 0)
+        },
+        {
+          text: 'All Applications',
+          href: paths.applications.dashboard({}),
+          active: (activeTab === 'allApplications')
+        }
+      ]
+    })
+  }}
+{% endmacro %}

--- a/server/views/applications/dashboard.njk
+++ b/server/views/applications/dashboard.njk
@@ -1,0 +1,58 @@
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "moj/components/badge/macro.njk" import mojBadge %}
+{% from "./_navigation.njk" import navigation %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+  {% include "../_messages.njk" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+
+      <h1 class="govuk-heading-l">Approved Premises applications</h1>
+
+      {{ navigation('allApplications') }}
+
+      {{
+        govukTable({
+          caption: title,
+          captionClasses: "govuk-table__caption--m",
+          firstCellIsHeader: true,
+          head: [
+            {
+              text: "Name"
+            },
+            {
+              text: "CRN"
+            },
+            {
+              text: "Tier"
+            },
+            {
+              text: "Arrival date"
+            },
+            {
+              text: "Date of application"
+            },
+            {
+              text: "Status"
+            }
+          ],
+          rows: ApplyUtils.dashboardTableRows(applications)
+        })
+      }}
+
+      {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
+
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/server/views/applications/dashboard.njk
+++ b/server/views/applications/dashboard.njk
@@ -26,26 +26,7 @@
           caption: title,
           captionClasses: "govuk-table__caption--m",
           firstCellIsHeader: true,
-          head: [
-            {
-              text: "Name"
-            },
-            {
-              text: "CRN"
-            },
-            {
-              text: "Tier"
-            },
-            {
-              text: "Arrival date"
-            },
-            {
-              text: "Date of application"
-            },
-            {
-              text: "Status"
-            }
-          ],
+          head: ApplyUtils.dashboardTableHeader(sortBy, sortDirection, hrefPrefix),
           rows: ApplyUtils.dashboardTableRows(applications)
         })
       }}

--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -23,21 +23,21 @@
                         label: "In progress",
                         id: "applications",
                         panel: {
-                            html: applicationsTable("Applications", ApplyUtils.dashboardTableRows(applications.inProgress))
+                            html: applicationsTable("Applications", ApplyUtils.applicationTableRows(applications.inProgress))
                         }
                     },
                     {
                         label: "Further information requested",
                         id: "further-information-requested",
                         panel: {
-                            html: applicationsTable("Applications", ApplyUtils.dashboardTableRows(applications.requestedFurtherInformation))
+                            html: applicationsTable("Applications", ApplyUtils.applicationTableRows(applications.requestedFurtherInformation))
                         }
                     },
                     {
                         label: "Submitted",
                         id: "applications-submitted",
                         panel: {
-                            html: applicationsTable("Applications", ApplyUtils.dashboardTableRows(applications.submitted))
+                            html: applicationsTable("Applications", ApplyUtils.applicationTableRows(applications.submitted))
                         }
                     }
                 ]

--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -5,6 +5,7 @@
 {% from "moj/components/badge/macro.njk" import mojBadge %}
 {% from "./_table.njk" import applicationsTable %}
 {% extends "../partials/layout.njk" %}
+{% from "./_navigation.njk" import navigation %}
 
 {% set pageTitle = applicationName + " - " + pageHeading  %}
 {% set mainClasses = "app-container govuk-body" %}
@@ -16,6 +17,8 @@
         <div class="govuk-grid-column-full">
 
             <h1 class="govuk-heading-l">Approved Premises applications</h1>
+
+            {{ navigation('myApplications') }}
 
             {{ govukTabs({
                 items: [


### PR DESCRIPTION
This adds the controllers, views, services etc to allow viewing all applications as a paginated list. I've included sorting for now, but we'll be able to filter by CRN / Name and status soon too.

## Screenshot

![All applications -- lists all applications with pagination](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/5cea7424-328c-4eed-afbc-d47665c12d4c)
