### PR TITLE
(Chore) Run e2es in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,6 +182,7 @@ jobs:
   e2e_environment_test:
     docker:
       - image: mcr.microsoft.com/playwright:v1.41.2-focal
+    parallelism: 4
     circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
     steps:
       - run:
@@ -195,7 +196,16 @@ jobs:
       - run:
           name: E2E Check
           command: |
-            npm run test
+            SHARD="$((${CIRCLE_NODE_INDEX}+1))"
+            username="HMPPS_AUTH_USERNAME_$SHARD"
+            password="HMPPS_AUTH_PASSWORD_$SHARD"
+            email="HMPPS_AUTH_EMAIL_$SHARD"
+            name="HMPPS_AUTH_NAME_$SHARD"
+            HMPPS_AUTH_USERNAME="${!username}"
+            HMPPS_AUTH_PASSWORD="${!password}"
+            HMPPS_AUTH_EMAIL="${!email}"
+            HMPPS_AUTH_NAME="${!name}"
+            npm run test -- --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
       - store_artifacts:
           path: playwright-report
           destination: playwright-report
@@ -245,8 +255,6 @@ workflows:
             branches:
               only:
                 - main
-          requires:
-            - deploy_dev
       - request-preprod-approval:
           type: approval
           requires:


### PR DESCRIPTION
This follows the instructions in:

https://playwright.dev/docs/ci#circleci

To avoid stamping on user’s permissions, we also have a user for each shard, with the login details stored as with a prefix
(so `HMPPS_AUTH_USERNAME_1`, `HMPPS_AUTH_PASSWORD_1` etc etc), we then get the auth details for each shard in the setup process with a bit of Bash jiggery pokery and then run a selection of tests on each shard. This reduces the total runtime to around 3 minutes!
