### PR TITLE
(APS-165) Add new release types

### DIFF
--- a/server/@types/shared/models/ReleaseTypeOption.ts
+++ b/server/@types/shared/models/ReleaseTypeOption.ts
@@ -2,4 +2,4 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type ReleaseTypeOption = 'licence' | 'rotl' | 'hdc' | 'pss' | 'in_community' | 'not_applicable';
+export type ReleaseTypeOption = 'licence' | 'rotl' | 'hdc' | 'pss' | 'in_community' | 'not_applicable' | 'extendedDeterminateLicence' | 'paroleDirectedLicence';

--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseType.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseType.test.ts
@@ -43,11 +43,9 @@ describe('ReleaseType', () => {
 
         const items = new ReleaseType({}, application).items()
 
-        expect(items.length).toEqual(4)
-        expect(items[0].value).toEqual('licence')
-        expect(items[1].value).toEqual('rotl')
-        expect(items[2].value).toEqual('hdc')
-        expect(items[3].value).toEqual('pss')
+        expect(new Set(items.map(item => item.value))).toEqual(
+          new Set(['licence', 'rotl', 'hdc', 'pss', 'paroleDirectedLicence']),
+        )
       })
 
       it('if the sentence type is "extendedDeterminate" then the reduced list of items should be shown', () => {
@@ -55,9 +53,9 @@ describe('ReleaseType', () => {
 
         const items = new ReleaseType({}, application).items()
 
-        expect(items.length).toEqual(2)
-        expect(items[0].value).toEqual('rotl')
-        expect(items[1].value).toEqual('licence')
+        expect(new Set(items.map(item => item.value))).toEqual(
+          new Set(['rotl', 'extendedDeterminateLicence', 'paroleDirectedLicence']),
+        )
       })
 
       it('if the sentence type is "ipp" then the reduced list of items should be shown', () => {
@@ -65,9 +63,7 @@ describe('ReleaseType', () => {
 
         const items = new ReleaseType({}, application).items()
 
-        expect(items.length).toEqual(2)
-        expect(items[0].value).toEqual('rotl')
-        expect(items[1].value).toEqual('licence')
+        expect(new Set(items.map(item => item.value))).toEqual(new Set(['rotl', 'licence']))
       })
 
       it('if the sentence type is "life" then the reduced list of items should be shown', () => {
@@ -75,9 +71,7 @@ describe('ReleaseType', () => {
 
         const items = new ReleaseType({}, application).items()
 
-        expect(items.length).toEqual(2)
-        expect(items[0].value).toEqual('rotl')
-        expect(items[1].value).toEqual('licence')
+        expect(new Set(items.map(item => item.value))).toEqual(new Set(['rotl', 'licence']))
       })
     })
 

--- a/server/utils/applications/releaseTypeUtils.ts
+++ b/server/utils/applications/releaseTypeUtils.ts
@@ -7,4 +7,6 @@ export const allReleaseTypes: ReleaseTypeOptions = {
   pss: 'Post Sentence Supervision (PSS)',
   in_community: 'In Community',
   not_applicable: 'Not Applicable',
+  extendedDeterminateLicence: 'License (Extended Determinate sentence)',
+  paroleDirectedLicence: 'License (Parole directed)',
 }


### PR DESCRIPTION
This adds a couple of new release types for `standardDeterminate` and `extendedDeterminate` sentence types, which are needed to determine the correct referral type in Delius.

## Screenshots

### Standard Determinate

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/a9c0236d-7ec0-4499-853a-e8eae3b79122)

### Extended Determinate

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/6ee17520-ec01-420f-9e5d-9b274441a3cb)

