### PR TITLE
Don't run PR e2es post-merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,6 +289,10 @@ workflows:
           context: hmpps-common-vars
           requires:
             - build
+          filters:
+            branches:
+              ignore:
+                - main
       - e2e_environment_test_on_merge:
           context: hmpps-common-vars
           filters:


### PR DESCRIPTION
#1796 ensured we run the E2Es as expected post-merge but it also made the 'e2e_environment_test_on_pr' tests run post-merge. Having the two sets of e2es running concurrently causes lots of issues and is excessive so we can prevent 'e2e_environment_test_on_pr' from running post merge
