### PR TITLE
APS-16: Remove link from All Applications dashboard for in progress applications

### DIFF
--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -18,7 +18,7 @@ import Apply from '../../form-pages/apply'
 import Assess from '../../form-pages/assess'
 import PlacementRequest from '../../form-pages/placement-application'
 import { DateFormats } from '../dateUtils'
-import { isApplicableTier, isFullPerson, tierBadge } from '../personUtils'
+import { isApplicableTier, isFullPerson, nameOrPlaceholderCopy, tierBadge } from '../personUtils'
 
 import {
   applicationStatusSelectOptions,
@@ -417,6 +417,41 @@ describe('utils', () => {
         expect(result[0][2]).toEqual({
           html: '',
         })
+      })
+    })
+
+    describe('when linkInProgressApplications is false', () => {
+      it('returns the rows with the name cell without linking to the application', () => {
+        ;(tierBadge as jest.Mock).mockReturnValue('TIER_BADGE')
+        ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
+        ;(nameOrPlaceholderCopy as jest.MockedFunction<typeof nameOrPlaceholderCopy>).mockReturnValue(person.name)
+
+        const application = applicationSummaryFactory.build()
+
+        const result = dashboardTableRows([application], { linkInProgressApplications: false })
+
+        expect(result).toEqual([
+          [
+            {
+              text: person.name,
+            },
+            {
+              text: application.person.crn,
+            },
+            {
+              html: 'TIER_BADGE',
+            },
+            {
+              text: DateFormats.isoDateToUIDate(application.arrivalDate, { format: 'short' }),
+            },
+            {
+              text: DateFormats.isoDateToUIDate(application.createdAt, { format: 'short' }),
+            },
+            {
+              html: getStatus(application),
+            },
+          ],
+        ])
       })
     })
   })

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -29,7 +29,7 @@ import IsExceptionalCase from '../../form-pages/apply/reasons-for-placement/basi
 import paths from '../../paths/apply'
 import placementApplicationPaths from '../../paths/placementApplications'
 import Apply from '../../form-pages/apply'
-import { isApplicableTier, isFullPerson, tierBadge } from '../personUtils'
+import { isApplicableTier, isFullPerson, nameOrPlaceholderCopy, tierBadge } from '../personUtils'
 import { DateFormats } from '../dateUtils'
 import Assess from '../../form-pages/assess'
 import { arrivalDateFromApplication } from './arrivalDateFromApplication'
@@ -62,7 +62,7 @@ const applicationStatuses: Record<ApprovedPremisesApplicationStatus, string> = {
 
 const applicationTableRows = (applications: Array<ApplicationSummary>): Array<TableRow> => {
   return applications.map(application => [
-    createNameAnchorElement(application.person, application.id),
+    createNameAnchorElement(application.person, application),
     textValue(application.person.crn),
     htmlValue(getTierOrBlank(application.risks?.tier?.value?.level)),
     textValue(getArrivalDateorNA(application.arrivalDate)),
@@ -92,9 +92,12 @@ const dashboardTableHeader = (
   ]
 }
 
-const dashboardTableRows = (applications: Array<ApplicationSummary>): Array<TableRow> => {
+const dashboardTableRows = (
+  applications: Array<ApplicationSummary>,
+  { linkInProgressApplications = true } = {},
+): Array<TableRow> => {
   return applications.map(application => [
-    createNameAnchorElement(application.person, application.id),
+    createNameAnchorElement(application.person, application, { linkInProgressApplications }),
     textValue(application.person.crn),
     htmlValue(getTierOrBlank(application.risks?.tier?.value?.level)),
     textValue(getArrivalDateorNA(application.arrivalDate)),
@@ -143,10 +146,20 @@ export const htmlValue = (value: string) => {
   return { html: value }
 }
 
-const createNameAnchorElement = (person: Person, applicationId: string) => {
+const createNameAnchorElement = (
+  person: Person,
+  applicationSummary: ApplicationSummary,
+  { linkInProgressApplications }: { linkInProgressApplications: boolean } = { linkInProgressApplications: true },
+) => {
+  if (!linkInProgressApplications && applicationSummary.status === 'started') {
+    return textValue(nameOrPlaceholderCopy(person, `LAO: ${person.crn}`))
+  }
+
   return isFullPerson(person)
     ? htmlValue(
-        `<a href=${paths.applications.show({ id: applicationId })} data-cy-id="${applicationId}">${person.name}</a>`,
+        `<a href=${paths.applications.show({ id: applicationSummary.id })} data-cy-id="${applicationSummary.id}">${
+          person.name
+        }</a>`,
       )
     : textValue(`LAO CRN: ${person.crn}`)
 }

--- a/server/views/applications/dashboard.njk
+++ b/server/views/applications/dashboard.njk
@@ -82,7 +82,7 @@
           captionClasses: "govuk-table__caption--m",
           firstCellIsHeader: true,
           head: ApplyUtils.dashboardTableHeader(sortBy, sortDirection, hrefPrefix),
-          rows: ApplyUtils.dashboardTableRows(applications)
+          rows: ApplyUtils.dashboardTableRows(applications, { linkInProgressApplications: false })
         })
       }}
 

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -12,15 +12,6 @@
 {% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body" %}
 
-{% block beforeContent %}
-  {% if referrer %}
-    {{ govukBackLink({
-      text: "Back",
-      href: referrer
-    }) }}
-  {% endif %}
-{% endblock %}
-
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-width-container">


### PR DESCRIPTION
If an application is in progress (EG it has the 'started' status) then we don't want
people to be able to click on it and start editing it from the 'All applications' (dashboard)
view. So we pass in a boolean from the view which, when negative,  ensures if an application
isnt linked.