### PR TITLE
APS-56: Update workflow dashboard to filter by allocated, unallocated…

### DIFF
--- a/integration_tests/pages/tasks/listPage.ts
+++ b/integration_tests/pages/tasks/listPage.ts
@@ -21,8 +21,8 @@ export default class ListPage extends Page {
     return new ListPage(allocatedTasks, unallocatedTasks)
   }
 
-  shouldShowAllocatedTasks(): void {
-    shouldShowTableRows(this.allocatedTasks, allocatedTableRows)
+  shouldShowAllocatedTasks(allocatedTasks = this.allocatedTasks): void {
+    shouldShowTableRows(allocatedTasks, allocatedTableRows)
   }
 
   shouldShowUnallocatedTasks(): void {

--- a/integration_tests/tests/tasks/allocations.cy.ts
+++ b/integration_tests/tests/tasks/allocations.cy.ts
@@ -23,7 +23,12 @@ context('Tasks', () => {
       taskType: 'Assessment',
     })
 
-    cy.task('stubReallocatableTasks', [task])
+    cy.task('stubReallocatableTasks', {
+      tasks: [task],
+      allocatedFilter: 'allocated',
+      page: '1',
+      sortDirection: 'asc',
+    })
     cy.task('stubTaskGet', { application, task, users })
     cy.task('stubApplicationGet', { application })
 

--- a/integration_tests/tests/tasks/list.cy.ts
+++ b/integration_tests/tests/tasks/list.cy.ts
@@ -17,7 +17,19 @@ context('Tasks', () => {
     const allocatedTasks = taskFactory.buildList(5)
     const unallocatedTasks = taskFactory.buildList(5, { allocatedToStaffMember: undefined })
 
-    cy.task('stubReallocatableTasks', [...allocatedTasks, ...unallocatedTasks])
+    cy.task('stubReallocatableTasks', {
+      tasks: allocatedTasks,
+      allocatedFilter: 'allocated',
+      page: '1',
+      sortDirection: 'asc',
+    })
+
+    cy.task('stubReallocatableTasks', {
+      tasks: [...unallocatedTasks],
+      allocatedFilter: 'unallocated',
+      page: '1',
+      sortDirection: 'asc',
+    })
 
     // When I visit the tasks dashboard
     const listPage = ListPage.visit(allocatedTasks, unallocatedTasks)
@@ -27,5 +39,50 @@ context('Tasks', () => {
 
     // And the tasks that are unallocated
     listPage.shouldShowUnallocatedTasks()
+  })
+
+  it('supports pagination', () => {
+    cy.task('stubAuthUser')
+
+    // Given I am logged in
+    cy.signIn()
+
+    const allocatedTasksPage1 = taskFactory.buildList(10)
+    const allocatedTasksPage2 = taskFactory.buildList(10)
+    const allocatedTasksPage9 = taskFactory.buildList(10)
+    const unallocatedTasks = taskFactory.buildList(1, { allocatedToStaffMember: undefined })
+
+    cy.task('stubReallocatableTasks', { tasks: allocatedTasksPage1, allocatedFilter: 'allocated', page: '1' })
+
+    cy.task('stubReallocatableTasks', { tasks: allocatedTasksPage2, allocatedFilter: 'allocated', page: '2' })
+
+    cy.task('stubReallocatableTasks', { tasks: allocatedTasksPage9, allocatedFilter: 'allocated', page: '9' })
+
+    // When I visit the tasks dashboard
+    const listPage = ListPage.visit(allocatedTasksPage1, unallocatedTasks)
+
+    // Then I should see the tasks that are allocated
+    listPage.shouldShowAllocatedTasks()
+    // When I click next
+    listPage.clickNext()
+
+    // Then the API should have received a request for the next page
+    cy.task('verifyTasksRequests', { page: '2', allocatedFilter: 'allocated' }).then(requests => {
+      expect(requests).to.have.length(1)
+    })
+
+    // And I should see the tasks that are allocated
+    listPage.shouldShowAllocatedTasks(allocatedTasksPage2)
+
+    // When I click on a page number
+    listPage.clickPageNumber('9')
+
+    // Then the API should have received a request for the that page number
+    cy.task('verifyTasksRequests', { page: '9', allocatedFilter: 'allocated' }).then(requests => {
+      expect(requests).to.have.length(1)
+    })
+
+    // And I should see the tasks that are allocated
+    listPage.shouldShowAllocatedTasks(allocatedTasksPage9)
   })
 })

--- a/server/data/taskClient.test.ts
+++ b/server/data/taskClient.test.ts
@@ -30,6 +30,7 @@ describeClient('taskClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.tasks.reallocatable.index.pattern,
+          query: { allocatedFilter: 'allocated', page: '1', sortDirection: 'asc' },
           headers: {
             authorization: `Bearer ${token}`,
             'X-Service-Name': 'approved-premises',
@@ -38,12 +39,23 @@ describeClient('taskClient', provider => {
         willRespondWith: {
           status: 200,
           body: tasks,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
         },
       })
 
-      const result = await taskClient.allReallocatable()
+      const result = await taskClient.allReallocatable('allocated', 1, 'asc')
 
-      expect(result).toEqual(tasks)
+      expect(result).toEqual({
+        data: tasks,
+        pageNumber: '1',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
     })
   })
 

--- a/server/data/taskClient.ts
+++ b/server/data/taskClient.ts
@@ -11,8 +11,16 @@ export default class TaskClient {
     this.restClient = new RestClient('taskClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
-  async allReallocatable(): Promise<Array<Task>> {
-    return (await this.restClient.get({ path: paths.tasks.reallocatable.index.pattern })) as Promise<Array<Task>>
+  async allReallocatable(
+    allocatedFilter: string,
+    page: number,
+    sortDirection: string,
+  ): Promise<PaginatedResponse<Task>> {
+    return this.restClient.getPaginatedResponse({
+      path: paths.tasks.reallocatable.index.pattern,
+      page: page.toString(),
+      query: { allocatedFilter, sortDirection },
+    })
   }
 
   async allForUser(): Promise<Array<CategorisedTask>> {

--- a/server/services/taskService.test.ts
+++ b/server/services/taskService.test.ts
@@ -28,11 +28,21 @@ describe('taskService', () => {
   describe('getAllReallocatable', () => {
     it('calls the all method on the task client', async () => {
       const tasks: Array<Task> = taskFactory.buildList(2)
-      taskClient.allReallocatable.mockResolvedValue(tasks)
+      const paginatedResponse = paginatedResponseFactory.build({
+        data: tasks,
+      }) as PaginatedResponse<Task>
 
-      const result = await service.getAllReallocatable(token)
+      taskClient.allReallocatable.mockResolvedValue(paginatedResponse)
 
-      expect(result).toEqual(tasks)
+      const result = await service.getAllReallocatable(token, 'allocated')
+
+      expect(result).toEqual({
+        data: tasks,
+        pageNumber: '1',
+        pageSize: '10',
+        totalPages: '10',
+        totalResults: '100',
+      })
 
       expect(taskClientFactory).toHaveBeenCalledWith(token)
       expect(taskClient.allReallocatable).toHaveBeenCalled()

--- a/server/services/taskService.ts
+++ b/server/services/taskService.ts
@@ -1,4 +1,11 @@
-import { PlacementApplicationTask, PlacementRequestTask, Reallocation, Task, TaskWrapper } from '@approved-premises/api'
+import {
+  PlacementApplicationTask,
+  PlacementRequestTask,
+  Reallocation,
+  SortDirection,
+  Task,
+  TaskWrapper,
+} from '@approved-premises/api'
 import { GroupedMatchTasks, PaginatedResponse } from '@approved-premises/ui'
 import { RestClientBuilder } from '../data'
 import TaskClient from '../data/taskClient'
@@ -6,10 +13,15 @@ import TaskClient from '../data/taskClient'
 export default class TaskService {
   constructor(private readonly taskClientFactory: RestClientBuilder<TaskClient>) {}
 
-  async getAllReallocatable(token: string): Promise<Array<Task>> {
+  async getAllReallocatable(
+    token: string,
+    allocatedFilter: 'allocated' | 'unallocated' = 'allocated',
+    page: number = 1,
+    sortDirection: SortDirection = 'asc',
+  ): Promise<PaginatedResponse<Task>> {
     const taskClient = this.taskClientFactory(token)
 
-    const tasks = await taskClient.allReallocatable()
+    const tasks = await taskClient.allReallocatable(allocatedFilter, page, sortDirection)
     return tasks
   }
 
@@ -53,7 +65,6 @@ export default class TaskService {
     const taskClient = this.taskClientFactory(token)
 
     const task = await taskClient.find(premisesId, taskType)
-
     return task
   }
 

--- a/server/utils/tasks/index.ts
+++ b/server/utils/tasks/index.ts
@@ -5,7 +5,7 @@ import { SummaryListItem } from '../../@types/ui'
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
 import { getApplicationType } from '../applications/utils'
 import { DateFormats } from '../dateUtils'
-import { allocatedTableRows, unallocatedTableRows } from './table'
+import { allocatedTableRows, tasksTableHeader, tasksTableRows, unallocatedTableRows } from './table'
 
 type GroupedTasks = {
   allocated: Array<Task>
@@ -59,4 +59,11 @@ const applicationSummary = (application: Application): Array<SummaryListItem> =>
   return summary
 }
 
-export { applicationSummary, allocatedTableRows, groupByAllocation, unallocatedTableRows }
+export {
+  applicationSummary,
+  allocatedTableRows,
+  groupByAllocation,
+  unallocatedTableRows,
+  tasksTableHeader,
+  tasksTableRows,
+}

--- a/server/utils/tasks/table.test.ts
+++ b/server/utils/tasks/table.test.ts
@@ -8,6 +8,8 @@ import {
   statusBadge,
   statusCell,
   taskTypeCell,
+  tasksTableHeader,
+  tasksTableRows,
   unallocatedTableRows,
 } from './table'
 import { sentenceCase } from '../utils'
@@ -22,6 +24,30 @@ describe('table', () => {
         const task = taskFactory.build()
 
         expect(allocatedTableRows([task])).toEqual([
+          [
+            {
+              text: task.personName,
+            },
+            daysUntilDueCell(task),
+            {
+              text: task?.allocatedToStaffMember?.name,
+            },
+            {
+              html: statusBadge(task),
+            },
+            {
+              html: `<strong class="govuk-tag">${sentenceCase(task.taskType)}</strong>`,
+            },
+
+            allocationLinkCell(task, 'Reallocate'),
+          ],
+        ])
+      })
+
+      it('returns an array of allocated table rows', () => {
+        const task = taskFactory.build()
+
+        expect(tasksTableRows([task], 'allocated')).toEqual([
           [
             {
               text: task.personName,
@@ -65,6 +91,82 @@ describe('table', () => {
           ],
         ])
       })
+
+      it('returns an array of unallocated table rows', () => {
+        const task = taskFactory.build()
+
+        expect(tasksTableRows([task], 'unallocated')).toEqual([
+          [
+            {
+              text: task.personName,
+            },
+            daysUntilDueCell(task),
+            {
+              html: statusBadge(task),
+            },
+            {
+              html: `<strong class="govuk-tag">${sentenceCase(task.taskType)}</strong>`,
+            },
+            allocationLinkCell(task, 'Allocate'),
+          ],
+        ])
+      })
+    })
+  })
+
+  describe('unallocatedTableRows', () => {
+    it('returns an array of unallocated table headers', () => {
+      expect(tasksTableHeader('unallocated')).toEqual([
+        {
+          text: 'Person',
+        },
+        {
+          text: 'Days until due date',
+          attributes: {
+            'aria-sort': 'none',
+          },
+        },
+        {
+          text: 'Allocated to',
+        },
+        {
+          text: 'Status',
+        },
+        {
+          text: 'Task type',
+        },
+        {
+          html: '<span class="govuk-visually-hidden">Actions</span>',
+        },
+      ])
+    })
+  })
+
+  describe('allocatedTableRows', () => {
+    it('returns an array of allocated table headers', () => {
+      expect(tasksTableHeader('allocated')).toEqual([
+        {
+          text: 'Person',
+        },
+        {
+          text: 'Days until due date',
+          attributes: {
+            'aria-sort': 'none',
+          },
+        },
+        {
+          text: 'Allocated to',
+        },
+        {
+          text: 'Status',
+        },
+        {
+          text: 'Task type',
+        },
+        {
+          html: '<span class="govuk-visually-hidden">Actions</span>',
+        },
+      ])
     })
   })
 

--- a/server/utils/tasks/table.ts
+++ b/server/utils/tasks/table.ts
@@ -101,8 +101,72 @@ const unallocatedTableRows = (tasks: Array<Task>): Array<TableRow> => {
   return rows
 }
 
+const tasksTableRows = (tasks: Array<Task>, allocatedFilter: string): Array<TableRow> => {
+  const rows: Array<TableRow> =
+    allocatedFilter === 'allocated' ? allocatedTableRows(tasks) : unallocatedTableRows(tasks)
+
+  return rows
+}
+
+const allocatedTableHeader = () => {
+  return [
+    {
+      text: 'Person',
+    },
+    {
+      text: 'Days until due date',
+      attributes: {
+        'aria-sort': 'none',
+      },
+    },
+    {
+      text: 'Allocated to',
+    },
+    {
+      text: 'Status',
+    },
+    {
+      text: 'Task type',
+    },
+    {
+      html: '<span class="govuk-visually-hidden">Actions</span>',
+    },
+  ]
+}
+
+const unAllocatedTableHeader = () => {
+  return [
+    {
+      text: 'Person',
+    },
+    {
+      text: 'Days until due date',
+      attributes: {
+        'aria-sort': 'none',
+      },
+    },
+    {
+      text: 'Allocated to',
+    },
+    {
+      text: 'Status',
+    },
+    {
+      text: 'Task type',
+    },
+    {
+      html: '<span class="govuk-visually-hidden">Actions</span>',
+    },
+  ]
+}
+
+const tasksTableHeader = (allocatedFilter: string) => {
+  return allocatedFilter === 'allocated' ? allocatedTableHeader() : unAllocatedTableHeader()
+}
+
 export {
   allocatedTableRows,
+  tasksTableHeader,
   allocationLinkCell,
   formatDaysUntilDueWithWarning,
   daysUntilDueCell,
@@ -110,5 +174,6 @@ export {
   taskTypeCell,
   allocationCell,
   statusBadge,
+  tasksTableRows,
   unallocatedTableRows,
 }

--- a/server/views/tasks/_navigation.njk
+++ b/server/views/tasks/_navigation.njk
@@ -1,0 +1,21 @@
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+
+{% macro navigation(activeTab) %}
+  {{
+    mojSubNavigation({
+      label: 'Sub navigation',
+      items: [
+        {
+          text: 'Allocated',
+          href: paths.tasks.index({})+ "?allocatedFilter=allocated",
+          active: (activeTab === 'allocated' or activeTab|length === 0)
+        },
+        {
+          text: 'Unallocated',
+          href: paths.tasks.index({}) + "?allocatedFilter=unallocated",
+          active: (activeTab === 'unallocated')
+        }
+      ]
+    })
+  }}
+{% endmacro %}

--- a/server/views/tasks/index.njk
+++ b/server/views/tasks/index.njk
@@ -1,81 +1,12 @@
 {% extends "../partials/layout.njk" %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+{% from "./_navigation.njk" import navigation %}
 
 {% set pageTitle = applicationName + " - " + pageHeading  %}
 {% set mainClasses = "app-container govuk-body assessments--index" %}
-
-{% set allocatedHtml %}
-{{
-    govukTable({
-        attributes: {
-        'data-module': 'moj-sortable-table'
-        },
-        caption: "Allocated Tasks",
-        captionClasses: "govuk-table__caption--m",
-        firstCellIsHeader: true,
-        head: [
-        {
-            text: "Person"
-        },
-        {
-            text: "Days until due date",
-            attributes: {
-            "aria-sort": "none"
-            }
-        },
-        {
-            text: "Allocated to"
-        },
-        {
-            text: "Status"
-        },
-        {
-            text: "Task type"
-        },
-        {
-           html: '<span class="govuk-visually-hidden">Actions</span>'
-        }
-        ],
-        rows: TaskUtils.allocatedTableRows(tasks.allocated)
-    })
-    }}
-{% endset -%}
-
-{% set unallocatedHtml %}
-{{
-  govukTable({
-    attributes: {
-      'data-module': 'moj-sortable-table'
-    },
-    caption: "Unallocated Tasks",
-    captionClasses: "govuk-table__caption--m",
-    firstCellIsHeader: true,
-    head: [
-        {
-          text: "Person"
-        },
-        {
-          text: "Days until due date",
-          attributes: {
-            "aria-sort": "none"
-          }
-        },
-        {
-          text: "Status"
-        },
-        {
-          text: "Task type"
-        },
-        {
-           html: '<span class="govuk-visually-hidden">Actions</span>'
-        }
-      ],
-    rows: TaskUtils.unallocatedTableRows(tasks.unallocated)
-  })
-}}
-{% endset -%}
 
 {% block content %}
 
@@ -85,33 +16,18 @@
       <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
       {% include "../_messages.njk" %}
 
-      {{ govukTabs({
-                items: [
-                    {
-                    label: "Allocated",
-                    id: "allocated",
-                    panel: {
-                        html: allocatedHtml
-                    }
-                    },
-                    {
-                    label: "Unallocated",
-                    id: "unallocated",
-                    panel: {
-                        html: unallocatedHtml
-                    }
-                    }
-                ]
-            }) }}
+      {{ navigation(allocatedFilter) }}
+
+      {{
+        govukTable({
+            firstCellIsHeader: true,
+            head: TaskUtils.tasksTableHeader(allocatedFilter),
+            rows: TaskUtils.tasksTableRows(tasks, allocatedFilter)
+          })
+      }}
+
+      {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
 
     </div>
   </div>
-{% endblock %}
-
-{% block extraScripts %}
-  <script type="text/javascript" nonce="{{ cspNonce }}">
-    window
-      .MOJFrontend
-      .initAll()
-  </script>
 {% endblock %}


### PR DESCRIPTION
… and add pagination

# Context

<!-- [Is there a Jira ticket you can link to? ](https://dsdmoj.atlassian.net/browse/APS-56)-->

# Changes in this PR
Update workflow dashboard to filter by allocated/unallocated and add pagination
## Screenshots of UI changes

### Before
<img width="969" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/abb7a9b9-c622-4f2f-b1b8-4b1ee4e68b1f">

### After
<img width="976" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/056333d4-61de-426b-a301-b4c3988115d5">
<img width="978" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/351615fb-e02e-4a4b-b4c6-8765cfedf946">


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
      `production` in a backwards compatible way? (This includes our API,
      infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
      advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
