### PR TITLE
(APS-511) Ask timeliness question for all applications made less than 6 months before arrival date

### DIFF
--- a/integration_tests/helpers/index.ts
+++ b/integration_tests/helpers/index.ts
@@ -78,7 +78,7 @@ const shouldShowTableRows = (tableRows: Array<TableRow>): void => {
 }
 
 const updateApplicationReleaseDate = (data: AnyValue) => {
-  const releaseDate = add(new Date(), { months: 6 })
+  const releaseDate = add(new Date(), { months: 7 })
 
   return {
     ...data,

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -289,7 +289,7 @@ context('Apply', () => {
     const person = personFactory.build({ status: 'InCommunity' })
 
     // A 'regular' placement date (not emergency or short notice)
-    const placementDate = addMonths(new Date(), 6)
+    const placementDate = addMonths(new Date(), 7)
     // A release date in the past
     const releaseDate = subDays(new Date(), 1)
     this.application = addResponsesToFormArtifact(this.application, {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
@@ -13,9 +13,9 @@ import {
   isToday,
 } from '../../../../utils/dateUtils'
 import { Page } from '../../../utils/decorators'
-import { noticeTypeFromApplication } from '../../../../utils/applications/noticeTypeFromApplication'
 import ReleaseDate from './releaseDate'
 import { dateBodyProperties } from '../../../utils/dateBodyProperties'
+import { startDateOutsideOfNationalStandardsTimescales } from '../../../../utils/applications/startDateOutsideOfNationalStandardsTimescales'
 
 type PlacementDateBody = ObjectWithDateParts<'startDate'> & {
   startDateSameAsReleaseDate: YesOrNo
@@ -87,11 +87,11 @@ export default class PlacementDate implements TasklistPage {
   }
 
   next() {
-    if (this.getNoticeType() === 'standard') {
-      return 'placement-purpose'
+    if (this.isOutsideOfNationalStandardsTimescales()) {
+      return 'reason-for-short-notice'
     }
 
-    return 'reason-for-short-notice'
+    return 'placement-purpose'
   }
 
   previous() {
@@ -134,8 +134,8 @@ export default class PlacementDate implements TasklistPage {
     return errors
   }
 
-  private getNoticeType() {
-    return noticeTypeFromApplication({
+  private isOutsideOfNationalStandardsTimescales() {
+    return startDateOutsideOfNationalStandardsTimescales({
       ...this.application,
       data: {
         'basic-information': {

--- a/server/utils/applications/startDateOutsideOfNationalStandardsTimescales.test.ts
+++ b/server/utils/applications/startDateOutsideOfNationalStandardsTimescales.test.ts
@@ -1,0 +1,47 @@
+import { when } from 'jest-when'
+import { createMock } from '@golevelup/ts-jest'
+import { addDays, addMonths } from 'date-fns'
+import { arrivalDateFromApplication } from './arrivalDateFromApplication'
+import { DateFormats } from '../dateUtils'
+import { ApprovedPremisesApplication } from '../../@types/shared'
+import { startDateOutsideOfNationalStandardsTimescales } from './startDateOutsideOfNationalStandardsTimescales'
+
+jest.mock('./arrivalDateFromApplication')
+jest.mock('../dateUtils')
+
+describe('startDateOutsideOfNationalStandardsTimescales', () => {
+  const application = createMock<ApprovedPremisesApplication>()
+  const now = new Date()
+
+  beforeAll(() => {
+    when(arrivalDateFromApplication).calledWith(application).mockReturnValue(application.arrivalDate)
+  })
+
+  it('should return true if the start date is less than six months away', () => {
+    const startDate = addMonths(now, 2)
+    when(DateFormats.isoToDateObj).calledWith(application.arrivalDate).mockReturnValue(startDate)
+
+    expect(startDateOutsideOfNationalStandardsTimescales(application)).toEqual(true)
+  })
+
+  it('should return true with fractional dates', () => {
+    const startDate = addDays(addMonths(now, 5), 22)
+    when(DateFormats.isoToDateObj).calledWith(application.arrivalDate).mockReturnValue(startDate)
+
+    expect(startDateOutsideOfNationalStandardsTimescales(application)).toEqual(true)
+  })
+
+  it('should return false if the start date is more than six months away', () => {
+    const startDate = addMonths(now, 7)
+    when(DateFormats.isoToDateObj).calledWith(application.arrivalDate).mockReturnValue(startDate)
+
+    expect(startDateOutsideOfNationalStandardsTimescales(application)).toEqual(false)
+  })
+
+  it('should return false with fractional dates', () => {
+    const startDate = addDays(addMonths(now, 6), 3)
+    when(DateFormats.isoToDateObj).calledWith(application.arrivalDate).mockReturnValue(startDate)
+
+    expect(startDateOutsideOfNationalStandardsTimescales(application)).toEqual(false)
+  })
+})

--- a/server/utils/applications/startDateOutsideOfNationalStandardsTimescales.ts
+++ b/server/utils/applications/startDateOutsideOfNationalStandardsTimescales.ts
@@ -1,0 +1,11 @@
+import { subMonths } from 'date-fns'
+import { ApprovedPremisesApplication } from '../../@types/shared'
+import { DateFormats } from '../dateUtils'
+import { arrivalDateFromApplication } from './arrivalDateFromApplication'
+
+export const startDateOutsideOfNationalStandardsTimescales = (application: ApprovedPremisesApplication) => {
+  const arrivalDate = DateFormats.isoToDateObj(arrivalDateFromApplication(application))
+  const today = new Date()
+
+  return subMonths(arrivalDate, 6) < today
+}

--- a/server/utils/assessments/suitabilityAssessmentAdjacentPage.ts
+++ b/server/utils/assessments/suitabilityAssessmentAdjacentPage.ts
@@ -1,14 +1,14 @@
 import { ApprovedPremisesAssessment as Assessment } from '../../@types/shared'
 import SelectApType from '../../form-pages/apply/reasons-for-placement/type-of-ap/apType'
 import Rfap from '../../form-pages/apply/risk-and-need-factors/further-considerations/rfap'
-import { noticeTypeFromApplication } from '../applications/noticeTypeFromApplication'
 import {
   shouldShowContingencyPlanPartnersPages,
   shouldShowContingencyPlanQuestionsPage,
 } from '../applications/shouldShowContingencyPlanPages'
+import { startDateOutsideOfNationalStandardsTimescales } from '../applications/startDateOutsideOfNationalStandardsTimescales'
 import { retrieveOptionalQuestionResponseFromFormArtifact as responseFromAssessment } from '../retrieveQuestionResponseFromFormArtifact'
 
-const suitabilityAssessmentPageNames = [
+export const suitabilityAssessmentPageNames = [
   'suitability-assessment',
   'rfap-suitability',
   'esap-suitability',
@@ -17,7 +17,7 @@ const suitabilityAssessmentPageNames = [
   'contingency-plan-suitability',
 ] as const
 
-type SuitabilityAssessmentPageName = (typeof suitabilityAssessmentPageNames)[number]
+export type SuitabilityAssessmentPageName = (typeof suitabilityAssessmentPageNames)[number]
 
 export const suitabilityAssessmentAdjacentPage = (
   assessment: Assessment,
@@ -42,9 +42,7 @@ export const suitabilityAssessmentAdjacentPage = (
     },
     {
       pageName: 'application-timeliness',
-      needsAssessment:
-        noticeTypeFromApplication(assessment.application) === 'short_notice' ||
-        noticeTypeFromApplication(assessment.application) === 'emergency',
+      needsAssessment: startDateOutsideOfNationalStandardsTimescales(assessment.application),
     },
     {
       pageName: 'contingency-plan-suitability',


### PR DESCRIPTION
This adds a new `startDateOutsideOfNationalStandardsTimescales` helper which is separate from the `noticeTypeFromApplication` helper. Now if an application is made outside the six month timescale, but not short notice / emergency, the applicant should be prompted to justify the reason, and the assessor should be able to state if they agree with the justification