### PR TITLE
Fix pagination when filtering users

### DIFF
--- a/integration_tests/mockApis/users.ts
+++ b/integration_tests/mockApis/users.ts
@@ -30,6 +30,7 @@ const stubUsers = (args: {
   users: Array<User>
   roles?: Array<UserRole>
   qualifications?: Array<UserQualification>
+  apAreaId: string
   page: string
   sortBy: string
   sortDirection: string
@@ -47,11 +48,21 @@ const stubUsers = (args: {
   } as Record<string, unknown>
 
   if (args.roles) {
-    queryParameters.roles = args.roles.join(',')
+    queryParameters.roles = {
+      equalTo: args.roles.join(','),
+    }
   }
 
   if (args.qualifications) {
-    queryParameters.qualifications = args.qualifications.join(',')
+    queryParameters.qualifications = {
+      equalTo: args.qualifications.join(','),
+    }
+  }
+
+  if (args.apAreaId) {
+    queryParameters.apAreaId = {
+      equalTo: args.apAreaId,
+    }
   }
 
   return stubFor({
@@ -120,28 +131,6 @@ const stubUserSearch = (args: { results: Array<User>; searchTerm: string }) =>
     request: {
       method: 'GET',
       url: `${paths.users.search({})}?${QueryString.stringify({ name: args.searchTerm })}`,
-    },
-    response: {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: args.results,
-    },
-  })
-
-const stubUserFilter = (args: { results: Array<User>; roles: string; qualifications: string; apAreaId: string }) =>
-  stubFor({
-    request: {
-      method: 'GET',
-      url: `${paths.users.index({})}?${QueryString.stringify({
-        page: 1,
-        roles: args.roles,
-        qualifications: args.qualifications,
-        apAreaId: args.apAreaId,
-        sortBy: 'name',
-        sortDirection: 'asc',
-      })}`,
     },
     response: {
       status: 200,
@@ -232,5 +221,4 @@ export default {
   verifyUsersRequest,
   stubProbationRegionsReferenceData,
   stubApAreaReferenceData,
-  stubUserFilter,
 }

--- a/integration_tests/tests/admin/userManagement.cy.ts
+++ b/integration_tests/tests/admin/userManagement.cy.ts
@@ -1,3 +1,4 @@
+import { ApprovedPremisesUserRole, UserQualification } from '../../../server/@types/shared'
 import paths from '../../../server/paths/admin'
 import { userFactory } from '../../../server/testutils/factories'
 import ConfirmDeletionPage from '../../pages/admin/userManagement/confirmDeletionPage'
@@ -279,7 +280,9 @@ context('User management', () => {
   })
 
   it('allows filter for users', () => {
-    const usersForResults = userFactory.buildList(1)
+    const usersForResultsPage1 = userFactory.buildList(1)
+    const usersForResultsPage2 = userFactory.buildList(1)
+
     const initialUsers = userFactory.buildList(10)
     cy.task('stubUsers', { users: initialUsers })
     cy.task('stubApAreaReferenceData', {
@@ -295,17 +298,31 @@ context('User management', () => {
     page.shouldShowUsers(initialUsers)
 
     // When I search for a user
-    cy.task('stubUserFilter', {
-      results: usersForResults,
-      roles: 'assessor',
-      qualifications: 'lao',
+    cy.task('stubUsers', {
+      users: usersForResultsPage1,
+      roles: ['assessor'] as Array<ApprovedPremisesUserRole>,
+      qualifications: ['lao'] as Array<UserQualification>,
       apAreaId: '0544d95a-f6bb-43f8-9be7-aae66e3bf244',
     })
-    page.searchBy('roles', 'assessor')
-    page.searchBy('areas', '0544d95a-f6bb-43f8-9be7-aae66e3bf244')
-    page.searchBy('qualifications', 'lao')
+    cy.task('stubUsers', {
+      users: usersForResultsPage2,
+      roles: ['assessor'] as Array<ApprovedPremisesUserRole>,
+      qualifications: ['lao'] as Array<UserQualification>,
+      apAreaId: '0544d95a-f6bb-43f8-9be7-aae66e3bf244',
+      page: '2',
+    })
+    page.searchBy('role', 'assessor')
+    page.searchBy('area', '0544d95a-f6bb-43f8-9be7-aae66e3bf244')
+    page.searchBy('qualification', 'lao')
     page.clickApplyFilter()
+
     // Then the page should show the results
-    page.shouldShowUsers(usersForResults)
+    page.shouldShowUsers(usersForResultsPage1)
+
+    // When I click on a page number
+    page.clickPageNumber('2')
+
+    // Then the page should show the results for the second page
+    page.shouldShowUsers(usersForResultsPage2)
   })
 })

--- a/server/controllers/admin/userManagementController.test.ts
+++ b/server/controllers/admin/userManagementController.test.ts
@@ -75,6 +75,11 @@ describe('UserManagementController', () => {
         sortBy: paginationDetails.sortBy,
         sortDirection: paginationDetails.sortDirection,
       })
+      expect(getPaginationDetails).toHaveBeenCalledWith(request, paths.admin.userManagement.index({}), {
+        role: undefined,
+        qualification: undefined,
+        selectedArea: undefined,
+      })
     })
 
     it('should render the template with AP Areas based on the current user token', async () => {
@@ -99,7 +104,7 @@ describe('UserManagementController', () => {
     })
 
     it('filters users by AP area', async () => {
-      const requestWithQuery = { ...request, query: { areas: '1234' } }
+      const requestWithQuery = { ...request, query: { area: '1234' } }
       const requestHandler = userManagementController.index()
 
       await requestHandler(requestWithQuery, response, next)
@@ -124,10 +129,15 @@ describe('UserManagementController', () => {
         sortDirection: paginationDetails.sortDirection,
         selectedArea: '1234',
       })
+      expect(getPaginationDetails).toHaveBeenCalledWith(requestWithQuery, paths.admin.userManagement.index({}), {
+        role: undefined,
+        qualification: undefined,
+        area: '1234',
+      })
     })
 
     it('filters users by role', async () => {
-      const requestWithQuery = { ...request, query: { roles: 'assessor' } }
+      const requestWithQuery = { ...request, query: { role: 'assessor' } }
       const requestHandler = userManagementController.index()
 
       await requestHandler(requestWithQuery, response, next)
@@ -151,11 +161,16 @@ describe('UserManagementController', () => {
         sortBy: paginationDetails.sortBy,
         sortDirection: paginationDetails.sortDirection,
         selectedRole: 'assessor',
+      })
+      expect(getPaginationDetails).toHaveBeenCalledWith(requestWithQuery, paths.admin.userManagement.index({}), {
+        role: 'assessor',
+        qualification: undefined,
+        area: undefined,
       })
     })
 
     it('filters users by qualification', async () => {
-      const requestWithQuery = { ...request, query: { qualifications: 'esap' } }
+      const requestWithQuery = { ...request, query: { qualification: 'esap' } }
       const requestHandler = userManagementController.index()
 
       await requestHandler(requestWithQuery, response, next)
@@ -180,10 +195,15 @@ describe('UserManagementController', () => {
         sortDirection: paginationDetails.sortDirection,
         selectedQualification: 'esap',
       })
+      expect(getPaginationDetails).toHaveBeenCalledWith(requestWithQuery, paths.admin.userManagement.index({}), {
+        role: undefined,
+        qualification: 'esap',
+        area: undefined,
+      })
     })
 
     it('applies more than one filter', async () => {
-      const requestWithQuery = { ...request, query: { qualifications: 'esap', roles: 'assessor' } }
+      const requestWithQuery = { ...request, query: { qualification: 'esap', role: 'assessor' } }
       const requestHandler = userManagementController.index()
 
       await requestHandler(requestWithQuery, response, next)
@@ -208,6 +228,11 @@ describe('UserManagementController', () => {
         sortDirection: paginationDetails.sortDirection,
         selectedQualification: 'esap',
         selectedRole: 'assessor',
+      })
+      expect(getPaginationDetails).toHaveBeenCalledWith(requestWithQuery, paths.admin.userManagement.index({}), {
+        role: 'assessor',
+        qualification: 'esap',
+        area: undefined,
       })
     })
   })

--- a/server/controllers/admin/userManagementController.ts
+++ b/server/controllers/admin/userManagementController.ts
@@ -14,13 +14,14 @@ export default class UserController {
 
   index(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
-      const role = req.query.roles as UserRole
-      const qualification = req.query.qualifications as UserQualification
-      const selectedArea = req.query.areas as string
+      const role = req.query.role as UserRole
+      const qualification = req.query.qualification as UserQualification
+      const selectedArea = req.query.area as string
 
       const { pageNumber, sortBy, sortDirection, hrefPrefix } = getPaginationDetails<UserSortField>(
         req,
         paths.admin.userManagement.index({}),
+        { role, qualification, area: selectedArea },
       )
 
       const usersResponse = await this.userService.getUsers(

--- a/server/views/admin/users/index.njk
+++ b/server/views/admin/users/index.njk
@@ -61,34 +61,34 @@
           <div class="govuk-grid-column-one-quarter">
             {{ govukSelect({
                 label: {
-                  text: "Roles",
+                  text: "Role",
                   classes: "govuk-label--s"
                 },
-                id: "roles",
-                name: "roles",
+                id: "role",
+                name: "role",
                 items: UserUtils.userRolesSelectOptions(selectedRole)
               }) }}
           </div>
           <div class="govuk-grid-column-one-quarter">
             {{ govukSelect({
                 label: {
-                  text: "AP Areas",
+                  text: "AP Area",
                   classes: "govuk-label--s"
                 },
                 classes: "govuk-input--width-20",
-                id: "areas",
-                name: "areas",
+                id: "area",
+                name: "area",
                 items: convertObjectsToSelectOptions(apAreas, 'All areas', 'name', 'id', 'selectedArea')
               }) }}
           </div>
           <div class="govuk-grid-column-one-quarter">
             {{ govukSelect({
                 label: {
-                text: "Allocations",
+                text: "Allocation",
                 classes: "govuk-label--s"
                 },
-                id: "qualifications",
-                name: "qualifications",
+                id: "qualification",
+                name: "qualification",
                 items: UserUtils.userQualificationsSelectOptions(selectedQualification)
               }) }}
           </div>


### PR DESCRIPTION
The pagination information was losing the filter queries. I’ve also made the queries singular, as we’re only searching by one area/role/qualification etc and it was a bit confusing.

I’ve additionally got rid of the `stubUserFilter` stub method, as the bulk of the logic was covered in `stubUsers` and uses the `queryParameters` API withing wiremock, making is easier / more reliable to match query params.