### PR TITLE
APS 106 -  add ESAP assessment screens

### DIFF
--- a/integration_tests/fixtures/assessmentData.json
+++ b/integration_tests/fixtures/assessmentData.json
@@ -14,8 +14,12 @@
     },
     "rfap-suitability": {
       "rfapIdentifiedAsSuitable": "no",
-      "unsuitabilityForRfapRationale": "some comments",
+      "unsuitabilityForRfapRationale": "Some RFAP comments",
       "noDetail": "some detail"
+    },
+    "contingency-plan-suitability": {
+      "contingencyPlanSufficient": "yes",
+      "additionalComments": "Some contingency plan comments"
     }
   },
   "required-actions": {

--- a/integration_tests/helpers/assess.ts
+++ b/integration_tests/helpers/assess.ts
@@ -212,6 +212,12 @@ export default class AseessHelper {
 
     this.pages.assessSuitability = [suitabilityAssessmentPage, rfapSuitabilityPage]
 
+    if (!options.isShortNoticeApplication) {
+      const contingencyPlanSuitabilityPage = new ContingencyPlanSuitabilityPage(this.assessment)
+      contingencyPlanSuitabilityPage.completeForm()
+      contingencyPlanSuitabilityPage.clickSubmit()
+    }
+
     if (options.isShortNoticeApplication) {
       // Then I should be taken to the application timeliness page
       const applicationTimelinessPage = new ApplicationTimelinessPage(this.assessment)

--- a/integration_tests/pages/assess/index.ts
+++ b/integration_tests/pages/assess/index.ts
@@ -12,6 +12,8 @@ import CheckYourAnswersPage from './checkYourAnswersPage'
 import SubmissionConfirmation from './submissionConfirmation'
 import ShowPage from './showPage'
 import ApplicationTimelinessPage from './applicationTimelinessPage'
+import RfapSuitabilityPage from './rfapSuitability'
+import ContingencyPlanSuitabilityPage from './contingencyPlanSuitability'
 
 export {
   ClarificationNoteConfirmPage,
@@ -28,4 +30,6 @@ export {
   SubmissionConfirmation,
   ShowPage,
   ApplicationTimelinessPage,
+  RfapSuitabilityPage,
+  ContingencyPlanSuitabilityPage,
 }

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -13,5 +13,3 @@ echo "==> Installing application dependencies..."
 
 nodenv install --skip-existing
 npm install
-
-script/utils/start-backing-services.sh

--- a/script/server
+++ b/script/server
@@ -13,10 +13,9 @@ cleanup() {
 }
 trap cleanup EXIT
 
-script/utils/launch-docker.sh
-
-script/utils/start-backing-services.sh
 
 echo "==> Starting the server..."
+
+script/utils/launch-docker.sh
 
 npm run start:dev

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.test.ts
@@ -4,12 +4,12 @@ import { YesOrNo } from '../../../../@types/ui'
 import { retrieveOptionalQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 
 import ApplicationTimeliness from './applicationTimeliness'
-import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
 import { arrivalDateFromApplication } from '../../../../utils/applications/arrivalDateFromApplication'
 import { ShortNoticeReasons } from '../../../apply/reasons-for-placement/basic-information/reasonForShortNotice'
+import { suitabilityAssessmentAdjacentPage } from '../../../../utils/assessments/suitabilityAssessmentAdjacentPage'
 
 jest.mock('../../../../utils/retrieveQuestionResponseFromFormArtifact')
-jest.mock('../../../../utils/applications/noticeTypeFromApplication')
+jest.mock('../../../../utils/assessments/suitabilityAssessmentAdjacentPage')
 jest.mock('../../../../utils/applications/arrivalDateFromApplication')
 
 const body = {
@@ -32,30 +32,20 @@ describe('ApplicationTimeliness', () => {
   })
 
   describe('next', () => {
-    it('returns an empty string if the application has a notice type other than emergency', () => {
-      expect(new ApplicationTimeliness(body, assessment).next()).toEqual('')
-    })
-
-    it('returns contingency-plan-suitability if the application ahs a notice type of emergency', () => {
-      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('emergency')
-      expect(new ApplicationTimeliness(body, assessment).next()).toEqual('contingency-plan-suitability')
+    it('returns the result of suitabilityAssessmentAdjacentPage', () => {
+      ;(suitabilityAssessmentAdjacentPage as jest.Mock).mockReturnValue('application-timeliness')
+      expect(new ApplicationTimeliness(body, assessment).next()).toEqual('application-timeliness')
     })
   })
 
   describe('previous', () => {
-    it('returns rfap-suitability if the applicant requires an RFAP', () => {
-      ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue('yes')
-
-      expect(new ApplicationTimeliness(body, assessment).previous()).toEqual('rfap-suitability')
-    })
-
-    it('returns suitability-assessment if the applicant doesnt require an RFAP', () => {
-      ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue(undefined)
-
+    it('returns the result of suitabilityAssessmentAdjacentPage', () => {
+      ;(suitabilityAssessmentAdjacentPage as jest.MockedFn<typeof suitabilityAssessmentAdjacentPage>).mockReturnValue(
+        'suitability-assessment',
+      )
       expect(new ApplicationTimeliness(body, assessment).previous()).toEqual('suitability-assessment')
     })
   })
-
   describe('errors', () => {
     it('should have an error if there are no answers', () => {
       const page = new ApplicationTimeliness(

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.ts
@@ -11,9 +11,8 @@ import { Page } from '../../../utils/decorators'
 import TasklistPage from '../../../tasklistPage'
 import { responsesForYesNoAndCommentsSections } from '../../../utils/index'
 import { retrieveOptionalQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
-import Rfap from '../../../apply/risk-and-need-factors/further-considerations/rfap'
-import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
 import { arrivalDateFromApplication } from '../../../../utils/applications/arrivalDateFromApplication'
+import { suitabilityAssessmentAdjacentPage } from '../../../../utils/assessments/suitabilityAssessmentAdjacentPage'
 
 export type ApplicationTimelinessSection = {
   agreeWithShortNoticeReason: string
@@ -30,7 +29,7 @@ export type ApplicationDetails = {
   bodyProperties: ['agreeWithShortNoticeReason', 'agreeWithShortNoticeReasonComments', 'reasonForLateApplication'],
 })
 export default class ApplicationTimeliness implements TasklistPage {
-  name = 'application-timeliness'
+  name = 'application-timeliness' as const
 
   title = 'Application timeliness'
 
@@ -77,17 +76,11 @@ export default class ApplicationTimeliness implements TasklistPage {
   }
 
   previous() {
-    const needsRfap = retrieveOptionalQuestionResponseFromFormArtifact(this.assessment.application, Rfap, 'needARfap')
-
-    if (needsRfap === 'yes') {
-      return 'rfap-suitability'
-    }
-
-    return 'suitability-assessment'
+    return suitabilityAssessmentAdjacentPage(this.assessment, this.name, { returnPreviousPage: true })
   }
 
   next() {
-    return noticeTypeFromApplication(this.assessment.application) === 'emergency' ? 'contingency-plan-suitability' : ''
+    return suitabilityAssessmentAdjacentPage(this.assessment, this.name)
   }
 
   response() {

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/contingencyPlanSuitability.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/contingencyPlanSuitability.test.ts
@@ -2,9 +2,10 @@ import { assessmentFactory } from '../../../../testutils/factories'
 import { itShouldHaveNextValue } from '../../../shared-examples'
 
 import ContingencyPlanSuitability, { ContingencyPlanSuitabilityBody } from './contingencyPlanSuitability'
-import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
 
-jest.mock('../../../../utils/applications/noticeTypeFromApplication')
+import { suitabilityAssessmentAdjacentPage } from '../../../../utils/assessments/suitabilityAssessmentAdjacentPage'
+
+jest.mock('../../../../utils/assessments/suitabilityAssessmentAdjacentPage')
 
 describe('ContingencyPlanSuitability', () => {
   const body: ContingencyPlanSuitabilityBody = {
@@ -30,16 +31,14 @@ describe('ContingencyPlanSuitability', () => {
   itShouldHaveNextValue(new ContingencyPlanSuitability(body, assessment), '')
 
   describe('previous', () => {
-    it('returns application-timeliness if the notice type is emergency', () => {
-      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('emergency')
-      expect(new ContingencyPlanSuitability(body, assessment).previous()).toBe('application-timeliness')
-    })
-
-    it('returns application-timeliness if the notice type is emergency', () => {
-      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('standard')
-      expect(new ContingencyPlanSuitability(body, assessment).previous()).toBe('suitability-assessment')
+    it('returns the result of suitabilityAssessmentAdjacentPage', () => {
+      ;(suitabilityAssessmentAdjacentPage as jest.MockedFn<typeof suitabilityAssessmentAdjacentPage>).mockReturnValue(
+        'application-timeliness',
+      )
+      expect(new ContingencyPlanSuitability(body, assessment).previous()).toEqual('application-timeliness')
     })
   })
+
   describe('errors', () => {
     it('should have an error if there are no answers', () => {
       const page = new ContingencyPlanSuitability({} as ContingencyPlanSuitabilityBody, assessment)

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/contingencyPlanSuitability.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/contingencyPlanSuitability.test.ts
@@ -57,8 +57,9 @@ describe('ContingencyPlanSuitability', () => {
       const page = new ContingencyPlanSuitability(body, assessment)
 
       expect(page.response()).toEqual({
-        'Additional comments': 'some comments',
         'Is the contingency plan sufficient to manage behaviour or a failure to return out of hours?': 'Yes',
+        'Is the contingency plan sufficient to manage behaviour or a failure to return out of hours? Additional comments':
+          'some comments',
       })
     })
   })

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/contingencyPlanSuitability.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/contingencyPlanSuitability.ts
@@ -1,11 +1,11 @@
 import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
-import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
 import { ApprovedPremisesAssessment as Assessment } from '../../../../@types/shared'
 
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
 import { sentenceCase } from '../../../../utils/utils'
+import { suitabilityAssessmentAdjacentPage } from '../../../../utils/assessments/suitabilityAssessmentAdjacentPage'
 
 export type ContingencyPlanSuitabilityBody = {
   contingencyPlanSufficient: YesOrNo
@@ -17,6 +17,8 @@ export type ContingencyPlanSuitabilityBody = {
   bodyProperties: ['contingencyPlanSufficient', 'additionalComments'],
 })
 export default class ContingencyPlanSuitability implements TasklistPage {
+  name = 'contingency-plan-suitability' as const
+
   title = 'Suitability assessment'
 
   questions = {
@@ -31,8 +33,7 @@ export default class ContingencyPlanSuitability implements TasklistPage {
   ) {}
 
   previous() {
-    if (noticeTypeFromApplication(this.assessment.application) === 'emergency') return 'application-timeliness'
-    return 'suitability-assessment'
+    return suitabilityAssessmentAdjacentPage(this.assessment, this.name, { returnPreviousPage: true })
   }
 
   next() {

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/contingencyPlanSuitability.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/contingencyPlanSuitability.ts
@@ -43,7 +43,7 @@ export default class ContingencyPlanSuitability implements TasklistPage {
     const response = {}
 
     response[this.questions.contingencyPlanSufficient] = sentenceCase(this.body.contingencyPlanSufficient)
-    response[this.questions.additionalComments] = this.body.additionalComments
+    response[`${this.questions.contingencyPlanSufficient} Additional comments`] = this.body.additionalComments
 
     return response
   }

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/esapSuitability.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/esapSuitability.test.ts
@@ -1,0 +1,91 @@
+import { assessmentFactory } from '../../../../testutils/factories'
+
+import EsapSuitability, { EsapSuitabilityBody } from './esapSuitability'
+import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
+import { retrieveOptionalQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
+
+jest.mock('../../../../utils/applications/noticeTypeFromApplication')
+jest.mock('../../../../utils/retrieveQuestionResponseFromFormArtifact')
+
+describe('EsapSuitability', () => {
+  const body: EsapSuitabilityBody = {
+    esapPlacementNeccessary: 'yes',
+    unsuitabilityForEsapRationale: 'some reasons',
+    yesDetail: 'Some yes detail',
+  }
+
+  const assessment = assessmentFactory.build()
+  describe('title', () => {
+    expect(new EsapSuitability(body, assessment).title).toBe('Suitability assessment')
+  })
+
+  describe('body', () => {
+    it('should set the body', () => {
+      const page = new EsapSuitability(body, assessment)
+      expect(page.body).toEqual(body)
+    })
+  })
+
+  describe('next', () => {
+    it('returns application-timeliness if the notice type is short_notice', () => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('short_notice')
+      expect(new EsapSuitability(body, assessment).next()).toEqual('application-timeliness')
+    })
+
+    it('returns application-timeliness if the notice type is emergency', () => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('emergency')
+      expect(new EsapSuitability(body, assessment).next()).toEqual('application-timeliness')
+    })
+
+    it('returns an empty string if the notice type is standard', () => {
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('standard')
+      expect(new EsapSuitability(body, assessment).next()).toEqual('')
+    })
+  })
+
+  describe('previous', () => {
+    it('returns rfap-suitability if the applicant requires an RFAP', () => {
+      ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue('yes')
+
+      expect(new EsapSuitability(body, assessment).previous()).toBe('rfap-suitability')
+    })
+  })
+
+  describe('errors', () => {
+    it('should have an error if there are no answers', () => {
+      const page = new EsapSuitability({} as EsapSuitabilityBody, assessment)
+
+      expect(page.errors()).toEqual({
+        esapPlacementNeccessary:
+          'You must confirm if a Enhanced Security Approved Premises (ESAP) has been identified as a suitable placement',
+      })
+    })
+  })
+
+  describe('response', () => {
+    it('returns the response when the asnwer is yes', () => {
+      const page = new EsapSuitability(body, assessment)
+
+      expect(page.response()).toEqual({
+        'Is an Enhanced Security Approved Premises (ESAP) placement necessary for the management of the individual referred?':
+          'Yes - Some yes detail',
+        'If the person is unsuitable for a ESAP placement yet suitable for a standard placement, summarise the rationale for the decision':
+          'some reasons',
+      })
+    })
+
+    it('returns the response when the asnwer is no', () => {
+      const page = new EsapSuitability(
+        { ...body, esapPlacementNeccessary: 'no', noDetail: 'Some no detail' },
+        assessment,
+      )
+
+      expect(page.response()).toEqual({
+        'Is an Enhanced Security Approved Premises (ESAP) placement necessary for the management of the individual referred?':
+          'No - Some no detail',
+        'If the person is unsuitable for a ESAP placement yet suitable for a standard placement, summarise the rationale for the decision':
+          'some reasons',
+      })
+    })
+  })
+})

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/esapSuitability.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/esapSuitability.test.ts
@@ -1,10 +1,9 @@
 import { assessmentFactory } from '../../../../testutils/factories'
 
 import EsapSuitability, { EsapSuitabilityBody } from './esapSuitability'
-import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
-import { retrieveOptionalQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
+import { suitabilityAssessmentAdjacentPage } from '../../../../utils/assessments/suitabilityAssessmentAdjacentPage'
 
-jest.mock('../../../../utils/applications/noticeTypeFromApplication')
+jest.mock('../../../../utils/assessments/suitabilityAssessmentAdjacentPage')
 jest.mock('../../../../utils/retrieveQuestionResponseFromFormArtifact')
 
 describe('EsapSuitability', () => {
@@ -27,27 +26,20 @@ describe('EsapSuitability', () => {
   })
 
   describe('next', () => {
-    it('returns application-timeliness if the notice type is short_notice', () => {
-      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('short_notice')
+    it('returns the result of suitabilityAssessmentAdjacentPage', () => {
+      ;(suitabilityAssessmentAdjacentPage as jest.MockedFn<typeof suitabilityAssessmentAdjacentPage>).mockReturnValue(
+        'application-timeliness',
+      )
       expect(new EsapSuitability(body, assessment).next()).toEqual('application-timeliness')
-    })
-
-    it('returns application-timeliness if the notice type is emergency', () => {
-      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('emergency')
-      expect(new EsapSuitability(body, assessment).next()).toEqual('application-timeliness')
-    })
-
-    it('returns an empty string if the notice type is standard', () => {
-      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('standard')
-      expect(new EsapSuitability(body, assessment).next()).toEqual('')
     })
   })
 
   describe('previous', () => {
-    it('returns rfap-suitability if the applicant requires an RFAP', () => {
-      ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue('yes')
-
-      expect(new EsapSuitability(body, assessment).previous()).toBe('rfap-suitability')
+    it('returns the result of suitabilityAssessmentAdjacentPage', () => {
+      ;(suitabilityAssessmentAdjacentPage as jest.MockedFn<typeof suitabilityAssessmentAdjacentPage>).mockReturnValue(
+        'suitability-assessment',
+      )
+      expect(new EsapSuitability(body, assessment).previous()).toEqual('suitability-assessment')
     })
   })
 

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/esapSuitability.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/esapSuitability.ts
@@ -1,12 +1,10 @@
 import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
-import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
 import { ApprovedPremisesAssessment as Assessment } from '../../../../@types/shared'
 
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
-import { retrieveOptionalQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
-import RfapSuitability from './rfapSuitability'
+import { suitabilityAssessmentAdjacentPage } from '../../../../utils/assessments/suitabilityAssessmentAdjacentPage'
 
 export type EsapSuitabilityBody = {
   esapPlacementNeccessary: YesOrNo
@@ -20,6 +18,8 @@ export type EsapSuitabilityBody = {
   bodyProperties: ['esapPlacementNeccessary', 'unsuitabilityForEsapRationale', 'yesDetail', 'noDetail'],
 })
 export default class EsapSuitability implements TasklistPage {
+  name = 'esap-suitability' as const
+
   title = 'Suitability assessment'
 
   questions = {
@@ -36,28 +36,11 @@ export default class EsapSuitability implements TasklistPage {
   ) {}
 
   previous() {
-    const needsRfap = retrieveOptionalQuestionResponseFromFormArtifact(
-      this.assessment.application,
-      RfapSuitability,
-      'needARfap',
-    )
-
-    if (needsRfap === 'yes') {
-      return 'rfap-suitability'
-    }
-
-    return 'suitability-assessment'
+    return suitabilityAssessmentAdjacentPage(this.assessment, this.name, { returnPreviousPage: true })
   }
 
   next() {
-    if (
-      noticeTypeFromApplication(this.assessment.application) === 'short_notice' ||
-      noticeTypeFromApplication(this.assessment.application) === 'emergency'
-    ) {
-      return 'application-timeliness'
-    }
-
-    return ''
+    return suitabilityAssessmentAdjacentPage(this.assessment, this.name)
   }
 
   response() {

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/esapSuitability.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/esapSuitability.ts
@@ -1,0 +1,93 @@
+import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
+import { ApprovedPremisesAssessment as Assessment } from '../../../../@types/shared'
+
+import { Page } from '../../../utils/decorators'
+
+import TasklistPage from '../../../tasklistPage'
+import { retrieveOptionalQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
+import RfapSuitability from './rfapSuitability'
+
+export type EsapSuitabilityBody = {
+  esapPlacementNeccessary: YesOrNo
+  unsuitabilityForEsapRationale: string
+  yesDetail?: string
+  noDetail?: string
+}
+
+@Page({
+  name: 'esap-suitability',
+  bodyProperties: ['esapPlacementNeccessary', 'unsuitabilityForEsapRationale', 'yesDetail', 'noDetail'],
+})
+export default class EsapSuitability implements TasklistPage {
+  title = 'Suitability assessment'
+
+  questions = {
+    esapPlacementNecessary:
+      'Is an Enhanced Security Approved Premises (ESAP) placement necessary for the management of the individual referred?',
+    unsuitabilityForEsapRationale:
+      'If the person is unsuitable for a ESAP placement yet suitable for a standard placement, summarise the rationale for the decision',
+    detail: 'Provide details to support the decision',
+  }
+
+  constructor(
+    public body: EsapSuitabilityBody,
+    private readonly assessment: Assessment,
+  ) {}
+
+  previous() {
+    const needsRfap = retrieveOptionalQuestionResponseFromFormArtifact(
+      this.assessment.application,
+      RfapSuitability,
+      'needARfap',
+    )
+
+    if (needsRfap === 'yes') {
+      return 'rfap-suitability'
+    }
+
+    return 'suitability-assessment'
+  }
+
+  next() {
+    if (
+      noticeTypeFromApplication(this.assessment.application) === 'short_notice' ||
+      noticeTypeFromApplication(this.assessment.application) === 'emergency'
+    ) {
+      return 'application-timeliness'
+    }
+
+    return ''
+  }
+
+  response() {
+    const response = {}
+
+    if (this.body.esapPlacementNeccessary === 'yes') {
+      response[this.questions.esapPlacementNecessary] = `Yes - ${this.body.yesDetail}`
+    }
+    if (this.body.esapPlacementNeccessary === 'no') {
+      response[this.questions.esapPlacementNecessary] = `No - ${this.body.noDetail}`
+    }
+
+    response[this.questions.unsuitabilityForEsapRationale] = this.body.unsuitabilityForEsapRationale
+
+    return response
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (this.body.esapPlacementNeccessary === 'yes' && !this.body.yesDetail)
+      errors.yesDetail = 'You must provide details to support the decision'
+
+    if (this.body.esapPlacementNeccessary === 'no' && !this.body.noDetail)
+      errors.noDetail = 'You must provide details to support the decision'
+
+    if (!this.body.esapPlacementNeccessary)
+      errors.esapPlacementNeccessary =
+        'You must confirm if a Enhanced Security Approved Premises (ESAP) has been identified as a suitable placement'
+
+    return errors
+  }
+}

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/index.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/index.ts
@@ -5,6 +5,7 @@ import ApplicationTimeliness from './applicationTimeliness'
 import RfapSuitability from './rfapSuitability'
 import ContingencyPlanSuitability from './contingencyPlanSuitability'
 import PipeSuitability from './pipeSuitability'
+import EsapSuitability from './esapSuitability'
 
 @Task({
   slug: 'suitability-assessment',
@@ -13,6 +14,7 @@ import PipeSuitability from './pipeSuitability'
     SuitabilityAssessmentPage,
     RfapSuitability,
     PipeSuitability,
+    EsapSuitability,
     ApplicationTimeliness,
     ContingencyPlanSuitability,
   ],

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/pipeSuitability.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/pipeSuitability.test.ts
@@ -1,10 +1,11 @@
 import { assessmentFactory } from '../../../../testutils/factories'
-import { itShouldHavePreviousValue } from '../../../shared-examples'
 
 import PipeSuitability, { PipeSuitabilityBody } from './pipeSuitability'
-import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
 
-jest.mock('../../../../utils/applications/noticeTypeFromApplication')
+import { suitabilityAssessmentAdjacentPage } from '../../../../utils/assessments/suitabilityAssessmentAdjacentPage'
+
+jest.mock('../../../../utils/assessments/suitabilityAssessmentAdjacentPage')
+jest.mock('../../../../utils/retrieveQuestionResponseFromFormArtifact')
 
 describe('PipeSuitability', () => {
   const body: PipeSuitabilityBody = {
@@ -25,24 +26,23 @@ describe('PipeSuitability', () => {
     })
   })
 
-  describe('next', () => {
-    it('returns application-timeliness if the notice type is short_notice', () => {
-      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('short_notice')
-      expect(new PipeSuitability(body, assessment).next()).toEqual('application-timeliness')
-    })
-
-    it('returns application-timeliness if the notice type is emergency', () => {
-      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('emergency')
-      expect(new PipeSuitability(body, assessment).next()).toEqual('application-timeliness')
-    })
-
-    it('returns an empty string if the notice type is standard', () => {
-      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('standard')
-      expect(new PipeSuitability(body, assessment).next()).toEqual('')
+  describe('previous', () => {
+    it('returns the result of suitabilityAssessmentAdjacentPage', () => {
+      ;(suitabilityAssessmentAdjacentPage as jest.MockedFn<typeof suitabilityAssessmentAdjacentPage>).mockReturnValue(
+        'suitability-assessment',
+      )
+      expect(new PipeSuitability(body, assessment).previous()).toEqual('suitability-assessment')
     })
   })
 
-  itShouldHavePreviousValue(new PipeSuitability(body, assessment), 'suitability-assessment')
+  describe('next', () => {
+    it('returns the result of suitabilityAssessmentAdjacentPage', () => {
+      ;(suitabilityAssessmentAdjacentPage as jest.MockedFn<typeof suitabilityAssessmentAdjacentPage>).mockReturnValue(
+        'application-timeliness',
+      )
+      expect(new PipeSuitability(body, assessment).next()).toEqual('application-timeliness')
+    })
+  })
 
   describe('errors', () => {
     it('should have an error if there are no answers', () => {

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/pipeSuitability.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/pipeSuitability.ts
@@ -1,10 +1,10 @@
 import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
-import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
 import { ApprovedPremisesAssessment as Assessment } from '../../../../@types/shared'
 
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
+import { suitabilityAssessmentAdjacentPage } from '../../../../utils/assessments/suitabilityAssessmentAdjacentPage'
 
 export type PipeSuitabilityBody = {
   pipeIdentifiedAsSuitable: YesOrNo
@@ -18,6 +18,8 @@ export type PipeSuitabilityBody = {
   bodyProperties: ['pipeIdentifiedAsSuitable', 'unsuitabilityForPipeRationale', 'yesDetail', 'noDetail'],
 })
 export default class PipeSuitability implements TasklistPage {
+  name = 'pipe-suitability' as const
+
   title = 'Suitability assessment'
 
   questions = {
@@ -34,18 +36,11 @@ export default class PipeSuitability implements TasklistPage {
   ) {}
 
   previous() {
-    return 'suitability-assessment'
+    return suitabilityAssessmentAdjacentPage(this.assessment, this.name, { returnPreviousPage: true })
   }
 
   next() {
-    if (
-      noticeTypeFromApplication(this.assessment.application) === 'short_notice' ||
-      noticeTypeFromApplication(this.assessment.application) === 'emergency'
-    ) {
-      return 'application-timeliness'
-    }
-
-    return ''
+    return suitabilityAssessmentAdjacentPage(this.assessment, this.name)
   }
 
   response() {

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.test.ts
@@ -1,10 +1,9 @@
 import { assessmentFactory } from '../../../../testutils/factories'
-import { itShouldHavePreviousValue } from '../../../shared-examples'
 
 import RfapSuitability, { RfapSuitabilityBody } from './rfapSuitability'
-import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
+import { suitabilityAssessmentAdjacentPage } from '../../../../utils/assessments/suitabilityAssessmentAdjacentPage'
 
-jest.mock('../../../../utils/applications/noticeTypeFromApplication')
+jest.mock('../../../../utils/assessments/suitabilityAssessmentAdjacentPage')
 
 describe('RfapSuitability', () => {
   const body: RfapSuitabilityBody = {
@@ -26,23 +25,22 @@ describe('RfapSuitability', () => {
   })
 
   describe('next', () => {
-    it('returns application-timeliness if the notice type is short_notice', () => {
-      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('short_notice')
+    it('returns the result of suitabilityAssessmentAdjacentPage', () => {
+      ;(suitabilityAssessmentAdjacentPage as jest.MockedFn<typeof suitabilityAssessmentAdjacentPage>).mockReturnValue(
+        'application-timeliness',
+      )
       expect(new RfapSuitability(body, assessment).next()).toEqual('application-timeliness')
-    })
-
-    it('returns application-timeliness if the notice type is emergency', () => {
-      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('emergency')
-      expect(new RfapSuitability(body, assessment).next()).toEqual('application-timeliness')
-    })
-
-    it('returns an empty string if the notice type is standard', () => {
-      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('standard')
-      expect(new RfapSuitability(body, assessment).next()).toEqual('')
     })
   })
 
-  itShouldHavePreviousValue(new RfapSuitability(body, assessment), 'suitability-assessment')
+  describe('previous', () => {
+    it('returns the result of suitabilityAssessmentAdjacentPage', () => {
+      ;(suitabilityAssessmentAdjacentPage as jest.MockedFn<typeof suitabilityAssessmentAdjacentPage>).mockReturnValue(
+        'suitability-assessment',
+      )
+      expect(new RfapSuitability(body, assessment).previous()).toEqual('suitability-assessment')
+    })
+  })
 
   describe('errors', () => {
     it('should have an error if there are no answers', () => {

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.ts
@@ -1,10 +1,10 @@
 import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
-import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
 import { ApprovedPremisesAssessment as Assessment } from '../../../../@types/shared'
 
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
+import { suitabilityAssessmentAdjacentPage } from '../../../../utils/assessments/suitabilityAssessmentAdjacentPage'
 
 export type RfapSuitabilityBody = {
   rfapIdentifiedAsSuitable: YesOrNo
@@ -18,6 +18,8 @@ export type RfapSuitabilityBody = {
   bodyProperties: ['rfapIdentifiedAsSuitable', 'unsuitabilityForRfapRationale', 'yesDetail', 'noDetail'],
 })
 export default class RfapSuitability implements TasklistPage {
+  name = 'rfap-suitability' as const
+
   title = 'Suitability assessment'
 
   questions = {
@@ -34,18 +36,11 @@ export default class RfapSuitability implements TasklistPage {
   ) {}
 
   previous() {
-    return 'suitability-assessment'
+    return suitabilityAssessmentAdjacentPage(this.assessment, this.name, { returnPreviousPage: true })
   }
 
   next() {
-    if (
-      noticeTypeFromApplication(this.assessment.application) === 'short_notice' ||
-      noticeTypeFromApplication(this.assessment.application) === 'emergency'
-    ) {
-      return 'application-timeliness'
-    }
-
-    return ''
+    return suitabilityAssessmentAdjacentPage(this.assessment, this.name)
   }
 
   response() {

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
@@ -1,15 +1,13 @@
 import { assessmentFactory } from '../../../../testutils/factories'
-import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
 import { YesOrNo } from '../../../../@types/ui'
 import { itShouldHavePreviousValue } from '../../../shared-examples'
 
 import SuitabilityAssessment from './suitabilityAssessment'
-import { shouldShowContingencyPlanPartnersPages } from '../../../../utils/applications/shouldShowContingencyPlanPages'
-import { retrieveOptionalQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
+import { suitabilityAssessmentAdjacentPage } from '../../../../utils/assessments/suitabilityAssessmentAdjacentPage'
 
-jest.mock('../../../../utils/applications/noticeTypeFromApplication')
 jest.mock('../../../../utils/applications/shouldShowContingencyPlanPages')
 jest.mock('../../../../utils/retrieveQuestionResponseFromFormArtifact')
+jest.mock('../../../../utils/assessments/suitabilityAssessmentAdjacentPage.ts')
 
 describe('SuitabilityAssessment', () => {
   const assessment = assessmentFactory.build()
@@ -54,7 +52,9 @@ describe('SuitabilityAssessment', () => {
 
   describe('next', () => {
     it('returns rfap-suitability if the application needs an RFAP', () => {
-      ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue('yes')
+      ;(suitabilityAssessmentAdjacentPage as jest.MockedFn<typeof suitabilityAssessmentAdjacentPage>).mockReturnValue(
+        'rfap-suitability',
+      )
       expect(
         new SuitabilityAssessment(
           {
@@ -69,7 +69,9 @@ describe('SuitabilityAssessment', () => {
     })
 
     it('returns pipe-suitability if the application needs a PIPE', () => {
-      ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue('pipe')
+      ;(suitabilityAssessmentAdjacentPage as jest.MockedFn<typeof suitabilityAssessmentAdjacentPage>).mockReturnValue(
+        'pipe-suitability',
+      )
       expect(
         new SuitabilityAssessment(
           {
@@ -83,8 +85,27 @@ describe('SuitabilityAssessment', () => {
       ).toEqual('pipe-suitability')
     })
 
+    it('returns esap-suitability if the application needs a ESAP', () => {
+      ;(suitabilityAssessmentAdjacentPage as jest.MockedFn<typeof suitabilityAssessmentAdjacentPage>).mockReturnValue(
+        'esap-suitability',
+      )
+      expect(
+        new SuitabilityAssessment(
+          {
+            riskFactors: 'yes',
+            riskManagement: 'yes',
+            locationOfPlacement: 'yes',
+            moveOnPlan: 'yes',
+          },
+          assessment,
+        ).next(),
+      ).toEqual('esap-suitability')
+    })
+
     it('returns application-timeliness if the notice type is short_notice', () => {
-      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('short_notice')
+      ;(suitabilityAssessmentAdjacentPage as jest.MockedFn<typeof suitabilityAssessmentAdjacentPage>).mockReturnValue(
+        'application-timeliness',
+      )
       expect(
         new SuitabilityAssessment(
           {
@@ -99,7 +120,9 @@ describe('SuitabilityAssessment', () => {
     })
 
     it('returns application-timeliness if the notice type is emergency', () => {
-      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('emergency')
+      ;(suitabilityAssessmentAdjacentPage as jest.MockedFn<typeof suitabilityAssessmentAdjacentPage>).mockReturnValue(
+        'application-timeliness',
+      )
       expect(
         new SuitabilityAssessment(
           {
@@ -113,8 +136,10 @@ describe('SuitabilityAssessment', () => {
       ).toEqual('application-timeliness')
     })
 
-    it('returns contingency-plan-suitability if shouldShowContingencyPlanPartnerPages returns true', () => {
-      ;(shouldShowContingencyPlanPartnersPages as jest.Mock).mockReturnValue(true)
+    it('returns contingency-plan-suitability if the application has a contingency plan', () => {
+      ;(suitabilityAssessmentAdjacentPage as jest.MockedFn<typeof suitabilityAssessmentAdjacentPage>).mockReturnValue(
+        'contingency-plan-suitability',
+      )
       expect(
         new SuitabilityAssessment(
           {
@@ -129,8 +154,9 @@ describe('SuitabilityAssessment', () => {
     })
 
     it('returns an empty string if the notice type is standard', () => {
-      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('standard')
-
+      ;(suitabilityAssessmentAdjacentPage as jest.MockedFn<typeof suitabilityAssessmentAdjacentPage>).mockReturnValue(
+        '',
+      )
       expect(
         new SuitabilityAssessment(
           {
@@ -209,24 +235,6 @@ describe('SuitabilityAssessment', () => {
         'Is the move on plan sufficient?': 'Yes',
         'Is the move on plan sufficient? Additional comments': 'Move on plan comments',
       })
-    })
-  })
-
-  describe('next', () => {
-    it('returns application-timeliness for a short notice application', () => {
-      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('short_notice')
-
-      const page = new SuitabilityAssessment(
-        {
-          riskFactors: 'yes',
-          riskManagement: 'yes',
-          locationOfPlacement: 'yes',
-          moveOnPlan: 'yes',
-        },
-        assessment,
-      )
-
-      expect(page.next()).toBe('application-timeliness')
     })
   })
 })

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.ts
@@ -1,15 +1,11 @@
 import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
-import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
 import { ApprovedPremisesAssessment as Assessment } from '../../../../@types/shared'
 
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
 import { responsesForYesNoAndCommentsSections } from '../../../utils/index'
-import { retrieveOptionalQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
-import Rfap from '../../../apply/risk-and-need-factors/further-considerations/rfap'
-import { shouldShowContingencyPlanPartnersPages } from '../../../../utils/applications/shouldShowContingencyPlanPages'
-import SelectApType from '../../../apply/reasons-for-placement/type-of-ap/apType'
+import { suitabilityAssessmentAdjacentPage } from '../../../../utils/assessments/suitabilityAssessmentAdjacentPage'
 
 export type SuitabilityAssessmentSection = {
   riskFactors: string
@@ -32,7 +28,7 @@ export type SuitabilityAssessmentSection = {
   ],
 })
 export default class SuitabilityAssessment implements TasklistPage {
-  name = 'suitability-assessment'
+  name = 'suitability-assessment' as const
 
   title = 'Suitability assessment'
 
@@ -62,30 +58,7 @@ export default class SuitabilityAssessment implements TasklistPage {
   }
 
   next() {
-    const needsRfap = retrieveOptionalQuestionResponseFromFormArtifact(this.assessment.application, Rfap, 'needARfap')
-
-    if (needsRfap === 'yes') {
-      return 'rfap-suitability'
-    }
-
-    if (retrieveOptionalQuestionResponseFromFormArtifact(this.assessment.application, SelectApType, 'type') === 'pipe')
-      return 'pipe-suitability'
-
-    if (retrieveOptionalQuestionResponseFromFormArtifact(this.assessment.application, SelectApType, 'type') === 'esap')
-      return 'esap-suitability'
-
-    if (
-      noticeTypeFromApplication(this.assessment.application) === 'short_notice' ||
-      noticeTypeFromApplication(this.assessment.application) === 'emergency'
-    ) {
-      return 'application-timeliness'
-    }
-
-    if (shouldShowContingencyPlanPartnersPages(this.assessment.application)) {
-      return 'contingency-plan-suitability'
-    }
-
-    return ''
+    return suitabilityAssessmentAdjacentPage(this.assessment, this.name)
   }
 
   response() {

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.ts
@@ -71,6 +71,9 @@ export default class SuitabilityAssessment implements TasklistPage {
     if (retrieveOptionalQuestionResponseFromFormArtifact(this.assessment.application, SelectApType, 'type') === 'pipe')
       return 'pipe-suitability'
 
+    if (retrieveOptionalQuestionResponseFromFormArtifact(this.assessment.application, SelectApType, 'type') === 'esap')
+      return 'esap-suitability'
+
     if (
       noticeTypeFromApplication(this.assessment.application) === 'short_notice' ||
       noticeTypeFromApplication(this.assessment.application) === 'emergency'

--- a/server/utils/applications/shouldShowContingencyPlanPages.test.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.test.ts
@@ -3,11 +3,10 @@ import {
   shouldShowContingencyPlanPartnersPages,
   shouldShowContingencyPlanQuestionsPage,
 } from './shouldShowContingencyPlanPages'
-import { mockOptionalQuestionResponse, mockQuestionResponse } from '../../testutils/mockQuestionResponse'
+import { mockOptionalQuestionResponse } from '../../testutils/mockQuestionResponse'
 import { noticeTypeFromApplication } from './noticeTypeFromApplication'
 
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
-jest.mock('./arrivalDateFromApplication')
 jest.mock('./noticeTypeFromApplication')
 
 const application = applicationFactory.build()
@@ -19,25 +18,25 @@ describe('shouldShowContingencyPlanPartnersPage', () => {
   })
 
   it('returns false if none of the conditions are met', () => {
-    mockQuestionResponse({ sentenceType: 'ipp', type: 'other' })
+    mockOptionalQuestionResponse({ sentenceType: 'ipp', type: 'other' })
 
     expect(shouldShowContingencyPlanPartnersPages(application)).toEqual(false)
   })
 
   it('returns true if the application has a sentence type of "Community Order/SSO"', () => {
-    mockQuestionResponse({ sentenceType: 'communityOrder' })
+    mockOptionalQuestionResponse({ sentenceType: 'communityOrder' })
 
     expect(shouldShowContingencyPlanPartnersPages(application)).toEqual(true)
   })
 
   it('returns true if the application has a sentence type of "Non-statutory, MAPPA case"', () => {
-    mockQuestionResponse({ sentenceType: 'nonStatutory' })
+    mockOptionalQuestionResponse({ sentenceType: 'nonStatutory' })
 
     expect(shouldShowContingencyPlanPartnersPages(application)).toEqual(true)
   })
 
   it('returns true if the application has a release type of "Post Sentence Supervision (PSS)"', () => {
-    mockQuestionResponse({ sentenceType: 'ipp', releaseType: 'pss' })
+    mockOptionalQuestionResponse({ sentenceType: 'ipp', releaseType: 'pss' })
 
     expect(shouldShowContingencyPlanPartnersPages(application)).toEqual(true)
   })
@@ -49,7 +48,7 @@ describe('shouldShowContingencyPlanPartnersPage', () => {
   })
 
   it('returns true if the application has a AP type of "ESAP"', () => {
-    mockQuestionResponse({ type: 'esap' })
+    mockOptionalQuestionResponse({ type: 'esap' })
 
     expect(shouldShowContingencyPlanPartnersPages(application)).toEqual(true)
   })

--- a/server/utils/applications/shouldShowContingencyPlanPages.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.ts
@@ -2,16 +2,13 @@ import SelectApType from '../../form-pages/apply/reasons-for-placement/type-of-a
 import ReleaseType from '../../form-pages/apply/reasons-for-placement/basic-information/releaseType'
 import SentenceType from '../../form-pages/apply/reasons-for-placement/basic-information/sentenceType'
 import { ApprovedPremisesApplication as Application, ReleaseTypeOption } from '../../@types/shared'
-import {
-  retrieveOptionalQuestionResponseFromFormArtifact,
-  retrieveQuestionResponseFromFormArtifact,
-} from '../retrieveQuestionResponseFromFormArtifact'
+import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
 import RelevantDates from '../../form-pages/apply/reasons-for-placement/basic-information/relevantDates'
 import { noticeTypeFromApplication } from './noticeTypeFromApplication'
 
 export const shouldShowContingencyPlanPartnersPages = (application: Application) => {
   let releaseType: ReleaseTypeOption
-  const sentenceType = retrieveQuestionResponseFromFormArtifact(application, SentenceType, 'sentenceType')
+  const sentenceType = retrieveOptionalQuestionResponseFromFormArtifact(application, SentenceType, 'sentenceType')
 
   if (
     sentenceType === 'standardDeterminate' ||
@@ -19,10 +16,10 @@ export const shouldShowContingencyPlanPartnersPages = (application: Application)
     sentenceType === 'ipp' ||
     sentenceType === 'life'
   ) {
-    releaseType = retrieveQuestionResponseFromFormArtifact(application, ReleaseType, 'releaseType')
+    releaseType = retrieveOptionalQuestionResponseFromFormArtifact(application, ReleaseType, 'releaseType')
   }
 
-  const apType = retrieveQuestionResponseFromFormArtifact(application, SelectApType, 'type')
+  const apType = retrieveOptionalQuestionResponseFromFormArtifact(application, SelectApType, 'type')
 
   if (
     sentenceType === 'communityOrder' ||

--- a/server/utils/assessments/suitabilityAssessmentAdjacentPage.test.ts
+++ b/server/utils/assessments/suitabilityAssessmentAdjacentPage.test.ts
@@ -1,0 +1,233 @@
+/* eslint-disable consistent-return */
+
+import { upper } from 'case'
+import { assessmentFactory } from '../../testutils/factories'
+import { noticeTypeFromApplication } from '../applications/noticeTypeFromApplication'
+import { shouldShowContingencyPlanPartnersPages } from '../applications/shouldShowContingencyPlanPages'
+import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
+import { suitabilityAssessmentAdjacentPage } from './suitabilityAssessmentAdjacentPage'
+
+jest.mock('../retrieveQuestionResponseFromFormArtifact')
+jest.mock('../applications/shouldShowContingencyPlanPages')
+jest.mock('../applications/noticeTypeFromApplication')
+
+describe('suitabilityAssessmentAdjacentPage', () => {
+  ;(
+    [
+      {
+        name: 'rfap',
+        pageName: 'rfap-suitability',
+        applicationQuestion: { name: 'needARfap', answer: 'yes' },
+      },
+      {
+        name: 'esap',
+        pageName: 'esap-suitability',
+        applicationQuestion: { name: 'type', answer: 'esap' },
+      },
+      {
+        name: 'pipe',
+        pageName: 'pipe-suitability',
+        applicationQuestion: { name: 'type', answer: 'pipe' },
+      },
+    ] as const
+  ).forEach(apType => {
+    beforeEach(() => {
+      jest.resetAllMocks()
+    })
+
+    describe(`${upper(apType.name)}`, () => {
+      describe('next page', () => {
+        describe(`an application that solely needs an ${apType.name}`, () => {
+          it(`returns ${apType.name}-suitability if the ${apType.name} suitability page hasnt been completed`, () => {
+            ;(
+              retrieveOptionalQuestionResponseFromFormArtifact as jest.MockedFn<
+                typeof retrieveOptionalQuestionResponseFromFormArtifact
+              >
+            ).mockImplementation((_, __, question) => {
+              if (apType.applicationQuestion.name === question) {
+                return apType.applicationQuestion.answer
+              }
+            })
+
+            expect(suitabilityAssessmentAdjacentPage(assessmentFactory.build(), 'suitability-assessment')).toEqual(
+              `${apType.name}-suitability`,
+            )
+          })
+
+          it(`returns an empty string if the ${apType.name} suitability page has been completed`, () => {
+            ;(
+              retrieveOptionalQuestionResponseFromFormArtifact as jest.MockedFn<
+                typeof retrieveOptionalQuestionResponseFromFormArtifact
+              >
+            ).mockReturnValue(`yes`)
+
+            expect(suitabilityAssessmentAdjacentPage(assessmentFactory.build(), apType.pageName)).toEqual('')
+          })
+        })
+
+        describe(`an emergency application that needs an ${apType.name}`, () => {
+          it(`returns ${apType.name}-suitability if the ${apType.name} suitability page hasnt been completed`, () => {
+            ;(
+              retrieveOptionalQuestionResponseFromFormArtifact as jest.MockedFn<
+                typeof retrieveOptionalQuestionResponseFromFormArtifact
+              >
+            ).mockImplementation((_, __, question) => {
+              if (apType.applicationQuestion.name === question) {
+                return apType.applicationQuestion.answer
+              }
+            })
+            ;(
+              shouldShowContingencyPlanPartnersPages as jest.MockedFn<typeof shouldShowContingencyPlanPartnersPages>
+            ).mockReturnValueOnce(true)
+
+            expect(suitabilityAssessmentAdjacentPage(assessmentFactory.build(), 'suitability-assessment')).toEqual(
+              `${apType.name}-suitability`,
+            )
+          })
+
+          it(`returns contingency-plan-suitability if the ${apType.name} suitability page has been completed`, () => {
+            ;(
+              retrieveOptionalQuestionResponseFromFormArtifact as jest.MockedFn<
+                typeof retrieveOptionalQuestionResponseFromFormArtifact
+              >
+            ).mockImplementation((_, __, question) => {
+              if (apType.applicationQuestion.name === question) {
+                return apType.applicationQuestion.answer
+              }
+
+              if (question === 'agreeWithShortNoticeReason') {
+                return 'yes'
+              }
+
+              if (question === 'contingencyPlanSufficient') {
+                return ''
+              }
+            })
+            ;(
+              shouldShowContingencyPlanPartnersPages as jest.MockedFn<typeof shouldShowContingencyPlanPartnersPages>
+            ).mockReturnValueOnce(true)
+
+            expect(suitabilityAssessmentAdjacentPage(assessmentFactory.build(), apType.pageName)).toEqual(
+              `contingency-plan-suitability`,
+            )
+          })
+
+          it(`returns an empty string if the ${apType.name} suitability + contingency plan suitability pages have been completed`, () => {
+            ;(
+              retrieveOptionalQuestionResponseFromFormArtifact as jest.MockedFn<
+                typeof retrieveOptionalQuestionResponseFromFormArtifact
+              >
+            ).mockReturnValue(`yes`)
+            ;(
+              shouldShowContingencyPlanPartnersPages as jest.MockedFn<typeof shouldShowContingencyPlanPartnersPages>
+            ).mockReturnValueOnce(true)
+
+            expect(
+              suitabilityAssessmentAdjacentPage(assessmentFactory.build(), 'contingency-plan-suitability'),
+            ).toEqual('')
+          })
+        })
+
+        describe(`a short notice application that needs an ${apType.name}`, () => {
+          it(`returns ${apType.name}-suitability if the ${apType.name} suitability page hasnt been completed`, () => {
+            ;(
+              retrieveOptionalQuestionResponseFromFormArtifact as jest.MockedFn<
+                typeof retrieveOptionalQuestionResponseFromFormArtifact
+              >
+            ).mockImplementation((_, __, question) => {
+              if (apType.applicationQuestion.name === question) {
+                return apType.applicationQuestion.answer
+              }
+            })
+            ;(
+              shouldShowContingencyPlanPartnersPages as jest.MockedFn<typeof shouldShowContingencyPlanPartnersPages>
+            ).mockReturnValueOnce(true)
+
+            expect(suitabilityAssessmentAdjacentPage(assessmentFactory.build(), 'suitability-assessment')).toEqual(
+              `${apType.name}-suitability`,
+            )
+          })
+
+          it(`returns application-timeliness if the ${apType.name} suitability page has been completed`, () => {
+            ;(noticeTypeFromApplication as jest.MockedFn<typeof noticeTypeFromApplication>).mockReturnValueOnce(
+              `short_notice`,
+            )
+
+            expect(suitabilityAssessmentAdjacentPage(assessmentFactory.build(), apType.pageName)).toEqual(
+              `application-timeliness`,
+            )
+          })
+
+          it(`returns an empty string if the ${apType.name} suitability + application timeliness pages have been completed`, () => {
+            ;(
+              retrieveOptionalQuestionResponseFromFormArtifact as jest.MockedFn<
+                typeof retrieveOptionalQuestionResponseFromFormArtifact
+              >
+            ).mockReturnValue(`yes`)
+            ;(noticeTypeFromApplication as jest.MockedFn<typeof noticeTypeFromApplication>).mockReturnValueOnce(
+              `short_notice`,
+            )
+
+            expect(suitabilityAssessmentAdjacentPage(assessmentFactory.build(), 'application-timeliness')).toEqual('')
+          })
+        })
+      })
+    })
+
+    describe('previous page', () => {
+      describe(`${apType.pageName}`, () => {
+        it(`returns "suitability-assessment" from the ${apType.name} page`, () => {
+          ;(
+            retrieveOptionalQuestionResponseFromFormArtifact as jest.MockedFn<
+              typeof retrieveOptionalQuestionResponseFromFormArtifact
+            >
+          ).mockImplementation((_, __, question) => {
+            if (apType.applicationQuestion.name === question) {
+              return apType.applicationQuestion.answer
+            }
+          })
+
+          expect(
+            suitabilityAssessmentAdjacentPage(assessmentFactory.build(), apType.pageName, { returnPreviousPage: true }),
+          ).toEqual('suitability-assessment')
+        })
+
+        it(`returns ${apType.name}-suitability from the application-timeliness page`, () => {
+          ;(
+            retrieveOptionalQuestionResponseFromFormArtifact as jest.MockedFn<
+              typeof retrieveOptionalQuestionResponseFromFormArtifact
+            >
+          ).mockImplementation((_, __, question) => {
+            if (apType.applicationQuestion.name === question) {
+              return apType.applicationQuestion.answer
+            }
+          })
+          ;(noticeTypeFromApplication as jest.MockedFn<typeof noticeTypeFromApplication>).mockReturnValueOnce(
+            'short_notice',
+          )
+
+          expect(
+            suitabilityAssessmentAdjacentPage(assessmentFactory.build(), 'application-timeliness', {
+              returnPreviousPage: true,
+            }),
+          ).toEqual(apType.pageName)
+        })
+
+        it(`returns application-timeliness from the contingency-plan-suitability page`, () => {
+          ;(noticeTypeFromApplication as jest.MockedFn<typeof noticeTypeFromApplication>).mockReturnValue(
+            'short_notice',
+          )
+          ;(
+            shouldShowContingencyPlanPartnersPages as jest.MockedFn<typeof shouldShowContingencyPlanPartnersPages>
+          ).mockReturnValueOnce(true)
+
+          expect(
+            suitabilityAssessmentAdjacentPage(assessmentFactory.build(), 'contingency-plan-suitability', {
+              returnPreviousPage: true,
+            }),
+          ).toEqual('application-timeliness')
+        })
+      })
+    })
+  })
+})

--- a/server/utils/assessments/suitabilityAssessmentAdjacentPage.ts
+++ b/server/utils/assessments/suitabilityAssessmentAdjacentPage.ts
@@ -1,0 +1,66 @@
+import { ApprovedPremisesAssessment as Assessment } from '../../@types/shared'
+import SelectApType from '../../form-pages/apply/reasons-for-placement/type-of-ap/apType'
+import Rfap from '../../form-pages/apply/risk-and-need-factors/further-considerations/rfap'
+import { noticeTypeFromApplication } from '../applications/noticeTypeFromApplication'
+import { shouldShowContingencyPlanPartnersPages } from '../applications/shouldShowContingencyPlanPages'
+import { retrieveOptionalQuestionResponseFromFormArtifact as responseFromAssessment } from '../retrieveQuestionResponseFromFormArtifact'
+
+const suitabilityAssessmentPageNames = [
+  'suitability-assessment',
+  'rfap-suitability',
+  'esap-suitability',
+  'pipe-suitability',
+  'application-timeliness',
+  'contingency-plan-suitability',
+] as const
+
+type SuitabilityAssessmentPageName = (typeof suitabilityAssessmentPageNames)[number]
+
+export const suitabilityAssessmentAdjacentPage = (
+  assessment: Assessment,
+  currentPage: SuitabilityAssessmentPageName,
+  { returnPreviousPage } = { returnPreviousPage: false },
+) => {
+  const suitabilityAssessmentPages: Array<{
+    pageName: SuitabilityAssessmentPageName
+    needsAssessment: boolean
+  }> = [
+    {
+      pageName: 'rfap-suitability',
+      needsAssessment: responseFromAssessment(assessment.application, Rfap, 'needARfap') === 'yes',
+    },
+    {
+      pageName: 'esap-suitability',
+      needsAssessment: responseFromAssessment(assessment.application, SelectApType, 'type') === 'esap',
+    },
+    {
+      pageName: 'pipe-suitability',
+      needsAssessment: responseFromAssessment(assessment.application, SelectApType, 'type') === 'pipe',
+    },
+    {
+      pageName: 'application-timeliness',
+      needsAssessment:
+        noticeTypeFromApplication(assessment.application) === 'short_notice' ||
+        noticeTypeFromApplication(assessment.application) === 'emergency',
+    },
+    {
+      pageName: 'contingency-plan-suitability',
+      needsAssessment: shouldShowContingencyPlanPartnersPages(assessment.application),
+    },
+  ]
+
+  if (returnPreviousPage) {
+    const pagesNeedingAssessment = suitabilityAssessmentPages.filter(page => page.needsAssessment)
+    const previousPageIndex = pagesNeedingAssessment.findIndex(page => currentPage === page.pageName) - 1
+
+    return pagesNeedingAssessment[previousPageIndex]?.pageName || 'suitability-assessment'
+  }
+
+  suitabilityAssessmentPages.splice(0, suitabilityAssessmentPages.findIndex(page => currentPage === page.pageName) + 1)
+
+  const nextPage = suitabilityAssessmentPages.find(page => {
+    return page.needsAssessment
+  })
+
+  return nextPage?.pageName || ''
+}

--- a/server/views/assessments/pages/suitability-assessment/esap-suitability.njk
+++ b/server/views/assessments/pages/suitability-assessment/esap-suitability.njk
@@ -1,0 +1,66 @@
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+
+{% extends "../layout.njk" %}
+
+{% block questions %}
+    <h1 class="govuk-heading-l">
+        {{page.title}}</h1>
+
+    {% set yesDetail %}
+    {{ formPageTextarea({
+        fieldName: "yesDetail",
+        label: {
+          text: page.questions.detail
+        }
+    }, fetchContext()) }}
+    {% endset -%}
+
+    {% set noDetail %}
+    {{ formPageTextarea({
+        fieldName: "noDetail",
+        label: {
+          text: page.questions.detail
+        }
+    }, fetchContext()) }}
+    {% endset -%}
+
+    {{
+            formPageRadios({
+                fieldset: {
+                    legend: {
+                        text: page.questions.esapPlacementNecessary,
+                        classes: "govuk-fieldset__legend--m"
+                    }
+                },
+                fieldName: "esapPlacementNeccessary",
+                    items: [
+                  {
+                        value: "yes",
+                        text: "Yes",
+                        conditional: {
+                            html: yesDetail
+                    }
+                    },
+                    {
+                        value: "no",
+                        text: "No",
+                        conditional: {
+                            html: noDetail
+                    }
+                    }
+                    ]
+                }, fetchContext()
+            )
+        }}
+
+    {{
+            formPageTextarea({
+                fieldName: "unsuitabilityForEsapRationale",
+                label: {
+                    text:page.questions.unsuitabilityForEsapRationale,
+                    classes: "govuk-label--s"
+                }
+            }, fetchContext())
+        }}
+
+{% endblock %}


### PR DESCRIPTION
# Context

We need to add a screen to Assess to ask if an ESAP placement is suitable. 
This screen will only show for applications which requested an ESAP placement.

Additionally I have abstracted the logic for the pages shown during the 'Suitability assessment' task to reduce duplication and improve maintainability. 

[JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?selectedIssue=APS-106)

# Changes in this PR
- We add the ESAP assess page
- we add a `suitabilityAssessmentAdjacentPage` function. This function takes the assessment and the current page and returns the next/previous page. This was necessary as the logic for which pages should be shown was being duplicate for each page in the Suitability Assessment. For each page added the logic would have to get more complicated. Now there is a single function which controls which pages should be displayed.

## Screenshots of UI changes
<img width="542" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/c35bbaad-69fb-4510-8466-3a5631c1e906">


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
      `production` in a backwards compatible way? (This includes our API,
      infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
      advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
