### PR TITLE
Fix/allow feature flags to fail gracefully

### DIFF
--- a/server/controllers/admin/cruDashboardController.test.ts
+++ b/server/controllers/admin/cruDashboardController.test.ts
@@ -21,10 +21,12 @@ import {
 } from '../../@types/shared'
 import paths from '../../paths/admin'
 import { getPaginationDetails } from '../../utils/getPaginationDetails'
+import { retrieveFlag } from '../../middleware/setupFeatureFlags'
 
 jest.mock('../../utils/applications/utils')
 jest.mock('../../utils/applications/getResponses')
 jest.mock('../../utils/getPaginationDetails')
+jest.mock('../../middleware/setupFeatureFlags')
 
 describe('CruDashboardController', () => {
   const token = 'SOME_TOKEN'
@@ -69,7 +71,7 @@ describe('CruDashboardController', () => {
       placementRequestService.getDashboard.mockResolvedValue(paginatedResponse)
       ;(getPaginationDetails as jest.Mock).mockReturnValue(paginationDetails)
       apAreaService.getApAreas.mockResolvedValue(apAreas)
-      featureFlagService.getBooleanFlag.mockResolvedValue(true)
+      when(retrieveFlag).calledWith('show-both-arrival-dates', featureFlagService).mockResolvedValue(true)
     })
 
     it('should render the placement requests template with the users AP area filtered by default', async () => {
@@ -140,6 +142,7 @@ describe('CruDashboardController', () => {
       )
 
       expect(getPaginationDetails).toHaveBeenCalledWith(notMatchedRequest, paths.admin.cruDashboard.index({}), filters)
+      expect(retrieveFlag).toHaveBeenCalledWith('show-both-arrival-dates', featureFlagService)
     })
 
     it('should not send an area query in the request if the  if the query is "all"', async () => {

--- a/server/controllers/admin/cruDashboardController.ts
+++ b/server/controllers/admin/cruDashboardController.ts
@@ -11,6 +11,7 @@ import adminPaths from '../../paths/admin'
 import { PlacementRequestDashboardSearchOptions } from '../../@types/ui'
 import { getPaginationDetails } from '../../utils/getPaginationDetails'
 import { getSearchOptions } from '../../utils/getSearchOptions'
+import { retrieveFlag } from '../../middleware/setupFeatureFlags'
 
 export default class CruDashboardController {
   constructor(
@@ -126,7 +127,7 @@ export default class CruDashboardController {
       sortDirection,
     )
 
-    const showRequestedAndActualArrivalDates = await this.featureFlagService.getBooleanFlag('show-both-arrival-dates')
+    const showRequestedAndActualArrivalDates = await retrieveFlag('show-both-arrival-dates', this.featureFlagService)
 
     return {
       placementRequests: dashboard.data,

--- a/server/middleware/setupFeatureFlags.ts
+++ b/server/middleware/setupFeatureFlags.ts
@@ -30,9 +30,10 @@ export const featureFlagHandler = (featureFlagService: FeatureFlagService): Requ
 }
 
 export const retrieveFlags = (featureFlagService: FeatureFlagService) => {
-  featureFlagsToUse.forEach(async flag => {
-    const flagBool = await featureFlagService.getBooleanFlag(flag)
-
-    process.env[flag] = flagBool.toString()
-  })
+  return Promise.all(
+    featureFlagsToUse.map(async flag => {
+      const flagBool = await featureFlagService.getBooleanFlag(flag)
+      process.env[flag] = flagBool.toString()
+    }),
+  )
 }


### PR DESCRIPTION


# Changes in this PR
Previously if our calls to the Feature Flag service failed then the call would throw an error and the page could crash. Now we just set the value to false.
