### PR TITLE
Don't skip to next page on application dashboard to find withdrawn application

### DIFF
--- a/e2e/pages/apply/listPage.ts
+++ b/e2e/pages/apply/listPage.ts
@@ -37,9 +37,6 @@ export class ListPage extends BasePage {
   }
 
   async shouldShowWithdrawnApplication(applicationId: string) {
-    // If there are multiple pages of applications, click through them to find the withdrawn application
-    await this.clickNextPage()
-
     await expect(
       this.page.getByRole('row').filter({ has: this.page.locator(`[data-cy-id="${applicationId}"]`) }),
     ).toContainText('Application withdrawn')


### PR DESCRIPTION
#1812 introduced a change to show the most recent applications first by default.
The E2E tests still assumed that the most recent application was shown last so would skip forward to the last application dashboard page if there was more than one.
As there was sometimes only one page which would contain the withdrawn application this meant that sometimes the tests passed but sometimes they failed.

