### PR TITLE
APS-837 Use report filename provided by the API

### DIFF
--- a/server/data/reportClient.ts
+++ b/server/data/reportClient.ts
@@ -15,13 +15,11 @@ export default class ReportClient {
   }
 
   async getReport(reportName: ReportType, month: string, year: string, response: Response): Promise<void> {
-    const filename = `${reportName}-${year}-${month.padStart(2, '0')}.xlsx`
-    response.set('Content-Disposition', `attachment; filename="${filename}"`)
-
     await this.restClient.pipe(
       {
         path: paths.reports({ reportName }),
         query: createQueryString({ month, year }),
+        passThroughHeaders: ['content-disposition'],
       },
       response,
     )


### PR DESCRIPTION
Instead of managing the report filename in the UI we have decided to move it to the API. This makes it easier to change report formats returned by the API as we don’t need to synchronise such changes with the filenames returned in the UI