### PR TITLE
APS 736 - Remove flaky assertion

### DIFF
--- a/server/utils/placementRequests/requestForPlacementSummaryCards.test.ts
+++ b/server/utils/placementRequests/requestForPlacementSummaryCards.test.ts
@@ -29,7 +29,7 @@ describe('RequestForPlacementSummaryCards', () => {
         },
         title: expect.objectContaining({}),
       },
-      rows: [
+      rows: expect.arrayContaining([
         {
           key: {
             text: 'Status',
@@ -38,7 +38,7 @@ describe('RequestForPlacementSummaryCards', () => {
             html: new RequestForPlacementStatusTag(requestForPlacement.status).html(),
           },
         },
-      ],
+      ]),
     })
   })
 


### PR DESCRIPTION
The rows array can include other properties dependent on status but this is the only one we're interested in


