### PR TITLE
Changed output filename for referrals report to applications

### DIFF
--- a/server/utils/reportUtils.test.ts
+++ b/server/utils/reportUtils.test.ts
@@ -5,7 +5,7 @@ describe('reportUtils', () => {
     it('should return a list of report options', () => {
       expect(reportOptions).toEqual([
         {
-          value: 'referrals',
+          value: 'applications',
           text: 'Raw Applications',
           hint: {
             text: 'A raw data extract for applications submitted within the month. Includes data up to the point of assessment completion.',

--- a/server/utils/reportUtils.ts
+++ b/server/utils/reportUtils.ts
@@ -1,5 +1,5 @@
 export const reportInputLabels = {
-  referrals: {
+  applications: {
     text: 'Raw Applications',
     hint: 'A raw data extract for applications submitted within the month. Includes data up to the point of assessment completion.',
   },
@@ -7,7 +7,7 @@ export const reportInputLabels = {
     text: 'Raw requests for placement',
     hint: 'A raw data extract for request for placements created within the month. Includes application data, but does not include matching or booking data.',
   },
-  applications: { text: 'Raw combined applications and placement requests', hint: '' },
+  'applications-and-placement-requests': { text: 'Raw combined applications and placement requests', hint: '' },
   'placement-matching-outcomes': {
     text: 'Raw data for Placement matching outcomes',
     hint: 'A raw data extract to help identify placement matching outcomes. This downloads Match requests based on the Expected Arrival Date.',
@@ -21,7 +21,7 @@ export const reportInputLabels = {
 
 export type ReportType = (keyof typeof reportInputLabels)[number]
 
-export const unusedReports = ['applications'] as Array<string>
+export const unusedReports = ['applications-and-placement-requests'] as Array<string>
 
 export const reportOptions = Object.entries(reportInputLabels)
   .filter(([reportName]) => {


### PR DESCRIPTION
# Context

Changed the filename of the report generated / downloaded for "Raw Applications".
The original filename changed
from :  `referrals-[year]-[month]`
to : `applications-[year]-[month]`

Additionally, the "Raw combined applications and placement requests" report was changed 
from:  `applications-[year]-[month]`
to: `applications-and-placement-requests-[year]-[month]`
This report is currently unavailable (hidden) on the form.


The changes are covered in [this](https://dsdmoj.atlassian.net/browse/APS-611) Jira ticket.

# Changes in this PR

## Screenshots of UI changes

### Before
No obvious change to the UI, it's in the file name of the downloaded file.

### After
