### PR TITLE
(APS-357) Prepopulate arson requirement

### DIFF
--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -31,7 +31,8 @@ const defaultArguments = {
   cruInformation: 'Some info',
 } as MatchingInformationBody
 
-const defaultMatchingInformationValuesReturnValue = {
+const defaultMatchingInformationValuesReturnValue: Partial<MatchingInformationBody> = {
+  isArsonDesignated: 'essential',
   isCatered: 'essential',
   isWheelchairDesignated: 'notRelevant',
   lengthOfStay: '32',
@@ -93,7 +94,6 @@ describe('MatchingInformation', () => {
       expect(page.errors()).toEqual({
         apType: 'You must select the type of AP required',
         isSingle: 'You must specify a preference for single room',
-        isArsonDesignated: 'You must specify a preference for designated arson room',
         isStepFreeDesignated: 'You must specify a preference for step-free access',
         hasEnSuite: 'You must specify a preference for en-suite bathroom',
         isSuitableForVulnerable: 'You must specify if vulnerable to exploitation is relevant',

--- a/server/form-pages/utils/defaultMatchingInformationValues.test.ts
+++ b/server/form-pages/utils/defaultMatchingInformationValues.test.ts
@@ -8,6 +8,7 @@ import { MatchingInformationBody } from '../assess/matchingInformation/matchingI
 import { defaultMatchingInformationValues } from './defaultMatchingInformationValues'
 import AccessNeedsFurtherQuestions from '../apply/risk-and-need-factors/access-and-healthcare/accessNeedsFurtherQuestions'
 import Catering from '../apply/risk-and-need-factors/further-considerations/catering'
+import Arson from '../apply/risk-and-need-factors/further-considerations/arson'
 
 jest.mock('../../utils/retrieveQuestionResponseFromFormArtifact')
 
@@ -42,6 +43,10 @@ describe('defaultMatchingInformationValues', () => {
 
   it('returns an object with current or sensible default values for relevant fields', () => {
     when(retrieveQuestionResponseFromFormArtifact)
+      .calledWith(assessment.application, Arson, 'arson')
+      .mockReturnValue('yes')
+
+    when(retrieveQuestionResponseFromFormArtifact)
       .calledWith(assessment.application, Catering, 'catering')
       .mockReturnValue('no')
 
@@ -57,9 +62,38 @@ describe('defaultMatchingInformationValues', () => {
     }
 
     expect(defaultMatchingInformationValues(body, assessment)).toEqual({
+      isArsonDesignated: 'essential',
       isCatered: 'essential',
       isWheelchairDesignated: 'essential',
       lengthOfStay: '24',
+    })
+  })
+
+  describe('isArsonDesignated', () => {
+    it('is set to the original value if defined', () => {
+      expect(
+        defaultMatchingInformationValues({ ...bodyWithUndefinedValues, isArsonDesignated: 'desirable' }, assessment),
+      ).toEqual(expect.objectContaining({ isArsonDesignated: 'desirable' }))
+    })
+
+    it("is set to 'essential' when there's no original value and `arson` === 'yes'", () => {
+      when(retrieveQuestionResponseFromFormArtifact)
+        .calledWith(assessment.application, Arson, 'arson')
+        .mockReturnValue('yes')
+
+      expect(defaultMatchingInformationValues(bodyWithUndefinedValues, assessment)).toEqual(
+        expect.objectContaining({ isArsonDesignated: 'essential' }),
+      )
+    })
+
+    it("is set to 'notRelevant' when there's no original value and `arson` === 'no'", () => {
+      when(retrieveQuestionResponseFromFormArtifact)
+        .calledWith(assessment.application, Arson, 'arson')
+        .mockReturnValue('no')
+
+      expect(defaultMatchingInformationValues(bodyWithUndefinedValues, assessment)).toEqual(
+        expect.objectContaining({ isArsonDesignated: 'notRelevant' }),
+      )
     })
   })
 

--- a/server/form-pages/utils/defaultMatchingInformationValues.ts
+++ b/server/form-pages/utils/defaultMatchingInformationValues.ts
@@ -10,6 +10,17 @@ import type {
 } from '../assess/matchingInformation/matchingInformationTask/matchingInformation'
 import AccessNeedsFurtherQuestions from '../apply/risk-and-need-factors/access-and-healthcare/accessNeedsFurtherQuestions'
 import Catering from '../apply/risk-and-need-factors/further-considerations/catering'
+import Arson from '../apply/risk-and-need-factors/further-considerations/arson'
+
+const isArsonDesignated = (body: MatchingInformationBody, assessment: Assessment): PlacementRequirementPreference => {
+  if (body.isArsonDesignated) {
+    return body.isArsonDesignated
+  }
+
+  const arsonRisk = retrieveQuestionResponseFromFormArtifact(assessment.application, Arson, 'arson')
+
+  return arsonRisk === 'yes' ? 'essential' : 'notRelevant'
+}
 
 const isCatered = (body: MatchingInformationBody, assessment: Assessment): PlacementRequirementPreference => {
   if (body.isCatered) {
@@ -54,6 +65,7 @@ export const defaultMatchingInformationValues = (
   assessment: Assessment,
 ): Partial<MatchingInformationBody> => {
   return {
+    isArsonDesignated: isArsonDesignated(body, assessment),
     isCatered: isCatered(body, assessment),
     isWheelchairDesignated: isWheelchairDesignated(body, assessment),
     lengthOfStay: lengthOfStay(body),


### PR DESCRIPTION
# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

[JIRA](https://dsdmoj.atlassian.net/browse/APS-357)

# Changes in this PR

Prepopulate the designated arson room placement requirement on the matching information Assess screen based on the `arson` field from the application

## Screenshots of UI changes

### Before

<img width="664" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/40244233/5e60201d-9d68-44f8-a18f-e3ae13bce0e2">

### After

<img width="649" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/40244233/387a5658-0b0c-4773-bafb-333b21c10be3">