### PR TITLE
Handle bookings without applicationIds

### DIFF
--- a/server/utils/bookings/index.test.ts
+++ b/server/utils/bookings/index.test.ts
@@ -235,20 +235,30 @@ describe('bookingUtils', () => {
 
   describe('v2BookingActions', () => {
     describe('if the booking has a status of awaiting-arrival', () => {
-      it('returns the withdrawal link ', () => {
-        const booking = bookingFactory.arrivingSoon().build()
+      describe('if applicationId is defined', () => {
+        it('returns the withdrawal link ', () => {
+          const booking = bookingFactory.arrivingSoon().build({ applicationId: 'someID' })
 
-        expect(v2BookingActions(booking)).toEqual([
-          {
-            items: [
-              {
-                text: 'Withdraw placement',
-                classes: 'govuk-button--secondary',
-                href: applyPaths.applications.withdraw.new({ id: booking.applicationId }),
-              },
-            ],
-          },
-        ])
+          expect(v2BookingActions(booking)).toEqual([
+            {
+              items: [
+                {
+                  text: 'Withdraw placement',
+                  classes: 'govuk-button--secondary',
+                  href: applyPaths.applications.withdraw.new({ id: 'someID' }),
+                },
+              ],
+            },
+          ])
+        })
+      })
+
+      describe('if applicationId is undefined', () => {
+        it('returns an empty array ', () => {
+          const booking = bookingFactory.arrivingSoon().build({ applicationId: undefined })
+
+          expect(v2BookingActions(booking)).toEqual([])
+        })
       })
     })
   })

--- a/server/utils/bookings/index.ts
+++ b/server/utils/bookings/index.ts
@@ -176,7 +176,7 @@ export const bookingActions = (user: UserDetails, booking: Booking): Array<Ident
 }
 
 export const v2BookingActions = (booking: Booking): Array<IdentityBarMenu> => {
-  if (booking.status === 'awaiting-arrival')
+  if (booking.status === 'awaiting-arrival' && booking?.applicationId)
     return [
       {
         items: [


### PR DESCRIPTION
This was breaking in dev when a booking didn't have an applicationId. The property access was valid but static-path was erroring as it can't create a path where id === undefined.
