### PR TITLE
(APS 452) Change notice type rules

### DIFF
--- a/server/utils/applications/noticeTypeFromApplication.test.ts
+++ b/server/utils/applications/noticeTypeFromApplication.test.ts
@@ -11,8 +11,8 @@ jest.mock('./arrivalDateFromApplication')
 describe('noticeTypeFromApplication', () => {
   const application = applicationFactory.build({})
 
-  it('returns emergency if the arrival date is less than 28 days away', () => {
-    const date = add(new Date(), { days: 14 })
+  it('returns emergency if the arrival date is less than 8 days away', () => {
+    const date = add(new Date(), { days: 4 })
     const arrivalDate = DateFormats.dateObjToIsoDate(date)
 
     ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(arrivalDate)
@@ -20,8 +20,8 @@ describe('noticeTypeFromApplication', () => {
     expect(noticeTypeFromApplication(application)).toEqual('emergency')
   })
 
-  it('returns short_notice if the arrival date is less than 6 months away', () => {
-    const date = add(new Date(), { months: 5 })
+  it('returns short_notice if the arrival date is less than 29 days away', () => {
+    const date = add(new Date(), { days: 22 })
     const arrivalDate = DateFormats.dateObjToIsoDate(date)
 
     ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(arrivalDate)
@@ -29,8 +29,8 @@ describe('noticeTypeFromApplication', () => {
     expect(noticeTypeFromApplication(application)).toEqual('short_notice')
   })
 
-  it('returns standard if the arrival date is more than 6 months away', () => {
-    const date = add(new Date(), { months: 6 })
+  it('returns standard if the arrival date is more than 28 days away', () => {
+    const date = add(new Date(), { weeks: 6 })
     const arrivalDate = DateFormats.dateObjToIsoDate(date)
 
     ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(arrivalDate)
@@ -38,7 +38,7 @@ describe('noticeTypeFromApplication', () => {
     expect(noticeTypeFromApplication(application)).toEqual('standard')
   })
 
-  it('returns standard if there isnt an arrival date for the application', () => {
+  it('returns standard if there is not an arrival date for the application', () => {
     ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(null)
 
     expect(noticeTypeFromApplication(application)).toEqual('standard')

--- a/server/utils/applications/noticeTypeFromApplication.ts
+++ b/server/utils/applications/noticeTypeFromApplication.ts
@@ -1,4 +1,4 @@
-import { differenceInCalendarMonths, differenceInDays } from 'date-fns'
+import { differenceInDays } from 'date-fns'
 import { ApprovedPremisesApplication as Application } from '@approved-premises/api'
 import { arrivalDateFromApplication } from './arrivalDateFromApplication'
 import { DateFormats } from '../dateUtils'
@@ -13,9 +13,9 @@ export const noticeTypeFromApplication = (application: Application): Application
   const arrivalDateObj = DateFormats.isoToDateObj(arrivalDateString)
 
   switch (true) {
-    case differenceInDays(arrivalDateObj, new Date()) <= 28:
+    case differenceInDays(arrivalDateObj, new Date()) <= 7:
       return 'emergency'
-    case differenceInCalendarMonths(arrivalDateObj, new Date()) < 6:
+    case differenceInDays(arrivalDateObj, new Date()) <= 28:
       return 'short_notice'
     default:
       return 'standard'


### PR DESCRIPTION
During the pilot, in the interests of stabilising things, we treated all applications with less than 28 days as emergency and all applications with less than 6 months notice as short notice. Now the rules are:

- Less than or equal to 7 calendar days between application and start date - emergency application
- Less than or equal to 28 calendar days between application and start date - short notice
- More than 28 calendar days between application and start date - standard