### PR TITLE
APS-199 - Ensure that the status filter is retained when another filter is applied

### DIFF
--- a/integration_tests/pages/admin/placementApplications/listPage.ts
+++ b/integration_tests/pages/admin/placementApplications/listPage.ts
@@ -15,8 +15,9 @@ export default class ListPage extends Page {
     super('Record and update placement details')
   }
 
-  static visit(): ListPage {
-    cy.visit(paths.admin.placementRequests.index({}))
+  static visit(query?: string): ListPage {
+    const path = paths.admin.placementRequests.index({})
+    cy.visit(query ? `${path}?${query}` : path)
     return new ListPage()
   }
 
@@ -34,6 +35,10 @@ export default class ListPage extends Page {
           })
         })
     })
+  }
+
+  shouldHaveActiveTab(tabName: 'Ready to match' | 'Unable to match'): void {
+    cy.get('a.moj-sub-navigation__link').contains(tabName).should('have.attr', 'aria-current', 'page')
   }
 
   clickPlacementRequest(placementRequest: PlacementRequest): void {

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -487,4 +487,29 @@ context('Placement Requests', () => {
       expect(requestType.values).to.deep.equal(['parole'])
     })
   })
+
+  it('retains the status filter when applying other filters', () => {
+    cy.task('stubPlacementRequestsDashboard', {
+      placementRequests: [
+        ...unmatchedPlacementRequests,
+        ...matchedPlacementRequests,
+        ...unableToMatchPlacementRequests,
+      ],
+      status: 'notMatched',
+      sortBy: 'created_at',
+      sortDirection: 'asc',
+    })
+    cy.task('stubApAreaReferenceData', apArea)
+
+    // Given I am on the placement request dashboard filtering by the unableToMatch status
+    const listPage = ListPage.visit('status=unableToMatch')
+
+    // When I filter by AP area and request type
+    listPage.getSelectInputByIdAndSelectAnEntry('apArea', apArea.name)
+    listPage.getSelectInputByIdAndSelectAnEntry('requestType', 'parole')
+    listPage.clickApplyFilters()
+
+    // Then the status filter should be retained
+    listPage.shouldHaveActiveTab('Unable to match')
+  })
 })

--- a/server/controllers/admin/placementRequests/placementRequestsController.test.ts
+++ b/server/controllers/admin/placementRequests/placementRequestsController.test.ts
@@ -86,7 +86,7 @@ describe('PlacementRequestsController', () => {
       })
     })
 
-    it('should handle the parameters correctly', async () => {
+    it('should handle the parameters', async () => {
       const apAreas = apAreaFactory.buildList(1)
       apAreaService.getApAreas.mockResolvedValue(apAreas)
 
@@ -125,6 +125,48 @@ describe('PlacementRequestsController', () => {
 
       expect(getPaginationDetails).toHaveBeenCalledWith(notMatchedRequest, paths.admin.placementRequests.index({}), {
         status: 'notMatched',
+      })
+    })
+
+    it('should retain the status filter when there is one present in the body', async () => {
+      const apAreas = apAreaFactory.buildList(1)
+      apAreaService.getApAreas.mockResolvedValue(apAreas)
+
+      const requestHandler = placementRequestsController.index()
+
+      const apArea = 'some-ap-area-id'
+      const requestType = 'parole'
+      const status = 'unableToMatch'
+      const filters = { requestType, apArea }
+
+      const statusRequest = { ...request, query: filters, body: { status } }
+
+      await requestHandler(statusRequest, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('admin/placementRequests/index', {
+        pageHeading: 'Record and update placement details',
+        placementRequests: paginatedResponse.data,
+        status,
+        pageNumber: Number(paginatedResponse.pageNumber),
+        totalPages: Number(paginatedResponse.totalPages),
+        hrefPrefix: paginationDetails.hrefPrefix,
+        sortBy: paginationDetails.sortBy,
+        sortDirection: paginationDetails.sortDirection,
+        apAreas,
+        apArea,
+        requestType,
+      })
+
+      expect(placementRequestService.getDashboard).toHaveBeenCalledWith(
+        token,
+        { requestType, status, apAreaId: apArea },
+        paginationDetails.pageNumber,
+        paginationDetails.sortBy,
+        paginationDetails.sortDirection,
+      )
+
+      expect(getPaginationDetails).toHaveBeenCalledWith(statusRequest, paths.admin.placementRequests.index({}), {
+        status: 'unableToMatch',
       })
     })
   })

--- a/server/controllers/admin/placementRequests/placementRequestsController.ts
+++ b/server/controllers/admin/placementRequests/placementRequestsController.ts
@@ -1,11 +1,10 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 import { ApAreaService, PlacementRequestService } from '../../../services'
-import { ApArea, PlacementRequestSortField, PlacementRequestStatus } from '../../../@types/shared'
+import { PlacementRequestSortField } from '../../../@types/shared'
 import paths from '../../../paths/admin'
 import { PlacementRequestDashboardSearchOptions } from '../../../@types/ui'
 import { getPaginationDetails } from '../../../utils/getPaginationDetails'
 import { getSearchOptions } from '../../../utils/getSearchOptions'
-import { DashboardFilters } from '../../../data/placementRequestClient'
 
 export default class PlacementRequestsController {
   constructor(
@@ -15,9 +14,13 @@ export default class PlacementRequestsController {
 
   index(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
-      const status = (req.query.status as PlacementRequestStatus) || 'notMatched'
-      const apAreaId = req.query.apArea as ApArea['id'] | undefined
-      const requestType = req.query.requestType as DashboardFilters['requestType'] | undefined
+      const [apAreaId, requestType] = ['apArea', 'requestType'].map(filter =>
+        req.query[filter] ? req.query[filter] : req.body[filter],
+      )
+      let status = req.query.status ? req.query.status : req.body.status
+      if (status === undefined) {
+        status = 'notMatched'
+      }
 
       const apAreas = await this.apAreaService.getApAreas(req.user.token)
 

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -23,6 +23,9 @@ export default function routes(controllers: Controllers, router: Router, service
   get(paths.admin.placementRequests.index.pattern, adminPlacementRequestsController.index(), {
     auditEvent: 'ADMIN_LIST_PLACEMENT_REQUESTS',
   })
+  post(paths.admin.placementRequests.index.pattern, adminPlacementRequestsController.index(), {
+    auditEvent: 'ADMIN_LIST_FILTER_PLACEMENT_REQUESTS',
+  })
   get(paths.admin.placementRequests.search.pattern, adminPlacementRequestsController.search(), {
     auditEvent: 'ADMIN_SEARCH_PLACEMENT_REQUESTS',
   })

--- a/server/views/admin/placementRequests/index.njk
+++ b/server/views/admin/placementRequests/index.njk
@@ -21,7 +21,9 @@
         All applications that have been assessed as suitable and require matching to an AP are listed below
       </p>
       <div class="search-and-filter__wrapper">
-        <form action="{{ paths.admin.placementRequests.index({}) }}" method="get">
+        <form action="{{ paths.admin.placementRequests.index({}) }}" method="post">
+          <input type="hidden" name="status" value="{{ status }}">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-quarter">

--- a/server/views/admin/placementRequests/index.njk
+++ b/server/views/admin/placementRequests/index.njk
@@ -21,7 +21,7 @@
         All applications that have been assessed as suitable and require matching to an AP are listed below
       </p>
       <div class="search-and-filter__wrapper">
-        <form action="{{ paths.admin.placementRequests.index({}) }}" method="post">
+        <form action="{{ paths.admin.placementRequests.index({}) }}" method="get">
           <input type="hidden" name="status" value="{{ status }}">
           <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 

--- a/server/views/admin/placementRequests/search.njk
+++ b/server/views/admin/placementRequests/search.njk
@@ -25,7 +25,7 @@
 
       <div class="search-and-filter__wrapper">
 
-        <form action="{{ paths.admin.placementRequests.search({}) }}" method="post">
+        <form action="{{ paths.admin.placementRequests.search({}) }}" method="get">
           <input type="hidden" name="status" value="{{ status }}">
           <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 

--- a/server/views/admin/placementRequests/search.njk
+++ b/server/views/admin/placementRequests/search.njk
@@ -25,7 +25,9 @@
 
       <div class="search-and-filter__wrapper">
 
-        <form action="{{ paths.admin.placementRequests.search({}) }}" method="get">
+        <form action="{{ paths.admin.placementRequests.search({}) }}" method="post">
+          <input type="hidden" name="status" value="{{ status }}">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">


### PR DESCRIPTION
The status filter on the admin Placement Request dashboard (CRU dashboard) is applied using tabs. When the user is on a given tab and they click to apply additional filters to the tab they would not expect the tab to then revert to default (notMatched). We need to retain the tab filter by passing it through the template as a hidden input.

## Screenshots of UI changes

### Before
![output2](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/5645680e-02db-4529-89c5-2c56b85db72c)

### After
https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/50752284/b03333c9-3e9e-4fd5-bd27-7972b24ccff8

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
      `production` in a backwards compatible way? (This includes our API,
      infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
      advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
