### PR TITLE
APS-248 - Add reasons to the placement application withdraw page

### DIFF
--- a/integration_tests/mockApis/placementApplication.ts
+++ b/integration_tests/mockApis/placementApplication.ts
@@ -104,4 +104,11 @@ export default {
         url: paths.placementApplications.submitDecision({ id: applicationId }),
       })
     ).body.requests,
+  verifyPlacementApplicationWithdrawn: async (applicationId: string) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: paths.placementApplications.withdraw({ id: applicationId }),
+      })
+    ).body.requests,
 }

--- a/integration_tests/pages/match/placementApplicationWithdrawalConfirmationPage.ts
+++ b/integration_tests/pages/match/placementApplicationWithdrawalConfirmationPage.ts
@@ -1,8 +1,13 @@
+import { WithdrawPlacementRequestReason } from '../../../server/@types/shared/models/WithdrawPlacementRequestReason'
 import Page from '../page'
 
 export default class ConfirmationPage extends Page {
   constructor() {
-    super('Are you sure you want to withdraw this placement application?')
+    super('Why is this placement request being withdrawn?')
+  }
+
+  selectReason(withdrawalReason: WithdrawPlacementRequestReason) {
+    this.checkRadioByNameAndValue('reason', withdrawalReason)
   }
 
   clickConfirm() {

--- a/server/controllers/placementApplications/withdrawalsController.test.ts
+++ b/server/controllers/placementApplications/withdrawalsController.test.ts
@@ -47,7 +47,7 @@ describe('withdrawalsController', () => {
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('placement-applications/withdraw/new', {
-        pageHeading: 'Are you sure you want to withdraw this placement application?',
+        pageHeading: 'Why is this placement request being withdrawn?',
         placementApplicationId: placementApplication.id,
         applicationId,
         errors: errorsAndUserInput.errors,
@@ -62,12 +62,16 @@ describe('withdrawalsController', () => {
     it('calls the service method, redirects to the application screen and shows a confirmation message', async () => {
       request.body.applicationId = applicationId
       request.params.id = placementApplicationId
-
+      request.body.reason = 'DuplicatePlacementRequest'
       const requestHandler = withdrawalsController.create()
 
       await requestHandler(request, response, next)
 
-      expect(placementApplicationService.withdraw).toHaveBeenCalledWith(token, placementApplicationId)
+      expect(placementApplicationService.withdraw).toHaveBeenCalledWith(
+        token,
+        placementApplicationId,
+        request.body.reason,
+      )
       expect(response.redirect).toHaveBeenCalledWith(applicationShowPageTab(applicationId, 'placementRequests'))
       expect(request.flash).toHaveBeenCalledWith('success', 'Placement application withdrawn')
     })

--- a/server/controllers/placementApplications/withdrawalsController.ts
+++ b/server/controllers/placementApplications/withdrawalsController.ts
@@ -6,6 +6,8 @@ import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../
 
 import placementApplicationPaths from '../../paths/placementApplications'
 import { applicationShowPageTab } from '../../utils/applications/utils'
+import { WithdrawPlacementRequestReason } from '../../@types/shared/models/WithdrawPlacementRequestReason'
+import { Application } from '../../@types/shared'
 
 export default class WithdrawlsController {
   constructor(private readonly placementApplicationService: PlacementApplicationService) {}
@@ -19,7 +21,7 @@ export default class WithdrawlsController {
       )
 
       return res.render('placement-applications/withdraw/new', {
-        pageHeading: 'Are you sure you want to withdraw this placement application?',
+        pageHeading: 'Why is this placement request being withdrawn?',
         placementApplicationId: placementApplication.id,
         applicationId: placementApplication.applicationId,
         errors,
@@ -32,8 +34,13 @@ export default class WithdrawlsController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       try {
-        await this.placementApplicationService.withdraw(req.user.token, req.params.id)
-        const { applicationId } = req.body
+        const { reason, applicationId } = req.body as {
+          reason: WithdrawPlacementRequestReason | undefined
+          applicationId: Application['id'] | undefined
+        }
+
+        await this.placementApplicationService.withdraw(req.user.token, req.params.id, reason)
+
         req.flash('success', 'Placement application withdrawn')
 
         return res.redirect(applicationShowPageTab(applicationId, 'placementRequests'))

--- a/server/data/placementApplicationClient.test.ts
+++ b/server/data/placementApplicationClient.test.ts
@@ -4,6 +4,7 @@ import paths from '../paths/api'
 import { placementApplicationDecisionEnvelopeFactory, placementApplicationFactory } from '../testutils/factories'
 import describeClient from '../testutils/describeClient'
 import { SubmitPlacementApplication } from '../@types/shared'
+import { WithdrawPlacementRequestReason } from '../@types/shared/models/WithdrawPlacementRequestReason'
 
 describeClient('placementApplicationClient', provider => {
   let placementApplicationClient: PlacementApplicationClient
@@ -157,6 +158,7 @@ describeClient('placementApplicationClient', provider => {
   describe('withdraw', () => {
     it('withdraws a placement application and returns the result', async () => {
       const placementApplication = placementApplicationFactory.build()
+      const reason: WithdrawPlacementRequestReason = 'AlternativeProvisionIdentified'
 
       provider.addInteraction({
         state: 'Server is healthy',
@@ -164,6 +166,7 @@ describeClient('placementApplicationClient', provider => {
         withRequest: {
           method: 'POST',
           path: paths.placementApplications.withdraw({ id: placementApplication.id }),
+          body: { reason },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -174,7 +177,7 @@ describeClient('placementApplicationClient', provider => {
         },
       })
 
-      const result = await placementApplicationClient.withdraw(placementApplication.id)
+      const result = await placementApplicationClient.withdraw(placementApplication.id, reason)
 
       expect(result).toEqual(placementApplication)
     })

--- a/server/data/placementApplicationClient.ts
+++ b/server/data/placementApplicationClient.ts
@@ -6,6 +6,7 @@ import {
 import config, { ApiConfig } from '../config'
 import RestClient from './restClient'
 import paths from '../paths/api'
+import { WithdrawPlacementRequestReason } from '../@types/shared/models/WithdrawPlacementRequestReason'
 
 export default class PlacementApplicationClient {
   restClient: RestClient
@@ -54,9 +55,13 @@ export default class PlacementApplicationClient {
     })) as Promise<PlacementApplication>
   }
 
-  async withdraw(placementApplicationId: string): Promise<PlacementApplication> {
+  async withdraw(
+    placementApplicationId: string,
+    reason: WithdrawPlacementRequestReason,
+  ): Promise<PlacementApplication> {
     return (await this.restClient.post({
       path: paths.placementApplications.withdraw({ id: placementApplicationId }),
+      data: { reason },
     })) as Promise<PlacementApplication>
   }
 }

--- a/server/services/placementApplicationService.test.ts
+++ b/server/services/placementApplicationService.test.ts
@@ -206,10 +206,11 @@ describe('placementApplicationService', () => {
   describe('withdraw', () => {
     it('calls the client method and returns the result', async () => {
       const placementApplication = placementApplicationFactory.build()
+      const reason = 'AlternativeProvisionIdentified'
 
       placementApplicationClient.withdraw.mockResolvedValue(placementApplication)
 
-      const result = await service.withdraw(token, placementApplication.id)
+      const result = await service.withdraw(token, placementApplication.id, reason)
 
       expect(result).toEqual(placementApplication)
     })

--- a/server/services/placementApplicationService.ts
+++ b/server/services/placementApplicationService.ts
@@ -11,6 +11,7 @@ import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
 import { getBody, getPageName, getTaskName } from '../form-pages/utils'
 import { ValidationError } from '../utils/errors'
 import { placementApplicationSubmissionData } from '../utils/placementRequests/placementApplicationSubmissionData'
+import { WithdrawPlacementRequestReason } from '../@types/shared/models/WithdrawPlacementRequestReason'
 
 export default class PlacementApplicationService {
   constructor(private readonly placementApplicationClientFactory: RestClientBuilder<PlacementApplicationClient>) {}
@@ -85,9 +86,9 @@ export default class PlacementApplicationService {
     return placementApplicationClient.decisionSubmission(placementApplicationId, decisionEnvelope)
   }
 
-  async withdraw(token: string, placementApplicationId: string) {
+  async withdraw(token: string, placementApplicationId: string, reason: WithdrawPlacementRequestReason) {
     const placementApplicationClient = this.placementApplicationClientFactory(token)
 
-    return placementApplicationClient.withdraw(placementApplicationId)
+    return placementApplicationClient.withdraw(placementApplicationId, reason)
   }
 }

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -13,7 +13,6 @@ import {
   userFactory,
 } from '../../testutils/factories'
 import paths from '../../paths/apply'
-import placementApplicationPaths from '../../paths/placementApplications'
 import Apply from '../../form-pages/apply'
 import Assess from '../../form-pages/assess'
 import PlacementRequest from '../../form-pages/placement-application'
@@ -761,8 +760,8 @@ describe('utils', () => {
             actions: {
               items: [
                 {
-                  href: placementApplicationPaths.placementApplications.withdraw.new({
-                    id: placementApplications[0].id,
+                  href: paths.applications.withdraw.new({
+                    id: application.id,
                   }),
                   text: 'Withdraw',
                 },
@@ -825,8 +824,8 @@ describe('utils', () => {
             actions: {
               items: [
                 {
-                  href: placementApplicationPaths.placementApplications.withdraw.new({
-                    id: placementApplications[0].id,
+                  href: paths.applications.withdraw.new({
+                    id: application.id,
                   }),
                   text: 'Withdraw',
                 },

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -27,7 +27,6 @@ import type {
 import MaleAp from '../../form-pages/apply/reasons-for-placement/basic-information/maleAp'
 import IsExceptionalCase from '../../form-pages/apply/reasons-for-placement/basic-information/isExceptionalCase'
 import paths from '../../paths/apply'
-import placementApplicationPaths from '../../paths/placementApplications'
 import Apply from '../../form-pages/apply'
 import { isApplicableTier, isFullPerson, nameOrPlaceholderCopy, tierBadge } from '../personUtils'
 import { DateFormats } from '../dateUtils'
@@ -47,7 +46,11 @@ import { durationAndArrivalDateFromPlacementApplication } from '../placementRequ
 import { sortHeader } from '../sortHeader'
 import { linkTo } from '../utils'
 
-export { withdrawableTypeRadioOptions, withdrawableRadioOptions } from './withdrawables'
+export {
+  withdrawableTypeRadioOptions,
+  withdrawableRadioOptions,
+  placementApplicationWithdrawalReasons,
+} from './withdrawables'
 
 const applicationStatuses: Record<ApprovedPremisesApplicationStatus, string> = {
   started: 'Application started',
@@ -334,8 +337,8 @@ const mapPlacementApplicationToSummaryCards = (
 
     if (placementApplication?.canBeWithdrawn && placementApplication.createdByUserId === actingUser.id) {
       actionItems.push({
-        href: placementApplicationPaths.placementApplications.withdraw.new({
-          id: placementApplications[0].id,
+        href: paths.applications.withdraw.new({
+          id: application.id,
         }),
         text: 'Withdraw',
       })

--- a/server/utils/applications/withdrawables/index.test.ts
+++ b/server/utils/applications/withdrawables/index.test.ts
@@ -1,5 +1,5 @@
 import { bookingFactory, withdrawableFactory } from '../../../testutils/factories'
-import { withdrawableRadioOptions, withdrawableTypeRadioOptions } from '.'
+import { placementApplicationWithdrawalReasons, withdrawableRadioOptions, withdrawableTypeRadioOptions } from '.'
 import { DateFormats } from '../../dateUtils'
 import { linkTo } from '../../utils'
 import matchPaths from '../../../paths/match'
@@ -118,6 +118,21 @@ describe('withdrawableTypeRadioOptions', () => {
             .map(datePeriod => DateFormats.formatDurationBetweenTwoDates(datePeriod.startDate, datePeriod.endDate))
             .join(', ')}`,
           value: bookingWithdrawable.id,
+        },
+      ])
+    })
+  })
+
+  describe('placementApplicationWithdrawalReasons', () => {
+    it('returns the reasons for withdrawing a placement application', () => {
+      expect(placementApplicationWithdrawalReasons('DuplicatePlacementRequest')).toEqual([
+        { divider: 'Problem in placement request' },
+        { text: 'Duplicate placement request', value: 'DuplicatePlacementRequest', checked: true },
+        { divider: 'Placement no longer required' },
+        {
+          text: 'Alternative provision identified',
+          value: 'AlternativeProvisionIdentified',
+          checked: false,
         },
       ])
     })

--- a/server/utils/applications/withdrawables/index.ts
+++ b/server/utils/applications/withdrawables/index.ts
@@ -4,6 +4,7 @@ import matchPaths from '../../../paths/match'
 import managePaths from '../../../paths/manage'
 import { DateFormats } from '../../dateUtils'
 import { linkTo } from '../../utils'
+import { WithdrawPlacementRequestReason } from '../../../@types/shared/models/WithdrawPlacementRequestReason'
 
 export type SelectedWithdrawableType = 'application' | 'placementRequest' | 'booking'
 
@@ -103,4 +104,23 @@ export const withdrawableRadioOptions = (
     }
     throw new Error(`Unknown withdrawable type: ${withdrawable.type}`)
   })
+}
+
+export const placementApplicationWithdrawalReasons = (
+  selectedReason: WithdrawPlacementRequestReason,
+): Array<RadioItem | { divider: string }> => {
+  return [
+    { divider: 'Problem in placement request' },
+    {
+      text: 'Duplicate placement request',
+      value: 'DuplicatePlacementRequest',
+      checked: selectedReason === 'DuplicatePlacementRequest',
+    },
+    { divider: 'Placement no longer required' },
+    {
+      text: 'Alternative provision identified',
+      value: 'AlternativeProvisionIdentified',
+      checked: selectedReason === 'AlternativeProvisionIdentified',
+    },
+  ]
 }

--- a/server/views/admin/placementRequests/withdrawals/new.njk
+++ b/server/views/admin/placementRequests/withdrawals/new.njk
@@ -31,7 +31,7 @@
           fieldset: {
               legend: {
                   text: pageHeading,
-                  classes: "govuk-fieldset__legend--l",
+                  classes: "govuk-fieldset__legend--m",
                   isPageHeading: true
               }
           },

--- a/server/views/placement-applications/withdraw/new.njk
+++ b/server/views/placement-applications/withdraw/new.njk
@@ -8,13 +8,6 @@
 {% set pageTitle = applicationName + " - " + pageHeading  %}
 {% set mainClasses = "app-container govuk-body" %}
 
-{% block beforeContent %}
-    {{ govukBackLink({
-		text: "Back",
-		href: ApplyUtils.applicationShowPageTab(applicationId, ApplyUtils.applicationShowPageTabs.placementRequests)
-	}) }}
-{% endblock %}
-
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -26,10 +19,21 @@
 
                 {{ showErrorSummary(errorSummary) }}
 
-                <h1>{{pageHeading}}</h1>
+                {{ govukRadios({
+                    name: "reason",              
+                    classes: "govuk-radios--withdrawal-reasons",
+                    fieldset: {
+                        legend: {
+                            text: pageHeading,
+                            classes: "govuk-fieldset__legend--m",
+                            isPageHeading: true
+                        }
+                    },
+                    items: ApplyUtils.placementApplicationWithdrawalReasons(selectedReason)
+
+                }) }}
 
                 {{ govukButton({
-                    name: 'submit',
                     text: "Continue"
                 }) }}
 


### PR DESCRIPTION
This adds PAs to the withdrawable flow as added in [#1413](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/1431). The user now has to specify a reason that the Placement Application is being withdrawn

[Jira ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&selectedIssue=APS-248)


## Screenshots of UI changes
![show applications -- should show placement applications](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/32a1bceb-6e45-40a1-b4b7-81c0b18cf78e)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
      `production` in a backwards compatible way? (This includes our API,
      infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
      advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
