### PR TITLE
Handle applications with an ApType of 'standard'

### DIFF
--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/apType.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/apType.test.ts
@@ -49,5 +49,13 @@ describe('SelectApType', () => {
         [page.title]: 'Psychologically Informed Planned Environment (PIPE)',
       })
     })
+
+    it('should return a translated version of the response', () => {
+      const page = new SelectApType({ type: 'standard' })
+
+      expect(page.response()).toEqual({
+        [page.title]: 'Standard AP',
+      })
+    })
   })
 })

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/apType.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/apType.ts
@@ -1,4 +1,4 @@
-import type { TaskListErrors } from '@approved-premises/ui'
+import type { BackwardsCompatibleApplyApType, TaskListErrors } from '@approved-premises/ui'
 
 import { ApType } from '@approved-premises/api'
 import TasklistPage from '../../../tasklistPage'
@@ -21,7 +21,7 @@ export const apTypeLabels: Record<ApType, string> = {
 export default class SelectApType implements TasklistPage {
   title = `Which type of AP does the person require?`
 
-  constructor(public body: { type?: ApType }) {}
+  constructor(public body: { type?: BackwardsCompatibleApplyApType }) {}
 
   previous() {
     return 'dashboard'
@@ -39,7 +39,9 @@ export default class SelectApType implements TasklistPage {
   }
 
   response() {
-    return { [`${this.title}`]: apTypeLabels[this.body.type] }
+    const type = this.body.type === 'standard' ? 'normal' : this.body.type
+
+    return { [`${this.title}`]: apTypeLabels[type] }
   }
 
   errors() {

--- a/server/utils/applications/summaryListUtils.ts
+++ b/server/utils/applications/summaryListUtils.ts
@@ -45,7 +45,7 @@ const taskResponsesAsSummaryListItems = (
         items.push(summaryListItemForResponse(key, value, task.id, pageName, applicationOrAssessment, showActions))
       } catch (e) {
         throw Error(
-          `Error rendering summary list. Page name: ${pageName}, response: ${response}, question: ${key}, error: ${e}`,
+          `Error rendering summary list. Page name: ${pageName}, response: ${JSON.stringify(response)}, question: ${key}, error: ${e}`,
         )
       }
     })


### PR DESCRIPTION
Whilst [we have removed 'standard'  as a possible response for new applications](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/1653) there may be some legacy applications that use it as an answer.
As [we still use the `application.data` blob to render withdrawn unsubmitted application](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/1671) we need to be able to handle this response for legacy applications
[JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&selectedIssue=APS-564)
