### PR TITLE
APS-612: Show applicant guidance when blocked by LAO restriction

### DIFF
--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -337,7 +337,7 @@ describe('applicationsController', () => {
       beforeEach(() => {
         request = createMock<Request>({
           user: { token },
-          flash: jest.fn().mockReturnValue([person.crn]),
+          flash: jest.fn().mockReturnValueOnce([person.crn]).mockReturnValueOnce(['true']),
         })
         personService.findByCrn.mockResolvedValue(person)
         personService.getOffences.mockResolvedValue([offence])
@@ -424,6 +424,7 @@ describe('applicationsController', () => {
           errors: errorsAndUserInput.errors,
           errorSummary: errorsAndUserInput.errorSummary,
           ...errorsAndUserInput.userInput,
+          restrictedPerson: 'true',
         })
         expect(request.flash).toHaveBeenCalledWith('crn')
       })

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -145,12 +145,13 @@ export default class ApplicationsController {
           })
         }
       }
-
+      const restrictedPerson = req.flash('restrictedPerson')[0]
       return res.render('applications/new', {
         pageHeading: "Enter the person's CRN",
         errors,
         errorSummary,
         ...userInput,
+        restrictedPerson,
       })
     }
   }

--- a/server/controllers/peopleController.ts
+++ b/server/controllers/peopleController.ts
@@ -24,6 +24,7 @@ export default class PeopleController {
         } catch (error) {
           const knownError = error as RestrictedPersonError | HttpError | Error
           if ('type' in knownError && knownError.type === 'RESTRICTED_PERSON') {
+            req.flash('restrictedPerson', 'true')
             addErrorMessageToFlash(req, knownError.message, 'crn')
           } else if ('data' in knownError && knownError.status === 404) {
             addErrorMessageToFlash(req, `No person with an CRN of '${crn}' was found`, 'crn')

--- a/server/views/applications/new.njk
+++ b/server/views/applications/new.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../components/formFields/form-page-input/macro.njk" import formPageInput %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -16,6 +17,16 @@
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ showErrorSummary(errorSummary) }}
+        {% if restrictedPerson === 'true' %}
+
+          {% set html %}
+          <p class='govuk-body'>You do not have access to this offender as this person is a limited access offender (LAO).</p>
+          <p class='govuk-body'>You cannot continue with the application without requesting LAO access.</p>
+          <p class='govuk-body'>Please follow the guidance in Equip to remove the restriction if this is not correct or to request access.</p>
+          {% endset %}
+
+          {{ govukNotificationBanner({ html: html }) }}
+        {% endif %}
 
         {{
           formPageInput(


### PR DESCRIPTION
# Context

<!-- https://dsdmoj.atlassian.net/browse/APS-612 -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Show applicant guidance when blocked by LAO restriction
## Screenshots of UI changes

### Before
<img width="868" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/387e6f85-e279-438d-b9d9-54c93ec12f8c">


### After
<img width="1728" alt="Screenshot 2024-04-12 at 17 30 37" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/4e5c56fc-662b-44a2-a292-39d2d5d94b0d">