### PR TITLE
APS-378: use notification bar instead of using inset html as per the …

### DIFF
--- a/server/views/applications/pages/oasys-import/_oasys-screen.njk
+++ b/server/views/applications/pages/oasys-import/_oasys-screen.njk
@@ -1,10 +1,10 @@
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% from "../../../components/riskWidgets/macro.njk" import widgets %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% extends "../layout.njk" %}
 
 {% set columnClasses = "govuk-grid-column-full" %}
-{% set InsetHtml %}
+{% set html %}
 <p>This information has been imported from OASys. You must:</p>
 <ul>
   <li>Remove any out of date information or information that is not relevant to this application.</li>
@@ -29,9 +29,11 @@
   <div class="govuk-grid-row">
     {% if oasysDisabled %}
       <div class="govuk-grid-column-full" id="{{ pageName }}">
-        {{ govukInsetText({
-            html: InsetHtml
-          }) }}
+        {{ govukNotificationBanner({
+            titleText: 'Important',
+            html: html,
+            titleId: 'info-title'
+        }) }}
         <p>
           {{ guidance }}
         </p>
@@ -39,9 +41,11 @@
       </div>
     {% else %}
       <div class="govuk-grid-column-two-thirds" id="{{ pageName }}">
-        {{ govukInsetText({
-            html: InsetHtml
-          }) }}
+        {{ govukNotificationBanner({
+            titleText: 'Important',
+            html: html,
+            titleId: 'info-title'
+        }) }}
         {% if page.oasysSuccess == true %}
           <h2 class="govuk-heading-m">
             {{ heading }}


### PR DESCRIPTION
…user request

# Context

<!-- https://dsdmoj.atlassian.net/browse/APS-378 -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
use notification bar instead of using inset html as per the user request
## Screenshots of UI changes

### Before
<img width="1728" alt="Screenshot 2024-03-15 at 09 11 38" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/5c2ff26f-9ea7-455d-abbf-17753c3ee066">

### After
<img width="1728" alt="Screenshot 2024-03-15 at 10 32 21" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/7a129d57-d6d5-42bd-95d4-2ff0fe59200a">
