### PR TITLE
(APS-535) Investigate Flipt for feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,8 @@ head over to [our infrastructure documentation](/doc/how-to/manage-infrastructur
 ## E2E tests
 
 End to end tests for this project can be found [in a seperate repo](https://github.com/ministryofjustice/hmpps-approved-premises-e2e).
+
+## Feature flags
+
+We use [Flipt](http://flipt.io) for feature flags. See https://github.com/ministryofjustice/hmpps-approved-premises-ui/blob/main/doc/how-to/add-a-feature-flag.md
+for more details

--- a/doc/architecture/decisions/0012-handling-feature-flags-with-flipt.md
+++ b/doc/architecture/decisions/0012-handling-feature-flags-with-flipt.md
@@ -1,0 +1,59 @@
+# 12. Handling feature flags with Flipt
+
+Date: 2024-03-25
+
+## Status
+
+Accepted
+
+## Context
+
+As the service gets used by more people, and communicating new features / changes with
+users becomes more essential, it's important that sometimes we hide certain features
+behind a feature flag to ensure we can roll out features in a controlled manner, whilst
+not slowing down the development process.
+
+Previously we've handled feature flags in an adhoc way, by use of environment variables,
+but this causes a couple of issues, most importantly, to roll back or introduce a feature
+we need to start a new deploy, which can take time, as we need to go through the whole
+deployment process, from PR, through to E2E tests and deployment to various different
+environments. We also need to have a lot of code that handles fetching these variables,
+adding conditionals etc, which gives us more code to maintain.
+
+## Decision
+
+The integrations team have recently deployed an instance of [Flipt](https://www.flipt.io/),
+which is a simple service that allows us to manage feature flags and turn them on and off
+at will via a UI, without having to redeploy the service.
+
+There are instances for each environment, Dev, Prod and Prepod, meaning we can have
+different values for feature flags in each environment.
+
+To manage feature flags, we will add a new Feature Flag service, which (initially at least)
+will accept the name of a feature flag and return a boolean value indicating whether the
+feature flag is enabled or not.
+
+In local development, or where we set `FLIPT_ENABLED` to false, we will enable all feature
+flags by default.
+
+When we want to add a feature flag, we will import the Feature Flag service into a
+controller, and request the enabled value of the given feature flag, and send that value
+to wherever it is neeeded (another service, the view, or any utils).
+
+## Consequences
+
+It's important to point out that even now, feature flags have a cost to their maintenance,
+and we should only use them as a last resort. We should also consider the risks that occur
+if someone within the team enables or disables a feature flag without communicating this
+to the team, so we should ensure that when we do anything related to feature flags we are
+sure that:
+
+- This has been communicated to the team; and
+- We have agreement from the business (SMEs etc) that this feature flag is ready to be enabled
+
+Once a feature is stable, we should remove any associated code and logic to enable/disable
+the feature as soon as possible.
+
+Additionally, the Dev instance of the Flipt service can only be accessed via GlobalProtect
+or the dxw VPN, so if we're using Flipt locally, we should either be on an MoJ machine or
+connected to the dxw VPN.

--- a/doc/how-to/add-a-feature-flag.md
+++ b/doc/how-to/add-a-feature-flag.md
@@ -1,0 +1,65 @@
+# Feature flags
+
+Feature flags are managed by [Flipt](https://www.flipt.io). We use hosted Flipt instances
+for all of our live environments:
+
+- [Dev / Test](https://feature-flags-dev.hmpps.service.justice.gov.uk)
+- [Preprod](https://feature-flags-preprod.hmpps.service.justice.gov.uk)
+- [Prod](https://feature-flags-dev.hmpps.service.justice.gov.uk)
+
+## Adding a feature flag
+
+### Step 0: Are you sure you need a feature flag?
+
+Consider if a feature flag is necessary for the feature. If it's a small feature, like
+a copy change, or some other small quality of life change, then you probably don't need a
+feature flag. If it's a large feature that requires multiple PRs and is likely to need
+communicating to users, then a feature flag _might_ be the way to go. It is still worth
+considering other alternative routes before going down this one though.
+
+### Step 1: Add a new flag in the Flipt UI
+
+Go to the Flipt UI for each environment, and create a new flag in the
+`community-accommodation` namespace for each environment. Currently only boolean flags
+are supported:
+
+![KgXgB09MLS](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/2365414a-7d45-41b4-8370-625d78285b56)
+
+## Step 2: Inject the FeatureFlagService into your controller
+
+In your controller, add the `FeatureFlagService` to the constructor of the controller
+you want to add the feature flag to, e.g:
+
+```typescript
+export default class PlacementRequestsController {
+  constructor(
+    private readonly placementRequestService: PlacementRequestService,
+    private readonly apAreaService: ApAreaService,
+    private readonly featureFlagService: FeatureFlagService,
+  ) {}
+```
+
+## Step 3: Call the `getBooleanFlag` method in your controller action
+
+You can then call the `getBooleanFlag` method to return a boolean value depending on if
+the flag is enabled or not, e.g (where `FLAG_NAME` is a string specifying the key of the
+flag you created in step 1):
+
+```typescript
+const flagEnabled = await this.featureFlagService.getBooleanFlag(FLAG_NAME)
+```
+
+You can then pass that boolean value to wherever it is required in your code.
+
+NOTE: By default, Flipt is disabled in local development environments, and `getBooleanFlag`
+will always return true
+
+## Step 5: Enable/disable the flag in the appropriate environment
+
+Once your code is deployed, you can then enable/disable the flag in the appropriate
+environment like so:
+
+![cq4ZJ73Z6a](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/92b1892c-0fbe-4537-9ef1-11e6ed1c9566)
+
+NOTE: Ensure that when enabling/disabling feature flags this has been clearly discussed
+with users / SMEs

--- a/helm_deploy/hmpps-approved-premises-ui/values.yaml
+++ b/helm_deploy/hmpps-approved-premises-ui/values.yaml
@@ -58,6 +58,7 @@ generic-service:
       SYSTEM_CLIENT_SECRET: 'SYSTEM_CLIENT_SECRET'
       SESSION_SECRET: 'SESSION_SECRET'
       SENTRY_DSN: 'SENTRY_DSN'
+      FLIPT_TOKEN: 'FLIPT_TOKEN'
     elasticache-redis:
       REDIS_HOST: 'primary_endpoint_address'
       REDIS_AUTH_TOKEN: 'auth_token'

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,6 +19,9 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_SERVICE_NAME: approved-premises
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
+    FLIPT_ENABLED: true
+    FLIPT_URL: 'https://feature-flags-dev.hmpps.service.justice.gov.uk/'
+    FLIPT_NAMESPACE: 'community-accommodation'
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -17,6 +17,9 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_SERVICE_NAME: approved-premises
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
+    FLIPT_ENABLED: true
+    FLIPT_URL: 'https://feature-flags-preprod.hmpps.service.justice.gov.uk/'
+    FLIPT_NAMESPACE: 'community-accommodation'
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -17,6 +17,9 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_SERVICE_NAME: approved-premises
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
+    FLIPT_ENABLED: true
+    FLIPT_URL: 'https://feature-flags.hmpps.service.justice.gov.uk/'
+    FLIPT_NAMESPACE: 'community-accommodation'
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -19,7 +19,9 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_SERVICE_NAME: approved-premises
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
-
+    FLIPT_ENABLED: true
+    FLIPT_URL: 'https://feature-flags-dev.hmpps.service.justice.gov.uk/'
+    FLIPT_NAMESPACE: 'community-accommodation'
   allowlist: null
 
 generic-prometheus-alerts:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.359.0",
         "@faker-js/faker": "^8.0.0",
+        "@flipt-io/flipt": "^1.0.0",
         "@ministryofjustice/frontend": "^2.0.0",
         "@sentry/node": "^7.14.1",
         "@sentry/tracing": "^7.14.1",
@@ -1814,6 +1815,11 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
         "npm": ">=6.14.13"
       }
+    },
+    "node_modules/@flipt-io/flipt": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@flipt-io/flipt/-/flipt-1.0.0.tgz",
+      "integrity": "sha512-DAEH5YVgjw2cLZBDTxgekEc8Zn2jlclLYlJdIC9cPE3wMSSudKgeWyh61GfQ3bV7YEz7LjPGhk1YBH+obeR4qw=="
     },
     "node_modules/@golevelup/ts-jest": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.359.0",
     "@faker-js/faker": "^8.0.0",
+    "@flipt-io/flipt": "^1.0.0",
     "@ministryofjustice/frontend": "^2.0.0",
     "@sentry/node": "^7.14.1",
     "@sentry/tracing": "^7.14.1",

--- a/server/config.ts
+++ b/server/config.ts
@@ -40,9 +40,12 @@ export interface AuditConfig {
   logErrors: boolean
 }
 
+const fliptEnabled = get('FLIPT_ENABLED', false)
+
 export default {
   https: production,
   staticResourceCacheDuration: 20,
+  fliptEnabled,
   flags: {
     oasysDisabled: process.env.OASYS_DISABLED || false,
   },
@@ -97,6 +100,11 @@ export default {
       queueUrl: get('AUDIT_SQS_QUEUE_URL', ''),
       serviceName: get('AUDIT_SERVICE_NAME', 'approved-premises-ui'),
       logErrors: false,
+    },
+    flipt: {
+      url: get('FLIPT_URL', null, fliptEnabled ? requiredInProduction : null),
+      token: get('FLIPT_TOKEN', null, fliptEnabled ? requiredInProduction : null),
+      namespace: get('FLIPT_NAMESPACE', null, fliptEnabled ? requiredInProduction : null),
     },
   },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),

--- a/server/services/featureFlagService.test.ts
+++ b/server/services/featureFlagService.test.ts
@@ -1,0 +1,89 @@
+import { createMock } from '@golevelup/ts-jest'
+import { FliptClient } from '@flipt-io/flipt'
+import { when } from 'jest-when'
+import { BooleanEvaluationResponse } from '@flipt-io/flipt/dist/evaluation/models'
+import config from '../config'
+import FeatureFlagService from './featureFlagService'
+import logger from '../../logger'
+
+jest.mock('@flipt-io/flipt')
+jest.mock('../../logger')
+
+describe('FeatureFlagService', () => {
+  let featureFlagService: FeatureFlagService
+
+  describe('when flipt is enabled', () => {
+    const mockClient = createMock<FliptClient>({
+      evaluation: {
+        boolean: jest.fn(),
+      },
+    })
+
+    beforeEach(() => {
+      config.fliptEnabled = true
+      config.apis.flipt = {
+        namespace: 'some-namespace',
+        token: 'some-token',
+        url: 'http://localhost',
+      }
+      ;(FliptClient as jest.Mock).mockReturnValue(mockClient)
+      featureFlagService = new FeatureFlagService()
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    describe('getBooleanFlag', () => {
+      it.each([true, false])(
+        'returns the enabled response from the flipt client when enabled is %s',
+        async (enabled: boolean) => {
+          const booleanEvaluationResponse = createMock<BooleanEvaluationResponse>({
+            enabled,
+          })
+
+          when(mockClient.evaluation.boolean)
+            .calledWith({
+              namespaceKey: featureFlagService.namespaceKey,
+              flagKey: 'some-flag',
+              entityId: '',
+              context: {},
+            })
+            .mockResolvedValue(booleanEvaluationResponse)
+
+          const response = await featureFlagService.getBooleanFlag('some-flag')
+          expect(response).toEqual(enabled)
+        },
+      )
+
+      it('returns false and logs an error when the feature flag does not exist', async () => {
+        when(mockClient.evaluation.boolean)
+          .calledWith({
+            namespaceKey: featureFlagService.namespaceKey,
+            flagKey: 'some-flag',
+            entityId: '',
+            context: {},
+          })
+          .mockImplementation(() => {
+            throw new Error('Feature flag not found')
+          })
+
+        const response = await featureFlagService.getBooleanFlag('some-flag')
+
+        expect(response).toEqual(false)
+        expect(logger.error).toHaveBeenCalledWith('Feature flag some-flag not found, defaulting to false')
+      })
+    })
+  })
+
+  describe('when flipt is not enabled', () => {
+    beforeEach(() => {
+      config.fliptEnabled = false
+    })
+
+    it('should return true', async () => {
+      const response = await featureFlagService.getBooleanFlag('some-flag')
+      expect(response).toEqual(true)
+    })
+  })
+})

--- a/server/services/featureFlagService.ts
+++ b/server/services/featureFlagService.ts
@@ -1,0 +1,42 @@
+import { ClientTokenAuthentication, FliptClient } from '@flipt-io/flipt'
+import config from '../config'
+import logger from '../../logger'
+
+export default class FeatureFlagService {
+  fliptClient: FliptClient | null
+
+  namespaceKey: string | null
+
+  constructor() {
+    if (config.fliptEnabled) {
+      this.fliptClient = new FliptClient({
+        url: config.apis.flipt.url,
+        authenticationStrategy: new ClientTokenAuthentication(config.apis.flipt.token),
+      })
+      this.namespaceKey = config.apis.flipt.namespace
+    }
+  }
+
+  async getBooleanFlag(flag: string): Promise<boolean> {
+    if (!config.fliptEnabled) {
+      return true
+    }
+
+    try {
+      const response = await this.fliptClient.evaluation.boolean({
+        namespaceKey: this.namespaceKey,
+        flagKey: flag,
+        entityId: '',
+        context: {},
+      })
+
+      return response.enabled
+    } catch (err) {
+      if (err.message?.includes('not found')) {
+        logger.error(`Feature flag ${flag} not found, defaulting to false`)
+        return false
+      }
+      throw err
+    }
+  }
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -21,6 +21,7 @@ import BedService from './bedService'
 import ReportService from './reportService'
 import ApAreaService from './apAreaService'
 import AppealService from './appealService'
+import FeatureFlagService from './featureFlagService'
 
 import config, { AuditConfig } from '../config'
 
@@ -62,6 +63,7 @@ export const services = () => {
   const bedService = new BedService(bedClientBuilder)
   const reportService = new ReportService(reportClientBuilder)
   const apAreaService = new ApAreaService(referenceDataClientBuilder)
+  const featureFlagService = new FeatureFlagService()
 
   return {
     appealService,
@@ -83,6 +85,7 @@ export const services = () => {
     bedService,
     reportService,
     apAreaService,
+    featureFlagService,
   }
 }
 
@@ -107,4 +110,5 @@ export {
   BedService,
   ReportService,
   ApAreaService,
+  FeatureFlagService,
 }


### PR DESCRIPTION
This adds an ADR / config for the use of [Flipt](https://www.flipt.io) for easy use of feature flags. This is already used by the integrations team in production, and all the necessary infrastructure is in place. 

Assuming we decide to go with this, I have another PR waiting in the wings as a proof of concept.