### PR TITLE
APS 27 Placement Application Review handles nested values

### DIFF
--- a/server/form-pages/apply/add-documents/attachDocuments.test.ts
+++ b/server/form-pages/apply/add-documents/attachDocuments.test.ts
@@ -137,5 +137,11 @@ describe('attachDocuments', () => {
 
       expect(page.response()).toEqual({ 'file1.pdf': 'Description goes here', 'file2.pdf': 'No description' })
     })
+
+    it('should return a record with the document filename as the key and the description as the value', () => {
+      const page = new AttachDocuments({ selectedDocuments: [] }, application)
+
+      expect(page.response()).toEqual({ 'N/A': 'No documents attached' })
+    })
   })
 })

--- a/server/form-pages/apply/add-documents/attachDocuments.ts
+++ b/server/form-pages/apply/add-documents/attachDocuments.ts
@@ -63,6 +63,12 @@ export default class AttachDocuments implements TasklistPage {
   response() {
     const response = {}
 
+    if (this.body.selectedDocuments.length === 0) {
+      return {
+        'N/A': 'No documents attached',
+      }
+    }
+
     this.body.selectedDocuments.forEach(d => {
       response[d.fileName] = d.description || 'No description'
     })

--- a/server/utils/placementRequests/checkYourAnswersUtils.test.ts
+++ b/server/utils/placementRequests/checkYourAnswersUtils.test.ts
@@ -88,7 +88,7 @@ describe('checkYourAnswersUtils', () => {
   })
 
   describe('placementApplicationQuestionsForReview', () => {
-    it('should return the responses in the correct format', () => {
+    it('should return the responses in the correct format when the values are primitives', () => {
       const placementApp = placementApplicationFactory.build({
         document: { 'request-a-placement': [{ 'question 1': 'answer 1', 'question 2': 'answer 2' }] },
       })
@@ -102,6 +102,81 @@ describe('checkYourAnswersUtils', () => {
         rows: [
           { key: { text: 'question 1' }, value: { text: 'answer 1' } },
           { key: { text: 'question 2' }, value: { text: 'answer 2' } },
+        ],
+      }
+
+      expect(placementApplicationQuestionsForReview(placementApp)).toEqual(expected)
+    })
+
+    it('should return the responses in the correct format when the values contain an array', () => {
+      const placementApp = placementApplicationFactory.build({
+        document: {
+          'request-a-placement': [
+            {
+              'Dates of placement': [
+                {
+                  'How long should the Approved Premises placement last?': '2 weeks, 1 day',
+                  'When will the person arrive?': 'Friday 1 December 2023',
+                },
+                {
+                  'How long should the Approved Premises placement last?': '3 weeks, 2 days',
+                  'When will the person arrive?': 'Tuesday 2 January 2024',
+                },
+              ],
+            },
+          ],
+        },
+      })
+
+      const expected = {
+        card: {
+          title: {
+            text: 'Placement application information',
+          },
+        },
+        rows: [
+          {
+            key: { text: 'Dates of placement' },
+            value: {
+              html: `<dl class="govuk-summary-list govuk-summary-list--embedded">
+      <div class="govuk-summary-list__row govuk-summary-list__row--embedded">
+        <dt class="govuk-summary-list__key govuk-summary-list__key--embedded">
+          How long should the Approved Premises placement last?
+        </dt>
+        <dd class="govuk-summary-list__value govuk-summary-list__value--embedded">
+        2 weeks, 1 day
+        </dd>
+      </div>
+      
+      <div class="govuk-summary-list__row govuk-summary-list__row--embedded">
+        <dt class="govuk-summary-list__key govuk-summary-list__key--embedded">
+          When will the person arrive?
+        </dt>
+        <dd class="govuk-summary-list__value govuk-summary-list__value--embedded">
+        Friday 1 December 2023
+        </dd>
+      </div>
+      </dl><dl class="govuk-summary-list govuk-summary-list--embedded">
+      <div class="govuk-summary-list__row govuk-summary-list__row--embedded">
+        <dt class="govuk-summary-list__key govuk-summary-list__key--embedded">
+          How long should the Approved Premises placement last?
+        </dt>
+        <dd class="govuk-summary-list__value govuk-summary-list__value--embedded">
+        3 weeks, 2 days
+        </dd>
+      </div>
+      
+      <div class="govuk-summary-list__row govuk-summary-list__row--embedded">
+        <dt class="govuk-summary-list__key govuk-summary-list__key--embedded">
+          When will the person arrive?
+        </dt>
+        <dd class="govuk-summary-list__value govuk-summary-list__value--embedded">
+        Tuesday 2 January 2024
+        </dd>
+      </div>
+      </dl>`,
+            },
+          },
         ],
       }
 

--- a/server/utils/placementRequests/checkYourAnswersUtils.ts
+++ b/server/utils/placementRequests/checkYourAnswersUtils.ts
@@ -36,16 +36,21 @@ export const placementApplicationQuestionsForReview = (placementApplication: Pla
 
 const placementApplicationResponsesAsSummaryListItems = (placementApplication: PlacementApplication) => {
   const listItems: Array<SummaryListItem> = []
-  ;(placementApplication.document['request-a-placement'] as Array<Record<string, string>>).forEach(questions => {
+  ;(
+    placementApplication.document['request-a-placement'] as Array<
+      Record<string, string | Array<Record<string, string>>>
+    >
+  ).forEach(questions => {
     const keys = Object.keys(questions)
     keys.forEach(key => {
       listItems.push({
         key: {
           text: key,
         },
-        value: {
-          text: questions[key],
-        },
+        value:
+          typeof questions[key] === 'string' || questions[key] instanceof String
+            ? { text: questions[key] as string }
+            : { html: embeddedSummaryListItem(questions[key] as Array<Record<string, unknown>>) },
       })
     })
   })


### PR DESCRIPTION
Previously nested values in the Placement Application review screens would show as '[Object Object]'
as we didn't handle them in the same way as we do in [summaryListUtils](https://github.com/ministryofjustice/hmpps-approved-premises-ui/blob/f3a0a3c7cfce28b1aa0c98182021bd22b9f74582/server/utils/applications/summaryListUtils.ts#L38) where we check to see if an object is a string or a nested value.

