### PR TITLE
APS 244 - Update booking withdrawal flow

### DIFF
--- a/server/utils/applications/withdrawalReasons.ts
+++ b/server/utils/applications/withdrawalReasons.ts
@@ -1,18 +1,14 @@
 import { WithdrawalReason } from '../../@types/shared'
 import { convertKeyValuePairToRadioItems } from '../formUtils'
 
-const newApplicationToBeSubmittedReasons = ['change_in_circumstances_new_application_to_be_submitted'] as const
+const newApplicationToBeSubmittedReason = 'change_in_circumstances_new_application_to_be_submitted' as const
 const applicationProblemReasons = ['error_in_application', 'duplicate_application'] as const
 const otherReasons = ['other'] as const
 
-export type NewApplicationToBeSubmittedReasons = Extract<
-  WithdrawalReason,
-  (typeof newApplicationToBeSubmittedReasons)[number]
->
 export type ApplicationProblemReasons = Extract<WithdrawalReason, (typeof applicationProblemReasons)[number]>
 export type OtherReasons = Extract<WithdrawalReason, (typeof otherReasons)[number]>
 
-export const withdrawlReasons: Record<WithdrawalReason, string> = {
+export const withdrawlReasons = {
   change_in_circumstances_new_application_to_be_submitted: 'Change in circumstances',
   error_in_application: 'Error in application',
   duplicate_application: 'Duplicate application',
@@ -25,9 +21,9 @@ const filterByType = <T extends WithdrawalReason>(keys: Readonly<Array<string>>)
     .reduce((criteria, key) => ({ ...criteria, [key]: withdrawlReasons[key] }), {}) as Record<T, string>
 }
 
-export const newApplicationToBeSubmittedOptions = filterByType<NewApplicationToBeSubmittedReasons>(
-  newApplicationToBeSubmittedReasons,
-)
+export const newApplicationToBeSubmittedOptions = filterByType<typeof newApplicationToBeSubmittedReason>([
+  newApplicationToBeSubmittedReason,
+])
 export const applicationProblemOptions = filterByType<ApplicationProblemReasons>(applicationProblemReasons)
 export const otherOptions = filterByType<OtherReasons>(otherReasons)
 


### PR DESCRIPTION
Similar to #1440 #1439 we now add bookings to the new withdrawal flow. 
As the booking can be withdrawn from the Application now we need to show and hide different inputs for the different roles. 'Manager's will see all the input and other roles won't. 

[Jira ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&selectedIssue=APS-251)

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
      `production` in a backwards compatible way? (This includes our API,
      infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
      advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
