### PR TITLE
Remove notes and date inputs on booking withdrawal screen

### DIFF
--- a/integration_tests/pages/manage/cancellationCreate.ts
+++ b/integration_tests/pages/manage/cancellationCreate.ts
@@ -17,14 +17,7 @@ export default class CancellationCreatePage extends Page {
     return new CancellationCreatePage(premisesId, bookingId)
   }
 
-  completeForm(cancellation: Cancellation, { completeFullForm }: { completeFullForm: boolean }): void {
-    if (completeFullForm) {
-      this.getLegend('What is the date of withdrawal?')
-      this.completeDateInputs('date', cancellation.date)
-      this.getLabel('Provide any additional notes on why this placement is being withdrawn')
-      this.completeTextArea('cancellation[notes]', cancellation.notes)
-    }
-
+  completeForm(cancellation: Cancellation): void {
     this.getLegend('Why is this placement being withdrawn?')
     this.checkRadioByNameAndValue('cancellation[reason]', cancellation.reason.id)
 

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -22,7 +22,6 @@ import { signIn } from '../signIn'
 import { withdrawPlacementRequestOrApplication } from '../../support/helpers'
 import paths from '../../../server/paths/api'
 import BookingCancellationConfirmPage from '../../pages/manage/bookingCancellationConfirmation'
-import { DateFormats } from '../../../server/utils/dateUtils'
 
 context('Placement Requests', () => {
   let application = applicationFactory.build()
@@ -256,7 +255,7 @@ context('Placement Requests', () => {
 
   it('allows me to cancel a booking', () => {
     const premises = premisesFactory.buildList(3)
-    const cancellation = cancellationFactory.build({ date: '2022-06-01' })
+    const cancellation = cancellationFactory.build()
     const withdrawable = withdrawableFactory.build({ id: matchedPlacementRequest.booking.id, type: 'booking' })
     cy.task('stubAllPremises', premises)
     cy.task('stubBookingFromPlacementRequest', matchedPlacementRequest)
@@ -303,7 +302,7 @@ context('Placement Requests', () => {
     const cancellationPage = Page.verifyOnPage(CancellationCreatePage, matchedPlacementRequest)
 
     // And I cancel my booking
-    cancellationPage.completeForm(cancellation, { completeFullForm: false })
+    cancellationPage.completeForm(cancellation)
 
     // Then I should see a confirmation message
     const confirmationPage = new BookingCancellationConfirmPage()
@@ -318,7 +317,6 @@ context('Placement Requests', () => {
       expect(requests).to.have.length(1)
       const requestBody = JSON.parse(requests[0].body)
 
-      expect(requestBody.date).equal(DateFormats.dateObjToIsoDate(new Date()))
       expect(requestBody.reason).equal(cancellation.reason.id)
     })
   })

--- a/integration_tests/tests/manage/cancellation.cy.ts
+++ b/integration_tests/tests/manage/cancellation.cy.ts
@@ -36,7 +36,7 @@ context('Cancellation', () => {
     cy.task('stubBookingGet', { premisesId: premises.id, booking })
 
     // When I navigate to the booking's cancellation page
-    const cancellation = cancellationFactory.build({ date: '2022-06-01' })
+    const cancellation = cancellationFactory.build()
     const withdrawable = withdrawableFactory.build({ id: booking.id, type: 'booking' })
     cy.task('stubCancellationCreate', { premisesId: premises.id, bookingId: booking.id, cancellation })
     cy.task('stubPremisesSummary', premises)
@@ -59,7 +59,7 @@ context('Cancellation', () => {
 
     // And I fill out the cancellation form
     const cancellationPage = new CancellationCreatePage(premises.id, booking.id)
-    cancellationPage.completeForm(cancellation, { completeFullForm: true })
+    cancellationPage.completeForm(cancellation)
 
     // Then a cancellation should have been created in the API
     cy.task('verifyCancellationCreate', {
@@ -70,8 +70,6 @@ context('Cancellation', () => {
       expect(requests).to.have.length(1)
       const requestBody = JSON.parse(requests[0].body)
 
-      expect(requestBody.date).equal(cancellation.date)
-      expect(requestBody.notes).equal(cancellation.notes)
       expect(requestBody.reason).equal(cancellation.reason.id)
     })
 
@@ -87,7 +85,7 @@ context('Cancellation', () => {
     cy.task('stubBookingGet', { premisesId: premises.id, booking })
 
     // When I navigate to the booking's cancellation page
-    const cancellation = cancellationFactory.build({ date: '2022-06-01' })
+    const cancellation = cancellationFactory.build()
     cy.task('stubCancellationCreate', { premisesId: premises.id, bookingId: booking.id, cancellation })
 
     const page = CancellationCreatePage.visit(premises.id, booking.id)
@@ -96,7 +94,7 @@ context('Cancellation', () => {
     page.shouldShowBacklinkToBooking()
 
     // When I fill out the cancellation form
-    page.completeForm(cancellation, { completeFullForm: true })
+    page.completeForm(cancellation)
 
     // Then a cancellation should have been created in the API
     cy.task('verifyCancellationCreate', {
@@ -107,8 +105,6 @@ context('Cancellation', () => {
       expect(requests).to.have.length(1)
       const requestBody = JSON.parse(requests[0].body)
 
-      expect(requestBody.date).equal(cancellation.date)
-      expect(requestBody.notes).equal(cancellation.notes)
       expect(requestBody.reason).equal(cancellation.reason.id)
     })
 

--- a/server/views/cancellations/new.njk
+++ b/server/views/cancellations/new.njk
@@ -80,32 +80,6 @@
           items: convertObjectsToRadioItems(cancellationReasons, 'name', 'id', 'cancellation[reason]')
           }) }}
 
-        {% if apManager %}
-          {{ govukDateInput({
-            id: "date",
-            namePrefix: "date",
-            fieldset: {
-                legend: {
-                    text: "What is the date of withdrawal?",
-                    classes: "govuk-fieldset__legend--m"
-                    }
-            },
-            hint: {
-                text: "For example, 27 3 2007"
-            },
-            errorMessage: errors.date,
-            items: dateFieldValues('date', errors)
-        }) }}
-
-          {{ govukTextarea({
-            name: "cancellation[notes]",
-            id: "notes",
-            label: {
-            text: "Provide any additional notes on why this placement is being withdrawn"
-            }
-        }) }}
-        {% endif %}
-
         {{ govukButton({
             text: "Withdraw"
         }) }}


### PR DESCRIPTION
These are no longer required for any users

## Screenshots of UI changes

### Before
![before](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/5b5811b3-fc17-4c92-8c61-a87ad98673e9)

### After
![after](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/ccb9a7a1-5570-4cfd-8ca5-33756326b200)
