### PR TITLE
APS-905: When viewing a placement, show the 'Other Reason' free text …

### DIFF
--- a/integration_tests/tests/manage/booking.cy.ts
+++ b/integration_tests/tests/manage/booking.cy.ts
@@ -5,6 +5,8 @@ import {
   bedDetailFactory,
   bedSummaryFactory,
   bookingFactory,
+  cancellationFactory,
+  cancellationReasonFactory,
   dateCapacityFactory,
   extendedPremisesSummaryFactory,
   personFactory,
@@ -29,12 +31,15 @@ context('Booking', () => {
   const assessment = assessmentFactory.build({
     status: 'completed',
   })
+  const cancellationReason = cancellationReasonFactory.build({ name: 'Other' })
+  const cancellation = cancellationFactory.build({ reason: cancellationReason, otherReason: 'otherReason' })
   const booking = bookingFactory.build({
     person,
     arrivalDate: '2022-06-01',
     departureDate: '2022-06-01',
     applicationId: application.id,
     assessmentId: assessment.id,
+    cancellations: [cancellation],
   })
   const offences = activeOffenceFactory.buildList(1)
 
@@ -266,6 +271,8 @@ context('Booking', () => {
   it('should allow me to see a booking', () => {
     // Given I am signed in as a workflow manager
     signIn(['workflow_manager'])
+
+    cy.task('stubBookingGet', { premisesId: premises.id, booking })
 
     // When I navigate to the booking's manage page
     const page = BookingShowPage.visit(premises.id, booking)

--- a/server/testutils/factories/cancellationReason.ts
+++ b/server/testutils/factories/cancellationReason.ts
@@ -1,0 +1,11 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { CancellationReason } from '@approved-premises/api'
+
+export default Factory.define<CancellationReason>(() => ({
+  id: faker.string.uuid(),
+  serviceScope: faker.lorem.sentence(),
+  name: faker.lorem.sentence(),
+  isActive: faker.datatype.boolean(),
+}))

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -86,6 +86,7 @@ import placementApplicationDecisionEnvelopeFactory from './placementApplicationD
 import premisesBookingFactory from './premisesBooking'
 import bookingPremisesSummaryFactory from './bookingPremisesSummary'
 import withdrawableFactory from './withdrawableFactory'
+import cancellationReasonFactory from './cancellationReason'
 
 export {
   acctAlertFactory,
@@ -180,4 +181,5 @@ export {
   userDetailsFactory,
   userWithWorkloadFactory,
   withdrawableFactory,
+  cancellationReasonFactory,
 }

--- a/server/utils/bookings/index.test.ts
+++ b/server/utils/bookings/index.test.ts
@@ -25,6 +25,7 @@ import {
   bookingFactory,
   bookingSummaryFactory,
   cancellationFactory,
+  cancellationReasonFactory,
   departureFactory,
   personFactory,
   premisesBookingFactory,
@@ -571,7 +572,8 @@ describe('bookingUtils', () => {
     })
 
     it('returns an details of a cancellations', () => {
-      const cancellation = cancellationFactory.build()
+      const cancellationReason = cancellationReasonFactory.build({ name: 'Recall' })
+      const cancellation = cancellationFactory.build({ reason: cancellationReason })
       const booking = bookingFactory.build({ cancellation })
 
       expect(cancellationRows(booking)).toEqual([
@@ -589,6 +591,31 @@ describe('bookingUtils', () => {
           },
           value: {
             text: cancellation.reason.name,
+          },
+        },
+      ])
+    })
+
+    it('returns an details of a cancellations for other reason', () => {
+      const cancellationReason = cancellationReasonFactory.build({ name: 'Other' })
+      const cancellation = cancellationFactory.build({ reason: cancellationReason })
+      const booking = bookingFactory.build({ cancellation })
+
+      expect(cancellationRows(booking)).toEqual([
+        {
+          key: {
+            text: 'Cancelled on',
+          },
+          value: {
+            text: DateFormats.isoDateToUIDate(cancellation.createdAt),
+          },
+        },
+        {
+          key: {
+            text: 'Reason',
+          },
+          value: {
+            text: `${booking.cancellation.reason.name} - ${booking.cancellation.otherReason}`,
           },
         },
       ])

--- a/server/utils/bookings/index.ts
+++ b/server/utils/bookings/index.ts
@@ -386,7 +386,10 @@ export const cancellationRows = (booking: Booking): Array<SummaryListItem> => {
           text: 'Reason',
         },
         value: {
-          text: booking.cancellation.reason.name,
+          text:
+            booking.cancellation.reason.name === 'Other'
+              ? `${booking.cancellation.reason.name} - ${booking.cancellation.otherReason}`
+              : booking.cancellation.reason.name,
         },
       },
     ]


### PR DESCRIPTION
…if a booking is withdrawn

# Context

<!-- https://dsdmoj.atlassian.net/browse/APS-905 -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
When viewing a placement, show the 'Other Reason' free text if a booking is withdrawn
## Screenshots of UI changes

### Before
<img width="596" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/e12c050f-3aac-4572-ab77-c9da2ca1e504">

### After
<img width="1728" alt="Screenshot 2024-06-18 at 10 44 10" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/08bdb8f8-705d-46c9-a2f4-da7626c902d8">
