### PR TITLE
APS 589 - View timeline events by crn

### DIFF
--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -11,6 +11,7 @@ import type {
   Person,
   PersonAcctAlert,
   PersonRisks,
+  PersonalTimeline,
   PrisonCaseNote,
 } from '@approved-premises/api'
 
@@ -116,6 +117,18 @@ export default {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: args.offences,
+      },
+    }),
+  stubPersonalTimeline: (args: { person: Person; timeline: PersonalTimeline }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: paths.people.timeline({ crn: args.person.crn }),
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: args.timeline,
       },
     }),
   verifyFindPerson: async (args: { person: Person }) =>

--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -3,7 +3,6 @@ import type {
   ApplicationTimelineNote,
   FullPerson,
   PlacementApplication,
-  TimelineEvent,
 } from '@approved-premises/api'
 import { fromPartial } from '@total-typescript/shoehorn'
 import { DateFormats } from '../../../server/utils/dateUtils'
@@ -12,7 +11,6 @@ import Page from '../page'
 import {
   ApplicationShowPageTab,
   applicationShowPageTab,
-  eventTypeTranslations,
   mapPlacementApplicationToSummaryCards,
 } from '../../../server/utils/applications/utils'
 import { TextItem } from '../../../server/@types/ui'
@@ -135,33 +133,6 @@ export default class ShowPage extends Page {
 
   verifyOnTimelineTab() {
     cy.get('a').contains('Placement').should('contain', '[aria-page="current"]')
-  }
-
-  shouldShowTimeline(timelineEvents: Array<TimelineEvent>) {
-    const sortedTimelineEvents = timelineEvents.sort((a, b) => {
-      return new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime()
-    })
-
-    cy.get('h2').contains('Application history').should('exist')
-    cy.get('.moj-timeline').within(() => {
-      cy.get('.moj-timeline__item').should('have.length', timelineEvents.length)
-
-      cy.get('.moj-timeline__item').each(($el, index) => {
-        cy.wrap($el).within(() => {
-          cy.get('.moj-timeline__header').should('contain', eventTypeTranslations[sortedTimelineEvents[index].type])
-          cy.get('time').should('have.attr', { time: sortedTimelineEvents[index].occurredAt })
-          if (timelineEvents[index].createdBy?.name) {
-            cy.get('.moj-timeline__header > .moj-timeline__byline').should(
-              'contain',
-              timelineEvents[index].createdBy.name,
-            )
-          }
-          cy.get('.govuk-link').should('have.attr', { time: timelineEvents[index].associatedUrls[0].url })
-          cy.get('.govuk-link').should('contain', timelineEvents[index].associatedUrls[0].type)
-          cy.get('time').should('contain', DateFormats.isoDateTimeToUIDateTime(timelineEvents[index].occurredAt))
-        })
-      })
-    })
   }
 
   shouldShowPlacementApplications(

--- a/integration_tests/pages/people/timeline/find.ts
+++ b/integration_tests/pages/people/timeline/find.ts
@@ -1,0 +1,15 @@
+import { Person } from '../../../../server/@types/shared'
+import Page from '../../page'
+
+export class FindPage extends Page {
+  person: Person
+
+  constructor(person: Person) {
+    super("Find someone's application history")
+    this.person = person
+  }
+
+  enterCrn() {
+    this.getTextInputByIdAndEnterDetails('crn', this.person.crn)
+  }
+}

--- a/integration_tests/pages/people/timeline/show.ts
+++ b/integration_tests/pages/people/timeline/show.ts
@@ -1,0 +1,21 @@
+import { Person, PersonalTimeline } from '../../../../server/@types/shared'
+import { getStatus } from '../../../../server/utils/applications/getStatus'
+import Page from '../../page'
+
+export class ShowPage extends Page {
+  timeline: PersonalTimeline
+
+  constructor(timeline: PersonalTimeline, crn: Person['crn']) {
+    super(`Application history for ${crn}`)
+    this.timeline = timeline
+  }
+
+  shouldShowTimeline() {
+    this.timeline.applications.forEach(applicationTimeline => {
+      cy.get('h2').contains(applicationTimeline.createdBy.name)
+      cy.get('.govuk-tag').contains(getStatus(applicationTimeline))
+
+      this.shouldShowApplicationTimeline(applicationTimeline.timelineEvents)
+    })
+  }
+}

--- a/integration_tests/tests/apply/viewApplication.cy.ts
+++ b/integration_tests/tests/apply/viewApplication.cy.ts
@@ -55,7 +55,7 @@ context('show applications', () => {
     // When I click on the 'Timeline' tab
     // Then I should see timeline page
     showPage.clickTimelineTab()
-    showPage.shouldShowTimeline(timeline)
+    showPage.shouldShowApplicationTimeline(timeline)
   })
 
   it('shows a read-only version of an unsubmitted withdrawn application', function test() {
@@ -228,7 +228,7 @@ context('show applications', () => {
     showPage.showsNoteAddedConfirmationMessage()
 
     // And I should see the note in the timeline
-    showPage.shouldShowTimeline(updatedTimeline)
+    showPage.shouldShowApplicationTimeline(updatedTimeline)
 
     // And the API should have been called with the new note
     cy.task('verifyApplicationNoteAdded', { id: application.id }).then(requests => {

--- a/integration_tests/tests/people/timeline.cy.ts
+++ b/integration_tests/tests/people/timeline.cy.ts
@@ -1,0 +1,37 @@
+import paths from '../../../server/paths/people'
+import { personFactory, personalTimelineFactory } from '../../../server/testutils/factories'
+import Page from '../../pages/page'
+import { FindPage } from '../../pages/people/timeline/find'
+import { ShowPage } from '../../pages/people/timeline/show'
+
+context('Application timeline', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser', { roles: [] })
+
+    // Given I am logged in
+    cy.signIn()
+  })
+
+  it('shows a timeline for a CRN', () => {
+    const timeline = personalTimelineFactory.build()
+    const person = personFactory.build()
+
+    cy.task('stubPersonalTimeline', { timeline, person })
+    cy.visit(paths.timeline.find({}))
+
+    // Given I am on the timeline find page
+    const findPage = Page.verifyOnPage(FindPage, person)
+
+    // When I enter a CRN
+    findPage.enterCrn()
+    // And click submit
+    findPage.clickSubmit()
+
+    // Then I should be on the timeline show page
+    const timelinePage = Page.verifyOnPage(ShowPage, timeline, person.crn)
+    // And I should see the timeline for that person
+    timelinePage.checkForBackButton(paths.timeline.find({}))
+  })
+})

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -12,6 +12,7 @@ import type { Services } from '../services'
 import DashboardController from './dashboardController'
 import PagesController from './placementApplications/pagesController'
 import PeopleController from './people/peopleController'
+import TimelineController from './people/timelineController'
 import ReviewController from './placementApplications/reviewController'
 import WithdrawalsController from './placementApplications/withdrawalsController'
 import RedirectController from './redirectController'
@@ -33,6 +34,7 @@ export const controllers = (services: Services) => {
   const placementApplicationReviewController = new ReviewController(services.placementApplicationService)
   const placementApplicationWithdrawalsController = new WithdrawalsController(services.placementApplicationService)
   const peopleController = new PeopleController(services.personService)
+  const timelineController = new TimelineController(services.personService)
 
   return {
     redirectController,
@@ -43,6 +45,7 @@ export const controllers = (services: Services) => {
     placementApplicationReviewController,
     placementApplicationWithdrawalsController,
     peopleController,
+    timelineController,
     ...applyControllers(services),
     ...assessControllers(services),
     ...matchControllers(services),

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -11,6 +11,7 @@ import AllocationsController from './tasks/allocationsController'
 import type { Services } from '../services'
 import DashboardController from './dashboardController'
 import PagesController from './placementApplications/pagesController'
+import PeopleController from './people/peopleController'
 import ReviewController from './placementApplications/reviewController'
 import WithdrawalsController from './placementApplications/withdrawalsController'
 import RedirectController from './redirectController'
@@ -31,6 +32,7 @@ export const controllers = (services: Services) => {
   )
   const placementApplicationReviewController = new ReviewController(services.placementApplicationService)
   const placementApplicationWithdrawalsController = new WithdrawalsController(services.placementApplicationService)
+  const peopleController = new PeopleController(services.personService)
 
   return {
     redirectController,
@@ -40,6 +42,7 @@ export const controllers = (services: Services) => {
     placementApplicationPagesController,
     placementApplicationReviewController,
     placementApplicationWithdrawalsController,
+    peopleController,
     ...applyControllers(services),
     ...assessControllers(services),
     ...matchControllers(services),

--- a/server/controllers/manage/index.ts
+++ b/server/controllers/manage/index.ts
@@ -8,7 +8,6 @@ import NonArrivalsController from './nonArrivalsController'
 import DeparturesController from './departuresController'
 import CancellationsController from './cancellationsController'
 import LostBedsController from './lostBedsController'
-import PeopleController from '../peopleController'
 import MoveBedsController from './moveBedsController'
 import BedsController from './premises/bedsController'
 import DateChangesController from './dateChangesController'
@@ -24,7 +23,6 @@ export const controllers = (services: Services) => {
   const departuresController = new DeparturesController(services.departureService, services.bookingService)
   const cancellationsController = new CancellationsController(services.cancellationService, services.bookingService)
   const lostBedsController = new LostBedsController(services.lostBedService)
-  const peopleController = new PeopleController(services.personService)
   const bedsController = new BedsController(services.premisesService)
   const moveBedsController = new MoveBedsController(services.bookingService, services.premisesService)
   const dateChangesController = new DateChangesController(services.bookingService)
@@ -39,7 +37,6 @@ export const controllers = (services: Services) => {
     departuresController,
     cancellationsController,
     lostBedsController,
-    peopleController,
     bedsController,
     moveBedsController,
   }
@@ -52,6 +49,5 @@ export {
   ArrivalsController,
   NonArrivalsController,
   DeparturesController,
-  PeopleController,
   MoveBedsController,
 }

--- a/server/controllers/people/peopleController.test.ts
+++ b/server/controllers/people/peopleController.test.ts
@@ -2,10 +2,10 @@ import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
 import PeopleController from './peopleController'
-import PersonService from '../services/personService'
-import { personFactory } from '../testutils/factories'
-import { errorMessage, errorSummary } from '../utils/validation'
-import { RestrictedPersonError } from '../utils/errors'
+import PersonService from '../../services/personService'
+import { personFactory } from '../../testutils/factories'
+import { errorMessage, errorSummary } from '../../utils/validation'
+import { RestrictedPersonError } from '../../utils/errors'
 
 describe('PeopleController', () => {
   const token = 'SOME_TOKEN'

--- a/server/controllers/people/peopleController.ts
+++ b/server/controllers/people/peopleController.ts
@@ -1,10 +1,10 @@
 import type { Request, RequestHandler, Response } from 'express'
 
 import { HttpError } from 'http-errors'
-import PersonService from '../services/personService'
-import { addErrorMessageToFlash } from '../utils/validation'
-import { isFullPerson } from '../utils/personUtils'
-import { RestrictedPersonError } from '../utils/errors'
+import PersonService from '../../services/personService'
+import { addErrorMessageToFlash } from '../../utils/validation'
+import { isFullPerson } from '../../utils/personUtils'
+import { RestrictedPersonError } from '../../utils/errors'
 
 export default class PeopleController {
   constructor(private readonly personService: PersonService) {}

--- a/server/controllers/people/timelineController.test.ts
+++ b/server/controllers/people/timelineController.test.ts
@@ -1,0 +1,58 @@
+import type { NextFunction, Request, Response } from 'express'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+
+import TimelineController from './timelineController'
+import PersonService from '../../services/personService'
+import { personalTimelineFactory } from '../../testutils/factories'
+
+describe('TimelineController', () => {
+  const token = 'SOME_TOKEN'
+  const premisesId = 'premisesId'
+  const flashSpy = jest.fn()
+
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const personService = createMock<PersonService>({})
+
+  let timelineController: TimelineController
+  let request: Readonly<DeepMocked<Request>>
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    timelineController = new TimelineController(personService)
+    request = createMock<Request>({
+      user: { token },
+      flash: flashSpy,
+      params: { premisesId },
+      headers: {
+        referer: 'some-referrer/',
+      },
+    })
+  })
+
+  describe('find', () => {
+    it('renders the timeline view', async () => {
+      const requestHandler = timelineController.find()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('people/find', { pageHeading: "Find someone's application history" })
+    })
+  })
+
+  describe('show', () => {
+    it('renders the timeline view', async () => {
+      const crn = 'CRN'
+      const timeline = personalTimelineFactory.build()
+
+      personService.getTimeline.mockResolvedValue(timeline)
+
+      const requestHandler = timelineController.show()
+
+      await requestHandler({ ...request, body: { crn } }, response, next)
+
+      expect(personService.getTimeline).toHaveBeenCalledWith(token, crn)
+    })
+  })
+})

--- a/server/controllers/people/timelineController.ts
+++ b/server/controllers/people/timelineController.ts
@@ -1,0 +1,23 @@
+import type { Request, RequestHandler, Response } from 'express'
+
+import PersonService from '../../services/personService'
+
+export default class TimelineController {
+  constructor(private readonly personService: PersonService) {}
+
+  find(): RequestHandler {
+    return async (_: Request, res: Response) => {
+      res.render('people/find', { pageHeading: "Find someone's application history" })
+    }
+  }
+
+  show(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { crn } = req.body
+
+      const timeline = await this.personService.getTimeline(req.user.token, crn)
+
+      res.render('people/timeline/show', { timeline, crn })
+    }
+  }
+}

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -327,4 +327,27 @@ describeClient('PersonClient', provider => {
       await personClient.document(crn, documentId, response)
     })
   })
+
+  describe('timeline', () => {
+    it('calls the API with CRN', async () => {
+      const crn = 'crn'
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get the timeline for a person',
+        withRequest: {
+          method: 'GET',
+          path: paths.people.timeline({ crn }),
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+        },
+      })
+
+      await personClient.timeline(crn)
+    })
+  })
 })

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -8,6 +8,7 @@ import type {
   Person,
   PersonAcctAlert,
   PersonRisks,
+  PersonalTimeline,
   PrisonCaseNote,
 } from '@approved-premises/api'
 
@@ -100,5 +101,9 @@ export default class PersonClient {
       { path: paths.people.documents({ crn, documentId }), passThroughHeaders: ['content-disposition'] },
       response,
     )
+  }
+
+  async timeline(crn: string): Promise<PersonalTimeline> {
+    return (await this.restClient.get({ path: paths.people.timeline({ crn }) })) as Promise<PersonalTimeline>
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -191,6 +191,7 @@ export default {
       selection: oasysPath.path('selection'),
       sections: oasysPath.path('sections'),
     },
+    timeline: personPath.path('timeline'),
   },
   users: {
     index: usersPath,

--- a/server/paths/people.ts
+++ b/server/paths/people.ts
@@ -1,0 +1,13 @@
+import { path } from 'static-path'
+
+const people = path('/people')
+const timeline = people.path('timeline')
+
+const paths = {
+  timeline: {
+    find: timeline.path('find'),
+    show: timeline.path('show'),
+  },
+}
+
+export default paths

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -13,6 +13,7 @@ import manageRoutes from './manage'
 import tasksRoutes from './tasks'
 import placementApplicationRoutes from './placementApplications'
 import adminRoutes from './admin'
+import peopleRoutes from './people'
 
 export default function routes(controllers: Controllers, services: Partial<Services>): Router {
   const router = Router()
@@ -30,6 +31,7 @@ export default function routes(controllers: Controllers, services: Partial<Servi
   tasksRoutes(controllers, router, services)
   placementApplicationRoutes(controllers, router, services)
   adminRoutes(controllers, router, services)
+  peopleRoutes(controllers, router, services)
 
   return router
 }

--- a/server/routes/manage.ts
+++ b/server/routes/manage.ts
@@ -21,7 +21,7 @@ export default function routes(controllers: Controllers, router: Router, service
     departuresController,
     cancellationsController,
     lostBedsController,
-    peopleController,
+
     bedsController,
     moveBedsController,
   } = controllers
@@ -54,8 +54,6 @@ export default function routes(controllers: Controllers, router: Router, service
     allowedRoles: ['workflow_manager'],
   })
   get(paths.bookings.confirm.pattern, bookingsController.confirm(), { allowedRoles: ['workflow_manager'] })
-
-  post(paths.people.find.pattern, peopleController.find(), { auditEvent: 'FIND_PERSON', auditBodyParams: ['crn'] })
 
   get(paths.bookings.extensions.new.pattern, bookingExtensionsController.new(), {
     auditEvent: 'NEW_BOOKING_EXTENSION',

--- a/server/routes/people.ts
+++ b/server/routes/people.ts
@@ -20,7 +20,11 @@ export default function routes(controllers: Controllers, router: Router, service
     auditBodyParams: ['crn'],
   })
 
-  get(peoplePaths.timeline.find.pattern, timelineController.find(), { auditEvent: 'SHOW_PERSON' })
+  get(peoplePaths.timeline.find.pattern, timelineController.find(), { auditEvent: 'SEARCH_FOR_TIMELINE' })
+  post(peoplePaths.timeline.find.pattern, timelineController.show(), {
+    auditEvent: 'SHOW_PERSON_TIMELINE',
+    auditBodyParams: ['crn'],
+  })
 
   return router
 }

--- a/server/routes/people.ts
+++ b/server/routes/people.ts
@@ -1,0 +1,26 @@
+/* istanbul ignore file */
+
+import type { Router } from 'express'
+
+import type { Controllers } from '../controllers'
+import type { Services } from '../services'
+
+import managePaths from '../paths/manage'
+import peoplePaths from '../paths/people'
+
+import actions from './utils'
+
+export default function routes(controllers: Controllers, router: Router, services: Partial<Services>): Router {
+  const { get, post } = actions(router, services.auditService)
+
+  const { peopleController, timelineController } = controllers
+
+  post(managePaths.people.find.pattern, peopleController.find(), {
+    auditEvent: 'FIND_PERSON',
+    auditBodyParams: ['crn'],
+  })
+
+  get(peoplePaths.timeline.find.pattern, timelineController.find(), { auditEvent: 'SHOW_PERSON' })
+
+  return router
+}

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -2,6 +2,7 @@ import { Response } from 'express'
 import { createMock } from '@golevelup/ts-jest'
 import type { Person } from '@approved-premises/api'
 
+import { when } from 'jest-when'
 import { SanitisedError } from '../sanitisedError'
 import PersonService, { OasysNotFoundError } from './personService'
 import PersonClient from '../data/personClient'
@@ -12,6 +13,7 @@ import {
   oasysSectionsFactory,
   oasysSelectionFactory,
   personFactory,
+  personalTimelineFactory,
   prisonCaseNotesFactory,
   risksFactory,
 } from '../testutils/factories'
@@ -237,6 +239,20 @@ describe('PersonService', () => {
 
       expect(personClientFactory).toHaveBeenCalledWith(token)
       expect(personClient.document).toHaveBeenCalledWith('crn', 'applicationId', response)
+    })
+  })
+
+  describe('getTimeline', () => {
+    it('calls the client method and retuns the result', async () => {
+      const expected = personalTimelineFactory.build()
+      const crn = 'crn'
+      when(personClient.timeline).calledWith(crn).mockResolvedValue(expected)
+
+      const actual = await service.getTimeline(token, crn)
+
+      expect(personClientFactory).toHaveBeenCalledWith(token)
+      expect(personClient.timeline).toHaveBeenCalledWith('crn')
+      expect(actual).toEqual(expected)
     })
   })
 })

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -7,6 +7,7 @@ import type {
   OASysSections,
   Person,
   PersonAcctAlert,
+  PersonalTimeline,
   PrisonCaseNote,
 } from '@approved-premises/api'
 import { HttpError } from 'http-errors'
@@ -101,5 +102,11 @@ export default class PersonService {
     const personClient = this.personClientFactory(token)
 
     return personClient.document(crn, documentId, response)
+  }
+
+  async getTimeline(token: string, crn: string): Promise<PersonalTimeline> {
+    const personClient = this.personClientFactory(token)
+
+    return personClient.timeline(crn)
   }
 }

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -73,7 +73,7 @@ import roomFactory from './room'
 import staffMemberFactory from './staffMember'
 import taskFactory from './task'
 import taskWrapperFactory from './taskWrapperFactory'
-import timelineEventFactory from './timelineEvent'
+import { applicationTimelineFactory, personalTimelineFactory, timelineEventFactory } from './timeline'
 import userFactory, { userWithWorkloadFactory } from './user'
 import userDetailsFactory from './userDetails'
 import placementApplicationDecisionEnvelopeFactory from './placementApplicationDecisionEnvelope'
@@ -90,6 +90,7 @@ export {
   apCharacteristicPairFactory,
   applicationFactory,
   applicationSummaryFactory,
+  applicationTimelineFactory,
   arrivalFactory,
   assessmentTaskFactory,
   assessmentFactory,
@@ -140,6 +141,7 @@ export {
   oasysSelectionFactory,
   paginatedResponseFactory,
   personFactory,
+  personalTimelineFactory,
   placementApplicationFactory,
   placementApplicationTaskFactory,
   placementApplicationDecisionEnvelopeFactory,

--- a/server/testutils/factories/timeline.ts
+++ b/server/testutils/factories/timeline.ts
@@ -1,10 +1,10 @@
 import { Factory } from 'fishery'
-import { TimelineEvent } from '@approved-premises/api'
+import { ApplicationTimeline, PersonalTimeline, TimelineEvent } from '@approved-premises/api'
 import { faker } from '@faker-js/faker'
 import { DateFormats } from '../../utils/dateUtils'
 import userFactory from './user'
 
-export default Factory.define<TimelineEvent>(() => ({
+export const timelineEventFactory = Factory.define<TimelineEvent>(() => ({
   id: faker.string.uuid(),
   occurredAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
   type: faker.helpers.arrayElement([
@@ -27,3 +27,30 @@ export default Factory.define<TimelineEvent>(() => ({
   createdBy: userFactory.build(),
   associatedUrls: [{ type: 'application', url: faker.internet.url() }],
 }))
+
+export const applicationTimelineFactory = Factory.define<ApplicationTimeline>(() => ({
+  createdAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
+  id: faker.string.uuid(),
+  status: faker.helpers.arrayElement([
+    'started',
+    'submitted',
+    'rejected',
+    'awaitingAssesment',
+    'unallocatedAssesment',
+    'assesmentInProgress',
+    'awaitingPlacement',
+    'placementAllocated',
+    'inapplicable',
+    'withdrawn',
+    'requestedFurtherInformation',
+    'pendingPlacementRequest',
+  ] as const),
+  createdBy: userFactory.build(),
+  timelineEvents: timelineEventFactory.buildList(5),
+}))
+
+export const personalTimelineFactory = Factory.define<PersonalTimeline>(() => ({
+  applications: applicationTimelineFactory.buildList(2),
+}))
+
+export default timelineEventFactory

--- a/server/utils/applications/getStatus.ts
+++ b/server/utils/applications/getStatus.ts
@@ -1,8 +1,4 @@
-import {
-  ApprovedPremisesApplication as Application,
-  ApprovedPremisesApplicationSummary as ApplicationSummary,
-  ApprovedPremisesApplicationStatus as Status,
-} from '../../@types/shared'
+import { ApprovedPremisesApplicationStatus, ApprovedPremisesApplicationStatus as Status } from '../../@types/shared'
 
 export const applicationStatuses: Record<Status, string> = {
   started: 'Application started',
@@ -44,6 +40,9 @@ export const statusTags = (classes?: string): Record<Status, string> => {
   )
 }
 
-export const getStatus = (application: ApplicationSummary | Application, classes?: string) => {
+export const getStatus = <T extends { status: ApprovedPremisesApplicationStatus }>(
+  application: T,
+  classes?: string,
+) => {
   return statusTags(classes)[application.status]
 }

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -11,8 +11,10 @@ import { mockOptionalQuestionResponse } from '../../testutils/mockQuestionRespon
 import {
   applicationFactory,
   applicationSummaryFactory,
+  applicationTimelineFactory,
   assessmentFactory,
   personFactory,
+  personalTimelineFactory,
   placementApplicationFactory,
   restrictedPersonFactory,
   tierEnvelopeFactory,
@@ -42,8 +44,9 @@ import {
   getStatus,
   isInapplicable,
   lengthOfStayForUI,
-  mapPlacementApplicationToSummaryCards,
   mapApplicationTimelineEventsForUi,
+  mapPersonalTimelineForUi,
+  mapPlacementApplicationToSummaryCards,
   mapTimelineUrlsForUi,
   withdrawnStatusTag,
 } from './utils'
@@ -858,6 +861,20 @@ describe('utils', () => {
     ])('Translates a "%s" url type to "%s"', (urlType: TimelineEventUrlType, translation: string) => {
       const timelineUrl = { type: urlType, url: faker.internet.url() }
       expect(mapTimelineUrlsForUi([timelineUrl])).toEqual([{ url: timelineUrl.url, type: translation }])
+    })
+  })
+
+  describe('mapPersonTimelineForUi', () => {
+    it('maps the application timelines events for the UI', () => {
+      const applicationTimeline = applicationTimelineFactory.build()
+      const personalTimeline = personalTimelineFactory.build({ applications: [applicationTimeline] })
+
+      expect(mapPersonalTimelineForUi(personalTimeline)).toEqual([
+        {
+          ...applicationTimeline,
+          timelineEvents: mapApplicationTimelineEventsForUi(applicationTimeline.timelineEvents),
+        },
+      ])
     })
   })
 

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -43,7 +43,7 @@ import {
   isInapplicable,
   lengthOfStayForUI,
   mapPlacementApplicationToSummaryCards,
-  mapTimelineEventsForUi,
+  mapApplicationTimelineEventsForUi,
   mapTimelineUrlsForUi,
   withdrawnStatusTag,
 } from './utils'
@@ -756,10 +756,10 @@ describe('utils', () => {
     )
   })
 
-  describe('mapTimelineEventsForUi', () => {
+  describe('mapApplicationTimelineEventsForUi', () => {
     it('maps the events into the format required by the MoJ UI Timeline component', () => {
       const timelineEvents = timelineEventFactory.buildList(1)
-      expect(mapTimelineEventsForUi(timelineEvents)).toEqual([
+      expect(mapApplicationTimelineEventsForUi(timelineEvents)).toEqual([
         {
           datetime: {
             timestamp: timelineEvents[0].occurredAt,
@@ -783,7 +783,7 @@ describe('utils', () => {
     it('maps the events into the format required by the MoJ UI Timeline component without associatedUrls', () => {
       const timelineEvents = timelineEventFactory.buildList(1, { associatedUrls: undefined })
 
-      expect(mapTimelineEventsForUi(timelineEvents)).toEqual([
+      expect(mapApplicationTimelineEventsForUi(timelineEvents)).toEqual([
         {
           datetime: {
             timestamp: timelineEvents[0].occurredAt,
@@ -802,7 +802,7 @@ describe('utils', () => {
     it('sorts the events in ascending order', () => {
       const timelineEvents = timelineEventFactory.buildList(3)
 
-      const actual = mapTimelineEventsForUi(timelineEvents)
+      const actual = mapApplicationTimelineEventsForUi(timelineEvents)
 
       expect(
         isAfter(
@@ -824,6 +824,28 @@ describe('utils', () => {
           DateFormats.isoToDateObj(actual[2].datetime.timestamp),
         ),
       ).toEqual(true)
+    })
+
+    it('doesnt error when there are events without "occuredAt" property', () => {
+      const timelineEventWithoutOccurredAt = timelineEventFactory.build({ occurredAt: undefined })
+      const pastTimelineEvent = timelineEventFactory.build({
+        occurredAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
+      })
+      const futureTimelineEvent = timelineEventFactory.build({
+        occurredAt: DateFormats.dateObjToIsoDateTime(faker.date.future()),
+      })
+
+      const actual = mapApplicationTimelineEventsForUi([
+        timelineEventWithoutOccurredAt,
+        pastTimelineEvent,
+        futureTimelineEvent,
+      ])
+
+      expect(actual).toEqual([
+        ...mapApplicationTimelineEventsForUi([timelineEventWithoutOccurredAt]),
+        ...mapApplicationTimelineEventsForUi([futureTimelineEvent]),
+        ...mapApplicationTimelineEventsForUi([pastTimelineEvent]),
+      ])
     })
   })
 

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -280,15 +280,20 @@ export const eventTypeTranslations: Record<TimelineEventType, string> = {
   approved_premises_match_request_withdrawn: 'Request for placement withdrawn',
 }
 
-const mapTimelineEventsForUi = (timelineEvents: Array<TimelineEvent>): Array<UiTimelineEvent> => {
+const mapApplicationTimelineEventsForUi = (timelineEvents: Array<TimelineEvent>): Array<UiTimelineEvent> => {
   return timelineEvents
-    .sort((a, b) => Number(DateFormats.isoToDateObj(b.occurredAt)) - Number(DateFormats.isoToDateObj(a.occurredAt)))
+    .sort((a, b) => {
+      if (b?.occurredAt && a?.occurredAt) {
+        return Number(DateFormats.isoToDateObj(b.occurredAt)) - Number(DateFormats.isoToDateObj(a.occurredAt))
+      }
+      return 1
+    })
     .map(timelineEvent => {
       const event = {
         label: { text: eventTypeTranslations[timelineEvent.type] },
         datetime: {
           timestamp: timelineEvent.occurredAt,
-          date: DateFormats.isoDateTimeToUIDateTime(timelineEvent.occurredAt),
+          date: timelineEvent.occurredAt ? DateFormats.isoDateTimeToUIDateTime(timelineEvent.occurredAt) : '',
         },
         content: timelineEvent.content,
         associatedUrls: timelineEvent.associatedUrls ? mapTimelineUrlsForUi(timelineEvent.associatedUrls) : [],
@@ -475,7 +480,7 @@ export {
   getApplicationType,
   getStatus,
   isInapplicable,
-  mapTimelineEventsForUi,
+  mapApplicationTimelineEventsForUi,
   mapTimelineUrlsForUi,
   mapPlacementApplicationToSummaryCards,
   lengthOfStayForUI,

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -18,6 +18,7 @@ import type {
   ApplicationSortField,
   ApprovedPremisesApplicationSummary as ApplicationSummary,
   ApprovedPremisesApplicationStatus,
+  PersonalTimeline,
   PlacementApplication,
   PlacementType,
   SortDirection,
@@ -312,6 +313,15 @@ const mapTimelineUrlsForUi = (timelineUrls: Array<TimelineEventAssociatedUrl>) =
   return timelineUrls.map(item => ({ url: item.url, type: urlTypeForUi(item.type) }))
 }
 
+const mapPersonalTimelineForUi = (personalTimeline: PersonalTimeline) => {
+  return personalTimeline.applications.map(applicationTimeline => {
+    return {
+      ...applicationTimeline,
+      timelineEvents: mapApplicationTimelineEventsForUi(applicationTimeline.timelineEvents),
+    }
+  })
+}
+
 const urlTypeForUi = (type: TimelineEventUrlType) => {
   const translations: Record<TimelineEventUrlType, string> = {
     application: 'application',
@@ -482,6 +492,7 @@ export {
   isInapplicable,
   mapApplicationTimelineEventsForUi,
   mapTimelineUrlsForUi,
+  mapPersonalTimelineForUi,
   mapPlacementApplicationToSummaryCards,
   lengthOfStayForUI,
   applicationStatusSelectOptions,

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -60,6 +60,7 @@ import assessPaths from '../paths/assess'
 import tasksPaths from '../paths/tasks'
 import matchPaths from '../paths/match'
 import adminPaths from '../paths/admin'
+import peoplePaths from '../paths/people'
 import placementApplicationsPaths from '../paths/placementApplications'
 import { radioMatrixTable } from './radioMatrixTable'
 import * as AppealsUtils from './appealsUtils'
@@ -180,6 +181,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
     ...matchPaths,
     ...placementApplicationsPaths,
     ...adminPaths,
+    ...peoplePaths,
   })
 
   njkEnv.addGlobal('linkTo', linkTo)

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -22,7 +22,6 @@ import {
   convertObjectsToSelectOptions,
   dateFieldValues,
 } from './formUtils'
-import { mapTimelineEventsForUi } from './applications/utils'
 import { relevantDatesOptions } from './applications/relevantDatesOptions'
 import { navigationItems } from './navigationItems'
 
@@ -203,7 +202,6 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addFilter('kebabCase', kebabCase)
 
   njkEnv.addGlobal('numberToOrdinal', numberToOrdinal)
-  njkEnv.addGlobal('mapTimelineEventsForUi', mapTimelineEventsForUi)
   njkEnv.addGlobal('navigationItems', navigationItems)
   njkEnv.addGlobal('withdrawalRadioOptions', withdrawalRadioOptions)
   njkEnv.addGlobal('relevantDatesOptions', relevantDatesOptions)

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -22,6 +22,7 @@ import {
   convertObjectsToSelectOptions,
   dateFieldValues,
 } from './formUtils'
+import { getStatus as applicationStatusTag } from './applications/utils'
 import { relevantDatesOptions } from './applications/relevantDatesOptions'
 import { navigationItems } from './navigationItems'
 
@@ -196,6 +197,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('oasysDisabled', config.flags.oasysDisabled)
 
   njkEnv.addFilter('mapApiPersonRisksForUi', mapApiPersonRisksForUi)
+  njkEnv.addFilter('applicationStatusTag', applicationStatusTag)
 
   njkEnv.addFilter('removeBlankSummaryListItems', removeBlankSummaryListItems)
   njkEnv.addFilter('sentenceCase', sentenceCase)

--- a/server/views/applications/partials/_timeline.njk
+++ b/server/views/applications/partials/_timeline.njk
@@ -1,7 +1,7 @@
 {%- from "moj/components/timeline/macro.njk" import mojTimeline -%}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-
+{% from "../../partials/_applicationTimeline.njk" import applicationTimeline %}
 {% macro timeline(timelineEvents, application, csrfToken) %}
 
   <form action="{{ paths.applications.notes.new({id: application.id}) }}" method="post">
@@ -22,40 +22,6 @@
   </form>
 
   <h2 class="govuk-heading-m">Application history</h2>
-  <div class="moj-timeline">
+  {{applicationTimeline(timelineEvents)}}</div>
 
-    {% for event in timelineEvents %}
-      <div class="moj-timeline__item">
-
-        <div class="moj-timeline__header">
-          <h3 class="moj-timeline__title">{{event.label.text}}</h3>
-          {% if event.createdBy %}
-            <p class="moj-timeline__byline">by {{event.createdBy}}</p>
-            {%endif%}
-          </div>
-
-          <p class="moj-timeline__date">
-            <time datetime="{{event.datetime.timestamp}}">{{event.datetime.date}}</time>
-          </p>
-
-          {% if event.content %}
-            <div class="moj-timeline__description">
-              <p>{{event.content}}</p>
-            </div>
-            {%endif%}
-            {% if event.associatedUrls %}
-              {% for associatedUrl in event.associatedUrls %}
-                <div class="moj-timeline__description">
-                  <ul class="govuk-list govuk-list--bullet">
-                    <li>
-                      <a class="govuk-link" href="{{associatedUrl.url}}">View {{associatedUrl.type}}</a>
-                    </li>
-                  </ul>
-                </div>
-              {% endfor %}
-              {%endif%}
-            </div>
-          {% endfor %}
-        </div>
-
-      {% endmacro %}
+{% endmacro %}

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -58,7 +58,7 @@
 
       <div class="govuk-grid-column-full">
         {% if tab === ApplyUtils.applicationShowPageTabs.timeline %}
-          {{ timeline(mapTimelineEventsForUi(timelineEvents), application, csrfToken) }}
+          {{ timeline(ApplyUtils.mapApplicationTimelineEventsForUi(timelineEvents), application, csrfToken) }}
         {% elif tab === ApplyUtils.applicationShowPageTabs.placementRequests %}
           {{ requestAPlacement(placementApplications, application, user, csrfToken) }}
         {% else %}

--- a/server/views/partials/_applicationTimeline.njk
+++ b/server/views/partials/_applicationTimeline.njk
@@ -1,0 +1,36 @@
+{% macro applicationTimeline(timelineEvents) %}
+    <div class="moj-timeline">
+        {% for event in timelineEvents %}
+            <div class="moj-timeline__item">
+
+                <div class="moj-timeline__header">
+                    <h3 class="moj-timeline__title">{{event.label.text}}</h3>
+                    {% if event.createdBy %}
+                        <p class="moj-timeline__byline">by {{event.createdBy}}</p>
+                        {%endif%}
+                    </div>
+
+                    <p class="moj-timeline__date">
+                        <time datetime="{{event.datetime.timestamp}}">{{event.datetime.date}}</time>
+                    </p>
+
+                    {% if event.content %}
+                        <div class="moj-timeline__description">
+                            <p>{{event.content}}</p>
+                        </div>
+                        {%endif%}
+                        {% if event.associatedUrls %}
+                            {% for associatedUrl in event.associatedUrls %}
+                                <div class="moj-timeline__description">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>
+                                            <a class="govuk-link" href="{{associatedUrl.url}}">View {{associatedUrl.type}}</a>
+                                        </li>
+                                    </ul>
+                                </div>
+                            {% endfor %}
+                            {%endif%}
+                        </div>
+                    {% endfor %}
+                </div>
+                {%endmacro%}

--- a/server/views/people/find.njk
+++ b/server/views/people/find.njk
@@ -1,0 +1,45 @@
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "../components/formFields/form-page-input/macro.njk" import formPageInput %}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form action="{{ paths.timeline.find() }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        <h1>{{ pageHeading }}</h1>
+        {{ showErrorSummary(errorSummary) }}
+
+        {{
+          formPageInput(
+            {
+              label: {
+                text: "Enter the person's CRN",
+                classes: "govuk-label--m"
+              },
+              hint: {
+                html: "<p>For example, a CRN is DO16821</p>"
+              },
+              classes: "govuk-input--width-10",
+              fieldName: "crn"
+            },
+            fetchContext()
+          )
+        }}
+
+        {{ govukButton({
+                    name: 'submit',
+                    text: "Save and continue"
+                }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/people/timeline/show.njk
+++ b/server/views/people/timeline/show.njk
@@ -1,0 +1,29 @@
+{% extends "../../partials/layout.njk" %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "../../partials/_applicationTimeline.njk" import applicationTimeline %}
+
+{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+		text: "Back",
+        href: paths.timeline.find({})
+	}) }}
+{% endblock %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">Application history for {{crn}}</h2>
+            {% for application in ApplyUtils.mapPersonalTimelineForUi(timeline) %}
+                <h2 class="govuk-heading-s">Application made by: {{application.createdBy.name}}</h2>
+                <h2 class="govuk-heading-s">Status: {{application | applicationStatusTag | safe}}</h2>
+
+                {{applicationTimeline(application.timelineEvents)}}
+
+                {%endfor%}
+            </div>
+        </div>
+    {% endblock %}


### PR DESCRIPTION
# Context
[JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&selectedIssue=APS-589) 


# Changes in this PR
- This adds the timeline screen but it isn't easy to judge how it will look without realistic data that we have in preprod. Rather than feature switch it I have opted to not link to the first page from anywhere in the in the service

## Screenshots of UI changes
![Application timeline -- shows a timeline for a CRN](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/5e4b432c-671c-4664-ae32-28960a90b9b7)

![Application timeline -- shows a timeline for a CRN (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/a6964a99-44b3-428a-a893-cab4d7e59d60)
