### PR TITLE
(APS-237) Add `appeals_manager` role to users

### DIFF
--- a/server/@types/shared/models/ApprovedPremisesUserRole.ts
+++ b/server/@types/shared/models/ApprovedPremisesUserRole.ts
@@ -2,4 +2,4 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type ApprovedPremisesUserRole = 'assessor' | 'matcher' | 'manager' | 'workflow_manager' | 'applicant' | 'role_admin' | 'report_viewer' | 'excluded_from_assess_allocation' | 'excluded_from_match_allocation' | 'excluded_from_placement_application_allocation';
+export type ApprovedPremisesUserRole = 'assessor' | 'matcher' | 'manager' | 'workflow_manager' | 'applicant' | 'role_admin' | 'report_viewer' | 'excluded_from_assess_allocation' | 'excluded_from_match_allocation' | 'excluded_from_placement_application_allocation' | 'appeals_manager';

--- a/server/utils/users/roleCheckboxes/index.ts
+++ b/server/utils/users/roleCheckboxes/index.ts
@@ -13,6 +13,10 @@ export const roleLabelDictionary: RoleLabelDictionary = {
     label: 'Workflow manager',
     hint: 'Manage the allocation of assessments and matches to staff, and view reports',
   },
+  appeals_manager: {
+    label: 'Appeals manager',
+    hint: 'Log appeals against rejected applications',
+  },
 }
 
 export const allocationRoleLabelDictionary: AllocationRoleLabelDictionary = {
@@ -41,6 +45,7 @@ export const roles: ReadonlyArray<UserRole> = [
   'excluded_from_assess_allocation',
   'excluded_from_match_allocation',
   'excluded_from_placement_application_allocation',
+  'appeals_manager',
 ]
 
 export const allocationRoles = [

--- a/server/utils/users/userManagement.test.ts
+++ b/server/utils/users/userManagement.test.ts
@@ -115,6 +115,11 @@ describe('userRolesSelectOptions', () => {
         text: 'Excluded from placement application allocation',
         value: 'excluded_from_placement_application_allocation',
       },
+      {
+        selected: false,
+        text: 'Appeals manager',
+        value: 'appeals_manager',
+      },
     ])
   })
 
@@ -134,6 +139,11 @@ describe('userRolesSelectOptions', () => {
         selected: false,
         text: 'Excluded from placement application allocation',
         value: 'excluded_from_placement_application_allocation',
+      },
+      {
+        selected: false,
+        text: 'Appeals manager',
+        value: 'appeals_manager',
       },
     ])
   })

--- a/server/utils/users/userManagement.ts
+++ b/server/utils/users/userManagement.ts
@@ -56,6 +56,7 @@ const userRoles: Record<ApprovedPremisesUserRole, string> = {
   excluded_from_assess_allocation: 'Excluded from assess allocation',
   excluded_from_match_allocation: 'Excluded from match allocation',
   excluded_from_placement_application_allocation: 'Excluded from placement application allocation',
+  appeals_manager: 'Appeals manager',
 }
 export const userRolesSelectOptions = (
   selectedOption: ApprovedPremisesUserRole | undefined | null,


### PR DESCRIPTION
This adds a new appeals manage role to users, and allows it to be selected in the UI