### PR TITLE
(APS-315) Add created column to application lisitings

### DIFF
--- a/integration_tests/pages/apply/list.ts
+++ b/integration_tests/pages/apply/list.ts
@@ -84,7 +84,14 @@ export default class ListPage extends Page {
                 format: 'short',
               }),
             )
-          cy.get('td').eq(3).contains(status)
+          cy.get('td')
+            .eq(3)
+            .contains(
+              DateFormats.isoDateToUIDate(application.createdAt, {
+                format: 'short',
+              }),
+            )
+          cy.get('td').eq(4).contains(status)
         })
     })
   }

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -214,6 +214,9 @@ describe('utils', () => {
             text: 'N/A',
           },
           {
+            text: DateFormats.isoDateToUIDate(applicationA.createdAt, { format: 'short' }),
+          },
+          {
             html: getStatus(applicationA),
           },
           actionsCell(applicationA),
@@ -232,6 +235,9 @@ describe('utils', () => {
           },
           {
             text: DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' }),
+          },
+          {
+            text: DateFormats.isoDateToUIDate(applicationB.createdAt, { format: 'short' }),
           },
           {
             html: getStatus(applicationB),

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -63,6 +63,7 @@ const applicationTableRows = (applications: Array<ApplicationSummary>): Array<Ta
     textValue(application.person.crn),
     htmlValue(getTierOrBlank(application.risks?.tier?.value?.level)),
     textValue(getArrivalDateorNA(application.arrivalDate)),
+    textValue(DateFormats.isoDateToUIDate(application.createdAt, { format: 'short' })),
     htmlValue(getStatus(application)),
     actionsCell(application),
   ])

--- a/server/views/applications/_table.njk
+++ b/server/views/applications/_table.njk
@@ -21,6 +21,9 @@
               text: "Arrival date"
             },
             {
+              text: "Started"
+            },
+            {
               text: "Status"
             },
             {


### PR DESCRIPTION
This adds a "Created" column to the listing of a user's applications to make it easier to identify which application is which if there are multiple users

## Screenshots

### Before

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/805f2548-744a-419f-bb5d-ffab0e233d4d)

### After

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/0fe4d9c9-9ae0-4a69-bca6-c9c78c3033f3)
