### PR TITLE
APS-99 - Show current location in Assessments list for assessments where further information is requested

### DIFF
--- a/integration_tests/tests/assess/list.cy.ts
+++ b/integration_tests/tests/assess/list.cy.ts
@@ -14,8 +14,8 @@ context('List assessments', () => {
     cy.signIn()
 
     // And I have some assessments
-    const awaitingAssessments = assessmentSummaryFactory.buildList(3)
-    const awaitingResponseAssessments = assessmentSummaryFactory.buildList(2)
+    const awaitingAssessments = assessmentSummaryFactory.buildList(6)
+    const awaitingResponseAssessments = assessmentSummaryFactory.buildList(6)
     const completedAssessments = assessmentSummaryFactory.buildList(6)
 
     cy.task('stubAssessments', {

--- a/server/utils/assessments/tableUtils.test.ts
+++ b/server/utils/assessments/tableUtils.test.ts
@@ -144,10 +144,13 @@ describe('tableUtils', () => {
             text: 'Tier',
           },
           {
+            text: 'Current location',
+          },
+          {
             text: 'Arrival date',
           },
           {
-            text: 'Current location',
+            text: 'Days since received',
           },
           {
             text: 'Days until assessment due',
@@ -239,6 +242,7 @@ describe('tableUtils', () => {
           { html: assessmentLink(assessment, person) },
           crnCell({ crn: assessment.person.crn }),
           tierCell({ tier: assessment.risks.tier }),
+          { text: person.prisonName },
           { text: formattedArrivalDate(assessment) },
           { text: formatDays(daysSinceReceived(assessment)) },
           { text: formatDays(daysSinceInfoRequest(assessment)) },
@@ -255,6 +259,7 @@ describe('tableUtils', () => {
       expect(requestedFurtherInformationTableRows([assessment])).toEqual([
         [
           restrictedPersonCell(assessment.person),
+          emptyCell(),
           emptyCell(),
           emptyCell(),
           emptyCell(),

--- a/server/utils/assessments/tableUtils.ts
+++ b/server/utils/assessments/tableUtils.ts
@@ -107,11 +107,15 @@ const assessmentTable = (activeTab: AssessmentCurrentTab, assessments: Array<Ass
             text: 'Tier',
           },
           {
+            text: 'Current location',
+          },
+          {
             text: 'Arrival date',
           },
           {
-            text: 'Current location',
+            text: 'Days since received',
           },
+
           {
             text: 'Days until assessment due',
           },
@@ -236,6 +240,7 @@ const requestedFurtherInformationTableRows = (assessments: Array<AssessmentSumma
         linkCell(assessment, assessment.person),
         crnCell({ crn: assessment.person.crn }),
         tierCell({ tier: assessment.risks.tier }),
+        prisonCell(assessment.person),
         arrivalDateCell(assessment),
         daysSinceReceivedCell(assessment),
         daysSinceInfoRequestCell(assessment),
@@ -244,6 +249,7 @@ const requestedFurtherInformationTableRows = (assessments: Array<AssessmentSumma
     } else {
       rows.push([
         restrictedPersonCell(assessment.person),
+        emptyCell(),
         emptyCell(),
         emptyCell(),
         emptyCell(),


### PR DESCRIPTION
Previously the table showed the 'Days since received'  column under the 'Current location' heading
This PR fixes it.



[JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328/backlog?selectedIssue=APS-99) 



## Screenshots of UI changes

### Before

![before](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/cb79aae3-d814-4cd6-936c-3aeea51e8ccb)


### After
![after (5)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/667b4985-71ab-439a-b47c-068b5c7d443d)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
      `production` in a backwards compatible way? (This includes our API,
      infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
      advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
