### PR TITLE
(APS 691) Show requested information on information received page

### DIFF
--- a/integration_tests/helpers/assess.ts
+++ b/integration_tests/helpers/assess.ts
@@ -152,6 +152,8 @@ export default class AseessHelper {
     const assessmentStatus = informationReceived === 'yes' ? 'in_progress' : 'awaiting_response'
     this.updateAssessmentStatus(assessmentStatus).then(() => {
       const informationReceivedPage = Page.verifyOnPage(InformationReceivedPage, this.assessment)
+      // Then I should see the information I requested
+      informationReceivedPage.shouldShowQuery()
 
       // When I complete the form
       informationReceivedPage.completeForm()

--- a/integration_tests/pages/assess/informationReceivedPage.ts
+++ b/integration_tests/pages/assess/informationReceivedPage.ts
@@ -5,8 +5,14 @@ import AssessPage from './assessPage'
 import InformationReceived from '../../../server/form-pages/assess/reviewApplication/sufficientInformation/informationReceived'
 
 export default class InformationReceivedPage extends AssessPage {
-  constructor(assessment: Assessment) {
+  constructor(private readonly assessment: Assessment) {
     super('Additional information', assessment, 'sufficient-information', 'information-received')
+  }
+
+  shouldShowQuery() {
+    cy.get('span.govuk-details__summary-text').contains('View requested information').click()
+    const { query } = this.assessment.data['sufficient-information']['sufficient-information']
+    cy.get('.govuk-details__text').contains(query).should('be.visible')
   }
 
   completeForm() {

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -203,7 +203,12 @@ export interface IdentityBarMenuItem {
   text: string
 }
 
-export type UiTimelineEvent = { label: { text: string }; datetime: { timestamp: string; type?: 'datetime' } }
+export type UiTimelineEvent = {
+  label: { text: string }
+  datetime: { timestamp: string; type?: 'datetime' }
+  content: string
+  associatedUrls: Array<TimelineEventAssociatedUrl>
+}
 
 export type RiskLevel = 'Low' | 'Medium' | 'High' | 'Very High'
 

--- a/server/form-pages/assess/reviewApplication/sufficientInformation/informationReceived.ts
+++ b/server/form-pages/assess/reviewApplication/sufficientInformation/informationReceived.ts
@@ -1,5 +1,6 @@
 import type { ObjectWithDateParts, TaskListErrors, YesOrNo } from '@approved-premises/ui'
 import type { User } from '@approved-premises/api'
+import { ApprovedPremisesAssessment as Assessment } from '../../../../@types/shared'
 
 import { Page } from '../../../utils/decorators'
 import { sentenceCase } from '../../../../utils/utils'
@@ -7,6 +8,8 @@ import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank } from '../../
 
 import TasklistPage from '../../../tasklistPage'
 import { dateBodyProperties } from '../../../utils/dateBodyProperties'
+import { retrieveQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
+import SufficientInformation from './sufficientInformation'
 
 type InformationReceivedBody = ObjectWithDateParts<'responseReceivedOn'> & {
   informationReceived?: YesOrNo
@@ -30,7 +33,14 @@ export default class InformationReceived implements TasklistPage {
 
   user: User
 
-  constructor(private _body: Partial<InformationReceivedBody>) {}
+  query: string
+
+  constructor(
+    private _body: Partial<InformationReceivedBody>,
+    private readonly assessment: Assessment,
+  ) {
+    this.query = retrieveQuestionResponseFromFormArtifact(assessment, SufficientInformation, 'query')
+  }
 
   public set body(value: Partial<InformationReceivedBody>) {
     this._body = {

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -55,6 +55,7 @@ import { RestrictedPersonError } from '../errors'
 import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
 import { durationAndArrivalDateFromPlacementApplication } from '../placementRequests/placementApplicationSubmissionData'
 import { sortHeader } from '../sortHeader'
+import { escape } from '../formUtils'
 
 jest.mock('../placementRequests/placementApplicationSubmissionData')
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
@@ -804,7 +805,7 @@ describe('utils', () => {
           label: {
             text: eventTypeTranslations[timelineEvents[0].type],
           },
-          content: timelineEvents[0].content,
+          content: escape(timelineEvents[0].content),
           createdBy: timelineEvents[0].createdBy.name,
           associatedUrls: mapTimelineUrlsForUi([
             {
@@ -828,7 +829,7 @@ describe('utils', () => {
           label: {
             text: eventTypeTranslations[timelineEvents[0].type],
           },
-          content: timelineEvents[0].content,
+          content: escape(timelineEvents[0].content),
           createdBy: timelineEvents[0].createdBy.name,
           associatedUrls: [],
         },
@@ -882,6 +883,14 @@ describe('utils', () => {
         ...mapApplicationTimelineEventsForUi([futureTimelineEvent]),
         ...mapApplicationTimelineEventsForUi([pastTimelineEvent]),
       ])
+    })
+
+    it('escapes any rogue HTML', () => {
+      const timelineEventWithRogueHTML = timelineEventFactory.build({ content: '<div>Hello!</div>' })
+
+      const actual = mapApplicationTimelineEventsForUi([timelineEventWithRogueHTML])
+
+      expect(actual[0].content).toEqual('&lt;div&gt;Hello!&lt;/div&gt;')
     })
   })
 

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -54,6 +54,7 @@ import { sortHeader } from '../sortHeader'
 import { linkTo } from '../utils'
 import { applicationStatuses, getStatus } from './getStatus'
 import { createNameAnchorElement, getTierOrBlank, htmlValue, textValue } from './helpers'
+import { escape } from '../formUtils'
 
 export { withdrawableTypeRadioOptions, withdrawableRadioOptions } from './withdrawables'
 export { placementApplicationWithdrawalReasons } from './withdrawables/withdrawalReasons'
@@ -304,7 +305,7 @@ const mapApplicationTimelineEventsForUi = (timelineEvents: Array<TimelineEvent>)
           timestamp: timelineEvent.occurredAt,
           date: timelineEvent.occurredAt ? DateFormats.isoDateTimeToUIDateTime(timelineEvent.occurredAt) : '',
         },
-        content: timelineEvent.content,
+        content: escape(timelineEvent.content),
         associatedUrls: timelineEvent.associatedUrls ? mapTimelineUrlsForUi(timelineEvent.associatedUrls) : [],
       }
       if (timelineEvent.createdBy?.name) {

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -10,6 +10,7 @@ import { ApprovedPremisesApplication as Application, PersonStatus } from '@appro
 import {
   initialiseName,
   kebabCase,
+  linebreaksToParagraphs,
   linkTo,
   mapApiPersonRisksForUi,
   numberToOrdinal,
@@ -207,6 +208,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addFilter('removeBlankSummaryListItems', removeBlankSummaryListItems)
   njkEnv.addFilter('sentenceCase', sentenceCase)
   njkEnv.addFilter('kebabCase', kebabCase)
+  njkEnv.addFilter('linebreaksToParagraphs', linebreaksToParagraphs)
 
   njkEnv.addGlobal('numberToOrdinal', numberToOrdinal)
   njkEnv.addGlobal('navigationItems', navigationItems)

--- a/server/views/assessments/pages/sufficient-information/information-received.njk
+++ b/server/views/assessments/pages/sufficient-information/information-received.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% extends "../layout.njk" %}
 
@@ -6,6 +7,13 @@
   <h1 class="govuk-heading-l">
     Additional information
   </h1>
+
+  {% set hintHtml %}
+    {{ govukDetails({
+      summaryText: "View requested information",
+      html: page.query | linebreaksToParagraphs
+    }) }}
+  {% endset %}
 
   {% set informationReceivedHtml %}
   {{ formPageTextarea({
@@ -37,6 +45,9 @@
           legend: {
             html: '<h2 class="govuk-heading-m">' + page.title + '</h2>'
           }
+        },
+        hint: {
+          html: hintHtml
         },
         items: [
           {

--- a/server/views/partials/_applicationTimeline.njk
+++ b/server/views/partials/_applicationTimeline.njk
@@ -16,7 +16,7 @@
 
                     {% if event.content %}
                         <div class="moj-timeline__description">
-                            <p>{{event.content}}</p>
+                            {{ event.content | linebreaksToParagraphs | safe }}
                         </div>
                         {%endif%}
                         {% if event.associatedUrls %}


### PR DESCRIPTION
We've had a user request that they've "lost" the information they requested after submitting a request for information, which is needed for them to review what their request was. This adds a details component which surfaces this information for them to refer back to.

I've also updated the timeline to add HTML linebreaks to break up long pieces of text in the timeline (preparing us for https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1783).

## Screenshot

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/8598cabf-7a8b-425b-9cec-b1bd587ae2a2)

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/77a5cd7d-3657-4c74-83e1-aaeb87ae2ebd)

