### PR TITLE
E2Es: Assert the expected task due date is >= actual due date

### DIFF
--- a/e2e/pages/workflow/listPage.ts
+++ b/e2e/pages/workflow/listPage.ts
@@ -43,10 +43,15 @@ export class ListPage extends BasePage {
     await row.getByRole('link').click()
   }
 
-  async shouldHaveCorrectDeadlineAndAllocation(id: string, deadline: string, user?: string | null) {
+  async shouldHaveCorrectDeadlineAndAllocation(id: string, expectedDeadlineInDays: number, user?: string | null) {
     const row = await this.getAssignmentWithId(id, !!user)
 
-    await expect(row.locator('td').nth(0)).toContainText(deadline)
+    const actualDeadline = await row.locator('td').nth(0).innerText()
+    const actualDeadlineInDays = Number(actualDeadline.split(' ')[0])
+
+    expect(
+      actualDeadlineInDays >= expectedDeadlineInDays && actualDeadlineInDays <= expectedDeadlineInDays + 4,
+    ).toBeTruthy()
 
     if (user) {
       await expect(row.locator('td').nth(1)).toContainText(user)

--- a/e2e/steps/apply.ts
+++ b/e2e/steps/apply.ts
@@ -542,7 +542,7 @@ export const recordAnAppealOnApplication = async (page: Page, applicationId: str
 
 export const assessmentShouldBeAllocatedToCorrectUser = async (page: Page, applicationId: string, user: string) => {
   const dashboard = await visitDashboard(page)
-  await assessmentShouldHaveCorrectDeadlineAndAllocatedUser(dashboard, page, applicationId, '10 Days', user)
+  await assessmentShouldHaveCorrectDeadlineAndAllocatedUser(dashboard, page, applicationId, 10, user)
 }
 
 const withdrawApplication = async (page: Page) => {

--- a/e2e/steps/assess.ts
+++ b/e2e/steps/assess.ts
@@ -196,30 +196,31 @@ export const assessApplication = async (
   const dashboard = await visitDashboard(page)
 
   // Then the task should contain the expected deadline
-  let deadline: string
+  let deadlineInDays: number
   let emailBody: string
   switch (true) {
     case applicationType === 'shortNotice':
-      deadline = '2 Days'
+      deadlineInDays = 2
       emailBody = '2 working days'
       break
     case applicationType === 'emergency' && new Date().getHours() < 13:
       // If the application has been submitted before 1pm the deadline is today
-      deadline = 'Today'
+      deadlineInDays = 0
       emailBody =
         'As this assessment is an emergency assessment, you have 2 hours to complete the assessment, including any requests for further information'
       break
-    case applicationType === 'emergency' && new Date().getHours() >= 13:
-      // If the application has been submitted after 1pm the deadline is tomorrow
-      deadline = '1 Day'
-      emailBody = 'As this assessment is an emergency assessment, you have until 1pm'
-      break
     default:
-      deadline = '10 Days'
+      deadlineInDays = 10
       emailBody = '10 working days'
   }
 
-  await assessmentShouldHaveCorrectDeadlineAndAllocatedUser(dashboard, page, applicationId, deadline, allocatedUser)
+  await assessmentShouldHaveCorrectDeadlineAndAllocatedUser(
+    dashboard,
+    page,
+    applicationId,
+    deadlineInDays,
+    allocatedUser,
+  )
 
   // And I allocate the assessement to myself
   await assignAssessmentToMe(dashboard, page, user.name, applicationId, !!allocatedUser)

--- a/e2e/steps/workflow.ts
+++ b/e2e/steps/workflow.ts
@@ -6,7 +6,7 @@ export const assessmentShouldHaveCorrectDeadlineAndAllocatedUser = async (
   dashboard: DashboardPage,
   page: Page,
   id: string,
-  deadline: string,
+  deadline: number,
   user: string | null,
 ) => {
   await dashboard.clickWorkflow()


### PR DESCRIPTION
We've been having CI failures whereby the E2Es expect the due date for a task to be completed by was further in the future than the API said it was because the API accounts for working days and bank holidays. In order to counter this we now peform a comparison of the range the due date should be in. The alternative is duplicating the entire logic from the API into the E2Es which seems like the greater evil.
