### PR TITLE
(Fix) APS-317 all areas not retained on pagination

### DIFF
--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -1,6 +1,6 @@
 import jwt from 'jsonwebtoken'
 import { Response } from 'superagent'
-import { ApprovedPremisesUserRole as UserRole } from '../../server/@types/shared'
+import { ApArea, ApprovedPremisesUserRole as UserRole } from '../../server/@types/shared'
 
 import { getMatchingRequests, stubFor } from './setup'
 import tokenVerification from './tokenVerification'
@@ -141,7 +141,7 @@ const stubUser = (name: string) =>
 
 export const defaultUserId = '70596333-63d4-4fb2-8acc-9ca55563d878'
 
-const stubProfile = (roles = [], userId = defaultUserId, isActive = true) =>
+const stubProfile = (roles = [], userId = defaultUserId, isActive = true, apArea = undefined) =>
   stubFor({
     request: {
       method: 'GET',
@@ -156,6 +156,7 @@ const stubProfile = (roles = [], userId = defaultUserId, isActive = true) =>
         id: userId,
         roles,
         isActive,
+        apArea,
       },
     },
   })
@@ -181,7 +182,11 @@ export default {
   stubSignIn: (): Promise<[Response, Response, Response, Response, Response, Response]> =>
     Promise.all([favicon(), redirect(), signOut(), manageDetails(), token(), tokenVerification.stubVerifyToken()]),
   stubAuthUser: (
-    args: { name?: string; userId?: string; roles?: Array<UserRole> } = {},
+    args: { name?: string; userId?: string; roles?: Array<UserRole>; apArea?: ApArea } = {},
   ): Promise<[Response, Response, Response]> =>
-    Promise.all([stubUser(args.name || 'john smith'), stubUserRoles(), stubProfile(args.roles || [], args.userId)]),
+    Promise.all([
+      stubUser(args.name || 'john smith'),
+      stubUserRoles(),
+      stubProfile(args.roles || [], args.userId, true, args.apArea),
+    ]),
 }

--- a/integration_tests/tests/tasks/list.cy.ts
+++ b/integration_tests/tests/tasks/list.cy.ts
@@ -260,6 +260,13 @@ context('Tasks', () => {
     })
 
     cy.task('stubReallocatableTasks', {
+      tasks: allocatedTasksFiltered,
+      allocatedFilter: 'allocated',
+      sortDirection: 'desc',
+      apAreaId: '',
+    })
+
+    cy.task('stubReallocatableTasks', {
       tasks: allocatedTasksFilteredPage2,
       allocatedFilter: 'allocated',
       page: '2',
@@ -283,7 +290,6 @@ context('Tasks', () => {
     listPage.shouldShowAllocatedTasks(allocatedTasksFiltered)
 
     // When I visit the next page
-
     listPage.clickNext()
 
     cy.task('verifyTasksRequests', { page: '2', allocatedFilter: 'allocated' }).then(requests => {
@@ -292,5 +298,14 @@ context('Tasks', () => {
 
     // Then the page should show the results
     listPage.shouldShowAllocatedTasks(allocatedTasksFilteredPage2)
+
+    // When I sort by created at in ascending order
+    listPage.clickSortBy('createdAt')
+
+    // Then the dashboard should be sorted by created at
+    listPage.shouldBeSortedByField('createdAt', 'descending')
+
+    // Then the page should show the filtered results
+    listPage.shouldShowAllocatedTasks(allocatedTasksFiltered)
   })
 })

--- a/server/controllers/tasksController.test.ts
+++ b/server/controllers/tasksController.test.ts
@@ -108,7 +108,7 @@ describe('TasksController', () => {
       })
       expect(getPaginationDetails).toHaveBeenCalledWith(unallocatedRequest, paths.tasks.index({}), {
         allocatedFilter: 'unallocated',
-        areas: '1234',
+        area: '1234',
       })
       expect(taskService.getAllReallocatable).toHaveBeenCalledWith(
         token,

--- a/server/controllers/tasksController.ts
+++ b/server/controllers/tasksController.ts
@@ -25,7 +25,7 @@ export default class TasksController {
         hrefPrefix,
       } = getPaginationDetails<TaskSortField>(req, paths.tasks.index({}), {
         allocatedFilter,
-        areas: apAreaId,
+        area: apAreaId,
       })
 
       const tasks = await this.taskService.getAllReallocatable(


### PR DESCRIPTION
In #1432 I changed the area query to be singular, but the parameter name is also used in the creation of the href prefix used for pagination, and so the wrong query name was being passed when using sort or pagination. This fixes that.

Also adding an integration test that covers these scenarios:
- A user's area is filtered by default
- The user can still filter by all areas
- The 'All areas' filter is retained on pagination and sort

[Jira](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328/backlog?issueType=1&selectedIssue=APS-317)

## Screenshots of UI changes

### Before

'All areas' filter was not being retained on pagination or sort:

https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/50752284/7b00548b-d644-4b31-91ed-d28caf267a58

### After

https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/50752284/65e0d7e9-1b51-4f95-8104-92faa85a78a0

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
      `production` in a backwards compatible way? (This includes our API,
      infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
      advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
