### PR TITLE
Fix/ Remove applications from selectable withdrawables

### DIFF
--- a/server/utils/applications/withdrawables/index.test.ts
+++ b/server/utils/applications/withdrawables/index.test.ts
@@ -113,5 +113,20 @@ describe('withdrawableTypeRadioOptions', () => {
         },
       ])
     })
+
+    it('filters out applications', () => {
+      const paWithdrawable = withdrawableFactory.build({ type: 'placement_application' })
+      const applicationWithdrawable = withdrawableFactory.build({ type: 'application' })
+
+      expect(withdrawableRadioOptions([paWithdrawable, applicationWithdrawable], paWithdrawable.id)).toEqual([
+        {
+          text: paWithdrawable.dates
+            .map(datePeriod => DateFormats.formatDurationBetweenTwoDates(datePeriod.startDate, datePeriod.endDate))
+            .join(', '),
+          checked: true,
+          value: paWithdrawable.id,
+        },
+      ])
+    })
   })
 })

--- a/server/utils/applications/withdrawables/index.ts
+++ b/server/utils/applications/withdrawables/index.ts
@@ -61,60 +61,63 @@ export const withdrawableRadioOptions = (
   selectedWithdrawable?: Withdrawable['id'],
   bookings: Array<Booking> = [],
 ): Array<RadioItem> => {
-  return withdrawables.map(withdrawable => {
-    if (withdrawable.type === 'placement_application') {
-      return {
-        text: withdrawable.dates
-          .map(datePeriod => DateFormats.formatDurationBetweenTwoDates(datePeriod.startDate, datePeriod.endDate))
-          .join(', '),
-        value: withdrawable.id,
-        checked: selectedWithdrawable === withdrawable.id,
+  return withdrawables
+    .filter(withdrawable => withdrawable.type !== 'application')
+    .map(withdrawable => {
+      if (withdrawable.type === 'placement_application') {
+        return {
+          text: withdrawable.dates
+            .map(datePeriod => DateFormats.formatDurationBetweenTwoDates(datePeriod.startDate, datePeriod.endDate))
+            .join(', '),
+          value: withdrawable.id,
+          checked: selectedWithdrawable === withdrawable.id,
+        }
       }
-    }
-    if (withdrawable.type === 'placement_request') {
-      return {
-        text: withdrawable.dates
-          .map(datePeriod => DateFormats.formatDurationBetweenTwoDates(datePeriod.startDate, datePeriod.endDate))
-          .join(', '),
-        value: withdrawable.id,
-        checked: selectedWithdrawable === withdrawable.id,
-        hint: {
-          html: linkTo(
-            matchPaths.placementRequests.show,
-            { id: withdrawable.id },
-            {
-              text: 'See placement details (opens in a new tab)',
-              attributes: { 'data-cy-withdrawable-id': withdrawable.id },
-              openInNewTab: true,
-            },
-          ),
-        },
+      if (withdrawable.type === 'placement_request') {
+        return {
+          text: withdrawable.dates
+            .map(datePeriod => DateFormats.formatDurationBetweenTwoDates(datePeriod.startDate, datePeriod.endDate))
+            .join(', '),
+          value: withdrawable.id,
+          checked: selectedWithdrawable === withdrawable.id,
+          hint: {
+            html: linkTo(
+              matchPaths.placementRequests.show,
+              { id: withdrawable.id },
+              {
+                text: 'See placement details (opens in a new tab)',
+                attributes: { 'data-cy-withdrawable-id': withdrawable.id },
+                openInNewTab: true,
+              },
+            ),
+          },
+        }
       }
-    }
-    if (withdrawable.type === 'booking') {
-      const booking = bookings.find(b => b.id === withdrawable.id)
+      if (withdrawable.type === 'booking') {
+        const booking = bookings.find(b => b.id === withdrawable.id)
 
-      if (!booking) throw new Error(`Booking not found for withdrawable: ${withdrawable.id}`)
+        if (!booking) throw new Error(`Booking not found for withdrawable: ${withdrawable.id}`)
 
-      return {
-        text: `${booking.premises.name} - ${withdrawable.dates
-          .map(datePeriod => DateFormats.formatDurationBetweenTwoDates(datePeriod.startDate, datePeriod.endDate))
-          .join(', ')}`,
-        value: withdrawable.id,
-        checked: selectedWithdrawable === withdrawable.id,
-        hint: {
-          html: linkTo(
-            managePaths.bookings.show,
-            { premisesId: booking.premises.id, bookingId: booking.id },
-            {
-              text: 'See placement details (opens in a new tab)',
-              attributes: { 'data-cy-withdrawable-id': withdrawable.id },
-              openInNewTab: true,
-            },
-          ),
-        },
+        return {
+          text: `${booking.premises.name} - ${withdrawable.dates
+            .map(datePeriod => DateFormats.formatDurationBetweenTwoDates(datePeriod.startDate, datePeriod.endDate))
+            .join(', ')}`,
+          value: withdrawable.id,
+          checked: selectedWithdrawable === withdrawable.id,
+          hint: {
+            html: linkTo(
+              managePaths.bookings.show,
+              { premisesId: booking.premises.id, bookingId: booking.id },
+              {
+                text: 'See placement details (opens in a new tab)',
+                attributes: { 'data-cy-withdrawable-id': withdrawable.id },
+                openInNewTab: true,
+              },
+            ),
+          },
+        }
       }
-    }
-    throw new Error(`Unknown withdrawable type: ${withdrawable.type}`)
-  })
+
+      throw new Error(`Unknown withdrawable type: ${withdrawable.type}`)
+    })
 }


### PR DESCRIPTION
Since applications were added to the [withdrawable.type enum](https://github.com/ministryofjustice/hmpps-approved-premises-ui/blob/83eab29d000ae1c8b0dfde2b73e213d491ca3246/server/%40types/shared/models/WithdrawableType.ts#L5) they can be passed into the [withdrawableRadioOptions](https://github.com/ministryofjustice/hmpps-approved-premises-ui/blob/83eab29d000ae1c8b0dfde2b73e213d491ca3246/server/utils/applications/withdrawables/index.ts#L59) function.
It doesn't make sense to show them when selecting a withdrawable to withdraw as I did in [#1477](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/1477) so I reverted it in [#1487](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/1487) but this meant that the new withdrawals journey errored. Now, we filter out the application from the list of possible withdrawables which should prevent the error and prevent applications showing up as a selectable withdrawable.

