### PR TITLE
(APS-364) Prepopulate sexual offences against children

### DIFF
--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -32,6 +32,7 @@ const defaultArguments = {
 } as MatchingInformationBody
 
 const defaultMatchingInformationValuesReturnValue: Partial<MatchingInformationBody> = {
+  acceptsChildSexOffenders: 'relevant',
   acceptsHateCrimeOffenders: 'relevant',
   acceptsSexOffenders: 'relevant',
   isArsonDesignated: 'essential',
@@ -101,7 +102,6 @@ describe('MatchingInformation', () => {
         apType: 'You must select the type of AP required',
         isStepFreeDesignated: 'You must specify a preference for step-free access',
         hasEnSuite: 'You must specify a preference for en-suite bathroom',
-        acceptsChildSexOffenders: 'You must specify if sexual offences against children is relevant',
         acceptsNonSexualChildOffenders: 'You must specify if non sexual offences against children is relevant',
         lengthOfStayAgreed: 'You must state if you agree with the length of the stay',
       })

--- a/server/form-pages/utils/defaultMatchingInformationValues.test.ts
+++ b/server/form-pages/utils/defaultMatchingInformationValues.test.ts
@@ -85,6 +85,7 @@ describe('defaultMatchingInformationValues', () => {
     }
 
     expect(defaultMatchingInformationValues(body, application)).toEqual({
+      acceptsChildSexOffenders: 'relevant',
       acceptsHateCrimeOffenders: 'relevant',
       acceptsSexOffenders: 'relevant',
       isArsonDesignated: 'essential',
@@ -101,6 +102,7 @@ describe('defaultMatchingInformationValues', () => {
   describe('values for placement requirements and offence and risk criteria', () => {
     it('uses current values where they exist', () => {
       const currentValues: Partial<MatchingInformationBody> = {
+        acceptsChildSexOffenders: 'relevant',
         acceptsHateCrimeOffenders: 'relevant',
         acceptsSexOffenders: 'relevant',
         isArsonDesignated: 'desirable',
@@ -119,6 +121,37 @@ describe('defaultMatchingInformationValues', () => {
 
     describe("when there's no current value for a given field", () => {
       const truthyCurrentPreviousValues = [['current'], ['previous'], ['current', 'previous']]
+
+      describe('acceptsChildSexOffenders', () => {
+        truthyCurrentPreviousValues.forEach(value => {
+          it.each(childSexualOffencesFields)(
+            `is set to 'essential' when \`%s\` === ['${value.join("', '")}']`,
+            testedField => {
+              childSexualOffencesFields.forEach(field =>
+                when(retrieveOptionalQuestionResponseFromFormArtifact)
+                  .calledWith(application, DateOfOffence, field)
+                  .mockReturnValue(testedField === field ? value : undefined),
+              )
+
+              expect(defaultMatchingInformationValues(bodyWithUndefinedValues, application)).toEqual(
+                expect.objectContaining({ acceptsChildSexOffenders: 'relevant' }),
+              )
+            },
+          )
+        })
+
+        it("is set to 'notRelevant' when all relevant fields === undefined", () => {
+          childSexualOffencesFields.forEach(field =>
+            when(retrieveOptionalQuestionResponseFromFormArtifact)
+              .calledWith(application, DateOfOffence, field)
+              .mockReturnValue(undefined),
+          )
+
+          expect(defaultMatchingInformationValues(bodyWithUndefinedValues, application)).toEqual(
+            expect.objectContaining({ acceptsChildSexOffenders: 'notRelevant' }),
+          )
+        })
+      })
 
       describe('acceptsHateCrimeOffenders', () => {
         truthyCurrentPreviousValues.forEach(value => {

--- a/server/form-pages/utils/defaultMatchingInformationValues.test.ts
+++ b/server/form-pages/utils/defaultMatchingInformationValues.test.ts
@@ -320,7 +320,7 @@ describe('defaultMatchingInformationValues', () => {
           )
 
           expect(defaultMatchingInformationValues(bodyWithUndefinedValues, application)).toEqual(
-            expect.objectContaining({ isSingle: 'notRelevant' }),
+            expect.objectContaining({ isSuitedForSexOffenders: 'notRelevant' }),
           )
         })
       })

--- a/server/form-pages/utils/defaultMatchingInformationValues.ts
+++ b/server/form-pages/utils/defaultMatchingInformationValues.ts
@@ -77,6 +77,18 @@ export const defaultMatchingInformationValues = (
   application: ApprovedPremisesApplication,
 ): Partial<MatchingInformationBody> => {
   return {
+    acceptsChildSexOffenders: getValue<GetValueOffenceAndRisk>(
+      body,
+      'acceptsChildSexOffenders',
+      application,
+      [
+        { name: 'contactSexualOffencesAgainstChildren', page: DateOfOffence, optional: true },
+        { name: 'nonContactSexualOffencesAgainstChildren', page: DateOfOffence, optional: true },
+      ],
+      ['current', 'previous'],
+      'relevant',
+      'notRelevant',
+    ),
     acceptsSexOffenders: getValue<GetValueOffenceAndRisk>(
       body,
       'acceptsSexOffenders',


### PR DESCRIPTION
# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

[JIRA](https://dsdmoj.atlassian.net/browse/APS-364)

# Changes in this PR

- Prepopulate sexual offences against children value on matching information screen in Assess

### Before

<img width="533" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/40244233/77a926dd-9f2d-4bc9-9042-bfc29a80ebaf">

### After

<img width="522" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/40244233/c125deff-0062-4c6d-aae5-3ed870c2776a">