### PR TITLE
Add additional logging to Auth errors

### DIFF
--- a/logger.ts
+++ b/logger.ts
@@ -6,6 +6,6 @@ const formatOut = bunyanFormat({ outputMode: 'short', color: true })
 const logger =
   process.env.NODE_ENV !== 'test'
     ? bunyan.createLogger({ name: 'Approved Premises Ui', stream: formatOut, level: 'debug' })
-    : bunyan.createLogger({ name: 'Approved Premises Ui', stream: formatOut, level: 'fatal' })
+    : bunyan.createLogger({ name: 'Approved Premises Ui', stream: formatOut, level: 'error' })
 
 export default logger

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -11,6 +11,7 @@ declare module 'express-session' {
     application: ApprovedPremisesApplication
     user: UserDetails
     placementApplicationDecisions: Record<string, Partial<PlacementApplicationDecisionEnvelope>>
+    messages: Array<string>
   }
 }
 

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -10,7 +10,7 @@ export default function authorisationMiddleware(authorisedRoles: Array<string> =
       const { authorities: roles = [] } = jwtDecode(res.locals.user.token) as { authorities?: Array<string> }
 
       if (authorisedRoles.length && !roles.some(role => authorisedRoles.includes(role))) {
-        logger.error('User is not authorised to access this')
+        logger.error(`User ${res.locals.user} does not have any of the the required roles ${roles.join(', ')}`)
         return res.redirect('/autherror')
       }
 

--- a/server/middleware/populateCurrentUser.test.ts
+++ b/server/middleware/populateCurrentUser.test.ts
@@ -79,7 +79,7 @@ describe('populateCurrentUser', () => {
 
     expect(userService.getActingUser).toHaveBeenCalledWith(token)
     expect(response.redirect).toHaveBeenCalledWith('/autherror')
-    expect(logger.error).toHaveBeenCalledWith('User is inactive')
+    expect(logger.error).toHaveBeenCalledWith(`User ${user.name} is inactive`)
   })
 
   it('should catch an error when an error is raised', async () => {

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -16,7 +16,7 @@ export default function populateCurrentUser(userService: UserService): RequestHa
         }
 
         if (!req.session.user.active) {
-          logger.error('User is inactive')
+          logger.error(`User ${req.session.user.name} is inactive`)
           return res.redirect('/autherror')
         }
       }

--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -4,6 +4,7 @@ import passport from 'passport'
 import flash from 'connect-flash'
 import config from '../config'
 import auth from '../authentication/auth'
+import logger from '../../logger'
 
 const router = express.Router()
 
@@ -16,6 +17,9 @@ export default function setUpAuth(): Router {
 
   router.get('/autherror', (req, res) => {
     res.status(401)
+    if (req.session.messages) {
+      logger.error(`Authentication error: ${req.session.messages.join}`)
+    }
     return res.render('autherror', { hideNav: true })
   })
 
@@ -25,6 +29,7 @@ export default function setUpAuth(): Router {
     passport.authenticate('oauth2', {
       successReturnToOrRedirect: req.session.returnTo || '/',
       failureRedirect: '/autherror',
+      failureMessage: true,
     })(req, res, next),
   )
 


### PR DESCRIPTION
As part of an attempt to diagnose what’s going on with the authentication errors, I’ve decreased the logger level to `error` so anything `error` or above gets sent to Application Insights, as well as adding some more verbose logging, so we have a bit more information about what’s happening.