### PR TITLE
APS-26: Retain checkbox states on rerender

### DIFF
--- a/integration_tests/pages/apply/relevantDates.ts
+++ b/integration_tests/pages/apply/relevantDates.ts
@@ -1,10 +1,17 @@
 import type { ApprovedPremisesApplication } from '@approved-premises/api'
 
 import ApplyPage from './applyPage'
+import paths from '../../../server/paths/apply'
 
 export default class RelevantDatesPage extends ApplyPage {
   constructor(application: ApprovedPremisesApplication) {
-    super('Which of the following dates are relevant?', application, 'basic-information', 'relevant-dates')
+    super(
+      'Which of the following dates are relevant?',
+      application,
+      'basic-information',
+      'relevant-dates',
+      paths.applications.pages.show({ id: application.id, page: 'transgender', task: 'basic-information' }),
+    )
   }
 
   completeForm() {

--- a/server/utils/applications/relevantDatesOptions.test.ts
+++ b/server/utils/applications/relevantDatesOptions.test.ts
@@ -9,16 +9,19 @@ describe('relevantDatesOptions', () => {
       {
         text: 'Parole eligibility date',
         value: 'paroleEligibilityDate',
+        checked: false,
         conditional: { html: '<div>Conditional 1</div>' },
       },
       {
         text: 'Home Detention Curfew (HDC) date',
         value: 'homeDetentionCurfewDate',
+        checked: false,
         conditional: { html: '<div>Conditional 2</div>' },
       },
       {
         text: 'Licence expiry date',
         value: 'licenceExpiryDate',
+        checked: true,
         conditional: { html: '<div>Conditional 3</div>' },
       },
     ]
@@ -30,6 +33,7 @@ describe('relevantDatesOptions', () => {
         licenceExpiryDate: 'Licence expiry date',
       }),
       conditionals,
+      ['licenceExpiryDate'],
     )
     expect(result).toEqual(expected)
   })

--- a/server/utils/applications/relevantDatesOptions.ts
+++ b/server/utils/applications/relevantDatesOptions.ts
@@ -4,11 +4,13 @@ import { RelevantDatesT } from '../../form-pages/apply/reasons-for-placement/bas
 export const relevantDatesOptions = (
   relevantDates: RelevantDatesT,
   conditionals: Array<string>,
+  selectedDates: Array<string> = [],
 ): Array<CheckBoxItem> => {
   return Object.entries(relevantDates).map(([key, label], i) => {
     return {
       text: label,
       value: key,
+      checked: selectedDates.includes(key),
       conditional: { html: conditionals[i] },
     }
   })

--- a/server/views/applications/pages/basic-information/relevant-dates.njk
+++ b/server/views/applications/pages/basic-information/relevant-dates.njk
@@ -36,7 +36,7 @@
       hint: {
         text: page.hint
       },
-      items: relevantDatesOptions(page.relevantDatesDictionary, conditionals)
+      items: relevantDatesOptions(page.relevantDatesDictionary, conditionals, page.body.selectedDates)
     }, fetchContext()) }}
 
 {% endblock %}


### PR DESCRIPTION
Previously we weren't passing in the selected values so on rerender the selected values were lost. We would retain the date's values but not the checkboxes.
[JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?selectedIssue=APS-26)