### PR TITLE
Add call to init Sentry

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -2,7 +2,7 @@
 
 // Sentry.init needs to be called first before any other imports
 // eslint-disable-next-line import/order
-import { setupSentry } from './middleware/setUpSentry'
+import { initSentry, setupSentry } from './middleware/setUpSentry'
 
 import path from 'path'
 import express from 'express'
@@ -37,6 +37,7 @@ export default function createApp(controllers: Controllers, services: Services):
   app.set('trust proxy', true)
   app.set('port', process.env.PORT || 3000)
 
+  initSentry()
   setupSentry(app)
 
   // Add method-override to allow us to use PUT and DELETE methods

--- a/server/middleware/setUpSentry.ts
+++ b/server/middleware/setUpSentry.ts
@@ -3,36 +3,39 @@ import { Express } from 'express'
 import config from '../config'
 import applicationVersion from '../applicationVersion'
 
-Sentry.init({
-  dsn: config.sentry.dsn,
-  environment: config.environment,
-  release: applicationVersion.gitRef,
-  integrations: [Sentry.httpIntegration()],
-  tracesSampler: samplingContext => {
-    const transactionName = samplingContext?.transactionContext?.name
-    if (
-      transactionName?.includes('ping') ||
-      transactionName?.includes('health') ||
-      transactionName?.includes('assets')
-    ) {
-      return 0
-    }
+export const initSentry = () => {
+  Sentry.init({
+    dsn: config.sentry.dsn,
+    environment: config.environment,
+    release: applicationVersion.gitRef,
+    integrations: [Sentry.httpIntegration()],
+    tracesSampler: samplingContext => {
+      const transactionName = samplingContext?.transactionContext?.name
+      if (
+        transactionName?.includes('ping') ||
+        transactionName?.includes('health') ||
+        transactionName?.includes('assets')
+      ) {
+        return 0
+      }
 
-    if (config.environment === 'prod') {
-      return 1
-    }
+      if (config.environment === 'prod') {
+        return 1
+      }
 
-    // Default sample rate
-    return 0.05
-  },
-})
+      // Default sample rate
+      return 0.05
+    },
+  })
+}
 
 export function setupSentry(app: Express): void {
   if (config.sentry.dsn) {
+    Sentry.setupExpressErrorHandler(app)
+
     // Prevent usernames which are PII from being sent to Sentry
     // https://docs.sentry.io/platforms/python/guides/logging/data-management/sensitive-data/#examples
     const anonymousId = Math.random().toString()
     Sentry.setUser({ id: anonymousId, username: anonymousId })
-    Sentry.setupExpressErrorHandler(app)
   }
 }


### PR DESCRIPTION
When upgrading Sentry (#1832) I missed this.
This copies the approach used:
https://github.com/ministryofjustice/probation-search-ui
