### PR TITLE
APS-876 Use new CAS1 Report Endpoint

### DIFF
--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -24,12 +24,12 @@ test('download reports', async ({ page }) => {
   // When I download the lost beds report
   const lostBedsDownload = await reportsPage.downloadLostBedsReports({ month, year })
   // Then the file should be downloaded with the correct suggested name
-  expect(lostBedsDownload.suggestedFilename()).toMatch(`lost-beds-${year}-${month}.xlsx`)
+  expect(lostBedsDownload.suggestedFilename()).toMatch(`lost-beds-${year}-${month}-[0-9_]*.xlsx`)
 
   // When I download the applications report
   const applicationsDownload = await reportsPage.downloadRawRequestsForPlacementsReports({ month, year })
   // Then the file should be downloaded with the correct suggested name
-  expect(applicationsDownload.suggestedFilename()).toMatch(`placement-applications-${year}-${month}.xlsx`)
+  expect(applicationsDownload.suggestedFilename()).toMatch(`placement-applications-${year}-${month}-[0-9_]*.xlsx`)
 })
 
 test('manage users', async ({ page }) => {

--- a/server/data/reportClient.test.ts
+++ b/server/data/reportClient.test.ts
@@ -4,10 +4,10 @@ import { createMock } from '@golevelup/ts-jest'
 import ReportClient from './reportClient'
 import paths from '../paths/api'
 
-import describeClient from '../testutils/describeClient'
+import { describeCas1NamespaceClient } from '../testutils/describeClient'
 import { ReportType, reportInputLabels } from '../utils/reportUtils'
 
-describeClient('ReportClient', provider => {
+describeCas1NamespaceClient('ReportClient', provider => {
   let client: ReportClient
 
   const token = 'token-1'
@@ -42,11 +42,6 @@ describeClient('ReportClient', provider => {
         })
 
         await client.getReport(reportName, month, year, response)
-
-        expect(response.set).toHaveBeenCalledWith(
-          'Content-Disposition',
-          `attachment; filename="${reportName}-2023-12.xlsx"`,
-        )
       },
     )
   })

--- a/server/data/reportClient.ts
+++ b/server/data/reportClient.ts
@@ -15,13 +15,11 @@ export default class ReportClient {
   }
 
   async getReport(reportName: ReportType, month: string, year: string, response: Response): Promise<void> {
-    const filename = `${reportName}-${year}-${month.padStart(2, '0')}.xlsx`
-    response.set('Content-Disposition', `attachment; filename="${filename}"`)
-
     await this.restClient.pipe(
       {
         path: paths.reports({ reportName }),
         query: createQueryString({ month, year }),
+        passThroughHeaders: ['content-disposition'],
       },
       response,
     )

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -8,6 +8,7 @@ const singlePremisesPath = premisesPath.path(':premisesId')
 const cas1NamespacePath = path('/cas1')
 const cas1SinglePremisesPath = cas1NamespacePath.path('premises/:premisesId')
 const lostBedsPath = cas1SinglePremisesPath.path('lost-beds')
+const reportsPath = cas1NamespacePath.path('reports')
 
 // Manage V2 paths
 const managePremisesPath = path('/manage/premises')
@@ -63,8 +64,6 @@ const placementRequestPath = placementRequestsPath.path(':id')
 
 const placementApplicationsPath = path('/placement-applications')
 const placementApplicationPath = placementApplicationsPath.path(':id')
-
-const reportsPath = path('/reports')
 
 const tasksPaths = {
   index: tasksPath,

--- a/server/testutils/jest.setup.ts
+++ b/server/testutils/jest.setup.ts
@@ -25,7 +25,8 @@ const apiSpecs = {
     url: 'https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/main/src/main/resources/static/codegen/built-cas1-api-spec.yml',
     command: (openAPIUrl: string) => `if [ ! -f ${apiSpecPaths.cas1Spec} ]; then
     curl -s "${openAPIUrl}" |
-    sed -E 's@/premises@/cas1/premises@g' > ${apiSpecPaths.cas1Spec}
+    sed -E 's@/premises@/cas1/premises@g' |
+    sed -E 's@/reports@/cas1/reports@g' > ${apiSpecPaths.cas1Spec}
   fi`,
     specPath: apiSpecPaths.cas1Spec,
   },

--- a/server/utils/reportUtils.test.ts
+++ b/server/utils/reportUtils.test.ts
@@ -12,28 +12,28 @@ describe('reportUtils', () => {
           },
         },
         {
-          value: 'placement-applications',
+          value: 'placementApplications',
           text: 'Raw requests for placement',
           hint: {
             text: 'A raw data extract for request for placements created within the month. Includes application data, but does not include matching or booking data.',
           },
         },
         {
-          value: 'placement-matching-outcomes',
+          value: 'placementMatchingOutcomes',
           text: 'Raw data for Placement matching outcomes',
           hint: {
             text: 'A raw data extract to help identify placement matching outcomes. This downloads Match requests based on the Expected Arrival Date.',
           },
         },
         {
-          value: 'lost-beds',
+          value: 'lostBeds',
           text: 'Lost beds',
           hint: {
             text: 'A report on all lost beds for that month and how long they were unavailable for.',
           },
         },
         {
-          value: 'daily-metrics',
+          value: 'dailyMetrics',
           text: 'Daily metrics',
           hint: {
             text: 'Counts of key actions across the service grouped by day.',

--- a/server/utils/reportUtils.ts
+++ b/server/utils/reportUtils.ts
@@ -3,25 +3,24 @@ export const reportInputLabels = {
     text: 'Raw Applications',
     hint: 'A raw data extract for applications submitted within the month. Includes data up to the point of assessment completion.',
   },
-  'placement-applications': {
+  placementApplications: {
     text: 'Raw requests for placement',
     hint: 'A raw data extract for request for placements created within the month. Includes application data, but does not include matching or booking data.',
   },
-  'applications-and-placement-requests': { text: 'Raw combined applications and placement requests', hint: '' },
-  'placement-matching-outcomes': {
+  placementMatchingOutcomes: {
     text: 'Raw data for Placement matching outcomes',
     hint: 'A raw data extract to help identify placement matching outcomes. This downloads Match requests based on the Expected Arrival Date.',
   },
-  'lost-beds': {
+  lostBeds: {
     text: 'Lost beds',
     hint: 'A report on all lost beds for that month and how long they were unavailable for.',
   },
-  'daily-metrics': { text: 'Daily metrics', hint: 'Counts of key actions across the service grouped by day.' },
+  dailyMetrics: { text: 'Daily metrics', hint: 'Counts of key actions across the service grouped by day.' },
 } as const
 
 export type ReportType = (keyof typeof reportInputLabels)[number]
 
-export const unusedReports = ['applications-and-placement-requests'] as Array<string>
+export const unusedReports = [] as Array<string>
 
 export const reportOptions = Object.entries(reportInputLabels)
   .filter(([reportName]) => {


### PR DESCRIPTION
This commit downloads reports from the new cas1-specific reports endpoint.

As this new endpoint provides filenames via the Content-Disposition header, this is passed through by the UI. The new filenames included a generated timestamp, so the E2E tests have been updated to reflect this.

This commit also removes unused reports as they are no longer available in the API on the new and old endpoints.

# Context

# Changes in this PR

## Screenshots of UI changes

The UI is unchanged.

The screenshot shows reports downloaded locally, with a timestamp included in the filename which is being provided by the new report endpoint.

![Screenshot 2024-06-07 at 08 22 46](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22135634/dbe53c88-9d42-4ac6-9c89-46fb18bdc6a4)
