### PR TITLE
APS-91: Add prison information case note limit

### DIFF
--- a/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.test.ts
@@ -111,25 +111,21 @@ describe('caseNoteCheckbox', () => {
     })
 
     expect(caseNoteCheckbox(caseNote, true)).toMatchStringIgnoringWhitespace(`
-    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
       <div class="govuk-checkboxes__item">
         <input type="checkbox" class="govuk-checkboxes__input" name="caseNoteIds" value="A" id="A" checked>
         <label class="govuk-label govuk-checkboxes__label" for="A">
           <span class="govuk-visually-hidden">Select case note from Friday 31 January 2020</span>
         </label>
       </div>
-     </div>
     `)
 
     expect(caseNoteCheckbox(caseNote, false)).toMatchStringIgnoringWhitespace(`
-    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-        <div class="govuk-checkboxes__item">
-          <input type="checkbox" class="govuk-checkboxes__input" name="caseNoteIds" value="A" id="A">
-          <label class="govuk-label govuk-checkboxes__label" for="A">
-            <span class="govuk-visually-hidden">Select case note from Friday 31 January 2020</span>
-          </label>
-        </div>
-    </div>
+      <div class="govuk-checkboxes__item">
+        <input type="checkbox" class="govuk-checkboxes__input" name="caseNoteIds" value="A" id="A">
+        <label class="govuk-label govuk-checkboxes__label" for="A">
+          <span class="govuk-visually-hidden">Select case note from Friday 31 January 2020</span>
+        </label>
+      </div>
     `)
   })
 })

--- a/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.test.ts
@@ -348,7 +348,7 @@ describe('CaseNotes', () => {
   })
 
   describe('errors', () => {
-    it('returns an empty object if nomisFailed is false', () => {
+    it('returns an empty object if nomisFailed is false and no form errors', () => {
       const page = new CaseNotes({}, application)
       page.nomisFailed = false
       expect(page.errors()).toEqual({})
@@ -366,6 +366,21 @@ describe('CaseNotes', () => {
       expect(page.errors()).toEqual({
         informationFromPrisonDetail: 'You must provide detail of the information you have from prison',
       })
+    })
+
+    it('returns an error if user has selected more than 10 case notes', () => {
+      const selectedCaseNotes = prisonCaseNotesFactory.buildList(11)
+      const page = new CaseNotes({ selectedCaseNotes }, application)
+
+      expect(page.errors()).toEqual({
+        selectedCaseNotes: 'You can only select up to 10 prison case notes that support this application',
+      })
+    })
+
+    it('does not return an error for selectedCaseNotes if 10 or less prison case notes are selected', () => {
+      const selectedCaseNotes = prisonCaseNotesFactory.buildList(10)
+      const page = new CaseNotes({ selectedCaseNotes }, application)
+      expect(page.errors()).toEqual({})
     })
   })
 })

--- a/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
+++ b/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
@@ -53,7 +53,6 @@ export const acctAlertResponse = (acctAlert: PersonAcctAlert) => {
 
 export const caseNoteCheckbox = (caseNote: PrisonCaseNote, checked: boolean) => {
   return `
-  <div class="govuk-checkboxes" data-module="govuk-checkboxes">
     <div class="govuk-checkboxes__item">
       <input type="checkbox" class="govuk-checkboxes__input" name="caseNoteIds" value="${caseNote.id}" id="${
         caseNote.id
@@ -66,7 +65,6 @@ export const caseNoteCheckbox = (caseNote: PrisonCaseNote, checked: boolean) => 
         )}</span>
       </label>
     </div>
-  </div>
   `
 }
 

--- a/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
+++ b/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
@@ -193,6 +193,10 @@ export default class CaseNotes implements TasklistPage {
       }
     }
 
+    if (this.body.selectedCaseNotes.length > 10) {
+      errors.selectedCaseNotes = 'You can only select up to 10 prison case notes that support this application'
+    }
+
     return errors
   }
 

--- a/server/views/applications/pages/prison-information/case-notes.njk
+++ b/server/views/applications/pages/prison-information/case-notes.njk
@@ -11,33 +11,43 @@
 {% endif %}
 
 {% set caseNotes %}
-<table class="govuk-table">
-  <caption class="govuk-table__caption govuk-table__caption--m">Prison case notes</caption>
-
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">Select</th>
-      <th scope="col" class="govuk-table__header">Created</th>
-      <th scope="col" class="govuk-table__header">Comments</th>
-    </tr>
-  </thead>
-
-  <tbody class="govuk-table__body">
-    {% for caseNote in page.caseNotes %}
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell">{{ page.checkBoxForCaseNoteId(caseNote.id) | safe }}</td>
-        <td class="govuk-table__cell">{{ uiDateOrDateEmptyMessage(caseNote, 'createdAt', formatDate) }}</td>
-        <td class="govuk-table__cell">
-          <p>
-            <strong>Type: {{caseNote.type}}: {{caseNote.subType}}</strong>
-          </p>
-          <p>{{caseNote.note}}</p>
-        </td>
-      </tr>
-    {% endfor %}
-  </tbody>
-</table>
-
+  <div class="govuk-form-group{% if errors.selectedCaseNotes %} govuk-form-group--error{% endif %}">
+    <fieldset class="govuk-fieldset" {% if errors.selectedCaseNotes %}aria-describedby="case-notes-error"{% endif %}>
+      {% if errors.selectedCaseNotes %}
+        <p id="case-notes-error" class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span> You can only select up to 10 prison case notes that support this application
+        </p>
+      {% endif %}
+      <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+        <table class="govuk-table">
+          <caption class="govuk-table__caption govuk-table__caption--m">Prison case notes</caption>
+  
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">Select</th>
+              <th scope="col" class="govuk-table__header">Created</th>
+              <th scope="col" class="govuk-table__header">Comments</th>
+            </tr>
+          </thead>
+    
+          <tbody class="govuk-table__body govuk-checkboxes">
+            {% for caseNote in page.caseNotes %}
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell">{{ page.checkBoxForCaseNoteId(caseNote.id) | safe }}</td>
+                <td class="govuk-table__cell">{{ uiDateOrDateEmptyMessage(caseNote, 'createdAt', formatDate) }}</td>
+                <td class="govuk-table__cell">
+                  <p>
+                    <strong>Type: {{caseNote.type}}: {{caseNote.subType}}</strong>
+                  </p>
+                  <p>{{caseNote.note}}</p>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </fieldset>
+  </div>
 {% endset %}
 
 {% block questions %}

--- a/server/views/applications/pages/prison-information/case-notes.njk
+++ b/server/views/applications/pages/prison-information/case-notes.njk
@@ -1,6 +1,8 @@
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% from "../../../components/formFields/form-page-textarea/macro.njk" import formPageTextarea %}
 {% from "../../../partials/prisonInformationTable.njk" import prisonInformationTable %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
 
 {% set title = "Select prison case notes" %}
 
@@ -16,7 +18,7 @@
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--m" id="prison-case-notes">Prison case notes</legend>
       {% if errors.selectedCaseNotes %}
         <p id="case-notes-error" class="govuk-error-message">
-          <span class="govuk-visually-hidden">Error:</span> You can only select up to 10 prison case notes that support this application
+          <span class="govuk-visually-hidden">Error:</span> You can only select up to 10 prison case notes that support this application.
         </p>
       {% endif %}
       <div class="govuk-checkboxes" data-module="govuk-checkboxes">
@@ -69,6 +71,11 @@
         <p>Select any prison case notes that will help Approved Premises (AP) managers understand factors that may help with the person's risk management in an AP. </p>
         <p>Adjudications from the person's current sentence and ACCT (Assessment, Care in Custody and Teamwork) information will be sent automatically.</p>
       </div>
+
+      {{ govukWarningText({
+          text: "You can select up to 10 prison case notes that support this application.",
+          iconFallbackText: "Warning"
+        }) }}
 
       {{prisonInformationTable(caseNotes, page.body.adjudications, page.body.acctAlerts)}}
     </div>

--- a/server/views/applications/pages/prison-information/case-notes.njk
+++ b/server/views/applications/pages/prison-information/case-notes.njk
@@ -64,20 +64,18 @@
     {% set key = 'informationFromPrison' %}
     {% include "./../../partials/_yes-no-with-detail.njk" %}
   {% else %}
-    <div class="govuk-grid-row">
-      <div>
-        <h1 class="govuk-heading-l">{{page.title}}</h1>
-        <p>This information is imported from NOMIS</p>
-        <p>Select any prison case notes that will help Approved Premises (AP) managers understand factors that may help with the person's risk management in an AP. </p>
-        <p>Adjudications from the person's current sentence and ACCT (Assessment, Care in Custody and Teamwork) information will be sent automatically.</p>
-      </div>
-
-      {{ govukWarningText({
-          text: "You can select up to 10 prison case notes that support this application.",
-          iconFallbackText: "Warning"
-        }) }}
-
-      {{prisonInformationTable(caseNotes, page.body.adjudications, page.body.acctAlerts)}}
+    <div>
+      <h1 class="govuk-heading-l">{{page.title}}</h1>
+      <p>This information is imported from NOMIS</p>
+      <p>Select any prison case notes that will help Approved Premises (AP) managers understand factors that may help with the person's risk management in an AP. </p>
+      <p>Adjudications from the person's current sentence and ACCT (Assessment, Care in Custody and Teamwork) information will be sent automatically.</p>
     </div>
+
+    {{ govukWarningText({
+        text: "You can select up to 10 prison case notes that support this application.",
+        iconFallbackText: "Warning"
+      }) }}
+
+    {{prisonInformationTable(caseNotes, page.body.adjudications, page.body.acctAlerts)}}
   {% endif %}
 {% endblock %}

--- a/server/views/applications/pages/prison-information/case-notes.njk
+++ b/server/views/applications/pages/prison-information/case-notes.njk
@@ -12,7 +12,8 @@
 
 {% set caseNotes %}
   <div class="govuk-form-group{% if errors.selectedCaseNotes %} govuk-form-group--error{% endif %}">
-    <fieldset class="govuk-fieldset" {% if errors.selectedCaseNotes %}aria-describedby="case-notes-error"{% endif %}>
+    <fieldset class="govuk-fieldset" aria-describedby="case-notes-error">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m" id="prison-case-notes">Prison case notes</legend>
       {% if errors.selectedCaseNotes %}
         <p id="case-notes-error" class="govuk-error-message">
           <span class="govuk-visually-hidden">Error:</span> You can only select up to 10 prison case notes that support this application
@@ -20,8 +21,6 @@
       {% endif %}
       <div class="govuk-checkboxes" data-module="govuk-checkboxes">
         <table class="govuk-table">
-          <caption class="govuk-table__caption govuk-table__caption--m">Prison case notes</caption>
-  
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">
               <th scope="col" class="govuk-table__header">Select</th>


### PR DESCRIPTION
# Context

This change adds validation to the prison information form page in the application journey, which does not allow a user to select more than 10 case notes to attach to a case. 
[Jira](https://dsdmoj.atlassian.net/browse/APS-91)

# Changes in this PR
- Add server-side validation to check the number of case notes selected on the form, and return an error message if the selected number exceeds 10.
- Update case-notes html to allow the display of an error message directly next to the checkboxes using the GOV.UK validation pattern. I have also wrapped the table in a fieldset to properly group the form elements.
- Add a warning message to let the user know the case note limit up front.
- Fix page alignment by removing a nested `govuk-row` class.

I have tested the error response with unit tests, as I cannot see that we are testing form validation in our integration tests, however let me know if this needs one. 

## Screenshots of UI changes

### After

A error summary is now shown at the top of the page if more than 10 checkboxes are selected:
<img width="894" alt="Screenshot 2024-01-26 at 10 50 20" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/50752284/5d711905-96da-400c-9838-34e716d86b9c">

An error message is shown directly next to the table of case notes
<img width="891" alt="Screenshot 2024-01-26 at 10 50 38" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/50752284/1754214b-dee1-48c4-8b56-29aaea298158">

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
      `production` in a backwards compatible way? (This includes our API,
      infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
      advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
