### PR TITLE
APS 842 - Migrate to new lost beds endpoints

### DIFF
--- a/integration_tests/mockApis/lostBed.ts
+++ b/integration_tests/mockApis/lostBed.ts
@@ -12,7 +12,7 @@ export default {
     stubFor({
       request: {
         method: 'POST',
-        url: `/premises/${args.premisesId}/lost-beds`,
+        url: paths.premises.lostBeds.create({ premisesId: args.premisesId }),
       },
       response: {
         status: 201,
@@ -25,7 +25,7 @@ export default {
     stubFor({
       request: {
         method: 'PUT',
-        url: `/premises/${args.premisesId}/lost-beds/${args.lostBed.id}`,
+        url: paths.premises.lostBeds.update({ premisesId: args.premisesId, id: args.lostBed.id }),
       },
       response: {
         status: 201,
@@ -38,7 +38,7 @@ export default {
     stubFor({
       request: {
         method: 'PUT',
-        url: `/premises/${args.premisesId}/lost-beds/${args.lostBed.id}`,
+        url: paths.premises.lostBeds.update({ premisesId: args.premisesId, id: args.lostBed.id }),
       },
       response: {
         status: 400,
@@ -61,7 +61,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/premises/${args.premisesId}/lost-beds`,
+        url: paths.premises.lostBeds.index({ premisesId: args.premisesId }),
       },
       response: {
         status: 200,
@@ -74,7 +74,7 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        url: `/premises/${args.premisesId}/lost-beds/${args.lostBed.id}`,
+        url: paths.premises.lostBeds.show({ premisesId: args.premisesId, id: args.lostBed.id }),
       },
       response: {
         status: 200,
@@ -115,7 +115,7 @@ export default {
       },
     }),
   stubLostBedErrors: (args: { premisesId: string; params: Array<string> }): SuperAgentRequest =>
-    stubFor(errorStub(args.params, `/premises/${args.premisesId}/lost-beds`)),
+    stubFor(errorStub(args.params, paths.premises.lostBeds.create({ premisesId: args.premisesId }))),
 
   stubLostBedReferenceData: (): Promise<Response> => stubFor(lostBedReasons),
 
@@ -123,7 +123,7 @@ export default {
     (
       await getMatchingRequests({
         method: 'POST',
-        url: `/premises/${args.premisesId}/lost-beds`,
+        url: paths.premises.lostBeds.create({ premisesId: args.premisesId }),
       })
     ).body.requests,
 
@@ -131,7 +131,7 @@ export default {
     (
       await getMatchingRequests({
         method: 'PUT',
-        url: `/premises/${args.premisesId}/lost-beds/${args.lostBed.id}`,
+        url: paths.premises.lostBeds.update({ premisesId: args.premisesId, id: args.lostBed.id }),
       })
     ).body.requests,
 

--- a/server/data/lostBedClient.test.ts
+++ b/server/data/lostBedClient.test.ts
@@ -1,10 +1,10 @@
 import LostBedClient from './lostBedClient'
 import { lostBedCancellationFactory, lostBedFactory, newLostBedFactory } from '../testutils/factories'
 import paths from '../paths/api'
-import describeClient from '../testutils/describeClient'
+import { describeCas1NamespaceClient } from '../testutils/describeClient'
 import { NewLostBedCancellation } from '../@types/shared'
 
-describeClient('LostBedClient', provider => {
+describeCas1NamespaceClient('LostBedClient', provider => {
   let lostBedClient: LostBedClient
 
   const token = 'token-1'

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -3,11 +3,15 @@ import { path } from 'static-path'
 const premisesPath = path('/premises')
 const singlePremisesPath = premisesPath.path(':premisesId')
 
+// CAS1 namespace
+
+const cas1NamespacePath = path('/cas1')
+const cas1SinglePremisesPath = cas1NamespacePath.path('premises/:premisesId')
+const lostBedsPath = cas1SinglePremisesPath.path('lost-beds')
+
 // Manage V2 paths
 const managePremisesPath = path('/manage/premises')
 const manageSinglePremisesPath = managePremisesPath.path(':premisesId')
-
-const lostBedsPath = singlePremisesPath.path('lost-beds')
 
 const outOfServiceBedsPath = manageSinglePremisesPath.path('out-of-service-beds')
 

--- a/server/testutils/describeClient.ts
+++ b/server/testutils/describeClient.ts
@@ -5,6 +5,18 @@ import { Pact } from '@pact-foundation/pact'
 import config from '../config'
 
 const describeClient = (consumer: string, fn: (provider: Pact) => void) => {
+  verifyClientMeetsContract(consumer, fn, { cas1Namespace: false })
+}
+
+export const describeCas1NamespaceClient = (consumer: string, fn: (provider: Pact) => void) => {
+  verifyClientMeetsContract(consumer, fn, { cas1Namespace: true })
+}
+
+const verifyClientMeetsContract = (
+  consumer: string,
+  fn: (provider: Pact) => void,
+  { cas1Namespace } = { cas1Namespace: false },
+) => {
   const provider = 'API'
   const dir = path.join(__dirname, '..', '..', 'tmp', 'pacts')
 
@@ -19,7 +31,7 @@ const describeClient = (consumer: string, fn: (provider: Pact) => void) => {
 
     it('meets the contract for the service', () => {
       const pactPath = `${dir}/${consumer}-${provider}.json`
-      expect(pactPath).toMatchOpenAPISpec()
+      expect(pactPath).toMatchOpenAPISpec({ cas1Namespace })
     })
   })
 }

--- a/server/testutils/jest.setup.ts
+++ b/server/testutils/jest.setup.ts
@@ -10,9 +10,32 @@ declare global {
   namespace jest {
     interface Matchers<R> {
       toMatchStringIgnoringWhitespace(expected: string): R
-      toMatchOpenAPISpec(): R
+      toMatchOpenAPISpec({ cas1Namespace }: { cas1Namespace: boolean }): R
     }
   }
+}
+
+const apiSpecPaths = {
+  cas1Spec: path.join(__dirname, '..', '..', 'tmp', 'cas1-api.yml'),
+  apiSpec: path.join(__dirname, '..', '..', 'tmp', 'api.yml'),
+}
+
+const apiSpecs = {
+  cas1: {
+    url: 'https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/main/src/main/resources/static/codegen/built-cas1-api-spec.yml',
+    command: (openAPIUrl: string) => `if [ ! -f ${apiSpecPaths.cas1Spec} ]; then
+    curl -s "${openAPIUrl}" |
+    sed -E 's@/premises@/cas1/premises@g' > ${apiSpecPaths.cas1Spec}
+  fi`,
+    specPath: apiSpecPaths.cas1Spec,
+  },
+  api: {
+    url: 'https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/main/src/main/resources/static/codegen/built-api-spec.yml',
+    command: (openAPIUrl: string) => `if [ ! -f ${apiSpecPaths.apiSpec} ]; then
+    curl -s "${openAPIUrl}" > ${apiSpecPaths.apiSpec}
+  fi`,
+    specPath: apiSpecPaths.apiSpec,
+  },
 }
 
 expect.extend({
@@ -26,19 +49,12 @@ expect.extend({
         : () => `expected received to match expected ${diffStringsUnified(expected, received)}`,
     }
   },
-  toMatchOpenAPISpec(pactPath) {
-    const openAPIUrl =
-      'https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/main/src/main/resources/static/codegen/built-api-spec.yml'
-
-    const openAPIPath = path.join(__dirname, '..', '..', 'tmp', 'api.yml')
+  toMatchOpenAPISpec(pactPath, { cas1Namespace }) {
+    const { url, command, specPath } = cas1Namespace ? apiSpecs.cas1 : apiSpecs.api
 
     try {
-      execSync(`
-        if [ ! -f ${openAPIPath} ]; then
-          curl -s "${openAPIUrl}" > ${openAPIPath}
-        fi
-      `)
-      execSync(`npx swagger-mock-validator ${openAPIPath} ${pactPath}`)
+      execSync(command(url))
+      execSync(`npx swagger-mock-validator ${specPath} ${pactPath}`)
       return {
         message: () => `Swagger mock validator for ${pactPath} did not fail`,
         pass: true,


### PR DESCRIPTION
# Context
[JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&selectedIssue=APS-842&sprints=6188%2C6585) 

The lost beds endpoints [have been namespaced in the API](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1909) so we need to migrate the UI to use them. 

# Changes in this PR
Moving the endpoints over is trivial. 
However the new namespace has introduced a new spec. 
As our client tests [read the API spec](https://github.com/ministryofjustice/hmpps-approved-premises-ui/blob/12491a0e0b698b3773e40638dc5f9f867d6a281c/server/testutils/jest.setup.ts#L29) to validate the correctness of the clients this means we need to introduce a way of telling the tests which spec to read. 
The new spec uses the `servers.url` property which `swagger-mock-validator can't read so we need to borrow some bash scripting from CAS2 in order to prepend the namespace to the URLs.
