### PR TITLE
Add link to Withdraw application from the application show page

### DIFF
--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -16,6 +16,7 @@ import {
   mapPlacementApplicationToSummaryCards,
 } from '../../../server/utils/applications/utils'
 import { TextItem } from '../../../server/@types/ui'
+import paths from '../../../server/paths/apply'
 
 export default class ShowPage extends Page {
   constructor(private readonly application: Application) {
@@ -39,6 +40,18 @@ export default class ShowPage extends Page {
 
   clickAddNote() {
     cy.get('button').contains('Add note').click()
+  }
+
+  clickActions() {
+    cy.get('.moj-button-menu > .govuk-button').click()
+  }
+
+  shouldHaveWithdrawalLink() {
+    cy.get(`[data-cy-withdraw-application="${this.application.id}"]`).should(
+      'have.attr',
+      'href',
+      paths.applications.withdrawables.show({ id: this.application.id }),
+    )
   }
 
   shouldNotShowCreatePlacementButton() {

--- a/integration_tests/tests/apply/viewApplication.cy.ts
+++ b/integration_tests/tests/apply/viewApplication.cy.ts
@@ -43,6 +43,9 @@ context('show applications', () => {
     showPage.shouldShowPersonInformation()
     showPage.shouldShowResponses()
 
+    showPage.clickActions()
+    showPage.shouldHaveWithdrawalLink()
+
     // When I click on the 'Timeline' tab
     // Then I should see timeline page
     showPage.clickTimelineTab()

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -153,6 +153,48 @@ describe('applicationsController', () => {
       })
     })
 
+    describe('when NEW_WITHDRAWALS_FLOW_DISABLED is truthy', () => {
+      it('returns the old withdrawals link', async () => {
+        process.env.NEW_WITHDRAWALS_FLOW_DISABLED = '1'
+
+        application.status = 'submitted'
+
+        const requestHandler = applicationsController.show()
+
+        applicationService.findApplication.mockResolvedValue(application)
+
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith('applications/show', {
+          application,
+          referrer,
+          tab: 'application',
+          pageHeading: 'Approved Premises application',
+          withdrawalLink: paths.applications.withdraw.new({ id: application.id }),
+        })
+      })
+
+      it('returns the old withdrawals link', async () => {
+        process.env.NEW_WITHDRAWALS_FLOW_DISABLED = ''
+
+        application.status = 'submitted'
+
+        const requestHandler = applicationsController.show()
+
+        applicationService.findApplication.mockResolvedValue(application)
+
+        await requestHandler(request, response, next)
+
+        expect(response.render).toHaveBeenCalledWith('applications/show', {
+          application,
+          referrer,
+          tab: 'application',
+          pageHeading: 'Approved Premises application',
+          withdrawalLink: paths.applications.withdrawables.show({ id: application.id }),
+        })
+      })
+    })
+
     it('fetches the application from the API and renders the task list if the application is started', async () => {
       application.status = 'started'
 
@@ -274,6 +316,7 @@ describe('applicationsController', () => {
         referrer,
         tab: 'application',
         pageHeading: 'Approved Premises application',
+        withdrawalLink: paths.applications.withdrawables.show({ id: application.id }),
       })
 
       expect(applicationService.findApplication).toHaveBeenCalledWith(token, application.id)

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -76,6 +76,10 @@ export default class ApplicationsController {
       const { errors, errorSummary } = fetchErrorsAndUserInput(req)
 
       if (application.status !== 'started') {
+        const withdrawalLink = process.env.NEW_WITHDRAWALS_FLOW_DISABLED
+          ? paths.applications.withdraw.new({ id: application.id })
+          : paths.applications.withdrawables.show({ id: application.id })
+
         const referrer = req.headers.referer
         const defaultParams = { application, referrer, pageHeading: 'Approved Premises application' }
 
@@ -101,7 +105,7 @@ export default class ApplicationsController {
           })
         }
 
-        return res.render('applications/show', { ...defaultParams, tab: 'application' })
+        return res.render('applications/show', { ...defaultParams, tab: 'application', withdrawalLink })
       }
       return res.render('applications/tasklist', { application, taskList, errorSummary, errors })
     }

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -5,6 +5,7 @@
 {% from "./partials/_readonly-application.njk" import applicationReadonlyView %}
 {% from "./partials/_timeline.njk" import timeline %}
 {% from "./partials/_request-a-placement.njk" import requestAPlacement %}
+{%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
 
 {% extends "../partials/layout.njk" %}
@@ -46,7 +47,14 @@
         }) }}
       {% endif %}
 
-      {{ mojSubNavigation({
+      {% set subNavClasses = "govuk-grid-column-full" %}
+
+      {% if tab === ApplyUtils.applicationShowPageTabs.application %}
+        {% set subNavClasses =  "govuk-grid-column-three-quarters govuk-!-padding-right-0" %}
+      {% endif %}
+
+      <div class="{{subNavClasses}}">
+        {{ mojSubNavigation({
         items: [{
           text: 'Application',
           href: ApplyUtils.applicationShowPageTab(application.id, ApplyUtils.applicationShowPageTabs.application),
@@ -60,17 +68,50 @@
           text: 'Placement requests',
           href: ApplyUtils.applicationShowPageTab(application.id, ApplyUtils.applicationShowPageTabs.placementRequests),
           active: tab === ApplyUtils.applicationShowPageTabs.placementRequests
-        }]
+        }
+        ]
       }) }}
+      </div>
 
-      {% if tab === ApplyUtils.applicationShowPageTabs.timeline %}
-        {{ timeline(mapTimelineEventsForUi(timelineEvents), application, csrfToken) }}
-      {% elif tab === ApplyUtils.applicationShowPageTabs.placementRequests %}
-        {{ requestAPlacement(placementApplications, application, user, csrfToken) }}
-      {% else %}
-        {{ applicationReadonlyView(application) }}
-      {% endif %}
+      {% if tab === ApplyUtils.applicationShowPageTabs.application %}
+        <div class="govuk-grid-column-one-quarter govuk-!-padding-left-0 govuk-!-padding-right-0">
 
+          {{ mojIdentityBar({
+          classes: 'govuk-!-padding-top-0 govuk-!-padding-bottom-0 govuk-!-margin-top-0 govuk-!-margin-bottom-0',
+          menus: [{
+            items: [
+            {
+              text: "Withdraw application",
+              href: withdrawalLink,
+              classes: "govuk-button--secondary",
+              attributes: {
+                "data-cy-withdraw-application": application.id
+              }
+            }
+          ]
+          }]
+        }) }}
+        </div>
+
+        {%endif%}
+
+        <div class="govuk-grid-column-full">
+          {% if tab === ApplyUtils.applicationShowPageTabs.timeline %}
+            {{ timeline(mapTimelineEventsForUi(timelineEvents), application, csrfToken) }}
+          {% elif tab === ApplyUtils.applicationShowPageTabs.placementRequests %}
+            {{ requestAPlacement(placementApplications, application, user, csrfToken) }}
+          {% else %}
+            {{ applicationReadonlyView(application) }}
+          {% endif %}
+        </div>
+      </div>
     </div>
-  </div>
-{% endblock %}
+  {% endblock %}
+
+  {% block extraScripts %}
+    {% if tab === ApplyUtils.applicationShowPageTabs.application %}
+      <script type="text/javascript" nonce="{{ cspNonce }}">
+        new MOJFrontend.ButtonMenu({container: $('.moj-button-menu'), mq: "(min-width: 200em)", buttonText: "Actions", menuClasses: "moj-button-menu__wrapper--right"});
+      </script>
+      {%endif%}
+    {% endblock %}


### PR DESCRIPTION
This was in [the mocks](https://www.figma.com/file/kP7jyX3L01CQap6ErAX648/Approved-Premises-Beta?type=design&mode=design&t=JvIQmfnWt288NG7I-0) but missed on implementation.

### Before
![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/90f8dedc-2dca-4978-9dcf-7c9ddddaa846)

### After
<img width="731" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/1a30cc73-0626-4c8c-a72a-9e9f61748158">
