### PR TITLE
Fix typo in user management path

### DIFF
--- a/server/paths/admin.ts
+++ b/server/paths/admin.ts
@@ -4,7 +4,7 @@ const adminPath = path('/admin')
 const placementRequestsPath = adminPath.path('placement-requests')
 const placementRequestPath = placementRequestsPath.path(':id')
 
-const userManagementPath = adminPath.path('user-mangement')
+const userManagementPath = adminPath.path('user-management')
 
 const bookingsPath = placementRequestPath.path('bookings')
 


### PR DESCRIPTION
Previously the URL was `admin/user-mangement/`. Now it is `admin/user-management`