### PR TITLE
Allow access to all probation networks

### DIFF
--- a/helm_deploy/hmpps-approved-premises-ui/values.yaml
+++ b/helm_deploy/hmpps-approved-premises-ui/values.yaml
@@ -70,6 +70,7 @@ generic-service:
     ark-nps-hmcts-ttp5: 194.33.197.0/25
     groups:
       - internal
+      - probation
 
 generic-prometheus-alerts:
   targetApplication: hmpps-approved-premises-ui

--- a/helm_deploy/hmpps-approved-premises-ui/values.yaml
+++ b/helm_deploy/hmpps-approved-premises-ui/values.yaml
@@ -63,11 +63,6 @@ generic-service:
       REDIS_AUTH_TOKEN: 'auth_token'
 
   allowlist:
-    ark-nps-hmcts-ttp1: 195.59.75.0/24
-    ark-nps-hmcts-ttp2: 194.33.192.0/25
-    ark-nps-hmcts-ttp3: 194.33.193.0/25
-    ark-nps-hmcts-ttp4: 194.33.196.0/25
-    ark-nps-hmcts-ttp5: 194.33.197.0/25
     groups:
       - internal
       - probation


### PR DESCRIPTION
We've learnt that some users can't access the service. On investigation
we see that not all probation VPNs are being allowed. In this PR
we introduce the new-style probation "group" which does away with
needing to manually maintain a list of IP ranges.

See https://github.com/ministryofjustice/hmpps-ip-allowlists

At present this group allows:

```
probation:
  dom1-ark-1: 195.59.75.0/24
  dom1-ark-2: 194.33.192.0/25
  dom1-ark-3: 194.33.193.0/25
  dom1-ark-4: 194.33.196.0/25
  dom1-ark-5: 194.33.197.0/25
  vodafone-dia-1: 194.33.200.0/21
  vodafone-dia-2: 194.33.216.0/24
  vodafone-dia-3: 194.33.217.0/24
  vodafone-dia-4: 194.33.218.0/24
  moj-official-prod: 51.149.250.0/24
  moj-official-preprod: 51.149.251.0/24
  moj-official-ark-c-expo-e: 51.149.249.0/29
  moj-official-ark-c-vodafone: 194.33.248.0/29
  moj-official-ark-f-vodafone: 194.33.249.0/29
  moj-official-ark-f-expo-e: 51.149.249.32/29
  moj-official-azure-landing-zone-public-egress-1: 20.49.214.199/32
  moj-official-azure-landing-zone-public-egress-2: 20.49.214.228/32
  moj-official-azure-landing-zone-public-egress-3: 20.26.11.71/32
  moj-official-azure-landing-zone-public-egress-4: 20.26.11.108/32
```

For the full list of IP ranges available see https://github.com/ministryofjustice/hmpps-ip-allowlists/blob/main/ip-allowlist-groups.yaml