### PR TITLE
APS 447 - Submit case manager information to the api and retrieve it for the assessment

### DIFF
--- a/integration_tests/pages/assess/clarificationNoteConfirmPage.ts
+++ b/integration_tests/pages/assess/clarificationNoteConfirmPage.ts
@@ -13,9 +13,24 @@ export default class SufficientInformationPage extends Page {
 
   confirmUserDetails(application: ApprovedPremisesApplication) {
     cy.get('dl').within(() => {
-      this.assertDefinition('Name', application.data['basic-information']['confirm-your-details'].name)
-      this.assertDefinition('Email', application.data['basic-information']['confirm-your-details'].emailAddress)
-      this.assertDefinition('Contact number', application.data['basic-information']['confirm-your-details'].phoneNumber)
+      this.assertDefinition(
+        'Name',
+        application.caseManagerIsNotApplicant
+          ? application.caseManagerUserDetails.name
+          : application.applicantUserDetails.name,
+      )
+      this.assertDefinition(
+        'Email',
+        application.caseManagerIsNotApplicant
+          ? application.caseManagerUserDetails.email
+          : application.applicantUserDetails.email,
+      )
+      this.assertDefinition(
+        'Contact number',
+        application.caseManagerIsNotApplicant
+          ? application.caseManagerUserDetails.telephoneNumber
+          : application.applicantUserDetails.telephoneNumber,
+      )
     })
   }
 }

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -58,6 +58,9 @@ context('Apply', () => {
         'isEsapApplication',
         'isEmergencyApplication',
         'apAreaId',
+        'applicantUserDetails',
+        'caseManagerIsNotApplicant',
+        'caseManagerUserDetails',
       )
       expect(body.data).to.deep.equal(this.applicationData)
 
@@ -85,6 +88,9 @@ context('Apply', () => {
         'situation',
         'type',
         'apAreaId',
+        'applicantUserDetails',
+        'caseManagerIsNotApplicant',
+        'caseManagerUserDetails',
       )
     })
 
@@ -335,6 +341,9 @@ context('Apply', () => {
         'isEsapApplication',
         'isEmergencyApplication',
         'apAreaId',
+        'applicantUserDetails',
+        'caseManagerIsNotApplicant',
+        'caseManagerUserDetails',
       )
 
       expect(body.data).to.deep.equal(this.applicationData)
@@ -363,6 +372,9 @@ context('Apply', () => {
         'situation',
         'type',
         'apAreaId',
+        'applicantUserDetails',
+        'caseManagerIsNotApplicant',
+        'caseManagerUserDetails',
       )
     })
   })

--- a/integration_tests/tests/apply/invalidations.cy.ts
+++ b/integration_tests/tests/apply/invalidations.cy.ts
@@ -50,6 +50,9 @@ context('Apply', () => {
         'isEsapApplication',
         'isEmergencyApplication',
         'apAreaId',
+        'applicantUserDetails',
+        'caseManagerIsNotApplicant',
+        'caseManagerUserDetails',
       )
       expect(body.data).not.to.have.keys(['check-your-answers'])
     })
@@ -89,6 +92,9 @@ context('Apply', () => {
         'isEsapApplication',
         'isEmergencyApplication',
         'apAreaId',
+        'applicantUserDetails',
+        'caseManagerIsNotApplicant',
+        'caseManagerUserDetails',
       )
       expect(body.data).to.have.any.keys(['check-your-answers'])
     })

--- a/server/form-pages/apply/reasons-for-placement/basic-information/caseManagerInformation.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/caseManagerInformation.test.ts
@@ -1,6 +1,6 @@
 import { lowerCase } from '../../../../utils/utils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
-import CaseManagerInformation, { CaseManagerDetails, fields } from './caseManagerInformation'
+import CaseManagerInformation, { CaseManagerDetails, caseManagerKeys } from './caseManagerInformation'
 
 describe('CaseMangerInformation', () => {
   const body: CaseManagerDetails = {
@@ -22,7 +22,7 @@ describe('CaseMangerInformation', () => {
   itShouldHavePreviousValue(new CaseManagerInformation(body), 'confirm-your-details')
 
   describe('errors', () => {
-    describe.each(fields)('when the %s is not supplied', field => {
+    describe.each(caseManagerKeys)('when the %s is not supplied', field => {
       it('should return an error', () => {
         const bodyWithoutField: Partial<CaseManagerDetails> = { ...body, [field]: undefined }
         const page = new CaseManagerInformation(bodyWithoutField)

--- a/server/form-pages/apply/reasons-for-placement/basic-information/caseManagerInformation.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/caseManagerInformation.ts
@@ -3,16 +3,13 @@ import type { TaskListErrors } from '@approved-premises/ui'
 import { lowerCase } from '../../../../utils/utils'
 import TasklistPage from '../../../tasklistPage'
 import { Page } from '../../../utils/decorators'
+import { UserDetails, userDetailsKeys } from './confirmYourDetails'
 
-export type CaseManagerDetails = {
-  name: string
-  emailAddress: string
-  phoneNumber: string
-}
+export type CaseManagerDetails = Omit<UserDetails, 'area'>
 
-export const fields: ReadonlyArray<keyof CaseManagerDetails> = ['name', 'emailAddress', 'phoneNumber']
+export const caseManagerKeys = userDetailsKeys.filter(key => key !== 'area')
 
-@Page({ name: 'case-manager-information', bodyProperties: ['name', 'emailAddress', 'phoneNumber'] })
+@Page({ name: 'case-manager-information', bodyProperties: caseManagerKeys })
 export default class CaseManagerInformation implements TasklistPage {
   title = 'Add case manager information'
 
@@ -45,7 +42,7 @@ export default class CaseManagerInformation implements TasklistPage {
   errors() {
     const errors: TaskListErrors<this> = {}
 
-    fields.forEach(field => {
+    caseManagerKeys.forEach(field => {
       if (!this.body[field]) {
         errors[field] = `You must enter the case manager's ${lowerCase(field)}`
       }

--- a/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.test.ts
@@ -7,7 +7,7 @@ import { apAreaFactory, applicationFactory } from '../../../../testutils/factori
 import { RestrictedPersonError } from '../../../../utils/errors'
 import { isApplicableTier, isFullPerson } from '../../../../utils/personUtils'
 import { lowerCase } from '../../../../utils/utils'
-import ConfirmYourDetails, { Body, updatableDetails } from './confirmYourDetails'
+import ConfirmYourDetails, { Body, userDetailsKeys } from './confirmYourDetails'
 
 jest.mock('../../../../utils/personUtils')
 
@@ -180,7 +180,7 @@ describe('ConfirmYourDetails', () => {
       expect(page.errors()).toEqual({})
     })
 
-    describe.each(updatableDetails)('when %s is in the detailsToUpdate array but the field is not populated', field => {
+    describe.each(userDetailsKeys)('when %s is in the detailsToUpdate array but the field is not populated', field => {
       const bodyWithoutField: Readonly<Partial<Body>> = { ...body, detailsToUpdate: [field], [field]: undefined }
       const page = new ConfirmYourDetails(bodyWithoutField, application)
 

--- a/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.test.ts
@@ -191,24 +191,32 @@ describe('ConfirmYourDetails', () => {
       })
     })
 
-    it('should return an error if there is no area ID in Delius and one is not entered in the form ', () => {
-      const page = new ConfirmYourDetails(
-        {
-          ...body,
-          area: '',
-          detailsToUpdate: [],
-          userDetailsFromDelius: {
-            ...body.userDetailsFromDelius,
-            area: undefined,
+    it.each([
+      ['area', 'AP area'],
+      ['name', 'name'],
+      ['emailAddress', 'email address'],
+      ['phoneNumber', 'phone number'],
+    ])(
+      `should return an error if there is no %s in Delius and one is not entered in the form`,
+      (fieldName, errorCopy) => {
+        const page = new ConfirmYourDetails(
+          {
+            ...body,
+            [fieldName]: '',
+            detailsToUpdate: [],
+            userDetailsFromDelius: {
+              ...body.userDetailsFromDelius,
+              [fieldName]: undefined,
+            },
           },
-        },
-        application,
-      )
+          application,
+        )
 
-      expect(page.errors()).toEqual({
-        area: 'You must enter your AP area',
-      })
-    })
+        expect(page.errors()).toEqual({
+          [fieldName]: `You must enter your ${errorCopy}`,
+        })
+      },
+    )
 
     it('should return an error if there is no response for caseManagementResponsibility', () => {
       const page = new ConfirmYourDetails({ ...body, caseManagementResponsibility: undefined }, application)

--- a/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.ts
@@ -14,6 +14,10 @@ export const updatableDetails: ReadonlyArray<UpdatableDetails> = [
   'area',
 ] as const
 
+const updatableDetailsLabels: Record<'area', string> = {
+  area: 'AP area',
+}
+
 type UpdatableDetails = 'name' | 'emailAddress' | 'phoneNumber' | 'area'
 
 export type UserDetailsFromDelius = {
@@ -199,9 +203,12 @@ export default class ConfirmYourDetails implements TasklistPage {
       }
     })
 
-    if (!this.body.userDetailsFromDelius.area && !this.body.area) {
-      errors.area = 'You must enter your AP area'
-    }
+    updatableDetails.forEach(detail => {
+      if (!this.body.userDetailsFromDelius[detail] && !this.body[detail]) {
+        const label = updatableDetailsLabels[detail] ? updatableDetailsLabels[detail] : lowerCase(detail)
+        errors[detail] = `You must enter your ${label}`
+      }
+    })
 
     if (!this.body.caseManagementResponsibility) {
       errors.caseManagementResponsibility = 'You must enter whether you have case management responsibility'

--- a/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.ts
@@ -7,28 +7,25 @@ import { lowerCase, sentenceCase } from '../../../../utils/utils'
 import TasklistPage from '../../../tasklistPage'
 import { Page } from '../../../utils/decorators'
 
-export const updatableDetails: ReadonlyArray<UpdatableDetails> = [
-  'name',
-  'emailAddress',
-  'phoneNumber',
-  'area',
-] as const
-
 const updatableDetailsLabels: Record<'area', string> = {
   area: 'AP area',
 }
 
-type UpdatableDetails = 'name' | 'emailAddress' | 'phoneNumber' | 'area'
+export const userDetailsKeys: Array<keyof UserDetails> = ['name', 'emailAddress', 'phoneNumber', 'area']
 
-export type UserDetailsFromDelius = {
-  name?: string
-  emailAddress?: string
-  phoneNumber?: string
+export type UserDetails = {
+  name: string
+  emailAddress: string
+  phoneNumber: string
+  area: ApArea['id']
+}
+
+export type UserDetailsFromDelius = Omit<UserDetails, 'area'> & {
   area: ApArea
 }
 
 export type Body = {
-  detailsToUpdate?: Array<UpdatableDetails>
+  detailsToUpdate?: Array<keyof UserDetails>
   emailAddress?: string
   name?: string
   phoneNumber?: string
@@ -59,7 +56,7 @@ export default class ConfirmYourDetails implements TasklistPage {
       label: 'If you need to update your details, select the relevant box below',
       hint: `<p class="govuk-hint">Select all that need to be changed.</p>
       <p class="govuk-hint">This information will not be written back to Delius</p>`,
-      items: updatableDetails,
+      items: userDetailsKeys,
     },
     caseManagementResponsibility: {
       label: 'Do you have case management responsibility?',
@@ -80,7 +77,7 @@ export default class ConfirmYourDetails implements TasklistPage {
 
   userDetailsFromDelius: UserDetailsFromDelius
 
-  detailsToUpdate: ReadonlyArray<UpdatableDetails>
+  detailsToUpdate: Array<keyof UserDetails>
 
   public get body(): Body {
     let area
@@ -154,23 +151,23 @@ export default class ConfirmYourDetails implements TasklistPage {
 
     response[this.questions.updateDetails.label] = detailsToUpdate.length ? detailsToUpdate : 'None'
 
-    updatableDetails.forEach(detail => {
-      if (this.body?.[detail] && this.body?.detailsToUpdate?.includes(detail)) {
-        if (detail !== 'area') {
-          response[this.responseKey(detail)] = this.body[detail]
+    userDetailsKeys.forEach(detailKey => {
+      if (this.body?.[detailKey] && this.body?.detailsToUpdate?.includes(detailKey)) {
+        if (detailKey !== 'area') {
+          response[this.responseKey(detailKey)] = this.body[detailKey]
         }
-        if (detail === 'area') {
+        if (detailKey === 'area') {
           response[`Applicant AP area`] = this.translateAreaIdToName(this.body.area)
         }
-      } else if (this.body.userDetailsFromDelius?.[detail]) {
-        if (detail !== 'area') {
-          response[this.responseKey(detail)] = this.body.userDetailsFromDelius?.[detail]
+      } else if (this.body.userDetailsFromDelius?.[detailKey]) {
+        if (detailKey !== 'area') {
+          response[this.responseKey(detailKey)] = this.body.userDetailsFromDelius?.[detailKey]
         }
-        if (detail === 'area') {
-          response[`Applicant AP area`] = this.translateAreaIdToName(this.body.userDetailsFromDelius?.[detail].id)
+        if (detailKey === 'area') {
+          response[`Applicant AP area`] = this.translateAreaIdToName(this.body.userDetailsFromDelius?.[detailKey].id)
         }
       } else {
-        response[this.responseKey(detail)] = ''
+        response[this.responseKey(detailKey)] = ''
       }
     })
 
@@ -197,16 +194,20 @@ export default class ConfirmYourDetails implements TasklistPage {
   errors() {
     const errors: TaskListErrors<this> = {}
 
-    updatableDetails.forEach(detail => {
-      if (this.body?.detailsToUpdate?.length && this.body?.detailsToUpdate.includes(detail) && !this.body[detail]) {
-        errors[detail] = `You must enter your updated ${lowerCase(detail)}`
+    userDetailsKeys.forEach(detailKey => {
+      if (
+        this.body?.detailsToUpdate?.length &&
+        this.body?.detailsToUpdate.includes(detailKey) &&
+        !this.body[detailKey]
+      ) {
+        errors[detailKey] = `You must enter your updated ${lowerCase(detailKey)}`
       }
     })
 
-    updatableDetails.forEach(detail => {
-      if (!this.body.userDetailsFromDelius[detail] && !this.body[detail]) {
-        const label = updatableDetailsLabels[detail] ? updatableDetailsLabels[detail] : lowerCase(detail)
-        errors[detail] = `You must enter your ${label}`
+    userDetailsKeys.forEach(detailKey => {
+      if (!this.body.userDetailsFromDelius[detailKey] && !this.body[detailKey]) {
+        const label = updatableDetailsLabels[detailKey] ? updatableDetailsLabels[detailKey] : lowerCase(detailKey)
+        errors[detailKey] = `You must enter your ${label}`
       }
     })
 
@@ -217,7 +218,7 @@ export default class ConfirmYourDetails implements TasklistPage {
     return errors
   }
 
-  private responseKey(detail: UpdatableDetails) {
+  private responseKey(detail: keyof UserDetails) {
     const { label } = this.questions[detail]
 
     if (detail !== 'area') return `Applicant ${lowerCase(label)}`

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -77,32 +77,41 @@
               "type": "string"
             },
             "userDetailsFromDelius": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "emailAddress": {
-                  "type": "string"
-                },
-                "phoneNumber": {
-                  "type": "string"
-                },
-                "area": {
+              "allOf": [
+                {
                   "type": "object",
                   "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "identifier": {
-                      "type": "string"
-                    },
                     "name": {
+                      "type": "string"
+                    },
+                    "emailAddress": {
+                      "type": "string"
+                    },
+                    "phoneNumber": {
                       "type": "string"
                     }
                   }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "area": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "identifier": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
                 }
-              }
+              ]
             },
             "area": {
               "type": "string"
@@ -236,132 +245,113 @@
           }
         },
         "relevant-dates": {
-          "allOf": [
-            {
-              "type": "object",
-              "properties": {
-                "selectedDates": {
-                  "type": "array",
-                  "items": {
-                    "enum": [
-                      "homeDetentionCurfewDate",
-                      "licenceExpiryDate",
-                      "paroleEligibilityDate",
-                      "pssEndDate",
-                      "pssStartDate",
-                      "sentenceExpiryDate"
-                    ],
-                    "type": "string"
-                  }
-                }
+          "type": "object",
+          "properties": {
+            "selectedDates": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "homeDetentionCurfewDate",
+                  "licenceExpiryDate",
+                  "paroleEligibilityDate",
+                  "pssEndDate",
+                  "pssStartDate",
+                  "sentenceExpiryDate"
+                ],
+                "type": "string"
               }
             },
-            {
-              "type": "object",
-              "properties": {
-                "paroleEligibilityDate-year": {
-                  "type": "string"
-                },
-                "homeDetentionCurfewDate-year": {
-                  "type": "string"
-                },
-                "licenceExpiryDate-year": {
-                  "type": "string"
-                },
-                "pssStartDate-year": {
-                  "type": "string"
-                },
-                "pssEndDate-year": {
-                  "type": "string"
-                },
-                "sentenceExpiryDate-year": {
-                  "type": "string"
-                },
-                "paroleEligibilityDate-month": {
-                  "type": "string"
-                },
-                "homeDetentionCurfewDate-month": {
-                  "type": "string"
-                },
-                "licenceExpiryDate-month": {
-                  "type": "string"
-                },
-                "pssStartDate-month": {
-                  "type": "string"
-                },
-                "pssEndDate-month": {
-                  "type": "string"
-                },
-                "sentenceExpiryDate-month": {
-                  "type": "string"
-                },
-                "paroleEligibilityDate-day": {
-                  "type": "string"
-                },
-                "homeDetentionCurfewDate-day": {
-                  "type": "string"
-                },
-                "licenceExpiryDate-day": {
-                  "type": "string"
-                },
-                "pssStartDate-day": {
-                  "type": "string"
-                },
-                "pssEndDate-day": {
-                  "type": "string"
-                },
-                "sentenceExpiryDate-day": {
-                  "type": "string"
-                }
-              }
+            "paroleEligibilityDate-year": {
+              "type": "string"
             },
-            {
-              "type": "object",
-              "properties": {
-                "paroleEligibilityDate-time": {
-                  "type": "string"
-                },
-                "homeDetentionCurfewDate-time": {
-                  "type": "string"
-                },
-                "licenceExpiryDate-time": {
-                  "type": "string"
-                },
-                "pssStartDate-time": {
-                  "type": "string"
-                },
-                "pssEndDate-time": {
-                  "type": "string"
-                },
-                "sentenceExpiryDate-time": {
-                  "type": "string"
-                }
-              }
+            "homeDetentionCurfewDate-year": {
+              "type": "string"
             },
-            {
-              "type": "object",
-              "properties": {
-                "paroleEligibilityDate": {
-                  "type": "string"
-                },
-                "homeDetentionCurfewDate": {
-                  "type": "string"
-                },
-                "licenceExpiryDate": {
-                  "type": "string"
-                },
-                "pssStartDate": {
-                  "type": "string"
-                },
-                "pssEndDate": {
-                  "type": "string"
-                },
-                "sentenceExpiryDate": {
-                  "type": "string"
-                }
-              }
+            "licenceExpiryDate-year": {
+              "type": "string"
+            },
+            "pssStartDate-year": {
+              "type": "string"
+            },
+            "pssEndDate-year": {
+              "type": "string"
+            },
+            "sentenceExpiryDate-year": {
+              "type": "string"
+            },
+            "paroleEligibilityDate-month": {
+              "type": "string"
+            },
+            "homeDetentionCurfewDate-month": {
+              "type": "string"
+            },
+            "licenceExpiryDate-month": {
+              "type": "string"
+            },
+            "pssStartDate-month": {
+              "type": "string"
+            },
+            "pssEndDate-month": {
+              "type": "string"
+            },
+            "sentenceExpiryDate-month": {
+              "type": "string"
+            },
+            "paroleEligibilityDate-day": {
+              "type": "string"
+            },
+            "homeDetentionCurfewDate-day": {
+              "type": "string"
+            },
+            "licenceExpiryDate-day": {
+              "type": "string"
+            },
+            "pssStartDate-day": {
+              "type": "string"
+            },
+            "pssEndDate-day": {
+              "type": "string"
+            },
+            "sentenceExpiryDate-day": {
+              "type": "string"
+            },
+            "paroleEligibilityDate-time": {
+              "type": "string"
+            },
+            "homeDetentionCurfewDate-time": {
+              "type": "string"
+            },
+            "licenceExpiryDate-time": {
+              "type": "string"
+            },
+            "pssStartDate-time": {
+              "type": "string"
+            },
+            "pssEndDate-time": {
+              "type": "string"
+            },
+            "sentenceExpiryDate-time": {
+              "type": "string"
+            },
+            "paroleEligibilityDate": {
+              "type": "string"
+            },
+            "homeDetentionCurfewDate": {
+              "type": "string"
+            },
+            "licenceExpiryDate": {
+              "type": "string"
+            },
+            "pssStartDate": {
+              "type": "string"
+            },
+            "pssEndDate": {
+              "type": "string"
+            },
+            "sentenceExpiryDate": {
+              "type": "string"
             }
-          ]
+          }
         },
         "situation": {
           "type": "object",

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.test.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.test.ts
@@ -1,17 +1,8 @@
-import { createMock } from '@golevelup/ts-jest'
-
-import { fromPartial } from '@total-typescript/shoehorn'
-import { UserService } from '../../../../services'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
 import SufficientInformation from './sufficientInformation'
 
-import { assessmentFactory, userFactory } from '../../../../testutils/factories'
-
 describe('SufficientInformation', () => {
-  const user = userFactory.build()
-  const assessment = assessmentFactory.build()
-
   describe('title', () => {
     expect(new SufficientInformation({}).title).toBe(
       'Is there enough information in the application for you to make a decision?',
@@ -22,25 +13,6 @@ describe('SufficientInformation', () => {
     it('should set the body', () => {
       const page = new SufficientInformation({ sufficientInformation: 'yes' })
       expect(page.body).toEqual({ sufficientInformation: 'yes' })
-    })
-  })
-
-  describe('initialize', () => {
-    it('should fetch the user and return the page', async () => {
-      const getUserByIdMock = jest.fn()
-
-      const userService = createMock<UserService>({
-        getUserById: getUserByIdMock,
-      })
-
-      getUserByIdMock.mockResolvedValue(user)
-
-      const page = await SufficientInformation.initialize({}, assessment, 'some-token', fromPartial({ userService }))
-
-      expect(page).toBeInstanceOf(SufficientInformation)
-      expect(page.user).toEqual(user)
-
-      expect(userService.getUserById).toHaveBeenCalledWith('some-token', assessment.application.createdByUserId)
     })
   })
 

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.ts
@@ -1,5 +1,4 @@
-import type { DataServices, TaskListErrors, YesOrNo } from '@approved-premises/ui'
-import type { ApprovedPremisesAssessment as Assessment, User } from '@approved-premises/api'
+import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
 
 import { Page } from '../../../utils/decorators'
 import { sentenceCase } from '../../../../utils/utils'
@@ -17,23 +16,7 @@ export default class SufficientInformation implements TasklistPage {
 
   furtherInformationQuestion = 'What additional information is needed?'
 
-  user: User
-
   constructor(public body: { sufficientInformation?: YesOrNo; query?: string }) {}
-
-  static async initialize(
-    body: Record<string, unknown>,
-    assessment: Assessment,
-    token: string,
-    dataServices: DataServices,
-  ) {
-    const user = await dataServices.userService.getUserById(token, assessment.application.createdByUserId)
-
-    const page = new SufficientInformation(body)
-    page.user = user
-
-    return page
-  }
 
   previous() {
     return 'dashboard'

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -7,6 +7,7 @@ import { addDays } from 'date-fns'
 import type {
   ApprovedPremisesApplication,
   AssessmentDecision,
+  Cas1ApplicationUserDetails,
   OASysSection,
   ReleaseTypeOption,
   SentenceTypeOption,
@@ -123,6 +124,12 @@ class ApplicationFactory extends Factory<ApprovedPremisesApplication> {
   }
 }
 
+export const applicationUserDetailsFactory = new Factory<Cas1ApplicationUserDetails>(() => ({
+  name: faker.person.fullName(),
+  email: faker.internet.email(),
+  telephoneNumber: faker.phone.number(),
+}))
+
 export default ApplicationFactory.define(() => ({
   type: 'CAS1',
   id: faker.string.uuid(),
@@ -140,4 +147,7 @@ export default ApplicationFactory.define(() => ({
   status: 'started' as const,
   personStatusOnSubmission: 'InCustody' as const,
   apArea: apAreaFactory.build(),
+  caseManagerIsNotApplicant: faker.datatype.boolean(),
+  caseManagerUserDetails: applicationUserDetailsFactory.build(),
+  applicantUserDetails: applicationUserDetailsFactory.build(),
 }))

--- a/server/testutils/mockQuestionResponse.ts
+++ b/server/testutils/mockQuestionResponse.ts
@@ -1,8 +1,12 @@
-import { ApprovedPremisesApplication as Application } from '@approved-premises/api'
+import {
+  ApprovedPremisesApplication as Application,
+  Cas1ApplicationUserDetails as UserDetails,
+} from '@approved-premises/api'
 import {
   retrieveOptionalQuestionResponseFromFormArtifact,
   retrieveQuestionResponseFromFormArtifact,
 } from '../utils/retrieveQuestionResponseFromFormArtifact'
+import { applicantAndCaseManagerDetails } from '../utils/applications/applicantAndCaseManagerDetails'
 
 export const mockQuestionResponse = ({
   postcodeArea = 'ABC 123',
@@ -13,6 +17,9 @@ export const mockQuestionResponse = ({
   duration,
   situation,
   apAreaId,
+  applicantUserDetails,
+  caseManagerUserDetails,
+  caseManagerIsNotApplicant,
 }: {
   postcodeArea?: string
   type?: string
@@ -22,6 +29,9 @@ export const mockQuestionResponse = ({
   alternativeRadius?: string
   situation?: string
   apAreaId?: string
+  applicantUserDetails?: UserDetails
+  caseManagerUserDetails?: UserDetails
+  caseManagerIsNotApplicant?: boolean
 }) => {
   ;(retrieveQuestionResponseFromFormArtifact as jest.Mock).mockImplementation(
     // eslint-disable-next-line consistent-return
@@ -57,6 +67,11 @@ export const mockQuestionResponse = ({
       if (question === 'area') return apAreaId
     },
   )
+  ;(applicantAndCaseManagerDetails as jest.MockedFn<typeof applicantAndCaseManagerDetails>).mockReturnValue({
+    applicantUserDetails,
+    caseManagerUserDetails,
+    caseManagerIsNotApplicant,
+  })
 }
 
 export const mockOptionalQuestionResponse = ({
@@ -74,6 +89,9 @@ export const mockOptionalQuestionResponse = ({
   pssDate,
   situation,
   apAreaId,
+  applicantUserDetails,
+  caseManagerUserDetails,
+  caseManagerIsNotApplicant,
 }: {
   releaseType?: string
   duration?: string
@@ -89,6 +107,9 @@ export const mockOptionalQuestionResponse = ({
   pssDate?: string
   situation?: string
   apAreaId?: string
+  applicantUserDetails?: UserDetails
+  caseManagerUserDetails?: UserDetails
+  caseManagerIsNotApplicant?: boolean
 }) => {
   ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockImplementation(
     // eslint-disable-next-line consistent-return
@@ -150,4 +171,9 @@ export const mockOptionalQuestionResponse = ({
       }
     },
   )
+  ;(applicantAndCaseManagerDetails as jest.MockedFn<typeof applicantAndCaseManagerDetails>).mockReturnValue({
+    applicantUserDetails,
+    caseManagerUserDetails,
+    caseManagerIsNotApplicant,
+  })
 }

--- a/server/utils/applications/applicantAndCaseManagerDetails.test.ts
+++ b/server/utils/applications/applicantAndCaseManagerDetails.test.ts
@@ -1,0 +1,52 @@
+import { when } from 'jest-when'
+import { applicationFactory } from '../../testutils/factories'
+import { userDetailsFromCaseManagerPage, userDetailsFromConfirmYourDetailsPage } from './userDetailsFromApplication'
+import { applicantAndCaseManagerDetails } from './applicantAndCaseManagerDetails'
+import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
+import ConfirmYourDetails from '../../form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails'
+import { applicationUserDetailsFactory } from '../../testutils/factories/application'
+
+jest.mock('./userDetailsFromApplication')
+jest.mock('../retrieveQuestionResponseFromFormArtifact')
+
+describe('applicantAndCaseManagerDetails', () => {
+  describe('when the case manager is the applicant', () => {
+    it('returns the applicant details, undefined for caseManagerUserDetails and false for caseManagerIsNotApplicant', () => {
+      const application = applicationFactory.build()
+      const applicantUserDetails = applicationUserDetailsFactory.build()
+
+      when(userDetailsFromConfirmYourDetailsPage).calledWith(application).mockReturnValue(applicantUserDetails)
+
+      when(retrieveOptionalQuestionResponseFromFormArtifact)
+        .calledWith(application, ConfirmYourDetails, 'caseManagementResponsibility')
+        .mockReturnValue('yes')
+
+      const result = applicantAndCaseManagerDetails(application)
+
+      expect(result.applicantUserDetails).toEqual(applicantUserDetails)
+      expect(result.caseManagerIsNotApplicant).toEqual(false)
+      expect(result.caseManagerUserDetails).toEqual(undefined)
+    })
+  })
+
+  describe('when the case manager is not the applicant', () => {
+    it('returns the applicant details, the caseManagerUserDetails and true for caseManagerIsNotApplicant', () => {
+      const application = applicationFactory.build()
+      const applicantUserDetails = applicationUserDetailsFactory.build()
+      const caseManagerUserDetails = applicationUserDetailsFactory.build()
+
+      when(userDetailsFromConfirmYourDetailsPage).calledWith(application).mockReturnValue(applicantUserDetails)
+      when(userDetailsFromCaseManagerPage).calledWith(application).mockReturnValue(caseManagerUserDetails)
+
+      when(retrieveOptionalQuestionResponseFromFormArtifact)
+        .calledWith(application, ConfirmYourDetails, 'caseManagementResponsibility')
+        .mockReturnValue('no')
+
+      const result = applicantAndCaseManagerDetails(application)
+
+      expect(result.applicantUserDetails).toEqual(applicantUserDetails)
+      expect(result.caseManagerIsNotApplicant).toEqual(true)
+      expect(result.caseManagerUserDetails).toEqual(caseManagerUserDetails)
+    })
+  })
+})

--- a/server/utils/applications/applicantAndCaseManagerDetails.ts
+++ b/server/utils/applications/applicantAndCaseManagerDetails.ts
@@ -1,0 +1,30 @@
+import {
+  ApprovedPremisesApplication as Application,
+  Cas1ApplicationUserDetails as UserDetails,
+} from '../../@types/shared'
+import ConfirmYourDetails from '../../form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails'
+import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
+import { userDetailsFromCaseManagerPage, userDetailsFromConfirmYourDetailsPage } from './userDetailsFromApplication'
+
+export const applicantAndCaseManagerDetails = (
+  application: Application,
+): {
+  applicantUserDetails: UserDetails
+  caseManagerUserDetails: UserDetails
+  caseManagerIsNotApplicant: boolean
+} => {
+  const applicantUserDetails = userDetailsFromConfirmYourDetailsPage(application)
+  const caseManagerUserDetails = userDetailsFromCaseManagerPage(application)
+  const doesNotHaveCaseManagementResponsibility =
+    retrieveOptionalQuestionResponseFromFormArtifact(
+      application,
+      ConfirmYourDetails,
+      'caseManagementResponsibility',
+    ) === 'no'
+
+  return {
+    applicantUserDetails: Object.keys(applicantUserDetails).length ? applicantUserDetails : undefined,
+    caseManagerUserDetails: doesNotHaveCaseManagementResponsibility ? caseManagerUserDetails : undefined,
+    caseManagerIsNotApplicant: doesNotHaveCaseManagementResponsibility,
+  }
+}

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -4,13 +4,18 @@ import { getApplicationSubmissionData, getApplicationUpdateData } from './getApp
 import { mockOptionalQuestionResponse, mockQuestionResponse } from '../../testutils/mockQuestionResponse'
 import { arrivalDateFromApplication } from './arrivalDateFromApplication'
 import { isInapplicable } from './utils'
+import { applicationUserDetailsFactory } from '../../testutils/factories/application'
 
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
+jest.mock('../applications/applicantAndCaseManagerDetails')
 jest.mock('./arrivalDateFromApplication')
 jest.mock('./utils')
 
 describe('getApplicationData', () => {
   const apAreaId = 'test-id'
+
+  const applicantUserDetails = applicationUserDetailsFactory.build()
+  const caseManagerUserDetails = applicationUserDetailsFactory.build()
 
   describe('getApplicationSubmissionData', () => {
     const releaseType: ReleaseTypeOption = 'licence'
@@ -20,11 +25,24 @@ describe('getApplicationData', () => {
 
     beforeEach(() => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(arrivalDate)
-      mockOptionalQuestionResponse({ releaseType, sentenceType, apAreaId })
+      mockOptionalQuestionResponse({
+        releaseType,
+        sentenceType,
+        apAreaId,
+        applicantUserDetails,
+        caseManagerUserDetails,
+        caseManagerIsNotApplicant: false,
+      })
     })
 
     it('returns the correct data for a pipe application', () => {
-      mockQuestionResponse({ type: 'pipe', postcodeArea: targetLocation, apAreaId })
+      mockQuestionResponse({
+        type: 'pipe',
+        postcodeArea: targetLocation,
+        apAreaId,
+        applicantUserDetails,
+        caseManagerIsNotApplicant: false,
+      })
 
       const application = applicationFactory.build()
 
@@ -40,11 +58,20 @@ describe('getApplicationData', () => {
         isEmergencyApplication: true,
         isEsapApplication: false,
         apAreaId,
+        applicantUserDetails,
+        caseManagerUserDetails: undefined,
+        caseManagerIsNotApplicant: false,
       })
     })
 
     it('returns the correct data for a non-pipe application', () => {
-      mockQuestionResponse({ type: 'standard', postcodeArea: targetLocation, apAreaId })
+      mockQuestionResponse({
+        type: 'standard',
+        postcodeArea: targetLocation,
+        apAreaId,
+        applicantUserDetails,
+        caseManagerIsNotApplicant: false,
+      })
 
       const application = applicationFactory.build()
 
@@ -60,12 +87,20 @@ describe('getApplicationData', () => {
         isEmergencyApplication: true,
         isEsapApplication: false,
         apAreaId,
+        applicantUserDetails,
+        caseManagerIsNotApplicant: false,
+        caseManagerUserDetails: undefined,
       })
     })
 
     it('handles when a release type is missing', () => {
-      mockOptionalQuestionResponse({ releaseType: undefined })
-      mockQuestionResponse({ postcodeArea: targetLocation, apAreaId })
+      mockOptionalQuestionResponse({ releaseType: undefined, apAreaId, applicantUserDetails })
+      mockQuestionResponse({
+        postcodeArea: targetLocation,
+        apAreaId,
+        applicantUserDetails,
+        caseManagerIsNotApplicant: false,
+      })
 
       const application = applicationFactory.build()
 
@@ -81,6 +116,9 @@ describe('getApplicationData', () => {
         isEmergencyApplication: true,
         isEsapApplication: false,
         apAreaId,
+        applicantUserDetails,
+        caseManagerIsNotApplicant: false,
+        caseManagerUserDetails: undefined,
       })
     })
 
@@ -90,6 +128,8 @@ describe('getApplicationData', () => {
         postcodeArea: targetLocation,
         situation: 'riskManagement',
         apAreaId,
+        applicantUserDetails,
+        caseManagerIsNotApplicant: false,
       })
 
       const application = applicationFactory.build()
@@ -106,6 +146,9 @@ describe('getApplicationData', () => {
         isEmergencyApplication: true,
         isEsapApplication: false,
         apAreaId,
+        applicantUserDetails,
+        caseManagerIsNotApplicant: false,
+        caseManagerUserDetails: undefined,
       })
     })
 
@@ -115,6 +158,8 @@ describe('getApplicationData', () => {
         postcodeArea: targetLocation,
         situation: 'riskManagement',
         apAreaId,
+        applicantUserDetails,
+        caseManagerIsNotApplicant: false,
       })
 
       const application = applicationFactory.build()
@@ -131,11 +176,20 @@ describe('getApplicationData', () => {
         isEmergencyApplication: true,
         isEsapApplication: false,
         apAreaId,
+        applicantUserDetails,
+        caseManagerIsNotApplicant: false,
+        caseManagerUserDetails: undefined,
       })
     })
 
     it('returns not_applicable for a non-statutory application', () => {
-      mockQuestionResponse({ sentenceType: 'nonStatutory', postcodeArea: targetLocation, apAreaId })
+      mockQuestionResponse({
+        sentenceType: 'nonStatutory',
+        postcodeArea: targetLocation,
+        apAreaId,
+        applicantUserDetails,
+        caseManagerIsNotApplicant: false,
+      })
 
       const application = applicationFactory.build()
 
@@ -151,6 +205,9 @@ describe('getApplicationData', () => {
         isEmergencyApplication: true,
         isEsapApplication: false,
         apAreaId,
+        applicantUserDetails,
+        caseManagerIsNotApplicant: false,
+        caseManagerUserDetails: undefined,
       })
     })
   })
@@ -176,6 +233,9 @@ describe('getApplicationData', () => {
         isEmergencyApplication: false,
         isEsapApplication: undefined,
         apAreaId: undefined,
+        caseManagerIsNotApplicant: undefined,
+        applicantUserDetails: undefined,
+        caseManagerUserDetails: undefined,
       })
     })
 
@@ -188,6 +248,9 @@ describe('getApplicationData', () => {
         postcodeArea: 'ABC',
         sentenceType: 'standardDeterminate',
         apAreaId,
+        caseManagerIsNotApplicant: true,
+        applicantUserDetails,
+        caseManagerUserDetails,
       })
 
       const application = applicationFactory.build()
@@ -205,6 +268,9 @@ describe('getApplicationData', () => {
         isEmergencyApplication: true,
         isEsapApplication: false,
         apAreaId,
+        caseManagerIsNotApplicant: true,
+        applicantUserDetails,
+        caseManagerUserDetails,
       })
     })
 

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -21,6 +21,7 @@ import { FormArtifact } from '../../@types/ui'
 import { noticeTypeFromApplication } from './noticeTypeFromApplication'
 import Situation from '../../form-pages/apply/reasons-for-placement/basic-information/situation'
 import ConfirmYourDetails from '../../form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails'
+import { applicantAndCaseManagerDetails } from './applicantAndCaseManagerDetails'
 
 type FirstClassFields<T> = T extends UpdateApprovedPremisesApplication
   ? Omit<UpdateApprovedPremisesApplication, 'data'>
@@ -58,6 +59,8 @@ const firstClassFields = <T>(
   const arrivalDate = arrivalDateFromApplication(application)
   const isEmergencyApplication = noticeTypeFromApplication(application) === 'emergency'
   const apAreaId = retrieveQuestionResponse(application, ConfirmYourDetails, 'area')
+  const { applicantUserDetails, caseManagerUserDetails, caseManagerIsNotApplicant } =
+    applicantAndCaseManagerDetails(application)
 
   return {
     isWomensApplication: false,
@@ -70,6 +73,9 @@ const firstClassFields = <T>(
     arrivalDate,
     isEmergencyApplication,
     apAreaId,
+    applicantUserDetails,
+    caseManagerUserDetails,
+    caseManagerIsNotApplicant,
   } as FirstClassFields<T>
 }
 

--- a/server/utils/applications/shouldShowContingencyPlanPages.test.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.test.ts
@@ -7,6 +7,7 @@ import { mockOptionalQuestionResponse } from '../../testutils/mockQuestionRespon
 import { noticeTypeFromApplication } from './noticeTypeFromApplication'
 
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
+jest.mock('../applications/applicantAndCaseManagerDetails')
 jest.mock('./noticeTypeFromApplication')
 
 const application = applicationFactory.build()

--- a/server/utils/applications/userDetailsFromApplication.test.ts
+++ b/server/utils/applications/userDetailsFromApplication.test.ts
@@ -1,0 +1,134 @@
+import { when } from 'jest-when'
+import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
+import { applicationFactory } from '../../testutils/factories'
+import ConfirmYourDetails from '../../form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails'
+import CaseManagerInformation, {
+  caseManagerKeys,
+} from '../../form-pages/apply/reasons-for-placement/basic-information/caseManagerInformation'
+import { userDetailsFromCaseManagerPage, userDetailsFromConfirmYourDetailsPage } from './userDetailsFromApplication'
+import { applicationUserDetailsFactory } from '../../testutils/factories/application'
+
+jest.mock('../retrieveQuestionResponseFromFormArtifact')
+
+describe('userDetailsFromApplication', () => {
+  const application = applicationFactory.build()
+  const user = applicationUserDetailsFactory.build()
+
+  const details = [
+    { fieldName: 'name', value: user.name },
+    { fieldName: 'emailAddress', value: user.email },
+    { fieldName: 'phoneNumber', value: user.telephoneNumber },
+  ]
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+  describe('userDetailsFromConfirmYourDetailsPage', () => {
+    describe('if details were entered into the fields on the page', () => {
+      it('returns the details entered in the ConfirmYourDetails page', () => {
+        when(retrieveOptionalQuestionResponseFromFormArtifact)
+          .calledWith(application, ConfirmYourDetails, 'detailsToUpdate')
+          .mockReturnValue(['name', 'emailAddress', 'phoneNumber'])
+
+        details.forEach(({ fieldName, value }) => {
+          when(retrieveOptionalQuestionResponseFromFormArtifact)
+            .calledWith(application, ConfirmYourDetails, fieldName)
+            .mockReturnValue(value)
+        })
+
+        expect(userDetailsFromConfirmYourDetailsPage(application)).toEqual({
+          email: user.email,
+          name: user.name,
+          telephoneNumber: user.telephoneNumber,
+        })
+        expect(retrieveOptionalQuestionResponseFromFormArtifact).toHaveBeenNthCalledWith(
+          1,
+          application,
+          ConfirmYourDetails,
+          'userDetailsFromDelius',
+        )
+        expect(retrieveOptionalQuestionResponseFromFormArtifact).toHaveBeenNthCalledWith(
+          2,
+          application,
+          ConfirmYourDetails,
+          'detailsToUpdate',
+        )
+        caseManagerKeys.forEach((fieldName, i) => {
+          expect(retrieveOptionalQuestionResponseFromFormArtifact).toHaveBeenNthCalledWith(
+            i + 3,
+            application,
+            ConfirmYourDetails,
+            fieldName,
+          )
+        })
+      })
+    })
+
+    describe('if the user details werent changed', () => {
+      it('returns the details shown on the ConfirmYourDetails page', () => {
+        const userDetails = applicationUserDetailsFactory.build()
+        const userDetailsFromDelius = {
+          name: userDetails.name,
+          emailAddress: userDetails.email,
+          phoneNumber: userDetails.telephoneNumber,
+        }
+
+        details.forEach(({ fieldName }) => {
+          when(retrieveOptionalQuestionResponseFromFormArtifact)
+            .calledWith(application, ConfirmYourDetails, fieldName)
+            .mockReturnValue(undefined)
+        })
+        when(retrieveOptionalQuestionResponseFromFormArtifact)
+          .calledWith(application, ConfirmYourDetails, 'userDetailsFromDelius')
+          .mockReturnValue(userDetailsFromDelius)
+
+        expect(userDetailsFromConfirmYourDetailsPage(application)).toEqual(userDetails)
+        expect(retrieveOptionalQuestionResponseFromFormArtifact).toHaveBeenNthCalledWith(
+          1,
+          application,
+          ConfirmYourDetails,
+          'userDetailsFromDelius',
+        )
+        expect(retrieveOptionalQuestionResponseFromFormArtifact).toHaveBeenNthCalledWith(
+          2,
+          application,
+          ConfirmYourDetails,
+          'detailsToUpdate',
+        )
+        caseManagerKeys.forEach((fieldName, i) => {
+          expect(retrieveOptionalQuestionResponseFromFormArtifact).toHaveBeenNthCalledWith(
+            i + 3,
+            application,
+            ConfirmYourDetails,
+            fieldName,
+          )
+        })
+      })
+    })
+  })
+
+  describe('userDetailsFromCaseManagerPage', () => {
+    it('returns the details entered in the CaseManagerInformationPage page', () => {
+      details.forEach(({ fieldName, value }) => {
+        when(retrieveOptionalQuestionResponseFromFormArtifact)
+          .calledWith(application, CaseManagerInformation, fieldName)
+          .mockReturnValue(value)
+      })
+
+      expect(userDetailsFromCaseManagerPage(application)).toEqual({
+        name: user.name,
+        email: user.email,
+        telephoneNumber: user.telephoneNumber,
+      })
+
+      caseManagerKeys.forEach((fieldName, i) => {
+        expect(retrieveOptionalQuestionResponseFromFormArtifact).toHaveBeenNthCalledWith(
+          i + 1,
+          application,
+          CaseManagerInformation,
+          fieldName,
+        )
+      })
+      expect(retrieveOptionalQuestionResponseFromFormArtifact).toHaveBeenCalledTimes(details.length)
+    })
+  })
+})

--- a/server/utils/applications/userDetailsFromApplication.ts
+++ b/server/utils/applications/userDetailsFromApplication.ts
@@ -1,0 +1,51 @@
+import { ApprovedPremisesApplication as Application, Cas1ApplicationUserDetails } from '@approved-premises/api'
+import CaseManagerInformation, {
+  caseManagerKeys,
+} from '../../form-pages/apply/reasons-for-placement/basic-information/caseManagerInformation'
+import ConfirmYourDetails, {
+  UserDetails,
+} from '../../form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails'
+import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
+
+export const userDetailsFromConfirmYourDetailsPage = (application: Application): Cas1ApplicationUserDetails => {
+  const detailsForConsumer: Cas1ApplicationUserDetails = {} as Cas1ApplicationUserDetails
+  const detailsFromPage: UserDetails = {} as UserDetails
+
+  const userDetailsFromDelius = retrieveOptionalQuestionResponseFromFormArtifact(
+    application,
+    ConfirmYourDetails,
+    'userDetailsFromDelius',
+  )
+  const detailsToUpdate = retrieveOptionalQuestionResponseFromFormArtifact(
+    application,
+    ConfirmYourDetails,
+    'detailsToUpdate',
+  )
+
+  caseManagerKeys.forEach(field => {
+    detailsFromPage[field] =
+      (detailsToUpdate?.includes(field) &&
+        retrieveOptionalQuestionResponseFromFormArtifact(application, ConfirmYourDetails, field)) ||
+      userDetailsFromDelius?.[field]
+  })
+
+  detailsForConsumer.name = detailsFromPage.name
+  detailsForConsumer.email = detailsFromPage.emailAddress
+  detailsForConsumer.telephoneNumber = detailsFromPage.phoneNumber
+
+  return detailsForConsumer
+}
+
+export const userDetailsFromCaseManagerPage = (application: Application): Cas1ApplicationUserDetails => {
+  const details: Cas1ApplicationUserDetails = {} as Cas1ApplicationUserDetails
+
+  details.name = retrieveOptionalQuestionResponseFromFormArtifact(application, CaseManagerInformation, 'name')
+  details.email = retrieveOptionalQuestionResponseFromFormArtifact(application, CaseManagerInformation, 'emailAddress')
+  details.telephoneNumber = retrieveOptionalQuestionResponseFromFormArtifact(
+    application,
+    CaseManagerInformation,
+    'phoneNumber',
+  )
+
+  return details
+}

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -49,6 +49,7 @@ import { sortHeader } from '../sortHeader'
 
 jest.mock('../placementRequests/placementApplicationSubmissionData')
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
+jest.mock('../applications/applicantAndCaseManagerDetails')
 jest.mock('../journeyTypeFromArtifact')
 const FirstApplyPage = jest.fn()
 const SecondApplyPage = jest.fn()

--- a/server/utils/assessments/acceptanceData.test.ts
+++ b/server/utils/assessments/acceptanceData.test.ts
@@ -11,6 +11,7 @@ import { getResponses } from '../applications/getResponses'
 jest.mock('../../form-pages/utils')
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
 jest.mock('../applications/arrivalDateFromApplication')
+jest.mock('../applications/applicantAndCaseManagerDetails')
 jest.mock('./placementDurationFromApplication')
 jest.mock('../applications/getResponses')
 

--- a/server/views/assessments/pages/sufficient-information/sufficient-information-sent.njk
+++ b/server/views/assessments/pages/sufficient-information/sufficient-information-sent.njk
@@ -33,7 +33,7 @@
                 text: "Name"
               },
               value: {
-                text: page.userName
+                text: page.caseManager.name
               }
             },
             {
@@ -41,7 +41,7 @@
                 text: "Email"
               },
               value: {
-                text: page.emailAddress
+                text: page.caseManager.email
               }
             },
             {
@@ -49,7 +49,7 @@
                 text: "Contact number"
               },
               value: {
-                html: page.phoneNumber
+                html: page.caseManager.telephoneNumber
               }
             }
           ]


### PR DESCRIPTION
# Context

[JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&selectedIssue=APS-447)  

We need to submit the details of the applicant and the case manager (if they are different people) and whether they are different people to the API to be used for notifications etc. 

# Changes in this PR
- Ensure that the fields on the Confirm Your Details page are always populated - this will cover gaps in missing Delius data
- Add a function to retrieve these details and the details entered into the Case Manager Details page if the applicant is not the case manager
- Submit these fields to the API on update and submission of the application
- Now the API has these fields it returns them with the Application object so we can use them to show the Case Manager details on the 'Sufficient Information Sent' page in Assess
