### PR TITLE
(APS-240) Record appeal decision

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -1,6 +1,7 @@
 import { SuperAgentRequest } from 'superagent'
 
 import type {
+  Appeal,
   ApplicationSortField,
   ApplicationTimelineNote,
   ApprovedPremisesApplication,
@@ -14,6 +15,7 @@ import type {
 import { getMatchingRequests, stubFor } from './setup'
 import paths from '../../server/paths/api'
 import { ApplicationDashboardSearchOptions } from '../../server/@types/ui'
+import { errorStub } from './utils'
 
 export default {
   stubApplications: (applications: Array<ApprovedPremisesApplicationSummary>): SuperAgentRequest =>
@@ -276,6 +278,20 @@ export default {
         jsonBody: withdrawables,
       },
     }),
+  stubAppealCreate: ({ applicationId, appeal }: { applicationId: string; appeal: Appeal }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: paths.applications.appeals.create({ id: applicationId }),
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: appeal,
+      },
+    }),
+  stubAppealErrors: ({ applicationId, params }: { applicationId: string; params: Array<string> }) =>
+    stubFor(errorStub(params, paths.applications.appeals.create({ id: applicationId }))),
   verifyApplicationWithdrawn: async (args: { applicationId: string }) =>
     (
       await getMatchingRequests({
@@ -309,6 +325,13 @@ export default {
       await getMatchingRequests({
         method: 'POST',
         url: paths.applications.addNote({ id: args.id }),
+      })
+    ).body.requests,
+  verifyAppealCreated: async (args: { applicationId: string }) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: paths.applications.appeals.create({ id: args.applicationId }),
       })
     ).body.requests,
 }

--- a/integration_tests/pages/apply/appeal.ts
+++ b/integration_tests/pages/apply/appeal.ts
@@ -1,0 +1,23 @@
+import type { ApprovedPremisesApplication as Application, FullPerson, NewAppeal } from '@approved-premises/api'
+import Page from '../page'
+import paths from '../../../server/paths/apply'
+
+export default class AppealsPage extends Page {
+  constructor(private readonly application: Application) {
+    super((application.person as FullPerson).name)
+  }
+
+  static visit(application: Application): AppealsPage {
+    cy.visit(paths.applications.appeals.new({ id: application.id }))
+    return new AppealsPage(application)
+  }
+
+  completeForm(appeal: NewAppeal): void {
+    this.completeDateInputs('appealDate', appeal.appealDate)
+    this.completeTextArea('appeal[appealDetail]', appeal.appealDetail)
+    this.completeTextArea('appeal[reviewer]', appeal.reviewer)
+    this.checkRadioByNameAndValue('appeal[decision]', appeal.decision)
+    this.completeTextArea('appeal[decisionDetail]', appeal.decisionDetail)
+    this.clickSubmit()
+  }
+}

--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -46,6 +46,10 @@ export default class ShowPage extends Page {
     cy.get('.moj-button-menu > .govuk-button').click()
   }
 
+  clickAppealLink() {
+    cy.get(`[data-cy-appeal-application="${this.application.id}"]`).click()
+  }
+
   shouldHaveWithdrawalLink() {
     cy.get(`[data-cy-withdraw-application="${this.application.id}"]`).should(
       'have.attr',

--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -54,6 +54,10 @@ export default class ShowPage extends Page {
     )
   }
 
+  clickCreatePlacementButton() {
+    cy.get('button').contains('Create placement request').click()
+  }
+
   shouldNotShowCreatePlacementButton() {
     cy.get('Create placement request').should('not.exist')
   }

--- a/integration_tests/tests/apply/appeals.cy.ts
+++ b/integration_tests/tests/apply/appeals.cy.ts
@@ -7,7 +7,7 @@ context('Appeals', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubAuthUser', { roles: ['appeals_manager'] })
 
     // Given I am logged in
     cy.signIn()
@@ -16,21 +16,28 @@ context('Appeals', () => {
   it('should create an appeal', () => {
     // Given there is an application
     const person = personFactory.build()
-    const application = applicationFactory.build({ person, status: 'submitted' })
+    const application = applicationFactory.build({ person, status: 'rejected' })
     const appeal = appealFactory.build()
 
     cy.task('stubApplicationGet', { application })
     cy.task('stubAppealCreate', { applicationId: application.id, appeal })
 
-    // And I visit the appeals page
-    const appealsPage = AppealsPage.visit(application)
+    // And I visit the application page
+    let showPage = ShowPage.visit(application)
 
-    // And I fill in the form with the appeal details
+    // And I lodge an appeal
+    showPage.clickActions()
+    showPage.clickAppealLink()
+
+    // Then I should be on the appeals page
+    const appealsPage = Page.verifyOnPage(AppealsPage, application)
+
+    // When I fill in the form with the appeal details
     const newAppeal = newAppealFactory.build()
     appealsPage.completeForm(newAppeal)
 
     // And I should see a confirmation message
-    const showPage = Page.verifyOnPage(ShowPage, application)
+    showPage = Page.verifyOnPage(ShowPage, application)
     showPage.shouldShowBanner('Assessment reopened')
 
     // And the appeal should have been created

--- a/integration_tests/tests/apply/appeals.cy.ts
+++ b/integration_tests/tests/apply/appeals.cy.ts
@@ -1,0 +1,76 @@
+import { appealFactory, applicationFactory, newAppealFactory, personFactory } from '../../../server/testutils/factories'
+import { ShowPage } from '../../pages/apply'
+import AppealsPage from '../../pages/apply/appeal'
+import Page from '../../pages/page'
+
+context('Appeals', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+
+    // Given I am logged in
+    cy.signIn()
+  })
+
+  it('should create an appeal', () => {
+    // Given there is an application
+    const person = personFactory.build()
+    const application = applicationFactory.build({ person, status: 'submitted' })
+    const appeal = appealFactory.build()
+
+    cy.task('stubApplicationGet', { application })
+    cy.task('stubAppealCreate', { applicationId: application.id, appeal })
+
+    // And I visit the appeals page
+    const appealsPage = AppealsPage.visit(application)
+
+    // And I fill in the form with the appeal details
+    const newAppeal = newAppealFactory.build()
+    appealsPage.completeForm(newAppeal)
+
+    // And I should see a confirmation message
+    const showPage = Page.verifyOnPage(ShowPage, application)
+    showPage.shouldShowBanner('Assessment reopened')
+
+    // And the appeal should have been created
+    cy.task('verifyAppealCreated', { applicationId: application.id }).then(requests => {
+      expect(requests).to.have.length(1)
+
+      const body = JSON.parse(requests[0].body)
+
+      expect(body.appealDate).equal(newAppeal.appealDate)
+      expect(body.appealDetail).equal(newAppeal.appealDetail)
+      expect(body.decision).equal(newAppeal.decision)
+      expect(body.decisionDetail).equal(newAppeal.decisionDetail)
+      expect(body.reviewer).equal(newAppeal.reviewer)
+    })
+  })
+
+  it('should show error messages for missed fields', () => {
+    // Given there is an application
+    const person = personFactory.build()
+    const application = applicationFactory.build({ person, status: 'submitted' })
+
+    cy.task('stubApplicationGet', { application })
+    cy.task('stubAppealErrors', {
+      applicationId: application.id,
+      params: ['appealDate', 'appealDetail', 'decision', 'decisionDetail', 'reviewer'],
+    })
+
+    // And I visit the appeals page
+    const appealsPage = AppealsPage.visit(application)
+
+    // And I click submit
+    appealsPage.clickSubmit()
+
+    // Then I should see the error messages
+    appealsPage.shouldShowErrorMessagesForFields([
+      'appealDate',
+      'appealDetail',
+      'decision',
+      'decisionDetail',
+      'reviewer',
+    ])
+  })
+})

--- a/integration_tests/tests/match/placementApplications.cy.ts
+++ b/integration_tests/tests/match/placementApplications.cy.ts
@@ -71,8 +71,8 @@ context('Placement Applications', () => {
       // When I click the Request Placement Application tab
       showPage.clickRequestAPlacementTab()
 
-      // Then I should be able to click submit
-      showPage.clickSubmit()
+      // Then I should be able to create a placement
+      showPage.clickCreatePlacementButton()
 
       // Given I am on the placement application form and start and application
       const placementReasonPage = ReasonForPlacementPage.visit(placementApplicationId)
@@ -148,8 +148,8 @@ context('Placement Applications', () => {
       // When I click the Request Placement Application tab
       showPage.clickRequestAPlacementTab()
 
-      // Then I should be able to click submit
-      showPage.clickSubmit()
+      // Then I should be able to create a placement
+      showPage.clickCreatePlacementButton()
 
       // Given I am on the placement application form and start and application
       const placementReasonPage = ReasonForPlacementPage.visit(placementApplicationId)
@@ -230,8 +230,8 @@ context('Placement Applications', () => {
       // When I click the Request Placement Application tab
       showPage.clickRequestAPlacementTab()
 
-      // Then I should be able to click submit
-      showPage.clickSubmit()
+      // Then I should be able to create a placement
+      showPage.clickCreatePlacementButton()
 
       // Given I am on the placement application form and start and application
       const placementReasonPage = ReasonForPlacementPage.visit(placementApplicationId)

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -196,6 +196,7 @@ export interface IdentityBarMenu {
 
 export interface IdentityBarMenuItem {
   classes?: string
+  attributes?: HtmlAttributes
   href: string
   text: string
 }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -186,6 +186,7 @@ export interface IdentityBar {
   title: {
     html: string
   }
+  classes?: string
   menus: Array<IdentityBarMenu>
 }
 

--- a/server/controllers/apply/appealsController.test.ts
+++ b/server/controllers/apply/appealsController.test.ts
@@ -1,0 +1,143 @@
+import { NextFunction, Request, Response } from 'express'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import type { ErrorsAndUserInput } from '@approved-premises/ui'
+
+import AppealService from '../../services/appealService'
+import AppealsController from './appealsController'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
+import paths from '../../paths/apply'
+import { AppealDecision } from '../../@types/shared'
+import { ApplicationService } from '../../services'
+import { applicationFactory } from '../../testutils/factories'
+
+jest.mock('../../utils/validation')
+
+describe('AppealsController', () => {
+  const token = 'SOME_TOKEN'
+  const application = applicationFactory.build()
+
+  const request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const appealService = createMock<AppealService>({})
+  const applicationService = createMock<ApplicationService>({})
+  const appealsController = new AppealsController(appealService, applicationService)
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    ;(applicationService.findApplication as jest.Mock).mockResolvedValue(application)
+  })
+
+  describe('new', () => {
+    it('renders the form', async () => {
+      const requestHandler = appealsController.new()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [], userInput: {} })
+
+      request.params = {
+        id: 'applicationId',
+      }
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('applications/appeals/new', {
+        applicationId: 'applicationId',
+        application,
+        pageHeading: 'Approved Premises Application',
+        errors: {},
+        errorSummary: [],
+      })
+      expect(applicationService.findApplication).toHaveBeenCalledWith(token, request.params.id)
+    })
+
+    it('renders the form with errors and user input if an error has been sent to the flash', async () => {
+      const requestHandler = appealsController.new()
+
+      request.params = {
+        id: 'applicationId',
+      }
+
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('applications/appeals/new', {
+        applicationId: 'applicationId',
+        application,
+        pageHeading: 'Approved Premises Application',
+        errors: errorsAndUserInput.errors,
+        errorSummary: errorsAndUserInput.errorSummary,
+        ...errorsAndUserInput.userInput,
+      })
+    })
+  })
+
+  describe('create', () => {
+    it.each([
+      ['accepted', 'Assessment reopened'],
+      ['rejected', 'Appeal marked as rejected'],
+    ])(
+      'creates an appeal and redirects back to the application page',
+      async (decision: AppealDecision, flashMessage: string) => {
+        const requestHandler = appealsController.create()
+
+        const req = createMock<Request>({
+          user: { token },
+          params: { id: 'applicationId' },
+          body: {
+            'appealDate-year': 2022,
+            'appealDate-month': 12,
+            'appealDate-day': 11,
+            appeal: {
+              appealDetail: 'detail',
+              reviewer: 'reviewer',
+              decisionDetail: 'decisionDetail',
+              decision,
+            },
+          },
+        })
+
+        await requestHandler(req, response, next)
+
+        const expectedAppeal = {
+          ...req.body.appeal,
+          appealDate: '2022-12-11',
+        }
+
+        expect(response.redirect).toHaveBeenCalledWith(paths.applications.show({ id: req.params.id }))
+
+        expect(req.flash).toHaveBeenCalledWith('success', flashMessage)
+        expect(appealService.createAppeal).toHaveBeenCalledWith(token, req.params.id, expectedAppeal)
+      },
+    )
+
+    it('renders with errors if the API returns an error', async () => {
+      const requestHandler = appealsController.create()
+
+      request.params = {
+        id: 'applicationId',
+      }
+
+      request.body = {
+        appeal: {},
+      }
+
+      const err = new Error()
+
+      appealService.createAppeal.mockImplementation(() => {
+        throw err
+      })
+
+      await requestHandler(request, response, next)
+
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+        request,
+        response,
+        err,
+        paths.applications.appeals.new({ id: request.params.id }),
+      )
+    })
+  })
+})

--- a/server/controllers/apply/appealsController.ts
+++ b/server/controllers/apply/appealsController.ts
@@ -1,0 +1,58 @@
+import { Request, RequestHandler, Response } from 'express'
+import AppealService from '../../services/appealService'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
+import { DateFormats } from '../../utils/dateUtils'
+import { AppealDecision, NewAppeal } from '../../@types/shared'
+import paths from '../../paths/apply'
+import { ApplicationService } from '../../services'
+
+export default class AppealsController {
+  constructor(
+    private readonly appealService: AppealService,
+    private readonly applicationService: ApplicationService,
+  ) {}
+
+  new(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const applicationId = req.params.id
+      const application = await this.applicationService.findApplication(req.user.token, applicationId)
+      const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
+
+      res.render('applications/appeals/new', {
+        application,
+        applicationId,
+        errors,
+        errorSummary,
+        pageHeading: 'Approved Premises Application',
+        ...userInput,
+      })
+    }
+  }
+
+  create(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const applicationId = req.params.id
+      const { body } = req
+
+      const { appealDate } = DateFormats.dateAndTimeInputsToIsoString(body, 'appealDate')
+
+      const appeal: NewAppeal = {
+        appealDate,
+        appealDetail: body.appeal.appealDetail,
+        reviewer: body.appeal.reviewer,
+        decisionDetail: body.appeal.decisionDetail,
+        decision: body.appeal.decision as AppealDecision,
+      }
+
+      try {
+        await this.appealService.createAppeal(req.user.token, applicationId, appeal)
+
+        const successMessage = appeal.decision === 'accepted' ? 'Assessment reopened' : 'Appeal marked as rejected'
+        req.flash('success', successMessage)
+        res.redirect(paths.applications.show({ id: applicationId }))
+      } catch (err) {
+        catchValidationErrorOrPropogate(req, res, err, paths.applications.appeals.new({ id: applicationId }))
+      }
+    }
+  }
+}

--- a/server/controllers/apply/index.ts
+++ b/server/controllers/apply/index.ts
@@ -9,9 +9,18 @@ import WithdrawablesController from './withdrawablesController'
 import NotesController from './applications/notesController'
 
 import type { Services } from '../../services'
+import AppealsController from './appealsController'
 
 export const controllers = (services: Services) => {
-  const { applicationService, personService, premisesService, userService, apAreaService, bookingService } = services
+  const {
+    applicationService,
+    personService,
+    premisesService,
+    userService,
+    apAreaService,
+    bookingService,
+    appealService,
+  } = services
   const applicationsController = new ApplicationsController(applicationService, personService)
   const pagesController = new PagesController(applicationService, {
     personService,
@@ -25,8 +34,10 @@ export const controllers = (services: Services) => {
   const withdrawalsController = new WithdrawalsController(applicationService)
   const notesController = new NotesController(applicationService)
   const withdrawablesController = new WithdrawablesController(applicationService, bookingService)
+  const appealsController = new AppealsController(appealService, applicationService)
 
   return {
+    appealsController,
     applicationsController,
     pagesController,
     offencesController,

--- a/server/data/appealClient.test.ts
+++ b/server/data/appealClient.test.ts
@@ -1,0 +1,42 @@
+import AppealClient from './appealClient'
+import { appealFactory, newAppealFactory } from '../testutils/factories'
+import describeClient from '../testutils/describeClient'
+import paths from '../paths/api'
+
+describeClient('AppealClient', provider => {
+  let appealsClient: AppealClient
+
+  const token = 'token-1'
+
+  beforeEach(() => {
+    appealsClient = new AppealClient(token)
+  })
+
+  describe('create', () => {
+    it('should create an appeal', async () => {
+      const newAppeal = newAppealFactory.build()
+      const appeal = appealFactory.build()
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request for an appeal',
+        withRequest: {
+          method: 'POST',
+          path: paths.applications.appeals.create({ id: appeal.applicationId }),
+          body: newAppeal,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 201,
+          body: appeal,
+        },
+      })
+
+      const result = await appealsClient.create(appeal.applicationId, newAppeal)
+
+      expect(result).toEqual(appeal)
+    })
+  })
+})

--- a/server/data/appealClient.ts
+++ b/server/data/appealClient.ts
@@ -1,0 +1,19 @@
+import RestClient from './restClient'
+import config, { ApiConfig } from '../config'
+import { Appeal, NewAppeal } from '../@types/shared'
+import paths from '../paths/api'
+
+export default class AppealClient {
+  restClient: RestClient
+
+  constructor(token: string) {
+    this.restClient = new RestClient('applicationClient', config.apis.approvedPremises as ApiConfig, token)
+  }
+
+  async create(applicationId: string, appeal: NewAppeal): Promise<Appeal> {
+    return (await this.restClient.post({
+      path: paths.applications.appeals.create({ id: applicationId }),
+      data: appeal,
+    })) as Appeal
+  }
+}

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -27,10 +27,12 @@ import PlacementRequestClient from './placementRequestClient'
 import PlacementApplicationClient from './placementApplicationClient'
 import BedClient from './bedClient'
 import ReportClient from './reportClient'
+import AppealClient from './appealClient'
 
 type RestClientBuilder<T> = (token: string) => T
 
 export const dataAccess = () => ({
+  appealClientBuilder: ((token: string) => new AppealClient(token)) as RestClientBuilder<AppealClient>,
   hmppsAuthClient: new HmppsAuthClient(new TokenStore(createRedisClient())),
   approvedPremisesClientBuilder: ((token: string) => new PremisesClient(token)) as RestClientBuilder<PremisesClient>,
   bookingClientBuilder: ((token: string) => new BookingClient(token)) as RestClientBuilder<BookingClient>,
@@ -53,6 +55,7 @@ export const dataAccess = () => ({
 export type DataAccess = ReturnType<typeof dataAccess>
 
 export {
+  AppealClient,
   BedClient,
   BookingClient,
   PremisesClient,

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -106,5 +106,10 @@
     "empty": "You must choose a user to allocate the application to",
     "lackingQualifications": "This user lacks the necessary qualifications"
   },
-  "moveBed": { "empty": "You must select a bed to move the person to" }
+  "moveBed": { "empty": "You must select a bed to move the person to" },
+  "appealDate": { "empty": "You must enter an appeal date", "invalid": "You must enter a valid appeal date" },
+  "appealDetail": { "empty": "You must enter the reason for the appeal" },
+  "reviewer": { "empty": "You must enter who made the decision" },
+  "decision": { "empty": "You must provide the decision" },
+  "decisionDetail": { "empty": "You must enter the reasons for the appeal decision" }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -37,6 +37,8 @@ const managePaths = {
 const applicationsPath = path('/applications')
 const singleApplicationPath = applicationsPath.path(':id')
 
+const appealsPath = singleApplicationPath.path('appeals')
+
 const peoplePath = path('/people')
 const personPath = peoplePath.path(':crn')
 const oasysPath = personPath.path('oasys')
@@ -128,6 +130,9 @@ export default {
     placementApplications: applyPaths.applications.show.path('placement-applications'),
     addNote: applyPaths.applications.show.path('notes'),
     withdrawables: applyPaths.applications.show.path('withdrawables'),
+    appeals: {
+      create: appealsPath,
+    },
   },
   assessments: {
     index: assessPaths.assessments,

--- a/server/paths/apply.ts
+++ b/server/paths/apply.ts
@@ -8,6 +8,7 @@ const peoplePath = applicationsPath.path('people')
 const personPath = peoplePath.path(':crn')
 const withdrawalsPath = applicationPath.path('withdrawals')
 const withdrawablesPath = applicationPath.path('withdrawables')
+const appealsPath = applicationPath.path('appeals')
 
 const paths = {
   applications: {
@@ -40,6 +41,10 @@ const paths = {
     notes: {
       new: applicationPath.path('notes/new'),
       create: applicationPath.path('notes/create'),
+    },
+    appeals: {
+      create: appealsPath,
+      new: appealsPath.path('new'),
     },
   },
 }

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -14,6 +14,7 @@ export default function routes(controllers: Controllers, router: Router, service
   const { get, post, put } = actions(router, services.auditService)
   const {
     applicationsController,
+    appealsController,
     pagesController,
     peopleController,
     offencesController,
@@ -66,6 +67,12 @@ export default function routes(controllers: Controllers, router: Router, service
   })
   post(paths.applications.notes.create.pattern, notesController.create(), {
     auditEvent: 'CREATE_NEW_NOTE',
+  })
+  get(paths.applications.appeals.new.pattern, appealsController.new(), {
+    auditEvent: 'NEW_APPEAL',
+  })
+  post(paths.applications.appeals.create.pattern, appealsController.create(), {
+    auditEvent: 'CREATE_APPEAL',
   })
 
   Object.keys(pages).forEach((taskKey: string) => {

--- a/server/services/appealService.test.ts
+++ b/server/services/appealService.test.ts
@@ -1,0 +1,34 @@
+import { AppealClient } from '../data'
+import AppealService from './appealService'
+import { appealFactory, newAppealFactory } from '../testutils/factories'
+
+jest.mock('../data/appealClient.ts')
+
+describe('AppealService', () => {
+  const appealClient = new AppealClient(null) as jest.Mocked<AppealClient>
+  const appealClientFactory = jest.fn()
+
+  const service = new AppealService(appealClientFactory)
+
+  const token = 'SOME_TOKEN'
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    appealClientFactory.mockReturnValue(appealClient)
+  })
+
+  describe('createAppeal', () => {
+    it('calls the createAppeal client method and returns the result', async () => {
+      const appeal = appealFactory.build()
+      const newAppeal = newAppealFactory.build()
+
+      appealClient.create.mockResolvedValue(appeal)
+
+      const result = await service.createAppeal(token, appeal.applicationId, newAppeal)
+
+      expect(appealClientFactory).toHaveBeenCalledWith(token)
+      expect(appealClient.create).toHaveBeenCalledWith(appeal.applicationId, newAppeal)
+      expect(result).toEqual(appeal)
+    })
+  })
+})

--- a/server/services/appealService.ts
+++ b/server/services/appealService.ts
@@ -1,0 +1,14 @@
+import type { RestClientBuilder } from '../data'
+
+import { Appeal, NewAppeal } from '../@types/shared'
+import AppealClient from '../data/appealClient'
+
+export default class AppealService {
+  constructor(private readonly appealClientFactory: RestClientBuilder<AppealClient>) {}
+
+  async createAppeal(token: string, applicationId: string, appeal: NewAppeal): Promise<Appeal> {
+    const client = this.appealClientFactory(token)
+
+    return client.create(applicationId, appeal)
+  }
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -20,10 +20,13 @@ import PlacementApplicationService from './placementApplicationService'
 import BedService from './bedService'
 import ReportService from './reportService'
 import ApAreaService from './apAreaService'
+import AppealService from './appealService'
+
 import config, { AuditConfig } from '../config'
 
 export const services = () => {
   const {
+    appealClientBuilder,
     hmppsAuthClient,
     approvedPremisesClientBuilder,
     bookingClientBuilder,
@@ -40,6 +43,7 @@ export const services = () => {
     reportClientBuilder,
   } = dataAccess()
 
+  const appealService = new AppealService(appealClientBuilder)
   const userService = new UserService(hmppsAuthClient, userClientBuilder, referenceDataClientBuilder)
   const auditService = new AuditService(config.apis.audit as AuditConfig)
   const premisesService = new PremisesService(approvedPremisesClientBuilder)
@@ -60,6 +64,7 @@ export const services = () => {
   const apAreaService = new ApAreaService(referenceDataClientBuilder)
 
   return {
+    appealService,
     userService,
     auditService,
     premisesService,
@@ -84,6 +89,7 @@ export const services = () => {
 export type Services = ReturnType<typeof services>
 
 export {
+  AppealService,
   UserService,
   PremisesService,
   PersonService,

--- a/server/testutils/factories/appealFactory.ts
+++ b/server/testutils/factories/appealFactory.ts
@@ -1,0 +1,17 @@
+import { faker } from '@faker-js/faker'
+import { Factory } from 'fishery'
+import { Appeal } from '../../@types/shared'
+import { DateFormats } from '../../utils/dateUtils'
+
+export default Factory.define<Appeal>(() => ({
+  id: faker.string.uuid(),
+  appealDate: DateFormats.dateObjToIsoDate(faker.date.past()),
+  appealDetail: faker.lorem.sentence(),
+  reviewer: faker.person.fullName(),
+  decision: 'accepted',
+  decisionDetail: faker.lorem.sentence(),
+  createdAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
+  applicationId: faker.string.uuid(),
+  assessmentId: faker.string.uuid(),
+  createdByUserId: faker.string.uuid(),
+}))

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -3,6 +3,7 @@
 import acctAlertFactory from './acctAlert'
 import activeOffenceFactory from './activeOffence'
 import adjudicationFactory from './adjudication'
+import appealFactory from './appealFactory'
 import applicationFactory from './application'
 import applicationSummaryFactory from './applicationSummary'
 import arrivalFactory from './arrival'
@@ -49,6 +50,7 @@ import {
   newPlacementRequestBookingConfirmationFactory,
   newPlacementRequestBookingFactory,
 } from './newPlacementRequestBooking'
+import newAppealFactory from './newAppealFactory'
 import nonArrivalFactory from './nonArrival'
 import noteFactory from './noteFactory'
 import oasysSectionsFactory, { roshSummaryFactory } from './oasysSections'
@@ -83,6 +85,7 @@ export {
   acctAlertFactory,
   activeOffenceFactory,
   adjudicationFactory,
+  appealFactory,
   apAreaFactory,
   apCharacteristicPairFactory,
   applicationFactory,
@@ -130,6 +133,7 @@ export {
   newDepartureFactory,
   newLostBedFactory,
   newNonArrivalFactory,
+  newAppealFactory,
   nonArrivalFactory,
   noteFactory,
   oasysSectionsFactory,

--- a/server/testutils/factories/newAppealFactory.ts
+++ b/server/testutils/factories/newAppealFactory.ts
@@ -1,0 +1,12 @@
+import { faker } from '@faker-js/faker'
+import { Factory } from 'fishery'
+import { NewAppeal } from '../../@types/shared'
+import { DateFormats } from '../../utils/dateUtils'
+
+export default Factory.define<NewAppeal>(() => ({
+  appealDate: DateFormats.dateObjToIsoDate(faker.date.past()),
+  appealDetail: faker.lorem.sentence(),
+  reviewer: faker.person.fullName(),
+  decision: 'accepted',
+  decisionDetail: faker.lorem.sentence(),
+}))

--- a/server/utils/applications/applicationIdentityBar.test.ts
+++ b/server/utils/applications/applicationIdentityBar.test.ts
@@ -1,0 +1,72 @@
+import { applicationFactory, personFactory } from '../../testutils/factories'
+import { applicationIdentityBar, applicationMenuItems, applicationTitle } from './applicationIdentityBar'
+import paths from '../../paths/apply'
+
+describe('applicationIdentityBar', () => {
+  describe('applicationTitle', () => {
+    it('should return the title of the application', () => {
+      const person = personFactory.build()
+      const application = applicationFactory.build({ person })
+
+      expect(applicationTitle(application, 'heading')).toMatchStringIgnoringWhitespace(`
+        <span class="govuk-caption-l">heading</span>
+        <h1 class="govuk-heading-l">${person.name}</h1>
+      `)
+    })
+
+    it('should return the show a tag for an offline application', () => {
+      const person = personFactory.build()
+      const application = applicationFactory.build({ person, type: 'Offline' })
+
+      expect(applicationTitle(application, 'heading')).toMatchStringIgnoringWhitespace(`
+        <span class="govuk-caption-l">heading</span>
+        <h1 class="govuk-heading-l">${person.name}</h1>
+        <strong class="govuk-tag govuk-tag--grey govuk-!-margin-5">Offline application</strong>
+      `)
+    })
+  })
+
+  describe('applicationMenuItems', () => {
+    it('should return the old withdrawal link when NEW_WITHDRAWALS_FLOW_DISABLED is truthy', () => {
+      process.env.NEW_WITHDRAWALS_FLOW_DISABLED = '1'
+      const application = applicationFactory.build()
+      expect(applicationMenuItems(application)).toEqual([
+        {
+          text: 'Withdraw application',
+          href: paths.applications.withdraw.new({ id: application.id }),
+          classes: 'govuk-button--secondary',
+          attributes: {
+            'data-cy-withdraw-application': application.id,
+          },
+        },
+      ])
+    })
+
+    it('should return the new withdrawal link when NEW_WITHDRAWALS_FLOW_DISABLED is falsy', () => {
+      process.env.NEW_WITHDRAWALS_FLOW_DISABLED = ''
+      const application = applicationFactory.build()
+      expect(applicationMenuItems(application)).toEqual([
+        {
+          text: 'Withdraw application',
+          href: paths.applications.withdrawables.show({ id: application.id }),
+          classes: 'govuk-button--secondary',
+          attributes: {
+            'data-cy-withdraw-application': application.id,
+          },
+        },
+      ])
+    })
+  })
+
+  describe('applicationIdentityBar', () => {
+    it('should return the identity bar', () => {
+      const application = applicationFactory.build()
+
+      expect(applicationIdentityBar(application, 'title')).toEqual({
+        title: { html: applicationTitle(application, 'title') },
+        classes: 'application-identity-bar',
+        menus: [{ items: applicationMenuItems(application) }],
+      })
+    })
+  })
+})

--- a/server/utils/applications/applicationIdentityBar.test.ts
+++ b/server/utils/applications/applicationIdentityBar.test.ts
@@ -30,7 +30,7 @@ describe('applicationIdentityBar', () => {
     it('should return the old withdrawal link when NEW_WITHDRAWALS_FLOW_DISABLED is truthy', () => {
       process.env.NEW_WITHDRAWALS_FLOW_DISABLED = '1'
       const application = applicationFactory.build()
-      expect(applicationMenuItems(application)).toEqual([
+      expect(applicationMenuItems(application, ['applicant'])).toEqual([
         {
           text: 'Withdraw application',
           href: paths.applications.withdraw.new({ id: application.id }),
@@ -45,7 +45,57 @@ describe('applicationIdentityBar', () => {
     it('should return the new withdrawal link when NEW_WITHDRAWALS_FLOW_DISABLED is falsy', () => {
       process.env.NEW_WITHDRAWALS_FLOW_DISABLED = ''
       const application = applicationFactory.build()
-      expect(applicationMenuItems(application)).toEqual([
+      expect(applicationMenuItems(application, ['excluded_from_assess_allocation'])).toEqual([
+        {
+          text: 'Withdraw application',
+          href: paths.applications.withdrawables.show({ id: application.id }),
+          classes: 'govuk-button--secondary',
+          attributes: {
+            'data-cy-withdraw-application': application.id,
+          },
+        },
+      ])
+    })
+
+    it('should return an appeals link when userRoles includes appeals_manager and the application has been rejected', () => {
+      const application = applicationFactory.build({ status: 'rejected' })
+      expect(applicationMenuItems(application, ['appeals_manager'])).toEqual([
+        {
+          text: 'Withdraw application',
+          href: paths.applications.withdrawables.show({ id: application.id }),
+          classes: 'govuk-button--secondary',
+          attributes: {
+            'data-cy-withdraw-application': application.id,
+          },
+        },
+        {
+          text: 'Process an appeal',
+          href: paths.applications.appeals.new({ id: application.id }),
+          classes: 'govuk-button--secondary',
+          attributes: {
+            'data-cy-appeal-application': application.id,
+          },
+        },
+      ])
+    })
+
+    it('should not return an appeals link when userRoles includes appeals_manager and the application has not been rejected', () => {
+      const application = applicationFactory.build({ status: 'assesmentInProgress' })
+      expect(applicationMenuItems(application, ['appeals_manager'])).toEqual([
+        {
+          text: 'Withdraw application',
+          href: paths.applications.withdrawables.show({ id: application.id }),
+          classes: 'govuk-button--secondary',
+          attributes: {
+            'data-cy-withdraw-application': application.id,
+          },
+        },
+      ])
+    })
+
+    it('should not return an appeals link when userRoles does not include appeals_manager and the application has been rejected', () => {
+      const application = applicationFactory.build({ status: 'rejected' })
+      expect(applicationMenuItems(application, ['assessor'])).toEqual([
         {
           text: 'Withdraw application',
           href: paths.applications.withdrawables.show({ id: application.id }),
@@ -62,10 +112,10 @@ describe('applicationIdentityBar', () => {
     it('should return the identity bar', () => {
       const application = applicationFactory.build()
 
-      expect(applicationIdentityBar(application, 'title')).toEqual({
+      expect(applicationIdentityBar(application, 'title', ['appeals_manager'])).toEqual({
         title: { html: applicationTitle(application, 'title') },
         classes: 'application-identity-bar',
-        menus: [{ items: applicationMenuItems(application) }],
+        menus: [{ items: applicationMenuItems(application, ['appeals_manager']) }],
       })
     })
   })

--- a/server/utils/applications/applicationIdentityBar.ts
+++ b/server/utils/applications/applicationIdentityBar.ts
@@ -1,4 +1,4 @@
-import { Application, FullPerson } from '../../@types/shared'
+import { ApprovedPremisesApplication as Application, ApprovedPremisesUserRole, FullPerson } from '../../@types/shared'
 import { IdentityBar, IdentityBarMenuItem } from '../../@types/ui'
 import paths from '../../paths/apply'
 
@@ -15,12 +15,15 @@ export const applicationTitle = (application: Application, pageHeading: string):
   return title
 }
 
-export const applicationMenuItems = (application: Application): Array<IdentityBarMenuItem> => {
+export const applicationMenuItems = (
+  application: Application,
+  userRoles: Array<ApprovedPremisesUserRole>,
+): Array<IdentityBarMenuItem> => {
   const withdrawalLink = process.env.NEW_WITHDRAWALS_FLOW_DISABLED
     ? paths.applications.withdraw.new({ id: application.id })
     : paths.applications.withdrawables.show({ id: application.id })
 
-  const items = [
+  const items: Array<IdentityBarMenuItem> = [
     {
       text: 'Withdraw application',
       href: withdrawalLink,
@@ -31,13 +34,28 @@ export const applicationMenuItems = (application: Application): Array<IdentityBa
     },
   ]
 
+  if (userRoles.includes('appeals_manager') && application.status === 'rejected') {
+    items.push({
+      text: 'Process an appeal',
+      href: paths.applications.appeals.new({ id: application.id }),
+      classes: 'govuk-button--secondary',
+      attributes: {
+        'data-cy-appeal-application': application.id,
+      },
+    })
+  }
+
   return items
 }
 
-export const applicationIdentityBar = (application: Application, pageHeading: string): IdentityBar => {
+export const applicationIdentityBar = (
+  application: Application,
+  pageHeading: string,
+  userRoles: Array<ApprovedPremisesUserRole>,
+): IdentityBar => {
   return {
     title: { html: applicationTitle(application, pageHeading) },
     classes: 'application-identity-bar',
-    menus: [{ items: applicationMenuItems(application) }],
+    menus: [{ items: applicationMenuItems(application, userRoles) }],
   }
 }

--- a/server/utils/applications/applicationIdentityBar.ts
+++ b/server/utils/applications/applicationIdentityBar.ts
@@ -1,0 +1,43 @@
+import { Application, FullPerson } from '../../@types/shared'
+import { IdentityBar, IdentityBarMenuItem } from '../../@types/ui'
+import paths from '../../paths/apply'
+
+export const applicationTitle = (application: Application, pageHeading: string): string => {
+  let title = `
+    <span class="govuk-caption-l">${pageHeading}</span>
+    <h1 class="govuk-heading-l">${(application.person as FullPerson).name}</h1>
+  `
+
+  if (application.type === 'Offline') {
+    title += '<strong class="govuk-tag govuk-tag--grey govuk-!-margin-5">Offline application</strong>'
+  }
+
+  return title
+}
+
+export const applicationMenuItems = (application: Application): Array<IdentityBarMenuItem> => {
+  const withdrawalLink = process.env.NEW_WITHDRAWALS_FLOW_DISABLED
+    ? paths.applications.withdraw.new({ id: application.id })
+    : paths.applications.withdrawables.show({ id: application.id })
+
+  const items = [
+    {
+      text: 'Withdraw application',
+      href: withdrawalLink,
+      classes: 'govuk-button--secondary',
+      attributes: {
+        'data-cy-withdraw-application': application.id,
+      },
+    },
+  ]
+
+  return items
+}
+
+export const applicationIdentityBar = (application: Application, pageHeading: string): IdentityBar => {
+  return {
+    title: { html: applicationTitle(application, pageHeading) },
+    classes: 'application-identity-bar',
+    menus: [{ items: applicationMenuItems(application) }],
+  }
+}

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -21,6 +21,7 @@ import { DateFormats } from '../dateUtils'
 import { isApplicableTier, isFullPerson, nameOrPlaceholderCopy, tierBadge } from '../personUtils'
 
 import {
+  appealDecisionRadioItems,
   applicationStatusSelectOptions,
   applicationStatuses,
   applicationTableRows,
@@ -1099,6 +1100,22 @@ describe('utils', () => {
         { selected: false, text: 'Application withdrawn', value: 'withdrawn' },
         { selected: false, text: 'Further information requested', value: 'requestedFurtherInformation' },
         { selected: false, text: 'Pending placement request', value: 'pendingPlacementRequest' },
+      ])
+    })
+  })
+
+  describe('appealDecisionRadioItems', () => {
+    it('should return radio items when selectedOption is empty', () => {
+      expect(appealDecisionRadioItems(undefined)).toEqual([
+        { text: 'Upheld', value: 'accepted', checked: false },
+        { text: 'Rejected', value: 'rejected', checked: false },
+      ])
+    })
+
+    it('should return radio items when the the selected item checked', () => {
+      expect(appealDecisionRadioItems('accepted')).toEqual([
+        { text: 'Upheld', value: 'accepted', checked: true },
+        { text: 'Rejected', value: 'rejected', checked: false },
       ])
     })
   })

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -12,6 +12,7 @@ import type {
   UiTimelineEvent,
 } from '@approved-premises/ui'
 import type {
+  AppealDecision,
   ApprovedPremisesApplication as Application,
   ApplicationSortField,
   ApprovedPremisesApplicationSummary as ApplicationSummary,
@@ -424,6 +425,19 @@ const applicationStatusSelectOptions = (
   return options
 }
 
+const appealDecisionRadioItems = (selectedOption: AppealDecision | undefined) => {
+  const appealDecisions: Record<AppealDecision, string> = {
+    accepted: 'Upheld',
+    rejected: 'Rejected',
+  }
+
+  return Object.keys(appealDecisions).map(status => ({
+    text: appealDecisions[status],
+    value: status,
+    checked: status === selectedOption,
+  }))
+}
+
 export {
   applicationStatuses,
   applicationTableRows,
@@ -439,4 +453,5 @@ export {
   lengthOfStayForUI,
   statusTags,
   applicationStatusSelectOptions,
+  appealDecisionRadioItems,
 }

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -50,6 +50,7 @@ import { linkTo } from '../utils'
 
 export { withdrawableTypeRadioOptions, withdrawableRadioOptions } from './withdrawables'
 export { placementApplicationWithdrawalReasons } from './withdrawables/withdrawalReasons'
+export { applicationIdentityBar } from './applicationIdentityBar'
 
 const applicationStatuses: Record<ApprovedPremisesApplicationStatus, string> = {
   started: 'Application started',

--- a/server/views/applications/appeals/new.njk
+++ b/server/views/applications/appeals/new.njk
@@ -1,0 +1,108 @@
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "../../components/formFields/form-page-input/macro.njk" import formPageInput %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="moj-page-header-actions">
+        <div class="moj-page-header-actions__title">
+          <span class="govuk-caption-l">{{ pageHeading }}</span>
+          <h1 class="govuk-heading-l">
+            {{ application.person.name }}
+            {% if application.type == 'Offline' %}
+              {{
+                govukTag({
+                  text: "Offline application",
+                  classes: "govuk-tag--grey govuk-!-margin-5"
+                })
+              }}
+            {% endif %}
+          </h1>
+        </div>
+      </div>
+      <form action="{{ paths.applications.appeals.create({ id: applicationId }) }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {{ showErrorSummary(errorSummary) }}
+
+        {{ govukDateInput({
+                    id: "appealDate",
+                    namePrefix: "appealDate",
+                    fieldset: {
+                    legend: {
+                        text: "What was the date of the appeal?",
+                        classes: "govuk-fieldset__legend--s"
+                        }
+                    },
+                    hint: {
+                    text: "For example, 27 3 2007"
+                    },
+                    items: dateFieldValues('appealDate', errors),
+                    errorMessage: errors.appealDate
+                }) }}
+
+        {{ govukTextarea({
+            name: "appeal[appealDetail]",
+            id: "appealDetail",
+            value: appeal.appealDetail,
+            label: {
+            text: "What was the reason for the appeal?",
+            classes: "govuk-fieldset__legend--s"
+            },
+            errorMessage: errors.appealDetail
+        }) }}
+
+        {{ govukTextarea({
+            name: "appeal[reviewer]",
+            id: "reviewer",
+            value: appeal.reviewer,
+            label: {
+            text: "Who made the decision on the appeal?",
+            classes: "govuk-fieldset__legend--s"
+            },
+            errorMessage: errors.reviewer
+        }) }}
+
+        {{ govukRadios({
+            name: "appeal[decision]",
+            classes: "govuk-radios",
+            fieldset: {
+                legend: {
+                    text: "What was the appeal decision?",
+                    classes: "govuk-fieldset__legend--s"
+                }
+            },
+            items: ApplyUtils.appealDecisionRadioItems(appeal.decision),
+            errorMessage: errors.decision
+        }) }}
+
+        {{ govukTextarea({
+            name: "appeal[decisionDetail]",
+            id: "decisionDetail",
+            value: appeal.decisionDetail,
+            label: {
+            text: "What are the reasons for the appeal decision?",
+            classes: "govuk-fieldset__legend--s"
+            },
+            errorMessage: errors.decisionDetail
+        }) }}
+
+        {{ govukButton({
+                    name: 'submit',
+                    text: "Save appeal decision"
+                }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -16,44 +16,27 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-width-container">
-      <div class="moj-page-header-actions">
-        <div class="moj-page-header-actions__title">
-          <span class="govuk-caption-l">{{ pageHeading }}</span>
-          <h1 class="govuk-heading-l">
-            {{ application.person.name }}
-            {% if application.type == 'Offline' %}
-              {{
-                govukTag({
-                  text: "Offline application",
-                  classes: "govuk-tag--grey govuk-!-margin-5"
-                })
-              }}
-            {% endif %}
-          </h1>
-        </div>
-      </div>
-      {% include "../_messages.njk" %}
+      <div class="govuk-grid-column-full">
+        {{ mojIdentityBar(ApplyUtils.applicationIdentityBar(application, pageHeading)) }}
 
-      {% if application.assessmentDecision %}
-        {% set html %}
-        <p class="govuk-body">Application was {{ application.assessmentDecision }} on {{ formatDate(application.assessmentDecisionDate) }}</p>
-        <p class="govuk-body">
-          <a href="{{paths.assessments.show({id: application.assessmentId})}}" data-cy-assessmentId="{{ application.assessmentId }}">View assessment</a>
-        </p>
-        {% endset %}
+        {% include "../_messages.njk" %}
 
-        {{ govukInsetText({
+        {% if application.assessmentDecision %}
+          {% set html %}
+          <p class="govuk-body">Application was {{ application.assessmentDecision }} on {{ formatDate(application.assessmentDecisionDate) }}</p>
+          <p class="govuk-body">
+            <a href="{{paths.assessments.show({id: application.assessmentId})}}" data-cy-assessmentId="{{ application.assessmentId }}">View assessment</a>
+          </p>
+          {% endset %}
+
+          {{ govukInsetText({
           html: html
         }) }}
-      {% endif %}
+        {% endif %}
 
-      {% set subNavClasses = "govuk-grid-column-full" %}
+      </div>
 
-      {% if tab === ApplyUtils.applicationShowPageTabs.application %}
-        {% set subNavClasses =  "govuk-grid-column-three-quarters govuk-!-padding-right-0" %}
-      {% endif %}
-
-      <div class="{{subNavClasses}}">
+      <div class="govuk-grid-column-full">
         {{ mojSubNavigation({
         items: [{
           text: 'Application',
@@ -73,45 +56,21 @@
       }) }}
       </div>
 
-      {% if tab === ApplyUtils.applicationShowPageTabs.application %}
-        <div class="govuk-grid-column-one-quarter govuk-!-padding-left-0 govuk-!-padding-right-0">
-
-          {{ mojIdentityBar({
-          classes: 'govuk-!-padding-top-0 govuk-!-padding-bottom-0 govuk-!-margin-top-0 govuk-!-margin-bottom-0',
-          menus: [{
-            items: [
-            {
-              text: "Withdraw application",
-              href: withdrawalLink,
-              classes: "govuk-button--secondary",
-              attributes: {
-                "data-cy-withdraw-application": application.id
-              }
-            }
-          ]
-          }]
-        }) }}
-        </div>
-
-        {%endif%}
-
-        <div class="govuk-grid-column-full">
-          {% if tab === ApplyUtils.applicationShowPageTabs.timeline %}
-            {{ timeline(mapTimelineEventsForUi(timelineEvents), application, csrfToken) }}
-          {% elif tab === ApplyUtils.applicationShowPageTabs.placementRequests %}
-            {{ requestAPlacement(placementApplications, application, user, csrfToken) }}
-          {% else %}
-            {{ applicationReadonlyView(application) }}
-          {% endif %}
-        </div>
+      <div class="govuk-grid-column-full">
+        {% if tab === ApplyUtils.applicationShowPageTabs.timeline %}
+          {{ timeline(mapTimelineEventsForUi(timelineEvents), application, csrfToken) }}
+        {% elif tab === ApplyUtils.applicationShowPageTabs.placementRequests %}
+          {{ requestAPlacement(placementApplications, application, user, csrfToken) }}
+        {% else %}
+          {{ applicationReadonlyView(application) }}
+        {% endif %}
       </div>
     </div>
-  {% endblock %}
+  </div>
+{% endblock %}
 
-  {% block extraScripts %}
-    {% if tab === ApplyUtils.applicationShowPageTabs.application %}
-      <script type="text/javascript" nonce="{{ cspNonce }}">
-        new MOJFrontend.ButtonMenu({container: $('.moj-button-menu'), mq: "(min-width: 200em)", buttonText: "Actions", menuClasses: "moj-button-menu__wrapper--right"});
-      </script>
-      {%endif%}
-    {% endblock %}
+{% block extraScripts %}
+  <script type="text/javascript" nonce="{{ cspNonce }}">
+    new MOJFrontend.ButtonMenu({container: $('.application-identity-bar .moj-button-menu'), mq: "(min-width: 200em)", buttonText: "Actions", menuClasses: "moj-button-menu__wrapper--right"});
+  </script>
+{% endblock %}

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -17,7 +17,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-width-container">
       <div class="govuk-grid-column-full">
-        {{ mojIdentityBar(ApplyUtils.applicationIdentityBar(application, pageHeading)) }}
+        {{ mojIdentityBar(ApplyUtils.applicationIdentityBar(application, pageHeading, user.roles)) }}
 
         {% include "../_messages.njk" %}
 


### PR DESCRIPTION
This adds logic to record an appeal decision against a rejected application. Only appeal managers should see the link to do this, and it should only show when the application has been rejected

## Screenshot

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/900b67ad-8c2d-4859-99ac-8c0011897187)

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/831ae381-2315-4df5-a1f2-0486dae1449d)
