### PR TITLE
Handle withdrawn unsubmitted applications

### DIFF
--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -111,6 +111,10 @@ export default class ShowPage extends Page {
     this.shouldShowResponseFromSubmittedApplication(this.application)
   }
 
+  shouldShowResponsesForUnsubmittedWithdrawnApplication() {
+    this.shouldShowCheckYourAnswersResponses(this.application)
+  }
+
   shouldNotShowCreatePlacementRequestButton() {
     cy.get('Create placement request').should('not.exist')
   }

--- a/integration_tests/tests/apply/viewApplication.cy.ts
+++ b/integration_tests/tests/apply/viewApplication.cy.ts
@@ -58,6 +58,19 @@ context('show applications', () => {
     showPage.shouldShowTimeline(timeline)
   })
 
+  it('shows a read-only version of an unsubmitted withdrawn application', function test() {
+    // Given I have a withdrawn unsubmitted application
+    const updatedApplication = { ...this.application, status: 'withdrawn', document: undefined }
+    cy.task('stubApplicationGet', { application: updatedApplication })
+    cy.task('stubApplications', [updatedApplication])
+
+    // Then I should see a read-only version of the application
+    const showPage = ShowPage.visit(updatedApplication, 'application')
+
+    // And I should see the application details
+    showPage.shouldShowResponsesForUnsubmittedWithdrawnApplication()
+  })
+
   it('links to an assessment when an application has been assessed', function test() {
     // Given I have completed an application
     const application = {

--- a/server/views/applications/partials/_readonly-application.njk
+++ b/server/views/applications/partials/_readonly-application.njk
@@ -3,17 +3,23 @@
 
 {% macro applicationReadonlyView(application) %}
 
-  {{ personDetails(application.person, statusOnSubmission = application.personStatusOnSubmission) }}
+  {% if application.status === 'withdrawn' %}
+    {% set sections = SummaryListUtils.summaryListSections(application, false) %}
+  {%else%}
+    {% set sections = getSummaryCardsForApplication(application) %}
+  {%endif%}
 
-  {% if application.type !== 'Offline' %}
-    {% for section in getSummaryCardsForApplication(application) %}
-      <h2 class="govuk-heading-l">{{ section.title }}</h2>
-      {% for task in section.tasks %}
-        {{
+    {{ personDetails(application.person, statusOnSubmission = application.personStatusOnSubmission) }}
+
+    {% if application.type !== 'Offline' %}
+      {% for section in sections %}
+        <h2 class="govuk-heading-l">{{ section.title }}</h2>
+        {% for task in section.tasks %}
+          {{
               govukSummaryList(task)
             }}
+        {% endfor %}
       {% endfor %}
-    {% endfor %}
-  {% endif %}
+    {% endif %}
 
-{% endmacro %}
+  {% endmacro %}


### PR DESCRIPTION
#1668 switched to using the `application.document` for showing applications in the read only view. This won't work for unsubmitted withdrawn applications as they don't have the 'document' property. For now we revert to the legacy way of showing applications if they are withdrawn and unsubmitted. In future we will want to address this in a more changeproof manner but this unblocks us for now.

[JIRA](https://dsdmoj.atlassian.net/browse/APS-564)