### PR TITLE
Add translations to timeline URLs

### DIFF
--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -1,5 +1,6 @@
-import { ApplicationSortField } from '@approved-premises/api'
+import { ApplicationSortField, TimelineEventUrlType } from '@approved-premises/api'
 import { isAfter } from 'date-fns'
+import { faker } from '@faker-js/faker'
 import { mockOptionalQuestionResponse } from '../../testutils/mockQuestionResponse'
 import {
   applicationFactory,
@@ -37,6 +38,7 @@ import {
   lengthOfStayForUI,
   mapPlacementApplicationToSummaryCards,
   mapTimelineEventsForUi,
+  mapTimelineUrlsForUi,
   withdrawnStatusTag,
 } from './utils'
 import { journeyTypeFromArtifact } from '../journeyTypeFromArtifact'
@@ -723,12 +725,12 @@ describe('utils', () => {
           },
           content: timelineEvents[0].content,
           createdBy: timelineEvents[0].createdBy.name,
-          associatedUrls: [
+          associatedUrls: mapTimelineUrlsForUi([
             {
               type: timelineEvents[0].associatedUrls[0].type,
               url: timelineEvents[0].associatedUrls[0].url,
             },
-          ],
+          ]),
         },
       ])
     })
@@ -747,6 +749,7 @@ describe('utils', () => {
           },
           content: timelineEvents[0].content,
           createdBy: timelineEvents[0].createdBy.name,
+          associatedUrls: [],
         },
       ])
     })
@@ -776,6 +779,18 @@ describe('utils', () => {
           DateFormats.isoToDateObj(actual[2].datetime.timestamp),
         ),
       ).toEqual(true)
+    })
+  })
+
+  describe('mapTimelineUrlsForUi', () => {
+    it.each([
+      ['application', 'application'],
+      ['assessment', 'assessment'],
+      ['booking', 'booking'],
+      ['assessmentAppeal', 'appeal'],
+    ])('Translates a "%s" url type to "%s"', (urlType: TimelineEventUrlType, translation: string) => {
+      const timelineUrl = { type: urlType, url: faker.internet.url() }
+      expect(mapTimelineUrlsForUi([timelineUrl])).toEqual([{ url: timelineUrl.url, type: translation }])
     })
   })
 

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -23,7 +23,9 @@ import type {
   PlacementType,
   SortDirection,
   TimelineEvent,
+  TimelineEventAssociatedUrl,
   TimelineEventType,
+  TimelineEventUrlType,
   User,
 } from '@approved-premises/api'
 import MaleAp from '../../form-pages/apply/reasons-for-placement/basic-information/maleAp'
@@ -288,7 +290,7 @@ const mapTimelineEventsForUi = (timelineEvents: Array<TimelineEvent>): Array<UiT
           date: DateFormats.isoDateTimeToUIDateTime(timelineEvent.occurredAt),
         },
         content: timelineEvent.content,
-        associatedUrls: timelineEvent.associatedUrls,
+        associatedUrls: timelineEvent.associatedUrls ? mapTimelineUrlsForUi(timelineEvent.associatedUrls) : [],
       }
       if (timelineEvent.createdBy?.name) {
         return {
@@ -298,6 +300,20 @@ const mapTimelineEventsForUi = (timelineEvents: Array<TimelineEvent>): Array<UiT
       }
       return event
     })
+}
+
+const mapTimelineUrlsForUi = (timelineUrls: Array<TimelineEventAssociatedUrl>) => {
+  return timelineUrls.map(item => ({ url: item.url, type: urlTypeForUi(item.type) }))
+}
+
+const urlTypeForUi = (type: TimelineEventUrlType) => {
+  const translations: Record<TimelineEventUrlType, string> = {
+    application: 'application',
+    assessment: 'assessment',
+    booking: 'booking',
+    assessmentAppeal: 'appeal',
+  }
+  return translations[type]
 }
 
 const mapPlacementApplicationToSummaryCards = (
@@ -455,6 +471,7 @@ export {
   getStatus,
   isInapplicable,
   mapTimelineEventsForUi,
+  mapTimelineUrlsForUi,
   mapPlacementApplicationToSummaryCards,
   lengthOfStayForUI,
   applicationStatusSelectOptions,


### PR DESCRIPTION
Most of the time, the URL types translate in a human-readable fashion, but the newly-added `assessmentAppeal` type needs a bit of attention before it gets exposed to the user. This adds a translation method to `mapTimelineEventsForUi` to translate the url type to something human readable.

## Screenshots

### Before

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/b5d6841f-61db-444c-a1d4-da6ae14f4416)

### After

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/851bc83c-c536-4cc8-929b-46a4e7f36030)
