### PR TITLE
Don’t request apAreaId on placement request list

### DIFF
--- a/server/controllers/match/placementRequestsController.test.ts
+++ b/server/controllers/match/placementRequestsController.test.ts
@@ -90,7 +90,6 @@ describe('PlacementRequestsController', () => {
         sortBy: 'createdAt',
         sortDirection: 'asc',
         allocatedToUserId: response.locals.user.id,
-        apAreaId: response.locals.user.apArea.id,
       })
     })
   })

--- a/server/controllers/match/placementRequestsController.ts
+++ b/server/controllers/match/placementRequestsController.ts
@@ -26,7 +26,6 @@ export default class PlacementRequestsController {
         sortBy: 'createdAt',
         sortDirection: 'asc',
         allocatedToUserId: res.locals?.user?.id,
-        apAreaId: res.locals.user.apArea?.id,
       })
 
       res.render('match/placementRequests/index', {


### PR DESCRIPTION
If people are allocated a placement request that isn’t in their area, then they currently won’t see placement requests in that view because we’re filtering by the logged in user’s AP area.