### PR TITLE
(APS-569) Remove `getActingUser` HMPPS Auth call

### DIFF
--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -387,7 +387,9 @@ export default class ApplyHelper {
   }
 
   stubApAreasEndpoint() {
-    cy.task('stubApAreaReferenceData', { id: '5e44b880-df20-4751-938f-a14be5fe609d', name: 'Greater Manchester' })
+    cy.task('stubApAreaReferenceData', {
+      apArea: { id: '5e44b880-df20-4751-938f-a14be5fe609d', name: 'Greater Manchester' },
+    })
   }
 
   private addContingencyPlanDetails() {

--- a/integration_tests/mockApis/users.ts
+++ b/integration_tests/mockApis/users.ts
@@ -205,8 +205,22 @@ const stubUserDelete = (args: { id: string }) =>
 
 const stubProbationRegionsReferenceData = (): Promise<Response> => stubFor(probationRegions)
 
-const stubApAreaReferenceData = (args?: ApArea): Promise<Response> =>
-  stubFor({
+const stubApAreaReferenceData = (
+  {
+    apArea = null,
+    additionalAreas = [],
+  }: {
+    apArea: ApArea | null
+    additionalAreas: Array<ApArea>
+  } = { apArea: null, additionalAreas: [] },
+): Promise<Response> => {
+  const apAreas = [...additionalAreas.map(area => apAreaFactory.build(area)), ...apAreaFactory.buildList(10)]
+
+  if (apArea != null) {
+    apAreas.push(apAreaFactory.build(apArea))
+  }
+
+  return stubFor({
     request: {
       method: 'GET',
       url: '/reference-data/ap-areas',
@@ -216,9 +230,10 @@ const stubApAreaReferenceData = (args?: ApArea): Promise<Response> =>
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
       },
-      jsonBody: args ? [apAreaFactory.build(args), ...apAreaFactory.buildList(10)] : apAreaFactory.buildList(10),
+      jsonBody: apAreas,
     },
   })
+}
 
 const verifyUserUpdate = async (userId: string) =>
   (

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -79,7 +79,7 @@ context('Placement Requests', () => {
     cy.task('stubPlacementRequest', unmatchedPlacementRequest)
     cy.task('stubPlacementRequest', matchedPlacementRequest)
     cy.task('stubPlacementRequest', unableToMatchPlacementRequest)
-    cy.task('stubApAreaReferenceData', apArea)
+    cy.task('stubApAreaReferenceData', { apArea })
   })
 
   it('allows me to view a placement request', () => {
@@ -496,7 +496,7 @@ context('Placement Requests', () => {
       sortDirection: 'asc',
     })
     cy.task('stubPlacementRequestsDashboard', { placementRequests: matchedPlacementRequests, status: 'matched' })
-    cy.task('stubApAreaReferenceData', apArea)
+    cy.task('stubApAreaReferenceData', { apArea })
 
     // Given I am on the placement request dashboard
     const listPage = ListPage.visit()
@@ -536,7 +536,7 @@ context('Placement Requests', () => {
       sortBy: 'created_at',
       sortDirection: 'asc',
     })
-    cy.task('stubApAreaReferenceData', apArea)
+    cy.task('stubApAreaReferenceData', { apArea })
 
     // Given I am on the placement request dashboard filtering by the unableToMatch status
     const listPage = ListPage.visit('status=unableToMatch')

--- a/integration_tests/tests/admin/userManagement.cy.ts
+++ b/integration_tests/tests/admin/userManagement.cy.ts
@@ -286,8 +286,10 @@ context('User management', () => {
     const initialUsers = userFactory.buildList(10)
     cy.task('stubUsers', { users: initialUsers })
     cy.task('stubApAreaReferenceData', {
-      id: '0544d95a-f6bb-43f8-9be7-aae66e3bf244',
-      name: 'Midlands',
+      apArea: {
+        id: '0544d95a-f6bb-43f8-9be7-aae66e3bf244',
+        name: 'Midlands',
+      },
     })
 
     // When I visit the list page

--- a/integration_tests/tests/login.cy.ts
+++ b/integration_tests/tests/login.cy.ts
@@ -21,6 +21,7 @@ context('SignIn', () => {
   })
 
   it('User name visible in header', () => {
+    cy.task('stubAuthUser', { name: 'J. Smith' })
     cy.signIn()
     const indexPage = Page.verifyOnPage(DashboardPage)
     indexPage.headerUserName().should('contain.text', 'J. Smith')
@@ -60,7 +61,7 @@ context('SignIn', () => {
     cy.request('/').its('body').should('contain', 'Sign in')
 
     cy.task('stubVerifyToken', true)
-    cy.task('stubAuthUser', { name: 'bobby brown' })
+    cy.task('stubAuthUser', { name: 'B. BROWN' })
     cy.signIn()
 
     indexPage.headerUserName().contains('B. Brown')

--- a/integration_tests/tests/tasks/allocations.cy.ts
+++ b/integration_tests/tests/tasks/allocations.cy.ts
@@ -55,15 +55,16 @@ context('Task Allocation', () => {
       allocatedFilter: 'allocated',
       page: '1',
       sortDirection: 'asc',
+      apAreaId: apArea.id,
     })
     cy.task('stubTaskGet', { application, task, users })
     cy.task('stubApplicationGet', { application })
-    cy.task('stubApAreaReferenceData', apArea)
+    cy.task('stubApAreaReferenceData', { apArea })
     cy.task('stubUserList', { users, roles: ['assessor', 'matcher'] })
 
     // And I am logged in as a workflow manager
-    const me = userFactory.build()
-    cy.task('stubAuthUser', { roles: ['workflow_manager'], userId: me.id })
+    const me = userFactory.build({ apArea })
+    cy.task('stubAuthUser', { roles: ['workflow_manager'], userId: me.id, apArea: me.apArea })
     cy.signIn()
 
     // When I visit the task list page

--- a/integration_tests/tests/tasks/list.cy.ts
+++ b/integration_tests/tests/tasks/list.cy.ts
@@ -4,18 +4,18 @@ import { apAreaFactory, taskFactory, userFactory } from '../../../server/testuti
 
 context('Task Allocation', () => {
   const users = userFactory.buildList(5)
+  const apArea = apAreaFactory.build()
+  const additionalArea = apAreaFactory.build()
 
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubUserList', { users, roles: ['assessor', 'matcher'] })
+    cy.task('stubAuthUser', { apArea })
+    cy.task('stubApAreaReferenceData', { apArea, additionalAreas: [additionalArea] })
   })
 
-  const apAreaId = '0544d95a-f6bb-43f8-9be7-aae66e3bf244'
-
   it('shows a list of tasks', () => {
-    cy.task('stubAuthUser')
-
     // Given I am logged in
     cy.signIn()
 
@@ -27,6 +27,7 @@ context('Task Allocation', () => {
       allocatedFilter: 'allocated',
       page: '1',
       sortDirection: 'asc',
+      apAreaId: apArea.id,
     })
 
     cy.task('stubGetAllTasks', {
@@ -34,11 +35,7 @@ context('Task Allocation', () => {
       allocatedFilter: 'unallocated',
       page: '1',
       sortDirection: 'asc',
-    })
-
-    cy.task('stubApAreaReferenceData', {
-      id: apAreaId,
-      name: 'Midlands',
+      apAreaId: apArea.id,
     })
 
     // When I visit the tasks dashboard
@@ -59,8 +56,6 @@ context('Task Allocation', () => {
   })
 
   it('supports pagination', () => {
-    cy.task('stubAuthUser')
-
     // Given I am logged in
     cy.signIn()
 
@@ -69,15 +64,25 @@ context('Task Allocation', () => {
     const allocatedTasksPage9 = taskFactory.buildList(10)
     const unallocatedTasks = taskFactory.buildList(1, { allocatedToStaffMember: undefined })
 
-    cy.task('stubGetAllTasks', { tasks: allocatedTasksPage1, allocatedFilter: 'allocated', page: '1' })
+    cy.task('stubGetAllTasks', {
+      tasks: allocatedTasksPage1,
+      allocatedFilter: 'allocated',
+      page: '1',
+      apAreaId: apArea.id,
+    })
 
-    cy.task('stubGetAllTasks', { tasks: allocatedTasksPage2, allocatedFilter: 'allocated', page: '2' })
+    cy.task('stubGetAllTasks', {
+      tasks: allocatedTasksPage2,
+      allocatedFilter: 'allocated',
+      page: '2',
+      apAreaId: apArea.id,
+    })
 
-    cy.task('stubGetAllTasks', { tasks: allocatedTasksPage9, allocatedFilter: 'allocated', page: '9' })
-
-    cy.task('stubApAreaReferenceData', {
-      id: apAreaId,
-      name: 'Midlands',
+    cy.task('stubGetAllTasks', {
+      tasks: allocatedTasksPage9,
+      allocatedFilter: 'allocated',
+      page: '9',
+      apAreaId: apArea.id,
     })
 
     // When I visit the tasks dashboard
@@ -110,7 +115,6 @@ context('Task Allocation', () => {
 
   it('supports sorting', () => {
     const sortFields = ['dueAt', 'person', 'allocatedTo']
-    cy.task('stubAuthUser')
 
     // Given I am logged in
     cy.signIn()
@@ -122,6 +126,7 @@ context('Task Allocation', () => {
       allocatedFilter: 'allocated',
       sortDirection: 'asc',
       sortBy: 'createdAt',
+      apAreaId: apArea.id,
     })
 
     sortFields.forEach(sortField => {
@@ -131,6 +136,7 @@ context('Task Allocation', () => {
         page: '1',
         sortDirection: 'asc',
         sortBy: sortField,
+        apAreaId: apArea.id,
       })
 
       cy.task('stubGetAllTasks', {
@@ -139,12 +145,8 @@ context('Task Allocation', () => {
         page: '1',
         sortDirection: 'desc',
         sortBy: sortField,
+        apAreaId: apArea.id,
       })
-    })
-
-    cy.task('stubApAreaReferenceData', {
-      id: apAreaId,
-      name: 'Midlands',
     })
 
     // When I visit the tasks dashboard
@@ -181,7 +183,7 @@ context('Task Allocation', () => {
   const filterOptions = {
     area: {
       apiKey: 'apAreaId',
-      value: apAreaId,
+      value: apArea.id,
     },
     allocatedToUserId: {
       apiKey: 'allocatedToUserId',
@@ -200,8 +202,6 @@ context('Task Allocation', () => {
 
   Object.keys(filterOptions).forEach(key => {
     it(`allows filter by ${key}`, () => {
-      cy.task('stubAuthUser')
-
       // Given I am logged in
       cy.signIn()
 
@@ -209,10 +209,11 @@ context('Task Allocation', () => {
       const allocatedTasksFiltered = taskFactory.buildList(1)
       const unallocatedTasks = taskFactory.buildList(1, { allocatedToStaffMember: undefined })
 
-      cy.task('stubGetAllTasks', { tasks: allocatedTasks, allocatedFilter: 'allocated', page: '1' })
-      cy.task('stubApAreaReferenceData', {
-        id: apAreaId,
-        name: 'Midlands',
+      cy.task('stubGetAllTasks', {
+        tasks: allocatedTasks,
+        allocatedFilter: 'allocated',
+        page: '1',
+        apAreaId: apArea.id,
       })
 
       // When I visit the tasks dashboard
@@ -227,6 +228,8 @@ context('Task Allocation', () => {
         allocatedFilter: 'allocated',
         page: '1',
         sortDirection: 'asc',
+        apAreaId: apArea.id,
+
         [filterOptions[key].apiKey]: filterOptions[key].value,
       })
 
@@ -243,8 +246,6 @@ context('Task Allocation', () => {
   })
 
   it('maintains filter on tab change', () => {
-    cy.task('stubAuthUser')
-
     // Given I am logged in
     cy.signIn()
 
@@ -252,11 +253,7 @@ context('Task Allocation', () => {
     const allocatedTasksFiltered = taskFactory.buildList(1)
     const unallocatedTasks = taskFactory.buildList(1, { allocatedToStaffMember: undefined })
 
-    cy.task('stubGetAllTasks', { tasks: allocatedTasks, allocatedFilter: 'allocated', page: '1' })
-    cy.task('stubApAreaReferenceData', {
-      id: apAreaId,
-      name: 'Midlands',
-    })
+    cy.task('stubGetAllTasks', { tasks: allocatedTasks, allocatedFilter: 'allocated', page: '1', apAreaId: apArea.id })
 
     // When I visit the tasks dashboard
     const listPage = ListPage.visit(allocatedTasks, unallocatedTasks)
@@ -270,7 +267,7 @@ context('Task Allocation', () => {
       allocatedFilter: 'allocated',
       page: '1',
       sortDirection: 'asc',
-      apAreaId,
+      apAreaId: additionalArea.id,
     })
 
     cy.task('stubGetAllTasks', {
@@ -278,10 +275,10 @@ context('Task Allocation', () => {
       allocatedFilter: 'unallocated',
       page: '1',
       sortDirection: 'asc',
-      apAreaId,
+      apAreaId: additionalArea.id,
     })
 
-    listPage.searchBy('area', apAreaId)
+    listPage.searchBy('area', additionalArea.id)
     listPage.clickApplyFilter()
 
     // Then the page should show the results
@@ -291,12 +288,10 @@ context('Task Allocation', () => {
     listPage.clickTab('Unallocated')
 
     // Then the page should keep the area filter
-    listPage.shouldHaveSelectText('area', 'Midlands')
+    listPage.shouldHaveSelectText('area', additionalArea.name)
   })
 
   it('retains the unallocated filter when applying other filters', () => {
-    cy.task('stubAuthUser')
-
     // Given I am logged in
     cy.signIn()
 
@@ -309,10 +304,7 @@ context('Task Allocation', () => {
       allocatedFilter: 'unallocated',
       page: '1',
       sortDirection: 'asc',
-    })
-    cy.task('stubApAreaReferenceData', {
-      id: apAreaId,
-      name: 'Midlands',
+      apAreaId: apArea.id,
     })
 
     // Given I am on the tasks dashboard filtering by the unallocated tab
@@ -327,10 +319,10 @@ context('Task Allocation', () => {
       allocatedFilter: 'unallocated',
       page: '1',
       sortDirection: 'asc',
-      apAreaId,
+      apAreaId: apArea.id,
     })
 
-    listPage.searchBy('area', apAreaId)
+    listPage.searchBy('area', apArea.id)
     listPage.clickApplyFilter()
 
     // Then the status filter should be retained and allocated results should be shown
@@ -339,11 +331,7 @@ context('Task Allocation', () => {
   })
 
   it('defaults to user area but allows filter by all areas', () => {
-    // Given I have a default area
-    const apArea = apAreaFactory.build()
-    cy.task('stubAuthUser', { apArea })
-
-    // And i am signed in
+    // Given I am signed in
     cy.signIn()
 
     const allocatedTasks = taskFactory.buildList(1)
@@ -380,8 +368,6 @@ context('Task Allocation', () => {
       sortBy: 'dueAt',
       apAreaId: '',
     })
-
-    cy.task('stubApAreaReferenceData', apArea)
 
     // When I visit the tasks dashboard
     const listPage = ListPage.visit(allocatedTasks, unallocatedTasks)

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -30,32 +30,6 @@ describe('hmppsAuthClient', () => {
     nock.cleanAll()
   })
 
-  describe('getUser', () => {
-    it('should return data from api', async () => {
-      const response = { data: 'data' }
-
-      fakeHmppsAuthApi
-        .get('/api/user/me')
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
-        .reply(200, response)
-
-      const output = await hmppsAuthClient.getActingUser(token.access_token)
-      expect(output).toEqual(response)
-    })
-  })
-
-  describe('getUserRoles', () => {
-    it('should return data from api', async () => {
-      fakeHmppsAuthApi
-        .get('/api/user/me/roles')
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
-        .reply(200, [{ roleCode: 'role1' }, { roleCode: 'role2' }])
-
-      const output = await hmppsAuthClient.getUserRoles(token.access_token)
-      expect(output).toEqual(['role1', 'role2'])
-    })
-  })
-
   describe('getSystemClientToken', () => {
     it('should instantiate the redis client', async () => {
       tokenStore.getToken.mockResolvedValue(token.access_token)

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -5,7 +5,6 @@ import type TokenStore from './tokenStore'
 import logger from '../../logger'
 import config from '../config'
 import generateOauthClientToken from '../authentication/clientCredentials'
-import RestClient from './restClient'
 
 const timeoutSpec = config.apis.hmppsAuth.timeout
 const hmppsAuthUrl = config.apis.hmppsAuth.url
@@ -42,21 +41,6 @@ export interface UserRole {
 
 export default class HmppsAuthClient {
   constructor(private readonly tokenStore: TokenStore) {}
-
-  private static restClient(token: string): RestClient {
-    return new RestClient('HMPPS Auth Client', config.apis.hmppsAuth, token)
-  }
-
-  getActingUser(token: string): Promise<User> {
-    logger.info(`Getting user details: calling HMPPS Auth`)
-    return HmppsAuthClient.restClient(token).get({ path: '/api/user/me' }) as Promise<User>
-  }
-
-  getUserRoles(token: string): Promise<Array<string>> {
-    return HmppsAuthClient.restClient(token)
-      .get({ path: '/api/user/me/roles' })
-      .then(roles => (<Array<UserRole>>roles).map(role => role.roleCode))
-  }
 
   async getSystemClientToken(username?: string): Promise<string> {
     const key = username || '%ANONYMOUS%'

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -28,7 +28,6 @@ import config, { AuditConfig } from '../config'
 export const services = () => {
   const {
     appealClientBuilder,
-    hmppsAuthClient,
     approvedPremisesClientBuilder,
     bookingClientBuilder,
     referenceDataClientBuilder,
@@ -45,7 +44,7 @@ export const services = () => {
   } = dataAccess()
 
   const appealService = new AppealService(appealClientBuilder)
-  const userService = new UserService(hmppsAuthClient, userClientBuilder, referenceDataClientBuilder)
+  const userService = new UserService(userClientBuilder, referenceDataClientBuilder)
   const auditService = new AuditService(config.apis.audit as AuditConfig)
   const premisesService = new PremisesService(approvedPremisesClientBuilder)
   const personService = new PersonService(personClient)

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -10,23 +10,20 @@ import {
 import { PaginatedResponse, UserDetails } from '@approved-premises/ui'
 import { ReferenceDataClient, RestClientBuilder, UserClient } from '../data'
 import { convertToTitleCase } from '../utils/utils'
-import type HmppsAuthClient from '../data/hmppsAuthClient'
 
 export default class UserService {
   constructor(
-    private readonly hmppsAuthClient: HmppsAuthClient,
     private readonly userClientFactory: RestClientBuilder<UserClient>,
     private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
   ) {}
 
   async getActingUser(token: string): Promise<UserDetails> {
-    const user = await this.hmppsAuthClient.getActingUser(token)
     const client = this.userClientFactory(token)
     const profile = await client.getUserProfile()
     return {
-      ...user,
+      name: profile.deliusUsername,
       id: profile.id,
-      displayName: convertToTitleCase(user.name),
+      displayName: convertToTitleCase(profile.name),
       roles: profile.roles,
       active: profile.isActive,
       apArea: profile.apArea,


### PR DESCRIPTION
This has been retired in favour of the manage users API. However, all of the profile information we need is fetched via the Approved Premises API, so this is a call that we no longer need to make.

I had to do a bit of jiggery pokery with the task integration tests, because they assumed a user wouldn’t have an AP Area by default, which is no longer the case anyway.

I've tested this to destruction in the local env and seems to work absolutely fine with the ap-tools setup. Will do some more robust testing in dev and preprod too