### PR TITLE
(APS 370) Surface that an assessment is an appealed assessment so that staff are aware

### DIFF
--- a/integration_tests/helpers/assess.ts
+++ b/integration_tests/helpers/assess.ts
@@ -93,7 +93,7 @@ export default class AseessHelper {
     listPage.clickAssessment(this.assessment)
 
     // Then I should be taken to the task list
-    Page.verifyOnPage(TaskListPage)
+    return Page.verifyOnPage(TaskListPage, this.assessment)
   }
 
   completeAssessment(options: { isShortNoticeApplication?: boolean } = {}) {
@@ -173,7 +173,7 @@ export default class AseessHelper {
     this.pages.reviewApplication = [reviewPage]
 
     // Then I should be taken to the task list
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+    const tasklistPage = Page.verifyOnPage(TaskListPage, this.assessment)
 
     // And the review application task should show a completed status
     tasklistPage.shouldShowTaskStatus('review-application', 'Completed')
@@ -191,7 +191,7 @@ export default class AseessHelper {
     this.pages.sufficientInformation = [page]
 
     // Then I should be taken to the task list
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+    const tasklistPage = Page.verifyOnPage(TaskListPage, this.assessment)
 
     // And the sufficient-information application task should show a completed status
     tasklistPage.shouldShowTaskStatus('sufficient-information', 'Completed')
@@ -236,7 +236,7 @@ export default class AseessHelper {
     }
 
     // Then I should be taken to the task list
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+    const tasklistPage = Page.verifyOnPage(TaskListPage, this.assessment)
 
     // And the suitability-assessment application task should show a completed status
     tasklistPage.shouldShowTaskStatus('suitability-assessment', 'Completed')
@@ -254,7 +254,7 @@ export default class AseessHelper {
     this.pages.requiredActions = [page]
 
     // Then I should be taken to the task list
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+    const tasklistPage = Page.verifyOnPage(TaskListPage, this.assessment)
 
     // And the required-actions application task should show a completed status
     tasklistPage.shouldShowTaskStatus('required-actions', 'Completed')
@@ -272,7 +272,7 @@ export default class AseessHelper {
     this.pages.makeADecision.push(page)
 
     // Then I should be taken to the task list
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+    const tasklistPage = Page.verifyOnPage(TaskListPage, this.assessment)
 
     // And the make-a-decision application task should show a completed status
     tasklistPage.shouldShowTaskStatus('make-a-decision', 'Completed')
@@ -290,7 +290,7 @@ export default class AseessHelper {
     this.pages.matchingInformation.push(page)
 
     // Then I should be taken to the task list
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+    const tasklistPage = Page.verifyOnPage(TaskListPage, this.assessment)
 
     // And the matching-information application task should show a completed status
     tasklistPage.shouldShowTaskStatus('matching-information', 'Completed')
@@ -322,14 +322,14 @@ export default class AseessHelper {
     page.clickSubmit()
 
     // Then I should be taken to the task list
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+    const tasklistPage = Page.verifyOnPage(TaskListPage, this.assessment)
 
     // And the check-your-answers application task should show a completed status
     tasklistPage.shouldShowTaskStatus('check-your-answers', 'Completed')
   }
 
   submitAssessment(isSuitable = true) {
-    const tasklistPage = Page.verifyOnPage(TaskListPage)
+    const tasklistPage = Page.verifyOnPage(TaskListPage, this.assessment)
     tasklistPage.clickSubmit()
 
     tasklistPage.shouldShowMissingCheckboxErrorMessage()

--- a/integration_tests/pages/assess/taskListPage.ts
+++ b/integration_tests/pages/assess/taskListPage.ts
@@ -2,12 +2,23 @@ import { ApprovedPremisesAssessment } from '../../../server/@types/shared/models
 import TaskList from '../taskListPage'
 
 export default class TaskListPage extends TaskList {
-  constructor() {
+  constructor(assessment: ApprovedPremisesAssessment) {
     super('Assess an Approved Premises (AP) application')
+    if (!assessment.createdFromAppeal) {
+      this.shouldNotShowAppealBanner()
+    }
   }
 
   static visit(assessment: ApprovedPremisesAssessment) {
     cy.visit(`/assessments/${assessment.id}`)
-    return new TaskListPage()
+    return new TaskListPage(assessment)
+  }
+
+  shouldShowAppealBanner() {
+    cy.contains('This is an appealed assessment').should('exist')
+  }
+
+  shouldNotShowAppealBanner() {
+    cy.contains('This is an appealed assessment').should('not.exist')
   }
 }

--- a/integration_tests/tests/assess/assess.cy.ts
+++ b/integration_tests/tests/assess/assess.cy.ts
@@ -88,6 +88,19 @@ context('Assess', () => {
     })
   })
 
+  it('shows a banner when the assessment has come from an appeal', function test() {
+    // Given there is an assessment that has come from an appeal
+    const assessmentFromAppeal = { ...this.assessment, createdFromAppeal: true }
+    const assessHelper = new AssessHelper(assessmentFromAppeal, this.documents, this.user, this.clarificationNote)
+    assessHelper.setupStubs()
+
+    // And I start an assessment
+    const taskList = assessHelper.startAssessment()
+
+    // Then I should see a banner telling me that the assessment has come from an appeal
+    taskList.shouldShowAppealBanner()
+  })
+
   it('allows me to create and update a clarification note', function test() {
     let assessmentNeedingClarification = addResponsesToFormArtifact<Assessment>(this.assessment, {
       task: 'sufficient-information',
@@ -152,7 +165,7 @@ context('Assess', () => {
         assessHelper.updateClarificationNote('yes')
 
         // Then I should be redirected to the tasklist page
-        const tasklistPage = Page.verifyOnPage(TaskListPage)
+        const tasklistPage = Page.verifyOnPage(TaskListPage, this.assessment)
 
         // And the sufficient information task should show a completed status
         tasklistPage.shouldShowTaskStatus('review-application', 'Completed')
@@ -217,7 +230,7 @@ context('Assess', () => {
         // And I respond 'no' to the 'informationReceived' question
         assessHelper.updateClarificationNote('no')
         // Then I should be redirected to the tasklist page
-        const tasklistPage = Page.verifyOnPage(TaskListPage)
+        const tasklistPage = Page.verifyOnPage(TaskListPage, this.assessment)
 
         // And the sufficient information task should show a completed status
         tasklistPage.shouldShowTaskStatus('review-application', 'Completed')
@@ -343,7 +356,7 @@ context('Assess', () => {
     const contingencyPlanPage = new ContingencyPlanSuitabilityPage(assessment)
     contingencyPlanPage.clickSubmit()
 
-    Page.verifyOnPage(TaskListPage)
+    Page.verifyOnPage(TaskListPage, assessment)
 
     // Then the application should be updated with the Check Your Answers section removed
     cy.task('verifyAssessmentUpdate', assessment).then((requests: Array<{ body: string }>) => {

--- a/server/utils/tasks/assertions.test.ts
+++ b/server/utils/tasks/assertions.test.ts
@@ -1,0 +1,31 @@
+import {
+  assessmentTaskFactory,
+  placementApplicationTaskFactory,
+  placementRequestTaskFactory,
+} from '../../testutils/factories'
+import { isAssessmentTask, isPlacementApplicationTask, isPlacementRequestTask } from './assertions'
+
+describe('assertions', () => {
+  ;[isAssessmentTask, isPlacementApplicationTask, isPlacementRequestTask].forEach(assertion => {
+    describe(assertion, () => {
+      ;[
+        {
+          task: placementRequestTaskFactory.build(),
+          expectedResponse: assertion === isPlacementRequestTask,
+        },
+        {
+          task: placementApplicationTaskFactory.build(),
+          expectedResponse: assertion === isPlacementApplicationTask,
+        },
+        {
+          task: assessmentTaskFactory.build(),
+          expectedResponse: assertion === isAssessmentTask,
+        },
+      ].forEach(args => {
+        it(`Should return ${args.expectedResponse} for ${args.task.taskType}`, () => {
+          expect(assertion(args.task)).toEqual(args.expectedResponse)
+        })
+      })
+    })
+  })
+})

--- a/server/utils/tasks/assertions.ts
+++ b/server/utils/tasks/assertions.ts
@@ -1,0 +1,12 @@
+import { AssessmentTask, PlacementApplicationTask, PlacementRequestTask, Task } from '../../@types/shared'
+
+const isAssessmentTask = (task: Task): task is AssessmentTask =>
+  (task as AssessmentTask)?.createdFromAppeal !== undefined && task.taskType === 'Assessment'
+
+const isPlacementApplicationTask = (task: Task): task is PlacementApplicationTask =>
+  (task as PlacementApplicationTask).taskType === 'PlacementApplication'
+
+const isPlacementRequestTask = (task: Task): task is PlacementRequestTask =>
+  (task as PlacementRequestTask).taskType === 'PlacementRequest'
+
+export { isAssessmentTask, isPlacementApplicationTask, isPlacementRequestTask }

--- a/server/utils/tasks/listTable.test.ts
+++ b/server/utils/tasks/listTable.test.ts
@@ -1,4 +1,9 @@
-import { taskFactory } from '../../testutils/factories'
+import {
+  assessmentTaskFactory,
+  placementApplicationTaskFactory,
+  placementRequestTaskFactory,
+  taskFactory,
+} from '../../testutils/factories'
 import {
   allocatedTableRows,
   allocationCell,
@@ -39,7 +44,7 @@ describe('table', () => {
               html: statusBadge(task),
             },
             {
-              html: `<strong class="govuk-tag">${getTaskType(task.taskType)}</strong>`,
+              html: `<strong class="govuk-tag">${getTaskType(task)}</strong>`,
             },
             {
               text: task.apArea?.name || 'No area supplied',
@@ -62,7 +67,7 @@ describe('table', () => {
               html: statusBadge(task),
             },
             {
-              html: `<strong class="govuk-tag">${getTaskType(task.taskType)}</strong>`,
+              html: `<strong class="govuk-tag">${getTaskType(task)}</strong>`,
             },
             {
               text: task.apArea?.name || 'No area supplied',
@@ -86,7 +91,7 @@ describe('table', () => {
               html: statusBadge(task),
             },
             {
-              html: `<strong class="govuk-tag">${getTaskType(task.taskType)}</strong>`,
+              html: `<strong class="govuk-tag">${getTaskType(task)}</strong>`,
             },
             { text: task.apArea?.name || 'No area supplied' },
           ],
@@ -104,7 +109,7 @@ describe('table', () => {
               html: statusBadge(task),
             },
             {
-              html: `<strong class="govuk-tag">${getTaskType(task.taskType)}</strong>`,
+              html: `<strong class="govuk-tag">${getTaskType(task)}</strong>`,
             },
             {
               text: task.apArea?.name,
@@ -192,7 +197,7 @@ describe('table', () => {
     it('returns the task type formatted for the UI as a TableCell object', () => {
       const task = taskFactory.build()
       expect(taskTypeCell(task)).toEqual({
-        html: `<strong class="govuk-tag">${getTaskType(task.taskType)}</strong>`,
+        html: `<strong class="govuk-tag">${getTaskType(task)}</strong>`,
       })
     })
   })
@@ -263,6 +268,33 @@ describe('table', () => {
       expect(result).toEqual({
         id: task.id,
         taskType: 'placement-request',
+      })
+    })
+  })
+
+  describe('getTaskType', () => {
+    ;[
+      { task: placementRequestTaskFactory.build(), expectedTaskType: 'Match request', taskType: 'Placement Request' },
+      {
+        task: placementApplicationTaskFactory.build(),
+        expectedTaskType: 'Request for placement',
+        taskType: 'Placement Application',
+      },
+      {
+        task: assessmentTaskFactory.build({ createdFromAppeal: false }),
+        expectedTaskType: 'Assessment',
+        taskType: 'Assessment',
+      },
+      {
+        task: assessmentTaskFactory.build({ createdFromAppeal: true }),
+        expectedTaskType: 'Assessment (Appealed)',
+        taskType: 'Appealed Assessment',
+      },
+    ].forEach(args => {
+      it(`should return '${args.expectedTaskType}' for a task of type '${args.taskType}'`, () => {
+        const result = getTaskType(args.task)
+
+        expect(result).toEqual(args.expectedTaskType)
       })
     })
   })

--- a/server/utils/tasks/listTable.ts
+++ b/server/utils/tasks/listTable.ts
@@ -1,3 +1,4 @@
+import { isAssessmentTask, isPlacementApplicationTask, isPlacementRequestTask } from './assertions'
 import { SortDirection, Task, TaskSortField } from '../../@types/shared'
 import { TableCell, TableRow } from '../../@types/ui'
 import paths from '../../paths/tasks'
@@ -18,18 +19,26 @@ const statusCell = (task: Task): TableCell => ({
   html: statusBadge(task),
 })
 
-const getTaskType = (taskType: string): string => {
-  if (taskType === 'PlacementRequest') {
-    return 'Match request'
+const getTaskType = (task: Task): string => {
+  let taskType
+  if (isPlacementRequestTask(task)) {
+    taskType = 'Match request'
   }
-  if (taskType === 'PlacementApplication') {
-    return 'Request for placement'
+  if (isPlacementApplicationTask(task)) {
+    taskType = 'Request for placement'
   }
-  return sentenceCase(taskType)
+  if (isAssessmentTask(task)) {
+    taskType = 'Assessment'
+    if (task.createdFromAppeal) {
+      taskType += ' (Appealed)'
+    }
+  }
+
+  return taskType
 }
 
 const taskTypeCell = (task: Task): TableCell => ({
-  html: `<strong class="govuk-tag">${getTaskType(task.taskType)}</strong>`,
+  html: `<strong class="govuk-tag">${getTaskType(task)}</strong>`,
 })
 
 const allocationCell = (task: Task): TableCell => ({

--- a/server/views/assessments/tasklist.njk
+++ b/server/views/assessments/tasklist.njk
@@ -1,6 +1,8 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
 {% from "../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../components/riskWidgets/macro.njk" import widgets %}
 {% from "../components/keyDetails/macro.njk" import keyDetails %}
@@ -10,6 +12,16 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-width-container">
+
+      {% if assessment.createdFromAppeal %}
+        {% set html %}
+          <h3 class="govuk-!-margin-top-2">This is an appealed assessment</h3>
+          <p class="govuk-body">This application has been reopened for reassessment.</p>
+        {% endset %}
+        {{ govukNotificationBanner({
+          html: html
+        }) }}
+      {% endif %}
 
       <h1 class="govuk-heading-xl">
         {{ pageHeading }}

--- a/server/views/tasks/index.njk
+++ b/server/views/tasks/index.njk
@@ -8,7 +8,7 @@
 {% from "./_navigation.njk" import navigation %}
 
 {% set pageTitle = applicationName + " - " + pageHeading  %}
-{% set mainClasses = "app-container govuk-body assessments--index" %}
+{% set mainClasses = "app-container govuk-body tasks--index" %}
 
 {% block content %}
 


### PR DESCRIPTION
This builds on https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1512 to allow users to see when an assessment has appealed. This is because there is an expectation that the assessment will be approved and they should look for the appeal information.

## Screenshots

![Assess -- shows a banner when the assessment has come from an appeal (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/8c50f332-4b3c-42b7-9daa-22e6d4008f3f)

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/18f6632b-fee9-4869-a1ab-8d9a90832e69)
