### PR TITLE
(APS-550) Add other reason to Application Timeliness page

### DIFF
--- a/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.ts
@@ -64,9 +64,13 @@ export default class ApplicationTimeliness implements TasklistPage {
     )
     const arrivalDate = arrivalDateFromApplication(this.assessment.application)
 
-    const lateApplicationReason = lateApplicationReasonId
-      ? shortNoticeReasons[lateApplicationReasonId]
-      : 'None supplied'
+    let lateApplicationReason = shortNoticeReasons[lateApplicationReasonId] || 'None supplied'
+
+    if (lateApplicationReasonId === 'other') {
+      lateApplicationReason =
+        retrieveOptionalQuestionResponseFromFormArtifact(this.assessment.application, ReasonForShortNotice, 'other') ||
+        lateApplicationReason
+    }
 
     return {
       applicationDate,


### PR DESCRIPTION
If the reason ID is `other` then we fetch the “other” reason from the ReasonForShortNotice page and return that

## Before

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/0ab278e0-d0e0-49cc-9ad3-c107659a039e)

## After 

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/577868c5-293b-460c-b21e-af9a257e2a3f)
