### PR TITLE
(APS-82) Group premises by region

### DIFF
--- a/assets/js/flattenPremisesOptions.js
+++ b/assets/js/flattenPremisesOptions.js
@@ -1,0 +1,108 @@
+function flattenPremisesOptions(select, index) {
+  var formGroup = select.parentNode
+  var formElement = formGroup.parentNode
+  var optgroups = select.getElementsByTagName('optgroup')
+  var selectedRegion
+
+  function hideSelect() {
+    formGroup.classList.add('govuk-visually-hidden')
+
+    var options = select.getElementsByTagName('option')
+
+    for (let r = 0; r < options.length; ++r) {
+      options[r].setAttribute('hidden', true)
+    }
+  }
+
+  function getRegions() {
+    var regions = []
+
+    for (let i = 0; i < optgroups.length; ++i) {
+      regions.push(optgroups[i].label)
+    }
+
+    return regions
+  }
+
+  function flattenOptions() {
+    var ungroupedOptions = []
+
+    for (let i = 0; i < optgroups.length; ++i) {
+      var options = optgroups[i].getElementsByTagName('option')
+
+      for (let r = 0; r < options.length; ++r) {
+        options[r].dataset.region = optgroups[i].label
+        ungroupedOptions.push(options[r])
+      }
+    }
+
+    for (let i = 0; i < ungroupedOptions.length; ++i) {
+      if (ungroupedOptions[i].hasAttribute('selected')) {
+        selectedRegion = ungroupedOptions[i].dataset.region
+      }
+      select.appendChild(ungroupedOptions[i])
+    }
+
+    while (optgroups[0]) {
+      optgroups[0].parentNode.removeChild(optgroups[0])
+    }
+  }
+
+  function createRegionSelect(regions) {
+    var regionFormGroup = formGroup.cloneNode(true)
+    var regionSelect = regionFormGroup.querySelector('select')
+    var regionLabel = regionFormGroup.querySelector('label')
+    var formName = 'region' + index
+
+    var prompt = document.createElement('option')
+    var promptText = select.dataset.regionPrompt ? select.dataset.regionPrompt : 'Select a region'
+
+    regionSelect.innerHTML = ''
+    prompt.innerText = promptText
+    regionSelect.appendChild(prompt)
+    regionSelect.id = formName
+    regionSelect.name = formName
+    regionFormGroup.classList.remove('govuk-visually-hidden')
+
+    regionLabel.innerText = 'Select a Region'
+    regionLabel.setAttribute('for', formName)
+
+    for (let i = 0; i < regions.length; ++i) {
+      var option = document.createElement('option')
+      option.innerText = regions[i]
+      option.selected = option.innerText === selectedRegion
+      regionSelect.appendChild(option)
+    }
+
+    formElement.insertBefore(regionFormGroup, formGroup)
+
+    regionSelect.addEventListener('change', function (e) {
+      hideSelect()
+      var region = e.target.value
+
+      formGroup.classList.remove('govuk-visually-hidden')
+
+      var premisesWithRegion = formGroup.querySelectorAll('option[data-region="' + region + '"]')
+
+      for (let i = 0; i < premisesWithRegion.length; ++i) {
+        premisesWithRegion[i].removeAttribute('hidden')
+      }
+    })
+  }
+
+  var regions = getRegions()
+  flattenOptions()
+
+  if (regions.length > 1) {
+    if (select.value.length === 0) {
+      hideSelect()
+    }
+    createRegionSelect(regions, selectedRegion)
+  }
+}
+
+var selectItems = document.querySelectorAll('[data-premises-with-regions]')
+
+for (let i = 0; i < selectItems.length; ++i) {
+  flattenPremisesOptions(selectItems[i], i)
+}

--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -36,7 +36,7 @@ import {
   documentFactory,
   oasysSectionsFactory,
   oasysSelectionFactory,
-  premisesFactory,
+  premisesSummaryFactory,
   prisonCaseNotesFactory,
   userFactory,
 } from '../../server/testutils/factories'
@@ -185,9 +185,9 @@ export default class ApplyHelper {
   }
 
   private stubPremisesEndpoint() {
-    const premises1 = premisesFactory.build({ id: '1' })
-    const premises2 = premisesFactory.build({ id: '2' })
-    const premises3 = premisesFactory.build({ id: '3' })
+    const premises1 = premisesSummaryFactory.build({ id: '1', probationRegion: 'region1' })
+    const premises2 = premisesSummaryFactory.build({ id: '2', probationRegion: 'region2' })
+    const premises3 = premisesSummaryFactory.build({ id: '3', probationRegion: 'region3' })
     cy.task('stubAllPremises', [premises1, premises2, premises3])
   }
 

--- a/integration_tests/pages/admin/placementApplications/createPlacementPage.ts
+++ b/integration_tests/pages/admin/placementApplications/createPlacementPage.ts
@@ -1,4 +1,4 @@
-import { PlacementRequestDetail } from '../../../../server/@types/shared'
+import { ApprovedPremisesSummary, PlacementRequestDetail } from '../../../../server/@types/shared'
 import { placementDates } from '../../../../server/utils/matchUtils'
 import Page from '../../page'
 
@@ -14,12 +14,13 @@ export default class CreatePlacementPage extends Page {
     this.dateInputsShouldContainDate('departureDate', dates.endDate)
   }
 
-  completeForm(startDate: string, endDate: string, premisesId: string): void {
+  completeForm(startDate: string, endDate: string, premises: ApprovedPremisesSummary): void {
     this.clearDateInputs('arrivalDate')
     this.completeDateInputs('arrivalDate', startDate)
 
     this.clearDateInputs('departureDate')
     this.completeDateInputs('departureDate', endDate)
-    this.getSelectInputByIdAndSelectAnEntry('premisesId', premisesId)
+    this.getSelectInputByIdAndSelectAnEntry('region0', premises.probationRegion)
+    this.getSelectInputByIdAndSelectAnEntry('premisesId', premises.id)
   }
 }

--- a/integration_tests/pages/apply/preferredAps.ts
+++ b/integration_tests/pages/apply/preferredAps.ts
@@ -19,8 +19,11 @@ export default class PreferredAps extends ApplyPage {
   }
 
   completeForm() {
+    this.getSelectInputByIdAndSelectAnEntry('region0', 'region1')
     this.selectSelectOptionFromPageBody('preferredAp1')
+    this.getSelectInputByIdAndSelectAnEntry('region1', 'region2')
     this.selectSelectOptionFromPageBody('preferredAp2')
+    this.getSelectInputByIdAndSelectAnEntry('region2', 'region3')
     this.selectSelectOptionFromPageBody('preferredAp3')
   }
 }

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -7,6 +7,7 @@ import {
   placementRequestDetailFactory,
   placementRequestWithFullPersonFactory,
   premisesFactory,
+  premisesSummaryFactory,
 } from '../../../server/testutils/factories'
 import Page from '../../pages/page'
 import CreatePlacementPage from '../../pages/admin/placementApplications/createPlacementPage'
@@ -141,7 +142,7 @@ context('Placement Requests', () => {
   })
 
   it('allows me to create a booking', () => {
-    const premises = premisesFactory.buildList(3)
+    const premises = premisesSummaryFactory.buildList(3)
     cy.task('stubAllPremises', premises)
     cy.task('stubBookingFromPlacementRequest', unmatchedPlacementRequest)
 
@@ -164,7 +165,7 @@ context('Placement Requests', () => {
     createPage.dateInputsShouldBePrepopulated()
 
     // When I complete the form
-    createPage.completeForm('2022-01-01', '2022-02-01', premises[0].id)
+    createPage.completeForm('2022-01-01', '2022-02-01', premises[0])
     createPage.clickSubmit()
 
     // Then I should see a confirmation message

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -145,6 +145,11 @@ export interface SelectOption {
   selected?: boolean
 }
 
+export interface SelectGroup {
+  label: string
+  items: Array<SelectOption>
+}
+
 export interface SummaryList {
   classes?: string
   attributes?: HtmlAttributes

--- a/server/utils/premisesUtils.test.ts
+++ b/server/utils/premisesUtils.test.ts
@@ -3,8 +3,10 @@ import {
   bedOccupancyEntryFactory,
   bedOccupancyRangeFactory,
   extendedPremisesSummaryFactory,
+  premisesSummaryFactory,
 } from '../testutils/factories'
 import {
+  groupedSelectOptions,
   mapApiOccupancyEntryToUiOccupancyEntry,
   mapApiOccupancyToUiOccupancy,
   overcapacityMessage,
@@ -185,6 +187,50 @@ describe('premisesUtils', () => {
           },
         ],
       })
+    })
+  })
+
+  describe('groupedSelectOptions', () => {
+    const region1Premises = premisesSummaryFactory.buildList(2, { probationRegion: 'Region 1' })
+    const region2Premises = premisesSummaryFactory.buildList(2, { probationRegion: 'Region 2' })
+    const premises = [...region1Premises, ...region2Premises]
+
+    it('should group premises by region', () => {
+      expect(groupedSelectOptions(premises, { premisesId: region2Premises[1].id })).toEqual([
+        {
+          items: [
+            { selected: false, text: region1Premises[0].name, value: region1Premises[0].id },
+            { selected: false, text: region1Premises[1].name, value: region1Premises[1].id },
+          ],
+          label: 'Region 1',
+        },
+        {
+          items: [
+            { selected: false, text: region2Premises[0].name, value: region2Premises[0].id },
+            { selected: true, text: region2Premises[1].name, value: region2Premises[1].id },
+          ],
+          label: 'Region 2',
+        },
+      ])
+    })
+
+    it('should support a field name', () => {
+      expect(groupedSelectOptions(premises, { premises: region2Premises[1].id }, 'premises')).toEqual([
+        {
+          items: [
+            { selected: false, text: region1Premises[0].name, value: region1Premises[0].id },
+            { selected: false, text: region1Premises[1].name, value: region1Premises[1].id },
+          ],
+          label: 'Region 1',
+        },
+        {
+          items: [
+            { selected: false, text: region2Premises[0].name, value: region2Premises[0].id },
+            { selected: true, text: region2Premises[1].name, value: region2Premises[1].id },
+          ],
+          label: 'Region 2',
+        },
+      ])
     })
   })
 })

--- a/server/utils/premisesUtils.ts
+++ b/server/utils/premisesUtils.ts
@@ -1,5 +1,10 @@
-import type { BedOccupancyRange, DateCapacity, ExtendedPremisesSummary } from '@approved-premises/api'
-import { BedOccupancyRangeUi, SummaryList } from '@approved-premises/ui'
+import type {
+  ApprovedPremisesSummary,
+  BedOccupancyRange,
+  DateCapacity,
+  ExtendedPremisesSummary,
+} from '@approved-premises/api'
+import { BedOccupancyRangeUi, SelectGroup, SummaryList } from '@approved-premises/ui'
 import { DateFormats } from './dateUtils'
 import { addOverbookingsToSchedule } from './addOverbookingsToSchedule'
 import { textValue } from './applications/utils'
@@ -103,4 +108,22 @@ export const summaryListForPremises = (premises: ExtendedPremisesSummary): Summa
       },
     ],
   }
+}
+
+export const groupedSelectOptions = (
+  premises: Array<ApprovedPremisesSummary>,
+  context: Record<string, unknown>,
+  fieldName: string = 'premisesId',
+): Array<SelectGroup> => {
+  const regions = [...new Set(premises.map(item => item.probationRegion))]
+  return regions.map(region => ({
+    label: region,
+    items: premises
+      .filter(item => item.probationRegion === region)
+      .map(item => ({
+        text: item.name,
+        value: item.id,
+        selected: context[fieldName] === item.id,
+      })),
+  }))
 }

--- a/server/views/admin/placementRequests/bookings/new.njk
+++ b/server/views/admin/placementRequests/bookings/new.njk
@@ -5,6 +5,7 @@
 {% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../../../components/formFields/form-page-input/macro.njk" import formPageInput %}
 {% from "../../../components/formFields/form-page-date-input/macro.njk" import formPageDateInput %}
+{% from "../../../components/formFields/selectWithOptgroup.njk" import govukSelectWithOptgroup %}
 
 {% extends "../../../partials/layout.njk" %}
 
@@ -36,14 +37,18 @@
         {{ showErrorSummary(errorSummary) }}
 
         {{
-          govukSelect({
+          govukSelectWithOptgroup({
             label: {
               classes: "govuk-fieldset__legend--m",
               html: 'Select an Approved Premises'
             },
+            attributes: {
+              "data-premises-with-regions": true
+            },
+            prompt: "Select a premises",
             id: "premisesId",
             name: "premisesId",
-            items: convertObjectsToSelectOptions(premises, 'Please select', 'name', 'id', 'premisesId'),
+            items: PremisesUtils.groupedSelectOptions(premises, fetchContext()),
             errorMessage: errors.premisesId
           })
         }}
@@ -87,4 +92,8 @@
       </form>
     </div>
   </div>
+{% endblock %}
+
+{% block extraScripts %}
+  <script type="text/javascript" src="/assets/js/flattenPremisesOptions.js"></script>
 {% endblock %}

--- a/server/views/applications/pages/location-factors/preferred-aps.njk
+++ b/server/views/applications/pages/location-factors/preferred-aps.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "../../../components/formFields/form-page-select-with-optgroup/macro.njk" import formPageSelectWithOptgroup %}
 
 {% extends "../layout.njk" %}
 
@@ -9,16 +10,34 @@
   </h1>
 
   {% for preferredAp in page.preferredApOptions %}
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+        {{page.preferredApLabels[loop.index0]}}
+      </legend>
 
-    {{ formPageSelect({
-      fieldName: preferredAp,
-      label: {
-        text: page.preferredApLabels[loop.index0], 
-        classes: "govuk-label--m"
-      },
-      items: convertObjectsToSelectOptions(page.allPremises, 'No preference', 'name', 'id', preferredAp)
-    }, fetchContext()) }}
+      {{
+      formPageSelectWithOptgroup({
+        label: {
+          classes: "govuk-fieldset__legend--s",
+          html: "Select a premises"
+        },
+        attributes: {
+          "data-premises-with-regions": true,
+          "data-region-prompt": "No preference"
+        },
+        prompt: "No preference",
+        fieldName: preferredAp,
+        items: PremisesUtils.groupedSelectOptions(page.allPremises, fetchContext(), preferredAp)
+      })
+    }}
 
+    </fieldset>
+
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     {%endfor%}
 
+  {% endblock %}
+
+  {% block extraScripts %}
+    <script type="text/javascript" src="/assets/js/flattenPremisesOptions.js"></script>
   {% endblock %}

--- a/server/views/components/formFields/form-page-select-with-optgroup/macro.njk
+++ b/server/views/components/formFields/form-page-select-with-optgroup/macro.njk
@@ -1,0 +1,20 @@
+{% from "../selectWithOptgroup.njk" import govukSelectWithOptgroup %}
+
+{% macro formPageSelectWithOptgroup(params, context) %}
+  {% set selectItems = [] %}
+
+  {% for item in params.items %}
+    {% set selectItems = (selectItems.push(mergeObjects(item, {
+      selected: context[params.fieldName] == item.value
+    })), selectItems) %}
+  {% endfor %}
+
+  {{
+      govukSelectWithOptgroup(
+        mergeObjects(
+          mergeObjects(params, { items: selectItems }),
+          { id: params.fieldName, name: params.fieldName, errorMessage: context.errors[params.fieldName] }
+        )
+      )
+  }}
+{% endmacro %}

--- a/server/views/components/formFields/selectWithOptgroup.njk
+++ b/server/views/components/formFields/selectWithOptgroup.njk
@@ -1,0 +1,70 @@
+{% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
+{% from "govuk/components/hint/macro.njk" import govukHint %}
+{% from "govuk/components/label/macro.njk" import govukLabel %}
+
+{% macro govukSelectWithOptgroup(params) %}
+  {#- a record of other elements that we need to associate with the input using
+  aria-describedby – for example hints or error messages -#}
+  {% set describedBy = params.describedBy if params.describedBy else 
+    "" %}
+
+  {% set prompt = params.prompt if params.prompt else 
+    "Please select" %}
+  <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}" {%- for attribute, value in params.formGroup.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+    {{ govukLabel({
+    html: params.label.html,
+    text: params.label.text,
+    classes: params.label.classes,
+    isPageHeading: params.label.isPageHeading,
+    attributes: params.label.attributes,
+    for: params.id
+  }) | indent(2) | trim }}
+    {% if params.hint %}
+      {% set hintId = params.id + '-hint' %}
+      {% set describedBy = describedBy + ' ' + hintId if describedBy else 
+        hintId %}
+      {{ govukHint({
+    id: hintId,
+    classes: params.hint.classes,
+    attributes: params.hint.attributes,
+    html: params.hint.html,
+    text: params.hint.text
+  }) | indent(2) | trim }}
+    {% endif %}
+    {% if params.errorMessage %}
+      {% set errorId = params.id + '-error' %}
+      {% set describedBy = describedBy + ' ' + errorId if describedBy else 
+        errorId %}
+      {{ govukErrorMessage({
+    id: errorId,
+    classes: params.errorMessage.classes,
+    attributes: params.errorMessage.attributes,
+    html: params.errorMessage.html,
+    text: params.errorMessage.text,
+    visuallyHiddenText: params.errorMessage.visuallyHiddenText
+  }) | indent(2) | trim }}
+    {% endif %}
+    <select class="govuk-select
+    {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-select--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}"
+    {%- if params.disabled %} disabled{% endif %}
+    {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
+    {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+      <option value="" selected>{{ prompt }}</option>
+      {% for optgroup in params.items %}
+        {% if optgroup %}
+          <optgroup label="{{ optgroup.label }}">
+            {% for item in optgroup.items %}
+              {% if item %}
+                {# Allow selecting by text content (the value for an option when no value attribute is specified) #}
+                {% set effectiveValue = item.value | default(item.text) %}
+                <option {%- if item.value !== undefined %} value="{{ item.value }}"{% endif %}
+              {{-" selected" if item.selected | default((effectiveValue == params.value and item.selected != false) if params.value else false, true) }}
+              {{-" disabled" if item.disabled }}
+              {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>{{ item.text }}</option>
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+        {% endfor %}
+      </select>
+    </div>
+  {% endmacro %}


### PR DESCRIPTION
This adds optgroups to the premises select options in the CRU dashboard and the Preferred APs screen in Apply.

To get around the usability issues with optgroups (and also maintain functionality without JS) I've added some frontend JS to allow regions to be selected which then populate only the APs in that region. 

## Screenshots (well, gifs)

![](http://g.recordit.co/jqwGMi5wRf.gif)
![](http://g.recordit.co/ri9hYZKogh.gif)