### PR TITLE
Add sorting to OOS beds index page table

### DIFF
--- a/integration_tests/mockApis/outOfServiceBed.ts
+++ b/integration_tests/mockApis/outOfServiceBed.ts
@@ -1,5 +1,6 @@
 import { SuperAgentRequest } from 'superagent'
 
+import { Cas1OutOfServiceBedSortField as OutOfServiceBedSortField, SortDirection } from '@approved-premises/api'
 import { getMatchingRequests, stubFor } from './setup'
 import { bedspaceConflictResponseBody, errorStub } from './utils'
 import paths from '../../server/paths/api'
@@ -64,11 +65,16 @@ export default {
       },
     }),
 
-  stubOutOfServiceBedsList: ({ outOfServiceBeds, page = 1 }): SuperAgentRequest =>
+  stubOutOfServiceBedsList: ({
+    outOfServiceBeds,
+    page = 1,
+    sortBy = 'outOfServiceFrom',
+    sortDirection = 'asc',
+  }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
-        url: `${paths.manage.outOfServiceBeds.index.pattern}?page=${page}`,
+        url: `${paths.manage.outOfServiceBeds.index.pattern}?page=${page}&sortBy=${sortBy}&sortDirection=${sortDirection}`,
       },
       response: {
         status: 200,
@@ -146,7 +152,15 @@ export default {
         url: paths.manage.premises.outOfServiceBeds.cancel({ premisesId, id: outOfServiceBedId }),
       })
     ).body.requests,
-  verifyOutOfServiceBedsDashboard: async ({ page = '1' }: { page: string }) =>
+  verifyOutOfServiceBedsDashboard: async ({
+    page = '1',
+    sortBy = 'outOfServiceFrom',
+    sortDirection = 'asc',
+  }: {
+    page: string
+    sortBy: OutOfServiceBedSortField
+    sortDirection: SortDirection
+  }) =>
     (
       await getMatchingRequests({
         method: 'GET',
@@ -154,6 +168,12 @@ export default {
         queryParameters: {
           page: {
             equalTo: page,
+          },
+          sortBy: {
+            equalTo: sortBy,
+          },
+          sortDirection: {
+            equalTo: sortDirection,
           },
         },
       })

--- a/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
+++ b/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
@@ -278,5 +278,80 @@ context('OutOfServiceBeds', () => {
         expect(requests).to.have.length(1)
       })
     })
+
+    it('supports sorting by premisesName', () => {
+      shouldSortByField('premisesName')
+    })
+
+    it('supports sorting by roomName', () => {
+      shouldSortByField('roomName')
+    })
+
+    it('supports sorting by bedName', () => {
+      shouldSortByField('bedName')
+    })
+
+    it('supports sorting by outOfServiceFrom', () => {
+      shouldSortByField('outOfServiceFrom')
+    })
+
+    it('supports sorting by outOfServiceTo', () => {
+      shouldSortByField('outOfServiceTo')
+    })
+
+    it('supports sorting by reason', () => {
+      shouldSortByField('reason')
+    })
+
+    it('supports sorting by daysLost', () => {
+      shouldSortByField('daysLost')
+    })
   })
+
+  const shouldSortByField = (field: string) => {
+    // And there is a page of out of service beds
+    const outOfServiceBeds = outOfServiceBedFactory.buildList(10)
+
+    cy.task('stubOutOfServiceBedsList', { outOfServiceBeds, page: 1 })
+    cy.task('stubOutOfServiceBedsList', {
+      outOfServiceBeds,
+      page: '1',
+      sortBy: field,
+      sortDirection: 'asc',
+    })
+    cy.task('stubOutOfServiceBedsList', {
+      outOfServiceBeds,
+      page: '1',
+      sortBy: field,
+      sortDirection: 'desc',
+    })
+
+    // When I access the out of service beds dashboard
+    const page = OutOfServiceBedIndexPage.visit()
+
+    // Then I should see the first result
+    page.shouldShowOutOfServiceBeds(outOfServiceBeds)
+
+    // When I click the column to sort by
+    page.clickSortBy(field)
+
+    // Then the API should have received a request for the sort
+    cy.task('verifyOutOfServiceBedsDashboard', { page: '1', sortBy: field, sortDirection: 'asc' }).then(requests => {
+      expect(requests).to.have.length(field === 'outOfServiceFrom' ? 2 : 1)
+    })
+
+    // And the page should show the sorted items
+    page.shouldBeSortedByField(field, 'ascending')
+
+    // When I click the sort button again
+    page.clickSortBy(field)
+
+    // Then the API should have received a request for the sort
+    cy.task('verifyOutOfServiceBedsDashboard', { page: '1', sortBy: field, sortDirection: 'desc' }).then(requests => {
+      expect(requests).to.have.length(1)
+    })
+
+    // And the page should show the sorted items
+    page.shouldBeSortedByField(field, 'descending')
+  }
 })

--- a/server/controllers/manage/outOfServiceBedsController.test.ts
+++ b/server/controllers/manage/outOfServiceBedsController.test.ts
@@ -20,9 +20,11 @@ import {
   outOfServiceBedFactory,
   paginatedResponseFactory,
 } from '../../testutils/factories'
+import { getPaginationDetails } from '../../utils/getPaginationDetails'
 
 jest.mock('../../utils/validation')
 jest.mock('../../utils/bookings')
+jest.mock('../../utils/getPaginationDetails')
 
 describe('OutOfServiceBedsController', () => {
   const token = 'SOME_TOKEN'
@@ -202,7 +204,15 @@ describe('OutOfServiceBedsController', () => {
       const paginatedResponse = paginatedResponseFactory.build({
         data: outOfServiceBedFactory.buildList(2),
       }) as PaginatedResponse<OutOfServiceBed>
+      const paginationDetails = {
+        hrefPrefix: paths.v2Manage.outOfServiceBeds.index({}),
+        pageNumber: 1,
+        sortBy: 'roomName',
+        sortDirection: 'desc',
+      }
+
       outOfServiceBedService.getAllOutOfServiceBeds.mockResolvedValue(paginatedResponse)
+      ;(getPaginationDetails as jest.Mock).mockReturnValue(paginationDetails)
 
       const requestHandler = outOfServiceBedController.index()
 
@@ -213,9 +223,16 @@ describe('OutOfServiceBedsController', () => {
         pageHeading: 'View out of service beds',
         pageNumber: Number(paginatedResponse.pageNumber),
         totalPages: Number(paginatedResponse.totalPages),
-        hrefPrefix: '/manage/out-of-service-beds?',
+        hrefPrefix: paginationDetails.hrefPrefix,
+        sortBy: paginationDetails.sortBy,
+        sortDirection: paginationDetails.sortDirection,
       })
-      expect(outOfServiceBedService.getAllOutOfServiceBeds).toHaveBeenCalledWith(token, undefined)
+      expect(outOfServiceBedService.getAllOutOfServiceBeds).toHaveBeenCalledWith(
+        token,
+        paginationDetails.pageNumber,
+        paginationDetails.sortBy,
+        paginationDetails.sortDirection,
+      )
     })
   })
 

--- a/server/controllers/manage/outOfServiceBedsController.ts
+++ b/server/controllers/manage/outOfServiceBedsController.ts
@@ -1,5 +1,6 @@
 import type { Request, RequestHandler, Response } from 'express'
 
+import { Cas1OutOfServiceBedSortField as OutOfServiceBedSortField } from '@approved-premises/api'
 import {
   catchValidationErrorOrPropogate,
   fetchErrorsAndUserInput,
@@ -9,6 +10,7 @@ import paths from '../../paths/manage'
 import { DateFormats } from '../../utils/dateUtils'
 import { SanitisedError } from '../../sanitisedError'
 import OutOfServiceBedService from '../../services/outOfServiceBedService'
+import { getPaginationDetails } from '../../utils/getPaginationDetails'
 
 export default class OutOfServiceBedsController {
   constructor(private readonly outOfServiceBedService: OutOfServiceBedService) {}
@@ -89,16 +91,26 @@ export default class OutOfServiceBedsController {
 
   index(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const pageNumber = req.query.page ? Number(req.query.page) : undefined
+      const { pageNumber, hrefPrefix, sortBy, sortDirection } = getPaginationDetails<OutOfServiceBedSortField>(
+        req,
+        paths.v2Manage.outOfServiceBeds.index({}),
+      )
 
-      const outOfServiceBeds = await this.outOfServiceBedService.getAllOutOfServiceBeds(req.user.token, pageNumber)
+      const outOfServiceBeds = await this.outOfServiceBedService.getAllOutOfServiceBeds(
+        req.user.token,
+        pageNumber,
+        sortBy,
+        sortDirection,
+      )
 
       return res.render('outOfServiceBeds/index', {
         pageHeading: 'View out of service beds',
         outOfServiceBeds: outOfServiceBeds.data,
         pageNumber: Number(outOfServiceBeds.pageNumber),
         totalPages: Number(outOfServiceBeds.totalPages),
-        hrefPrefix: `${paths.v2Manage.outOfServiceBeds.index({})}?`,
+        hrefPrefix,
+        sortBy,
+        sortDirection,
       })
     }
   }

--- a/server/data/outOfServiceBedClient.test.ts
+++ b/server/data/outOfServiceBedClient.test.ts
@@ -116,7 +116,7 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.manage.outOfServiceBeds.index({}),
-          query: { page: pageNumber.toString() },
+          query: { page: pageNumber.toString(), sortBy: 'roomName', sortDirection: 'asc' },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -132,7 +132,7 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
         },
       })
 
-      const result = await outOfServiceBedClient.get(pageNumber)
+      const result = await outOfServiceBedClient.get('roomName', 'asc', pageNumber)
 
       expect(result).toEqual({
         data: outOfServiceBeds,

--- a/server/data/outOfServiceBedClient.ts
+++ b/server/data/outOfServiceBedClient.ts
@@ -1,19 +1,19 @@
 /* istanbul ignore file */
 
-import superagent from 'superagent'
 import {
   NewCas1OutOfServiceBed as NewOutOfServiceBed,
   NewCas1OutOfServiceBedCancellation as NewOutOfServiceBedCancellation,
   Cas1OutOfServiceBed as OutOfServiceBed,
   Cas1OutOfServiceBedCancellation as OutOfServiceBedCancellation,
+  Cas1OutOfServiceBedSortField as OutOfServiceBedSortField,
   Premises,
+  SortDirection,
   UpdateCas1OutOfServiceBed as UpdateOutOfServiceBed,
 } from '@approved-premises/api'
 import { PaginatedResponse } from '@approved-premises/ui'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
-import { createQueryString } from '../utils/utils'
 
 export default class OutOfServiceBedClient {
   restClient: RestClient
@@ -43,20 +43,16 @@ export default class OutOfServiceBedClient {
     })) as Array<OutOfServiceBed>
   }
 
-  async get(page = 1): Promise<PaginatedResponse<OutOfServiceBed>> {
-    const response = (await this.restClient.get({
-      path: paths.manage.outOfServiceBeds.index({}),
-      query: createQueryString({ page }),
-      raw: true,
-    })) as superagent.Response
-
-    return {
-      data: response.body,
-      pageNumber: page.toString(),
-      totalPages: response.headers['x-pagination-totalpages'],
-      totalResults: response.headers['x-pagination-totalresults'],
-      pageSize: response.headers['x-pagination-pagesize'],
-    }
+  async get(
+    sortBy: OutOfServiceBedSortField,
+    sortDirection: SortDirection,
+    page = 1,
+  ): Promise<PaginatedResponse<OutOfServiceBed>> {
+    return this.restClient.getPaginatedResponse<OutOfServiceBed>({
+      path: paths.manage.outOfServiceBeds.index.pattern,
+      page: page.toString(),
+      query: { sortBy, sortDirection },
+    })
   }
 
   async update(

--- a/server/services/outOfServiceBedService.test.ts
+++ b/server/services/outOfServiceBedService.test.ts
@@ -74,7 +74,7 @@ describe('OutOfServiceBedService', () => {
   })
 
   describe('getAllOutOfServiceBeds', () => {
-    it('calls the get method on the outOfServiceBedClient with a page', async () => {
+    it('calls the get method on the outOfServiceBedClient with a page and sort options', async () => {
       const token = 'SOME_TOKEN'
 
       const response = paginatedResponseFactory.build({
@@ -86,7 +86,7 @@ describe('OutOfServiceBedService', () => {
 
       expect(outOfServiceBeds).toEqual(response)
       expect(OutOfServiceBedClientFactory).toHaveBeenCalledWith(token)
-      expect(outOfServiceBedClient.get).toHaveBeenCalledWith(3)
+      expect(outOfServiceBedClient.get).toHaveBeenCalledWith('outOfServiceFrom', 'asc', 3)
     })
   })
 

--- a/server/services/outOfServiceBedService.ts
+++ b/server/services/outOfServiceBedService.ts
@@ -3,6 +3,8 @@ import type {
   NewCas1OutOfServiceBedCancellation as NewOutOfServiceBedCancellation,
   Cas1OutOfServiceBed as OutOfServiceBed,
   Cas1OutOfServiceBedCancellation as OutOfServiceBedCancellation,
+  Cas1OutOfServiceBedSortField as OutOfServiceBedSortField,
+  SortDirection,
   UpdateCas1OutOfServiceBed as UpdateOutOfServiceBed,
 } from '@approved-premises/api'
 import { PaginatedResponse } from '@approved-premises/ui'
@@ -56,9 +58,14 @@ export default class OutOfServiceBedService {
     return outOfServiceBeds
   }
 
-  async getAllOutOfServiceBeds(token: string, page = 1): Promise<PaginatedResponse<OutOfServiceBed>> {
+  async getAllOutOfServiceBeds(
+    token: string,
+    page = 1,
+    sortBy: OutOfServiceBedSortField = 'outOfServiceFrom',
+    sortDirection: SortDirection = 'asc',
+  ): Promise<PaginatedResponse<OutOfServiceBed>> {
     const outOfServiceBedClient = this.outOfServiceBedClientFactory(token)
-    const outOfServiceBeds = await outOfServiceBedClient.get(page)
+    const outOfServiceBeds = await outOfServiceBedClient.get(sortBy, sortDirection, page)
 
     return outOfServiceBeds
   }

--- a/server/utils/outOfServiceBedUtils.test.ts
+++ b/server/utils/outOfServiceBedUtils.test.ts
@@ -3,6 +3,7 @@ import { outOfServiceBedFactory, userDetailsFactory } from '../testutils/factori
 import { DateFormats } from './dateUtils'
 import {
   actionCell,
+  allOutOfServiceBedsTableHeaders,
   allOutOfServiceBedsTableRows,
   outOfServiceBedCountForToday,
   outOfServiceBedTableHeaders,
@@ -10,10 +11,35 @@ import {
   referenceNumberCell,
 } from './outOfServiceBedUtils'
 import { getRandomInt } from './utils'
-import { ApprovedPremisesUserRole } from '../@types/shared'
+import { ApprovedPremisesUserRole, Cas1OutOfServiceBedSortField as OutOfServiceBedSortField } from '../@types/shared'
+import { sortHeader } from './sortHeader'
 
 describe('outOfServiceBedUtils', () => {
   const managerRoles: ReadonlyArray<ApprovedPremisesUserRole> = ['workflow_manager', 'future_manager'] as const
+
+  describe('allOutOfServiceBedsTableHeaders', () => {
+    it('returns the table headers', () => {
+      const sortBy = 'bedName'
+      const sortDirection = 'asc'
+      const hrefPrefix = 'http://example.com'
+
+      expect(allOutOfServiceBedsTableHeaders(sortBy, sortDirection, hrefPrefix)).toEqual([
+        sortHeader<OutOfServiceBedSortField>('Premises', 'premisesName', sortBy, sortDirection, hrefPrefix),
+        sortHeader<OutOfServiceBedSortField>('Room', 'roomName', sortBy, sortDirection, hrefPrefix),
+        sortHeader<OutOfServiceBedSortField>('Bed', 'bedName', sortBy, sortDirection, hrefPrefix),
+        sortHeader<OutOfServiceBedSortField>('Start date', 'outOfServiceFrom', sortBy, sortDirection, hrefPrefix),
+        sortHeader<OutOfServiceBedSortField>('End date', 'outOfServiceTo', sortBy, sortDirection, hrefPrefix),
+        sortHeader<OutOfServiceBedSortField>('Reason', 'reason', sortBy, sortDirection, hrefPrefix),
+        {
+          text: 'Ref number',
+        },
+        sortHeader<OutOfServiceBedSortField>('Days lost', 'daysLost', sortBy, sortDirection, hrefPrefix),
+        {
+          text: 'Actions',
+        },
+      ])
+    })
+  })
 
   describe('allOutOfServiceBedsTableRows', () => {
     const outOfServiceBed = outOfServiceBedFactory.build()

--- a/server/utils/outOfServiceBedUtils.ts
+++ b/server/utils/outOfServiceBedUtils.ts
@@ -1,4 +1,9 @@
-import { Cas1OutOfServiceBed as OutOfServiceBed, Premises } from '@approved-premises/api'
+import {
+  Cas1OutOfServiceBed as OutOfServiceBed,
+  Cas1OutOfServiceBedSortField as OutOfServiceBedSortField,
+  Premises,
+  SortDirection,
+} from '@approved-premises/api'
 import { TableCell, UserDetails } from '@approved-premises/ui'
 
 import { isWithinInterval } from 'date-fns'
@@ -7,6 +12,29 @@ import { linkTo } from './utils'
 import { hasRole } from './users'
 import { DateFormats } from './dateUtils'
 import { textValue } from './applications/helpers'
+import { sortHeader } from './sortHeader'
+
+export const allOutOfServiceBedsTableHeaders = (
+  sortBy: OutOfServiceBedSortField,
+  sortDirection: SortDirection,
+  hrefPrefix: string,
+): Array<TableCell> => {
+  return [
+    sortHeader<OutOfServiceBedSortField>('Premises', 'premisesName', sortBy, sortDirection, hrefPrefix),
+    sortHeader<OutOfServiceBedSortField>('Room', 'roomName', sortBy, sortDirection, hrefPrefix),
+    sortHeader<OutOfServiceBedSortField>('Bed', 'bedName', sortBy, sortDirection, hrefPrefix),
+    sortHeader<OutOfServiceBedSortField>('Start date', 'outOfServiceFrom', sortBy, sortDirection, hrefPrefix),
+    sortHeader<OutOfServiceBedSortField>('End date', 'outOfServiceTo', sortBy, sortDirection, hrefPrefix),
+    sortHeader<OutOfServiceBedSortField>('Reason', 'reason', sortBy, sortDirection, hrefPrefix),
+    {
+      text: 'Ref number',
+    },
+    sortHeader<OutOfServiceBedSortField>('Days lost', 'daysLost', sortBy, sortDirection, hrefPrefix),
+    {
+      text: 'Actions',
+    },
+  ]
+}
 
 export const allOutOfServiceBedsTableRows = (beds: Array<OutOfServiceBed>) => {
   return beds.map(bed => {

--- a/server/views/outOfServiceBeds/index.njk
+++ b/server/views/outOfServiceBeds/index.njk
@@ -16,28 +16,6 @@
 	}) }}
 {% endblock %}
 
-{% set tableHeadings = [
-  {
-    text: 'Premises'
-  }, {
-    text: 'Room'
-  }, {
-    text: 'Bed'
-  }, {
-    text: 'Out of service from'
-  }, {
-    text: 'Out of service until'
-  }, {
-    text: 'Reason'
-  }, {
-    text: 'Ref number'
-  }, {
-    text: 'Days lost'
-  }, {
-    text: 'Action'
-  }
-] %}
-
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-width">
@@ -49,7 +27,7 @@
           govukTable({
             caption: "Out of service beds",
             captionClasses: "govuk-table__caption--m",
-            head: tableHeadings,
+            head: OutOfServiceBedUtils.allOutOfServiceBedsTableHeaders(sortBy, sortDirection, hrefPrefix),
             rows: OutOfServiceBedUtils.allOutOfServiceBedsTableRows(outOfServiceBeds)
           })
         }}


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?selectedIssue=APS-897&sprints=6188

# Changes in this PR

Adds sorting to the OOS beds index page for CRU teams. Users can sort by all columns other than reference number and action.