### PR TITLE
APS-878 - Add IP Whitelist for Palo Alto Egress

### DIFF
--- a/helm_deploy/hmpps-approved-premises-ui/values.yaml
+++ b/helm_deploy/hmpps-approved-premises-ui/values.yaml
@@ -67,6 +67,7 @@ generic-service:
     groups:
       - internal
       - probation
+    palo-alto-prisma-access-egress: '128.77.75.64/26'
 
 generic-prometheus-alerts:
   targetApplication: hmpps-approved-premises-ui


### PR DESCRIPTION
This IP range has been added to the whitelist to support project evolve, migrating/upgrading users to MOJO devices and network. This specific palo-alto-prisma-access-egress range doesn’t exist in the common whitelisting.

I've taken the same approach as CAS3 for this (see https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/983/files)