### PR TITLE
(APS-358) Prepopulate single room requirement

### DIFF
--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -34,6 +34,7 @@ const defaultArguments = {
 const defaultMatchingInformationValuesReturnValue: Partial<MatchingInformationBody> = {
   isArsonDesignated: 'essential',
   isCatered: 'essential',
+  isSingle: 'desirable',
   isWheelchairDesignated: 'notRelevant',
   lengthOfStay: '32',
 }
@@ -93,7 +94,6 @@ describe('MatchingInformation', () => {
 
       expect(page.errors()).toEqual({
         apType: 'You must select the type of AP required',
-        isSingle: 'You must specify a preference for single room',
         isStepFreeDesignated: 'You must specify a preference for step-free access',
         hasEnSuite: 'You must specify a preference for en-suite bathroom',
         isSuitableForVulnerable: 'You must specify if vulnerable to exploitation is relevant',


### PR DESCRIPTION
# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

[JIRA](https://dsdmoj.atlassian.net/browse/APS-358)

# Changes in this PR

Prepopulate the single room placement requirement on the matching information Assess screen based on the various fields from the application

This one is a little more complicated than the others, in that it looks at multiple fields and if any of them have a value of `'yes'`, the requirement is set to `'essential'`, otherwise `'notRelevant'`

I've taken this opportunity to introduce a `TaskListPageYesNoField` interface that holds information about the fields we're checking: the name of the field, the page it appears on, and optionally the value it should be set to and whether it's an optional field. This allows us to use iterators in a few places to keep the code DRY as the number of fields we check and mock increase

## Screenshots of UI changes

### Before

<img width="649" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/40244233/387a5658-0b0c-4773-bafb-333b21c10be3">

### After

<img width="651" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/40244233/0213d71d-57a3-42ab-beca-fbb7e93ce3a7">
