### PR TITLE
Increase frontend timeout

### DIFF
--- a/helm_deploy/hmpps-approved-premises-ui/values.yaml
+++ b/helm_deploy/hmpps-approved-premises-ui/values.yaml
@@ -16,6 +16,10 @@ generic-service:
     tlsSecretName: approved-premises-ui-cert # override per environment
     v1_2_enabled: true
     v0_47_enabled: false
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: '120'
+      nginx.ingress.kubernetes.io/proxy-send-timeout: '120'
+      nginx.ingress.kubernetes.io/proxy-read-timeout: '120'
 
   livenessProbe:
     httpGet:


### PR DESCRIPTION
We’re getting some issues when downloading reports as it can take a long time to generate them at the API side. Ideally we’d want to fix the root cause of this, but in the meantime, this should increase the timeout on the UI side.
