### PR TITLE
APS 482 - Update booking withdrawal reasons

### DIFF
--- a/integration_tests/pages/manage/cancellationCreate.ts
+++ b/integration_tests/pages/manage/cancellationCreate.ts
@@ -1,7 +1,8 @@
-import type { Cancellation } from '@approved-premises/api'
+import type { NewCancellation } from '@approved-premises/api'
 import Page from '../page'
 import paths from '../../../server/paths/manage'
 import applyPaths from '../../../server/paths/apply'
+import { otherCancellationReasonId } from '../../../server/testutils/factories/newCancellation'
 
 export default class CancellationCreatePage extends Page {
   constructor(
@@ -17,9 +18,13 @@ export default class CancellationCreatePage extends Page {
     return new CancellationCreatePage(premisesId, bookingId)
   }
 
-  completeForm(cancellation: Cancellation): void {
+  completeForm(cancellation: NewCancellation): void {
     this.getLegend('Why is this placement being withdrawn?')
-    this.checkRadioByNameAndValue('cancellation[reason]', cancellation.reason.id)
+    this.checkRadioByNameAndValue('cancellation[reason]', cancellation.reason)
+
+    if (cancellation.reason === otherCancellationReasonId && cancellation.otherReason) {
+      this.completeTextArea('cancellation[otherReason]', cancellation.otherReason)
+    }
 
     this.clickSubmit()
   }

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -6,7 +6,7 @@ import {
   apAreaFactory,
   applicationFactory,
   bookingFactory,
-  cancellationFactory,
+  newCancellationFactory,
   placementRequestDetailFactory,
   placementRequestWithFullPersonFactory,
   premisesFactory,
@@ -255,7 +255,7 @@ context('Placement Requests', () => {
 
   it('allows me to cancel a booking', () => {
     const premises = premisesFactory.buildList(3)
-    const cancellation = cancellationFactory.build()
+    const cancellation = newCancellationFactory.build()
     const withdrawable = withdrawableFactory.build({ id: matchedPlacementRequest.booking.id, type: 'booking' })
     cy.task('stubAllPremises', premises)
     cy.task('stubBookingFromPlacementRequest', matchedPlacementRequest)
@@ -318,7 +318,7 @@ context('Placement Requests', () => {
       expect(requests).to.have.length(1)
       const requestBody = JSON.parse(requests[0].body)
 
-      expect(requestBody.reason).equal(cancellation.reason.id)
+      expect(requestBody.reason).equal(cancellation.reason)
     })
   })
 

--- a/server/testutils/factories/newCancellation.ts
+++ b/server/testutils/factories/newCancellation.ts
@@ -4,8 +4,17 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 import type { NewCancellation } from '@approved-premises/api'
 import referenceDataFactory from './referenceData'
 import { DateFormats } from '../../utils/dateUtils'
+import cancellationReasonsJson from '../referenceData/stubs/cancellation-reasons.json'
 
-export default Factory.define<NewCancellation>(() => {
+export const otherCancellationReasonId = cancellationReasonsJson.find(r => r.name === 'Other').id
+
+class NewCancellationFactory extends Factory<NewCancellation> {
+  withOtherReason() {
+    return this.params({ reason: otherCancellationReasonId })
+  }
+}
+
+export default NewCancellationFactory.define(() => {
   const date = faker.date.soon()
   return {
     id: faker.string.uuid(),

--- a/server/testutils/referenceData/stubs/cancellation-reasons.json
+++ b/server/testutils/referenceData/stubs/cancellation-reasons.json
@@ -18,5 +18,10 @@
     "id": "7f3eb6cd-b3fc-4a8d-b9ce-5959918ffbe8",
     "name": "Non-arrival",
     "isActive": true
+  },
+  {
+    "id": "73bbf24c-4274-4e9a-aeed-f8446fe581d7",
+    "name": "Other",
+    "isActive": true
   }
 ]

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -11,6 +11,7 @@ import {
   bookingStatus,
   bookingSummaryList,
   bookingsToTableRows,
+  cancellationReasonsRadioItems,
   cancellationRows,
   departingTodayOrLate,
   generateConflictBespokeError,
@@ -754,6 +755,39 @@ describe('bookingUtils', () => {
           value: {
             text: cancellation.reason.name,
           },
+        },
+      ])
+    })
+  })
+
+  describe('cancellationReasonRadioItems', () => {
+    const objects = [
+      {
+        id: '123',
+        name: 'Other',
+      },
+      {
+        id: '345',
+        name: 'foo',
+      },
+    ]
+
+    it('converts objects to an array of radio items', () => {
+      const result = cancellationReasonsRadioItems(objects, 'somehtml', {})
+
+      expect(result).toEqual([
+        {
+          text: 'Other',
+          value: '123',
+          checked: false,
+          conditional: {
+            html: 'somehtml',
+          },
+        },
+        {
+          text: 'foo',
+          value: '345',
+          checked: false,
         },
       ])
     })

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -16,6 +16,7 @@ import { DateFormats, todayAtMidnight } from './dateUtils'
 import { SanitisedError } from '../sanitisedError'
 import { linebreaksToParagraphs, linkTo } from './utils'
 import { isFullPerson, laoName } from './personUtils'
+import { convertObjectsToRadioItems } from './formUtils'
 
 const UPCOMING_WINDOW_IN_DAYS = 365 * 10
 
@@ -489,4 +490,22 @@ export const cancellationRows = (booking: Booking): Array<SummaryListItem> => {
     ]
   }
   return []
+}
+
+export const cancellationReasonsRadioItems = (
+  cancellationReasons: Array<Record<string, string>>,
+  otherHtml: string,
+  context: Record<string, unknown>,
+): Array<SelectOption> => {
+  const items = convertObjectsToRadioItems(cancellationReasons, 'name', 'id', 'cancellation[reason]', context)
+
+  return items.map(item => {
+    if (item.text === 'Other') {
+      item.conditional = {
+        html: otherHtml,
+      }
+    }
+
+    return item
+  })
 }

--- a/server/views/cancellations/new.njk
+++ b/server/views/cancellations/new.njk
@@ -23,6 +23,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+
       <h1>{{pageHeading}}</h1>
 
       <form action="{{ paths.bookings.cancellations.create({ premisesId: premisesId, bookingId: booking.id }) }}" method="post">
@@ -67,6 +68,21 @@
 
         {{ showErrorSummary(errorSummary) }}
 
+        {% set noteConditional %}
+        {{
+          govukTextarea(
+            {
+            name: "cancellation[otherReason]",
+            id: "otherReason",
+            errorMessage: errors.otherReason,
+            label: {
+              text: "Provide more information"
+            }
+            })
+          }}
+
+        {% endset -%}
+
         {{ govukRadios({
           name: "cancellation[reason]",
           id: "reason",
@@ -77,7 +93,7 @@
               }
           },
           errorMessage: errors.reason,
-          items: convertObjectsToRadioItems(cancellationReasons, 'name', 'id', 'cancellation[reason]')
+          items: BookingUtils.cancellationReasonsRadioItems(cancellationReasons, noteConditional, fetchContext())
           }) }}
 
         {{ govukButton({


### PR DESCRIPTION
# Context
[JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&selectedIssue=APS-482)

We need to give users the option to select 'other' and give them a free text input to describe the 'other' reason for Booking cancellations/withdrawals.

# Changes in this PR

- Add a util for displaying the Booking Cancellation/Withdrawal reasons that adds an 'other' reason
- Add the reason to the UI and add the validation

## Screenshots of UI changes

### Before
![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/f60744c6-c353-4261-b642-93572f55148b)

### After
![after](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/2542aaca-6d70-4cd7-a030-78ad9546e35a)

