### PR TITLE
APS 251  -  update booking cancellation design

### DIFF
--- a/integration_tests/pages/admin/placementApplications/showPage.ts
+++ b/integration_tests/pages/admin/placementApplications/showPage.ts
@@ -45,9 +45,9 @@ export default class ShowPage extends Page {
     cy.contains('.moj-button-menu__item', 'Amend placement').click()
   }
 
-  clickCancelBooking() {
+  clickWithdrawBooking() {
     cy.get('.moj-button-menu__toggle-button').click()
-    cy.contains('.moj-button-menu__item', 'Cancel placement').click()
+    cy.contains('.moj-button-menu__item', 'Withdraw placement').click()
   }
 
   clickWithdraw() {

--- a/integration_tests/pages/admin/placementApplications/showPage.ts
+++ b/integration_tests/pages/admin/placementApplications/showPage.ts
@@ -69,7 +69,7 @@ export default class ShowPage extends Page {
   }
 
   shouldShowCancelBookingOption() {
-    this.buttonShouldExist('Cancel placement')
+    this.buttonShouldExist('Withdraw placement')
   }
 
   shouldNotShowCreateBookingOption() {

--- a/integration_tests/pages/manage/booking/show.ts
+++ b/integration_tests/pages/manage/booking/show.ts
@@ -19,6 +19,11 @@ export default class BookingShowPage extends Page {
     cy.get('a').contains('Extend placement').click()
   }
 
+  clickWithdrawPlacement() {
+    cy.get('.moj-button-menu__toggle-button').click()
+    cy.get('a').contains('Withdraw placement').click()
+  }
+
   clickMoveBooking() {
     cy.get('.moj-button-menu__toggle-button').click()
     cy.get('a').contains('Move person to a new bed').click()

--- a/integration_tests/pages/manage/bookingCancellationConfirmation.ts
+++ b/integration_tests/pages/manage/bookingCancellationConfirmation.ts
@@ -1,0 +1,11 @@
+import Page from '../page'
+
+export default class BookingCancellationConfirmPage extends Page {
+  constructor() {
+    super('Booking withdrawn')
+  }
+
+  shouldShowPanel() {
+    cy.get('.govuk-panel').should('contain', 'Booking withdrawn')
+  }
+}

--- a/integration_tests/pages/manage/cancellationCreate.ts
+++ b/integration_tests/pages/manage/cancellationCreate.ts
@@ -7,7 +7,7 @@ export default class CancellationCreatePage extends Page {
     public readonly premisesId: string,
     public readonly bookingId: string,
   ) {
-    super('Confirm cancelled placement')
+    super('Confirm withdrawn placement')
   }
 
   static visit(premisesId: string, bookingId: string): CancellationCreatePage {
@@ -16,15 +16,16 @@ export default class CancellationCreatePage extends Page {
     return new CancellationCreatePage(premisesId, bookingId)
   }
 
-  completeForm(cancellation: Cancellation): void {
-    this.getLegend('When was this placement cancelled?')
-    this.completeDateInputs('date', cancellation.date)
+  completeForm(cancellation: Cancellation, { completeFullForm }: { completeFullForm: boolean }): void {
+    if (completeFullForm) {
+      this.getLegend('When was this placement withdrawn?')
+      this.completeDateInputs('date', cancellation.date)
+      this.getLabel('Provide any additional notes on why this placement was withdrawn')
+      this.completeTextArea('cancellation[notes]', cancellation.notes)
+    }
 
-    this.getLegend('Why was this placement cancelled?')
+    this.getLegend('Why was this placement withdrawn?')
     this.checkRadioByNameAndValue('cancellation[reason]', cancellation.reason.id)
-
-    this.getLabel('Provide any additional notes on why this placement was cancelled')
-    this.completeTextArea('cancellation[notes]', cancellation.notes)
 
     this.clickSubmit()
   }

--- a/integration_tests/pages/manage/premisesShow.ts
+++ b/integration_tests/pages/manage/premisesShow.ts
@@ -106,6 +106,10 @@ export default class PremisesShowPage extends Page {
     )
   }
 
+  clickManageBooking(booking: PremisesBooking) {
+    cy.get(`[data-cy-booking-id="${booking.id}"]`).click()
+  }
+
   shouldShowMoveConfirmation() {
     this.shouldShowBanner('Bed move logged')
   }

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -281,7 +281,7 @@ context('Placement Requests', () => {
     const cancellationPage = Page.verifyOnPage(CancellationCreatePage, matchedPlacementRequest)
 
     // And I cancel my booking
-    cancellationPage.completeForm(cancellation)
+    cancellationPage.completeForm(cancellation, { completeFullForm: true })
     cancellationPage.clickSubmit()
 
     // Then I should see a confirmation message

--- a/integration_tests/tests/manage/cancellation.cy.ts
+++ b/integration_tests/tests/manage/cancellation.cy.ts
@@ -1,8 +1,18 @@
-import { bookingFactory, cancellationFactory, premisesFactory } from '../../../server/testutils/factories'
+import {
+  applicationFactory,
+  bookingFactory,
+  cancellationFactory,
+  extendedPremisesSummaryFactory,
+  premisesBookingFactory,
+  premisesFactory,
+  withdrawableFactory,
+} from '../../../server/testutils/factories'
+import { fullPersonFactory } from '../../../server/testutils/factories/person'
 
-import { BookingShowPage, CancellationCreatePage } from '../../pages/manage'
-import Page from '../../pages/page'
+import { BookingShowPage, CancellationCreatePage, PremisesShowPage } from '../../pages/manage'
+import NewWithdrawalPage from '../../pages/apply/newWithdrawal'
 import { signIn } from '../signIn'
+import BookingCancellationConfirmPage from '../../pages/manage/bookingCancellationConfirmation'
 
 context('Cancellation', () => {
   beforeEach(() => {
@@ -10,28 +20,51 @@ context('Cancellation', () => {
     cy.task('stubCancellationReferenceData')
 
     // Given I am signed in
-    signIn(['workflow_manager'])
+    signIn(['workflow_manager', 'manager'])
   })
 
   it('should allow me to create a cancellation', () => {
     // Given a booking is available
-    const premises = premisesFactory.build()
-    const booking = bookingFactory.build()
+    const application = applicationFactory.build()
+
+    const booking = bookingFactory.arrivingToday().build({ applicationId: application.id })
+    const bookings = premisesBookingFactory
+      .arrivingToday()
+      .buildList(1)
+      .map(b => ({ ...b, person: fullPersonFactory.build(), id: booking.id }))
+    const premises = extendedPremisesSummaryFactory.build({ bookings, id: booking.premises.id })
     cy.task('stubBookingGet', { premisesId: premises.id, booking })
 
     // When I navigate to the booking's cancellation page
     const cancellation = cancellationFactory.build({ date: '2022-06-01' })
+    const withdrawable = withdrawableFactory.build({ id: booking.id, type: 'booking' })
     cy.task('stubCancellationCreate', { premisesId: premises.id, bookingId: booking.id, cancellation })
+    cy.task('stubPremisesSummary', premises)
+    cy.task('stubWithdrawables', { applicationId: application.id, withdrawables: [withdrawable] })
+    cy.task('stubBookingFindWithoutPremises', booking)
 
-    const page = CancellationCreatePage.visit(premises.id, booking.id)
+    const premisesShowPage = PremisesShowPage.visit(premises)
+    premisesShowPage.clickManageBooking(booking)
+
+    const bookingPage = new BookingShowPage()
+    bookingPage.clickWithdrawPlacement()
+
+    const withdrawalTypePage = new NewWithdrawalPage('What do you want to withdraw?')
+    withdrawalTypePage.selectType('booking')
+    withdrawalTypePage.clickSubmit()
+
+    const withdrawablePage = new NewWithdrawalPage('Select your booking')
+    withdrawablePage.selectWithdrawable(booking.id)
+    withdrawablePage.clickSubmit()
 
     // And I fill out the cancellation form
-    page.completeForm(cancellation)
+    const cancellationPage = new CancellationCreatePage(premises.id, booking.id)
+    cancellationPage.completeForm(cancellation, { completeFullForm: true })
 
     // Then a cancellation should have been created in the API
     cy.task('verifyCancellationCreate', {
       premisesId: premises.id,
-      bookingId: booking.id,
+      bookingId: bookings[0].id,
       cancellation,
     }).then(requests => {
       expect(requests).to.have.length(1)
@@ -43,8 +76,8 @@ context('Cancellation', () => {
     })
 
     // And I should see a confirmation message
-    const bookingPage = Page.verifyOnPage(BookingShowPage, [premises.id, booking])
-    bookingPage.shouldShowBanner('Booking cancelled')
+    const confirmationPage = new BookingCancellationConfirmPage()
+    confirmationPage.shouldShowPanel()
   })
 
   it('should show errors', () => {
@@ -63,13 +96,13 @@ context('Cancellation', () => {
     cy.task('stubCancellationErrors', {
       premisesId: premises.id,
       bookingId: booking.id,
-      params: ['date', 'reason'],
+      params: ['reason'],
     })
 
     page.clickSubmit()
 
     // Then I should see error messages relating to that field
-    page.shouldShowErrorMessagesForFields(['date', 'reason'])
+    page.shouldShowErrorMessagesForFields(['reason'])
 
     // And the back link should be populated correctly
     page.shouldHaveCorrectBacklink()

--- a/server/controllers/apply/withdrawablesController.ts
+++ b/server/controllers/apply/withdrawablesController.ts
@@ -55,7 +55,6 @@ export default class WithdrawalsController {
       const withdrawable = (await this.applicationService.getWithdrawables(req.user.token, id)).find(
         w => w.id === selectedWithdrawable,
       )
-
       if (!withdrawable) {
         return res.redirect(302, applyPaths.applications.withdraw.new({ id }))
       }
@@ -70,7 +69,7 @@ export default class WithdrawalsController {
         const booking = await this.bookingService.findWithoutPremises(req.user.token, selectedWithdrawable)
         return res.redirect(
           302,
-          managePaths.bookings.cancellations.new({ bookingId: selectedWithdrawable, premisesId: booking.premises.id }),
+          managePaths.bookings.cancellations.new({ bookingId: booking.id, premisesId: booking.premises.id }),
         )
       }
 

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -47,7 +47,7 @@ describe('bookingUtils', () => {
       expect(manageBookingLink(premisesId, booking)).toMatchStringIgnoringWhitespace(`<a href="${paths.bookings.show({
         premisesId,
         bookingId: booking.id,
-      })}">
+      })}" data-cy-booking-id="${booking.id}">
       Manage
       <span class="govuk-visually-hidden">
         booking for ${booking.person.crn}
@@ -61,7 +61,7 @@ describe('bookingUtils', () => {
       expect(manageBookingLink(premisesId, booking)).toMatchStringIgnoringWhitespace(`<a href="${paths.bookings.show({
         premisesId,
         bookingId: booking.id,
-      })}">
+      })}" data-cy-booking-id="${booking.id}">
       Manage
       <span class="govuk-visually-hidden">
         booking for ${booking.person.crn}
@@ -216,9 +216,9 @@ describe('bookingUtils', () => {
               href: paths.bookings.nonArrivals.new({ premisesId, bookingId: booking.id }),
             },
             {
-              text: 'Cancel placement',
+              text: 'Withdraw placement',
               classes: 'govuk-button--secondary',
-              href: paths.bookings.cancellations.new({ premisesId, bookingId: booking.id }),
+              href: applyPaths.applications.withdraw.new({ id: booking.applicationId }),
             },
             {
               text: 'Change placement dates',
@@ -252,9 +252,9 @@ describe('bookingUtils', () => {
               href: paths.bookings.extensions.new({ premisesId, bookingId: booking.id }),
             },
             {
-              text: 'Cancel placement',
+              text: 'Withdraw placement',
               classes: 'govuk-button--secondary',
-              href: paths.bookings.cancellations.new({ premisesId, bookingId: booking.id }),
+              href: applyPaths.applications.withdraw.new({ id: booking.applicationId }),
             },
           ],
         },

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -70,7 +70,7 @@ export const bookingSummaryList = (booking: BookingSummary): SummaryListWithCard
 
 export const manageBookingLink = (premisesId: string, booking: Booking | PremisesBooking): string => {
   return booking.id && booking.person
-    ? `<a href="${paths.bookings.show({ premisesId, bookingId: booking.id })}">
+    ? `<a href="${paths.bookings.show({ premisesId, bookingId: booking.id })}" data-cy-booking-id="${booking.id}">
     Manage
     <span class="govuk-visually-hidden">
       booking for ${booking.person.crn}
@@ -188,9 +188,9 @@ export const bookingActions = (booking: Booking, premisesId: string): Array<Iden
         href: paths.bookings.nonArrivals.new({ premisesId, bookingId: booking.id }),
       })
       items.push({
-        text: 'Cancel placement',
+        text: 'Withdraw placement',
         classes: 'govuk-button--secondary',
-        href: paths.bookings.cancellations.new({ premisesId, bookingId: booking.id }),
+        href: applyPaths.applications.withdraw.new({ id: booking.applicationId }),
       })
       items.push({
         text: 'Change placement dates',
@@ -211,9 +211,9 @@ export const bookingActions = (booking: Booking, premisesId: string): Array<Iden
         href: paths.bookings.extensions.new({ premisesId, bookingId: booking.id }),
       })
       items.push({
-        text: 'Cancel placement',
+        text: 'Withdraw placement',
         classes: 'govuk-button--secondary',
-        href: paths.bookings.cancellations.new({ premisesId, bookingId: booking.id }),
+        href: applyPaths.applications.withdraw.new({ id: booking.applicationId }),
       })
     }
 

--- a/server/utils/placementRequests/adminIdentityBar.test.ts
+++ b/server/utils/placementRequests/adminIdentityBar.test.ts
@@ -20,11 +20,8 @@ describe('adminIdentityBar', () => {
           text: 'Amend placement',
         },
         {
-          href: managePaths.bookings.cancellations.new({
-            premisesId: placementRequestDetail.booking?.premisesId || '',
-            bookingId: placementRequestDetail.booking?.id || '',
-          }),
-          text: 'Cancel placement',
+          href: applyPaths.applications.withdraw.new({ id: placementRequestDetail.applicationId }),
+          text: 'Withdraw placement',
         },
       ])
     })

--- a/server/utils/placementRequests/adminIdentityBar.ts
+++ b/server/utils/placementRequests/adminIdentityBar.ts
@@ -24,11 +24,8 @@ export const adminActions = (placementRequest: PlacementRequestDetail): Array<Id
         text: 'Amend placement',
       },
       {
-        href: managePaths.bookings.cancellations.new({
-          premisesId: placementRequest?.booking?.premisesId || '',
-          bookingId: placementRequest?.booking?.id || '',
-        }),
-        text: 'Cancel placement',
+        href: applyPaths.applications.withdraw.new({ id: placementRequest.applicationId }),
+        text: 'Withdraw placement',
       },
     ]
   }

--- a/server/utils/premisesUtils.ts
+++ b/server/utils/premisesUtils.ts
@@ -14,7 +14,7 @@ import { linkTo } from './utils'
 
 export type NegativeDateRange = { start?: string; end?: string }
 
-export const overcapacityMessage = (premisesCapacity: Array<DateCapacity>): string => {
+export const overcapacityMessage = (premisesCapacity: Array<DateCapacity> = []): string => {
   let dateRange: NegativeDateRange = {}
   const overcapacityDateRanges: Array<NegativeDateRange> = []
   let message: string

--- a/server/views/cancellations/confirm.njk
+++ b/server/views/cancellations/confirm.njk
@@ -1,0 +1,18 @@
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+            {{ govukPanel({
+                titleText: pageHeading
+            }) }}
+
+        </div>
+    </div>
+{% endblock %}

--- a/server/views/cancellations/new.njk
+++ b/server/views/cancellations/new.njk
@@ -25,12 +25,8 @@
     <div class="govuk-grid-column-two-thirds">
       <h1>{{pageHeading}}</h1>
 
-      <p>Confirm that the Approved Premises has cancelled this placement.</p>
-
       <form action="{{ paths.bookings.cancellations.create({ premisesId: premisesId, bookingId: booking.id }) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-        <input type="hidden" name="backLink" value="{{ backLink }}"/>
-
         {{ govukSummaryList({
             rows: [
                 {
@@ -71,12 +67,26 @@
 
         {{ showErrorSummary(errorSummary) }}
 
-        {{ govukDateInput({
+        {{ govukRadios({
+          name: "cancellation[reason]",
+          id: "reason",
+          fieldset: {
+              legend: {
+              text: "Why was this placement withdrawn?",
+              classes: "govuk-fieldset__legend--m"
+              }
+          },
+          errorMessage: errors.reason,
+          items: convertObjectsToRadioItems(cancellationReasons, 'name', 'id', 'cancellation[reason]')
+          }) }}
+
+        {% if apManager %}
+          {{ govukDateInput({
             id: "date",
             namePrefix: "date",
             fieldset: {
                 legend: {
-                    text: "When was this placement cancelled?",
+                    text: "When was this placement withdrawn?",
                     classes: "govuk-fieldset__legend--m"
                     }
             },
@@ -87,26 +97,14 @@
             items: dateFieldValues('date', errors)
         }) }}
 
-        {{ govukRadios({
-          name: "cancellation[reason]",
-          id: "reason",
-          fieldset: {
-              legend: {
-              text: "Why was this placement cancelled?",
-              classes: "govuk-fieldset__legend--m"
-              }
-          },
-          errorMessage: errors.reason,
-          items: convertObjectsToRadioItems(cancellationReasons, 'name', 'id', 'cancellation[reason]')
-          }) }}
-
-        {{ govukTextarea({
+          {{ govukTextarea({
             name: "cancellation[notes]",
             id: "notes",
             label: {
-            text: "Provide any additional notes on why this placement was cancelled"
+            text: "Provide any additional notes on why this placement was withdrawn"
             }
         }) }}
+        {% endif %}
 
         {{ govukButton({
             text: "Submit"


### PR DESCRIPTION
Similar to https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/1440 https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/1439 we now add bookings to the new withdrawal flow.
As the booking can be withdrawn from the Application now we need to show and hide different inputs for the different roles. 'Manager's will see all the input and other roles won't.

It's difficult to determine the page that the user began the journey from after these changes from as they could have come from a range of different places so once the booking has been withdrawn we will navigate them to a confirmation page as per the mocks.

[Jira ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&selectedIssue=APS-251)

## Screenshots of UI changes

### Before

### After

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
      `production` in a backwards compatible way? (This includes our API,
      infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
      advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
