### PR TITLE
Ignore main branch for 'on PR' e2es

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,6 +291,10 @@ workflows:
           context: hmpps-common-vars
           requires:
             - build
+          filters:
+            branches:
+              ignore:
+                - main
       - e2e_environment_test_on_merge:
           context: hmpps-common-vars
           filters:


### PR DESCRIPTION
#1900 introduced running E2E tests on PRs again but it also introduced running the E2Es *for the PR* run once merged which meant they were running twice, concurrently in CI.
Now for the e2e_environment_test_on_pr job we ignore the main branch and only run them on other branches
