### PR TITLE
Set flash messages on res.locals

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -51,8 +51,8 @@ export default function createApp(controllers: Controllers, services: Services):
   app.use(setUpCsrf())
   app.use(setUpCurrentUser(services))
   app.use((req, res, next) => {
-    res.app.locals.infoMessages = req.flash('info')
-    res.app.locals.successMessages = req.flash('success')
+    res.locals.infoMessages = req.flash('info')
+    res.locals.successMessages = req.flash('success')
     return next()
   })
   app.use(routes(controllers, services))


### PR DESCRIPTION
While looking at https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/1513 I noticed some issues with Flash messages not appearing, I had a look and found https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/557 which seems to address the issues we're having.

This updates app.ts so that flash messages are set on res.locals rather than res.app.locals. This ensures their scope is a single request, rather than the application as a whole.
