### PR TITLE
(APS-354b) Fix `isGroundFloor` property

### DIFF
--- a/integration_tests/fixtures/assessmentData.json
+++ b/integration_tests/fixtures/assessmentData.json
@@ -52,7 +52,6 @@
       "isSingle": "notRelevant",
       "isStepFreeDesignated": "notRelevant",
       "isCatered": "notRelevant",
-      "isGroundFloor": "notRelevant",
       "hasEnSuite": "notRelevant",
       "isSuitedForSexOffenders": "notRelevant",
       "isArsonDesignated": "notRelevant",

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -74,7 +74,7 @@ context.skip('Placement Requests', () => {
     // Given there is a placement request waiting for me to match
     const person = personFactory.build()
 
-    const essentialCriteria = ['isPIPE', 'acceptsHateCrimeOffenders', 'isGroundFloor'] as Array<PlacementCriteria>
+    const essentialCriteria = ['isPIPE', 'acceptsHateCrimeOffenders'] as Array<PlacementCriteria>
     const desirableCriteria = ['isCatered', 'hasEnSuite'] as Array<PlacementCriteria>
 
     const placementRequest = placementRequestDetailFactory.build({

--- a/server/@types/shared/models/PlacementCriteria.ts
+++ b/server/@types/shared/models/PlacementCriteria.ts
@@ -2,24 +2,4 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type PlacementCriteria =
-  | 'isPIPE'
-  | 'isESAP'
-  | 'isSemiSpecialistMentalHealth'
-  | 'isRecoveryFocussed'
-  | 'hasBrailleSignage'
-  | 'hasTactileFlooring'
-  | 'hasHearingLoop'
-  | 'isStepFreeDesignated'
-  | 'isArsonDesignated'
-  | 'isWheelchairDesignated'
-  | 'isSingle'
-  | 'isCatered'
-  | 'isSuitedForSexOffenders'
-  | 'isSuitableForVulnerable'
-  | 'acceptsSexOffenders'
-  | 'acceptsHateCrimeOffenders'
-  | 'acceptsChildSexOffenders'
-  | 'acceptsNonSexualChildOffenders'
-  | 'isArsonSuitable'
-  | 'hasEnSuite'
+export type PlacementCriteria = 'isPIPE' | 'isESAP' | 'isSemiSpecialistMentalHealth' | 'isRecoveryFocussed' | 'hasBrailleSignage' | 'hasTactileFlooring' | 'hasHearingLoop' | 'isStepFreeDesignated' | 'isArsonDesignated' | 'isWheelchairDesignated' | 'isSingle' | 'isCatered' | 'isSuitedForSexOffenders' | 'isSuitableForVulnerable' | 'acceptsSexOffenders' | 'acceptsHateCrimeOffenders' | 'acceptsChildSexOffenders' | 'acceptsNonSexualChildOffenders' | 'isArsonSuitable' | 'isGroundFloor' | 'hasEnSuite';

--- a/server/utils/placementCriteriaUtils.ts
+++ b/server/utils/placementCriteriaUtils.ts
@@ -31,7 +31,7 @@ type PlacementCriteriaCategory =
   | OffenceAndRiskCriteria
   | PlacementRequirementCriteria
 
-export const placementCriteria: Record<PlacementCriteria, string> = {
+export const placementCriteria: Record<Exclude<PlacementCriteria, 'isGroundFloor'>, string> = {
   isPIPE: 'Psychologically Informed Planned Environment (PIPE)',
   isESAP: 'Enhanced Security AP (ESAP)',
   isRecoveryFocussed: 'Recovery Focused Approved Premises (RFAP)',


### PR DESCRIPTION
# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

[JIRA](https://dsdmoj.atlassian.net/browse/APS-354)

`isGroundFloor` was removed from the `PlacementCriteria` type in #1517, but the shared type files shouldn't be edited directly as they're synced from the API side

# Changes in this PR

The field will need removing from the API, but for now, this reverts the type to match the API and then excludes `isGroundFloor` where needed for the code to type check

A couple of `isGroundFloor` instances in the `integration_tests` directory were missed when making the earlier change, so those are also removed here