### PR TITLE
APS-522: Reinstate text box to record rationale for decision in assess

### DIFF
--- a/integration_tests/fixtures/assessmentData.json
+++ b/integration_tests/fixtures/assessmentData.json
@@ -39,7 +39,7 @@
       "outlineOfDiscussion": "Some discussion"
     }
   },
-  "make-a-decision": { "make-a-decision": { "decision": "accept" } },
+  "make-a-decision": { "make-a-decision": { "decision": "accept", "decisionRationale": "some rejected comment" } },
   "matching-information": {
     "matching-information": {
       "apType": "normal",

--- a/integration_tests/helpers/assess.ts
+++ b/integration_tests/helpers/assess.ts
@@ -266,6 +266,7 @@ export default class AseessHelper {
 
     // Then I should be taken to the make a decision page
     const page = new MakeADecisionPage(this.assessment)
+    page.enterDecisionRationale()
     page.completeForm()
     page.clickSubmit()
 

--- a/integration_tests/pages/assess/makeADecisionPage.ts
+++ b/integration_tests/pages/assess/makeADecisionPage.ts
@@ -10,4 +10,8 @@ export default class MakeADecisionPage extends AssessPage {
   completeForm() {
     this.checkRadioButtonFromPageBody('decision')
   }
+
+  enterDecisionRationale() {
+    this.completeTextInputFromPageBody('decisionRationale')
+  }
 }

--- a/integration_tests/tests/assess/assess.cy.ts
+++ b/integration_tests/tests/assess/assess.cy.ts
@@ -205,11 +205,13 @@ context('Assess', () => {
       key: 'informationReceived',
       value: 'no',
     })
-    assessment = addResponseToFormArtifact<Assessment>(assessment, {
+    assessment = addResponsesToFormArtifact<Assessment>(assessment, {
       task: 'make-a-decision',
       page: 'make-a-decision',
-      key: 'decision',
-      value: 'otherReasons',
+      keyValuePairs: {
+        decision: 'otherReasons',
+        decisionRationale: 'reject reason',
+      },
     })
     delete assessment.data['matching-information']
     const assessHelper = new AssessHelper(assessment, this.documents, this.user, this.clarificationNote)

--- a/server/form-pages/assess/makeADecision/makeADecisionTask/makeADecision.test.ts
+++ b/server/form-pages/assess/makeADecision/makeADecisionTask/makeADecision.test.ts
@@ -15,9 +15,11 @@ describe('MakeADecision', () => {
     it('should set the body', () => {
       const page = new MakeADecision({
         decision: 'accommodationNeedOnly',
+        decisionRationale: 'decisionRationale',
       })
       expect(page.body).toEqual({
         decision: 'accommodationNeedOnly',
+        decisionRationale: 'decisionRationale',
       })
     })
   })
@@ -44,6 +46,28 @@ describe('MakeADecision', () => {
         decision: 'You must select one option',
       })
     })
+    it('should have an error if the decision is rejected and a reason has not been provided', () => {
+      const page = new MakeADecision({
+        decision: 'informationNotProvided',
+      })
+
+      expect(page.errors()).toEqual({
+        decisionRationale: 'You must provide the rationale for your decision',
+      })
+    })
+  })
+
+  describe('no errors', () => {
+    it.each(['accept', 'withdrawnByPp'])(
+      'should not raise error if the decision is %s and a reason has not been provided',
+      async decision => {
+        const page = new MakeADecision({
+          decision,
+        })
+
+        expect(page.errors()).toEqual({})
+      },
+    )
   })
 
   describe('response', () => {

--- a/server/form-pages/assess/makeADecision/makeADecisionTask/makeADecision.ts
+++ b/server/form-pages/assess/makeADecision/makeADecisionTask/makeADecision.ts
@@ -7,7 +7,7 @@ import TasklistPage from '../../../tasklistPage'
 
 @Page({
   name: 'make-a-decision',
-  bodyProperties: ['decision'],
+  bodyProperties: ['decision', 'decisionRationale'],
 })
 export default class MakeADecision implements TasklistPage {
   name = 'make-a-decision'
@@ -43,6 +43,7 @@ export default class MakeADecision implements TasklistPage {
   constructor(
     public body: {
       decision: string
+      decisionRationale?: string
     },
   ) {}
 
@@ -65,6 +66,8 @@ export default class MakeADecision implements TasklistPage {
     const errors: TaskListErrors<this> = {}
 
     if (!this.body.decision) errors.decision = 'You must select one option'
+    if (this.body.decision && !['accept', 'withdrawnByPp'].includes(this.body.decision) && !this.body.decisionRationale)
+      errors.decisionRationale = 'You must provide the rationale for your decision'
 
     return errors
   }

--- a/server/views/assessments/pages/make-a-decision/make-a-decision.njk
+++ b/server/views/assessments/pages/make-a-decision/make-a-decision.njk
@@ -37,4 +37,18 @@
 
       {%endcall%}
     </div>
+    {{
+        formPageTextarea(
+          {
+            fieldName: "decisionRationale",
+            type: "textarea",
+            spellcheck: false,
+            label: {
+              text: "Rationale for your decision",
+              classes: "govuk-label--m"
+            }
+          },
+          fetchContext()
+        )
+      }}
   {% endblock %}


### PR DESCRIPTION
# Context

<!-- https://dsdmoj.atlassian.net/browse/APS-522-->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Reinstate text area to record rationale for decision in assess 
## Screenshots of UI changes

### Before
<img width="1728" alt="Screenshot 2024-03-21 at 13 33 45" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/d3648dbd-86c2-487e-a86a-8f28e22e19f2">

### After
<img width="1728" alt="Screenshot 2024-03-21 at 10 35 42" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/e1e598c6-3b6f-4d6d-a2e8-db5b8be2b463">
