### PR TITLE
APS 23 -  Add a manual note to the timeline

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -2,6 +2,7 @@ import { SuperAgentRequest } from 'superagent'
 
 import type {
   ApplicationSortField,
+  ApplicationTimelineNote,
   ApprovedPremisesApplication,
   ApprovedPremisesApplicationSummary,
   ApprovedPremisesAssessment,
@@ -218,6 +219,21 @@ export default {
         jsonBody: args.placementApplications,
       },
     }),
+  stubApplicationNote: (args: {
+    applicationId: ApprovedPremisesApplication['id']
+    note: ApplicationTimelineNote
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: paths.applications.addNote({ id: args.applicationId }),
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.note,
+      },
+    }),
 
   verifyApplicationWithdrawn: async (args: { applicationId: string }) =>
     (
@@ -245,6 +261,13 @@ export default {
       await getMatchingRequests({
         method: 'POST',
         url: `/applications/${applicationId}/submission`,
+      })
+    ).body.requests,
+  verifyApplicationNoteAdded: async (args: { id: string }) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: paths.applications.addNote({ id: args.id }),
       })
     ).body.requests,
 }

--- a/integration_tests/pages/apply/index.ts
+++ b/integration_tests/pages/apply/index.ts
@@ -30,6 +30,7 @@ import IsExceptionalCasePage from './isExceptionalCase'
 import ListPage from './list'
 import MaleApPage from './maleAp'
 import NationalSecurityDivision from './nationalSecurityDivision'
+import NotesConfirmationPage from './notesConfirmation'
 import OffenceDetailsPage from './offenceDetails'
 import OptionalOasysSectionsPage from './optionalOasysSections'
 import PlacementDurationPage from './placementDuration'
@@ -96,6 +97,7 @@ export {
   ListPage,
   MaleApPage,
   NationalSecurityDivision,
+  NotesConfirmationPage,
   OffenceDetailsPage,
   OptionalOasysSectionsPage,
   PlacementDurationPage,

--- a/integration_tests/pages/apply/notesConfirmation.ts
+++ b/integration_tests/pages/apply/notesConfirmation.ts
@@ -1,0 +1,16 @@
+import { ApplicationTimelineNote } from '../../../server/@types/shared'
+import Page from '../page'
+
+export default class ConfirmationPage extends Page {
+  constructor() {
+    super('Do you want to add this note')
+  }
+
+  shouldShowNote(note: ApplicationTimelineNote) {
+    cy.get('.govuk-inset-text').should('contain', note.note)
+  }
+
+  clickConfirm() {
+    cy.get('button').contains('Confirm').click()
+  }
+}

--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -10,7 +10,12 @@ import { DateFormats } from '../../../server/utils/dateUtils'
 import { summaryListSections } from '../../../server/utils/applications/summaryListUtils'
 
 import Page from '../page'
-import { eventTypeTranslations, mapPlacementApplicationToSummaryCards } from '../../../server/utils/applications/utils'
+import {
+  ApplicationShowPageTab,
+  applicationShowPageTab,
+  eventTypeTranslations,
+  mapPlacementApplicationToSummaryCards,
+} from '../../../server/utils/applications/utils'
 import { TextItem } from '../../../server/@types/ui'
 
 export default class ShowPage extends Page {
@@ -18,8 +23,13 @@ export default class ShowPage extends Page {
     super((application.person as FullPerson).name)
   }
 
-  static visit(application: Application) {
-    cy.visit(`/applications/${application.id}`)
+  static visit(application: Application, tab?: ApplicationShowPageTab) {
+    const path = `/applications/${application.id}`
+    if (tab) {
+      cy.visit(`${path}?${applicationShowPageTab(tab)}`)
+    } else {
+      cy.visit(path)
+    }
     return new ShowPage(application)
   }
 

--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -1,5 +1,6 @@
 import type {
   ApprovedPremisesApplication as Application,
+  ApplicationTimelineNote,
   FullPerson,
   PlacementApplication,
   TimelineEvent,
@@ -26,11 +27,20 @@ export default class ShowPage extends Page {
   static visit(application: Application, tab?: ApplicationShowPageTab) {
     const path = `/applications/${application.id}`
     if (tab) {
-      cy.visit(`${path}?${applicationShowPageTab(tab)}`)
+      cy.visit(applicationShowPageTab(application.id, tab))
     } else {
       cy.visit(path)
     }
+
     return new ShowPage(application)
+  }
+
+  enterNote(note: ApplicationTimelineNote) {
+    cy.get('textarea[name="note"]').type(note.note)
+  }
+
+  clickAddNote() {
+    cy.get('button').contains('Add note').click()
   }
 
   shouldNotShowCreatePlacementButton() {
@@ -157,5 +167,9 @@ export default class ShowPage extends Page {
 
   showsWithdrawalConfirmationMessage() {
     this.shouldShowBanner('Placement application withdrawn')
+  }
+
+  showsNoteAddedConfirmationMessage() {
+    this.shouldShowBanner('Note added')
   }
 }

--- a/integration_tests/tests/apply/viewApplication.cy.ts
+++ b/integration_tests/tests/apply/viewApplication.cy.ts
@@ -9,6 +9,7 @@ import { addResponseToFormArtifact, addResponsesToFormArtifact } from '../../../
 import { ApprovedPremisesApplication as Application, User } from '../../../server/@types/shared'
 import { defaultUserId } from '../../mockApis/auth'
 import PlacementApplicationWithdrawalConfirmationPage from '../../pages/match/placementApplicationWithdrawalConfirmationPage'
+import paths from '../../../server/paths/api'
 
 context('show applications', () => {
   beforeEach(setup)
@@ -187,6 +188,10 @@ context('show applications', () => {
 
     // Then I should see a flash confirming the note has been added
     showPage.showsNoteAddedConfirmationMessage()
+
+    // And I should see the note in the timeline
+    showPage.shouldShowTimeline(updatedTimeline)
+
     // And the API should have been called with the new note
     cy.task('verifyApplicationNoteAdded', { id: application.id }).then(requests => {
       expect(requests).to.have.length(1)

--- a/server/controllers/apply/applications/notesController.test.ts
+++ b/server/controllers/apply/applications/notesController.test.ts
@@ -1,0 +1,79 @@
+import type { NextFunction, Request, Response } from 'express'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+
+import type { ErrorsAndUserInput } from '@approved-premises/ui'
+import { ApplicationService, UserService } from '../../../services'
+import { fetchErrorsAndUserInput } from '../../../utils/validation'
+
+import NotesController from './notesController'
+import { userDetailsFactory } from '../../../testutils/factories'
+import { applicationShowPageTab } from '../../../utils/applications/utils'
+
+jest.mock('../../../utils/validation')
+
+describe('notesController', () => {
+  const token = 'SOME_TOKEN'
+
+  let request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  let response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = jest.fn()
+
+  const applicationService = createMock<ApplicationService>({})
+  const userService = createMock<UserService>({})
+
+  let notesController: NotesController
+
+  beforeEach(() => {
+    notesController = new NotesController(applicationService, userService)
+    request = createMock<Request>({ user: { token } })
+    response = createMock<Response>({})
+    jest.clearAllMocks()
+  })
+
+  describe('new', () => {
+    it('renders the template', async () => {
+      const applicationId = 'some-id'
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
+      request.params.id = applicationId
+      request.body.note = 'Some note'
+
+      const requestHandler = notesController.new()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('applications/notes/new', {
+        pageHeading: 'Do you want to add this note?',
+        applicationId,
+        note: 'Some note',
+      })
+    })
+  })
+
+  describe('create', () => {
+    const applicationId = 'some-id'
+
+    beforeEach(() => {
+      request.params.id = applicationId
+      request.body = {
+        note: 'Some note',
+      }
+    })
+
+    it('calls the service method, redirects to the index screen and shows a confirmation message', async () => {
+      const user = userDetailsFactory.build()
+      userService.getActingUser.mockResolvedValue(user)
+      const requestHandler = notesController.create()
+
+      await requestHandler(request, response, next)
+
+      expect(applicationService.addNote).toHaveBeenCalledWith(token, applicationId, {
+        note: request.body.note,
+        createdByUserId: user.id,
+      })
+      expect(userService.getActingUser).toHaveBeenCalledWith(token)
+      expect(response.redirect).toHaveBeenCalledWith(applicationShowPageTab(applicationId, 'timeline'))
+      expect(request.flash).toHaveBeenCalledWith('success', 'Note added')
+    })
+  })
+})

--- a/server/controllers/apply/applications/notesController.ts
+++ b/server/controllers/apply/applications/notesController.ts
@@ -1,0 +1,43 @@
+import type { Request, RequestHandler, Response } from 'express'
+
+import { ApplicationTimelineNote } from '../../../@types/shared'
+import { ApplicationService, UserService } from '../../../services'
+import { applicationShowPageTab } from '../../../utils/applications/utils'
+
+export const tasklistPageHeading = 'Apply for an Approved Premises (AP) placement'
+
+type NewApplicationTimelineNote = Omit<ApplicationTimelineNote, 'id' | 'createdAt'>
+
+export default class NotesController {
+  constructor(
+    private readonly applicationService: ApplicationService,
+    private readonly userService: UserService,
+  ) {}
+
+  new(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      return res.render('applications/notes/new', {
+        pageHeading: 'Do you want to add this note?',
+        applicationId: req.params.id,
+        note: req.body.note,
+      })
+    }
+  }
+
+  create(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const noteContent = req.body.note as string
+      const user = await this.userService.getActingUser(req.user.token)
+      const applicationId = req.params.id
+      const note: NewApplicationTimelineNote = {
+        note: noteContent,
+        createdByUserId: user.id,
+      }
+
+      await this.applicationService.addNote(req.user.token, applicationId, note)
+
+      req.flash('success', 'Note added')
+      return res.redirect(applicationShowPageTab(applicationId, 'timeline'))
+    }
+  }
+}

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -18,7 +18,7 @@ import {
 
 import paths from '../../paths/apply'
 import { DateFormats } from '../../utils/dateUtils'
-import { firstPageOfApplicationJourney } from '../../utils/applications/utils'
+import { applicationShowPageTabs, firstPageOfApplicationJourney } from '../../utils/applications/utils'
 import { getResponses } from '../../utils/applications/getResponses'
 import { ApprovedPremisesApplication } from '../../@types/shared'
 import { getPaginationDetails } from '../../utils/getPaginationDetails'
@@ -174,12 +174,12 @@ describe('applicationsController', () => {
         applicationService.findApplication.mockResolvedValue(application)
         applicationService.timeline.mockResolvedValue(timelineEvents)
 
-        await requestHandler({ ...request, query: { tab: 'timeline' } }, response, next)
+        await requestHandler({ ...request, query: { tab: applicationShowPageTabs.timeline } }, response, next)
 
         expect(response.render).toHaveBeenCalledWith('applications/show', {
           application,
           referrer,
-          tab: 'timeline',
+          tab: applicationShowPageTabs.timeline,
           timelineEvents,
           pageHeading: 'Approved Premises application',
         })
@@ -199,12 +199,12 @@ describe('applicationsController', () => {
         applicationService.findApplication.mockResolvedValue(application)
         applicationService.getPlacementApplications.mockResolvedValue(placementApplications)
 
-        await requestHandler({ ...request, query: { tab: 'placementRequests' } }, response, next)
+        await requestHandler({ ...request, query: { tab: applicationShowPageTabs.placementRequests } }, response, next)
 
         expect(response.render).toHaveBeenCalledWith('applications/show', {
           application,
           referrer,
-          tab: 'placementRequests',
+          tab: applicationShowPageTabs.placementRequests,
           placementApplications,
           pageHeading: 'Approved Premises application',
         })

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -6,7 +6,7 @@ import { PersonService } from '../../services'
 import { addErrorMessageToFlash, fetchErrorsAndUserInput } from '../../utils/validation'
 import paths from '../../paths/apply'
 import { DateFormats } from '../../utils/dateUtils'
-import { firstPageOfApplicationJourney } from '../../utils/applications/utils'
+import { applicationShowPageTabs, firstPageOfApplicationJourney } from '../../utils/applications/utils'
 import { getResponses } from '../../utils/applications/getResponses'
 import { isFullPerson } from '../../utils/personUtils'
 import { getPaginationDetails } from '../../utils/getPaginationDetails'
@@ -67,13 +67,13 @@ export default class ApplicationsController {
         const referrer = req.headers.referer
         const defaultParams = { application, referrer, pageHeading: 'Approved Premises application' }
 
-        if (req.query.tab === 'timeline') {
+        if (req.query.tab === applicationShowPageTabs.timeline) {
           const timelineEvents = await this.applicationService.timeline(req.user.token, application.id)
 
           return res.render('applications/show', { ...defaultParams, timelineEvents, tab: 'timeline' })
         }
 
-        if (req.query.tab === 'placementRequests') {
+        if (req.query.tab === applicationShowPageTabs.placementRequests) {
           const placementApplications = await this.applicationService.getPlacementApplications(
             req.user.token,
             application.id,

--- a/server/controllers/apply/index.ts
+++ b/server/controllers/apply/index.ts
@@ -5,6 +5,7 @@ import PagesController from './applications/pagesController'
 import OffencesController from './people/offencesController'
 import DocumentsController from './people/documentsController'
 import WithdrawalsController from './applications/withdrawalsController'
+import NotesController from './applications/notesController'
 
 import type { Services } from '../../services'
 
@@ -20,6 +21,7 @@ export const controllers = (services: Services) => {
   const offencesController = new OffencesController(personService)
   const documentsController = new DocumentsController(personService)
   const withdrawalsController = new WithdrawalsController(applicationService)
+  const notesController = new NotesController(applicationService, userService)
 
   return {
     applicationsController,
@@ -27,6 +29,7 @@ export const controllers = (services: Services) => {
     offencesController,
     documentsController,
     withdrawalsController,
+    notesController,
   }
 }
 

--- a/server/controllers/placementApplications/withdrawalsController.test.ts
+++ b/server/controllers/placementApplications/withdrawalsController.test.ts
@@ -7,9 +7,9 @@ import { PlacementApplicationService } from '../../services'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
 
 import placementApplicationPaths from '../../paths/placementApplications'
-import applyPaths from '../../paths/apply'
 import WithdrawalsController from './withdrawalsController'
 import { placementApplicationFactory } from '../../testutils/factories'
+import { applicationShowPageTab } from '../../utils/applications/utils'
 
 jest.mock('../../utils/validation')
 
@@ -68,9 +68,7 @@ describe('withdrawalsController', () => {
       await requestHandler(request, response, next)
 
       expect(placementApplicationService.withdraw).toHaveBeenCalledWith(token, placementApplicationId)
-      expect(response.redirect).toHaveBeenCalledWith(
-        `${applyPaths.applications.show({ id: applicationId })}?tab=requestAPlacement`,
-      )
+      expect(response.redirect).toHaveBeenCalledWith(applicationShowPageTab(applicationId, 'placementRequests'))
       expect(request.flash).toHaveBeenCalledWith('success', 'Placement application withdrawn')
     })
 

--- a/server/controllers/placementApplications/withdrawalsController.ts
+++ b/server/controllers/placementApplications/withdrawalsController.ts
@@ -4,8 +4,8 @@ import { PlacementApplicationService } from '../../services'
 
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
 
-import applyPaths from '../../paths/apply'
 import placementApplicationPaths from '../../paths/placementApplications'
+import { applicationShowPageTab } from '../../utils/applications/utils'
 
 export default class WithdrawlsController {
   constructor(private readonly placementApplicationService: PlacementApplicationService) {}
@@ -36,7 +36,7 @@ export default class WithdrawlsController {
         const { applicationId } = req.body
         req.flash('success', 'Placement application withdrawn')
 
-        return res.redirect(`${applyPaths.applications.show({ id: applicationId })}?tab=requestAPlacement`)
+        return res.redirect(applicationShowPageTab(applicationId, 'placementRequests'))
       } catch (err) {
         return catchValidationErrorOrPropogate(
           req,

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -6,6 +6,7 @@ import {
   applicationSummaryFactory,
   assessmentFactory,
   documentFactory,
+  noteFactory,
   placementApplicationFactory,
   timelineEventFactory,
 } from '../testutils/factories'
@@ -426,6 +427,33 @@ describeClient('ApplicationClient', provider => {
       })
 
       await applicationClient.placementApplications(applicationId)
+    })
+  })
+
+  describe('addNote', () => {
+    it('calls the notes endpoint with the note', async () => {
+      const applicationId = 'applicationId'
+      const note = noteFactory.build({ id: undefined })
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request for to add a note to an application',
+        withRequest: {
+          method: 'POST',
+          path: paths.applications.addNote({ id: applicationId }),
+          body: note,
+          headers: {
+            authorization: `Bearer ${token}`,
+            'X-Service-Name': 'approved-premises',
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: { ...note, id: 'some-uuid' },
+        },
+      })
+
+      await applicationClient.addNote(applicationId, note)
     })
   })
 })

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -3,6 +3,7 @@ import type {
   ApprovedPremisesApplication as Application,
   ApplicationSortField,
   ApprovedPremisesApplicationSummary as ApplicationSummary,
+  ApplicationTimelineNote,
   ApprovedPremisesApplicationSummary,
   ApprovedPremisesAssessment as Assessment,
   Document,
@@ -101,5 +102,12 @@ export default class ApplicationClient {
     return (await this.restClient.get({
       path: paths.applications.placementApplications({ id: applicationId }),
     })) as Array<PlacementApplication>
+  }
+
+  async addNote(applicationId: string, note: ApplicationTimelineNote): Promise<ApplicationTimelineNote> {
+    return (await this.restClient.post({
+      path: paths.applications.addNote({ id: applicationId }),
+      data: note,
+    })) as ApplicationTimelineNote
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -122,6 +122,7 @@ export default {
     withdrawal: applyPaths.applications.show.path('withdrawal'),
     timeline: applyPaths.applications.show.path('timeline'),
     placementApplications: applyPaths.applications.show.path('placement-applications'),
+    addNote: applyPaths.applications.show.path('notes'),
   },
   assessments: {
     index: assessPaths.assessments,

--- a/server/paths/apply.ts
+++ b/server/paths/apply.ts
@@ -32,6 +32,10 @@ const paths = {
       show: pagesPath,
       update: pagesPath,
     },
+    notes: {
+      new: applicationPath.path('notes/new'),
+      create: applicationPath.path('notes/create'),
+    },
   },
 }
 

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -19,6 +19,7 @@ export default function routes(controllers: Controllers, router: Router, service
     offencesController,
     documentsController,
     withdrawalsController,
+    notesController,
   } = controllers
 
   get(paths.applications.start.pattern, applicationsController.start(), { auditEvent: 'START_APPLICATION' })
@@ -46,6 +47,12 @@ export default function routes(controllers: Controllers, router: Router, service
   })
   post(paths.applications.withdraw.create.pattern, withdrawalsController.create(), {
     auditEvent: 'WITHDRAW_APPLICATION',
+  })
+  post(paths.applications.notes.new.pattern, notesController.new(), {
+    auditEvent: 'CONFIRM_NEW_NOTE',
+  })
+  post(paths.applications.notes.create.pattern, notesController.create(), {
+    auditEvent: 'CREATE_NEW_NOTE',
   })
 
   Object.keys(pages).forEach((taskKey: string) => {

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -23,6 +23,7 @@ import {
   applicationSummaryFactory,
   assessmentFactory,
   documentFactory,
+  noteFactory,
   paginatedResponseFactory,
   placementApplicationFactory,
 } from '../testutils/factories'
@@ -436,6 +437,25 @@ describe('ApplicationService', () => {
 
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
       expect(applicationClient.placementApplications).toHaveBeenCalledWith(id)
+    })
+  })
+
+  describe('addNote', () => {
+    it('calls the client with the id, token and note and returns the result', async () => {
+      const token = 'some-token'
+      const applicationId = 'some-uuid'
+      const noteId = 'note-id'
+      const newNote = noteFactory.build({ id: undefined })
+      const noteWithId = { ...newNote, id: noteId }
+
+      applicationClient.addNote.mockResolvedValue(noteWithId)
+
+      const result = await service.addNote(token, applicationId, newNote)
+
+      expect(result).toEqual(noteWithId)
+
+      expect(applicationClientFactory).toHaveBeenCalledWith(token)
+      expect(applicationClient.addNote).toHaveBeenCalledWith(applicationId, newNote)
     })
   })
 })

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -2,8 +2,9 @@ import type { Request } from 'express'
 import type { DataServices, GroupedApplications, PaginatedResponse } from '@approved-premises/ui'
 import type {
   ActiveOffence,
+  ApprovedPremisesApplication as Application,
   ApplicationSortField,
-  ApprovedPremisesApplication,
+  ApplicationTimelineNote,
   ApprovedPremisesApplicationSummary,
   ApprovedPremisesAssessment as Assessment,
   Document,
@@ -23,11 +24,7 @@ import Review from '../form-pages/apply/check-your-answers/review'
 export default class ApplicationService {
   constructor(private readonly applicationClientFactory: RestClientBuilder<ApplicationClient>) {}
 
-  async createApplication(
-    token: string,
-    crn: string,
-    activeOffence: ActiveOffence,
-  ): Promise<ApprovedPremisesApplication> {
+  async createApplication(token: string, crn: string, activeOffence: ActiveOffence): Promise<Application> {
     const applicationClient = this.applicationClientFactory(token)
 
     const application = await applicationClient.create(crn, activeOffence)
@@ -35,7 +32,7 @@ export default class ApplicationService {
     return application
   }
 
-  async findApplication(token: string, id: string): Promise<ApprovedPremisesApplication> {
+  async findApplication(token: string, id: string): Promise<Application> {
     const applicationClient = this.applicationClientFactory(token)
 
     const application = await applicationClient.find(id)
@@ -82,7 +79,7 @@ export default class ApplicationService {
     return result
   }
 
-  async getDocuments(token: string, application: ApprovedPremisesApplication): Promise<Array<Document>> {
+  async getDocuments(token: string, application: Application): Promise<Array<Document>> {
     const applicationClient = this.applicationClientFactory(token)
 
     const documents = await applicationClient.documents(application)
@@ -121,13 +118,13 @@ export default class ApplicationService {
     }
   }
 
-  async submit(token: string, application: ApprovedPremisesApplication) {
+  async submit(token: string, application: Application) {
     const client = this.applicationClientFactory(token)
 
     await client.submit(application.id, getApplicationSubmissionData(application))
   }
 
-  async getApplicationFromSessionOrAPI(request: Request): Promise<ApprovedPremisesApplication> {
+  async getApplicationFromSessionOrAPI(request: Request): Promise<Application> {
     const { application } = request.session
 
     if (application && application.id === request.params.id) {
@@ -163,5 +160,13 @@ export default class ApplicationService {
     const placementApplications = await client.placementApplications(applicationId)
 
     return placementApplications
+  }
+
+  async addNote(token: Request['user']['token'], applicationId: Application['id'], note: ApplicationTimelineNote) {
+    const client = this.applicationClientFactory(token)
+
+    const addedNote = await client.addNote(applicationId, note)
+
+    return addedNote
   }
 }

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -50,6 +50,7 @@ import {
   newPlacementRequestBookingFactory,
 } from './newPlacementRequestBooking'
 import nonArrivalFactory from './nonArrival'
+import noteFactory from './noteFactory'
 import oasysSectionsFactory, { roshSummaryFactory } from './oasysSections'
 import oasysSelectionFactory from './oasysSelection'
 import paginatedResponseFactory from './paginatedResponse'
@@ -126,6 +127,7 @@ export {
   newLostBedFactory,
   newNonArrivalFactory,
   nonArrivalFactory,
+  noteFactory,
   oasysSectionsFactory,
   oasysSelectionFactory,
   paginatedResponseFactory,

--- a/server/testutils/factories/noteFactory.ts
+++ b/server/testutils/factories/noteFactory.ts
@@ -1,0 +1,15 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { ApplicationTimelineNote } from '@approved-premises/api'
+import { DateFormats } from '../../utils/dateUtils'
+
+export default Factory.define<ApplicationTimelineNote>(() => {
+  const date = faker.date.past()
+  return {
+    id: faker.string.uuid(),
+    note: faker.lorem.paragraph(),
+    createdByUserId: faker.string.uuid(),
+    createdAt: DateFormats.dateObjToIsoDateTime(date),
+  }
+})

--- a/server/testutils/factories/timelineEvent.ts
+++ b/server/testutils/factories/timelineEvent.ts
@@ -18,7 +18,10 @@ export default Factory.define<TimelineEvent>(() => ({
     'approved_premises_booking_changed',
     'approved_premises_application_withdrawn',
     'approved_premises_information_request',
+    'application_timeline_note',
     'cas3_person_arrived',
     'cas3_person_departed',
   ] as const),
+  content: Math.random() < 0.5 ? faker.lorem.sentences() : undefined,
+  createdBy: faker.string.uuid(),
 }))

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -617,6 +617,7 @@ describe('utils', () => {
           label: {
             text: eventTypeTranslations[timelineEvents[0].type],
           },
+          content: timelineEvents[0].content,
         },
       ])
     })

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -331,6 +331,17 @@ const lengthOfStayForUI = (duration: string) => {
   return 'None supplied'
 }
 
+export const applicationShowPageTabs = {
+  application: 'application',
+  timeline: 'timeline',
+  placementRequests: 'placementRequests',
+}
+
+export type ApplicationShowPageTab = keyof typeof applicationShowPageTabs
+
+export const applicationShowPageTab = (id: Application['id'], tab: ApplicationShowPageTab) =>
+  `${paths.applications.show({ id })}?tab=${applicationShowPageTabs[tab]}`
+
 export {
   applicationTableRows,
   dashboardTableRows,

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -251,6 +251,7 @@ const mapTimelineEventsForUi = (timelineEvents: Array<TimelineEvent>): Array<UiT
           timestamp: timelineEvent.occurredAt,
           date: DateFormats.isoDateTimeToUIDateTime(timelineEvent.occurredAt),
         },
+        content: timelineEvent.content,
       }
     })
 }

--- a/server/views/applications/notes/new.njk
+++ b/server/views/applications/notes/new.njk
@@ -1,0 +1,28 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="{{ paths.applications.notes.create({ id: applicationId }) }}" method="post">
+
+                <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+                <input type="hidden" name="note" value="{{ note }}"/>
+
+                {{govukInsetText({
+                    text: note
+                })}}
+
+                {{ govukButton({
+                        name: 'submit',
+                        text: "Confirm"
+                 }) }}
+            </div>
+        </div>
+    {% endblock %}

--- a/server/views/applications/partials/_timeline.njk
+++ b/server/views/applications/partials/_timeline.njk
@@ -35,8 +35,13 @@
           <time datetime="{{event.datetime.timestamp}}">{{event.datetime.date}}</time>
         </p>
 
-      </div>
-    {% endfor %}
-  </div>
+        {% if event.content %}
+          <div class="moj-timeline__description">
+            <p>{{event.content}}</p>
+          </div>
+          {%endif%}
+        </div>
+      {% endfor %}
+    </div>
 
-{% endmacro %}
+  {% endmacro %}

--- a/server/views/applications/partials/_timeline.njk
+++ b/server/views/applications/partials/_timeline.njk
@@ -1,9 +1,27 @@
-
 {%- from "moj/components/timeline/macro.njk" import mojTimeline -%}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% macro timeline(timelineEvents) %}
+{% macro timeline(timelineEvents, application, csrfToken) %}
 
-<h2 class="govuk-heading-m">Application history</h2>
+  <form action="{{ paths.applications.notes.new({id: application.id}) }}" method="post">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+    {{ govukTextarea({
+          name: "note",
+          id: "note",
+          label: {
+            text: "Add a note to the application", 
+            classes: "govuk-label--m"
+          }
+        }) }}
+
+    {{ govukButton({
+        text: "Add note"
+    }) }}
+  </form>
+
+  <h2 class="govuk-heading-m">Application history</h2>
   <div class="moj-timeline">
 
     {% for event in timelineEvents %}
@@ -19,8 +37,6 @@
 
       </div>
     {% endfor %}
-</div>
-
-
+  </div>
 
 {% endmacro %}

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -58,23 +58,23 @@
       {{ mojSubNavigation({
         items: [{
           text: 'Application',
-          href: paths.applications.show({id: application.id}) + '?tab=application',
-          active: tab === 'application'
+          href: ApplyUtils.applicationShowPageTab(application.id, ApplyUtils.applicationShowPageTabs.application),
+          active: tab === ApplyUtils.applicationShowPageTabs.application
         }, {
           text: 'Timeline',
-          href:  paths.applications.show({id: application.id}) + '?tab=timeline',
-          active: tab === 'timeline'
+          href:  ApplyUtils.applicationShowPageTab(application.id, ApplyUtils.applicationShowPageTabs.timeline),
+          active: tab === ApplyUtils.applicationShowPageTabs.timeline
         },
         {
           text: 'Placement requests',
-          href: paths.applications.show({id: application.id}) + '?tab=placementRequests',
-          active: tab === 'placementRequests'
+          href: ApplyUtils.applicationShowPageTab(application.id, ApplyUtils.applicationShowPageTabs.placementRequests),
+          active: tab === ApplyUtils.applicationShowPageTabs.placementRequests
         }]
       }) }}
 
-      {% if tab === 'timeline' %}
-        {{ timeline(mapTimelineEventsForUi(timelineEvents)) }}
-      {% elif tab === 'placementRequests'%}
+      {% if tab === ApplyUtils.applicationShowPageTabs.timeline %}
+        {{ timeline(mapTimelineEventsForUi(timelineEvents), application, csrfToken) }}
+      {% elif tab === ApplyUtils.applicationShowPageTabs.placementRequests %}
         {{ requestAPlacement(placementApplications, application, user, csrfToken) }}
       {% else %}
         {{ applicationReadonlyView(application) }}

--- a/server/views/placement-applications/withdraw/new.njk
+++ b/server/views/placement-applications/withdraw/new.njk
@@ -11,7 +11,7 @@
 {% block beforeContent %}
     {{ govukBackLink({
 		text: "Back",
-		href: paths.applications.show({ id: applicationId }) + '?tab=requestAPlacement'
+		href: ApplyUtils.applicationShowPageTab(applicationId, ApplyUtils.applicationShowPageTabs.placementRequests)
 	}) }}
 {% endblock %}
 


### PR DESCRIPTION
# Context
Users need to be able to add notes to an application. 
This PR enables that. 

[Jira card](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?selectedIssue=APS-23)

# Changes in this PR
- Add an enum to control the tabs on the Application Show page
- Enable adding a note
- Enable showing the content of a note in the timeline

## Screenshots of UI changes

### Before
![before (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/c2403e78-86d2-4fa5-98f3-b5b4cbbab365)

### After
![after2](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/def5be4b-05a1-4cc4-8594-2f2fcf39afba)

