### PR TITLE
(APS-362) Prepopulate hate based offences

### DIFF
--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -32,6 +32,7 @@ const defaultArguments = {
 } as MatchingInformationBody
 
 const defaultMatchingInformationValuesReturnValue: Partial<MatchingInformationBody> = {
+  acceptsHateCrimeOffenders: 'relevant',
   isArsonDesignated: 'essential',
   isArsonSuitable: 'relevant',
   isCatered: 'essential',
@@ -102,7 +103,6 @@ describe('MatchingInformation', () => {
         acceptsSexOffenders: 'You must specify if sexual offences against an adult is relevant',
         acceptsChildSexOffenders: 'You must specify if sexual offences against children is relevant',
         acceptsNonSexualChildOffenders: 'You must specify if non sexual offences against children is relevant',
-        acceptsHateCrimeOffenders: 'You must specify if hate based offences is relevant',
         lengthOfStayAgreed: 'You must state if you agree with the length of the stay',
       })
     })

--- a/server/form-pages/utils/defaultMatchingInformationValues.test.ts
+++ b/server/form-pages/utils/defaultMatchingInformationValues.test.ts
@@ -72,7 +72,7 @@ describe('defaultMatchingInformationValues', () => {
         .mockReturnValue(value || 'yes'),
     )
 
-    const dateOfOffenceFieldsToMock = ['arsonOffence', ...sexualOffencesFields]
+    const dateOfOffenceFieldsToMock = ['arsonOffence', 'hateCrime', ...sexualOffencesFields]
 
     dateOfOffenceFieldsToMock.forEach(field =>
       when(retrieveOptionalQuestionResponseFromFormArtifact)
@@ -88,6 +88,7 @@ describe('defaultMatchingInformationValues', () => {
     }
 
     expect(defaultMatchingInformationValues(body, application)).toEqual({
+      acceptsHateCrimeOffenders: 'relevant',
       isArsonDesignated: 'essential',
       isArsonSuitable: 'relevant',
       isCatered: 'essential',
@@ -102,6 +103,7 @@ describe('defaultMatchingInformationValues', () => {
   describe('values for placement requirements and offence and risk criteria', () => {
     it('uses current values where they exist', () => {
       const currentValues: Partial<MatchingInformationBody> = {
+        acceptsHateCrimeOffenders: 'relevant',
         isArsonDesignated: 'desirable',
         isArsonSuitable: 'relevant',
         isCatered: 'desirable',
@@ -118,6 +120,30 @@ describe('defaultMatchingInformationValues', () => {
 
     describe("when there's no current value for a given field", () => {
       const truthyCurrentPreviousValues = [['current'], ['previous'], ['current', 'previous']]
+
+      describe('acceptsHateCrimeOffenders', () => {
+        truthyCurrentPreviousValues.forEach(value => {
+          it(`is set to 'relevant' when \`hateCrime\` === ['${value.join("', '")}']`, () => {
+            when(retrieveOptionalQuestionResponseFromFormArtifact)
+              .calledWith(application, DateOfOffence, 'hateCrime')
+              .mockReturnValue(value)
+
+            expect(defaultMatchingInformationValues(bodyWithUndefinedValues, application)).toEqual(
+              expect.objectContaining({ acceptsHateCrimeOffenders: 'relevant' }),
+            )
+          })
+        })
+
+        it("is set to 'notRelevant' when `hateCrime` === undefined", () => {
+          when(retrieveOptionalQuestionResponseFromFormArtifact)
+            .calledWith(application, DateOfOffence, 'hateCrime')
+            .mockReturnValue(undefined)
+
+          expect(defaultMatchingInformationValues(bodyWithUndefinedValues, application)).toEqual(
+            expect.objectContaining({ acceptsHateCrimeOffenders: 'notRelevant' }),
+          )
+        })
+      })
 
       describe('isArsonDesignated', () => {
         it("is set to 'essential' when `arson` === 'yes'", () => {

--- a/server/form-pages/utils/defaultMatchingInformationValues.ts
+++ b/server/form-pages/utils/defaultMatchingInformationValues.ts
@@ -77,6 +77,15 @@ export const defaultMatchingInformationValues = (
   application: ApprovedPremisesApplication,
 ): Partial<MatchingInformationBody> => {
   return {
+    acceptsHateCrimeOffenders: getValue<GetValueOffenceAndRisk>(
+      body,
+      'acceptsHateCrimeOffenders',
+      application,
+      [{ name: 'hateCrime', page: DateOfOffence, optional: true }],
+      ['current', 'previous'],
+      'relevant',
+      'notRelevant',
+    ),
     isArsonDesignated: getValue<GetValuePlacementRequirement>(
       body,
       'isArsonDesignated',


### PR DESCRIPTION
# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

[JIRA](https://dsdmoj.atlassian.net/browse/APS-362)

# Changes in this PR

- Prepopulate hate based offences values on matching information screen in Assess

## Screenshots of UI changes

### Before

<img width="658" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/40244233/725484da-5c02-405e-a591-ba1e03feaa30">

### After

<img width="529" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/40244233/a9b1cadd-7e01-4ba8-8eb1-c3e8cda13ae7">