### PR TITLE
APS-840: Use /applications/{applicationId}/withdrawablesWithNotes and…

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -11,9 +11,8 @@ import type {
   RequestForPlacement,
   SortDirection,
   TimelineEvent,
-  Withdrawable,
 } from '@approved-premises/api'
-
+import { Withdrawables } from '@approved-premises/api'
 import { getMatchingRequests, stubFor } from './setup'
 import paths from '../../server/paths/api'
 import { ApplicationDashboardSearchOptions } from '../../server/@types/ui'
@@ -282,17 +281,18 @@ export default {
         jsonBody: args.note,
       },
     }),
-  stubWithdrawables: ({
+
+  stubWithdrawablesWithNotes: ({
     applicationId,
     withdrawables,
   }: {
     applicationId: string
-    withdrawables: Array<Withdrawable>
+    withdrawables: Withdrawables
   }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
-        url: paths.applications.withdrawables({ id: applicationId }),
+        url: paths.applications.withdrawablesWithNotes({ id: applicationId }),
       },
       response: {
         status: 200,

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -24,6 +24,7 @@ import { withdrawPlacementRequestOrApplication } from '../../support/helpers'
 import paths from '../../../server/paths/api'
 import BookingCancellationConfirmPage from '../../pages/manage/bookingCancellationConfirmation'
 import { allReleaseTypes } from '../../../server/utils/applications/releaseTypeUtils'
+import withdrawablesFactory from '../../../server/testutils/factories/withdrawablesFactory'
 
 context('Placement Requests', () => {
   let application = applicationFactory.build()
@@ -271,9 +272,11 @@ context('Placement Requests', () => {
       booking: matchedPlacementRequest.booking,
     })
     cy.task('stubCancellationReferenceData')
-    cy.task('stubWithdrawables', {
+    const withdrawables = withdrawablesFactory.build({ withdrawables: [withdrawable] })
+
+    cy.task('stubWithdrawablesWithNotes', {
       applicationId: matchedPlacementRequest.applicationId,
-      withdrawables: [withdrawable],
+      withdrawables,
     })
     cy.task('stubBookingFindWithoutPremises', booking)
 
@@ -327,10 +330,15 @@ context('Placement Requests', () => {
   it('allows me to withdraw a placement request', () => {
     cy.task('stubPlacementRequestWithdrawal', unmatchedPlacementRequest)
     const withdrawable = withdrawableFactory.build({ id: unmatchedPlacementRequest.id, type: 'placement_request' })
+    const withdrawables = withdrawablesFactory.build({ withdrawables: [withdrawable] })
 
-    cy.task('stubWithdrawables', {
+    cy.task('stubWithdrawablesWithNotes', {
+      applicationId: matchedPlacementRequest.applicationId,
+      withdrawables,
+    })
+    cy.task('stubWithdrawablesWithNotes', {
       applicationId: application.id,
-      withdrawables: [withdrawable],
+      withdrawables,
     })
 
     // When I visit the tasks dashboard

--- a/integration_tests/tests/apply/viewApplication.cy.ts
+++ b/integration_tests/tests/apply/viewApplication.cy.ts
@@ -15,6 +15,7 @@ import { defaultUserId } from '../../mockApis/auth'
 import paths from '../../../server/paths/api'
 import { withdrawPlacementRequestOrApplication } from '../../support/helpers'
 import applicationDocument from '../../fixtures/applicationDocument.json'
+import withdrawablesFactory from '../../../server/testutils/factories/withdrawablesFactory'
 
 context('show applications', () => {
   beforeEach(setup)
@@ -149,8 +150,12 @@ context('show applications', () => {
       applicationId: application.id,
       requestsForPlacement: [...requestsForPlacement, withdrawableRequestForPlacement],
     })
-    cy.task('stubWithdrawables', { applicationId: application.id, withdrawables: [withdrawable] })
+    const withdrawables = withdrawablesFactory.build({ withdrawables: [withdrawable] })
 
+    cy.task('stubWithdrawablesWithNotes', {
+      applicationId: application.id,
+      withdrawables,
+    })
     cy.task('stubPlacementApplication', placementApplication)
     cy.task('stubSubmitPlacementApplicationWithdraw', placementApplication)
 

--- a/integration_tests/tests/apply/withdrawApplication.cy.ts
+++ b/integration_tests/tests/apply/withdrawApplication.cy.ts
@@ -6,6 +6,7 @@ import WithdrawApplicationPage from '../../pages/apply/withdrawApplicationPage'
 import { setup } from './setup'
 import { applicationSummaryFactory, withdrawableFactory } from '../../../server/testutils/factories'
 import { WithdrawalReason } from '../../../server/@types/shared'
+import withdrawablesFactory from '../../../server/testutils/factories/withdrawablesFactory'
 
 context('Withdraw Application', () => {
   beforeEach(setup)
@@ -23,7 +24,9 @@ context('Withdraw Application', () => {
     cy.task('stubApplicationGet', { application: this.application })
     cy.task('stubApplications', [inProgressApplication])
     cy.task('stubApplicationWithdrawn', { applicationId: inProgressApplication.id })
-    cy.task('stubWithdrawables', { applicationId: inProgressApplication.id, withdrawables: [withdrawable] })
+    const withdrawables = withdrawablesFactory.build({ withdrawables: [withdrawable] })
+
+    cy.task('stubWithdrawablesWithNotes', { applicationId: inProgressApplication.id, withdrawables })
 
     const withdrawalReason: WithdrawalReason = 'other'
     const reasonDescription = 'Some reason'

--- a/integration_tests/tests/manage/cancellation.cy.ts
+++ b/integration_tests/tests/manage/cancellation.cy.ts
@@ -14,6 +14,7 @@ import { BookingShowPage, CancellationCreatePage, PremisesShowPage } from '../..
 import NewWithdrawalPage from '../../pages/apply/newWithdrawal'
 import { signIn } from '../signIn'
 import BookingCancellationConfirmPage from '../../pages/manage/bookingCancellationConfirmation'
+import withdrawablesFactory from '../../../server/testutils/factories/withdrawablesFactory'
 
 context('Cancellation', () => {
   beforeEach(() => {
@@ -41,7 +42,9 @@ context('Cancellation', () => {
     const withdrawable = withdrawableFactory.build({ id: booking.id, type: 'booking' })
     cy.task('stubCancellationCreate', { premisesId: premises.id, bookingId: booking.id, cancellation })
     cy.task('stubPremisesSummary', premises)
-    cy.task('stubWithdrawables', { applicationId: application.id, withdrawables: [withdrawable] })
+    const withdrawables = withdrawablesFactory.build({ withdrawables: [withdrawable] })
+
+    cy.task('stubWithdrawablesWithNotes', { applicationId: application.id, withdrawables })
     cy.task('stubBookingFindWithoutPremises', booking)
 
     const premisesShowPage = PremisesShowPage.visit(premises)
@@ -94,7 +97,7 @@ context('Cancellation', () => {
     })
     const withdrawable = withdrawableFactory.build({ id: booking.id, type: 'booking' })
     cy.task('stubPremisesSummary', premises)
-    cy.task('stubWithdrawables', { applicationId: application.id, withdrawables: [withdrawable] })
+    cy.task('stubWithdrawablesWithNotes', { applicationId: application.id, withdrawables: [withdrawable] })
     cy.task('stubBookingFindWithoutPremises', booking)
 
     // And I fill out the cancellation form with a reason of "other" but without a note

--- a/integration_tests/tests/withdrawals/withdrawals.cy.ts
+++ b/integration_tests/tests/withdrawals/withdrawals.cy.ts
@@ -17,6 +17,7 @@ import PlacementApplicationWithdrawalConfirmationPage from '../../pages/match/pl
 import Page from '../../pages/page'
 import { signIn } from '../signIn'
 import paths from '../../../server/paths/apply'
+import withdrawablesFactory from '../../../server/testutils/factories/withdrawablesFactory'
 
 context('Withdrawals', () => {
   describe('as a CRU user', () => {
@@ -41,10 +42,13 @@ context('Withdrawals', () => {
         id: placementApplication.id,
       })
       const applicationWithdrawable = withdrawableFactory.build({ type: 'application' })
-
-      cy.task('stubWithdrawables', {
-        applicationId: application.id,
+      const withdrawables = withdrawablesFactory.build({
         withdrawables: [placementApplicationWithdrawable, applicationWithdrawable],
+      })
+
+      cy.task('stubWithdrawablesWithNotes', {
+        applicationId: application.id,
+        withdrawables,
       })
       cy.task('stubPlacementApplication', placementApplication)
 
@@ -85,10 +89,11 @@ context('Withdrawals', () => {
       const applicationWithdrawable = withdrawableFactory.build({
         type: 'application',
       })
+      const withdrawables = withdrawablesFactory.build({ withdrawables: [applicationWithdrawable] })
 
-      cy.task('stubWithdrawables', {
+      cy.task('stubWithdrawablesWithNotes', {
         applicationId: application.id,
-        withdrawables: [applicationWithdrawable],
+        withdrawables,
       })
       cy.task('stubApplications', [application])
       cy.task('stubApplicationGet', { application })
@@ -121,10 +126,13 @@ context('Withdrawals', () => {
         type: 'placement_application',
       })
       const applicationWithdrawable = withdrawableFactory.build({ type: 'application' })
-
-      cy.task('stubWithdrawables', {
-        applicationId: application.id,
+      const withdrawables = withdrawablesFactory.build({
         withdrawables: [placementWithdrawable, placementApplicationWithdrawable, applicationWithdrawable],
+      })
+
+      cy.task('stubWithdrawablesWithNotes', {
+        applicationId: application.id,
+        withdrawables,
       })
       cy.task('stubApplications', [application])
       cy.task('stubApplicationGet', { application })
@@ -181,7 +189,7 @@ context('Withdrawals', () => {
         hasRequestsForPlacement: false,
       })
 
-      cy.task('stubWithdrawables', {
+      cy.task('stubWithdrawablesWithNotes', {
         applicationId: application.id,
         withdrawables: [],
       })
@@ -216,9 +224,12 @@ const withdrawsAPlacementRequest = (userRoles: Array<ApprovedPremisesUserRole>) 
   const placementWithdrawable = withdrawableFactory.build({
     type: 'booking',
   })
-  cy.task('stubWithdrawables', {
-    applicationId: application.id,
+  const withdrawables = withdrawablesFactory.build({
     withdrawables: [placementRequestWithdrawable, placementApplicationWithdrawable, placementWithdrawable],
+  })
+  cy.task('stubWithdrawablesWithNotes', {
+    applicationId: application.id,
+    withdrawables,
   })
   cy.task('stubApplications', [application])
   cy.task('stubApplicationGet', { application })

--- a/server/controllers/apply/applications/withdrawalsController.test.ts
+++ b/server/controllers/apply/applications/withdrawalsController.test.ts
@@ -12,6 +12,7 @@ import {
 import paths from '../../../paths/apply'
 import WithdrawalsController from './withdrawalsController'
 import { withdrawableFactory } from '../../../testutils/factories'
+import withdrawablesFactory from '../../../testutils/factories/withdrawablesFactory'
 
 jest.mock('../../../utils/validation')
 
@@ -41,9 +42,9 @@ describe('withdrawalsController', () => {
         ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
 
         const selectedWithdrawableType = 'booking'
-        const withdrawables = withdrawableFactory.buildList(1)
-
-        applicationService.getWithdrawables.mockResolvedValue(withdrawables)
+        const withdrawable = withdrawableFactory.buildList(1)
+        const withdrawables = withdrawablesFactory.build({ withdrawables: withdrawable })
+        applicationService.getWithdrawablesWithNotes.mockResolvedValue(withdrawables)
 
         const requestHandler = withdrawalsController.new()
 
@@ -57,7 +58,7 @@ describe('withdrawalsController', () => {
           next,
         )
 
-        expect(applicationService.getWithdrawables).toHaveBeenCalledWith(token, applicationId)
+        expect(applicationService.getWithdrawablesWithNotes).toHaveBeenCalledWith(token, applicationId)
         expect(response.redirect).toHaveBeenCalledWith(
           302,
           `${paths.applications.withdrawables.show({ id: applicationId })}?selectedWithdrawableType=${selectedWithdrawableType}`,
@@ -69,9 +70,10 @@ describe('withdrawalsController', () => {
         ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
 
         const selectedWithdrawableType = 'booking'
-        const withdrawables = withdrawableFactory.buildList(1)
+        const withdrawable = withdrawableFactory.buildList(1)
+        const withdrawables = withdrawablesFactory.build({ withdrawables: withdrawable })
 
-        applicationService.getWithdrawables.mockResolvedValue(withdrawables)
+        applicationService.getWithdrawablesWithNotes.mockResolvedValue(withdrawables)
 
         const requestHandler = withdrawalsController.new()
 
@@ -86,7 +88,7 @@ describe('withdrawalsController', () => {
           next,
         )
 
-        expect(applicationService.getWithdrawables).toHaveBeenCalledWith(token, applicationId)
+        expect(applicationService.getWithdrawablesWithNotes).toHaveBeenCalledWith(token, applicationId)
         expect(response.redirect).toHaveBeenCalledWith(
           302,
           `${paths.applications.withdrawables.show({ id: applicationId })}?selectedWithdrawableType=${selectedWithdrawableType}`,
@@ -100,20 +102,22 @@ describe('withdrawalsController', () => {
         const errorsAndUserInput = createMock<ErrorsAndUserInput>()
         ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
 
-        const withdrawables = withdrawableFactory.buildList(1)
+        const withdrawable = withdrawableFactory.buildList(1)
+        const withdrawables = withdrawablesFactory.build({ withdrawables: withdrawable })
 
-        applicationService.getWithdrawables.mockResolvedValue(withdrawables)
+        applicationService.getWithdrawablesWithNotes.mockResolvedValue(withdrawables)
 
         const requestHandler = withdrawalsController.new()
 
         await requestHandler({ ...request, params: { id: applicationId }, headers: { referer } }, response, next)
 
-        expect(applicationService.getWithdrawables).toHaveBeenCalledWith(token, applicationId)
+        expect(applicationService.getWithdrawablesWithNotes).toHaveBeenCalledWith(token, applicationId)
         expect(response.render).toHaveBeenCalledWith('applications/withdrawables/new', {
           pageHeading: 'What do you want to withdraw?',
           id: applicationId,
-          withdrawables,
+          withdrawables: withdrawables.withdrawables,
           referer,
+          notes: withdrawables.notes,
         })
       })
     })
@@ -124,7 +128,8 @@ describe('withdrawalsController', () => {
       const errorsAndUserInput = createMock<ErrorsAndUserInput>()
       ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
       request.params.id = applicationId
-      applicationService.getWithdrawables.mockResolvedValue([])
+      const withdrawables = withdrawablesFactory.build({ withdrawables: [] })
+      applicationService.getWithdrawablesWithNotes.mockResolvedValue(withdrawables)
 
       const requestHandler = withdrawalsController.new()
 
@@ -134,16 +139,18 @@ describe('withdrawalsController', () => {
         pageHeading: 'What do you want to withdraw?',
         id: applicationId,
         withdrawables: [],
+        notes: withdrawables.notes,
       })
     })
   })
 
   describe('if the selectedWithdrawalType is application', () => {
     it('renders the withdrawals reasons template', async () => {
-      const withdrawables = withdrawableFactory.buildList(1)
+      const withdrawable = withdrawableFactory.buildList(1)
+      const withdrawables = withdrawablesFactory.build({ withdrawables: withdrawable })
       const errorsAndUserInput = createMock<ErrorsAndUserInput>()
       ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
-      applicationService.getWithdrawables.mockResolvedValue(withdrawables)
+      applicationService.getWithdrawablesWithNotes.mockResolvedValue(withdrawables)
       request.params.id = applicationId
       request.body.selectedWithdrawableType = 'application'
 

--- a/server/controllers/apply/applications/withdrawalsController.ts
+++ b/server/controllers/apply/applications/withdrawalsController.ts
@@ -23,7 +23,7 @@ export default class WithdrawalsController {
         | SelectedWithdrawableType
         | undefined
 
-      const withdrawables = await this.applicationService.getWithdrawables(req.user.token, id)
+      const withdrawables = await this.applicationService.getWithdrawablesWithNotes(req.user.token, id)
 
       if (selectedWithdrawableType === 'application') {
         return res.render('applications/withdrawals/new', {
@@ -39,8 +39,9 @@ export default class WithdrawalsController {
         return res.render('applications/withdrawables/new', {
           pageHeading: 'What do you want to withdraw?',
           id,
-          withdrawables,
+          withdrawables: withdrawables.withdrawables,
           referer: req.headers.referer,
+          notes: withdrawables.notes,
         })
       }
 

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -16,6 +16,7 @@ import {
 import paths from '../paths/api'
 import describeClient from '../testutils/describeClient'
 import { normaliseCrn } from '../utils/normaliseCrn'
+import withdrawablesFactory from '../testutils/factories/withdrawablesFactory'
 
 describeClient('ApplicationClient', provider => {
   let applicationClient: ApplicationClient
@@ -538,16 +539,17 @@ describeClient('ApplicationClient', provider => {
   })
 
   describe('withdrawables', () => {
-    it('calls the withdrawables endpoint with the application ID', async () => {
+    it('calls the withdrawables with notes endpoint with the application ID', async () => {
       const applicationId = 'applicationId'
-      const withdrawables = withdrawableFactory.buildList(1)
+      const withdrawable = withdrawableFactory.buildList(1)
+      const withdrawables = withdrawablesFactory.build({ withdrawables: withdrawable })
 
       provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request for to add a note to an application',
         withRequest: {
           method: 'GET',
-          path: paths.applications.withdrawables({ id: applicationId }),
+          path: paths.applications.withdrawablesWithNotes({ id: applicationId }),
           headers: {
             authorization: `Bearer ${token}`,
             'X-Service-Name': 'approved-premises',
@@ -559,7 +561,7 @@ describeClient('ApplicationClient', provider => {
         },
       })
 
-      await applicationClient.withdrawables(applicationId)
+      await applicationClient.withdrawablesWithNotes(applicationId)
     })
   })
 })

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -14,7 +14,7 @@ import type {
   SubmitApprovedPremisesApplication,
   TimelineEvent,
   UpdateApprovedPremisesApplication,
-  Withdrawable,
+  Withdrawables,
 } from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
@@ -123,9 +123,9 @@ export default class ApplicationClient {
     })) as ApplicationTimelineNote
   }
 
-  async withdrawables(applicationId: string): Promise<Array<Withdrawable>> {
+  async withdrawablesWithNotes(applicationId: string): Promise<Withdrawables> {
     return (await this.restClient.get({
-      path: paths.applications.withdrawables({ id: applicationId }),
-    })) as Array<Withdrawable>
+      path: paths.applications.withdrawablesWithNotes({ id: applicationId }),
+    })) as Withdrawables
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -154,6 +154,7 @@ export default {
     requestsForPlacement: applyPaths.applications.show.path('requests-for-placement'),
     addNote: applyPaths.applications.show.path('notes'),
     withdrawables: applyPaths.applications.show.path('withdrawables'),
+    withdrawablesWithNotes: applyPaths.applications.show.path('withdrawablesWithNotes'),
     appeals: {
       show: appealsPath.path(':appealId'),
       create: appealsPath,

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -31,6 +31,7 @@ import {
 } from '../testutils/factories'
 import { TasklistPageInterface } from '../form-pages/tasklistPage'
 import { getApplicationSubmissionData, getApplicationUpdateData } from '../utils/applications/getApplicationData'
+import withdrawablesFactory from '../testutils/factories/withdrawablesFactory'
 
 const FirstPage = jest.fn()
 const SecondPage = jest.fn()
@@ -469,17 +470,17 @@ describe('ApplicationService', () => {
     })
   })
 
-  describe('getWithdrawables', () => {
+  describe('getWithdrawablesWithNotes', () => {
     it('calls the client with the ID and the token and returns the result', async () => {
-      const withdrawables = withdrawableFactory.buildList(1)
+      const withdrawable = withdrawableFactory.buildList(1)
+      const withdrawables = withdrawablesFactory.build({ withdrawables: withdrawable })
+      applicationClient.withdrawablesWithNotes.mockResolvedValue(withdrawables)
 
-      applicationClient.withdrawables.mockResolvedValue(withdrawables)
-
-      const result = await service.getWithdrawables(token, applicationId)
+      const result = await service.getWithdrawablesWithNotes(token, applicationId)
 
       expect(result).toEqual(withdrawables)
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
-      expect(applicationClient.withdrawables).toHaveBeenCalledWith(applicationId)
+      expect(applicationClient.withdrawablesWithNotes).toHaveBeenCalledWith(applicationId)
     })
   })
 })

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -184,10 +184,10 @@ export default class ApplicationService {
     return addedNote
   }
 
-  async getWithdrawables(token: Request['user']['token'], applicationId: Application['id']) {
+  async getWithdrawablesWithNotes(token: Request['user']['token'], applicationId: Application['id']) {
     const client = this.applicationClientFactory(token)
 
-    const withdrawables = await client.withdrawables(applicationId)
+    const withdrawables = await client.withdrawablesWithNotes(applicationId)
 
     return withdrawables
   }

--- a/server/testutils/factories/withdrawablesFactory.ts
+++ b/server/testutils/factories/withdrawablesFactory.ts
@@ -1,0 +1,11 @@
+import { Factory } from 'fishery'
+import { Withdrawables } from '../../@types/shared'
+import { withdrawableFactory } from './index'
+
+export default Factory.define<Withdrawables>(() => ({
+  notes: [
+    '1 or more placements cannot be withdrawn as they have an arrival',
+    '1 or more placements cannot be withdrawn as they have an arrival recorded in Delius',
+  ],
+  withdrawables: withdrawableFactory.buildList(1, { type: 'application' }),
+}))

--- a/server/views/applications/withdrawables/new.njk
+++ b/server/views/applications/withdrawables/new.njk
@@ -19,6 +19,13 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             {% if withdrawables.length %}
+                {% if notes | length > 0 %}
+                    <ul class="govuk-list govuk-list--bullet">
+                        {% for note in notes %}
+                            <li>{{note}}</li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
 
                 <form action={{paths.applications.withdraw.new({id: id})}} method="post"/>
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>

--- a/server/views/applications/withdrawables/show.njk
+++ b/server/views/applications/withdrawables/show.njk
@@ -17,6 +17,7 @@
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
+
             {% set hintHtml %}
             {{ govukInsetText({
                     text: "Withdraw one " + withdrawableType + " at a time. Contact the CRU if you do not see the placement you wish to withdraw."

--- a/server/views/applications/withdrawals/new.njk
+++ b/server/views/applications/withdrawals/new.njk
@@ -24,6 +24,13 @@
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ showErrorSummary(errorSummary) }}
+        {% if notes | length > 0 %}
+          <ul class="govuk-list govuk-list--bullet">
+            {% for note in notes %}
+              <li>{{note}}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
 
         {{
           formPageRadios(


### PR DESCRIPTION
… show notes in UI

# Context

<!-- https://dsdmoj.atlassian.net/browse/APS-840 -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
(UI) Use /applications/{applicationId}/withdrawablesWithNotes and show notes
## Screenshots of UI changes

### Before
<img width="870" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/50b91d47-4efe-445b-900f-45d5391b3601">
<img width="703" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/3a74e5fc-4bca-460c-9d1c-520cbf17ef43">


### After
<img width="1728" alt="Screenshot 2024-06-11 at 09 17 49" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/a3f80938-aa2d-4c69-9661-e9eec1e593c3">
<img width="1728" alt="Screenshot 2024-06-11 at 09 21 34" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/a2625789-06c7-4c45-89c2-b0dbe420da29">

