### PR TITLE
(APS-109) Surface cancellation details on booking page

### DIFF
--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -8,6 +8,7 @@ import {
   bookingDepartureRows,
   bookingPersonRows,
   bookingShowDocumentRows,
+  bookingStatus,
   bookingSummaryList,
   bookingsToTableRows,
   cancellationRows,
@@ -34,7 +35,7 @@ import assessPaths from '../paths/assess'
 import applyPaths from '../paths/apply'
 import { DateFormats } from './dateUtils'
 import { linebreaksToParagraphs, linkTo } from './utils'
-import { FullPerson } from '../@types/shared'
+import { BookingStatus, FullPerson } from '../@types/shared'
 
 describe('bookingUtils', () => {
   const premisesId = 'e8f29a4a-dd4d-40a2-aa58-f3f60245c8fc'
@@ -451,6 +452,26 @@ describe('bookingUtils', () => {
     })
   })
 
+  describe('bookingStatus', () => {
+    const lookup: Record<BookingStatus, string> = {
+      arrived: '<strong class="govuk-tag govuk-tag--">Arrived</strong>',
+      'awaiting-arrival': '<strong class="govuk-tag govuk-tag--blue">Awaiting arrival</strong>',
+      'not-arrived': '<strong class="govuk-tag govuk-tag--red">Not arrived</strong>',
+      departed: '<strong class="govuk-tag govuk-tag--pink">Departed</strong>',
+      cancelled: '<strong class="govuk-tag govuk-tag--red">Cancelled</strong>',
+      provisional: '<strong class="govuk-tag govuk-tag--yellow">Provisional</strong>',
+      confirmed: '<strong class="govuk-tag govuk-tag--blue">Confirmed</strong>',
+      closed: '<strong class="govuk-tag govuk-tag--red">Closed</strong>',
+    }
+
+    Object.keys(lookup).forEach((status: BookingStatus) => {
+      it(`Returns the correct status for a '${status}' booking`, () => {
+        const booking = bookingFactory.build({ status })
+        expect(bookingStatus(booking)).toEqual(lookup[status])
+      })
+    })
+  })
+
   describe('bookingPersonRows', () => {
     it('returns the correct rows for a person', () => {
       const booking = bookingFactory.build()
@@ -468,6 +489,14 @@ describe('bookingUtils', () => {
           },
           value: {
             text: booking.person.crn,
+          },
+        },
+        {
+          key: {
+            text: 'Status',
+          },
+          value: {
+            html: bookingStatus(booking),
           },
         },
       ])

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -10,6 +10,7 @@ import {
   bookingShowDocumentRows,
   bookingSummaryList,
   bookingsToTableRows,
+  cancellationRows,
   departingTodayOrLate,
   generateConflictBespokeError,
   manageBookingLink,
@@ -22,6 +23,7 @@ import {
   bedSummaryFactory,
   bookingFactory,
   bookingSummaryFactory,
+  cancellationFactory,
   departureFactory,
   personFactory,
   premisesBookingFactory,
@@ -617,6 +619,38 @@ describe('bookingUtils', () => {
           ),
         )
       })
+    })
+  })
+
+  describe('cancellationRows', () => {
+    it('returns an empty array if there is no cancellation', () => {
+      const booking = bookingFactory.build({ cancellation: null })
+
+      expect(cancellationRows(booking)).toEqual([])
+    })
+
+    it('returns an details of a cancellations', () => {
+      const cancellation = cancellationFactory.build()
+      const booking = bookingFactory.build({ cancellation })
+
+      expect(cancellationRows(booking)).toEqual([
+        {
+          key: {
+            text: 'Cancelled on',
+          },
+          value: {
+            text: DateFormats.isoDateToUIDate(cancellation.createdAt),
+          },
+        },
+        {
+          key: {
+            text: 'Reason',
+          },
+          value: {
+            text: cancellation.reason.name,
+          },
+        },
+      ])
     })
   })
 })

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -7,7 +7,7 @@ import type {
   TableCell,
   TableRow,
 } from '@approved-premises/ui'
-import type { BedSummary, Booking, BookingSummary, PremisesBooking } from '@approved-premises/api'
+import type { BedSummary, Booking, BookingStatus, BookingSummary, PremisesBooking } from '@approved-premises/api'
 import { addDays, isBefore, isEqual, isWithinInterval } from 'date-fns'
 import paths from '../paths/manage'
 import applyPaths from '../paths/apply'
@@ -274,6 +274,41 @@ export const bedsAsSelectItems = (beds: Array<BedSummary>, selectedId: string): 
   }))
 }
 
+const bookingStatuses: Record<BookingStatus, string> = {
+  arrived: 'Arrived',
+  'awaiting-arrival': 'Awaiting arrival',
+  'not-arrived': 'Not arrived',
+  departed: 'Departed',
+  cancelled: 'Cancelled',
+  provisional: 'Provisional',
+  confirmed: 'Confirmed',
+  closed: 'Closed',
+}
+
+const statusTags = (): Record<BookingStatus, string> => {
+  const colours: Record<BookingStatus, string> = {
+    arrived: '',
+    'awaiting-arrival': 'blue',
+    'not-arrived': 'red',
+    departed: 'pink',
+    cancelled: 'red',
+    provisional: 'yellow',
+    confirmed: 'blue',
+    closed: 'red',
+  }
+  return Object.keys(bookingStatuses).reduce(
+    (item, key) => {
+      item[key] = `<strong class="govuk-tag govuk-tag--${colours[key]}">${bookingStatuses[key]}</strong>`
+      return item
+    },
+    {} as Record<BookingStatus, string>,
+  )
+}
+
+export const bookingStatus = (booking: Booking): string => {
+  return statusTags()[booking.status]
+}
+
 export const bookingPersonRows = (booking: Booking): Array<SummaryListItem> => {
   return [
     {
@@ -288,6 +323,14 @@ export const bookingPersonRows = (booking: Booking): Array<SummaryListItem> => {
       },
       value: {
         text: booking.person.crn,
+      },
+    },
+    {
+      key: {
+        text: 'Status',
+      },
+      value: {
+        html: bookingStatus(booking),
       },
     },
   ]

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -418,3 +418,27 @@ export const bookingShowDocumentRows = (booking: Booking): Array<SummaryListItem
 
   return rows
 }
+
+export const cancellationRows = (booking: Booking): Array<SummaryListItem> => {
+  if (booking.cancellation) {
+    return [
+      {
+        key: {
+          text: 'Cancelled on',
+        },
+        value: {
+          text: DateFormats.isoDateToUIDate(booking.cancellation.createdAt),
+        },
+      },
+      {
+        key: {
+          text: 'Reason',
+        },
+        value: {
+          text: booking.cancellation.reason.name,
+        },
+      },
+    ]
+  }
+  return []
+}

--- a/server/views/bookings/show.njk
+++ b/server/views/bookings/show.njk
@@ -46,6 +46,21 @@
 
       <br>
 
+      {% if booking.cancellation %}
+
+        <h2>Cancellation information</h2>
+
+        {{
+        govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          rows: BookingUtils.cancellationRows(booking)
+        })
+      }}
+
+        <br>
+
+      {% endif %}
+
       <h2>Arrival information</h2>
 
       {{

--- a/server/views/bookings/show.njk
+++ b/server/views/bookings/show.njk
@@ -32,7 +32,6 @@
       {% endif %}
 
       <br>
-      <h2>Person details</h2>
 
       {{
         govukSummaryList({


### PR DESCRIPTION
This shows the cancellation details of a booking, as well as the status to make it easier to see when a booking has been cancelled

## Screenshots

### Before

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/610db064-612d-4b23-85e0-f20cbfdce609)

### After

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/00b7c1c4-6468-47b5-bda0-6efc7e01a2b4)