### PR TITLE
APS-777: Show newest applications first in Apply -- as default ordering

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -36,7 +36,7 @@ export default {
     applications,
     page = '1',
     sortBy = 'createdAt',
-    sortDirection = 'asc',
+    sortDirection = 'desc',
     searchOptions = {},
   }: {
     applications: Array<ApprovedPremisesApplicationSummary>
@@ -86,7 +86,7 @@ export default {
   verifyDashboardRequest: async ({
     page = '1',
     sortBy = 'createdAt',
-    sortDirection = 'asc',
+    sortDirection = 'desc',
     searchOptions = {},
   }: {
     page: string

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -555,7 +555,7 @@ context('Placement Requests', () => {
   it('should list applications that have no placement request', () => {
     const applications = applicationSummaryFactory.buildList(2)
 
-    cy.task('stubAllApplications', { applications, page: '1' })
+    cy.task('stubAllApplications', { applications, page: '1', sortDirection: 'asc' })
 
     // Given I am on the placement request dashboard filtering by the pendingPlacement status
     const listPage = ListPage.visit('status=pendingPlacement')
@@ -563,7 +563,7 @@ context('Placement Requests', () => {
     // Then I should see a list of applications with no placement requests
     listPage.shouldShowApplications(applications)
 
-    cy.task('verifyDashboardRequest', { status: 'pendingPlacementRequest' }).then(requests => {
+    cy.task('verifyDashboardRequest', { status: 'pendingPlacementRequest', sortDirection: 'asc' }).then(requests => {
       expect(requests).to.have.length(1)
     })
 
@@ -575,6 +575,7 @@ context('Placement Requests', () => {
     cy.task('stubAllApplications', {
       applications: apAreaApplications,
       page: '1',
+      sortDirection: 'asc',
       searchOptions: { apAreaId: apArea.id, releaseType: 'rotl' },
     })
     listPage.getSelectInputByIdAndSelectAnEntry('apArea', apArea.name)
@@ -586,6 +587,7 @@ context('Placement Requests', () => {
 
     cy.task('verifyDashboardRequest', {
       status: 'pendingPlacementRequest',
+      sortDirection: 'asc',
       searchOptions: { apAreaId: apArea.id, releaseType: 'rotl' },
     }).then(requests => {
       expect(requests).to.have.length(1)
@@ -594,7 +596,7 @@ context('Placement Requests', () => {
   ;(['tier', 'releaseType'] as const).forEach(field => {
     it(`supports pending placement requests sorting by ${field}`, () => {
       const applications = applicationSummaryFactory.buildList(2)
-      cy.task('stubAllApplications', { applications, page: '1' })
+      cy.task('stubAllApplications', { applications, page: '1', sortDirection: 'asc' })
       cy.task('stubAllApplications', {
         applications,
         sortBy: field,

--- a/integration_tests/tests/apply/dashboard.cy.ts
+++ b/integration_tests/tests/apply/dashboard.cy.ts
@@ -65,7 +65,52 @@ context('All applications', () => {
   })
 
   it('supports sorting by createdAt', () => {
-    shouldSortByField('createdAt')
+    // Given I am logged in
+    cy.signIn()
+
+    // And there is a page of applications
+    const applications = applicationSummaryFactory.buildList(10)
+
+    cy.task('stubAllApplications', { applications, page: '1' })
+    cy.task('stubAllApplications', {
+      applications,
+      page: '1',
+      sortBy: 'createdAt',
+      sortDirection: 'asc',
+    })
+
+    // When I access the applications dashboard
+    const page = DashboardPage.visit(applications)
+
+    // Then I should see the first result
+    page.shouldShowApplications()
+
+    // Then the API should have received a request for the sort
+    cy.task('verifyDashboardRequest', { page: '1', sortBy: 'createdAt', sortDirection: 'desc' }).then(requests => {
+      expect(requests).to.have.length(1)
+    })
+
+    // When I sort by created at
+    page.clickSortBy('createdAt')
+
+    // Then the API should have received a request for the sort
+    cy.task('verifyDashboardRequest', { page: '1', sortBy: 'createdAt', sortDirection: 'desc' }).then(requests => {
+      expect(requests).to.have.length(2)
+    })
+
+    // And the page should show the sorted items
+    page.shouldBeSortedByField('createdAt', 'descending')
+
+    // When I click the sort button again
+    page.clickSortBy('createdAt')
+
+    // Then the API should have received a request for the sort
+    cy.task('verifyDashboardRequest', { page: '1', sortBy: 'createdAt', sortDirection: 'asc' }).then(requests => {
+      expect(requests).to.have.length(1)
+    })
+
+    // And the page should show the sorted items
+    page.shouldBeSortedByField('createdAt', 'ascending')
   })
 
   it('supports sorting by arrivalDate', () => {

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -128,6 +128,87 @@ describe('applicationsController', () => {
       expect(getSearchOptions).toHaveBeenCalledWith(request, ['crnOrName', 'status'])
       expect(getPaginationDetails).toHaveBeenCalledWith(request, paths.applications.dashboard({}), searchOptions)
     })
+    it('if sort by and sort direction not provided, calls the dashboard service with the sort direction desc', async () => {
+      const searchOptions = createMock<ApplicationDashboardSearchOptions>()
+      const paginatedResponse = paginatedResponseFactory.build({
+        data: applicationFactory.buildList(2),
+      }) as PaginatedResponse<ApprovedPremisesApplicationSummary>
+
+      const paginationDetails = {
+        hrefPrefix: paths.applications.dashboard({}),
+        pageNumber: 1,
+      }
+
+      applicationService.dashboard.mockResolvedValue(paginatedResponse)
+      ;(getSearchOptions as jest.Mock).mockReturnValue(searchOptions)
+      ;(getPaginationDetails as jest.Mock).mockReturnValue(paginationDetails)
+
+      const requestHandler = applicationsController.dashboard()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('applications/dashboard', {
+        pageHeading: 'Approved Premises applications',
+        applications: paginatedResponse.data,
+        pageNumber: Number(paginationDetails.pageNumber),
+        totalPages: Number(paginatedResponse.totalPages),
+        hrefPrefix: paginationDetails.hrefPrefix,
+        sortBy: undefined,
+        sortDirection: 'desc',
+        ...searchOptions,
+      })
+
+      expect(applicationService.dashboard).toHaveBeenCalledWith(
+        token,
+        paginationDetails.pageNumber,
+        undefined,
+        'desc',
+        searchOptions,
+      )
+      expect(getSearchOptions).toHaveBeenCalledWith(request, ['crnOrName', 'status'])
+      expect(getPaginationDetails).toHaveBeenCalledWith(request, paths.applications.dashboard({}), searchOptions)
+    })
+    it('if sort by created at and sort direction not provided, calls the dashboard service with the sort direction desc', async () => {
+      const searchOptions = createMock<ApplicationDashboardSearchOptions>()
+      const paginatedResponse = paginatedResponseFactory.build({
+        data: applicationFactory.buildList(2),
+      }) as PaginatedResponse<ApprovedPremisesApplicationSummary>
+
+      const paginationDetails = {
+        hrefPrefix: paths.applications.dashboard({}),
+        pageNumber: 1,
+        sortBy: 'createdAt',
+      }
+
+      applicationService.dashboard.mockResolvedValue(paginatedResponse)
+      ;(getSearchOptions as jest.Mock).mockReturnValue(searchOptions)
+      ;(getPaginationDetails as jest.Mock).mockReturnValue(paginationDetails)
+
+      const requestHandler = applicationsController.dashboard()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('applications/dashboard', {
+        pageHeading: 'Approved Premises applications',
+        applications: paginatedResponse.data,
+        pageNumber: Number(paginationDetails.pageNumber),
+        totalPages: Number(paginatedResponse.totalPages),
+        hrefPrefix: paginationDetails.hrefPrefix,
+        sortBy: paginationDetails.sortBy,
+        sortDirection: 'desc',
+        ...searchOptions,
+      })
+
+      expect(applicationService.dashboard).toHaveBeenCalledWith(
+        token,
+        paginationDetails.pageNumber,
+        paginationDetails.sortBy,
+        'desc',
+        searchOptions,
+      )
+      expect(getSearchOptions).toHaveBeenCalledWith(request, ['crnOrName', 'status'])
+      expect(getPaginationDetails).toHaveBeenCalledWith(request, paths.applications.dashboard({}), searchOptions)
+    })
   })
 
   describe('show', () => {

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -34,11 +34,19 @@ export default class ApplicationsController {
     return async (req: Request, res: Response) => {
       const searchOptions = getSearchOptions<ApplicationDashboardSearchOptions>(req, ['crnOrName', 'status'])
 
-      const { pageNumber, hrefPrefix, sortBy, sortDirection } = getPaginationDetails<ApplicationSortField>(
+      const paginationDetails = getPaginationDetails<ApplicationSortField>(
         req,
         paths.applications.dashboard({}),
         searchOptions,
       )
+
+      const { pageNumber, hrefPrefix, sortBy } = paginationDetails
+      let { sortDirection } = paginationDetails
+
+      if (!sortBy || (sortBy === 'createdAt' && !sortDirection)) {
+        sortDirection = 'desc'
+      }
+
       const result = await this.applicationService.dashboard(
         req.user.token,
         pageNumber,


### PR DESCRIPTION
…s unsuitable

# Context

 https://dsdmoj.atlassian.net/browse/APS-777 
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Show newest applications first in Apply -- as default ordering
## Screenshots of UI changes

### Before
![Uploading Screenshot 2024-05-10 at 16.05.18.png…]()

### After
<img width="1728" alt="Screenshot 2024-05-10 at 15 31 35" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/017dc750-91ab-4d54-8ea3-a8b8f121da52">
