### PR TITLE
APS-859: fix Add double click protection to 'Allocate' task buttons

### DIFF
--- a/server/utils/tasks/usersTable.ts
+++ b/server/utils/tasks/usersTable.ts
@@ -66,6 +66,6 @@ export const buttonCell = (user: UserWithWorkload, task: Task, csrfToken: string
   })}" method="post">
   <input type="hidden" name="userId" value="${user.id}" />
   <input type="hidden" name="_csrf" value="${csrfToken}" />
-   <button class="govuk-button govuk-button--secondary" data-prevent-double-click="true" type="submit" data-cy-userId="${user.id}">Allocate</button>
+   <button class="govuk-button govuk-button--secondary" data-prevent-double-click="true" name="submit" type="submit" data-cy-userId="${user.id}" data-module="govuk-button">Allocate</button>
   </form>`,
 })


### PR DESCRIPTION
# Context

<!-- https://dsdmoj.atlassian.net/browse/APS-875 -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
 Add double click protection to 'Allocate' task buttons
Tested on chrome with multiple clicks on Allocate and sent the post request only once
## Screenshots of UI changes
No UI changes
### Before

### After
