### PR TITLE
APS 686 - View timeline events by CRN

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -19,6 +19,7 @@ $path: "/assets/images/"
 @import './components/search-and-filter'
 @import './components/key-details-bar'
 @import './components/moj-identity-bar.scss'
+@import './components/status-tag.scss'
 
 @import './pages/assessments-index'
 @import './pages/applications-pages-attach-document'

--- a/assets/sass/components/_status-tag.scss
+++ b/assets/sass/components/_status-tag.scss
@@ -1,0 +1,5 @@
+.govuk-tag {
+  &--timeline-tag {
+    max-width: 250px;
+  }
+}

--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -134,7 +134,7 @@ export default class ApplyHelper {
 
     // And I see the person on the confirmation page
     const confirmDetailsPage = new ApplyPages.ConfirmDetailsPage(this.person as FullPerson)
-    confirmDetailsPage.verifyPersonIsVisible()
+    confirmDetailsPage.shouldShowPersonDetails(this.person as FullPerson)
 
     // And I confirm the person is who I expect to see
     confirmDetailsPage.clickSaveAndContinue()

--- a/integration_tests/pages/apply/confirmDetails.ts
+++ b/integration_tests/pages/apply/confirmDetails.ts
@@ -1,25 +1,10 @@
 import type { FullPerson } from '@approved-premises/api'
-import { DateFormats } from '../../../server/utils/dateUtils'
 
 import Page from '../page'
 
 export default class ConfirmDetailsPage extends Page {
   constructor(private person: FullPerson) {
     super(`Confirm ${person.name}'s details`)
-  }
-
-  verifyPersonIsVisible(): void {
-    cy.get('dl[data-cy-person-info]').within(() => {
-      this.assertDefinition('Name', this.person.name)
-      this.assertDefinition('CRN', this.person.crn)
-      this.assertDefinition('Date of Birth', DateFormats.isoDateToUIDate(this.person.dateOfBirth, { format: 'short' }))
-      this.assertDefinition('NOMIS Number', this.person.nomsNumber)
-      this.assertDefinition('Nationality', this.person.nationality)
-      this.assertDefinition('Religion or belief', this.person.religionOrBelief)
-      this.assertDefinition('Sex', this.person.sex)
-      cy.get(`[data-cy-status]`).should('have.attr', 'data-cy-status').and('equal', this.person.status)
-      this.assertDefinition('Prison', this.person.prisonName)
-    })
   }
 
   verifyRestrictedPersonMessaging() {

--- a/integration_tests/pages/people/timeline/show.ts
+++ b/integration_tests/pages/people/timeline/show.ts
@@ -1,12 +1,12 @@
-import { Person, PersonalTimeline } from '../../../../server/@types/shared'
+import { FullPerson, PersonalTimeline } from '../../../../server/@types/shared'
 import { getStatus } from '../../../../server/utils/applications/getStatus'
 import Page from '../../page'
 
 export class ShowPage extends Page {
   timeline: PersonalTimeline
 
-  constructor(timeline: PersonalTimeline, crn: Person['crn']) {
-    super(`Application history for ${crn}`)
+  constructor(timeline: PersonalTimeline, person: FullPerson) {
+    super(`Application history for ${person.name}`)
     this.timeline = timeline
   }
 
@@ -18,7 +18,7 @@ export class ShowPage extends Page {
         getStatus(applicationTimeline, 'govuk-tag--timeline-tag'),
       )
 
-      this.shouldShowApplicationTimeline(applicationTimeline.timelineEvents)
+      this.shouldShowApplicationTimeline(applicationTimeline.timelineEvents, index)
     })
   }
 }

--- a/integration_tests/pages/people/timeline/show.ts
+++ b/integration_tests/pages/people/timeline/show.ts
@@ -11,9 +11,12 @@ export class ShowPage extends Page {
   }
 
   shouldShowTimeline() {
-    this.timeline.applications.forEach(applicationTimeline => {
+    this.timeline.applications.forEach((applicationTimeline, index) => {
       cy.get('h2').contains(applicationTimeline.createdBy.name)
-      cy.get('.govuk-tag').contains(getStatus(applicationTimeline))
+      cy.get(`[data-cy-status="application ${index}"]`).should(
+        'contain.html',
+        getStatus(applicationTimeline, 'govuk-tag--timeline-tag'),
+      )
 
       this.shouldShowApplicationTimeline(applicationTimeline.timelineEvents)
     })

--- a/integration_tests/tests/people/timeline.cy.ts
+++ b/integration_tests/tests/people/timeline.cy.ts
@@ -15,8 +15,8 @@ context('Application timeline', () => {
   })
 
   it('shows a timeline for a CRN', () => {
-    const timeline = personalTimelineFactory.build()
-    const person = personFactory.build()
+    const person = personFactory.build({ type: 'FullPerson' })
+    const timeline = personalTimelineFactory.build({ person })
 
     cy.task('stubPersonalTimeline', { timeline, person })
     cy.visit(paths.timeline.find({}))
@@ -30,8 +30,10 @@ context('Application timeline', () => {
     findPage.clickSubmit()
 
     // Then I should be on the timeline show page
-    const timelinePage = Page.verifyOnPage(ShowPage, timeline, person.crn)
+    const timelinePage = Page.verifyOnPage(ShowPage, timeline, person)
     // And I should see the timeline for that person
     timelinePage.checkForBackButton(paths.timeline.find({}))
+    timelinePage.shouldShowTimeline()
+    timelinePage.shouldShowPersonDetails(person)
   })
 })

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -203,7 +203,12 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('oasysDisabled', config.flags.oasysDisabled)
 
   njkEnv.addFilter('mapApiPersonRisksForUi', mapApiPersonRisksForUi)
-  njkEnv.addFilter('applicationStatusTag', applicationStatusTag)
+  njkEnv.addFilter(
+    'applicationStatusTag',
+    function applicationStatusTagFilter(application: Application, classes: string) {
+      return applicationStatusTag(application, classes)
+    },
+  )
 
   njkEnv.addFilter('removeBlankSummaryListItems', removeBlankSummaryListItems)
   njkEnv.addFilter('sentenceCase', sentenceCase)

--- a/server/utils/users/homePageDashboard.ts
+++ b/server/utils/users/homePageDashboard.ts
@@ -7,6 +7,7 @@ import managePaths from '../../paths/manage'
 import taskPaths from '../../paths/tasks'
 import matchPaths from '../../paths/match'
 import adminPaths from '../../paths/admin'
+import peoplePaths from '../../paths/people'
 
 export const sections = {
   apply: {
@@ -66,6 +67,13 @@ export const sections = {
       'Manage user roles and permissions. Stop automatic allocations for assessments, matches, and placement requests.',
     shortTitle: 'Users',
     href: adminPaths.admin.userManagement.index({}),
+  },
+  personalTimeline: {
+    id: 'timeline',
+    title: "View a person's timeline",
+    description: 'View activity about a person, including previous applications, placements, and assessments.',
+    shortTitle: 'Timeline',
+    href: peoplePaths.timeline.find({}),
   },
 }
 

--- a/server/views/people/timeline/find.njk
+++ b/server/views/people/timeline/find.njk
@@ -33,7 +33,7 @@
           }) }}
 
         {{ govukButton({
-                    text: "Save and continue"
+                    text: "Search"
                 }) }}
       </form>
     </div>

--- a/server/views/people/timeline/show.njk
+++ b/server/views/people/timeline/show.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "../../partials/_applicationTimeline.njk" import applicationTimeline %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "../../partials/personDetails.njk" import personDetails %}
 
 {% set pageTitle = applicationName + " - " + pageHeading  %}
 {% set mainClasses = "app-container govuk-body" %}
@@ -22,7 +23,8 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-l">Application history for {{crn}}</h2>
+            <h1 class="govuk-heading-l">Application history for {{timeline.person.name}}</h1>
+            {{personDetails(timeline.person, false)}}
             <h2 class="govuk-heading-m">Total applications: {{applications | length}}</h2>
             <hr/>
             {% for application in applications %}
@@ -30,6 +32,8 @@
                 {% set html%}
                 <h2 class="govuk-heading-s">Application made by: <span class="govuk-body">{{application.createdBy.name}}</span></h2>
                 <h2 class="govuk-heading-s">Application made on: <span class="govuk-body">{{formatDate(application.createdAt, {format: 'short'})}}</span></h2>
+                {%set statusAttribute = "application " + loop.index0 %}
+                <h2 class="govuk-heading-s" data-cy-status="{{statusAttribute}}"  >Status: {{ application | applicationStatusTag('govuk-tag--timeline-tag') | safe}}</h2>
                 {% endset %}
 
                 {{ govukInsetText({

--- a/server/views/people/timeline/show.njk
+++ b/server/views/people/timeline/show.njk
@@ -1,12 +1,15 @@
 {% extends "../../partials/layout.njk" %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "../../partials/_applicationTimeline.njk" import applicationTimeline %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 {% set pageTitle = applicationName + " - " + pageHeading  %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% set query = "?crn=" + crn if crn else 
     "" %}
+
+{% set applications = ApplyUtils.mapPersonalTimelineForUi(timeline) %}
 
 {% block beforeContent %}
     {{ govukBackLink({
@@ -20,12 +23,23 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-l">Application history for {{crn}}</h2>
-            {% for application in ApplyUtils.mapPersonalTimelineForUi(timeline) %}
-                <h2 class="govuk-heading-s">Application made by: {{application.createdBy.name}}</h2>
-                <h2 class="govuk-heading-s">Status: {{ application | applicationStatusTag('govuk-tag--timeline-tag') | safe}}</h2>
+            <h2 class="govuk-heading-m">Total applications: {{applications | length}}</h2>
+            <hr/>
+            {% for application in applications %}
+                <h2 class="govuk-heading-m">Application {{loop.index}} of {{applications.length}}</h2>
+                {% set html%}
+                <h2 class="govuk-heading-s">Application made by: <span class="govuk-body">{{application.createdBy.name}}</span></h2>
+                <h2 class="govuk-heading-s">Application made on: <span class="govuk-body">{{formatDate(application.createdAt, {format: 'short'})}}</span></h2>
+                {% endset %}
+
+                {{ govukInsetText({
+                        html: html
+                })}}
 
                 {{applicationTimeline(application.timelineEvents)}}
-
+                {% if not loop.last %}
+                    <hr/>
+                {% endif %}
                 {%endfor%}
             </div>
         </div>

--- a/server/views/people/timeline/show.njk
+++ b/server/views/people/timeline/show.njk
@@ -22,7 +22,7 @@
             <h1 class="govuk-heading-l">Application history for {{crn}}</h2>
             {% for application in ApplyUtils.mapPersonalTimelineForUi(timeline) %}
                 <h2 class="govuk-heading-s">Application made by: {{application.createdBy.name}}</h2>
-                <h2 class="govuk-heading-s">Status: {{application | applicationStatusTag | safe}}</h2>
+                <h2 class="govuk-heading-s">Status: {{ application | applicationStatusTag('govuk-tag--timeline-tag') | safe}}</h2>
 
                 {{applicationTimeline(application.timelineEvents)}}
 


### PR DESCRIPTION
# Context

[JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&selectedIssue=APS-686)
- Styling changes to the timeline added in #1722 #1731 visible in screenshots below
# Changes in this PR
- Show details of the person whose CRN has been searched for
- Some tidying of the status tags
- Introduce inset text to show metadata about the application we are showing the timeline
- Add a `hr` between timelines to improve differentiation
- Show the total number of applications for that CRN and the `n of x applications` at the top of the page
 
## Screenshots of UI changes

### Before
![image](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/8a4db0b0-e946-47fa-b5b9-b8611dcb4ce5)

### After
![after-timeline (2)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/ec482a51-ad77-4dbb-9db3-c7f19c3dc253)

