### PR TITLE
APS-812: If users navigates away from application when told tier not …

### DIFF
--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -995,6 +995,10 @@ export default class ApplyHelper {
     attachDocumentsPage.shouldDisplayNoDocuments()
   }
 
+  clickBasicInformation() {
+    cy.get('[data-cy-task-name="basic-information"]').click()
+  }
+
   private completeCheckYourAnswersSection() {
     // Given I click the check your answers task
     cy.get('[data-cy-task-name="check-your-answers"]').click()

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../server/testutils/factories'
 import ApplyHelper from '../../helpers/apply'
 import { DateFormats } from '../../../server/utils/dateUtils'
+import * as ApplyPages from '../../pages/apply'
 import { ConfirmDetailsPage, ConfirmYourDetailsPage, EnterCRNPage, ListPage, StartPage } from '../../pages/apply'
 import IsExceptionalCasePage from '../../pages/apply/isExceptionalCase'
 import NoOffencePage from '../../pages/apply/noOffence'
@@ -101,6 +102,33 @@ context('Apply', () => {
 
     // Then I am taken back to the dashboard
     Page.verifyOnPage(ListPage)
+  })
+
+  it('If users navigates away from application when told tier not eligible, return to is exceptional case page', function test() {
+    // Given the person does not have an eligible risk tier
+    this.application.risks = risksFactory.build({
+      crn: this.person.crn,
+      tier: tierEnvelopeFactory.build({ value: { level: 'D1' } }),
+    })
+    cy.task('stubApplicationGet', { application: this.application })
+    cy.task('stubApplications', [this.application])
+
+    // And I start the application and left
+    const apply = new ApplyHelper(this.application, this.person, this.offences)
+    apply.setupApplicationStubs()
+    apply.startApplication()
+
+    // And I visit the list page
+    const listPage = ListPage.visit([this.application], [], [])
+
+    // When I click the application from list
+    listPage.clickApplication(this.application)
+
+    // And I click the basic information
+    apply.clickBasicInformation()
+
+    // Then I should see the is exceptional case page
+    Page.verifyOnPage(ApplyPages.IsExceptionalCasePage, this.application)
   })
 
   it('throws an error if the the CRN entered is an LAO', function test() {

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -206,7 +206,7 @@ const isInapplicable = (application: Application): boolean => {
   return false
 }
 
-const firstPageOfApplicationJourney = (application: Application) => {
+const tierQualificationPage = (application: Application) => {
   if (!isFullPerson(application.person)) throw new RestrictedPersonError(application.person.crn)
 
   if (!application?.risks?.tier?.value) {
@@ -215,6 +215,15 @@ const firstPageOfApplicationJourney = (application: Application) => {
 
   if (!isApplicableTier(application.person.sex, application.risks?.tier?.value?.level)) {
     return paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'is-exceptional-case' })
+  }
+  return undefined
+}
+
+const firstPageOfApplicationJourney = (application: Application) => {
+  const firstPage = tierQualificationPage(application)
+
+  if (firstPage) {
+    return firstPage
   }
 
   return paths.applications.pages.show({
@@ -423,4 +432,5 @@ export {
   lengthOfStayForUI,
   applicationStatusSelectOptions,
   appealDecisionRadioItems,
+  tierQualificationPage,
 }

--- a/server/utils/taskListUtils.test.ts
+++ b/server/utils/taskListUtils.test.ts
@@ -1,9 +1,24 @@
+import { when } from 'jest-when'
 import { TaskStatus as TaskListStatus, TaskWithStatus } from '../@types/ui'
 import applyPaths from '../paths/apply'
 import assessPaths from '../paths/assess'
 import { applicationFactory, assessmentFactory } from '../testutils/factories'
 import { TaskListStatusTag, taskLink } from './taskListUtils'
+import { isApplicableTier, isFullPerson } from './personUtils'
 
+jest.mock('./personUtils')
+
+beforeEach(() => {
+  when(isFullPerson as jest.MockedFunction<typeof isFullPerson>)
+    .calledWith(expect.anything())
+    .mockReturnValue(true)
+  when(isApplicableTier as jest.Mock)
+    .calledWith(expect.anything(), expect.anything())
+    .mockReturnValue(true)
+})
+afterEach(() => {
+  jest.resetAllMocks()
+})
 describe('taskListUtils', () => {
   const task = {
     id: 'second-task',
@@ -66,6 +81,24 @@ describe('taskListUtils', () => {
             task: 'second-task',
             page: 'foo',
           })}" aria-describedby="eligibility-second-task" data-cy-task-name="second-task">Second Task</a>`,
+        )
+      })
+
+      it('should return a link of is-exceptional-case if page is basic information and risk tier not applicable', () => {
+        const basicTask = {
+          id: 'basic-information',
+          title: 'Basic Information',
+          pages: { foo: 'bar', bar: 'baz' },
+          status: 'in_progress',
+        } as TaskWithStatus
+        ;(isApplicableTier as jest.MockedFunction<typeof isApplicableTier>).mockReturnValue(false)
+
+        expect(taskLink(basicTask, application)).toEqual(
+          `<a href="${applyPaths.applications.pages.show({
+            id: application.id,
+            task: 'basic-information',
+            page: 'is-exceptional-case',
+          })}" aria-describedby="eligibility-basic-information" data-cy-task-name="basic-information">Basic Information</a>`,
         )
       })
     })

--- a/server/utils/taskListUtils.ts
+++ b/server/utils/taskListUtils.ts
@@ -4,6 +4,7 @@ import applyPaths from '../paths/apply'
 import assessPaths from '../paths/assess'
 import isAssessment from './assessments/isAssessment'
 import { StatusTag, StatusTagOptions } from './statusTag'
+import { tierQualificationPage } from './applications/utils'
 
 export const taskLink = (task: TaskWithStatus, applicationOrAssessment: Application | Assessment): string => {
   if (task.status !== 'cannot_start') {
@@ -15,7 +16,8 @@ export const taskLink = (task: TaskWithStatus, applicationOrAssessment: Applicat
           task: task.id,
           page: firstPage,
         })
-      : applyPaths.applications.pages.show({
+      : (task.id === 'basic-information' && tierQualificationPage(applicationOrAssessment)) ||
+        applyPaths.applications.pages.show({
           id: applicationOrAssessment.id,
           task: task.id,
           page: firstPage,


### PR DESCRIPTION
…eligible, if they return they're always prompted to select risk level

# Context

<!-- https://dsdmoj.atlassian.net/browse/APS-812 -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
If users navigates away from application when told tier not eligible, if they return they're always prompted to select risk level
## Screenshots of UI changes
No changes in UI
### Before

### After
