### PR TITLE
Hide 'actions' if an application is withdrawn

### DIFF
--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -112,7 +112,7 @@ export default class ShowPage extends Page {
   }
 
   shouldNotShowCreatePlacementRequestButton() {
-    cy.get('button').contains('Create placement request').should('not.exist')
+    cy.get('Create placement request').should('not.exist')
   }
 
   clickTimelineTab() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "axe-core": "^4.7.0",
         "concurrently": "^8.0.0",
         "cookie-session": "^2.0.0",
-        "cypress": "^13.1.0",
+        "cypress": "^13.6.5",
         "cypress-axe": "^1.4.0",
         "cypress-multi-reporters": "^1.6.1",
         "dotenv": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "axe-core": "^4.7.0",
     "concurrently": "^8.0.0",
     "cookie-session": "^2.0.0",
-    "cypress": "^13.1.0",
+    "cypress": "^13.6.5",
     "cypress-axe": "^1.4.0",
     "cypress-multi-reporters": "^1.6.1",
     "dotenv": "^16.0.3",

--- a/server/utils/applications/applicationIdentityBar.test.ts
+++ b/server/utils/applications/applicationIdentityBar.test.ts
@@ -113,5 +113,15 @@ describe('applicationIdentityBar', () => {
         menus: [{ items: applicationMenuItems(application, ['appeals_manager']) }],
       })
     })
+
+    it('should return an empty array for menus if the application has a status of withdrawn', () => {
+      const application = applicationFactory.build({ status: 'withdrawn' })
+
+      expect(applicationIdentityBar(application, 'title', ['appeals_manager'])).toEqual({
+        title: { html: applicationTitle(application, 'title') },
+        classes: 'application-identity-bar',
+        menus: [],
+      })
+    })
   })
 })

--- a/server/utils/applications/applicationIdentityBar.ts
+++ b/server/utils/applications/applicationIdentityBar.ts
@@ -57,6 +57,6 @@ export const applicationIdentityBar = (
   return {
     title: { html: applicationTitle(application, pageHeading) },
     classes: 'application-identity-bar',
-    menus: [{ items: applicationMenuItems(application, userRoles) }],
+    menus: application.status !== 'withdrawn' ? [{ items: applicationMenuItems(application, userRoles) }] : [],
   }
 }


### PR DESCRIPTION
It doesn't make sense to perform actions on a withdrawn application so lets not show the 'actions' button

## Screenshots of UI changes

### Before
![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/abda9212-d1e1-4aae-9e9c-fca25c8f1226)

### After
![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/766667a3-8dbc-4639-8c54-7a7285610027)
