### PR TITLE
(APS-30) Users need to be able to provide information in the application specific to pregnant women

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -359,6 +359,8 @@
       "expectedDeliveryDate-year": "2023",
       "expectedDeliveryDate-month": "12",
       "expectedDeliveryDate-day": "31",
+      "socialCareInvolvement": "yes",
+      "socialCareInvolvementDetail": "Some detail",
       "otherPregnancyConsiderations": "yes",
       "otherPregnancyConsiderationsDetail": "some considerations",
       "childRemoved": "decisionPending",

--- a/integration_tests/pages/apply/accessNeedsFurtherQuestions.ts
+++ b/integration_tests/pages/apply/accessNeedsFurtherQuestions.ts
@@ -23,6 +23,8 @@ export default class AccessNeedsFurtherQuestionsPage extends ApplyPage {
     this.completeTextInputFromPageBody('prescribedMedicationDetail')
     this.checkRadioButtonFromPageBody('isPersonPregnant')
     this.completeDateInputsFromPageBody('expectedDeliveryDate')
+    this.checkRadioButtonFromPageBody('socialCareInvolvement')
+    this.completeTextInputFromPageBody('socialCareInvolvementDetail')
     this.checkRadioButtonFromPageBody('otherPregnancyConsiderations')
     this.completeTextInputFromPageBody('otherPregnancyConsiderationsDetail')
     this.checkRadioButtonFromPageBody('childRemoved')

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsFurtherQuestions.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsFurtherQuestions.test.ts
@@ -21,6 +21,8 @@ describe('AccessNeedsFurtherQuestions', () => {
     ...DateFormats.dateObjectToDateInputs(expectedDeliveryDate, 'expectedDeliveryDate'),
     otherPregnancyConsiderations: 'yes',
     otherPregnancyConsiderationsDetail: 'Some detail',
+    socialCareInvolvement: 'yes',
+    socialCareInvolvementDetail: 'Some detail',
     childRemoved: 'no',
     isPersonPregnant: 'yes',
     additionalAdjustments: 'Adjustments',
@@ -52,6 +54,8 @@ describe('AccessNeedsFurtherQuestions', () => {
         'expectedDeliveryDate-day': '19',
         otherPregnancyConsiderations: 'yes',
         otherPregnancyConsiderationsDetail: 'Some detail',
+        socialCareInvolvement: 'yes',
+        socialCareInvolvementDetail: 'Some detail',
         childRemoved: 'no',
         additionalAdjustments: 'Adjustments',
       })
@@ -123,12 +127,31 @@ describe('AccessNeedsFurtherQuestions', () => {
           'expectedDeliveryDate-month': undefined,
           'expectedDeliveryDate-day': undefined,
           childRemoved: undefined,
+          socialCareInvolvement: undefined,
         },
         application,
       )
       expect(page.errors()).toEqual({
         expectedDeliveryDate: 'You must enter the expected delivery date',
         childRemoved: 'You must confirm if the child will be removed at birth',
+        socialCareInvolvement: 'You must confirm if there is social care involvement',
+      })
+    })
+
+    it('should return a socialCareInvolvementDetail error if the person is pregnant and socialCareInvolvement is yes and socialCareInvolvementDetail is blank', () => {
+      ;(retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.Mock).mockReturnValue(['pregnancy'])
+
+      const page = new AccessNeedsFurtherQuestions(
+        {
+          ...body,
+          isPersonPregnant: 'yes',
+          socialCareInvolvement: 'yes',
+          socialCareInvolvementDetail: undefined,
+        },
+        application,
+      )
+      expect(page.errors()).toEqual({
+        socialCareInvolvementDetail: 'You must provide details of any social care involvement',
       })
     })
   })
@@ -174,6 +197,7 @@ describe('AccessNeedsFurtherQuestions', () => {
         'Does the person have any known health conditions?': 'Yes - Some detail',
         'Does the person have any prescribed medication?': 'Yes - Some detail',
         'Is the person pregnant?': 'Yes',
+        'Is there social care involvement?': 'Yes - Some detail',
         'What is their expected date of delivery?': 'Sunday 19 February 2023',
         "Will the child be removed from the person's care at birth?": 'No',
         'Are there any pregnancy related issues relevant to placement?': 'Yes - Some detail',

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsFurtherQuestions.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsFurtherQuestions.ts
@@ -23,6 +23,7 @@ export type AccessNeedsFurtherQuestionsBody = {
 } & ObjectWithDateParts<'expectedDeliveryDate'> &
   YesOrNoWithDetail<'healthConditions'> &
   YesNoOrIDKWithDetail<'prescribedMedication'> &
+  YesNoOrIDKWithDetail<'socialCareInvolvement'> &
   YesOrNoWithDetail<'otherPregnancyConsiderations'>
 
 @Page({
@@ -39,6 +40,8 @@ export type AccessNeedsFurtherQuestionsBody = {
     'expectedDeliveryDate-year',
     'expectedDeliveryDate-month',
     'expectedDeliveryDate-day',
+    'socialCareInvolvement',
+    'socialCareInvolvementDetail',
     'otherPregnancyConsiderations',
     'otherPregnancyConsiderationsDetail',
     'additionalAdjustments',
@@ -56,6 +59,8 @@ export default class AccessNeedsFurtherQuestions implements TasklistPage {
     isPersonPregnant: `Is the person pregnant?`,
     expectedDeliveryDate: 'What is their expected date of delivery?',
     otherPregnancyConsiderationsDetail: 'Provide details',
+    socialCareInvolvement: 'Is there social care involvement?',
+    socialCareInvolvementDetail: 'Provide details',
     otherPregnancyConsiderations: 'Are there any pregnancy related issues relevant to placement?',
     childRemoved: `Will the child be removed from the person's care at birth?`,
     additionalAdjustments: `Specify any additional details and adjustments required for the person's ${this.listOfNeeds}`,
@@ -132,6 +137,10 @@ export default class AccessNeedsFurtherQuestions implements TasklistPage {
       if (this.body.isPersonPregnant === 'yes') {
         response[this.questions.expectedDeliveryDate] = DateFormats.isoDateToUIDate(this.body.expectedDeliveryDate)
         response[this.questions.childRemoved] = sentenceCase(this.body.childRemoved)
+        response[this.questions.socialCareInvolvement] = yesNoOrDontKnowResponseWithDetail(
+          'socialCareInvolvement',
+          this.body,
+        )
       }
 
       response[this.questions.otherPregnancyConsiderations] = yesOrNoResponseWithDetailForYes(
@@ -179,6 +188,12 @@ export default class AccessNeedsFurtherQuestions implements TasklistPage {
         }
         if (!this.body.childRemoved) {
           errors.childRemoved = 'You must confirm if the child will be removed at birth'
+        }
+        if (!this.body.socialCareInvolvement) {
+          errors.socialCareInvolvement = 'You must confirm if there is social care involvement'
+        }
+        if (this.body.socialCareInvolvement === 'yes' && !this.body.socialCareInvolvementDetail) {
+          errors.socialCareInvolvementDetail = 'You must provide details of any social care involvement'
         }
       }
 

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -1712,6 +1712,27 @@
             {
               "type": "object",
               "properties": {
+                "socialCareInvolvement": {
+                  "enum": [
+                    "iDontKnow",
+                    "no",
+                    "yes"
+                  ],
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "socialCareInvolvementDetail": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
                 "otherPregnancyConsiderations": {
                   "enum": [
                     "no",

--- a/server/views/applications/pages/access-and-healthcare/access-needs-further-questions.njk
+++ b/server/views/applications/pages/access-and-healthcare/access-needs-further-questions.njk
@@ -160,6 +160,38 @@
       ]
     }, fetchContext()) }}
 
+    {% set socialCareInvolvementDetail %}
+    {{ formPageTextarea({
+        fieldName: "socialCareInvolvementDetail",
+        label: {
+          text: page.questions.socialCareInvolvementDetail
+        }
+    }, fetchContext()) }}
+    {% endset -%}
+
+    {{ formPageRadios({
+      fieldName: "socialCareInvolvement",
+      fieldset: {
+        legend: {
+          text: page.questions.socialCareInvolvement,
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: [
+        {
+          value: "yes",
+          text: "Yes",
+          conditional: {
+            html: socialCareInvolvementDetail
+          }
+        },
+        {
+          value: "no",
+          text: "No"
+        }
+      ]
+    }, fetchContext()) }}
+
     {% set otherPregnancyConsiderationsDetail %}
     {{ formPageTextarea({
         fieldName: "otherPregnancyConsiderationsDetail",


### PR DESCRIPTION
This adds two additional questions to the accessNeedsFurtherQuestions page:

- Is there social care involvement?; and
- Provide details

If the person is pregnant then the social care involvement question should be answered. If the answer is yes, then details must be provided.

There’s probably going to be a need to split this page into seperate pages in future, but for now, let’s add the question as the designs show.

## Screenshot

### Before

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/56e290bc-3a00-490e-b71d-10706452763a)

### After

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/aa04f7d1-2d29-4063-91a0-db213c953e6d)
