### PR TITLE
Allow retries by increasing number of maxFailures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,42 +179,7 @@ jobs:
           channel: << pipeline.parameters.alerts-slack-channel >>
           template: basic_fail_1
 
-  e2e_environment_test_on_pr:
-    executor:
-      name: hmpps/node
-      tag: << pipeline.parameters.node-version >>
-    parallelism: 4
-    circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
-    steps:
-      - checkout
-      - attach_workspace:
-          at: ~/app
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-      - run:
-          name: Install Playwright
-          command: npx playwright install
-      - run:
-          name: E2E Check
-          command: |
-            SHARD="$((${CIRCLE_NODE_INDEX}+1))"
-            username="HMPPS_AUTH_USERNAME_$SHARD"
-            password="HMPPS_AUTH_PASSWORD_$SHARD"
-            email="HMPPS_AUTH_EMAIL_$SHARD"
-            name="HMPPS_AUTH_NAME_$SHARD"
-            HMPPS_AUTH_USERNAME="${!username}"
-            HMPPS_AUTH_PASSWORD="${!password}"
-            HMPPS_AUTH_EMAIL="${!email}"
-            HMPPS_AUTH_NAME="${!name}"
-            npm run test:e2e:ci -- --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
-      - store_artifacts:
-          path: playwright-report
-          destination: playwright-report
-      - store_artifacts:
-          path: test-results
-          destination: test-results
-
-  e2e_environment_test_on_merge:
+  e2e_environment_test:
     executor:
       name: hmpps/node
       tag: << pipeline.parameters.node-version >>
@@ -287,15 +252,7 @@ workflows:
           requires:
             - helm_lint
             - build_docker
-      - e2e_environment_test_on_pr:
-          context: hmpps-common-vars
-          requires:
-            - build
-          filters:
-            branches:
-              ignore:
-                - main
-      - e2e_environment_test_on_merge:
+      - e2e_environment_test:
           context: hmpps-common-vars
           filters:
             branches:
@@ -311,7 +268,7 @@ workflows:
               only:
                 - main
           requires:
-            - e2e_environment_test_on_merge
+            - e2e_environment_test
             - deploy_dev
       - hmpps/deploy_env:
           name: deploy_preprod

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig<TestOptions>({
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  maxFailures: 1,
+  maxFailures: process.env.CI ? 3 : 1,
   workers: 1,
   reporter: 'html',
   timeout: process.env.CI ? 5 * 60 * 1000 : 2 * 60 * 1000,


### PR DESCRIPTION
Previously despite allowing 2 retries in CI Playwright would never retry test because once the number of failures specified in maxFailures was reached then Playwright would halt execution of the test. By increasing the number of maxFailures we allow there to be 2 retries.
