### PR TITLE
APS-512 - Show both the applicant and the case manager details on the assess screen

### DIFF
--- a/integration_tests/pages/assess/clarificationNoteConfirmPage.ts
+++ b/integration_tests/pages/assess/clarificationNoteConfirmPage.ts
@@ -12,25 +12,32 @@ export default class SufficientInformationPage extends Page {
   }
 
   confirmUserDetails(application: ApprovedPremisesApplication) {
-    cy.get('dl').within(() => {
-      this.assertDefinition(
-        'Name',
-        application.caseManagerIsNotApplicant
-          ? application.caseManagerUserDetails.name
-          : application.applicantUserDetails.name,
-      )
-      this.assertDefinition(
-        'Email',
-        application.caseManagerIsNotApplicant
-          ? application.caseManagerUserDetails.email
-          : application.applicantUserDetails.email,
-      )
-      this.assertDefinition(
-        'Contact number',
-        application.caseManagerIsNotApplicant
-          ? application.caseManagerUserDetails.telephoneNumber
-          : application.applicantUserDetails.telephoneNumber,
-      )
-    })
+    cy.get('h2').contains(
+      application.caseManagerIsNotApplicant ? 'Applicant details' : 'Case manager and applicant details',
+    )
+
+    if (application.caseManagerIsNotApplicant) {
+      cy.get('dl')
+        .first()
+        .within(() => {
+          this.assertDefinition('Name', application.applicantUserDetails.name)
+          this.assertDefinition('Email', application.applicantUserDetails.email)
+          this.assertDefinition('Contact number', application.applicantUserDetails.telephoneNumber)
+        })
+
+      cy.get('dl')
+        .last()
+        .within(() => {
+          this.assertDefinition('Name', application.caseManagerUserDetails.name)
+          this.assertDefinition('Email', application.caseManagerUserDetails.email)
+          this.assertDefinition('Contact number', application.caseManagerUserDetails.telephoneNumber)
+        })
+    } else {
+      cy.get('dl').within(() => {
+        this.assertDefinition('Name', application.applicantUserDetails.name)
+        this.assertDefinition('Email', application.applicantUserDetails.email)
+        this.assertDefinition('Contact number', application.applicantUserDetails.telephoneNumber)
+      })
+    }
   }
 }

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformationSent.test.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformationSent.test.ts
@@ -1,16 +1,8 @@
-import { when } from 'jest-when'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
 import SufficientInformationSent from './sufficientInformationSent'
 
-import { assessmentFactory } from '../../../../testutils/factories'
-import { retrieveOptionalQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
-import ConfirmYourDetails from '../../../apply/reasons-for-placement/basic-information/confirmYourDetails'
-import {
-  userDetailsFromCaseManagerPage,
-  userDetailsFromConfirmYourDetailsPage,
-} from '../../../../utils/applications/userDetailsFromApplication'
-import { applicationUserDetailsFactory } from '../../../../testutils/factories/application'
+import { applicationFactory, assessmentFactory } from '../../../../testutils/factories'
 
 jest.mock('../../../../utils/retrieveQuestionResponseFromFormArtifact')
 jest.mock('../../../../utils/applications/userDetailsFromApplication')
@@ -28,81 +20,35 @@ describe('SufficientInformationSent', () => {
 
   describe('constructor', () => {
     describe('if there are user details on the application', () => {
-      describe('if the applicant is the case manager', () => {
-        it('should set the case manager details with the applicants details on the page', () => {
-          const assessmentWithApplication = assessmentFactory.build({
-            application: {
-              caseManagerIsNotApplicant: false,
-            },
-          })
-
-          const page = new SufficientInformationSent({}, assessmentWithApplication)
-          expect(page.caseManager).toEqual(assessmentWithApplication.application.applicantUserDetails)
-        })
-      })
-
-      describe('if the applicant is not the case manager', () => {
-        it('should set the case manager details', () => {
-          const assessmentWithApplication = assessmentFactory.build({
-            application: {
-              caseManagerIsNotApplicant: true,
-            },
-          })
-
-          const page = new SufficientInformationSent({}, assessmentWithApplication)
-          expect(page.caseManager).toEqual(assessmentWithApplication.application.caseManagerUserDetails)
-        })
+      it('should set the case manager details with the applicants details on the page', () => {
+        const page = new SufficientInformationSent({}, assessment)
+        expect(page.applicant).toEqual(assessment.application.applicantUserDetails)
+        expect(page.caseManager).toEqual(assessment.application.caseManagerUserDetails)
       })
     })
 
-    describe('if there are not user details on the application', () => {
-      const legacyAsssessmentWithoutUserDetails = assessmentFactory.build({
-        application: {
-          caseManagerIsNotApplicant: undefined,
-          caseManagerUserDetails: undefined,
+    describe('if the user details are missing fields', () => {
+      it('returns "no $fieldName is supplied"', () => {
+        const application = applicationFactory.build({
           applicantUserDetails: undefined,
-        },
-      })
-
-      describe('if the applicant is the case manager', () => {
-        it('should set the case manager details on the page with details from the form data', () => {
-          const applicantDetails = applicationUserDetailsFactory.build()
-
-          when(retrieveOptionalQuestionResponseFromFormArtifact)
-            .calledWith(
-              legacyAsssessmentWithoutUserDetails.application,
-              ConfirmYourDetails,
-              'caseManagementResponsibility',
-            )
-            .mockReturnValue('yes')
-
-          when(userDetailsFromConfirmYourDetailsPage)
-            .calledWith(legacyAsssessmentWithoutUserDetails.application)
-            .mockReturnValue(applicantDetails)
-
-          const page = new SufficientInformationSent({}, legacyAsssessmentWithoutUserDetails)
-          expect(page.caseManager).toEqual(applicantDetails)
+          caseManagerUserDetails: undefined,
         })
-      })
 
-      describe('if the applicant is not the case manager', () => {
-        it('should set the case manager details on the page with details from the form data', () => {
-          const caseManagerDetails = applicationUserDetailsFactory.build()
-          when(retrieveOptionalQuestionResponseFromFormArtifact)
-            .calledWith(
-              legacyAsssessmentWithoutUserDetails.application,
-              ConfirmYourDetails,
-              'caseManagementResponsibility',
-            )
-            .mockReturnValue('no')
+        const assessmentWithoutUserDetails = assessmentFactory.build({
+          application,
+        })
 
-          when(userDetailsFromCaseManagerPage)
-            .calledWith(legacyAsssessmentWithoutUserDetails.application)
-            .mockReturnValue(caseManagerDetails)
+        const page = new SufficientInformationSent({}, assessmentWithoutUserDetails)
 
-          const page = new SufficientInformationSent({}, legacyAsssessmentWithoutUserDetails)
-
-          expect(page.caseManager).toEqual(caseManagerDetails)
+        expect(page.applicant).toEqual({
+          email: 'No email supplied',
+          name: 'No name supplied',
+          telephoneNumber: 'No telephone number supplied',
+        })
+        expect(page.caseManager).toEqual({
+          email: 'No email supplied',
+          name: 'No name supplied',
+          telephoneNumber: 'No telephone number supplied',
         })
       })
     })

--- a/server/views/assessments/pages/sufficient-information/sufficient-information-sent.njk
+++ b/server/views/assessments/pages/sufficient-information/sufficient-information-sent.njk
@@ -7,59 +7,95 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
-  <div class="govuk-width-container">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">
-        {{ page.title }}
-      </h1>
+      <h1 class="govuk-heading-l">{{ page.title }}</h1>
 
       <div class="govuk-inset-text">
-    No progress can be made on this assessment until you've contacted the probation practitioner.
-  </div>
-
-      <ol class="govuk-list govuk-list--number">
-        <li>Contact the probation practitioner to ask them for the information.</li>
-        <li>They are given 5 days to respond.</li>
-        <li>When they've responded, or the 5 days has passed, you can submit the assessment.</li>
-      </ol>
+        No progress can be made on this assessment until you've contacted the probation practitioner.
+        <ol class="govuk-list govuk-list--number">
+          <li>Contact the probation practitioner to ask them for the information.</li>
+          <li>They are given 5 days to respond.</li>
+          <li>When they've responded, or the 5 days has passed, you can submit the assessment.</li>
+        </ol>
+      </div>
 
       <p>Missing information will be included in pre-arrival planning. When you submit the assessment, you can indicate if the information was not provided.</p>
 
-      {{
-      govukSummaryList({
-          rows: [
-            {
-              key: {
-                text: "Name"
-              },
-              value: {
-                text: page.caseManager.name
-              }
-            },
-            {
-              key: {
-                text: "Email"
-              },
-              value: {
-                text: page.caseManager.email
-              }
-            },
-            {
-              key: {
-                text: "Contact number"
-              },
-              value: {
-                html: page.caseManager.telephoneNumber
-              }
-            }
-          ]
-      })
-    }}
+      <section>
+        <h2>{{ "Applicant details" if page.caseManagerIsNotApplicant else "Case manager and applicant details" }}</h2>
+        {{
+          govukSummaryList({
+              rows: [
+                {
+                  key: {
+                    text: "Name"
+                  },
+                  value: {
+                    text: page.applicant.name
+                  }
+                },
+                {
+                  key: {
+                    text: "Email"
+                  },
+                  value: {
+                    text: page.applicant.email
+                  }
+                },
+                {
+                  key: {
+                    text: "Contact number"
+                  },
+                  value: {
+                    html: page.applicant.telephoneNumber
+                  }
+                }
+              ]
+          })
+        }}
+      </section>
+      {% if page.caseManagerIsNotApplicant %}
+        <section>
+
+          <h2>{{ "Case manager details" }}</h2>
+          {{
+            govukSummaryList({
+              rows: [
+                {
+                  key: {
+                    text: "Name"
+                  },
+                  value: {
+                    text: page.caseManager.name
+                  }
+                },
+                {
+                  key: {
+                    text: "Email"
+                  },
+                  value: {
+                    text: page.caseManager.email
+                  }
+                },
+                {
+                  key: {
+                    text: "Contact number"
+                  },
+                  value: {
+                    html: page.caseManager.telephoneNumber
+                  }
+                }
+              ]
+          })
+        }}
+        </section>
+      {% endif %}
 
       {{ govukButton({
-      text: "Return to dashboard",
-      href: paths.assessments.index()
-    }) }}
+          text: "Return to dashboard",
+          href: paths.assessments.index()
+        }) }}
     </div>
   </div>
 


### PR DESCRIPTION

# Context 

We need to the user the details for both the case manager and the applicant. Often this is the same person so we only show one set of details and indicate in the heading that they're the same person. Otherwise we show both sets of details. As the backfill has now been completed in the API to fill the 'caseManagerIsNotApplicant', 'applicantUserDetails' and 'caseManagerUserDetails' we can remove the code responsible for fetching this information from the application itself and just use the first class properties instead. 

[JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&selectedIssue=APS-512) 

# Changes in this PR

## Screenshots of UI changes

### Before
![before](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/a7ef5cde-89d0-4453-84ac-504d48c88df8)

### After
#### When the case manager and applicant are different people
![after (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/10c20989-d19c-4c73-b28e-f1fadb70740a)
#### When the case manager and applicant are the same person
![after](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/2900bc48-808a-4ff5-adaa-8bdac82d1f4e)
