### PR TITLE
(APS-637) Always ask applicant to confirm index offence

### DIFF
--- a/integration_tests/pages/apply/confirmDetails.ts
+++ b/integration_tests/pages/apply/confirmDetails.ts
@@ -26,4 +26,8 @@ export default class ConfirmDetailsPage extends Page {
     cy.get('p').contains('This person is a limited access offender (LAO).')
     cy.get('a').contains('Guidance on managing user access to LAOs is available on EQUIP.')
   }
+
+  clickSaveAndContinue() {
+    cy.get('a').contains('Save and continue').click()
+  }
 }

--- a/integration_tests/pages/apply/selectOffence.ts
+++ b/integration_tests/pages/apply/selectOffence.ts
@@ -12,12 +12,12 @@ export default class SelectOffencePage extends Page {
 
   shouldDisplayOffences(): void {
     this.offences.forEach((item: ActiveOffence) => {
-      cy.contains(item.offenceId)
+      cy.contains(item.deliusEventNumber)
         .parent()
         .within(() => {
-          cy.get('td').eq(2).contains(item.offenceDescription)
+          cy.get('td').eq(1).contains(item.offenceDescription)
+          cy.get('td').eq(2).contains(item.deliusEventNumber)
           cy.get('td').eq(3).contains(DateFormats.isoDateToUIDate(item.offenceDate))
-          cy.get('td').eq(4).contains(item.convictionId)
         })
     })
   }

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -11,14 +11,7 @@ import {
 } from '../../../server/testutils/factories'
 import ApplyHelper from '../../helpers/apply'
 import { DateFormats } from '../../../server/utils/dateUtils'
-import {
-  ConfirmDetailsPage,
-  ConfirmYourDetailsPage,
-  EnterCRNPage,
-  ListPage,
-  SelectOffencePage,
-  StartPage,
-} from '../../pages/apply'
+import { ConfirmDetailsPage, ConfirmYourDetailsPage, EnterCRNPage, ListPage, StartPage } from '../../pages/apply'
 import IsExceptionalCasePage from '../../pages/apply/isExceptionalCase'
 import NoOffencePage from '../../pages/apply/noOffence'
 import NotEligiblePage from '../../pages/apply/notEligiblePage'
@@ -150,36 +143,15 @@ context('Apply', () => {
     confirmDetailsPage.verifyRestrictedPersonMessaging()
   })
 
-  it('allows the user to select an index offence if there is more than one offence', function test() {
+  it('creates an application with the correct index offence when there are multiple offences present', function test() {
     // Given the person has more than one offence listed under their CRN
     const offences = activeOffenceFactory.buildList(4)
 
     const apply = new ApplyHelper(this.application, this.person, offences)
     apply.setupApplicationStubs()
-    apply.startApplication()
 
-    // Then I should be forwarded to select an offence
-    const selectOffencePage = Page.verifyOnPage(SelectOffencePage, this.person, offences)
-    selectOffencePage.shouldDisplayOffences()
-
-    // When I select an offence
-    const selectedOffence = offences[0]
-    selectOffencePage.selectOffence(selectedOffence)
-
-    // And I click submit
-    selectOffencePage.clickSubmit()
-
-    // Then the API should have created the application with my selected offence
-    cy.task('verifyApplicationCreate').then(requests => {
-      expect(requests).to.have.length(1)
-
-      const body = JSON.parse(requests[0].body)
-
-      expect(body.crn).equal(this.person.crn)
-      expect(body.convictionId).equal(selectedOffence.convictionId)
-      expect(body.deliusEventNumber).equal(selectedOffence.deliusEventNumber)
-      expect(body.offenceId).equal(selectedOffence.offenceId)
-    })
+    // Then I should be able to select an offence
+    apply.startApplication(offences[2])
 
     // Then I should be on the Confirm Your Details page
     Page.verifyOnPage(ConfirmYourDetailsPage, this.application)

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -160,10 +160,6 @@ export default class ApplicationsController {
     return async (req: Request, res: Response) => {
       const { crn, offenceId } = req.body
 
-      if (!offenceId) {
-        return res.redirect(paths.applications.people.selectOffence({ crn }))
-      }
-
       const offences = await this.personService.getOffences(req.user.token, crn)
       const indexOffence = offences.find(o => o.offenceId === offenceId)
       const application = await this.applicationService.createApplication(req.user.token, crn, indexOffence)

--- a/server/utils/offenceUtils.test.ts
+++ b/server/utils/offenceUtils.test.ts
@@ -31,34 +31,30 @@ describe('offenceUtils', () => {
           {
             html: offenceRadioButton(offences[0]),
           },
-          {
-            text: offences[0].offenceId,
-          },
+
           {
             text: offences[0].offenceDescription,
           },
           {
-            text: DateFormats.isoDateToUIDate(offences[0].offenceDate),
+            text: offences[0].deliusEventNumber,
           },
           {
-            text: String(offences[0].convictionId),
+            text: DateFormats.isoDateToUIDate(offences[0].offenceDate),
           },
         ],
         [
           {
             html: offenceRadioButton(offences[1]),
           },
-          {
-            text: offences[1].offenceId,
-          },
+
           {
             text: offences[1].offenceDescription,
           },
           {
-            text: DateFormats.isoDateToUIDate(offences[1].offenceDate),
+            text: offences[1].deliusEventNumber,
           },
           {
-            text: String(offences[1].convictionId),
+            text: DateFormats.isoDateToUIDate(offences[1].offenceDate),
           },
         ],
       ])
@@ -73,16 +69,13 @@ describe('offenceUtils', () => {
             html: offenceRadioButton(offence),
           },
           {
-            text: offence.offenceId,
-          },
-          {
             text: offence.offenceDescription,
           },
           {
-            text: 'No offence date available',
+            text: offence.deliusEventNumber,
           },
           {
-            text: String(offence.convictionId),
+            text: 'No offence date available',
           },
         ],
       ])

--- a/server/utils/offenceUtils.ts
+++ b/server/utils/offenceUtils.ts
@@ -15,16 +15,13 @@ const offenceTableRows = (offences: Array<ActiveOffence>): Array<TableRow> => {
         html: offenceRadioButton(offence),
       },
       {
-        text: offence.offenceId,
-      },
-      {
         text: offence.offenceDescription,
       },
       {
-        text: offenceDate,
+        text: offence.deliusEventNumber,
       },
       {
-        text: String(offence.convictionId),
+        text: offenceDate,
       },
     ])
   })

--- a/server/views/applications/people/confirm.njk
+++ b/server/views/applications/people/confirm.njk
@@ -8,7 +8,7 @@
 
 {% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body" %}
-{% set nomsNumber = nomsNumber if nomsNumber else 
+{% set nomsNumber = nomsNumber if nomsNumber else
   "" %}
 
 {% block beforeContent %}
@@ -21,30 +21,14 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="{{ paths.applications.create() }}" method="post">
+      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+      <p class="govuk-body">
+        Taken from NDelius, <strong>{{ date }}</strong>
+      </p>
 
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-        <input type="hidden" name="name" value="{{ person.name }}"/>
-        <input type="hidden" name="crn" value="{{ person.crn }}"/>
-        <input type="hidden" name="dateOfBirth" value="{{ person.dateOfBirth }}"/>
-        <input type="hidden" name="sex" value="{{ person.sex }}"/>
-        <input type="hidden" name="nationality" value="{{ person.nationality }}"/>
-        <input type="hidden" name="religion" value="{{ person.religion }}"/>
-        <input type="hidden" name="offenceId" value="{{ offenceId }}"/>
+      {{ personDetails(person, false) }}
 
-        <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-
-        <p>
-          Taken from NDelius, <strong>{{ date }}</strong>
-        </p>
-
-        {{ personDetails(person, false) }}
-
-
-
-
-        {%if person.isRestricted %}
-
+      {% if person.isRestricted %}
         {% set html %}
           <p class='govuk-!-font-weight-bold'>This person is a limited access offender (LAO).</p>
           <p class='govuk-!-font-weight-bold'>You can continue with the application as you have access to this record, however please verify that the level of restriction is not broader than necessary.</p>
@@ -54,24 +38,25 @@
           </p>
         {% endset %}
 
-          {{ govukWarningText({
-          html: html, 
-          iconFallbackText: "Warning"
-          }) }}
-        {%endif%}
+        {{
+          govukWarningText({
+            html: html,
+            iconFallbackText: "Warning"
+          })
+        }}
+      {% endif %}
 
-        <p>If these details are wrong, update this case in NDelius before you start.</p>
-        <p>If you've entered the wrong CRN, go back to the CRN screen.</p>
+      <p class="govuk-body">If these details are wrong, update this case in NDelius before you start.</p>
+      <p class="govuk-body">If you've entered the wrong CRN, go back to the CRN screen.</p>
 
-        {{ govukButton({
-            text: "Save and continue"
-        }) }}
+      {{ govukButton({
+          text: "Save and continue",
+          href: paths.applications.people.selectOffence({ crn: person.crn })
+      }) }}
 
-        <p>
-          <a href="{{ paths.applications.new() }}"> Back to CRN screen </a>
-        </p>
-
-      </form>
+      <p class="govuk-body">
+        <a href="{{ paths.applications.new() }}"> Back to CRN screen </a>
+      </p>
     </div>
   </div>
 {% endblock %}

--- a/server/views/applications/people/selectOffence.njk
+++ b/server/views/applications/people/selectOffence.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - " + pageHeading  %}
@@ -22,12 +22,14 @@
       <h1>{{ pageHeading}}</h1>
 
       <p class="govuk-body">
-        {{ person.name }} has more than one offence identified against their CRN.
-
-      <p class="govuk-body">
-        Please select the main offence that will be used to assess their sutability
+        Please select the main offence that will be used to assess {{ person.name }}'s sutability
         for an Approved Premises (the 'index offence') below:
       </p>
+
+      {{ govukWarningText({
+        text: "If the required offence is not visible here, you will not be able to proceed with the application until the offence has been added to NDelius",
+        iconFallbackText: "Warning"
+      }) }}
 
         <form action="{{ paths.applications.create() }}" method="post">
           <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>

--- a/server/views/applications/people/selectOffence.njk
+++ b/server/views/applications/people/selectOffence.njk
@@ -43,16 +43,13 @@
                   html: '<span class="govuk-visually-hidden">Select offence</span>'
                 },
                 {
-                  text: "Offence ID"
-                },
-                {
                   text: "Offence description"
                 },
                 {
-                  text: "Offence date"
+                  text: "Delius event number"
                 },
                 {
-                  text: "Conviction ID"
+                  text: "Offence date"
                 }
               ],
               rows: OffenceUtils.offenceTableRows(offences)


### PR DESCRIPTION
This updates the Apply flow to ensure we always ask a user to confirm the index offence, as well as updating the copy to make sure the user knows that they cannot continue without the relevant offence being present. I've also made a couple of tweaks to the displayed data, as some of the fields were not relevant to users.

## Screenshot

### Before

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/f94d3fe4-81f4-4a56-b2fe-794f22e5bd03)

### After

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/9f5518f5-c9af-4139-af03-8e54532c4b0c)
