### PR TITLE
Use new endpoint to fetch Placement Applications

### DIFF
--- a/integration_tests/mockApis/tasks.ts
+++ b/integration_tests/mockApis/tasks.ts
@@ -35,6 +35,20 @@ export default {
         jsonBody: tasks,
       },
     }),
+  stubTasksOfType: (args: { tasks: Array<Task>; type: string }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: paths.tasks.type.index({ taskType: args.type }),
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: args.tasks,
+      },
+    }),
   stubTaskGet: (args: { task: Task; users: Array<User> }): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/pages/match/listPlacementRequestsPage.ts
+++ b/integration_tests/pages/match/listPlacementRequestsPage.ts
@@ -9,7 +9,7 @@ import { shouldShowTableRows } from '../../helpers'
 
 export default class ListPage extends Page {
   constructor() {
-    super('Placement Applications')
+    super('Placement Requests')
     this.checkPhaseBanner('Give us your feedback')
   }
 

--- a/integration_tests/tests/match/placementApplications.cy.ts
+++ b/integration_tests/tests/match/placementApplications.cy.ts
@@ -269,7 +269,7 @@ context('Placement Applications', () => {
     const placementApplication = placementApplicationFactory.build({ id: placementApplicationTasks[0].id, document })
     cy.task('stubPlacementApplication', placementApplication)
 
-    cy.task('stubTasks', placementApplicationTasks)
+    cy.task('stubTasksOfType', { type: 'placement-application', tasks: placementApplicationTasks })
 
     // When I visit the placementRequests dashboard
     const listPage = ListPage.visit()
@@ -321,7 +321,7 @@ context('Placement Applications', () => {
     const placementApplication = placementApplicationFactory.build({ id: placementApplicationTasks[0].id, document })
     cy.task('stubPlacementApplication', placementApplication)
 
-    cy.task('stubTasks', placementApplicationTasks)
+    cy.task('stubTasksOfType', { type: 'placement-application', tasks: placementApplicationTasks })
 
     // When I visit the placementRequests dashboard
     const listPage = ListPage.visit()
@@ -352,7 +352,7 @@ context('Placement Applications', () => {
     const placementApplication = placementApplicationFactory.build({ id: placementApplicationTasks[0].id, document })
     cy.task('stubPlacementApplication', placementApplication)
 
-    cy.task('stubTasks', placementApplicationTasks)
+    cy.task('stubTasksOfType', { type: 'placement-application', tasks: placementApplicationTasks })
 
     // When I visit the placementRequests dashboard
     const listPage = ListPage.visit()

--- a/server/controllers/match/placementRequestsController.test.ts
+++ b/server/controllers/match/placementRequestsController.test.ts
@@ -1,7 +1,6 @@
 import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
-import { GroupedMatchTasks } from '@approved-premises/ui'
 import PlacementRequestsController from './placementRequestsController'
 
 import { ApplicationService, PlacementApplicationService, PlacementRequestService, TaskService } from '../../services'
@@ -9,6 +8,7 @@ import {
   applicationFactory,
   placementApplicationFactory,
   placementRequestDetailFactory,
+  taskFactory,
 } from '../../testutils/factories'
 import paths from '../../paths/placementApplications'
 import { getResponses } from '../../utils/applications/getResponses'
@@ -46,9 +46,9 @@ describe('PlacementRequestsController', () => {
 
   describe('index', () => {
     it('should render the placement requests template', async () => {
-      const tasks = createMock<GroupedMatchTasks>()
+      const tasks = taskFactory.buildList(5)
 
-      taskService.getMatchTasks.mockResolvedValue(tasks)
+      taskService.getTasksOfType.mockResolvedValue(tasks)
 
       const requestHandler = placementRequestsController.index()
 
@@ -58,7 +58,7 @@ describe('PlacementRequestsController', () => {
         pageHeading: 'My Cases',
         tasks,
       })
-      expect(taskService.getMatchTasks).toHaveBeenCalledWith(token)
+      expect(taskService.getTasksOfType).toHaveBeenCalledWith(token, 'placement-application')
     })
   })
 

--- a/server/controllers/match/placementRequestsController.ts
+++ b/server/controllers/match/placementRequestsController.ts
@@ -14,7 +14,7 @@ export default class PlacementRequestsController {
 
   index(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
-      const tasks = await this.taskService.getMatchTasks(req.user.token)
+      const tasks = await this.taskService.getTasksOfType(req.user.token, 'placement-application')
 
       res.render('match/placementRequests/index', {
         pageHeading: 'My Cases',

--- a/server/data/taskClient.test.ts
+++ b/server/data/taskClient.test.ts
@@ -47,6 +47,33 @@ describeClient('taskClient', provider => {
     })
   })
 
+  describe('allByType', () => {
+    it('makes a get request to the tasks type endpoint', async () => {
+      const tasks = taskFactory.buildList(2)
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: `A request to get a list of tasks of a type`,
+        withRequest: {
+          method: 'GET',
+          path: paths.tasks.type.index({ taskType: 'placement-application' }),
+          headers: {
+            authorization: `Bearer ${token}`,
+            'X-Service-Name': 'approved-premises',
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: tasks,
+        },
+      })
+
+      const result = await taskClient.allByType('placement-application')
+
+      expect(result).toEqual(tasks)
+    })
+  })
+
   describe('allForUser', () => {
     it('makes a get request to the tasks endpoint', async () => {
       const tasks = [

--- a/server/data/taskClient.ts
+++ b/server/data/taskClient.ts
@@ -19,6 +19,10 @@ export default class TaskClient {
     return (await this.restClient.get({ path: paths.tasks.index.pattern })) as Promise<Array<CategorisedTask>>
   }
 
+  async allByType(taskType: string): Promise<Array<Task>> {
+    return (await this.restClient.get({ path: paths.tasks.type.index({ taskType }) })) as Promise<Array<Task>>
+  }
+
   async find(applicationId: string, taskType: string): Promise<TaskWrapper> {
     return (await this.restClient.get({
       path: paths.tasks.show({ id: applicationId, taskType }),

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -143,6 +143,9 @@ export default {
     reallocatable: {
       index: tasksPaths.index.path('reallocatable'),
     },
+    type: {
+      index: tasksPaths.index.path(':taskType'),
+    },
     show: tasksPaths.show,
     allocations: {
       create: tasksPaths.allocations.create,

--- a/server/services/taskService.test.ts
+++ b/server/services/taskService.test.ts
@@ -38,6 +38,20 @@ describe('taskService', () => {
     })
   })
 
+  describe('getTasksOfType', () => {
+    it('calls the allByType method on the task client', async () => {
+      const tasks: Array<Task> = taskFactory.buildList(2)
+      taskClient.allByType.mockResolvedValue(tasks)
+
+      const result = await service.getTasksOfType(token, 'placement-application')
+
+      expect(result).toEqual(tasks)
+
+      expect(taskClientFactory).toHaveBeenCalledWith(token)
+      expect(taskClient.allByType).toHaveBeenCalledWith('placement-application')
+    })
+  })
+
   describe('getMatchTasks', () => {
     it('calls the all method on the task client', async () => {
       const applicationTasks = placementApplicationTaskFactory.buildList(1)

--- a/server/services/taskService.ts
+++ b/server/services/taskService.ts
@@ -13,6 +13,12 @@ export default class TaskService {
     return tasks
   }
 
+  async getTasksOfType(token: string, type: string): Promise<Array<Task>> {
+    const taskClient = this.taskClientFactory(token)
+
+    return taskClient.allByType(type)
+  }
+
   async getMatchTasks(token: string): Promise<GroupedMatchTasks> {
     const taskClient = this.taskClientFactory(token)
 

--- a/server/views/match/placementRequests/index.njk
+++ b/server/views/match/placementRequests/index.njk
@@ -13,14 +13,14 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
 
-            <h1 class="govuk-heading-l">Placement Applications</h1>
+            <h1 class="govuk-heading-l">Placement Requests</h1>
             {% include "../../_messages.njk" %}
 
             <p class="govuk-body">
-                All additional placements applications that have been assessed as suitable, require matching to an AP, and have been allocated to you are listed below
+                All additional placement requests that have been assessed as suitable, require matching to an AP, and have been allocated to you are listed below
             </p>
 
-            {{ placementApplicationTable("Placement Applications", PlacementApplicationUtils.tableUtils.tableRows(tasks.placementApplications)) }}
+            {{ placementApplicationTable("Placement Requests", PlacementApplicationUtils.tableUtils.tableRows(tasks)) }}
 
         </div>
     </div>


### PR DESCRIPTION
Before we were fetching all tasks, but only displaying the Placement Applications, which was a waste of resources (and also causing timeouts!). This will still return a lot of data, but less data than we were requesting before!

Next step is paginating the response, but let’s do one thing at a time