### PR TITLE
Add referenceNumber to OOS bed

### DIFF
--- a/server/utils/outOfServiceBedUtils.test.ts
+++ b/server/utils/outOfServiceBedUtils.test.ts
@@ -80,7 +80,7 @@ describe('outOfServiceBedUtils', () => {
   })
 
   describe('outOfServiceBedTableRows', () => {
-    const outOfServiceBed = outOfServiceBedFactory.build()
+    const outOfServiceBed = outOfServiceBedFactory.build({ referenceNumber: '123' })
     const premisesId = 'premisesId'
 
     it.each(managerRoles)('returns table rows for a %s', role => {


### PR DESCRIPTION
The factory will either add a reference number or leave it undefined as per the spec. However these tests always need a referenceNumber defined.
