### PR TITLE
(APS-305) Sort by and return `dueAt` in tasks view

### DIFF
--- a/integration_tests/tests/tasks/list.cy.ts
+++ b/integration_tests/tests/tasks/list.cy.ts
@@ -110,15 +110,24 @@ context('Task Allocation', () => {
     cy.task('stubGetAllTasks', {
       tasks,
       allocatedFilter: 'allocated',
-      page: '1',
       sortDirection: 'asc',
-      sortField: 'createdAt',
+      sortBy: 'createdAt',
     })
+
     cy.task('stubGetAllTasks', {
       tasks,
       allocatedFilter: 'allocated',
+      page: '1',
+      sortDirection: 'asc',
+      sortBy: 'dueAt',
+    })
+
+    cy.task('stubGetAllTasks', {
+      tasks,
+      allocatedFilter: 'allocated',
+      page: '1',
       sortDirection: 'desc',
-      sortField: 'createdAt',
+      sortBy: 'dueAt',
     })
 
     cy.task('stubApAreaReferenceData', {
@@ -132,18 +141,24 @@ context('Task Allocation', () => {
     // Then I should see the tasks that are allocated
     listPage.shouldShowAllocatedTasks()
 
-    // When I sort by created at in ascending order
-    listPage.clickSortBy('createdAt')
+    // When I sort by the due date in ascending order
+    listPage.clickSortBy('dueAt')
 
-    // Then the dashboard should be sorted by created at
-    listPage.shouldBeSortedByField('createdAt', 'descending')
+    // Then the dashboard should be sorted by the due date in ascending order
+    listPage.shouldBeSortedByField('dueAt', 'ascending')
+
+    // When I sort by the due date in descending order
+    listPage.clickSortBy('dueAt')
+
+    // Then the dashboard should be sorted by the due date in ascending order
+    listPage.shouldBeSortedByField('dueAt', 'descending')
 
     // And the API should have received a request for the correct sort order
     cy.task('verifyTasksRequests', {
       allocatedFilter: 'allocated',
       page: '1',
       sortDirection: 'desc',
-      sortField: 'createdAt',
+      sortBy: 'dueAt',
     }).then(requests => {
       expect(requests).to.have.length(1)
     })
@@ -307,14 +322,6 @@ context('Task Allocation', () => {
       tasks: allocatedTasksFiltered,
       allocatedFilter: 'allocated',
       page: '1',
-      sortDirection: 'asc',
-      apAreaId: '',
-    })
-
-    cy.task('stubGetAllTasks', {
-      tasks: allocatedTasksFiltered,
-      allocatedFilter: 'allocated',
-      sortDirection: 'desc',
       apAreaId: '',
     })
 
@@ -322,7 +329,15 @@ context('Task Allocation', () => {
       tasks: allocatedTasksFilteredPage2,
       allocatedFilter: 'allocated',
       page: '2',
+      apAreaId: '',
+    })
+
+    cy.task('stubGetAllTasks', {
+      tasks: allocatedTasksFiltered,
+      allocatedFilter: 'allocated',
       sortDirection: 'asc',
+      page: '1',
+      sortBy: 'dueAt',
       apAreaId: '',
     })
 
@@ -351,11 +366,11 @@ context('Task Allocation', () => {
     // Then the page should show the results
     listPage.shouldShowAllocatedTasks(allocatedTasksFilteredPage2)
 
-    // When I sort by created at in ascending order
-    listPage.clickSortBy('createdAt')
+    // When I sort by the due date at in ascending order
+    listPage.clickSortBy('dueAt')
 
-    // Then the dashboard should be sorted by created at
-    listPage.shouldBeSortedByField('createdAt', 'descending')
+    // Then the dashboard should be sorted by the due date
+    listPage.shouldBeSortedByField('dueAt', 'ascending')
 
     // Then the page should show the filtered results
     listPage.shouldShowAllocatedTasks(allocatedTasksFiltered)

--- a/server/utils/tasks/listTable.test.ts
+++ b/server/utils/tasks/listTable.test.ts
@@ -122,7 +122,7 @@ describe('table', () => {
   })
 
   describe('unallocatedTableRows', () => {
-    const sortBy = 'createdAt'
+    const sortBy = 'dueAt'
     const sortDirection = 'asc'
     const hrefPrefix = 'http://localhost'
 
@@ -131,7 +131,7 @@ describe('table', () => {
         {
           text: 'Person',
         },
-        sortHeader<TaskSortField>('Due', 'createdAt', sortBy, sortDirection, hrefPrefix),
+        sortHeader<TaskSortField>('Due', 'dueAt', sortBy, sortDirection, hrefPrefix),
         {
           text: 'Status',
         },
@@ -146,7 +146,7 @@ describe('table', () => {
   })
 
   describe('allocatedTableRows', () => {
-    const sortBy = 'createdAt'
+    const sortBy = 'dueAt'
     const sortDirection = 'asc'
     const hrefPrefix = 'http://localhost'
 
@@ -155,7 +155,7 @@ describe('table', () => {
         {
           text: 'Person',
         },
-        sortHeader<TaskSortField>('Due', 'createdAt', sortBy, sortDirection, hrefPrefix),
+        sortHeader<TaskSortField>('Due', 'dueAt', sortBy, sortDirection, hrefPrefix),
         {
           text: 'Allocated to',
         },

--- a/server/utils/tasks/listTable.test.ts
+++ b/server/utils/tasks/listTable.test.ts
@@ -1,3 +1,4 @@
+import { when } from 'jest-when'
 import {
   assessmentTaskFactory,
   placementApplicationTaskFactory,
@@ -29,6 +30,10 @@ import paths from '../../paths/tasks'
 jest.mock('../dateUtils')
 
 describe('table', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
   describe('allocatedTableRows', () => {
     describe('when all the optional task properties are populated', () => {
       it('returns an array of table rows', () => {
@@ -174,8 +179,13 @@ describe('table', () => {
 
   describe('daysUntilDueCell', () => {
     it('returns the days until due formatted for the UI as a TableCell object', () => {
-      ;(DateFormats.differenceInBusinessDays as jest.Mock).mockReturnValue(10)
       const task = taskFactory.build()
+
+      ;(DateFormats.differenceInBusinessDays as jest.Mock).mockReturnValue(10)
+      when(DateFormats.differenceInBusinessDays)
+        .calledWith(DateFormats.isoToDateObj(task.dueAt), new Date())
+        .mockReturnValue(10)
+
       expect(daysUntilDueCell(task)).toEqual({
         html: formatDaysUntilDueWithWarning(task),
         attributes: {
@@ -229,14 +239,22 @@ describe('table', () => {
 
   describe('formatDaysUntilDueWithWarning', () => {
     it('returns the number of days until the task is due', () => {
-      ;(DateFormats.differenceInBusinessDays as jest.Mock).mockReturnValue(10)
       const task = taskFactory.build()
+
+      when(DateFormats.differenceInBusinessDays)
+        .calledWith(DateFormats.isoToDateObj(task.dueAt), expect.any(Date))
+        .mockReturnValue(10)
+
       expect(formatDaysUntilDueWithWarning(task)).toEqual('10 Days')
     })
 
     it('returns "overdue" if the task is overdue', () => {
-      ;(DateFormats.differenceInBusinessDays as jest.Mock).mockReturnValue(2)
       const task = taskFactory.build()
+
+      when(DateFormats.differenceInBusinessDays)
+        .calledWith(DateFormats.isoToDateObj(task.dueAt), expect.any(Date))
+        .mockReturnValue(2)
+
       expect(formatDaysUntilDueWithWarning(task)).toEqual(
         `<strong class="task--index__warning">2 Days<span class="govuk-visually-hidden"> (Approaching due date)</span></strong>`,
       )

--- a/server/utils/tasks/listTable.ts
+++ b/server/utils/tasks/listTable.ts
@@ -119,7 +119,7 @@ const allocatedTableHeader = (sortBy: TaskSortField, sortDirection: SortDirectio
     {
       text: 'Person',
     },
-    sortHeader<TaskSortField>('Due', 'createdAt', sortBy, sortDirection, hrefPrefix),
+    sortHeader<TaskSortField>('Due', 'dueAt', sortBy, sortDirection, hrefPrefix),
     {
       text: 'Allocated to',
     },
@@ -140,7 +140,7 @@ const unAllocatedTableHeader = (sortBy: TaskSortField, sortDirection: SortDirect
     {
       text: 'Person',
     },
-    sortHeader<TaskSortField>('Due', 'createdAt', sortBy, sortDirection, hrefPrefix),
+    sortHeader<TaskSortField>('Due', 'dueAt', sortBy, sortDirection, hrefPrefix),
     {
       text: 'Status',
     },

--- a/server/utils/tasks/listTable.ts
+++ b/server/utils/tasks/listTable.ts
@@ -11,7 +11,7 @@ const DUE_DATE_APPROACHING_DAYS_WINDOW = 3
 const daysUntilDueCell = (task: Task): TableCell => ({
   html: formatDaysUntilDueWithWarning(task),
   attributes: {
-    'data-sort-value': DateFormats.differenceInBusinessDays(DateFormats.isoToDateObj(task.dueDate), new Date()),
+    'data-sort-value': DateFormats.differenceInBusinessDays(DateFormats.isoToDateObj(task.dueAt), new Date()),
   },
 })
 
@@ -70,7 +70,7 @@ const statusBadge = (task: Task): string => {
 }
 
 const formatDaysUntilDueWithWarning = (task: Task): string => {
-  const differenceInDays = DateFormats.differenceInBusinessDays(DateFormats.isoToDateObj(task.dueDate), new Date())
+  const differenceInDays = DateFormats.differenceInBusinessDays(DateFormats.isoToDateObj(task.dueAt), new Date())
   const formattedDifference = `${differenceInDays} Day${differenceInDays > 1 ? 's' : ''}`
 
   if (differenceInDays < DUE_DATE_APPROACHING_DAYS_WINDOW) {


### PR DESCRIPTION
https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1546 adds a new field called `dueAt`, which returns the due datetime for a task. In turn, this is now stored in the database, rather than calculated on the fly, so we can use this field to sort tasks by when they are due, rather than "faking it" by searching by "created at" (this will soon not be possible, as different tasks have different due dates depending on their status)