### PR TITLE
APS 282 - filter users when viewing a task

### DIFF
--- a/server/services/taskService.ts
+++ b/server/services/taskService.ts
@@ -7,6 +7,7 @@ import {
   TaskSortField,
   TaskWrapper,
   ApprovedPremisesUser as User,
+  UserQualification,
 } from '@approved-premises/api'
 import { GroupedMatchTasks, PaginatedResponse } from '@approved-premises/ui'
 import { RestClientBuilder } from '../data'
@@ -65,10 +66,26 @@ export default class TaskService {
     return results
   }
 
-  async find(token: string, premisesId: string, taskType: string): Promise<TaskWrapper> {
+  async find(
+    token: string,
+    premisesId: string,
+    taskType: string,
+    userFilters: { apAreaId?: string; qualification?: UserQualification },
+  ): Promise<TaskWrapper> {
     const taskClient = this.taskClientFactory(token)
 
     const task = await taskClient.find(premisesId, taskType)
+
+    const { apAreaId, qualification } = userFilters
+
+    if (apAreaId || qualification) {
+      task.users = task.users.filter(user => {
+        const includesApAreaIdIfFilter = apAreaId ? user.apArea.id === apAreaId : true
+        const includesQualificationIfFilter = qualification ? user.qualifications.includes(qualification) : true
+        return includesApAreaIdIfFilter && includesQualificationIfFilter
+      })
+    }
+
     return task
   }
 

--- a/server/testutils/factories/user.ts
+++ b/server/testutils/factories/user.ts
@@ -45,7 +45,7 @@ const roleFactory = Factory.define<UserRole>(() =>
   ]),
 )
 
-const qualificationFactory = Factory.define<UserQualification>(() =>
+export const qualificationFactory = Factory.define<UserQualification>(() =>
   faker.helpers.arrayElement(['pipe', 'emergency', 'esap', 'lao', 'womens']),
 )
 

--- a/server/utils/tasks/index.ts
+++ b/server/utils/tasks/index.ts
@@ -6,7 +6,7 @@ import { arrivalDateFromApplication } from '../applications/arrivalDateFromAppli
 import { getApplicationType } from '../applications/utils'
 import { DateFormats } from '../dateUtils'
 import { nameOrPlaceholderCopy } from '../personUtils'
-import { allocatedTableRows, tasksTableHeader, tasksTableRows, unallocatedTableRows } from './listTable'
+import { allocatedTableRows, taskParams, tasksTableHeader, tasksTableRows, unallocatedTableRows } from './listTable'
 import { userTableHeader, userTableRows } from './usersTable'
 
 type GroupedTasks = {
@@ -86,6 +86,7 @@ export {
   allocatedTableRows,
   groupByAllocation,
   unallocatedTableRows,
+  taskParams,
   tasksTableHeader,
   tasksTableRows,
   userTableHeader,

--- a/server/utils/tasks/listTable.test.ts
+++ b/server/utils/tasks/listTable.test.ts
@@ -7,6 +7,7 @@ import {
   nameAnchorCell,
   statusBadge,
   statusCell,
+  taskParams,
   taskTypeCell,
   tasksTableHeader,
   tasksTableRows,
@@ -233,6 +234,18 @@ describe('table', () => {
             attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
           },
         ),
+      })
+    })
+  })
+
+  describe('taskParams', () => {
+    it('returns task parameter object with task type in correct case', () => {
+      const task = taskFactory.build({ taskType: 'PlacementRequest' })
+      const result = taskParams(task)
+
+      expect(result).toEqual({
+        id: task.id,
+        taskType: 'placement-request',
       })
     })
   })

--- a/server/utils/tasks/listTable.ts
+++ b/server/utils/tasks/listTable.ts
@@ -27,14 +27,10 @@ const allocationCell = (task: Task): TableCell => ({
 })
 
 const nameAnchorCell = (task: Task): TableCell => ({
-  html: linkTo(
-    paths.tasks.show,
-    { id: task.id, taskType: kebabCase(task.taskType) },
-    {
-      text: task.personName,
-      attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
-    },
-  ),
+  html: linkTo(paths.tasks.show, taskParams(task), {
+    text: task.personName,
+    attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
+  }),
 })
 
 const statusBadge = (task: Task): string => {
@@ -138,6 +134,8 @@ const tasksTableHeader = (
     : unAllocatedTableHeader(sortBy, sortDirection, hrefPrefix)
 }
 
+const taskParams = (task: Task) => ({ id: task.id, taskType: kebabCase(task.taskType) })
+
 export {
   allocatedTableRows,
   tasksTableHeader,
@@ -150,4 +148,5 @@ export {
   statusBadge,
   tasksTableRows,
   unallocatedTableRows,
+  taskParams,
 }

--- a/server/utils/tasks/usersTable.test.ts
+++ b/server/utils/tasks/usersTable.test.ts
@@ -11,7 +11,7 @@ describe('userTableRows', () => {
       [
         { text: user.name },
         {
-          text: user.region.name,
+          text: user.apArea?.name,
         },
         qualificationCell(user),
         allocationCell(user, 'numTasksPending'),
@@ -33,7 +33,7 @@ describe('userTableHeader', () => {
         },
       },
       {
-        text: 'Region',
+        text: 'AP Area',
       },
       {
         text: 'Qualification',

--- a/server/utils/tasks/usersTable.ts
+++ b/server/utils/tasks/usersTable.ts
@@ -11,7 +11,7 @@ export const userTableHeader = () => [
       'aria-sort': 'ascending',
     },
   },
-  { text: 'Region' },
+  { text: 'AP Area' },
   { text: 'Qualification' },
   {
     text: 'Tasks pending',
@@ -37,7 +37,7 @@ export const userTableHeader = () => [
 export const userTableRows = (users: Array<UserWithWorkload>, task: Task, csrfToken: string): Array<TableRow> => {
   return users.map(user => [
     nameCell(user),
-    regionCell(user),
+    apAreaCell(user),
     qualificationCell(user),
     allocationCell(user, 'numTasksPending'),
     allocationCell(user, 'numTasksCompleted7Days'),
@@ -52,7 +52,7 @@ type AllocationType = Extract<
 >
 
 export const nameCell = (user: UserWithWorkload): TableCell => ({ text: user.name })
-export const regionCell = (user: UserWithWorkload): TableCell => ({ text: user.region.name })
+export const apAreaCell = (user: UserWithWorkload): TableCell => ({ text: user.apArea?.name })
 export const qualificationCell = (user: UserWithWorkload): TableCell => ({
   text: user.qualifications.map(qualification => qualificationDictionary[qualification]).join(', '),
 })

--- a/server/views/tasks/show.njk
+++ b/server/views/tasks/show.njk
@@ -22,23 +22,63 @@
 
       {{ showErrorSummary(errorSummary) }}
     </div>
-
-    <div class="govuk-grid-column-full">
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">Allocate task to</h2>
-
-      {{
-        govukTable({
-            attributes: {
-              'data-module': 'moj-sortable-table'
-            },
-            firstCellIsHeader: true,
-            head: TaskUtils.userTableHeader(),
-            rows: TaskUtils.userTableRows(users, task, csrfToken)
-          })
-      }}
-
     </div>
   </div>
+  <div class="search-and-filter__wrapper">
+    <form action="{{ paths.tasks.show(TaskUtils.taskParams(task)) }}" method="get">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-quarter">
+          <h2 class="govuk-heading-m">Filters</h2>
+        </div>
+      </div>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-quarter">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+          {{ govukSelect({
+                  label: {
+                    text: "Region",
+                    classes: "govuk-label--s"
+                  },
+                  id: "apAreaId",
+                  name: "apAreaId",
+                  items: convertObjectsToSelectOptions(apAreas, 'All areas', 'name', 'id', 'apAreaId')
+                }) }}
+        </div>
+        <div class="govuk-grid-column-one-quarter">
+          {{ govukSelect({
+                  label: {
+                    text: "Qualifications",
+                    classes: "govuk-label--s"
+                  },
+                  id: "qualification",
+                  name: "qualification",
+                  items: UserUtils.userQualificationsSelectOptions(qualification)
+                }) }}
+        </div>
+        <div class="govuk-grid-column-one-quarter">
+          {{ govukButton({
+                  "name": "submit",
+                  "text": "Apply filters",
+                  "classes": "search-and-filter__submit"
+              }) }}
+        </div>
+      </div>
+    </form>
+  </div>
+  {{
+    govukTable({
+      attributes: {
+        'data-module': 'moj-sortable-table'
+      },
+      firstCellIsHeader: true,
+      head: TaskUtils.userTableHeader(),
+      rows: TaskUtils.userTableRows(users, task, csrfToken)
+    })
+  }}
 </div>
 
 {% endblock %}


### PR DESCRIPTION
# Context

This adds the option to filter users by AP Area and/or qualification on a task allocations page.
As we are filtering by AP Area, have also changed the 'region' column to show 'AP Area'.

[Jira](https://dsdmoj.atlassian.net/browse/APS-282?atlOrigin=eyJpIjoiM2NmN2VmNmQ0NDU1NDA4N2FjMmQyYWU2Yzc0NDQ0MzUiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- Change 'Region' column to AP Area
- Add a filter form to the view to match other table filters
- Update tasksService to filter users associated with a task by new filter parameters
- Add a method to taskUtils class to return the task parameters with the correct kebab case for task type
- Add integration tests for different filter scenarios

## Screenshots of UI changes

### Before

User table on task allocations page with no filters:
![](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/50752284/92fcebc9-487e-4c06-a605-7c35ade776ad)

### After

Now able to filter the user table on task allocations page:

https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/50752284/c9e99a97-e1a9-434c-ac71-b4448368493c

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
      `production` in a backwards compatible way? (This includes our API,
      infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
      advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
