### PR TITLE
Tweak application tag styling

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -22,6 +22,7 @@ $path: "/assets/images/"
 @import './pages/assessments-index'
 @import './pages/applications-pages-attach-document'
 @import './pages/dashboard-index'
+@import './pages/application-show'
 
 @import './local'
 

--- a/assets/sass/pages/_application-show.scss
+++ b/assets/sass/pages/_application-show.scss
@@ -1,0 +1,10 @@
+.application--show {
+  .moj-identity-bar {
+    &__title {
+      .govuk-tag {
+        display: inline;
+        vertical-align: super;
+      }
+    }
+  }
+}

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -11,7 +11,7 @@
 {% extends "../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - " + pageHeading %}
-{% set mainClasses = "app-container govuk-body" %}
+{% set mainClasses = "app-container govuk-body application--show" %}
 
 {% block content %}
   <div class="govuk-grid-row">


### PR DESCRIPTION
Looking at the styling for the application tag made my teeth itch a bit, so I had a little play with some of the CSS to make the tag show inline a bit more nicely. It’s not pixel perfect by any stretch of the imagination, but it’s a bit of an improvement.

# Screenshots

## Before

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/302b297d-d299-4555-ab46-a2417f8a352d)

## After

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/e31a8e29-281d-465c-b7b0-e0ba12df4324)
