### PR TITLE
(APS 16) Allow searching on application dashboard

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -12,6 +12,7 @@ import type {
 
 import { getMatchingRequests, stubFor } from '../../wiremock'
 import paths from '../../server/paths/api'
+import { ApplicationDashboardSearchOptions } from '../../server/@types/ui'
 
 export default {
   stubApplications: (applications: Array<ApprovedPremisesApplicationSummary>): SuperAgentRequest =>
@@ -31,11 +32,13 @@ export default {
     page = '1',
     sortBy = 'createdAt',
     sortDirection = 'asc',
+    searchOptions = {},
   }: {
     applications: Array<ApprovedPremisesApplicationSummary>
     page: string
     sortBy: ApplicationSortField
     sortDirection: SortDirection
+    searchOptions: Partial<ApplicationDashboardSearchOptions>
   }): SuperAgentRequest => {
     const queryParameters = {
       page: {
@@ -48,6 +51,14 @@ export default {
         equalTo: sortDirection,
       },
     }
+
+    Object.keys(searchOptions).forEach(key => {
+      if (searchOptions[key]) {
+        queryParameters[key] = {
+          equalTo: searchOptions[key],
+        }
+      }
+    })
 
     return stubFor({
       request: {
@@ -71,28 +82,40 @@ export default {
     page = '1',
     sortBy = 'createdAt',
     sortDirection = 'asc',
+    searchOptions = {},
   }: {
     page: string
     sortBy: ApplicationSortField
     sortDirection: SortDirection
-  }) =>
-    (
-      await getMatchingRequests({
-        method: 'GET',
-        urlPathPattern: paths.applications.all.pattern,
-        queryParameters: {
-          page: {
-            equalTo: page,
-          },
-          sortBy: {
-            equalTo: sortBy,
-          },
-          sortDirection: {
-            equalTo: sortDirection,
-          },
-        },
-      })
-    ).body.requests,
+    searchOptions: Partial<ApplicationDashboardSearchOptions>
+  }) => {
+    const queryParameters = {
+      page: {
+        equalTo: page,
+      },
+      sortBy: {
+        equalTo: sortBy,
+      },
+      sortDirection: {
+        equalTo: sortDirection,
+      },
+    }
+    Object.keys(searchOptions).forEach(key => {
+      if (searchOptions[key]) {
+        queryParameters[key] = {
+          equalTo: searchOptions[key],
+        }
+      }
+    })
+
+    const request = await getMatchingRequests({
+      method: 'GET',
+      urlPathPattern: paths.applications.all.pattern,
+      queryParameters,
+    })
+
+    return request.body.requests
+  },
   stubApplicationCreate: (args: { application: ApprovedPremisesApplication }): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/pages/apply/dashboard.ts
+++ b/integration_tests/pages/apply/dashboard.ts
@@ -1,6 +1,6 @@
 import Page from '../page'
 import paths from '../../../server/paths/apply'
-import { ApprovedPremisesApplicationSummary } from '../../../server/@types/shared'
+import { ApprovedPremisesApplicationStatus, ApprovedPremisesApplicationSummary } from '../../../server/@types/shared'
 import { dashboardTableRows } from '../../../server/utils/applications/utils'
 import { shouldShowTableRows } from '../../helpers'
 
@@ -17,5 +17,15 @@ export default class DashboardPage extends Page {
 
   shouldShowApplications(): void {
     shouldShowTableRows(this.applications, dashboardTableRows)
+  }
+
+  searchByCrnOrName(crnOrName: string): void {
+    this.clearAndCompleteTextInputById('crnOrName', crnOrName)
+    this.clickSubmit()
+  }
+
+  searchByStatus(status: ApprovedPremisesApplicationStatus): void {
+    this.getSelectInputByIdAndSelectAnEntry('status', status)
+    this.clickSubmit()
   }
 }

--- a/integration_tests/pages/apply/list.ts
+++ b/integration_tests/pages/apply/list.ts
@@ -27,15 +27,15 @@ export default class ListPage extends Page {
   }
 
   shouldShowInProgressApplications(): void {
-    this.shouldShowApplications(this.inProgressApplications, 'In Progress')
+    this.shouldShowApplications(this.inProgressApplications, 'Application started')
   }
 
   shouldShowFurtherInformationRequestedApplications(): void {
-    this.shouldShowApplications(this.requestedFurtherInformationApplications, 'Info Request')
+    this.shouldShowApplications(this.requestedFurtherInformationApplications, 'Further information requested')
   }
 
   shouldShowSubmittedApplications(): void {
-    this.shouldShowApplications(this.submittedApplications, 'Submitted')
+    this.shouldShowApplications(this.submittedApplications, 'Application submitted')
   }
 
   clickSubmit() {

--- a/integration_tests/tests/apply/list.cy.ts
+++ b/integration_tests/tests/apply/list.cy.ts
@@ -15,7 +15,7 @@ context('Applications dashboard', () => {
     cy.signIn()
 
     // And there are applications in the database
-    const inProgressApplications = applicationSummaryFactory.buildList(5, { status: 'inProgress' })
+    const inProgressApplications = applicationSummaryFactory.buildList(5, { status: 'started' })
     const submittedApplications = applicationSummaryFactory.buildList(5, { status: 'submitted' })
     const requestedFurtherInformationApplications = applicationSummaryFactory.buildList(5, {
       status: 'requestedFurtherInformation',

--- a/integration_tests/tests/apply/withdrawApplication.cy.ts
+++ b/integration_tests/tests/apply/withdrawApplication.cy.ts
@@ -1,22 +1,22 @@
-import { ApprovedPremisesApplication as Application } from '../../../server/@types/shared'
 import { ListPage } from '../../pages/apply'
 
 import Page from '../../pages/page'
 import WithdrawApplicationPage from '../../pages/apply/withdrawApplicationPage'
 import { setup } from './setup'
+import { applicationSummaryFactory } from '../../../server/testutils/factories'
 
 context('Withdraw Application', () => {
   beforeEach(setup)
 
   it('allows me to withdraw an in progress application', function test() {
     // Given I have completed an application
-    const inProgressApplication: Application = {
-      ...this.application,
-      status: 'inProgress',
+    const inProgressApplication = applicationSummaryFactory.build({
+      id: this.application.id,
+      status: 'started',
       createdByUserId: '123',
       submittedAt: undefined,
-    }
-    cy.task('stubApplicationGet', { application: inProgressApplication })
+    })
+    cy.task('stubApplicationGet', { application: this.application })
     cy.task('stubApplications', [inProgressApplication])
     cy.task('stubApplicationWithdrawn', { applicationId: inProgressApplication.id })
 

--- a/server/@types/shared/models/ApprovedPremisesApplicationSummary.ts
+++ b/server/@types/shared/models/ApprovedPremisesApplicationSummary.ts
@@ -3,8 +3,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import type { ApplicationStatus } from './ApplicationStatus';
 import type { ApplicationSummary } from './ApplicationSummary';
+import type { ApprovedPremisesApplicationStatus } from './ApprovedPremisesApplicationStatus';
 import type { PersonRisks } from './PersonRisks';
 
 export type ApprovedPremisesApplicationSummary = (ApplicationSummary & {
@@ -15,7 +15,7 @@ export type ApprovedPremisesApplicationSummary = (ApplicationSummary & {
     arrivalDate?: string;
     risks?: PersonRisks;
     createdByUserId: string;
-    status: ApplicationStatus;
+    status: ApprovedPremisesApplicationStatus;
     tier?: string;
 });
 

--- a/server/@types/shared/models/MigrationJobType.ts
+++ b/server/@types/shared/models/MigrationJobType.ts
@@ -3,4 +3,4 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type MigrationJobType = 'update_all_users_from_community_api' | 'update_application_statuses';
+export type MigrationJobType = 'update_all_users_from_community_api';

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -2,6 +2,7 @@ import {
   Application,
   ApprovedPremisesApplicationSummary as ApplicationSummary,
   ApprovedPremisesApplication,
+  ApprovedPremisesApplicationStatus,
   ApprovedPremisesAssessment,
   ApprovedPremisesUserRole,
   ArrayOfOASysOffenceDetailsQuestions,
@@ -448,4 +449,9 @@ export type PlacementRequestDashboardSearchOptions = {
   tier?: RiskTierLevel
   arrivalDateStart?: string
   arrivalDateEnd?: string
+}
+
+export type ApplicationDashboardSearchOptions = {
+  crnOrName?: string
+  status?: ApprovedPremisesApplicationStatus
 }

--- a/server/controllers/admin/placementRequests/placementRequestsController.ts
+++ b/server/controllers/admin/placementRequests/placementRequestsController.ts
@@ -2,8 +2,9 @@ import type { Request, Response, TypedRequestHandler } from 'express'
 import { PlacementRequestService } from '../../../services'
 import { PlacementRequestSortField, PlacementRequestStatus } from '../../../@types/shared'
 import paths from '../../../paths/admin'
-import { PlacementRequestDashboardSearchOptions, RiskTierLevel } from '../../../@types/ui'
+import { PlacementRequestDashboardSearchOptions } from '../../../@types/ui'
 import { getPaginationDetails } from '../../../utils/getPaginationDetails'
+import { getSearchOptions } from '../../../utils/getSearchOptions'
 
 export default class PlacementRequestsController {
   constructor(private readonly placementRequestService: PlacementRequestService) {}
@@ -51,18 +52,12 @@ export default class PlacementRequestsController {
 
   search(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
-      const searchOptions = {} as PlacementRequestDashboardSearchOptions
-
-      searchOptions.crnOrName = req.query?.crnOrName as string
-      searchOptions.tier = req.query?.tier as RiskTierLevel
-      searchOptions.arrivalDateStart = req.query?.arrivalDateStart as string
-      searchOptions.arrivalDateEnd = req.query?.arrivalDateEnd as string
-
-      Object.keys(searchOptions).forEach(k => {
-        if (!searchOptions[k]) {
-          delete searchOptions[k]
-        }
-      })
+      const searchOptions = getSearchOptions<PlacementRequestDashboardSearchOptions>(req, [
+        'crnOrName',
+        'tier',
+        'arrivalDateStart',
+        'arrivalDateEnd',
+      ])
 
       const { pageNumber, sortBy, sortDirection, hrefPrefix } = getPaginationDetails<PlacementRequestSortField>(
         req,

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -25,7 +25,7 @@ import paths from '../../paths/apply'
 import { DateFormats } from '../../utils/dateUtils'
 import { applicationShowPageTabs, firstPageOfApplicationJourney } from '../../utils/applications/utils'
 import { getResponses } from '../../utils/applications/getResponses'
-import { ApprovedPremisesApplication } from '../../@types/shared'
+import { ApprovedPremisesApplicationSummary } from '../../@types/shared'
 import { getPaginationDetails } from '../../utils/getPaginationDetails'
 import { getSearchOptions } from '../../utils/getSearchOptions'
 import placementApplication from '../../testutils/factories/placementApplication'
@@ -91,7 +91,7 @@ describe('applicationsController', () => {
       const searchOptions = createMock<ApplicationDashboardSearchOptions>()
       const paginatedResponse = paginatedResponseFactory.build({
         data: applicationFactory.buildList(2),
-      }) as PaginatedResponse<ApprovedPremisesApplication>
+      }) as PaginatedResponse<ApprovedPremisesApplicationSummary>
 
       const paginationDetails = {
         hrefPrefix: paths.applications.dashboard({}),

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -11,6 +11,8 @@ import { getResponses } from '../../utils/applications/getResponses'
 import { isFullPerson } from '../../utils/personUtils'
 import { getPaginationDetails } from '../../utils/getPaginationDetails'
 import { ApplicationSortField } from '../../@types/shared'
+import { ApplicationDashboardSearchOptions } from '../../@types/ui'
+import { getSearchOptions } from '../../utils/getSearchOptions'
 
 export const tasklistPageHeading = 'Apply for an Approved Premises (AP) placement'
 
@@ -30,11 +32,20 @@ export default class ApplicationsController {
 
   dashboard(): RequestHandler {
     return async (req: Request, res: Response) => {
+      const searchOptions = getSearchOptions<ApplicationDashboardSearchOptions>(req, ['crnOrName', 'status'])
+
       const { pageNumber, hrefPrefix, sortBy, sortDirection } = getPaginationDetails<ApplicationSortField>(
         req,
         paths.applications.dashboard({}),
+        searchOptions,
       )
-      const result = await this.applicationService.dashboard(req.user.token, pageNumber, sortBy, sortDirection)
+      const result = await this.applicationService.dashboard(
+        req.user.token,
+        pageNumber,
+        sortBy,
+        sortDirection,
+        searchOptions,
+      )
 
       res.render('applications/dashboard', {
         pageHeading: 'Approved Premises applications',
@@ -44,6 +55,7 @@ export default class ApplicationsController {
         hrefPrefix,
         sortBy,
         sortDirection,
+        ...searchOptions,
       })
     }
   }

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -216,7 +216,7 @@ describeClient('ApplicationClient', provider => {
         },
       })
 
-      const result = await applicationClient.dashboard(1, 'arrivalDate', 'asc')
+      const result = await applicationClient.dashboard(1, 'arrivalDate', 'asc', {})
 
       expect(result).toEqual({
         data: allApplications,
@@ -253,7 +253,44 @@ describeClient('ApplicationClient', provider => {
         },
       })
 
-      const result = await applicationClient.dashboard(2, 'createdAt', 'desc')
+      const result = await applicationClient.dashboard(2, 'createdAt', 'desc', {})
+
+      expect(result).toEqual({
+        data: allApplications,
+        pageNumber: '2',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
+    })
+
+    it('should pass search options', async () => {
+      const allApplications = applicationSummaryFactory.buildList(5)
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request for all applications',
+        withRequest: {
+          method: 'GET',
+          path: paths.applications.all.pattern,
+          query: { page: '2', sortBy: 'createdAt', sortDirection: 'desc', crnOrName: 'foo', status: 'rejected' },
+          headers: {
+            authorization: `Bearer ${token}`,
+            'X-Service-Name': 'approved-premises',
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: allApplications,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
+        },
+      })
+
+      const result = await applicationClient.dashboard(2, 'createdAt', 'desc', { crnOrName: 'foo', status: 'rejected' })
 
       expect(result).toEqual({
         data: allApplications,

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -17,7 +17,7 @@ import type {
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
-import { PaginatedResponse } from '../@types/ui'
+import { ApplicationDashboardSearchOptions, PaginatedResponse } from '../@types/ui'
 
 export default class ApplicationClient {
   restClient: RestClient
@@ -58,11 +58,12 @@ export default class ApplicationClient {
     page: number,
     sortBy: ApplicationSortField,
     sortDirection: SortDirection,
+    searchOptions: ApplicationDashboardSearchOptions,
   ): Promise<PaginatedResponse<ApprovedPremisesApplicationSummary>> {
     return this.restClient.getPaginatedResponse<ApprovedPremisesApplicationSummary>({
       path: paths.applications.all.pattern,
       page: page.toString(),
-      query: { sortBy, sortDirection },
+      query: { ...searchOptions, sortBy, sortDirection },
     })
   }
 

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -383,16 +383,22 @@ describe('ApplicationService', () => {
       expect(result).toEqual(paginatedResponse)
 
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
-      expect(applicationClient.dashboard).toHaveBeenCalledWith(1, 'createdAt', 'asc')
+      expect(applicationClient.dashboard).toHaveBeenCalledWith(1, 'createdAt', 'asc', {})
     })
 
     it('passes a page number and sort options', async () => {
-      const result = await service.dashboard(token, 2, 'arrivalDate', 'desc')
+      const result = await service.dashboard(token, 2, 'arrivalDate', 'desc', {
+        crnOrName: 'foo',
+        status: 'assesmentInProgress',
+      })
 
       expect(result).toEqual(paginatedResponse)
 
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
-      expect(applicationClient.dashboard).toHaveBeenCalledWith(2, 'arrivalDate', 'desc')
+      expect(applicationClient.dashboard).toHaveBeenCalledWith(2, 'arrivalDate', 'desc', {
+        crnOrName: 'foo',
+        status: 'assesmentInProgress',
+      })
     })
   })
 

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -66,13 +66,13 @@ describe('ApplicationService', () => {
     const token = 'SOME_TOKEN'
 
     const applications: Record<ApplicationStatus, Array<ApprovedPremisesApplicationSummary>> = {
-      inProgress: applicationSummaryFactory.buildList(1, { status: 'inProgress' }),
+      inProgress: applicationSummaryFactory.buildList(1, { status: 'started' }),
       requestedFurtherInformation: applicationSummaryFactory.buildList(1, { status: 'requestedFurtherInformation' }),
       submitted: applicationSummaryFactory.buildList(1, { status: 'submitted' }),
-      pending: applicationSummaryFactory.buildList(1, { status: 'pending' }),
+      pending: applicationSummaryFactory.buildList(1, { status: 'assesmentInProgress' }),
       rejected: applicationSummaryFactory.buildList(1, { status: 'rejected' }),
       awaitingPlacement: applicationSummaryFactory.buildList(1, { status: 'awaitingPlacement' }),
-      placed: applicationSummaryFactory.buildList(1, { status: 'placed' }),
+      placed: applicationSummaryFactory.buildList(1, { status: 'placementAllocated' }),
       inapplicable: applicationSummaryFactory.buildList(1, { status: 'inapplicable' }),
       withdrawn: applicationSummaryFactory.buildList(1, { status: 'withdrawn' }),
     }

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -69,7 +69,7 @@ export default class ApplicationService {
     await Promise.all(
       allApplications.map(async application => {
         switch (application.status) {
-          case 'inProgress':
+          case 'started':
             result.inProgress.push(application)
             break
           case 'requestedFurtherInformation':

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -1,5 +1,10 @@
 import type { Request } from 'express'
-import type { DataServices, GroupedApplications, PaginatedResponse } from '@approved-premises/ui'
+import type {
+  ApplicationDashboardSearchOptions,
+  DataServices,
+  GroupedApplications,
+  PaginatedResponse,
+} from '@approved-premises/ui'
 import type {
   ActiveOffence,
   ApprovedPremisesApplication as Application,
@@ -45,10 +50,11 @@ export default class ApplicationService {
     page: number = 1,
     sortBy: ApplicationSortField = 'createdAt',
     sortDirection: SortDirection = 'asc',
+    searchOptions: ApplicationDashboardSearchOptions = {},
   ): Promise<PaginatedResponse<ApprovedPremisesApplicationSummary>> {
     const applicationClient = this.applicationClientFactory(token)
 
-    return applicationClient.dashboard(page, sortBy, sortDirection)
+    return applicationClient.dashboard(page, sortBy, sortDirection, searchOptions)
   }
 
   async getAllForLoggedInUser(token: string): Promise<GroupedApplications> {

--- a/server/testutils/factories/applicationSummary.ts
+++ b/server/testutils/factories/applicationSummary.ts
@@ -17,5 +17,5 @@ export default Factory.define<ApplicationSummary>(() => ({
   arrivalDate: DateFormats.dateObjToIsoDate(faker.date.soon()),
   risks: risksFactory.build(),
   createdByUserId: faker.string.uuid(),
-  status: 'inProgress',
+  status: 'started',
 }))

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -1,4 +1,4 @@
-import { ApplicationSortField, ApplicationStatus } from '@approved-premises/api'
+import { ApplicationSortField, ApprovedPremisesApplicationStatus } from '@approved-premises/api'
 import { isAfter } from 'date-fns'
 import { mockOptionalQuestionResponse } from '../../testutils/mockQuestionResponse'
 import {
@@ -22,6 +22,7 @@ import { isApplicableTier, isFullPerson, tierBadge } from '../personUtils'
 
 import {
   applicationStatusSelectOptions,
+  applicationStatuses,
   applicationTableRows,
   createWithdrawElement,
   dashboardTableHeader,
@@ -246,7 +247,7 @@ describe('utils', () => {
           arrivalDate,
           person,
           risks: { tier: undefined },
-          status: 'inProgress',
+          status: 'started',
         })
 
         const result = applicationTableRows([application])
@@ -385,7 +386,7 @@ describe('utils', () => {
           arrivalDate,
           person,
           risks: { tier: undefined },
-          status: 'inProgress',
+          status: 'started',
         })
 
         const result = dashboardTableRows([application])
@@ -420,13 +421,32 @@ describe('utils', () => {
     })
   })
 
+  describe('statusTags', () => {
+    it('should return a list of tags for each status', () => {
+      expect(statusTags()).toEqual({
+        assesmentInProgress: '<strong class="govuk-tag govuk-tag--blue">Assessment in progress</strong>',
+        awaitingAssesment: '<strong class="govuk-tag govuk-tag--blue">Awaiting assessment</strong>',
+        awaitingPlacement: '<strong class="govuk-tag govuk-tag--blue">Awaiting placement</strong>',
+        inapplicable: '<strong class="govuk-tag govuk-tag--red">Application inapplicable</strong>',
+        placementAllocated: '<strong class="govuk-tag govuk-tag--pink">Placement allocated</strong>',
+        rejected: '<strong class="govuk-tag govuk-tag--red">Application rejected</strong>',
+        requestedFurtherInformation:
+          '<strong class="govuk-tag govuk-tag--yellow">Further information requested</strong>',
+        started: '<strong class="govuk-tag govuk-tag--blue">Application started</strong>',
+        submitted: '<strong class="govuk-tag govuk-tag--">Application submitted</strong>',
+        unallocatedAssesment: '<strong class="govuk-tag govuk-tag--blue">Unallocated assessment</strong>',
+        withdrawn: '<strong class="govuk-tag govuk-tag--red">Application withdrawn</strong>',
+      })
+    })
+  })
+
   describe('getStatus', () => {
-    const statuses = Object.keys(statusTags) as Array<ApplicationStatus>
+    const statuses = Object.keys(applicationStatuses) as Array<ApprovedPremisesApplicationStatus>
 
     statuses.forEach(status => {
       it(`returns the correct tag for each an application with a status of ${status}`, () => {
-        const application = applicationFactory.build({ status })
-        expect(getStatus(application)).toEqual(statusTags[status])
+        const application = applicationSummaryFactory.build({ status })
+        expect(getStatus(application)).toEqual(statusTags()[status])
       })
     })
   })
@@ -579,12 +599,14 @@ describe('utils', () => {
   })
 
   describe('createWithdrawElement', () => {
-    const withdrawalableApplicationStatues: Array<ApplicationStatus> = [
+    const withdrawalableApplicationStatues: Array<ApprovedPremisesApplicationStatus> = [
       'awaitingPlacement',
-      'inProgress',
-      'pending',
-      'requestedFurtherInformation',
+      'started',
       'submitted',
+      'awaitingAssesment',
+      'unallocatedAssesment',
+      'requestedFurtherInformation',
+      'assesmentInProgress',
     ]
 
     it.each(withdrawalableApplicationStatues)(
@@ -838,9 +860,9 @@ describe('utils', () => {
     it('should return select options for tiers with the all tiers option selected by default', () => {
       expect(applicationStatusSelectOptions(null)).toEqual([
         { selected: true, text: 'All statuses', value: '' },
-        { selected: false, text: 'Application Started', value: 'started' },
-        { selected: false, text: 'Application Submitted', value: 'submitted' },
-        { selected: false, text: 'Application Rejected', value: 'rejected' },
+        { selected: false, text: 'Application started', value: 'started' },
+        { selected: false, text: 'Application submitted', value: 'submitted' },
+        { selected: false, text: 'Application rejected', value: 'rejected' },
         { selected: false, text: 'Awaiting assessment', value: 'awaitingAssesment' },
         { selected: false, text: 'Unallocated assessment', value: 'unallocatedAssesment' },
         { selected: false, text: 'Assessment in progress', value: 'assesmentInProgress' },
@@ -855,9 +877,9 @@ describe('utils', () => {
     it('should return the selected status if provided', () => {
       expect(applicationStatusSelectOptions('awaitingPlacement')).toEqual([
         { selected: false, text: 'All statuses', value: '' },
-        { selected: false, text: 'Application Started', value: 'started' },
-        { selected: false, text: 'Application Submitted', value: 'submitted' },
-        { selected: false, text: 'Application Rejected', value: 'rejected' },
+        { selected: false, text: 'Application started', value: 'started' },
+        { selected: false, text: 'Application submitted', value: 'submitted' },
+        { selected: false, text: 'Application rejected', value: 'rejected' },
         { selected: false, text: 'Awaiting assessment', value: 'awaitingAssesment' },
         { selected: false, text: 'Unallocated assessment', value: 'unallocatedAssesment' },
         { selected: false, text: 'Assessment in progress', value: 'assesmentInProgress' },

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -21,6 +21,7 @@ import { DateFormats } from '../dateUtils'
 import { isApplicableTier, isFullPerson, tierBadge } from '../personUtils'
 
 import {
+  applicationStatusSelectOptions,
   applicationTableRows,
   createWithdrawElement,
   dashboardTableHeader,
@@ -830,6 +831,42 @@ describe('utils', () => {
 
     it('returns "None supplied if the length of stay is an empty string', () => {
       expect(lengthOfStayForUI('')).toEqual('None supplied')
+    })
+  })
+
+  describe('applicationStatusSelectOptions', () => {
+    it('should return select options for tiers with the all tiers option selected by default', () => {
+      expect(applicationStatusSelectOptions(null)).toEqual([
+        { selected: true, text: 'All statuses', value: '' },
+        { selected: false, text: 'Application Started', value: 'started' },
+        { selected: false, text: 'Application Submitted', value: 'submitted' },
+        { selected: false, text: 'Application Rejected', value: 'rejected' },
+        { selected: false, text: 'Awaiting assessment', value: 'awaitingAssesment' },
+        { selected: false, text: 'Unallocated assessment', value: 'unallocatedAssesment' },
+        { selected: false, text: 'Assessment in progress', value: 'assesmentInProgress' },
+        { selected: false, text: 'Awaiting placement', value: 'awaitingPlacement' },
+        { selected: false, text: 'Placement allocated', value: 'placementAllocated' },
+        { selected: false, text: 'Application inapplicable', value: 'inapplicable' },
+        { selected: false, text: 'Application withdrawn', value: 'withdrawn' },
+        { selected: false, text: 'Further information requested', value: 'requestedFurtherInformation' },
+      ])
+    })
+
+    it('should return the selected status if provided', () => {
+      expect(applicationStatusSelectOptions('awaitingPlacement')).toEqual([
+        { selected: false, text: 'All statuses', value: '' },
+        { selected: false, text: 'Application Started', value: 'started' },
+        { selected: false, text: 'Application Submitted', value: 'submitted' },
+        { selected: false, text: 'Application Rejected', value: 'rejected' },
+        { selected: false, text: 'Awaiting assessment', value: 'awaitingAssesment' },
+        { selected: false, text: 'Unallocated assessment', value: 'unallocatedAssesment' },
+        { selected: false, text: 'Assessment in progress', value: 'assesmentInProgress' },
+        { selected: true, text: 'Awaiting placement', value: 'awaitingPlacement' },
+        { selected: false, text: 'Placement allocated', value: 'placementAllocated' },
+        { selected: false, text: 'Application inapplicable', value: 'inapplicable' },
+        { selected: false, text: 'Application withdrawn', value: 'withdrawn' },
+        { selected: false, text: 'Further information requested', value: 'requestedFurtherInformation' },
+      ])
     })
   })
 })

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -14,7 +14,6 @@ import type {
 import type {
   ApprovedPremisesApplication as Application,
   ApplicationSortField,
-  ApplicationStatus,
   ApprovedPremisesApplicationSummary as ApplicationSummary,
   ApprovedPremisesApplicationStatus,
   Person,
@@ -46,6 +45,20 @@ import ReasonForPlacement, {
 } from '../../form-pages/placement-application/request-a-placement/reasonForPlacement'
 import { durationAndArrivalDateFromPlacementApplication } from '../placementRequests/placementApplicationSubmissionData'
 import { sortHeader } from '../sortHeader'
+
+const applicationStatuses: Record<ApprovedPremisesApplicationStatus, string> = {
+  started: 'Application started',
+  submitted: 'Application submitted',
+  rejected: 'Application rejected',
+  awaitingAssesment: 'Awaiting assessment',
+  unallocatedAssesment: 'Unallocated assessment',
+  assesmentInProgress: 'Assessment in progress',
+  awaitingPlacement: 'Awaiting placement',
+  placementAllocated: 'Placement allocated',
+  inapplicable: 'Application inapplicable',
+  withdrawn: 'Application withdrawn',
+  requestedFurtherInformation: 'Further information requested',
+}
 
 const applicationTableRows = (applications: Array<ApplicationSummary>): Array<TableRow> => {
   return applications.map(application => [
@@ -95,20 +108,31 @@ const getTierOrBlank = (tier: string | null | undefined) => (tier ? tierBadge(ti
 const getArrivalDateorNA = (arrivalDate: string | null | undefined) =>
   arrivalDate ? DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' }) : 'N/A'
 
-const statusTags: Record<ApplicationStatus, string> = {
-  inProgress: `<strong class="govuk-tag govuk-tag--blue">In Progress</strong>`,
-  requestedFurtherInformation: `<strong class="govuk-tag govuk-tag--yellow">Info Request</strong>`,
-  submitted: `<strong class="govuk-tag">Submitted</strong>`,
-  pending: `<strong class="govuk-tag govuk-tag--blue">Pending</strong>`,
-  rejected: `<strong class="govuk-tag govuk-tag--red">Rejected</strong>`,
-  awaitingPlacement: `<strong class="govuk-tag govuk-tag--blue">Awaiting Placement</strong>`,
-  placed: `<strong class="govuk-tag govuk-tag--pink">Placed</strong>`,
-  inapplicable: `<strong class="govuk-tag govuk-tag--red">Inapplicable</strong>`,
-  withdrawn: `<strong class="govuk-tag govuk-tag--red">Withdrawn</strong>`,
+const statusTags = (): Record<ApprovedPremisesApplicationStatus, string> => {
+  const colours: Record<ApprovedPremisesApplicationStatus, string> = {
+    started: 'blue',
+    submitted: '',
+    rejected: 'red',
+    awaitingAssesment: 'blue',
+    unallocatedAssesment: 'blue',
+    assesmentInProgress: 'blue',
+    awaitingPlacement: 'blue',
+    placementAllocated: 'pink',
+    inapplicable: 'red',
+    withdrawn: 'red',
+    requestedFurtherInformation: 'yellow',
+  }
+  return Object.keys(applicationStatuses).reduce(
+    (item, key) => {
+      item[key] = `<strong class="govuk-tag govuk-tag--${colours[key]}">${applicationStatuses[key]}</strong>`
+      return item
+    },
+    {} as Record<ApprovedPremisesApplicationStatus, string>,
+  )
 }
 
 const getStatus = (application: ApplicationSummary): string => {
-  return statusTags[application.status]
+  return statusTags()[application.status]
 }
 
 export const textValue = (value: string) => {
@@ -127,8 +151,8 @@ const createNameAnchorElement = (person: Person, applicationId: string) => {
     : textValue(`LAO CRN: ${person.crn}`)
 }
 
-export const unwithdrawableApplicationStatuses: Array<ApplicationStatus> = [
-  'placed',
+export const unwithdrawableApplicationStatuses: Array<ApprovedPremisesApplicationStatus> = [
+  'placementAllocated',
   'inapplicable',
   'withdrawn',
   'rejected',
@@ -348,22 +372,8 @@ export const applicationShowPageTab = (id: Application['id'], tab: ApplicationSh
 const applicationStatusSelectOptions = (
   selectedOption: ApprovedPremisesApplicationStatus | undefined | null,
 ): Array<SelectOption> => {
-  const statuses: Record<ApprovedPremisesApplicationStatus, string> = {
-    started: 'Application Started',
-    submitted: 'Application Submitted',
-    rejected: 'Application Rejected',
-    awaitingAssesment: 'Awaiting assessment',
-    unallocatedAssesment: 'Unallocated assessment',
-    assesmentInProgress: 'Assessment in progress',
-    awaitingPlacement: 'Awaiting placement',
-    placementAllocated: 'Placement allocated',
-    inapplicable: 'Application inapplicable',
-    withdrawn: 'Application withdrawn',
-    requestedFurtherInformation: 'Further information requested',
-  }
-
-  const options = Object.keys(statuses).map(status => ({
-    text: statuses[status],
+  const options = Object.keys(applicationStatuses).map(status => ({
+    text: applicationStatuses[status],
     value: status,
     selected: status === selectedOption,
   }))
@@ -378,6 +388,7 @@ const applicationStatusSelectOptions = (
 }
 
 export {
+  applicationStatuses,
   applicationTableRows,
   dashboardTableRows,
   dashboardTableHeader,

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -5,6 +5,7 @@ import type {
   FormSections,
   JourneyType,
   PageResponse,
+  SelectOption,
   SummaryListWithCard,
   TableCell,
   TableRow,
@@ -15,6 +16,7 @@ import type {
   ApplicationSortField,
   ApplicationStatus,
   ApprovedPremisesApplicationSummary as ApplicationSummary,
+  ApprovedPremisesApplicationStatus,
   Person,
   PlacementApplication,
   PlacementType,
@@ -343,6 +345,38 @@ export type ApplicationShowPageTab = keyof typeof applicationShowPageTabs
 export const applicationShowPageTab = (id: Application['id'], tab: ApplicationShowPageTab) =>
   `${paths.applications.show({ id })}?tab=${applicationShowPageTabs[tab]}`
 
+const applicationStatusSelectOptions = (
+  selectedOption: ApprovedPremisesApplicationStatus | undefined | null,
+): Array<SelectOption> => {
+  const statuses: Record<ApprovedPremisesApplicationStatus, string> = {
+    started: 'Application Started',
+    submitted: 'Application Submitted',
+    rejected: 'Application Rejected',
+    awaitingAssesment: 'Awaiting assessment',
+    unallocatedAssesment: 'Unallocated assessment',
+    assesmentInProgress: 'Assessment in progress',
+    awaitingPlacement: 'Awaiting placement',
+    placementAllocated: 'Placement allocated',
+    inapplicable: 'Application inapplicable',
+    withdrawn: 'Application withdrawn',
+    requestedFurtherInformation: 'Further information requested',
+  }
+
+  const options = Object.keys(statuses).map(status => ({
+    text: statuses[status],
+    value: status,
+    selected: status === selectedOption,
+  }))
+
+  options.unshift({
+    text: 'All statuses',
+    value: '',
+    selected: !selectedOption,
+  })
+
+  return options
+}
+
 export {
   applicationTableRows,
   dashboardTableRows,
@@ -356,4 +390,5 @@ export {
   mapPlacementApplicationToSummaryCards,
   lengthOfStayForUI,
   statusTags,
+  applicationStatusSelectOptions,
 }

--- a/server/utils/getSearchOptions.test.ts
+++ b/server/utils/getSearchOptions.test.ts
@@ -1,0 +1,42 @@
+import type { Request } from 'express'
+import { createMock } from '@golevelup/ts-jest'
+import { getSearchOptions } from './getSearchOptions'
+
+interface MySearchOptions {
+  foo: string
+  fizz: string
+}
+
+describe('getSearchOptions', () => {
+  it('should return all search options if provided', () => {
+    const request = createMock<Request>({
+      query: {
+        foo: 'bar',
+        fizz: 'buzz',
+      },
+    })
+
+    expect(getSearchOptions<MySearchOptions>(request, ['foo', 'fizz'])).toEqual({ foo: 'bar', fizz: 'buzz' })
+  })
+
+  it('should not return empty search options', () => {
+    const request = createMock<Request>({
+      query: {
+        foo: 'bar',
+        fizz: undefined,
+      },
+    })
+
+    expect(getSearchOptions<MySearchOptions>(request, ['foo', 'fizz'])).toEqual({ foo: 'bar' })
+  })
+
+  it('should return an empty array if there are no search filters provided', () => {
+    const request = createMock<Request>({
+      query: {
+        something: 'else',
+      },
+    })
+
+    expect(getSearchOptions<MySearchOptions>(request, ['foo', 'fizz'])).toEqual({})
+  })
+})

--- a/server/utils/getSearchOptions.ts
+++ b/server/utils/getSearchOptions.ts
@@ -1,0 +1,14 @@
+import type { Request } from 'express'
+
+export const getSearchOptions = <T>(request: Request, keys: Array<string>): T => {
+  const searchOptions = {}
+
+  keys.forEach(key => {
+    const option = request.query?.[key]
+    if (option) {
+      searchOptions[key] = option
+    }
+  })
+
+  return searchOptions as T
+}

--- a/server/views/applications/dashboard.njk
+++ b/server/views/applications/dashboard.njk
@@ -4,6 +4,7 @@
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "moj/components/badge/macro.njk" import mojBadge %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "./_navigation.njk" import navigation %}
 
 {% extends "../partials/layout.njk" %}
@@ -20,6 +21,60 @@
       <h1 class="govuk-heading-l">Approved Premises applications</h1>
 
       {{ navigation('allApplications') }}
+
+      <div class="placement-request-search__wrapper">
+
+        <form action="{{ paths.applications.dashboard({}) }}" method="get">
+
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+              <div class="govuk-form-group">
+                <label class="placement-request-search__crn-label" for="crnOrName">
+                 Find an application
+                </label>
+
+                <div id="crn-hint" class="govuk-hint moj-crn__hint ">
+                  You can search by CRN or name
+                </div>
+
+                <input class="govuk-input moj-search__input" id="crnOrName" name="crnOrName" type="search" aria-describedby="crn-hint" value="{{ crnOrName }}">
+              </div>
+            </div>
+          </div>
+
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-quarter">
+              <h2 class="govuk-heading-m">Filters</h2>
+            </div>
+          </div>
+
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-quarter">
+              {{
+                govukSelect({
+                  label: {
+                      text: "Statuses",
+                      classes: "govuk-label--s"
+                  },
+                  id: "status",
+                  name: "status",
+                  items: ApplyUtils.applicationStatusSelectOptions(status)
+                })
+              }}
+            </div>
+            <div class="govuk-grid-column-one-quarter">
+              {{
+                govukButton({
+                  name: 'submit',
+                  text: 'Apply filters',
+                  classes: 'placement-request-search__submit'
+                })
+              }}
+            </div>
+          </div>
+
+        </form>
+      </div>
 
       {{
         govukTable({


### PR DESCRIPTION
This extends the applications dashboard to add searching functionality by name/CRN and status, as well as uses the new statuses returned from the API.

This shouldn't be merged until https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1159 is merged.

## Screenshot

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/f04a148a-21c7-4fc1-a6e7-ddb67c2e6b17)
