### PR TITLE
(APS-618) Handle offline applications in summary cards

### DIFF
--- a/integration_tests/tests/apply/viewApplication.cy.ts
+++ b/integration_tests/tests/apply/viewApplication.cy.ts
@@ -107,6 +107,7 @@ context('show applications', () => {
     const application = {
       ...this.application,
       type: 'Offline',
+      document: undefined,
       status: undefined,
     }
     cy.task('stubApplicationGet', { application })

--- a/server/utils/applications/submittedApplicationSummaryCards.test.ts
+++ b/server/utils/applications/submittedApplicationSummaryCards.test.ts
@@ -307,4 +307,25 @@ describe('SumbmittedApplicationSummaryCards', () => {
     expect(getActionsForTaskId).not.toHaveBeenCalled()
     expect(cards[0].tasks[0].card.actions).toEqual(undefined)
   })
+
+  it('should handle offline applications, returning an empty array for task rows', () => {
+    const section = createMock<FormSection>({
+      title: 'My Section',
+      tasks: [
+        createMock<UiTask>({
+          title: 'Task 1',
+          id: 'task-1',
+        }),
+      ],
+    })
+
+    const application = applicationFactory.build({ type: 'offline', document: undefined, status: undefined })
+    const cards = new SumbmittedApplicationSummaryCards(application, null, [section]).response
+
+    cards.forEach(card => {
+      card.tasks.forEach(task => {
+        expect(task.rows).toEqual([])
+      })
+    })
+  })
 })

--- a/server/utils/applications/submittedApplicationSummaryCards.ts
+++ b/server/utils/applications/submittedApplicationSummaryCards.ts
@@ -42,7 +42,7 @@ export class SumbmittedApplicationSummaryCards {
   }
 
   summaryCardRowsForTaskId = (taskId: string): Array<SummaryListItem> => {
-    const pages = (this.application.document[taskId] as TaskResponse) || []
+    const pages = (this.application.document?.[taskId] as TaskResponse) || []
     if (taskId === 'attach-required-documents') {
       return this.summaryCardRowsForDocuments()
     }


### PR DESCRIPTION
# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

[JIRA](https://dsdmoj.atlassian.net/browse/APS-618)

# Changes in this PR

The recently added `SubmittedApplicationSummaryCards` class is throwing errors for offline applications. Application documents are a JSON blob representing the responses to the online form at submission time. Offline applications by definition don't have these. The summary cards class was attempting to read from the document without checking it exists (strict mode might have caught this)

This fixes that issue, adds a related unit test, and makes the related integration test setup more realistic so that it can catch this error if it reappears