### PR TITLE
APS 452 - Show contingency plan screens on all short notice applications

### DIFF
--- a/server/utils/applications/shouldShowContingencyPlanPages.test.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.test.ts
@@ -72,9 +72,9 @@ describe('shouldShowContingencyPlanQuestionsScreen', () => {
     expect(shouldShowContingencyPlanQuestionsPage(application)).toEqual(false)
   })
 
-  it('returns false if the application notice type is shortNotice"', () => {
+  it('returns true if the application notice type is shortNotice"', () => {
     ;(noticeTypeFromApplication as jest.Mock).mockReturnValue('shortNotice')
 
-    expect(shouldShowContingencyPlanQuestionsPage(application)).toEqual(false)
+    expect(shouldShowContingencyPlanQuestionsPage(application)).toEqual(true)
   })
 })

--- a/server/utils/applications/shouldShowContingencyPlanPages.ts
+++ b/server/utils/applications/shouldShowContingencyPlanPages.ts
@@ -38,4 +38,4 @@ export const shouldShowContingencyPlanPartnersPages = (application: Application)
 }
 
 export const shouldShowContingencyPlanQuestionsPage = (application: Application) =>
-  noticeTypeFromApplication(application) === 'emergency'
+  noticeTypeFromApplication(application) === 'shortNotice' || noticeTypeFromApplication(application) === 'emergency'


### PR DESCRIPTION
We should have changed this when updating the notice type rules #1567 but it was missed. We need to show the contingency plan screens to all applicants who submit their application within 28 days which is now short notice, not emergency


[JIRA](https://dsdmoj.atlassian.net/browse/APS-542) 
