### PR TITLE
(APS-209) Fix incorrect lost beds count

### DIFF
--- a/server/controllers/manage/lostBedsController.test.ts
+++ b/server/controllers/manage/lostBedsController.test.ts
@@ -208,7 +208,6 @@ describe('LostBedsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('lostBeds/index', {
         lostBeds: [lostBed],
-        numberOfLostBeds: 1,
         pageHeading: 'Manage out of service beds',
         premisesId,
       })

--- a/server/controllers/manage/lostBedsController.ts
+++ b/server/controllers/manage/lostBedsController.ts
@@ -80,7 +80,6 @@ export default class LostBedsController {
 
       res.render('lostBeds/index', {
         lostBeds,
-        numberOfLostBeds: lostBeds.length,
         pageHeading: 'Manage out of service beds',
         premisesId,
       })

--- a/server/utils/lostBedUtils.test.ts
+++ b/server/utils/lostBedUtils.test.ts
@@ -1,5 +1,8 @@
+import { add, sub } from 'date-fns'
 import { lostBedFactory, userDetailsFactory } from '../testutils/factories'
-import { lostBedTableHeaders, lostBedTableRows, referenceNumberCell } from './lostBedUtils'
+import { DateFormats } from './dateUtils'
+import { lostBedTableHeaders, lostBedTableRows, lostBedsCountForToday, referenceNumberCell } from './lostBedUtils'
+import { getRandomInt } from './utils'
 
 describe('lostBedUtils', () => {
   describe('referenceNumberCell', () => {
@@ -104,6 +107,33 @@ describe('lostBedUtils', () => {
       ]
       const rows = lostBedTableRows([lostBed], premisesId, user)
       expect(rows).toEqual(expectedRows)
+    })
+  })
+
+  describe('lostBedsCountForToday', () => {
+    it('returns the correct number of lost beds for today', () => {
+      const lostBedsForToday = [...Array(getRandomInt(1, 10))].map(() =>
+        lostBedFactory.build({
+          startDate: DateFormats.dateObjToIsoDate(sub(Date.now(), { days: getRandomInt(1, 10) })),
+          endDate: DateFormats.dateObjToIsoDate(add(Date.now(), { days: getRandomInt(1, 10) })),
+        }),
+      )
+      const futureLostBeds = [...Array(getRandomInt(1, 10))].map(() =>
+        lostBedFactory.build({
+          startDate: DateFormats.dateObjToIsoDate(add(Date.now(), { days: getRandomInt(1, 10) })),
+          endDate: DateFormats.dateObjToIsoDate(add(Date.now(), { days: getRandomInt(1, 10) })),
+        }),
+      )
+      const pastLostBeds = [...Array(getRandomInt(1, 10))].map(() =>
+        lostBedFactory.build({
+          startDate: DateFormats.dateObjToIsoDate(sub(Date.now(), { days: getRandomInt(1, 10) })),
+          endDate: DateFormats.dateObjToIsoDate(sub(Date.now(), { days: getRandomInt(1, 10) })),
+        }),
+      )
+
+      expect(lostBedsCountForToday([...lostBedsForToday, ...futureLostBeds, ...pastLostBeds])).toEqual(
+        lostBedsForToday.length,
+      )
     })
   })
 })

--- a/server/utils/lostBedUtils.ts
+++ b/server/utils/lostBedUtils.ts
@@ -1,9 +1,11 @@
 import { LostBed } from '@approved-premises/api'
 import { TableCell, UserDetails } from '@approved-premises/ui'
 
+import { isWithinInterval } from 'date-fns'
 import paths from '../paths/manage'
 import { linkTo } from './utils'
 import { hasRole } from './users'
+import { DateFormats } from './dateUtils'
 
 export const lostBedTableHeaders = (user: UserDetails) => {
   const headers = [
@@ -60,6 +62,15 @@ export const referenceNumberCell = (value: string): TableCell => ({ text: value 
 export const actionCell = (bed: LostBed, premisesId: string): TableCell => ({
   html: bedLink(bed, premisesId),
 })
+
+export const lostBedsCountForToday = (lostBeds: Array<LostBed>): number => {
+  return lostBeds.filter(lostBed =>
+    isWithinInterval(Date.now(), {
+      start: DateFormats.isoToDateObj(lostBed.startDate),
+      end: DateFormats.isoToDateObj(lostBed.endDate),
+    }),
+  ).length
+}
 
 const bedLink = (bed: LostBed, premisesId: string): string =>
   linkTo(

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -167,3 +167,14 @@ export const linebreaksToParagraphs = (text: string) =>
   `<p class="govuk-body">${text
     .replace(/\r?\n([ \t]*\r?\n)+/g, '</p><p class="govuk-body">')
     .replace(/\r?\n/g, '<br />')}</p>`
+
+/**
+ * Returns a random integer between min (inclusive) and max (inclusive).
+ * The value is no lower than min (or the next integer greater than min
+ * if min isn't an integer) and no greater than max (or the next integer
+ * lower than max if max isn't an integer).
+ * Using Math.round() will give you a non-uniform distribution!
+ */
+export const getRandomInt = (min: number, max: number): number => {
+  return Math.floor(Math.random() * (Math.floor(max) - Math.ceil(min) + 1)) + Math.ceil(min)
+}

--- a/server/views/lostBeds/index.njk
+++ b/server/views/lostBeds/index.njk
@@ -30,7 +30,7 @@
                 text: "Out of service"
               },
               value: {
-                text: numberOfLostBeds
+                text: LostBedUtils.lostBedsCountForToday(lostBeds)
               }
             }
           ]


### PR DESCRIPTION
This adds a `lostBedsCountForToday` helper to gather and count all the beds that are currently lost on a given day. I’ve also added a `getRandomInt` helper to build a random number of lost beds in the tests to make them a bit more robust.