### PR TITLE
Remove Offence ID when setting up applications

### DIFF
--- a/integration_tests/pages/apply/selectOffence.ts
+++ b/integration_tests/pages/apply/selectOffence.ts
@@ -12,17 +12,18 @@ export default class SelectOffencePage extends Page {
 
   shouldDisplayOffences(): void {
     this.offences.forEach((item: ActiveOffence) => {
-      cy.contains(item.offenceId)
+      cy.contains(item.offenceDescription)
+        .parent()
+        .parent()
         .parent()
         .within(() => {
-          cy.get('td').eq(2).contains(item.offenceDescription)
-          cy.get('td').eq(3).contains(DateFormats.isoDateToUIDate(item.offenceDate))
-          cy.get('td').eq(4).contains(item.convictionId)
+          cy.get('td').eq(1).contains(item.offenceDescription)
+          cy.get('td').eq(2).contains(DateFormats.isoDateToUIDate(item.offenceDate))
         })
     })
   }
 
   selectOffence(selectedOffence: ActiveOffence): void {
-    this.checkRadioByNameAndValue('offenceId', selectedOffence.offenceId)
+    this.checkRadioByNameAndId('offences', String(selectedOffence.convictionId))
   }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -104,6 +104,10 @@ export default abstract class Page {
     cy.get(`#${id}`).select(entry)
   }
 
+  checkRadioByNameAndId(name: string, id: string): void {
+    cy.get(`input[name="${name}"][id="${id}"]`).check()
+  }
+
   checkRadioByNameAndValue(name: string, option: string): void {
     cy.get(`input[name="${name}"][value="${option}"]`).check()
   }

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -93,7 +93,7 @@ context('Apply', () => {
       expect(body.crn).equal(this.person.crn)
       expect(body.convictionId).equal(selectedOffence.convictionId)
       expect(body.deliusEventNumber).equal(selectedOffence.deliusEventNumber)
-      expect(body.offenceId).equal(selectedOffence.offenceId)
+      expect(body.convictionId).equal(selectedOffence.convictionId)
     })
 
     // Then I should be on the Confirm Your Details page

--- a/integration_tests/tests/apply/personSearch.cy.ts
+++ b/integration_tests/tests/apply/personSearch.cy.ts
@@ -21,7 +21,7 @@ context('Apply - Person Search', () => {
       expect(body.crn).equal(this.person.crn)
       expect(body.convictionId).equal(offence.convictionId)
       expect(body.deliusEventNumber).equal(offence.deliusEventNumber)
-      expect(body.offenceId).equal(offence.offenceId)
+      expect(body.convictionId).equal(offence.convictionId)
     })
 
     // And I complete the basic information step

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -10,7 +10,8 @@ import { firstPageOfApplicationJourney } from '../../utils/applications/utils'
 import { getResponses } from '../../utils/applications/getResponses'
 import { isFullPerson } from '../../utils/personUtils'
 import { getPaginationDetails } from '../../utils/getPaginationDetails'
-import { ActiveOffence, ApplicationSortField } from '../../@types/shared'
+import { ApplicationSortField } from '../../@types/shared'
+import { parseOffence } from '../../utils/offenceUtils'
 
 export const tasklistPageHeading = 'Apply for an Approved Premises (AP) placement'
 
@@ -133,7 +134,7 @@ export default class ApplicationsController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { crn } = req.body
-      const offences = JSON.parse(req.body.offences) as Array<ActiveOffence>
+      const offences = parseOffence(req.body.offences)
 
       if (offences.length > 1) {
         return res.redirect(paths.applications.people.selectOffence({ crn }))

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -41,7 +41,6 @@ describeClient('ApplicationClient', provider => {
             crn: application.person.crn,
             convictionId: offence.convictionId,
             deliusEventNumber: offence.deliusEventNumber,
-            offenceId: offence.offenceId,
             type: 'CAS1',
           },
           headers: {
@@ -54,7 +53,11 @@ describeClient('ApplicationClient', provider => {
         },
       })
 
-      const result = await applicationClient.create(application.person.crn, offence)
+      const result = await applicationClient.create(
+        application.person.crn,
+        offence.convictionId,
+        offence.deliusEventNumber,
+      )
 
       expect(result).toEqual(application)
     })
@@ -81,7 +84,6 @@ describeClient('ApplicationClient', provider => {
               crn: application.person.crn,
               convictionId: offence.convictionId,
               deliusEventNumber: offence.deliusEventNumber,
-              offenceId: offence.offenceId,
               type: 'CAS1',
             },
             headers: {
@@ -94,7 +96,11 @@ describeClient('ApplicationClient', provider => {
           },
         })
 
-        const result = await applicationClient.create(application.person.crn, offence)
+        const result = await applicationClient.create(
+          application.person.crn,
+          offence.convictionId,
+          offence.deliusEventNumber,
+        )
 
         expect(result).toEqual(application)
       })

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -1,5 +1,4 @@
 import type {
-  ActiveOffence,
   ApprovedPremisesApplication as Application,
   ApplicationSortField,
   ApprovedPremisesApplicationSummary as ApplicationSummary,
@@ -31,12 +30,10 @@ export default class ApplicationClient {
     })) as Application
   }
 
-  async create(crn: string, activeOffence: ActiveOffence): Promise<Application> {
-    const { convictionId, deliusEventNumber, offenceId } = activeOffence
-
+  async create(crn: string, convictionId: number, deliusEventNumber: string): Promise<Application> {
     return (await this.restClient.post({
       path: `${paths.applications.new.pattern}?createWithRisks=${!config.flags.oasysDisabled}`,
-      data: { crn, convictionId, deliusEventNumber, offenceId, type: 'CAS1' },
+      data: { crn, convictionId, deliusEventNumber, type: 'CAS1' },
     })) as Application
   }
 

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -109,12 +109,21 @@ describe('ApplicationService', () => {
 
       applicationClient.create.mockResolvedValue(application)
 
-      const result = await service.createApplication(token, application.person.crn, offence)
+      const result = await service.createApplication(
+        token,
+        application.person.crn,
+        offence.convictionId,
+        offence.deliusEventNumber,
+      )
 
       expect(result).toEqual(application)
 
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
-      expect(applicationClient.create).toHaveBeenCalledWith(application.person.crn, offence)
+      expect(applicationClient.create).toHaveBeenCalledWith(
+        application.person.crn,
+        offence.convictionId,
+        offence.deliusEventNumber,
+      )
     })
   })
 

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -1,7 +1,6 @@
 import type { Request } from 'express'
 import type { DataServices, GroupedApplications, PaginatedResponse } from '@approved-premises/ui'
 import type {
-  ActiveOffence,
   ApplicationSortField,
   ApprovedPremisesApplication,
   ApprovedPremisesApplicationSummary,
@@ -26,11 +25,12 @@ export default class ApplicationService {
   async createApplication(
     token: string,
     crn: string,
-    activeOffence: ActiveOffence,
+    convictionId: number,
+    deliusEventNumber: string,
   ): Promise<ApprovedPremisesApplication> {
     const applicationClient = this.applicationClientFactory(token)
 
-    const application = await applicationClient.create(crn, activeOffence)
+    const application = await applicationClient.create(crn, convictionId, deliusEventNumber)
 
     return application
   }

--- a/server/utils/offenceUtils.test.ts
+++ b/server/utils/offenceUtils.test.ts
@@ -1,23 +1,26 @@
 import { DateFormats } from './dateUtils'
 
 import { offenceRadioButton, offenceTableRows } from './offenceUtils'
+import { escape } from './formUtils'
 
 import { activeOffenceFactory } from '../testutils/factories'
 
 describe('offenceUtils', () => {
   describe('offenceRadioButton', () => {
     it('returns a radio button for the offence', () => {
-      const offence = activeOffenceFactory.build({ offenceId: '123', offenceDescription: 'Description goes here' })
+      const offence = activeOffenceFactory.build({ convictionId: 123, offenceDescription: 'Description goes here' })
 
       expect(offenceRadioButton(offence)).toMatchStringIgnoringWhitespace(`
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input" id="123" name="offenceId" type="radio" value="123" />
-        <label class="govuk-label govuk-radios__label" for="123">
-          <span class="govuk-visually-hidden">
-            Select Description goes here as index offence
-          </span>
-        </label>
-      </div>
+      <input class="govuk-radios__input" id="${offence.convictionId}" name="offences" type="radio" value="[${escape(
+        JSON.stringify(offence),
+      )}]" />
+      <label class="govuk-label govuk-radios__label" for="${offence.convictionId}">
+        <span class="govuk-visually-hidden">
+          Select Description goes here as index offence
+        </span>
+      </label>
+    </div>
       `)
     })
   })
@@ -32,16 +35,10 @@ describe('offenceUtils', () => {
             html: offenceRadioButton(offences[0]),
           },
           {
-            text: offences[0].offenceId,
-          },
-          {
             text: offences[0].offenceDescription,
           },
           {
             text: DateFormats.isoDateToUIDate(offences[0].offenceDate),
-          },
-          {
-            text: String(offences[0].convictionId),
           },
         ],
         [
@@ -49,16 +46,10 @@ describe('offenceUtils', () => {
             html: offenceRadioButton(offences[1]),
           },
           {
-            text: offences[1].offenceId,
-          },
-          {
             text: offences[1].offenceDescription,
           },
           {
             text: DateFormats.isoDateToUIDate(offences[1].offenceDate),
-          },
-          {
-            text: String(offences[1].convictionId),
           },
         ],
       ])
@@ -73,16 +64,10 @@ describe('offenceUtils', () => {
             html: offenceRadioButton(offence),
           },
           {
-            text: offence.offenceId,
-          },
-          {
             text: offence.offenceDescription,
           },
           {
             text: 'No offence date available',
-          },
-          {
-            text: String(offence.convictionId),
           },
         ],
       ])

--- a/server/utils/offenceUtils.test.ts
+++ b/server/utils/offenceUtils.test.ts
@@ -1,6 +1,6 @@
 import { DateFormats } from './dateUtils'
 
-import { offenceRadioButton, offenceTableRows } from './offenceUtils'
+import { offenceRadioButton, offenceTableRows, parseOffence } from './offenceUtils'
 import { escape } from './formUtils'
 
 import { activeOffenceFactory } from '../testutils/factories'
@@ -71,6 +71,20 @@ describe('offenceUtils', () => {
           },
         ],
       ])
+    })
+  })
+
+  describe('parseOffence', () => {
+    it('should parse an array of offences', () => {
+      const offences = activeOffenceFactory.buildList(2)
+
+      expect(parseOffence(JSON.stringify(offences))).toEqual(offences)
+    })
+
+    it('should return null if the offences are not valid', () => {
+      expect(parseOffence('[]')).toEqual([])
+      expect(parseOffence('[{"foo": "bar"}]')).toEqual([])
+      expect(parseOffence('invalid json')).toEqual([])
     })
   })
 })

--- a/server/utils/offenceUtils.ts
+++ b/server/utils/offenceUtils.ts
@@ -1,6 +1,7 @@
 import { ActiveOffence } from '@approved-premises/api'
 import { TableRow } from '@approved-premises/ui'
 import { DateFormats } from './dateUtils'
+import { escape } from './formUtils'
 
 const offenceTableRows = (offences: Array<ActiveOffence>): Array<TableRow> => {
   const rows = [] as Array<TableRow>
@@ -15,16 +16,10 @@ const offenceTableRows = (offences: Array<ActiveOffence>): Array<TableRow> => {
         html: offenceRadioButton(offence),
       },
       {
-        text: offence.offenceId,
-      },
-      {
         text: offence.offenceDescription,
       },
       {
         text: offenceDate,
-      },
-      {
-        text: String(offence.convictionId),
       },
     ])
   })
@@ -35,8 +30,10 @@ const offenceTableRows = (offences: Array<ActiveOffence>): Array<TableRow> => {
 const offenceRadioButton = (offence: ActiveOffence) => {
   return `
   <div class="govuk-radios__item">
-    <input class="govuk-radios__input" id="${offence.offenceId}" name="offenceId" type="radio" value="${offence.offenceId}" />
-    <label class="govuk-label govuk-radios__label" for="${offence.offenceId}">
+    <input class="govuk-radios__input" id="${offence.convictionId}" name="offences" type="radio" value="[${escape(
+      JSON.stringify(offence),
+    )}]" />
+    <label class="govuk-label govuk-radios__label" for="${offence.convictionId}">
       <span class="govuk-visually-hidden">
         Select ${offence.offenceDescription} as index offence
       </span>

--- a/server/utils/offenceUtils.ts
+++ b/server/utils/offenceUtils.ts
@@ -42,4 +42,28 @@ const offenceRadioButton = (offence: ActiveOffence) => {
   `
 }
 
-export { offenceTableRows, offenceRadioButton }
+const parseOffence = (input: string): Array<ActiveOffence> => {
+  try {
+    const rawJson = [JSON.parse(input)].flatMap(x => x)
+    return rawJson.map(item => {
+      if (
+        'deliusEventNumber' in item &&
+        'deliusEventNumber' in item &&
+        'offenceDescription' in item &&
+        'offenceId' in item &&
+        'convictionId' in item &&
+        'offenceDate' in item
+      ) {
+        return item as ActiveOffence
+      }
+      throw new SyntaxError('Item is not an ActiveOffence')
+    })
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      return []
+    }
+    throw e
+  }
+}
+
+export { offenceTableRows, offenceRadioButton, parseOffence }

--- a/server/views/applications/people/confirm.njk
+++ b/server/views/applications/people/confirm.njk
@@ -30,7 +30,7 @@
         <input type="hidden" name="sex" value="{{ person.sex }}"/>
         <input type="hidden" name="nationality" value="{{ person.nationality }}"/>
         <input type="hidden" name="religion" value="{{ person.religion }}"/>
-        <input type="hidden" name="offenceId" value="{{ offenceId }}"/>
+        <input type="hidden" name="offences" value="{{ offences }}"/>
 
         <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
@@ -40,37 +40,34 @@
 
         {{ personDetails(person, false) }}
 
-
-
-
         {%if person.isRestricted %}
 
-        {% set html %}
+          {% set html %}
           <p class='govuk-!-font-weight-bold'>This person is a limited access offender (LAO).</p>
           <p class='govuk-!-font-weight-bold'>Central referral unit and Approved Premises staff must have access to records in order to process the application and manage the person in Approved Premises.</p>
           <p class='govuk-!-font-weight-bold'>
             <a href="https://equip-portal.equip.service.justice.gov.uk/CtrlWebIsapi.dll/?__id=webDiagram.show&map=0%3AFF2D8D3F16B44268B814F7F8177A16F7&dgm=0CCF9118DFAC43F697E66CE331889D60">Guidance for managing user access to LAOs is available on EQuiP.</a>
           </p>
-        {% endset %}
+          {% endset %}
 
           {{ govukWarningText({
-          html: html, 
+          html: html,
           iconFallbackText: "Warning"
           }) }}
-        {%endif%}
+          {%endif%}
 
-        <p>If these details are wrong, update this case in NDelius before you start.</p>
-        <p>If you've entered the wrong CRN, go back to the CRN screen.</p>
+          <p>If these details are wrong, update this case in NDelius before you start.</p>
+          <p>If you've entered the wrong CRN, go back to the CRN screen.</p>
 
-        {{ govukButton({
+          {{ govukButton({
             text: "Save and continue"
         }) }}
 
-        <p>
-          <a href="{{ paths.applications.new() }}"> Back to CRN screen </a>
-        </p>
+          <p>
+            <a href="{{ paths.applications.new() }}"> Back to CRN screen </a>
+          </p>
 
-      </form>
+        </form>
+      </div>
     </div>
-  </div>
-{% endblock %}
+  {% endblock %}

--- a/server/views/applications/people/selectOffence.njk
+++ b/server/views/applications/people/selectOffence.njk
@@ -41,16 +41,10 @@
                   html: '<span class="govuk-visually-hidden">Select offence</span>'
                 },
                 {
-                  text: "Offence ID"
-                },
-                {
                   text: "Offence description"
                 },
                 {
                   text: "Offence date"
-                },
-                {
-                  text: "Conviction ID"
                 }
               ],
               rows: OffenceUtils.offenceTableRows(offences)


### PR DESCRIPTION
This is an internal Delius ID, so isn’t relevant to us. The new AP to Delus API does not return it, so we need to tweak the new application journey.

To save all the calls to `getOffences`, we instead pass around the entire JSON object. If the size of the offences array is more than one, we redirect to a redesigned select offences screen.

We need to do a small chunk of API work to get this over the line too, so this is blocked until that's done

## Screenshot

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/639f8109-173e-4ff2-91f1-92c7ccea7cb6)
