### PR TITLE
Withdrawals fixes

### DIFF
--- a/integration_tests/pages/manage/cancellationCreate.ts
+++ b/integration_tests/pages/manage/cancellationCreate.ts
@@ -1,6 +1,7 @@
 import type { Cancellation } from '@approved-premises/api'
 import Page from '../page'
 import paths from '../../../server/paths/manage'
+import applyPaths from '../../../server/paths/apply'
 
 export default class CancellationCreatePage extends Page {
   constructor(
@@ -30,9 +31,15 @@ export default class CancellationCreatePage extends Page {
     this.clickSubmit()
   }
 
-  shouldHaveCorrectBacklink(): void {
+  shouldShowBacklinkToBooking(): void {
     cy.get('.govuk-back-link')
       .should('have.attr', 'href')
       .and('include', paths.bookings.show({ premisesId: this.premisesId, bookingId: this.bookingId }))
+  }
+
+  shouldShowBackLinkToApplicationWithdraw(applicationId: string): void {
+    cy.get('.govuk-back-link')
+      .should('have.attr', 'href')
+      .and('include', applyPaths.applications.withdrawables.show({ id: applicationId }))
   }
 }

--- a/integration_tests/tests/apply/withdrawApplication.cy.ts
+++ b/integration_tests/tests/apply/withdrawApplication.cy.ts
@@ -1,4 +1,5 @@
 import { ListPage } from '../../pages/apply'
+import NewWithdrawalPage from '../../pages/apply/newWithdrawal'
 
 import Page from '../../pages/page'
 import WithdrawApplicationPage from '../../pages/apply/withdrawApplicationPage'
@@ -29,6 +30,13 @@ context('Withdraw Application', () => {
 
     // When I click 'Withdraw' on an application
     listPage.clickWithdraw()
+
+    // Then I should see the withdrawal type page
+    const withdrawalTypePage = Page.verifyOnPage(NewWithdrawalPage, 'What do you want to withdraw?')
+
+    // When I select the withdrawal type and click submit
+    withdrawalTypePage.selectType('application')
+    withdrawalTypePage.clickSubmit()
 
     // Then I should see the withdraw confirmation page
     const withdrawConfirmationPage = Page.verifyOnPage(WithdrawApplicationPage)

--- a/server/controllers/apply/applications/withdrawalsController.test.ts
+++ b/server/controllers/apply/applications/withdrawalsController.test.ts
@@ -31,31 +31,29 @@ describe('withdrawalsController', () => {
   })
 
   describe('new', () => {
-    describe('if there are withdrawables', () => {
-      describe('and a selectedWithdrawableType', () => {
-        it('redirects to the withdrawables show page', async () => {
-          const errorsAndUserInput = createMock<ErrorsAndUserInput>()
-          ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
+    describe('if there is a selectedWithdrawableType', () => {
+      it('redirects to the withdrawables show page', async () => {
+        const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+        ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
 
-          const selectedWithdrawableType = 'booking'
-          const withdrawables = withdrawableFactory.buildList(1)
+        const selectedWithdrawableType = 'booking'
+        const withdrawables = withdrawableFactory.buildList(1)
 
-          applicationService.getWithdrawables.mockResolvedValue(withdrawables)
+        applicationService.getWithdrawables.mockResolvedValue(withdrawables)
 
-          const requestHandler = withdrawalsController.new()
+        const requestHandler = withdrawalsController.new()
 
-          await requestHandler(
-            { ...request, params: { id: applicationId }, body: { selectedWithdrawableType } },
-            response,
-            next,
-          )
+        await requestHandler(
+          { ...request, params: { id: applicationId }, body: { selectedWithdrawableType } },
+          response,
+          next,
+        )
 
-          expect(applicationService.getWithdrawables).toHaveBeenCalledWith(token, applicationId)
-          expect(response.redirect).toHaveBeenCalledWith(
-            302,
-            `${paths.applications.withdrawables.show({ id: applicationId })}?selectedWithdrawableType=${selectedWithdrawableType}`,
-          )
-        })
+        expect(applicationService.getWithdrawables).toHaveBeenCalledWith(token, applicationId)
+        expect(response.redirect).toHaveBeenCalledWith(
+          302,
+          `${paths.applications.withdrawables.show({ id: applicationId })}?selectedWithdrawableType=${selectedWithdrawableType}`,
+        )
       })
 
       describe('and no selectedWithdrawableType', () => {
@@ -83,7 +81,7 @@ describe('withdrawalsController', () => {
   })
 
   describe('if there are no withdrawables', () => {
-    it('renders the withdrawals reasons template', async () => {
+    it('renders the withdrawals type template', async () => {
       const errorsAndUserInput = createMock<ErrorsAndUserInput>()
       ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
       request.params.id = applicationId
@@ -93,12 +91,10 @@ describe('withdrawalsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('applications/withdrawals/new', {
-        pageHeading: 'Do you want to withdraw this application?',
-        applicationId,
-        errors: errorsAndUserInput.errors,
-        errorSummary: errorsAndUserInput.errorSummary,
-        ...errorsAndUserInput.userInput,
+      expect(response.render).toHaveBeenCalledWith('applications/withdrawables/new', {
+        pageHeading: 'What do you want to withdraw?',
+        id: applicationId,
+        withdrawables: [],
       })
     })
   })

--- a/server/controllers/apply/applications/withdrawalsController.ts
+++ b/server/controllers/apply/applications/withdrawalsController.ts
@@ -19,7 +19,7 @@ export default class WithdrawlsController {
 
       const withdrawables = await this.applicationService.getWithdrawables(req.user.token, id)
 
-      if (withdrawables.length === 0 || selectedWithdrawableType === 'application') {
+      if (selectedWithdrawableType === 'application') {
         return res.render('applications/withdrawals/new', {
           pageHeading: 'Do you want to withdraw this application?',
           applicationId: req.params.id,

--- a/server/controllers/manage/cancellationsController.ts
+++ b/server/controllers/manage/cancellationsController.ts
@@ -7,6 +7,7 @@ import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../
 import { DateFormats } from '../../utils/dateUtils'
 
 import paths from '../../paths/manage'
+import applyPaths from '../../paths/apply'
 import { hasRole } from '../../utils/users'
 
 export default class CancellationsController {
@@ -24,10 +25,8 @@ export default class CancellationsController {
       const cancellationReasons = await this.cancellationService.getCancellationReasons(req.user.token)
       let backLink: string
 
-      if (userInput.backLink) {
-        backLink = userInput.backLink as string
-      } else if (req.headers.referer) {
-        backLink = req.headers.referer
+      if (booking?.applicationId) {
+        backLink = applyPaths.applications.withdrawables.show({ id: booking.applicationId })
       } else {
         backLink = paths.bookings.show({ premisesId, bookingId })
       }

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -43,6 +43,7 @@ import { RestrictedPersonError } from '../errors'
 import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
 import { durationAndArrivalDateFromPlacementApplication } from '../placementRequests/placementApplicationSubmissionData'
 import { sortHeader } from '../sortHeader'
+import { linkTo } from '../utils'
 
 jest.mock('../placementRequests/placementApplicationSubmissionData')
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
@@ -648,8 +649,9 @@ describe('utils', () => {
       'returns a link to withdraw the application if the application status is %s',
       status => {
         const applicationSummary = applicationSummaryFactory.build({ status })
+
         expect(createWithdrawElement('id', applicationSummary)).toEqual({
-          html: '<a href="/applications/id/withdrawals/new" >Withdraw</a>',
+          html: linkTo(paths.applications.withdraw.new, { id: 'id' }, { text: 'Withdraw' }),
         })
       },
     )

--- a/server/utils/applications/withdrawables/index.test.ts
+++ b/server/utils/applications/withdrawables/index.test.ts
@@ -97,6 +97,7 @@ describe('withdrawableTypeRadioOptions', () => {
               {
                 text: 'See placement details (opens in a new tab)',
                 attributes: { 'data-cy-withdrawable-id': prWithdrawable.id },
+                openInNewTab: true,
               },
             ),
           },
@@ -111,6 +112,7 @@ describe('withdrawableTypeRadioOptions', () => {
               {
                 text: 'See booking details (opens in a new tab)',
                 attributes: { 'data-cy-withdrawable-id': booking.id },
+                openInNewTab: true,
               },
             ),
           },

--- a/server/utils/applications/withdrawables/index.ts
+++ b/server/utils/applications/withdrawables/index.ts
@@ -74,6 +74,7 @@ export const withdrawableRadioOptions = (
             {
               text: 'See placement details (opens in a new tab)',
               attributes: { 'data-cy-withdrawable-id': withdrawable.id },
+              openInNewTab: true,
             },
           ),
         },
@@ -97,6 +98,7 @@ export const withdrawableRadioOptions = (
             {
               text: 'See booking details (opens in a new tab)',
               attributes: { 'data-cy-withdrawable-id': withdrawable.id },
+              openInNewTab: true,
             },
           ),
         },

--- a/server/utils/assessments/tableUtils.test.ts
+++ b/server/utils/assessments/tableUtils.test.ts
@@ -22,6 +22,8 @@ import paths from '../../paths/assess'
 import { crnCell, tierCell } from '../tableUtils'
 import { AssessmentSortField, ApprovedPremisesAssessmentSummary as AssessmentSummary } from '../../@types/shared'
 import { sortHeader } from '../sortHeader'
+import { linkTo } from '../utils'
+import { laoName } from '../personUtils'
 
 jest.mock('../applications/arrivalDateFromApplication')
 
@@ -65,11 +67,16 @@ describe('tableUtils', () => {
     })
 
     it('returns a link to an assessment', () => {
-      expect(assessmentLink(assessment, person)).toMatchStringIgnoringWhitespace(`
-        <a href="${paths.assessments.show({
-          id: '123',
-        })}" data-cy-assessmentId="123" data-cy-applicationId="345">John Wayne</a>
-      `)
+      expect(assessmentLink(assessment, person)).toBe(
+        linkTo(
+          paths.assessments.show,
+          { id: assessment.id },
+          {
+            text: laoName(person),
+            attributes: { 'data-cy-assessmentId': assessment.id, 'data-cy-applicationId': assessment.applicationId },
+          },
+        ),
+      )
     })
 
     it('allows custom text to be specified', () => {

--- a/server/utils/bedUtils.test.ts
+++ b/server/utils/bedUtils.test.ts
@@ -12,6 +12,7 @@ import {
   actionCell,
   bedActions,
   bedDetails,
+  bedLink,
   bedNameCell,
   bedTableRows,
   characteristicsRow,
@@ -65,7 +66,7 @@ describe('bedUtils', () => {
   describe('actionCell', () => {
     it('returns a link to manage the room', () => {
       expect(actionCell(bed, premisesId)).toEqual({
-        html: `<a href="/premises/${premisesId}/beds/${bed.id}" data-cy-bedId="${bed.id}">Manage <span class="govuk-visually-hidden">bed ${bed.name}</span></a>`,
+        html: bedLink(bed, premisesId),
       })
     })
   })

--- a/server/utils/bedUtils.ts
+++ b/server/utils/bedUtils.ts
@@ -65,7 +65,7 @@ export const bedActions = (bed: BedDetail, premisesId: string) => {
   }
 }
 
-const bedLink = (bed: BedSummary, premisesId: string): string =>
+export const bedLink = (bed: BedSummary, premisesId: string): string =>
   linkTo(
     paths.premises.beds.show,
     { bedId: bed.id, premisesId },

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -260,6 +260,39 @@ describe('bookingUtils', () => {
         },
       ])
     })
+
+    it('should return link to the cancellations new page if the booking doesnt have an applicationId', () => {
+      const booking = bookingFactory.arrived().build({
+        applicationId: undefined,
+      })
+
+      expect(bookingActions(booking, premisesId)).toEqual([
+        {
+          items: [
+            {
+              text: 'Move person to a new bed',
+              classes: 'govuk-button--secondary',
+              href: paths.bookings.moves.new({ premisesId, bookingId: booking.id }),
+            },
+            {
+              text: 'Log departure',
+              classes: 'govuk-button--secondary',
+              href: paths.bookings.departures.new({ premisesId, bookingId: booking.id }),
+            },
+            {
+              text: 'Update departure date',
+              classes: 'govuk-button--secondary',
+              href: paths.bookings.extensions.new({ premisesId, bookingId: booking.id }),
+            },
+            {
+              text: 'Withdraw placement',
+              classes: 'govuk-button--secondary',
+              href: paths.bookings.cancellations.new({ premisesId, bookingId: booking.id }),
+            },
+          ],
+        },
+      ])
+    })
   })
 
   describe('generateConflictBespokeError', () => {

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -167,6 +167,10 @@ export const nameCell = (booking: PremisesBooking): TableCell =>
   isFullPerson(booking.person) ? { text: laoName(booking.person) } : { text: `LAO: ${booking.person.crn}` }
 
 export const bookingActions = (booking: Booking, premisesId: string): Array<IdentityBarMenu> => {
+  const withdrawalLink = booking?.applicationId
+    ? applyPaths.applications.withdraw.new({ id: booking?.applicationId })
+    : paths.bookings.cancellations.new({ premisesId, bookingId: booking.id })
+
   if (booking.status === 'awaiting-arrival' || booking.status === 'arrived') {
     const items = [
       {
@@ -190,7 +194,7 @@ export const bookingActions = (booking: Booking, premisesId: string): Array<Iden
       items.push({
         text: 'Withdraw placement',
         classes: 'govuk-button--secondary',
-        href: applyPaths.applications.withdraw.new({ id: booking.applicationId }),
+        href: withdrawalLink,
       })
       items.push({
         text: 'Change placement dates',
@@ -213,7 +217,7 @@ export const bookingActions = (booking: Booking, premisesId: string): Array<Iden
       items.push({
         text: 'Withdraw placement',
         classes: 'govuk-button--secondary',
-        href: applyPaths.applications.withdraw.new({ id: booking.applicationId }),
+        href: withdrawalLink,
       })
     }
 

--- a/server/utils/lostBedUtils.test.ts
+++ b/server/utils/lostBedUtils.test.ts
@@ -1,7 +1,13 @@
 import { add, sub } from 'date-fns'
 import { lostBedFactory, userDetailsFactory } from '../testutils/factories'
 import { DateFormats } from './dateUtils'
-import { lostBedTableHeaders, lostBedTableRows, lostBedsCountForToday, referenceNumberCell } from './lostBedUtils'
+import {
+  actionCell,
+  lostBedTableHeaders,
+  lostBedTableRows,
+  lostBedsCountForToday,
+  referenceNumberCell,
+} from './lostBedUtils'
 import { getRandomInt } from './utils'
 
 describe('lostBedUtils', () => {
@@ -76,6 +82,7 @@ describe('lostBedUtils', () => {
 
     it('returns table rows for a workflow manager', () => {
       const user = userDetailsFactory.build({ roles: ['workflow_manager'] })
+
       const expectedRows = [
         [
           { text: lostBed.bedName },
@@ -84,9 +91,7 @@ describe('lostBedUtils', () => {
           { text: lostBed.endDate },
           { text: lostBed.reason.name },
           { text: lostBed.referenceNumber },
-          {
-            html: `<a href="/premises/${premisesId}/beds/${lostBed.bedId}/lost-beds/${lostBed.id}" data-cy-lostBedId="${lostBed.id}">Manage <span class="govuk-visually-hidden">lost bed ${lostBed.bedName}</span></a>`,
-          },
+          actionCell(lostBed, premisesId),
         ],
       ]
       const rows = lostBedTableRows([lostBed], premisesId, user)

--- a/server/utils/matchUtils.test.ts
+++ b/server/utils/matchUtils.test.ts
@@ -1,3 +1,4 @@
+import paths from '../paths/match'
 import {
   apCharacteristicPairFactory,
   bedSearchParametersFactory,
@@ -42,6 +43,9 @@ import {
   specialistApTypeOptions,
   specialistSupportOptions,
 } from './placementCriteriaUtils'
+import { linkTo } from './utils'
+
+jest.mock('./utils.ts')
 
 describe('matchUtils', () => {
   beforeEach(() => {
@@ -272,12 +276,19 @@ describe('matchUtils', () => {
       const durationWeeks = '4'
       const durationDays = '1'
 
-      expect(
-        summaryCardHeader({ bedSearchResult, placementRequestId, startDate, durationDays, durationWeeks }),
-      ).toEqual(
-        `<a href="/placement-requests/${placementRequestId}/bookings/confirm?bedSearchResult=${encodeURIComponent(
-          encodeBedSearchResult(bedSearchResult),
-        )}&startDate=${startDate}&duration=29" >${bedSearchResult.premises.name} (Bed ${bedSearchResult.bed.name})</a>`,
+      summaryCardHeader({ bedSearchResult, placementRequestId, startDate, durationDays, durationWeeks })
+
+      expect(linkTo).toHaveBeenCalledWith(
+        paths.placementRequests.bookings.confirm,
+        { id: placementRequestId },
+        {
+          text: `${bedSearchResult.premises.name} (Bed ${bedSearchResult.bed.name})`,
+          query: {
+            bedSearchResult: encodeBedSearchResult(bedSearchResult),
+            startDate,
+            duration: String(Number(durationWeeks) * 7 + Number(durationDays)),
+          },
+        },
       )
     })
   })

--- a/server/utils/placementApplications/table.test.ts
+++ b/server/utils/placementApplications/table.test.ts
@@ -1,15 +1,34 @@
 import { placementApplicationTaskFactory } from '../../testutils/factories'
 import { nameCell, placementTypeCell, statusCell, tableRows } from './table'
 import { crnCell, tierCell } from '../tableUtils'
+import { linkTo, sentenceCase } from '../utils'
+import paths from '../../paths/placementApplications'
+
+jest.mock('../utils')
 
 describe('table', () => {
+  const stubLink = 'LINK'
+  const stubSentenceCase = 'SENTENCE_CASE'
+
+  beforeEach(() => {
+    jest.mocked(linkTo).mockReturnValue(stubLink)
+    jest.mocked(sentenceCase).mockReturnValue(stubSentenceCase)
+  })
+
   describe('nameCell', () => {
     it('returns the name of the service user and a link', () => {
       const task = placementApplicationTaskFactory.build()
 
-      expect(nameCell(task)).toEqual({
-        html: `<a href="/placement-applications/${task.id}/review" data-cy-placementApplicationId="${task.id}" data-cy-applicationId="${task.applicationId}">${task.personName}</a>`,
-      })
+      nameCell(task)
+
+      expect(linkTo).toHaveBeenCalledWith(
+        paths.placementApplications.review.show,
+        { id: task.id },
+        {
+          text: task.personName,
+          attributes: { 'data-cy-placementApplicationId': task.id, 'data-cy-applicationId': task.applicationId },
+        },
+      )
     })
   })
 
@@ -25,15 +44,37 @@ describe('table', () => {
     it('returns the correct placement type', () => {
       const task = placementApplicationTaskFactory.build({ status: 'complete' })
 
-      expect(statusCell(task)).toEqual({ html: '<strong class="govuk-tag">Complete</strong>' })
+      expect(statusCell(task)).toEqual({ html: `<strong class="govuk-tag">${stubSentenceCase}</strong>` })
+      expect(sentenceCase).toHaveBeenCalledWith(task.status)
     })
   })
 
   describe('tableRows', () => {
-    const tasks = placementApplicationTaskFactory.buildList(1)
+    it('returns the correct table rows', () => {
+      const tasks = placementApplicationTaskFactory.buildList(1)
 
-    expect(tableRows(tasks)).toEqual([
-      [nameCell(tasks[0]), crnCell(tasks[0]), tierCell(tasks[0]), placementTypeCell(tasks[0]), statusCell(tasks[0])],
-    ])
+      expect(tableRows(tasks)).toEqual([
+        [
+          {
+            html: stubLink,
+          },
+          crnCell(tasks[0]),
+          tierCell(tasks[0]),
+          placementTypeCell(tasks[0]),
+          statusCell(tasks[0]),
+        ],
+      ])
+      expect(linkTo).toHaveBeenCalledWith(
+        paths.placementApplications.review.show,
+        { id: tasks[0].id },
+        {
+          text: tasks[0].personName,
+          attributes: {
+            'data-cy-placementApplicationId': tasks[0].id,
+            'data-cy-applicationId': tasks[0].applicationId,
+          },
+        },
+      )
+    })
   })
 })

--- a/server/utils/placementRequests/applicationLink.test.ts
+++ b/server/utils/placementRequests/applicationLink.test.ts
@@ -1,12 +1,20 @@
-import { applicationLink } from './applicationLink'
 import { placementRequestFactory } from '../../testutils/factories'
+import { linkTo } from '../utils'
+import applyPaths from '../../paths/apply'
+import { applicationLink } from './applicationLink'
+
+jest.mock('../utils')
 
 describe('applicationLink', () => {
   it('returns a link to the application', () => {
     const placementRequest = placementRequestFactory.build()
 
-    expect(applicationLink(placementRequest, 'link text', 'hidden text')).toEqual(
-      `<a href="/applications/${placementRequest.applicationId}" >link text <span class="govuk-visually-hidden">hidden text</span></a>`,
+    applicationLink(placementRequest, 'link text', 'hidden text')
+
+    expect(linkTo).toHaveBeenCalledWith(
+      applyPaths.applications.show,
+      { id: placementRequest.applicationId },
+      { text: 'link text', hiddenText: 'hidden text' },
     )
   })
 })

--- a/server/utils/placementRequests/table.test.ts
+++ b/server/utils/placementRequests/table.test.ts
@@ -25,27 +25,45 @@ import { DateFormats } from '../dateUtils'
 import { allReleaseTypes } from '../applications/releaseTypeUtils'
 import { crnCell, tierCell } from '../tableUtils'
 import { sortHeader } from '../sortHeader'
-import { isFullPerson } from '../personUtils'
+import { laoName } from '../personUtils'
 import { FullPerson, PlacementRequestSortField } from '../../@types/shared'
+import { linkTo } from '../utils'
+import matchPaths from '../../paths/match'
+import adminPaths from '../../paths/admin'
+
+jest.mock('../utils.ts')
 
 describe('tableUtils', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
   describe('nameCell', () => {
     it('returns the name of the service user and a link with a task', () => {
       const task = placementRequestTaskFactory.build()
 
-      expect(nameCell(task)).toEqual({
-        html: `<a href="/placement-requests/${task.id}" data-cy-placementRequestId="${task.id}">${task.personName}</a>`,
-      })
+      nameCell(task)
+
+      expect(linkTo).toHaveBeenCalledWith(
+        matchPaths.placementRequests.show,
+        { id: task.id },
+        { text: task.personName, attributes: { 'data-cy-placementRequestId': task.id } },
+      )
     })
 
     it('returns the name of the service user and a link with a placement request', () => {
       const placementRequest = placementRequestWithFullPersonFactory.build()
 
-      expect(nameCell(placementRequest)).toEqual({
-        html: `<a href="/admin/placement-requests/${placementRequest.id}" data-cy-placementRequestId="${
-          placementRequest.id
-        }">${isFullPerson(placementRequest.person) ? placementRequest.person.name : placementRequest.person.crn}</a>`,
-      })
+      nameCell(placementRequest)
+
+      expect(linkTo).toHaveBeenCalledWith(
+        adminPaths.admin.placementRequests.show,
+        { id: placementRequest.id },
+        {
+          text: laoName(placementRequest.person as FullPerson),
+          attributes: { 'data-cy-placementRequestId': placementRequest.id },
+        },
+      )
     })
 
     it('returns an empty cell if the personName is blank', () => {
@@ -77,11 +95,16 @@ describe('tableUtils', () => {
       const restrictedPersonTask = placementRequestFactory.build()
       restrictedPersonTask.person = personFactory.build({ isRestricted: true })
 
-      expect(nameCell(restrictedPersonTask)).toEqual({
-        html: `<a href="/admin/placement-requests/${restrictedPersonTask.id}" data-cy-placementRequestId="${
-          restrictedPersonTask.id
-        }">LAO: ${(restrictedPersonTask.person as FullPerson)?.name}</a>`,
-      })
+      nameCell(restrictedPersonTask)
+
+      expect(linkTo).toHaveBeenCalledWith(
+        adminPaths.admin.placementRequests.show,
+        { id: restrictedPersonTask.id },
+        {
+          text: laoName(restrictedPersonTask.person as FullPerson),
+          attributes: { 'data-cy-placementRequestId': restrictedPersonTask.id },
+        },
+      )
     })
   })
 

--- a/server/utils/placementRequests/utils.test.ts
+++ b/server/utils/placementRequests/utils.test.ts
@@ -1,5 +1,10 @@
 import { personFactory, placementRequestFactory } from '../../testutils/factories'
 import { assessmentLink, formatReleaseType, mapPlacementRequestToBedSearchParams, searchButton } from './utils'
+import { linkTo } from '../utils'
+import paths from '../../paths/match'
+import assessPaths from '../../paths/assess'
+
+jest.mock('../utils')
 
 describe('utils', () => {
   describe('formatReleaseType', () => {
@@ -13,8 +18,12 @@ describe('utils', () => {
     it('returns a link to the search query', () => {
       const placementRequest = placementRequestFactory.build()
 
-      expect(searchButton(placementRequest)).toEqual(
-        `<a href="/placement-requests/${placementRequest.id}/beds/search" class="govuk-button">Search</a>`,
+      searchButton(placementRequest)
+
+      expect(linkTo).toHaveBeenCalledWith(
+        paths.placementRequests.beds.search,
+        { id: placementRequest.id },
+        { text: 'Search', attributes: { class: 'govuk-button' } },
       )
     })
   })
@@ -46,8 +55,12 @@ describe('utils', () => {
     it('returns a link to the assessment', () => {
       const placementRequest = placementRequestFactory.build()
 
-      expect(assessmentLink(placementRequest, 'link text', 'hidden text')).toEqual(
-        `<a href="/assessments/${placementRequest.assessmentId}" >link text <span class="govuk-visually-hidden">hidden text</span></a>`,
+      assessmentLink(placementRequest, 'link text', 'hidden text')
+
+      expect(linkTo).toHaveBeenCalledWith(
+        assessPaths.assessments.show,
+        { id: placementRequest.assessmentId },
+        { text: 'link text', hiddenText: 'hidden text' },
       )
     })
   })

--- a/server/utils/premisesUtils.test.ts
+++ b/server/utils/premisesUtils.test.ts
@@ -16,6 +16,7 @@ import {
 import { addOverbookingsToSchedule } from './addOverbookingsToSchedule'
 import { textValue } from './applications/utils'
 import paths from '../paths/manage'
+import { linkTo } from './utils'
 
 jest.mock('./addOverbookingsToSchedule')
 
@@ -256,9 +257,11 @@ describe('premisesUtils', () => {
             text: premises2.bedCount.toString(),
           },
           {
-            html: `<a href="${paths.premises.show({
-              premisesId: premises2.id,
-            })}" >View <span class="govuk-visually-hidden">about ${premises2.name}</span></a>`,
+            html: linkTo(
+              paths.premises.show,
+              { premisesId: premises2.id },
+              { text: 'View', hiddenText: `about ${premises2.name}` },
+            ),
           },
         ],
         [
@@ -272,9 +275,11 @@ describe('premisesUtils', () => {
             text: premises3.bedCount.toString(),
           },
           {
-            html: `<a href="${paths.premises.show({
-              premisesId: premises3.id,
-            })}" >View <span class="govuk-visually-hidden">about ${premises3.name}</span></a>`,
+            html: linkTo(
+              paths.premises.show,
+              { premisesId: premises3.id },
+              { text: 'View', hiddenText: `about ${premises3.name}` },
+            ),
           },
         ],
         [
@@ -288,9 +293,11 @@ describe('premisesUtils', () => {
             text: premises1.bedCount.toString(),
           },
           {
-            html: `<a href="${paths.premises.show({
-              premisesId: premises1.id,
-            })}" >View <span class="govuk-visually-hidden">about ${premises1.name}</span></a>`,
+            html: linkTo(
+              paths.premises.show,
+              { premisesId: premises1.id },
+              { text: 'View', hiddenText: `about ${premises1.name}` },
+            ),
           },
         ],
       ])

--- a/server/utils/tasks/listTable.test.ts
+++ b/server/utils/tasks/listTable.test.ts
@@ -12,10 +12,11 @@ import {
   tasksTableRows,
   unallocatedTableRows,
 } from './listTable'
-import { sentenceCase } from '../utils'
+import { kebabCase, linkTo, sentenceCase } from '../utils'
 import { DateFormats } from '../dateUtils'
 import { sortHeader } from '../sortHeader'
 import { TaskSortField } from '../../@types/shared'
+import paths from '../../paths/tasks'
 
 jest.mock('../dateUtils')
 
@@ -224,7 +225,14 @@ describe('table', () => {
         taskType: 'Assessment',
       })
       expect(nameAnchorCell(task)).toEqual({
-        html: `<a href="/tasks/assessment/${task.id}" data-cy-taskId="${task.id}" data-cy-applicationId="${task.applicationId}">${task.personName}</a>`,
+        html: linkTo(
+          paths.tasks.show,
+          { id: task.id, taskType: kebabCase(task.taskType) },
+          {
+            text: task.personName,
+            attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
+          },
+        ),
       })
     })
   })

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -300,7 +300,7 @@ describe('linkTo', () => {
   it('returns a link that will open in a new tab', () => {
     expect(
       linkTo(path('/foo'), {}, { text: 'Hello', query: { foo: 'bar' }, openInNewTab: true }),
-    ).toMatchStringIgnoringWhitespace('<a href="/foo?foo=bar">Hello</a>')
+    ).toMatchStringIgnoringWhitespace('<a href="/foo?foo=bar" target="_blank">Hello</a>')
   })
 })
 

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -296,6 +296,12 @@ describe('linkTo', () => {
       '<a href="/foo?foo=bar">Hello</a>',
     )
   })
+
+  it('returns a link that will open in a new tab', () => {
+    expect(
+      linkTo(path('/foo'), {}, { text: 'Hello', query: { foo: 'bar' }, openInNewTab: true }),
+    ).toMatchStringIgnoringWhitespace('<a href="/foo?foo=bar">Hello</a>')
+  })
 })
 
 describe('resolvePath', () => {

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -113,11 +113,13 @@ export const linkTo = <Pattern extends `/${string}`>(
     query = {},
     attributes = {},
     hiddenText = '',
+    openInNewTab = false,
   }: {
     text: string
     query?: Record<string, string>
     attributes?: Record<string, string>
     hiddenText?: string
+    openInNewTab?: boolean
   },
 ): string => {
   let linkBody = text
@@ -130,7 +132,7 @@ export const linkTo = <Pattern extends `/${string}`>(
     .map(a => `${a}="${attributes[a]}"`)
     .join(' ')
 
-  return `<a href="${path(params)}${createQueryString(query, { addQueryPrefix: true })}" ${attrBody}>${linkBody}</a>`
+  return `<a href="${path(params)}${createQueryString(query, { addQueryPrefix: true })}" ${attrBody} ${openInNewTab ? 'target="_blank"' : ''}>${linkBody}</a>`
 }
 
 /**


### PR DESCRIPTION
# Changes
1. Show the withdrawables select screen when there is only an Application to withdraw
2. Open booking/placement requests views in new tabs
3. Bookings without application IDs use the old withdrawables flow



