### PR TITLE
APS 699 Ensure user has selected to change at least one date when changing a booking

### DIFF
--- a/integration_tests/pages/manage/booking/dateChanges/new.ts
+++ b/integration_tests/pages/manage/booking/dateChanges/new.ts
@@ -32,7 +32,7 @@ export default class NewDateChange extends Page {
   }
 
   checkDatesToChangeOption(option: 'newArrivalDate' | 'newDepartureDate'): void {
-    cy.get(`input[name="datesToChange"][value="${option}"]`).click()
+    cy.get(`input[name="datesToChange[]"][value="${option}"]`).click()
   }
 
   shouldHaveCorrectBacklink(): void {

--- a/integration_tests/tests/manage/dateChanges.cy.ts
+++ b/integration_tests/tests/manage/dateChanges.cy.ts
@@ -19,6 +19,19 @@ context('Date Changes', () => {
     cy.task('stubBookingGet', { premisesId: premises.id, booking })
   })
 
+  it('shows an error if neither date is selected', () => {
+    // And I visit the date change page
+    const dateChangePage = NewDateChangePage.visit(premises.id, booking.id)
+
+    // And I click submit without selecting any dates
+    dateChangePage.clickSubmit()
+
+    // Then I should see an error message
+    dateChangePage.shouldShowErrorMessagesForFields(['datesToChange'], {
+      datesToChange: 'You must select a date to change',
+    })
+  })
+
   it('changes a date', () => {
     cy.task('stubDateChange', { premisesId: premises.id, bookingId: booking.id })
 
@@ -78,6 +91,8 @@ context('Date Changes', () => {
     const dateChangePage = NewDateChangePage.visit(premises.id, booking.id)
 
     // And I click submit
+    dateChangePage.checkDatesToChangeOption('newArrivalDate')
+    dateChangePage.checkDatesToChangeOption('newDepartureDate')
     dateChangePage.clickSubmit()
 
     // Then I should see errors

--- a/server/controllers/manage/dateChangesController.test.ts
+++ b/server/controllers/manage/dateChangesController.test.ts
@@ -109,7 +109,7 @@ describe('dateChangesController', () => {
     const bodies = {
       'with new arrival date': {
         body: {
-          datesToChange: 'newArrivalDate',
+          datesToChange: ['newArrivalDate'],
           ...DateFormats.isoDateToDateInputs('2022-01-01', 'newArrivalDate'),
         },
         expectedPayload: {
@@ -118,7 +118,7 @@ describe('dateChangesController', () => {
       },
       'with new departure date': {
         body: {
-          datesToChange: 'newDepartureDate',
+          datesToChange: ['newDepartureDate'],
           ...DateFormats.isoDateToDateInputs('2022-01-01', 'newDepartureDate'),
         },
         expectedPayload: {
@@ -188,11 +188,11 @@ describe('dateChangesController', () => {
           ],
         },
         'newArrivalDate is checked': {
-          body: { datesToChange: 'newArrivalDate' },
+          body: { datesToChange: ['newArrivalDate'] },
           expectedErrorParams: [{ propertyName: `$.newArrivalDate`, errorType: 'empty' }],
         },
         'newDepartureDate is checked': {
-          body: { datesToChange: 'newDepartureDate' },
+          body: { datesToChange: ['newDepartureDate'] },
           expectedErrorParams: [{ propertyName: `$.newDepartureDate`, errorType: 'empty' }],
         },
       }

--- a/server/controllers/manage/dateChangesController.ts
+++ b/server/controllers/manage/dateChangesController.ts
@@ -2,7 +2,6 @@ import type { Request, RequestHandler, Response } from 'express'
 
 import type { NewDateChange } from '@approved-premises/api'
 
-import { flattenCheckboxInput } from '../../utils/formUtils'
 import { ErrorWithData } from '../../utils/errors'
 import { BookingService } from '../../services'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../utils/validation'
@@ -47,10 +46,9 @@ export default class DateChangeController {
       const { premisesId, bookingId } = req.params
 
       try {
-        const { backLink } = req.body
+        const { backLink, datesToChange } = req.body
         const payload: NewDateChange = {}
         const emptyDates: Array<keyof NewDateChange> = []
-        const datesToChange = flattenCheckboxInput(req.body.datesToChange)
 
         datesToChange.forEach((itemKey: keyof NewDateChange) => {
           const date = DateFormats.dateAndTimeInputsToIsoString(req.body, itemKey)[itemKey]

--- a/server/views/bookings/dateChanges/new.njk
+++ b/server/views/bookings/dateChanges/new.njk
@@ -115,7 +115,7 @@
         {% endset -%}
 
         {{ govukCheckboxes({
-          name: "datesToChange",
+          name: "datesToChange[]",
           fieldset: {
             legend: {
               text: "What dates do you want to change?",
@@ -125,6 +125,7 @@
           hint: {
             text: "Select all options that are relevant to you."
           },
+          errorMessage: errors.datesToChange,
           items: [
             {
               value: "newArrivalDate",


### PR DESCRIPTION
# Context

It’s currently possible to not select any checkbox and the click on ‘submit’. This will create a timeline event and a domain event despite no dates being changed. This PR ensures an error is thrown if no dates are selected to prevent this happening.
[JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?selectedIssue=APS-699)

