### PR TITLE
Add back button to Withdrawable select page

### DIFF
--- a/integration_tests/tests/withdrawals/withdrawals.cy.ts
+++ b/integration_tests/tests/withdrawals/withdrawals.cy.ts
@@ -14,6 +14,7 @@ import PrListPage from '../../pages/admin/placementApplications/listPage'
 import PlacementApplicationWithdrawalConfirmationPage from '../../pages/match/placementApplicationWithdrawalConfirmationPage'
 import Page from '../../pages/page'
 import { signIn } from '../signIn'
+import paths from '../../../server/paths/apply'
 
 context('Withdrawals', () => {
   beforeEach(() => {
@@ -67,6 +68,7 @@ context('Withdrawals', () => {
 
     // Then I am shown a list of placement requests that can be withdrawn
     const selectWithdrawablePage = new NewWithdrawalPage('Select your placement')
+    selectWithdrawablePage.checkForBackButton(paths.applications.withdraw.new({ id: application.id }))
     selectWithdrawablePage.veryifyLink(placementRequest.id, 'placement_request')
     selectWithdrawablePage.shouldShowWithdrawables([placementRequestWithdrawable, placementApplicationWithdrawable])
     selectWithdrawablePage.shouldNotShowWithdrawables([placementWithdrawable])
@@ -123,6 +125,7 @@ context('Withdrawals', () => {
 
     // Then I am shown a list of placement applications that can be withdrawn
     const selectWithdrawablePage = new NewWithdrawalPage('Select your placement')
+    selectWithdrawablePage.checkForBackButton(paths.applications.withdraw.new({ id: application.id }))
     selectWithdrawablePage.shouldShowWithdrawables([placementApplicationWithdrawable])
     selectWithdrawablePage.shouldNotShowWithdrawables([applicationWithdrawable])
 
@@ -205,6 +208,7 @@ context('Withdrawals', () => {
 
     // Then I am shown a list of placements that can be withdrawn
     const selectWithdrawablePage = new NewWithdrawalPage('Select your placement')
+    selectWithdrawablePage.checkForBackButton(paths.applications.withdraw.new({ id: application.id }))
     selectWithdrawablePage.shouldShowWithdrawables([placementWithdrawable])
     selectWithdrawablePage.shouldNotShowWithdrawables([placementApplicationWithdrawable, applicationWithdrawable])
     selectWithdrawablePage.veryifyLink(placement.id, 'booking')

--- a/server/views/applications/withdrawables/show.njk
+++ b/server/views/applications/withdrawables/show.njk
@@ -1,10 +1,17 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+		text: "Back",
+		href: paths.applications.withdraw.new({id: id})
+	}) }}
+{% endblock %}
 
 {% block content %}
     <div class="govuk-grid-row">


### PR DESCRIPTION
This will help the user navigate back if they change their mind about the type of withdrawable they need to select

## Screenshots of UI changes

### Before
![before](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/344a94a2-9617-4793-9cd7-945f012c6116)

### After
![after](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/4c1cbbc2-0a9f-49dc-a4d7-7034696ab89f)
