### PR TITLE
(AP6 86 / APS 152) Normalise CRN when searching

### DIFF
--- a/integration_tests/tests/admin/searchPlacementRequests.cy.ts
+++ b/integration_tests/tests/admin/searchPlacementRequests.cy.ts
@@ -2,6 +2,7 @@ import SearchPage from '../../pages/admin/placementApplications/searchPage'
 
 import { placementRequestFactory } from '../../../server/testutils/factories'
 import { PlacementRequestDashboardSearchOptions } from '../../../server/@types/ui'
+import { normaliseCrn } from '../../../server/utils/normaliseCrn'
 
 context('Search placement Requests', () => {
   const placementRequests = placementRequestFactory.buildList(3)
@@ -23,7 +24,11 @@ context('Search placement Requests', () => {
     cy.signIn()
 
     cy.task('stubPlacementRequestsSearch', { placementRequests })
-    cy.task('stubPlacementRequestsSearch', { placementRequests: searchResults, ...searchQuery })
+    cy.task('stubPlacementRequestsSearch', {
+      placementRequests: searchResults,
+      ...searchQuery,
+      crnOrName: normaliseCrn(searchQuery.crnOrName),
+    })
   })
 
   it('allows me to search for placement requests', () => {

--- a/integration_tests/tests/apply/dashboard.cy.ts
+++ b/integration_tests/tests/apply/dashboard.cy.ts
@@ -1,4 +1,5 @@
 import { applicationSummaryFactory } from '../../../server/testutils/factories'
+import { normaliseCrn } from '../../../server/utils/normaliseCrn'
 import DashboardPage from '../../pages/apply/dashboard'
 
 context('All applications', () => {
@@ -88,9 +89,11 @@ context('All applications', () => {
     page.searchByCrnOrName('foo')
 
     // Then the API should have received a request for the query
-    cy.task('verifyDashboardRequest', { page: '1', searchOptions: { crnOrName: 'foo' } }).then(requests => {
-      expect(requests).to.have.length.greaterThan(0)
-    })
+    cy.task('verifyDashboardRequest', { page: '1', searchOptions: { crnOrName: normaliseCrn('foo') } }).then(
+      requests => {
+        expect(requests).to.have.length.greaterThan(0)
+      },
+    )
 
     // And I should see the search results that match that query
     page = new DashboardPage([applications[1]])

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -13,6 +13,7 @@ import {
 import paths from '../paths/api'
 import describeClient from '../testutils/describeClient'
 import { WithdrawalReason } from '../@types/shared'
+import { normaliseCrn } from '../utils/normaliseCrn'
 
 describeClient('ApplicationClient', provider => {
   let applicationClient: ApplicationClient
@@ -273,7 +274,13 @@ describeClient('ApplicationClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.applications.all.pattern,
-          query: { page: '2', sortBy: 'createdAt', sortDirection: 'desc', crnOrName: 'foo', status: 'rejected' },
+          query: {
+            page: '2',
+            sortBy: 'createdAt',
+            sortDirection: 'desc',
+            crnOrName: normaliseCrn('foo'),
+            status: 'rejected',
+          },
           headers: {
             authorization: `Bearer ${token}`,
             'X-Service-Name': 'approved-premises',
@@ -290,7 +297,10 @@ describeClient('ApplicationClient', provider => {
         },
       })
 
-      const result = await applicationClient.dashboard(2, 'createdAt', 'desc', { crnOrName: 'foo', status: 'rejected' })
+      const result = await applicationClient.dashboard(2, 'createdAt', 'desc', {
+        crnOrName: 'foo',
+        status: 'rejected',
+      })
 
       expect(result).toEqual({
         data: allApplications,

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -18,6 +18,7 @@ import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
 import { ApplicationDashboardSearchOptions, PaginatedResponse } from '../@types/ui'
+import { normaliseCrn } from '../utils/normaliseCrn'
 
 export default class ApplicationClient {
   restClient: RestClient
@@ -60,6 +61,7 @@ export default class ApplicationClient {
     sortDirection: SortDirection,
     searchOptions: ApplicationDashboardSearchOptions,
   ): Promise<PaginatedResponse<ApprovedPremisesApplicationSummary>> {
+    searchOptions.crnOrName = normaliseCrn(searchOptions.crnOrName)
     return this.restClient.getPaginatedResponse<ApprovedPremisesApplicationSummary>({
       path: paths.applications.all.pattern,
       page: page.toString(),

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -16,6 +16,7 @@ import {
 import paths from '../paths/api'
 
 import describeClient from '../testutils/describeClient'
+import { normaliseCrn } from '../utils/normaliseCrn'
 
 describeClient('PersonClient', provider => {
   let personClient: PersonClient
@@ -38,7 +39,7 @@ describeClient('PersonClient', provider => {
           method: 'GET',
           path: `/people/search`,
           query: {
-            crn: 'crn',
+            crn: normaliseCrn('crn'),
           },
           headers: {
             authorization: `Bearer ${token}`,
@@ -65,7 +66,7 @@ describeClient('PersonClient', provider => {
           method: 'GET',
           path: `/people/search`,
           query: {
-            crn: 'crn',
+            crn: normaliseCrn('crn'),
             checkCaseload: 'true',
           },
           headers: {

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -17,6 +17,7 @@ import paths from '../paths/api'
 import { createQueryString } from '../utils/utils'
 
 import oasysStubs from './stubs/oasysStubs.json'
+import { normaliseCrn } from '../utils/normaliseCrn'
 
 export default class PersonClient {
   restClient: RestClient
@@ -26,7 +27,7 @@ export default class PersonClient {
   }
 
   async search(crn: string, checkCaseload: boolean): Promise<Person> {
-    let query = { crn } as Record<string, string | boolean>
+    let query = { crn: normaliseCrn(crn) } as Record<string, string | boolean>
 
     if (checkCaseload) {
       query = { ...query, checkCaseload: true }

--- a/server/data/placementRequestClient.test.ts
+++ b/server/data/placementRequestClient.test.ts
@@ -9,6 +9,7 @@ import {
   placementRequestFactory,
 } from '../testutils/factories'
 import describeClient from '../testutils/describeClient'
+import { normaliseCrn } from '../utils/normaliseCrn'
 
 describeClient('placementRequestClient', provider => {
   let placementRequestClient: PlacementRequestClient
@@ -123,7 +124,7 @@ describeClient('placementRequestClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.placementRequests.dashboard.pattern,
-          query: { crnOrName: 'CRN123', page: '1', sortBy: 'created_at', sortDirection: 'asc' },
+          query: { crnOrName: normaliseCrn('crn123'), page: '1', sortBy: 'created_at', sortDirection: 'asc' },
           headers: {
             authorization: `Bearer ${token}`,
           },

--- a/server/data/placementRequestClient.ts
+++ b/server/data/placementRequestClient.ts
@@ -13,6 +13,7 @@ import config, { ApiConfig } from '../config'
 import RestClient from './restClient'
 import paths from '../paths/api'
 import { PaginatedResponse, PlacementRequestDashboardSearchOptions } from '../@types/ui'
+import { normaliseCrn } from '../utils/normaliseCrn'
 
 export default class PlacementRequestClient {
   restClient: RestClient
@@ -35,6 +36,9 @@ export default class PlacementRequestClient {
     sortBy: PlacementRequestSortField = 'created_at',
     sortDirection: SortDirection = 'asc',
   ): Promise<PaginatedResponse<PlacementRequest>> {
+    if ('crnOrName' in filters) {
+      filters.crnOrName = normaliseCrn(filters.crnOrName)
+    }
     return this.restClient.getPaginatedResponse<PlacementRequest>({
       path: paths.placementRequests.dashboard.pattern,
       page: page.toString(),

--- a/server/utils/normaliseCrn.test.ts
+++ b/server/utils/normaliseCrn.test.ts
@@ -1,0 +1,11 @@
+import { normaliseCrn } from './normaliseCrn'
+
+describe('normaliseCrn', () => {
+  it('capitalises and removes leading and trailing spaces from crns', () => {
+    expect(normaliseCrn('abc123')).toEqual('ABC123')
+  })
+
+  it('returns undefined if the crn is empty', () => {
+    expect(normaliseCrn(undefined)).toEqual(undefined)
+  })
+})

--- a/server/utils/normaliseCrn.ts
+++ b/server/utils/normaliseCrn.ts
@@ -1,0 +1,1 @@
+export const normaliseCrn = (crn: string | undefined) => (crn ? crn.toUpperCase().trim() : undefined)


### PR DESCRIPTION
This removes all trailing/leading spaces and capitalises when searching for a CRN.  When searching for applications and placement requests, the param is `crnOrName`, but when we search for names in the API, these are capitalised anyway, so this won’t make any difference.