### PR TITLE
APS 429 Change date formats across the service

### DIFF
--- a/server/form-pages/apply/move-on/foreignNational.test.ts
+++ b/server/form-pages/apply/move-on/foreignNational.test.ts
@@ -1,3 +1,4 @@
+import { DateFormats } from '../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
 
 import ForeignNational from './foreignNational'
@@ -60,17 +61,17 @@ describe('ForeignNational', () => {
     })
 
     it("If the response is 'yes' the response is returned with the date", () => {
-      expect(
-        new ForeignNational({
-          response: 'yes',
-          'date-day': '22',
-          'date-month': '2',
-          'date-year': '2022',
-        }).response(),
-      ).toEqual({
+      const body = {
+        response: 'yes' as const,
+        'date-day': '22',
+        'date-month': '2',
+        'date-year': '2022',
+      }
+
+      expect(new ForeignNational(body).response()).toEqual({
         "Have you informed the Home Office 'Foreign National Returns Command' that accommodation will be required after placement?":
           'Yes',
-        'Date of notification': 'Tuesday 22 February 2022',
+        'Date of notification': DateFormats.dateAndTimeInputsToUiDate(body, 'date'),
       })
     })
   })

--- a/server/form-pages/apply/move-on/placementDuration.test.ts
+++ b/server/form-pages/apply/move-on/placementDuration.test.ts
@@ -1,10 +1,12 @@
 import { ApprovedPremisesApplication } from '@approved-premises/api'
+import { addDays } from 'date-fns'
 import { getDefaultPlacementDurationInDays } from '../../../utils/applications/getDefaultPlacementDurationInDays'
 
 import PlacementDuration from './placementDuration'
 import { applicationFactory } from '../../../testutils/factories'
 import { addResponsesToFormArtifact } from '../../../testutils/addToApplication'
 import { arrivalDateFromApplication } from '../../../utils/applications/arrivalDateFromApplication'
+import { DateFormats } from '../../../utils/dateUtils'
 
 jest.mock('../../../utils/applications/getDefaultPlacementDurationInDays')
 jest.mock('../../../utils/applications/arrivalDateFromApplication')
@@ -48,13 +50,15 @@ describe('PlacementDuration', () => {
 
   describe('initializeDates', () => {
     it('sets the dates based on arrivalDateFromApplication', () => {
-      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2022-11-11')
+      const arrivalDate = '2022-11-11'
+      ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(arrivalDate)
       ;(getDefaultPlacementDurationInDays as jest.Mock).mockReturnValue(30)
 
       const page = new PlacementDuration({}, application)
 
-      expect(page.arrivalDate).toEqual('Friday 11 November 2022')
-      expect(page.departureDate).toEqual('Sunday 11 December 2022')
+      expect(page.arrivalDate).toEqual(DateFormats.isoDateToUIDate(arrivalDate))
+      const arrivalDatePlus30Days = addDays(new Date(arrivalDate), 30)
+      expect(page.departureDate).toEqual(DateFormats.dateObjtoUIDate(arrivalDatePlus30Days))
     })
 
     it('sets the dates to undefined if the dates are not specified', () => {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/exceptionDetails.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/exceptionDetails.test.ts
@@ -1,3 +1,4 @@
+import { DateFormats } from '../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
 import ExceptionDetails, { ExceptionDetailsBody } from './exceptionDetails'
@@ -88,7 +89,7 @@ describe('ExceptionDetails', () => {
         'Have you agreed the case with a senior manager?': 'Yes',
         'Name of senior manager': 'Mr Manager',
         'Provide a summary of the reasons why this is an exempt application': 'Some Summary',
-        'What date was this agreed?': 'Friday 1 December 2023',
+        'What date was this agreed?': DateFormats.dateAndTimeInputsToUiDate(body, 'agreementDate'),
       })
     })
   })

--- a/server/form-pages/apply/reasons-for-placement/basic-information/oralHearing.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/oralHearing.test.ts
@@ -1,3 +1,4 @@
+import { DateFormats } from '../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
 import OralHearing from './oralHearing'
@@ -80,16 +81,17 @@ describe('OralHearing', () => {
     })
 
     it('should return a translated version of the response when the start date is not the same as the release date', () => {
-      const page = new OralHearing({
-        knowOralHearingDate: 'yes',
+      const body = {
+        knowOralHearingDate: 'yes' as const,
         'oralHearingDate-year': '2022',
         'oralHearingDate-month': '11',
         'oralHearingDate-day': '11',
-      })
+      }
+      const page = new OralHearing(body)
 
       expect(page.response()).toEqual({
         [page.title]: 'Yes',
-        'Oral Hearing Date': 'Friday 11 November 2022',
+        'Oral Hearing Date': DateFormats.dateAndTimeInputsToUiDate(body, 'oralHearingDate'),
       })
     })
   })

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.test.ts
@@ -350,20 +350,17 @@ describe('PlacementDate', () => {
             typeof retrieveOptionalQuestionResponseFromFormArtifact
           >
         ).mockReturnValue(futureReleaseDate)
-
-        const page = new PlacementDate(
-          {
-            startDateSameAsReleaseDate: 'no',
-            'startDate-year': '2022',
-            'startDate-month': '11',
-            'startDate-day': '11',
-          },
-          application,
-        )
+        const body = {
+          startDateSameAsReleaseDate: 'no' as const,
+          'startDate-year': '2022',
+          'startDate-month': '11',
+          'startDate-day': '11',
+        }
+        const page = new PlacementDate(body, application)
 
         expect(page.response()).toEqual({
           [page.title]: 'No',
-          'Placement Start Date': 'Friday 11 November 2022',
+          'Placement Start Date': DateFormats.dateAndTimeInputsToUiDate(body, 'startDate'),
         })
       })
     })
@@ -376,17 +373,16 @@ describe('PlacementDate', () => {
           >
         ).mockReturnValue(pastReleaseDate)
 
-        const page = new PlacementDate(
-          {
-            'startDate-year': '2022',
-            'startDate-month': '11',
-            'startDate-day': '11',
-          },
-          application,
-        )
+        const body = {
+          'startDate-year': '2022',
+          'startDate-month': '11',
+          'startDate-day': '11',
+        }
+
+        const page = new PlacementDate(body, application)
 
         expect(page.response()).toEqual({
-          'What date you want the placement to start?': 'Friday 11 November 2022',
+          'What date you want the placement to start?': DateFormats.dateAndTimeInputsToUiDate(body, 'startDate'),
         })
       })
     })

--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseDate.test.ts
@@ -141,19 +141,17 @@ describe('ReleaseDate', () => {
     })
 
     it('should return a translated version of the response when the user knows the release date', () => {
-      const page = new ReleaseDate(
-        {
-          knowReleaseDate: 'yes',
-          'releaseDate-year': '2022',
-          'releaseDate-month': '11',
-          'releaseDate-day': '11',
-        },
-        application,
-      )
+      const body = {
+        knowReleaseDate: 'yes' as const,
+        'releaseDate-year': '2022',
+        'releaseDate-month': '11',
+        'releaseDate-day': '11',
+      }
+      const page = new ReleaseDate(body, application)
 
       expect(page.response()).toEqual({
         [page.title]: 'Yes',
-        'Release Date': 'Friday 11 November 2022',
+        'Release Date': DateFormats.dateAndTimeInputsToUiDate(body, 'releaseDate'),
       })
     })
   })

--- a/server/form-pages/apply/reasons-for-placement/basic-information/relevantDates.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/relevantDates.test.ts
@@ -1,4 +1,5 @@
 import { applicationFactory } from '../../../../testutils/factories'
+import { DateFormats } from '../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
 import RelevantDates, { RelevantDatesBody, relevantDateKeys } from './relevantDates'
@@ -144,12 +145,12 @@ describe('RelevantDates', () => {
       const page = new RelevantDates(body, application)
 
       expect(page.response()).toEqual({
-        'Home Detention Curfew (HDC) date': 'Sunday 1 January 2023',
-        'Licence expiry date': 'Thursday 2 February 2023',
-        'Parole eligibility date': 'Friday 3 March 2023',
-        'Post sentence supervision (PSS) end date': 'Tuesday 4 April 2023',
-        'Post sentence supervision (PSS) start date': 'Friday 5 May 2023',
-        'Sentence expiry date': 'Tuesday 6 June 2023',
+        'Home Detention Curfew (HDC) date': DateFormats.dateAndTimeInputsToUiDate(body, 'homeDetentionCurfewDate'),
+        'Licence expiry date': DateFormats.dateAndTimeInputsToUiDate(body, 'licenceExpiryDate'),
+        'Parole eligibility date': DateFormats.dateAndTimeInputsToUiDate(body, 'paroleEligibilityDate'),
+        'Post sentence supervision (PSS) end date': DateFormats.dateAndTimeInputsToUiDate(body, 'pssEndDate'),
+        'Post sentence supervision (PSS) start date': DateFormats.dateAndTimeInputsToUiDate(body, 'pssStartDate'),
+        'Sentence expiry date': DateFormats.dateAndTimeInputsToUiDate(body, 'sentenceExpiryDate'),
       })
     })
 

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapExceptionalCase.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapExceptionalCase.test.ts
@@ -1,3 +1,4 @@
+import { DateFormats } from '../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
 import EsapExceptionalCase, { EsapExceptionalCaseBody } from './esapExceptionalCase'
@@ -89,7 +90,7 @@ describe('EsapExceptionalCase', () => {
         [`${page.title}`]: 'Yes',
         'Name of Community HOPP': 'Mr Manager',
         'Provide a summary of the reasons why this is an exempt application': 'Some Summary',
-        'Date of agreement': 'Friday 1 December 2023',
+        'Date of agreement': DateFormats.dateAndTimeInputsToUiDate(body, 'agreementDate'),
       })
     })
   })

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/pipeReferral.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/pipeReferral.test.ts
@@ -1,3 +1,4 @@
+import { DateFormats } from '../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
 import PipeReferral from './pipeReferral'
@@ -83,16 +84,20 @@ describe('PipeReferral', () => {
     })
 
     it('should return a translated version of the response when opdPathway is "yes"', () => {
-      const page = new PipeReferral({
-        opdPathway: 'yes',
+      const body = {
+        opdPathway: 'yes' as const,
         'opdPathwayDate-year': '2022',
         'opdPathwayDate-month': '11',
         'opdPathwayDate-day': '11',
-      })
+      }
+      const page = new PipeReferral(body)
 
       expect(page.response()).toEqual({
         [page.title]: 'Yes',
-        "When was the person's last consultation or formulation?": 'Friday 11 November 2022',
+        "When was the person's last consultation or formulation?": DateFormats.dateAndTimeInputsToUiDate(
+          body,
+          'opdPathwayDate',
+        ),
       })
     })
   })

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsFurtherQuestions.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsFurtherQuestions.test.ts
@@ -198,7 +198,7 @@ describe('AccessNeedsFurtherQuestions', () => {
         'Does the person have any prescribed medication?': 'Yes - Some detail',
         'Is the person pregnant?': 'Yes',
         'Is there social care involvement?': 'Yes - Some detail',
-        'What is their expected date of delivery?': 'Sunday 19 February 2023',
+        'What is their expected date of delivery?': DateFormats.dateAndTimeInputsToUiDate(body, 'expectedDeliveryDate'),
         "Will the child be removed from the person's care at birth?": 'No',
         'Are there any pregnancy related issues relevant to placement?': 'Yes - Some detail',
         "Specify any additional details and adjustments required for the person's pregnancy needs": 'Adjustments',

--- a/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.test.ts
@@ -32,8 +32,8 @@ describe('caseNoteResponse', () => {
     })
 
     expect(caseNoteResponse(caseNote)).toEqual({
-      'Date created': 'Friday 31 January 2020',
-      'Date occurred': 'Wednesday 1 January 2020',
+      'Date created': DateFormats.isoDateToUIDate(caseNote.createdAt),
+      'Date occurred': DateFormats.isoDateToUIDate(caseNote.occurredAt),
       'Is the case note sensitive?': 'No',
       'Name of author': 'Dennis Ziemann',
       Note: 'a note',
@@ -75,8 +75,8 @@ describe('acctAlertResponse', () => {
     expect(acctAlertResponse(acctAlert)).toEqual({
       'Alert type': 123,
       'ACCT description': 'Some description',
-      'Date created': 'Saturday 1 January 2022',
-      'Expiry date': 'Sunday 9 January 2022',
+      'Date created': DateFormats.isoDateToUIDate(acctAlert.dateCreated),
+      'Expiry date': DateFormats.isoDateToUIDate(acctAlert.dateExpires),
     })
   })
 
@@ -90,8 +90,8 @@ describe('acctAlertResponse', () => {
 
     expect(acctAlertResponse(acctAlert)).toEqual({
       'Alert type': 123,
-      'Date created': 'Saturday 1 January 2022',
-      'Expiry date': 'Sunday 9 January 2022',
+      'Date created': DateFormats.isoDateToUIDate(acctAlert.dateCreated),
+      'Expiry date': DateFormats.isoDateToUIDate(acctAlert.dateExpires),
       'ACCT description': '',
     })
   })
@@ -114,7 +114,7 @@ describe('caseNoteCheckbox', () => {
       <div class="govuk-checkboxes__item">
         <input type="checkbox" class="govuk-checkboxes__input" name="caseNoteIds" value="A" id="A" checked>
         <label class="govuk-label govuk-checkboxes__label" for="A">
-          <span class="govuk-visually-hidden">Select case note from Friday 31 January 2020</span>
+          <span class="govuk-visually-hidden">Select case note from ${DateFormats.isoDateToUIDate(caseNote.createdAt)}</span>
         </label>
       </div>
     `)
@@ -123,7 +123,7 @@ describe('caseNoteCheckbox', () => {
       <div class="govuk-checkboxes__item">
         <input type="checkbox" class="govuk-checkboxes__input" name="caseNoteIds" value="A" id="A">
         <label class="govuk-label govuk-checkboxes__label" for="A">
-          <span class="govuk-visually-hidden">Select case note from Friday 31 January 2020</span>
+          <span class="govuk-visually-hidden">Select case note from ${DateFormats.isoDateToUIDate(caseNote.createdAt)}</span>
         </label>
       </div>
     `)

--- a/server/form-pages/assess/assessApplication/requiredActions/requiredActions.test.ts
+++ b/server/form-pages/assess/assessApplication/requiredActions/requiredActions.test.ts
@@ -1,4 +1,5 @@
 import { YesOrNo } from '../../../../@types/ui'
+import { DateFormats } from '../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
 import RequiredActions from './requiredActions'
@@ -142,21 +143,22 @@ describe('RequiredActions', () => {
 
   describe('response', () => {
     it('returns the response', () => {
-      const page = new RequiredActions({
-        additionalActions: 'yes',
+      const body = {
+        additionalActions: 'yes' as const,
         additionalActionsComments: 'one',
-        curfewsOrSignIns: 'yes',
+        curfewsOrSignIns: 'yes' as const,
         curfewsOrSignInsComments: 'two',
-        concernsOfUnmanagableRisk: 'yes',
+        concernsOfUnmanagableRisk: 'yes' as const,
         concernsOfUnmanagableRiskComments: 'three',
         nameOfAreaManager: 'frank',
         'dateOfDiscussion-year': '2022',
         'dateOfDiscussion-month': '11',
         'dateOfDiscussion-day': '11',
         outlineOfDiscussion: 'foo bar baz',
-        additionalRecommendations: 'yes',
+        additionalRecommendations: 'yes' as const,
         additionalRecommendationsComments: 'four',
-      })
+      }
+      const page = new RequiredActions(body)
 
       expect(page.response()).toEqual({
         'Are any additional curfews or sign ins recommended?': 'Yes',
@@ -169,7 +171,7 @@ describe('RequiredActions', () => {
         'Are there concerns that the person poses a potentially unmanageable risk to staff or others?': 'Yes',
         'Are there concerns that the person poses a potentially unmanageable risk to staff or others? Additional comments':
           'three',
-        'Date of discussion': 'Friday 11 November 2022',
+        'Date of discussion': DateFormats.dateAndTimeInputsToUiDate(body, 'dateOfDiscussion'),
         'Name of area manager': 'frank',
         'Outline the discussion, including any additional measures that have been agreed.': 'foo bar baz',
       })

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/informationReceived.test.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/informationReceived.test.ts
@@ -1,3 +1,4 @@
+import { DateFormats } from '../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
 import InformationReceived from './informationReceived'
@@ -83,19 +84,20 @@ describe('InformationReceived', () => {
 
   describe('response', () => {
     it('returns the response', () => {
-      const page = new InformationReceived({
-        informationReceived: 'yes',
+      const body = {
+        informationReceived: 'yes' as const,
         'responseReceivedOn-year': '2022',
         'responseReceivedOn-month': '3',
         'responseReceivedOn-day': '3',
         responseReceivedOn: '2022-03-03',
         response: 'some text',
-      })
+      }
+      const page = new InformationReceived(body)
 
       expect(page.response()).toEqual({
         'Have you received additional information from the probation practitioner?': 'Yes',
         'Provide the additional information received from the probation practitioner': 'some text',
-        'When did you receive this information?': 'Thursday 3 March 2022',
+        'When did you receive this information?': DateFormats.dateAndTimeInputsToUiDate(body, 'responseReceivedOn'),
       })
     })
   })

--- a/server/form-pages/placement-application/request-a-placement/additionalPlacementDetails.test.ts
+++ b/server/form-pages/placement-application/request-a-placement/additionalPlacementDetails.test.ts
@@ -2,6 +2,7 @@ import { fromPartial } from '@total-typescript/shoehorn'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
 
 import AdditionalPlacementDetails, { Body } from './additionalPlacementDetails'
+import { DateFormats } from '../../../utils/dateUtils'
 
 describe('AdditionalPlacementDetails', () => {
   const body = {
@@ -68,7 +69,7 @@ describe('AdditionalPlacementDetails', () => {
 
       expect(page.response()).toEqual({
         'How long should the Approved Premises placement last?': '5 weeks, 1 day',
-        'When will the person arrive?': 'Friday 1 December 2023',
+        'When will the person arrive?': DateFormats.dateAndTimeInputsToUiDate(body, 'arrivalDate'),
         'Why are you requesting this placement?': 'Some reason',
       })
     })

--- a/server/form-pages/placement-application/request-a-placement/datesOfPlacement.test.ts
+++ b/server/form-pages/placement-application/request-a-placement/datesOfPlacement.test.ts
@@ -5,6 +5,7 @@ import DateOfPlacementPage from './datesOfPlacement'
 import { placementApplicationFactory } from '../../../testutils/factories'
 import { addResponseToFormArtifact } from '../../../testutils/addToApplication'
 import { retrieveQuestionResponseFromFormArtifact } from '../../../utils/retrieveQuestionResponseFromFormArtifact'
+import { DateFormats } from '../../../utils/dateUtils'
 
 jest.mock('../../../utils/retrieveQuestionResponseFromFormArtifact')
 
@@ -174,11 +175,17 @@ describe('DateOfPlacement', () => {
         'Dates of placement': [
           {
             'How long should the Approved Premises placement last?': '2 weeks, 1 day',
-            'When will the person arrive?': 'Friday 1 December 2023',
+            'When will the person arrive?': DateFormats.dateAndTimeInputsToUiDate(
+              body.datesOfPlacement[0],
+              'arrivalDate',
+            ),
           },
           {
             'How long should the Approved Premises placement last?': '3 weeks, 2 days',
-            'When will the person arrive?': 'Tuesday 2 January 2024',
+            'When will the person arrive?': DateFormats.dateAndTimeInputsToUiDate(
+              body.datesOfPlacement[1],
+              'arrivalDate',
+            ),
           },
         ],
       })

--- a/server/form-pages/placement-application/request-a-placement/decisionToRelease.test.ts
+++ b/server/form-pages/placement-application/request-a-placement/decisionToRelease.test.ts
@@ -2,6 +2,7 @@ import { fromPartial } from '@total-typescript/shoehorn'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared-examples'
 
 import DecisionToRelease, { Body } from './decisionToRelease'
+import { DateFormats } from '../../../utils/dateUtils'
 
 describe('DecisionToRelease', () => {
   const body = {
@@ -62,7 +63,7 @@ describe('DecisionToRelease', () => {
       const page = new DecisionToRelease(body)
 
       expect(page.response()).toEqual({
-        'Enter the date of decision': 'Friday 1 December 2023',
+        'Enter the date of decision': DateFormats.dateAndTimeInputsToUiDate(body, 'decisionToReleaseDate'),
         'Provide relevant information from the direction to release that will impact the placement': 'Some information',
       })
     })

--- a/server/form-pages/placement-application/request-a-placement/previousRotlPlacement.test.ts
+++ b/server/form-pages/placement-application/request-a-placement/previousRotlPlacement.test.ts
@@ -2,6 +2,7 @@ import { fromPartial } from '@total-typescript/shoehorn'
 import { itShouldHavePreviousValue } from '../../shared-examples'
 
 import PreviousRotlPlacement, { Body } from './previousRotlPlacement'
+import { DateFormats } from '../../../utils/dateUtils'
 
 describe('PreviousRotlPlacement', () => {
   const body = {
@@ -98,7 +99,7 @@ describe('PreviousRotlPlacement', () => {
         'Has this person previously had a placement at an Approved Premises for ROTL?': 'Yes',
         'Provide details of any other previous ROTL placements (including the location) and dates of stays.':
           'Some Summary',
-        'When was the last placement?': 'Friday 1 December 2023',
+        'When was the last placement?': DateFormats.dateAndTimeInputsToUiDate(body, 'lastPlacementDate'),
         'Which Approved Premises did the person last stay at?': 'An AP',
       })
     })

--- a/server/utils/calendarUtils.test.ts
+++ b/server/utils/calendarUtils.test.ts
@@ -181,7 +181,10 @@ describe('calendarUtils', () => {
         lostBedId: '123',
       })
 
-      const expectedText = 'Out of Service (14 days 27/06/2023 - 11/07/2023)'
+      const startDate = DateFormats.dateObjtoUIDate(lostBedOccupancyEntry.startDate, { format: 'short' })
+      const endDate = DateFormats.dateObjtoUIDate(lostBedOccupancyEntry.endDate, { format: 'short' })
+
+      const expectedText = `Out of Service (14 days ${startDate} - ${endDate})`
 
       expect(labelForScheduleItem(lostBedOccupancyEntry, premisesId, bedId)).toMatchStringIgnoringWhitespace(
         `<span title="${expectedText}" class="tooltip">
@@ -199,7 +202,7 @@ describe('calendarUtils', () => {
         endDate: DateFormats.isoToDateObj('2023-07-11'),
       })
 
-      const expectedText = 'John Wayne (14 days 27/06/2023 - 11/07/2023)'
+      const expectedText = `John Wayne (14 days ${DateFormats.dateObjtoUIDate(bedOccupancyEntry.startDate, { format: 'short' })} - ${DateFormats.dateObjtoUIDate(bedOccupancyEntry.endDate, { format: 'short' })})`
 
       expect(labelForScheduleItem(bedOccupancyEntry, premisesId, bedId)).toMatchStringIgnoringWhitespace(
         `<span title="${expectedText}" class="tooltip">
@@ -215,7 +218,7 @@ describe('calendarUtils', () => {
         endDate: DateFormats.isoToDateObj('2023-07-11'),
       })
 
-      const expectedText = 'Overbooked (14 days 27/06/2023 - 11/07/2023)'
+      const expectedText = `Overbooked (14 days ${DateFormats.dateObjtoUIDate(bedOccupancyEntry.startDate, { format: 'short' })} - ${DateFormats.dateObjtoUIDate(bedOccupancyEntry.endDate, { format: 'short' })})`
 
       expect(labelForScheduleItem(bedOccupancyEntry, premisesId, bedId)).toMatchStringIgnoringWhitespace(
         `<span title="${expectedText}" class="tooltip">

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -67,13 +67,13 @@ describe('DateFormats', () => {
     it('converts a ISO8601 date string to a GOV.UK formatted date', () => {
       const date = '2022-11-11T00:00:00.000Z'
 
-      expect(DateFormats.isoDateToUIDate(date)).toEqual('Friday 11 November 2022')
+      expect(DateFormats.isoDateToUIDate(date)).toEqual('Fri 11 Nov 2022')
     })
 
     it('converts a ISO8601 date string to a short format date', () => {
       const date = '2022-11-11T00:00:00.000Z'
 
-      expect(DateFormats.isoDateToUIDate(date, { format: 'short' })).toEqual('11/11/2022')
+      expect(DateFormats.isoDateToUIDate(date, { format: 'short' })).toEqual('11 Nov 2022')
     })
 
     it('raises an error if the date is not a valid ISO8601 date string', () => {
@@ -190,9 +190,10 @@ describe('DateFormats', () => {
 
   describe('dateAndTimeInputsToUiDate', () => {
     it('converts a date and time input object to a human readable date', () => {
-      const dateTimeInputs = DateFormats.dateObjectToDateInputs(new Date('2022-11-11T10:00:00.000Z'), 'key')
+      const date = new Date('2022-11-11T10:00:00.000Z')
+      const dateTimeInputs = DateFormats.dateObjectToDateInputs(date, 'key')
 
-      expect(DateFormats.dateAndTimeInputsToUiDate(dateTimeInputs, 'key')).toEqual('Friday 11 November 2022')
+      expect(DateFormats.dateAndTimeInputsToUiDate(dateTimeInputs, 'key')).toEqual(DateFormats.dateObjtoUIDate(date))
     })
 
     it('throws an error if an object without date inputs for the key is entered', () => {

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -52,13 +52,15 @@ export class DateFormats {
 
   /**
    * @param date JS Date object.
-   * @returns the date in the to be shown in the UI: "Thursday, 20 December 2012".
+   * @returns the date in the to be shown in the UI.
+   * Long: "Thu 20 Dec 2012"
+   * Short: "20 Dec 2012"
    */
   static dateObjtoUIDate(date: Date, options: { format: 'short' | 'long' } = { format: 'long' }) {
     if (options.format === 'long') {
-      return format(date, 'cccc d MMMM y')
+      return format(date, 'ccc d MMM y')
     }
-    return format(date, 'dd/LL/y')
+    return format(date, 'dd MMM y')
   }
 
   /**
@@ -93,7 +95,7 @@ export class DateFormats {
 
   /**
    * @param isoDate an ISO8601 date string.
-   * @returns the date in the to be shown in the UI: "Thursday, 20 December 2012".
+   * @returns the date in the to be shown in the UI: "Thu 20 Dec 2012".
    */
   static isoDateToUIDate(isoDate: string, options: { format: 'short' | 'long' } = { format: 'long' }) {
     return DateFormats.dateObjtoUIDate(DateFormats.isoToDateObj(isoDate), options)
@@ -101,7 +103,7 @@ export class DateFormats {
 
   /**
    * @param isoDate an ISO8601 date string.
-   * @returns the date in the to be shown in the UI: "Thursday, 20 December 2012".
+   * @returns the date in the to be shown in the UI: "Thu 20 Dec 2012".
    */
   static isoDateTimeToUIDateTime(isoDate: string) {
     return format(DateFormats.isoToDateObj(isoDate), 'd MMM y, HH:mm')

--- a/server/utils/placementRequests/checkYourAnswersUtils.test.ts
+++ b/server/utils/placementRequests/checkYourAnswersUtils.test.ts
@@ -278,11 +278,11 @@ describe('checkYourAnswersUtils', () => {
             {
               'Dates of placement': [
                 {
-                  'When will the person arrive?': 'Tuesday 1 August 2023',
+                  'When will the person arrive?': DateFormats.dateObjtoUIDate(new Date(2023, 7, 1)),
                   'How long should the Approved Premises placement last?': '5 days',
                 },
                 {
-                  'When will the person arrive?': 'Thursday 1 August 2024',
+                  'When will the person arrive?': DateFormats.dateObjtoUIDate(new Date(2024, 7, 1)),
                   'How long should the Approved Premises placement last?': '3 weeks, 4 days',
                 },
               ],

--- a/server/utils/placementRequests/utils.test.ts
+++ b/server/utils/placementRequests/utils.test.ts
@@ -9,6 +9,7 @@ import {
 import { linkTo } from '../utils'
 import paths from '../../paths/match'
 import assessPaths from '../../paths/assess'
+import { DateFormats } from '../dateUtils'
 
 jest.mock('../utils')
 
@@ -73,8 +74,9 @@ describe('utils', () => {
 
   describe('withdrawalMessage', () => {
     it('returns the message and inserts the duration and expected arrival date', () => {
-      expect(withdrawalMessage(15, '2021-01-01')).toEqual(
-        'Request for placement for 2 weeks, 1 day starting on 01/01/2021 withdrawn successfully',
+      const date = '2021-01-01'
+      expect(withdrawalMessage(15, date)).toEqual(
+        `Request for placement for 2 weeks, 1 day starting on ${DateFormats.isoDateToUIDate(date, { format: 'short' })} withdrawn successfully`,
       )
     })
   })

--- a/server/utils/premisesUtils.test.ts
+++ b/server/utils/premisesUtils.test.ts
@@ -17,6 +17,7 @@ import { addOverbookingsToSchedule } from './addOverbookingsToSchedule'
 import { textValue } from './applications/utils'
 import paths from '../paths/manage'
 import { linkTo } from './utils'
+import { DateFormats } from './dateUtils'
 
 jest.mock('./addOverbookingsToSchedule')
 
@@ -47,7 +48,7 @@ describe('premisesUtils', () => {
       const result = overcapacityMessage(dateCapacities)
 
       expect(result).toEqual(
-        '<h3 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity on Saturday 1 January 2022</h3>',
+        `<h3 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity on ${DateFormats.isoDateToUIDate(dateCapacities[0].date)}</h3>`,
       )
     })
 
@@ -60,8 +61,10 @@ describe('premisesUtils', () => {
       ]
       const result = overcapacityMessage(dateCapacities)
 
+      const startDate = DateFormats.isoDateToUIDate(dateCapacities[0].date)
+      const endDate = DateFormats.isoDateToUIDate(dateCapacities[2].date)
       expect(result).toEqual(
-        '<h3 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity for the period Saturday 1 January 2022 to Monday 3 January 2022</h3>',
+        `<h3 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity for the period ${startDate} to ${endDate}</h3>`,
       )
     })
 
@@ -80,8 +83,8 @@ describe('premisesUtils', () => {
         `
           <h3 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity for the periods:</h3>
           <ul class="govuk-list govuk-list--bullet">
-            <li>Saturday 1 January 2022 to Sunday 2 January 2022</li>
-            <li>Tuesday 4 January 2022 to Wednesday 5 January 2022</li>
+            <li>${DateFormats.isoDateToUIDate(dateCapacities[0].date)} to ${DateFormats.isoDateToUIDate(dateCapacities[1].date)}</li>
+            <li>${DateFormats.isoDateToUIDate(dateCapacities[3].date)} to${DateFormats.isoDateToUIDate(dateCapacities[4].date)}</li>
           </ul>
         `,
       )
@@ -101,8 +104,8 @@ describe('premisesUtils', () => {
         `
           <h3 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity for the periods:</h3>
           <ul class="govuk-list govuk-list--bullet">
-            <li>Saturday 1 January 2022</li>
-            <li>Tuesday 4 January 2022 to Wednesday 5 January 2022</li>
+            <li>${DateFormats.isoDateToUIDate(dateCapacities[0].date)}</li>
+            <li>${DateFormats.isoDateToUIDate(dateCapacities[2].date)} to ${DateFormats.isoDateToUIDate(dateCapacities[3].date)}</li>
           </ul>
         `,
       )


### PR DESCRIPTION
# Context

[Jira](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?selectedIssue=APS-429) 

We currently use the following two date formats: 
- short: 28/02/2024
- long: Thursday 29 February 2024

Design recommendation change as follows:
- short: 21 Feb 2024
- long:  Thurs 28 Feb 2024
