### PR TITLE
Fix - Allow a null to be passed in the selectedList array

### DIFF
--- a/server/utils/oasysImportUtils.test.ts
+++ b/server/utils/oasysImportUtils.test.ts
@@ -353,5 +353,19 @@ describe('OASysImportUtils', () => {
         },
       ])
     })
+
+    it('can handle being passed null as a selected item', () => {
+      const needLinkedToReoffendingA = oasysSelectionFactory.needsLinkedToReoffending().build({ section: 1 })
+
+      const items = sectionCheckBoxes([needLinkedToReoffendingA], [null])
+
+      expect(items).toEqual([
+        {
+          checked: false,
+          text: `1. ${sentenceCase(needLinkedToReoffendingA.name)}`,
+          value: '1',
+        },
+      ])
+    })
   })
 })

--- a/server/utils/oasysImportUtils.ts
+++ b/server/utils/oasysImportUtils.ts
@@ -147,7 +147,7 @@ export const sectionCheckBoxes = (fullList: Array<OASysSection>, selectedList: A
     return {
       value: need.section.toString(),
       text: sectionAndName,
-      checked: selectedList.map(n => n.section).includes(need.section),
+      checked: selectedList.map(n => n?.section).includes(need.section),
     }
   })
 }


### PR DESCRIPTION
We are seeing 'null' being passed in as an array value in production. Whilst we track down the cause of this we can handle the error by only checking the 'section' if the OASysSection exists. This will allow users to proceed without having the page error.
