### PR TITLE
(APS 50) Add pagination to placement applications page

### DIFF
--- a/integration_tests/mockApis/tasks.ts
+++ b/integration_tests/mockApis/tasks.ts
@@ -35,16 +35,24 @@ export default {
         jsonBody: tasks,
       },
     }),
-  stubTasksOfType: (args: { tasks: Array<Task>; type: string }): SuperAgentRequest =>
+  stubTasksOfType: (args: { tasks: Array<Task>; type: string; page: string }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
-        urlPattern: paths.tasks.type.index({ taskType: args.type }),
+        urlPathPattern: paths.tasks.type.index({ taskType: args.type }),
+        queryParameters: {
+          page: {
+            equalTo: args.page || '1',
+          },
+        },
       },
       response: {
         status: 200,
         headers: {
           'Content-Type': 'application/json;charset=UTF-8',
+          'X-Pagination-TotalPages': '10',
+          'X-Pagination-TotalResults': '100',
+          'X-Pagination-PageSize': '10',
         },
         jsonBody: args.tasks,
       },

--- a/integration_tests/tests/match/listPlacementApplications.cy.ts
+++ b/integration_tests/tests/match/listPlacementApplications.cy.ts
@@ -1,0 +1,36 @@
+import { placementApplicationTaskFactory } from '../../../server/testutils/factories'
+import ListPage from '../../pages/match/listPlacementRequestsPage'
+
+describe('List placement applications', () => {
+  it('should list pages of placement applications', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And some placement applications exist
+    const page1PlacementApplications = placementApplicationTaskFactory.buildList(10)
+    const page2PlacementApplications = placementApplicationTaskFactory.buildList(10)
+    const page3PlacementApplications = placementApplicationTaskFactory.buildList(10)
+
+    cy.task('stubTasksOfType', { type: 'placement-application', tasks: page1PlacementApplications, page: '1' })
+    cy.task('stubTasksOfType', { type: 'placement-application', tasks: page2PlacementApplications, page: '2' })
+    cy.task('stubTasksOfType', { type: 'placement-application', tasks: page3PlacementApplications, page: '3' })
+
+    // When I visit the placementRequests dashboard
+    const listPage = ListPage.visit()
+
+    // Then I should see the first page of results
+    listPage.shouldShowPlacementApplicationTasks(page1PlacementApplications)
+
+    // When I click page 2
+    listPage.clickPageNumber('2')
+
+    // Then I should see the second page of results
+    listPage.shouldShowPlacementApplicationTasks(page2PlacementApplications)
+
+    // When I click the next page
+    listPage.clickNext()
+
+    // Then I should see the third page of results
+    listPage.shouldShowPlacementApplicationTasks(page3PlacementApplications)
+  })
+})

--- a/server/controllers/match/placementRequestsController.ts
+++ b/server/controllers/match/placementRequestsController.ts
@@ -1,8 +1,10 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 import { ApplicationService, PlacementApplicationService, PlacementRequestService, TaskService } from '../../services'
 import paths from '../../paths/placementApplications'
+import matchpaths from '../../paths/match'
 import { addErrorMessageToFlash } from '../../utils/validation'
 import { getResponses } from '../../utils/applications/getResponses'
+import { getPaginationDetails } from '../../utils/getPaginationDetails'
 
 export default class PlacementRequestsController {
   constructor(
@@ -14,11 +16,19 @@ export default class PlacementRequestsController {
 
   index(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
-      const tasks = await this.taskService.getTasksOfType(req.user.token, 'placement-application')
+      const { pageNumber, hrefPrefix } = getPaginationDetails(req, matchpaths.placementRequests.index({}))
+      const paginatedResponse = await this.taskService.getTasksOfType(
+        req.user.token,
+        'placement-application',
+        pageNumber,
+      )
 
       res.render('match/placementRequests/index', {
         pageHeading: 'My Cases',
-        tasks,
+        hrefPrefix,
+        pageNumber: Number(paginatedResponse.pageNumber),
+        totalPages: Number(paginatedResponse.totalPages),
+        tasks: paginatedResponse.data,
       })
     }
   }

--- a/server/data/taskClient.test.ts
+++ b/server/data/taskClient.test.ts
@@ -57,6 +57,9 @@ describeClient('taskClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.tasks.type.index({ taskType: 'placement-application' }),
+          query: {
+            page: '1',
+          },
           headers: {
             authorization: `Bearer ${token}`,
             'X-Service-Name': 'approved-premises',
@@ -65,12 +68,23 @@ describeClient('taskClient', provider => {
         willRespondWith: {
           status: 200,
           body: tasks,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
         },
       })
 
       const result = await taskClient.allByType('placement-application')
 
-      expect(result).toEqual(tasks)
+      expect(result).toEqual({
+        data: tasks,
+        pageNumber: '1',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
     })
   })
 

--- a/server/data/taskClient.ts
+++ b/server/data/taskClient.ts
@@ -1,4 +1,4 @@
-import { CategorisedTask } from '@approved-premises/ui'
+import { CategorisedTask, PaginatedResponse } from '@approved-premises/ui'
 import config, { ApiConfig } from '../config'
 import RestClient from './restClient'
 import paths from '../paths/api'
@@ -19,8 +19,12 @@ export default class TaskClient {
     return (await this.restClient.get({ path: paths.tasks.index.pattern })) as Promise<Array<CategorisedTask>>
   }
 
-  async allByType(taskType: string): Promise<Array<Task>> {
-    return (await this.restClient.get({ path: paths.tasks.type.index({ taskType }) })) as Promise<Array<Task>>
+  async allByType(taskType: string, page = 1): Promise<PaginatedResponse<Task>> {
+    return this.restClient.getPaginatedResponse({
+      path: paths.tasks.type.index({ taskType }),
+      page: page.toString(),
+      query: {},
+    })
   }
 
   async find(applicationId: string, taskType: string): Promise<TaskWrapper> {

--- a/server/services/taskService.test.ts
+++ b/server/services/taskService.test.ts
@@ -1,7 +1,8 @@
-import { CategorisedTask } from '@approved-premises/ui'
+import { CategorisedTask, PaginatedResponse } from '@approved-premises/ui'
 import { Task } from '../@types/shared'
 import TaskClient from '../data/taskClient'
 import {
+  paginatedResponseFactory,
   placementApplicationTaskFactory,
   placementRequestTaskFactory,
   taskFactory,
@@ -41,14 +42,15 @@ describe('taskService', () => {
   describe('getTasksOfType', () => {
     it('calls the allByType method on the task client', async () => {
       const tasks: Array<Task> = taskFactory.buildList(2)
-      taskClient.allByType.mockResolvedValue(tasks)
+      const paginatedResponse = paginatedResponseFactory.build({ data: tasks }) as PaginatedResponse<Task>
+      taskClient.allByType.mockResolvedValue(paginatedResponse)
 
-      const result = await service.getTasksOfType(token, 'placement-application')
+      const result = await service.getTasksOfType(token, 'placement-application', 1)
 
-      expect(result).toEqual(tasks)
+      expect(result).toEqual(paginatedResponse)
 
       expect(taskClientFactory).toHaveBeenCalledWith(token)
-      expect(taskClient.allByType).toHaveBeenCalledWith('placement-application')
+      expect(taskClient.allByType).toHaveBeenCalledWith('placement-application', 1)
     })
   })
 

--- a/server/services/taskService.ts
+++ b/server/services/taskService.ts
@@ -1,5 +1,5 @@
 import { PlacementApplicationTask, PlacementRequestTask, Reallocation, Task, TaskWrapper } from '@approved-premises/api'
-import { GroupedMatchTasks } from '@approved-premises/ui'
+import { GroupedMatchTasks, PaginatedResponse } from '@approved-premises/ui'
 import { RestClientBuilder } from '../data'
 import TaskClient from '../data/taskClient'
 
@@ -13,10 +13,10 @@ export default class TaskService {
     return tasks
   }
 
-  async getTasksOfType(token: string, type: string): Promise<Array<Task>> {
+  async getTasksOfType(token: string, type: string, page: number = 1): Promise<PaginatedResponse<Task>> {
     const taskClient = this.taskClientFactory(token)
 
-    return taskClient.allByType(type)
+    return taskClient.allByType(type, page)
   }
 
   async getMatchTasks(token: string): Promise<GroupedMatchTasks> {

--- a/server/views/match/placementRequests/index.njk
+++ b/server/views/match/placementRequests/index.njk
@@ -4,6 +4,7 @@
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% from "./_table.njk" import placementRequestTable %}
 {% from "./_table.njk" import placementApplicationTable %}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
 
 {% set pageTitle = applicationName + " - Placement Applications"  %}
 {% set mainClasses = "app-container govuk-body assessments--index" %}
@@ -22,6 +23,7 @@
 
             {{ placementApplicationTable("Placement Requests", PlacementApplicationUtils.tableUtils.tableRows(tasks)) }}
 
+            {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
This adds pagination helpers to the Placement Applications page. It's pretty rare that folks will have too many placement applications assigned to them that pagination will be necessary, but as the API now supports it, we should add it while it's fresh in our minds.