### PR TITLE
APS-184 - Fix - Add getter for area

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -12,7 +12,7 @@
         "name": "Frank",
         "emailAddress": "frank@test.com",
         "phoneNumber": "01234567890",
-        "area": "Greater Manchester"
+        "area": { "name": "Greater Manchester", "id": "5e44b880-df20-4751-938f-a14be5fe609d" }
       }
     },
     "case-manager-information": {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.test.ts
@@ -28,7 +28,7 @@ describe('ConfirmYourDetails', () => {
       name: 'Acting user from delius name',
       emailAddress: 'Acting user from delius email address',
       phoneNumber: 'Acting user from delius phone number',
-      area: area.name,
+      area,
     },
   }
 
@@ -41,6 +41,30 @@ describe('ConfirmYourDetails', () => {
       const page = new ConfirmYourDetails(body, application)
 
       expect(page.body).toEqual(body)
+    })
+
+    describe('if the "area" isnt present in the "body" it should use the one from Delius', () => {
+      const areaFromDelius = apAreaFactory.build()
+      const page = new ConfirmYourDetails(
+        {
+          ...body,
+          area: undefined,
+          detailsToUpdate: [],
+          userDetailsFromDelius: {
+            ...body.userDetailsFromDelius,
+            area: areaFromDelius,
+          },
+        },
+        application,
+      )
+
+      expect(page.body.area).toEqual(areaFromDelius.id)
+    })
+
+    it('should set the body with the area from the body if it is present', () => {
+      const page = new ConfirmYourDetails({ ...body, area: 'area' }, application)
+
+      expect(page.body).toEqual({ ...body, area: 'area' })
     })
   })
 
@@ -57,7 +81,7 @@ describe('ConfirmYourDetails', () => {
         name: actingUserFromDelius.name,
         emailAddress: actingUserFromDelius.email,
         phoneNumber: actingUserFromDelius.telephoneNumber,
-        area: actingUserFromDelius.apArea.name,
+        area: actingUserFromDelius.apArea,
       }
 
       const getUserByIdMock = jest.fn().mockResolvedValue(actingUserFromDelius)
@@ -88,7 +112,7 @@ describe('ConfirmYourDetails', () => {
         name: actingUserFromDelius.name,
         emailAddress: actingUserFromDelius.email,
         phoneNumber: actingUserFromDelius.telephoneNumber,
-        area: actingUserFromDelius.apArea.name,
+        area: actingUserFromDelius.apArea,
       }
 
       expect(getUserByIdMock).toHaveBeenCalledWith('token', application.createdByUserId)
@@ -175,7 +199,7 @@ describe('ConfirmYourDetails', () => {
           detailsToUpdate: [],
           userDetailsFromDelius: {
             ...body.userDetailsFromDelius,
-            area: '',
+            area: undefined,
           },
         },
         application,
@@ -230,7 +254,7 @@ describe('ConfirmYourDetails', () => {
         'Applicant name': body.userDetailsFromDelius.name,
         'Applicant email address': body.userDetailsFromDelius.emailAddress,
         'Applicant phone number': body.userDetailsFromDelius.phoneNumber,
-        'Applicant AP area': body.userDetailsFromDelius.area,
+        'Applicant AP area': body.userDetailsFromDelius.area.name,
         'Do you have case management responsibility?': 'Yes',
       })
     })
@@ -244,7 +268,7 @@ describe('ConfirmYourDetails', () => {
             ...body.userDetailsFromDelius,
             phoneNumber: undefined,
             emailAddress: undefined,
-            area: '',
+            area: undefined,
           },
         },
         application,

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -89,7 +89,18 @@
                   "type": "string"
                 },
                 "area": {
-                  "type": "string"
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "identifier": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             },
@@ -219,14 +230,8 @@
           "type": "object",
           "properties": {
             "releaseType": {
-              "enum": [
-                "hdc",
-                "licence",
-                "not_applicable",
-                "pss",
-                "rotl"
-              ],
-              "type": "string"
+              "type": "string",
+              "const": "rotl"
             }
           }
         },

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -18,7 +18,7 @@ function version(): string {
 export function initialiseAppInsights(): void {
   if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
     // eslint-disable-next-line no-console
-    console.log('Enabling azure application insights')
+    console.info('Enabling azure application insights')
 
     setup().setDistributedTracingMode(DistributedTracingModes.AI_AND_W3C).start()
   }

--- a/server/views/applications/pages/basic-information/confirm-your-details.njk
+++ b/server/views/applications/pages/basic-information/confirm-your-details.njk
@@ -40,7 +40,7 @@
                 text: "Area"
             },
             value: {
-                text: page.userDetailsFromDelius.area
+                text: page.userDetailsFromDelius.area.name
             }
         }
     ])


### PR DESCRIPTION
If the area property isnt in the body then we want to use the version from Delius. We need this because the 'area' is a first class field which is sent to the API in getApplicationData function
