### PR TITLE
E2Es: Correct deadline assertion

### DIFF
--- a/e2e/pages/workflow/listPage.ts
+++ b/e2e/pages/workflow/listPage.ts
@@ -54,9 +54,8 @@ export class ListPage extends BasePage {
 
     const actualDeadlineInDays: number = numberOfDaysOrToday === 'Today' ? 0 : Number(numberOfDaysOrToday)
 
-    expect(
-      actualDeadlineInDays >= expectedDeadlineInDays && actualDeadlineInDays <= expectedDeadlineInDays + 4,
-    ).toBeTruthy()
+    expect(actualDeadlineInDays).toBeGreaterThanOrEqual(expectedDeadlineInDays)
+    expect(actualDeadlineInDays).toBeLessThanOrEqual(expectedDeadlineInDays + 4)
 
     if (user) {
       await expect(row.locator('td').nth(1)).toContainText(user)

--- a/e2e/steps/assess.ts
+++ b/e2e/steps/assess.ts
@@ -203,7 +203,7 @@ export const assessApplication = async (
       deadlineInDays = 2
       emailBody = '2 working days'
       break
-    case applicationType === 'emergency' && new Date().getHours() < 13:
+    case applicationType === 'emergency':
       // If the application has been submitted before 1pm the deadline is today
       deadlineInDays = 0
       emailBody =


### PR DESCRIPTION
Trying to manually calculate if the emergency application was due today or tomorrow was prone to error. Now we use a more fuzzy date range it can be avoided