### PR TITLE
Throw error if OASys summary can't be found for CYA page

### DIFF
--- a/server/utils/oasysImportUtils.test.ts
+++ b/server/utils/oasysImportUtils.test.ts
@@ -14,6 +14,7 @@ import { mapApiPersonRisksForUi, sentenceCase } from './utils'
 import {
   Constructor,
   fetchOptionalOasysSections,
+  findSummary,
   getOasysSections,
   oasysImportReponse,
   sectionCheckBoxes,
@@ -242,6 +243,16 @@ describe('OASysImportUtils', () => {
       const result = oasysImportReponse({}, [])
 
       expect(result).toEqual({})
+    })
+  })
+
+  describe('findSummary', () => {
+    it('returns a summary if one exists', () => {
+      expect(findSummary('2.1', oasysStubs.offenceDetails)).toEqual(oasysStubs.offenceDetails[0])
+    })
+
+    it('throws an error if the summary isnt found', () => {
+      expect(() => findSummary('1', [])).toThrow('No summary found for question number 1')
     })
   })
 

--- a/server/utils/oasysImportUtils.ts
+++ b/server/utils/oasysImportUtils.ts
@@ -109,8 +109,14 @@ export const oasysImportReponse = (answers: Record<string, string>, summaries: A
   }, {}) as Record<string, string>
 }
 
-const findSummary = (questionNumber: string, summaries: Array<OASysQuestion>) => {
-  return summaries.find(i => i.questionNumber === questionNumber)
+export const findSummary = (questionNumber: string, summaries: Array<OASysQuestion>) => {
+  const summary = summaries.find(i => i.questionNumber === questionNumber)
+
+  if (!summary) {
+    throw new Error(`No summary found for question number ${questionNumber}`)
+  }
+
+  return summary
 }
 
 export const fetchOptionalOasysSections = (application: Application): Array<number> => {


### PR DESCRIPTION
We assume that when a summary can't be found on the Check Your Answers pageit's because the OASys pages haven't been completed as we'd expect. Users can click through the tabs instead of clicking the 'Save and continue' button at the bottom of the page which is harder to find.
The result of this is an error on the check your answers screen. In order to see a more helpful error in the logs I think it is worth handling this error.
