### PR TITLE
APS 736 - Allow document on RfPs to be nullable

### DIFF
--- a/server/utils/placementRequests/requestForPlacementSummaryCards.test.ts
+++ b/server/utils/placementRequests/requestForPlacementSummaryCards.test.ts
@@ -6,6 +6,7 @@ import { applicationFactory, requestForPlacementFactory, userFactory } from '../
 import paths from '../../paths/apply'
 import { DateFormats } from '../dateUtils'
 import { RequestForPlacementStatusTag } from './statusTag'
+import { sentenceCase } from '../utils'
 
 describe('RequestForPlacementSummaryCards', () => {
   const actingUserId = '123'
@@ -64,7 +65,7 @@ describe('RequestForPlacementSummaryCards', () => {
             'data-cy-placement-application-id': requestForPlacement.id,
           },
         }),
-        rows: [
+        rows: expect.arrayContaining([
           {
             key: {
               text: 'Status',
@@ -145,7 +146,7 @@ describe('RequestForPlacementSummaryCards', () => {
               text: 'No',
             },
           },
-        ],
+        ]),
       })
     })
 
@@ -183,7 +184,7 @@ describe('RequestForPlacementSummaryCards', () => {
             'data-cy-placement-application-id': requestForPlacement.id,
           },
         }),
-        rows: [
+        rows: expect.arrayContaining([
           {
             key: {
               text: 'Status',
@@ -264,7 +265,7 @@ describe('RequestForPlacementSummaryCards', () => {
               text: 'No',
             },
           },
-        ],
+        ]),
       })
     })
 
@@ -283,6 +284,23 @@ describe('RequestForPlacementSummaryCards', () => {
       ).response()
 
       expect(summaryCard.card.actions.items).toContainEqual(expectedActionItem)
+    })
+  })
+
+  describe('if the RfP has a status of request_withdrawn', () => {
+    it('adds a row for the withdrawal reason', () => {
+      const requestForPlacement = requestForPlacementFactory.build({ status: 'request_withdrawn' })
+
+      const summaryCard = new RequestForPlacementSummaryCards(
+        requestForPlacement,
+        applicationId,
+        actingUserId,
+      ).response()
+
+      expect(summaryCard.rows).toContainEqual({
+        key: { text: 'Withdrawal reason' },
+        value: { text: sentenceCase(requestForPlacement?.withdrawalReason) },
+      })
     })
   })
 })

--- a/server/utils/placementRequests/requestForPlacementSummaryCards.test.ts
+++ b/server/utils/placementRequests/requestForPlacementSummaryCards.test.ts
@@ -11,6 +11,36 @@ describe('RequestForPlacementSummaryCards', () => {
   const actingUserId = '123'
   const applicationId = '456'
 
+  it('allows document to be nullable', () => {
+    const requestForPlacement = requestForPlacementFactory.build({
+      document: undefined,
+    })
+
+    const actual = new RequestForPlacementSummaryCards(requestForPlacement, applicationId, actingUserId).response()
+
+    expect(actual).toEqual({
+      card: {
+        actions: {
+          items: [],
+        },
+        attributes: {
+          'data-cy-placement-application-id': requestForPlacement.id,
+        },
+        title: expect.objectContaining({}),
+      },
+      rows: [
+        {
+          key: {
+            text: 'Status',
+          },
+          value: {
+            html: new RequestForPlacementStatusTag(requestForPlacement.status).html(),
+          },
+        },
+      ],
+    })
+  })
+
   describe('if the RfP cannot be directly withdrawn', () => {
     const requestForPlacement = requestForPlacementFactory.build({
       isWithdrawn: false,

--- a/server/utils/placementRequests/requestForPlacementSummaryCards.ts
+++ b/server/utils/placementRequests/requestForPlacementSummaryCards.ts
@@ -5,6 +5,7 @@ import { DateFormats } from '../dateUtils'
 import paths from '../../paths/apply'
 import { embeddedSummaryListItem } from '../applications/summaryListUtils/embeddedSummaryListItem'
 import { RequestForPlacementStatusTag } from './statusTag'
+import { sentenceCase } from '../utils'
 
 export class RequestForPlacementSummaryCards {
   private rows: Array<SummaryListItem> = []
@@ -77,8 +78,18 @@ export class RequestForPlacementSummaryCards {
     }
   }
 
+  private withdrawalReason() {
+    this.rows.push({
+      key: { text: 'Withdrawal reason' },
+      value: { text: sentenceCase(this.requestForPlacement?.withdrawalReason || 'Not supplied') },
+    })
+  }
+
   response() {
     this.statusTag()
+    if (this.requestForPlacement.status === 'request_withdrawn') {
+      this.withdrawalReason()
+    }
     this.questionAndAnswerRows()
     this.withdrawAction()
 

--- a/server/utils/placementRequests/requestForPlacementSummaryCards.ts
+++ b/server/utils/placementRequests/requestForPlacementSummaryCards.ts
@@ -19,9 +19,9 @@ export class RequestForPlacementSummaryCards {
 
   private questionAndAnswerRows(): void {
     const taskName = 'request-a-placement'
-    const pageResponses = this.requestForPlacement.document[taskName]
+    const pageResponses = this.requestForPlacement?.document?.[taskName]
 
-    pageResponses.forEach((pageResponse: PageResponse) => {
+    pageResponses?.forEach((pageResponse: PageResponse) => {
       const questionsAndAnswers = Object.entries(pageResponse)
 
       questionsAndAnswers.forEach(([question, answer]) => {


### PR DESCRIPTION
We are seeing [this error](https://ministryofjustice.sentry.io/issues/5325707450/?environment=preprod&project=4503931667742720&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=90d&stream_index=0) when rendering the RfPs pages as the document can be nullable but the UI code doesn't allow for this. 

We also add a 'Withdrawal Reason' field for when a RfP is withdrawn


## Before 
<img width="750" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/9e88e899-504e-4a83-a57f-1155944323af">

## After
<img width="754" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/4ed475e9-9b22-48a8-a2ca-43e44869635f">
