### PR TITLE
Add roles for manage.spec.ts

### DIFF
--- a/e2e/tests/manage.spec.ts
+++ b/e2e/tests/manage.spec.ts
@@ -18,6 +18,7 @@ import { ChangePlacementDatesPage } from '../pages/manage/changePlacementDates'
 import { MoveBedPage } from '../pages/manage/moveBedPage'
 import { ChangeDepartureDatePage } from '../pages/manage/changeDepartureDate'
 import { OutOfServiceBedsPage } from '../pages/manage/outOfServiceBedsPage'
+import { setRoles } from '../steps/admin'
 
 const premisesName = 'Test AP 10'
 const apArea = 'South West & South Central'
@@ -95,8 +96,10 @@ test('Manually book a bed', async ({ page, person }) => {
   await manuallyBookPlacement({ page, person, filterPremisesPage: true })
 })
 
-test('Mark a booking as cancelled', async ({ page }) => {
-  // Given there is a placement for today
+test('Mark a booking as cancelled', async ({ page, user }) => {
+  // Given I have the 'legacy_manager' & 'workflow_manager' role
+  await setRoles(page, user.name, ['legacy_manager', 'workflow_manager'])
+  // And there is a placement for today
   // await manuallyBookPlacement(page)
   await navigateToTodaysBooking(page)
   // And I am on the placement's page
@@ -116,8 +119,11 @@ test('Mark a booking as cancelled', async ({ page }) => {
   await placementPage.showsCancellationLoggedMessage()
 })
 
-test('Change placement dates', async ({ page, person }) => {
-  // Given there is a placement for today
+test('Change placement dates', async ({ page, person, user }) => {
+  // Given I have the 'legacy_manager' role
+  await setRoles(page, user.name, ['legacy_manager'])
+
+  // And there is a placement for today
   await manuallyBookPlacement({ page, person })
   await navigateToTodaysBooking(page)
   // And I am on the placement's page
@@ -138,8 +144,10 @@ test('Change placement dates', async ({ page, person }) => {
   await confirmationPage.shouldShowBookingChangeSuccessMessage()
 })
 
-test('Mark a bed as lost', async ({ page }) => {
-  // Given I am on the list of premises page
+test('Mark a bed as lost', async ({ page, user }) => {
+  // Given I have the 'legacy_manager' role
+  await setRoles(page, user.name, ['legacy_manager'])
+  // And I am on the list of premises page
   const dashboard = await visitDashboard(page)
   await dashboard.clickManage()
   const listPage = await PremisesListPage.initialize(page, 'List of Approved Premises')
@@ -168,8 +176,10 @@ test('Mark a bed as lost', async ({ page }) => {
   await premisesPage.showsLostBedLoggedMessage()
 })
 
-test('Mark a booking as arrived and extend it', async ({ page, person }) => {
-  // Given there is a placement for today
+test('Mark a booking as arrived and extend it', async ({ page, person, user }) => {
+  // Given I have the 'legacy_manager' role
+  await setRoles(page, user.name, ['legacy_manager'])
+  // And there is a placement for today
   // And I am on the premises's page
   await manuallyBookPlacement({ page, person })
   await navigateToTodaysBooking(page)
@@ -199,8 +209,10 @@ test('Mark a booking as arrived and extend it', async ({ page, person }) => {
   await confirmationPage.shouldShowDepartureDateChangedMessage()
 })
 
-test('Mark a booking as not arrived', async ({ page, person }) => {
-  // Given there is a placement for today
+test('Mark a booking as not arrived', async ({ page, person, user }) => {
+  // Given I have the 'legacy_manager' role
+  await setRoles(page, user.name, ['legacy_manager'])
+  // And there is a placement for today
   // And I am on the premises's page
   await manuallyBookPlacement({ page, person })
   await navigateToPremisesPage(page)
@@ -223,8 +235,10 @@ test('Mark a booking as not arrived', async ({ page, person }) => {
   await placementPage.showsNonArrivalLoggedMessage()
 })
 
-test('Move a booking', async ({ page, person }) => {
-  // Given there is a placement for today
+test('Move a booking', async ({ page, person, user }) => {
+  // Given I have the 'legacy_manager' role
+  await setRoles(page, user.name, ['legacy_manager'])
+  // And there is a placement for today
   // And I am on the premises's page
   await manuallyBookPlacement({ page, person })
   await navigateToPremisesPage(page)
@@ -247,8 +261,10 @@ test('Move a booking', async ({ page, person }) => {
   await placementPage.showsBedMoveLoggedMessage()
 })
 
-test('View all out of service beds', async ({ page }) => {
-  // Given I am on the dashboard page
+test('View all out of service beds', async ({ page, user }) => {
+  // Given I have the 'future_manager' role
+  await setRoles(page, user.name, ['future_manager'])
+  // And I am on the dashboard page
   const dashboard = await visitDashboard(page)
 
   // And I click the 'View out of service beds' tile


### PR DESCRIPTION
These tests were failing because the test users were given all the roles in dev. However 'View all out of service beds' requires the 'future_manager' role to pass and 'Mark a booking as cancelled' requires the user *does not* have the 'future_manager' role to pass. This is because in the `bookingActions` function we will return the v2BookingActions if the user has the 'future_manager' role and the cancellation test neccessitates the 'legacyBookingActions' function. Now we set the roles before each test as we do for the apply and assess tests.
