### PR TITLE
Don't run E2E tests on PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,33 +179,6 @@ jobs:
           channel: << pipeline.parameters.alerts-slack-channel >>
           template: basic_fail_1
 
-  e2e_environment_test_on_pr:
-    executor:
-      name: hmpps/node
-      tag: << pipeline.parameters.node-version >>
-    parallelism: 4
-    circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
-    steps:
-      - checkout
-      - attach_workspace:
-          at: ~/app
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-      - run:
-          name: Install Playwright
-          command: npx playwright install
-      - run:
-          name: E2E Check
-          command: |
-            SHARD="$((${CIRCLE_NODE_INDEX}+1))"
-            npm run test:e2e:ci -- --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
-      - store_artifacts:
-          path: playwright-report
-          destination: playwright-report
-      - store_artifacts:
-          path: test-results
-          destination: test-results
-
   e2e_environment_test_on_merge:
     executor:
       name: hmpps/node
@@ -279,14 +252,6 @@ workflows:
           requires:
             - helm_lint
             - build_docker
-      - e2e_environment_test_on_pr:
-          context: hmpps-common-vars
-          requires:
-            - build
-          filters:
-            branches:
-              ignore:
-                - main
       - e2e_environment_test_on_merge:
           context: hmpps-common-vars
           filters:


### PR DESCRIPTION
Now that we can run the E2E tests *locally* we can:

1. include E2E test changes which describe the changed behaviour in our PR by running locally:

  - feature branch of  UI
  - main branch of API (what's on `dev`)

2. be confident that the E2E test will pass in the deployed `dev` environment once merged

Having the E2E tests running on PR makes (1) impossible as the tests in the PR are run against the `main` branch of the UI as deployed to `dev`, rather than against the feature branch in the PR!


