### PR TITLE
APS-793 Remove preventDoubleClick from reports download

### DIFF
--- a/server/views/admin/reports/new.njk
+++ b/server/views/admin/reports/new.njk
@@ -75,8 +75,7 @@
 
         {{ govukButton({
             name: 'submit',
-            text: "Download data",
-            preventDoubleClick: true
+            text: "Download data"
         }) }}
       </form>
 


### PR DESCRIPTION
Whilst preventDoubleClick should be used in most places in the application (because buttons typically have a side affect in the API), it isn’t required when downloading reports.

Furthermore, we have found that this is causing issues when running end to end tests because the tests click the button multiple times in quick succession when downloading multiple reports
