### PR TITLE
(APS 637) Always show offences on adhoc booking screen

### DIFF
--- a/integration_tests/pages/manage/booking/new.ts
+++ b/integration_tests/pages/manage/booking/new.ts
@@ -55,7 +55,10 @@ export default class BookingNewPage extends Page {
     return cy.get('#departureDate-year')
   }
 
-  completeForm(booking: Booking): void {
+  completeForm(booking: Booking, offence?: ActiveOffence): void {
+    if (offence != null) {
+      this.selectOffence(offence)
+    }
     this.getLegend('What is their expected arrival date?')
 
     const arrivalDate = new Date(Date.parse(booking.arrivalDate))

--- a/integration_tests/tests/manage/booking.cy.ts
+++ b/integration_tests/tests/manage/booking.cy.ts
@@ -127,9 +127,12 @@ context('Booking', () => {
       expect(requests).to.have.length(2)
     })
 
+    // And the index offence radio buttons should be visible
+    bookingCreatePage.shouldShowOffences(offences)
+
     // Given I have entered a CRN and the person has been found
     // When I fill in the booking form
-    bookingCreatePage.completeForm(booking)
+    bookingCreatePage.completeForm(booking, offences[0])
     bookingCreatePage.clickSubmit()
 
     // Then I should be redirected to the confirmation page
@@ -176,8 +179,7 @@ context('Booking', () => {
 
     // Given I have entered a CRN and the person has been found
     // When I fill in the booking form
-    bookingCreatePage.completeForm(booking)
-    bookingCreatePage.selectOffence(multipleOffences[1])
+    bookingCreatePage.completeForm(booking, multipleOffences[1])
     bookingCreatePage.clickSubmit()
 
     // Then I should be redirected to the confirmation page

--- a/server/utils/offenceUtils.test.ts
+++ b/server/utils/offenceUtils.test.ts
@@ -1,6 +1,6 @@
 import { DateFormats } from './dateUtils'
 
-import { offenceRadioButton, offenceTableRows } from './offenceUtils'
+import { offenceRadioButton, offenceRadioItems, offenceTableRows } from './offenceUtils'
 
 import { activeOffenceFactory } from '../testutils/factories'
 
@@ -78,6 +78,26 @@ describe('offenceUtils', () => {
             text: 'No offence date available',
           },
         ],
+      ])
+    })
+  })
+
+  describe('offenceRadioItems', () => {
+    it('Returns radio item options', () => {
+      const offence1 = activeOffenceFactory.build()
+      const offence2 = activeOffenceFactory.build()
+
+      expect(offenceRadioItems([offence1, offence2], offence2.deliusEventNumber)).toEqual([
+        {
+          html: `${offence1.offenceDescription}<br /><span class="govuk-hint">(Delius event number: ${offence1.deliusEventNumber})</span>`,
+          value: offence1.deliusEventNumber,
+          checked: false,
+        },
+        {
+          html: `${offence2.offenceDescription}<br /><span class="govuk-hint">(Delius event number: ${offence2.deliusEventNumber})</span>`,
+          value: offence2.deliusEventNumber,
+          checked: true,
+        },
       ])
     })
   })

--- a/server/utils/offenceUtils.ts
+++ b/server/utils/offenceUtils.ts
@@ -42,4 +42,17 @@ const offenceRadioButton = (offence: ActiveOffence) => {
   `
 }
 
-export { offenceTableRows, offenceRadioButton }
+const offenceRadioItems = (
+  offences: Array<ActiveOffence>,
+  selectedOffenceNumber: ActiveOffence['offenceId'] | null | undefined,
+) => {
+  return offences.map((offence: ActiveOffence) => {
+    return {
+      html: `${offence.offenceDescription}<br /><span class="govuk-hint">(Delius event number: ${offence.deliusEventNumber})</span>`,
+      value: offence.deliusEventNumber,
+      checked: selectedOffenceNumber === offence.deliusEventNumber,
+    }
+  })
+}
+
+export { offenceTableRows, offenceRadioButton, offenceRadioItems }

--- a/server/views/bookings/new.njk
+++ b/server/views/bookings/new.njk
@@ -7,6 +7,7 @@
 {% from "../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% extends "../partials/layout.njk" %}
 
@@ -51,35 +52,36 @@
                 ]
                 }) }}
 
-                {% if offences | length == 1 %}
-                    <input type="hidden" name="eventNumber" value="{{ offences[0].deliusEventNumber }}"/>
-                {% else %}
-                    {{
-                        govukRadios({
-                            name: "eventNumber",
-                            id: "eventNumber",
-                            fieldset: {
-                                legend: {
-                                    text: "Select an index offence",
-                                    classes: "govuk-fieldset__legend--m"
-                                }
-                            },
-                            hint: {
-                                text: "This person has more than one index offence identified against their CRN. Select the most relevant index offence."
-                            },
-                            errorMessage: errors.eventNumber,
-                            items: convertObjectsToRadioItems(offences, 'offenceDescription', 'deliusEventNumber', 'eventNumber')
-                        })
-                    }}
-                {% endif %}
+                {{
+                    govukRadios({
+                        name: "eventNumber",
+                        id: "eventNumber",
+                        fieldset: {
+                            legend: {
+                                text: "Select an index offence",
+                                classes: "govuk-fieldset__legend--m"
+                            }
+                        },
+                        hint: {
+                            text: "Select the most relevant index offence for this person"
+                        },
+                        errorMessage: errors.eventNumber,
+                        items: OffenceUtils.offenceRadioItems(offences, eventNumber)
+                    })
+                }}
+
+                {{ govukWarningText({
+                    text: "If the required offence is not visible here, you will not be able to proceed with the booking until the offence has been added to NDelius",
+                    iconFallbackText: "Warning"
+                }) }}
 
                 {{ govukDateInput({
                     id: "arrivalDate",
                     namePrefix: "arrivalDate",
                     fieldset: {
-                    legend: {
-                        text: "What is their expected arrival date?",
-                        classes: "govuk-fieldset__legend--m"
+                        legend: {
+                            text: "What is their expected arrival date?",
+                            classes: "govuk-fieldset__legend--m"
                         }
                     },
                     hint: {


### PR DESCRIPTION
This follows on from #1728 to update the adhoc bookings screen to always show the offences, rather than assuming if one is present then that's the correct one.

## Screenshot

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/00f6b815-f8cf-4873-859d-16d23b9ce5a4)
