### PR TITLE
APS-61: If the document is not listed below, upload the document to D…

### DIFF
--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -139,7 +139,7 @@ export default class ApplyHelper {
     confirmDetailsPage.clickSubmit()
   }
 
-  completeApplication(isExceptionalCase?: boolean, isInComunity?: boolean) {
+  completeApplication({ isExceptionalCase = false, isInComunity = false, isNoDocuments = false } = {}) {
     if (isExceptionalCase) {
       this.completeExceptionalCase()
     }
@@ -151,9 +151,11 @@ export default class ApplyHelper {
     this.completeAccessAndHealthcareSection()
     this.completeFurtherConsiderationsSection()
     this.completeMoveOnSection()
-    this.completeDocumentsSection()
-    this.completeCheckYourAnswersSection()
-    this.submitApplication()
+    if (!isNoDocuments) {
+      this.completeDocumentsSection()
+      this.completeCheckYourAnswersSection()
+      this.submitApplication()
+    }
   }
 
   completeEmergencyApplication() {
@@ -369,10 +371,10 @@ export default class ApplyHelper {
     cy.task('stubAcctAlerts', { person: this.person, acctAlerts: this.acctAlerts })
   }
 
-  private stubDocumentEndpoints() {
+  stubDocumentEndpoints(documents?: Array<Document>) {
     // And there are documents in the database
     this.selectedDocuments = documentsFromApplication(this.application)
-    this.documents = [this.selectedDocuments, documentFactory.buildList(4)].flat()
+    this.documents = documents || [this.selectedDocuments, documentFactory.buildList(4)].flat()
 
     cy.task('stubApplicationDocuments', { application: this.application, documents: this.documents })
     this.documents.forEach(document => {
@@ -943,6 +945,18 @@ export default class ApplyHelper {
     // And the Attach Documents task should show a completed status
     tasklistPage.shouldShowTaskStatus('attach-required-documents', 'Completed')
     tasklistPage.shouldNotShowSubmitComponents()
+  }
+
+  verifyNoDocumentsDisplayed() {
+    // Given I click on the Attach Documents task
+    cy.get('[data-cy-task-name="attach-required-documents"]').click()
+    const attachDocumentsPage = new ApplyPages.AttachDocumentsPage(
+      this.documents,
+      this.selectedDocuments,
+      this.application,
+    )
+    // Then I should be able to see the no documents message
+    attachDocumentsPage.shouldDisplayNoDocuments()
   }
 
   private completeCheckYourAnswersSection() {

--- a/integration_tests/pages/apply/attachDocumentsPage.ts
+++ b/integration_tests/pages/apply/attachDocumentsPage.ts
@@ -40,6 +40,10 @@ export default class AttachDocumentsPage extends ApplyPage {
     })
   }
 
+  shouldDisplayNoDocuments() {
+    cy.get('p').contains('No documents have been imported from Delius')
+  }
+
   completeForm() {
     this.selectedDocuments.forEach(d => {
       const textareaSelector = `textarea[name="documentDescriptions[${d.id}]"]`

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -218,7 +218,7 @@ context('Apply', () => {
 
     apply.setupApplicationStubs(uiRisks)
     apply.startApplication()
-    apply.completeApplication(false, true)
+    apply.completeApplication({ isExceptionalCase: false, isInComunity: true })
 
     // Then the application should be submitted to the API
     cy.task('verifyApplicationUpdate', this.application.id).then((requests: Array<{ body: string }>) => {
@@ -356,5 +356,21 @@ context('Apply', () => {
 
     // Then I should see a screen telling me they have no offences
     Page.verifyOnPage(NoOffencePage)
+  })
+
+  it('shows the user a message if there are no documents imported from Delius', function test() {
+    // Given I complete the documents selection of application
+    const uiRisks = mapApiPersonRisksForUi(this.application.risks)
+    const apply = new ApplyHelper(this.application, this.person, this.offences)
+
+    apply.setupApplicationStubs(uiRisks)
+
+    // And no documents uploaded to the application
+    apply.stubDocumentEndpoints([])
+    apply.startApplication()
+    apply.completeApplication({ isNoDocuments: true })
+
+    // Then should display No documents have been imported from Delius message will be displayed
+    apply.verifyNoDocumentsDisplayed()
   })
 })

--- a/server/form-pages/apply/add-documents/attachDocuments.test.ts
+++ b/server/form-pages/apply/add-documents/attachDocuments.test.ts
@@ -89,6 +89,23 @@ describe('attachDocuments', () => {
       })
       expect(page.documents).toEqual(documents)
     })
+
+    it('returns no documents if documents not uploaded in the application', async () => {
+      applicationService.getDocuments.mockResolvedValue(documentFactory.buildList(0))
+      const page = await AttachDocuments.initialize(
+        {
+          selectedDocuments: [],
+        },
+        application,
+        'SOME_TOKEN',
+        fromPartial({ applicationService, personService }),
+      )
+
+      expect(page.body).toEqual({
+        selectedDocuments: [],
+      })
+      expect(page.documents).toEqual([])
+    })
   })
 
   itShouldHaveNextValue(new AttachDocuments({}, application), '')

--- a/server/views/applications/pages/attach-required-documents/attach-documents.njk
+++ b/server/views/applications/pages/attach-required-documents/attach-documents.njk
@@ -10,6 +10,7 @@
   
   <p>These documents are imported from NDelius. </p>
   <p>Select any additional documents that you want to include to support your application. </p>
+  <p>If the document is not listed below, upload the document to Delius and reload this page to add them to your application. </p>
 
   {% set detailsHTML %}
   <strong>All applications should include the following documents:</strong>
@@ -67,5 +68,8 @@
     ],
     rows: AttachDocumentsUtils.tableRows(page.documents, page.body.selectedDocuments, page.application, errors)
   }) }}
+  {% if page.documents.length === 0 %}
+      <p class="govuk-body">No documents have been imported from Delius</p>
+  {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
…elius and reload this page to add them to your application

# Context

<!-- [Is there a Jira ticket you can link to?](https://dsdmoj.atlassian.net/browse/APS-61) -->

# Changes in this PR
If the document is not listed in select additional documents table then upload the document to Delius and reload this page to add them to your application
and 
No documents have been imported from Delius 
will be displayed in the table
## Screenshots of UI changes

### Before
<img width="983" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/fee11153-7535-45ad-a8ee-e0c9dab7fc33">

### After
<img width="978" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/7c6159e1-1307-46e5-9c09-bcf753ca8b31">

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
      `production` in a backwards compatible way? (This includes our API,
      infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
      advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
