### PR TITLE
Feature/aps 39 display offender status at time of submission

### DIFF
--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -79,7 +79,9 @@ export default class ShowPage extends Page {
       this.assertDefinition('Religion or belief', person.religionOrBelief)
       this.assertDefinition('Sex', person.sex)
 
-      cy.get(`[data-cy-status]`).should('have.attr', 'data-cy-status').and('equal', person.status)
+      cy.get(`[data-cy-status]`)
+        .should('have.attr', 'data-cy-status')
+        .and('equal', this.application.personStatusOnSubmission)
       this.assertDefinition('Prison', person.prisonName)
     })
   }

--- a/integration_tests/pages/assess/reviewPage.ts
+++ b/integration_tests/pages/assess/reviewPage.ts
@@ -1,4 +1,5 @@
 import type {
+  ApprovedPremisesApplication,
   ApprovedPremisesAssessment as Assessment,
   Document,
   FullPerson,
@@ -21,7 +22,7 @@ export default class ReviewPage extends AssessPage {
     this.pageClass = new Review({ reviewed: 'yes' }, assessment)
   }
 
-  shouldShowPersonInformation(person: FullPerson) {
+  shouldShowPersonInformation(person: FullPerson, application: ApprovedPremisesApplication) {
     cy.get('[data-cy-section="person-details"]').within(() => {
       this.assertDefinition('Name', person.name)
       this.assertDefinition('CRN', person.crn)
@@ -30,8 +31,9 @@ export default class ReviewPage extends AssessPage {
       this.assertDefinition('Nationality', person.nationality)
       this.assertDefinition('Religion or belief', person.religionOrBelief)
       this.assertDefinition('Sex', person.sex)
-
-      cy.get(`[data-cy-status]`).should('have.attr', 'data-cy-status').and('equal', person.status)
+      cy.get(`[data-cy-status]`)
+        .should('have.attr', 'data-cy-status')
+        .and('equal', application.personStatusOnSubmission)
       this.assertDefinition('Prison', person.prisonName)
     })
   }
@@ -130,7 +132,7 @@ export default class ReviewPage extends AssessPage {
   }
 
   shouldShowAnswers(assessment: Assessment) {
-    this.shouldShowPersonInformation(assessment.application.person as FullPerson)
+    this.shouldShowPersonInformation(assessment.application.person as FullPerson, assessment.application)
 
     this.shouldShowDocuments(
       assessment.application.data?.['attach-required-documents']['attach-documents'].selectedDocuments,

--- a/integration_tests/pages/assess/showPage.ts
+++ b/integration_tests/pages/assess/showPage.ts
@@ -6,13 +6,14 @@ import { summaryListSections } from '../../../server/utils/applications/summaryL
 import Page from '../page'
 
 export default class ShowPage extends Page {
-  constructor(private readonly asssessment: ApprovedPremisesAssessment) {
+  constructor(private readonly assessment: ApprovedPremisesAssessment) {
     super('View Assessment')
   }
 
   shouldShowPersonInformation() {
     cy.get('[data-cy-section="person-details"]').within(() => {
-      const person = this.asssessment.application.person as FullPerson
+      const { application } = this.assessment
+      const person = this.assessment.application.person as FullPerson
 
       this.assertDefinition('Name', person.name)
       this.assertDefinition('CRN', person.crn)
@@ -22,13 +23,15 @@ export default class ShowPage extends Page {
       this.assertDefinition('Religion or belief', person.religionOrBelief)
       this.assertDefinition('Sex', person.sex)
 
-      cy.get(`[data-cy-status]`).should('have.attr', 'data-cy-status').and('equal', person.status)
+      cy.get(`[data-cy-status]`)
+        .should('have.attr', 'data-cy-status')
+        .and('equal', application.personStatusOnSubmission)
       this.assertDefinition('Prison', person.prisonName)
     })
   }
 
   shouldShowResponses() {
-    const sections = summaryListSections(this.asssessment, false)
+    const sections = summaryListSections(this.assessment, false)
 
     sections.forEach(section => {
       cy.get('h2.govuk-heading-l').contains(section.title).should('exist')

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -236,8 +236,6 @@ export type TaskListErrors<K extends TasklistPage> = Partial<Record<keyof K['bod
 export type YesOrNo = 'yes' | 'no'
 export type YesNoOrIDK = YesOrNo | 'iDontKnow'
 
-export type PersonStatus = 'InCustody' | 'InCommunity'
-
 export interface ReferenceData {
   id: string
   name: string

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -137,4 +137,5 @@ export default ApplicationFactory.define(() => ({
   isPipeApplication: faker.datatype.boolean(),
   risks: risksFactory.build(),
   status: 'started' as const,
+  personStatusOnSubmission: 'InCustody' as const,
 }))

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -5,7 +5,8 @@ import * as pathModule from 'path'
 import nunjucks from 'nunjucks'
 import express from 'express'
 
-import type { ErrorMessages, PersonStatus } from '@approved-premises/ui'
+import type { ErrorMessages } from '@approved-premises/ui'
+import { PersonStatus } from '@approved-premises/api'
 import {
   initialiseName,
   kebabCase,

--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -12,6 +12,10 @@ describe('personUtils', () => {
     it('returns an "In Custody" tag for an InCustody status', () => {
       expect(statusTag('InCustody')).toEqual(`<strong class="govuk-tag" data-cy-status="InCustody">In Custody</strong>`)
     })
+
+    it('returns an "Unknown" tag for an Unknown status', () => {
+      expect(statusTag('Unknown')).toEqual(`<strong class="govuk-tag" data-cy-status="Unknown">Unknown</strong>`)
+    })
   })
 
   describe('tierBadge', () => {

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -1,12 +1,13 @@
-import type { PersonStatus } from '@approved-premises/ui'
-import { FullPerson, Person } from '../@types/shared'
+import { FullPerson, Person, PersonStatus } from '../@types/shared'
+
+const statuses: Record<PersonStatus, string> = {
+  InCommunity: 'In Community',
+  InCustody: 'In Custody',
+  Unknown: 'Unknown',
+}
 
 const statusTag = (status: PersonStatus): string => {
-  if (status === 'InCommunity') {
-    return `<strong class="govuk-tag" data-cy-status="${status}">In Community</strong>`
-  }
-
-  return `<strong class="govuk-tag" data-cy-status="${status}">In Custody</strong>`
+  return `<strong class="govuk-tag" data-cy-status="${status}">${statuses[status]}</strong>`
 }
 
 const tierBadge = (tier: string): string => {

--- a/server/views/applications/partials/_readonly-application.njk
+++ b/server/views/applications/partials/_readonly-application.njk
@@ -3,7 +3,7 @@
 
 {% macro applicationReadonlyView(application) %}
 
-  {{ personDetails(application.person) }}
+  {{ personDetails(application.person, statusOnSubmission = application.personStatusOnSubmission) }}
 
   {% if application.type !== 'Offline' %}
     {% for section in SummaryListUtils.summaryListSections(application, false) %}

--- a/server/views/assessments/pages/review-application/review.njk
+++ b/server/views/assessments/pages/review-application/review.njk
@@ -97,10 +97,10 @@
           },
           {
             key: {
-              text: "Status"
+              text: "Status on Submission"
             },
             value: {
-              html: statusTag(page.document.application.person.status)
+              html: statusTag(page.document.application.personStatusOnSubmission)
             }
           },
           {

--- a/server/views/assessments/show.njk
+++ b/server/views/assessments/show.njk
@@ -25,7 +25,7 @@
         {{ pageHeading }}
       </h1>
 
-      {{ personDetails(assessment.application.person) }}
+      {{ personDetails(assessment.application.person, statusOnSubmission = assessment.application.personStatusOnSubmission) }}
 
       {% for section in SummaryListUtils.summaryListSections(assessment, false) %}
         <h2 class="govuk-heading-l">{{ section.title }}</h3>

--- a/server/views/partials/personDetails.njk
+++ b/server/views/partials/personDetails.njk
@@ -1,6 +1,6 @@
 {%- from "govuk/components/summary-list/macro.njk" import govukSummaryList -%}
 
-{% macro personDetails(person, showTitle = true) %}
+{% macro personDetails(person, showTitle = true, statusOnSubmission = '') %}
   {% set rows = ([
     {
       key: {
@@ -59,14 +59,18 @@
       value: {
         text: person.genderIdentity
       }
-    }, {
+    },
+
+    {
       key: {
-        text: "Status"
+        text: "Status on Submission" if statusOnSubmission else "Status"
       },
       value: {
-        html: statusTag(person.status)
+        html: statusTag(statusOnSubmission) if statusOnSubmission else statusTag(person.status)
       }
-    }, {
+    },
+
+    {
       key: {
         text: "Prison"
       },


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-39

# Changes in this PR

All pages that show information about a submitted application have been updated to show the person’s status when the application was submitted, instead of the person’s status at the point in time the page is viewed.

This is achieved by using a new ‘personStatusOnSubmission’ field on the Application model.

The person status tag has also been updated to support showing the ‘Unknown’ type

There are 5 pages that currently show a person's status. Some have been updated to show the new 'status on submission' value, as detailed below:

* _readonly-application.njk - Shown when the applicant views a submitted application
* assessments/pages/review-application/review.njk - This is the page shown to assessors when viewing a submitted application
* views/assessments/show.njk - Shown when viewing a completed assessment

## Screenshots of UI changes

### Before

![_readonly-app-before](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22135634/6804119e-1abf-456a-a41f-81fe5300cb0e)
![assessments-show-before](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22135634/d11a0255-1049-4c81-8313-c965585f0a9c)
![review-application-before](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22135634/820c26ce-2136-43d0-97a2-abec23c9d5b8)

### After

![_readonly-app-after](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22135634/f4a98b11-576e-4a20-a3fc-9307714b1828)
![assessments-show-after](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22135634/f61809fa-f7db-4a22-818f-8d9c90909520)
![review-application-after](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22135634/d7ebe1ec-690d-4776-8a62-4cbd4056ef7a)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
      `production` in a backwards compatible way? (This includes our API,
      infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
      advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
