### PR TITLE
(Fix) task list should retain active tab when filtering

### DIFF
--- a/integration_tests/pages/admin/placementApplications/listPage.ts
+++ b/integration_tests/pages/admin/placementApplications/listPage.ts
@@ -37,10 +37,6 @@ export default class ListPage extends Page {
     })
   }
 
-  shouldHaveActiveTab(tabName: 'Ready to match' | 'Unable to match'): void {
-    cy.get('a.moj-sub-navigation__link').contains(tabName).should('have.attr', 'aria-current', 'page')
-  }
-
   clickPlacementRequest(placementRequest: PlacementRequest): void {
     cy.get(`[data-cy-placementRequestId="${placementRequest.id}"]`).click()
   }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -443,4 +443,8 @@ export default abstract class Page {
       }
     })
   }
+
+  shouldHaveActiveTab(tabName: string): void {
+    cy.get('a.moj-sub-navigation__link').contains(tabName).should('have.attr', 'aria-current', 'page')
+  }
 }

--- a/integration_tests/pages/tasks/listPage.ts
+++ b/integration_tests/pages/tasks/listPage.ts
@@ -16,8 +16,9 @@ export default class ListPage extends Page {
     this.unallocatedTasks = unallocatedTasks
   }
 
-  static visit(allocatedTasks: Array<Task>, unallocatedTasks: Array<Task>): ListPage {
-    cy.visit(paths.tasks.index({}))
+  static visit(allocatedTasks: Array<Task>, unallocatedTasks: Array<Task>, query?: string): ListPage {
+    const path = paths.tasks.index({})
+    cy.visit(query ? `${path}?${query}` : path)
     return new ListPage(allocatedTasks, unallocatedTasks)
   }
 
@@ -25,12 +26,15 @@ export default class ListPage extends Page {
     shouldShowTableRows(allocatedTableRows(allocatedTasks))
   }
 
-  shouldShowUnallocatedTasks(): void {
-    cy.get('a').contains('Unallocated').click()
-    shouldShowTableRows(unallocatedTableRows(this.unallocatedTasks))
+  shouldShowUnallocatedTasks(unallocatedTasks = this.unallocatedTasks): void {
+    shouldShowTableRows(unallocatedTableRows(unallocatedTasks))
   }
 
   clickTask(task: Task) {
     cy.get(`a[data-cy-taskId="${task.id}"]`).click()
+  }
+
+  clickTab(tabName: string): void {
+    cy.get('a').contains(tabName).click()
   }
 }

--- a/integration_tests/tests/tasks/list.cy.ts
+++ b/integration_tests/tests/tasks/list.cy.ts
@@ -8,6 +8,8 @@ context('Tasks', () => {
     cy.task('stubSignIn')
   })
 
+  const apAreaId = '0544d95a-f6bb-43f8-9be7-aae66e3bf244'
+
   it('shows a list of tasks', () => {
     cy.task('stubAuthUser')
 
@@ -32,7 +34,7 @@ context('Tasks', () => {
     })
 
     cy.task('stubApAreaReferenceData', {
-      id: '0544d95a-f6bb-43f8-9be7-aae66e3bf244',
+      id: apAreaId,
       name: 'Midlands',
     })
 
@@ -43,6 +45,7 @@ context('Tasks', () => {
     listPage.shouldShowAllocatedTasks()
 
     // And the tasks that are unallocated
+    listPage.clickTab('Unallocated')
     listPage.shouldShowUnallocatedTasks()
   })
 
@@ -64,7 +67,7 @@ context('Tasks', () => {
     cy.task('stubReallocatableTasks', { tasks: allocatedTasksPage9, allocatedFilter: 'allocated', page: '9' })
 
     cy.task('stubApAreaReferenceData', {
-      id: '0544d95a-f6bb-43f8-9be7-aae66e3bf244',
+      id: apAreaId,
       name: 'Midlands',
     })
 
@@ -119,7 +122,7 @@ context('Tasks', () => {
     })
 
     cy.task('stubApAreaReferenceData', {
-      id: '0544d95a-f6bb-43f8-9be7-aae66e3bf244',
+      id: apAreaId,
       name: 'Midlands',
     })
 
@@ -158,7 +161,7 @@ context('Tasks', () => {
 
     cy.task('stubReallocatableTasks', { tasks: allocatedTasks, allocatedFilter: 'allocated', page: '1' })
     cy.task('stubApAreaReferenceData', {
-      id: '0544d95a-f6bb-43f8-9be7-aae66e3bf244',
+      id: apAreaId,
       name: 'Midlands',
     })
 
@@ -174,13 +177,57 @@ context('Tasks', () => {
       allocatedFilter: 'allocated',
       page: '1',
       sortDirection: 'asc',
-      apAreaId: '0544d95a-f6bb-43f8-9be7-aae66e3bf244',
+      apAreaId,
     })
 
-    listPage.searchBy('areas', '0544d95a-f6bb-43f8-9be7-aae66e3bf244')
+    listPage.searchBy('areas', apAreaId)
     listPage.clickApplyFilter()
 
     // Then the page should show the results
     listPage.shouldShowAllocatedTasks(allocatedTasksFiltered)
+  })
+
+  it('retains the unallocated filter when applying other filters', () => {
+    cy.task('stubAuthUser')
+
+    // Given I am logged in
+    cy.signIn()
+
+    const allocatedTasks = taskFactory.buildList(10)
+    const unallocatedTasks = taskFactory.buildList(10, { allocatedToStaffMember: undefined })
+    const unallocatedTasksFiltered = taskFactory.buildList(1, { allocatedToStaffMember: undefined })
+
+    cy.task('stubReallocatableTasks', {
+      tasks: unallocatedTasks,
+      allocatedFilter: 'unallocated',
+      page: '1',
+      sortDirection: 'asc',
+    })
+    cy.task('stubApAreaReferenceData', {
+      id: apAreaId,
+      name: 'Midlands',
+    })
+
+    // Given I am on the tasks dashboard filtering by the unallocated tab
+    const listPage = ListPage.visit(allocatedTasks, unallocatedTasks, 'allocatedFilter=unallocated')
+
+    // Then I should see the tasks that are allocated
+    listPage.shouldShowUnallocatedTasks()
+
+    // When I filter by region
+    cy.task('stubReallocatableTasks', {
+      tasks: unallocatedTasksFiltered,
+      allocatedFilter: 'unallocated',
+      page: '1',
+      sortDirection: 'asc',
+      apAreaId,
+    })
+
+    listPage.searchBy('areas', apAreaId)
+    listPage.clickApplyFilter()
+
+    // Then the status filter should be retained and allocated results should be shown
+    listPage.shouldHaveActiveTab('Unallocated')
+    listPage.shouldShowUnallocatedTasks(unallocatedTasksFiltered)
   })
 })

--- a/integration_tests/tests/tasks/list.cy.ts
+++ b/integration_tests/tests/tasks/list.cy.ts
@@ -180,7 +180,7 @@ context('Tasks', () => {
       apAreaId,
     })
 
-    listPage.searchBy('areas', apAreaId)
+    listPage.searchBy('area', apAreaId)
     listPage.clickApplyFilter()
 
     // Then the page should show the results
@@ -223,7 +223,7 @@ context('Tasks', () => {
       apAreaId,
     })
 
-    listPage.searchBy('areas', apAreaId)
+    listPage.searchBy('area', apAreaId)
     listPage.clickApplyFilter()
 
     // Then the status filter should be retained and allocated results should be shown

--- a/server/controllers/tasksController.test.ts
+++ b/server/controllers/tasksController.test.ts
@@ -92,7 +92,7 @@ describe('TasksController', () => {
 
       const requestHandler = tasksController.index()
 
-      const unallocatedRequest = { ...request, query: { allocatedFilter: 'unallocated', areas: '1234' } }
+      const unallocatedRequest = { ...request, query: { allocatedFilter: 'unallocated', area: '1234' } }
 
       await requestHandler(unallocatedRequest, response, next)
 

--- a/server/controllers/tasksController.ts
+++ b/server/controllers/tasksController.ts
@@ -16,7 +16,7 @@ export default class TasksController {
   index(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       const allocatedFilter = (req.query.allocatedFilter as AllocatedFilter) || 'allocated'
-      const apAreaId = req.query.areas ? req.query.areas : res.locals.user.apArea?.id
+      const apAreaId = req.query.area ? req.query.area : res.locals.user.apArea?.id
       const {
         pageNumber,
         sortDirection = 'asc',

--- a/server/views/tasks/index.njk
+++ b/server/views/tasks/index.njk
@@ -33,8 +33,8 @@
                         text: "AP Areas",
                         classes: "govuk-label--s"
                       },
-                      id: "areas",
-                      name: "areas",
+                      id: "area",
+                      name: "area",
                       items: convertObjectsToSelectOptions(apAreas, 'All areas', 'name', 'id', 'selectedArea')
                     }) }}
             </div>

--- a/server/views/tasks/index.njk
+++ b/server/views/tasks/index.njk
@@ -20,6 +20,7 @@
       <div class="search-and-filter__wrapper">
         <form action="{{ paths.tasks.index({}) }}" method="get">
           <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+           <input type="hidden" name="allocatedFilter" value="{{ allocatedFilter }}">
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-quarter">
               <h2 class="govuk-heading-m">Filters</h2>


### PR DESCRIPTION
# Context

Following on from #1412, adding a fix to the Task allocation page which ensures that the tab the user has selected on the Task Allocation page (Allocated or Unallocated), remains active when applying an AP Area filter to the tasks table. 

Also changing the query name 'areas' to be singular, as it only refers to one area (as in #1413)

## Screenshots of UI changes

### Before

https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/50752284/f60e16c4-2b6d-4415-b697-8537fa384beb

### After

https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/50752284/2ef5a1b2-5d0a-42c0-9a08-f52c7e10ef5b

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
      `production` in a backwards compatible way? (This includes our API,
      infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
      advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
