### PR TITLE
Use the placementDates from the placementApplication object if they exist

### DIFF
--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -328,11 +328,9 @@ const mapPlacementApplicationToSummaryCards = (
       'reason',
     ) as PlacementType
 
-    const datesOfPlacements = durationAndArrivalDateFromPlacementApplication(
-      placementApplication,
-      reasonForPlacement,
-      application,
-    )
+    const datesOfPlacements = placementApplication?.placementDates?.length
+      ? placementApplication?.placementDates
+      : durationAndArrivalDateFromPlacementApplication(placementApplication, reasonForPlacement, application)
 
     const actionItems = []
 


### PR DESCRIPTION
As with #1537 if placementDates exist on a placementApplication object we should use them as they are more accurate.
If not we'll fall back to the dates in the data blob.

[JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?selectedIssue=APS-405)
