### PR TITLE
APS-291 Use enhanced withdrawables endpoint to determine if an application can be withdrawn

### DIFF
--- a/integration_tests/tests/apply/withdrawApplication.cy.ts
+++ b/integration_tests/tests/apply/withdrawApplication.cy.ts
@@ -4,7 +4,7 @@ import NewWithdrawalPage from '../../pages/apply/newWithdrawal'
 import Page from '../../pages/page'
 import WithdrawApplicationPage from '../../pages/apply/withdrawApplicationPage'
 import { setup } from './setup'
-import { applicationSummaryFactory } from '../../../server/testutils/factories'
+import { applicationSummaryFactory, withdrawableFactory } from '../../../server/testutils/factories'
 import { WithdrawalReason } from '../../../server/@types/shared'
 
 context('Withdraw Application', () => {
@@ -18,10 +18,11 @@ context('Withdraw Application', () => {
       createdByUserId: '123',
       submittedAt: undefined,
     })
+    const withdrawable = withdrawableFactory.build({ type: 'application' })
     cy.task('stubApplicationGet', { application: this.application })
     cy.task('stubApplications', [inProgressApplication])
     cy.task('stubApplicationWithdrawn', { applicationId: inProgressApplication.id })
-    cy.task('stubWithdrawables', { applicationId: inProgressApplication.id, withdrawables: [] })
+    cy.task('stubWithdrawables', { applicationId: inProgressApplication.id, withdrawables: [withdrawable] })
 
     const withdrawalReason: WithdrawalReason = 'change_in_circumstances_new_application_to_be_submitted'
 

--- a/integration_tests/tests/withdrawals/withdrawals.cy.ts
+++ b/integration_tests/tests/withdrawals/withdrawals.cy.ts
@@ -114,13 +114,13 @@ context('Withdrawals', () => {
   it('withdraws an application', () => {
     const application = applicationSummaryFactory.build()
 
-    const placementRequestWithdrawable = withdrawableFactory.build({
-      type: 'placement_request',
+    const applicationWithdrawable = withdrawableFactory.build({
+      type: 'application',
     })
 
     cy.task('stubWithdrawables', {
       applicationId: application.id,
-      withdrawables: [placementRequestWithdrawable],
+      withdrawables: [applicationWithdrawable],
     })
     cy.task('stubApplications', [application])
     cy.task('stubApplicationGet', { application })

--- a/server/controllers/apply/withdrawablesController.test.ts
+++ b/server/controllers/apply/withdrawablesController.test.ts
@@ -8,6 +8,7 @@ import adminPaths from '../../paths/admin'
 import managePaths from '../../paths/manage'
 import placementAppPaths from '../../paths/placementApplications'
 import { Withdrawable } from '../../@types/shared'
+import applyPaths from '../../paths/apply'
 
 describe('withdrawablesController', () => {
   const token = 'SOME_TOKEN'
@@ -96,6 +97,10 @@ describe('withdrawablesController', () => {
       {
         type: 'placement_application',
         path: placementAppPaths.placementApplications.withdraw.new,
+      },
+      {
+        type: 'application',
+        path: applyPaths.applications.withdraw.new,
       },
     ].forEach(w => {
       it(`redirects to the ${w.type} withdrawal page`, async () => {

--- a/server/controllers/apply/withdrawablesController.ts
+++ b/server/controllers/apply/withdrawablesController.ts
@@ -73,6 +73,10 @@ export default class WithdrawalsController {
         )
       }
 
+      if (withdrawable.type === 'application') {
+        return res.redirect(302, applyPaths.applications.withdraw.new({ id: selectedWithdrawable }))
+      }
+
       throw new Error(`Invalid withdrawable type ${withdrawable.type}`)
     }
   }

--- a/server/utils/applications/withdrawables/index.test.ts
+++ b/server/utils/applications/withdrawables/index.test.ts
@@ -33,28 +33,29 @@ describe('withdrawableTypeRadioOptions', () => {
     },
   }
 
-  it('should return the application radio item if passed an empty array', () => {
-    expect(withdrawableTypeRadioOptions([])).toEqual([applicationRadioItem])
+  it('should return the application radio item if passed an application withdrawable', () => {
+    const applicationWithdrawable = withdrawableFactory.buildList(1, { type: 'application' })
+
+    expect(withdrawableTypeRadioOptions(applicationWithdrawable)).toEqual([applicationRadioItem])
   })
 
   it('should return the placementRequest item if passed a placement request Withdrawable', () => {
     const paWithdrawable = withdrawableFactory.buildList(1, { type: 'placement_application' })
-    expect(withdrawableTypeRadioOptions(paWithdrawable)).toEqual([applicationRadioItem, placementRequestRadioItem])
+    expect(withdrawableTypeRadioOptions(paWithdrawable)).toEqual([placementRequestRadioItem])
 
     const prWithdrawable = withdrawableFactory.buildList(1, { type: 'placement_request' })
-    expect(withdrawableTypeRadioOptions(prWithdrawable)).toEqual([applicationRadioItem, placementRequestRadioItem])
+    expect(withdrawableTypeRadioOptions(prWithdrawable)).toEqual([placementRequestRadioItem])
   })
 
   it('should return the booking item if passed a booking Withdrawable', () => {
     const withdrawable = withdrawableFactory.buildList(1, { type: 'booking' })
-    expect(withdrawableTypeRadioOptions(withdrawable)).toEqual([applicationRadioItem, bookingRadioItem])
+    expect(withdrawableTypeRadioOptions(withdrawable)).toEqual([bookingRadioItem])
   })
 
   it('should return the booking item if passed a booking Withdrawable', () => {
     const bookingWithdrawable = withdrawableFactory.build({ type: 'booking' })
     const paWithdrawable = withdrawableFactory.build({ type: 'placement_request' })
     expect(withdrawableTypeRadioOptions([bookingWithdrawable, paWithdrawable])).toEqual([
-      applicationRadioItem,
       bookingRadioItem,
       placementRequestRadioItem,
     ])
@@ -62,10 +63,7 @@ describe('withdrawableTypeRadioOptions', () => {
 
   it('returns checked: true if an item is selected', () => {
     const withdrawable = withdrawableFactory.buildList(1, { type: 'booking' })
-    expect(withdrawableTypeRadioOptions(withdrawable, 'booking')).toEqual([
-      applicationRadioItem,
-      { ...bookingRadioItem, checked: true },
-    ])
+    expect(withdrawableTypeRadioOptions(withdrawable, 'booking')).toEqual([{ ...bookingRadioItem, checked: true }])
   })
 
   describe('withdrawableRadioOptions', () => {

--- a/server/utils/applications/withdrawables/index.ts
+++ b/server/utils/applications/withdrawables/index.ts
@@ -11,16 +11,18 @@ export const withdrawableTypeRadioOptions = (
   withdrawables: Array<Withdrawable>,
   selectedItem?: SelectedWithdrawableType,
 ) => {
-  const radioItems: Array<RadioItem> = [
-    {
+  const radioItems: Array<RadioItem> = []
+
+  if (withdrawables.find(w => w.type === 'application')) {
+    radioItems.push({
       text: 'Application',
       value: 'application',
       checked: selectedItem === 'application',
       hint: {
         text: `This will withdraw the application, assessment, and any related placement requests and bookings.`,
       },
-    },
-  ]
+    })
+  }
 
   if (withdrawables.find(w => w.type === 'booking')) {
     radioItems.push({


### PR DESCRIPTION
Previously we always assumed that an application is withdrawable. This may not be the case. We hand over responsibility to the API to determine if an application so we no longer automatically add it to the withdrawables array.

[JIRA ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&selectedIssue=APS-291)

