### PR TITLE
Fix/Only show the withdraw button to users who made the application

### DIFF
--- a/integration_tests/tests/apply/setup.ts
+++ b/integration_tests/tests/apply/setup.ts
@@ -7,11 +7,12 @@ import {
   tierEnvelopeFactory,
 } from '../../../server/testutils/factories'
 import { DateFormats } from '../../../server/utils/dateUtils'
+import { defaultUserId } from '../../mockApis/auth'
 
 export const setup = () => {
   cy.task('reset')
   cy.task('stubSignIn')
-  cy.task('stubAuthUser')
+  cy.task('stubAuthUser', { userId: defaultUserId })
 
   // Given I am logged in
   cy.signIn()
@@ -22,6 +23,7 @@ export const setup = () => {
       person,
       status: 'started',
       createdAt: DateFormats.dateObjToIsoDate(new Date()),
+      createdByUserId: defaultUserId,
     })
     const risks = risksFactory.build({
       crn: person.crn,

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -17,7 +17,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-width-container">
       <div class="govuk-grid-column-full">
-        {{ mojIdentityBar(ApplyUtils.applicationIdentityBar(application, pageHeading, user.roles)) }}
+        {{ mojIdentityBar(ApplyUtils.applicationIdentityBar(application, pageHeading, user)) }}
 
         {% include "../_messages.njk" %}
 
@@ -71,6 +71,8 @@
 
 {% block extraScripts %}
   <script type="text/javascript" nonce="{{ cspNonce }}">
-    new MOJFrontend.ButtonMenu({container: $('.application-identity-bar .moj-button-menu'), mq: "(min-width: 200em)", buttonText: "Actions", menuClasses: "moj-button-menu__wrapper--right"});
+    if ($('.application-identity-bar .moj-button-menu').length) {
+      new MOJFrontend.ButtonMenu({container: $('.application-identity-bar .moj-button-menu'), mq: "(min-width: 200em)", buttonText: "Actions", menuClasses: "moj-button-menu__wrapper--right"});
+    }
   </script>
 {% endblock %}


### PR DESCRIPTION
Previously we gave the option to all users viewing an application to withdraw it. However the API only allows the user who made the application to withdraw it so when the user reached the 'what would you like to withdraw?' screen they weren't seeing any options to choose. This change hides the button so they can't reach that screen
