### PR TITLE
Fix order of table headers

### DIFF
--- a/server/utils/tasks/listTable.test.ts
+++ b/server/utils/tasks/listTable.test.ts
@@ -420,10 +420,10 @@ describe('table', () => {
           text: 'Completed by',
         },
         {
-          text: 'Decision',
+          text: 'Task type',
         },
         {
-          text: 'Task type',
+          text: 'Decision',
         },
       ])
     })

--- a/server/utils/tasks/listTable.ts
+++ b/server/utils/tasks/listTable.ts
@@ -213,10 +213,10 @@ const completedTableHeader = (sortBy: TaskSortField, sortDirection: SortDirectio
       text: 'Completed by',
     },
     {
-      text: 'Decision',
+      text: 'Task type',
     },
     {
-      text: 'Task type',
+      text: 'Decision',
     },
   ]
 }


### PR DESCRIPTION
The headers were in the wrong order when viewing completed tasks

## Screenshots

### Before

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/a2b0782c-1e29-45f1-b62e-b984b59b0250)

### After

![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/109774/d92dcb41-26bf-428c-81ba-eaf2017bbe10)
