### PR TITLE
Use npx to install Playwright instead of the Playwright Docker container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,12 +180,10 @@ jobs:
           template: basic_fail_1
 
   e2e_environment_test_on_pr:
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.41.2-focal
-    parallelism: 4
     executor:
       name: hmpps/node
       tag: << pipeline.parameters.node-version >>
+    parallelism: 4
     circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
     steps:
       - checkout
@@ -193,6 +191,9 @@ jobs:
           at: ~/app
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
+      - run:
+          name: Install Playwright
+          command: npx playwright install
       - run:
           name: E2E Check
           command: |
@@ -214,12 +215,10 @@ jobs:
           destination: test-results
 
   e2e_environment_test_on_merge:
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.41.2-focal
-    parallelism: 4
     executor:
       name: hmpps/node
       tag: << pipeline.parameters.node-version >>
+    parallelism: 4
     circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
     steps:
       - checkout
@@ -227,6 +226,9 @@ jobs:
           at: ~/app
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
+      - run:
+          name: Install Playwright
+          command: npx playwright install
       - run:
           name: E2E Check
           command: |

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@faker-js/faker": "^8.0.0",
     "@flipt-io/flipt": "^1.0.0",
     "@ministryofjustice/frontend": "^2.0.0",
-    "@playwright/test": "1.41.2",
+    "@playwright/test": "^1.41.2",
     "@sentry/node": "^7.14.1",
     "@sentry/tracing": "^7.14.1",
     "@total-typescript/shoehorn": "^0.1.0",


### PR DESCRIPTION
#1793 [broke our CI pipeline](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-approved-premises-ui/9491/workflows/b8688d91-54f1-4c7f-9b1c-e9424c324891/jobs/38349) by introducing a higher version of @playwright/test to our package.json than was available in our CI pipeline. In CI we used the [Microsoft Docker Image](https://mcr.microsoft.com/en-us/product/playwright/about) which comes with the dependencies that Playwright needs preinstalled, this container supports one version of Playwright [specified in the image name](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/1495/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L184). However the *version* of Playwright that is run is [specified in the package.json](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/1495/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R117). 
So when Renovate helpfully upgraded Playwright to the latest version in the package.json it didn't match the version that was actually being used (the docker container) which caused an error.  
#1799 ensured that we used the same version of Playwright in the package.json as a temporary fix but now this PR ensures that rather than use the Docker container prebuilt with Playwright we use npx to install playwright which will mean the version used will be compatible. This may mean it takes a little while longer for the E2Es to run but I believe the pay off is worth it in reduced maintenance burden.