### PR TITLE
(APS-564) Use `document` when rendering submitted applications

### DIFF
--- a/integration_tests/fixtures/applicationDocument.json
+++ b/integration_tests/fixtures/applicationDocument.json
@@ -1,0 +1,304 @@
+{
+  "basic-information": [
+    {
+      "If you need to update your details, select the relevant box below": "Phone number, Email address, Name, Area",
+      "Applicant name": "Bob Smith",
+      "Applicant email address": "bob@test.com",
+      "Applicant phone number": "01234567890",
+      "Applicant AP area": "Greater Manchester",
+      "Do you have case management responsibility?": "No"
+    },
+    {
+      "Case manager name": "Bob Smith",
+      "Case manager email": "bob@test.com",
+      "Case manager phone number": "01234567890"
+    },
+    {
+      "Is the person transgender or do they have a transgender history?": "Yes"
+    },
+    {
+      "Does the person's gender identity require a complex case board to review their application?": "Yes"
+    },
+    {
+      "Has the Complex Case Board taken place?": "Yes"
+    },
+    {
+      "Has the Complex Case Board determined that the person should be placed in a male AP?": "Yes"
+    },
+    {
+      "Parole eligibility date": "Thu 14 Nov 2024",
+      "Home Detention Curfew (HDC) date": "Mon 14 Oct 2024",
+      "Licence expiry date": "Sat 14 Sep 2024",
+      "Post sentence supervision (PSS) start date": "Wed 14 Aug 2024",
+      "Post sentence supervision (PSS) end date": "Sun 14 Jul 2024",
+      "Sentence expiry date": "Fri 14 Jun 2024"
+    },
+    {
+      "Which of the following best describes the sentence type the person is on?": "Community Order (CO) / Suspended Sentence Order (SSO)"
+    },
+    {
+      "Which of the following options best describes the situation?": "Application for risk management/public protection"
+    },
+    {
+      "Do you know the person's release date?": "Yes",
+      "Release Date": "Sun 27 Oct 2024"
+    },
+    {
+      "Is Sun 27 Oct 2024 the date you want the placement to start?": "Yes"
+    },
+    {
+      "What is the purpose of the AP placement?": "Provide drug or alcohol monitoring, Other",
+      "Other purpose for AP Placement": "Reason"
+    }
+  ],
+  "type-of-ap": [
+    {
+      "Which type of AP does the person require?": "Recovery Focused AP (RFAP)"
+    }
+  ],
+  "oasys-import": [
+    {
+      "Needs linked to reoffending": "1. Accommodation, 2. Relationships",
+      "Needs not linked to risk of serious harm or reoffending": "3. Emotional, 4. Thinking"
+    },
+    {
+      "Q1: The first RoSH question": "Some answer for the first RoSH question. With an extra comment Q1",
+      "Q2: The second RoSH question": "Some answer for the second RoSH question. With an extra comment Q2",
+      "Q3: The third RoSH question": "Some answer for the third RoSH question. With an extra comment Q3"
+    },
+    {
+      "Q1: The first offence details question": "Some answer for the first offence details question. With an extra comment Q1",
+      "Q2: The second offence details question": "Some answer for the second offence details question. With an extra comment Q2",
+      "Q3: The third offence details question": "Some answer for the third offence details question. With an extra comment Q3"
+    },
+    {
+      "Q1: The first supporting information question": "Some answer for the first supporting information question. With an extra comment Q1",
+      "Q2: The second supporting information question": "Some answer for the second supporting information question. With an extra comment Q2",
+      "Q3: The third supporting information question": "Some answer for the third supporting information question. With an extra comment Q3"
+    },
+    {
+      "Q1: The first risk management question": "Some answer for the first risk management question. With an extra comment Q1",
+      "Q2: The second risk management question": "Some answer for the second risk management question. With an extra comment Q2",
+      "Q3: The third risk management question": "Some answer for the third risk management question. With an extra comment Q3"
+    },
+    {
+      "Q1: The first risk to self question": "Some answer for the first risk to self question. With an extra comment Q1",
+      "Q2: The second risk to self question": "Some answer for the second risk to self question. With an extra comment Q2",
+      "Q3: The third risk to self question": "Some answer for the third risk to self question. With an extra comment Q3"
+    }
+  ],
+  "risk-management-features": [
+    {
+      "Describe why an AP placement is needed to manage the risk of the person": "est vero nesciunt",
+      "Provide details of any additional measures that will be necessary for the management of risk": "deleniti enim necessitatibus"
+    },
+    {
+      "Has the person ever been convicted of any arson offences, sexual offences, hate crimes or non-sexual offences against children?": "Yes"
+    },
+    {
+      "Is the arson offence current or previous?": "Current",
+      "Is the hate crime current or previous?": "Previous",
+      "Is the non sexual offences against children current or previous?": "Current and previous",
+      "Is the contact sexual offences against adults current or previous?": "Current and previous",
+      "Is the non contact sexual offences against adults current or previous?": "Current and previous",
+      "Is the contact sexual offences against children current or previous?": "Current and previous",
+      "Is the non contact sexual offences against children current or previous?": "Current and previous"
+    },
+    {
+      "Which of the rehabilitative activities will assist the person's rehabilitation in the Approved Premises (AP)?": "Accommodation, Drugs and alcohol, Children and families, Health, Education, training and employment, Finance, benefits and debt, Attitudes, thinking and behaviour, Abuse, Sex working, Other",
+      "Provide a summary of how these interventions will assist the persons rehabilitation in the AP.": "A summary of how these interventions will assist the person rehabilitation",
+      "Other intervention": "Another"
+    }
+  ],
+  "prison-information": [
+    {
+      "Selected prison case notes that support this application": [
+        {
+          "Date created": "Thu 10 Nov 2022",
+          "Date occurred": "Wed 19 Oct 2022",
+          "Is the case note sensitive?": "No",
+          "Name of author": "Denise Collins",
+          "Type": "Social Care",
+          "Subtype": "Ressettlement",
+          "Note": "Note 1"
+        },
+        {
+          "Date created": "Sun 24 Jul 2022",
+          "Date occurred": "Thu 22 Sep 2022",
+          "Is the case note sensitive?": "Yes",
+          "Name of author": "Leticia Mann",
+          "Type": "General",
+          "Subtype": "Quality Work",
+          "Note": "Note 2"
+        }
+      ],
+      "Adjudications": [
+        {
+          "Adjudication number": 69927,
+          "Report date and time": "9 Oct 2022, 00:00",
+          "Establishment": "Hawthorne",
+          "Offence description": "Nam vel nisi fugiat veniam possimus omnis.",
+          "Finding": "Not proved"
+        },
+        {
+          "Adjudication number": 39963,
+          "Report date and time": "10 Jul 2022, 00:00",
+          "Establishment": "Oklahoma City",
+          "Offence description": "Illum maxime enim explicabo soluta sequi voluptas.",
+          "Finding": "Proved"
+        },
+        {
+          "Adjudication number": 77431,
+          "Report date and time": "30 May 2022, 00:00",
+          "Establishment": "Jurupa Valley",
+          "Offence description": "Quis porro nemo voluptates doloribus atque quis provident iure.",
+          "Finding": "Proved"
+        }
+      ],
+      "ACCT Alerts": [
+        {
+          "Alert type": 47419,
+          "ACCT description": "Soluta harum harum hic maxime reprehenderit quis harum necessitatibus.",
+          "Date created": "Mon 5 Dec 2022",
+          "Expiry date": "Mon 29 May 2023"
+        },
+        {
+          "Alert type": 429,
+          "ACCT description": "Quia ex nisi deserunt voluptatibus sit ipsa.",
+          "Date created": "Sat 21 May 2022",
+          "Expiry date": "Sat 16 Dec 2023"
+        }
+      ]
+    }
+  ],
+  "location-factors": [
+    {
+      "What is the preferred postcode area for the Approved Premises (AP) placement?": "SW11",
+      "Give details of why this postcode area would benefit the person": "Some positive factors",
+      "Are there any restrictions linked to placement location?": "Yes",
+      "Provide details of any restraining orders, exclusion zones or other location based licence conditions. You must also provide an exclusion zone map in the ‘attach required documents’ screen.": "Restrictions go here",
+      "If an AP Placement is not available in the persons preferred area, would a placement further away be considered?": "Yes",
+      "Choose the maximum radius (in miles)": "70 miles"
+    },
+    {
+      "First choice AP": "No preference",
+      "Second choice AP": "No preference",
+      "Third choice AP": "No preference",
+      "Fourth choice AP": "No preference",
+      "Fifth choice AP": "No preference"
+    }
+  ],
+  "access-and-healthcare": [
+    {
+      "Does the person have any of the following needs?": "Mobility, learning disability, neurodivergent conditions, pregnancy",
+      "Does the person have any religious or cultural needs?": "Yes - sunt at minus",
+      "Does this person have care and support needs?": "Yes - some detail",
+      "Does the person need an interpreter?": "Yes",
+      "Has a care act assessment been completed?": "Yes",
+      "Which language is an interpreter needed for?": "beatae eligendi explicabo"
+    },
+    {
+      "Does the person require the use of a wheelchair?": "Yes",
+      "Does the person have any known health conditions?": "Yes - Some detail",
+      "Does the person have any prescribed medication?": "Yes - Some detail",
+      "Is the person pregnant?": "Yes",
+      "What is their expected date of delivery?": "Sun 31 Dec 2023",
+      "Will the child be removed from the person's care at birth?": "Decision pending",
+      "Is there social care involvement?": "Yes - Some detail",
+      "Are there any pregnancy related issues relevant to placement?": "Yes - some considerations",
+      "Specify any additional details and adjustments required for the person's mobility, learning disability, neurodivergent conditions or pregnancy needs": "Some detail"
+    },
+    {
+      "Is the person eligible for COVID-19 vaccination boosters?": "Yes - some details",
+      "Is the person immunosuppressed, eligible for nMAB treatment or higher risk as per the definitions in the COVID-19 guidance?": "Yes"
+    }
+  ],
+  "further-considerations": [
+    {
+      "Is there any evidence that the person may pose a risk to AP staff?": "No",
+      "Is there any evidence that the person may pose a risk to other AP residents?": "No",
+      "Do you have any concerns about the person sharing a bedroom?": "Yes - Some details here",
+      "Is there any evidence of previous trauma or significant event in the persons history which would indicate that room share may not be suitable?": "No",
+      "Is there potential for the person to benefit from a room share?": "No"
+    },
+    {
+      "Are you aware that the person is vulnerable to exploitation from others?": "No",
+      "Is there any evidence or expectation that the person may groom, radicalise or exploit others?": "Yes - Some details here"
+    },
+    {
+      "Has the person stayed or been offered a placement in an AP before?": "Yes - Some details here"
+    },
+    {
+      "Does this person need a RFAP?": "Yes"
+    },
+    {
+      "How has the person demonstrated their motivation to address their substance misuse?": "Some motivation",
+      "Is this person receiving clinical, medical and/or psychosocial treatment for their substance misuse?": "Yes - Some details here",
+      "How is the person planning to continue their recovery work whilst in the AP?": "Some work"
+    },
+    {
+      "Can the person be placed in a self-catered Approved Premises (AP)?": "No - Some details here"
+    },
+    {
+      "Does the person pose an arson risk?": "Yes - Some details here"
+    },
+    {
+      "Are there are any additional circumstances that have helped the person do well in the past?": "Yes - Some details here"
+    },
+    {
+      "Contingency plan partners": [
+        {
+          "Role in plan": "Test role 1",
+          "Phone number": "01234567891",
+          "Named contact": "Test contact 1",
+          "Partner agency name": "Test agency 1"
+        },
+        {
+          "Role in plan": "Test role 2",
+          "Phone number": "01234567892",
+          "Named contact": "Test contact 2",
+          "Partner agency name": "Test agency 2"
+        }
+      ]
+    },
+    {
+      "If the person does not return to the AP for curfew, what actions should be taken?": "Action to be taken",
+      "If the person's placement needs to be withdrawn out of hours, what actions should be taken?": "Further action to be taken",
+      "Provide any victim considerations that the AP need to be aware of when out of hours": "Considerations for victim",
+      "In the event of an out of hours placement withdrawal, provide any unsuitable addresses that the person cannot reside at": "An unsuitable address",
+      "In the event of an out of hours placement withdrawal, provide alternative suitable addresses that the person can reside at": "Some suitable addresses",
+      "In the event of a breach, provide any further information to support Out of Hours (OoH) decision making": "Breach information to assist decision making",
+      "Are there any other considerations?": "Some other considerations"
+    },
+    {
+      "Is there a trigger plan in place?": "Yes",
+      "Have additional Licence conditions been requested as an alternative to recall?": "Yes - Some details here"
+    }
+  ],
+  "move-on": [
+    {
+      "Does this application require a different placement duration?": "Yes",
+      "How many weeks will the person stay at the AP?": "6 weeks",
+      "Why does this person require a different placement duration?": "some reason"
+    },
+    {
+      "Where is the person most likely to live when they move on from the AP?": "SW11"
+    },
+    {
+      "Are move on arrangements already in place for when the person leaves the AP?": "Yes - Some detail"
+    },
+    {
+      "What type of accommodation will the person have when they leave the AP?": "Accommodation provided through Home Office section 10 for foreign national"
+    },
+    {
+      "Have you informed the Home Office 'Foreign National Returns Command' that accommodation will be required after placement?": "Yes",
+      "Date of notification": "Thu 1 Jan 2015"
+    }
+  ],
+  "attach-required-documents": [
+    {
+      "Random offender document1.pdf": "Some Description 1",
+      "national.asm": "Some Description 2"
+    }
+  ]
+}

--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -108,7 +108,7 @@ export default class ShowPage extends Page {
   }
 
   shouldShowResponses() {
-    this.shouldShowCheckYourAnswersResponses(this.application)
+    this.shouldShowResponseFromSubmittedApplication(this.application)
   }
 
   shouldNotShowCreatePlacementRequestButton() {

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -13,6 +13,7 @@ import errorLookups from '../../server/i18n/en/errors.json'
 import { summaryListSections } from '../../server/utils/applications/summaryListUtils'
 import { DateFormats } from '../../server/utils/dateUtils'
 import { sentenceCase } from '../../server/utils/utils'
+import { SumbmittedApplicationSummaryCards } from '../../server/utils/applications/submittedApplicationSummaryCards'
 
 export type PageElement = Cypress.Chainable<JQuery>
 
@@ -230,6 +231,20 @@ export default abstract class Page {
   shouldShowCheckYourAnswersTitle(taskName: string, taskTitle: string) {
     cy.get(`[data-cy-section="${taskName}"]`).within(() => {
       cy.get('.govuk-summary-card__title').should('contain', taskTitle)
+    })
+  }
+
+  shouldShowResponseFromSubmittedApplication(application: Application) {
+    const sections = new SumbmittedApplicationSummaryCards(application).response
+
+    sections.forEach(section => {
+      cy.get('h2.govuk-heading-l').contains(section.title).should('exist')
+      section.tasks.forEach(task => {
+        cy.get(`[data-cy-section="${task.card.attributes['data-cy-section']}"]`).within(() => {
+          cy.get('.govuk-summary-card__title').contains(task.card.title.text).should('exist')
+          this.shouldContainSummaryListItems(task.rows)
+        })
+      })
     })
   }
 

--- a/integration_tests/tests/apply/appeals.cy.ts
+++ b/integration_tests/tests/apply/appeals.cy.ts
@@ -3,6 +3,7 @@ import { appealFactory, applicationFactory, newAppealFactory, personFactory } fr
 import { ShowPage } from '../../pages/apply'
 import Page from '../../pages/page'
 import AppealsShowPage from '../../pages/apply/appeals/show'
+import applicationDocument from '../../fixtures/applicationDocument.json'
 
 context('Appeals', () => {
   beforeEach(() => {
@@ -17,7 +18,11 @@ context('Appeals', () => {
   it('should create an appeal', () => {
     // Given there is an application
     const person = personFactory.build()
-    const application = applicationFactory.build({ person, status: 'rejected' })
+    const application = applicationFactory.build({
+      person,
+      status: 'rejected',
+      document: applicationDocument,
+    })
     const appeal = appealFactory.build()
 
     cy.task('stubApplicationGet', { application })

--- a/integration_tests/tests/apply/viewApplication.cy.ts
+++ b/integration_tests/tests/apply/viewApplication.cy.ts
@@ -15,6 +15,7 @@ import { ApprovedPremisesApplication as Application, User } from '../../../serve
 import { defaultUserId } from '../../mockApis/auth'
 import paths from '../../../server/paths/api'
 import { withdrawPlacementRequestOrApplication } from '../../support/helpers'
+import applicationDocument from '../../fixtures/applicationDocument.json'
 
 context('show applications', () => {
   beforeEach(setup)
@@ -23,7 +24,7 @@ context('show applications', () => {
     // Given I have completed an application
     const timeline = timelineEventFactory.buildList(10)
 
-    const updatedApplication = { ...this.application, status: 'submitted' }
+    const updatedApplication = { ...this.application, status: 'submitted', document: applicationDocument }
     cy.task('stubApplicationGet', { application: updatedApplication })
     cy.task('stubApplicationTimeline', { applicationId: updatedApplication.id, timeline })
     cy.task('stubApplications', [updatedApplication])
@@ -65,6 +66,7 @@ context('show applications', () => {
       assessmentDecision: 'accepted',
       assessmentDecisionDate: '2023-01-01',
       assessmentId: faker.string.uuid(),
+      document: applicationDocument,
     }
     cy.task('stubApplicationGet', { application })
     cy.task('stubApplications', [application])
@@ -261,6 +263,7 @@ const makeReleaseFollowingDecisionPlacementApplication = (application: Applicati
     assessmentDecision: 'accepted',
     assessmentDecisionDate: '2023-01-01',
     assessmentId: 'low',
+    document: applicationDocument,
   }
 
   let releaseFollowingDecisionPlacementApplication = placementApplication.build({

--- a/integration_tests/tests/assess/assess.cy.ts
+++ b/integration_tests/tests/assess/assess.cy.ts
@@ -23,6 +23,7 @@ import {
 import Page from '../../pages/page'
 import { awaitingAssessmentStatuses } from '../../../server/utils/assessments/utils'
 import { addResponseToFormArtifact, addResponsesToFormArtifact } from '../../../server/testutils/addToApplication'
+import applicationDocument from '../../fixtures/applicationDocument.json'
 
 context('Assess', () => {
   beforeEach(() => {
@@ -39,7 +40,7 @@ context('Assess', () => {
         const clarificationNote = clarificationNoteFactory.build({ response: undefined })
         const assessment = assessmentFactory.build({
           decision: undefined,
-          application: { data: applicationData, person: personFactory.build() },
+          application: { data: applicationData, person: personFactory.build(), document: applicationDocument },
           clarificationNotes: [clarificationNote],
         })
 

--- a/integration_tests/tests/assess/shortNoticeAssessments.cy.ts
+++ b/integration_tests/tests/assess/shortNoticeAssessments.cy.ts
@@ -14,6 +14,7 @@ import { acceptanceData } from '../../../server/utils/assessments/acceptanceData
 import AssessHelper from '../../helpers/assess'
 import { addResponseToFormArtifact, addResponsesToFormArtifact } from '../../../server/testutils/addToApplication'
 import { ApprovedPremisesApplication as Application } from '../../../server/@types/shared/models/ApprovedPremisesApplication'
+import applicationDocument from '../../fixtures/applicationDocument.json'
 
 describe('Short notice assessments', () => {
   beforeEach(() => {
@@ -32,7 +33,7 @@ describe('Short notice assessments', () => {
 
         let application = applicationFactory
           .withFullPerson()
-          .build({ submittedAt: DateFormats.dateObjToIsoDate(today) })
+          .build({ submittedAt: DateFormats.dateObjToIsoDate(today), document: applicationDocument })
 
         application.data = applicationData
 

--- a/integration_tests/tests/match/placementApplications.cy.ts
+++ b/integration_tests/tests/match/placementApplications.cy.ts
@@ -25,6 +25,7 @@ import paths from '../../../server/paths/api'
 import { addResponseToFormArtifact } from '../../../server/testutils/addToApplication'
 import ReviewApplicationConfirmPage from '../../pages/match/reviewApplicationForm/confirmPage'
 import { defaultUserId } from '../../mockApis/auth'
+import applicationDocument from '../../fixtures/applicationDocument.json'
 
 context('Placement Applications', () => {
   beforeEach(() => {
@@ -44,6 +45,7 @@ context('Placement Applications', () => {
         id: '123',
         createdByUserId: defaultUserId,
         person: personFactory.build(),
+        document: applicationDocument,
       })
       cy.task('stubApplicationGet', { application: completedApplication })
       cy.task('stubApplications', [completedApplication])
@@ -121,6 +123,7 @@ context('Placement Applications', () => {
         id: '123',
         createdByUserId: defaultUserId,
         person: personFactory.build(),
+        document: applicationDocument,
       })
       cy.task('stubApplicationGet', { application: completedApplication })
       cy.task('stubApplications', [completedApplication])
@@ -191,6 +194,7 @@ context('Placement Applications', () => {
         id: '123',
         createdByUserId: defaultUserId,
         person,
+        document: applicationDocument,
       })
       completedApplication = addResponseToFormArtifact(completedApplication, {
         task: 'type-of-ap',
@@ -403,6 +407,7 @@ context('Placement Applications', () => {
     const application = applicationFactory.completed('accepted').build({
       id: '123',
       person: personFactory.build(),
+      document: applicationDocument,
     })
     cy.task('stubApplicationGet', { application })
 
@@ -419,6 +424,7 @@ context('Placement Applications', () => {
       id: '123',
       createdByUserId: defaultUserId,
       person: personFactory.build(),
+      document: applicationDocument,
     })
     cy.task('stubApplicationGet', { application })
 
@@ -437,6 +443,7 @@ context('Placement Applications', () => {
       createdByUserId: defaultUserId,
       assessmentDecision: undefined,
       person: personFactory.build(),
+      document: applicationDocument,
     })
     cy.task('stubApplicationGet', { application })
 

--- a/server/utils/applications/submittedApplicationSummaryCards.test.ts
+++ b/server/utils/applications/submittedApplicationSummaryCards.test.ts
@@ -1,0 +1,310 @@
+import { createMock } from '@golevelup/ts-jest'
+import { when } from 'jest-when'
+import { FormSection, SummaryListActionItem, UiTask } from '../../@types/ui'
+import { applicationFactory, documentFactory } from '../../testutils/factories'
+import { SumbmittedApplicationSummaryCards } from './submittedApplicationSummaryCards'
+import { embeddedSummaryListItem } from './summaryListUtils'
+import { linebreaksToParagraphs } from '../utils'
+import { documentsFromApplication } from '../assessments/documentUtils'
+import { getActionsForTaskId } from '../assessments/getActionsForTaskId'
+
+jest.mock('../assessments/documentUtils')
+jest.mock('../assessments/getActionsForTaskId')
+
+describe('SumbmittedApplicationSummaryCards', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should return a summary card for each section', () => {
+    const section1 = createMock<FormSection>({
+      title: 'Type of AP required',
+      tasks: [
+        createMock<UiTask>({
+          title: 'Basic information',
+          id: 'basic-information',
+        }),
+        createMock<UiTask>({
+          title: 'Type of AP required',
+          id: 'type-of-ap-required',
+        }),
+      ],
+    })
+
+    const section2 = createMock<FormSection>({
+      title: 'Considerations for when the placement ends',
+      tasks: [
+        createMock<UiTask>({
+          title: 'Add move on information',
+          id: 'move-on-information',
+        }),
+      ],
+    })
+
+    const sections = [section1, section2]
+
+    const application = applicationFactory.build({
+      document: {
+        'basic-information': [
+          {
+            'Is this an exceptional case?': 'Yes',
+            'Have you agreed the case with a senior manager?': 'Yes',
+          },
+          {
+            'Is the person transgender or do they have a transgender history?': 'No',
+          },
+          {
+            'Parole eligibility date': 'Wednesday 24 April 2024',
+            'Home Detention Curfew (HDC) date': 'No date supplied',
+            'Licence expiry date': 'No date supplied',
+            'Post sentence supervision (PSS) start date': 'No date supplied',
+            'Post sentence supervision (PSS) end date': 'No date supplied',
+            'Sentence expiry date': 'No date supplied',
+          },
+        ],
+        'type-of-ap-required': [
+          {
+            'Which type of AP does the person require?': 'Standard AP',
+          },
+        ],
+        'move-on-information': [
+          {
+            'Does this application require a different placement duration?': 'No',
+          },
+          {
+            'Where is the person most likely to live when they move on from the AP?': 'BD1',
+          },
+          {
+            'Are move on arrangements already in place for when the person leaves the AP?':
+              'No - A DTR will be complete for the local council\r\nCAS3 will be completed \r\nfamily address to be assessed ',
+          },
+          {
+            'What type of accommodation will the person have when they leave the AP?':
+              'CAS3 (Community Accommodation Service) provided',
+          },
+        ],
+      },
+    })
+
+    const cards = new SumbmittedApplicationSummaryCards(application, null, sections).response
+
+    expect(cards).toEqual([
+      {
+        title: 'Type of AP required',
+        tasks: [
+          {
+            card: {
+              title: { text: 'Basic information', headingLevel: 2 },
+              attributes: { 'data-cy-section': 'basic-information' },
+            },
+            rows: [
+              { key: { text: 'Is this an exceptional case?' }, value: { html: '<p class="govuk-body">Yes</p>' } },
+              {
+                key: { text: 'Have you agreed the case with a senior manager?' },
+                value: { html: '<p class="govuk-body">Yes</p>' },
+              },
+              {
+                key: { text: 'Is the person transgender or do they have a transgender history?' },
+                value: { html: '<p class="govuk-body">No</p>' },
+              },
+              {
+                key: { text: 'Parole eligibility date' },
+                value: { html: '<p class="govuk-body">Wednesday 24 April 2024</p>' },
+              },
+              {
+                key: { text: 'Home Detention Curfew (HDC) date' },
+                value: { html: '<p class="govuk-body">No date supplied</p>' },
+              },
+              { key: { text: 'Licence expiry date' }, value: { html: '<p class="govuk-body">No date supplied</p>' } },
+              {
+                key: { text: 'Post sentence supervision (PSS) start date' },
+                value: { html: '<p class="govuk-body">No date supplied</p>' },
+              },
+              {
+                key: { text: 'Post sentence supervision (PSS) end date' },
+                value: { html: '<p class="govuk-body">No date supplied</p>' },
+              },
+              { key: { text: 'Sentence expiry date' }, value: { html: '<p class="govuk-body">No date supplied</p>' } },
+            ],
+          },
+          {
+            card: {
+              title: { text: 'Type of AP required', headingLevel: 2 },
+              attributes: { 'data-cy-section': 'type-of-ap-required' },
+            },
+            rows: [
+              {
+                key: { text: 'Which type of AP does the person require?' },
+                value: { html: '<p class="govuk-body">Standard AP</p>' },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        title: 'Considerations for when the placement ends',
+        tasks: [
+          {
+            card: {
+              title: { text: 'Add move on information', headingLevel: 2 },
+              attributes: { 'data-cy-section': 'move-on-information' },
+            },
+            rows: [
+              {
+                key: { text: 'Does this application require a different placement duration?' },
+                value: { html: '<p class="govuk-body">No</p>' },
+              },
+              {
+                key: { text: 'Where is the person most likely to live when they move on from the AP?' },
+                value: { html: '<p class="govuk-body">BD1</p>' },
+              },
+              {
+                key: { text: 'Are move on arrangements already in place for when the person leaves the AP?' },
+                value: {
+                  html: '<p class="govuk-body">No - A DTR will be complete for the local council<br />CAS3 will be completed <br />family address to be assessed </p>',
+                },
+              },
+              {
+                key: { text: 'What type of accommodation will the person have when they leave the AP?' },
+                value: { html: '<p class="govuk-body">CAS3 (Community Accommodation Service) provided</p>' },
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  it('should return an embedded summary list item when the response is multilevelled', () => {
+    const section = createMock<FormSection>({
+      title: 'My Section',
+      tasks: [
+        createMock<UiTask>({
+          title: 'Task 1',
+          id: 'task-1',
+        }),
+      ],
+    })
+
+    const application = applicationFactory.build({
+      document: {
+        'task-1': [
+          {
+            'Question 1': [
+              {
+                'Subquestion 1': 'Answer 1',
+                'Subquestion 2': 'Answer 2',
+              },
+              {
+                'Subquestion 3': 'Answer 3',
+              },
+            ],
+          },
+          {
+            'Question 2': 'Answer',
+          },
+        ],
+      },
+    })
+
+    const cards = new SumbmittedApplicationSummaryCards(application, null, [section]).response
+
+    expect(cards[0].tasks[0].rows[0]).toEqual({
+      key: { text: 'Question 1' },
+      value: {
+        html: embeddedSummaryListItem([
+          {
+            'Subquestion 1': 'Answer 1',
+            'Subquestion 2': 'Answer 2',
+          },
+          {
+            'Subquestion 3': 'Answer 3',
+          },
+        ]),
+      },
+    })
+    expect(cards[0].tasks[0].rows[1]).toEqual({
+      key: { text: 'Question 2' },
+      value: {
+        html: linebreaksToParagraphs('Answer'),
+      },
+    })
+  })
+
+  it('should add documents', () => {
+    const section = createMock<FormSection>({
+      title: 'My Section',
+      tasks: [
+        createMock<UiTask>({
+          title: 'Documents',
+          id: 'attach-required-documents',
+        }),
+      ],
+    })
+
+    const application = applicationFactory.build()
+    const documents = documentFactory.buildList(2)
+
+    when(documentsFromApplication).calledWith(application).mockReturnValue(documents)
+
+    const cards = new SumbmittedApplicationSummaryCards(application, null, [section]).response
+
+    expect(cards[0].tasks[0].rows).toEqual([
+      {
+        key: {
+          html: `<a href="/applications/people/${application.person.crn}/documents/${documents[0].id}" data-cy-documentId="${documents[0].id}">${documents[0].fileName}</a>`,
+        },
+        value: { text: documents[0].description },
+      },
+      {
+        key: {
+          html: `<a href="/applications/people/${application.person.crn}/documents/${documents[1].id}" data-cy-documentId="${documents[1].id}">${documents[1].fileName}</a>`,
+        },
+        value: { text: documents[1].description },
+      },
+    ])
+  })
+
+  it('should add actions for specific tasks when the assessment ID is provided', () => {
+    const section = createMock<FormSection>({
+      title: 'My Section',
+      tasks: [
+        createMock<UiTask>({
+          title: 'Task 1',
+          id: 'task-1',
+        }),
+      ],
+    })
+
+    const application = applicationFactory.build()
+    const assessmentId = '123'
+
+    const summaryListActionItems = { items: [createMock<SummaryListActionItem>()] }
+
+    when(getActionsForTaskId).calledWith(section.tasks[0].id, assessmentId).mockReturnValue(summaryListActionItems)
+
+    const cards = new SumbmittedApplicationSummaryCards(application, assessmentId, [section]).response
+
+    expect(getActionsForTaskId).toHaveBeenCalledWith(section.tasks[0].id, assessmentId)
+
+    expect(cards[0].tasks[0].card.actions).toEqual(summaryListActionItems)
+  })
+
+  it('should not call getActionsForTaskId when an assessment ID is not specified', () => {
+    const section = createMock<FormSection>({
+      title: 'My Section',
+      tasks: [
+        createMock<UiTask>({
+          title: 'Task 1',
+          id: 'task-1',
+        }),
+      ],
+    })
+
+    const application = applicationFactory.build()
+    const cards = new SumbmittedApplicationSummaryCards(application, null, [section]).response
+
+    expect(getActionsForTaskId).not.toHaveBeenCalled()
+    expect(cards[0].tasks[0].card.actions).toEqual(undefined)
+  })
+})

--- a/server/utils/applications/submittedApplicationSummaryCards.ts
+++ b/server/utils/applications/submittedApplicationSummaryCards.ts
@@ -1,0 +1,77 @@
+import { ApprovedPremisesApplication as Application } from '../../@types/shared'
+import { FormSections, SummaryListItem, UiTask } from '../../@types/ui'
+import Apply from '../../form-pages/apply'
+import { documentsFromApplication } from '../assessments/documentUtils'
+import { getActionsForTaskId } from '../assessments/getActionsForTaskId'
+import { linebreaksToParagraphs } from '../utils'
+import { embeddedSummaryListItem } from './summaryListUtils'
+
+type QuestionResponse = string | Array<Record<string, unknown>>
+
+type PageResponse = Record<string, QuestionResponse>
+
+type TaskResponse = Array<PageResponse>
+
+export class SumbmittedApplicationSummaryCards {
+  constructor(
+    private readonly application: Application,
+    private readonly assessmentId?: string,
+    private readonly sections: FormSections = Apply.sections.slice(0, -1), // Defaults to all Apply sections except the final "Check your answers" section
+  ) {}
+
+  get response() {
+    return this.sections.map(section => {
+      return {
+        title: section.title,
+        tasks: section.tasks.map(task => this.taskToSummaryCard(task)),
+      }
+    })
+  }
+
+  taskToSummaryCard = (task: UiTask) => {
+    return {
+      card: {
+        title: { text: task.title, headingLevel: 2 },
+        actions: this.assessmentId ? getActionsForTaskId(task.id, this.assessmentId) : undefined,
+        attributes: {
+          'data-cy-section': task.id,
+        },
+      },
+      rows: this.summaryCardRowsForTaskId(task.id),
+    }
+  }
+
+  summaryCardRowsForTaskId = (taskId: string): Array<SummaryListItem> => {
+    const pages = (this.application.document[taskId] as TaskResponse) || []
+    if (taskId === 'attach-required-documents') {
+      return this.summaryCardRowsForDocuments()
+    }
+    return pages.flatMap(page => {
+      return Object.keys(page).map(question => {
+        const answer = page[question]
+        return this.questionToSummaryCardRow(question, answer)
+      })
+    })
+  }
+
+  summaryCardRowsForDocuments = (): Array<SummaryListItem> => {
+    return documentsFromApplication(this.application).map(document => ({
+      key: {
+        html: `<a href="/applications/people/${this.application.person.crn}/documents/${document.id}" data-cy-documentId="${document.id}">${document.fileName}</a>`,
+      },
+      value: { text: document?.description || '' },
+    }))
+  }
+
+  questionToSummaryCardRow = (question: string, anwser: QuestionResponse): SummaryListItem => {
+    const value =
+      typeof anwser === 'string' || anwser instanceof String
+        ? { html: linebreaksToParagraphs(anwser as string) }
+        : { html: embeddedSummaryListItem(anwser) }
+
+    return {
+      key: { text: question },
+      value,
+    }
+  }
+}

--- a/server/utils/applications/summaryListUtils.test.ts
+++ b/server/utils/applications/summaryListUtils.test.ts
@@ -1,15 +1,9 @@
 import { createMock } from '@golevelup/ts-jest'
 import { applicationFactory, assessmentFactory, documentFactory } from '../../testutils/factories'
 import { forPagesInTask } from './forPagesInTask'
-import {
-  embeddedSummaryListItem,
-  reviewApplicationSections,
-  summaryListSections,
-  taskResponsesAsSummaryListItems,
-} from './summaryListUtils'
+import { embeddedSummaryListItem, summaryListSections, taskResponsesAsSummaryListItems } from './summaryListUtils'
 import reviewSections from '../reviewUtils'
 import { documentsFromApplication } from '../assessments/documentUtils'
-import { getActionsForTaskId } from '../assessments/getActionsForTaskId'
 import { getResponseForPage } from './getResponseForPage'
 import TasklistPage from '../../form-pages/tasklistPage'
 import { linebreaksToParagraphs } from '../utils'
@@ -237,21 +231,6 @@ describe('summaryListUtils', () => {
           },
         ])
       })
-    })
-  })
-
-  describe('reviewApplicationSections', () => {
-    it('sends a cardActionFunction to reviewSections, which passes the correct assessment ID on to `getActionsForTaskId`', () => {
-      const application = applicationFactory.build()
-
-      reviewApplicationSections(application, 'assessmentId')
-
-      const { mock } = reviewSections as jest.Mock
-      const cardActionFunction = mock.calls[2][3]
-
-      cardActionFunction('task')
-
-      expect(getActionsForTaskId).toHaveBeenCalledWith('task', 'assessmentId')
     })
   })
 })

--- a/server/utils/applications/summaryListUtils.ts
+++ b/server/utils/applications/summaryListUtils.ts
@@ -10,7 +10,6 @@ import placementApplicationsPaths from '../../paths/placementApplications'
 
 import reviewSections from '../reviewUtils'
 import { documentsFromApplication } from '../assessments/documentUtils'
-import { getActionsForTaskId } from '../assessments/getActionsForTaskId'
 import { journeyTypeFromArtifact } from '../journeyTypeFromArtifact'
 import { getResponseForPage } from './getResponseForPage'
 import { forPagesInTask } from './forPagesInTask'
@@ -78,12 +77,6 @@ const attachDocumentsSummaryListItems = (
   })
 
   return items
-}
-
-const reviewApplicationSections = (application: Application, assessmentId: string) => {
-  const cardActionFunction = (taskId: string) => getActionsForTaskId(taskId, assessmentId)
-
-  return reviewSections(application, taskResponsesAsSummaryListItems, false, cardActionFunction)
 }
 
 const embeddedSummaryListItem = (answers: Array<Record<string, unknown>>): string => {
@@ -155,4 +148,4 @@ const linkToPage = (pageName: string, taskName: string, formArtifact: FormArtifa
   }
 }
 
-export { summaryListSections, embeddedSummaryListItem, taskResponsesAsSummaryListItems, reviewApplicationSections }
+export { summaryListSections, embeddedSummaryListItem, taskResponsesAsSummaryListItems }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -6,7 +6,7 @@ import nunjucks from 'nunjucks'
 import express from 'express'
 
 import type { ErrorMessages } from '@approved-premises/ui'
-import { PersonStatus } from '@approved-premises/api'
+import { ApprovedPremisesApplication as Application, PersonStatus } from '@approved-premises/api'
 import {
   initialiseName,
   kebabCase,
@@ -30,6 +30,7 @@ import { statusTag } from './personUtils'
 import { DateFormats, monthOptions, uiDateOrDateEmptyMessage, yearOptions } from './dateUtils'
 import { pagination } from './pagination'
 import { sortHeader } from './sortHeader'
+import { SumbmittedApplicationSummaryCards } from './applications/submittedApplicationSummaryCards'
 
 import * as ApplyUtils from './applications/utils'
 import * as AssessmentUtils from './assessments/utils'
@@ -233,4 +234,10 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('PremisesUtils', PremisesUtils)
   njkEnv.addGlobal('ReportUtils', ReportUtils)
   njkEnv.addGlobal('AppealsUtils', AppealsUtils)
+
+  njkEnv.addGlobal(
+    'getSummaryCardsForApplication',
+    (application: Application, assessmentId?: string) =>
+      new SumbmittedApplicationSummaryCards(application, assessmentId).response,
+  )
 }

--- a/server/views/applications/partials/_readonly-application.njk
+++ b/server/views/applications/partials/_readonly-application.njk
@@ -6,7 +6,7 @@
   {{ personDetails(application.person, statusOnSubmission = application.personStatusOnSubmission) }}
 
   {% if application.type !== 'Offline' %}
-    {% for section in SummaryListUtils.summaryListSections(application, false) %}
+    {% for section in getSummaryCardsForApplication(application) %}
       <h2 class="govuk-heading-l">{{ section.title }}</h2>
       {% for task in section.tasks %}
         {{

--- a/server/views/assessments/pages/review-application/review.njk
+++ b/server/views/assessments/pages/review-application/review.njk
@@ -5,7 +5,7 @@
 {% extends "../layout.njk" %}
 
 {% set columnClasses= "govuk-grid-column-full" %}
-{% set nomsNumber = page.document.application.person.nomsNumber if page.document.application.person.nomsNumber else 
+{% set nomsNumber = page.document.application.person.nomsNumber if page.document.application.person.nomsNumber else
   "" %}
 
 {% block questions %}
@@ -115,7 +115,7 @@
     })
   }}
 
-  {% for section in SummaryListUtils.reviewApplicationSections(page.document.application, assessmentId) %}
+  {% for section in getSummaryCardsForApplication(page.document.application, assessmentId) %}
     <h2 class="govuk-heading-l" id={{section.title | kebabCase }}>{{ section.title }}</h2>
     {% for task in section.tasks %}
       {{ govukSummaryList(task) }}


### PR DESCRIPTION
When viewing applications in the read only version, or when assessing, we still build up the response using the `data` response and the form classes. This causes issues if the schema changes, as we will get errors. This was one of the reasons why we have a persisted `document` field in an application, but this wasn’t getting used for some reason

This adds a new `SumbmittedApplicationSummaryCards` class to get all the sections for a form (unfortunately this is not yet persisted) and walk through each task and page and return each question in each page as a summary list.