### PR TITLE
(APS-334) Show requested and actual arrival dates

### DIFF
--- a/integration_tests/pages/admin/placementApplications/listPage.ts
+++ b/integration_tests/pages/admin/placementApplications/listPage.ts
@@ -22,7 +22,7 @@ export default class ListPage extends Page {
   }
 
   shouldShowPlacementRequests(placementRequests: Array<PlacementRequest>, status?: PlacementRequestStatus): void {
-    const tableRows = dashboardTableRows(placementRequests, status)
+    const tableRows = dashboardTableRows(placementRequests, status, { showRequestedAndActualArrivalDates: true })
     const rowItems = tableRowsToArrays(tableRows)
 
     rowItems.forEach(columns => {

--- a/integration_tests/pages/admin/placementApplications/searchPage.ts
+++ b/integration_tests/pages/admin/placementApplications/searchPage.ts
@@ -1,5 +1,8 @@
+import { PlacementRequest } from '../../../../server/@types/shared'
 import { PlacementRequestDashboardSearchOptions } from '../../../../server/@types/ui'
 import paths from '../../../../server/paths/admin'
+import { tableRowsToArrays } from '../../../helpers'
+import { dashboardTableRows } from '../../../../server/utils/placementRequests/table'
 
 import ListPage from './listPage'
 
@@ -16,5 +19,21 @@ export default class SearchPage extends ListPage {
     this.getTextInputByIdAndEnterDetails('arrivalDateStart', searchOptions.arrivalDateStart)
     this.getTextInputByIdAndEnterDetails('arrivalDateEnd', searchOptions.arrivalDateEnd)
     this.clickSubmit()
+  }
+
+  shouldShowPlacementRequests(placementRequests: Array<PlacementRequest>): void {
+    const tableRows = dashboardTableRows(placementRequests, undefined)
+    const rowItems = tableRowsToArrays(tableRows)
+
+    rowItems.forEach(columns => {
+      const headerCell = columns.shift()
+      cy.contains('th', headerCell)
+        .parent('tr')
+        .within(() => {
+          columns.forEach((e, i) => {
+            cy.get('td').eq(i).invoke('text').should('contain', e)
+          })
+        })
+    })
   }
 }

--- a/integration_tests/tests/admin/searchPlacementRequests.cy.ts
+++ b/integration_tests/tests/admin/searchPlacementRequests.cy.ts
@@ -37,13 +37,13 @@ context('Search placement Requests', () => {
     const searchPage = SearchPage.visit()
 
     // Then I should see a list of placement requests
-    searchPage.shouldShowPlacementRequests(placementRequests, undefined)
+    searchPage.shouldShowPlacementRequests(placementRequests)
 
     // When I search for a CRN
     searchPage.enterSearchQuery(searchQuery)
 
     // Then I should see the search results
-    searchPage.shouldShowPlacementRequests(searchResults, undefined)
+    searchPage.shouldShowPlacementRequests(searchResults)
 
     // And the API should have received a request for the CRN
     cy.task('verifyPlacementRequestsSearch', searchQuery).then(requests => {
@@ -67,7 +67,7 @@ context('Search placement Requests', () => {
     const searchPage = SearchPage.visit()
 
     // Then I should see a list of placement requests
-    searchPage.shouldShowPlacementRequests(placementRequests, undefined)
+    searchPage.shouldShowPlacementRequests(placementRequests)
 
     // And I search for a CRN
     searchPage.enterSearchQuery(searchQuery)
@@ -107,7 +107,7 @@ context('Search placement Requests', () => {
     const searchPage = SearchPage.visit()
 
     // Then I should see a list of placement requests
-    searchPage.shouldShowPlacementRequests(placementRequests, undefined)
+    searchPage.shouldShowPlacementRequests(placementRequests)
 
     // And I search for a CRN
     searchPage.enterSearchQuery(searchQuery)

--- a/server/controllers/admin/index.ts
+++ b/server/controllers/admin/index.ts
@@ -11,8 +11,12 @@ import ReportsController from './reportsController'
 import type { Services } from '../../services'
 
 export const controllers = (services: Services) => {
-  const { placementRequestService, premisesService, reportService, apAreaService } = services
-  const adminPlacementRequestsController = new AdminPlacementRequestsController(placementRequestService, apAreaService)
+  const { placementRequestService, premisesService, reportService, apAreaService, featureFlagService } = services
+  const adminPlacementRequestsController = new AdminPlacementRequestsController(
+    placementRequestService,
+    apAreaService,
+    featureFlagService,
+  )
   const placementRequestsBookingsController = new PlacementRequestsBookingsController(
     placementRequestService,
     premisesService,

--- a/server/controllers/admin/placementRequests/placementRequestsController.test.ts
+++ b/server/controllers/admin/placementRequests/placementRequestsController.test.ts
@@ -3,7 +3,7 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
 import PlacementRequestsController from './placementRequestsController'
 
-import { ApAreaService, PlacementRequestService } from '../../../services'
+import { ApAreaService, FeatureFlagService, PlacementRequestService } from '../../../services'
 import {
   apAreaFactory,
   paginatedResponseFactory,
@@ -30,12 +30,17 @@ describe('PlacementRequestsController', () => {
 
   const placementRequestService = createMock<PlacementRequestService>({})
   const apAreaService = createMock<ApAreaService>({})
+  const featureFlagService = createMock<FeatureFlagService>({})
 
   let placementRequestsController: PlacementRequestsController
 
   beforeEach(() => {
     jest.resetAllMocks()
-    placementRequestsController = new PlacementRequestsController(placementRequestService, apAreaService)
+    placementRequestsController = new PlacementRequestsController(
+      placementRequestService,
+      apAreaService,
+      featureFlagService,
+    )
   })
 
   describe('index', () => {
@@ -56,6 +61,7 @@ describe('PlacementRequestsController', () => {
       placementRequestService.getDashboard.mockResolvedValue(paginatedResponse)
       ;(getPaginationDetails as jest.Mock).mockReturnValue(paginationDetails)
       apAreaService.getApAreas.mockResolvedValue(apAreas)
+      featureFlagService.getBooleanFlag.mockResolvedValue(true)
     })
 
     it('should render the placement requests template with the users AP area filtered by default', async () => {
@@ -75,6 +81,7 @@ describe('PlacementRequestsController', () => {
         apAreas,
         apArea: user.apArea.id,
         requestType: undefined,
+        showRequestedAndActualArrivalDates: true,
       })
 
       expect(placementRequestService.getDashboard).toHaveBeenCalledWith(
@@ -117,6 +124,7 @@ describe('PlacementRequestsController', () => {
         apAreas,
         apArea,
         requestType,
+        showRequestedAndActualArrivalDates: true,
       })
 
       expect(placementRequestService.getDashboard).toHaveBeenCalledWith(
@@ -162,6 +170,7 @@ describe('PlacementRequestsController', () => {
         status: 'notMatched',
         apAreas,
         apArea,
+        showRequestedAndActualArrivalDates: true,
       })
     })
   })

--- a/server/controllers/admin/placementRequests/placementRequestsController.ts
+++ b/server/controllers/admin/placementRequests/placementRequestsController.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
-import { ApAreaService, PlacementRequestService } from '../../../services'
+import { ApAreaService, FeatureFlagService, PlacementRequestService } from '../../../services'
 import { PlacementRequestRequestType, PlacementRequestSortField, PlacementRequestStatus } from '../../../@types/shared'
 import paths from '../../../paths/admin'
 import { PlacementRequestDashboardSearchOptions } from '../../../@types/ui'
@@ -10,6 +10,7 @@ export default class PlacementRequestsController {
   constructor(
     private readonly placementRequestService: PlacementRequestService,
     private readonly apAreaService: ApAreaService,
+    private readonly featureFlagService: FeatureFlagService,
   ) {}
 
   index(): TypedRequestHandler<Request, Response> {
@@ -38,6 +39,8 @@ export default class PlacementRequestsController {
         sortDirection,
       )
 
+      const showRequestedAndActualArrivalDates = await this.featureFlagService.getBooleanFlag('show-both-arrival-dates')
+
       res.render('admin/placementRequests/index', {
         pageHeading: 'CRU Dashboard',
         placementRequests: dashboard.data,
@@ -50,6 +53,7 @@ export default class PlacementRequestsController {
         hrefPrefix,
         sortBy,
         sortDirection,
+        showRequestedAndActualArrivalDates,
       })
     }
   }

--- a/server/services/featureFlagService.test.ts
+++ b/server/services/featureFlagService.test.ts
@@ -45,13 +45,13 @@ describe('FeatureFlagService', () => {
           when(mockClient.evaluation.boolean)
             .calledWith({
               namespaceKey: featureFlagService.namespaceKey,
-              flagKey: 'some-flag',
+              flagKey: 'show-both-arrival-dates',
               entityId: '',
               context: {},
             })
             .mockResolvedValue(booleanEvaluationResponse)
 
-          const response = await featureFlagService.getBooleanFlag('some-flag')
+          const response = await featureFlagService.getBooleanFlag('show-both-arrival-dates')
           expect(response).toEqual(enabled)
         },
       )
@@ -60,7 +60,7 @@ describe('FeatureFlagService', () => {
         when(mockClient.evaluation.boolean)
           .calledWith({
             namespaceKey: featureFlagService.namespaceKey,
-            flagKey: 'some-flag',
+            flagKey: 'show-both-arrival-dates',
             entityId: '',
             context: {},
           })
@@ -68,10 +68,10 @@ describe('FeatureFlagService', () => {
             throw new Error('Feature flag not found')
           })
 
-        const response = await featureFlagService.getBooleanFlag('some-flag')
+        const response = await featureFlagService.getBooleanFlag('show-both-arrival-dates')
 
         expect(response).toEqual(false)
-        expect(logger.error).toHaveBeenCalledWith('Feature flag some-flag not found, defaulting to false')
+        expect(logger.error).toHaveBeenCalledWith('Feature flag show-both-arrival-dates not found, defaulting to false')
       })
     })
   })
@@ -82,7 +82,7 @@ describe('FeatureFlagService', () => {
     })
 
     it('should return true', async () => {
-      const response = await featureFlagService.getBooleanFlag('some-flag')
+      const response = await featureFlagService.getBooleanFlag('show-both-arrival-dates')
       expect(response).toEqual(true)
     })
   })

--- a/server/services/featureFlagService.ts
+++ b/server/services/featureFlagService.ts
@@ -2,6 +2,8 @@ import { ClientTokenAuthentication, FliptClient } from '@flipt-io/flipt'
 import config from '../config'
 import logger from '../../logger'
 
+type FeatureFlag = 'show-both-arrival-dates'
+
 export default class FeatureFlagService {
   fliptClient: FliptClient | null
 
@@ -17,7 +19,7 @@ export default class FeatureFlagService {
     }
   }
 
-  async getBooleanFlag(flag: string): Promise<boolean> {
+  async getBooleanFlag(flag: FeatureFlag): Promise<boolean> {
     if (!config.fliptEnabled) {
       return true
     }

--- a/server/utils/placementRequests/table.ts
+++ b/server/utils/placementRequests/table.ts
@@ -35,7 +35,24 @@ export const tableRows = (tasks: Array<PlacementRequestTask>): Array<TableRow> =
 export const dashboardTableRows = (
   placementRequests: Array<PlacementRequest>,
   status: PlacementRequestStatus | undefined,
+  { showRequestedAndActualArrivalDates }: { showRequestedAndActualArrivalDates: boolean } = {
+    showRequestedAndActualArrivalDates: false,
+  },
 ): Array<TableRow> => {
+  if (showRequestedAndActualArrivalDates) {
+    return placementRequests.map((placementRequest: PlacementRequest) => {
+      return [
+        nameCell(placementRequest),
+        tierCell(placementRequest.risks),
+        expectedArrivalDateCell(placementRequest, 'short'),
+        actualArrivalDateCell(placementRequest),
+        applicationDateCell(placementRequest),
+        status === 'matched' ? premisesNameCell(placementRequest) : durationCell(placementRequest),
+        requestTypeCell(placementRequest),
+        statusCell(placementRequest),
+      ]
+    })
+  }
   return placementRequests.map((placementRequest: PlacementRequest) => {
     return [
       nameCell(placementRequest),
@@ -90,6 +107,10 @@ export const expectedArrivalDateCell = (
   text: DateFormats.isoDateToUIDate(item.expectedArrival, { format }),
 })
 
+export const actualArrivalDateCell = (item: PlacementRequest): TableCell => ({
+  text: item.booking?.arrivalDate ? DateFormats.isoDateToUIDate(item.booking?.arrivalDate, { format: 'short' }) : 'N/A',
+})
+
 export const applicationDateCell = (item: PlacementRequest): TableCell => ({
   text: DateFormats.isoDateToUIDate(item.applicationDate, { format: 'short' }),
 })
@@ -134,7 +155,34 @@ export const dashboardTableHeader = (
   sortBy: PlacementRequestSortField,
   sortDirection: SortDirection,
   hrefPrefix: string,
+  showRequestedAndActualArrivalDates: boolean = false,
 ): Array<TableCell> => {
+  if (showRequestedAndActualArrivalDates) {
+    return [
+      sortHeader<PlacementRequestSortField>('Name', 'person_name', sortBy, sortDirection, hrefPrefix),
+      sortHeader<PlacementRequestSortField>('Tier', 'person_risks_tier', sortBy, sortDirection, hrefPrefix),
+      sortHeader<PlacementRequestSortField>(
+        'Requested arrival date',
+        'expected_arrival',
+        sortBy,
+        sortDirection,
+        hrefPrefix,
+      ),
+      {
+        text: 'Actual arrival date',
+      },
+      sortHeader<PlacementRequestSortField>('Application date', 'application_date', sortBy, sortDirection, hrefPrefix),
+      status === 'matched'
+        ? {
+            text: 'Approved Premises',
+          }
+        : sortHeader<PlacementRequestSortField>('Length of stay', 'duration', sortBy, sortDirection, hrefPrefix),
+      sortHeader<PlacementRequestSortField>('Request type', 'request_type', sortBy, sortDirection, hrefPrefix),
+      {
+        text: 'Status',
+      },
+    ]
+  }
   return [
     sortHeader<PlacementRequestSortField>('Name', 'person_name', sortBy, sortDirection, hrefPrefix),
     {

--- a/server/views/admin/placementRequests/index.njk
+++ b/server/views/admin/placementRequests/index.njk
@@ -73,8 +73,8 @@
       {{
         govukTable({
             firstCellIsHeader: true,
-            head: PlacementRequestUtils.tableUtils.dashboardTableHeader(status, sortBy, sortDirection, hrefPrefix),
-            rows: PlacementRequestUtils.tableUtils.dashboardTableRows(placementRequests, status)
+            head: PlacementRequestUtils.tableUtils.dashboardTableHeader(status, sortBy, sortDirection, hrefPrefix, showRequestedAndActualArrivalDates),
+            rows: PlacementRequestUtils.tableUtils.dashboardTableRows(placementRequests, status, { showRequestedAndActualArrivalDates: showRequestedAndActualArrivalDates })
           })
       }}
 


### PR DESCRIPTION
There was some degree of confusion on the CRU dashboard where users assumed the “Arrival Date” against match requests would change when a booking was made. This updates the table to show both the requested aand actual arrival dates to avoid confusion.

This is behind a new `show-both-arrival-dates` feature flag . Ordinarily this wouldn’t be behind a feature flag, but this is just a proof of concept

## Before

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/61fbd769-8ab2-4662-9095-2e9f14ff5279)

## After

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/e0106460-a223-4443-a835-1aa5ed44769a)
