### PR TITLE
Fix withdrawal reasons

### DIFF
--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -47,11 +47,8 @@ import { durationAndArrivalDateFromPlacementApplication } from '../placementRequ
 import { sortHeader } from '../sortHeader'
 import { linkTo } from '../utils'
 
-export {
-  withdrawableTypeRadioOptions,
-  withdrawableRadioOptions,
-  placementApplicationWithdrawalReasons,
-} from './withdrawables'
+export { withdrawableTypeRadioOptions, withdrawableRadioOptions } from './withdrawables'
+export { placementApplicationWithdrawalReasons } from './withdrawables/withdrawlReasons'
 
 const applicationStatuses: Record<ApprovedPremisesApplicationStatus, string> = {
   started: 'Application started',

--- a/server/utils/applications/withdrawables/index.test.ts
+++ b/server/utils/applications/withdrawables/index.test.ts
@@ -1,5 +1,5 @@
 import { bookingFactory, withdrawableFactory } from '../../../testutils/factories'
-import { placementApplicationWithdrawalReasons, withdrawableRadioOptions, withdrawableTypeRadioOptions } from '.'
+import { withdrawableRadioOptions, withdrawableTypeRadioOptions } from '.'
 import { DateFormats } from '../../dateUtils'
 import { linkTo } from '../../utils'
 import matchPaths from '../../../paths/match'
@@ -120,62 +120,6 @@ describe('withdrawableTypeRadioOptions', () => {
             .map(datePeriod => DateFormats.formatDurationBetweenTwoDates(datePeriod.startDate, datePeriod.endDate))
             .join(', ')}`,
           value: bookingWithdrawable.id,
-        },
-      ])
-    })
-  })
-
-  describe('placementApplicationWithdrawalReasons', () => {
-    it('returns the reasons for withdrawing a placement application', () => {
-      expect(placementApplicationWithdrawalReasons('DuplicatePlacementRequest')).toEqual([
-        {
-          divider: 'The placement is no longer needed',
-        },
-        {
-          checked: false,
-          text: 'Another provision has been identified',
-          value: 'AlternativeProvisionIdentified',
-        },
-        {
-          checked: false,
-          text: 'Their circumstances changed',
-          value: 'CircumstancesChanged',
-        },
-        {
-          checked: false,
-          text: 'The release decision changed',
-          value: 'ReleaseDecisionChanged',
-        },
-        {
-          divider: 'The placement is unavailable',
-        },
-        {
-          checked: false,
-          text: "There's no capacity due to a lost bed",
-          value: 'NoCapacityLostBed',
-        },
-        {
-          checked: false,
-          text: "There's no capacity due to placement prioritisation",
-          value: 'NoCapcityPlacementPrioritisation',
-        },
-        {
-          checked: false,
-          text: "There's no capacity",
-          value: 'NoCapacity',
-        },
-        {
-          divider: 'Problem in placement',
-        },
-        {
-          checked: false,
-          text: 'There was an error in the request',
-          value: 'ErrorInRequest',
-        },
-        {
-          checked: true,
-          text: 'The request was a duplicate',
-          value: 'DuplicatePlacementRequest',
         },
       ])
     })

--- a/server/utils/applications/withdrawables/index.ts
+++ b/server/utils/applications/withdrawables/index.ts
@@ -4,7 +4,6 @@ import matchPaths from '../../../paths/match'
 import managePaths from '../../../paths/manage'
 import { DateFormats } from '../../dateUtils'
 import { linkTo } from '../../utils'
-import { WithdrawPlacementRequestReason } from '../../../@types/shared/models/WithdrawPlacementRequestReason'
 
 export type SelectedWithdrawableType = 'application' | 'placementRequest' | 'booking'
 
@@ -106,55 +105,4 @@ export const withdrawableRadioOptions = (
     }
     throw new Error(`Unknown withdrawable type: ${withdrawable.type}`)
   })
-}
-
-export const placementApplicationWithdrawalReasons = (
-  selectedReason: WithdrawPlacementRequestReason,
-): Array<RadioItem | { divider: string }> => {
-  return [
-    { divider: 'The placement is no longer needed' },
-    {
-      text: 'Another provision has been identified',
-      value: 'AlternativeProvisionIdentified',
-      checked: selectedReason === 'AlternativeProvisionIdentified',
-    },
-    {
-      text: 'Their circumstances changed',
-      value: 'CircumstancesChanged',
-      checked: selectedReason === 'ChangeInCircumstances',
-    },
-    {
-      text: 'The release decision changed',
-      value: 'ReleaseDecisionChanged',
-      checked: selectedReason === 'ChangeInReleaseDecision',
-    },
-
-    { divider: 'The placement is unavailable' },
-    {
-      text: "There's no capacity due to a lost bed",
-      value: 'NoCapacityLostBed',
-      checked: selectedReason === 'NoCapacityDueToLostBed',
-    },
-    {
-      text: "There's no capacity due to placement prioritisation",
-      value: 'NoCapcityPlacementPrioritisation',
-      checked: selectedReason === 'NoCapacityDueToPlacementPrioritisation',
-    },
-    {
-      text: "There's no capacity",
-      value: 'NoCapacity',
-      checked: selectedReason === 'NoCapacity',
-    },
-    { divider: 'Problem in placement' },
-    {
-      text: 'There was an error in the request',
-      value: 'ErrorInRequest',
-      checked: selectedReason === 'ErrorInPlacementRequest',
-    },
-    {
-      text: 'The request was a duplicate',
-      value: 'DuplicatePlacementRequest',
-      checked: selectedReason === 'DuplicatePlacementRequest',
-    },
-  ]
 }

--- a/server/utils/applications/withdrawables/withdrawlReasons.test.ts
+++ b/server/utils/applications/withdrawables/withdrawlReasons.test.ts
@@ -1,0 +1,57 @@
+import { placementApplicationWithdrawalReasons } from './withdrawlReasons'
+
+describe('placementApplicationWithdrawalReasons', () => {
+  it('returns the reasons for withdrawing a placement application', () => {
+    expect(placementApplicationWithdrawalReasons('DuplicatePlacementRequest')).toEqual([
+      {
+        divider: 'The placement is no longer needed',
+      },
+      {
+        checked: false,
+        text: 'Another provision has been identified',
+        value: 'AlternativeProvisionIdentified',
+      },
+      {
+        checked: false,
+        text: 'Their circumstances changed',
+        value: 'ChangeInCircumstances',
+      },
+      {
+        checked: false,
+        text: 'The release decision changed',
+        value: 'ChangeInReleaseDecision',
+      },
+      {
+        divider: 'The placement is unavailable',
+      },
+      {
+        checked: false,
+        text: "There's no capacity due to a lost bed",
+        value: 'NoCapacityDueToLostBed',
+      },
+      {
+        checked: false,
+        text: "There's no capacity due to placement prioritisation",
+        value: 'NoCapacityDueToPlacementPrioritisation',
+      },
+      {
+        checked: false,
+        text: "There's no capacity",
+        value: 'NoCapacity',
+      },
+      {
+        divider: 'Problem in placement',
+      },
+      {
+        checked: false,
+        text: 'There was an error in the request',
+        value: 'ErrorInPlacementRequest',
+      },
+      {
+        checked: true,
+        text: 'The request was a duplicate',
+        value: 'DuplicatePlacementRequest',
+      },
+    ])
+  })
+})

--- a/server/utils/applications/withdrawables/withdrawlReasons.ts
+++ b/server/utils/applications/withdrawables/withdrawlReasons.ts
@@ -1,0 +1,56 @@
+import { WithdrawPlacementRequestReason } from '../../../@types/shared/models/WithdrawPlacementRequestReason'
+import { RadioItem } from '../../../@types/ui'
+import { convertKeyValuePairToRadioItems } from '../../formUtils'
+
+const withdrawalReasons: Record<WithdrawPlacementRequestReason, string> = {
+  AlternativeProvisionIdentified: 'Another provision has been identified',
+  ChangeInCircumstances: 'Their circumstances changed',
+  ChangeInReleaseDecision: 'The release decision changed',
+  NoCapacityDueToLostBed: "There's no capacity due to a lost bed",
+  NoCapacityDueToPlacementPrioritisation: "There's no capacity due to placement prioritisation",
+  NoCapacity: "There's no capacity",
+  ErrorInPlacementRequest: 'There was an error in the request',
+  DuplicatePlacementRequest: 'The request was a duplicate',
+}
+
+const placementNoLongerNeededReasons = [
+  'AlternativeProvisionIdentified',
+  'ChangeInCircumstances',
+  'ChangeInReleaseDecision',
+] as const
+
+const noCapacityReasons = ['NoCapacityDueToLostBed', 'NoCapacityDueToPlacementPrioritisation', 'NoCapacity'] as const
+
+const problemInPlacementReasons = ['ErrorInPlacementRequest', 'DuplicatePlacementRequest'] as const
+
+type PlacementNoLongerNeededReasons = Extract<
+  WithdrawPlacementRequestReason,
+  (typeof placementNoLongerNeededReasons)[number]
+>
+
+type NoCapacityReasons = Extract<WithdrawPlacementRequestReason, (typeof noCapacityReasons)[number]>
+
+type ProblemInPlacementReasons = Extract<WithdrawPlacementRequestReason, (typeof problemInPlacementReasons)[number]>
+
+const filterByType = <T extends WithdrawPlacementRequestReason>(keys: Readonly<Array<string>>): Record<T, string> => {
+  return Object.keys(withdrawalReasons)
+    .filter(k => keys.includes(k))
+    .reduce((criteria, key) => ({ ...criteria, [key]: withdrawalReasons[key] }), {}) as Record<T, string>
+}
+
+const placementNoLongerNeededOptions = filterByType<PlacementNoLongerNeededReasons>(placementNoLongerNeededReasons)
+const noCapacityOptions = filterByType<NoCapacityReasons>(noCapacityReasons)
+const problemInPlacementOptions = filterByType<ProblemInPlacementReasons>(problemInPlacementReasons)
+
+export const placementApplicationWithdrawalReasons = (
+  selectedReason: WithdrawPlacementRequestReason,
+): Array<RadioItem | { divider: string }> => {
+  return [
+    { divider: 'The placement is no longer needed' },
+    ...convertKeyValuePairToRadioItems(placementNoLongerNeededOptions, selectedReason),
+    { divider: 'The placement is unavailable' },
+    ...convertKeyValuePairToRadioItems(noCapacityOptions, selectedReason),
+    { divider: 'Problem in placement' },
+    ...convertKeyValuePairToRadioItems(problemInPlacementOptions, selectedReason),
+  ]
+}


### PR DESCRIPTION
Some of these reasons weren’t matching up with the ones in the API, so we were getting Bad Request errors. This tightens up the reasons so they’re more strongly typed, so we know the API is going to accept them.