### PR TITLE
Fix unable to filter by all areas

### DIFF
--- a/server/controllers/admin/placementRequests/placementRequestsController.ts
+++ b/server/controllers/admin/placementRequests/placementRequestsController.ts
@@ -28,7 +28,11 @@ export default class PlacementRequestsController {
 
       const dashboard = await this.placementRequestService.getDashboard(
         req.user.token,
-        { status, apAreaId, requestType },
+        {
+          status,
+          apAreaId: apAreaId === 'all' ? undefined : apAreaId,
+          requestType,
+        },
         pageNumber,
         sortBy,
         sortDirection,

--- a/server/controllers/match/placementRequestsController.test.ts
+++ b/server/controllers/match/placementRequestsController.test.ts
@@ -5,11 +5,13 @@ import PlacementRequestsController from './placementRequestsController'
 
 import { ApplicationService, PlacementApplicationService, PlacementRequestService, TaskService } from '../../services'
 import {
+  apAreaFactory,
   applicationFactory,
   paginatedResponseFactory,
   placementApplicationFactory,
   placementRequestDetailFactory,
   taskFactory,
+  userDetailsFactory,
 } from '../../testutils/factories'
 import paths from '../../paths/placementApplications'
 import matchpaths from '../../paths/match'
@@ -81,6 +83,12 @@ describe('PlacementRequestsController', () => {
         'placement-application',
         Number(paginatedResponse.pageNumber),
       )
+    })
+
+    it('should send a request with an AP Area query value of the users area by default', async () => {
+      const apArea = apAreaFactory.build()
+      const user = userDetailsFactory.build({ apArea })
+      response.locals.user = user
     })
   })
 

--- a/server/controllers/tasksController.ts
+++ b/server/controllers/tasksController.ts
@@ -17,6 +17,7 @@ export default class TasksController {
     return async (req: Request, res: Response) => {
       const allocatedFilter = (req.query.allocatedFilter as AllocatedFilter) || 'allocated'
       const apAreaId = req.query.area ? req.query.area : res.locals.user.apArea?.id
+
       const {
         pageNumber,
         sortDirection = 'asc',
@@ -26,13 +27,14 @@ export default class TasksController {
         allocatedFilter,
         areas: apAreaId,
       })
+
       const tasks = await this.taskService.getAllReallocatable(
         req.user.token,
         allocatedFilter,
         sortBy,
         sortDirection,
         pageNumber,
-        apAreaId,
+        apAreaId === 'all' ? '' : apAreaId,
       )
       const apAreas = await this.apAreaService.getApAreas(req.user.token)
 

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -274,7 +274,7 @@ describe('formUtils', () => {
     ]
 
     it('converts objects to an array of select options', () => {
-      const result = convertObjectsToSelectOptions(objects, 'Select a keyworker', 'name', 'id', 'field', {})
+      const result = convertObjectsToSelectOptions(objects, 'Select a keyworker', 'name', 'id', 'field', '', {})
 
       expect(result).toEqual([
         {
@@ -296,7 +296,7 @@ describe('formUtils', () => {
     })
 
     it('marks the object that is in the context as selected', () => {
-      const result = convertObjectsToSelectOptions(objects, 'Select a keyworker', 'name', 'id', 'field', {
+      const result = convertObjectsToSelectOptions(objects, 'Select a keyworker', 'name', 'id', 'field', '', {
         field: '123',
       })
 
@@ -310,6 +310,28 @@ describe('formUtils', () => {
           text: 'abc',
           value: '123',
           selected: true,
+        },
+        {
+          text: 'def',
+          value: '345',
+          selected: false,
+        },
+      ])
+    })
+
+    it('accepts a different default value', () => {
+      const result = convertObjectsToSelectOptions(objects, 'All workers', 'name', 'id', 'field', 'all', {})
+
+      expect(result).toEqual([
+        {
+          value: 'all',
+          text: 'All workers',
+          selected: true,
+        },
+        {
+          text: 'abc',
+          value: '123',
+          selected: false,
         },
         {
           text: 'def',

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -49,11 +49,12 @@ export const convertObjectsToSelectOptions = (
   textKey: string,
   valueKey: string,
   fieldName: string,
+  selectAllValue: string,
   context: Record<string, unknown>,
 ): Array<SelectOption> => {
   const options = [
     {
-      value: '',
+      value: selectAllValue,
       text: prompt,
       selected: !context[fieldName] || context[fieldName] === '',
     },

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -147,8 +147,9 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
       textKey: string,
       valueKey: string,
       fieldName: string,
+      selectAllValue = '',
     ) {
-      return convertObjectsToSelectOptions(items, prompt, textKey, valueKey, fieldName, this.ctx)
+      return convertObjectsToSelectOptions(items, prompt, textKey, valueKey, fieldName, selectAllValue, this.ctx)
     },
   )
   njkEnv.addGlobal(

--- a/server/views/admin/placementRequests/index.njk
+++ b/server/views/admin/placementRequests/index.njk
@@ -42,7 +42,7 @@
                 classes: "govuk-input--width-20",
                 id: "apArea",
                 name: "apArea",
-                items: convertObjectsToSelectOptions(apAreas, 'All areas', 'name', 'id', 'apArea', context)
+                items: convertObjectsToSelectOptions(apAreas, 'All areas', 'name', 'id', 'apArea', 'all', context)
               }) }}
             </div>
             <div class="govuk-grid-column-one-quarter">
@@ -53,7 +53,7 @@
                 },
                 id: "requestType",
                 name: "requestType",
-                items: convertObjectsToSelectOptions(PlacementRequestUtils.requestTypes, 'All request types', 'name', 'value', 'requestType', context)
+                items: convertObjectsToSelectOptions(PlacementRequestUtils.requestTypes, 'All request types', 'name', 'value', 'requestType', '', context)
               }) }}
             </div>
 

--- a/server/views/applications/pages/basic-information/confirm-your-details.njk
+++ b/server/views/applications/pages/basic-information/confirm-your-details.njk
@@ -103,7 +103,7 @@
                 classes: "govuk-visually-hidden"
             },
             classes: "govuk-input--width-20",
-            items: convertObjectsToSelectOptions(areas, 'All areas', 'name', 'id', 'area', context.page)
+            items: convertObjectsToSelectOptions(areas, 'All areas', 'name', 'id', 'area', '', context.page)
             },
             fetchContext())
         }}

--- a/server/views/assessments/pages/suitability-assessment/application-timeliness.njk
+++ b/server/views/assessments/pages/suitability-assessment/application-timeliness.njk
@@ -33,7 +33,7 @@
                             text: page.reasonForLateApplicationQuestion
 
                     },
-                    items: convertObjectsToSelectOptions(page.reasonsForLateApplicationReasons, 'Select an option', 'text', 'value', context)
+                    items: convertObjectsToSelectOptions(page.reasonsForLateApplicationReasons, 'Select an option', 'text', 'value', '', context)
                     },
                     fetchContext()
                 )

--- a/server/views/premises/index.njk
+++ b/server/views/premises/index.njk
@@ -24,7 +24,7 @@
               classes: "govuk-input--width-20",
               id: "selectedArea",
               name: "selectedArea",
-              items: convertObjectsToSelectOptions(areas, 'All areas', 'name', 'id', 'selectedArea', context)
+              items: convertObjectsToSelectOptions(areas, 'All areas', 'name', 'id', 'selectedArea', '', context)
           }) }}
       </div>
 

--- a/server/views/tasks/index.njk
+++ b/server/views/tasks/index.njk
@@ -35,7 +35,7 @@
                       },
                       id: "area",
                       name: "area",
-                      items: convertObjectsToSelectOptions(apAreas, 'All areas', 'name', 'id', 'selectedArea')
+                      items: convertObjectsToSelectOptions(apAreas, 'All areas', 'name', 'id', 'selectedArea', 'all')
                     }) }}
             </div>
             <div class="govuk-grid-column-two-third">


### PR DESCRIPTION
# Context

On the Task allocation dashboard and the CRU dashboard we are filtering the table by the users AP Area by default - by setting the users AP Area id as the query value if no value is selected. However as the 'All areas' option in the select is associated with a blank value, this means the user can no longer select All Areas - it will always default to their area.

# Changes in this PR

Instead adding a value of 'all' to the select option 'All areas', and changing this to undefined in the controller.

In order to make this change I have added a default parameter to the nunjucks global `convertObjectsToSelectOptions`, which allows us to pass in an alternative value for the first select item. I believe 'context' cannot be passed in from the nunjucks template, but I can see it has been passed in in some places, so we may want to check these.

## Screenshots of UI changes

### Before


https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/50752284/da52accc-62d8-4e57-8052-b8af54b6db71

https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/50752284/4c55952e-5a5c-4a4e-ac08-2112372ab53e

### After

https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/50752284/42b0de8a-ecad-415e-8dd8-711d6fca48f2

https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/50752284/7602d6e4-1a68-458a-b426-4efedef86dae

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
      `production` in a backwards compatible way? (This includes our API,
      infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
      advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
