### PR TITLE
(APS 83) - Add drop down clusters in manage to allow user to select preferred region

### DIFF
--- a/integration_tests/mockApis/premises.ts
+++ b/integration_tests/mockApis/premises.ts
@@ -5,7 +5,7 @@ import type {
   Booking,
   ExtendedPremisesSummary,
   Premises,
-  PremisesSummary,
+  ApprovedPremisesSummary as PremisesSummary,
   StaffMember,
 } from '@approved-premises/api'
 

--- a/integration_tests/mockApis/users.ts
+++ b/integration_tests/mockApis/users.ts
@@ -8,6 +8,7 @@ import { Response } from 'superagent'
 import { getMatchingRequests, stubFor } from './setup'
 import paths from '../../server/paths/api'
 import { probationRegions } from '../../server/testutils/referenceData/stubs/referenceDataStubs'
+import { apAreaFactory } from '../../server/testutils/factories'
 
 const stubFindUser = (args: { user: User; id: string }) =>
   stubFor({
@@ -195,6 +196,21 @@ const stubUserDelete = (args: { id: string }) =>
 
 const stubProbationRegionsReferenceData = (): Promise<Response> => stubFor(probationRegions)
 
+const stubApAreaReferenceData = (): Promise<Response> =>
+  stubFor({
+    request: {
+      method: 'GET',
+      url: '/reference-data/ap-areas',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: apAreaFactory.buildList(10),
+    },
+  })
+
 const verifyUserUpdate = async (userId: string) =>
   (
     await getMatchingRequests({
@@ -214,5 +230,6 @@ export default {
   verifyUserUpdate,
   verifyUsersRequest,
   stubProbationRegionsReferenceData,
+  stubApAreaReferenceData,
   stubUserFilter,
 }

--- a/integration_tests/pages/manage/premisesList.ts
+++ b/integration_tests/pages/manage/premisesList.ts
@@ -1,4 +1,4 @@
-import type { ApprovedPremises } from '@approved-premises/api'
+import type { ApprovedPremisesSummary as PremisesSummary, ProbationRegion } from '@approved-premises/api'
 
 import Page from '../page'
 import paths from '../../../server/paths/manage'
@@ -14,8 +14,8 @@ export default class PremisesListPage extends Page {
     return new PremisesListPage()
   }
 
-  shouldShowPremises(premises: Array<ApprovedPremises>): void {
-    premises.forEach((item: ApprovedPremises) => {
+  shouldShowPremises(premises: Array<PremisesSummary>): void {
+    premises.forEach((item: PremisesSummary) => {
       cy.contains(item.name)
         .parent()
         .within(() => {

--- a/integration_tests/pages/manage/premisesList.ts
+++ b/integration_tests/pages/manage/premisesList.ts
@@ -28,4 +28,15 @@ export default class PremisesListPage extends Page {
         })
     })
   }
+
+  shouldNotShowPremises(premises: Array<PremisesSummary>): void {
+    premises.forEach((item: PremisesSummary) => {
+      cy.get('td').should('not.contain', item.name)
+    })
+  }
+
+  filterPremisesByRegion(region: ProbationRegion['name']): void {
+    cy.get('#region').select(region)
+    this.clickSubmit()
+  }
 }

--- a/integration_tests/tests/manage/premises.cy.ts
+++ b/integration_tests/tests/manage/premises.cy.ts
@@ -6,6 +6,7 @@ import {
   extendedPremisesSummaryFactory,
   premisesBookingFactory,
   premisesFactory,
+  premisesSummaryFactory,
 } from '../../../server/testutils/factories'
 import { DateFormats } from '../../../server/utils/dateUtils'
 
@@ -21,16 +22,19 @@ context('Premises', () => {
     signIn(['workflow_manager'])
   })
 
-  it('should list all premises', () => {
-    // Given there are premises in the database
-    const premises = premisesFactory.buildList(5)
-    cy.task('stubAllPremises', premises)
+  describe('list', () => {
+    it('should list all premises', () => {
+      // Given there are premises in the database
+      const premises = premisesSummaryFactory.buildList(5)
+      cy.task('stubAllPremises', premises)
+      cy.task('stubProbationRegionsReferenceData')
 
-    // When I visit the premises page
-    const page = PremisesListPage.visit()
+      // When I visit the premises page
+      const page = PremisesListPage.visit()
 
-    // Then I should see all of the premises listed
-    page.shouldShowPremises(premises)
+      // Then I should see all of the premises listed
+      page.shouldShowPremises(premises)
+    })
   })
 
   it('should show a single premises', () => {

--- a/integration_tests/tests/manage/premises.cy.ts
+++ b/integration_tests/tests/manage/premises.cy.ts
@@ -5,7 +5,6 @@ import {
   dateCapacityFactory,
   extendedPremisesSummaryFactory,
   premisesBookingFactory,
-  premisesFactory,
   premisesSummaryFactory,
 } from '../../../server/testutils/factories'
 import { DateFormats } from '../../../server/utils/dateUtils'
@@ -24,10 +23,9 @@ context('Premises', () => {
 
   describe('list', () => {
     it('should list all premises', () => {
-      // Given there are premises in the database
       const premises = premisesSummaryFactory.buildList(5)
       cy.task('stubAllPremises', premises)
-      cy.task('stubProbationRegionsReferenceData')
+      cy.task('stubApAreaReferenceData')
 
       // When I visit the premises page
       const page = PremisesListPage.visit()

--- a/server/controllers/admin/placementRequests/bookingsController.test.ts
+++ b/server/controllers/admin/placementRequests/bookingsController.test.ts
@@ -7,7 +7,7 @@ import { PlacementRequestService, PremisesService } from '../../../services'
 import {
   newPlacementRequestBookingConfirmationFactory,
   placementRequestDetailFactory,
-  premisesFactory,
+  premisesSummaryFactory,
 } from '../../../testutils/factories'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import { ErrorsAndUserInput } from '../../../@types/ui'
@@ -35,7 +35,7 @@ describe('PlacementRequestsController', () => {
   })
 
   describe('new', () => {
-    const premises = premisesFactory.buildList(2)
+    const premises = premisesSummaryFactory.buildList(2)
 
     beforeEach(() => {
       placementRequestService.getPlacementRequest.mockResolvedValue(placementRequest)

--- a/server/controllers/manage/index.ts
+++ b/server/controllers/manage/index.ts
@@ -16,7 +16,7 @@ import DateChangesController from './dateChangesController'
 import type { Services } from '../../services'
 
 export const controllers = (services: Services) => {
-  const premisesController = new PremisesController(services.premisesService)
+  const premisesController = new PremisesController(services.premisesService, services.apAreaService)
   const bookingsController = new BookingsController(services.bookingService, services.personService)
   const bookingExtensionsController = new BookingExtensionsController(services.bookingService)
   const arrivalsController = new ArrivalsController(services.arrivalService, services.premisesService)

--- a/server/controllers/manage/index.ts
+++ b/server/controllers/manage/index.ts
@@ -16,7 +16,7 @@ import DateChangesController from './dateChangesController'
 import type { Services } from '../../services'
 
 export const controllers = (services: Services) => {
-  const premisesController = new PremisesController(services.premisesService, services.bookingService)
+  const premisesController = new PremisesController(services.premisesService)
   const bookingsController = new BookingsController(services.bookingService, services.personService)
   const bookingExtensionsController = new BookingExtensionsController(services.bookingService)
   const arrivalsController = new ArrivalsController(services.arrivalService, services.premisesService)

--- a/server/controllers/manage/premises/premisesController.test.ts
+++ b/server/controllers/manage/premises/premisesController.test.ts
@@ -25,15 +25,20 @@ describe('PremisesController', () => {
   })
 
   describe('index', () => {
-    it('should return the table rows to the template', async () => {
-      premisesService.tableRows.mockResolvedValue([])
+    it('should render the template with the premises and regions', async () => {
+      const premisesSummaries = premisesSummaryFactory.buildList(1)
+
+      const regions = probationRegionFactory.buildList(1)
+
+      regionService.getRegions.mockResolvedValue(regions)
+      premisesService.getAll.mockResolvedValue(premisesSummaries)
 
       const requestHandler = premisesController.index()
       await requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('premises/index', { tableRows: [] })
+      expect(response.render).toHaveBeenCalledWith('premises/index', { premisesSummaries: [] })
 
-      expect(premisesService.tableRows).toHaveBeenCalledWith(token)
+      expect(premisesService.getAll).toHaveBeenCalledWith(token)
     })
   })
 

--- a/server/controllers/manage/premises/premisesController.test.ts
+++ b/server/controllers/manage/premises/premisesController.test.ts
@@ -3,7 +3,6 @@ import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
 import PremisesService from '../../../services/premisesService'
-import BookingService from '../../../services/bookingService'
 import PremisesController from './premisesController'
 
 import { bedOccupancyRangeFactoryUi, extendedPremisesSummaryFactory } from '../../../testutils/factories'
@@ -18,8 +17,7 @@ describe('PremisesController', () => {
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
   const premisesService = createMock<PremisesService>({})
-  const bookingService = createMock<BookingService>({})
-  const premisesController = new PremisesController(premisesService, bookingService)
+  const premisesController = new PremisesController(premisesService)
 
   beforeEach(() => {
     request = createMock<Request>({ user: { token }, params: { premisesId } })

--- a/server/controllers/manage/premises/premisesController.ts
+++ b/server/controllers/manage/premises/premisesController.ts
@@ -9,8 +9,9 @@ export default class PremisesController {
 
   index(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const tableRows = await this.premisesService.tableRows(req.user.token)
-      return res.render('premises/index', { tableRows })
+      const premisesSummaries = await this.premisesService.getAll(req.user.token)
+
+      return res.render('premises/index', { premisesSummaries })
     }
   }
 

--- a/server/controllers/manage/premises/premisesController.ts
+++ b/server/controllers/manage/premises/premisesController.ts
@@ -2,14 +2,10 @@ import type { Request, RequestHandler, Response } from 'express'
 import { addDays, subDays } from 'date-fns'
 
 import PremisesService from '../../../services/premisesService'
-import BookingService from '../../../services/bookingService'
 import { DateFormats } from '../../../utils/dateUtils'
 
 export default class PremisesController {
-  constructor(
-    private readonly premisesService: PremisesService,
-    private readonly bookingService: BookingService,
-  ) {}
+  constructor(private readonly premisesService: PremisesService) {}
 
   index(): RequestHandler {
     return async (req: Request, res: Response) => {

--- a/server/controllers/manage/premises/premisesController.ts
+++ b/server/controllers/manage/premises/premisesController.ts
@@ -1,17 +1,27 @@
 import type { Request, RequestHandler, Response } from 'express'
 import { addDays, subDays } from 'date-fns'
 
-import PremisesService from '../../../services/premisesService'
+import { ApAreaService, PremisesService } from '../../../services'
 import { DateFormats } from '../../../utils/dateUtils'
+import { ApArea } from '../../../@types/shared'
 
 export default class PremisesController {
-  constructor(private readonly premisesService: PremisesService) {}
+  constructor(
+    private readonly premisesService: PremisesService,
+    private readonly apAreaService: ApAreaService,
+  ) {}
 
   index(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const premisesSummaries = await this.premisesService.getAll(req.user.token)
+      const selectedArea = req.body.selectedArea as ApArea['id'] | undefined
+      const premisesSummaries = await this.premisesService.getAll(req.user.token, selectedArea)
+      const areas = await this.apAreaService.getApAreas(req.user.token)
 
-      return res.render('premises/index', { premisesSummaries })
+      return res.render('premises/index', {
+        premisesSummaries,
+        areas,
+        selectedArea: selectedArea || '',
+      })
     }
   }
 

--- a/server/data/premisesClient.test.ts
+++ b/server/data/premisesClient.test.ts
@@ -24,11 +24,12 @@ describeClient('PremisesClient', provider => {
 
   describe('all', () => {
     it('should get all premises', async () => {
+      const apAreaId = 'test'
       const premisesSummaries = premisesSummaryFactory.buildList(5)
 
       provider.addInteraction({
         state: 'Server is healthy',
-        uponReceiving: 'A request to get all premises',
+        uponReceiving: 'A request to get all premises summaries',
         withRequest: {
           method: 'GET',
           path: paths.premises.index({}),
@@ -36,6 +37,7 @@ describeClient('PremisesClient', provider => {
             authorization: `Bearer ${token}`,
             'X-Service-Name': 'approved-premises',
           },
+          query: { apAreaId },
         },
         willRespondWith: {
           status: 200,
@@ -43,7 +45,7 @@ describeClient('PremisesClient', provider => {
         },
       })
 
-      const output = await premisesClient.all()
+      const output = await premisesClient.all(apAreaId)
       expect(output).toEqual(premisesSummaries)
     })
   })

--- a/server/data/premisesClient.ts
+++ b/server/data/premisesClient.ts
@@ -20,8 +20,12 @@ export default class PremisesClient {
     this.restClient = new RestClient('premisesClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
-  async all(): Promise<Array<PremisesSummary>> {
-    return (await this.restClient.get({ path: paths.premises.index({}) })) as Array<PremisesSummary>
+  async all(apAreaId: string = ''): Promise<Array<PremisesSummary>> {
+    const query = apAreaId ? { apAreaId } : {}
+    return (await this.restClient.get({
+      path: paths.premises.index({}),
+      query,
+    })) as Array<PremisesSummary>
   }
 
   async find(id: string): Promise<ApprovedPremises> {

--- a/server/data/referenceDataClient.test.ts
+++ b/server/data/referenceDataClient.test.ts
@@ -5,12 +5,12 @@ import {
   LostBedReason,
   MoveOnCategory,
   NonArrivalReason,
-  ProbationRegion,
 } from '@approved-premises/api'
 
 import ReferenceDataClient from './referenceDataClient'
-import { referenceDataFactory } from '../testutils/factories'
+import { probationRegionFactory, referenceDataFactory } from '../testutils/factories'
 import describeClient from '../testutils/describeClient'
+import { apAreaFactory } from '../testutils/factories/referenceData'
 
 describeClient('ReferenceDataClient', provider => {
   let referenceDataClient: ReferenceDataClient
@@ -29,7 +29,6 @@ describeClient('ReferenceDataClient', provider => {
       'cancellation-reasons': referenceDataFactory.cancellationReasons().buildList(5) as Array<CancellationReason>,
       'lost-bed-reasons': referenceDataFactory.lostBedReasons().buildList(5) as Array<LostBedReason>,
       'non-arrival-reasons': referenceDataFactory.nonArrivalReason().buildList(5) as Array<NonArrivalReason>,
-      'probation-regions': referenceDataFactory.probationRegions().buildList(5) as Array<ProbationRegion>,
     }
 
     Object.keys(data).forEach(key => {
@@ -53,6 +52,56 @@ describeClient('ReferenceDataClient', provider => {
         const output = await referenceDataClient.getReferenceData(key)
         expect(output).toEqual(data[key])
       })
+    })
+  })
+
+  describe('getProbationRegions', () => {
+    it('should return an array of probation regions', async () => {
+      const probationRegions = probationRegionFactory.buildList(5)
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: `A request to get probation regions`,
+        withRequest: {
+          method: 'GET',
+          path: `/reference-data/probation-regions`,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: probationRegions,
+        },
+      })
+
+      const output = await referenceDataClient.getProbationRegions()
+      expect(output).toEqual(probationRegions)
+    })
+  })
+
+  describe('getApAreas', () => {
+    it('should return an array of AP areas', async () => {
+      const apAreas = apAreaFactory.buildList(5)
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: `A request to get AP areas`,
+        withRequest: {
+          method: 'GET',
+          path: `/reference-data/ap-areas`,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: apAreas,
+        },
+      })
+
+      const output = await referenceDataClient.getApAreas()
+      expect(output).toEqual(apAreas)
     })
   })
 })

--- a/server/data/referenceDataClient.ts
+++ b/server/data/referenceDataClient.ts
@@ -1,6 +1,7 @@
 import type { ReferenceData } from '@approved-premises/ui'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
+import { ApArea, ProbationRegion } from '../@types/shared'
 
 export default class ReferenceDataClient {
   restClient: RestClient
@@ -11,5 +12,13 @@ export default class ReferenceDataClient {
 
   async getReferenceData(objectType: string): Promise<Array<ReferenceData>> {
     return (await this.restClient.get({ path: `/reference-data/${objectType}` })) as Array<ReferenceData>
+  }
+
+  async getProbationRegions(): Promise<Array<ProbationRegion>> {
+    return (await this.restClient.get({ path: `/reference-data/probation-regions` })) as Array<ProbationRegion>
+  }
+
+  async getApAreas(): Promise<Array<ApArea>> {
+    return (await this.restClient.get({ path: `/reference-data/ap-areas` })) as Array<ApArea>
   }
 }

--- a/server/routes/manage.ts
+++ b/server/routes/manage.ts
@@ -27,6 +27,7 @@ export default function routes(controllers: Controllers, router: Router, service
   } = controllers
 
   get(paths.premises.index.pattern, premisesController.index(), { auditEvent: 'LIST_PREMISES' })
+  post(paths.premises.index.pattern, premisesController.index(), { auditEvent: 'FILTER_PREMISES' })
   get(paths.premises.show.pattern, premisesController.show(), { auditEvent: 'SHOW_PREMISES' })
   get(paths.premises.calendar.pattern, premisesController.calendar(), { auditEvent: 'SHOW_PREMISES_CALENDAR' })
 

--- a/server/services/apAreaService.test.ts
+++ b/server/services/apAreaService.test.ts
@@ -1,0 +1,33 @@
+import { ReferenceDataClient } from '../data'
+import ApAreaService from './apAreaService'
+import { apAreaFactory } from '../testutils/factories/referenceData'
+
+jest.mock('../data/referenceDataClient.ts')
+
+describe('ApAreaService', () => {
+  const referenceDataClient = new ReferenceDataClient(null) as jest.Mocked<ReferenceDataClient>
+  const referenceDataClientFactory = jest.fn()
+
+  const service = new ApAreaService(referenceDataClientFactory)
+
+  const token = 'SOME_TOKEN'
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    referenceDataClientFactory.mockReturnValue(referenceDataClient)
+  })
+
+  describe('getApAreas', () => {
+    it('calls the getApAreas client method and returns the result', async () => {
+      const apAreas = apAreaFactory.buildList(1)
+
+      referenceDataClient.getApAreas.mockResolvedValue(apAreas)
+
+      const result = await service.getApAreas(token)
+
+      expect(referenceDataClientFactory).toHaveBeenCalledWith(token)
+      expect(referenceDataClient.getApAreas).toHaveBeenCalled()
+      expect(result).toEqual(apAreas)
+    })
+  })
+})

--- a/server/services/apAreaService.ts
+++ b/server/services/apAreaService.ts
@@ -1,0 +1,13 @@
+import type { ReferenceDataClient, RestClientBuilder } from '../data'
+
+import { ApArea } from '../@types/shared'
+
+export default class apAreaService {
+  constructor(private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>) {}
+
+  async getApAreas(token: string): Promise<Array<ApArea>> {
+    const client = this.referenceDataClientFactory(token)
+
+    return client.getApAreas()
+  }
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -19,6 +19,7 @@ import PlacementRequestService from './placementRequestService'
 import PlacementApplicationService from './placementApplicationService'
 import BedService from './bedService'
 import ReportService from './reportService'
+import ApAreaService from './apAreaService'
 import config, { AuditConfig } from '../config'
 
 export const services = () => {
@@ -56,6 +57,7 @@ export const services = () => {
   const placementApplicationService = new PlacementApplicationService(placementApplicationClientBuilder)
   const bedService = new BedService(bedClientBuilder)
   const reportService = new ReportService(reportClientBuilder)
+  const apAreaService = new ApAreaService(referenceDataClientBuilder)
 
   return {
     userService,
@@ -75,6 +77,7 @@ export const services = () => {
     placementApplicationService,
     bedService,
     reportService,
+    apAreaService,
   }
 }
 
@@ -97,4 +100,5 @@ export {
   PlacementApplicationService,
   BedService,
   ReportService,
+  ApAreaService,
 }

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -41,6 +41,17 @@ describe('PremisesService', () => {
       expect(premisesClient.all).toHaveBeenCalled()
     })
 
+    it('supports optional region param', async () => {
+      const probationRegionId = 'test'
+      const premises = premisesSummaryFactory.buildList(1)
+
+      premisesClient.all.mockResolvedValue(premises)
+      await service.getAll(token, probationRegionId)
+
+      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClient.all).toHaveBeenCalledWith(probationRegionId)
+    })
+
     it('sorts the premises returned by name', async () => {
       const premisesA = premisesSummaryFactory.build({ name: 'A' })
       const premisesB = premisesSummaryFactory.build({ name: 'B' })

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -11,7 +11,6 @@ import {
   staffMemberFactory,
 } from '../testutils/factories'
 import { mapApiOccupancyToUiOccupancy } from '../utils/premisesUtils'
-import paths from '../paths/manage'
 
 jest.mock('../data/premisesClient')
 jest.mock('../utils/premisesUtils')
@@ -121,72 +120,6 @@ describe('PremisesService', () => {
 
       expect(premisesClientFactory).toHaveBeenCalledWith(token)
       expect(premisesClient.getRoom).toHaveBeenCalledWith(premisesId, room.id)
-    })
-  })
-
-  describe('tableRows', () => {
-    it('returns a table view of the premises', async () => {
-      const premises1 = premisesSummaryFactory.build({ name: 'XYZ' })
-      const premises2 = premisesSummaryFactory.build({ name: 'ABC' })
-      const premises3 = premisesSummaryFactory.build({ name: 'GHI' })
-
-      const premises = [premises1, premises2, premises3]
-      premisesClient.all.mockResolvedValue(premises)
-
-      const rows = await service.tableRows(token)
-      expect(rows).toEqual([
-        [
-          {
-            text: premises2.name,
-          },
-          {
-            text: premises2.apCode,
-          },
-          {
-            text: premises2.bedCount.toString(),
-          },
-          {
-            html: `<a href="${paths.premises.show({
-              premisesId: premises2.id,
-            })}">View<span class="govuk-visually-hidden">about ${premises2.name}</span></a>`,
-          },
-        ],
-        [
-          {
-            text: premises3.name,
-          },
-          {
-            text: premises3.apCode,
-          },
-          {
-            text: premises3.bedCount.toString(),
-          },
-          {
-            html: `<a href="${paths.premises.show({
-              premisesId: premises3.id,
-            })}">View<span class="govuk-visually-hidden">about ${premises3.name}</span></a>`,
-          },
-        ],
-        [
-          {
-            text: premises1.name,
-          },
-          {
-            text: premises1.apCode,
-          },
-          {
-            text: premises1.bedCount.toString(),
-          },
-          {
-            html: `<a href="${paths.premises.show({
-              premisesId: premises1.id,
-            })}">View<span class="govuk-visually-hidden">about ${premises1.name}</span></a>`,
-          },
-        ],
-      ])
-
-      expect(premisesClientFactory).toHaveBeenCalledWith(token)
-      expect(premisesClient.all).toHaveBeenCalled()
     })
   })
 

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -1,6 +1,4 @@
-import type { TableRow } from '@approved-premises/ui'
 import type {
-  ApprovedPremisesSummary,
   BedDetail,
   BedSummary,
   ExtendedPremisesSummary,
@@ -10,7 +8,6 @@ import type {
   StaffMember,
 } from '@approved-premises/api'
 import type { PremisesClient, RestClientBuilder } from '../data'
-import paths from '../paths/manage'
 
 import { mapApiOccupancyToUiOccupancy } from '../utils/premisesUtils'
 
@@ -68,26 +65,6 @@ export default class PremisesService {
     return room
   }
 
-  async tableRows(token: string): Promise<Array<TableRow>> {
-    const premisesClient = this.premisesClientFactory(token)
-    const premises = await premisesClient.all()
-
-    return premises
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .map((p: ApprovedPremisesSummary) => {
-        return [
-          this.textValue(p.name),
-          this.textValue(p.apCode),
-          this.textValue(p.bedCount.toString()),
-          this.htmlValue(
-            `<a href="${paths.premises.show({ premisesId: p.id })}">View<span class="govuk-visually-hidden">about ${
-              p.name
-            }</span></a>`,
-          ),
-        ]
-      })
-  }
-
   async find(token: string, id: string): Promise<Premises> {
     const premisesClient = this.premisesClientFactory(token)
     const premises = await premisesClient.find(id)
@@ -106,13 +83,5 @@ export default class PremisesService {
     const occupancyForUi = await mapApiOccupancyToUiOccupancy(apiOccupancy)
 
     return occupancyForUi
-  }
-
-  private textValue(value: string) {
-    return { text: value }
-  }
-
-  private htmlValue(value: string) {
-    return { html: value }
   }
 }

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -14,9 +14,9 @@ import { mapApiOccupancyToUiOccupancy } from '../utils/premisesUtils'
 export default class PremisesService {
   constructor(private readonly premisesClientFactory: RestClientBuilder<PremisesClient>) {}
 
-  async getAll(token: string): Promise<Array<ApprovedPremisesSummary>> {
+  async getAll(token: string, selectedAreaId = ''): Promise<Array<ApprovedPremisesSummary>> {
     const premisesClient = this.premisesClientFactory(token)
-    const premises = await premisesClient.all()
+    const premises = await premisesClient.all(selectedAreaId)
 
     return premises.sort((a, b) => {
       if (a.name < b.name) {

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -1,9 +1,9 @@
 import type {
+  ApprovedPremisesSummary,
   BedDetail,
   BedSummary,
   ExtendedPremisesSummary,
   Premises,
-  PremisesSummary,
   Room,
   StaffMember,
 } from '@approved-premises/api'
@@ -14,7 +14,7 @@ import { mapApiOccupancyToUiOccupancy } from '../utils/premisesUtils'
 export default class PremisesService {
   constructor(private readonly premisesClientFactory: RestClientBuilder<PremisesClient>) {}
 
-  async getAll(token: string): Promise<Array<PremisesSummary>> {
+  async getAll(token: string): Promise<Array<ApprovedPremisesSummary>> {
     const premisesClient = this.premisesClientFactory(token)
     const premises = await premisesClient.all()
 

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -152,13 +152,13 @@ describe('User service', () => {
 
   describe('reference data', () => {
     it('should return the probation regions data needed', async () => {
-      const probationRegions = referenceDataFactory.buildList(2)
+      const probationRegions = referenceDataFactory.probationRegions().buildList(2)
 
-      referenceDataClient.getReferenceData.mockResolvedValue(probationRegions)
+      referenceDataClient.getProbationRegions.mockResolvedValue(probationRegions)
 
       const result = await userService.getProbationRegions(token)
       expect(result).toEqual(probationRegions)
-      expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('probation-regions')
+      expect(referenceDataClient.getProbationRegions).toHaveBeenCalled()
     })
   })
 })

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,4 +1,5 @@
 import {
+  ProbationRegion,
   SortDirection,
   ApprovedPremisesUser as User,
   UserQualification,
@@ -6,12 +7,11 @@ import {
   UserRolesAndQualifications,
   UserSortField,
 } from '@approved-premises/api'
-import { PaginatedResponse, ReferenceData, UserDetails } from '@approved-premises/ui'
+import { PaginatedResponse, UserDetails } from '@approved-premises/ui'
 import { ReferenceDataClient, RestClientBuilder, UserClient } from '../data'
 import { convertToTitleCase } from '../utils/utils'
 import type HmppsAuthClient from '../data/hmppsAuthClient'
 
-export type ProbationRegionsReferenceData = Array<ReferenceData>
 export default class UserService {
   constructor(
     private readonly hmppsAuthClient: HmppsAuthClient,
@@ -75,9 +75,9 @@ export default class UserService {
     await client.delete(id)
   }
 
-  async getProbationRegions(token: string): Promise<ProbationRegionsReferenceData> {
+  async getProbationRegions(token: string): Promise<Array<ProbationRegion>> {
     const referenceDataClient = this.referenceDataClientFactory(token)
 
-    return referenceDataClient.getReferenceData('probation-regions')
+    return referenceDataClient.getProbationRegions()
   }
 }

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -65,7 +65,7 @@ import premisesFactory from './premises'
 import premisesSummaryFactory from './premisesSummary'
 import prisonCaseNotesFactory from './prisonCaseNotes'
 import reallocationFactory from './reallocation'
-import referenceDataFactory from './referenceData'
+import referenceDataFactory, { apAreaFactory, probationRegionFactory } from './referenceData'
 import risksFactory, { tierEnvelopeFactory } from './risks'
 import roomFactory from './room'
 import staffMemberFactory from './staffMember'
@@ -81,6 +81,7 @@ export {
   acctAlertFactory,
   activeOffenceFactory,
   adjudicationFactory,
+  apAreaFactory,
   apCharacteristicPairFactory,
   applicationFactory,
   applicationSummaryFactory,
@@ -144,6 +145,7 @@ export {
   premisesBookingFactory,
   premisesSummaryFactory,
   prisonCaseNotesFactory,
+  probationRegionFactory,
   reallocationFactory,
   referenceDataFactory,
   restrictedPersonFactory,

--- a/server/testutils/factories/referenceData.ts
+++ b/server/testutils/factories/referenceData.ts
@@ -9,6 +9,8 @@ import destinationProvidersJson from '../referenceData/stubs/destination-provide
 import cancellationReasonsJson from '../referenceData/stubs/cancellation-reasons.json'
 import lostBedReasonsJson from '../referenceData/stubs/lost-bed-reasons.json'
 import nonArrivalReasonsJson from '../referenceData/stubs/non-arrival-reasons.json'
+import probationRegionsJson from '../referenceData/stubs/probation-regions.json'
+import { ApArea, ProbationRegion } from '../../@types/shared'
 
 class ReferenceDataFactory extends Factory<ReferenceData> {
   departureReasons() {
@@ -42,7 +44,7 @@ class ReferenceDataFactory extends Factory<ReferenceData> {
   }
 
   probationRegions() {
-    const data = faker.helpers.arrayElement(nonArrivalReasonsJson)
+    const data = faker.helpers.arrayElement(probationRegionsJson)
     return this.params(data)
   }
 }
@@ -52,4 +54,14 @@ export default ReferenceDataFactory.define(() => ({
   name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
   serviceScope: 'approved-premises',
   isActive: true,
+}))
+
+export const probationRegionFactory = ReferenceDataFactory.define<ProbationRegion>(() =>
+  faker.helpers.arrayElement(probationRegionsJson),
+)
+
+export const apAreaFactory = Factory.define<ApArea>(() => ({
+  id: faker.string.uuid(),
+  name: faker.location.city(),
+  identifier: faker.location.countryCode(),
 }))

--- a/server/utils/premisesUtils.test.ts
+++ b/server/utils/premisesUtils.test.ts
@@ -10,10 +10,12 @@ import {
   mapApiOccupancyEntryToUiOccupancyEntry,
   mapApiOccupancyToUiOccupancy,
   overcapacityMessage,
+  premisesTableRows,
   summaryListForPremises,
 } from './premisesUtils'
 import { addOverbookingsToSchedule } from './addOverbookingsToSchedule'
 import { textValue } from './applications/utils'
+import paths from '../paths/manage'
 
 jest.mock('./addOverbookingsToSchedule')
 
@@ -230,6 +232,67 @@ describe('premisesUtils', () => {
           ],
           label: 'Region 2',
         },
+      ])
+    })
+  })
+
+  describe('premisesTableRows', () => {
+    it('returns a table view of the premises', async () => {
+      const premises1 = premisesSummaryFactory.build({ name: 'XYZ' })
+      const premises2 = premisesSummaryFactory.build({ name: 'ABC' })
+      const premises3 = premisesSummaryFactory.build({ name: 'GHI' })
+
+      const premises = [premises1, premises2, premises3]
+
+      expect(premisesTableRows(premises)).toEqual([
+        [
+          {
+            text: premises2.name,
+          },
+          {
+            text: premises2.apCode,
+          },
+          {
+            text: premises2.bedCount.toString(),
+          },
+          {
+            html: `<a href="${paths.premises.show({
+              premisesId: premises2.id,
+            })}" >View <span class="govuk-visually-hidden">about ${premises2.name}</span></a>`,
+          },
+        ],
+        [
+          {
+            text: premises3.name,
+          },
+          {
+            text: premises3.apCode,
+          },
+          {
+            text: premises3.bedCount.toString(),
+          },
+          {
+            html: `<a href="${paths.premises.show({
+              premisesId: premises3.id,
+            })}" >View <span class="govuk-visually-hidden">about ${premises3.name}</span></a>`,
+          },
+        ],
+        [
+          {
+            text: premises1.name,
+          },
+          {
+            text: premises1.apCode,
+          },
+          {
+            text: premises1.bedCount.toString(),
+          },
+          {
+            html: `<a href="${paths.premises.show({
+              premisesId: premises1.id,
+            })}" >View <span class="govuk-visually-hidden">about ${premises1.name}</span></a>`,
+          },
+        ],
       ])
     })
   })

--- a/server/utils/premisesUtils.ts
+++ b/server/utils/premisesUtils.ts
@@ -3,11 +3,14 @@ import type {
   BedOccupancyRange,
   DateCapacity,
   ExtendedPremisesSummary,
+  PremisesSummary,
 } from '@approved-premises/api'
 import { BedOccupancyRangeUi, SelectGroup, SummaryList } from '@approved-premises/ui'
 import { DateFormats } from './dateUtils'
 import { addOverbookingsToSchedule } from './addOverbookingsToSchedule'
-import { textValue } from './applications/utils'
+import { htmlValue, textValue } from './applications/utils'
+import paths from '../paths/manage'
+import { linkTo } from './utils'
 
 export type NegativeDateRange = { start?: string; end?: string }
 
@@ -126,4 +129,17 @@ export const groupedSelectOptions = (
         selected: context[fieldName] === item.id,
       })),
   }))
+}
+
+export const premisesTableRows = (premisesSummaries: Array<PremisesSummary>) => {
+  return premisesSummaries
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((p: ApprovedPremisesSummary) => {
+      return [
+        textValue(p.name),
+        textValue(p.apCode),
+        textValue(p.bedCount.toString()),
+        htmlValue(linkTo(paths.premises.show, { premisesId: p.id }, { text: 'View', hiddenText: `about ${p.name}` })),
+      ]
+    })
 }

--- a/server/utils/premisesUtils.ts
+++ b/server/utils/premisesUtils.ts
@@ -3,7 +3,7 @@ import type {
   BedOccupancyRange,
   DateCapacity,
   ExtendedPremisesSummary,
-  PremisesSummary,
+  ApprovedPremisesSummary as PremisesSummary,
 } from '@approved-premises/api'
 import { BedOccupancyRangeUi, SelectGroup, SummaryList } from '@approved-premises/ui'
 import { DateFormats } from './dateUtils'

--- a/server/views/premises/index.njk
+++ b/server/views/premises/index.njk
@@ -28,7 +28,7 @@
             html: '<span class="govuk-visually-hidden">Actions</span>'
           }
         ],
-        rows: tableRows
+        rows: PremisesUtils.premisesTableRows(premisesSummaries)
       })
     }}
 

--- a/server/views/premises/index.njk
+++ b/server/views/premises/index.njk
@@ -1,4 +1,6 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 {% extends "../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - Home" %}
@@ -6,10 +8,36 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-width">
-      {% include "../_messages.njk" %}
 
       <h1 class="govuk-heading-l">List of Approved Premises</h1>
+    </div>
 
+    <form action="{{ paths.premises.index({}) }}" method="post">
+      <div class="govuk-grid-column-one-quarter">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+        {{ govukSelect({
+              label: {
+              text: "Areas",
+              classes: "govuk-label--s"
+              },
+              classes: "govuk-input--width-20",
+              id: "selectedArea",
+              name: "selectedArea",
+              items: convertObjectsToSelectOptions(areas, 'All areas', 'name', 'id', 'selectedArea', context)
+          }) }}
+      </div>
+
+      <div class="govuk-grid-column-one-quarter">
+        {{ govukButton({
+                  "text": "Apply filter",
+                  "type": "submit",
+                  classes: "govuk-!-margin-top-6"
+              }) }}
+      </div>
+    </form>
+
+    <div class="govuk-grid-column-full-width">
       {{
       govukTable({
         captionClasses: "govuk-table__caption--m",
@@ -31,7 +59,6 @@
         rows: PremisesUtils.premisesTableRows(premisesSummaries)
       })
     }}
-
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
# Context
When we go multi-region users will want to be able to filter the APs by region. 
[Jira](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?selectedIssue=APS-83)


## Screenshots of UI changes

### Before
![after (2)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/f6b9e687-ee8f-4d8c-bfc0-cd61bcd5e3bb)

### After
![after (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/ee7da988-1343-4147-bfa3-a63dcd4362eb)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
      `production` in a backwards compatible way? (This includes our API,
      infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
      advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
