### PR TITLE
(APS-363) Prepopulate accepts adult sexual offences

### DIFF
--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -33,6 +33,7 @@ const defaultArguments = {
 
 const defaultMatchingInformationValuesReturnValue: Partial<MatchingInformationBody> = {
   acceptsHateCrimeOffenders: 'relevant',
+  acceptsSexOffenders: 'relevant',
   isArsonDesignated: 'essential',
   isArsonSuitable: 'relevant',
   isCatered: 'essential',
@@ -100,7 +101,6 @@ describe('MatchingInformation', () => {
         apType: 'You must select the type of AP required',
         isStepFreeDesignated: 'You must specify a preference for step-free access',
         hasEnSuite: 'You must specify a preference for en-suite bathroom',
-        acceptsSexOffenders: 'You must specify if sexual offences against an adult is relevant',
         acceptsChildSexOffenders: 'You must specify if sexual offences against children is relevant',
         acceptsNonSexualChildOffenders: 'You must specify if non sexual offences against children is relevant',
         lengthOfStayAgreed: 'You must state if you agree with the length of the stay',

--- a/server/form-pages/utils/defaultMatchingInformationValues.test.ts
+++ b/server/form-pages/utils/defaultMatchingInformationValues.test.ts
@@ -297,7 +297,7 @@ describe('defaultMatchingInformationValues', () => {
       describe('isSuitedForSexOffenders', () => {
         truthyCurrentPreviousValues.forEach(value => {
           it.each(sexualOffencesFields)(
-            `is set to 'essential' when \`$name\` === ['${value.join("', '")}']`,
+            `is set to 'essential' when \`%s\` === ['${value.join("', '")}']`,
             testedField => {
               sexualOffencesFields.forEach(field =>
                 when(retrieveOptionalQuestionResponseFromFormArtifact)

--- a/server/form-pages/utils/defaultMatchingInformationValues.ts
+++ b/server/form-pages/utils/defaultMatchingInformationValues.ts
@@ -77,6 +77,18 @@ export const defaultMatchingInformationValues = (
   application: ApprovedPremisesApplication,
 ): Partial<MatchingInformationBody> => {
   return {
+    acceptsSexOffenders: getValue<GetValueOffenceAndRisk>(
+      body,
+      'acceptsSexOffenders',
+      application,
+      [
+        { name: 'contactSexualOffencesAgainstAdults', page: DateOfOffence, optional: true },
+        { name: 'nonContactSexualOffencesAgainstAdults', page: DateOfOffence, optional: true },
+      ],
+      ['current', 'previous'],
+      'relevant',
+      'notRelevant',
+    ),
     acceptsHateCrimeOffenders: getValue<GetValueOffenceAndRisk>(
       body,
       'acceptsHateCrimeOffenders',


### PR DESCRIPTION
# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

[JIRA](https://dsdmoj.atlassian.net/browse/APS-363)

# Changes in this PR

- Prepopulate sexual offences against an adult value on matching information screen in Assess

## Screenshots of UI changes

### Before

<img width="529" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/40244233/a9b1cadd-7e01-4ba8-8eb1-c3e8cda13ae7">

### After

<img width="533" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/40244233/77a926dd-9f2d-4bc9-9042-bfc29a80ebaf">