### PR TITLE
APS-616 Remove ‘NAT’ option when defining app ap area

### DIFF
--- a/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.ts
@@ -117,7 +117,7 @@ export default class ConfirmYourDetails implements TasklistPage {
     dataServices: DataServices,
   ): Promise<ConfirmYourDetails> {
     const user = await dataServices.userService.getUserById(token, application.createdByUserId)
-    const areas = await dataServices.apAreaService.getApAreas(token)
+    const areas = (await dataServices.apAreaService.getApAreas(token)).filter(area => area.name !== 'NAT')
 
     const userForUi = {
       name: user.name,


### PR DESCRIPTION
We want to remove the National AP Area. As a precursor to this we need to ensure no applicaiton exist in the system with this AP Area.

# Context

See https://dsdmoj.atlassian.net/browse/APS-616

# Changes in this PR

## Screenshots of UI changes

### Before

![Screenshot 2024-04-05 at 12 02 41](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22135634/423cfed7-049b-49fe-abd0-0e026bac5141)

### After

![Screenshot 2024-04-05 at 11 56 51](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22135634/d537a452-adce-4335-98d4-cb15c91a49ed)

