### PR TITLE
(APS-622) Mappa missing error message could be more helpful

### DIFF
--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -256,11 +256,15 @@ export interface ReferenceData {
   serviceScope: string
 }
 
+export interface MappaUi extends Mappa {
+  status?: RiskEnvelopeStatus
+}
+
 export interface PersonRisksUI {
   roshRisks: RoshRisks
   tier: RiskTier
   flags: FlagsEnvelope['value']
-  mappa: Mappa
+  mappa: MappaUi
 }
 
 export type GroupedListofBookings = {

--- a/server/testutils/factories/risks.ts
+++ b/server/testutils/factories/risks.ts
@@ -16,7 +16,7 @@ export default Factory.define<PersonRisks>(() => ({
   tier: tierEnvelopeFactory.build(),
 }))
 
-const roshRisksFactory = Factory.define<PersonRisks['roshRisks']>(() => ({
+export const roshRisksFactory = Factory.define<PersonRisks['roshRisks']>(() => ({
   status: faker.helpers.arrayElement(riskEnvelopeStatuses),
   value: {
     overallRisk: faker.helpers.arrayElement(riskLevels),
@@ -28,12 +28,12 @@ const roshRisksFactory = Factory.define<PersonRisks['roshRisks']>(() => ({
   },
 }))
 
-const mappaFactory = Factory.define<PersonRisks['mappa']>(() => ({
+export const mappaFactory = Factory.define<PersonRisks['mappa']>(() => ({
   status: faker.helpers.arrayElement(riskEnvelopeStatuses),
   value: { level: 'CAT 2 / LEVEL 1', lastUpdated: DateFormats.dateObjToIsoDate(faker.date.past()) },
 }))
 
-const flagsFactory = Factory.define<PersonRisks['flags']>(() => {
+export const flagsFactory = Factory.define<PersonRisks['flags']>(() => {
   return {
     status: faker.helpers.arrayElement(riskEnvelopeStatuses),
     value: faker.helpers.arrayElements([

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -188,6 +188,7 @@ describe('mapApiPersonRiskForUI', () => {
     expect(actual).toEqual(
       expect.objectContaining({
         mappa: {
+          status: undefined,
           lastUpdated: '',
         },
       }),

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -142,27 +142,26 @@ describe('mapApiPersonRiskForUI', () => {
 
   it('maps the PersonRisks from the API into a shape thats useful for the UI', () => {
     const actual = mapApiPersonRisksForUi(risks)
+
     expect(actual).toEqual({
       crn: risks.crn,
       flags: risks.flags.value,
       mappa: {
-        lastUpdated: risks?.mappa?.value?.lastUpdated
-          ? DateFormats.isoDateToUIDate(risks?.mappa?.value?.lastUpdated)
-          : '',
-        level: 'CAT 2 / LEVEL 1',
+        lastUpdated: DateFormats.isoDateToUIDate(risks.mappa.value.lastUpdated),
+        level: risks.mappa.value.level,
+        status: risks.mappa.status,
       },
       roshRisks: {
-        lastUpdated:
-          risks?.roshRisks?.value?.lastUpdated && DateFormats.isoDateToUIDate(risks.roshRisks.value.lastUpdated),
-        overallRisk: risks?.roshRisks?.value?.overallRisk ?? '',
-        riskToChildren: risks?.roshRisks?.value?.riskToChildren ?? '',
-        riskToKnownAdult: risks?.roshRisks?.value?.riskToKnownAdult ?? '',
-        riskToPublic: risks?.roshRisks?.value?.riskToPublic ?? '',
-        riskToStaff: risks?.roshRisks?.value?.riskToStaff ?? '',
+        lastUpdated: DateFormats.isoDateToUIDate(risks.roshRisks.value.lastUpdated),
+        overallRisk: risks.roshRisks.value.overallRisk,
+        riskToChildren: risks.roshRisks.value.riskToChildren,
+        riskToKnownAdult: risks.roshRisks.value.riskToKnownAdult,
+        riskToPublic: risks.roshRisks.value.riskToPublic,
+        riskToStaff: risks.roshRisks.value.riskToStaff,
       },
       tier: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks?.tier?.value?.lastUpdated ?? ''),
-        level: risks?.tier?.value?.level || '',
+        lastUpdated: DateFormats.isoDateToUIDate(risks.tier.value.lastUpdated),
+        level: risks.tier.value.level,
       },
     })
   })
@@ -172,21 +171,13 @@ describe('mapApiPersonRiskForUI', () => {
 
     const actual = mapApiPersonRisksForUi(risks)
 
-    expect(actual).toEqual({
-      crn: risks.crn,
-      flags: risks.flags.value,
-      mappa: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks?.mappa?.value?.lastUpdated || ''),
-        level: 'CAT 2 / LEVEL 1',
-      },
-      roshRisks: {
-        lastUpdated: '',
-      },
-      tier: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks?.tier?.value?.lastUpdated || ''),
-        level: risks?.tier?.value?.level,
-      },
-    })
+    expect(actual).toEqual(
+      expect.objectContaining({
+        roshRisks: {
+          lastUpdated: '',
+        },
+      }),
+    )
   })
 
   it('handles the case where mappa is null', () => {
@@ -194,25 +185,13 @@ describe('mapApiPersonRiskForUI', () => {
 
     const actual = mapApiPersonRisksForUi(risks)
 
-    expect(actual).toEqual({
-      crn: risks.crn,
-      flags: risks.flags.value,
-      mappa: {
-        lastUpdated: '',
-      },
-      roshRisks: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks?.roshRisks?.value?.lastUpdated || ''),
-        overallRisk: risks.roshRisks.value?.overallRisk,
-        riskToChildren: risks.roshRisks.value?.riskToChildren,
-        riskToKnownAdult: risks.roshRisks.value?.riskToKnownAdult,
-        riskToPublic: risks.roshRisks.value?.riskToPublic,
-        riskToStaff: risks.roshRisks.value?.riskToStaff,
-      },
-      tier: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks.tier?.value?.lastUpdated || ''),
-        level: risks.tier.value?.level,
-      },
-    })
+    expect(actual).toEqual(
+      expect.objectContaining({
+        mappa: {
+          lastUpdated: '',
+        },
+      }),
+    )
   })
 
   it('handles the case where tier is null', () => {
@@ -220,25 +199,13 @@ describe('mapApiPersonRiskForUI', () => {
 
     const actual = mapApiPersonRisksForUi(risks)
 
-    expect(actual).toEqual({
-      crn: risks.crn,
-      flags: risks.flags.value,
-      mappa: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks?.mappa?.value?.lastUpdated || ''),
-        level: 'CAT 2 / LEVEL 1',
-      },
-      roshRisks: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks?.roshRisks?.value?.lastUpdated || ''),
-        overallRisk: risks.roshRisks.value?.overallRisk,
-        riskToChildren: risks.roshRisks.value?.riskToChildren,
-        riskToKnownAdult: risks.roshRisks.value?.riskToKnownAdult,
-        riskToPublic: risks.roshRisks.value?.riskToPublic,
-        riskToStaff: risks.roshRisks.value?.riskToStaff,
-      },
-      tier: {
-        lastUpdated: '',
-      },
-    })
+    expect(actual).toEqual(
+      expect.objectContaining({
+        tier: {
+          lastUpdated: '',
+        },
+      }),
+    )
   })
 
   it('handles the case where flags is null', () => {
@@ -246,26 +213,11 @@ describe('mapApiPersonRiskForUI', () => {
 
     const actual = mapApiPersonRisksForUi(risks)
 
-    expect(actual).toEqual({
-      crn: risks.crn,
-      flags: null,
-      mappa: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks.mappa?.value?.lastUpdated || ''),
-        level: 'CAT 2 / LEVEL 1',
-      },
-      roshRisks: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks?.roshRisks?.value?.lastUpdated || ''),
-        overallRisk: risks.roshRisks.value?.overallRisk,
-        riskToChildren: risks.roshRisks.value?.riskToChildren,
-        riskToKnownAdult: risks.roshRisks.value?.riskToKnownAdult,
-        riskToPublic: risks.roshRisks.value?.riskToPublic,
-        riskToStaff: risks.roshRisks.value?.riskToStaff,
-      },
-      tier: {
-        lastUpdated: DateFormats.isoDateToUIDate(risks.tier.value?.lastUpdated || ''),
-        level: risks.tier.value?.level,
-      },
-    })
+    expect(actual).toEqual(
+      expect.objectContaining({
+        flags: null,
+      }),
+    )
   })
 })
 

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -95,6 +95,7 @@ export const mapApiPersonRisksForUi = (risks: PersonRisks): PersonRisksUI => {
     },
     mappa: {
       ...risks.mappa?.value,
+      status: risks.mappa?.status,
       lastUpdated: risks.mappa?.value?.lastUpdated ? DateFormats.isoDateToUIDate(risks.mappa.value.lastUpdated) : '',
     },
     tier: {

--- a/server/views/components/riskWidgets/mappa-widget/template.njk
+++ b/server/views/components/riskWidgets/mappa-widget/template.njk
@@ -1,5 +1,9 @@
 <div class="mappa-widget">
     <h3 class="govuk-heading-m"><strong>{{ params.level | default("NO", true) }}</strong> MAPPA</h3>
     <p class="govuk-body-m">Multi-agency public protection arrangements</p>
-    {% if params.level %}<p class="govuk-hint govuk-body-m">Last updated: {{ params.lastUpdated | default("Not known") }}</p>{% endif %}
+    {% if params.status == 'error' %}
+        <p class="govuk-hint govuk-body-m">Error retrieving MAPPA values</p>
+    {% else %}
+        {% if params.level %}<p class="govuk-hint govuk-body-m">Last updated: {{ params.lastUpdated | default("Not known") }}</p>{% endif %}
+    {% endif %}
 </div>


### PR DESCRIPTION
This adds an error message to the Risk Flags sidebar to inform a user that the Mappa is not showing because of an error. This allows us to differentiate between cases that genuinely do not have a Mappa value and those that have failed.

We need to do some other work to ensure we can backfill when errors do occur, but this should help reduce confusion in the meantime.

## Screenshot

### Before

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/52189cb5-e2c6-4e03-88e5-149b73cc2c3c)

### After

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/0ce42457-ec89-478e-9d9b-20e7d4386631)
