### PR TITLE
(APS-261) Retain filters in tasks when paginating on Tasks page

### DIFF
--- a/server/controllers/admin/placementRequests/placementRequestsController.test.ts
+++ b/server/controllers/admin/placementRequests/placementRequestsController.test.ts
@@ -89,6 +89,7 @@ describe('PlacementRequestsController', () => {
 
       expect(getPaginationDetails).toHaveBeenCalledWith(request, paths.admin.placementRequests.index({}), {
         status: 'notMatched',
+        apArea: user.apArea.id,
       })
     })
 
@@ -129,9 +130,11 @@ describe('PlacementRequestsController', () => {
         paginationDetails.sortDirection,
       )
 
-      expect(getPaginationDetails).toHaveBeenCalledWith(notMatchedRequest, paths.admin.placementRequests.index({}), {
-        status: 'notMatched',
-      })
+      expect(getPaginationDetails).toHaveBeenCalledWith(
+        notMatchedRequest,
+        paths.admin.placementRequests.index({}),
+        filters,
+      )
     })
   })
 

--- a/server/controllers/admin/placementRequests/placementRequestsController.ts
+++ b/server/controllers/admin/placementRequests/placementRequestsController.ts
@@ -23,7 +23,7 @@ export default class PlacementRequestsController {
       const { pageNumber, sortBy, sortDirection, hrefPrefix } = getPaginationDetails<PlacementRequestSortField>(
         req,
         paths.admin.placementRequests.index({}),
-        { status },
+        { status, apArea: apAreaId, requestType },
       )
 
       const dashboard = await this.placementRequestService.getDashboard(

--- a/server/controllers/tasksController.test.ts
+++ b/server/controllers/tasksController.test.ts
@@ -108,6 +108,10 @@ describe('TasksController', () => {
         sortDirection: paginationDetails.sortDirection,
         selectedArea: '1234',
       })
+      expect(getPaginationDetails).toHaveBeenCalledWith(unallocatedRequest, paths.tasks.index({}), {
+        allocatedFilter: 'unallocated',
+        areas: '1234',
+      })
       expect(taskService.getAllReallocatable).toHaveBeenCalledWith(
         token,
         'unallocated',

--- a/server/controllers/tasksController.ts
+++ b/server/controllers/tasksController.ts
@@ -24,6 +24,7 @@ export default class TasksController {
         hrefPrefix,
       } = getPaginationDetails<TaskSortField>(req, paths.tasks.index({}), {
         allocatedFilter,
+        areas: apAreaId,
       })
       const tasks = await this.taskService.getAllReallocatable(
         req.user.token,


### PR DESCRIPTION
When an area is selected, we want to add the selected area to the `hrefPrefix`, so the pagination links get generated correctly.

I also noticed this was an issue on the CRU dashboard too, so have fixed it there too.