### PR TITLE
APS-221: Rename report options

### DIFF
--- a/server/utils/reportUtils.test.ts
+++ b/server/utils/reportUtils.test.ts
@@ -4,12 +4,12 @@ describe('reportUtils', () => {
   describe('reportOptions', () => {
     it('should return a list of report options', () => {
       expect(reportOptions).toEqual([
-        { value: 'applications', text: 'Applications' },
+        { value: 'referrals', text: 'Applications' },
+        { value: 'applications', text: 'Combined applications and placement requests' },
         { value: 'daily-metrics', text: 'Daily Metrics' },
         { value: 'lost-beds', text: 'Lost Beds' },
         { value: 'placement-metrics', text: 'Placement Metrics' },
         { value: 'placement-applications', text: 'Placement Requests' },
-        { value: 'referrals', text: 'Referrals' },
         { value: 'referrals-by-ap-type', text: 'Referrals by AP Type' },
         { value: 'referrals-by-tier', text: 'Referrals by Tier' },
       ])

--- a/server/utils/reportUtils.ts
+++ b/server/utils/reportUtils.ts
@@ -3,8 +3,8 @@ export const reportNames = {
   'placement-metrics': 'Placement Metrics',
   'referrals-by-ap-type': 'Referrals by AP Type',
   'referrals-by-tier': 'Referrals by Tier',
-  applications: 'Applications',
-  referrals: 'Referrals',
+  applications: 'Combined applications and placement requests',
+  referrals: 'Applications',
   'lost-beds': 'Lost Beds',
   'placement-applications': 'Placement Requests',
 } as const


### PR DESCRIPTION
# Context

Rename downloadable report options to include a combined applications and placement requests report
[Jira](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328/backlog?selectedIssue=APS-221)

## Screenshots of UI changes

### Before

<img width="1440" alt="Screenshot of reports download page" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/50752284/6b53df9a-d829-4d03-a2e9-6b94d0a61704">


### After

Reports export options now include 'Combined applications and placement requests' option:
<img width="1440" alt="Screenshot of reports download page" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/50752284/f2930703-9c21-4981-813d-e026abd267d8">

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
      `production` in a backwards compatible way? (This includes our API,
      infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
      advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
