### PR TITLE
Aps 898 - add filtering to out of service beds list

### DIFF
--- a/integration_tests/mockApis/outOfServiceBed.ts
+++ b/integration_tests/mockApis/outOfServiceBed.ts
@@ -70,11 +70,12 @@ export default {
     page = 1,
     sortBy = 'outOfServiceFrom',
     sortDirection = 'asc',
+    temporality = 'current',
   }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
-        url: `${paths.manage.outOfServiceBeds.index.pattern}?page=${page}&sortBy=${sortBy}&sortDirection=${sortDirection}`,
+        url: `${paths.manage.outOfServiceBeds.index.pattern}?page=${page}&sortBy=${sortBy}&sortDirection=${sortDirection}&temporality=${temporality}`,
       },
       response: {
         status: 200,

--- a/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedIndex.ts
+++ b/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedIndex.ts
@@ -14,6 +14,10 @@ export class OutOfServiceBedIndexPage extends Page {
     return new OutOfServiceBedIndexPage()
   }
 
+  clickTab(temporality: string): void {
+    cy.get('a').contains(temporality).click()
+  }
+
   shouldShowOutOfServiceBeds(outOfServiceBeds: Array<OutOfServiceBed>): void {
     outOfServiceBeds.forEach((item: OutOfServiceBed) => {
       cy.get(`[data-cy-bedId="${item.bed.id}"]`)

--- a/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedIndex.ts
+++ b/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedIndex.ts
@@ -1,4 +1,4 @@
-import { Cas1OutOfServiceBed as OutOfServiceBed } from '@approved-premises/api'
+import { Cas1OutOfServiceBed as OutOfServiceBed, Temporality } from '@approved-premises/api'
 import paths from '../../../../server/paths/manage'
 
 import Page from '../../page'
@@ -9,8 +9,8 @@ export class OutOfServiceBedIndexPage extends Page {
     super('View out of service beds')
   }
 
-  static visit(): OutOfServiceBedIndexPage {
-    cy.visit(paths.v2Manage.outOfServiceBeds.index({}))
+  static visit(temporality: Temporality): OutOfServiceBedIndexPage {
+    cy.visit(paths.v2Manage.outOfServiceBeds.index({ temporality }))
     return new OutOfServiceBedIndexPage()
   }
 

--- a/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
+++ b/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
@@ -236,7 +236,7 @@ context('OutOfServiceBeds', () => {
   })
 
   describe('list of all OOS beds', () => {
-    const outOfServiceBeds = outOfServiceBedFactory.buildList(10)
+    const outOfServiceBeds = outOfServiceBedFactory.buildList(3)
 
     it('allows me to view all out of service beds', () => {
       cy.task('stubOutOfServiceBedsList', { outOfServiceBeds, page: 1 })
@@ -260,7 +260,7 @@ context('OutOfServiceBeds', () => {
       cy.task('stubOutOfServiceBedsList', { outOfServiceBeds, page: '9' })
 
       // When I visit the OOS beds index page
-      const page = OutOfServiceBedIndexPage.visit()
+      const page = OutOfServiceBedIndexPage.visit('current')
 
       // And I click next
       page.clickNext()
@@ -277,6 +277,42 @@ context('OutOfServiceBeds', () => {
       cy.task('verifyOutOfServiceBedsDashboard', { page: '9' }).then(requests => {
         expect(requests).to.have.length(1)
       })
+    })
+
+    it('allows me to filter by temporality', () => {
+      const futureBeds = outOfServiceBedFactory.buildList(3)
+      const historicBeds = outOfServiceBedFactory.buildList(3)
+
+      cy.task('stubOutOfServiceBedsList', {
+        outOfServiceBeds,
+        page: '1',
+        temporality: 'current',
+      })
+      cy.task('stubOutOfServiceBedsList', {
+        outOfServiceBeds: futureBeds,
+        page: '1',
+        temporality: 'future',
+      })
+      cy.task('stubOutOfServiceBedsList', {
+        outOfServiceBeds: historicBeds,
+        page: '1',
+        temporality: 'historic',
+      })
+
+      // Given I'm on the out of service beds index page
+      const page = OutOfServiceBedIndexPage.visit('current')
+
+      // When I click the 'future' tab
+      page.clickTab('Future')
+
+      // Then I see a list of future out of service beds
+      page.shouldShowOutOfServiceBeds(futureBeds)
+
+      // And when I click the 'historic' tab
+      page.clickTab('Historic')
+
+      // Then I see a list of historic out of service beds
+      page.shouldShowOutOfServiceBeds(historicBeds)
     })
 
     it('supports sorting by premisesName', () => {
@@ -310,7 +346,7 @@ context('OutOfServiceBeds', () => {
 
   const shouldSortByField = (field: string) => {
     // And there is a page of out of service beds
-    const outOfServiceBeds = outOfServiceBedFactory.buildList(10)
+    const outOfServiceBeds = outOfServiceBedFactory.buildList(5)
 
     cy.task('stubOutOfServiceBedsList', { outOfServiceBeds, page: 1 })
     cy.task('stubOutOfServiceBedsList', {
@@ -318,16 +354,18 @@ context('OutOfServiceBeds', () => {
       page: '1',
       sortBy: field,
       sortDirection: 'asc',
+      temporality: 'current',
     })
     cy.task('stubOutOfServiceBedsList', {
       outOfServiceBeds,
       page: '1',
       sortBy: field,
       sortDirection: 'desc',
+      temporality: 'current',
     })
 
     // When I access the out of service beds dashboard
-    const page = OutOfServiceBedIndexPage.visit()
+    const page = OutOfServiceBedIndexPage.visit('current')
 
     // Then I should see the first result
     page.shouldShowOutOfServiceBeds(outOfServiceBeds)

--- a/server/data/outOfServiceBedClient.test.ts
+++ b/server/data/outOfServiceBedClient.test.ts
@@ -105,10 +105,14 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
   })
 
   describe('get', () => {
-    it('makes a request to the outOfServiceBeds endpoint with a page number', async () => {
+    it('makes a request to the outOfServiceBeds endpoint with a page number, sort and filter options', async () => {
       const outOfServiceBeds = outOfServiceBedFactory.buildList(2)
 
       const pageNumber = 3
+      const sortBy = 'roomName'
+      const sortDirection = 'asc'
+      const temporality = 'future'
+      const apAreaId = '123'
 
       provider.addInteraction({
         state: 'Server is healthy',
@@ -116,7 +120,7 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.manage.outOfServiceBeds.index({}),
-          query: { page: pageNumber.toString(), sortBy: 'roomName', sortDirection: 'asc' },
+          query: { page: pageNumber.toString(), sortBy, sortDirection, temporality, apAreaId },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -132,7 +136,13 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
         },
       })
 
-      const result = await outOfServiceBedClient.get('roomName', 'asc', pageNumber)
+      const result = await outOfServiceBedClient.get({
+        page: pageNumber,
+        sortBy,
+        sortDirection,
+        temporality,
+        apAreaId,
+      })
 
       expect(result).toEqual({
         data: outOfServiceBeds,

--- a/server/data/outOfServiceBedClient.ts
+++ b/server/data/outOfServiceBedClient.ts
@@ -8,9 +8,12 @@ import {
   Cas1OutOfServiceBedSortField as OutOfServiceBedSortField,
   Premises,
   SortDirection,
+  Temporality,
   UpdateCas1OutOfServiceBed as UpdateOutOfServiceBed,
 } from '@approved-premises/api'
 import { PaginatedResponse } from '@approved-premises/ui'
+import superagent from 'superagent'
+import { createQueryString } from '../utils/utils'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -43,16 +46,34 @@ export default class OutOfServiceBedClient {
     })) as Array<OutOfServiceBed>
   }
 
-  async get(
-    sortBy: OutOfServiceBedSortField,
-    sortDirection: SortDirection,
-    page = 1,
-  ): Promise<PaginatedResponse<OutOfServiceBed>> {
-    return this.restClient.getPaginatedResponse<OutOfServiceBed>({
-      path: paths.manage.outOfServiceBeds.index.pattern,
-      page: page.toString(),
-      query: { sortBy, sortDirection },
-    })
+  async get({
+    page,
+    sortBy,
+    sortDirection,
+    temporality,
+    premisesId,
+    apAreaId,
+  }: {
+    page: number
+    sortBy: OutOfServiceBedSortField
+    sortDirection: SortDirection
+    temporality: Temporality
+    premisesId?: string
+    apAreaId?: string
+  }): Promise<PaginatedResponse<OutOfServiceBed>> {
+    const response = (await this.restClient.get({
+      path: paths.manage.outOfServiceBeds.index({}),
+      query: createQueryString({ page, sortBy, sortDirection, temporality, premisesId, apAreaId }),
+      raw: true,
+    })) as superagent.Response
+
+    return {
+      data: response.body,
+      pageNumber: page.toString(),
+      totalPages: response.headers['x-pagination-totalpages'],
+      totalResults: response.headers['x-pagination-totalresults'],
+      pageSize: response.headers['x-pagination-pagesize'],
+    }
   }
 
   async update(

--- a/server/paths/manage.ts
+++ b/server/paths/manage.ts
@@ -130,7 +130,7 @@ const v2Manage = {
     new: outOfServiceBedsPath.path('new'),
     create: outOfServiceBedsPath,
     premisesIndex: singlePremisesPath.path('out-of-service-beds'),
-    index: outOfServiceBedsIndexPath,
+    index: outOfServiceBedsIndexPath.path(':temporality'),
     show: outOfServiceBedsPath.path(':id'),
     update: singlePremisesPath.path('out-of-service-beds').path(':id'),
     cancel: singlePremisesPath.path('out-of-service-beds').path(':id').path('cancellations'),

--- a/server/services/outOfServiceBedService.test.ts
+++ b/server/services/outOfServiceBedService.test.ts
@@ -74,19 +74,56 @@ describe('OutOfServiceBedService', () => {
   })
 
   describe('getAllOutOfServiceBeds', () => {
-    it('calls the get method on the outOfServiceBedClient with a page and sort options', async () => {
-      const token = 'SOME_TOKEN'
+    const token = 'SOME_TOKEN'
+
+    it('calls the get method on the outOfServiceBedClient with a page and sort and filter options', async () => {
+      const pageNumber = 3
+      const sortBy = 'roomName'
+      const sortDirection = 'asc'
+      const temporality = 'future'
+      const apAreaId = '123'
 
       const response = paginatedResponseFactory.build({
         data: outOfServiceBedFactory.buildList(1),
       }) as PaginatedResponse<OutOfServiceBed>
       outOfServiceBedClient.get.mockResolvedValue(response)
 
-      const outOfServiceBeds = await service.getAllOutOfServiceBeds(token, 3)
+      const outOfServiceBeds = await service.getAllOutOfServiceBeds({
+        token,
+        page: pageNumber,
+        sortBy,
+        sortDirection,
+        temporality,
+        apAreaId,
+        premisesId,
+      })
 
       expect(outOfServiceBeds).toEqual(response)
       expect(OutOfServiceBedClientFactory).toHaveBeenCalledWith(token)
-      expect(outOfServiceBedClient.get).toHaveBeenCalledWith('outOfServiceFrom', 'asc', 3)
+      expect(outOfServiceBedClient.get).toHaveBeenCalledWith({
+        page: pageNumber,
+        sortBy,
+        sortDirection,
+        temporality,
+        apAreaId,
+        premisesId,
+      })
+    })
+
+    it('defaults to filtering for current items only with no area or premises filter, sorted by "from date" ascending', async () => {
+      const response = paginatedResponseFactory.build({
+        data: outOfServiceBedFactory.buildList(1),
+      }) as PaginatedResponse<OutOfServiceBed>
+      outOfServiceBedClient.get.mockResolvedValue(response)
+
+      await service.getAllOutOfServiceBeds({ token })
+
+      expect(outOfServiceBedClient.get).toHaveBeenCalledWith({
+        page: 1,
+        sortBy: 'outOfServiceFrom',
+        sortDirection: 'asc',
+        temporality: 'current',
+      })
     })
   })
 

--- a/server/services/outOfServiceBedService.ts
+++ b/server/services/outOfServiceBedService.ts
@@ -5,6 +5,7 @@ import type {
   Cas1OutOfServiceBedCancellation as OutOfServiceBedCancellation,
   Cas1OutOfServiceBedSortField as OutOfServiceBedSortField,
   SortDirection,
+  Temporality,
   UpdateCas1OutOfServiceBed as UpdateOutOfServiceBed,
 } from '@approved-premises/api'
 import { PaginatedResponse } from '@approved-premises/ui'
@@ -58,14 +59,32 @@ export default class OutOfServiceBedService {
     return outOfServiceBeds
   }
 
-  async getAllOutOfServiceBeds(
-    token: string,
+  async getAllOutOfServiceBeds({
+    token,
     page = 1,
-    sortBy: OutOfServiceBedSortField = 'outOfServiceFrom',
-    sortDirection: SortDirection = 'asc',
-  ): Promise<PaginatedResponse<OutOfServiceBed>> {
+    sortBy = 'outOfServiceFrom',
+    sortDirection = 'asc',
+    temporality = 'current',
+    premisesId,
+    apAreaId,
+  }: {
+    token: string
+    page?: number
+    sortBy?: OutOfServiceBedSortField
+    sortDirection?: SortDirection
+    temporality?: Temporality
+    premisesId?: string
+    apAreaId?: string
+  }): Promise<PaginatedResponse<OutOfServiceBed>> {
     const outOfServiceBedClient = this.outOfServiceBedClientFactory(token)
-    const outOfServiceBeds = await outOfServiceBedClient.get(sortBy, sortDirection, page)
+    const outOfServiceBeds = await outOfServiceBedClient.get({
+      sortBy,
+      sortDirection,
+      page,
+      temporality,
+      premisesId,
+      apAreaId,
+    })
 
     return outOfServiceBeds
   }

--- a/server/utils/users/homePageDashboard.ts
+++ b/server/utils/users/homePageDashboard.ts
@@ -81,7 +81,7 @@ export const sections = {
     title: 'View out of service beds',
     description: 'View all currently out of service beds, across all Approved Premises.',
     shortTitle: 'Out of service beds',
-    href: managePaths.v2Manage.outOfServiceBeds.index({}),
+    href: managePaths.v2Manage.outOfServiceBeds.index({ temporality: 'current' }),
   },
 }
 export const managerRoles: ReadonlyArray<UserRole> = [

--- a/server/views/outOfServiceBeds/index.njk
+++ b/server/views/outOfServiceBeds/index.njk
@@ -4,6 +4,7 @@
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 
 {%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 
 {% extends "../partials/layout.njk" %}
 
@@ -20,6 +21,25 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-width">
       <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+      {{
+        mojSubNavigation({
+          label: 'Sub navigation',
+          items: [{
+              text: 'Current',
+              href: paths.v2Manage.outOfServiceBeds.index({temporality: 'current'}),
+              active: temporality === 'current'
+            }, {
+              text: 'Future',
+              href: paths.v2Manage.outOfServiceBeds.index({temporality: 'future'}),
+              active: temporality === 'future'
+            }, {
+              text: 'Historic',
+              href: paths.v2Manage.outOfServiceBeds.index({temporality: 'historic'}),
+              active: temporality === 'historic'
+          }]
+        })
+      }}
 
       {% if outOfServiceBeds %}
 


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=712020%3A23fbf793-ee9a-4ecd-ad4d-37beaa0edeaa&selectedIssue=APS-898&sprints=6188

# Changes in this PR

Allows users to filter between lists of current, future and historic out of service beds.

## Screenshots of UI changes

### Before

![OutOfServiceBeds -- list of all OOS beds -- supports pagination](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/70749355/edea1e3c-9e28-446d-a997-ae80678e4141)

### After

![OutOfServiceBeds -- list of all OOS beds -- allows me to filter by temporality (1)](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/70749355/771d4404-849c-4f90-8dc7-504f72130314)