### PR TITLE
APS-704: Copy change from 'Date of decision' to 'Estimated arrival da…

### DIFF
--- a/server/utils/placementRequests/adminSummary.test.ts
+++ b/server/utils/placementRequests/adminSummary.test.ts
@@ -73,7 +73,7 @@ describe('adminSummary', () => {
         ...adminSummaryRows.slice(0, 2),
         {
           key: {
-            text: 'Date of decision',
+            text: 'Estimated arrival date',
           },
           value: {
             text: DateFormats.isoDateToUIDate('2022-01-01'),

--- a/server/utils/placementRequests/adminSummary.ts
+++ b/server/utils/placementRequests/adminSummary.ts
@@ -29,7 +29,7 @@ export const adminSummary = (placementRequest: PlacementRequestDetail): SummaryL
     },
     {
       key: {
-        text: placementRequest.isParole ? 'Date of decision' : 'Requested Arrival Date',
+        text: placementRequest.isParole ? 'Estimated arrival date' : 'Requested Arrival Date',
       },
       value: {
         text: DateFormats.isoDateToUIDate(dates.startDate),

--- a/server/views/admin/placementRequests/show.njk
+++ b/server/views/admin/placementRequests/show.njk
@@ -24,7 +24,7 @@
                 Parole board directed release
               </p>
             <p class="govuk-body">
-                The person's arrival date has been calculated as {{ formatDate(placementRequest.expectedArrival) }}.
+                The person's arrival date has been estimated as {{ formatDate(placementRequest.expectedArrival) }}.
                 This is 6 weeks after the parole board's date of decision.
               </p>
             {% if placementRequest.booking %}


### PR DESCRIPTION
…te' on CRU dashboard placement request screen for parole cases

# Context

<!-- https://dsdmoj.atlassian.net/browse/APS-704 -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Copy change from 'Date of decision' to 'Estimated arrival date' on CRU dashboard placement request screen for parole cases
proposed tweaking the “Notification” so that it uses consistent language: “estimated“ rather than “calculated“
## Screenshots of UI changes

### Before
<img width="1728" alt="Screenshot 2024-04-26 at 11 29 58" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/ae238d5a-f680-4e34-b976-32667e50d841">

### After
<img width="1728" alt="Screenshot 2024-04-26 at 11 28 25" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/cc57811b-cbed-485a-860e-a14ee2d23228">
