### PR TITLE
Add pagination to out of service bed index page

### DIFF
--- a/integration_tests/mockApis/outOfServiceBed.ts
+++ b/integration_tests/mockApis/outOfServiceBed.ts
@@ -64,15 +64,20 @@ export default {
       },
     }),
 
-  stubOutOfServiceBedsList: ({ outOfServiceBeds }): SuperAgentRequest =>
+  stubOutOfServiceBedsList: ({ outOfServiceBeds, page = 1 }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
-        url: paths.manage.outOfServiceBeds.index({}),
+        url: `${paths.manage.outOfServiceBeds.index.pattern}?page=${page}`,
       },
       response: {
         status: 200,
-        headers,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+          'X-Pagination-TotalPages': '10',
+          'X-Pagination-TotalResults': '100',
+          'X-Pagination-PageSize': '10',
+        },
         jsonBody: outOfServiceBeds,
       },
     }),
@@ -139,6 +144,18 @@ export default {
       await getMatchingRequests({
         method: 'POST',
         url: paths.manage.premises.outOfServiceBeds.cancel({ premisesId, id: outOfServiceBedId }),
+      })
+    ).body.requests,
+  verifyOutOfServiceBedsDashboard: async ({ page = '1' }: { page: string }) =>
+    (
+      await getMatchingRequests({
+        method: 'GET',
+        urlPathPattern: paths.manage.outOfServiceBeds.index({}),
+        queryParameters: {
+          page: {
+            equalTo: page,
+          },
+        },
       })
     ).body.requests,
 }

--- a/server/controllers/manage/outOfServiceBedsController.ts
+++ b/server/controllers/manage/outOfServiceBedsController.ts
@@ -89,11 +89,16 @@ export default class OutOfServiceBedsController {
 
   index(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const outOfServiceBeds = await this.outOfServiceBedService.getAllOutOfServiceBeds(req.user.token)
+      const pageNumber = req.query.page ? Number(req.query.page) : undefined
+
+      const outOfServiceBeds = await this.outOfServiceBedService.getAllOutOfServiceBeds(req.user.token, pageNumber)
 
       return res.render('outOfServiceBeds/index', {
         pageHeading: 'View out of service beds',
-        outOfServiceBeds,
+        outOfServiceBeds: outOfServiceBeds.data,
+        pageNumber: Number(outOfServiceBeds.pageNumber),
+        totalPages: Number(outOfServiceBeds.totalPages),
+        hrefPrefix: `${paths.v2Manage.outOfServiceBeds.index({})}?`,
       })
     }
   }

--- a/server/data/outOfServiceBedClient.test.ts
+++ b/server/data/outOfServiceBedClient.test.ts
@@ -105,8 +105,10 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
   })
 
   describe('get', () => {
-    it('should get all outOfServiceBeds', async () => {
+    it('makes a request to the outOfServiceBeds endpoint with a page number', async () => {
       const outOfServiceBeds = outOfServiceBedFactory.buildList(2)
+
+      const pageNumber = 3
 
       provider.addInteraction({
         state: 'Server is healthy',
@@ -114,6 +116,7 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.manage.outOfServiceBeds.index({}),
+          query: { page: pageNumber.toString() },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -121,12 +124,23 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
         willRespondWith: {
           status: 200,
           body: outOfServiceBeds,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
         },
       })
 
-      const result = await outOfServiceBedClient.get()
+      const result = await outOfServiceBedClient.get(pageNumber)
 
-      expect(result).toEqual(outOfServiceBeds)
+      expect(result).toEqual({
+        data: outOfServiceBeds,
+        pageNumber: pageNumber.toString(),
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
     })
   })
 

--- a/server/data/outOfServiceBedClient.ts
+++ b/server/data/outOfServiceBedClient.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 
+import superagent from 'superagent'
 import {
   NewCas1OutOfServiceBed as NewOutOfServiceBed,
   NewCas1OutOfServiceBedCancellation as NewOutOfServiceBedCancellation,
@@ -8,9 +9,11 @@ import {
   Premises,
   UpdateCas1OutOfServiceBed as UpdateOutOfServiceBed,
 } from '@approved-premises/api'
+import { PaginatedResponse } from '@approved-premises/ui'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
+import { createQueryString } from '../utils/utils'
 
 export default class OutOfServiceBedClient {
   restClient: RestClient
@@ -40,10 +43,20 @@ export default class OutOfServiceBedClient {
     })) as Array<OutOfServiceBed>
   }
 
-  async get(): Promise<Array<OutOfServiceBed>> {
-    return (await this.restClient.get({
+  async get(page = 1): Promise<PaginatedResponse<OutOfServiceBed>> {
+    const response = (await this.restClient.get({
       path: paths.manage.outOfServiceBeds.index({}),
-    })) as Array<OutOfServiceBed>
+      query: createQueryString({ page }),
+      raw: true,
+    })) as superagent.Response
+
+    return {
+      data: response.body,
+      pageNumber: page.toString(),
+      totalPages: response.headers['x-pagination-totalpages'],
+      totalResults: response.headers['x-pagination-totalresults'],
+      pageSize: response.headers['x-pagination-pagesize'],
+    }
   }
 
   async update(

--- a/server/services/outOfServiceBedService.test.ts
+++ b/server/services/outOfServiceBedService.test.ts
@@ -1,4 +1,5 @@
 import { Cas1OutOfServiceBed as OutOfServiceBed } from '@approved-premises/api'
+import { PaginatedResponse } from '@approved-premises/ui'
 import OutOfServiceBedService from './outOfServiceBedService'
 import OutOfServiceBedClient from '../data/outOfServiceBedClient'
 
@@ -6,6 +7,7 @@ import {
   newOutOfServiceBedFactory,
   outOfServiceBedCancellationFactory,
   outOfServiceBedFactory,
+  paginatedResponseFactory,
 } from '../testutils/factories'
 
 jest.mock('../data/outOfServiceBedClient.ts')
@@ -72,17 +74,19 @@ describe('OutOfServiceBedService', () => {
   })
 
   describe('getAllOutOfServiceBeds', () => {
-    it('on success returns all outOfServiceBeds', async () => {
-      const expectedOutOfServiceBeds: Array<OutOfServiceBed> = outOfServiceBedFactory.buildList(2)
-
+    it('calls the get method on the outOfServiceBedClient with a page', async () => {
       const token = 'SOME_TOKEN'
-      outOfServiceBedClient.get.mockResolvedValue(expectedOutOfServiceBeds)
 
-      const outOfServiceBeds = await service.getAllOutOfServiceBeds(token)
+      const response = paginatedResponseFactory.build({
+        data: outOfServiceBedFactory.buildList(1),
+      }) as PaginatedResponse<OutOfServiceBed>
+      outOfServiceBedClient.get.mockResolvedValue(response)
 
-      expect(outOfServiceBeds).toEqual(expectedOutOfServiceBeds)
+      const outOfServiceBeds = await service.getAllOutOfServiceBeds(token, 3)
+
+      expect(outOfServiceBeds).toEqual(response)
       expect(OutOfServiceBedClientFactory).toHaveBeenCalledWith(token)
-      expect(outOfServiceBedClient.get).toHaveBeenCalled()
+      expect(outOfServiceBedClient.get).toHaveBeenCalledWith(3)
     })
   })
 

--- a/server/services/outOfServiceBedService.ts
+++ b/server/services/outOfServiceBedService.ts
@@ -5,6 +5,7 @@ import type {
   Cas1OutOfServiceBedCancellation as OutOfServiceBedCancellation,
   UpdateCas1OutOfServiceBed as UpdateOutOfServiceBed,
 } from '@approved-premises/api'
+import { PaginatedResponse } from '@approved-premises/ui'
 import type { OutOfServiceBedClient, RestClientBuilder } from '../data'
 import { Premises } from '../@types/shared'
 
@@ -55,9 +56,9 @@ export default class OutOfServiceBedService {
     return outOfServiceBeds
   }
 
-  async getAllOutOfServiceBeds(token: string): Promise<Array<OutOfServiceBed>> {
+  async getAllOutOfServiceBeds(token: string, page = 1): Promise<PaginatedResponse<OutOfServiceBed>> {
     const outOfServiceBedClient = this.outOfServiceBedClientFactory(token)
-    const outOfServiceBeds = await outOfServiceBedClient.get()
+    const outOfServiceBeds = await outOfServiceBedClient.get(page)
 
     return outOfServiceBeds
   }

--- a/server/views/outOfServiceBeds/index.njk
+++ b/server/views/outOfServiceBeds/index.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
 
 {%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
 
@@ -52,6 +53,8 @@
             rows: OutOfServiceBedUtils.allOutOfServiceBedsTableRows(outOfServiceBeds)
           })
         }}
+
+        {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
 
       {% endif %}
     </div>


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?selectedIssue=APS-895&sprints=6188

Not to be merged until [the API PR](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1945) is in.

# Changes in this PR

Adds pagination to the out of service beds index page, for viewing by CRU managers.