### PR TITLE
APS-785: Improve UX when advancing through the 5 OASys steps for risk

### DIFF
--- a/integration_tests/pages/apply/offenceDetails.ts
+++ b/integration_tests/pages/apply/offenceDetails.ts
@@ -9,7 +9,7 @@ export default class OffenceDetails extends ApplyPage {
     private readonly offenceDetailSummaries: ArrayOfOASysOffenceDetailsQuestions,
     private readonly oasysMissing: boolean,
   ) {
-    const title = oasysMissing ? 'Provide risk information' : 'Edit risk information'
+    const title = oasysMissing ? 'Provide risk information' : 'Offence details'
     super(
       title,
       application,

--- a/integration_tests/pages/apply/riskManagementPlan.ts
+++ b/integration_tests/pages/apply/riskManagementPlan.ts
@@ -9,7 +9,7 @@ export default class RiskManagementPlan extends ApplyPage {
     private readonly riskRiskManagementPlanSummaries: ArrayOfOASysRiskManagementPlanQuestions,
     private readonly oasysMissing: boolean,
   ) {
-    const title = oasysMissing ? 'Provide risk information' : 'Edit risk information'
+    const title = oasysMissing ? 'Provide risk information' : 'Risk management plan'
 
     super(
       title,

--- a/integration_tests/pages/apply/riskToSelf.ts
+++ b/integration_tests/pages/apply/riskToSelf.ts
@@ -9,7 +9,7 @@ export default class RiskToSelf extends ApplyPage {
     private readonly riskToSelfummaries: ArrayOfOASysRiskToSelfQuestions,
     private readonly oasysMissing: boolean,
   ) {
-    const title = oasysMissing ? 'Provide risk information' : 'Edit risk information'
+    const title = oasysMissing ? 'Provide risk information' : 'Risk to self'
 
     super(
       title,

--- a/integration_tests/pages/apply/roshSummary.ts
+++ b/integration_tests/pages/apply/roshSummary.ts
@@ -9,7 +9,7 @@ export default class RoshSummary extends ApplyPage {
     private readonly roshSummary: ArrayOfOASysRiskOfSeriousHarmSummaryQuestions,
     private readonly oasysMissing: boolean,
   ) {
-    const title = oasysMissing ? 'Provide risk information' : 'Edit risk information'
+    const title = oasysMissing ? 'Provide risk information' : 'RoSH summary'
 
     super(
       title,

--- a/integration_tests/pages/apply/supportingInformation.ts
+++ b/integration_tests/pages/apply/supportingInformation.ts
@@ -9,7 +9,7 @@ export default class SupportingInformation extends ApplyPage {
     private readonly supportingInformationSummaries: ArrayOfOASysSupportingInformationQuestions,
     private readonly oasysMissing: boolean,
   ) {
-    const title = oasysMissing ? 'Provide risk information' : 'Edit risk information'
+    const title = oasysMissing ? 'Provide risk information' : 'Supporting information'
 
     super(
       title,

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.ts
@@ -15,7 +15,9 @@ type OffenceDetailsBody = {
   bodyProperties: ['offenceDetailsAnswers', 'offenceDetailsSummaries'],
 })
 export default class OffenceDetails implements OasysPage {
-  title = 'Edit risk information'
+  title = 'Offence details'
+
+  riskTaskStep = 2
 
   offenceDetailsSummaries: OffenceDetailsBody['offenceDetailsSummaries']
 

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.ts
@@ -15,7 +15,9 @@ type RiskManagementBody = {
   bodyProperties: ['riskManagementAnswers', 'riskManagementSummaries'],
 })
 export default class RiskManagementPlan implements OasysPage {
-  title = 'Edit risk information'
+  title = 'Risk management plan'
+
+  riskTaskStep = 4
 
   riskManagementSummaries: RiskManagementBody['riskManagementSummaries'] = []
 

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.ts
@@ -15,7 +15,9 @@ type RiskToSelfBody = {
   bodyProperties: ['riskToSelfAnswers', 'riskToSelfSummaries'],
 })
 export default class RiskToSelf implements OasysPage {
-  title = 'Edit risk information'
+  title = 'Risk to self'
+
+  riskTaskStep = 5
 
   riskToSelfSummaries: RiskToSelfBody['riskToSelfSummaries']
 

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
@@ -16,7 +16,9 @@ type RoshSummaryBody = {
   bodyProperties: ['roshAnswers', 'roshSummaries'],
 })
 export default class RoshSummary implements OasysPage {
-  title = 'Edit risk information'
+  title = 'RoSH summary'
+
+  riskTaskStep = 1
 
   roshSummaries: RoshSummaryBody['roshSummaries']
 

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.ts
@@ -15,7 +15,9 @@ type SupportingInformationBody = {
   bodyProperties: ['supportingInformationAnswers', 'supportingInformationSummaries'],
 })
 export default class SupportingInformation implements OasysPage {
-  title = 'Edit risk information'
+  title = 'Supporting information'
+
+  riskTaskStep = 3
 
   supportingInformationSummaries: SupportingInformationBody['supportingInformationSummaries']
 

--- a/server/views/applications/pages/oasys-import/_oasys-screen.njk
+++ b/server/views/applications/pages/oasys-import/_oasys-screen.njk
@@ -17,7 +17,8 @@
       {% if oasysDisabled or page.oasysSuccess == false %}
         <h1 class="govuk-heading-l">Provide risk information</h1>
       {% else %}
-        <h1 class="govuk-heading-l">{{page.title}}</h1>
+        <h1 class="govuk-heading-l govuk-!-margin-bottom-2">{{page.title}}</h1>
+        <p>Risk Information (part {{page.riskTaskStep}} of 5)</p>
         <p>OASys last updated: {{formatDate(page.oasysCompleted)}}</p>
       {% endif %}
 


### PR DESCRIPTION
# Context

<!-- https://dsdmoj.atlassian.net/browse/APS-785 -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
 Improve UX when advancing through the 5 OASys steps for risk
## Screenshots of UI changes

### Before
<img width="1728" alt="Screenshot 2024-05-24 at 13 35 46" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/35a1ec79-d6d9-4306-87d8-f8814aaaab49">

### After
<img width="1728" alt="Screenshot 2024-05-23 at 15 12 42" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/71c87528-2551-451b-9a05-71c53fca8fa7">
<img width="1728" alt="Screenshot 2024-05-23 at 15 12 51" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/c22f1a8b-5c4a-43b0-ad86-b7f030cddad5">
<img width="1728" alt="Screenshot 2024-05-23 at 15 12 58" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/899b344f-078f-438e-b99d-0428a51dc484">
<img width="1728" alt="Screenshot 2024-05-23 at 15 13 05" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/35452004-da30-4640-b1c0-d3c708981eb2">
<img width="1728" alt="Screenshot 2024-05-23 at 15 14 10" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/b874214e-b793-49b0-a4c8-ca6d3e665038">
