### PR TITLE
Make A1 tiers eligible for AP without explanation

### DIFF
--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -14,7 +14,7 @@ describe('personUtils', () => {
 
   describe('isApplicableTier', () => {
     it(`returns true if the person's sex is male and has an applicable tier`, () => {
-      expect(isApplicableTier('Male', 'A3')).toBeTruthy()
+      expect(isApplicableTier('Male', 'A1')).toBeTruthy()
     })
 
     it(`returns false if the person's sex is male and has a tier that is not applicable to males`, () => {

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -9,7 +9,7 @@ const tierBadge = (tier: string): string => {
 }
 
 const isApplicableTier = (sex: string, tier: string): boolean => {
-  const applicableTiersAll = ['A3', 'A2', 'B1', 'B3', 'B2', 'B1']
+  const applicableTiersAll = ['A1', 'A3', 'A2', 'B1', 'B3', 'B2']
   const applicableTiersWomen = ['C3']
 
   const applicableTiers = sex === 'Female' ? [applicableTiersAll, applicableTiersWomen].flat() : applicableTiersAll

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -9,7 +9,7 @@ const tierBadge = (tier: string): string => {
 }
 
 const isApplicableTier = (sex: string, tier: string): boolean => {
-  const applicableTiersAll = ['A1', 'A3', 'A2', 'B1', 'B3', 'B2']
+  const applicableTiersAll = ['A1', 'A2', 'A3', 'B1', 'B2', 'B3']
   const applicableTiersWomen = ['C3']
 
   const applicableTiers = sex === 'Female' ? [applicableTiersAll, applicableTiersWomen].flat() : applicableTiersAll

--- a/server/views/applications/pages/basic-information/is-exceptional-case.njk
+++ b/server/views/applications/pages/basic-information/is-exceptional-case.njk
@@ -29,6 +29,7 @@
   <ul class="govuk-list govuk-list--bullet">
     <li>A3</li>
     <li>A2</li>
+    <li>A1</li>
     <li>B3</li>
     <li>B2</li>
     <li>B1</li>


### PR DESCRIPTION
Previously applicants for people with A1 tiers were told that the tier was ineligible and would have to explain why their's was an exceptional case. However A1s is an eligible case and shouldn't require explanation.
