### PR TITLE
APS-532: Sort assessments table by Due date

### DIFF
--- a/server/utils/assessments/tableUtils.test.ts
+++ b/server/utils/assessments/tableUtils.test.ts
@@ -118,7 +118,7 @@ describe('tableUtils', () => {
           {
             text: 'Current location',
           },
-          sortHeader<AssessmentSortField>('Days until assessment due', 'createdAt', sortBy, sortDirection, hrefPrefix),
+          sortHeader<AssessmentSortField>('Days until assessment due', 'dueAt', sortBy, sortDirection, hrefPrefix),
           sortHeader<AssessmentSortField>('Status', 'status', sortBy, sortDirection, hrefPrefix),
         ],
         rows: awaitingAssessmentTableRows(assessments),
@@ -141,7 +141,7 @@ describe('tableUtils', () => {
           {
             text: 'Days since received',
           },
-          sortHeader<AssessmentSortField>('Days until assessment due', 'createdAt', sortBy, sortDirection, hrefPrefix),
+          sortHeader<AssessmentSortField>('Days until assessment due', 'dueAt', sortBy, sortDirection, hrefPrefix),
           sortHeader<AssessmentSortField>('Status', 'status', sortBy, sortDirection, hrefPrefix),
         ],
         rows: requestedFurtherInformationTableRows(assessments),

--- a/server/utils/assessments/tableUtils.ts
+++ b/server/utils/assessments/tableUtils.ts
@@ -106,7 +106,7 @@ const assessmentTable = (
           {
             text: 'Days since received',
           },
-          sortHeader<AssessmentSortField>('Days until assessment due', 'createdAt', sortBy, sortDirection, hrefPrefix),
+          sortHeader<AssessmentSortField>('Days until assessment due', 'dueAt', sortBy, sortDirection, hrefPrefix),
           sortHeader<AssessmentSortField>('Status', 'status', sortBy, sortDirection, hrefPrefix),
         ],
         rows: requestedFurtherInformationTableRows(assessments),
@@ -138,7 +138,7 @@ const assessmentTable = (
           {
             text: 'Current location',
           },
-          sortHeader<AssessmentSortField>('Days until assessment due', 'createdAt', sortBy, sortDirection, hrefPrefix),
+          sortHeader<AssessmentSortField>('Days until assessment due', 'dueAt', sortBy, sortDirection, hrefPrefix),
           sortHeader<AssessmentSortField>('Status', 'status', sortBy, sortDirection, hrefPrefix),
         ],
         rows: awaitingAssessmentTableRows(assessments),


### PR DESCRIPTION
# Context

<!-- https://dsdmoj.atlassian.net/browse/APS-532 -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Sort assessments table by "Due date"
## Screenshots of UI changes
No UI chnages
### Before

### After
