### PR TITLE
Default arrivals and departures to today

### DIFF
--- a/integration_tests/pages/manage/arrivalCreate.ts
+++ b/integration_tests/pages/manage/arrivalCreate.ts
@@ -20,8 +20,11 @@ export default class ArrivalCreatePage extends Page {
     const arrivalDate = new Date(Date.parse(arrival.arrivalDate))
     const expectedDeparture = new Date(Date.parse(arrival.expectedDepartureDate))
 
+    cy.get('input[name="arrivalDateTime-day"]').clear()
     cy.get('input[name="arrivalDateTime-day"]').type(String(arrivalDate.getDate()))
+    cy.get('input[name="arrivalDateTime-month"]').clear()
     cy.get('input[name="arrivalDateTime-month"]').type(String(arrivalDate.getMonth() + 1))
+    cy.get('input[name="arrivalDateTime-year"]').clear()
     cy.get('input[name="arrivalDateTime-year"]').type(String(arrivalDate.getFullYear()))
     cy.get('input[name="arrivalDateTime-time"]').type(arrival.arrivalTime)
 

--- a/integration_tests/pages/manage/departureCreate.ts
+++ b/integration_tests/pages/manage/departureCreate.ts
@@ -27,8 +27,11 @@ export default class DepartureCreatePage extends Page {
     const minutes = dateTime.getMinutes()
     const hours = dateTime.getHours()
 
+    cy.get('input[name="dateTime-day"]').clear()
     cy.get('input[name="dateTime-day"]').type(String(dateTime.getDate()))
+    cy.get('input[name="dateTime-month"]').clear()
     cy.get('input[name="dateTime-month"]').type(String(dateTime.getMonth() + 1))
+    cy.get('input[name="dateTime-year"]').clear()
     cy.get('input[name="dateTime-year"]').type(String(dateTime.getFullYear()))
     cy.get('input[name="dateTime-time"]').type(`${hours}:${minutes}`)
 

--- a/integration_tests/tests/manage/arrivals.cy.ts
+++ b/integration_tests/tests/manage/arrivals.cy.ts
@@ -70,11 +70,11 @@ context('Arrivals', () => {
     cy.task('stubArrivalErrors', {
       premisesId: premises.id,
       bookingId,
-      params: ['arrivalDateTime', 'expectedDepartureDate', 'keyWorkerStaffCode'],
+      params: ['expectedDepartureDate', 'keyWorkerStaffCode'],
     })
     page.submitArrivalFormWithoutFields()
 
     // Then I should see error messages relating to that field
-    page.shouldShowErrorMessagesForFields(['arrivalDateTime', 'expectedDepartureDate'])
+    page.shouldShowErrorMessagesForFields(['expectedDepartureDate', 'keyWorkerStaffCode'])
   })
 })

--- a/integration_tests/tests/manage/departure.cy.ts
+++ b/integration_tests/tests/manage/departure.cy.ts
@@ -73,12 +73,12 @@ context('Departures', () => {
     cy.task('stubDepartureErrors', {
       premisesId: premises[0].id,
       bookingId: booking.id,
-      params: ['dateTime', 'destinationProviderId', 'moveOnCategoryId', 'reasonId'],
+      params: ['destinationProviderId', 'moveOnCategoryId', 'reasonId'],
     })
 
     page.clickSubmit()
 
     // Then I should see error messages relating to that field
-    page.shouldShowErrorMessagesForFields(['dateTime', 'reasonId', 'moveOnCategoryId', 'destinationProviderId'])
+    page.shouldShowErrorMessagesForFields(['reasonId', 'moveOnCategoryId', 'destinationProviderId'])
   })
 })

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -1,4 +1,4 @@
-import { createMock } from '@golevelup/ts-jest'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
 import type { ErrorMessages } from '@approved-premises/ui'
 import {
@@ -20,18 +20,30 @@ import {
 
 describe('formUtils', () => {
   describe('dateFieldValues', () => {
+    const context = {
+      'myField-day': 12,
+      'myField-month': 11,
+      'myField-year': 2022,
+    }
+    const fieldName = 'myField'
+
+    let errors: DeepMocked<ErrorMessages>
+
+    beforeEach(() => {
+      errors = createMock<ErrorMessages>({
+        someOtherField: {
+          text: 'Some error message',
+        },
+        myField: undefined,
+      })
+    })
+
     it('returns items with an error class when errors are present for the field', () => {
-      const errors = createMock<ErrorMessages>({
+      errors = createMock<ErrorMessages>({
         myField: {
           text: 'Some error message',
         },
       })
-      const context = {
-        'myField-day': 12,
-        'myField-month': 11,
-        'myField-year': 2022,
-      }
-      const fieldName = 'myField'
 
       expect(dateFieldValues(fieldName, context, errors)).toEqual([
         {
@@ -53,19 +65,6 @@ describe('formUtils', () => {
     })
 
     it('returns items without an error class when no errors are present for the field', () => {
-      const errors = createMock<ErrorMessages>({
-        someOtherField: {
-          text: 'Some error message',
-        },
-        myField: undefined,
-      })
-      const context = {
-        'myField-day': 12,
-        'myField-month': 11,
-        'myField-year': 2022,
-      }
-      const fieldName = 'myField'
-
       expect(dateFieldValues(fieldName, context, errors)).toEqual([
         {
           classes: 'govuk-input--width-2 ',
@@ -81,6 +80,97 @@ describe('formUtils', () => {
           classes: 'govuk-input--width-4 ',
           name: 'year',
           value: context['myField-year'],
+        },
+      ])
+    })
+
+    it('returns items without an error class when no errors are present for the field', () => {
+      expect(dateFieldValues(fieldName, context, errors)).toEqual([
+        {
+          classes: 'govuk-input--width-2 ',
+          name: 'day',
+          value: context['myField-day'],
+        },
+        {
+          classes: 'govuk-input--width-2 ',
+          name: 'month',
+          value: context['myField-month'],
+        },
+        {
+          classes: 'govuk-input--width-4 ',
+          name: 'year',
+          value: context['myField-year'],
+        },
+      ])
+    })
+
+    it("returns today's date by default when defaultToToday is true and the context is empty", () => {
+      const today = new Date()
+
+      expect(dateFieldValues(fieldName, {}, errors, true)).toEqual([
+        {
+          classes: 'govuk-input--width-2 ',
+          name: 'day',
+          value: today.getDate(),
+        },
+        {
+          classes: 'govuk-input--width-2 ',
+          name: 'month',
+          value: today.getMonth() + 1,
+        },
+        {
+          classes: 'govuk-input--width-4 ',
+          name: 'year',
+          value: today.getFullYear(),
+        },
+      ])
+    })
+
+    it('returns the data from the context when defaultToToday is true and the context is present', () => {
+      expect(dateFieldValues(fieldName, context, errors, true)).toEqual([
+        {
+          classes: 'govuk-input--width-2 ',
+          name: 'day',
+          value: context['myField-day'],
+        },
+        {
+          classes: 'govuk-input--width-2 ',
+          name: 'month',
+          value: context['myField-month'],
+        },
+        {
+          classes: 'govuk-input--width-4 ',
+          name: 'year',
+          value: context['myField-year'],
+        },
+      ])
+    })
+
+    it('returns the data from the context when defaultToToday is true and a partial date is given', () => {
+      expect(
+        dateFieldValues(
+          fieldName,
+          {
+            'myField-day': 12,
+          },
+          errors,
+          true,
+        ),
+      ).toEqual([
+        {
+          classes: 'govuk-input--width-2 ',
+          name: 'day',
+          value: context['myField-day'],
+        },
+        {
+          classes: 'govuk-input--width-2 ',
+          name: 'month',
+          value: undefined,
+        },
+        {
+          classes: 'govuk-input--width-4 ',
+          name: 'year',
+          value: undefined,
         },
       ])
     })

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -6,23 +6,40 @@ import { PlacementRequestStatus } from '@approved-premises/api'
 import { resolvePath, sentenceCase } from './utils'
 import postcodeAreas from '../etc/postcodeAreas.json'
 
-export const dateFieldValues = (fieldName: string, context: Record<string, unknown>, errors: ErrorMessages = {}) => {
+export const dateFieldValues = (
+  fieldName: string,
+  context: Record<string, unknown>,
+  errors: ErrorMessages = {},
+  defaultToToday = false,
+) => {
+  let day = context[`${fieldName}-day`]
+  let month = context[`${fieldName}-month`]
+  let year = context[`${fieldName}-year`]
+
+  if (defaultToToday && !day && !month && !year) {
+    const today = new Date()
+    day = day || today.getDate()
+    month = month || today.getMonth() + 1
+    year = year || today.getFullYear()
+  }
+
   const errorClass = errors[fieldName] ? 'govuk-input--error' : ''
+
   return [
     {
       classes: `govuk-input--width-2 ${errorClass}`,
       name: 'day',
-      value: context[`${fieldName}-day`],
+      value: day,
     },
     {
       classes: `govuk-input--width-2 ${errorClass}`,
       name: 'month',
-      value: context[`${fieldName}-month`],
+      value: month,
     },
     {
       classes: `govuk-input--width-4 ${errorClass}`,
       name: 'year',
-      value: context[`${fieldName}-year`],
+      value: year,
     },
   ]
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -120,9 +120,12 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   )
   njkEnv.addGlobal('formatDateTime', (date: string) => DateFormats.isoDateTimeToUIDateTime(date))
   njkEnv.addGlobal('dateObjToUIDate', (date: Date) => DateFormats.dateObjtoUIDate(date))
-  njkEnv.addGlobal('dateFieldValues', function sendContextToDateFieldValues(fieldName: string, errors: ErrorMessages) {
-    return dateFieldValues(fieldName, this.ctx, errors)
-  })
+  njkEnv.addGlobal(
+    'dateFieldValues',
+    function sendContextToDateFieldValues(fieldName: string, errors: ErrorMessages, defaultToToday = false) {
+      return dateFieldValues(fieldName, this.ctx, errors, defaultToToday)
+    },
+  )
   njkEnv.addGlobal(
     'uiDateOrDateEmptyMessage',
     (object: Record<string, string>, propertyName: string, dateFormFunc: (date: string) => string) =>

--- a/server/views/arrivals/new.njk
+++ b/server/views/arrivals/new.njk
@@ -34,7 +34,7 @@
               classes: "govuk-fieldset__legend--m"
               }
           },
-          items: dateFieldValues('arrivalDateTime', errors),
+          items: dateFieldValues('arrivalDateTime', errors, true),
           errorMessage: errors.arrivalDateTime,
           hint: {
               text: "For example, 27 3 2024"
@@ -71,7 +71,7 @@
           id: "keyWorkerStaffCode",
           name: "arrival[keyWorkerStaffCode]",
           items: convertObjectsToSelectOptions(staffMembers, 'Select a keyworker', 'name', 'code', 'keyWorkerStaffCode'),
-          errorMessage: errors.keyWorkerStaffCode.empty
+          errorMessage: errors.keyWorkerStaffCode
         }) }}
 
         {{ govukTextarea({

--- a/server/views/departures/new.njk
+++ b/server/views/departures/new.njk
@@ -64,7 +64,7 @@
                         text: "For example, 27 3 2007"
                     },
                     errorMessage: errors.dateTime,
-                    items: dateFieldValues('dateTime', errors)
+                    items: dateFieldValues('dateTime', errors, true)
                 }) }}
 
                 <label class="govuk-label govuk-label--m" for="dateTime-time">


### PR DESCRIPTION
We're getting a lot of requests to "change" arrival and departure dates, which is a bit annoying to do. This sets the arrival/departure dates to default to today's date, to give the user some guidance in the hope we can nip this issue in the bud.