### PR TITLE
APS-451 - Seperate area from the person details on Confirm Your Details screen

### DIFF
--- a/server/views/applications/pages/basic-information/confirm-your-details.njk
+++ b/server/views/applications/pages/basic-information/confirm-your-details.njk
@@ -13,6 +13,8 @@
     <input type="hidden" name="userDetailsFromDelius[phoneNumber]" value="{{ page.userDetailsFromDelius.phoneNumber }}"/>
     <input type="hidden" name="userDetailsFromDelius[area]" value="{{ page.userDetailsFromDelius.area }}"/>
 
+    <h2 class="govuk-heading-m">Your details</h2>
+
     {% set rows = ([
         {
             key: {
@@ -35,7 +37,18 @@
             value: {
                 text: page.userDetailsFromDelius.phoneNumber
             }
-        }, {
+        }
+    ]) %}
+
+    {{ govukSummaryList({
+      rows: rows
+    }) }}
+
+    <h2 class="govuk-heading-m">Case details</h2>
+
+    {{ govukSummaryList({
+      rows: [
+        {
             key: {
                 text: "Area"
             },
@@ -43,12 +56,8 @@
                 text: page.userDetailsFromDelius.area.name
             }
         }
-    ])
- %}
-
-    {{ govukSummaryList({
-      rows: rows
-    }) }}
+        ]
+    })}}
 
     {% set nameHtml %}
     {{


### PR DESCRIPTION
The area here relates to the case and not the user (if the case manager is different then the area should be the same). We want to make this clearer through the UI so we now show two different Summary lists: one for the case and one for the user

[JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&selectedIssue=APS-451)

## Screenshots of UI changes

### Before
![before](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/15561931-e11d-4357-b289-ff0e4df06593)

### After
![after (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/db499a85-ef1c-496c-b326-2e310fda38cc)
