### PR TITLE
Withdrawals feedback IV

### DIFF
--- a/integration_tests/pages/apply/newWithdrawal.ts
+++ b/integration_tests/pages/apply/newWithdrawal.ts
@@ -43,6 +43,17 @@ export default class SelectWithdrawableTypePage extends Page {
     })
   }
 
+  shouldShowNoWithdrawablesGuidance() {
+    cy.get('.govuk-warning-text__text').then(warningText => {
+      const { actual, expected } = parseHtml(
+        warningText,
+        'Warning You are not able to withdraw the application or any associated requests for placement or placements. If you need to make a withdrawal relating to this application, contact the CRU.',
+      )
+
+      expect(actual).to.equal(expected)
+    })
+  }
+
   selectType(type: 'placementRequest' | 'placement' | 'application') {
     this.checkRadioByNameAndValue('selectedWithdrawableType', type)
   }

--- a/integration_tests/support/helpers.ts
+++ b/integration_tests/support/helpers.ts
@@ -21,6 +21,7 @@ import PlacementApplicationWithdrawalConfirmationPage from '../pages/match/place
 import ShowPagePlacementApplications from '../pages/admin/placementApplications/showPage'
 import { ShowPage as ShowPageApply } from '../pages/apply'
 import Page from '../pages/page'
+import paths from '../../server/paths/apply'
 
 const documentsFromApplication = (application: ApprovedPremisesApplication): Array<Document> => {
   return application.data['attach-required-documents']['attach-documents'].selectedDocuments as Array<Document>
@@ -77,6 +78,7 @@ const createOccupancyEntry = (startDate: Date, endDate: Date, type: BedOccupancy
 const withdrawPlacementRequestOrApplication = async (
   withdrawable: Withdrawable,
   showPage: ShowPagePlacementApplications | ShowPageApply,
+  applicationId: string,
 ) => {
   // Then I should see the withdrawable type selection page
   const selectWithdrawableTypePage = new NewWithdrawalPage('What do you want to withdraw?')
@@ -93,6 +95,9 @@ const withdrawPlacementRequestOrApplication = async (
 
   // Then I should see the withdrawal confirmation page
   const confirmationPage = Page.verifyOnPage(PlacementApplicationWithdrawalConfirmationPage)
+  confirmationPage.checkForBackButton(
+    `${paths.applications.withdraw.new({ id: applicationId })}?selectedWithdrawableType=placementRequest`,
+  )
   // And be able to state a reason
   const withdrawalReason = 'DuplicatePlacementRequest'
   confirmationPage.selectReason(withdrawalReason)

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -343,7 +343,7 @@ context('Placement Requests', () => {
     // When I click on the withdraw button
     showPage.clickWithdraw()
 
-    withdrawPlacementRequestOrApplication(withdrawable, showPage)
+    withdrawPlacementRequestOrApplication(withdrawable, showPage, application.id)
 
     // And the API should have been called with the withdrawal reason
     cy.task('verifyPlacementRequestWithdrawal', withdrawable).then(requests => {

--- a/integration_tests/tests/apply/viewApplication.cy.ts
+++ b/integration_tests/tests/apply/viewApplication.cy.ts
@@ -151,7 +151,7 @@ context('show applications', () => {
     // When I click 'withdraw'
     showPage.clickWithdraw(placementApplications[0].id)
 
-    withdrawPlacementRequestOrApplication(withdrawable, showPage)
+    withdrawPlacementRequestOrApplication(withdrawable, showPage, application.id)
 
     showPage.showsWithdrawalConfirmationMessage()
 

--- a/integration_tests/tests/withdrawals/withdrawals.cy.ts
+++ b/integration_tests/tests/withdrawals/withdrawals.cy.ts
@@ -179,6 +179,29 @@ context('Withdrawals', () => {
 
     it('withdraws a placement request, showing all options for withdrawal reason excluding those relating to lack of capacity', () =>
       withdrawsAPlacementRequest(userRoles))
+
+    it('shows a warning message if there are no withdrawables', () => {
+      const application = applicationSummaryFactory.build()
+
+      cy.task('stubWithdrawables', {
+        applicationId: application.id,
+        withdrawables: [],
+      })
+      cy.task('stubApplications', [application])
+      cy.task('stubApplicationGet', { application })
+
+      // Given I am on the list page
+      const listPage = ListPage.visit([application], [], [])
+
+      // When I click 'Withdraw' on an application
+      listPage.clickWithdraw()
+
+      // Then I am asked what I want to withdraw
+      const newWithdrawalPage = new NewWithdrawalPage('What do you want to withdraw?')
+      newWithdrawalPage.checkForBackButton(paths.applications.index({}))
+
+      newWithdrawalPage.shouldShowNoWithdrawablesGuidance()
+    })
   })
 })
 

--- a/server/controllers/admin/placementRequests/withdrawalsController.ts
+++ b/server/controllers/admin/placementRequests/withdrawalsController.ts
@@ -18,9 +18,12 @@ export default class WithdrawalsController {
 
       const withdrawalReasonsRadioItems = placementApplicationWithdrawalReasons(req.session.user.roles)
 
+      const applicationId = req.flash('applicationId')?.[0] || ''
+
       return res.render('admin/placementRequests/withdrawals/new', {
         pageHeading: 'Why is this request for placement being withdrawn?',
         id: req.params.id,
+        applicationId,
         errors,
         errorSummary,
         withdrawalReasonsRadioItems,

--- a/server/controllers/apply/applications/withdrawalsController.test.ts
+++ b/server/controllers/apply/applications/withdrawalsController.test.ts
@@ -59,7 +59,11 @@ describe('withdrawalsController', () => {
         const requestHandler = withdrawalsController.new()
 
         await requestHandler(
-          { ...request, params: { id: applicationId }, body: { selectedWithdrawableType } },
+          {
+            ...request,
+            params: { id: applicationId },
+            body: { selectedWithdrawableType },
+          },
           response,
           next,
         )
@@ -103,6 +107,7 @@ describe('withdrawalsController', () => {
 
     describe('and no selectedWithdrawableType', () => {
       it('renders the select withdrawable view', async () => {
+        const referer = 'some-referer'
         const errorsAndUserInput = createMock<ErrorsAndUserInput>()
         ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
 
@@ -112,13 +117,14 @@ describe('withdrawalsController', () => {
 
         const requestHandler = withdrawalsController.new()
 
-        await requestHandler({ ...request, params: { id: applicationId } }, response, next)
+        await requestHandler({ ...request, params: { id: applicationId }, headers: { referer } }, response, next)
 
         expect(applicationService.getWithdrawables).toHaveBeenCalledWith(token, applicationId)
         expect(response.render).toHaveBeenCalledWith('applications/withdrawables/new', {
           pageHeading: 'What do you want to withdraw?',
           id: applicationId,
           withdrawables,
+          referer,
         })
       })
     })

--- a/server/controllers/apply/applications/withdrawalsController.ts
+++ b/server/controllers/apply/applications/withdrawalsController.ts
@@ -40,6 +40,7 @@ export default class WithdrawalsController {
           pageHeading: 'What do you want to withdraw?',
           id,
           withdrawables,
+          referer: req.headers.referer,
         })
       }
 

--- a/server/controllers/apply/withdrawablesController.test.ts
+++ b/server/controllers/apply/withdrawablesController.test.ts
@@ -20,6 +20,7 @@ describe('withdrawablesController', () => {
   let request: DeepMocked<Request> = createMock<Request>({ user: { token } })
   let response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = jest.fn()
+  const flash = jest.fn()
 
   const applicationService = createMock<ApplicationService>({})
   const bookingService = createMock<BookingService>({})
@@ -28,7 +29,7 @@ describe('withdrawablesController', () => {
 
   beforeEach(() => {
     withdrawablesController = new WithdrawablesController(applicationService, bookingService)
-    request = createMock<Request>({ user: { token } })
+    request = createMock<Request>({ user: { token }, flash })
     response = createMock<Response>({})
     jest.clearAllMocks()
   })
@@ -139,7 +140,7 @@ describe('withdrawablesController', () => {
           response,
           next,
         )
-
+        expect(request.flash).toHaveBeenCalledWith('applicationId', applicationId)
         expect(applicationService.getWithdrawables).toHaveBeenCalledWith(token, applicationId)
         expect(response.redirect).toHaveBeenCalledWith(302, w.path({ id: selectedWithdrawable }))
       })

--- a/server/controllers/apply/withdrawablesController.ts
+++ b/server/controllers/apply/withdrawablesController.ts
@@ -50,6 +50,7 @@ export default class WithdrawalsController {
         selectedWithdrawable: Withdrawable['id'] | undefined
       }
       const { id } = req.params as { id: Application['id'] | undefined }
+      req.flash('applicationId', id)
 
       const withdrawable = (await this.applicationService.getWithdrawables(req.user.token, id)).find(
         w => w.id === selectedWithdrawable,

--- a/server/controllers/manage/cancellationsController.test.ts
+++ b/server/controllers/manage/cancellationsController.test.ts
@@ -18,7 +18,8 @@ jest.mock('../../utils/validation')
 describe('cancellationsController', () => {
   const token = 'SOME_TOKEN'
   const booking = bookingFactory.build()
-  const backLink = applyPaths.applications.withdrawables.show({ id: booking.applicationId })
+  const backLink = `${applyPaths.applications.withdrawables.show({ id: booking.applicationId })}?selectedWithdrawableType=placement`
+
   const cancellationReasons = referenceDataFactory.buildList(4)
 
   const request: DeepMocked<Request> = createMock<Request>({ user: { token }, headers: { referer: backLink } })
@@ -66,7 +67,7 @@ describe('cancellationsController', () => {
     })
 
     it('renders the form with errors and user input if an error has been sent to the flash', async () => {
-      const errorsAndUserInput = createMock<ErrorsAndUserInput>({ userInput: { backLink: 'http://foo.com' } })
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>({})
 
       ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
 
@@ -79,7 +80,7 @@ describe('cancellationsController', () => {
         premisesId,
         bookingId,
         booking,
-        backLink: 'http://foo.com',
+        backLink,
         cancellationReasons,
         pageHeading: 'Confirm withdrawn placement',
         errors: errorsAndUserInput.errors,

--- a/server/controllers/manage/cancellationsController.ts
+++ b/server/controllers/manage/cancellationsController.ts
@@ -26,7 +26,7 @@ export default class CancellationsController {
       let backLink: string
 
       if (booking?.applicationId) {
-        backLink = applyPaths.applications.withdrawables.show({ id: booking.applicationId })
+        backLink = `${applyPaths.applications.withdrawables.show({ id: booking.applicationId })}?selectedWithdrawableType=placement`
       } else {
         backLink = paths.bookings.show({ premisesId, bookingId })
       }

--- a/server/utils/applications/applicationIdentityBar.test.ts
+++ b/server/utils/applications/applicationIdentityBar.test.ts
@@ -41,49 +41,18 @@ describe('applicationIdentityBar', () => {
   describe('applicationMenuItems', () => {
     const userId = 'some-id'
 
-    describe('if the user created the application', () => {
-      it('should return the option to withdraw an application', () => {
-        const application = applicationFactory.build({ createdByUserId: userId })
-        expect(applicationMenuItems(application, fromPartial({ roles: ['applicant'], id: userId }))).toEqual([
-          {
-            text: 'Withdraw application or placement request',
-            href: paths.applications.withdraw.new({ id: application.id }),
-            classes: 'govuk-button--secondary',
-            attributes: {
-              'data-cy-withdraw-application': application.id,
-            },
+    it('should return the option to withdraw an application', () => {
+      const application = applicationFactory.build({ createdByUserId: userId })
+      expect(applicationMenuItems(application, fromPartial({ roles: ['applicant'], id: userId }))).toEqual([
+        {
+          text: 'Withdraw application or placement request',
+          href: paths.applications.withdraw.new({ id: application.id }),
+          classes: 'govuk-button--secondary',
+          attributes: {
+            'data-cy-withdraw-application': application.id,
           },
-        ])
-      })
-    })
-
-    describe('if the user did not create the application', () => {
-      describe("and is not a 'workflow_manager'", () => {
-        it('should return an empty array', () => {
-          const userAId = 'user-a-id'
-          const userBId = 'user-b-id'
-          const application = applicationFactory.build({ createdByUserId: userAId })
-          expect(applicationMenuItems(application, fromPartial({ roles: ['applicant'], id: userBId }))).toEqual([])
-        })
-      })
-
-      describe("and is a 'workflow_manager'", () => {
-        it('should return the Withdraw menu item', () => {
-          const userAId = 'user-a-id'
-          const userBId = 'user-b-id'
-          const application = applicationFactory.build({ createdByUserId: userAId })
-          expect(applicationMenuItems(application, fromPartial({ roles: ['workflow_manager'], id: userBId }))).toEqual([
-            {
-              text: 'Withdraw application or placement request',
-              href: paths.applications.withdraw.new({ id: application.id }),
-              classes: 'govuk-button--secondary',
-              attributes: {
-                'data-cy-withdraw-application': application.id,
-              },
-            },
-          ])
-        })
-      })
+        },
+      ])
     })
 
     describe('if the application is withdrawn', () => {

--- a/server/utils/applications/applicationIdentityBar.ts
+++ b/server/utils/applications/applicationIdentityBar.ts
@@ -23,17 +23,15 @@ export const applicationTitle = (application: Application, pageHeading: string):
 export const applicationMenuItems = (application: Application, user: UserDetails): Array<IdentityBarMenuItem> => {
   const items: Array<IdentityBarMenuItem> = []
 
-  if (application.createdByUserId === user.id || user.roles.includes('workflow_manager')) {
-    if (application.status !== 'withdrawn') {
-      items.push({
-        text: 'Withdraw application or placement request',
-        href: paths.applications.withdraw.new({ id: application.id }),
-        classes: 'govuk-button--secondary',
-        attributes: {
-          'data-cy-withdraw-application': application.id,
-        },
-      })
-    }
+  if (application.status !== 'withdrawn') {
+    items.push({
+      text: 'Withdraw application or placement request',
+      href: paths.applications.withdraw.new({ id: application.id }),
+      classes: 'govuk-button--secondary',
+      attributes: {
+        'data-cy-withdraw-application': application.id,
+      },
+    })
   }
 
   if (user.roles.includes('appeals_manager') && application.status === 'rejected') {

--- a/server/utils/applications/withdrawables/index.test.ts
+++ b/server/utils/applications/withdrawables/index.test.ts
@@ -11,7 +11,7 @@ describe('withdrawableTypeRadioOptions', () => {
     value: 'application',
     checked: false,
     hint: {
-      text: hintCopy.application,
+      html: hintCopy.application,
     },
   }
 
@@ -26,10 +26,10 @@ describe('withdrawableTypeRadioOptions', () => {
 
   const placementRadioItem = {
     checked: false,
-    text: 'Placement',
+    text: 'Placement/Booking',
     value: 'placement',
     hint: {
-      text: hintCopy.placement,
+      html: hintCopy.placement,
     },
   }
 

--- a/server/utils/applications/withdrawables/index.ts
+++ b/server/utils/applications/withdrawables/index.ts
@@ -10,19 +10,27 @@ export { sortAndFilterWithdrawables } from './sortAndFilterWithdrawables'
 export type SelectedWithdrawableType = 'application' | 'placementRequest' | 'placement'
 
 export const hintCopy: Record<SelectedWithdrawableType, string> = {
-  application: `This will withdraw the application, the suitability assessment, any requests for placement, any matching tasks, and any placements assigned to an AP. You should only withdraw an application if your application is incorrect through circumstantial changes or error.If you choose this option you will have to make another application should you need this person to stay in an AP. This cannot be undone.`,
-  placement: `This will cancel a placement booked into a specific AP but will retain the request for placement so that the Applicant can be matched to another AP. 
-  This will mean the Applicant no longer has a space in this AP, but the request for placement will be reopened for matching into a AP space for the dates provided in the application or request for placement. If you want to request a placement for new/different dates, you should withdraw the placement request and make a new placement request. 
-  There is no guarantee that a further placement will be available.`,
-  placementRequest: `<p class="govuk-hint">This will withdraw the following Request for Placement tasks:</p>
-  <ul class="govuk-hint"><li>A match request made after an application where the date is known</li>
-  <li>A request for placement mini assessment</li>
-  <li>A match request made after a request for placement has been approved</li></ul>
-  <p class="govuk-hint">It will also remove any placements to an AP that are attached to these Request for Placements. 
-  This option should be selected if the applicant is no longer requiring an AP placement on the dates recorded but still needs an AP placement now or in the future. 
-  This will cancel the selected placement and allow you to request a new placement.</p>`,
+  application: `<p class="govuk-hint">You should only withdraw an application if your application is incorrect through significant changes in circumstances, an error in the application or duplication.</p>
+                <p class="govuk-hint">Choose this option if you want to withdraw:</p>
+                <ul class="govuk-hint">
+                  <li>The application AND</li>
+                  <li>The suitability assessment AND</li>
+                  <li>All requests for placement made that are linked to this application AND</li>
+                  <li>All AP placements that have already been made that are linked to this application AND</li>
+                </ul>
+                <p class="govuk-hint">
+                  If you choose this option you will have to make another application should you need this
+                  person to stay in an AP. <strong>This cannot be undone.</strong>
+                </p>`,
+  placement: `<p class="govuk-hint">This will cancel a placement booked into a specific AP and return the request for placement to the CRU to enable the person to be matched to an alternative placement</p>
+  <p class="govuk-hint">There is no guarantee that a further placement will be available</p>`,
+  placementRequest: `<p class="govuk-hint">Choose this option if you want to withdraw:</p>
+  <ul class="govuk-hint">
+    <li>A placement that has been requested and not yet booked or placements that have been booked AND</li>
+    <li>You want to retain the application and suitability assessment so that you can make further requests for placement without completing a new application</li>
+  </ul>
+  <p class="govuk-hint">If you choose this option you will be able to complete a request for placement without needing to make another application should you need this person to stay in an AP</p>`,
 }
-
 export const withdrawableTypeRadioOptions = (
   withdrawables: Array<Withdrawable>,
   selectedItem?: SelectedWithdrawableType,
@@ -35,7 +43,7 @@ export const withdrawableTypeRadioOptions = (
       value: 'application',
       checked: selectedItem === 'application',
       hint: {
-        text: hintCopy.application,
+        html: hintCopy.application,
       },
     })
   }
@@ -50,11 +58,11 @@ export const withdrawableTypeRadioOptions = (
 
   if (withdrawables.find(w => w.type === 'booking')) {
     radioItems.push({
-      text: 'Placement',
+      text: 'Placement/Booking',
       value: 'placement',
       checked: selectedItem === 'placement',
       hint: {
-        text: hintCopy.placement,
+        html: hintCopy.placement,
       },
     })
   }

--- a/server/views/admin/placementRequests/withdrawals/new.njk
+++ b/server/views/admin/placementRequests/withdrawals/new.njk
@@ -9,10 +9,14 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
-  {{ govukBackLink({
-		text: "Back",
-		href: paths.admin.placementRequests.show({ id: id })
-	}) }}
+
+  {% if applicationId %}
+    {{ govukBackLink({
+      text: "Back",
+      href: paths.applications.withdraw.new({id: applicationId }) + '?selectedWithdrawableType=placementRequest'
+    }) }}
+  {% endif %}
+
 {% endblock %}
 
 {% block content %}

--- a/server/views/applications/withdrawables/new.njk
+++ b/server/views/applications/withdrawables/new.njk
@@ -8,8 +8,14 @@
 {% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body" %}
 
-{% block content %}
+{% block beforeContent %}
+    {{ govukBackLink({
+		text: "Back",
+		href: referer
+	}) }}
+{% endblock %}
 
+{% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             {% if withdrawables.length %}

--- a/server/views/applications/withdrawables/new.njk
+++ b/server/views/applications/withdrawables/new.njk
@@ -1,5 +1,7 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -10,12 +12,14 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
+            {% if withdrawables.length %}
 
-            <form action={{paths.applications.withdraw.new({id: id})}} method="post"/>
-            <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+                <form action={{paths.applications.withdraw.new({id: id})}} method="post"/>
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-            {{ govukRadios({
+                {{ govukRadios({
                     name: "selectedWithdrawableType",
+                    hint: {text: "If you can't see the application, request for placement or placement you need to withdraw, contact the CRU"},
                     fieldset: {
                         legend: {
                             text: pageHeading,
@@ -26,9 +30,18 @@
                     items: ApplyUtils.withdrawableTypeRadioOptions(withdrawables, selectedWithdrawable)
                 }) }}
 
-            {{ govukButton({
+                {{ govukButton({
                     "text": "Continue"
                 }) }}
+
+            {% else %}
+                <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+                {{ govukWarningText({
+                    text: "You are not able to withdraw the application or any associated requests for placement or placements. If you need to make a withdrawal relating to this application, contact the CRU."
+                }) }}
+
+            {% endif %}
         </form>
 
     </div>

--- a/server/views/placement-applications/withdraw/new.njk
+++ b/server/views/placement-applications/withdraw/new.njk
@@ -8,6 +8,13 @@
 {% set pageTitle = applicationName + " - " + pageHeading  %}
 {% set mainClasses = "app-container govuk-body" %}
 
+{% block beforeContent %}
+    {{ govukBackLink({
+      text: "Back",
+      href: paths.applications.withdraw.new({id: applicationId }) + '?selectedWithdrawableType=placementRequest'
+    }) }}
+{% endblock %}
+
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
# Context
[JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?selectedIssue=APS-481)
[JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&selectedIssue=APS-489) 

Changes to Withdrawals journey from demo feedback

# Changes in this PR
- Show the 'withdraw' button on all non-withdrawn applications to all users
- Add messaging to show when the user cannot withdraw anything
- Add and update back buttons to all pages in journey
- Copy updates 

## Screenshots of UI changes

### Before
![withdraw-placement (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/0cfbd1b3-ba28-43a6-9a63-190efb33d69f)

### After
![withdraw-placement (5)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/66bad605-8a3e-4cc8-a682-62be59ee074c)


### New screen

![no-withdrawables (10)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/cd92f623-781b-4454-806a-68a9dd57868f)
