### PR TITLE
Add user qualifications for Recovery-focused and Mental Health tasks

### DIFF
--- a/integration_tests/tests/admin/userManagement.cy.ts
+++ b/integration_tests/tests/admin/userManagement.cy.ts
@@ -51,7 +51,7 @@ context('User management', () => {
         'excluded_from_match_allocation',
         'excluded_from_placement_application_allocation',
       ] as const,
-      qualifications: ['pipe', 'emergency', 'esap', 'lao'] as const,
+      qualifications: ['pipe', 'emergency', 'esap', 'lao', 'recovery_focused', 'mental_health_specialist'] as const,
     }
     showPage.completeForm({
       roles: updatedRoles.roles,

--- a/server/@types/shared/models/UserQualification.ts
+++ b/server/@types/shared/models/UserQualification.ts
@@ -2,4 +2,4 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type UserQualification = 'womens' | 'pipe' | 'lao' | 'emergency' | 'esap';
+export type UserQualification = 'womens' | 'pipe' | 'lao' | 'emergency' | 'esap' | 'recovery_focused' | 'mental_health_specialist';

--- a/server/utils/tasks/index.test.ts
+++ b/server/utils/tasks/index.test.ts
@@ -169,6 +169,8 @@ describe('index', () => {
         { selected: false, text: 'Emergency APs', value: 'emergency' },
         { selected: false, text: 'ESAP', value: 'esap' },
         { selected: false, text: 'PIPE', value: 'pipe' },
+        { selected: false, text: 'Recovery-focused APs', value: 'recovery_focused' },
+        { selected: false, text: 'Specialist Mental Health APs', value: 'mental_health_specialist' },
       ])
     })
 
@@ -179,6 +181,8 @@ describe('index', () => {
         { selected: false, text: 'Emergency APs', value: 'emergency' },
         { selected: false, text: 'ESAP', value: 'esap' },
         { selected: false, text: 'PIPE', value: 'pipe' },
+        { selected: false, text: 'Recovery-focused APs', value: 'recovery_focused' },
+        { selected: false, text: 'Specialist Mental Health APs', value: 'mental_health_specialist' },
       ])
     })
   })

--- a/server/utils/tasks/index.ts
+++ b/server/utils/tasks/index.ts
@@ -105,6 +105,8 @@ const userQualificationsSelectOptions = (
     emergency: 'Emergency APs',
     esap: 'ESAP',
     pipe: 'PIPE',
+    recovery_focused: 'Recovery-focused APs',
+    mental_health_specialist: 'Specialist Mental Health APs',
   }
 
   const options = Object.keys(qualificationDictionary).map(qualification => ({

--- a/server/utils/tasks/usersTable.test.ts
+++ b/server/utils/tasks/usersTable.test.ts
@@ -66,11 +66,11 @@ describe('userTableHeader', () => {
 describe('qualificationCell', () => {
   it('returns the qualifications in UI friendly format', () => {
     const user = userWithWorkloadFactory.build({
-      qualifications: ['pipe', 'emergency', 'esap', 'lao', 'womens'],
+      qualifications: ['pipe', 'emergency', 'esap', 'lao', 'womens', 'recovery_focused', 'mental_health_specialist'],
     })
 
     expect(qualificationCell(user)).toEqual({
-      text: "PIPE, Emergency APs, ESAP, Limited access offenders, Women's APs",
+      text: "PIPE, Emergency APs, ESAP, Limited access offenders, Women's APs, Recovery-focused APs, Specialist Mental Health APs",
     })
   })
 })

--- a/server/utils/users/roleCheckboxes/index.ts
+++ b/server/utils/users/roleCheckboxes/index.ts
@@ -58,7 +58,14 @@ export const unusedRoles = ['applicant', 'report_viewer'] as const
 
 export type AllocationRole = (typeof allocationRoles)[number]
 
-export const qualifications: ReadonlyArray<UserQualification> = ['pipe', 'emergency', 'esap', 'lao']
+export const qualifications: ReadonlyArray<UserQualification> = [
+  'pipe',
+  'emergency',
+  'esap',
+  'lao',
+  'recovery_focused',
+  'mental_health_specialist',
+]
 
 export const qualificationDictionary: Record<UserQualification, string> = {
   lao: 'Limited access offenders',
@@ -66,6 +73,8 @@ export const qualificationDictionary: Record<UserQualification, string> = {
   emergency: 'Emergency APs',
   esap: 'ESAP',
   pipe: 'PIPE',
+  recovery_focused: 'Recovery-focused APs',
+  mental_health_specialist: 'Specialist Mental Health APs',
 }
 
 export const filterUnusedRoles = (allRoles: Array<UserRole>) =>

--- a/server/utils/users/userManagement.test.ts
+++ b/server/utils/users/userManagement.test.ts
@@ -158,6 +158,8 @@ describe('userQualificationsSelectOptions', () => {
       { selected: false, text: 'Emergency APs', value: 'emergency' },
       { selected: false, text: 'ESAP', value: 'esap' },
       { selected: false, text: 'PIPE', value: 'pipe' },
+      { selected: false, text: 'Recovery-focused APs', value: 'recovery_focused' },
+      { selected: false, text: 'Specialist Mental Health APs', value: 'mental_health_specialist' },
     ])
   })
 
@@ -169,6 +171,8 @@ describe('userQualificationsSelectOptions', () => {
       { selected: false, text: 'Emergency APs', value: 'emergency' },
       { selected: false, text: 'ESAP', value: 'esap' },
       { selected: false, text: 'PIPE', value: 'pipe' },
+      { selected: false, text: 'Recovery-focused APs', value: 'recovery_focused' },
+      { selected: false, text: 'Specialist Mental Health APs', value: 'mental_health_specialist' },
     ])
   })
 })


### PR DESCRIPTION
See Jira [APS-617: Add mental health and recovery focused as user qualifications](https://dsdmoj.atlassian.net/browse/APS-617)

We add these two user qualifications to:

- the admin's "user management" section so that they can be:
 
    - added to and removed from users
    - used to filter the list of users by the qualification

- the "task allocation" section so that tasks can be filtered using these user qualifications

Note that there are two AP Types for the two different Mental Health Specialist APs:

- `MHAP_ST_JOSEPHS`
- `MHAP_ELLIOTT_HOUSE`

but only one user qualification `mental_health_specialist`. i.e. an assessor is qualified to asses applications to both St Joe's and Elliot House.

## Screenshots of UI changes

<img width="963" alt="assign_rf_mh_user_qualifications" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/20245/5797f5a9-1573-42cf-9f6e-6ebce7026716">
<img width="973" alt="filter_users_ by_rf_mh_qualification" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/20245/c90791b0-d6e8-464c-a25e-1e455fb81ba9">
<img width="1115" alt="filter_tasks_by_mh_rf_qualification" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/20245/05d2ecb7-4ebb-4f10-bcdc-47e996ac48e1">


## Dependencies

This should be merged with the corresponding API change: https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1725
