### PR TITLE
APS 538 - Add feature flag for sufficient information confirmation screen

### DIFF
--- a/integration_tests/helpers/assess.ts
+++ b/integration_tests/helpers/assess.ts
@@ -132,7 +132,7 @@ export default class AseessHelper {
     page.clickSubmit()
 
     // And I confirm that I want to send the note
-    const confirmPage = new SufficientInformationConfirmPage(this.assessment, 'yes')
+    const confirmPage = new SufficientInformationConfirmPage(this.assessment)
     confirmPage.completeForm()
     confirmPage.clickSubmit()
 

--- a/integration_tests/helpers/assess.ts
+++ b/integration_tests/helpers/assess.ts
@@ -107,7 +107,7 @@ export default class AseessHelper {
     this.submitAssessment()
   }
 
-  addClarificationNote() {
+  addClarificationNote({ testConfirmationPage = true } = {}) {
     // When I click on the 'review application' link
     cy.get('[data-cy-task-name="review-application"]').click()
 
@@ -131,10 +131,12 @@ export default class AseessHelper {
     // And I click submit
     page.clickSubmit()
 
-    // And I confirm that I want to send the note
-    const confirmPage = new SufficientInformationConfirmPage(this.assessment)
-    confirmPage.completeForm()
-    confirmPage.clickSubmit()
+    if (testConfirmationPage) {
+      // And I confirm that I want to send the note
+      const confirmPage = new SufficientInformationConfirmPage(this.assessment)
+      confirmPage.completeForm()
+      confirmPage.clickSubmit()
+    }
 
     // Then I should see a confirmation screen
     const confirmationScreen = Page.verifyOnPage(ClarificationNoteConfirmPage)

--- a/integration_tests/pages/assess/sufficientInformationConfirmPage.ts
+++ b/integration_tests/pages/assess/sufficientInformationConfirmPage.ts
@@ -1,16 +1,10 @@
 import type { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
-import type { YesOrNo } from '@approved-premises/ui'
 
 import AssessPage from './assessPage'
 
-import SufficientInformationConfirm from '../../../server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformationConfirm'
-
 export default class SufficientInformationConfirmPage extends AssessPage {
-  pageClass: SufficientInformationConfirm
-
-  constructor(assessment: Assessment, answer: YesOrNo = 'yes') {
+  constructor(assessment: Assessment) {
     super('Suitability Assessment', assessment, 'sufficient-information', 'sufficient-information-confirm', '')
-    this.pageClass = new SufficientInformationConfirm({ confirm: answer }, assessment)
   }
 
   completeForm() {

--- a/server/app.ts
+++ b/server/app.ts
@@ -24,6 +24,7 @@ import { setUpSentryErrorHandler, setUpSentryRequestHandler } from './middleware
 import routes from './routes'
 import type { Controllers } from './controllers'
 import type { Services } from './services'
+import { setupFeatureFlags } from './middleware/setupFeatureFlags'
 
 export default function createApp(controllers: Controllers, services: Services): express.Application {
   const app = express()
@@ -50,6 +51,7 @@ export default function createApp(controllers: Controllers, services: Services):
   app.use(authorisationMiddleware())
   app.use(setUpCsrf())
   app.use(setUpCurrentUser(services))
+  app.use(setupFeatureFlags(services))
   app.use((req, res, next) => {
     res.locals.infoMessages = req.flash('info')
     res.locals.successMessages = req.flash('success')

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.test.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.test.ts
@@ -1,34 +1,137 @@
-import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { fromPartial } from '@total-typescript/shoehorn'
+import { when } from 'jest-when'
+import { createMock } from '@golevelup/ts-jest'
+import { AssessmentService } from '../../../../services'
+import { itShouldHavePreviousValue } from '../../../shared-examples'
 
-import SufficientInformation from './sufficientInformation'
+import SufficientInformation, { Body } from './sufficientInformation'
+import { assessmentFactory } from '../../../../testutils/factories'
+import { retrieveOptionalQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
+import { retrieveFeatureFlag } from '../../../../utils/retrieveFeatureFlag'
+
+jest.mock('../../../../utils/retrieveQuestionResponseFromFormArtifact')
+jest.mock('../../../../utils/retrieveFeatureFlag')
 
 describe('SufficientInformation', () => {
+  const assessment = assessmentFactory.build()
+  const assessmentService = createMock<AssessmentService>({})
+  const query = 'some text'
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
   describe('title', () => {
-    expect(new SufficientInformation({}).title).toBe(
+    expect(new SufficientInformation({}, assessment).title).toBe(
       'Is there enough information in the application for you to make a decision?',
     )
   })
 
   describe('body', () => {
     it('should set the body', () => {
-      const page = new SufficientInformation({ sufficientInformation: 'yes' })
+      const page = new SufficientInformation({ sufficientInformation: 'yes' }, assessment)
       expect(page.body).toEqual({ sufficientInformation: 'yes' })
     })
   })
 
-  describe('when sufficientInformation is yes', () => {
-    itShouldHaveNextValue(new SufficientInformation({ sufficientInformation: 'yes' }), '')
+  describe('initialize', () => {
+    it('should initialize the page and not create a note when the body is not present', async () => {
+      const body: Body = {}
+      const page = await SufficientInformation.initialize(body, assessment, 'token', fromPartial({ assessmentService }))
+
+      expect(page.body).toEqual(body)
+      expect(assessmentService.createClarificationNote).not.toHaveBeenCalled()
+    })
+
+    it('should initialize the page and not create a note when sufficient information is yes', async () => {
+      const body: Body = { sufficientInformation: 'yes' }
+      const page = await SufficientInformation.initialize(body, assessment, 'token', fromPartial({ assessmentService }))
+
+      expect(page.body).toEqual(body)
+      expect(assessmentService.createClarificationNote).not.toHaveBeenCalled()
+    })
+
+    it('should initialize the page and create a note when sufficientInformation is no and the page has not already been completed', async () => {
+      const body: Body = { sufficientInformation: 'no', query }
+
+      when(retrieveFeatureFlag)
+        .calledWith('allow-sufficient-information-request-without-confirmation')
+        .mockReturnValue(true)
+
+      when(retrieveOptionalQuestionResponseFromFormArtifact)
+        .calledWith(assessment, SufficientInformation, 'sufficientInformation')
+        .mockReturnValue(undefined)
+
+      const page = await SufficientInformation.initialize(body, assessment, 'token', fromPartial({ assessmentService }))
+
+      expect(page.body).toEqual(body)
+      expect(assessmentService.createClarificationNote).toHaveBeenCalledWith('token', assessment.id, { query })
+    })
+
+    it('should initialize the page and not create a note when dontShowConfirmationPage is false', async () => {
+      const body: Body = { sufficientInformation: 'no', query }
+
+      const page = await SufficientInformation.initialize(body, assessment, 'token', fromPartial({ assessmentService }))
+
+      expect(page.body).toEqual(body)
+      expect(assessmentService.createClarificationNote).not.toHaveBeenCalled()
+    })
+
+    it('should initialize the page and not create a note when sufficientInformation is no and the page has already been completed', async () => {
+      const body: Body = { sufficientInformation: 'no', query }
+
+      when(retrieveOptionalQuestionResponseFromFormArtifact)
+        .calledWith(assessment, SufficientInformation, 'sufficientInformation')
+        .mockReturnValue('no')
+
+      const page = await SufficientInformation.initialize(body, assessment, 'token', fromPartial({ assessmentService }))
+
+      expect(page.body).toEqual(body)
+      expect(assessmentService.createClarificationNote).not.toHaveBeenCalled()
+    })
   })
 
-  describe('when sufficientInformation is no', () => {
-    itShouldHaveNextValue(new SufficientInformation({ sufficientInformation: 'no' }), 'sufficient-information-confirm')
+  describe('next', () => {
+    describe('when sufficientInformation is yes', () => {
+      expect(new SufficientInformation({ sufficientInformation: 'yes' }, assessment).next()).toBe('')
+    })
+
+    describe('when sufficientInformation is no', () => {
+      describe('if the information has been previously requested', () => {
+        when(retrieveOptionalQuestionResponseFromFormArtifact)
+          .calledWith(assessment, SufficientInformation, 'sufficientInformation')
+          .mockReturnValue('no')
+
+        expect(new SufficientInformation({ sufficientInformation: 'no' }, assessment).next()).toBe(
+          'information-received',
+        )
+      })
+    })
+
+    describe('if dontShowConfirmationPage is false', () => {
+      when(retrieveOptionalQuestionResponseFromFormArtifact)
+        .calledWith(assessment, SufficientInformation, 'sufficientInformation')
+        .mockReturnValue(undefined)
+
+      const page = new SufficientInformation({ sufficientInformation: 'no' }, assessment)
+      page.dontShowConfirmationPage = false
+
+      expect(page.next()).toBe('sufficient-information-confirm')
+    })
+
+    describe('if dontShowConfirmationPage is true', () => {
+      const page = new SufficientInformation({ sufficientInformation: 'no' }, assessment)
+      page.dontShowConfirmationPage = true
+
+      expect(page.next()).toBe('sufficient-information-sent')
+    })
   })
 
-  itShouldHavePreviousValue(new SufficientInformation({}), 'dashboard')
+  itShouldHavePreviousValue(new SufficientInformation({}, assessment), 'dashboard')
 
   describe('errors', () => {
     it('should have an error if there is no answer', () => {
-      const page = new SufficientInformation({})
+      const page = new SufficientInformation({}, assessment)
 
       expect(page.errors()).toEqual({
         sufficientInformation: 'You must confirm if there is enough information in the application to make a decision',
@@ -36,7 +139,7 @@ describe('SufficientInformation', () => {
     })
 
     it('should have an error if the answer is no and no query is specified', () => {
-      const page = new SufficientInformation({ sufficientInformation: 'no' })
+      const page = new SufficientInformation({ sufficientInformation: 'no' }, assessment)
 
       expect(page.errors()).toEqual({
         query: 'You must specify what additional information is needed',
@@ -46,7 +149,7 @@ describe('SufficientInformation', () => {
 
   describe('response', () => {
     it('returns the sufficientInformation response when the answer is yes and an empty string for the query', () => {
-      const page = new SufficientInformation({ sufficientInformation: 'yes' })
+      const page = new SufficientInformation({ sufficientInformation: 'yes' }, assessment)
 
       expect(page.response()).toEqual({
         'Is there enough information in the application for you to make a decision?': 'Yes',
@@ -55,7 +158,7 @@ describe('SufficientInformation', () => {
     })
 
     it('returns both responses when the answer is no', () => {
-      const page = new SufficientInformation({ sufficientInformation: 'no', query: 'some query' })
+      const page = new SufficientInformation({ sufficientInformation: 'no', query: 'some query' }, assessment)
 
       expect(page.response()).toEqual({
         'Is there enough information in the application for you to make a decision?': 'No',

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/sufficientInformation.ts
@@ -1,9 +1,14 @@
-import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import type { DataServices, TaskListErrors, YesOrNo } from '@approved-premises/ui'
 
 import { Page } from '../../../utils/decorators'
 import { sentenceCase } from '../../../../utils/utils'
 
 import TasklistPage from '../../../tasklistPage'
+import { ApprovedPremisesAssessment as Assessment } from '../../../../@types/shared'
+import { retrieveOptionalQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
+import { retrieveFeatureFlag } from '../../../../utils/retrieveFeatureFlag'
+
+export type Body = { sufficientInformation?: YesOrNo; query?: string }
 
 @Page({
   name: 'sufficient-information',
@@ -16,14 +21,48 @@ export default class SufficientInformation implements TasklistPage {
 
   furtherInformationQuestion = 'What additional information is needed?'
 
-  constructor(public body: { sufficientInformation?: YesOrNo; query?: string }) {}
+  dontShowConfirmationPage: boolean
+
+  constructor(
+    public body: Body,
+    private readonly assessment: Assessment,
+  ) {
+    this.dontShowConfirmationPage = retrieveFeatureFlag('allow-sufficient-information-request-without-confirmation')
+  }
+
+  static async initialize(
+    body: Body,
+    assessment: Assessment,
+    token: string,
+    dataServices: DataServices,
+  ): Promise<SufficientInformation> {
+    const dontShowConfirmationPage = retrieveFeatureFlag('allow-sufficient-information-request-without-confirmation')
+
+    const page = new SufficientInformation(body, assessment)
+
+    if (dontShowConfirmationPage && page.body.sufficientInformation === 'no' && !page.previouslyRequested()) {
+      await dataServices.assessmentService.createClarificationNote(token, assessment.id, { query: body.query })
+    }
+
+    return page
+  }
 
   previous() {
     return 'dashboard'
   }
 
   next() {
-    return this.body.sufficientInformation === 'no' ? 'sufficient-information-confirm' : ''
+    if (this.previouslyRequested()) {
+      return 'information-received'
+    }
+
+    if (this.body.sufficientInformation === 'no') {
+      if (this.dontShowConfirmationPage) {
+        return 'sufficient-information-sent'
+      }
+      return 'sufficient-information-confirm'
+    }
+    return ''
   }
 
   response() {
@@ -45,5 +84,16 @@ export default class SufficientInformation implements TasklistPage {
     }
 
     return errors
+  }
+
+  previouslyRequested() {
+    return (
+      this.body.sufficientInformation === 'no' &&
+      retrieveOptionalQuestionResponseFromFormArtifact(
+        this.assessment,
+        SufficientInformation,
+        'sufficientInformation',
+      ) === 'no'
+    )
   }
 }

--- a/server/middleware/setupFeatureFlags.test.ts
+++ b/server/middleware/setupFeatureFlags.test.ts
@@ -1,0 +1,58 @@
+import { createMock } from '@golevelup/ts-jest'
+import { Request, Response } from 'express'
+import { when } from 'jest-when'
+import { Cancelable, throttle } from 'underscore'
+import { FeatureFlagService } from '../services'
+import { featureFlagHandler, retrieveFlags, throttleTime } from './setupFeatureFlags'
+
+jest.mock('underscore')
+
+describe('populateFeatureFlags', () => {
+  const featureFlagService = createMock<FeatureFlagService>({})
+
+  const request = createMock<Request>()
+  const response = createMock<Response>()
+  const next = jest.fn()
+
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = { ...OLD_ENV }
+  })
+
+  afterAll(() => {
+    process.env = OLD_ENV
+  })
+
+  it('calls throttle with the flag retrieval function and returns a handler that calls the throttled function', async () => {
+    const throttledRetrieveFlags = jest.fn()
+
+    when(throttle)
+      .calledWith(expect.any(Function), throttleTime)
+      .mockReturnValue(throttledRetrieveFlags as jest.Mock & Cancelable)
+
+    const result = featureFlagHandler(featureFlagService)
+
+    await result(request, response, next)
+
+    expect(throttledRetrieveFlags).toHaveBeenCalledWith(featureFlagService)
+    expect(next).toHaveBeenCalled()
+  })
+})
+
+describe('retrieveFlags', () => {
+  const featureFlagService = createMock<FeatureFlagService>({})
+
+  it('calls the service for each flag and adds the result to process.env', async () => {
+    when(featureFlagService.getBooleanFlag)
+      .calledWith('allow-sufficient-information-request-without-confirmation')
+      .mockResolvedValue(true)
+
+    expect(process.env['allow-sufficient-information-request-without-confirmation']).toBeUndefined()
+
+    await retrieveFlags(featureFlagService)
+
+    expect(process.env['allow-sufficient-information-request-without-confirmation']).toBe('true')
+  })
+})

--- a/server/middleware/setupFeatureFlags.ts
+++ b/server/middleware/setupFeatureFlags.ts
@@ -1,0 +1,35 @@
+import { RequestHandler, Router } from 'express'
+import { throttle } from 'underscore'
+import { Services } from '../services'
+import FeatureFlagService, { FeatureFlag } from '../services/featureFlagService'
+
+export const featureFlagsToUse: Array<FeatureFlag> = ['allow-sufficient-information-request-without-confirmation']
+export const throttleTime = 15 * 1000
+
+export const setupFeatureFlags = ({ featureFlagService }: Services): Router => {
+  const router = Router()
+
+  router.use(featureFlagHandler(featureFlagService))
+  return router
+}
+
+export const featureFlagHandler = (featureFlagService: FeatureFlagService): RequestHandler => {
+  const retrieveFlagThrottled = throttle(retrieveFlags, throttleTime)
+  return async (_, __, next) => {
+    try {
+      retrieveFlagThrottled(featureFlagService)
+
+      return next()
+    } catch (error) {
+      return next(error)
+    }
+  }
+}
+
+export const retrieveFlags = (featureFlagService: FeatureFlagService) => {
+  featureFlagsToUse.forEach(async flag => {
+    const flagBool = await featureFlagService.getBooleanFlag(flag)
+
+    process.env[flag] = flagBool.toString()
+  })
+}

--- a/server/services/featureFlagService.ts
+++ b/server/services/featureFlagService.ts
@@ -2,7 +2,7 @@ import { ClientTokenAuthentication, FliptClient } from '@flipt-io/flipt'
 import config from '../config'
 import logger from '../../logger'
 
-export type FeatureFlag = 'show-both-arrival-dates'
+export type FeatureFlag = 'show-both-arrival-dates' | 'allow-sufficient-information-request-without-confirmation'
 
 export default class FeatureFlagService {
   fliptClient: FliptClient | null

--- a/server/services/featureFlagService.ts
+++ b/server/services/featureFlagService.ts
@@ -2,7 +2,7 @@ import { ClientTokenAuthentication, FliptClient } from '@flipt-io/flipt'
 import config from '../config'
 import logger from '../../logger'
 
-type FeatureFlag = 'show-both-arrival-dates'
+export type FeatureFlag = 'show-both-arrival-dates'
 
 export default class FeatureFlagService {
   fliptClient: FliptClient | null

--- a/server/utils/retrieveFeatureFlag.test.ts
+++ b/server/utils/retrieveFeatureFlag.test.ts
@@ -1,0 +1,20 @@
+import { FeatureFlag } from '../services/featureFlagService'
+import { retrieveFeatureFlag } from './retrieveFeatureFlag'
+
+describe('retrieveFeatureFlag', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = { ...OLD_ENV }
+  })
+
+  afterAll(() => {
+    process.env = OLD_ENV
+  })
+
+  it.each([true, false])('returns the value as a boolean', value => {
+    process.env['test-flag'] = value.toString()
+    expect(retrieveFeatureFlag('test-flag' as FeatureFlag)).toBe(value)
+  })
+})

--- a/server/utils/retrieveFeatureFlag.ts
+++ b/server/utils/retrieveFeatureFlag.ts
@@ -1,0 +1,5 @@
+import { FeatureFlag } from '../services/featureFlagService'
+
+export const retrieveFeatureFlag = (featureFlag: FeatureFlag): boolean => {
+  return process.env[featureFlag] === 'true'
+}


### PR DESCRIPTION
# Context
- [JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&selectedIssue=APS-591)
- [JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&selectedIssue=APS-538)

We want to add a feature flag for the 'Sufficient Information Confirmation' screen to see if removing it would be a viable user experience. 
Having the screen in place leaves open the possibility of creating an infinite loop [detailed here](https://dsdmoj.atlassian.net/browse/APS-541) and we think the simplest approach may be to remove the confirmation screen.
![GjLP1CYdOS(1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/b89a9763-482f-4c9f-a56a-a8675749ee3c)
By removing the screen the user may submit a 'clarification note' without properly considering how this will effect the assessment. 

# Technical considerations
In order to add feature flags to the Assessment journey I explored a number of approaches: 

1.  **Add a call to fetch the flags in the `initialize` method of the page class (`SufficientInformation`)**. This failed because although the `initialize` method is called when viewing the page in question it is not called in the `TasklistService` when determining if a task is complete. Therefore if the feature flag changes the logic around which page to display next (as ours does) then this will result in tasks showing as 'In progress' when the user has seen all the screens they are able to. This could be resolved by add the value to the `page` object, passing it through to the view and back to the `page` again via a hidden input but this is suboptimal
2. **Pass the feature flag values in to the `Page` class constructors**. This would work but there are many, many places we would have to make code changes including passing in the value of the feature flags to every view where we render Assessments, Applications and Placement Applications. I did attempt this but ultimately backed out because of the complexity it introduced to functions that shouldn't have to `know` about the feature flags - they were just passing the values along
3. **Introduce middleware to add the feature flag values to the `process.env`**. This allows us to access flags via `process.env` as we did before the introduction of flipit (#1651) but with the advantage of being able to toggle the flags without a deploy. However we now have to determine how often we want to call the feature flag service. Too often and it will cause performance issues in this app and potentially overload the feature flag service. Too little and there will be a delay in flipping the flag and the user seeing the desired changes. I have opted for a delay of 1.5 seconds to begin with which potentially tends towards the former but we can adjust as we go. 