### PR TITLE
(APS-361) Prepopulate arson offences

### DIFF
--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -33,6 +33,7 @@ const defaultArguments = {
 
 const defaultMatchingInformationValuesReturnValue: Partial<MatchingInformationBody> = {
   isArsonDesignated: 'essential',
+  isArsonSuitable: 'relevant',
   isCatered: 'essential',
   isSingle: 'desirable',
   isSuitableForVulnerable: 'relevant',
@@ -102,7 +103,6 @@ describe('MatchingInformation', () => {
         acceptsChildSexOffenders: 'You must specify if sexual offences against children is relevant',
         acceptsNonSexualChildOffenders: 'You must specify if non sexual offences against children is relevant',
         acceptsHateCrimeOffenders: 'You must specify if hate based offences is relevant',
-        isArsonSuitable: 'You must specify if arson offences is relevant',
         lengthOfStayAgreed: 'You must state if you agree with the length of the stay',
       })
     })

--- a/server/form-pages/utils/defaultMatchingInformationValues.test.ts
+++ b/server/form-pages/utils/defaultMatchingInformationValues.test.ts
@@ -5,7 +5,7 @@ import {
 } from '../../utils/retrieveQuestionResponseFromFormArtifact'
 import { applicationFactory } from '../../testutils/factories'
 import { MatchingInformationBody } from '../assess/matchingInformation/matchingInformationTask/matchingInformation'
-import { TaskListPageYesNoField, defaultMatchingInformationValues } from './defaultMatchingInformationValues'
+import { TaskListPageField, defaultMatchingInformationValues } from './defaultMatchingInformationValues'
 import AccessNeedsFurtherQuestions from '../apply/risk-and-need-factors/access-and-healthcare/accessNeedsFurtherQuestions'
 import Catering from '../apply/risk-and-need-factors/further-considerations/catering'
 import Arson from '../apply/risk-and-need-factors/further-considerations/arson'
@@ -53,7 +53,7 @@ describe('defaultMatchingInformationValues', () => {
   })
 
   it('returns an object with current or sensible default values for relevant fields', () => {
-    const yesNoFieldsToMock: Array<TaskListPageYesNoField> = [
+    const yesNoFieldsToMock: Array<TaskListPageField & { value?: 'yes' | 'no' }> = [
       { name: 'arson', page: Arson },
       { name: 'boosterEligibility', page: Covid },
       { name: 'catering', page: Catering, value: 'no' },
@@ -165,7 +165,7 @@ describe('defaultMatchingInformationValues', () => {
       })
 
       describe('isSingle', () => {
-        const yesNoFieldsToCheck: Array<TaskListPageYesNoField> = [
+        const fieldsToCheck: Array<TaskListPageField> = [
           { name: 'boosterEligibility', page: Covid },
           { name: 'immunosuppressed', page: Covid },
           { name: 'riskToOthers', page: RoomSharing },
@@ -174,8 +174,8 @@ describe('defaultMatchingInformationValues', () => {
           { name: 'traumaConcerns', page: RoomSharing },
         ]
 
-        it.each(yesNoFieldsToCheck)("is set to 'essential' when `$name` === 'yes'", ({ name: testedField }) => {
-          yesNoFieldsToCheck.forEach(({ name, page }) =>
+        it.each(fieldsToCheck)("is set to 'essential' when `$name` === 'yes'", ({ name: testedField }) => {
+          fieldsToCheck.forEach(({ name, page }) =>
             when(retrieveQuestionResponseFromFormArtifact)
               .calledWith(application, page, name)
               .mockReturnValue(testedField === name ? 'yes' : 'no'),
@@ -187,7 +187,7 @@ describe('defaultMatchingInformationValues', () => {
         })
 
         it("is set to 'notRelevant' when all relevant fields === 'no'", () => {
-          yesNoFieldsToCheck.forEach(({ name, page }) =>
+          fieldsToCheck.forEach(({ name, page }) =>
             when(retrieveQuestionResponseFromFormArtifact).calledWith(application, page, name).mockReturnValue('no'),
           )
 

--- a/server/form-pages/utils/defaultMatchingInformationValues.ts
+++ b/server/form-pages/utils/defaultMatchingInformationValues.ts
@@ -86,6 +86,15 @@ export const defaultMatchingInformationValues = (
       'essential',
       'notRelevant',
     ),
+    isArsonSuitable: getValue<GetValueOffenceAndRisk>(
+      body,
+      'isArsonSuitable',
+      application,
+      [{ name: 'arsonOffence', page: DateOfOffence, optional: true }],
+      ['current', 'previous'],
+      'relevant',
+      'notRelevant',
+    ),
     isCatered: getValue<GetValuePlacementRequirement>(
       body,
       'isCatered',

--- a/server/form-pages/utils/defaultMatchingInformationValues.ts
+++ b/server/form-pages/utils/defaultMatchingInformationValues.ts
@@ -19,14 +19,10 @@ import DateOfOffence from '../apply/risk-and-need-factors/risk-management-featur
 import Vulnerability from '../apply/risk-and-need-factors/further-considerations/vulnerability'
 import { OffenceAndRiskCriteria, PlacementRequirementCriteria } from '../../utils/placementCriteriaUtils'
 
-interface TaskListPageField {
+export interface TaskListPageField {
   name: string
   page: TasklistPageInterface
   optional?: boolean
-}
-
-export interface TaskListPageYesNoField extends TaskListPageField {
-  value?: 'yes' | 'no'
 }
 
 const lengthOfStay = (body: MatchingInformationBody): string | undefined => {


### PR DESCRIPTION
# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

[JIRA](https://dsdmoj.atlassian.net/browse/APS-361)

# Changes in this PR

- Prepopulate arson offences values on matching information screen in Assess

## Screenshots of UI changes

### Before

<img width="653" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/40244233/ea50a626-b7d5-4c85-a65e-e23239d301ae">

### After

<img width="658" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/40244233/725484da-5c02-405e-a591-ba1e03feaa30">