### PR TITLE
APS-840: Show the notes even if nothing is withdrawable

### DIFF
--- a/integration_tests/tests/withdrawals/withdrawals.cy.ts
+++ b/integration_tests/tests/withdrawals/withdrawals.cy.ts
@@ -189,9 +189,13 @@ context('Withdrawals', () => {
         hasRequestsForPlacement: false,
       })
 
+      const withdrawables = withdrawablesFactory.build({
+        withdrawables: [],
+      })
+
       cy.task('stubWithdrawablesWithNotes', {
         applicationId: application.id,
-        withdrawables: [],
+        withdrawables,
       })
       cy.task('stubApplications', [application])
       cy.task('stubApplicationGet', { application })

--- a/server/views/applications/withdrawables/new.njk
+++ b/server/views/applications/withdrawables/new.njk
@@ -18,15 +18,14 @@
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
+            {% if notes | length > 0 %}
+                <ul class="govuk-list govuk-list--bullet">
+                    {% for note in notes %}
+                        <li>{{note}}</li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
             {% if withdrawables.length %}
-                {% if notes | length > 0 %}
-                    <ul class="govuk-list govuk-list--bullet">
-                        {% for note in notes %}
-                            <li>{{note}}</li>
-                        {% endfor %}
-                    </ul>
-                {% endif %}
-
                 <form action={{paths.applications.withdraw.new({id: id})}} method="post"/>
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 


### PR DESCRIPTION
# Context

<!-- https://dsdmoj.atlassian.net/browse/APS-840 -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Show the withdraw notes even if nothing is withdrawable
## Screenshots of UI changes

### Before
<img width="765" alt="image" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/798d755d-7a48-4755-ac47-0e13fd995972">

### After
<img width="1728" alt="Screenshot 2024-06-19 at 17 33 58" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/eba81f90-9986-4744-951a-5807140798ba">
