### PR TITLE
APS-548 Remove copy suggesting email sent on assessment

### DIFF
--- a/server/views/assessments/confirm.njk
+++ b/server/views/assessments/confirm.njk
@@ -15,7 +15,6 @@
                 titleText: AssessmentUtils.confirmationPageResult(assessment)
             }) }}
             <p>
-          We’ve sent you a confirmation email.
         </p>
 
             <h2 class="govuk-heading-m">What happens next</h2>


### PR DESCRIPTION
An email is not sent to the assessor on completion of assessment, so this text is incorrect

# Context

# Changes in this PR

## Screenshots of UI changes

### Before

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22135634/8f9e7241-db03-4f67-872b-27dc3dc19e52)

### After

![Screenshot 2024-03-26 at 09 49 39](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22135634/18159523-be7d-4e9d-9cfc-acb853f26ca2)
![Screenshot 2024-03-26 at 09 50 52](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22135634/16fba064-20a9-4349-8bc1-fe99e4ec8101)

