### PR TITLE
(APS-514) Set notice type on update/submit

### DIFF
--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -61,6 +61,7 @@ context('Apply', () => {
         'applicantUserDetails',
         'caseManagerIsNotApplicant',
         'caseManagerUserDetails',
+        'noticeType',
       )
       expect(body.data).to.deep.equal(this.applicationData)
 
@@ -91,6 +92,7 @@ context('Apply', () => {
         'applicantUserDetails',
         'caseManagerIsNotApplicant',
         'caseManagerUserDetails',
+        'noticeType',
       )
     })
 
@@ -344,6 +346,7 @@ context('Apply', () => {
         'applicantUserDetails',
         'caseManagerIsNotApplicant',
         'caseManagerUserDetails',
+        'noticeType',
       )
 
       expect(body.data).to.deep.equal(this.applicationData)
@@ -375,6 +378,7 @@ context('Apply', () => {
         'applicantUserDetails',
         'caseManagerIsNotApplicant',
         'caseManagerUserDetails',
+        'noticeType',
       )
     })
   })

--- a/integration_tests/tests/apply/invalidations.cy.ts
+++ b/integration_tests/tests/apply/invalidations.cy.ts
@@ -53,6 +53,7 @@ context('Apply', () => {
         'applicantUserDetails',
         'caseManagerIsNotApplicant',
         'caseManagerUserDetails',
+        'noticeType',
       )
       expect(body.data).not.to.have.keys(['check-your-answers'])
     })
@@ -95,6 +96,7 @@ context('Apply', () => {
         'applicantUserDetails',
         'caseManagerIsNotApplicant',
         'caseManagerUserDetails',
+        'noticeType',
       )
       expect(body.data).to.have.any.keys(['check-your-answers'])
     })

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementPurpose.test.ts
@@ -95,9 +95,9 @@ describe('PlacementPurpose', () => {
     itShouldHavePreviousValue(new PlacementPurpose({}, application), 'reason-for-short-notice')
   })
 
-  describe('when the notice type is short_notice', () => {
+  describe('when the notice type is shortNotice', () => {
     beforeEach(() => {
-      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('short_notice')
+      ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('shortNotice')
     })
 
     itShouldHavePreviousValue(new PlacementPurpose({}, application), 'reason-for-short-notice')

--- a/server/form-pages/apply/reasons-for-placement/basic-information/reasonForShortNotice.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/reasonForShortNotice.test.ts
@@ -21,7 +21,7 @@ describe('ReasonForShortNotice', () => {
   })
 
   it('should return the correct title and question for short notice applications', () => {
-    ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('short_notice')
+    ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('shortNotice')
     const page = new ReasonForShortNotice({}, application)
 
     expect(page.title).toEqual('Short notice application')

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
@@ -102,7 +102,7 @@ describe('SuitabilityAssessment', () => {
       ).toEqual('esap-suitability')
     })
 
-    it('returns application-timeliness if the notice type is short_notice', () => {
+    it('returns application-timeliness if the notice type is shortNotice', () => {
       ;(suitabilityAssessmentAdjacentPage as jest.MockedFn<typeof suitabilityAssessmentAdjacentPage>).mockReturnValue(
         'application-timeliness',
       )

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -61,6 +61,7 @@ describe('getApplicationData', () => {
         applicantUserDetails,
         caseManagerUserDetails: undefined,
         caseManagerIsNotApplicant: false,
+        noticeType: 'emergency',
       })
     })
 
@@ -90,6 +91,7 @@ describe('getApplicationData', () => {
         applicantUserDetails,
         caseManagerIsNotApplicant: false,
         caseManagerUserDetails: undefined,
+        noticeType: 'emergency',
       })
     })
 
@@ -119,6 +121,7 @@ describe('getApplicationData', () => {
         applicantUserDetails,
         caseManagerIsNotApplicant: false,
         caseManagerUserDetails: undefined,
+        noticeType: 'emergency',
       })
     })
 
@@ -149,6 +152,7 @@ describe('getApplicationData', () => {
         applicantUserDetails,
         caseManagerIsNotApplicant: false,
         caseManagerUserDetails: undefined,
+        noticeType: 'emergency',
       })
     })
 
@@ -179,6 +183,7 @@ describe('getApplicationData', () => {
         applicantUserDetails,
         caseManagerIsNotApplicant: false,
         caseManagerUserDetails: undefined,
+        noticeType: 'emergency',
       })
     })
 
@@ -208,6 +213,7 @@ describe('getApplicationData', () => {
         applicantUserDetails,
         caseManagerIsNotApplicant: false,
         caseManagerUserDetails: undefined,
+        noticeType: 'emergency',
       })
     })
   })
@@ -236,6 +242,7 @@ describe('getApplicationData', () => {
         caseManagerIsNotApplicant: undefined,
         applicantUserDetails: undefined,
         caseManagerUserDetails: undefined,
+        noticeType: 'standard',
       })
     })
 
@@ -271,6 +278,7 @@ describe('getApplicationData', () => {
         caseManagerIsNotApplicant: true,
         applicantUserDetails,
         caseManagerUserDetails,
+        noticeType: 'emergency',
       })
     })
 

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -50,6 +50,7 @@ const firstClassFields = <T>(
   application: Application,
   retrieveQuestionResponse: QuestionResponseFunction,
 ): FirstClassFields<T> => {
+  const noticeType = noticeTypeFromApplication(application)
   const apType = retrieveQuestionResponse(application, SelectApType, 'type') as ApType
   const targetLocation = retrieveQuestionResponse(application, DescribeLocationFactors, 'postcodeArea')
   const sentenceType = getSentenceType(application, retrieveQuestionResponse)
@@ -57,7 +58,7 @@ const firstClassFields = <T>(
   const situation =
     releaseType === 'in_community' ? retrieveQuestionResponse(application, Situation, 'situation') : null
   const arrivalDate = arrivalDateFromApplication(application)
-  const isEmergencyApplication = noticeTypeFromApplication(application) === 'emergency'
+  const isEmergencyApplication = noticeType === 'emergency'
   const apAreaId = retrieveQuestionResponse(application, ConfirmYourDetails, 'area')
   const { applicantUserDetails, caseManagerUserDetails, caseManagerIsNotApplicant } =
     applicantAndCaseManagerDetails(application)
@@ -76,6 +77,7 @@ const firstClassFields = <T>(
     applicantUserDetails,
     caseManagerUserDetails,
     caseManagerIsNotApplicant,
+    noticeType,
   } as FirstClassFields<T>
 }
 

--- a/server/utils/applications/noticeTypeFromApplication.test.ts
+++ b/server/utils/applications/noticeTypeFromApplication.test.ts
@@ -20,13 +20,13 @@ describe('noticeTypeFromApplication', () => {
     expect(noticeTypeFromApplication(application)).toEqual('emergency')
   })
 
-  it('returns short_notice if the arrival date is less than 29 days away', () => {
+  it('returns shortNotice if the arrival date is less than 29 days away', () => {
     const date = add(new Date(), { days: 22 })
     const arrivalDate = DateFormats.dateObjToIsoDate(date)
 
     ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(arrivalDate)
 
-    expect(noticeTypeFromApplication(application)).toEqual('short_notice')
+    expect(noticeTypeFromApplication(application)).toEqual('shortNotice')
   })
 
   it('returns standard if the arrival date is more than 28 days away', () => {

--- a/server/utils/applications/noticeTypeFromApplication.ts
+++ b/server/utils/applications/noticeTypeFromApplication.ts
@@ -1,11 +1,9 @@
 import { differenceInDays } from 'date-fns'
-import { ApprovedPremisesApplication as Application } from '@approved-premises/api'
+import { ApprovedPremisesApplication as Application, Cas1ApplicationTimelinessCategory } from '@approved-premises/api'
 import { arrivalDateFromApplication } from './arrivalDateFromApplication'
 import { DateFormats } from '../dateUtils'
 
-type ApplicationType = 'emergency' | 'short_notice' | 'standard'
-
-export const noticeTypeFromApplication = (application: Application): ApplicationType => {
+export const noticeTypeFromApplication = (application: Application): Cas1ApplicationTimelinessCategory => {
   const arrivalDateString = arrivalDateFromApplication(application)
 
   if (!arrivalDateString) return 'standard'
@@ -16,7 +14,7 @@ export const noticeTypeFromApplication = (application: Application): Application
     case differenceInDays(arrivalDateObj, new Date()) <= 7:
       return 'emergency'
     case differenceInDays(arrivalDateObj, new Date()) <= 28:
-      return 'short_notice'
+      return 'shortNotice'
     default:
       return 'standard'
   }

--- a/server/utils/applications/shouldShowContingencyPlanPages.test.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.test.ts
@@ -72,8 +72,8 @@ describe('shouldShowContingencyPlanQuestionsScreen', () => {
     expect(shouldShowContingencyPlanQuestionsPage(application)).toEqual(false)
   })
 
-  it('returns false if the application notice type is standard"', () => {
-    ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('short_notice')
+  it('returns false if the application notice type is shortNotice"', () => {
+    ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('shortNotice')
 
     expect(shouldShowContingencyPlanQuestionsPage(application)).toEqual(false)
   })


### PR DESCRIPTION
This updates the UI to send a new notice type field to the API. This will soon replace the `isEmergencyApplication` field, so we have on field that will tell us if an application is an Emergency, Short Notice, or Standard application.