### PR TITLE
(APS-417) Filter out unselected date variables

### DIFF
--- a/server/form-pages/apply/reasons-for-placement/basic-information/relevantDates.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/relevantDates.test.ts
@@ -2,7 +2,7 @@ import { applicationFactory } from '../../../../testutils/factories'
 import { DateFormats } from '../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
-import RelevantDates, { RelevantDatesBody, relevantDateKeys } from './relevantDates'
+import RelevantDates, { RelevantDateKeys, RelevantDatesBody, relevantDateKeys } from './relevantDates'
 
 describe('RelevantDates', () => {
   const body = {
@@ -156,6 +156,19 @@ describe('RelevantDates', () => {
 
     it('should return a translated version of the response when the dates are blank', () => {
       const page = new RelevantDates({ ...emptyDateBody, selectedDates: relevantDateKeys }, application)
+
+      expect(page.response()).toEqual({
+        'Home Detention Curfew (HDC) date': 'No date supplied',
+        'Licence expiry date': 'No date supplied',
+        'Parole eligibility date': 'No date supplied',
+        'Post sentence supervision (PSS) end date': 'No date supplied',
+        'Post sentence supervision (PSS) start date': 'No date supplied',
+        'Sentence expiry date': 'No date supplied',
+      })
+    })
+
+    it('should ignore a date when not included in selectedDates', () => {
+      const page = new RelevantDates({ ...body, selectedDates: [] as Array<RelevantDateKeys> }, application)
 
       expect(page.response()).toEqual({
         'Home Detention Curfew (HDC) date': 'No date supplied',

--- a/server/form-pages/apply/reasons-for-placement/basic-information/relevantDates.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/relevantDates.test.ts
@@ -71,7 +71,32 @@ describe('RelevantDates', () => {
     it('should set the body when all the dates not present', () => {
       const page = new RelevantDates(emptyDateBody, application)
 
-      expect(page.body).toEqual(emptyDateBody)
+      expect(page.body).toEqual({ selectedDates: [] })
+    })
+
+    it('should remove unselected dates', () => {
+      const page = new RelevantDates(
+        {
+          homeDetentionCurfewDate: '2023-01-01',
+          'homeDetentionCurfewDate-day': '01',
+          'homeDetentionCurfewDate-month': '01',
+          'homeDetentionCurfewDate-year': '2023',
+          licenceExpiryDate: '2023-02-02',
+          'licenceExpiryDate-day': '02',
+          'licenceExpiryDate-month': '02',
+          'licenceExpiryDate-year': '2023',
+          selectedDates: ['licenceExpiryDate'],
+        },
+        application,
+      )
+
+      expect(page.body).toEqual({
+        licenceExpiryDate: '2023-02-02',
+        'licenceExpiryDate-day': '02',
+        'licenceExpiryDate-month': '02',
+        'licenceExpiryDate-year': '2023',
+        selectedDates: ['licenceExpiryDate'],
+      })
     })
   })
 

--- a/server/form-pages/apply/reasons-for-placement/basic-information/relevantDates.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/relevantDates.ts
@@ -50,9 +50,10 @@ export default class RelevantDates implements TasklistPage {
     const response = {}
 
     relevantDateKeys.forEach(key => {
-      response[this.relevantDatesDictionary[key]] = !dateIsBlank(this.body, key)
-        ? DateFormats.dateAndTimeInputsToUiDate(this.body, key)
-        : 'No date supplied'
+      response[this.relevantDatesDictionary[key]] =
+        this.body.selectedDates?.includes(key) && !dateIsBlank(this.body, key)
+          ? DateFormats.dateAndTimeInputsToUiDate(this.body, key)
+          : 'No date supplied'
     })
 
     return response

--- a/server/form-pages/apply/reasons-for-placement/basic-information/relevantDates.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/relevantDates.ts
@@ -39,12 +39,26 @@ export default class RelevantDates implements TasklistPage {
 
   relevantDatesDictionary = relevantDatesDictionary
 
-  body: RelevantDatesBody
+  _body: RelevantDatesBody
 
   constructor(
-    body: Partial<RelevantDatesBody>,
+    _body: Partial<RelevantDatesBody>,
     private readonly application: ApprovedPremisesApplication,
   ) {}
+
+  public set body(value: Partial<RelevantDatesBody>) {
+    this._body = {} as RelevantDatesBody
+    this._body.selectedDates = value.selectedDates || []
+    this._body.selectedDates.forEach((selectedDate: RelevantDateKeys) => {
+      dateBodyProperties(selectedDate).forEach(element => {
+        this._body[element] = value[element]
+      })
+    })
+  }
+
+  public get body() {
+    return this._body
+  }
 
   response() {
     const response = {}
@@ -52,7 +66,7 @@ export default class RelevantDates implements TasklistPage {
     relevantDateKeys.forEach(key => {
       response[this.relevantDatesDictionary[key]] =
         this.body.selectedDates?.includes(key) && !dateIsBlank(this.body, key)
-          ? DateFormats.dateAndTimeInputsToUiDate(this.body, key)
+          ? DateFormats.dateAndTimeInputsToUiDate(this._body, key)
           : 'No date supplied'
     })
 
@@ -78,7 +92,7 @@ export default class RelevantDates implements TasklistPage {
 
       if (dateIsBlank(this.body, date)) {
         errors[date] = `When the box is checked you must enter a ${this.relevantDatesDictionary[date]} date`
-      } else if (!dateAndTimeInputsAreValidDates(this.body, date)) {
+      } else if (!dateAndTimeInputsAreValidDates(this._body, date)) {
         errors[date] = `${this.relevantDatesDictionary[date]} must be a valid date`
       }
     })


### PR DESCRIPTION
We’ve had issues where a user inputs a date the the relevant dates section and then unchecks a checkbox. If the date is invalid, we don’t validate when updating the data, so when we return the response, we get an error. 

We need to:

a) Ensure we only return dates included in the `selectedDates` array when rendering the responses for that page; and
b) Ensure that we filter out any date inputs that have not been explicitly selected when updating the page