### PR TITLE
Migrate tasks endpoints

### DIFF
--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -4,6 +4,7 @@ import { ApArea, ApprovedPremisesUserRole as UserRole } from '../../server/@type
 
 import { getMatchingRequests, stubFor } from './setup'
 import tokenVerification from './tokenVerification'
+import { apAreaFactory } from '../../server/testutils/factories'
 
 const createToken = () => {
   const payload = {
@@ -135,11 +136,19 @@ const stubUser = (name: string) =>
         username: 'USER1',
         active: true,
         name,
+        ...defaultProfile,
       },
     },
   })
 
 export const defaultUserId = '70596333-63d4-4fb2-8acc-9ca55563d878'
+
+const defaultProfile = {
+  id: defaultUserId,
+  roles: [],
+  isActive: true,
+  apArea: apAreaFactory.build(),
+}
 
 const stubProfile = (roles = [], userId = defaultUserId, isActive = true, apArea = undefined) =>
   stubFor({
@@ -153,6 +162,7 @@ const stubProfile = (roles = [], userId = defaultUserId, isActive = true, apArea
         'Content-Type': 'application/json;charset=UTF-8',
       },
       jsonBody: {
+        ...defaultProfile,
         id: userId,
         roles,
         isActive,

--- a/integration_tests/mockApis/tasks.ts
+++ b/integration_tests/mockApis/tasks.ts
@@ -8,9 +8,10 @@ import { errorStub } from './utils'
 import { kebabCase } from '../../server/utils/utils'
 
 export default {
-  stubReallocatableTasks: ({
+  stubGetAllTasks: ({
     tasks,
     allocatedFilter = 'allocated',
+    allocatedToUserId = '',
     page = '1',
     sortDirection = 'asc',
     sortBy = 'createdAt',
@@ -19,6 +20,7 @@ export default {
     tasks: Array<Task>
     page: string
     allocatedFilter: string
+    allocatedToUserId: string
     sortDirection: SortDirection
     sortBy: TaskSortField
     apAreaId: string
@@ -39,11 +41,14 @@ export default {
       sortBy: {
         equalTo: sortBy,
       },
+      allocatedToUserId: {
+        equalTo: allocatedToUserId,
+      },
     }
     return stubFor({
       request: {
         method: 'GET',
-        urlPathPattern: paths.tasks.reallocatable.index.pattern,
+        urlPathPattern: paths.tasks.index.pattern,
         queryParameters,
       },
       response: {
@@ -157,7 +162,7 @@ export default {
     (
       await getMatchingRequests({
         method: 'GET',
-        urlPathPattern: paths.tasks.reallocatable.index.pattern,
+        urlPathPattern: paths.tasks.index.pattern,
         queryParameters: {
           allocatedFilter: {
             equalTo: allocatedFilter,

--- a/integration_tests/mockApis/tasks.ts
+++ b/integration_tests/mockApis/tasks.ts
@@ -77,28 +77,6 @@ export default {
         jsonBody: tasks,
       },
     }),
-  stubTasksOfType: (args: { tasks: Array<Task>; type: string; page: string }): SuperAgentRequest =>
-    stubFor({
-      request: {
-        method: 'GET',
-        urlPathPattern: paths.tasks.type.index({ taskType: args.type }),
-        queryParameters: {
-          page: {
-            equalTo: args.page || '1',
-          },
-        },
-      },
-      response: {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json;charset=UTF-8',
-          'X-Pagination-TotalPages': '10',
-          'X-Pagination-TotalResults': '100',
-          'X-Pagination-PageSize': '10',
-        },
-        jsonBody: args.tasks,
-      },
-    }),
   stubTaskGet: (args: { task: Task; users: Array<User> }): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/tests/match/listPlacementApplications.cy.ts
+++ b/integration_tests/tests/match/listPlacementApplications.cy.ts
@@ -1,4 +1,5 @@
 import { placementApplicationTaskFactory } from '../../../server/testutils/factories'
+import { defaultUserId } from '../../mockApis/auth'
 import ListPage from '../../pages/match/listPlacementRequestsPage'
 
 describe('List placement applications', () => {
@@ -11,9 +12,24 @@ describe('List placement applications', () => {
     const page2PlacementApplications = placementApplicationTaskFactory.buildList(10)
     const page3PlacementApplications = placementApplicationTaskFactory.buildList(10)
 
-    cy.task('stubTasksOfType', { type: 'placement-application', tasks: page1PlacementApplications, page: '1' })
-    cy.task('stubTasksOfType', { type: 'placement-application', tasks: page2PlacementApplications, page: '2' })
-    cy.task('stubTasksOfType', { type: 'placement-application', tasks: page3PlacementApplications, page: '3' })
+    cy.task('stubGetAllTasks', {
+      type: 'PlacementApplication',
+      tasks: page1PlacementApplications,
+      page: '1',
+      allocatedToUserId: defaultUserId,
+    })
+    cy.task('stubGetAllTasks', {
+      type: 'PlacementApplication',
+      tasks: page2PlacementApplications,
+      page: '2',
+      allocatedToUserId: defaultUserId,
+    })
+    cy.task('stubGetAllTasks', {
+      type: 'PlacementApplication',
+      tasks: page3PlacementApplications,
+      page: '3',
+      allocatedToUserId: defaultUserId,
+    })
 
     // When I visit the placementRequests dashboard
     const listPage = ListPage.visit()

--- a/integration_tests/tests/match/placementApplications.cy.ts
+++ b/integration_tests/tests/match/placementApplications.cy.ts
@@ -270,7 +270,12 @@ context('Placement Applications', () => {
     const placementApplication = placementApplicationFactory.build({ id: placementApplicationTasks[0].id, document })
     cy.task('stubPlacementApplication', placementApplication)
 
-    cy.task('stubTasksOfType', { type: 'placement-application', tasks: placementApplicationTasks })
+    cy.task('stubGetAllTasks', {
+      type: 'PlacementApplication',
+      tasks: placementApplicationTasks,
+      allocatedToUserId: 'some-user-id',
+      allocatedFilter: 'allocated',
+    })
 
     // When I visit the placementRequests dashboard
     const listPage = ListPage.visit()
@@ -322,7 +327,12 @@ context('Placement Applications', () => {
     const placementApplication = placementApplicationFactory.build({ id: placementApplicationTasks[0].id, document })
     cy.task('stubPlacementApplication', placementApplication)
 
-    cy.task('stubTasksOfType', { type: 'placement-application', tasks: placementApplicationTasks })
+    cy.task('stubGetAllTasks', {
+      type: 'PlacementApplication',
+      tasks: placementApplicationTasks,
+      allocatedToUserId: 'some-user-id',
+      allocatedFilter: 'allocated',
+    })
 
     // When I visit the placementRequests dashboard
     const listPage = ListPage.visit()
@@ -352,8 +362,12 @@ context('Placement Applications', () => {
     }
     const placementApplication = placementApplicationFactory.build({ id: placementApplicationTasks[0].id, document })
     cy.task('stubPlacementApplication', placementApplication)
-
-    cy.task('stubTasksOfType', { type: 'placement-application', tasks: placementApplicationTasks })
+    cy.task('stubGetAllTasks', {
+      type: 'PlacementApplication',
+      tasks: placementApplicationTasks,
+      allocatedToUserId: 'some-user-id',
+      allocatedFilter: 'allocated',
+    })
 
     // When I visit the placementRequests dashboard
     const listPage = ListPage.visit()

--- a/integration_tests/tests/tasks/allocations.cy.ts
+++ b/integration_tests/tests/tasks/allocations.cy.ts
@@ -51,7 +51,7 @@ context('Task Allocation', () => {
 
     const tasks = [task, taskWithRestrictedPerson]
 
-    cy.task('stubReallocatableTasks', {
+    cy.task('stubGetAllTasks', {
       tasks,
       allocatedFilter: 'allocated',
       page: '1',

--- a/integration_tests/tests/tasks/list.cy.ts
+++ b/integration_tests/tests/tasks/list.cy.ts
@@ -19,14 +19,14 @@ context('Task Allocation', () => {
     const allocatedTasks = taskFactory.buildList(5)
     const unallocatedTasks = taskFactory.buildList(5, { allocatedToStaffMember: undefined })
 
-    cy.task('stubReallocatableTasks', {
+    cy.task('stubGetAllTasks', {
       tasks: allocatedTasks,
       allocatedFilter: 'allocated',
       page: '1',
       sortDirection: 'asc',
     })
 
-    cy.task('stubReallocatableTasks', {
+    cy.task('stubGetAllTasks', {
       tasks: [...unallocatedTasks],
       allocatedFilter: 'unallocated',
       page: '1',
@@ -60,11 +60,11 @@ context('Task Allocation', () => {
     const allocatedTasksPage9 = taskFactory.buildList(10)
     const unallocatedTasks = taskFactory.buildList(1, { allocatedToStaffMember: undefined })
 
-    cy.task('stubReallocatableTasks', { tasks: allocatedTasksPage1, allocatedFilter: 'allocated', page: '1' })
+    cy.task('stubGetAllTasks', { tasks: allocatedTasksPage1, allocatedFilter: 'allocated', page: '1' })
 
-    cy.task('stubReallocatableTasks', { tasks: allocatedTasksPage2, allocatedFilter: 'allocated', page: '2' })
+    cy.task('stubGetAllTasks', { tasks: allocatedTasksPage2, allocatedFilter: 'allocated', page: '2' })
 
-    cy.task('stubReallocatableTasks', { tasks: allocatedTasksPage9, allocatedFilter: 'allocated', page: '9' })
+    cy.task('stubGetAllTasks', { tasks: allocatedTasksPage9, allocatedFilter: 'allocated', page: '9' })
 
     cy.task('stubApAreaReferenceData', {
       id: apAreaId,
@@ -107,14 +107,14 @@ context('Task Allocation', () => {
 
     const tasks = taskFactory.buildList(10)
 
-    cy.task('stubReallocatableTasks', {
+    cy.task('stubGetAllTasks', {
       tasks,
       allocatedFilter: 'allocated',
       page: '1',
       sortDirection: 'asc',
       sortField: 'createdAt',
     })
-    cy.task('stubReallocatableTasks', {
+    cy.task('stubGetAllTasks', {
       tasks,
       allocatedFilter: 'allocated',
       sortDirection: 'desc',
@@ -159,7 +159,7 @@ context('Task Allocation', () => {
     const allocatedTasksFiltered = taskFactory.buildList(1)
     const unallocatedTasks = taskFactory.buildList(1, { allocatedToStaffMember: undefined })
 
-    cy.task('stubReallocatableTasks', { tasks: allocatedTasks, allocatedFilter: 'allocated', page: '1' })
+    cy.task('stubGetAllTasks', { tasks: allocatedTasks, allocatedFilter: 'allocated', page: '1' })
     cy.task('stubApAreaReferenceData', {
       id: apAreaId,
       name: 'Midlands',
@@ -172,7 +172,7 @@ context('Task Allocation', () => {
     listPage.shouldShowAllocatedTasks()
 
     // When I filter by region
-    cy.task('stubReallocatableTasks', {
+    cy.task('stubGetAllTasks', {
       tasks: allocatedTasksFiltered,
       allocatedFilter: 'allocated',
       page: '1',
@@ -197,7 +197,7 @@ context('Task Allocation', () => {
     const unallocatedTasks = taskFactory.buildList(10, { allocatedToStaffMember: undefined })
     const unallocatedTasksFiltered = taskFactory.buildList(1, { allocatedToStaffMember: undefined })
 
-    cy.task('stubReallocatableTasks', {
+    cy.task('stubGetAllTasks', {
       tasks: unallocatedTasks,
       allocatedFilter: 'unallocated',
       page: '1',
@@ -215,7 +215,7 @@ context('Task Allocation', () => {
     listPage.shouldShowUnallocatedTasks()
 
     // When I filter by region
-    cy.task('stubReallocatableTasks', {
+    cy.task('stubGetAllTasks', {
       tasks: unallocatedTasksFiltered,
       allocatedFilter: 'unallocated',
       page: '1',
@@ -244,14 +244,14 @@ context('Task Allocation', () => {
     const allocatedTasksFilteredPage2 = taskFactory.buildList(10)
     const unallocatedTasks = taskFactory.buildList(1, { allocatedToStaffMember: undefined })
 
-    cy.task('stubReallocatableTasks', {
+    cy.task('stubGetAllTasks', {
       tasks: allocatedTasks,
       allocatedFilter: 'allocated',
       page: '1',
       apAreaId: apArea.id,
     })
 
-    cy.task('stubReallocatableTasks', {
+    cy.task('stubGetAllTasks', {
       tasks: allocatedTasksFiltered,
       allocatedFilter: 'allocated',
       page: '1',
@@ -259,14 +259,14 @@ context('Task Allocation', () => {
       apAreaId: '',
     })
 
-    cy.task('stubReallocatableTasks', {
+    cy.task('stubGetAllTasks', {
       tasks: allocatedTasksFiltered,
       allocatedFilter: 'allocated',
       sortDirection: 'desc',
       apAreaId: '',
     })
 
-    cy.task('stubReallocatableTasks', {
+    cy.task('stubGetAllTasks', {
       tasks: allocatedTasksFilteredPage2,
       allocatedFilter: 'allocated',
       page: '2',

--- a/server/controllers/match/placementRequestsController.ts
+++ b/server/controllers/match/placementRequestsController.ts
@@ -17,11 +17,11 @@ export default class PlacementRequestsController {
   index(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       const { pageNumber, hrefPrefix } = getPaginationDetails(req, matchpaths.placementRequests.index({}))
-      const paginatedResponse = await this.taskService.getTasksOfType(
-        req.user.token,
-        'placement-application',
-        pageNumber,
-      )
+      const paginatedResponse = await this.taskService.getAll({
+        token: req.user.token,
+        taskType: 'PlacementApplication',
+        page: pageNumber,
+      })
 
       res.render('match/placementRequests/index', {
         pageHeading: 'My Cases',

--- a/server/controllers/match/placementRequestsController.ts
+++ b/server/controllers/match/placementRequestsController.ts
@@ -17,10 +17,16 @@ export default class PlacementRequestsController {
   index(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       const { pageNumber, hrefPrefix } = getPaginationDetails(req, matchpaths.placementRequests.index({}))
+
       const paginatedResponse = await this.taskService.getAll({
         token: req.user.token,
         taskType: 'PlacementApplication',
         page: pageNumber,
+        allocatedFilter: 'allocated',
+        sortBy: 'createdAt',
+        sortDirection: 'asc',
+        allocatedToUserId: res.locals?.user?.id,
+        apAreaId: res.locals.user.apArea?.id,
       })
 
       res.render('match/placementRequests/index', {

--- a/server/controllers/tasksController.ts
+++ b/server/controllers/tasksController.ts
@@ -28,14 +28,15 @@ export default class TasksController {
         area: apAreaId,
       })
 
-      const tasks = await this.taskService.getAllReallocatable(
-        req.user.token,
+      const tasks = await this.taskService.getAll({
+        token: req.user.token,
         allocatedFilter,
         sortBy,
         sortDirection,
-        pageNumber,
-        apAreaId === 'all' ? '' : apAreaId,
-      )
+        page: pageNumber,
+        apAreaId: apAreaId === 'all' ? '' : apAreaId,
+      })
+
       const apAreas = await this.apAreaService.getApAreas(req.user.token)
 
       res.render('tasks/index', {

--- a/server/data/taskClient.test.ts
+++ b/server/data/taskClient.test.ts
@@ -10,6 +10,7 @@ import {
   taskWrapperFactory,
 } from '../testutils/factories'
 import describeClient from '../testutils/describeClient'
+import { TaskType } from '../@types/shared'
 
 describeClient('taskClient', provider => {
   let taskClient: TaskClient
@@ -20,22 +21,28 @@ describeClient('taskClient', provider => {
     taskClient = new TaskClient(token)
   })
 
-  describe('allReallocatable', () => {
-    it('makes a get request to the reallocatable tasks endpoint', async () => {
+  describe('getAll', () => {
+    it('makes a get request to the tasks endpoint', async () => {
       const tasks = taskFactory.buildList(2)
+
+      const apAreaId = 'ap-area-id'
+      const userId = 'user-id'
+      const taskType: TaskType = 'placement-application'
 
       provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: `A request to get a list of tasks`,
         withRequest: {
           method: 'GET',
-          path: paths.tasks.reallocatable.index.pattern,
+          path: paths.tasks.index.pattern,
           query: {
             allocatedFilter: 'allocated',
-            apAreaId: 'test',
+            apAreaId,
+            allocatedToUserId: userId,
             page: '1',
             sortDirection: 'asc',
             sortBy: 'createdAt',
+            taskType,
           },
           headers: {
             authorization: `Bearer ${token}`,
@@ -53,7 +60,15 @@ describeClient('taskClient', provider => {
         },
       })
 
-      const result = await taskClient.allReallocatable('allocated', 'test', 1, 'asc', 'createdAt')
+      const result = await taskClient.getAll({
+        allocatedFilter: 'allocated',
+        apAreaId,
+        allocatedToUserId: userId,
+        page: 1,
+        sortDirection: 'asc',
+        sortBy: 'createdAt',
+        taskType,
+      })
 
       expect(result).toEqual({
         data: tasks,

--- a/server/data/taskClient.test.ts
+++ b/server/data/taskClient.test.ts
@@ -27,7 +27,7 @@ describeClient('taskClient', provider => {
 
       const apAreaId = 'ap-area-id'
       const userId = 'user-id'
-      const taskType: TaskType = 'placement-application'
+      const taskType: TaskType = 'PlacementRequest'
 
       provider.addInteraction({
         state: 'Server is healthy',
@@ -69,47 +69,6 @@ describeClient('taskClient', provider => {
         sortBy: 'createdAt',
         taskType,
       })
-
-      expect(result).toEqual({
-        data: tasks,
-        pageNumber: '1',
-        totalPages: '10',
-        totalResults: '100',
-        pageSize: '10',
-      })
-    })
-  })
-
-  describe('allByType', () => {
-    it('makes a get request to the tasks type endpoint', async () => {
-      const tasks = taskFactory.buildList(2)
-
-      provider.addInteraction({
-        state: 'Server is healthy',
-        uponReceiving: `A request to get a list of tasks of a type`,
-        withRequest: {
-          method: 'GET',
-          path: paths.tasks.type.index({ taskType: 'placement-application' }),
-          query: {
-            page: '1',
-          },
-          headers: {
-            authorization: `Bearer ${token}`,
-            'X-Service-Name': 'approved-premises',
-          },
-        },
-        willRespondWith: {
-          status: 200,
-          body: tasks,
-          headers: {
-            'X-Pagination-TotalPages': '10',
-            'X-Pagination-TotalResults': '100',
-            'X-Pagination-PageSize': '10',
-          },
-        },
-      })
-
-      const result = await taskClient.allByType('placement-application')
 
       expect(result).toEqual({
         data: tasks,

--- a/server/data/taskClient.ts
+++ b/server/data/taskClient.ts
@@ -48,14 +48,6 @@ export default class TaskClient {
     return (await this.restClient.get({ path: paths.tasks.index.pattern })) as Promise<Array<CategorisedTask>>
   }
 
-  async allByType(taskType: string, page = 1): Promise<PaginatedResponse<Task>> {
-    return this.restClient.getPaginatedResponse({
-      path: paths.tasks.type.index({ taskType }),
-      page: page.toString(),
-      query: {},
-    })
-  }
-
   async find(applicationId: string, taskType: string): Promise<TaskWrapper> {
     return (await this.restClient.get({
       path: paths.tasks.show({ id: applicationId, taskType }),

--- a/server/data/taskClient.ts
+++ b/server/data/taskClient.ts
@@ -2,7 +2,16 @@ import { CategorisedTask, PaginatedResponse } from '@approved-premises/ui'
 import config, { ApiConfig } from '../config'
 import RestClient from './restClient'
 import paths from '../paths/api'
-import { Reallocation, Task, TaskSortField, TaskWrapper, User } from '../@types/shared'
+import {
+  AllocatedFilter,
+  ApArea,
+  Reallocation,
+  Task,
+  TaskSortField,
+  TaskType,
+  TaskWrapper,
+  User,
+} from '../@types/shared'
 
 export default class TaskClient {
   restClient: RestClient
@@ -11,17 +20,27 @@ export default class TaskClient {
     this.restClient = new RestClient('taskClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
-  async allReallocatable(
-    allocatedFilter: string,
-    apAreaId: string,
-    page: number,
-    sortDirection: string,
-    sortBy: TaskSortField,
-  ): Promise<PaginatedResponse<Task>> {
+  async getAll({
+    allocatedFilter,
+    apAreaId,
+    allocatedToUserId,
+    page,
+    sortDirection,
+    sortBy,
+    taskType,
+  }: {
+    allocatedFilter: AllocatedFilter
+    apAreaId: ApArea['id']
+    allocatedToUserId: string
+    page: number
+    sortDirection: string
+    sortBy: TaskSortField
+    taskType?: TaskType
+  }): Promise<PaginatedResponse<Task>> {
     return this.restClient.getPaginatedResponse({
-      path: paths.tasks.reallocatable.index.pattern,
+      path: paths.tasks.index.pattern,
       page: page.toString(),
-      query: { allocatedFilter, apAreaId, sortDirection, sortBy },
+      query: { allocatedFilter, allocatedToUserId, apAreaId, sortBy, sortDirection, taskType },
     })
   }
 

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -151,9 +151,6 @@ export default {
   },
   tasks: {
     index: tasksPaths.index,
-    reallocatable: {
-      index: tasksPaths.index.path('reallocatable'),
-    },
     type: {
       index: tasksPaths.index.path(':taskType'),
     },

--- a/server/services/taskService.test.ts
+++ b/server/services/taskService.test.ts
@@ -26,16 +26,23 @@ describe('taskService', () => {
     taskClientFactory.mockReturnValue(taskClient)
   })
 
-  describe('getAllReallocatable', () => {
-    it('calls the all method on the task client', async () => {
+  describe('getAll', () => {
+    it('calls the getAll method on the task client', async () => {
       const tasks: Array<Task> = taskFactory.buildList(2)
       const paginatedResponse = paginatedResponseFactory.build({
         data: tasks,
       }) as PaginatedResponse<Task>
 
-      taskClient.allReallocatable.mockResolvedValue(paginatedResponse)
+      taskClient.getAll.mockResolvedValue(paginatedResponse)
 
-      const result = await service.getAllReallocatable(token, 'allocated', 'createdAt', 'asc', 1, 'testAreaId')
+      const result = await service.getAll({
+        token,
+        allocatedFilter: 'allocated',
+        sortBy: 'createdAt',
+        sortDirection: 'asc',
+        page: 1,
+        apAreaId: 'testAreaId',
+      })
 
       expect(result).toEqual({
         data: tasks,
@@ -46,7 +53,14 @@ describe('taskService', () => {
       })
 
       expect(taskClientFactory).toHaveBeenCalledWith(token)
-      expect(taskClient.allReallocatable).toHaveBeenCalledWith('allocated', 'testAreaId', 1, 'asc', 'createdAt')
+      expect(taskClient.getAll).toHaveBeenCalledWith({
+        allocatedFilter: 'allocated',
+        apAreaId: 'testAreaId',
+        allocatedToUserId: '',
+        page: 1,
+        sortDirection: 'asc',
+        sortBy: 'createdAt',
+      })
     })
   })
 

--- a/server/services/taskService.test.ts
+++ b/server/services/taskService.test.ts
@@ -64,21 +64,6 @@ describe('taskService', () => {
     })
   })
 
-  describe('getTasksOfType', () => {
-    it('calls the allByType method on the task client', async () => {
-      const tasks: Array<Task> = taskFactory.buildList(2)
-      const paginatedResponse = paginatedResponseFactory.build({ data: tasks }) as PaginatedResponse<Task>
-      taskClient.allByType.mockResolvedValue(paginatedResponse)
-
-      const result = await service.getTasksOfType(token, 'placement-application', 1)
-
-      expect(result).toEqual(paginatedResponse)
-
-      expect(taskClientFactory).toHaveBeenCalledWith(token)
-      expect(taskClient.allByType).toHaveBeenCalledWith('placement-application', 1)
-    })
-  })
-
   describe('getMatchTasks', () => {
     it('calls the all method on the task client', async () => {
       const applicationTasks = placementApplicationTaskFactory.buildList(1)

--- a/server/services/taskService.ts
+++ b/server/services/taskService.ts
@@ -5,6 +5,7 @@ import {
   SortDirection,
   Task,
   TaskSortField,
+  TaskType,
   TaskWrapper,
   ApprovedPremisesUser as User,
   UserQualification,
@@ -16,24 +17,38 @@ import TaskClient from '../data/taskClient'
 export default class TaskService {
   constructor(private readonly taskClientFactory: RestClientBuilder<TaskClient>) {}
 
-  async getAllReallocatable(
-    token: string,
-    allocatedFilter: 'allocated' | 'unallocated',
-    sortBy: TaskSortField,
-    sortDirection: SortDirection,
-    page: number = 1,
-    apAreaId: string = '',
-  ): Promise<PaginatedResponse<Task>> {
+  async getAll({
+    token,
+    allocatedFilter,
+    allocatedToUserId = '',
+    sortBy,
+    sortDirection,
+    page = 1,
+    apAreaId = '',
+    taskType,
+  }: {
+    token: string
+    allocatedFilter: 'allocated' | 'unallocated'
+    allocatedToUserId?: string
+    sortBy: TaskSortField
+    sortDirection: SortDirection
+    page: number
+    apAreaId?: string
+    taskType?: TaskType
+  }): Promise<PaginatedResponse<Task>> {
     const taskClient = this.taskClientFactory(token)
 
-    const tasks = await taskClient.allReallocatable(allocatedFilter, apAreaId, page, sortDirection, sortBy)
+    const tasks = await taskClient.getAll({
+      allocatedFilter,
+      allocatedToUserId,
+      apAreaId,
+      page,
+      sortDirection,
+      sortBy,
+      taskType,
+    })
+
     return tasks
-  }
-
-  async getTasksOfType(token: string, type: string, page: number = 1): Promise<PaginatedResponse<Task>> {
-    const taskClient = this.taskClientFactory(token)
-
-    return taskClient.allByType(type, page)
   }
 
   async getMatchTasks(token: string): Promise<GroupedMatchTasks> {


### PR DESCRIPTION
# Context
[JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&selectedIssue=APS-283) 
Since [this API PR](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1447) the updated `/tasks`
endpoint has provided the behaviour provided two seperate endpoints (`tasks/reallocatable`, `tasks/:taskType`).  
This PR consolidate these endpoints to use the `/tasks` endpoint without any change to behaviour.


# Changes in this PR
- move the `tasks/reallocatable` calls to the `/tasks` endpoint
- move the `tasks/:taskType` calls to the `/tasks` endpoint.

