### PR TITLE
Fix/only allow selected withdrawable types to be selectable

### DIFF
--- a/integration_tests/pages/apply/newWithdrawal.ts
+++ b/integration_tests/pages/apply/newWithdrawal.ts
@@ -1,10 +1,35 @@
 import { Withdrawable } from '../../../server/@types/shared'
 import matchPaths from '../../../server/paths/match'
+import { SelectedWithdrawableType } from '../../../server/utils/applications/withdrawables'
 import Page from '../page'
 
 export default class SelectWithdrawableTypePage extends Page {
   constructor(heading: 'What do you want to withdraw?' | 'Select your placement') {
     super(heading)
+  }
+
+  shouldShowWithdrawableTypes(types: Array<SelectedWithdrawableType>) {
+    types.forEach(type => {
+      cy.get(`input[value="${type}"]`).should('exist')
+    })
+  }
+
+  shouldNotShowWithdrawableTypes(types: Array<SelectedWithdrawableType>) {
+    types.forEach(type => {
+      cy.get(`input[value="${type}"]`).should('not.exist')
+    })
+  }
+
+  shouldShowWithdrawables(withdrawables: Array<Withdrawable>) {
+    withdrawables.forEach(withdrawable => {
+      cy.get(`input[value="${withdrawable.id}"]`).should('exist')
+    })
+  }
+
+  shouldNotShowWithdrawables(withdrawables: Array<Withdrawable>) {
+    withdrawables.forEach(type => {
+      cy.get(`input[value="${type.id}"]`).should('not.exist')
+    })
   }
 
   selectType(type: 'placementRequest' | 'placement' | 'application') {

--- a/integration_tests/tests/withdrawals/withdrawals.cy.ts
+++ b/integration_tests/tests/withdrawals/withdrawals.cy.ts
@@ -142,17 +142,17 @@ context('Withdrawals', () => {
     Page.verifyOnPage(WithdrawApplicationPage)
   })
 
-  it('withdraws a booking', () => {
+  it('withdraws a placement', () => {
     const application = applicationSummaryFactory.build()
-    const booking = bookingFactory.build({ applicationId: application.id })
-    const bookingWithdrawable = withdrawableFactory.build({
+    const placement = bookingFactory.build({ applicationId: application.id })
+    const placementWithdrawable = withdrawableFactory.build({
       type: 'booking',
-      id: booking.id,
+      id: placement.id,
     })
 
     cy.task('stubWithdrawables', {
       applicationId: application.id,
-      withdrawables: [bookingWithdrawable],
+      withdrawables: [placementWithdrawable],
     })
     cy.task('stubApplications', [application])
     cy.task('stubApplicationGet', { application })

--- a/integration_tests/tests/withdrawals/withdrawals.cy.ts
+++ b/integration_tests/tests/withdrawals/withdrawals.cy.ts
@@ -31,9 +31,15 @@ context('Withdrawals', () => {
       type: 'placement_request',
       id: placementRequest.id,
     })
+    const placementApplicationWithdrawable = withdrawableFactory.build({
+      type: 'placement_application',
+    })
+    const placementWithdrawable = withdrawableFactory.build({
+      type: 'booking',
+    })
     cy.task('stubWithdrawables', {
       applicationId: application.id,
-      withdrawables: [placementRequestWithdrawable],
+      withdrawables: [placementRequestWithdrawable, placementApplicationWithdrawable, placementWithdrawable],
     })
     cy.task('stubApplications', [application])
     cy.task('stubApplicationGet', { application })
@@ -50,12 +56,20 @@ context('Withdrawals', () => {
 
     // Then I am asked what I want to withdraw
     const newWithdrawalPage = new NewWithdrawalPage('What do you want to withdraw?')
+
+    // And I am shown the correct withdrawables
+    newWithdrawalPage.shouldShowWithdrawableTypes(['placementRequest', 'placement'])
+    newWithdrawalPage.shouldNotShowWithdrawableTypes(['application'])
+
+    // When I select 'placementRequest'
     newWithdrawalPage.selectType('placementRequest')
     newWithdrawalPage.clickSubmit()
 
-    // And I am shown a list of placement requests that can be withdrawn
+    // Then I am shown a list of placement requests that can be withdrawn
     const selectWithdrawablePage = new NewWithdrawalPage('Select your placement')
     selectWithdrawablePage.veryifyLink(placementRequest.id, 'placement_request')
+    selectWithdrawablePage.shouldShowWithdrawables([placementRequestWithdrawable, placementApplicationWithdrawable])
+    selectWithdrawablePage.shouldNotShowWithdrawables([placementWithdrawable])
 
     // When I select a placement request
     selectWithdrawablePage.selectWithdrawable(placementRequest.id)
@@ -80,10 +94,11 @@ context('Withdrawals', () => {
       type: 'placement_application',
       id: placementApplication.id,
     })
+    const applicationWithdrawable = withdrawableFactory.build({ type: 'application' })
 
     cy.task('stubWithdrawables', {
       applicationId: application.id,
-      withdrawables: [placementApplicationWithdrawable],
+      withdrawables: [placementApplicationWithdrawable, applicationWithdrawable],
     })
     cy.task('stubApplications', [application])
     cy.task('stubApplicationGet', { application })
@@ -97,11 +112,19 @@ context('Withdrawals', () => {
 
     // Then I am asked what I want to withdraw
     const newWithdrawalPage = new NewWithdrawalPage('What do you want to withdraw?')
+
+    // And I am shown the correct withdrawables
+    newWithdrawalPage.shouldShowWithdrawableTypes(['placementRequest', 'application'])
+    newWithdrawalPage.shouldNotShowWithdrawableTypes(['placement'])
+
+    // When I select 'placementRequest'
     newWithdrawalPage.selectType('placementRequest')
     newWithdrawalPage.clickSubmit()
 
-    // And I am shown a list of placement applications that can be withdrawn
+    // Then I am shown a list of placement applications that can be withdrawn
     const selectWithdrawablePage = new NewWithdrawalPage('Select your placement')
+    selectWithdrawablePage.shouldShowWithdrawables([placementApplicationWithdrawable])
+    selectWithdrawablePage.shouldNotShowWithdrawables([applicationWithdrawable])
 
     // When I select a placement application
     selectWithdrawablePage.selectWithdrawable(placementApplication.id)
@@ -149,15 +172,19 @@ context('Withdrawals', () => {
       type: 'booking',
       id: placement.id,
     })
+    const placementApplicationWithdrawable = withdrawableFactory.build({
+      type: 'placement_application',
+    })
+    const applicationWithdrawable = withdrawableFactory.build({ type: 'application' })
 
     cy.task('stubWithdrawables', {
       applicationId: application.id,
-      withdrawables: [placementWithdrawable],
+      withdrawables: [placementWithdrawable, placementApplicationWithdrawable, applicationWithdrawable],
     })
     cy.task('stubApplications', [application])
     cy.task('stubApplicationGet', { application })
-    cy.task('stubBookingFindWithoutPremises', booking)
-    cy.task('stubBookingGet', { premisesId: booking.premises.id, booking })
+    cy.task('stubBookingFindWithoutPremises', placement)
+    cy.task('stubBookingGet', { premisesId: placement.premises.id, booking: placement })
     cy.task('stubCancellationReferenceData')
 
     // And I visit the list page
@@ -166,15 +193,27 @@ context('Withdrawals', () => {
     // When I click 'Withdraw' on an application
     listPage.clickWithdraw()
 
+    // Then I am asked what I want to withdraw
     const newWithdrawalPage = new NewWithdrawalPage('What do you want to withdraw?')
+
+    // And I should see the correct withdrawable types
+    newWithdrawalPage.shouldShowWithdrawableTypes(['placementRequest', 'placement', 'application'])
+
+    // When I select 'placement'
     newWithdrawalPage.selectType('placement')
     newWithdrawalPage.clickSubmit()
 
+    // Then I am shown a list of placements that can be withdrawn
     const selectWithdrawablePage = new NewWithdrawalPage('Select your placement')
-    selectWithdrawablePage.veryifyLink(booking.id, 'booking')
-    selectWithdrawablePage.selectWithdrawable(booking.id)
+    selectWithdrawablePage.shouldShowWithdrawables([placementWithdrawable])
+    selectWithdrawablePage.shouldNotShowWithdrawables([placementApplicationWithdrawable, applicationWithdrawable])
+    selectWithdrawablePage.veryifyLink(placement.id, 'booking')
+
+    // When I select a placement
+    selectWithdrawablePage.selectWithdrawable(placement.id)
     selectWithdrawablePage.clickSubmit()
 
+    // Then I am taken to the confirmation page
     Page.verifyOnPage(CancellationCreatePage)
   })
 })

--- a/server/controllers/apply/withdrawablesController.ts
+++ b/server/controllers/apply/withdrawablesController.ts
@@ -21,8 +21,9 @@ export default class WithdrawalsController {
       const withdrawables = await this.applicationService.getWithdrawables(req.user.token, id)
 
       if (selectedWithdrawableType === 'placement') {
+        const placementWithdrawables = withdrawables.filter(withdrawable => withdrawable.type === 'booking')
         const bookings = await Promise.all(
-          withdrawables.map(async withdrawable => {
+          placementWithdrawables.map(async withdrawable => {
             return this.bookingService.findWithoutPremises(req.user.token, withdrawable.id)
           }),
         )
@@ -30,17 +31,17 @@ export default class WithdrawalsController {
         return res.render('applications/withdrawables/show', {
           pageHeading: 'Select your placement',
           id,
-          selectedWithdrawableType,
-          withdrawables,
+          withdrawables: placementWithdrawables,
           bookings,
         })
       }
 
       return res.render('applications/withdrawables/show', {
         pageHeading: 'Select your placement',
-        withdrawables,
+        withdrawables: withdrawables.filter(
+          withdrawable => withdrawable.type === 'placement_request' || withdrawable.type === 'placement_application',
+        ),
         id,
-        selectedWithdrawableType,
       })
     }
   }

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -1174,27 +1174,6 @@
                   "type": "string"
                 }
               ]
-            },
-            "otherSexualOffences": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "enum": [
-                      "current",
-                      "previous"
-                    ],
-                    "type": "string"
-                  }
-                },
-                {
-                  "enum": [
-                    "current",
-                    "previous"
-                  ],
-                  "type": "string"
-                }
-              ]
             }
           }
         },

--- a/server/utils/applications/withdrawables/index.test.ts
+++ b/server/utils/applications/withdrawables/index.test.ts
@@ -63,10 +63,10 @@ describe('withdrawableTypeRadioOptions', () => {
       const paWithdrawable = withdrawableFactory.build({ type: 'placement_application' })
       const prWithdrawable = withdrawableFactory.build({ type: 'placement_request' })
       const booking = bookingFactory.build()
-      const bookingWithdrawable = withdrawableFactory.build({ type: 'booking', id: booking.id })
+      const placementWithdrawable = withdrawableFactory.build({ type: 'booking', id: booking.id })
 
       expect(
-        withdrawableRadioOptions([paWithdrawable, prWithdrawable, bookingWithdrawable], paWithdrawable.id, [booking]),
+        withdrawableRadioOptions([paWithdrawable, prWithdrawable, placementWithdrawable], paWithdrawable.id, [booking]),
       ).toEqual([
         {
           text: paWithdrawable.dates
@@ -106,10 +106,10 @@ describe('withdrawableTypeRadioOptions', () => {
               },
             ),
           },
-          text: `${booking.premises.name} - ${bookingWithdrawable.dates
+          text: `${booking.premises.name} - ${placementWithdrawable.dates
             .map(datePeriod => DateFormats.formatDurationBetweenTwoDates(datePeriod.startDate, datePeriod.endDate))
             .join(', ')}`,
-          value: bookingWithdrawable.id,
+          value: placementWithdrawable.id,
         },
       ])
     })

--- a/server/utils/applications/withdrawables/index.test.ts
+++ b/server/utils/applications/withdrawables/index.test.ts
@@ -113,20 +113,5 @@ describe('withdrawableTypeRadioOptions', () => {
         },
       ])
     })
-
-    it('filters out applications', () => {
-      const paWithdrawable = withdrawableFactory.build({ type: 'placement_application' })
-      const applicationWithdrawable = withdrawableFactory.build({ type: 'application' })
-
-      expect(withdrawableRadioOptions([paWithdrawable, applicationWithdrawable], paWithdrawable.id)).toEqual([
-        {
-          text: paWithdrawable.dates
-            .map(datePeriod => DateFormats.formatDurationBetweenTwoDates(datePeriod.startDate, datePeriod.endDate))
-            .join(', '),
-          checked: true,
-          value: paWithdrawable.id,
-        },
-      ])
-    })
   })
 })

--- a/server/utils/applications/withdrawables/index.ts
+++ b/server/utils/applications/withdrawables/index.ts
@@ -61,63 +61,61 @@ export const withdrawableRadioOptions = (
   selectedWithdrawable?: Withdrawable['id'],
   bookings: Array<Booking> = [],
 ): Array<RadioItem> => {
-  return withdrawables
-    .filter(withdrawable => withdrawable.type !== 'application')
-    .map(withdrawable => {
-      if (withdrawable.type === 'placement_application') {
-        return {
-          text: withdrawable.dates
-            .map(datePeriod => DateFormats.formatDurationBetweenTwoDates(datePeriod.startDate, datePeriod.endDate))
-            .join(', '),
-          value: withdrawable.id,
-          checked: selectedWithdrawable === withdrawable.id,
-        }
+  return withdrawables.map(withdrawable => {
+    if (withdrawable.type === 'placement_application') {
+      return {
+        text: withdrawable.dates
+          .map(datePeriod => DateFormats.formatDurationBetweenTwoDates(datePeriod.startDate, datePeriod.endDate))
+          .join(', '),
+        value: withdrawable.id,
+        checked: selectedWithdrawable === withdrawable.id,
       }
-      if (withdrawable.type === 'placement_request') {
-        return {
-          text: withdrawable.dates
-            .map(datePeriod => DateFormats.formatDurationBetweenTwoDates(datePeriod.startDate, datePeriod.endDate))
-            .join(', '),
-          value: withdrawable.id,
-          checked: selectedWithdrawable === withdrawable.id,
-          hint: {
-            html: linkTo(
-              matchPaths.placementRequests.show,
-              { id: withdrawable.id },
-              {
-                text: 'See placement details (opens in a new tab)',
-                attributes: { 'data-cy-withdrawable-id': withdrawable.id },
-                openInNewTab: true,
-              },
-            ),
-          },
-        }
+    }
+    if (withdrawable.type === 'placement_request') {
+      return {
+        text: withdrawable.dates
+          .map(datePeriod => DateFormats.formatDurationBetweenTwoDates(datePeriod.startDate, datePeriod.endDate))
+          .join(', '),
+        value: withdrawable.id,
+        checked: selectedWithdrawable === withdrawable.id,
+        hint: {
+          html: linkTo(
+            matchPaths.placementRequests.show,
+            { id: withdrawable.id },
+            {
+              text: 'See placement details (opens in a new tab)',
+              attributes: { 'data-cy-withdrawable-id': withdrawable.id },
+              openInNewTab: true,
+            },
+          ),
+        },
       }
-      if (withdrawable.type === 'booking') {
-        const booking = bookings.find(b => b.id === withdrawable.id)
+    }
+    if (withdrawable.type === 'booking') {
+      const booking = bookings.find(b => b.id === withdrawable.id)
 
-        if (!booking) throw new Error(`Booking not found for withdrawable: ${withdrawable.id}`)
+      if (!booking) throw new Error(`Booking not found for withdrawable: ${withdrawable.id}`)
 
-        return {
-          text: `${booking.premises.name} - ${withdrawable.dates
-            .map(datePeriod => DateFormats.formatDurationBetweenTwoDates(datePeriod.startDate, datePeriod.endDate))
-            .join(', ')}`,
-          value: withdrawable.id,
-          checked: selectedWithdrawable === withdrawable.id,
-          hint: {
-            html: linkTo(
-              managePaths.bookings.show,
-              { premisesId: booking.premises.id, bookingId: booking.id },
-              {
-                text: 'See placement details (opens in a new tab)',
-                attributes: { 'data-cy-withdrawable-id': withdrawable.id },
-                openInNewTab: true,
-              },
-            ),
-          },
-        }
+      return {
+        text: `${booking.premises.name} - ${withdrawable.dates
+          .map(datePeriod => DateFormats.formatDurationBetweenTwoDates(datePeriod.startDate, datePeriod.endDate))
+          .join(', ')}`,
+        value: withdrawable.id,
+        checked: selectedWithdrawable === withdrawable.id,
+        hint: {
+          html: linkTo(
+            managePaths.bookings.show,
+            { premisesId: booking.premises.id, bookingId: booking.id },
+            {
+              text: 'See placement details (opens in a new tab)',
+              attributes: { 'data-cy-withdrawable-id': withdrawable.id },
+              openInNewTab: true,
+            },
+          ),
+        },
       }
+    }
 
-      throw new Error(`Unknown withdrawable type: ${withdrawable.type}`)
-    })
+    throw new Error(`Unknown withdrawable type: ${withdrawable.type}`)
+  })
 }


### PR DESCRIPTION
# Changes in this PR
Following #1491 #1487 this PR ensures that the 'Select your placement'/'Select your placement request' screens only show the withdrawables of the type the user has shown on the preceding screen. 
Previously we would show all the possible withdrawables. Now if a use selects 'placement' on the 'What do you want to withdraw?' screen they will only see placements on the following screen. 
This slipped through the net as we were only testing that the withdrawables we wanted to see were in the view but now we also test that they withdrawables that shouldn't be visible aren't there also.