### PR TITLE
(APS-93) Add blue banner across Assess

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -17,6 +17,7 @@ $path: "/assets/images/"
 @import './components/withdrawal-reasons'
 @import './components/sortable-table'
 @import './components/placement-request-search'
+@import './components/key-details-bar'
 
 @import './pages/assessments-index'
 @import './pages/applications-pages-attach-document'

--- a/assets/sass/components/_key-details-bar.scss
+++ b/assets/sass/components/_key-details-bar.scss
@@ -1,0 +1,39 @@
+.key-details-bar {
+  background-color: govuk-colour('blue');
+
+  .govuk-body,
+  .govuk-body-l {
+    color: govuk-colour('white');
+  }
+
+  span {
+    white-space: nowrap;
+  }
+}
+
+.key-details-bar a {
+  color: govuk-colour('white');
+}
+
+.key-details-bar .key-details-bar__key-details {
+  padding: 20px 0;
+  position: relative;
+}
+
+.key-details-bar .key-details-bar__key-details .key-details-bar__name {
+  line-height: 1.04167;
+  line-height: 1.11111;
+  margin-inline-start: 0;
+  margin-right: 10px;
+}
+
+.key-details-bar .key-details-bar__key-details .key-details-bar__bottom-block {
+  margin-top: 6px;
+  padding-top: 10px;
+}
+@media (min-width: 40.0625em) {
+  .key-details-bar .key-details-bar__key-details .key-details-bar__name {
+    font-size: 1.675rem;
+    line-height: 1.11111;
+  }
+}

--- a/integration_tests/pages/assess/assessPage.ts
+++ b/integration_tests/pages/assess/assessPage.ts
@@ -3,8 +3,9 @@ import { ApprovedPremisesAssessment } from '@approved-premises/api'
 import Assess from '../../../server/form-pages/assess'
 import TasklistPage, { TasklistPageInterface } from '../../../server/form-pages/tasklistPage'
 import FormPage from '../formPage'
+import { keyDetails } from '../../../server/utils/assessments/utils'
 
-export default class NewAssesPage extends FormPage {
+export default class AssessPage extends FormPage {
   tasklistPage: TasklistPage
 
   constructor(
@@ -14,10 +15,11 @@ export default class NewAssesPage extends FormPage {
     pageName: string,
     backLink?: string,
   ) {
-    super(title, backLink)
+    super(title, backLink, false)
 
     const Class = Assess.pages[taskName][pageName] as TasklistPageInterface
 
     this.tasklistPage = new Class(assessment.data?.[taskName]?.[pageName], assessment)
+    this.shouldShowKeyDetails(keyDetails(assessment))
   }
 }

--- a/integration_tests/pages/formPage.ts
+++ b/integration_tests/pages/formPage.ts
@@ -4,14 +4,16 @@ import Page from './page'
 export default class FormPage extends Page {
   tasklistPage: TasklistPage
 
-  constructor(title: string, backLink?: string) {
+  constructor(title: string, backLink?: string, checkPhaseBanner: boolean = true) {
     super(title)
 
     if (backLink) {
       this.checkForBackButton(backLink)
     }
 
-    this.checkPhaseBanner('Give us your feedback')
+    if (checkPhaseBanner) {
+      this.checkPhaseBanner('Give us your feedback')
+    }
   }
 
   checkRadioButtonFromPageBody(fieldName: string) {

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -7,7 +7,7 @@ import {
   PersonAcctAlert,
   PrisonCaseNote,
 } from '../../server/@types/shared'
-import { PersonRisksUI, SummaryListItem, TableCell } from '../../server/@types/ui'
+import { KeyDetailsArgs, PersonRisksUI, SummaryListItem, TableCell } from '../../server/@types/ui'
 import errorLookups from '../../server/i18n/en/errors.json'
 import { summaryListSections } from '../../server/utils/applications/summaryListUtils'
 import { DateFormats } from '../../server/utils/dateUtils'
@@ -403,5 +403,35 @@ export default abstract class Page {
 
   shouldBeSortedByField(field: string, order: string): void {
     cy.get(`th[data-cy-sort-field="${field}"]`).should('have.attr', 'aria-sort', order)
+  }
+
+  shouldShowKeyDetails(keyDetails: KeyDetailsArgs): void {
+    if (keyDetails.header.showKey) {
+      cy.get('.key-details-bar__top-block').contains(keyDetails.header.key)
+    }
+    cy.get('.key-details-bar__name').contains(keyDetails.header.value)
+
+    keyDetails.items.forEach(item => {
+      if (item.key) {
+        if ('text' in item.key) {
+          cy.get('.key-details-bar__bottom-block').contains(item.key.text)
+        } else if ('html' in item.key) {
+          const { html } = item.key
+          cy.get('.key-details-bar__bottom-block').then($el => {
+            const { actual, expected } = parseHtml($el, html)
+            expect(actual).to.contain(expected)
+          })
+        }
+      }
+      if ('text' in item.value) {
+        cy.get('.key-details-bar__bottom-block').contains(item.value.text)
+      } else if ('html' in item.value) {
+        const { html } = item.value
+        cy.get('.key-details-bar__bottom-block').then($el => {
+          const { actual, expected } = parseHtml($el, html)
+          expect(actual).to.contain(expected)
+        })
+      }
+    })
   }
 }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -467,3 +467,15 @@ export type ApplicationDashboardSearchOptions = {
 }
 
 export type AssessmentCurrentTab = 'awaiting_assessment' | 'awaiting_response' | 'completed'
+
+export type KeyDetailsArgs = {
+  header: {
+    key: string
+    value: string
+    showKey: boolean
+  }
+  items: Array<{
+    key?: HtmlItem | TextItem
+    value: HtmlItem | TextItem
+  }>
+}

--- a/server/controllers/assess/assessments/pagesController.test.ts
+++ b/server/controllers/assess/assessments/pagesController.test.ts
@@ -69,6 +69,7 @@ describe('pagesController', () => {
       expect(assessmentService.initializePage).toHaveBeenCalledWith(PageConstructor, assessment, request, {}, {})
       expect(response.render).toHaveBeenCalledWith('assessments/pages/some/view', {
         assessmentId: request.params.id,
+        assessment,
         task: 'some-task',
         page,
         errors: {},
@@ -91,6 +92,7 @@ describe('pagesController', () => {
 
       expect(response.render).toHaveBeenCalledWith('assessments/pages/some/view', {
         assessmentId: request.params.id,
+        assessment,
         task: 'some-task',
         page,
         errors: errorsAndUserInput.errors,

--- a/server/controllers/assess/assessments/pagesController.ts
+++ b/server/controllers/assess/assessments/pagesController.ts
@@ -39,6 +39,7 @@ export default class PagesController {
 
         res.render(viewPath(page, 'assessments'), {
           assessmentId: req.params.id,
+          assessment,
           errors,
           errorSummary,
           task: taskName,

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -1,4 +1,4 @@
-import { ApplicationType, GroupedAssessments, SummaryListItem } from '@approved-premises/ui'
+import { ApplicationType, GroupedAssessments, KeyDetailsArgs, SummaryListItem } from '@approved-premises/ui'
 
 import {
   ApprovedPremisesAssessmentStatus,
@@ -10,11 +10,14 @@ import { TasklistPageInterface } from '../../form-pages/tasklistPage'
 import Assess from '../../form-pages/assess'
 import { UnknownPageError } from '../errors'
 import Apply from '../../form-pages/apply'
-import { kebabCase } from '../utils'
+import { kebabCase, linkTo } from '../utils'
 import { getApplicationType as getApplicationTypeFromApplication } from '../applications/utils'
 import { applicationAccepted, decisionFromAssessment } from './decisionUtils'
 import { assessmentsApproachingDue, formattedArrivalDate } from './dateUtils'
 import { getResponseForPage } from '../applications/getResponseForPage'
+import { nameOrPlaceholderCopy } from '../personUtils'
+import { DateFormats } from '../dateUtils'
+import applyPaths from '../../paths/apply'
 
 const awaitingAssessmentStatuses = ['in_progress', 'not_started'] as Array<ApprovedPremisesAssessmentStatus>
 
@@ -153,6 +156,39 @@ const rejectionRationaleFromAssessmentResponses = (assessment: Assessment): stri
   return response
 }
 
+const keyDetails = (assessment: Assessment): KeyDetailsArgs => {
+  return {
+    header: {
+      key: 'Name',
+      value: nameOrPlaceholderCopy(assessment.application.person),
+      showKey: false,
+    },
+    items: [
+      {
+        key: { text: 'CRN' },
+        value: { text: assessment.application.person.crn },
+      },
+      {
+        key: { text: 'Arrival Date' },
+        value: {
+          text: assessment.application.arrivalDate
+            ? DateFormats.isoDateToUIDate(assessment.application.arrivalDate)
+            : 'Not provided',
+        },
+      },
+      {
+        value: {
+          html: linkTo(
+            applyPaths.applications.show,
+            { id: assessment.application.id },
+            { text: 'View application (opens in new window)', attributes: { target: '_blank' } },
+          ),
+        },
+      },
+    ],
+  }
+}
+
 export {
   acctAlertsFromAssessment,
   adjudicationsFromAssessment,
@@ -169,4 +205,5 @@ export {
   groupAssessmements,
   rejectionRationaleFromAssessmentResponses,
   awaitingAssessmentStatuses,
+  keyDetails,
 }

--- a/server/views/assessments/layouts/with-details.njk
+++ b/server/views/assessments/layouts/with-details.njk
@@ -1,0 +1,10 @@
+{% from "../../components/keyDetails/macro.njk" import keyDetails %}
+{% extends "../../partials/layout.njk" %}
+
+{% set hideNav = true %}
+{% set hidePhaseBanner = true %}
+
+{% block header %}
+  {{ super() }}
+  {{ keyDetails(AssessmentUtils.keyDetails(assessment)) }}
+{% endblock %}

--- a/server/views/assessments/pages/check-your-answers/check-your-answers.njk
+++ b/server/views/assessments/pages/check-your-answers/check-your-answers.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% extends "../../../partials/layout.njk" %}
+{% extends "../../layouts/with-details.njk" %}
 
 {% set pageTitle = applicationName + " - " + page.title %}
 {% set mainClasses = "app-container govuk-body" %}

--- a/server/views/assessments/pages/layout.njk
+++ b/server/views/assessments/pages/layout.njk
@@ -14,8 +14,9 @@
 {% from "../../components/formFields/form-page-checkboxes/macro.njk" import formPageCheckboxes %}
 {% from "../../components/formFields/form-page-textarea/macro.njk" import formPageTextarea %}
 {% from "../../components/formFields/form-page-select/macro.njk" import formPageSelect %}
+{% from "../../components/keyDetails/macro.njk" import keyDetails %}
 
-{% extends "../../partials/layout.njk" %}
+{% extends "../layouts/with-details.njk" %}
 
 {% set pageTitle = applicationName + " - " + page.title %}
 {% set mainClasses = "app-container govuk-body" %}

--- a/server/views/assessments/tasklist.njk
+++ b/server/views/assessments/tasklist.njk
@@ -3,12 +3,14 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../components/riskWidgets/macro.njk" import widgets %}
+{% from "../components/keyDetails/macro.njk" import keyDetails %}
 
-{% extends "../partials/layout.njk" %}
+{% extends "./layouts/with-details.njk" %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-width-container">
+
       <h1 class="govuk-heading-xl">
         {{ pageHeading }}
       </h1>

--- a/server/views/components/keyDetails/macro.njk
+++ b/server/views/components/keyDetails/macro.njk
@@ -1,0 +1,30 @@
+{% macro keyDetails(args) %}
+  <section class="key-details-bar" aria-label="Key details">
+    <div class="key-details-bar__key-details govuk-width-container govuk-body">
+      <div class="prisoner-info">
+        <div class="key-details-bar__top-block">
+          {% if args.header.showKey == true %}
+            {{ args.header.key }}
+          {% else %}
+            <span class="govuk-visually-hidden">{{ args.header.key }}:</span>
+          {% endif %}
+          <span class="key-details-bar__name govuk-body-l govuk-!-margin-right-6">
+            <strong>
+              {{ args.header.value }}
+            </strong>
+          </span>
+          <div class="key-details-bar__bottom-block">
+            {% for item in args.items %}
+              <span class="govuk-body">
+                {% if item.key %}
+                  <strong>{{ item.key.html | safe if item.key.html else item.key.text }}:</strong>
+                {% endif %}
+                {{ item.value.html | safe if item.value.html else item.value.text }}
+              </span>
+              {% if not loop.last %}|{% endif %}
+            {% endfor %}
+          </div>
+        </div>
+      </div>
+    </section>
+  {% endmacro %}

--- a/server/views/partials/header.njk
+++ b/server/views/partials/header.njk
@@ -45,7 +45,8 @@
 {% endif %}
 
 {% block phaseBanner %}
-  {{ govukPhaseBanner({
+  {% if not hidePhaseBanner %}
+    {{ govukPhaseBanner({
     attributes: { "data-cy-phase-banner": "phase-banner" },
     classes: "hmpps-header__container",
     tag: {
@@ -53,4 +54,5 @@
     },
     html: PhaseBannerUtils.getContent(currentUrl)
   }) }}
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
This adds a blue banner with key details about an application to Assess. This helps orientate assessors, as well as gives them easy access to view a full application. This banner is lifted from the [DWP Key Details bar](https://design-system.dwp.gov.uk/components/key-details-bar), as used elsewhere in MoJ.

## Screenshots

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/6ca45e49-935b-4c55-ba75-45455fb532d6)

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/34fcf1a0-5fa2-4a2c-8644-2976c52d8601)

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/d3da5300-457d-4ceb-a469-9418c0d997b4)
