### PR TITLE
APS-916: Only users with the role 'Admin' should be able to access 'M…

### DIFF
--- a/server/utils/users/homePageDashboard.test.ts
+++ b/server/utils/users/homePageDashboard.test.ts
@@ -42,7 +42,6 @@ describe('homePageDashboard', () => {
       expect(sectionsForUser(user)).toContain(sections.apply)
       expect(sectionsForUser(user)).toContain(sections.workflow)
       expect(sectionsForUser(user)).toContain(sections.cruDashboard)
-      expect(sectionsForUser(user)).toContain(sections.userManagement)
       expect(sectionsForUser(user)).toContain(sections.manage)
     })
 
@@ -63,7 +62,6 @@ describe('homePageDashboard', () => {
         sections.manage,
         sections.workflow,
         sections.cruDashboard,
-        sections.userManagement,
         sections.reports,
       ])
     })

--- a/server/utils/users/homePageDashboard.ts
+++ b/server/utils/users/homePageDashboard.ts
@@ -113,7 +113,6 @@ export const sectionsForUser = (user: UserDetails): Array<ServiceSection> => {
   if (hasRole(user, 'workflow_manager')) {
     items.push(sections.workflow)
     items.push(sections.cruDashboard)
-    items.push(sections.userManagement)
   }
 
   if (hasRole(user, 'report_viewer')) {


### PR DESCRIPTION
…anage user roles'

# Context

<!-- https://dsdmoj.atlassian.net/browse/APS-916 -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Only users with the role 'Admin' should be able to access 'Manage user roles'/'Users'
## Screenshots of UI changes
No UI changes
### Before

### After
