### PR TITLE
APS-810:502 error gateway if submitting person timeline multiple time…

### DIFF
--- a/server/controllers/people/timelineController.ts
+++ b/server/controllers/people/timelineController.ts
@@ -28,16 +28,15 @@ export default class TimelineController {
 
       if (!crn?.trim()) {
         addErrorMessageToFlash(req, 'You must enter a CRN', 'crn')
-        res.redirect(paths.timeline.find({}))
+        return res.redirect(paths.timeline.find({}))
       }
 
       try {
         const timeline = await this.personService.getTimeline(req.user.token, crn.trim())
-
-        res.render('people/timeline/show', { timeline, crn, pageHeading: `Timeline for ${crn}` })
+        return res.render('people/timeline/show', { timeline, crn, pageHeading: `Timeline for ${crn}` })
       } catch (error) {
         crnErrorHandling(req, error, crn)
-        res.redirect(paths.timeline.find({}))
+        return res.redirect(paths.timeline.find({}))
       }
     }
   }


### PR DESCRIPTION
…s with no CRN

# Context

<!-- https://dsdmoj.atlassian.net/browse/APS-810 -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Fix 502 error gateway if submitting person timeline multiple times with no CRN
Person timeline crn search gives error on second time submit 
the issue is on TimelineController redirect with out return and so it is updating the response headers after repose send to client
## Screenshots of UI changes
No changes in UI
### Before

### After
