### PR TITLE
Add scripts to generate applications

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,10 @@
     "int-test-ui": "cypress open --e2e --browser chrome",
     "clean": "rm -rf dist build node_modules stylesheets",
     "start-test-wiremock": "docker-compose -f docker-compose-test.yml up -d",
-    "generate-types": "script/generate-types"
+    "generate-types": "script/generate-types",
+    "create-application:standard": "APPLICATION_TYPE='standard' npx playwright test --config ./e2e/playwright.config.ts --project=dev utils/createApplication.spec.ts",
+    "create-application:emergency": "APPLICATION_TYPE='emergency' npx playwright test --config ./e2e/playwright.config.ts --project=dev utils/createApplication.spec.ts",
+    "create-application:short-notice": "APPLICATION_TYPE='shortNotice' npx playwright test --config ./e2e/playwright.config.ts --project=dev utils/createApplication.spec.ts"
   },
   "engines": {
     "node": "^20.0.0",


### PR DESCRIPTION
These scripts use Playwright and our E2E test setup to generate applications in dev. They can be used to generate applications locally if the local projecrt is selected.
