### PR TITLE
(APS-27) - Display mutliple ROTL placement days on application show page

### DIFF
--- a/integration_tests/tests/apply/viewApplication.cy.ts
+++ b/integration_tests/tests/apply/viewApplication.cy.ts
@@ -268,6 +268,12 @@ const makeRotlPlacementApplication = (applicationId: string) => {
         durationDays: '20',
         duration: '20',
       },
+      {
+        arrivalDate: '2024-01-01',
+        durationDays: '10',
+        durationWeeks: '1',
+        duration: '17',
+      },
     ],
   })
   return rotlPlacementApplication

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -875,19 +875,19 @@ describe('utils', () => {
 
   describe('lengthOfStayForUI', () => {
     it('returns 0 days if the length of stay is "0"', () => {
-      expect(lengthOfStayForUI('0')).toEqual('0 days')
+      expect(lengthOfStayForUI(0)).toEqual('0 days')
     })
 
     it('returns 1 day if the length of stay is "1"', () => {
-      expect(lengthOfStayForUI('1')).toEqual('1 day')
+      expect(lengthOfStayForUI(1)).toEqual('1 day')
     })
 
     it('returns 2 days if the length of stay is "2"', () => {
-      expect(lengthOfStayForUI('2')).toEqual('2 days')
+      expect(lengthOfStayForUI(2)).toEqual('2 days')
     })
 
-    it('returns "None supplied if the length of stay is an empty string', () => {
-      expect(lengthOfStayForUI('')).toEqual('None supplied')
+    it('returns "None supplied if the length of stay is null', () => {
+      expect(lengthOfStayForUI(null)).toEqual('None supplied')
     })
   })
 

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -713,7 +713,7 @@ describe('utils', () => {
     const user = userFactory.build()
     const placementApplications = placementApplicationFactory.buildList(1, { createdByUserId: user.id })
     const arrivalDate = '2023-01-01'
-    const duration = '20'
+    const duration = 20
 
     it('returns a placement application mapped to SummaryCard including an action when the placement application can be withdrawn', () => {
       ;(
@@ -725,7 +725,7 @@ describe('utils', () => {
         durationAndArrivalDateFromPlacementApplication as jest.MockedFunction<
           typeof durationAndArrivalDateFromPlacementApplication
         >
-      ).mockReturnValue({ expectedArrival: arrivalDate, duration })
+      ).mockReturnValue([{ expectedArrival: arrivalDate, duration }])
 
       expect(mapPlacementApplicationToSummaryCards(placementApplications, application, user)).toEqual([
         {
@@ -771,6 +771,84 @@ describe('utils', () => {
       ])
     })
 
+    it('can display multiple placement dates', () => {
+      const arrivalDate1 = arrivalDate
+      const duration1 = duration
+      const arrivalDate2 = '2023-02-01'
+      const duration2 = 30
+
+      ;(
+        retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.MockedFunction<
+          typeof retrieveOptionalQuestionResponseFromApplicationOrAssessment
+        >
+      ).mockReturnValue('rotl')
+      ;(
+        durationAndArrivalDateFromPlacementApplication as jest.MockedFunction<
+          typeof durationAndArrivalDateFromPlacementApplication
+        >
+      ).mockReturnValue([
+        { expectedArrival: arrivalDate1, duration: duration1 },
+        { expectedArrival: arrivalDate2, duration: duration2 },
+      ])
+
+      expect(mapPlacementApplicationToSummaryCards(placementApplications, application, user)).toEqual([
+        {
+          card: {
+            title: { headingLevel: '3', text: DateFormats.isoDateToUIDate(placementApplications[0].createdAt) },
+            attributes: { 'data-cy-placement-application-id': placementApplications[0].id },
+            actions: {
+              items: [
+                {
+                  href: placementApplicationPaths.placementApplications.withdraw.new({
+                    id: placementApplications[0].id,
+                  }),
+                  text: 'Withdraw',
+                },
+              ],
+            },
+          },
+          rows: [
+            {
+              key: {
+                text: 'Reason for placement request',
+              },
+              value: {
+                text: 'Release on Temporary Licence (ROTL)',
+              },
+            },
+            {
+              key: {
+                text: 'Arrival date',
+              },
+              value: {
+                text: DateFormats.isoDateToUIDate(arrivalDate1),
+              },
+            },
+            {
+              key: {
+                text: 'Length of stay',
+              },
+              value: { text: lengthOfStayForUI(duration1) },
+            },
+            {
+              key: {
+                text: 'Arrival date',
+              },
+              value: {
+                text: DateFormats.isoDateToUIDate(arrivalDate2),
+              },
+            },
+            {
+              key: {
+                text: 'Length of stay',
+              },
+              value: { text: lengthOfStayForUI(duration2) },
+            },
+          ],
+        },
+      ])
+    })
+
     it('doesnt include an action when the placement application doesnt have the the canBeWithdrawn boolean', () => {
       ;(
         retrieveOptionalQuestionResponseFromApplicationOrAssessment as jest.MockedFunction<
@@ -781,7 +859,7 @@ describe('utils', () => {
         durationAndArrivalDateFromPlacementApplication as jest.MockedFunction<
           typeof durationAndArrivalDateFromPlacementApplication
         >
-      ).mockReturnValue({ expectedArrival: arrivalDate, duration })
+      ).mockReturnValue([{ expectedArrival: arrivalDate, duration }])
       placementApplications[0].canBeWithdrawn = undefined
 
       expect(mapPlacementApplicationToSummaryCards(placementApplications, application, user)).toEqual([
@@ -831,7 +909,7 @@ describe('utils', () => {
         durationAndArrivalDateFromPlacementApplication as jest.MockedFunction<
           typeof durationAndArrivalDateFromPlacementApplication
         >
-      ).mockReturnValue({ expectedArrival: arrivalDate, duration })
+      ).mockReturnValue([{ expectedArrival: arrivalDate, duration }])
       placementApplications[0].canBeWithdrawn = true
       placementApplications[0].createdByUserId = 'another-user-id'
 

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -307,7 +307,7 @@ const mapPlacementApplicationToSummaryCards = (
       'reason',
     ) as PlacementType
 
-    const { expectedArrival, duration } = durationAndArrivalDateFromPlacementApplication(
+    const datesOfPlacements = durationAndArrivalDateFromPlacementApplication(
       placementApplication,
       reasonForPlacement,
       application,
@@ -342,18 +342,24 @@ const mapPlacementApplicationToSummaryCards = (
           key: { text: 'Reason for placement request' },
           value: { text: reasonsDictionary[reasonForPlacement] || 'None supplied' },
         },
-        {
-          key: { text: 'Arrival date' },
-          value: {
-            text: expectedArrival ? DateFormats.isoDateToUIDate(expectedArrival) : 'None supplied',
-          },
-        },
-        {
-          key: { text: 'Length of stay' },
-          value: {
-            text: lengthOfStayForUI(duration),
-          },
-        },
+        ...datesOfPlacements
+          .map(({ expectedArrival, duration }) => {
+            return [
+              {
+                key: { text: 'Arrival date' },
+                value: {
+                  text: expectedArrival ? DateFormats.isoDateToUIDate(expectedArrival) : 'None supplied',
+                },
+              },
+              {
+                key: { text: 'Length of stay' },
+                value: {
+                  text: lengthOfStayForUI(duration),
+                },
+              },
+            ]
+          })
+          .flat(),
       ],
     }
   })

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -359,13 +359,9 @@ const mapPlacementApplicationToSummaryCards = (
   })
 }
 
-const lengthOfStayForUI = (duration: string) => {
-  if (duration === '') return 'None supplied'
-
-  const durationNumber = Number(duration)
-
-  if (durationNumber === 0 || durationNumber) {
-    return `${durationNumber} day${durationNumber === 1 ? '' : 's'}`
+const lengthOfStayForUI = (duration: number) => {
+  if (duration === 0 || duration) {
+    return `${duration} day${duration === 1 ? '' : 's'}`
   }
 
   return 'None supplied'

--- a/server/utils/assessments/placementDurationFromApplication.ts
+++ b/server/utils/assessments/placementDurationFromApplication.ts
@@ -5,7 +5,7 @@ import { retrieveOptionalQuestionResponseFromApplicationOrAssessment } from '../
 
 export const placementDurationFromApplication = (application: Application) => {
   return (
-    retrieveOptionalQuestionResponseFromApplicationOrAssessment(application, PlacementDuration, 'duration') ||
+    Number(retrieveOptionalQuestionResponseFromApplicationOrAssessment(application, PlacementDuration, 'duration')) ||
     getDefaultPlacementDurationInDays(application)
   )
 }

--- a/server/utils/placementRequests/placementApplicationSubmissionData.test.ts
+++ b/server/utils/placementRequests/placementApplicationSubmissionData.test.ts
@@ -130,21 +130,27 @@ describe('durationAndArrivalDateFromPlacementApplication', () => {
         'additional_placement',
         applicationFactory.build(),
       ),
-    ).toEqual({
-      expectedArrival: '2023-01-01',
-      duration: 1,
-    })
+    ).toEqual([
+      {
+        expectedArrival: '2023-01-01',
+        duration: 1,
+      },
+    ])
     expect(pageDataFromApplicationOrAssessment).toHaveBeenCalledWith(AdditionalPlacementDetails, placementApplication)
   })
 
   it('calculates the release date to be decision to release date + 6 weeks and retrieves the placement duration from the application if the "reason" is "release_following_decision"', () => {
-    const placementApplication = placementApplicationFactory.build({
+    let placementApplication = placementApplicationFactory.build({
       data: { 'request-a-placement': { 'reason-for-placement': { reason: 'release_following_decision' } } },
     })
-
+    placementApplication = addResponseToFormArtifact(placementApplication, {
+      task: 'request-a-placement',
+      page: 'decision-to-release',
+      key: 'decisionToReleaseDate',
+      value: '2023-01-01',
+    })
     ;(pageDataFromApplicationOrAssessment as jest.Mock).mockReturnValue({
       decisionToReleaseDate: '2023-01-01',
-      duration: '1',
     })
     ;(placementDurationFromApplication as jest.Mock).mockReturnValue('1')
 
@@ -154,10 +160,12 @@ describe('durationAndArrivalDateFromPlacementApplication', () => {
         'release_following_decision',
         applicationFactory.build(),
       ),
-    ).toEqual({
-      duration: '1',
-      expectedArrival: '2023-02-12',
-    })
+    ).toEqual([
+      {
+        duration: 1,
+        expectedArrival: '2023-02-12',
+      },
+    ])
     expect(pageDataFromApplicationOrAssessment).toHaveBeenCalledWith(DecisionToRelease, placementApplication)
   })
 })

--- a/server/utils/placementRequests/placementApplicationSubmissionData.test.ts
+++ b/server/utils/placementRequests/placementApplicationSubmissionData.test.ts
@@ -116,7 +116,7 @@ describe('durationAndArrivalDateFromPlacementApplication', () => {
 
   it('returns the arrivalDate and duration from the additional-placement-details page if the "reason" is "additional_placement"', () => {
     const placementApplication = placementApplicationFactory.build({
-      data: { 'request-a-placement': { 'reason-for-placement': { reason: 'rotl' } } },
+      data: { 'request-a-placement': { 'reason-for-placement': { reason: 'additional_placement' } } },
     })
 
     ;(pageDataFromApplicationOrAssessment as jest.Mock).mockReturnValue({

--- a/server/utils/placementRequests/placementApplicationSubmissionData.ts
+++ b/server/utils/placementRequests/placementApplicationSubmissionData.ts
@@ -15,6 +15,11 @@ import { placementDurationFromApplication } from '../assessments/placementDurati
 import DecisionToRelease from '../../form-pages/placement-application/request-a-placement/decisionToRelease'
 import { DateFormats } from '../dateUtils'
 
+type DatesOfStay = {
+  expectedArrival: string
+  duration: number | null
+}
+
 export const placementApplicationSubmissionData = (
   placementApplication: PlacementApplication,
   application: Application,
@@ -37,7 +42,7 @@ export const placementApplicationSubmissionData = (
   }
 }
 
-export const durationAndArrivalDateFromRotlPlacementApplication = (dateOfPlacement: DateOfPlacement) => {
+export const durationAndArrivalDateFromRotlPlacementApplication = (dateOfPlacement: DateOfPlacement): DatesOfStay => {
   return {
     expectedArrival: dateOfPlacement.arrivalDate,
     duration: Number(dateOfPlacement.duration),
@@ -48,7 +53,7 @@ export const durationAndArrivalDateFromPlacementApplication = (
   placementApplication: PlacementApplication,
   reasonForPlacement: PlacementType,
   application: Application,
-) => {
+): Array<DatesOfStay> => {
   switch (reasonForPlacement) {
     case 'rotl': {
       return retrieveQuestionResponseFromFormArtifact(placementApplication, DatesOfPlacement, 'datesOfPlacement').map(
@@ -56,16 +61,18 @@ export const durationAndArrivalDateFromPlacementApplication = (
       )
     }
     case 'additional_placement': {
-      return {
-        expectedArrival: retrieveQuestionResponseFromFormArtifact(
-          placementApplication,
-          AdditionalPlacementDetails,
-          'arrivalDate',
-        ),
-        duration: Number(
-          retrieveQuestionResponseFromFormArtifact(placementApplication, AdditionalPlacementDetails, 'duration'),
-        ),
-      }
+      return [
+        {
+          expectedArrival: retrieveQuestionResponseFromFormArtifact(
+            placementApplication,
+            AdditionalPlacementDetails,
+            'arrivalDate',
+          ),
+          duration: Number(
+            retrieveQuestionResponseFromFormArtifact(placementApplication, AdditionalPlacementDetails, 'duration'),
+          ),
+        },
+      ]
     }
     case 'release_following_decision': {
       const decisionToReleaseDate = retrieveQuestionResponseFromFormArtifact(
@@ -74,16 +81,20 @@ export const durationAndArrivalDateFromPlacementApplication = (
         'decisionToReleaseDate',
       )
 
-      return {
-        expectedArrival: DateFormats.dateObjToIsoDate(addWeeks(DateFormats.isoToDateObj(decisionToReleaseDate), 6)),
-        duration: placementDurationFromApplication(application),
-      }
+      return [
+        {
+          expectedArrival: DateFormats.dateObjToIsoDate(addWeeks(DateFormats.isoToDateObj(decisionToReleaseDate), 6)),
+          duration: Number(placementDurationFromApplication(application)),
+        },
+      ]
     }
 
     default:
-      return {
-        expectedArrival: '',
-        duration: '',
-      }
+      return [
+        {
+          expectedArrival: '',
+          duration: null,
+        },
+      ]
   }
 }


### PR DESCRIPTION
# Context
As Placement Applications can now have multiple dates of placement we need to display this on the `applications/show` page.

[JIRA ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?selectedIssue=APS-27) 

# Changes in this PR 
- Some minor refactorings
- We adapt the `mapPlacementApplicationToSummaryCards` to be able to handle multiple dates of placement

## Screenshots of UI changes

### Before
![before](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/c1c4b71f-ceb4-41df-b370-0b6ac535f1fa)



### After
![after](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/08027311-a87c-4754-a4d7-b08a92473abb)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
      `production` in a backwards compatible way? (This includes our API,
      infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
      advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
