### PR TITLE
Fix some strict mode errors

### DIFF
--- a/server/applicationVersion.ts
+++ b/server/applicationVersion.ts
@@ -7,7 +7,7 @@ function getBuild() {
   try {
     // eslint-disable-next-line import/no-unresolved,global-require
     return require('../build-info.json')
-  } catch (ex) {
+  } catch (error) {
     return null
   }
 }

--- a/server/controllers/admin/deliusUserController.ts
+++ b/server/controllers/admin/deliusUserController.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
+import { HttpError } from 'http-errors'
 import { UserService } from '../../services'
 import { addErrorMessageToFlash, fetchErrorsAndUserInput } from '../../utils/validation'
 import paths from '../../paths/admin'
@@ -19,12 +20,13 @@ export default class UserController {
       try {
         const user = await this.userService.searchDelius(req.user.token, req.body.username as string)
         return res.render('admin/users/confirm', { pageHeading: 'Confirm new user', user })
-      } catch (err) {
-        if ('data' in err && err.status === 404) {
+      } catch (error) {
+        const knownError = error as HttpError | Error
+        if ('data' in knownError && knownError.status === 404) {
           addErrorMessageToFlash(req, 'User not found. Enter the nDelius username as appears on nDelius', 'username')
           return res.redirect(paths.admin.userManagement.new({}))
         }
-        throw err
+        throw knownError
       }
     }
   }

--- a/server/controllers/admin/placementRequests/bookingsController.ts
+++ b/server/controllers/admin/placementRequests/bookingsController.ts
@@ -58,11 +58,11 @@ export default class PlacementRequestsController {
 
         req.flash('success', `Placement created for ${booking.premisesName}`)
         return res.redirect(paths.admin.placementRequests.show({ id: req.params.id }))
-      } catch (err) {
+      } catch (error) {
         return catchValidationErrorOrPropogate(
           req,
           res,
-          err,
+          error as Error,
           paths.admin.placementRequests.bookings.new({ id: req.params.id }),
         )
       }

--- a/server/controllers/admin/placementRequests/withdrawalsController.ts
+++ b/server/controllers/admin/placementRequests/withdrawalsController.ts
@@ -49,15 +49,15 @@ export default class WithdrawalsController {
 
         try {
           req.flash('success', withdrawalMessage(placementRequest.duration, placementRequest.expectedArrival))
-        } catch (e) {
+        } catch (error) {
           req.flash('success', 'Placement application withdrawn')
         }
         return res.redirect(paths.admin.placementRequests.index({}))
-      } catch (err) {
+      } catch (error) {
         return catchValidationErrorOrPropogate(
           req,
           res,
-          err,
+          error as Error,
           paths.admin.placementRequests.withdrawal.new({ id: req.params.id }),
         )
       }

--- a/server/controllers/admin/reportsController.ts
+++ b/server/controllers/admin/reportsController.ts
@@ -46,8 +46,8 @@ export default class ReportsController {
         }
 
         return await this.reportsService.getReport(req.user.token, month, year, reportType, res)
-      } catch (err) {
-        return catchValidationErrorOrPropogate(req, res, err, paths.admin.reports.new({}))
+      } catch (error) {
+        return catchValidationErrorOrPropogate(req, res, error as Error, paths.admin.reports.new({}))
       }
     }
   }

--- a/server/controllers/apply/appealsController.ts
+++ b/server/controllers/apply/appealsController.ts
@@ -49,8 +49,8 @@ export default class AppealsController {
         const successMessage = appeal.decision === 'accepted' ? 'Assessment reopened' : 'Appeal marked as rejected'
         req.flash('success', successMessage)
         res.redirect(paths.applications.show({ id: applicationId }))
-      } catch (err) {
-        catchValidationErrorOrPropogate(req, res, err, paths.applications.appeals.new({ id: applicationId }))
+      } catch (error) {
+        catchValidationErrorOrPropogate(req, res, error as Error, paths.applications.appeals.new({ id: applicationId }))
       }
     }
   }

--- a/server/controllers/apply/applications/pagesController.ts
+++ b/server/controllers/apply/applications/pagesController.ts
@@ -36,11 +36,11 @@ export default class PagesController {
           page,
           ...page.body,
         })
-      } catch (e) {
-        if (e instanceof UnknownPageError) {
+      } catch (error) {
+        if (error instanceof UnknownPageError) {
           next(createError(404, 'Not found'))
         } else {
-          catchAPIErrorOrPropogate(req, res, e)
+          catchAPIErrorOrPropogate(req, res, error as Error)
         }
       }
     }
@@ -59,11 +59,11 @@ export default class PagesController {
         } else {
           res.redirect(paths.applications.show({ id: req.params.id }))
         }
-      } catch (err) {
+      } catch (error) {
         catchValidationErrorOrPropogate(
           req,
           res,
-          err,
+          error as Error,
           paths.applications.pages.show({ id: req.params.id, task: taskName, page: pageName }),
         )
       }

--- a/server/controllers/apply/applications/withdrawalsController.ts
+++ b/server/controllers/apply/applications/withdrawalsController.ts
@@ -66,8 +66,13 @@ export default class WithdrawalsController {
 
         req.flash('success', 'Application withdrawn')
         return res.redirect(paths.applications.index({}))
-      } catch (err) {
-        return catchValidationErrorOrPropogate(req, res, err, paths.applications.withdraw.new({ id: req.params.id }))
+      } catch (error) {
+        return catchValidationErrorOrPropogate(
+          req,
+          res,
+          error as Error,
+          paths.applications.withdraw.new({ id: req.params.id }),
+        )
       }
     }
   }

--- a/server/controllers/assess/assessments/pagesController.ts
+++ b/server/controllers/assess/assessments/pagesController.ts
@@ -46,11 +46,11 @@ export default class PagesController {
           page,
           ...page.body,
         })
-      } catch (e) {
-        if (e instanceof UnknownPageError) {
+      } catch (error) {
+        if (error instanceof UnknownPageError) {
           next(createError(404, 'Not found'))
         } else {
-          catchAPIErrorOrPropogate(req, res, e)
+          catchAPIErrorOrPropogate(req, res, error as Error)
         }
       }
     }
@@ -109,11 +109,11 @@ export default class PagesController {
       await this.assessmentService.save(page, req)
 
       return page
-    } catch (err) {
+    } catch (error) {
       return catchValidationErrorOrPropogate(
         req,
         res,
-        err,
+        error as Error,
         paths.assessments.pages.show({ id: req.params.id, task: taskName, page: pageName }),
       )
     }

--- a/server/controllers/manage/arrivalsController.ts
+++ b/server/controllers/manage/arrivalsController.ts
@@ -55,8 +55,13 @@ export default class ArrivalsController {
 
         req.flash('success', 'Arrival logged')
         res.redirect(paths.premises.show({ premisesId }))
-      } catch (err) {
-        catchValidationErrorOrPropogate(req, res, err, paths.bookings.arrivals.new({ bookingId, premisesId }))
+      } catch (error) {
+        catchValidationErrorOrPropogate(
+          req,
+          res,
+          error as Error,
+          paths.bookings.arrivals.new({ bookingId, premisesId }),
+        )
       }
     }
   }

--- a/server/controllers/manage/bookingExtensionsController.ts
+++ b/server/controllers/manage/bookingExtensionsController.ts
@@ -46,11 +46,11 @@ export default class BookingExtensionsController {
             bookingId,
           }),
         )
-      } catch (err) {
+      } catch (error) {
         catchValidationErrorOrPropogate(
           req,
           res,
-          err,
+          error as Error,
           paths.bookings.extensions.new({
             premisesId,
             bookingId,

--- a/server/controllers/manage/bookingsController.ts
+++ b/server/controllers/manage/bookingsController.ts
@@ -90,10 +90,10 @@ export default class BookingsController {
             bookingId: confirmedBooking.id,
           }),
         )
-      } catch (err) {
+      } catch (error) {
         req.flash('crn', booking.crn)
         const redirectPath = paths.bookings.new({ premisesId })
-        return catchValidationErrorOrPropogate(req, res, err, redirectPath)
+        return catchValidationErrorOrPropogate(req, res, error as Error, redirectPath)
       }
     }
   }

--- a/server/controllers/manage/cancellationsController.ts
+++ b/server/controllers/manage/cancellationsController.ts
@@ -55,7 +55,7 @@ export default class CancellationsController {
       try {
         date = DateFormats.dateAndTimeInputsToIsoString(req.body, 'date').date
         DateFormats.isoToDateObj(date)
-      } catch (err) {
+      } catch (error) {
         date = DateFormats.dateObjToIsoDate(new Date())
       }
 
@@ -68,11 +68,11 @@ export default class CancellationsController {
         await this.cancellationService.createCancellation(req.user.token, premisesId, bookingId, cancellation)
 
         res.render('cancellations/confirm', { pageHeading: 'Booking withdrawn' })
-      } catch (err) {
+      } catch (error) {
         catchValidationErrorOrPropogate(
           req,
           res,
-          err,
+          error as Error,
           paths.bookings.cancellations.new({
             bookingId,
             premisesId,

--- a/server/controllers/manage/dateChangesController.ts
+++ b/server/controllers/manage/dateChangesController.ts
@@ -73,11 +73,11 @@ export default class DateChangeController {
 
         req.flash('success', 'Booking changed successfully')
         res.redirect(backLink)
-      } catch (err) {
+      } catch (error) {
         catchValidationErrorOrPropogate(
           req,
           res,
-          err,
+          error as Error,
           paths.bookings.dateChanges.new({
             bookingId,
             premisesId,

--- a/server/controllers/manage/departuresController.ts
+++ b/server/controllers/manage/departuresController.ts
@@ -49,11 +49,11 @@ export default class DeparturesController {
 
         req.flash('success', 'Departure recorded')
         res.redirect(paths.bookings.show({ premisesId, bookingId }))
-      } catch (err) {
+      } catch (error) {
         catchValidationErrorOrPropogate(
           req,
           res,
-          err,
+          error as Error,
           paths.bookings.departures.new({
             premisesId,
             bookingId,

--- a/server/controllers/manage/lostBedsController.ts
+++ b/server/controllers/manage/lostBedsController.ts
@@ -9,6 +9,7 @@ import {
 } from '../../utils/validation'
 import paths from '../../paths/manage'
 import { DateFormats } from '../../utils/dateUtils'
+import { SanitisedError } from '../../sanitisedError'
 
 export default class LostBedsController {
   constructor(private readonly lostBedService: LostBedService) {}
@@ -52,22 +53,24 @@ export default class LostBedsController {
 
         req.flash('success', 'Lost bed logged')
         return res.redirect(paths.premises.show({ premisesId }))
-      } catch (err) {
+      } catch (error) {
         const redirectPath = paths.lostBeds.new({ premisesId, bedId })
 
-        if (err.status === 409 && 'data' in err) {
+        const knownError = error as SanitisedError
+
+        if (knownError.status === 409 && 'data' in knownError) {
           return generateConflictErrorAndRedirect(
             req,
             res,
             premisesId,
             ['startDate', 'endDate'],
-            err,
+            knownError,
             redirectPath,
             bedId,
           )
         }
 
-        return catchValidationErrorOrPropogate(req, res, err, redirectPath)
+        return catchValidationErrorOrPropogate(req, res, knownError, redirectPath)
       }
     }
   }
@@ -127,10 +130,10 @@ export default class LostBedsController {
         req.flash('success', 'Bed updated')
 
         return res.redirect(paths.lostBeds.index({ premisesId }))
-      } catch (err) {
+      } catch (error) {
         const redirectPath = req.headers.referer
 
-        return catchValidationErrorOrPropogate(req, res, err, redirectPath)
+        return catchValidationErrorOrPropogate(req, res, error as Error, redirectPath)
       }
     }
   }
@@ -146,8 +149,8 @@ export default class LostBedsController {
         req.flash('success', 'Bed cancelled')
 
         return res.redirect(paths.lostBeds.index({ premisesId }))
-      } catch (err) {
-        return catchValidationErrorOrPropogate(req, res, err, paths.lostBeds.show({ premisesId, bedId, id }))
+      } catch (error) {
+        return catchValidationErrorOrPropogate(req, res, error as Error, paths.lostBeds.show({ premisesId, bedId, id }))
       }
     }
   }

--- a/server/controllers/manage/moveBedsController.ts
+++ b/server/controllers/manage/moveBedsController.ts
@@ -46,8 +46,8 @@ export default class MoveBedsController {
 
         req.flash('success', 'Bed move logged')
         res.redirect(paths.premises.show({ premisesId }))
-      } catch (err) {
-        catchValidationErrorOrPropogate(req, res, err, paths.bookings.moves.new({ premisesId, bookingId }))
+      } catch (error) {
+        catchValidationErrorOrPropogate(req, res, error as Error, paths.bookings.moves.new({ premisesId, bookingId }))
       }
     }
   }

--- a/server/controllers/manage/nonArrivalsController.ts
+++ b/server/controllers/manage/nonArrivalsController.ts
@@ -45,8 +45,13 @@ export default class NonArrivalsController {
 
         req.flash('success', 'Non-arrival logged')
         res.redirect(paths.premises.show({ premisesId }))
-      } catch (err) {
-        catchValidationErrorOrPropogate(req, res, err, paths.bookings.nonArrivals.new({ premisesId, bookingId }))
+      } catch (error) {
+        catchValidationErrorOrPropogate(
+          req,
+          res,
+          error as Error,
+          paths.bookings.nonArrivals.new({ premisesId, bookingId }),
+        )
       }
     }
   }

--- a/server/controllers/placementApplications/pagesController.ts
+++ b/server/controllers/placementApplications/pagesController.ts
@@ -42,11 +42,11 @@ export default class PagesController {
           page,
           ...page.body,
         })
-      } catch (e) {
-        if (e instanceof UnknownPageError) {
+      } catch (error) {
+        if (error instanceof UnknownPageError) {
           next(createError(404, 'Not found'))
         } else {
-          catchAPIErrorOrPropogate(req, res, e)
+          catchAPIErrorOrPropogate(req, res, error as Error)
         }
       }
     }
@@ -63,11 +63,11 @@ export default class PagesController {
         await this.placementApplicationService.save(page, req)
 
         res.redirect(paths.placementApplications.pages.show({ id: req.params.id, task: taskName, page: page.next() }))
-      } catch (err) {
+      } catch (error) {
         catchValidationErrorOrPropogate(
           req,
           res,
-          err,
+          error as Error,
           paths.placementApplications.pages.show({ id: req.params.id, task: taskName, page: pageName }),
         )
       }

--- a/server/controllers/placementApplications/reviewController.ts
+++ b/server/controllers/placementApplications/reviewController.ts
@@ -56,8 +56,9 @@ export default class ReviewController {
         return res.redirect(
           placementApplicationPaths.placementApplications.review.decision({ id: review.applicationId }),
         )
-      } catch (err) {
-        if (err.message === 'Invalid request body') {
+      } catch (error) {
+        const knownError = error as Error
+        if (knownError.message === 'Invalid request body') {
           const errorMessages = generateErrorMessages(review.errors)
           const errorSummary = generateErrorSummary(review.errors)
 
@@ -67,7 +68,7 @@ export default class ReviewController {
 
           return res.redirect(req.headers.referer)
         }
-        return catchValidationErrorOrPropogate(req, res, err, req.headers.referer)
+        return catchValidationErrorOrPropogate(req, res, knownError, req.headers.referer)
       }
     }
   }
@@ -88,8 +89,9 @@ export default class ReviewController {
         return res.redirect(
           placementApplicationPaths.placementApplications.review.confirm({ id: review.applicationId }),
         )
-      } catch (err) {
-        if (err.message === 'Invalid request body') {
+      } catch (error) {
+        const knownError = error as Error
+        if (knownError.message === 'Invalid request body') {
           const errorMessages = generateErrorMessages(review.errors)
           const errorSummary = generateErrorSummary(review.errors)
 
@@ -99,7 +101,7 @@ export default class ReviewController {
 
           return res.redirect(req.headers.referer)
         }
-        return catchAPIErrorOrPropogate(req, res, err)
+        return catchAPIErrorOrPropogate(req, res, knownError)
       }
     }
   }

--- a/server/controllers/placementApplications/withdrawalsController.ts
+++ b/server/controllers/placementApplications/withdrawalsController.ts
@@ -55,15 +55,15 @@ export default class WithdrawalsController {
             'success',
             withdrawalMessage(placementApplicationDate.duration, placementApplicationDate.expectedArrival),
           )
-        } catch (e) {
+        } catch (error) {
           req.flash('success', 'Placement application withdrawn')
         }
         return res.redirect(applicationShowPageTab(applicationId, 'placementRequests'))
-      } catch (err) {
+      } catch (error) {
         return catchValidationErrorOrPropogate(
           req,
           res,
-          err,
+          error as Error,
           placementApplicationPaths.placementApplications.withdraw.new({ id: req.params.id }),
         )
       }

--- a/server/controllers/tasks/allocationsController.ts
+++ b/server/controllers/tasks/allocationsController.ts
@@ -23,11 +23,11 @@ export default class AllocationsController {
           `${convertToTitleCase(sentenceCase(reallocation.taskType))} has been allocated to ${reallocation.user.name}`,
         )
         res.redirect(paths.tasks.index({}))
-      } catch (err) {
+      } catch (error) {
         catchValidationErrorOrPropogate(
           req,
           res,
-          err,
+          error as Error,
           paths.tasks.show({ id: req.params.id, taskType: req.params.taskType }),
         )
       }

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -1,12 +1,16 @@
 import nock from 'nock'
 
+import { createMock } from '@golevelup/ts-jest'
 import config from '../config'
 import HmppsAuthClient from './hmppsAuthClient'
 import TokenStore from './tokenStore'
+import { RedisClient } from './redisClient'
 
 jest.mock('./tokenStore')
+jest.mock('./redisClient')
 
-const tokenStore = new TokenStore(null) as jest.Mocked<TokenStore>
+const redisClient = createMock<RedisClient>({})
+const tokenStore = new TokenStore(redisClient) as jest.Mocked<TokenStore>
 
 const username = 'Bob'
 const token = { access_token: 'token-1', expires_in: 300 }
@@ -18,6 +22,7 @@ describe('hmppsAuthClient', () => {
   beforeEach(() => {
     fakeHmppsAuthApi = nock(config.apis.hmppsAuth.url)
     hmppsAuthClient = new HmppsAuthClient(tokenStore)
+    tokenStore.getToken.mockResolvedValue(token.access_token)
   })
 
   afterEach(() => {
@@ -58,12 +63,11 @@ describe('hmppsAuthClient', () => {
     })
 
     it('should return token from redis if one exists', async () => {
-      tokenStore.getToken.mockResolvedValue(token.access_token)
       const output = await hmppsAuthClient.getSystemClientToken(username)
       expect(output).toEqual(token.access_token)
     })
 
-    it('should return token from HMPPS Auth with username', async () => {
+    it("should fetch a new token from HMPPS Auth with username when one doesn't exist in redis", async () => {
       tokenStore.getToken.mockResolvedValue(null)
 
       fakeHmppsAuthApi
@@ -78,7 +82,7 @@ describe('hmppsAuthClient', () => {
       expect(tokenStore.setToken).toBeCalledWith('Bob', token.access_token, 240)
     })
 
-    it('should return token from HMPPS Auth without username', async () => {
+    it("should fetch a new token from HMPPS Auth without username when one doesn't exist in redis", async () => {
       tokenStore.getToken.mockResolvedValue(null)
 
       fakeHmppsAuthApi

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -86,7 +86,7 @@ export default class RestClient {
 
       return raw ? result : result.body
     } catch (error) {
-      const sanitisedError = sanitiseError(error)
+      const sanitisedError = sanitiseError(error as UnsanitisedError)
       logger.warn({ ...sanitisedError, query }, `Error calling ${this.name}, path: '${path}', verb: 'GET'`)
       throw sanitisedError
     }
@@ -113,7 +113,7 @@ export default class RestClient {
 
       return result.body
     } catch (error) {
-      const sanitisedError = sanitiseError(error)
+      const sanitisedError = sanitiseError(error as UnsanitisedError)
       logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: 'DELETE'`)
       throw sanitisedError
     }
@@ -231,7 +231,7 @@ export default class RestClient {
 
       return raw ? result : result.body
     } catch (error) {
-      const sanitisedError = sanitiseError(error)
+      const sanitisedError = sanitiseError(error as UnsanitisedError)
       logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: '${method}'`)
       throw sanitisedError
     }

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -67,7 +67,7 @@ export default class RestClient {
     return this.config.timeout
   }
 
-  async get({ path = null, query = '', headers = {}, responseType = '', raw = false }: GetRequest): Promise<unknown> {
+  async get({ path = '', query = '', headers = {}, responseType = '', raw = false }: GetRequest): Promise<unknown> {
     logger.info(`Get using user credentials: calling ${this.name}: ${path} ${query}`)
     try {
       const result = await superagent
@@ -119,7 +119,7 @@ export default class RestClient {
     }
   }
 
-  async stream({ path = null, headers = {} }: StreamRequest = {}): Promise<unknown> {
+  async stream({ path = '', headers = {} }: StreamRequest = {}): Promise<unknown> {
     logger.info(`Get using user credentials: calling ${this.name}: ${path}`)
     return new Promise((resolve, reject) => {
       superagent
@@ -150,7 +150,7 @@ export default class RestClient {
   }
 
   async pipe(
-    { path = null, query = '', headers = {}, passThroughHeaders = [] }: PipeRequest,
+    { path = '', query = '', headers = {}, passThroughHeaders = [] }: PipeRequest,
     response: Response,
   ): Promise<void> {
     logger.info(`Get using user credentials: calling ${this.name}: ${path}`)
@@ -213,7 +213,7 @@ export default class RestClient {
 
   private async postOrPut(
     method: 'post' | 'put',
-    { path = null, headers = {}, responseType = '', data = {}, raw = false }: PutRequest | PostRequest = {},
+    { path = '', headers = {}, responseType = '', data = {}, raw = false }: PutRequest | PostRequest = {},
   ): Promise<unknown> {
     logger.info(`${method} using user credentials: calling ${this.name}: ${path}`)
     try {

--- a/server/data/restClientMetricsMiddleware.test.ts
+++ b/server/data/restClientMetricsMiddleware.test.ts
@@ -33,17 +33,9 @@ describe('restClientMetricsMiddleware', () => {
       const requestHistogramLabelsSpy = jest.spyOn(requestHistogram, 'labels').mockReturnValue(requestHistogram)
       const requestHistogramStartSpy = jest.spyOn(requestHistogram, 'observe')
 
-      let code: number
+      const res = await superagent.get('https://httpbin.org/').use(restClientMetricsMiddleware).set('accept', 'json')
 
-      await superagent
-        .get('https://httpbin.org/')
-        .use(restClientMetricsMiddleware)
-        .set('accept', 'json')
-        .then(res => {
-          code = res.statusCode
-        })
-
-      expect(code).toBe(200)
+      expect(res.statusCode).toBe(200)
       expect(requestHistogramLabelsSpy).toHaveBeenCalledTimes(1)
       expect(requestHistogramLabelsSpy).toHaveBeenCalledWith('httpbin.org', 'GET', '/', '200')
       expect(requestHistogramStartSpy).toHaveBeenCalledTimes(1)

--- a/server/data/tokenStore.test.ts
+++ b/server/data/tokenStore.test.ts
@@ -22,7 +22,7 @@ describe('tokenStore', () => {
 
   describe('get token', () => {
     it('Can retrieve token', async () => {
-      redisClient.get.mockResolvedValue('token-1')
+      ;(redisClient.get as jest.Mock).mockResolvedValue('token-1')
 
       await expect(tokenStore.getToken('user-1')).resolves.toBe('token-1')
 

--- a/server/data/tokenStore.ts
+++ b/server/data/tokenStore.ts
@@ -24,7 +24,7 @@ export default class TokenStore {
     await this.client.set(`${this.prefix}${key}`, token, { EX: durationSeconds })
   }
 
-  public async getToken(key: string): Promise<string> {
+  public async getToken(key: string): Promise<string | null> {
     await this.ensureConnected()
     return this.client.get(`${this.prefix}${key}`)
   }

--- a/server/data/tokenVerification.ts
+++ b/server/data/tokenVerification.ts
@@ -2,7 +2,7 @@
 
 import superagent from 'superagent'
 import type { Request } from 'express'
-import getSanitisedError from '../sanitisedError'
+import sanitiseError from '../sanitisedError'
 import config from '../config'
 import logger from '../../logger'
 
@@ -13,7 +13,7 @@ function getApiClientToken(token: string) {
     .timeout(config.apis.tokenVerification.timeout)
     .then(response => Boolean(response.body && response.body.active))
     .catch(error => {
-      logger.error(getSanitisedError(error), 'Error calling tokenVerificationApi')
+      logger.error(sanitiseError(error), 'Error calling tokenVerificationApi')
     })
 }
 

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
@@ -70,13 +70,13 @@ export default class OptionalOasysSections implements TasklistPage {
       page.allNeedsLinkedToReoffending = allNeedsLinkedToReoffending
       page.allOtherNeeds = allOtherNeeds
       page.oasysSuccess = true
-    } catch (e) {
-      if (e instanceof OasysNotFoundError) {
+    } catch (error) {
+      if (error instanceof OasysNotFoundError) {
         page.oasysSuccess = false
         page.body.needsLinkedToReoffending = []
         page.body.otherNeeds = []
       } else {
-        throw e
+        throw error
       }
     }
 

--- a/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
+++ b/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
@@ -2,6 +2,7 @@ import type { DataServices, PageResponse, TaskListErrors, YesOrNoWithDetail } fr
 
 import type { Adjudication, ApprovedPremisesApplication, PersonAcctAlert, PrisonCaseNote } from '@approved-premises/api'
 
+import { HttpError } from 'http-errors'
 import { yesOrNoResponseWithDetailForYes } from '../../../utils'
 import { sentenceCase } from '../../../../utils/utils'
 import TasklistPage from '../../../tasklistPage'
@@ -136,11 +137,12 @@ export default class CaseNotes implements TasklistPage {
 
       page.caseNotes = caseNotes
       page.nomisFailed = false
-    } catch (e) {
-      if (e?.data?.status === 404) {
+    } catch (error) {
+      const knownError = error as HttpError
+      if (knownError?.data?.status === 404) {
         page.nomisFailed = true
       } else {
-        throw e
+        throw knownError
       }
     }
 

--- a/server/sanitisedError.test.ts
+++ b/server/sanitisedError.test.ts
@@ -1,4 +1,4 @@
-import sanitisedError, { UnsanitisedError } from './sanitisedError'
+import sanitiseError, { UnsanitisedError } from './sanitisedError'
 
 describe('sanitised error', () => {
   it('it should omit the request headers from the error object ', () => {
@@ -25,7 +25,7 @@ describe('sanitised error', () => {
       stack: 'stack description',
     } as unknown as UnsanitisedError
 
-    expect(sanitisedError(error)).toEqual({
+    expect(sanitiseError(error)).toEqual({
       headers: { date: 'Tue, 19 May 2020 15:16:20 GMT' },
       message: 'Not Found',
       stack: 'stack description',
@@ -39,7 +39,7 @@ describe('sanitised error', () => {
     const error = {
       message: 'error description',
     } as unknown as UnsanitisedError
-    expect(sanitisedError(error)).toEqual({
+    expect(sanitiseError(error)).toEqual({
       message: 'error description',
     })
   })
@@ -48,6 +48,6 @@ describe('sanitised error', () => {
     const error = {
       property: 'unknown',
     } as unknown as UnsanitisedError
-    expect(sanitisedError(error)).toEqual({})
+    expect(sanitiseError(error)).toEqual({})
   })
 })

--- a/server/sanitisedError.ts
+++ b/server/sanitisedError.ts
@@ -13,7 +13,7 @@ export interface SanitisedError {
 
 export type UnsanitisedError = ResponseError
 
-export default function sanitise(error: UnsanitisedError): SanitisedError {
+export default function sanitiseError(error: UnsanitisedError): SanitisedError {
   if (error.response) {
     return {
       text: error.response.text,

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -318,8 +318,8 @@ describe('ApplicationService', () => {
         expect.assertions(1)
         try {
           await service.save(page, request)
-        } catch (e) {
-          expect(e).toEqual(new ValidationError(errors))
+        } catch (error) {
+          expect(error).toEqual(new ValidationError(errors))
         }
       })
     })

--- a/server/services/assessmentService.test.ts
+++ b/server/services/assessmentService.test.ts
@@ -171,8 +171,8 @@ describe('AssessmentService', () => {
         expect.assertions(1)
         try {
           await service.save(page, request)
-        } catch (e) {
-          expect(e).toEqual(new ValidationError(errors))
+        } catch (error) {
+          expect(error).toEqual(new ValidationError(errors))
         }
       })
     })

--- a/server/services/healthCheck.ts
+++ b/server/services/healthCheck.ts
@@ -48,7 +48,7 @@ function getBuild() {
   try {
     // eslint-disable-next-line import/no-unresolved,global-require
     return require('../../build-info.json')
-  } catch (ex) {
+  } catch (error) {
     return null
   }
 }

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -166,8 +166,8 @@ describe('PersonService', () => {
 
       try {
         await service.getOasysSelections(token, 'crn')
-      } catch (e) {
-        expect(e).toEqual(err)
+      } catch (error) {
+        expect(error).toEqual(err)
       }
     })
 
@@ -215,8 +215,8 @@ describe('PersonService', () => {
 
       try {
         await service.getOasysSections(token, 'crn')
-      } catch (e) {
-        expect(e).toEqual(err)
+      } catch (error) {
+        expect(error).toEqual(err)
       }
     })
 

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -9,6 +9,7 @@ import type {
   PersonAcctAlert,
   PrisonCaseNote,
 } from '@approved-premises/api'
+import { HttpError } from 'http-errors'
 import type { PersonClient, RestClientBuilder } from '../data'
 
 import { mapApiPersonRisksForUi } from '../utils/utils'
@@ -71,11 +72,12 @@ export default class PersonService {
       const oasysSections = await personClient.oasysSelections(crn)
 
       return oasysSections
-    } catch (e) {
-      if (e?.data?.status === 404) {
+    } catch (error) {
+      const knownError = error as HttpError
+      if (knownError?.data?.status === 404) {
         throw new OasysNotFoundError(`Oasys record not found for CRN: ${crn}`)
       }
-      throw e
+      throw knownError
     }
   }
 
@@ -86,11 +88,12 @@ export default class PersonService {
       const oasysSections = await personClient.oasysSections(crn, selectedSections)
 
       return oasysSections
-    } catch (e) {
-      if (e?.data?.status === 404) {
+    } catch (error) {
+      const knownError = error as HttpError
+      if (knownError?.data?.status === 404) {
         throw new OasysNotFoundError(`Oasys record not found for CRN: ${crn}`)
       }
-      throw e
+      throw knownError
     }
   }
 

--- a/server/services/placementApplicationService.test.ts
+++ b/server/services/placementApplicationService.test.ts
@@ -169,8 +169,8 @@ describe('placementApplicationService', () => {
         expect.assertions(1)
         try {
           await service.save(page, request)
-        } catch (e) {
-          expect(e).toEqual(new ValidationError(errors))
+        } catch (error) {
+          expect(error).toEqual(new ValidationError(errors))
         }
       })
     })

--- a/server/testutils/jest.setup.ts
+++ b/server/testutils/jest.setup.ts
@@ -43,9 +43,9 @@ expect.extend({
         message: () => `Swagger mock validator for ${pactPath} did not fail`,
         pass: true,
       }
-    } catch (err) {
+    } catch (error) {
       return {
-        message: () => err.output.toString(),
+        message: () => error.output.toString(),
         pass: false,
       }
     }

--- a/server/utils/applications/convictedOffenceResponseFromApplication.ts
+++ b/server/utils/applications/convictedOffenceResponseFromApplication.ts
@@ -4,7 +4,7 @@ import { SessionDataError } from '../errors'
 export const convictedOffenceResponseFromApplication = (application: Application): string => {
   try {
     return application.data['risk-management-features']['convicted-offences'].response
-  } catch (e) {
+  } catch (error) {
     throw new SessionDataError('No convicted offences response found')
   }
 }

--- a/server/utils/applications/withdrawables/sortAndFilterWithdrawables.ts
+++ b/server/utils/applications/withdrawables/sortAndFilterWithdrawables.ts
@@ -1,5 +1,5 @@
 import { Withdrawable } from '../../../@types/shared'
-import { DateFormats } from '../../dateUtils'
+import { DateFormats, InvalidDateStringError } from '../../dateUtils'
 
 export const sortAndFilterWithdrawables = (
   withdrawables: Array<Withdrawable>,
@@ -17,8 +17,9 @@ export const sortAndFilterWithdrawables = (
           DateFormats.isoToDateObj(a.dates[0].startDate).getTime() -
           DateFormats.isoToDateObj(b.dates[0].startDate).getTime()
         )
-      } catch (e) {
-        throw new Error(`Error sorting withdrawables: ${e.message}`)
+      } catch (error) {
+        const knownError = error as InvalidDateStringError
+        throw new Error(`Error sorting withdrawables: ${knownError.message}`)
       }
     })
 }

--- a/server/utils/applications/withdrawables/withdrawalReasons.ts
+++ b/server/utils/applications/withdrawables/withdrawalReasons.ts
@@ -51,15 +51,15 @@ const problemInPlacementOptions = filterByType<ProblemInPlacementReasons>(proble
 
 const placementNoLongerNeededDividerAndRadioItems = [
   { divider: 'The placement is no longer needed' },
-  ...convertKeyValuePairToRadioItems(placementNoLongerNeededOptions, undefined),
+  ...convertKeyValuePairToRadioItems(placementNoLongerNeededOptions),
 ]
 const noCapacityDividerAndRadioItems = [
   { divider: 'The placement is unavailable (CRU use only)' },
-  ...convertKeyValuePairToRadioItems(noCapacityOptions, undefined),
+  ...convertKeyValuePairToRadioItems(noCapacityOptions),
 ]
 const problemInPlacementDividerAndRadioItems = [
   { divider: 'Problem in placement' },
-  ...convertKeyValuePairToRadioItems(problemInPlacementOptions, undefined),
+  ...convertKeyValuePairToRadioItems(problemInPlacementOptions),
 ]
 
 export const placementApplicationWithdrawalReasons = (

--- a/server/utils/applications/withdrawalReasons.test.ts
+++ b/server/utils/applications/withdrawalReasons.test.ts
@@ -39,9 +39,9 @@ describe('withdrawalReasons', () => {
         { divider: 'The application is no longer needed' },
         ...convertKeyValuePairToRadioItems(placementNoLongerNeededOptions, undefined, conditional),
         { divider: 'A new application is needed' },
-        ...convertKeyValuePairToRadioItems(newApplicationToBeSubmittedOptions, undefined),
+        ...convertKeyValuePairToRadioItems(newApplicationToBeSubmittedOptions),
         { divider: "There's a problem with the application" },
-        ...convertKeyValuePairToRadioItems(applicationProblemOptions, undefined),
+        ...convertKeyValuePairToRadioItems(applicationProblemOptions),
       ])
     })
   })

--- a/server/utils/applications/withdrawalReasons.ts
+++ b/server/utils/applications/withdrawalReasons.ts
@@ -40,7 +40,7 @@ export const withdrawalRadioOptions = (conditionals: Partial<Record<WithdrawalRe
   { divider: 'The application is no longer needed' },
   ...convertKeyValuePairToRadioItems(placementNoLongerNeededOptions, undefined, conditionals),
   { divider: 'A new application is needed' },
-  ...convertKeyValuePairToRadioItems(newApplicationToBeSubmittedOptions, undefined),
+  ...convertKeyValuePairToRadioItems(newApplicationToBeSubmittedOptions),
   { divider: "There's a problem with the application" },
-  ...convertKeyValuePairToRadioItems(applicationProblemOptions, undefined),
+  ...convertKeyValuePairToRadioItems(applicationProblemOptions),
 ]

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -82,7 +82,7 @@ export class DateFormats {
 
     try {
       parsedDate = parseISO(date)
-    } catch (err) {
+    } catch (error) {
       throw new InvalidDateStringError(`Invalid Date: ${date}`)
     }
 
@@ -265,8 +265,8 @@ export const dateAndTimeInputsAreValidDates = <K extends string | number>(
 
   try {
     DateFormats.isoToDateObj(dateString[key])
-  } catch (err) {
-    if (err instanceof InvalidDateStringError) {
+  } catch (error) {
+    if (error instanceof InvalidDateStringError) {
       return false
     }
   }

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -218,7 +218,7 @@ describe('formUtils', () => {
     }
 
     it('should convert a key value pair to radio items', () => {
-      expect(convertKeyValuePairToRadioItems(obj, '')).toEqual([
+      expect(convertKeyValuePairToRadioItems(obj)).toEqual([
         {
           value: 'foo',
           text: 'Foo',
@@ -270,7 +270,7 @@ describe('formUtils', () => {
         },
       }
 
-      expect(convertKeyValuePairToRadioItems(obj, '', conditionals)).toEqual([
+      expect(convertKeyValuePairToRadioItems(obj, undefined, conditionals)).toEqual([
         {
           value: 'foo',
           text: 'Foo',

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -73,7 +73,7 @@ export const convertObjectsToSelectOptions = (
 
 export function convertKeyValuePairToRadioItems<T extends object>(
   object: T,
-  checkedItem: string,
+  checkedItem?: keyof T,
   conditionals?: Partial<Record<keyof T, RadioItem['conditional']>>,
 ): Array<RadioItem> {
   return Object.keys(object).map(key => {

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -71,7 +71,7 @@ export const convertObjectsToSelectOptions = (
   return options
 }
 
-export function convertKeyValuePairToRadioItems<T>(
+export function convertKeyValuePairToRadioItems<T extends object>(
   object: T,
   checkedItem: string,
   conditionals?: Partial<Record<keyof T, RadioItem['conditional']>>,
@@ -86,7 +86,7 @@ export function convertKeyValuePairToRadioItems<T>(
   })
 }
 
-export function convertKeyValuePairToCheckBoxItems<T>(
+export function convertKeyValuePairToCheckBoxItems<T extends object>(
   object: T,
   checkedItems: Array<string> = [],
 ): Array<CheckBoxItem> {
@@ -122,7 +122,7 @@ export function convertArrayToCheckboxItems(
   })
 }
 
-export function convertKeyValuePairsToSummaryListItems<T>(
+export function convertKeyValuePairsToSummaryListItems<T extends object>(
   values: T,
   titles: Record<string, string>,
 ): Array<SummaryListItem> {

--- a/server/utils/oasysImportUtils.ts
+++ b/server/utils/oasysImportUtils.ts
@@ -38,12 +38,12 @@ export const getOasysSections = async <T extends OasysPage>(
   try {
     oasysSections = await dataServices.personService.getOasysSections(token, application.person.crn, selectedSections)
     oasysSuccess = true
-  } catch (e) {
-    if (e instanceof OasysNotFoundError) {
+  } catch (error) {
+    if (error instanceof OasysNotFoundError) {
       oasysSections = oasysStubs
       oasysSuccess = false
     } else {
-      throw e
+      throw error
     }
   }
 
@@ -132,8 +132,8 @@ export const fetchOptionalOasysSections = (application: Application): Array<numb
     return [...optionalOasysSections.needsLinkedToReoffending, ...optionalOasysSections.otherNeeds]
       .map((oasysSection: OASysSection) => oasysSection?.section)
       .filter(section => !!section)
-  } catch (e) {
-    throw new SessionDataError(`Oasys supporting information error: ${e}`)
+  } catch (error) {
+    throw new SessionDataError(`Oasys supporting information error: ${error}`)
   }
 }
 

--- a/server/utils/retrieveQuestionResponseFromFormArtifact.ts
+++ b/server/utils/retrieveQuestionResponseFromFormArtifact.ts
@@ -49,7 +49,7 @@ export const retrieveOptionalQuestionResponseFromFormArtifact = (
 
   try {
     response = retrieveQuestionResponseFromFormArtifact(formArtifact, Page, question)
-  } catch (e) {
+  } catch (error) {
     response = undefined
   }
 


### PR DESCRIPTION
# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

Back in June 2023, Rich flagged that the [HMPPS TypeScript template](https://github.com/ministryofjustice/hmpps-template-typescript) doesn't have strict mode on by default. You can turn it on by adding `"strict": true` to the `compilerOptions` in `tsconfig.json`

Strict mode tightens TypeScript's checks which in turn minimises risk of incorrectness, allows us to make safer assumptions about the data we're passing around (particularly around nullish data), and can improve the usefulness of in-editor type hints

There's a `tsconfig.json` file in both the root of the project directory and within the `integration_tests` subdirectory. Back in June, Rich reported over 600 errors, which were presumably just those outside of `integration_tests` (the `integration_tests` checks don't run unless there are no errors in the standard checks). There are now 766 errors outside of `integration_tests`, so the problem hasn't grown a great deal

In Accredited Programmes, thanks to Rich's flagging we turned this on much earlier in the project lifecycle, so we managed to fix the errors in [one (substantial) PR](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/pull/62). However, strict mode compliant typing works fine with strict mode off, so this feels like something we can tackle gradually when time allows, with the aim of eventually cutting down the errors to zero so that strict mode can be turned on permanently

# Changes in this PR

Address a few errors highlighted by turning on strict mode in the main `tsconfig.json`. This brings the total errors down:

| scope | before | after|
| --- | --- | ---|
| outside integration tests | 766 | 698 |
| inside integration tests | 776 | 754 |

Strict mode remains off