### PR TITLE
Parallelize match and admin tests

### DIFF
--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -9,6 +9,8 @@ import { NewUserConfirmationPage } from '../pages/admin/newUserConfirmationPage'
 import { DeleteUserConfirmationPage } from '../pages/admin/deleteUserConfirmationPage'
 import { signIn } from '../steps/signIn'
 
+test.describe.configure({ mode: 'parallel' })
+
 test('download reports', async ({ page, reportViewer }) => {
   // Given I am signed in as a report viewer
   await signIn(page, reportViewer)

--- a/e2e/tests/manage.spec.ts
+++ b/e2e/tests/manage.spec.ts
@@ -20,6 +20,8 @@ import { ChangeDepartureDatePage } from '../pages/manage/changeDepartureDate'
 import { signIn } from '../steps/signIn'
 import { OutOfServiceBedsPage } from '../pages/manage/outOfServiceBedsPage'
 
+test.describe.configure({ mode: 'parallel' })
+
 const premisesName = 'Test AP 10'
 const apArea = 'South West & South Central'
 


### PR DESCRIPTION
These tests are already faster than the other tests that rely on creating an application. But we can make them faster still.

