### PR TITLE
APS-822: Populate 'reasonForShortNotice' and 'reasonForShortNoticeOth…

### DIFF
--- a/server/testutils/mockQuestionResponse.ts
+++ b/server/testutils/mockQuestionResponse.ts
@@ -20,9 +20,13 @@ export type RequiredQuestionResponses = {
   applicantUserDetails?: UserDetails
   caseManagerUserDetails?: UserDetails
   caseManagerIsNotApplicant?: boolean
+  reason?: string
+  other?: string
 }
 
 export const mockQuestionResponse = ({
+  reason = 'other',
+  other = 'test',
   postcodeArea = 'ABC 123',
   type = 'standard',
   sentenceType = 'standardDeterminate',
@@ -67,6 +71,8 @@ export const mockQuestionResponse = ({
       }
 
       if (question === 'area') return apAreaId
+      if (question === 'reason') return reason
+      if (question === 'other') return other
     },
   )
   ;(applicantAndCaseManagerDetails as jest.MockedFn<typeof applicantAndCaseManagerDetails>).mockReturnValue({

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -22,6 +22,7 @@ import { noticeTypeFromApplication } from './noticeTypeFromApplication'
 import Situation from '../../form-pages/apply/reasons-for-placement/basic-information/situation'
 import ConfirmYourDetails from '../../form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails'
 import { applicantAndCaseManagerDetails } from './applicantAndCaseManagerDetails'
+import { reasonForShortNoticeDetails } from './reasonForShortNoticeDetails'
 
 type FirstClassFields<T> = T extends UpdateApprovedPremisesApplication
   ? Omit<UpdateApprovedPremisesApplication, 'data'>
@@ -63,6 +64,7 @@ const firstClassFields = <T>(
   const apAreaId = retrieveQuestionResponse(application, ConfirmYourDetails, 'area')
   const { applicantUserDetails, caseManagerUserDetails, caseManagerIsNotApplicant } =
     applicantAndCaseManagerDetails(application)
+  const { reasonForShortNotice, reasonForShortNoticeOther } = reasonForShortNoticeDetails(application)
 
   return {
     isWomensApplication: false,
@@ -78,6 +80,8 @@ const firstClassFields = <T>(
     caseManagerUserDetails,
     caseManagerIsNotApplicant,
     noticeType,
+    reasonForShortNotice,
+    reasonForShortNoticeOther,
   } as FirstClassFields<T>
 }
 

--- a/server/utils/applications/reasonForShortNoticeDetails.test.ts
+++ b/server/utils/applications/reasonForShortNoticeDetails.test.ts
@@ -1,0 +1,52 @@
+import { when } from 'jest-when'
+import { applicationFactory } from '../../testutils/factories'
+import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
+import { startDateOutsideOfNationalStandardsTimescales } from './startDateOutsideOfNationalStandardsTimescales'
+import { reasonForShortNoticeDetails } from './reasonForShortNoticeDetails'
+import ReasonForShortNotice from '../../form-pages/apply/reasons-for-placement/basic-information/reasonForShortNotice'
+
+jest.mock('../retrieveQuestionResponseFromFormArtifact')
+jest.mock('../applications/applicantAndCaseManagerDetails')
+jest.mock('./arrivalDateFromApplication')
+jest.mock('./utils')
+jest.mock('./startDateOutsideOfNationalStandardsTimescales')
+
+jest.mock('../retrieveQuestionResponseFromFormArtifact')
+
+describe('reasonFosShortNoticeDetails', () => {
+  it('returns reason for short notice details if startDate outside of NationalStandardsTimescales ', () => {
+    const application = applicationFactory.build()
+
+    when(startDateOutsideOfNationalStandardsTimescales).calledWith(application).mockReturnValue(true)
+
+    when(retrieveOptionalQuestionResponseFromFormArtifact)
+      .calledWith(application, ReasonForShortNotice, 'reason')
+      .mockReturnValue('reason')
+    when(retrieveOptionalQuestionResponseFromFormArtifact)
+      .calledWith(application, ReasonForShortNotice, 'other')
+      .mockReturnValue('other')
+
+    const { reasonForShortNotice, reasonForShortNoticeOther } = reasonForShortNoticeDetails(application)
+
+    expect(reasonForShortNotice).toEqual('reason')
+    expect(reasonForShortNoticeOther).toEqual('other')
+  })
+
+  it('returns reason for short notice details if startDate is in range of NationalStandardsTimescales ', () => {
+    const application = applicationFactory.build()
+
+    when(startDateOutsideOfNationalStandardsTimescales).calledWith(application).mockReturnValue(false)
+
+    when(retrieveOptionalQuestionResponseFromFormArtifact)
+      .calledWith(application, ReasonForShortNotice, 'reason')
+      .mockReturnValue('reason')
+    when(retrieveOptionalQuestionResponseFromFormArtifact)
+      .calledWith(application, ReasonForShortNotice, 'other')
+      .mockReturnValue('other')
+
+    const { reasonForShortNotice, reasonForShortNoticeOther } = reasonForShortNoticeDetails(application)
+
+    expect(reasonForShortNotice).toEqual(undefined)
+    expect(reasonForShortNoticeOther).toEqual(undefined)
+  })
+})

--- a/server/utils/applications/reasonForShortNoticeDetails.ts
+++ b/server/utils/applications/reasonForShortNoticeDetails.ts
@@ -1,0 +1,24 @@
+import { ApprovedPremisesApplication as Application } from '../../@types/shared'
+import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
+import { startDateOutsideOfNationalStandardsTimescales } from './startDateOutsideOfNationalStandardsTimescales'
+import ReasonForShortNotice from '../../form-pages/apply/reasons-for-placement/basic-information/reasonForShortNotice'
+
+export const reasonForShortNoticeDetails = (
+  application: Application,
+): {
+  reasonForShortNotice: string
+  reasonForShortNoticeOther: string
+} => {
+  const startDateOutsideOfTimescales = startDateOutsideOfNationalStandardsTimescales(application)
+  let reasonForShortNotice
+  let reasonForShortNoticeOther
+  if (startDateOutsideOfTimescales) {
+    reasonForShortNotice = retrieveOptionalQuestionResponseFromFormArtifact(application, ReasonForShortNotice, 'reason')
+    reasonForShortNoticeOther = retrieveOptionalQuestionResponseFromFormArtifact(
+      application,
+      ReasonForShortNotice,
+      'other',
+    )
+  }
+  return { reasonForShortNotice, reasonForShortNoticeOther }
+}


### PR DESCRIPTION
…er' on app submission

# Context

<!-- https://dsdmoj.atlassian.net/browse/APS-822 -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
 Populate 'reasonForShortNotice' and 'reasonForShortNoticeOther' on app submission
## Screenshots of UI changes
No ui changes
### Before

### After
