### PR TITLE
Pin @playwright/test at v1.42.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@faker-js/faker": "^8.0.0",
         "@flipt-io/flipt": "^1.0.0",
         "@ministryofjustice/frontend": "^2.0.0",
-        "@playwright/test": "^1.41.2",
+        "@playwright/test": "1.41.2",
         "@sentry/node": "^7.14.1",
         "@sentry/tracing": "^7.14.1",
         "@total-typescript/shoehorn": "^0.1.0",
@@ -3562,11 +3562,11 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.43.1.tgz",
-      "integrity": "sha512-HgtQzFgNEEo4TE22K/X7sYTYNqEMMTZmFS8kTq6m8hXj+m1D8TgwgIbumHddJa9h4yl4GkKb8/bgAl2+g7eDgA==",
+      "version": "1.41.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.2.tgz",
+      "integrity": "sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==",
       "dependencies": {
-        "playwright": "1.43.1"
+        "playwright": "1.41.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -13373,11 +13373,11 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.1.tgz",
-      "integrity": "sha512-V7SoH0ai2kNt1Md9E3Gwas5B9m8KR2GVvwZnAI6Pg0m3sh7UvgiYhRrhsziCmqMJNouPckiOhk8T+9bSAK0VIA==",
+      "version": "1.41.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.2.tgz",
+      "integrity": "sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==",
       "dependencies": {
-        "playwright-core": "1.43.1"
+        "playwright-core": "1.41.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -13390,9 +13390,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.1.tgz",
-      "integrity": "sha512-EI36Mto2Vrx6VF7rm708qSnesVQKbxEWvPrfA1IPY6HgczBplDx7ENtx+K2n4kJ41sLLkuGfmb0ZLSSXlDhqPg==",
+      "version": "1.41.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.2.tgz",
+      "integrity": "sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@faker-js/faker": "^8.0.0",
     "@flipt-io/flipt": "^1.0.0",
     "@ministryofjustice/frontend": "^2.0.0",
-    "@playwright/test": "^1.41.2",
+    "@playwright/test": "1.41.2",
     "@sentry/node": "^7.14.1",
     "@sentry/tracing": "^7.14.1",
     "@total-typescript/shoehorn": "^0.1.0",


### PR DESCRIPTION
In #1793 Rennovate unhelpfully upgraded Playwright to a version that's incompatible with our docker container that runs the E2E. This pins playwright to the version specificied in our ./.circleci/config.yml file.
It would be better to use a generic (non-playwright) docker container and npx install and run playwright (as CAS2 do) but this is a shorter term fix

