### PR TITLE
Verify feedback form link works

### DIFF
--- a/integration_tests/pages/dashboard.ts
+++ b/integration_tests/pages/dashboard.ts
@@ -18,4 +18,12 @@ export default class DashboardPage extends Page {
   shouldNotShowCard(service: string) {
     cy.get(`[data-cy-card-service="${service}"]`).should('not.exist')
   }
+
+  clickFeedbackBanner() {
+    cy.get('a').contains('Give us your feedback').click()
+  }
+
+  shouldShowFeedbackPage() {
+    cy.get('span').contains('Satisfaction survey - Approved Premises (AP) also known as CAS1')
+  }
 }

--- a/integration_tests/tests/feedbackBanner.cy.ts
+++ b/integration_tests/tests/feedbackBanner.cy.ts
@@ -1,0 +1,18 @@
+import DashboardPage from '../pages/dashboard'
+import { signIn } from './signIn'
+
+context('Dashboard', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    signIn(['workflow_manager'])
+  })
+
+  it('displays all services when a user has all roles', () => {
+    const dashboardPage = DashboardPage.visit()
+
+    dashboardPage.clickFeedbackBanner()
+
+    dashboardPage.shouldShowFeedbackPage()
+  })
+})


### PR DESCRIPTION
It would be good to know next time the feedback form is changed. I think it makes sense to live in the integration test code even though it is more of an 'e2e' test so we are alerted quicker if it breaks. We need to navigate to the page and test it loads rather than just verify the link is what we'd expect as the link may stop working without us knowing.
