### PR TITLE
(APS-626) Change text on Assessment submit button

### DIFF
--- a/server/views/assessments/tasklist.njk
+++ b/server/views/assessments/tasklist.njk
@@ -68,7 +68,7 @@
           <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
           {{ govukButton({
-          text: "Submit application",
+          text: "Submit assessment",
           preventDoubleClick: true
           }) }}
         {% endif %}


### PR DESCRIPTION
It referred to “application”, not “assessment”