### PR TITLE
Trim postcode input before validation

### DIFF
--- a/server/form-pages/apply/move-on/relocationRegion.ts
+++ b/server/form-pages/apply/move-on/relocationRegion.ts
@@ -20,7 +20,7 @@ export default class RelocationRegion implements TasklistPage {
       postcodeArea?: string
     },
   ) {
-    this.body.postcodeArea = body?.postcodeArea?.toUpperCase()
+    this.body.postcodeArea = body?.postcodeArea?.toUpperCase().trim()
   }
 
   previous() {

--- a/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors.ts
@@ -50,7 +50,7 @@ export default class DescribeLocationFactors implements TasklistPage {
       delete body.alternativeRadius
       this.body = body as DescribeLocationFactorsBody
     }
-    this.body.postcodeArea = body?.postcodeArea?.toUpperCase()
+    this.body.postcodeArea = body?.postcodeArea?.toUpperCase().trim()
   }
 
   previous() {

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -399,6 +399,10 @@ describe('formUtils', () => {
       expect(validPostcodeArea('HR1')).toBe(true)
     })
 
+    it('when passed a valid postcode area with a space after the postcode it returns true', () => {
+      expect(validPostcodeArea('HR1 ')).toBe(true)
+    })
+
     it('when passed a lowecase postcode area it returns true', () => {
       expect(validPostcodeArea('hr1')).toBe(true)
     })

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -146,7 +146,7 @@ export function convertKeyValuePairsToSummaryListItems<T extends object>(
  * @returns true if the string is valid, false otherwise.
  */
 export function validPostcodeArea(potentialPostcode: string) {
-  return postcodeAreas.includes(potentialPostcode.toUpperCase())
+  return postcodeAreas.includes(potentialPostcode.trim().toUpperCase())
 }
 
 /**


### PR DESCRIPTION
Otherwise users could enter a valid postcode with a space after it and it would fail validation
