### PR TITLE
APS 408 - Applicants see permission error trying to withdraw the original apps placement request

### DIFF
--- a/integration_tests/mockApis/placementRequests.ts
+++ b/integration_tests/mockApis/placementRequests.ts
@@ -273,6 +273,7 @@ export default {
         headers: {
           'Content-Type': 'application/json;charset=UTF-8',
         },
+        jsonBody: placementRequest,
       },
     }),
 

--- a/server/controllers/admin/placementRequests/withdrawalsController.test.ts
+++ b/server/controllers/admin/placementRequests/withdrawalsController.test.ts
@@ -37,8 +37,6 @@ describe('withdrawalsController', () => {
       const applicationId = 'some-id'
       const errorsAndUserInput = createMock<ErrorsAndUserInput>()
       ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
-      const placementRequest = placementRequestDetailFactory.build({ applicationId })
-      placementRequestService.getPlacementRequest.mockResolvedValue(placementRequest)
       request.params.id = applicationId
 
       const requestHandler = withdrawalsController.new()
@@ -50,10 +48,7 @@ describe('withdrawalsController', () => {
         id: request.params.id,
         errors: errorsAndUserInput.errors,
         errorSummary: errorsAndUserInput.errorSummary,
-        expectedArrival: placementRequest.expectedArrival,
-        duration: placementRequest.duration,
       })
-      expect(placementRequestService.getPlacementRequest).toHaveBeenCalledWith(token, applicationId)
     })
   })
 
@@ -69,8 +64,6 @@ describe('withdrawalsController', () => {
     beforeEach(() => {
       request.params.id = applicationId
       request.body = {
-        duration: placementRequestDetail.duration,
-        expectedArrival: placementRequestDetail.expectedArrival,
         reason: placementRequestDetail.withdrawalReason,
       }
     })
@@ -80,6 +73,8 @@ describe('withdrawalsController', () => {
       const requestHandler = withdrawalsController.create()
 
       ;(withdrawalMessage as jest.MockedFn<typeof withdrawalMessage>).mockReturnValue(withdrawalMessageContent)
+      placementRequestService.withdraw.mockResolvedValue(placementRequestDetail)
+
       await requestHandler(request, response, next)
 
       expect(placementRequestService.withdraw).toHaveBeenCalledWith(

--- a/server/data/placementRequestClient.ts
+++ b/server/data/placementRequestClient.ts
@@ -91,10 +91,10 @@ export default class PlacementRequestClient {
     })) as Promise<BookingNotMade>
   }
 
-  async withdraw(id: string, reason: WithdrawPlacementRequestReason): Promise<void> {
-    await this.restClient.post({
+  async withdraw(id: string, reason: WithdrawPlacementRequestReason): Promise<PlacementRequest> {
+    return (await this.restClient.post({
       path: paths.placementRequests.withdrawal.create({ id }),
       data: { reason },
-    })
+    })) as Promise<PlacementRequest>
   }
 }

--- a/server/services/placementRequestService.test.ts
+++ b/server/services/placementRequestService.test.ts
@@ -200,7 +200,8 @@ describe('placementRequestService', () => {
 
   describe('withdraw', () => {
     it('it should call the service', async () => {
-      placementRequestClient.withdraw.mockResolvedValue()
+      const placementRequestDetail = placementRequestDetailFactory.build()
+      placementRequestClient.withdraw.mockResolvedValue(placementRequestDetail)
 
       const reason: WithdrawPlacementRequestReason = 'AlternativeProvisionIdentified'
       const id = 'some-uuid'

--- a/server/views/admin/placementRequests/withdrawals/new.njk
+++ b/server/views/admin/placementRequests/withdrawals/new.njk
@@ -24,8 +24,6 @@
 
         {{ showErrorSummary(errorSummary) }}
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-        <input type="hidden" name="expectedArrival" value="{{ expectedArrival }}"/>
-        <input type="hidden" name="duration" value="{{ duration }}"/>
 
         {{ showErrorSummary(errorSummary) }}
 


### PR DESCRIPTION
Previously the API didn't return the `PlacementRequestDetail` when the `/placement-requests/:id/withdrawal` endpoint was called.
This meant we had to do a GET in the 'new' method of the `withdrawalsController` and pass
the `duration` and `expectedArrivalDate` through the view as a hidden input and back into the create method.
Sometimes however a use could reach the 'new' method without having permission to call the
GET endpoint which would cause an error.
Now we remove the GET and use the `PlacementRequestDetail` that the API now returns to render the
details in the flash message

[Jira](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?selectedIssue=APS-408) 
