### PR TITLE
APS 27 - Placement Applications - Multiple ROTL dates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 # Context
 
-<!-- Is there a Trello ticket you can link to? -->
+<!-- Is there a Jira ticket you can link to? -->
 <!-- Do you need to add any environment variables? -->
 <!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->
 
@@ -21,10 +21,10 @@ confirm:
 ## Pre merge checklist
 
 - [ ] Have all changes to any dependencies been deployed to both `preprod` and
-    `production` in a backwards compatible way? (This includes our API,
-    infrastructure, third-party integrations and any secrets or environment variables)
+      `production` in a backwards compatible way? (This includes our API,
+      infrastructure, third-party integrations and any secrets or environment variables)
 - [ ] Has a required data migration been included in this change or been done in
-    advance?
+      advance?
 
 ## Post merge checklist
 

--- a/integration_tests/fixtures/rotlPlacementApplicationData.json
+++ b/integration_tests/fixtures/rotlPlacementApplicationData.json
@@ -16,13 +16,26 @@
       "sameAp": "yes"
     },
     "dates-of-placement": {
-      "arrivalDate": "2023-08-01",
-      "arrivalDate-day": "01",
-      "arrivalDate-month": "8",
-      "arrivalDate-year": "2023",
-      "duration": "5",
-      "durationDays": "5",
-      "durationWeeks": "0"
+      "datesOfPlacement": [
+        {
+          "arrivalDate": "2023-08-01",
+          "arrivalDate-day": "01",
+          "arrivalDate-month": "8",
+          "arrivalDate-year": "2023",
+          "duration": "5",
+          "durationDays": "5",
+          "durationWeeks": "0"
+        },
+        {
+          "arrivalDate": "2024-08-01",
+          "arrivalDate-day": "01",
+          "arrivalDate-month": "8",
+          "arrivalDate-year": "2024",
+          "duration": "25",
+          "durationDays": "3",
+          "durationWeeks": "4 "
+        }
+      ]
     },
     "updates-to-application": {
       "significantEvents": "yes",

--- a/integration_tests/pages/match/placementRequestForm/datesOfPlacement.ts
+++ b/integration_tests/pages/match/placementRequestForm/datesOfPlacement.ts
@@ -1,3 +1,4 @@
+import { DateFormats } from '../../../../server/utils/dateUtils'
 import Page from '../../page'
 
 export default class DatesOfPlacement extends Page {
@@ -5,9 +6,48 @@ export default class DatesOfPlacement extends Page {
     super('Dates of placement')
   }
 
+  inputPrefix(index: string) {
+    return `datesOfPlacement[${index}]`
+  }
+
+  datesOfPlacement = [
+    { dateOfPlacement: '2023-08-01', duration: { days: 5, weeks: 2 } },
+    { dateOfPlacement: '2023-07-02', duration: { days: 4, weeks: 1 } },
+  ]
+
   completeForm() {
-    this.clearAndCompleteDateInputs('arrivalDate', '2023-08-01')
-    this.clearAndCompleteTextInputById('durationWeeks', '12')
-    this.clearAndCompleteTextInputById('durationDays', '5')
+    this.datesOfPlacement.forEach((date, index) => {
+      const parsedDate = DateFormats.isoToDateObj(date.dateOfPlacement)
+
+      this.completeDatesOfPlacementDateInputs(parsedDate, index.toString())
+      this.completeDurationInputs(index.toString(), date.duration.weeks, date.duration.days)
+    })
+  }
+
+  clickAddAnother() {
+    cy.get('button').contains('Add another').click()
+  }
+
+  completeDatesOfPlacementDateInputs(date: Date, index: string): void {
+    const prefix = this.inputPrefix(index)
+    this.clearDateInputs(prefix)
+    cy.get(`[name="${prefix}[arrivalDate-day]"`).type(date.getDate().toString())
+    cy.get(`[name="${prefix}[arrivalDate-month]"`).type(`${date.getMonth() + 1}`)
+    cy.get(`[name="${prefix}[arrivalDate-year]`).type(date.getFullYear().toString())
+  }
+
+  completeDurationInputs(index: string, weeks: number, days: number) {
+    this.clearAndCompleteTextInputById(`datesOfPlacement_${index}_duration_weeks`, weeks.toString())
+    this.clearAndCompleteTextInputById(`datesOfPlacement_${index}_duration_days`, days.toString())
+  }
+
+  clearDateInputs(prefix: string): void {
+    cy.get(`[name="${prefix}[arrivalDate-day]"`).clear()
+    cy.get(`[name="${prefix}[arrivalDate-month]"`).clear()
+    cy.get(`[name="${prefix}[arrivalDate-year]"`).clear()
+  }
+
+  clickSaveAndContinue() {
+    cy.get('button').contains('Save and continue').click()
   }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -131,6 +131,14 @@ export default abstract class Page {
     cy.get(`#${prefix}-year`).type(parsedDate.getFullYear().toString())
   }
 
+  completeDateInputsByName(prefix: string, date: string): void {
+    const parsedDate = DateFormats.isoToDateObj(date)
+
+    cy.get(`[name="${prefix}[day]"`).type(parsedDate.getDate().toString())
+    cy.get(`[name="${prefix}[month]"`).type(`${parsedDate.getMonth() + 1}`)
+    cy.get(`[name="${prefix}[year]`).type(parsedDate.getFullYear().toString())
+  }
+
   dateInputsShouldContainDate(prefix: string, date: string): void {
     const parsedDate = DateFormats.isoToDateObj(date)
     cy.get(`#${prefix}-day`).should('have.value', parsedDate.getDate().toString())
@@ -272,6 +280,12 @@ export default abstract class Page {
     cy.get(`#${prefix}-day`).clear()
     cy.get(`#${prefix}-month`).clear()
     cy.get(`#${prefix}-year`).clear()
+  }
+
+  clearDateInputsByName(prefix: string): void {
+    cy.get(`[name="${prefix}-day"]`).clear()
+    cy.get(`[name="${prefix}-month"]`).clear()
+    cy.get(`[name="${prefix}-year"]`).clear()
   }
 
   clearAndCompleteDateInputs(prefix: string, date: string): void {

--- a/integration_tests/tests/apply/viewApplication.cy.ts
+++ b/integration_tests/tests/apply/viewApplication.cy.ts
@@ -258,14 +258,17 @@ const makeRotlPlacementApplication = (applicationId: string) => {
     key: 'reason',
     value: 'rotl',
   })
-  rotlPlacementApplication = addResponsesToFormArtifact(rotlPlacementApplication, {
+  rotlPlacementApplication = addResponseToFormArtifact(rotlPlacementApplication, {
     task: 'request-a-placement',
     page: 'dates-of-placement',
-    keyValuePairs: {
-      arrivalDate: '2023-01-01',
-      durationDays: '20',
-      duration: '20',
-    },
+    key: 'datesOfPlacement',
+    value: [
+      {
+        arrivalDate: '2023-01-01',
+        durationDays: '20',
+        duration: '20',
+      },
+    ],
   })
   return rotlPlacementApplication
 }

--- a/integration_tests/tests/match/placementApplications.cy.ts
+++ b/integration_tests/tests/match/placementApplications.cy.ts
@@ -37,6 +37,7 @@ context('Placement Applications', () => {
   beforeEach(() => {
     cy.signIn()
   })
+
   it('allows me to complete form if the reason for placement is ROTL', () => {
     cy.fixture('rotlPlacementApplicationData.json').then(placementApplicationData => {
       // Given I have completed an application I am viewing a completed application
@@ -90,7 +91,7 @@ context('Placement Applications', () => {
 
       const datesOfPlacementPage = new DateOfPlacement()
       datesOfPlacementPage.completeForm()
-      datesOfPlacementPage.clickSubmit()
+      datesOfPlacementPage.clickSaveAndContinue()
 
       const updatesToApplication = new UpdatesToApplication()
       updatesToApplication.completeForm()

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -149,58 +149,6 @@
         "refer-to-delius": {
           "type": "object"
         },
-        "exception-details": {
-          "allOf": [
-            {
-              "type": "object",
-              "properties": {
-                "agreementDate-year": {
-                  "type": "string"
-                },
-                "agreementDate-month": {
-                  "type": "string"
-                },
-                "agreementDate-day": {
-                  "type": "string"
-                }
-              }
-            },
-            {
-              "type": "object",
-              "properties": {
-                "agreementDate-time": {
-                  "type": "string"
-                }
-              }
-            },
-            {
-              "type": "object",
-              "properties": {
-                "agreementDate": {
-                  "type": "string"
-                }
-              }
-            },
-            {
-              "type": "object",
-              "properties": {
-                "agreedCaseWithManager": {
-                  "enum": [
-                    "no",
-                    "yes"
-                  ],
-                  "type": "string"
-                },
-                "managerName": {
-                  "type": "string"
-                },
-                "agreementSummary": {
-                  "type": "string"
-                }
-              }
-            }
-          ]
-        },
         "sentence-type": {
           "type": "object",
           "properties": {

--- a/server/form-pages/placement-application/request-a-placement/datesOfPlacement.test.ts
+++ b/server/form-pages/placement-application/request-a-placement/datesOfPlacement.test.ts
@@ -1,29 +1,51 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
 
-import DateOfPlacement, { Body } from './datesOfPlacement'
+import DateOfPlacement from './datesOfPlacement'
 
 describe('DateOfPlacement', () => {
   const body = {
-    durationDays: '1',
-    durationWeeks: '2',
-    'arrivalDate-year': '2023',
-    'arrivalDate-month': '12',
-    'arrivalDate-day': '1',
-  } as Body
+    datesOfPlacement: [
+      {
+        durationDays: '1',
+        durationWeeks: '2',
+        'arrivalDate-day': '1',
+        'arrivalDate-month': '12',
+        'arrivalDate-year': '2023',
+      },
+      {
+        durationDays: '2',
+        durationWeeks: '3',
+        'arrivalDate-day': '2',
+        'arrivalDate-month': '1',
+        'arrivalDate-year': '2024',
+      },
+    ],
+  }
 
   describe('body', () => {
     it('should set the body', () => {
-      const page = new DateOfPlacement(body)
-
-      expect(page.body).toEqual({
-        duration: '15',
-        durationDays: '1',
-        durationWeeks: '2',
-        'arrivalDate-year': '2023',
-        'arrivalDate-month': '12',
-        'arrivalDate-day': '1',
-        arrivalDate: '2023-12-01',
+      expect(new DateOfPlacement(body).body).toEqual({
+        datesOfPlacement: [
+          {
+            duration: '15',
+            durationDays: '1',
+            durationWeeks: '2',
+            'arrivalDate-year': '2023',
+            'arrivalDate-month': '12',
+            'arrivalDate-day': '1',
+            arrivalDate: '2023-12-01',
+          },
+          {
+            duration: '23',
+            durationDays: '2',
+            durationWeeks: '3',
+            'arrivalDate-year': '2024',
+            'arrivalDate-month': '1',
+            'arrivalDate-day': '2',
+            arrivalDate: '2024-01-02',
+          },
+        ],
       })
     })
   })
@@ -38,24 +60,62 @@ describe('DateOfPlacement', () => {
       expect(page.errors()).toEqual({})
     })
 
-    it('should return errors if dateOfPlacement is blank', () => {
+    it('should return errors if the first date and duration is blank', () => {
       const page = new DateOfPlacement(fromPartial({}))
       expect(page.errors()).toEqual({
-        arrivalDate: "You must state the person's arrival date",
-        duration: 'You must state the duration of the placement',
+        datesOfPlacement_0_arrivalDate: 'You must enter a date for the placement',
+        datesOfPlacement_0_duration: 'You must enter a duration for the placement',
       })
     })
 
-    it('should return errors if the last placement date is invalid', () => {
-      const page = new DateOfPlacement({
-        ...body,
-        'arrivalDate-year': '99999',
-        'arrivalDate-month': '99999',
-        'arrivalDate-day': '199999',
-      })
+    it('should return an error if the first date is blank', () => {
+      const page = new DateOfPlacement(
+        fromPartial({
+          datesOfPlacement: [
+            { ...body.datesOfPlacement[0], 'arrivalDate-day': '', 'arrivalDate-month': '', 'arrivalDate-year': '' },
+          ],
+        }),
+      )
       expect(page.errors()).toEqual({
-        arrivalDate: 'The placement date is invalid',
+        datesOfPlacement_0_arrivalDate: 'You must state a valid arrival date',
       })
+    })
+
+    it('should return an error if the first duration is blank', () => {
+      const page = new DateOfPlacement(
+        fromPartial({ datesOfPlacement: [{ ...body.datesOfPlacement[0], durationDays: '', durationWeeks: '' }] }),
+      )
+      expect(page.errors()).toEqual({
+        datesOfPlacement_0_duration: 'You must state the duration of the placement',
+      })
+    })
+
+    it('should return errors if the placement date is invalid', () => {
+      const page = new DateOfPlacement({
+        datesOfPlacement: [
+          {
+            ...body.datesOfPlacement[0],
+            'arrivalDate-day': '9999999',
+            'arrivalDate-month': '99',
+            'arrivalDate-year': '32',
+          },
+        ],
+      })
+      expect(page.errors()).toEqual({ datesOfPlacement_0_arrivalDate: 'You must state a valid arrival date' })
+    })
+
+    it('should return errors if the duration is empty', () => {
+      const page = new DateOfPlacement({
+        datesOfPlacement: [
+          {
+            ...body.datesOfPlacement[0],
+            durationDays: '0',
+            durationWeeks: '0',
+          },
+        ],
+      })
+
+      expect(page.errors()).toEqual({ datesOfPlacement_0_duration: 'You must state the duration of the placement' })
     })
   })
 
@@ -64,8 +124,16 @@ describe('DateOfPlacement', () => {
       const page = new DateOfPlacement(body)
 
       expect(page.response()).toEqual({
-        'How long should the Approved Premises placement last?': '2 weeks, 1 day',
-        'When will the person arrive?': 'Friday 1 December 2023',
+        'Dates of placement': [
+          {
+            'How long should the Approved Premises placement last?': '2 weeks, 1 day',
+            'When will the person arrive?': 'Friday 1 December 2023',
+          },
+          {
+            'How long should the Approved Premises placement last?': '3 weeks, 2 days',
+            'When will the person arrive?': 'Tuesday 2 January 2024',
+          },
+        ],
       })
     })
   })

--- a/server/form-pages/placement-application/request-a-placement/previousRotlPlacement.test.ts
+++ b/server/form-pages/placement-application/request-a-placement/previousRotlPlacement.test.ts
@@ -1,5 +1,5 @@
 import { fromPartial } from '@total-typescript/shoehorn'
-import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
+import { itShouldHavePreviousValue } from '../../shared-examples'
 
 import PreviousRotlPlacement, { Body } from './previousRotlPlacement'
 
@@ -31,7 +31,20 @@ describe('PreviousRotlPlacement', () => {
 
   itShouldHavePreviousValue(new PreviousRotlPlacement(body), 'reason-for-placement')
 
-  itShouldHaveNextValue(new PreviousRotlPlacement(body), 'same-ap')
+  describe('next', () => {
+    describe('if there has been a previous ROTL placementment', () => {
+      it('returns same-ap', () => {
+        const page = new PreviousRotlPlacement(body)
+        expect(page.next()).toEqual('same-ap')
+      })
+    })
+    describe('if there has not been a previous ROTL placementment', () => {
+      it('returns dates-of-placement', () => {
+        const page = new PreviousRotlPlacement({ ...body, previousRotlPlacement: 'no' })
+        expect(page.next()).toEqual('dates-of-placement')
+      })
+    })
+  })
 
   describe('errors', () => {
     it('should return an empty object if the body is provided correctly', () => {

--- a/server/form-pages/placement-application/request-a-placement/previousRotlPlacement.ts
+++ b/server/form-pages/placement-application/request-a-placement/previousRotlPlacement.ts
@@ -55,7 +55,7 @@ export default class PreviousRotlPlacement implements TasklistPage {
   }
 
   next() {
-    return 'same-ap'
+    return this.body.previousRotlPlacement === 'yes' ? 'same-ap' : 'dates-of-placement'
   }
 
   response() {

--- a/server/testutils/addToApplication.ts
+++ b/server/testutils/addToApplication.ts
@@ -12,7 +12,7 @@ export const addResponseToFormArtifact = <T extends FormArtifact>(
     },
   }
 
-  return formArtifact
+  return formArtifact as T
 }
 
 export const addResponsesToFormArtifact = <T extends FormArtifact>(
@@ -27,5 +27,5 @@ export const addResponsesToFormArtifact = <T extends FormArtifact>(
     },
   }
 
-  return formArtifact
+  return formArtifact as T
 }

--- a/server/utils/placementRequests/placementApplicationSubmissionData.ts
+++ b/server/utils/placementRequests/placementApplicationSubmissionData.ts
@@ -22,13 +22,16 @@ export const placementApplicationSubmissionData = (
     ReasonForPlacement,
     'reason',
   )
+  const placementDates = durationAndArrivalDateFromPlacementApplication(
+    placementApplication,
+    reasonForPlacement,
+    application,
+  )
   return {
     translatedDocument: placementApplication.document,
     placementType: reasonForPlacement,
     // At a later date we want to support multiple placement dates, but for now we will hard code the first one
-    placementDates: [
-      durationAndArrivalDateFromPlacementApplication(placementApplication, reasonForPlacement, application),
-    ],
+    placementDates: Array.isArray(placementDates) ? placementDates : [placementDates],
   }
 }
 
@@ -39,14 +42,7 @@ export const durationAndArrivalDateFromPlacementApplication = (
 ) => {
   switch (reasonForPlacement) {
     case 'rotl': {
-      return {
-        expectedArrival: retrieveQuestionResponseFromFormArtifact(
-          placementApplication,
-          DatesOfPlacement,
-          'arrivalDate',
-        ),
-        duration: Number(retrieveQuestionResponseFromFormArtifact(placementApplication, DatesOfPlacement, 'duration')),
-      }
+      return retrieveQuestionResponseFromFormArtifact(placementApplication, DatesOfPlacement, 'datesOfPlacement')
     }
     case 'additional_placement': {
       return {

--- a/server/views/placement-applications/pages/request-a-placement/dates-of-placement.njk
+++ b/server/views/placement-applications/pages/request-a-placement/dates-of-placement.njk
@@ -1,30 +1,296 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "../../../components/formFields/form-page-day-weeks-input/macro.njk" import formPageDaysAndWeeksInput %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% extends "../../layout.njk" %}
 
-{% block questions %}
-
-  <h1 class="govuk-heading-l">
-    {{ page.title }}
-  </h1>
-
-  {{
-    formPageDateInput(
-      {
-        fieldName: "arrivalDate",
-        fieldset: {
-          legend: {
-            classes: "govuk-fieldset__legend--m",
-            text: page.questions.arrivalDate
-          }
-        },
-        items: dateFieldValues('arrivalDate', errors)
+{% macro fieldset(index, includeButton = false) %}
+  {%
+    call govukFieldset({
+      classes: "govuk-fieldset toplevel-fieldset",
+      legend: {
+        text: "ROTL placement " + (
+        index + 1),
+        classes: "govuk-fieldset__legend govuk-fieldset__legend--m"
       },
-      fetchContext()
-    )
+      attributes: {
+        "data-fieldset": index
+      }
+    })
+  %}
+  {% set fieldPrefix = "datesOfPlacement[" + index + "]" %}
+  {% set fieldName = fieldPrefix + '[arrivalDate]' %}
+  {% set dayFieldName = "datesOfPlacement[" + index + "][arrivalDate-day]" %}
+  {% set monthFieldName = "datesOfPlacement[" + index + "][arrivalDate-month]" %}
+  {% set yearFieldName = "datesOfPlacement[" + index + "][arrivalDate-year]" %}
+  {% set fieldId = "datesOfPlacement_" + index + "_arrivalDate" %}
+  {% set context = fetchContext() %}
+  {% set body = context.page.body %}
+
+  {%set durationWeeks = "durationWeeks"%}
+  {%set durationDays = "durationDays"%}
+
+  {% set durationWeeksName = "datesOfPlacement[" + index + "][" + durationWeeks + "]" %}
+  {% set durationDaysName = "datesOfPlacement[" + index + "][" + durationDays + "]" %}
+
+  {%set arrivalDateDay = "arrivalDate-day"%}
+  {%set arrivalDateMonth = "arrivalDate-month"%}
+  {%set arrivalDateYear = "arrivalDate-year"%}
+
+  {{ govukDateInput({
+          id: fieldName,
+          fieldset: {
+          legend: {
+              text: "What is the arrival date?",
+                text: page.questions.arrivalDate
+              }
+          },
+          items: [
+                  {
+                    classes: "govuk-input--width-2 ",
+                    id: fieldId + '[day]',
+                    name: dayFieldName,
+                    label: 'Day',
+                    value: context.datesOfPlacement[index][arrivalDateDay]
+                  },
+                  {
+                    classes: "govuk-input--width-2 ",
+                    id: fieldId + '[month]',
+                    name: monthFieldName,
+                    label: 'Month',                    
+                    value: context.datesOfPlacement[index][arrivalDateMonth]
+
+                  },
+                  {
+                    classes: "govuk-input--width-4 ",
+                    id: fieldId + '[year]',
+                    name: yearFieldName,
+                    label: 'Year',                    
+                    value: context.datesOfPlacement[index][arrivalDateYear]
+                  }
+                  ],
+          errorMessage: errors[fieldId],
+          hint: {
+              text: "For example, 27 3 2024"
+          }
+        }) }}
+
+  {% set durationFieldId = "datesOfPlacement_" + index + "_duration" %}
+  {% set hasDurationErrors = errors[durationFieldId].text %}
+
+  {% if hasDurationErrors %}
+    {% set wrapperClasses = "govuk-form-group govuk-form-group--error" %}
+    {% set inputClasses = "govuk-input--width-2 govuk-input--error" %}
+  {% else %}
+    {% set wrapperClasses = "govuk-form-group" %}
+    {% set inputClasses = "govuk-input--width-2" %}
+  {% endif %}
+
+  {% set durationFieldName = fieldPrefix + '[duration]' %}
+  <div class="{{ wrapperClasses }}" id="{{ durationFieldId }}">
+
+    {% call govukFieldset({
+      legend: {
+        text: context.page.questions.duration,
+        classes: legendClasses
+      }
+    })
+ %}
+
+    {% if hasDurationErrors %}
+      <p id="{{ durationFieldId }}-error" class="govuk-error-message" data-cy-error-{{ durationFieldId }}="true">
+        <span class="govuk-visually-hidden">Error:</span>
+        {{ errors[durationFieldId].text }}
+      </p>
+    {% endif %}
+
+    {{
+      govukInput(
+        {
+          classes: inputClasses,
+          name: durationWeeksName,
+          id: "datesOfPlacement_" + index + "_duration_weeks",
+          formGroup: {
+            classes: "govuk-form-group--inline"
+          },
+          label: {
+            text: "Weeks"
+          },
+          value:  context.datesOfPlacement[index][durationWeeks]
+        },
+        context
+      )
+    }}
+
+    {{
+      govukInput(
+        {
+          classes: inputClasses,
+          name: durationDaysName,
+          id: "datesOfPlacement_" + index + "_duration_days",
+          formGroup: {
+            classes: "govuk-form-group--inline"
+          },
+          label: {
+            text: "Days"
+          },
+          value: context.datesOfPlacement[index][durationDays]
+        },
+        context
+      )
+    }}
+
+    {% endcall %}
+  </div>
+
+  {% if includeButton %}
+    {{ addButton() }}
+  {% endif %}
+
+  {% endcall %}
+{% endmacro %}
+  const errorClass = errors[durationFieldId] ? 'govuk-input--error' : ''
+{% macro addButton() %}
+  {{
+    govukButton({
+      text: "Remove",
+      attributes: {
+        "data-remove-input": "true"
+      },
+      classes: "govuk-button govuk-button--secondary moj-add-another__remove-button"
+    })
   }}
+{% endmacro %}
 
-  {{ formPageDaysAndWeeksInput("duration", "govuk-fieldset__legend--m", fetchContext()) }}
+{% block content %}
 
-{% endblock %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form action="{{ paths.placementApplications.pages.update({ id: placementApplicationId, task: task, page: page.name }) }}?_method=PUT" method="post">
+        <h1 class="govuk-heading-l">
+          {{ page.title }}
+        </h1>
+
+        {% if errorSummary | length %}
+          {{ govukErrorSummary({
+            titleText: "There is a problem",
+            errorList: errorSummary
+          }) }}
+        {% endif %}
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        <div id="fieldset-wrapper">
+          {% for i in range(0, 5) -%}
+            {{ fieldset(i) }}
+          {% endfor %}
+        </div>
+
+        {{
+          govukButton({
+            text: "Add another placement",
+            attributes: {
+              "data-add-input": "true"
+            },
+            classes: "govuk-button--secondary"
+          })
+        }}
+
+        {{
+          govukButton({
+            text: "Save and continue"
+          })
+        }}
+
+      </form>
+
+    </div>
+
+  {% endblock %}
+
+  {% block extraScripts %}
+    <script type="text/javascript" nonce="{{ cspNonce }}">
+      function initializeAddButton() {
+        var addButton = document.querySelector('button[data-add-input]');
+
+        addButton.addEventListener("click", (event) => {
+          var fieldsets = document.querySelectorAll('.toplevel-fieldset')
+          var hiddenFieldsets = document.querySelectorAll('fieldset[class*="govuk-visually-hidden"]');
+
+          if (hiddenFieldsets.length) {
+            hiddenFieldsets[0]
+              .classList
+              .remove("govuk-visually-hidden");
+          } else {
+            var fieldsetWrapper = document.querySelector('#fieldset-wrapper')
+            var newFieldset = `{{ fieldset("INDEX", true) }}`
+              .replace('INDEX1', fieldsets.length + 1)
+              .replaceAll('INDEX', fieldsets.length + 1)
+            fieldsetWrapper.innerHTML += newFieldset;
+
+            var removeButtons = fieldsetWrapper.querySelectorAll('button[data-remove-input]');
+            initializeRemoveButtons(removeButtons);
+          }
+
+          event.preventDefault();
+        })
+      }
+
+      function initializeRemoveButtons(buttons) {
+        for (let i = 0; i < buttons.length; i++) {
+
+          buttons[i].addEventListener("click", (event) => {
+            var fieldset = event.target.parentElement;
+            var inputs = fieldset.querySelectorAll('input');
+
+            fieldset
+              .classList
+              .add('govuk-visually-hidden');
+
+            for (var i = 0; i < inputs.length; i++) {
+              inputs[i].value = '';
+            }
+
+            event.preventDefault();
+          })
+        }
+      }
+
+      function initializeFieldsets() {
+        var fieldsets = document.querySelectorAll('fieldset[data-fieldset]')
+
+        for (let i = 1; i < fieldsets.length; i++) {
+          var complete = false;
+
+          var arrivalDateDay = document.querySelector('input[name="datesOfPlacement[' + i + '][arrivalDate-day]"]');
+          var arrivalDateMonth = document.querySelector('input[name="datesOfPlacement[' + i + '][arrivalDate-month]"]');
+          var arrivalDateYear = document.querySelector('input[name="datesOfPlacement[' + i + '][arrivalDate-year]"]');
+          var durationWeeks = document.querySelector('input[name="datesOfPlacement[' + i + '][durationWeeks]"]');
+          var durationDays = document.querySelector('input[name="datesOfPlacement[' + i + '][durationDays]"]');
+
+          var fields = [arrivalDateDay, arrivalDateMonth, arrivalDateYear, durationWeeks, durationDays];
+
+          fields.forEach(function (field) {
+            if (field.value) {
+              complete = true;
+            }
+          })
+
+          if (complete === false) {
+            fieldsets[i]
+              .classList
+              .add('govuk-visually-hidden');
+          }
+          fieldsets[i].innerHTML += `{{ addButton() }}`
+        }
+
+        var removeButtons = document.querySelectorAll('button[data-remove-input]');
+
+        initializeAddButton();
+        initializeRemoveButtons(removeButtons);
+      }
+
+      initializeFieldsets();
+    </script>
+  {% endblock %}


### PR DESCRIPTION
# Context

ROTL cases often have multiple release dates. 
Previously users would have to complete a Placement Application for each release which causes more work and friction. 
This change enables users to add as many Dates Of Placement as they need in one application.

[JIRA Card](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?selectedIssue=APS-27)

# Changes in this PR

## Screenshots of UI changes

### Before

![Placement Applications -- allows me to complete form if the reason for placement is ROTL (3)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/9dd3ceb3-246b-4ad7-b84b-fe8db7dd52d5)

### After
<img width="419" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/03ae3918-e3c3-4873-ac60-18dcdfecd1d8">

![Placement Applications -- allows me to complete form if the reason for placement is ROTL (2)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/19790a0e-af64-4a55-9a5f-7745ac0a0af1)
