### PR TITLE
APS 589 - View timeline events by crn

### DIFF
--- a/server/controllers/people/timelineController.test.ts
+++ b/server/controllers/people/timelineController.test.ts
@@ -45,9 +45,14 @@ describe('TimelineController', () => {
 
       const requestHandler = timelineController.show()
 
-      await requestHandler({ ...request, body: { crn } }, response, next)
+      await requestHandler({ ...request, params: { crn } }, response, next)
 
       expect(personService.getTimeline).toHaveBeenCalledWith(token, crn)
+      expect(response.render).toHaveBeenCalledWith({
+        timeline,
+        crn,
+        pageHeading: `Timeline for ${crn}`,
+      })
     })
   })
 })

--- a/server/controllers/people/timelineController.test.ts
+++ b/server/controllers/people/timelineController.test.ts
@@ -7,7 +7,6 @@ import { personalTimelineFactory } from '../../testutils/factories'
 
 describe('TimelineController', () => {
   const token = 'SOME_TOKEN'
-  const premisesId = 'premisesId'
   const flashSpy = jest.fn()
 
   const response: DeepMocked<Response> = createMock<Response>({})
@@ -24,10 +23,6 @@ describe('TimelineController', () => {
     request = createMock<Request>({
       user: { token },
       flash: flashSpy,
-      params: { premisesId },
-      headers: {
-        referer: 'some-referrer/',
-      },
     })
   })
 

--- a/server/controllers/people/timelineController.ts
+++ b/server/controllers/people/timelineController.ts
@@ -1,19 +1,29 @@
-import type { Request, RequestHandler, Response } from 'express'
+import { type Request, type RequestHandler, type Response } from 'express'
 
 import PersonService from '../../services/personService'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
+import paths from '../../paths/people'
 
 export default class TimelineController {
   constructor(private readonly personService: PersonService) {}
 
   find(): RequestHandler {
-    return async (_: Request, res: Response) => {
-      res.render('people/find', { pageHeading: "Find someone's application history" })
+    return async (req: Request, res: Response) => {
+      const { crn } = req.query as { crn: string | undefined }
+      const { errorSummary, userInput } = fetchErrorsAndUserInput(req)
+
+      res.render('people/timeline/find', {
+        pageHeading: "Find someone's application history",
+        errors: errorSummary.length ? { crn: `No offender with an ID of ${crn} found` } : undefined,
+        errorSummary,
+        ...userInput,
+      })
     }
   }
 
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { crn } = req.body
+      const crn = req?.query.crn as string | undefined
 
       const timeline = await this.personService.getTimeline(req.user.token, crn)
 

--- a/server/routes/people.ts
+++ b/server/routes/people.ts
@@ -21,7 +21,7 @@ export default function routes(controllers: Controllers, router: Router, service
   })
 
   get(peoplePaths.timeline.find.pattern, timelineController.find(), { auditEvent: 'SEARCH_FOR_TIMELINE' })
-  post(peoplePaths.timeline.find.pattern, timelineController.show(), {
+  get(peoplePaths.timeline.show.pattern, timelineController.show(), {
     auditEvent: 'SHOW_PERSON_TIMELINE',
     auditBodyParams: ['crn'],
   })

--- a/server/utils/people/index.test.ts
+++ b/server/utils/people/index.test.ts
@@ -1,0 +1,54 @@
+import { Request } from 'express'
+import { crnErrorHandling } from './index'
+import { RestrictedPersonError } from '../errors'
+import { addErrorMessageToFlash } from '../validation'
+
+jest.mock('../errors')
+jest.mock('../validation')
+
+describe('crnErrorHandling', () => {
+  let req: Request
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req = {} as Request
+    req.flash = jest.fn()
+  })
+
+  describe('restricted person error', () => {
+    it('adds an error to the flash if the ', () => {
+      const error = new RestrictedPersonError('SOME_CRN')
+      error.type = 'RESTRICTED_PERSON'
+      error.message = 'Some error message'
+      const crn = 'SOME_CRN'
+
+      crnErrorHandling(req, error, crn)
+
+      expect(req.flash).toHaveBeenNthCalledWith(1, 'restrictedPerson', 'true')
+      expect(addErrorMessageToFlash).toHaveBeenCalledWith(req, error.message, 'crn')
+    })
+  })
+
+  describe('404 error', () => {
+    it('should handle a 404 error', () => {
+      const error = {
+        data: {},
+        status: 404,
+      }
+      const crn = 'SOME_CRN'
+
+      crnErrorHandling(req, error, crn)
+
+      expect(addErrorMessageToFlash).toHaveBeenCalledWith(req, `No person with an CRN of '${crn}' was found`, 'crn')
+    })
+  })
+
+  describe('all other errors', () => {
+    it('should throw an error for other types of errors', () => {
+      const error = new Error('Some error')
+      const crn = 'SOME_CRN'
+
+      expect(() => crnErrorHandling(req, error, crn)).toThrow(error)
+    })
+  })
+})

--- a/server/utils/people/index.ts
+++ b/server/utils/people/index.ts
@@ -1,0 +1,18 @@
+import type { Request } from 'express'
+import { HttpError } from 'http-errors'
+import { RestrictedPersonError } from '../errors'
+import { addErrorMessageToFlash } from '../validation'
+import { Person } from '../../@types/shared'
+
+export const crnErrorHandling = (req: Request, error: unknown, crn: Person['crn']) => {
+  const knownError = error as RestrictedPersonError | HttpError | Error
+
+  if ('type' in knownError && knownError.type === 'RESTRICTED_PERSON') {
+    req.flash('restrictedPerson', 'true')
+    addErrorMessageToFlash(req, knownError.message, 'crn')
+  } else if ('data' in knownError && knownError.status === 404) {
+    addErrorMessageToFlash(req, `No person with an CRN of '${crn}' was found`, 'crn')
+  } else {
+    throw knownError
+  }
+}

--- a/server/views/people/timeline/find.njk
+++ b/server/views/people/timeline/find.njk
@@ -17,22 +17,20 @@
         <h1>{{ pageHeading }}</h1>
         {{ showErrorSummary(errorSummary) }}
 
-        {{
-          formPageInput(
-            {
-              label: {
+        {{ govukInput({
+            label: {
                 text: "Enter the person's CRN",
                 classes: "govuk-label--m"
               },
+              id: 'crn',
               hint: {
-                html: "<p>For example, a CRN is DO16821</p>"
+                text: "For example, a CRN is DO16821"
               },
-              classes: "govuk-input--width-10",
-              fieldName: "crn"
-            },
-            fetchContext()
-          )
-        }}
+              name: "crn",
+              value: crn,
+              errorMessage: errors.crn,
+              classes: "govuk-input--width-10"
+          }) }}
 
         {{ govukButton({
                     text: "Save and continue"

--- a/server/views/people/timeline/find.njk
+++ b/server/views/people/timeline/find.njk
@@ -1,9 +1,9 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "../partials/showErrorSummary.njk" import showErrorSummary %}
-{% from "../components/formFields/form-page-input/macro.njk" import formPageInput %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "../../components/formFields/form-page-input/macro.njk" import formPageInput %}
 
-{% extends "../partials/layout.njk" %}
+{% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - " + pageHeading  %}
 {% set mainClasses = "app-container govuk-body" %}

--- a/server/views/people/timeline/find.njk
+++ b/server/views/people/timeline/find.njk
@@ -12,8 +12,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="{{ paths.timeline.find() }}" method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+      <form action="{{ paths.timeline.show({}) }}" method="get">
 
         <h1>{{ pageHeading }}</h1>
         {{ showErrorSummary(errorSummary) }}
@@ -36,7 +35,6 @@
         }}
 
         {{ govukButton({
-                    name: 'submit',
                     text: "Save and continue"
                 }) }}
       </form>

--- a/server/views/people/timeline/show.njk
+++ b/server/views/people/timeline/show.njk
@@ -5,10 +5,13 @@
 {% set pageTitle = applicationName + " - " + pageHeading  %}
 {% set mainClasses = "app-container govuk-body" %}
 
+{% set query = "?crn=" + crn if crn else 
+    "" %}
+
 {% block beforeContent %}
     {{ govukBackLink({
 		text: "Back",
-        href: paths.timeline.find({})
+        href: paths.timeline.find({}) + "?crn=" + crn
 	}) }}
 {% endblock %}
 


### PR DESCRIPTION
# Context
#1722 added the timeline and this PR builds on it. 
We add usability improvements like error handling and changing the initial request from a POST to a GET to allow the user to bookmark, share the link and use the back button in the browser.

[JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&selectedIssue=APS-589)
