### PR TITLE
(APS-177) Add sorting to user workload screen

### DIFF
--- a/server/utils/tasks/usersTable.test.ts
+++ b/server/utils/tasks/usersTable.test.ts
@@ -28,6 +28,9 @@ describe('userTableHeader', () => {
     expect(userTableHeader()).toEqual([
       {
         text: 'Name',
+        attributes: {
+          'aria-sort': 'ascending',
+        },
       },
       {
         text: 'Region',
@@ -37,12 +40,21 @@ describe('userTableHeader', () => {
       },
       {
         text: 'Tasks pending',
+        attributes: {
+          'aria-sort': 'none',
+        },
       },
       {
         text: 'Tasks completed in previous 7 days',
+        attributes: {
+          'aria-sort': 'none',
+        },
       },
       {
         text: 'Tasks completed in previous 30 days',
+        attributes: {
+          'aria-sort': 'none',
+        },
       },
       {
         text: 'Action',

--- a/server/utils/tasks/usersTable.ts
+++ b/server/utils/tasks/usersTable.ts
@@ -5,12 +5,32 @@ import { qualificationDictionary } from '../users'
 import { kebabCase } from '../utils'
 
 export const userTableHeader = () => [
-  { text: 'Name' },
+  {
+    text: 'Name',
+    attributes: {
+      'aria-sort': 'ascending',
+    },
+  },
   { text: 'Region' },
   { text: 'Qualification' },
-  { text: 'Tasks pending' },
-  { text: 'Tasks completed in previous 7 days' },
-  { text: 'Tasks completed in previous 30 days' },
+  {
+    text: 'Tasks pending',
+    attributes: {
+      'aria-sort': 'none',
+    },
+  },
+  {
+    text: 'Tasks completed in previous 7 days',
+    attributes: {
+      'aria-sort': 'none',
+    },
+  },
+  {
+    text: 'Tasks completed in previous 30 days',
+    attributes: {
+      'aria-sort': 'none',
+    },
+  },
   { text: 'Action' },
 ]
 

--- a/server/views/tasks/show.njk
+++ b/server/views/tasks/show.njk
@@ -28,6 +28,9 @@
 
       {{
         govukTable({
+            attributes: {
+              'data-module': 'moj-sortable-table'
+            },
             firstCellIsHeader: true,
             head: TaskUtils.userTableHeader(),
             rows: TaskUtils.userTableRows(users, task, csrfToken)
@@ -38,4 +41,12 @@
   </div>
 </div>
 
+{% endblock %}
+
+{% block extraScripts %}
+<script type="text/javascript" nonce="{{ cspNonce }}">
+  window
+    .MOJFrontend
+    .initAll()
+</script>
 {% endblock %}


### PR DESCRIPTION
This addds the MOJ Sortable table component to the user workload screen to make it easier for users to find people to allocate.

## Screenshots

### Before

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/ba8237fd-1247-4103-beb3-e29fa2d1cb3f)

### After

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/aaf80d84-1be0-4d48-a74c-820dd3c0ddfa)
