### PR TITLE
Remove trailing slash from Flipt urls

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -20,7 +20,7 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
     FLIPT_ENABLED: true
-    FLIPT_URL: 'https://feature-flags-dev.hmpps.service.justice.gov.uk/'
+    FLIPT_URL: 'https://feature-flags-dev.hmpps.service.justice.gov.uk'
     FLIPT_NAMESPACE: 'community-accommodation'
 
   namespace_secrets:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -18,7 +18,7 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
     FLIPT_ENABLED: true
-    FLIPT_URL: 'https://feature-flags-preprod.hmpps.service.justice.gov.uk/'
+    FLIPT_URL: 'https://feature-flags-preprod.hmpps.service.justice.gov.uk'
     FLIPT_NAMESPACE: 'community-accommodation'
 
   namespace_secrets:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -18,7 +18,7 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
     FLIPT_ENABLED: true
-    FLIPT_URL: 'https://feature-flags.hmpps.service.justice.gov.uk/'
+    FLIPT_URL: 'https://feature-flags.hmpps.service.justice.gov.uk'
     FLIPT_NAMESPACE: 'community-accommodation'
 
   namespace_secrets:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -20,7 +20,7 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
     FLIPT_ENABLED: true
-    FLIPT_URL: 'https://feature-flags-dev.hmpps.service.justice.gov.uk/'
+    FLIPT_URL: 'https://feature-flags-dev.hmpps.service.justice.gov.uk'
     FLIPT_NAMESPACE: 'community-accommodation'
   allowlist: null
 


### PR DESCRIPTION
The Flipt client isn't intelligent enough to strip these out, so was choking when trying to get the response