### PR TITLE
APS 852  - Use new OOS beds type definitions

### DIFF
--- a/integration_tests/components/bedspaceConflictErrorComponent.ts
+++ b/integration_tests/components/bedspaceConflictErrorComponent.ts
@@ -1,4 +1,4 @@
-import type { Booking, LostBed } from '@approved-premises/api'
+import type { Booking, Cas1OutOfServiceBed, LostBed } from '@approved-premises/api'
 import errorLookups from '../../server/i18n/en/errors.json'
 import Page from '../pages/page'
 import BookingShowPage from '../pages/manage/booking/show'
@@ -12,7 +12,7 @@ export default class BedspaceConflictErrorComponent {
 
   shouldShowDateConflictErrorMessages(
     fields: Array<string>,
-    conflictingEntity: Booking | LostBed,
+    conflictingEntity: Booking | LostBed | Cas1OutOfServiceBed,
     conflictingEntityType: 'booking' | 'lost-bed',
   ): void {
     fields.forEach(field => {

--- a/integration_tests/mockApis/outOfServiceBed.ts
+++ b/integration_tests/mockApis/outOfServiceBed.ts
@@ -33,7 +33,7 @@ export default {
       },
     }),
 
-  stubUpdateOutOfServiceBedErrors: ({ outOfServiceBed, premisesId }): SuperAgentRequest =>
+  stubUpdateOutOfServiceBedErrors: ({ outOfServiceBed, premisesId, params }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'PUT',
@@ -46,12 +46,7 @@ export default {
           type: 'https://example.net/validation-error',
           title: 'Invalid request parameters',
           code: 400,
-          'invalid-params': [
-            {
-              propertyName: `$.endDate`,
-              errorType: 'empty',
-            },
-          ],
+          'invalid-params': params,
         },
       },
     }),

--- a/integration_tests/pages/manage/outOfServiceBeds/outOfServiceBedCreate.ts
+++ b/integration_tests/pages/manage/outOfServiceBeds/outOfServiceBedCreate.ts
@@ -1,9 +1,8 @@
-import type { Booking, Premises } from '@approved-premises/api'
+import type { Booking, Cas1OutOfServiceBed as OutOfServiceBed, Premises } from '@approved-premises/api'
 import paths from '../../../../server/paths/manage'
 
 import Page from '../../page'
 import BedspaceConflictErrorComponent from '../../../components/bedspaceConflictErrorComponent'
-import { OutOfServiceBed } from '../../../../server/@types/ui'
 
 export class OutOfServiceBedCreatePage extends Page {
   private readonly bedspaceConflictErrorComponent: BedspaceConflictErrorComponent
@@ -20,20 +19,24 @@ export class OutOfServiceBedCreatePage extends Page {
   }
 
   public completeForm(outOfServiceBed: OutOfServiceBed): void {
-    const startDate = new Date(Date.parse(outOfServiceBed.startDate))
-    const endDate = new Date(Date.parse(outOfServiceBed.endDate))
+    const outOfServiceFrom = new Date(Date.parse(outOfServiceBed.outOfServiceFrom))
+    const outOfServiceTo = new Date(Date.parse(outOfServiceBed.outOfServiceTo))
 
-    cy.get('input[name="startDate-day"]').type(String(startDate.getDate()))
-    cy.get('input[name="startDate-month"]').type(String(startDate.getMonth() + 1))
-    cy.get('input[name="startDate-year"]').type(String(startDate.getFullYear()))
+    cy.get('input[name="outOfServiceFrom-day"]').type(String(outOfServiceFrom.getDate()))
+    cy.get('input[name="outOfServiceFrom-month"]').type(String(outOfServiceFrom.getMonth() + 1))
+    cy.get('input[name="outOfServiceFrom-year"]').type(String(outOfServiceFrom.getFullYear()))
 
-    cy.get('input[name="endDate-day"]').type(String(endDate.getDate()))
-    cy.get('input[name="endDate-month"]').type(String(endDate.getMonth() + 1))
-    cy.get('input[name="endDate-year"]').type(String(endDate.getFullYear()))
+    cy.get('input[name="outOfServiceTo-day"]').type(String(outOfServiceTo.getDate()))
+    cy.get('input[name="outOfServiceTo-month"]').type(String(outOfServiceTo.getMonth() + 1))
+    cy.get('input[name="outOfServiceTo-year"]').type(String(outOfServiceTo.getFullYear()))
 
-    cy.get('input[name="outOfServiceBed[referenceNumber]"]').type(outOfServiceBed.referenceNumber)
+    if (outOfServiceBed.referenceNumber) {
+      cy.get('input[name="outOfServiceBed[referenceNumber]"]').type(outOfServiceBed.referenceNumber)
+    }
 
-    cy.get('[name="outOfServiceBed[notes]"]').type(outOfServiceBed.notes)
+    if (outOfServiceBed.notes) {
+      cy.get('[name="outOfServiceBed[notes]"]').type(outOfServiceBed.notes)
+    }
   }
 
   public clickSubmit(): void {
@@ -45,7 +48,7 @@ export class OutOfServiceBedCreatePage extends Page {
     conflictingEntityType: 'booking' | 'lost-bed',
   ): void {
     this.bedspaceConflictErrorComponent.shouldShowDateConflictErrorMessages(
-      ['startDate', 'endDate'],
+      ['outOfServiceFrom', 'outOfServiceTo'],
       conflictingEntity,
       conflictingEntityType,
     )

--- a/integration_tests/pages/manage/outOfServiceBeds/outOfServiceBedList.ts
+++ b/integration_tests/pages/manage/outOfServiceBeds/outOfServiceBedList.ts
@@ -1,8 +1,7 @@
-import type { Premises } from '@approved-premises/api'
+import type { Cas1OutOfServiceBed as OutOfServiceBed, Premises } from '@approved-premises/api'
 import paths from '../../../../server/paths/manage'
 
 import Page from '../../page'
-import { OutOfServiceBed } from '../../../../server/@types/ui'
 
 export class OutOfServiceBedListPage extends Page {
   constructor() {
@@ -20,12 +19,14 @@ export class OutOfServiceBedListPage extends Page {
         .parent()
         .parent()
         .within(() => {
-          cy.get('td').eq(0).contains(item.bedName)
-          cy.get('td').eq(1).contains(item.roomName)
-          cy.get('td').eq(2).contains(item.startDate)
-          cy.get('td').eq(3).contains(item.endDate)
+          cy.get('td').eq(0).contains(item.bed.name)
+          cy.get('td').eq(1).contains(item.room.name)
+          cy.get('td').eq(2).contains(item.outOfServiceFrom)
+          cy.get('td').eq(3).contains(item.outOfServiceTo)
           cy.get('td').eq(4).contains(item.reason.name)
-          cy.get('td').eq(5).contains(item.referenceNumber)
+          if (item.referenceNumber) {
+            cy.get('td').eq(5).contains(item.referenceNumber)
+          }
         })
     })
   }

--- a/integration_tests/pages/manage/outOfServiceBeds/outOfServiceBedShow.ts
+++ b/integration_tests/pages/manage/outOfServiceBeds/outOfServiceBedShow.ts
@@ -2,8 +2,7 @@ import paths from '../../../../server/paths/manage'
 
 import Page from '../../page'
 import { DateFormats } from '../../../../server/utils/dateUtils'
-import { OutOfServiceBed } from '../../../../server/@types/ui'
-import { Premises } from '../../../../server/@types/shared'
+import { Cas1OutOfServiceBed as OutOfServiceBed, Premises } from '../../../../server/@types/shared'
 
 export class OutOfServiceBedShowPage extends Page {
   constructor(private readonly outOfServiceBed: OutOfServiceBed) {
@@ -11,20 +10,30 @@ export class OutOfServiceBedShowPage extends Page {
   }
 
   static visit(premisesId: Premises['id'], outOfServiceBed: OutOfServiceBed): OutOfServiceBedShowPage {
-    cy.visit(paths.v2Manage.outOfServiceBeds.show({ premisesId, id: outOfServiceBed.id, bedId: outOfServiceBed.bedId }))
+    cy.visit(
+      paths.v2Manage.outOfServiceBeds.show({ premisesId, id: outOfServiceBed.id, bedId: outOfServiceBed.bed.id }),
+    )
     return new OutOfServiceBedShowPage(outOfServiceBed)
   }
 
   shouldShowOutOfServiceBedDetail(): void {
-    this.assertDefinition('Room number', this.outOfServiceBed.roomName)
-    this.assertDefinition('Bed number', this.outOfServiceBed.bedName)
-    this.assertDefinition('Start date', DateFormats.isoDateToUIDate(this.outOfServiceBed.startDate, { format: 'long' }))
-    this.assertDefinition('End date', DateFormats.isoDateToUIDate(this.outOfServiceBed.startDate, { format: 'long' }))
-    this.assertDefinition('Reference number', this.outOfServiceBed.referenceNumber)
+    this.assertDefinition('Room number', this.outOfServiceBed.room.name)
+    this.assertDefinition('Bed number', this.outOfServiceBed.bed.name)
+    this.assertDefinition(
+      'Out of service from',
+      DateFormats.isoDateToUIDate(this.outOfServiceBed.outOfServiceFrom, { format: 'long' }),
+    )
+    this.assertDefinition(
+      'Out of service to',
+      DateFormats.isoDateToUIDate(this.outOfServiceBed.outOfServiceTo, { format: 'long' }),
+    )
+    if (this.outOfServiceBed.referenceNumber) {
+      this.assertDefinition('Reference number', this.outOfServiceBed.referenceNumber)
+    }
   }
 
-  public completeForm(endDateString: OutOfServiceBed['endDate'], notes: OutOfServiceBed['notes']): void {
-    super.completeDateInputs('endDate', endDateString)
+  public completeForm(endDateString: OutOfServiceBed['outOfServiceTo'], notes: OutOfServiceBed['notes']): void {
+    super.completeDateInputs('outOfServiceTo', endDateString)
 
     cy.get('textarea[name="notes"]').type(String(notes))
   }

--- a/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedCreate.ts
+++ b/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedCreate.ts
@@ -1,9 +1,8 @@
-import type { Booking, Premises } from '@approved-premises/api'
+import type { Booking, Cas1OutOfServiceBed as OutOfServiceBed, Premises } from '@approved-premises/api'
 import paths from '../../../../server/paths/manage'
 
 import Page from '../../page'
 import BedspaceConflictErrorComponent from '../../../components/bedspaceConflictErrorComponent'
-import { OutOfServiceBed } from '../../../../server/@types/ui'
 
 export class OutOfServiceBedCreatePage extends Page {
   private readonly bedspaceConflictErrorComponent: BedspaceConflictErrorComponent
@@ -20,8 +19,8 @@ export class OutOfServiceBedCreatePage extends Page {
   }
 
   public completeForm(outOfServiceBed: OutOfServiceBed): void {
-    const startDate = new Date(Date.parse(outOfServiceBed.startDate))
-    const endDate = new Date(Date.parse(outOfServiceBed.endDate))
+    const startDate = new Date(Date.parse(outOfServiceBed.outOfServiceFrom))
+    const endDate = new Date(Date.parse(outOfServiceBed.outOfServiceTo))
 
     cy.get('input[name="startDate-day"]').type(String(startDate.getDate()))
     cy.get('input[name="startDate-month"]').type(String(startDate.getMonth() + 1))
@@ -45,7 +44,7 @@ export class OutOfServiceBedCreatePage extends Page {
     conflictingEntityType: 'booking' | 'lost-bed',
   ): void {
     this.bedspaceConflictErrorComponent.shouldShowDateConflictErrorMessages(
-      ['startDate', 'endDate'],
+      ['outOfServiceFrom', 'outOfServiceTo'],
       conflictingEntity,
       conflictingEntityType,
     )

--- a/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedList.ts
+++ b/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedList.ts
@@ -1,8 +1,7 @@
-import type { Premises } from '@approved-premises/api'
+import type { Cas1OutOfServiceBed as OutOfServiceBed, Premises } from '@approved-premises/api'
 import paths from '../../../../server/paths/manage'
 
 import Page from '../../page'
-import { OutOfServiceBed } from '../../../../server/@types/ui'
 
 export class OutOfServiceBedListPage extends Page {
   constructor() {
@@ -20,10 +19,10 @@ export class OutOfServiceBedListPage extends Page {
         .parent()
         .parent()
         .within(() => {
-          cy.get('td').eq(0).contains(item.bedName)
-          cy.get('td').eq(1).contains(item.roomName)
-          cy.get('td').eq(2).contains(item.startDate)
-          cy.get('td').eq(3).contains(item.endDate)
+          cy.get('td').eq(0).contains(item.bed.name)
+          cy.get('td').eq(1).contains(item.room.name)
+          cy.get('td').eq(2).contains(item.outOfServiceFrom)
+          cy.get('td').eq(3).contains(item.outOfServiceTo)
           cy.get('td').eq(4).contains(item.reason.name)
           cy.get('td').eq(5).contains(item.referenceNumber)
         })

--- a/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
+++ b/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
@@ -2,8 +2,7 @@ import paths from '../../../../server/paths/manage'
 
 import Page from '../../page'
 import { DateFormats } from '../../../../server/utils/dateUtils'
-import { OutOfServiceBed } from '../../../../server/@types/ui'
-import { Premises } from '../../../../server/@types/shared'
+import { Cas1OutOfServiceBed as OutOfServiceBed, Premises } from '../../../../server/@types/shared'
 
 export class OutOfServiceBedShowPage extends Page {
   constructor(private readonly outOfServiceBed: OutOfServiceBed) {
@@ -11,20 +10,28 @@ export class OutOfServiceBedShowPage extends Page {
   }
 
   static visit(premisesId: Premises['id'], outOfServiceBed: OutOfServiceBed): OutOfServiceBedShowPage {
-    cy.visit(paths.v2Manage.outOfServiceBeds.show({ premisesId, id: outOfServiceBed.id, bedId: outOfServiceBed.bedId }))
+    cy.visit(
+      paths.v2Manage.outOfServiceBeds.show({ premisesId, id: outOfServiceBed.id, bedId: outOfServiceBed.bed.id }),
+    )
     return new OutOfServiceBedShowPage(outOfServiceBed)
   }
 
   shouldShowOutOfServiceBedDetail(): void {
-    this.assertDefinition('Room number', this.outOfServiceBed.roomName)
-    this.assertDefinition('Bed number', this.outOfServiceBed.bedName)
-    this.assertDefinition('Start date', DateFormats.isoDateToUIDate(this.outOfServiceBed.startDate, { format: 'long' }))
-    this.assertDefinition('End date', DateFormats.isoDateToUIDate(this.outOfServiceBed.startDate, { format: 'long' }))
+    this.assertDefinition('Room number', this.outOfServiceBed.room.name)
+    this.assertDefinition('Bed number', this.outOfServiceBed.bed.name)
+    this.assertDefinition(
+      'Start date',
+      DateFormats.isoDateToUIDate(this.outOfServiceBed.outOfServiceFrom, { format: 'long' }),
+    )
+    this.assertDefinition(
+      'End date',
+      DateFormats.isoDateToUIDate(this.outOfServiceBed.outOfServiceTo, { format: 'long' }),
+    )
     this.assertDefinition('Reference number', this.outOfServiceBed.referenceNumber)
   }
 
-  public completeForm(endDateString: OutOfServiceBed['endDate'], notes: OutOfServiceBed['notes']): void {
-    super.completeDateInputs('endDate', endDateString)
+  public completeForm(outOfServiceTo: OutOfServiceBed['outOfServiceTo'], notes: OutOfServiceBed['notes']): void {
+    super.completeDateInputs('endDate', outOfServiceTo)
 
     cy.get('textarea[name="notes"]').type(String(notes))
   }

--- a/integration_tests/tests/v2Manage/beds.cy.ts
+++ b/integration_tests/tests/v2Manage/beds.cy.ts
@@ -1,7 +1,7 @@
-import { bedDetailFactory, bedSummaryFactory, outOfServiceBedFactory } from '../../../server/testutils/factories'
+import { bedDetailFactory, bedSummaryFactory } from '../../../server/testutils/factories'
 
 import { BedShowPage, BedsListPage } from '../../pages/manage'
-import { OutOfServiceBedCreatePage, OutOfServiceBedListPage } from '../../pages/manage/outOfServiceBeds'
+import { OutOfServiceBedCreatePage } from '../../pages/manage/outOfServiceBeds'
 import Page from '../../pages/page'
 import { signIn } from '../signIn'
 
@@ -46,25 +46,5 @@ context('Beds', () => {
 
     // Then I am taken to the mark bed out of service page
     Page.verifyOnPage(OutOfServiceBedCreatePage)
-  })
-
-  it('should allow Future Manager to manage out of service beds from the bed list page', () => {
-    // Given there is an out of service bed in the database
-    const outOfServiceBed = outOfServiceBedFactory.build()
-    cy.task('stubOutOfServiceBed', { premisesId, outOfServiceBed })
-    cy.task('stubLostBedsList', { premisesId, lostBeds: [outOfServiceBed] })
-    cy.task('stubOutOfServiceBedUpdate', { premisesId, outOfServiceBed })
-
-    // Given I am signed in as a future_manager
-    signIn(['future_manager'])
-
-    // When I visit the rooms page
-    const bedsPage = BedsListPage.visit(premisesId, { v2: true })
-
-    // And I click on manage out of service beds
-    bedsPage.clickManageOutOfServiceBeds()
-
-    // Then I should see the list of out of service beds
-    Page.verifyOnPage(OutOfServiceBedListPage)
   })
 })

--- a/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
+++ b/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
@@ -29,12 +29,12 @@ context('OutOfServiceBeds', () => {
     // When I navigate to the out of service bed form
 
     const outOfServiceBed = outOfServiceBedFactory.build({
-      startDate: '2022-02-11',
-      endDate: '2022-03-11',
+      outOfServiceFrom: '2022-02-11',
+      outOfServiceTo: '2022-03-11',
     })
     cy.task('stubOutOfServiceBedCreate', { premisesId: premises.id, outOfServiceBed })
 
-    const page = OutOfServiceBedCreatePage.visit(premises.id, outOfServiceBed.bedId)
+    const page = OutOfServiceBedCreatePage.visit(premises.id, outOfServiceBed.bed.id)
 
     // And I fill out the form
     page.completeForm(outOfServiceBed)
@@ -48,8 +48,8 @@ context('OutOfServiceBeds', () => {
       expect(requests).to.have.length(1)
       const requestBody = JSON.parse(requests[0].body)
 
-      expect(requestBody.startDate).equal(outOfServiceBed.startDate)
-      expect(requestBody.endDate).equal(outOfServiceBed.endDate)
+      expect(requestBody.outOfServiceFrom).equal(outOfServiceBed.outOfServiceFrom)
+      expect(requestBody.outOfServiceTo).equal(outOfServiceBed.outOfServiceTo)
       expect(requestBody.notes).equal(outOfServiceBed.notes)
       expect(requestBody.referenceNumber).equal(outOfServiceBed.referenceNumber)
     })
@@ -68,13 +68,13 @@ context('OutOfServiceBeds', () => {
     // And I miss required fields
     cy.task('stubOutOfServiceBedErrors', {
       premisesId: premises.id,
-      params: ['startDate', 'endDate', 'referenceNumber'],
+      params: ['outOfServiceFrom', 'outOfServiceTo', 'referenceNumber'],
     })
 
     page.clickSubmit()
 
     // Then I should see error messages relating to that field
-    page.shouldShowErrorMessagesForFields(['startDate', 'endDate', 'referenceNumber'])
+    page.shouldShowErrorMessagesForFields(['outOfServiceFrom', 'outOfServiceTo', 'referenceNumber'])
   })
 
   it('should show an error when there are booking conflicts', () => {
@@ -86,8 +86,8 @@ context('OutOfServiceBeds', () => {
     // When I navigate to the out of service bed form
 
     const outOfServiceBed = outOfServiceBedFactory.build({
-      startDate: '2022-02-11',
-      endDate: '2022-03-11',
+      outOfServiceFrom: '2022-02-11',
+      outOfServiceTo: '2022-03-11',
     })
     cy.task('stubOutOfServiceBedConflictError', {
       premisesId: premises.id,
@@ -95,7 +95,7 @@ context('OutOfServiceBeds', () => {
       conflictingEntityType: 'booking',
     })
 
-    const page = OutOfServiceBedCreatePage.visit(premises.id, outOfServiceBed.bedId)
+    const page = OutOfServiceBedCreatePage.visit(premises.id, outOfServiceBed.bed.id)
 
     // And I fill out the form
     page.completeForm(outOfServiceBed)
@@ -143,9 +143,9 @@ context('OutOfServiceBeds', () => {
       outOfServiceBedShowPage.shouldShowOutOfServiceBedDetail()
 
       // // When I fill in the form and submit
-      const newEndDate = '2023-10-12'
+      const newOutOfServiceTo = '2023-10-12'
       const newNote = 'example'
-      outOfServiceBedShowPage.completeForm(newEndDate, newNote)
+      outOfServiceBedShowPage.completeForm(newOutOfServiceTo, newNote)
       outOfServiceBedShowPage.clickSubmit()
 
       // // Then I am taken back to the list of out of service beds
@@ -159,8 +159,8 @@ context('OutOfServiceBeds', () => {
         expect(requests).to.have.length(1)
         const requestBody = JSON.parse(requests[0].body)
 
-        expect(requestBody.startDate).equal(outOfServiceBed.startDate)
-        expect(requestBody.endDate).equal(newEndDate)
+        expect(requestBody.outOfServiceFrom).equal(outOfServiceBed.outOfServiceFrom)
+        expect(requestBody.outOfServiceTo).equal(newOutOfServiceTo)
         expect(requestBody.notes).equal(newNote)
         expect(requestBody.referenceNumber).equal(outOfServiceBed.referenceNumber)
       })
@@ -197,7 +197,7 @@ context('OutOfServiceBeds', () => {
       outOfServiceBedShowPage.clickSubmit()
 
       // Then I should see an error message
-      outOfServiceBedShowPage.shouldShowErrorMessagesForFields(['endDate'])
+      outOfServiceBedShowPage.shouldShowErrorMessagesForFields(['outOfServiceTo'])
     })
 
     it('should allow me to cancel a out of service bed', () => {

--- a/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
+++ b/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
@@ -181,7 +181,12 @@ context('OutOfServiceBeds', () => {
       cy.task('stubUpdateOutOfServiceBedErrors', {
         outOfServiceBed,
         premisesId,
-        params: ['endDate'],
+        params: [
+          {
+            propertyName: `$.outOfServiceTo`,
+            errorType: 'empty',
+          },
+        ],
       })
 
       // When I visit the out of service bed show page

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -22,11 +22,7 @@ import {
   Booking,
   Document,
   FlagsEnvelope,
-  LostBed,
-  LostBedCancellation,
   Mappa,
-  NewLostBed,
-  NewLostBedCancellation,
   OASysSection,
   Person,
   PersonAcctAlert,
@@ -40,7 +36,6 @@ import {
   RiskTier,
   RiskTierLevel,
   RoshRisks,
-  UpdateLostBed,
   ApprovedPremisesUser as User,
   UserQualification,
   ApprovedPremisesUserRole as UserRole,
@@ -512,9 +507,3 @@ export type KeyDetailsArgs = {
 export type TaskSearchQualification = Exclude<UserQualification, 'lao'>
 
 export type BackwardsCompatibleApplyApType = ApType | 'standard'
-
-export type OutOfServiceBed = LostBed
-export type NewOutOfServiceBed = NewLostBed
-export type NewOutOfServiceBedCancellation = NewLostBedCancellation
-export type OutOfServiceBedCancellation = LostBedCancellation
-export type UpdateOutOfServiceBed = UpdateLostBed

--- a/server/controllers/manage/outOfServiceBedsController.test.ts
+++ b/server/controllers/manage/outOfServiceBedsController.test.ts
@@ -39,7 +39,7 @@ describe('OutOfServiceBedsController', () => {
       headers: { referer: referrer },
       params: {
         premisesId,
-        bedId: outOfServiceBed.bedId,
+        bedId: outOfServiceBed.bed.id,
       },
     })
   })
@@ -87,16 +87,16 @@ describe('OutOfServiceBedsController', () => {
 
       request.params = {
         ...request.params,
-        bedId: outOfServiceBed.bedId,
+        bedId: outOfServiceBed.bed.id,
       }
 
       request.body = {
-        'startDate-year': 2022,
-        'startDate-month': 8,
-        'startDate-day': 22,
-        'endDate-year': 2022,
-        'endDate-month': 9,
-        'endDate-day': 22,
+        'outOfServiceFrom-year': 2022,
+        'outOfServiceFrom-month': 8,
+        'outOfServiceFrom-day': 22,
+        'outOfServiceTo-year': 2022,
+        'outOfServiceTo-month': 9,
+        'outOfServiceTo-day': 22,
         outOfServiceBed,
       }
 
@@ -104,8 +104,8 @@ describe('OutOfServiceBedsController', () => {
 
       expect(outOfServiceBedService.createOutOfServiceBed).toHaveBeenCalledWith(token, premisesId, {
         ...outOfServiceBed,
-        startDate: '2022-08-22',
-        endDate: '2022-09-22',
+        outOfServiceFrom: '2022-08-22',
+        outOfServiceTo: '2022-09-22',
         bedId: request.params.bedId,
       })
       expect(request.flash).toHaveBeenCalledWith('success', 'Out of service bed logged')
@@ -142,10 +142,10 @@ describe('OutOfServiceBedsController', () => {
           { ...request },
           { ...response },
           premisesId,
-          ['startDate', 'endDate'],
+          ['outOfServiceFrom', 'outOfServiceTo'],
           err,
           paths.v2Manage.outOfServiceBeds.new({ premisesId: request.params.premisesId, bedId: request.params.bedId }),
-          outOfServiceBed.bedId,
+          outOfServiceBed.bed.id,
         )
       })
     })
@@ -163,7 +163,7 @@ describe('OutOfServiceBedsController', () => {
 
       request.params = {
         ...request.params,
-        bedId: outOfServiceBed.bedId,
+        bedId: outOfServiceBed.bed.id,
       }
 
       await requestHandler(request, response, next)
@@ -199,15 +199,15 @@ describe('OutOfServiceBedsController', () => {
 
       request.params = {
         premisesId,
-        id: outOfServiceBed.id,
+        id: outOfServiceBed.bed.id,
       }
 
       request.body = {
-        'endDate-year': 2022,
-        'endDate-month': 9,
-        'endDate-day': 22,
+        'outOfServiceTo-year': 2022,
+        'outOfServiceTo-month': 9,
+        'outOfServiceTo-day': 22,
         notes: 'a note',
-        startDate: outOfServiceBed.startDate,
+        outOfServiceFrom: outOfServiceBed.outOfServiceFrom,
         reason: outOfServiceBed.reason.id,
         referenceNumber: outOfServiceBed.referenceNumber,
         submit: '',
@@ -217,7 +217,7 @@ describe('OutOfServiceBedsController', () => {
 
       expect(outOfServiceBedService.updateOutOfServiceBed).toHaveBeenCalledWith(
         request.user.token,
-        outOfServiceBed.id,
+        outOfServiceBed.bed.id,
         request.params.premisesId,
         request.body,
       )

--- a/server/controllers/manage/outOfServiceBedsController.ts
+++ b/server/controllers/manage/outOfServiceBedsController.ts
@@ -33,14 +33,14 @@ export default class OutOfServiceBedsController {
     return async (req: Request, res: Response) => {
       const { premisesId, bedId } = req.params
 
-      const { startDate } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'startDate')
-      const { endDate } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'endDate')
+      const { outOfServiceFrom } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'outOfServiceFrom')
+      const { outOfServiceTo } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'outOfServiceTo')
 
       const outOfServiceBed = {
         ...req.body.outOfServiceBed,
         bedId,
-        startDate,
-        endDate,
+        outOfServiceFrom,
+        outOfServiceTo,
       }
 
       try {
@@ -58,7 +58,7 @@ export default class OutOfServiceBedsController {
             req,
             res,
             premisesId,
-            ['startDate', 'endDate'],
+            ['outOfServiceFrom', 'outOfServiceTo'],
             knownError,
             redirectPath,
             bedId,
@@ -108,8 +108,8 @@ export default class OutOfServiceBedsController {
     return async (req: Request, res: Response) => {
       const { premisesId, id } = req.params
 
-      const { endDate } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'endDate')
-      req.body.endDate = endDate
+      const { outOfServiceTo } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'outOfServiceTo')
+      req.body.outOfServiceTo = outOfServiceTo
 
       try {
         if (req.body.cancel === '1') {

--- a/server/data/outOfServiceBedClient.test.ts
+++ b/server/data/outOfServiceBedClient.test.ts
@@ -1,14 +1,17 @@
+import {
+  NewCas1OutOfServiceBedCancellation as NewOutOfServiceBedCancellation,
+  UpdateCas1OutOfServiceBed as UpdateOutOfServiceBed,
+} from '@approved-premises/api'
 import OutOfServiceBedClient from './outOfServiceBedClient'
 import {
   newOutOfServiceBedFactory,
   outOfServiceBedCancellationFactory,
   outOfServiceBedFactory,
 } from '../testutils/factories'
-// import paths from '../paths/api'
-// import describeClient from '../testutils/describeClient'
-import { NewOutOfServiceBedCancellation, UpdateOutOfServiceBed } from '../@types/ui'
+import { describeCas1NamespaceClient } from '../testutils/describeClient'
+import paths from '../paths/api'
 
-xdescribe('OutOfServiceBedClient', () => {
+describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
   let outOfServiceBedClient: OutOfServiceBedClient
 
   const token = 'token-1'
@@ -21,27 +24,25 @@ xdescribe('OutOfServiceBedClient', () => {
 
   describe('create', () => {
     it('should create a outOfServiceBed', async () => {
-      const outOfServiceBed = outOfServiceBedFactory.build({
-        cancellation: {},
-      })
+      const outOfServiceBed = outOfServiceBedFactory.build({})
       const newOutOfServiceBed = newOutOfServiceBedFactory.build()
 
-      // provider.addInteraction({
-      //   state: 'Server is healthy',
-      //   uponReceiving: 'A request to create a lost bed',
-      //   withRequest: {
-      //     method: 'POST',
-      //     path: paths.manage.premises.outOfServiceBeds.create({ premisesId }),
-      //     body: newOutOfServiceBed,
-      //     headers: {
-      //       authorization: `Bearer ${token}`,
-      //     },
-      //   },
-      //   willRespondWith: {
-      //     status: 200,
-      //     body: outOfServiceBed,
-      //   },
-      // })
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to create a lost bed',
+        withRequest: {
+          method: 'POST',
+          path: paths.manage.premises.outOfServiceBeds.create({ premisesId }),
+          body: newOutOfServiceBed,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: outOfServiceBed,
+        },
+      })
 
       const result = await outOfServiceBedClient.create(premisesId, newOutOfServiceBed)
 
@@ -55,21 +56,21 @@ xdescribe('OutOfServiceBedClient', () => {
         cancellation: {},
       })
 
-      // provider.addInteraction({
-      //   state: 'Server is healthy',
-      //   uponReceiving: 'A request to find a lost bed',
-      //   withRequest: {
-      //     method: 'GET',
-      //     path: paths.manage.premises.outOfServiceBeds.show({ premisesId, id: outOfServiceBed.id }),
-      //     headers: {
-      //       authorization: `Bearer ${token}`,
-      //     },
-      //   },
-      //   willRespondWith: {
-      //     status: 200,
-      //     body: outOfServiceBed,
-      //   },
-      // })
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to find a lost bed',
+        withRequest: {
+          method: 'GET',
+          path: paths.manage.premises.outOfServiceBeds.show({ premisesId, id: outOfServiceBed.id }),
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: outOfServiceBed,
+        },
+      })
 
       const result = await outOfServiceBedClient.find('premisesId', outOfServiceBed.id)
 
@@ -81,21 +82,21 @@ xdescribe('OutOfServiceBedClient', () => {
     it('should get all outOfServiceBeds for a premises', async () => {
       const outOfServiceBeds = outOfServiceBedFactory.buildList(2)
 
-      // provider.addInteraction({
-      //   state: 'Server is healthy',
-      //   uponReceiving: 'A request to get lost beds',
-      //   withRequest: {
-      //     method: 'GET',
-      //     path: paths.manage.premises.outOfServiceBeds.index({ premisesId }),
-      //     headers: {
-      //       authorization: `Bearer ${token}`,
-      //     },
-      //   },
-      //   willRespondWith: {
-      //     status: 200,
-      //     body: outOfServiceBeds,
-      //   },
-      // })
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get lost beds',
+        withRequest: {
+          method: 'GET',
+          path: paths.manage.premises.outOfServiceBeds.index({ premisesId }),
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: outOfServiceBeds,
+        },
+      })
 
       const result = await outOfServiceBedClient.get('premisesId')
 
@@ -110,29 +111,29 @@ xdescribe('OutOfServiceBedClient', () => {
       const notes = 'note'
 
       const outOfServiceBedUpdateData: UpdateOutOfServiceBed = {
-        startDate: outOfServiceBed.startDate,
+        startDate: outOfServiceBed.outOfServiceFrom,
         endDate,
         reason: outOfServiceBed.reason.id,
         referenceNumber: outOfServiceBed.referenceNumber,
         notes,
       }
 
-      // provider.addInteraction({
-      //   state: 'Server is healthy',
-      //   uponReceiving: 'A request to update a lost bed',
-      //   withRequest: {
-      //     method: 'PUT',
-      //     path: paths.manage.premises.outOfServiceBeds.update({ premisesId, id: outOfServiceBed.id }),
-      //     body: outOfServiceBedUpdateData,
-      //     headers: {
-      //       authorization: `Bearer ${token}`,
-      //     },
-      //   },
-      //   willRespondWith: {
-      //     status: 200,
-      //     body: outOfServiceBed,
-      //   },
-      // })
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to update a lost bed',
+        withRequest: {
+          method: 'PUT',
+          path: paths.manage.premises.outOfServiceBeds.update({ premisesId, id: outOfServiceBed.id }),
+          body: outOfServiceBedUpdateData,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: outOfServiceBed,
+        },
+      })
 
       const result = await outOfServiceBedClient.update(outOfServiceBed.id, outOfServiceBedUpdateData, 'premisesId')
 
@@ -149,22 +150,22 @@ xdescribe('OutOfServiceBedClient', () => {
         notes,
       }
 
-      // provider.addInteraction({
-      //   state: 'Server is healthy',
-      //   uponReceiving: 'A request to cancel a lost bed',
-      //   withRequest: {
-      //     method: 'POST',
-      //     path: paths.manage.premises.outOfServiceBeds.cancel({ premisesId, id: outOfServiceBedCancellation.id }),
-      //     body: outOfServiceBedCancellationData,
-      //     headers: {
-      //       authorization: `Bearer ${token}`,
-      //     },
-      //   },
-      //   willRespondWith: {
-      //     status: 200,
-      //     body: outOfServiceBedCancellation,
-      //   },
-      // })
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to cancel a lost bed',
+        withRequest: {
+          method: 'POST',
+          path: paths.manage.premises.outOfServiceBeds.cancel({ premisesId, id: outOfServiceBedCancellation.id }),
+          body: outOfServiceBedCancellationData,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: outOfServiceBedCancellation,
+        },
+      })
 
       const result = await outOfServiceBedClient.cancel(
         outOfServiceBedCancellation.id,

--- a/server/data/outOfServiceBedClient.ts
+++ b/server/data/outOfServiceBedClient.ts
@@ -1,16 +1,16 @@
 /* istanbul ignore file */
 
+import {
+  NewCas1OutOfServiceBed as NewOutOfServiceBed,
+  NewCas1OutOfServiceBedCancellation as NewOutOfServiceBedCancellation,
+  Cas1OutOfServiceBed as OutOfServiceBed,
+  Cas1OutOfServiceBedCancellation as OutOfServiceBedCancellation,
+  Premises,
+  UpdateCas1OutOfServiceBed as UpdateOutOfServiceBed,
+} from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
-import {
-  NewOutOfServiceBed,
-  NewOutOfServiceBedCancellation,
-  OutOfServiceBed,
-  OutOfServiceBedCancellation,
-  UpdateOutOfServiceBed,
-} from '../@types/ui'
-import { Premises } from '../@types/shared'
 
 export default class OutOfServiceBedClient {
   restClient: RestClient

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -95,10 +95,20 @@
     "invalid": "The start date is an invalid date",
     "conflict": "This bedspace is not available for these dates"
   },
+  "outOfServiceFrom": {
+    "empty": "You must enter a start date",
+    "invalid": "The start date is an invalid date",
+    "conflict": "This bedspace is not available for these dates"
+  },
   "endDate": {
     "empty": "You must enter a end date",
     "invalid": "The end date is an invalid date",
     "beforeStartDate": "The end date must be before the start date",
+    "conflict": "This bedspace is not available for these dates"
+  },
+  "outOfServiceTo": {
+    "empty": "You must enter an end date",
+    "invalid": "The end date is an invalid date",
     "conflict": "This bedspace is not available for these dates"
   },
   "referenceNumber": { "empty": "You must enter a reference number" },

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -11,10 +11,10 @@ const lostBedsPath = cas1SinglePremisesPath.path('lost-beds')
 const reportsPath = cas1NamespacePath.path('reports')
 
 // Manage V2 paths
-const managePremisesPath = path('/manage/premises')
-const manageSinglePremisesPath = managePremisesPath.path(':premisesId')
+const v2ManagePremisesPath = cas1NamespacePath.path('/premises')
+const v2ManageSinglePremisesPath = v2ManagePremisesPath.path(':premisesId')
 
-const outOfServiceBedsPath = manageSinglePremisesPath.path('out-of-service-beds')
+const outOfServiceBedsPath = v2ManageSinglePremisesPath.path('out-of-service-beds')
 
 const bedsPath = singlePremisesPath.path('beds')
 

--- a/server/services/outOfServiceBedService.test.ts
+++ b/server/services/outOfServiceBedService.test.ts
@@ -6,7 +6,6 @@ import {
   outOfServiceBedCancellationFactory,
   outOfServiceBedFactory,
 } from '../testutils/factories'
-import { LostBed, NewLostBed, NewLostBedCancellation } from '../@types/shared'
 
 jest.mock('../data/outOfServiceBedClient.ts')
 jest.mock('../data/referenceDataClient.ts')
@@ -27,8 +26,8 @@ describe('OutOfServiceBedService', () => {
 
   describe('createOutOfServiceBed', () => {
     it('on success returns the outOfServiceBed that has been posted', async () => {
-      const outOfServiceBed: LostBed = outOfServiceBedFactory.build()
-      const newOutOfServiceBed: NewLostBed = newOutOfServiceBedFactory.build()
+      const outOfServiceBed = outOfServiceBedFactory.build()
+      const newOutOfServiceBed = newOutOfServiceBedFactory.build()
 
       const token = 'SOME_TOKEN'
       outOfServiceBedClient.create.mockResolvedValue(outOfServiceBed)
@@ -43,7 +42,7 @@ describe('OutOfServiceBedService', () => {
 
   describe('getOutOfServiceBed', () => {
     it('on success returns the outOfServiceBed that has been posted', async () => {
-      const outOfServiceBed: LostBed = outOfServiceBedFactory.build()
+      const outOfServiceBed = outOfServiceBedFactory.build()
 
       const token = 'SOME_TOKEN'
       outOfServiceBedClient.find.mockResolvedValue(outOfServiceBed)
@@ -58,7 +57,7 @@ describe('OutOfServiceBedService', () => {
 
   describe('getOutOfServiceBeds', () => {
     it('on success returns the outOfServiceBeds for a premises', async () => {
-      const expectedOutOfServiceBeds: Array<LostBed> = outOfServiceBedFactory.buildList(2)
+      const expectedOutOfServiceBeds = outOfServiceBedFactory.buildList(2)
 
       const token = 'SOME_TOKEN'
       outOfServiceBedClient.get.mockResolvedValue(expectedOutOfServiceBeds)
@@ -73,7 +72,7 @@ describe('OutOfServiceBedService', () => {
 
   describe('updateOutOfServiceBed', () => {
     it('updates and returns the specified outOfService bed', async () => {
-      const outOfServiceBed: LostBed = outOfServiceBedFactory.build()
+      const outOfServiceBed = outOfServiceBedFactory.build()
       const endDate = '2022-09-22'
       const notes = 'note'
 
@@ -81,7 +80,7 @@ describe('OutOfServiceBedService', () => {
       outOfServiceBedClient.update.mockResolvedValue(outOfServiceBed)
 
       const outOfServiceBedUpdateData = {
-        startDate: outOfServiceBed.startDate,
+        startDate: outOfServiceBed.outOfServiceFrom,
         endDate,
         reason: outOfServiceBed.reason.id,
         referenceNumber: outOfServiceBed.referenceNumber,
@@ -108,7 +107,7 @@ describe('OutOfServiceBedService', () => {
   describe('cancelOutOfServiceBed', () => {
     it('cancels and returns the cancelled outOfService bed', async () => {
       const outOfServiceBedId = 'outOfServiceBedId'
-      const newOutOfServiceBedCancellation: NewLostBedCancellation = {
+      const newOutOfServiceBedCancellation = {
         notes: 'some notes',
       }
       const outOfServiceBedCancellation = outOfServiceBedCancellationFactory.build()

--- a/server/services/outOfServiceBedService.ts
+++ b/server/services/outOfServiceBedService.ts
@@ -1,10 +1,10 @@
 import type {
-  NewOutOfServiceBed,
-  NewOutOfServiceBedCancellation,
-  OutOfServiceBed,
-  OutOfServiceBedCancellation,
-  UpdateOutOfServiceBed,
-} from '@approved-premises/ui'
+  NewCas1OutOfServiceBed as NewOutOfServiceBed,
+  NewCas1OutOfServiceBedCancellation as NewOutOfServiceBedCancellation,
+  Cas1OutOfServiceBed as OutOfServiceBed,
+  Cas1OutOfServiceBedCancellation as OutOfServiceBedCancellation,
+  UpdateCas1OutOfServiceBed as UpdateOutOfServiceBed,
+} from '@approved-premises/api'
 import type { OutOfServiceBedClient, RestClientBuilder } from '../data'
 import { Premises } from '../@types/shared'
 

--- a/server/testutils/factories/outOfServiceBed.ts
+++ b/server/testutils/factories/outOfServiceBed.ts
@@ -1,22 +1,36 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
+import {
+  NamedId,
+  NewCas1OutOfServiceBed as NewOutOfServiceBed,
+  Cas1OutOfServiceBed as OutOfServiceBed,
+  Cas1OutOfServiceBedCancellation as OutOfServiceBedCancellation,
+} from '../../@types/shared'
 
 import referenceDataFactory from './referenceData'
 import { DateFormats } from '../../utils/dateUtils'
-import { NewOutOfServiceBed, OutOfServiceBed, OutOfServiceBedCancellation } from '../../@types/ui'
 
 export const outOfServiceBedFactory = Factory.define<OutOfServiceBed>(() => ({
   id: faker.string.uuid(),
-  bedId: faker.string.uuid(),
-  bedName: faker.lorem.words(3),
-  roomName: faker.lorem.words(3),
-  notes: faker.lorem.sentence(),
-  startDate: DateFormats.dateObjToIsoDate(faker.date.soon()),
-  endDate: DateFormats.dateObjToIsoDate(faker.date.future()),
-  referenceNumber: faker.string.uuid(),
-  reason: referenceDataFactory.lostBedReasons().build(),
-  status: 'active',
-  cancellation: { id: faker.string.uuid(), createdAt: DateFormats.dateObjToIsoDateTime(faker.date.past()) },
+  createdAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
+  outOfServiceFrom: DateFormats.dateObjToIsoDate(faker.date.future()),
+  outOfServiceTo: DateFormats.dateObjToIsoDate(faker.date.future()),
+  bed: namedIdFactory.build(),
+  room: namedIdFactory.build(),
+  premises: namedIdFactory.build(),
+  apArea: namedIdFactory.build(),
+  reason: referenceDataFactory.outOfServiceBedReason().build(),
+  referenceNumber: faker.helpers.arrayElement([faker.string.uuid(), undefined]),
+  notes: faker.helpers.arrayElement([faker.lorem.sentence(), undefined]),
+  daysLostCount: faker.number.int({ min: 1, max: 100 }),
+  temporality: faker.helpers.arrayElement(['past', 'current', 'future'] as const),
+  status: faker.helpers.arrayElement(['active', 'cancelled'] as const),
+  cancellation: undefined,
+}))
+
+const namedIdFactory = Factory.define<NamedId>(() => ({
+  id: faker.string.uuid(),
+  name: faker.lorem.word(),
 }))
 
 export const newOutOfServiceBedFactory = Factory.define<NewOutOfServiceBed>(() => {

--- a/server/testutils/factories/referenceData.ts
+++ b/server/testutils/factories/referenceData.ts
@@ -10,6 +10,7 @@ import cancellationReasonsJson from '../referenceData/stubs/cancellation-reasons
 import lostBedReasonsJson from '../referenceData/stubs/lost-bed-reasons.json'
 import nonArrivalReasonsJson from '../referenceData/stubs/non-arrival-reasons.json'
 import probationRegionsJson from '../referenceData/stubs/probation-regions.json'
+import outOfServiceBedReasonsJson from '../referenceData/stubs/out-of-service-bed-reasons.json'
 import { ApArea, ProbationRegion } from '../../@types/shared'
 
 class ReferenceDataFactory extends Factory<ReferenceData> {
@@ -45,6 +46,11 @@ class ReferenceDataFactory extends Factory<ReferenceData> {
 
   probationRegions() {
     const data = faker.helpers.arrayElement(probationRegionsJson)
+    return this.params(data)
+  }
+
+  outOfServiceBedReason() {
+    const data = faker.helpers.arrayElement(outOfServiceBedReasonsJson)
     return this.params(data)
   }
 }

--- a/server/testutils/referenceData/stubs/out-of-service-bed-reasons.json
+++ b/server/testutils/referenceData/stubs/out-of-service-bed-reasons.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "78b9c1a4-1d60-11ed-861d-0242ac120002",
+    "name": "Fire",
+    "isActive": true
+  },
+  {
+    "id": "51b44b8c-f7f3-415d-90c3-61bb7fb96286",
+    "name": "Damaged",
+    "isActive": true
+  },
+  {
+    "id": "9ddc9bfc-72fa-4a25-88c0-cc0ff8c6c00e",
+    "name": "Refurbishment",
+    "isActive": true
+  },
+  {
+    "id": "7f3eb6cd-b3fc-4a8d-b9ce-5959918ffbe8",
+    "name": "Staff shortage",
+    "isActive": true
+  },
+  {
+    "id": "1f2eb6cd-b3fc-4a8d-b9ce-5959918ffbe8",
+    "name": "Planned FM works required",
+    "isActive": true
+  }
+]

--- a/server/utils/outOfServiceBedUtils.test.ts
+++ b/server/utils/outOfServiceBedUtils.test.ts
@@ -88,10 +88,10 @@ describe('outOfServiceBedUtils', () => {
 
       const expectedRows = [
         [
-          { text: outOfServiceBed.bedName },
-          { text: outOfServiceBed.roomName },
-          { text: outOfServiceBed.startDate },
-          { text: outOfServiceBed.endDate },
+          { text: outOfServiceBed.bed.name },
+          { text: outOfServiceBed.room.name },
+          { text: outOfServiceBed.outOfServiceFrom },
+          { text: outOfServiceBed.outOfServiceTo },
           { text: outOfServiceBed.reason.name },
           { text: outOfServiceBed.referenceNumber },
           actionCell(outOfServiceBed, premisesId),
@@ -105,10 +105,10 @@ describe('outOfServiceBedUtils', () => {
       const user = userDetailsFactory.build({ roles: ['manager'] })
       const expectedRows = [
         [
-          { text: outOfServiceBed.bedName },
-          { text: outOfServiceBed.roomName },
-          { text: outOfServiceBed.startDate },
-          { text: outOfServiceBed.endDate },
+          { text: outOfServiceBed.bed.name },
+          { text: outOfServiceBed.room.name },
+          { text: outOfServiceBed.outOfServiceFrom },
+          { text: outOfServiceBed.outOfServiceTo },
           { text: outOfServiceBed.reason.name },
           { text: outOfServiceBed.referenceNumber },
         ],
@@ -122,20 +122,20 @@ describe('outOfServiceBedUtils', () => {
     it('returns the correct number of out of service beds for today', () => {
       const outOfServiceBedsForToday = [...Array(getRandomInt(1, 10))].map(() =>
         outOfServiceBedFactory.build({
-          startDate: DateFormats.dateObjToIsoDate(sub(Date.now(), { days: getRandomInt(1, 10) })),
-          endDate: DateFormats.dateObjToIsoDate(add(Date.now(), { days: getRandomInt(1, 10) })),
+          outOfServiceFrom: DateFormats.dateObjToIsoDate(sub(Date.now(), { days: getRandomInt(1, 10) })),
+          outOfServiceTo: DateFormats.dateObjToIsoDate(add(Date.now(), { days: getRandomInt(1, 10) })),
         }),
       )
       const futureOutOfServiceBeds = [...Array(getRandomInt(1, 10))].map(() =>
         outOfServiceBedFactory.build({
-          startDate: DateFormats.dateObjToIsoDate(add(Date.now(), { days: getRandomInt(1, 10) })),
-          endDate: DateFormats.dateObjToIsoDate(add(Date.now(), { days: getRandomInt(1, 10) })),
+          outOfServiceFrom: DateFormats.dateObjToIsoDate(add(Date.now(), { days: getRandomInt(1, 10) })),
+          outOfServiceTo: DateFormats.dateObjToIsoDate(add(Date.now(), { days: getRandomInt(1, 10) })),
         }),
       )
       const pastOutOfServiceBeds = [...Array(getRandomInt(1, 10))].map(() =>
         outOfServiceBedFactory.build({
-          startDate: DateFormats.dateObjToIsoDate(sub(Date.now(), { days: getRandomInt(1, 10) })),
-          endDate: DateFormats.dateObjToIsoDate(sub(Date.now(), { days: getRandomInt(1, 10) })),
+          outOfServiceFrom: DateFormats.dateObjToIsoDate(sub(Date.now(), { days: getRandomInt(1, 10) })),
+          outOfServiceTo: DateFormats.dateObjToIsoDate(sub(Date.now(), { days: getRandomInt(1, 10) })),
         }),
       )
 

--- a/server/utils/outOfServiceBedUtils.ts
+++ b/server/utils/outOfServiceBedUtils.ts
@@ -1,5 +1,5 @@
-import { Premises } from '@approved-premises/api'
-import { OutOfServiceBed, TableCell, UserDetails } from '@approved-premises/ui'
+import { Cas1OutOfServiceBed as OutOfServiceBed, Premises } from '@approved-premises/api'
+import { TableCell, UserDetails } from '@approved-premises/ui'
 
 import { isWithinInterval } from 'date-fns'
 import paths from '../paths/manage'
@@ -42,10 +42,10 @@ export const outOfServiceBedTableHeaders = (user: UserDetails) => {
 export const outOfServiceBedTableRows = (beds: Array<OutOfServiceBed>, premisesId: string, user: UserDetails) => {
   return beds.map(bed => {
     const rows = [
-      textValue(bed.bedName),
-      textValue(bed.roomName),
-      textValue(bed.startDate),
-      textValue(bed.endDate),
+      textValue(bed.bed.name),
+      textValue(bed.room.name),
+      textValue(bed.outOfServiceFrom),
+      textValue(bed.outOfServiceTo),
       textValue(bed.reason.name),
       referenceNumberCell(bed.referenceNumber),
     ]
@@ -66,8 +66,8 @@ export const actionCell = (bed: OutOfServiceBed, premisesId: Premises['id']): Ta
 export const outOfServiceBedCountForToday = (outOfServiceBeds: Array<OutOfServiceBed>): number => {
   return outOfServiceBeds.filter(outOfServiceBed =>
     isWithinInterval(Date.now(), {
-      start: DateFormats.isoToDateObj(outOfServiceBed.startDate),
-      end: DateFormats.isoToDateObj(outOfServiceBed.endDate),
+      start: DateFormats.isoToDateObj(outOfServiceBed.outOfServiceFrom),
+      end: DateFormats.isoToDateObj(outOfServiceBed.outOfServiceTo),
     }),
   ).length
 }
@@ -75,10 +75,10 @@ export const outOfServiceBedCountForToday = (outOfServiceBeds: Array<OutOfServic
 const bedLink = (bed: OutOfServiceBed, premisesId: Premises['id']): string =>
   linkTo(
     paths.v2Manage.outOfServiceBeds.show,
-    { id: bed.id, bedId: bed.bedId, premisesId },
+    { id: bed.id, bedId: bed.bed.id, premisesId },
     {
       text: 'Manage',
-      hiddenText: `Out of service bed ${bed.bedName}`,
+      hiddenText: `Out of service bed ${bed.bed.name}`,
       attributes: { 'data-cy-bedId': bed.id },
     },
   )

--- a/server/views/outOfServiceBeds/new.njk
+++ b/server/views/outOfServiceBeds/new.njk
@@ -31,10 +31,10 @@
         <p> Provide details of beds that are out of service within your AP estate</p>
 
         {{ govukDateInput({
-        id: "startDate",
-        namePrefix: "startDate",
-        items: dateFieldValues('startDate', errors),
-        errorMessage: errors.startDate,
+        id: "outOfServiceFrom",
+        namePrefix: "outOfServiceFrom",
+        items: dateFieldValues('outOfServiceFrom', errors),
+        errorMessage: errors.outOfServiceFrom,
         fieldset: {
           legend: {
             text: "Out of service from",
@@ -44,13 +44,13 @@
       }) }}
 
         {{ govukDateInput({
-        id: "endDate",
-        namePrefix: "endDate",
-        items: dateFieldValues('endDate', errors),
-        errorMessage: errors.endDate,
+        id: "outOfServiceTo",
+        namePrefix: "outOfServiceTo",
+        items: dateFieldValues('outOfServiceTo', errors),
+        errorMessage: errors.outOfServiceTo,
         fieldset: {
           legend: {
-            text: "End date",
+            text: "Out of service to",
             classes: "govuk-fieldset__legend--s"
           }
         }

--- a/server/views/outOfServiceBeds/show.njk
+++ b/server/views/outOfServiceBeds/show.njk
@@ -38,7 +38,7 @@
                 text: "Room number"
               },
               value: {
-                text: outOfServiceBed.roomName
+                text: outOfServiceBed.room.name
               }
             },
             {
@@ -46,23 +46,23 @@
                 text: "Bed number"
               },
               value: {
-                text: outOfServiceBed.bedName
+                text: outOfServiceBed.bed.name
               }
             },
             {
               key: {
-                text: "Start date"
+                text: "Out of service from"
               },
               value: {
-                text: formatDate(outOfServiceBed.startDate, {format: 'long'})
+                text: formatDate(outOfServiceBed.outOfServiceFrom, {format: 'long'})
               }
             },
             {
               key: {
-                text: "End date"
+                text: "Out of service to"
               },
               value: {
-                text: formatDate(outOfServiceBed.endDate, {format: 'long'})
+                text: formatDate(outOfServiceBed.outOfServiceTo, {format: 'long'})
               }
             },
 
@@ -82,22 +82,22 @@
 
       <form action="{{ paths.v2Manage.outOfServiceBeds.update({ id: outOfServiceBed.id, bedId: outOfServiceBed.bedId, premisesId: premisesId }) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-        <input type="hidden" name="startDate" value="{{ outOfServiceBed.startDate }}"/>
+        <input type="hidden" name="outOfServiceFrom" value="{{ outOfServiceBed.outOfServiceFrom }}"/>
         <input type="hidden" name="referenceNumber" value="{{ outOfServiceBed.referenceNumber }}"/>
 
         {{ showErrorSummary(errorSummary, errorTitle) }}
 
         {{ govukDateInput({
-        id: "endDate",
-        namePrefix: "endDate",
-        items: dateFieldValues('endDate', errors),
-        errorMessage: errors.endDate,
+        id: "outOfServiceTo",
+        namePrefix: "outOfServiceTo",
+        items: dateFieldValues('outOfServiceTo', errors),
+        errorMessage: errors.outOfServiceTo,
         hint: {
         text: "For example, 27 3 2007"
         },
         fieldset: {
           legend: {
-            text: "End date",
+            text: "Out of service to",
             classes: "govuk-fieldset__legend--s"
           }
         }


### PR DESCRIPTION
# Context

[jira](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&assignee=712020%3A23fbf793-ee9a-4ecd-ad4d-37beaa0edeaa&selectedIssue=APS-858&sprints=6188%2C6585) 
#1850 introduced some stop-gap changes that allowed us to make a start on the v2 Out Of Service bed functionality without having to wait for the API to have the requisite changes. Now the API is ready we can remove these temporary changes and implement a more permanent solution.

# Changes in this PR
- We introduce the new OOS bed entities and adapt the code to use them
- Use the new OOS bed endpoints in the OOS bed client
- Remove the temporary OOS bed types
