### PR TITLE
APS 732 - Trim CRN input in timline search

### DIFF
--- a/server/controllers/people/timelineController.test.ts
+++ b/server/controllers/people/timelineController.test.ts
@@ -96,6 +96,14 @@ describe('TimelineController', () => {
       })
     })
 
+    it('trims the input', async () => {
+      const requestHandler = timelineController.show()
+
+      await requestHandler({ ...request, query: { crn: ' test ' } }, response, next)
+
+      expect(personService.getTimeline).toHaveBeenCalledWith(token, 'test')
+    })
+
     describe('when there the person service throws an error', () => {
       it('catches the error and redirects to the find page', async () => {
         const crn = 'CRN'
@@ -117,7 +125,7 @@ describe('TimelineController', () => {
       it('adds error message to flash and redirects to show', async () => {
         const requestHandler = timelineController.show()
 
-        await requestHandler({ ...request, query: { crn: undefined } }, response, next)
+        await requestHandler({ ...request, query: { crn: ' ' } }, response, next)
 
         expect(addErrorMessageToFlash).toHaveBeenCalledWith(request, 'You must enter a CRN', 'crn')
         expect(response.redirect).toHaveBeenCalledWith(paths.timeline.find({}))

--- a/server/controllers/people/timelineController.ts
+++ b/server/controllers/people/timelineController.ts
@@ -24,15 +24,15 @@ export default class TimelineController {
 
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const crn = req?.query.crn as string | undefined
+      const crn = req?.query?.crn as string | undefined
 
-      if (!crn) {
+      if (!crn?.trim()) {
         addErrorMessageToFlash(req, 'You must enter a CRN', 'crn')
         res.redirect(paths.timeline.find({}))
       }
 
       try {
-        const timeline = await this.personService.getTimeline(req.user.token, crn)
+        const timeline = await this.personService.getTimeline(req.user.token, crn.trim())
 
         res.render('people/timeline/show', { timeline, crn, pageHeading: `Timeline for ${crn}` })
       } catch (error) {


### PR DESCRIPTION
Previously the CRN may not be found if it had a leading or trailing whitespace. Also the validation would fail if a user enter a space. Now we trim the input so any whitespace is removed.
