### PR TITLE
(APS-7) Allow any user to create a placement application

### DIFF
--- a/server/views/applications/partials/_request-a-placement.njk
+++ b/server/views/applications/partials/_request-a-placement.njk
@@ -6,7 +6,7 @@
     <div class="moj-page-header-actions__actions">
         <div class="moj-button-menu">
             <div class="moj-button-menu__wrapper">
-                {% if application.createdByUserId === user.id and application.assessmentDecision === 'accepted' %}
+                {% if application.assessmentDecision === 'accepted' %}
                     <form action="{{paths.placementApplications.create({}) }}" method="post">
                         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
                         <input type="hidden" name="applicationId" value="{{ application.id }}"/>


### PR DESCRIPTION
We don’t have any safeguards in the API, so we can remove this check to allow anyone to make applications. The only slight downside is that any booking confirmations go to the original applicant, but I think this is fine for now.