### PR TITLE
APS-317: Task Allocation region filter isnt sticking

### DIFF
--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -447,4 +447,8 @@ export default abstract class Page {
   shouldHaveActiveTab(tabName: string): void {
     cy.get('a.moj-sub-navigation__link').contains(tabName).should('have.attr', 'aria-current', 'page')
   }
+
+  shouldHaveSelectText(id: string, text: string): void {
+    cy.get(`#${id}`).find('option:selected').should('have.text', text)
+  }
 }

--- a/integration_tests/tests/tasks/list.cy.ts
+++ b/integration_tests/tests/tasks/list.cy.ts
@@ -187,6 +187,58 @@ context('Task Allocation', () => {
     listPage.shouldShowAllocatedTasks(allocatedTasksFiltered)
   })
 
+  it('maintains filter on tab change', () => {
+    cy.task('stubAuthUser')
+
+    // Given I am logged in
+    cy.signIn()
+
+    const allocatedTasks = taskFactory.buildList(10)
+    const allocatedTasksFiltered = taskFactory.buildList(1)
+    const unallocatedTasks = taskFactory.buildList(1, { allocatedToStaffMember: undefined })
+
+    cy.task('stubGetAllTasks', { tasks: allocatedTasks, allocatedFilter: 'allocated', page: '1' })
+    cy.task('stubApAreaReferenceData', {
+      id: apAreaId,
+      name: 'Midlands',
+    })
+
+    // When I visit the tasks dashboard
+    const listPage = ListPage.visit(allocatedTasks, unallocatedTasks)
+
+    // Then I should see the tasks that are allocated
+    listPage.shouldShowAllocatedTasks()
+
+    // When I filter by region
+    cy.task('stubGetAllTasks', {
+      tasks: allocatedTasksFiltered,
+      allocatedFilter: 'allocated',
+      page: '1',
+      sortDirection: 'asc',
+      apAreaId,
+    })
+
+    cy.task('stubGetAllTasks', {
+      tasks: allocatedTasksFiltered,
+      allocatedFilter: 'unallocated',
+      page: '1',
+      sortDirection: 'asc',
+      apAreaId,
+    })
+
+    listPage.searchBy('area', apAreaId)
+    listPage.clickApplyFilter()
+
+    // Then the page should show the results
+    listPage.shouldShowAllocatedTasks(allocatedTasksFiltered)
+
+    // And click on unallocated tab
+    listPage.clickTab('Unallocated')
+
+    // Then the page should keep the area filter
+    listPage.shouldHaveSelectText('area', 'Midlands')
+  })
+
   it('retains the unallocated filter when applying other filters', () => {
     cy.task('stubAuthUser')
 

--- a/server/controllers/tasksController.test.ts
+++ b/server/controllers/tasksController.test.ts
@@ -72,7 +72,7 @@ describe('TasksController', () => {
         hrefPrefix: paginationDetails.hrefPrefix,
         sortBy: 'createdAt',
         sortDirection: 'asc',
-        selectedArea: apArea.id,
+        apArea: apArea.id,
       })
 
       expect(taskService.getAll).toHaveBeenCalledWith({
@@ -114,7 +114,7 @@ describe('TasksController', () => {
         hrefPrefix: paginationDetails.hrefPrefix,
         sortBy: paramPaginationDetails.sortBy,
         sortDirection: paramPaginationDetails.sortDirection,
-        selectedArea: apAreaId,
+        apArea: apAreaId,
       })
       expect(getPaginationDetails).toHaveBeenCalledWith(unallocatedRequest, paths.tasks.index({}), {
         allocatedFilter: 'unallocated',
@@ -154,7 +154,7 @@ describe('TasksController', () => {
         hrefPrefix: paginationDetails.hrefPrefix,
         sortBy: paramPaginationDetails.sortBy,
         sortDirection: paramPaginationDetails.sortDirection,
-        selectedArea: 'all',
+        apArea: 'all',
       })
 
       expect(taskService.getAll).toHaveBeenCalledWith({

--- a/server/controllers/tasksController.ts
+++ b/server/controllers/tasksController.ts
@@ -49,7 +49,7 @@ export default class TasksController {
         hrefPrefix,
         sortBy,
         sortDirection,
-        selectedArea: apAreaId,
+        apArea: apAreaId,
       })
     }
   }

--- a/server/utils/tasks/index.ts
+++ b/server/utils/tasks/index.ts
@@ -6,7 +6,14 @@ import { arrivalDateFromApplication } from '../applications/arrivalDateFromAppli
 import { getApplicationType } from '../applications/utils'
 import { DateFormats } from '../dateUtils'
 import { nameOrPlaceholderCopy } from '../personUtils'
-import { allocatedTableRows, taskParams, tasksTableHeader, tasksTableRows, unallocatedTableRows } from './listTable'
+import {
+  allocatedTableRows,
+  taskParams,
+  tasksTabItems,
+  tasksTableHeader,
+  tasksTableRows,
+  unallocatedTableRows,
+} from './listTable'
 import { userTableHeader, userTableRows } from './usersTable'
 
 type GroupedTasks = {
@@ -91,4 +98,5 @@ export {
   tasksTableRows,
   userTableHeader,
   userTableRows,
+  tasksTabItems,
 }

--- a/server/utils/tasks/listTable.test.ts
+++ b/server/utils/tasks/listTable.test.ts
@@ -15,6 +15,7 @@ import {
   statusCell,
   taskParams,
   taskTypeCell,
+  tasksTabItems,
   tasksTableHeader,
   tasksTableRows,
   unallocatedTableRows,
@@ -296,6 +297,53 @@ describe('table', () => {
 
         expect(result).toEqual(args.expectedTaskType)
       })
+    })
+  })
+
+  describe('tasksTabItems', () => {
+    it('returns tasks tab items when active tab and area not present', () => {
+      expect(tasksTabItems()).toEqual([
+        {
+          text: 'Allocated',
+          active: true,
+          href: '/tasks?allocatedFilter=allocated',
+        },
+        {
+          text: 'Unallocated',
+          active: false,
+          href: '/tasks?allocatedFilter=unallocated',
+        },
+      ])
+    })
+
+    it('returns tasks tab items when active tab and area present', () => {
+      expect(tasksTabItems('allocated', 'areaId')).toEqual([
+        {
+          text: 'Allocated',
+          active: true,
+          href: '/tasks?allocatedFilter=allocated&area=areaId',
+        },
+        {
+          text: 'Unallocated',
+          active: false,
+          href: '/tasks?allocatedFilter=unallocated&area=areaId',
+        },
+      ])
+    })
+
+    it('returns tasks tab items when active tab unallocated and area present', () => {
+      expect(tasksTabItems('unallocated', 'areaId')).toEqual([
+        {
+          text: 'Allocated',
+          active: false,
+          href: '/tasks?allocatedFilter=allocated&area=areaId',
+        },
+        {
+          text: 'Unallocated',
+          active: true,
+          href: '/tasks?allocatedFilter=unallocated&area=areaId',
+        },
+      ])
     })
   })
 })

--- a/server/utils/tasks/listTable.ts
+++ b/server/utils/tasks/listTable.ts
@@ -166,6 +166,31 @@ const tasksTableHeader = (
 
 const taskParams = (task: Task) => ({ id: task.id, taskType: kebabCase(task.taskType) })
 
+export type TabItem = {
+  text: string
+  active: boolean
+  href: string
+}
+
+const tasksTabItems = (activeTab?: string, apArea?: string): Array<TabItem> => {
+  const hrefSuffix = apArea ? `&area=${apArea}` : ''
+  const allocatedHref = `${paths.tasks.index({})}?allocatedFilter=allocated${hrefSuffix}`
+  const unallocatedHref = `${paths.tasks.index({})}?allocatedFilter=unallocated${hrefSuffix}`
+
+  return [
+    {
+      text: 'Allocated',
+      active: activeTab === 'allocated' || activeTab === undefined || activeTab?.length === 0,
+      href: allocatedHref,
+    },
+    {
+      text: 'Unallocated',
+      active: activeTab === 'unallocated',
+      href: unallocatedHref,
+    },
+  ]
+}
+
 export {
   allocatedTableRows,
   tasksTableHeader,
@@ -180,4 +205,5 @@ export {
   unallocatedTableRows,
   taskParams,
   getTaskType,
+  tasksTabItems,
 }

--- a/server/views/tasks/_navigation.njk
+++ b/server/views/tasks/_navigation.njk
@@ -1,21 +1,10 @@
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 
-{% macro navigation(activeTab) %}
+{% macro navigation(activeTab, apArea) %}
   {{
     mojSubNavigation({
       label: 'Sub navigation',
-      items: [
-        {
-          text: 'Allocated',
-          href: paths.tasks.index({})+ "?allocatedFilter=allocated",
-          active: (activeTab === 'allocated' or activeTab|length === 0)
-        },
-        {
-          text: 'Unallocated',
-          href: paths.tasks.index({}) + "?allocatedFilter=unallocated",
-          active: (activeTab === 'unallocated')
-        }
-      ]
+      items: TaskUtils.tasksTabItems(activeTab, apArea)
     })
   }}
 {% endmacro %}

--- a/server/views/tasks/index.njk
+++ b/server/views/tasks/index.njk
@@ -35,7 +35,7 @@
                       },
                       id: "area",
                       name: "area",
-                      items: convertObjectsToSelectOptions(apAreas, 'All areas', 'name', 'id', 'selectedArea', 'all')
+                      items: convertObjectsToSelectOptions(apAreas, 'All areas', 'name', 'id', 'apArea', 'all', context)
                     }) }}
             </div>
             <div class="govuk-grid-column-two-third">
@@ -48,7 +48,7 @@
           </div>
         </form>
       </div>
-      {{ navigation(allocatedFilter) }}
+      {{ navigation(allocatedFilter, apArea) }}
 
       {{
         govukTable({


### PR DESCRIPTION
# Context

<!-- https://dsdmoj.atlassian.net/browse/APS-317 -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Issue with the task allocation screen: it is defaulting back to home area when clicking on further pages or sorting in pre prod and the live service.  At the minute we have Midlands staff working in North East so this issue is preventing them from doing their work around task allocations.
## Screenshots of UI changes

### Before
<img width="1144" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/b59b3b5d-cb6c-4168-8288-3b8ce7eb3c1f">

### After
<img width="1728" alt="Screenshot 2024-02-22 at 15 39 09" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/4bd08dc2-bc45-43e1-8f15-bfaf4eaf135e">
