### PR TITLE
APS-876 - Fix test for new report endpoint

### DIFF
--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -24,12 +24,12 @@ test('download reports', async ({ page }) => {
   // When I download the lost beds report
   const lostBedsDownload = await reportsPage.downloadLostBedsReports({ month, year })
   // Then the file should be downloaded with the correct suggested name
-  expect(lostBedsDownload.suggestedFilename()).toMatch(`lost-beds-${year}-${month}-[0-9_]*.xlsx`)
+  expect(lostBedsDownload.suggestedFilename()).toMatch(/lost-beds-2023-01-[0-9_]*.xlsx/)
 
   // When I download the applications report
   const applicationsDownload = await reportsPage.downloadRawRequestsForPlacementsReports({ month, year })
   // Then the file should be downloaded with the correct suggested name
-  expect(applicationsDownload.suggestedFilename()).toMatch(`placement-applications-${year}-${month}-[0-9_]*.xlsx`)
+  expect(applicationsDownload.suggestedFilename()).toMatch(/placement-applications-2023-01-[0-9_]*.xlsx/)
 })
 
 test('manage users', async ({ page }) => {


### PR DESCRIPTION
# Context

Previously the tests for report names were updated to use a regex, but the regex was not correctly defined.

# Changes in this PR

## Screenshots of UI changes

N/A