### PR TITLE
(APS-643) Add Info Requested tag for assessment tasks

### DIFF
--- a/server/utils/tasks/listTable.test.ts
+++ b/server/utils/tasks/listTable.test.ts
@@ -14,7 +14,6 @@ import {
   getDecisionOutcome,
   getTaskType,
   nameAnchorCell,
-  statusBadge,
   statusCell,
   taskParams,
   taskTypeCell,
@@ -28,6 +27,7 @@ import { sortHeader } from '../sortHeader'
 import { TaskSortField } from '../../@types/shared'
 import paths from '../../paths/tasks'
 import { daysUntilDueCell } from '../tableUtils'
+import { statusBadge } from './statusBadge'
 
 describe('table', () => {
   beforeEach(() => {
@@ -193,23 +193,6 @@ describe('table', () => {
     it('returns the name of the staff member the task is allocated to as a TableCell object', () => {
       const task = taskFactory.build()
       expect(allocationCell(task)).toEqual({ text: task.allocatedToStaffMember?.name })
-    })
-  })
-
-  describe('statusBadge', () => {
-    it('returns the "complete" status tag', () => {
-      const completedTask = taskFactory.build({ status: 'complete' })
-      expect(statusBadge(completedTask)).toEqual('<strong class="govuk-tag">Complete</strong>')
-    })
-
-    it('returns the "not started" status tag', () => {
-      const notStartedTask = taskFactory.build({ status: 'not_started' })
-      expect(statusBadge(notStartedTask)).toEqual('<strong class="govuk-tag govuk-tag--yellow">Not started</strong>')
-    })
-
-    it('returns the "in_progress" status tag', () => {
-      const inProgressTask = taskFactory.build({ status: 'in_progress' })
-      expect(statusBadge(inProgressTask)).toEqual('<strong class="govuk-tag govuk-tag--grey">In progress</strong>')
     })
   })
 

--- a/server/utils/tasks/listTable.ts
+++ b/server/utils/tasks/listTable.ts
@@ -10,9 +10,10 @@ import {
 import { TableCell, TableRow } from '../../@types/ui'
 import paths from '../../paths/tasks'
 import { sortHeader } from '../sortHeader'
-import { kebabCase, linkTo, sentenceCase } from '../utils'
+import { kebabCase, linkTo } from '../utils'
 import { daysUntilDueCell } from '../tableUtils'
 import { DateFormats } from '../dateUtils'
+import { statusBadge } from './statusBadge'
 
 const statusCell = (task: Task): TableCell => ({
   html: statusBadge(task),
@@ -97,19 +98,6 @@ const nameAnchorCell = (task: Task): TableCell => ({
 const apAreaCell = (task: Task): TableCell => ({
   text: task.apArea?.name || 'No area supplied',
 })
-
-const statusBadge = (task: Task): string => {
-  switch (task.status) {
-    case 'complete':
-      return `<strong class="govuk-tag">${sentenceCase(task.status)}</strong>`
-    case 'not_started':
-      return `<strong class="govuk-tag govuk-tag--yellow">${sentenceCase(task.status)}</strong>`
-    case 'in_progress':
-      return `<strong class="govuk-tag govuk-tag--grey">${sentenceCase(task.status)}</strong>`
-    default:
-      return ''
-  }
-}
 
 const allocatedTableRows = (tasks: Array<Task>): Array<TableRow> => {
   const rows: Array<TableRow> = []
@@ -307,7 +295,6 @@ export {
   statusCell,
   taskTypeCell,
   allocationCell,
-  statusBadge,
   tasksTableRows,
   unallocatedTableRows,
   taskParams,

--- a/server/utils/tasks/statusBadge.test.ts
+++ b/server/utils/tasks/statusBadge.test.ts
@@ -1,0 +1,24 @@
+import { taskFactory } from '../../testutils/factories'
+import { statusBadge } from './statusBadge'
+
+describe('statusBadge', () => {
+  it('returns the "complete" status tag', () => {
+    const completedTask = taskFactory.build({ status: 'complete' })
+    expect(statusBadge(completedTask)).toEqual(`<strong class="govuk-tag govuk-tag--green">Complete</strong>`)
+  })
+
+  it('returns the "not started" status tag', () => {
+    const notStartedTask = taskFactory.build({ status: 'not_started' })
+    expect(statusBadge(notStartedTask)).toEqual(`<strong class="govuk-tag govuk-tag--blue">Not started</strong>`)
+  })
+
+  it('returns the "in_progress" status tag', () => {
+    const inProgressTask = taskFactory.build({ status: 'in_progress' })
+    expect(statusBadge(inProgressTask)).toEqual(`<strong class="govuk-tag govuk-tag--grey">In progress</strong>`)
+  })
+
+  it('returns the "info_requested" status tag', () => {
+    const inProgressTask = taskFactory.build({ status: 'info_requested' })
+    expect(statusBadge(inProgressTask)).toEqual(`<strong class="govuk-tag govuk-tag--yellow">Info requested</strong>`)
+  })
+})

--- a/server/utils/tasks/statusBadge.ts
+++ b/server/utils/tasks/statusBadge.ts
@@ -1,0 +1,22 @@
+import { Task, TaskStatus } from '../../@types/shared'
+
+type StatusColour = 'green' | 'grey' | 'blue' | 'yellow'
+type StatusTitle = 'Complete' | 'In progress' | 'Not started' | 'Info requested'
+type HtmlStatusTag = `<strong class="govuk-tag govuk-tag--${StatusColour}">${StatusTitle}</strong>`
+
+const statusTitles: Record<TaskStatus, StatusTitle> = {
+  complete: 'Complete',
+  in_progress: 'In progress',
+  not_started: 'Not started',
+  info_requested: 'Info requested',
+}
+
+const statusColours: Record<TaskStatus, StatusColour> = {
+  complete: 'green',
+  in_progress: 'grey',
+  not_started: 'blue',
+  info_requested: 'yellow',
+}
+
+export const statusBadge = (task: Task): HtmlStatusTag =>
+  `<strong class="govuk-tag govuk-tag--${statusColours[task.status]}">${statusTitles[task.status]}</strong>`


### PR DESCRIPTION
This allows CRU managers to see at a glance what assessments are awaiting information requests from PPs.

Not to be merged until https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1768 is live