### PR TITLE
APS-90 Update Convicted Offences labels

### DIFF
--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/convictedOffences.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/convictedOffences.test.ts
@@ -43,7 +43,7 @@ describe('ConvictedOffences', () => {
       const page = new ConvictedOffences({ response: 'yes' })
 
       expect(page.response()).toEqual({
-        'Has the person ever been convicted of any arson offences, sexual offences, hate crimes or offences against children?':
+        'Has the person ever been convicted of any arson offences, sexual offences, hate crimes or non-sexual offences against children?':
           'Yes',
       })
     })

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/convictedOffences.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/convictedOffences.ts
@@ -16,7 +16,7 @@ export default class ConvictedOffences implements TasklistPage {
 
   furtherDetails = `This includes any spent or unspent convictions over their lifetime.`
 
-  offences = ['Arson offences', 'Sexual offences', 'Hate crimes', 'Offences against children']
+  offences = ['Arson offences', 'Sexual offences', 'Hate crimes', 'Non-sexual offences against children']
 
   constructor(public body: { response?: YesOrNo }) {}
 


### PR DESCRIPTION
'Offences against children' becomes 'Non-sexual offences against children'

[JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?selectedIssue=APS-90)

## Screenshots of UI changes

### Before
![convicted-offences (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/7f5170ce-426a-4bcb-93a0-cc3d7366b506)


### After
![convicted-offences](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/7360b1d2-b323-41b9-949b-fea3b8ff3c52)
