### PR TITLE
Temporarily remove MHAPs

### DIFF
--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -535,6 +535,7 @@ export default class ApplyHelper {
     const apTypePage = new ApplyPages.ApType(this.application)
 
     // When I complete the form and click submit
+    apTypePage.shouldNotShowMentalHealthAps()
     apTypePage.completeForm()
     apTypePage.clickSubmit()
 

--- a/integration_tests/helpers/assess.ts
+++ b/integration_tests/helpers/assess.ts
@@ -285,6 +285,7 @@ export default class AseessHelper {
 
     // Then I should be taken to the matching information page
     const page = new MatchingInformationPage(this.assessment)
+    page.shouldNotShowMentalHealthAps()
     page.completeForm()
     page.clickSubmit()
 

--- a/integration_tests/pages/apply/apType.ts
+++ b/integration_tests/pages/apply/apType.ts
@@ -13,6 +13,11 @@ export default class TypeOfApPage extends ApplyPage {
     )
   }
 
+  shouldNotShowMentalHealthAps() {
+    cy.get(`input[name="type"][value="mhapElliottHouse"]`).should('not.exist')
+    cy.get(`input[name="type"][value="mhapStJosephs"]`).should('not.exist')
+  }
+
   completeForm() {
     this.checkRadioButtonFromPageBody('type')
   }

--- a/integration_tests/pages/assess/matchingInformationPage.ts
+++ b/integration_tests/pages/assess/matchingInformationPage.ts
@@ -7,6 +7,11 @@ export default class MatchingInformationPage extends AssessPage {
     super('Matching information', assessment, 'matching-information', 'matching-information', '')
   }
 
+  shouldNotShowMentalHealthAps() {
+    cy.get(`input[name="apType"][value="isMHAPElliottHouse"]`).should('not.exist')
+    cy.get(`input[name="apType"][value="isMHAPStJosephs"]`).should('not.exist')
+  }
+
   completeForm() {
     this.checkRadioButtonFromPageBody('apType')
 

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/apType.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/apType.ts
@@ -6,7 +6,7 @@ import { convertArrayToRadioItems } from '../../../../utils/formUtils'
 import { Page } from '../../../utils/decorators'
 
 // The ordering of AP types is meaningful to users
-export const apTypes: ReadonlyArray<ApType> = ['normal', 'pipe', 'esap', 'rfap', 'mhapElliottHouse', 'mhapStJosephs']
+export const apTypes: ReadonlyArray<ApType> = ['normal', 'pipe', 'esap', 'rfap']
 
 export const apTypeLabels: Record<ApType, string> = {
   normal: 'Standard AP',


### PR DESCRIPTION
We don't want to deploy the MHAP work yet but we need to unblock the pipeline.
In order to do this we remove them from the 'apTypes' array which will prevent them being shown on the AP type page in Apply and on the Matching Information page in Assess

## Screenshots of UI changes

### Before
![before](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/1a84bf56-4db5-4e49-8fb5-f659a59723c2)
![before (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/37ade019-213a-4d50-9dbf-a7bcc7c23f89)


### After
![after](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/42b5e5a6-cffb-42d5-b4ba-d727665057c2)
![after (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/8923225f-e4a2-433c-a7ed-daea873c3b89)
