### PR TITLE
(Fix) Preserve filter options between tabs on Task view

### DIFF
--- a/server/utils/tasks/listTable.test.ts
+++ b/server/utils/tasks/listTable.test.ts
@@ -267,7 +267,7 @@ describe('table', () => {
 
   describe('tasksTabItems', () => {
     it('returns tasks tab items when active tab and area not present', () => {
-      expect(tasksTabItems()).toEqual([
+      expect(tasksTabItems('/tasks')).toEqual([
         {
           text: 'Allocated',
           active: true,
@@ -282,7 +282,7 @@ describe('table', () => {
     })
 
     it('returns tasks tab items when active tab and area present', () => {
-      expect(tasksTabItems('allocated', 'areaId')).toEqual([
+      expect(tasksTabItems('/tasks?allocatedFilter=allocated&area=areaId', 'allocated')).toEqual([
         {
           text: 'Allocated',
           active: true,
@@ -297,7 +297,7 @@ describe('table', () => {
     })
 
     it('returns tasks tab items when active tab unallocated and area present', () => {
-      expect(tasksTabItems('unallocated', 'areaId')).toEqual([
+      expect(tasksTabItems('/tasks?allocatedFilter=allocated&area=areaId', 'unallocated')).toEqual([
         {
           text: 'Allocated',
           active: false,
@@ -307,6 +307,36 @@ describe('table', () => {
           text: 'Unallocated',
           active: true,
           href: '/tasks?allocatedFilter=unallocated&area=areaId',
+        },
+      ])
+    })
+
+    it('handles multiple arguments', () => {
+      expect(tasksTabItems('/tasks?allocatedFilter=allocated&area=areaId&foo=bar&abc=123', 'unallocated')).toEqual([
+        {
+          text: 'Allocated',
+          active: false,
+          href: '/tasks?allocatedFilter=allocated&area=areaId&foo=bar&abc=123',
+        },
+        {
+          text: 'Unallocated',
+          active: true,
+          href: '/tasks?allocatedFilter=unallocated&area=areaId&foo=bar&abc=123',
+        },
+      ])
+    })
+
+    it('Removes the allocatedToUserId from the unallocated tab', () => {
+      expect(tasksTabItems('/tasks?allocatedFilter=allocated&allocatedToUserId=123', 'unallocated')).toEqual([
+        {
+          text: 'Allocated',
+          active: false,
+          href: '/tasks?allocatedFilter=allocated&allocatedToUserId=123',
+        },
+        {
+          text: 'Unallocated',
+          active: true,
+          href: '/tasks?allocatedFilter=unallocated',
         },
       ])
     })

--- a/server/utils/tasks/listTable.ts
+++ b/server/utils/tasks/listTable.ts
@@ -152,21 +152,32 @@ export type TabItem = {
   href: string
 }
 
-const tasksTabItems = (activeTab?: string, apArea?: string): Array<TabItem> => {
-  const hrefSuffix = apArea ? `&area=${apArea}` : ''
-  const allocatedHref = `${paths.tasks.index({})}?allocatedFilter=allocated${hrefSuffix}`
-  const unallocatedHref = `${paths.tasks.index({})}?allocatedFilter=unallocated${hrefSuffix}`
+const tasksTabItems = (hrefPrefix: string, activeTab = 'allocated'): Array<TabItem> => {
+  const [path, query] = hrefPrefix.split('?')
+  const urlParams = new URLSearchParams(query)
+
+  const allocatedParams = {
+    ...Object.fromEntries(urlParams),
+    allocatedFilter: 'allocated',
+  } as Record<string, string>
+  const { allocatedToUserId: _, ...unallocatedParams } = {
+    ...Object.fromEntries(urlParams),
+    allocatedFilter: 'unallocated',
+  } as Record<string, string>
+
+  const allocatedTabHref = new URLSearchParams(allocatedParams).toString()
+  const unallocatedTabHref = new URLSearchParams(unallocatedParams).toString()
 
   return [
     {
       text: 'Allocated',
-      active: activeTab === 'allocated' || activeTab === undefined || activeTab?.length === 0,
-      href: allocatedHref,
+      active: activeTab === 'allocated',
+      href: `${path}?${allocatedTabHref}`,
     },
     {
       text: 'Unallocated',
       active: activeTab === 'unallocated',
-      href: unallocatedHref,
+      href: `${path}?${unallocatedTabHref}`,
     },
   ]
 }

--- a/server/views/tasks/_navigation.njk
+++ b/server/views/tasks/_navigation.njk
@@ -1,10 +1,10 @@
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 
-{% macro navigation(activeTab, apArea) %}
+{% macro navigation(activeTab, hrefPrefix) %}
   {{
     mojSubNavigation({
       label: 'Sub navigation',
-      items: TaskUtils.tasksTabItems(activeTab, apArea)
+      items: TaskUtils.tasksTabItems(hrefPrefix, activeTab)
     })
   }}
 {% endmacro %}

--- a/server/views/tasks/index.njk
+++ b/server/views/tasks/index.njk
@@ -19,7 +19,7 @@
       {% include "../_messages.njk" %}
       {% include "./_filters.njk" %}
 
-      {{ navigation(allocatedFilter, apArea) }}
+      {{ navigation(allocatedFilter, hrefPrefix) }}
 
       {{
         govukTable({


### PR DESCRIPTION
The new filter options on the task view were not being preserved when clicking on the Allocated / Unallocated tabs, which was already happening for the `apArea`

This PR makes the `tasksTabItems` generic to handle all query strings using the `hrefPrefix`, which we already use for pagination. 

As it doesn't make sense to filter unallocated tasks by who a task has been allocated, we strip that query option out.