### PR TITLE
Don't show withdrawals link for rejected or withdrawn applications

### DIFF
--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -1,4 +1,8 @@
-import { ApplicationSortField, TimelineEventUrlType } from '@approved-premises/api'
+import {
+  ApplicationSortField,
+  ApprovedPremisesApplicationStatus as ApplicationStatus,
+  TimelineEventUrlType,
+} from '@approved-premises/api'
 import { isAfter } from 'date-fns'
 import { faker } from '@faker-js/faker'
 import { mockOptionalQuestionResponse } from '../../testutils/mockQuestionResponse'
@@ -716,6 +720,17 @@ describe('utils', () => {
         html: '<ul class="govuk-list"><li><a href="/applications/an-application-id/withdrawals/new"  >Withdraw</a></li><li><a href="/placement-applications?id=an-application-id"  >Request for placement</a></li></ul>',
       })
     })
+
+    it.each(['rejected', 'withdrawn'])(
+      'does not return a link to withdraw the application if the status is %s',
+      (status: ApplicationStatus) => {
+        const application = applicationFactory.build({ id: 'an-application-id', status })
+
+        expect(actionsCell(application)).toEqual({
+          html: '',
+        })
+      },
+    )
   })
 
   describe('mapTimelineEventsForUi', () => {

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -152,8 +152,13 @@ const createNameAnchorElement = (
 
 export const actionsCell = (application: ApplicationSummary | Application) => {
   const actionItems: Array<string> = []
-  const withdrawLink = linkTo(paths.applications.withdraw.new, { id: application.id }, { text: 'Withdraw' })
-  actionItems.push(withdrawLink)
+
+  if (application.status !== 'rejected' && application.status !== 'withdrawn') {
+    const withdrawLink = linkTo(paths.applications.withdraw.new, { id: application.id }, { text: 'Withdraw' })
+
+    actionItems.push(withdrawLink)
+  }
+
   if (application.status === 'awaitingPlacement') {
     const requestForPlacementLink = linkTo(
       placementApplicationPaths.placementApplications.create,
@@ -162,7 +167,9 @@ export const actionsCell = (application: ApplicationSummary | Application) => {
     )
     actionItems.push(requestForPlacementLink)
   }
-  const actionLinks = `<ul class="govuk-list">${actionItems.map(actionItem => `<li>${actionItem}</li>`).join('')}</ul>`
+  const actionLinks = actionItems.length
+    ? `<ul class="govuk-list">${actionItems.map(actionItem => `<li>${actionItem}</li>`).join('')}</ul>`
+    : ''
 
   return htmlValue(actionLinks)
 }


### PR DESCRIPTION
The user can't withdraw a rejected or withdrawn application so it doesn't make sense to allow them to enter the flow
