### PR TITLE
APS 911 - allow users to access OOS beds list from premises page

### DIFF
--- a/integration_tests/mockApis/premises.ts
+++ b/integration_tests/mockApis/premises.ts
@@ -44,9 +44,25 @@ const stubPremisesSummary = (premises: ExtendedPremisesSummary) =>
     },
   })
 
+const stubSinglePremises = (premises: Premises) =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: `/premises/${premises.id}`,
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: premises,
+    },
+  })
+
 export default {
   stubAllPremises,
   stubPremisesSummary,
+  stubSinglePremises,
   stubPremisesWithBookings: (args: { premises: Premises; bookings: Array<Booking> }): Promise<[Response, Response]> =>
     Promise.all([
       stubPremisesSummary(args.premises),

--- a/integration_tests/pages/manage/premisesShow.ts
+++ b/integration_tests/pages/manage/premisesShow.ts
@@ -21,6 +21,10 @@ export default class PremisesShowPage extends Page {
     cy.get('a').contains('View calendar').click()
   }
 
+  shouldShowAPArea(apArea: string): void {
+    cy.get('span').should('contain', apArea)
+  }
+
   shouldShowPremisesDetail(): void {
     cy.get('.govuk-summary-list__key')
       .contains('Code')

--- a/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
+++ b/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
@@ -24,12 +24,13 @@ context('OutOfServiceBeds', () => {
   it('should allow me to create a out of service bed', () => {
     const premises = extendedPremisesSummaryFactory.build()
     cy.task('stubPremisesSummary', premises)
+    const fullPremises = premisesFactory.build({ id: premises.id })
+    cy.task('stubSinglePremises', fullPremises)
 
     // Given I am signed in as a future manager
     signIn(['future_manager'])
 
     // When I navigate to the out of service bed form
-
     const outOfServiceBed = outOfServiceBedFactory.build({
       outOfServiceFrom: '2022-02-11',
       outOfServiceTo: '2022-03-11',

--- a/integration_tests/tests/v2Manage/premises.cy.ts
+++ b/integration_tests/tests/v2Manage/premises.cy.ts
@@ -2,6 +2,7 @@ import {
   dateCapacityFactory,
   extendedPremisesSummaryFactory,
   premisesBookingFactory,
+  premisesFactory,
   premisesSummaryFactory,
 } from '../../../server/testutils/factories'
 
@@ -65,17 +66,24 @@ context('Premises', () => {
       availableBeds: -1,
     })
 
+    const premisesId = '123'
+
     const premises = extendedPremisesSummaryFactory.build({
       dateCapacities: [overcapacityStartDate, overcapacityEndDate],
       bookings,
+      id: premisesId,
     })
 
+    const fullPremises = premisesFactory.build({ id: premisesId })
+
     cy.task('stubPremisesSummary', premises)
+    cy.task('stubSinglePremises', fullPremises)
 
     // When I visit the premises page
     const page = PremisesShowPage.visit(premises, { v2: true })
 
     // Then I should see the premises details shown
+    page.shouldShowAPArea(fullPremises.apArea.name)
     page.shouldShowPremisesDetail()
 
     // And I should see all the bookings for that premises listed

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -5,6 +5,7 @@ import { controllers as assessControllers } from './assess'
 import { controllers as matchControllers } from './match'
 import { controllers as manageControllers } from './manage'
 import { controllers as adminControllers } from './admin'
+import { controllers as v2ManageControllers } from './v2Manage'
 import TasksController from './tasksController'
 import AllocationsController from './tasks/allocationsController'
 
@@ -51,6 +52,7 @@ export const controllers = (services: Services) => {
     ...matchControllers(services),
     ...manageControllers(services),
     ...adminControllers(services),
+    ...v2ManageControllers(services),
   }
 }
 

--- a/server/controllers/v2Manage/index.ts
+++ b/server/controllers/v2Manage/index.ts
@@ -1,0 +1,15 @@
+/* istanbul ignore file */
+
+import V2PremisesController from './premises/premisesController'
+
+import type { Services } from '../../services'
+
+export const controllers = (services: Services) => {
+  const v2PremisesController = new V2PremisesController(services.premisesService)
+
+  return {
+    v2PremisesController,
+  }
+}
+
+export { V2PremisesController }

--- a/server/controllers/v2Manage/premises/premisesController.test.ts
+++ b/server/controllers/v2Manage/premises/premisesController.test.ts
@@ -1,0 +1,45 @@
+import type { NextFunction, Request, Response } from 'express'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+
+import { PremisesService } from '../../../services'
+import V2PremisesController from './premisesController'
+
+import { extendedPremisesSummaryFactory, premisesFactory } from '../../../testutils/factories'
+
+describe('V2PremisesController', () => {
+  const token = 'SOME_TOKEN'
+  const premisesId = 'some-uuid'
+
+  let request: DeepMocked<Request>
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const premisesService = createMock<PremisesService>({})
+  const premisesController = new V2PremisesController(premisesService)
+
+  beforeEach(() => {
+    request = createMock<Request>({ user: { token }, params: { premisesId } })
+    jest.useFakeTimers()
+  })
+
+  describe('show', () => {
+    it('should return the premises detail to the template', async () => {
+      const fullPremises = premisesFactory.build()
+      const premises = extendedPremisesSummaryFactory.build()
+
+      premisesService.getPremisesDetails.mockResolvedValue(premises)
+      premisesService.find.mockResolvedValue(fullPremises)
+
+      const requestHandler = premisesController.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('v2Manage/premises/show', {
+        premises,
+        bookings: premises.bookings,
+        apArea: fullPremises.apArea,
+      })
+
+      expect(premisesService.getPremisesDetails).toHaveBeenCalledWith(token, premisesId)
+    })
+  })
+})

--- a/server/controllers/v2Manage/premises/premisesController.ts
+++ b/server/controllers/v2Manage/premises/premisesController.ts
@@ -1,0 +1,19 @@
+import type { Request, RequestHandler, Response } from 'express'
+
+import { PremisesService } from '../../../services'
+
+export default class V2PremisesController {
+  constructor(private readonly premisesService: PremisesService) {}
+
+  show(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const premises = await this.premisesService.getPremisesDetails(req.user.token, req.params.premisesId)
+      const { apArea } = await this.premisesService.find(req.user.token, req.params.premisesId)
+      return res.render('v2Manage/premises/show', {
+        premises,
+        bookings: premises.bookings,
+        apArea,
+      })
+    }
+  }
+}

--- a/server/routes/v2Manage.ts
+++ b/server/routes/v2Manage.ts
@@ -18,6 +18,7 @@ export default function routes(controllers: Controllers, router: Router, service
     bookingExtensionsController,
     outOfServiceBedsController,
     bedsController,
+    v2PremisesController,
   } = controllers
 
   // Premises
@@ -29,7 +30,7 @@ export default function routes(controllers: Controllers, router: Router, service
     auditEvent: 'FILTER_PREMISES',
     allowedRoles: ['future_manager'],
   })
-  get(paths.v2Manage.premises.show.pattern, premisesController.show(), {
+  get(paths.v2Manage.premises.show.pattern, v2PremisesController.show(), {
     auditEvent: 'SHOW_PREMISES',
     allowedRoles: ['future_manager'],
   })

--- a/server/utils/premises/premisesActions.test.ts
+++ b/server/utils/premises/premisesActions.test.ts
@@ -119,4 +119,24 @@ describe('premisesActions', () => {
       })
     })
   })
+
+  describe('for users with no role', () => {
+    const user = userDetails.build({ roles: [] })
+    const premises = premisesFactory.build()
+
+    it('includes the "manage beds" action', () => {
+      expect(premisesActions(user, premises)).toContainManageAction({
+        text: 'Manage beds',
+        classes: 'govuk-button--secondary',
+        href: paths.premises.beds.index({ premisesId: premises.id }),
+      })
+    })
+    it('includes the "out of service beds" action', () => {
+      expect(premisesActions(user, premises)).toContainManageAction({
+        text: 'Manage out of service bed records',
+        classes: 'govuk-button--secondary',
+        href: paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId: premises.id }),
+      })
+    })
+  })
 })

--- a/server/utils/premises/premisesActions.ts
+++ b/server/utils/premises/premisesActions.ts
@@ -9,6 +9,11 @@ export const premisesActions = (user: UserDetails, premises: Premises) => {
       classes: 'govuk-button--secondary',
       href: paths.premises.beds.index({ premisesId: premises.id }),
     },
+    {
+      text: 'Manage out of service bed records',
+      classes: 'govuk-button--secondary',
+      href: paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId: premises.id }),
+    },
   ]
 
   if (user.roles?.includes('workflow_manager')) {

--- a/server/views/v2Manage/premises/show.njk
+++ b/server/views/v2Manage/premises/show.njk
@@ -1,0 +1,131 @@
+e{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
+{% from "../../bookings/_table.njk" import bookingTable %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + premises.name %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+		text: "Back",
+		href: paths.premises.index()
+	}) }}
+{% endblock %}
+
+{%set titleHtml = '<span class="govuk-caption-xl">' + apArea.name + '</span><h1>' + premises.name + '</h1>'%}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      {% include "../../_messages.njk" %}
+
+      {% set overcapacityMessage = PremisesUtils.overcapacityMessage(premises.dateCapacities) %}
+
+      {% if overcapacityMessage | length %}
+        {{ govukNotificationBanner({
+          titleText: 'Important',
+          html: '<div class="govuk-heading-s">' + overcapacityMessage + '</div>',
+          titleId: 'info-title'
+        }) }}
+      {% endif %}
+
+      {{
+        mojIdentityBar({
+          title: {
+            html: titleHtml
+          },
+        menus: [{
+          items: PremisesUtils.premisesActions(user, premises)
+        }]
+        })
+      }}
+    </div>
+    <div class="govuk-grid-column-full-width">
+      {{
+		    govukSummaryList(
+          PremisesUtils.summaryListForPremises(premises)
+        )
+	    }}
+
+      <h2>Arrivals and Departures</h2>
+
+      {{
+        govukTabs({
+          items: [
+            {
+              label: "Arriving Today",
+              id: "arriving-today",
+              panel: {
+                html: bookingTable("Arriving Today", "Arrival", BookingUtils.arrivingTodayOrLate(bookings, premises.id))
+              }
+            },
+            {
+              label: "Departing Today",
+              id: "departing-today",
+              panel: {
+                html: bookingTable("Departing Today", "Departure", BookingUtils.departingTodayOrLate(bookings, premises.id))
+              }
+            },
+            {
+              label: "Upcoming Arrivals",
+              id: "upcoming-arrivals",
+              panel: {
+                html: bookingTable("Upcoming Arrivals", "Arrival", BookingUtils.upcomingArrivals(bookings, premises.id))
+              }
+            },
+            {
+              label: "Upcoming Departures",
+              id: "upcoming-departures",
+              panel: {
+                html: bookingTable("Upcoming Departures", "Departure", BookingUtils.upcomingDepartures(bookings, premises.id))
+              }
+            }
+          ]
+        })
+      }}
+
+      <h2>Current residents</h2>
+
+      {{
+        govukTable({
+          id:"current-residents",
+          caption: "Current residents",
+          captionClasses: "govuk-visually-hidden",
+          firstCellIsHeader: true,
+          head: [
+            {
+              text: "Resident Name"
+            },
+            {
+              text: "CRN"
+            },
+            {
+              text: "Expected Departure Date"
+            },
+            {
+              text: "Bed name"
+            },
+            {
+              text: "Actions"
+            }
+          ],
+          rows: BookingUtils.arrivedBookings(bookings, premises.id)
+        })
+      }}
+    </div>
+  </div>
+{% endblock %}
+
+{% block extraScripts %}
+  <script type="text/javascript" nonce="{{ cspNonce }}">
+    new MOJFrontend.ButtonMenu({container: $('.moj-button-menu'), mq: "(min-width: 200em)", buttonText: "Actions", menuClasses: "moj-button-menu__wrapper--right"});
+  </script>
+{% endblock %}


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/APS-911

# Changes in this PR

- adds new v2PremisesController to to render the new premises page
- updates actions menu on premises page to include 'Manage out of service bed records'
- adds AP area name above premises name

## Screenshots of UI changes

### Before

![Screenshot 2024-06-20 at 14 36 58](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/70749355/c9bf19fa-86b9-4a21-912f-da4bdf8f7187)

### After

![Screenshot 2024-06-20 at 14 36 34](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/70749355/804604b5-e8f4-4474-a1d9-3e5296bfebce)