### PR TITLE
Update Withdrawal select screen copy

### DIFF
--- a/integration_tests/pages/apply/newWithdrawal.ts
+++ b/integration_tests/pages/apply/newWithdrawal.ts
@@ -4,15 +4,15 @@ import { SelectedWithdrawableType } from '../../../server/utils/applications/wit
 import Page, { parseHtml } from '../page'
 
 export default class SelectWithdrawableTypePage extends Page {
-  constructor(heading: 'What do you want to withdraw?' | 'Select your placement') {
+  constructor(heading: 'What do you want to withdraw?' | `Select your ${'placement' | 'request'}`) {
     super(heading)
   }
 
-  shouldShowWithdrawableGuidance() {
+  shouldShowWithdrawableGuidance(withdrawableType: 'placement' | 'request') {
     cy.get('.govuk-inset-text').then(insetTextElement => {
       const { actual, expected } = parseHtml(
         insetTextElement,
-        'Withdraw one placement at a time. Contact the CRU if you do not see the placement you wish to withdraw.',
+        `Withdraw one ${withdrawableType} at a time. Contact the CRU if you do not see the placement you wish to withdraw.`,
       )
 
       expect(actual).to.equal(expected)

--- a/integration_tests/support/helpers.ts
+++ b/integration_tests/support/helpers.ts
@@ -80,6 +80,8 @@ const withdrawPlacementRequestOrApplication = async (
   showPage: ShowPagePlacementApplications | ShowPageApply,
   applicationId: string,
 ) => {
+  const withdrawableName = withdrawable.type === 'booking' ? 'placement' : 'request'
+
   // Then I should see the withdrawable type selection page
   const selectWithdrawableTypePage = new NewWithdrawalPage('What do you want to withdraw?')
   // And be able to select Placement Request
@@ -87,8 +89,8 @@ const withdrawPlacementRequestOrApplication = async (
   selectWithdrawableTypePage.clickSubmit()
 
   // Then I should see the withdrawable selection page
-  const selectWithdrawablePage = new NewWithdrawalPage('Select your placement')
-  selectWithdrawablePage.shouldShowWithdrawableGuidance()
+  const selectWithdrawablePage = new NewWithdrawalPage(`Select your ${withdrawableName}`)
+  selectWithdrawablePage.shouldShowWithdrawableGuidance(withdrawableName)
   // And be able to select a placement
   selectWithdrawablePage.selectWithdrawable(withdrawable.id)
   selectWithdrawablePage.clickSubmit()

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -295,7 +295,7 @@ context('Placement Requests', () => {
     withdrawableTypePage.clickSubmit()
 
     const withdrawablePage = new NewWithdrawalPage('Select your placement')
-    withdrawablePage.shouldShowWithdrawableGuidance()
+    withdrawablePage.shouldShowWithdrawableGuidance('placement')
     withdrawablePage.selectWithdrawable(withdrawable.id)
     withdrawablePage.clickSubmit()
 

--- a/integration_tests/tests/manage/cancellation.cy.ts
+++ b/integration_tests/tests/manage/cancellation.cy.ts
@@ -55,7 +55,7 @@ context('Cancellation', () => {
     withdrawalTypePage.clickSubmit()
 
     const withdrawablePage = new NewWithdrawalPage('Select your placement')
-    withdrawablePage.shouldShowWithdrawableGuidance()
+    withdrawablePage.shouldShowWithdrawableGuidance('placement')
     withdrawablePage.selectWithdrawable(booking.id)
     withdrawablePage.clickSubmit()
 

--- a/integration_tests/tests/withdrawals/withdrawals.cy.ts
+++ b/integration_tests/tests/withdrawals/withdrawals.cy.ts
@@ -67,8 +67,9 @@ context('Withdrawals', () => {
       newWithdrawalPage.clickSubmit()
 
       // Then I am shown a list of placement applications that can be withdrawn
-      const selectWithdrawablePage = new NewWithdrawalPage('Select your placement')
-      selectWithdrawablePage.shouldShowWithdrawableGuidance()
+      const selectWithdrawablePage = new NewWithdrawalPage('Select your request')
+      selectWithdrawablePage.shouldShowWithdrawableGuidance('request')
+      cy.screenshot('after')
       selectWithdrawablePage.checkForBackButton(paths.applications.withdraw.new({ id: application.id }))
       selectWithdrawablePage.shouldShowWithdrawables([placementApplicationWithdrawable])
       selectWithdrawablePage.shouldNotShowWithdrawables([applicationWithdrawable])
@@ -152,7 +153,7 @@ context('Withdrawals', () => {
 
       // Then I am shown a list of placements that can be withdrawn
       const selectWithdrawablePage = new NewWithdrawalPage('Select your placement')
-      selectWithdrawablePage.shouldShowWithdrawableGuidance()
+      selectWithdrawablePage.shouldShowWithdrawableGuidance('placement')
       selectWithdrawablePage.checkForBackButton(paths.applications.withdraw.new({ id: application.id }))
       selectWithdrawablePage.shouldShowWithdrawables([placementWithdrawable])
       selectWithdrawablePage.shouldNotShowWithdrawables([placementApplicationWithdrawable, applicationWithdrawable])
@@ -247,8 +248,8 @@ const withdrawsAPlacementRequest = (userRoles: Array<ApprovedPremisesUserRole>) 
   newWithdrawalPage.clickSubmit()
 
   // Then I am shown a list of placement requests that can be withdrawn
-  const selectWithdrawablePage = new NewWithdrawalPage('Select your placement')
-  selectWithdrawablePage.shouldShowWithdrawableGuidance()
+  const selectWithdrawablePage = new NewWithdrawalPage('Select your request')
+  selectWithdrawablePage.shouldShowWithdrawableGuidance('request')
   selectWithdrawablePage.checkForBackButton(paths.applications.withdraw.new({ id: application.id }))
   selectWithdrawablePage.veryifyLink(placementRequest.id, 'placement_request')
   selectWithdrawablePage.shouldShowWithdrawables([placementRequestWithdrawable, placementApplicationWithdrawable])

--- a/server/controllers/apply/withdrawablesController.test.ts
+++ b/server/controllers/apply/withdrawablesController.test.ts
@@ -63,9 +63,10 @@ describe('withdrawablesController', () => {
         ])
         expect(applicationService.getWithdrawables).toHaveBeenCalledWith(token, applicationId)
         expect(response.render).toHaveBeenCalledWith('applications/withdrawables/show', {
-          pageHeading: 'Select your placement',
+          pageHeading: 'Select your request',
           id: applicationId,
           withdrawables: [placementRequestWithdrawable, placementApplicationWithdrawable],
+          withdrawableType: 'request',
         })
       })
     })
@@ -100,6 +101,7 @@ describe('withdrawablesController', () => {
           id: applicationId,
           withdrawables: placementWithdrawables,
           bookings,
+          withdrawableType: 'placement',
         })
         expect(bookingService.findWithoutPremises).toHaveBeenCalledTimes(2)
         expect(bookingService.findWithoutPremises).toHaveBeenCalledWith(token, placementWithdrawables[0].id)

--- a/server/controllers/apply/withdrawablesController.ts
+++ b/server/controllers/apply/withdrawablesController.ts
@@ -33,13 +33,15 @@ export default class WithdrawalsController {
           id,
           withdrawables: placementWithdrawables,
           bookings,
+          withdrawableType: 'placement',
         })
       }
 
       return res.render('applications/withdrawables/show', {
-        pageHeading: 'Select your placement',
+        pageHeading: 'Select your request',
         withdrawables: sortAndFilterWithdrawables(withdrawables, ['placement_application', 'placement_request']),
         id,
+        withdrawableType: 'request',
       })
     }
   }

--- a/server/views/applications/withdrawables/show.njk
+++ b/server/views/applications/withdrawables/show.njk
@@ -18,8 +18,8 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             {% set hintHtml %}
-                {{ govukInsetText({
-                    text: "Withdraw one placement at a time. Contact the CRU if you do not see the placement you wish to withdraw."
+            {{ govukInsetText({
+                    text: "Withdraw one " + withdrawableType + " at a time. Contact the CRU if you do not see the placement you wish to withdraw."
                 }) }}
             {% endset %}
 


### PR DESCRIPTION
# Context
When the type of withdrawable is a request for placement we want the screen to say 'request' instead of 'placement'.

[Jira](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?selectedIssue=APS-543)
# Changes in this PR

## Screenshots of UI changes

### Before
![before (2)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/4bda3881-6ff5-457a-9f0b-75ecb2915fdc)

### After
![after (3)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/4d56a09a-9d82-4659-b6a4-7c0f0ffa5ff1)

