### PR TITLE
(APS-153) Sort tasks by created at

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -9,3 +9,6 @@
     float: left
     @include govuk-responsive-margin(4, 'right')
     @include govuk-responsive-margin(0, 'bottom')
+
+[aria-sort] a
+  display: inline-block

--- a/integration_tests/mockApis/tasks.ts
+++ b/integration_tests/mockApis/tasks.ts
@@ -1,6 +1,6 @@
 import { SuperAgentRequest } from 'superagent'
 
-import type { Reallocation, SortDirection, Task, User } from '@approved-premises/api'
+import type { Reallocation, SortDirection, Task, TaskSortField, User } from '@approved-premises/api'
 import { AllocatedFilter } from '@approved-premises/api'
 import { getMatchingRequests, stubFor } from './setup'
 import paths from '../../server/paths/api'
@@ -13,11 +13,13 @@ export default {
     allocatedFilter = 'allocated',
     page = '1',
     sortDirection = 'asc',
+    sortBy = 'createdAt',
   }: {
     tasks: Array<Task>
     page: string
     allocatedFilter: string
     sortDirection: SortDirection
+    sortBy: TaskSortField
   }): SuperAgentRequest => {
     const queryParameters = {
       page: {
@@ -28,6 +30,9 @@ export default {
       },
       sortDirection: {
         equalTo: sortDirection,
+      },
+      sortBy: {
+        equalTo: sortBy,
       },
     }
     return stubFor({
@@ -133,7 +138,17 @@ export default {
         }),
       ),
     ),
-  verifyTasksRequests: async ({ allocatedFilter, page = '1' }: { allocatedFilter: AllocatedFilter; page: string }) =>
+  verifyTasksRequests: async ({
+    allocatedFilter,
+    page = '1',
+    sortDirection = 'asc',
+    sortBy = 'createdAt',
+  }: {
+    allocatedFilter: AllocatedFilter
+    page: string
+    sortDirection: SortDirection
+    sortBy: TaskSortField
+  }) =>
     (
       await getMatchingRequests({
         method: 'GET',
@@ -144,6 +159,12 @@ export default {
           },
           page: {
             equalTo: page,
+          },
+          sortDirection: {
+            equalTo: sortDirection,
+          },
+          sortBy: {
+            equalTo: sortBy,
           },
         },
       })

--- a/integration_tests/tests/tasks/list.cy.ts
+++ b/integration_tests/tests/tasks/list.cy.ts
@@ -85,4 +85,49 @@ context('Tasks', () => {
     // And I should see the tasks that are allocated
     listPage.shouldShowAllocatedTasks(allocatedTasksPage9)
   })
+
+  it('supports sorting', () => {
+    cy.task('stubAuthUser')
+
+    // Given I am logged in
+    cy.signIn()
+
+    const tasks = taskFactory.buildList(10)
+
+    cy.task('stubReallocatableTasks', {
+      tasks,
+      allocatedFilter: 'allocated',
+      page: '1',
+      sortDirection: 'asc',
+      sortField: 'createdAt',
+    })
+    cy.task('stubReallocatableTasks', {
+      tasks,
+      allocatedFilter: 'allocated',
+      sortDirection: 'desc',
+      sortField: 'createdAt',
+    })
+
+    // When I visit the tasks dashboard
+    const listPage = ListPage.visit(tasks, [])
+
+    // Then I should see the tasks that are allocated
+    listPage.shouldShowAllocatedTasks()
+
+    // When I sort by created at in ascending order
+    listPage.clickSortBy('createdAt')
+
+    // Then the dashboard should be sorted by created at
+    listPage.shouldBeSortedByField('createdAt', 'descending')
+
+    // And the API should have received a request for the correct sort order
+    cy.task('verifyTasksRequests', {
+      allocatedFilter: 'allocated',
+      page: '1',
+      sortDirection: 'desc',
+      sortField: 'createdAt',
+    }).then(requests => {
+      expect(requests).to.have.length(1)
+    })
+  })
 })

--- a/server/controllers/tasksController.test.ts
+++ b/server/controllers/tasksController.test.ts
@@ -40,8 +40,6 @@ describe('TasksController', () => {
       const paginationDetails = {
         hrefPrefix: paths.tasks.index({}),
         pageNumber: 1,
-        sortBy: 'name',
-        sortDirection: 'desc',
       }
       ;(getPaginationDetails as jest.Mock).mockReturnValue(paginationDetails)
       taskService.getAllReallocatable.mockResolvedValue(paginatedResponse)
@@ -57,12 +55,13 @@ describe('TasksController', () => {
         pageNumber: Number(paginatedResponse.pageNumber),
         totalPages: Number(paginatedResponse.totalPages),
         hrefPrefix: paginationDetails.hrefPrefix,
-        sortDirection: paginationDetails.sortDirection,
+        sortBy: 'createdAt',
+        sortDirection: 'asc',
       })
-      expect(taskService.getAllReallocatable).toHaveBeenCalledWith(token, 'allocated', 1, 'desc')
+      expect(taskService.getAllReallocatable).toHaveBeenCalledWith(token, 'allocated', 'createdAt', 'asc', 1)
     })
 
-    it('should handle request parameter correctly', async () => {
+    it('should handle request parameters correctly', async () => {
       const tasks = taskFactory.buildList(1)
       const paginatedResponse = paginatedResponseFactory.build({
         data: tasks,
@@ -90,9 +89,16 @@ describe('TasksController', () => {
         pageNumber: Number(paginatedResponse.pageNumber),
         totalPages: Number(paginatedResponse.totalPages),
         hrefPrefix: paginationDetails.hrefPrefix,
+        sortBy: paginationDetails.sortBy,
         sortDirection: paginationDetails.sortDirection,
       })
-      expect(taskService.getAllReallocatable).toHaveBeenCalledWith(token, 'unallocated', 1, 'desc')
+      expect(taskService.getAllReallocatable).toHaveBeenCalledWith(
+        token,
+        'unallocated',
+        paginationDetails.sortBy,
+        paginationDetails.sortDirection,
+        1,
+      )
     })
   })
 

--- a/server/controllers/tasksController.ts
+++ b/server/controllers/tasksController.ts
@@ -4,7 +4,7 @@ import { ApplicationService, TaskService } from '../services'
 import { fetchErrorsAndUserInput } from '../utils/validation'
 import { getPaginationDetails } from '../utils/getPaginationDetails'
 import paths from '../paths/api'
-import { AllocatedFilter } from '../@types/shared'
+import { AllocatedFilter, TaskSortField } from '../@types/shared'
 
 export default class TasksController {
   constructor(
@@ -15,14 +15,20 @@ export default class TasksController {
   index(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       const allocatedFilter = (req.query.allocatedFilter as AllocatedFilter) || 'allocated'
-      const { pageNumber, sortDirection, hrefPrefix } = getPaginationDetails(req, paths.tasks.index({}), {
+      const {
+        pageNumber,
+        sortDirection = 'asc',
+        sortBy = 'createdAt',
+        hrefPrefix,
+      } = getPaginationDetails<TaskSortField>(req, paths.tasks.index({}), {
         allocatedFilter,
       })
       const tasks = await this.taskService.getAllReallocatable(
         req.user.token,
         allocatedFilter,
-        pageNumber,
+        sortBy,
         sortDirection,
+        pageNumber,
       )
 
       res.render('tasks/index', {
@@ -32,6 +38,7 @@ export default class TasksController {
         pageNumber: Number(tasks.pageNumber),
         totalPages: Number(tasks.totalPages),
         hrefPrefix,
+        sortBy,
         sortDirection,
       })
     }

--- a/server/data/taskClient.test.ts
+++ b/server/data/taskClient.test.ts
@@ -30,7 +30,7 @@ describeClient('taskClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.tasks.reallocatable.index.pattern,
-          query: { allocatedFilter: 'allocated', page: '1', sortDirection: 'asc' },
+          query: { allocatedFilter: 'allocated', page: '1', sortDirection: 'asc', sortBy: 'createdAt' },
           headers: {
             authorization: `Bearer ${token}`,
             'X-Service-Name': 'approved-premises',
@@ -47,7 +47,7 @@ describeClient('taskClient', provider => {
         },
       })
 
-      const result = await taskClient.allReallocatable('allocated', 1, 'asc')
+      const result = await taskClient.allReallocatable('allocated', 1, 'asc', 'createdAt')
 
       expect(result).toEqual({
         data: tasks,

--- a/server/data/taskClient.ts
+++ b/server/data/taskClient.ts
@@ -2,7 +2,7 @@ import { CategorisedTask, PaginatedResponse } from '@approved-premises/ui'
 import config, { ApiConfig } from '../config'
 import RestClient from './restClient'
 import paths from '../paths/api'
-import { Reallocation, Task, TaskWrapper } from '../@types/shared'
+import { Reallocation, Task, TaskSortField, TaskWrapper } from '../@types/shared'
 
 export default class TaskClient {
   restClient: RestClient
@@ -15,11 +15,12 @@ export default class TaskClient {
     allocatedFilter: string,
     page: number,
     sortDirection: string,
+    sortBy: TaskSortField,
   ): Promise<PaginatedResponse<Task>> {
     return this.restClient.getPaginatedResponse({
       path: paths.tasks.reallocatable.index.pattern,
       page: page.toString(),
-      query: { allocatedFilter, sortDirection },
+      query: { allocatedFilter, sortDirection, sortBy },
     })
   }
 

--- a/server/services/taskService.test.ts
+++ b/server/services/taskService.test.ts
@@ -34,7 +34,7 @@ describe('taskService', () => {
 
       taskClient.allReallocatable.mockResolvedValue(paginatedResponse)
 
-      const result = await service.getAllReallocatable(token, 'allocated')
+      const result = await service.getAllReallocatable(token, 'allocated', 'createdAt', 'asc', 1)
 
       expect(result).toEqual({
         data: tasks,
@@ -45,7 +45,7 @@ describe('taskService', () => {
       })
 
       expect(taskClientFactory).toHaveBeenCalledWith(token)
-      expect(taskClient.allReallocatable).toHaveBeenCalled()
+      expect(taskClient.allReallocatable).toHaveBeenCalledWith('allocated', 1, 'asc', 'createdAt')
     })
   })
 

--- a/server/services/taskService.ts
+++ b/server/services/taskService.ts
@@ -4,6 +4,7 @@ import {
   Reallocation,
   SortDirection,
   Task,
+  TaskSortField,
   TaskWrapper,
 } from '@approved-premises/api'
 import { GroupedMatchTasks, PaginatedResponse } from '@approved-premises/ui'
@@ -15,13 +16,14 @@ export default class TaskService {
 
   async getAllReallocatable(
     token: string,
-    allocatedFilter: 'allocated' | 'unallocated' = 'allocated',
+    allocatedFilter: 'allocated' | 'unallocated',
+    sortBy: TaskSortField,
+    sortDirection: SortDirection,
     page: number = 1,
-    sortDirection: SortDirection = 'asc',
   ): Promise<PaginatedResponse<Task>> {
     const taskClient = this.taskClientFactory(token)
 
-    const tasks = await taskClient.allReallocatable(allocatedFilter, page, sortDirection)
+    const tasks = await taskClient.allReallocatable(allocatedFilter, page, sortDirection, sortBy)
     return tasks
   }
 

--- a/server/utils/tasks/table.test.ts
+++ b/server/utils/tasks/table.test.ts
@@ -14,6 +14,8 @@ import {
 } from './table'
 import { sentenceCase } from '../utils'
 import { DateFormats } from '../dateUtils'
+import { sortHeader } from '../sortHeader'
+import { TaskSortField } from '../../@types/shared'
 
 jest.mock('../dateUtils')
 
@@ -115,17 +117,16 @@ describe('table', () => {
   })
 
   describe('unallocatedTableRows', () => {
+    const sortBy = 'createdAt'
+    const sortDirection = 'asc'
+    const hrefPrefix = 'http://localhost'
+
     it('returns an array of unallocated table headers', () => {
-      expect(tasksTableHeader('unallocated')).toEqual([
+      expect(tasksTableHeader('unallocated', sortBy, sortDirection, hrefPrefix)).toEqual([
         {
           text: 'Person',
         },
-        {
-          text: 'Days until due date',
-          attributes: {
-            'aria-sort': 'none',
-          },
-        },
+        sortHeader<TaskSortField>('Days until due date', 'createdAt', sortBy, sortDirection, hrefPrefix),
         {
           text: 'Allocated to',
         },
@@ -143,17 +144,16 @@ describe('table', () => {
   })
 
   describe('allocatedTableRows', () => {
+    const sortBy = 'createdAt'
+    const sortDirection = 'asc'
+    const hrefPrefix = 'http://localhost'
+
     it('returns an array of allocated table headers', () => {
-      expect(tasksTableHeader('allocated')).toEqual([
+      expect(tasksTableHeader('allocated', sortBy, sortDirection, hrefPrefix)).toEqual([
         {
           text: 'Person',
         },
-        {
-          text: 'Days until due date',
-          attributes: {
-            'aria-sort': 'none',
-          },
-        },
+        sortHeader<TaskSortField>('Days until due date', 'createdAt', sortBy, sortDirection, hrefPrefix),
         {
           text: 'Allocated to',
         },

--- a/server/utils/tasks/table.ts
+++ b/server/utils/tasks/table.ts
@@ -1,7 +1,8 @@
-import { Task } from '../../@types/shared'
+import { SortDirection, Task, TaskSortField } from '../../@types/shared'
 import { TableCell, TableRow } from '../../@types/ui'
 import paths from '../../paths/tasks'
 import { DateFormats } from '../dateUtils'
+import { sortHeader } from '../sortHeader'
 import { nameCell } from '../tableUtils'
 import { kebabCase, linkTo, sentenceCase } from '../utils'
 
@@ -108,17 +109,12 @@ const tasksTableRows = (tasks: Array<Task>, allocatedFilter: string): Array<Tabl
   return rows
 }
 
-const allocatedTableHeader = () => {
+const allocatedTableHeader = (sortBy: TaskSortField, sortDirection: SortDirection, hrefPrefix: string) => {
   return [
     {
       text: 'Person',
     },
-    {
-      text: 'Days until due date',
-      attributes: {
-        'aria-sort': 'none',
-      },
-    },
+    sortHeader<TaskSortField>('Days until due date', 'createdAt', sortBy, sortDirection, hrefPrefix),
     {
       text: 'Allocated to',
     },
@@ -134,17 +130,12 @@ const allocatedTableHeader = () => {
   ]
 }
 
-const unAllocatedTableHeader = () => {
+const unAllocatedTableHeader = (sortBy: TaskSortField, sortDirection: SortDirection, hrefPrefix: string) => {
   return [
     {
       text: 'Person',
     },
-    {
-      text: 'Days until due date',
-      attributes: {
-        'aria-sort': 'none',
-      },
-    },
+    sortHeader<TaskSortField>('Days until due date', 'createdAt', sortBy, sortDirection, hrefPrefix),
     {
       text: 'Allocated to',
     },
@@ -160,8 +151,15 @@ const unAllocatedTableHeader = () => {
   ]
 }
 
-const tasksTableHeader = (allocatedFilter: string) => {
-  return allocatedFilter === 'allocated' ? allocatedTableHeader() : unAllocatedTableHeader()
+const tasksTableHeader = (
+  allocatedFilter: string,
+  sortBy: TaskSortField,
+  sortDirection: SortDirection,
+  hrefPrefix: string,
+) => {
+  return allocatedFilter === 'allocated'
+    ? allocatedTableHeader(sortBy, sortDirection, hrefPrefix)
+    : unAllocatedTableHeader(sortBy, sortDirection, hrefPrefix)
 }
 
 export {

--- a/server/views/tasks/index.njk
+++ b/server/views/tasks/index.njk
@@ -21,7 +21,7 @@
       {{
         govukTable({
             firstCellIsHeader: true,
-            head: TaskUtils.tasksTableHeader(allocatedFilter),
+            head: TaskUtils.tasksTableHeader(allocatedFilter, sortBy, sortDirection, hrefPrefix),
             rows: TaskUtils.tasksTableRows(tasks, allocatedFilter)
           })
       }}


### PR DESCRIPTION
This updates the Tasks page to sort by when the task was last created using the API's sorting functionality.

## Screenshot

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/cdf7ed7c-512b-4703-b081-c4450e469578)
