### PR TITLE
(APS-365) Prepopulate nonsexual offences against children

### DIFF
--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -32,6 +32,7 @@ const defaultArguments = {
 } as MatchingInformationBody
 
 const defaultMatchingInformationValuesReturnValue: Partial<MatchingInformationBody> = {
+  acceptsNonSexualChildOffenders: 'relevant',
   acceptsChildSexOffenders: 'relevant',
   acceptsHateCrimeOffenders: 'relevant',
   acceptsSexOffenders: 'relevant',
@@ -102,7 +103,6 @@ describe('MatchingInformation', () => {
         apType: 'You must select the type of AP required',
         isStepFreeDesignated: 'You must specify a preference for step-free access',
         hasEnSuite: 'You must specify a preference for en-suite bathroom',
-        acceptsNonSexualChildOffenders: 'You must specify if non sexual offences against children is relevant',
         lengthOfStayAgreed: 'You must state if you agree with the length of the stay',
       })
     })

--- a/server/form-pages/utils/defaultMatchingInformationValues.test.ts
+++ b/server/form-pages/utils/defaultMatchingInformationValues.test.ts
@@ -69,7 +69,12 @@ describe('defaultMatchingInformationValues', () => {
         .mockReturnValue(value || 'yes'),
     )
 
-    const dateOfOffenceFieldsToMock = ['arsonOffence', 'hateCrime', ...sexualOffencesFields]
+    const dateOfOffenceFieldsToMock = [
+      'arsonOffence',
+      'hateCrime',
+      'nonSexualOffencesAgainstChildren',
+      ...sexualOffencesFields,
+    ]
 
     dateOfOffenceFieldsToMock.forEach(field =>
       when(retrieveOptionalQuestionResponseFromFormArtifact)
@@ -87,6 +92,7 @@ describe('defaultMatchingInformationValues', () => {
     expect(defaultMatchingInformationValues(body, application)).toEqual({
       acceptsChildSexOffenders: 'relevant',
       acceptsHateCrimeOffenders: 'relevant',
+      acceptsNonSexualChildOffenders: 'relevant',
       acceptsSexOffenders: 'relevant',
       isArsonDesignated: 'essential',
       isArsonSuitable: 'relevant',
@@ -104,6 +110,7 @@ describe('defaultMatchingInformationValues', () => {
       const currentValues: Partial<MatchingInformationBody> = {
         acceptsChildSexOffenders: 'relevant',
         acceptsHateCrimeOffenders: 'relevant',
+        acceptsNonSexualChildOffenders: 'relevant',
         acceptsSexOffenders: 'relevant',
         isArsonDesignated: 'desirable',
         isArsonSuitable: 'relevant',
@@ -173,6 +180,30 @@ describe('defaultMatchingInformationValues', () => {
 
           expect(defaultMatchingInformationValues(bodyWithUndefinedValues, application)).toEqual(
             expect.objectContaining({ acceptsHateCrimeOffenders: 'notRelevant' }),
+          )
+        })
+      })
+
+      describe('acceptsNonSexualChildOffenders', () => {
+        truthyCurrentPreviousValues.forEach(value => {
+          it(`is set to 'relevant' when \`nonSexualOffencesAgainstChildren\` === ['${value.join("', '")}']`, () => {
+            when(retrieveOptionalQuestionResponseFromFormArtifact)
+              .calledWith(application, DateOfOffence, 'nonSexualOffencesAgainstChildren')
+              .mockReturnValue(value)
+
+            expect(defaultMatchingInformationValues(bodyWithUndefinedValues, application)).toEqual(
+              expect.objectContaining({ acceptsNonSexualChildOffenders: 'relevant' }),
+            )
+          })
+        })
+
+        it("is set to 'notRelevant' when `nonSexualOffencesAgainstChildren` === undefined", () => {
+          when(retrieveOptionalQuestionResponseFromFormArtifact)
+            .calledWith(application, DateOfOffence, 'nonSexualOffencesAgainstChildren')
+            .mockReturnValue(undefined)
+
+          expect(defaultMatchingInformationValues(bodyWithUndefinedValues, application)).toEqual(
+            expect.objectContaining({ acceptsNonSexualChildOffenders: 'notRelevant' }),
           )
         })
       })

--- a/server/form-pages/utils/defaultMatchingInformationValues.ts
+++ b/server/form-pages/utils/defaultMatchingInformationValues.ts
@@ -89,6 +89,15 @@ export const defaultMatchingInformationValues = (
       'relevant',
       'notRelevant',
     ),
+    acceptsNonSexualChildOffenders: getValue<GetValueOffenceAndRisk>(
+      body,
+      'acceptsNonSexualChildOffenders',
+      application,
+      [{ name: 'nonSexualOffencesAgainstChildren', page: DateOfOffence, optional: true }],
+      ['current', 'previous'],
+      'relevant',
+      'notRelevant',
+    ),
     acceptsSexOffenders: getValue<GetValueOffenceAndRisk>(
       body,
       'acceptsSexOffenders',


### PR DESCRIPTION
# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

[JIRA](https://dsdmoj.atlassian.net/browse/APS-365)

# Changes in this PR

- Prepopulate non-sexual offences against children value on matching information screen in Assess

## Screenshots of UI changes

### Before

<img width="522" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/40244233/c125deff-0062-4c6d-aae5-3ed870c2776a">

### After

<img width="525" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/40244233/8073d4c8-32b1-4502-ae4b-cef4bb425151">