### PR TITLE
Use new triggerSource to show 'System' allocation of applications.

### DIFF
--- a/server/@types/shared/index.d.ts
+++ b/server/@types/shared/index.d.ts
@@ -253,6 +253,7 @@ export type { TimelineEvent } from './models/TimelineEvent';
 export type { TimelineEventAssociatedUrl } from './models/TimelineEventAssociatedUrl';
 export type { TimelineEventType } from './models/TimelineEventType';
 export type { TimelineEventUrlType } from './models/TimelineEventUrlType';
+export type { TriggerSourceType } from './models/TriggerSourceType';
 export type { Turnaround } from './models/Turnaround';
 export type { UnknownPerson } from './models/UnknownPerson';
 export type { UpdateApplication } from './models/UpdateApplication';

--- a/server/@types/shared/models/TimelineEvent.ts
+++ b/server/@types/shared/models/TimelineEvent.ts
@@ -4,6 +4,7 @@
 /* eslint-disable */
 import type { TimelineEventAssociatedUrl } from './TimelineEventAssociatedUrl';
 import type { TimelineEventType } from './TimelineEventType';
+import type { TriggerSourceType } from './TriggerSourceType';
 import type { User } from './User';
 export type TimelineEvent = {
     type?: TimelineEventType;
@@ -12,5 +13,6 @@ export type TimelineEvent = {
     content?: string;
     createdBy?: User;
     associatedUrls?: Array<TimelineEventAssociatedUrl>;
+    triggerSource?: TriggerSourceType;
 };
 

--- a/server/@types/shared/models/TriggerSourceType.ts
+++ b/server/@types/shared/models/TriggerSourceType.ts
@@ -1,0 +1,5 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type TriggerSourceType = 'user' | 'system';

--- a/server/testutils/factories/timeline.ts
+++ b/server/testutils/factories/timeline.ts
@@ -27,6 +27,7 @@ export const timelineEventFactory = Factory.define<TimelineEvent>(() => ({
   content: Math.random() < 0.5 ? faker.lorem.sentences() : undefined,
   createdBy: userFactory.build(),
   associatedUrls: [{ type: 'application', url: faker.internet.url() }],
+  triggerSource: 'user',
 }))
 
 export const applicationTimelineFactory = Factory.define<ApplicationTimeline>(() => ({

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -796,6 +796,30 @@ describe('utils', () => {
 
       expect(actual[0].content).toEqual('&lt;div&gt;Hello!&lt;/div&gt;')
     })
+
+    it('Sets createdBy to System if triggerSource is `system`', () => {
+      const timelineEvents = timelineEventFactory.buildList(1, { triggerSource: 'system' })
+
+      expect(mapApplicationTimelineEventsForUi(timelineEvents)).toEqual([
+        {
+          datetime: {
+            timestamp: timelineEvents[0].occurredAt,
+            date: DateFormats.isoDateTimeToUIDateTime(timelineEvents[0].occurredAt),
+          },
+          label: {
+            text: eventTypeTranslations[timelineEvents[0].type],
+          },
+          content: escape(timelineEvents[0].content),
+          createdBy: 'System',
+          associatedUrls: mapTimelineUrlsForUi([
+            {
+              type: timelineEvents[0].associatedUrls[0].type,
+              url: timelineEvents[0].associatedUrls[0].url,
+            },
+          ]),
+        },
+      ])
+    })
   })
 
   describe('mapTimelineUrlsForUi', () => {

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -301,10 +301,12 @@ const mapApplicationTimelineEventsForUi = (timelineEvents: Array<TimelineEvent>)
         content: escape(timelineEvent.content),
         associatedUrls: timelineEvent.associatedUrls ? mapTimelineUrlsForUi(timelineEvent.associatedUrls) : [],
       }
-      if (timelineEvent.createdBy?.name) {
+
+      const createdBy = timelineEvent.triggerSource === 'system' ? 'System' : timelineEvent.createdBy?.name
+      if (createdBy) {
         return {
           ...event,
-          createdBy: timelineEvent.createdBy?.name,
+          createdBy,
         }
       }
       return event


### PR DESCRIPTION
# Context
The addition of a new property provided in the API response for timeline events, 'triggerSource',  will allow the UI to provide accurate information on whether an allocation made at the time an application was submitted (CAS1) was generated by a user or by the system.   
Prior to this change, the timeline would incorrectly indicate that the submitting user had made an allocation rather than the system. 

Further detail of the issue can be found in this [Jira Ticket](https://dsdmoj.atlassian.net/browse/APS-326).

# Changes in this PR

## Screenshots of UI changes

### Before
![before](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/169666930/39988567-5970-44b7-b658-747c7e842227)
### After
<img width="814" alt="after" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/169666930/f1d660f4-8206-4e3f-82fe-7f81e136c3c0">
