### PR TITLE
APS-250 Update application withdrawal reasons

### DIFF
--- a/integration_tests/pages/apply/withdrawApplicationPage.ts
+++ b/integration_tests/pages/apply/withdrawApplicationPage.ts
@@ -1,3 +1,4 @@
+import { WithdrawalReason } from '../../../server/@types/shared'
 import paths from '../../../server/paths/apply'
 
 import Page from '../page'
@@ -8,7 +9,7 @@ export default class WithdrawApplicationPage extends Page {
     this.checkForBackButton(paths.applications.index.pattern)
   }
 
-  completeForm() {
-    this.checkRadioByNameAndValue('reason', 'alternative_identified_placement_no_longer_required')
+  completeForm(withdrawalReason: WithdrawalReason) {
+    this.checkRadioByNameAndValue('reason', withdrawalReason)
   }
 }

--- a/integration_tests/tests/apply/withdrawApplication.cy.ts
+++ b/integration_tests/tests/apply/withdrawApplication.cy.ts
@@ -4,6 +4,7 @@ import Page from '../../pages/page'
 import WithdrawApplicationPage from '../../pages/apply/withdrawApplicationPage'
 import { setup } from './setup'
 import { applicationSummaryFactory } from '../../../server/testutils/factories'
+import { WithdrawalReason } from '../../../server/@types/shared'
 
 context('Withdraw Application', () => {
   beforeEach(setup)
@@ -21,6 +22,8 @@ context('Withdraw Application', () => {
     cy.task('stubApplicationWithdrawn', { applicationId: inProgressApplication.id })
     cy.task('stubWithdrawables', { applicationId: inProgressApplication.id, withdrawables: [] })
 
+    const withdrawalReason: WithdrawalReason = 'change_in_circumstances_new_application_to_be_submitted'
+
     // And I visit the list page
     const listPage = ListPage.visit([inProgressApplication], [], [])
 
@@ -31,7 +34,7 @@ context('Withdraw Application', () => {
     const withdrawConfirmationPage = Page.verifyOnPage(WithdrawApplicationPage)
 
     // When I choose a reason and click submit
-    withdrawConfirmationPage.completeForm()
+    withdrawConfirmationPage.completeForm(withdrawalReason)
     withdrawConfirmationPage.clickSubmit()
 
     // Then I should see the list page and be shown confirmation of the withdrawal
@@ -43,7 +46,7 @@ context('Withdraw Application', () => {
 
       const body = JSON.parse(requests[0].body)
 
-      expect(body.reason).equal('alternative_identified_placement_no_longer_required')
+      expect(body.reason).equal(withdrawalReason)
     })
   })
 })

--- a/server/@types/shared/models/WithdrawalReason.ts
+++ b/server/@types/shared/models/WithdrawalReason.ts
@@ -2,4 +2,4 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type WithdrawalReason = 'alternative_identified_placement_no_longer_required' | 'change_in_circumstances_placement_no_longer_required' | 'change_in_circumstances_new_application_to_be_submitted' | 'change_in_release_date_placement_no_longer_required' | 'change_in_release_decision_placement_no_longer_required' | 'error_in_application' | 'duplicate_application' | 'other';
+export type WithdrawalReason = 'change_in_circumstances_new_application_to_be_submitted' | 'error_in_application' | 'duplicate_application' | 'other';

--- a/server/utils/applications/withdrawalReasons.test.ts
+++ b/server/utils/applications/withdrawalReasons.test.ts
@@ -3,30 +3,10 @@ import {
   applicationProblemOptions,
   newApplicationToBeSubmittedOptions,
   otherOptions,
-  placementNoLongerRequiredOptions,
   withdrawalRadioOptions,
 } from './withdrawalReasons'
 
 describe('withdrawlReasons', () => {
-  describe('placementNoLongerRequiredOptions', () => {
-    it('should return the correct options', () => {
-      expect(placementNoLongerRequiredOptions).toEqual({
-        alternative_identified_placement_no_longer_required: 'Alternative provision identified',
-        change_in_circumstances_placement_no_longer_required: 'Change in circumstances',
-        change_in_release_date_placement_no_longer_required: 'Release date changed',
-        change_in_release_decision_placement_no_longer_required: 'Change in release decision',
-      })
-    })
-  })
-
-  describe('newApplicationToBeSubmittedOptions', () => {
-    it('should return the correct options', () => {
-      expect(newApplicationToBeSubmittedOptions).toEqual({
-        change_in_circumstances_new_application_to_be_submitted: 'Change in circumstances',
-      })
-    })
-  })
-
   describe('applicationProblemOptions', () => {
     it('should return the correct options', () => {
       expect(applicationProblemOptions).toEqual({
@@ -47,8 +27,6 @@ describe('withdrawlReasons', () => {
   describe('withdrawalRadioOptions', () => {
     it('should return the correct options', () => {
       expect(withdrawalRadioOptions('CONDITIONAL VALUE')).toEqual([
-        { divider: 'Placement no longer required' },
-        ...convertKeyValuePairToRadioItems(placementNoLongerRequiredOptions, undefined),
         { divider: 'New application required' },
         ...convertKeyValuePairToRadioItems(newApplicationToBeSubmittedOptions, undefined),
         { divider: 'Problems with submitted application' },

--- a/server/utils/applications/withdrawalReasons.ts
+++ b/server/utils/applications/withdrawalReasons.ts
@@ -1,20 +1,10 @@
 import { WithdrawalReason } from '../../@types/shared'
 import { convertKeyValuePairToRadioItems } from '../formUtils'
 
-const placementNoLongerRequiredReasons = [
-  'alternative_identified_placement_no_longer_required',
-  'change_in_circumstances_placement_no_longer_required',
-  'change_in_release_date_placement_no_longer_required',
-  'change_in_release_decision_placement_no_longer_required',
-] as const
 const newApplicationToBeSubmittedReasons = ['change_in_circumstances_new_application_to_be_submitted'] as const
 const applicationProblemReasons = ['error_in_application', 'duplicate_application'] as const
 const otherReasons = ['other'] as const
 
-export type PlacementNoLongerRequiredReasons = Extract<
-  WithdrawalReason,
-  (typeof placementNoLongerRequiredReasons)[number]
->
 export type NewApplicationToBeSubmittedReasons = Extract<
   WithdrawalReason,
   (typeof newApplicationToBeSubmittedReasons)[number]
@@ -23,11 +13,7 @@ export type ApplicationProblemReasons = Extract<WithdrawalReason, (typeof applic
 export type OtherReasons = Extract<WithdrawalReason, (typeof otherReasons)[number]>
 
 export const withdrawlReasons: Record<WithdrawalReason, string> = {
-  alternative_identified_placement_no_longer_required: 'Alternative provision identified',
-  change_in_circumstances_placement_no_longer_required: 'Change in circumstances',
   change_in_circumstances_new_application_to_be_submitted: 'Change in circumstances',
-  change_in_release_date_placement_no_longer_required: 'Release date changed',
-  change_in_release_decision_placement_no_longer_required: 'Change in release decision',
   error_in_application: 'Error in application',
   duplicate_application: 'Duplicate application',
   other: 'Other',
@@ -39,9 +25,6 @@ const filterByType = <T extends WithdrawalReason>(keys: Readonly<Array<string>>)
     .reduce((criteria, key) => ({ ...criteria, [key]: withdrawlReasons[key] }), {}) as Record<T, string>
 }
 
-export const placementNoLongerRequiredOptions = filterByType<PlacementNoLongerRequiredReasons>(
-  placementNoLongerRequiredReasons,
-)
 export const newApplicationToBeSubmittedOptions = filterByType<NewApplicationToBeSubmittedReasons>(
   newApplicationToBeSubmittedReasons,
 )
@@ -49,8 +32,6 @@ export const applicationProblemOptions = filterByType<ApplicationProblemReasons>
 export const otherOptions = filterByType<OtherReasons>(otherReasons)
 
 export const withdrawalRadioOptions = (conditionalValue: string) => [
-  { divider: 'Placement no longer required' },
-  ...convertKeyValuePairToRadioItems(placementNoLongerRequiredOptions, undefined),
   { divider: 'New application required' },
   ...convertKeyValuePairToRadioItems(newApplicationToBeSubmittedOptions, undefined),
   { divider: 'Problems with submitted application' },


### PR DESCRIPTION

# Context
The reasons have been cut down to simplifiy things
[jira](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&selectedIssue=APS-250)

# Changes in this PR

Reduce number of Application withdrawal reasons

## Screenshots of UI changes

### Before
![after (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/b064e89d-3145-46fc-8644-1282d092f931)

### After
![after](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/7e682bc8-2e78-461d-b2a3-b24f874d3575)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
      `production` in a backwards compatible way? (This includes our API,
      infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
      advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
