### PR TITLE
(APS-546) Fix weeks and days being displayed incorrectly

### DIFF
--- a/server/form-pages/placement-application/request-a-placement/additionalPlacementDetails.test.ts
+++ b/server/form-pages/placement-application/request-a-placement/additionalPlacementDetails.test.ts
@@ -68,7 +68,7 @@ describe('AdditionalPlacementDetails', () => {
       const page = new AdditionalPlacementDetails(body)
 
       expect(page.response()).toEqual({
-        'How long should the Approved Premises placement last?': '5 weeks, 1 day',
+        'How long should the Approved Premises placement last?': '1 week, 5 days',
         'When will the person arrive?': DateFormats.dateAndTimeInputsToUiDate(body, 'arrivalDate'),
         'Why are you requesting this placement?': 'Some reason',
       })

--- a/server/form-pages/placement-application/request-a-placement/additionalPlacementDetails.ts
+++ b/server/form-pages/placement-application/request-a-placement/additionalPlacementDetails.ts
@@ -68,8 +68,8 @@ export default class AdditionalPlacementDetails implements TasklistPage {
     return {
       [this.questions.arrivalDate]: DateFormats.isoDateToUIDate(this.body.arrivalDate),
       [this.questions.duration]: DateFormats.formatDuration({
-        weeks: this.body.durationDays,
-        days: this.body.durationWeeks,
+        weeks: this.body.durationWeeks,
+        days: this.body.durationDays,
       }),
       [this.questions.reason]: this.body.reason,
     }


### PR DESCRIPTION
This fixes days and weeks being incorrectly flipped when playing back a placement request response for an additional request for placement.

## Before

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/f47653b1-7287-4d41-bdb7-94aec4abb91f)

## After

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/e44040a4-e69d-4062-9ed7-911224058177)
