### PR TITLE
APS-63 - Remove back button on 'Not eligible' page

### DIFF
--- a/server/views/applications/pages/basic-information/not-eligible.njk
+++ b/server/views/applications/pages/basic-information/not-eligible.njk
@@ -6,19 +6,6 @@
 {% set pageTitle = applicationName + " - " + pageHeading  %}
 {% set mainClasses = "app-container govuk-body" %}
 
-{% block beforeContent %}
-  {{
-    govukBackLink({
-      text: "Back",
-      href:  paths.applications.pages.show({
-              id: applicationId,
-              task: 'basic-information',
-              page: 'is-exceptional-case'
-          })
-    })
-  }}
-{% endblock %}
-
 {% block content %}
 
   <div class="govuk-grid-row">


### PR DESCRIPTION
We don't want to have a back button on this page as it can create duplicate applications.

[APS-63](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?selectedIssue=APS-63)

## Before
![after (3)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/2407ad35-cbe6-4dcf-acda-924f5bfb3edb)



## After
![after (4)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/8f51687e-d8e5-4a2c-b296-9010b4fc4392)


[APS-63]: https://dsdmoj.atlassian.net/browse/APS-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ