### PR TITLE
APS-597:  New user sees guidance if Delius acct missing staff details

### DIFF
--- a/integration_tests/pages/deliusMissingStaffDetails.ts
+++ b/integration_tests/pages/deliusMissingStaffDetails.ts
@@ -1,0 +1,7 @@
+import Page from './page'
+
+export default class DeliusMissingStaffDetails extends Page {
+  constructor() {
+    super(' Delius account missing staff details ')
+  }
+}

--- a/integration_tests/tests/login.cy.ts
+++ b/integration_tests/tests/login.cy.ts
@@ -2,6 +2,9 @@ import DashboardPage from '../pages/dashboard'
 import AuthSignInPage from '../pages/authSignIn'
 import Page from '../pages/page'
 import AuthManageDetailsPage from '../pages/authManageDetails'
+import { userProfileFactory } from '../../server/testutils/factories/user'
+import { userFactory } from '../../server/testutils/factories'
+import DeliusMissingStaffDetails from '../pages/deliusMissingStaffDetails'
 
 context('SignIn', () => {
   beforeEach(() => {
@@ -65,5 +68,12 @@ context('SignIn', () => {
     cy.signIn()
 
     indexPage.headerUserName().contains('B. Brown')
+  })
+
+  it('Delius account missing staff details user directed to DeliusMissingStaffDetails', () => {
+    const profile = userProfileFactory.build({ user: userFactory.build(), loadError: 'staff_record_not_found' })
+    cy.task('stubAuthUser', { name: 'J. Smith', profile })
+    cy.signIn()
+    Page.verifyOnPage(DeliusMissingStaffDetails)
   })
 })

--- a/server/data/userClient.test.ts
+++ b/server/data/userClient.test.ts
@@ -48,7 +48,7 @@ describeClient('UserClient', provider => {
         uponReceiving: 'A request to get a user profile',
         withRequest: {
           method: 'GET',
-          path: paths.users.profile({}),
+          path: paths.users.v2profile({}),
           headers: {
             authorization: `Bearer ${token}`,
             'X-Service-Name': 'approved-premises',

--- a/server/data/userClient.ts
+++ b/server/data/userClient.ts
@@ -1,4 +1,5 @@
 import type {
+  ProfileResponse,
   SortDirection,
   ApprovedPremisesUser as User,
   UserQualification,
@@ -23,8 +24,8 @@ export default class UserClient {
     return (await this.restClient.get({ path: paths.users.show({ id }) })) as User
   }
 
-  async getUserProfile(): Promise<User> {
-    return (await this.restClient.get({ path: paths.users.profile({}) })) as User
+  async getUserProfile(): Promise<ProfileResponse> {
+    return (await this.restClient.get({ path: paths.users.v2profile({}) })) as ProfileResponse
   }
 
   async getUserList(roles: Array<UserRole> = []): Promise<Array<User>> {

--- a/server/middleware/populateCurrentUser.test.ts
+++ b/server/middleware/populateCurrentUser.test.ts
@@ -5,6 +5,7 @@ import { UserService } from '../services'
 import populateCurrentUser from './populateCurrentUser'
 import { userDetailsFactory } from '../testutils/factories'
 import logger from '../../logger'
+import { DeliusAccountMissingStaffDetailsError } from '../services/userService'
 
 jest.mock('../../logger')
 
@@ -105,5 +106,20 @@ describe('populateCurrentUser', () => {
     await middleware(request, response, next)
 
     expect(next).toHaveBeenCalled()
+  })
+
+  it('it throws an DeliusAccountMissingStaffDetailsError', async () => {
+    const err = new DeliusAccountMissingStaffDetailsError()
+
+    ;(userService.getActingUser as jest.Mock).mockImplementation(() => {
+      throw err
+    })
+
+    const middleware = populateCurrentUser(userService)
+
+    await middleware(request, response, next)
+
+    expect(response.redirect).toHaveBeenCalledWith('/deliusMissingStaffDetails')
+    expect(logger.error).toHaveBeenCalledWith('Delius account missing staff details')
   })
 })

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -1,6 +1,6 @@
 import { RequestHandler } from 'express'
 import logger from '../../logger'
-import UserService from '../services/userService'
+import UserService, { DeliusAccountMissingStaffDetailsError } from '../services/userService'
 
 export default function populateCurrentUser(userService: UserService): RequestHandler {
   return async (req, res, next) => {
@@ -22,6 +22,10 @@ export default function populateCurrentUser(userService: UserService): RequestHa
       }
       return next()
     } catch (error) {
+      if (error instanceof DeliusAccountMissingStaffDetailsError) {
+        logger.error('Delius account missing staff details')
+        return res.redirect('/deliusMissingStaffDetails')
+      }
       logger.error(error, `Failed to retrieve user for: ${res.locals.user && res.locals.user.username}`)
       return next(error)
     }

--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -15,6 +15,10 @@ export default function setUpAuth(): Router {
   router.use(passport.session())
   router.use(flash())
 
+  router.get('/deliusMissingStaffDetails', (req, res) => {
+    return res.render('deliusMissingStaffDetails', { hideNav: true })
+  })
+
   router.get('/autherror', (req, res) => {
     res.status(401)
     if (req.session.messages) {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -20,6 +20,8 @@ const bedsPath = singlePremisesPath.path('beds')
 
 const bookingPath = singlePremisesPath.path('bookings/:bookingId')
 
+const profilePath = path('/profile')
+
 const managePaths = {
   premises: {
     index: premisesPath.path('summary'),
@@ -223,9 +225,10 @@ export default {
     search: usersPath.path('search'),
     searchDelius: usersPath.path('delius'),
     show: usersPath.path(':id'),
-    profile: path('/profile'),
+    profile: profilePath,
     update: usersPath.path(':id'),
     delete: usersPath.path(':id'),
+    v2profile: profilePath.path('/v2'),
   },
   reports: reportsPath.path(':reportName'),
 }

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -7,6 +7,7 @@ import { PaginatedResponse } from '../@types/ui'
 import { ApprovedPremisesUser } from '../@types/shared'
 import ReferenceDataClient from '../data/referenceDataClient'
 import { convertToTitleCase } from '../utils/utils'
+import { userProfileFactory } from '../testutils/factories/user'
 
 jest.mock('../data/userClient')
 jest.mock('../data/referenceDataClient.ts')
@@ -17,7 +18,8 @@ describe('User service', () => {
   const userClient: jest.Mocked<UserClient> = new UserClient(null) as jest.Mocked<UserClient>
   const userClientFactory = jest.fn()
   const referenceDataClientFactory = jest.fn()
-  const userProfile = userFactory.build({ roles: ['workflow_manager', 'assessor'] })
+  const approvedPremisesUser = userFactory.build({ roles: ['workflow_manager', 'assessor'] })
+  const userProfile = userProfileFactory.build({ user: approvedPremisesUser })
   const referenceDataClient = new ReferenceDataClient(null) as jest.Mocked<ReferenceDataClient>
 
   let userService: UserService
@@ -37,12 +39,12 @@ describe('User service', () => {
     it('retrieves and populates information from the API', async () => {
       const result = await userService.getActingUser(token)
 
-      expect(result.name).toEqual(userProfile.deliusUsername)
-      expect(result.id).toEqual(userProfile.id)
-      expect(result.displayName).toEqual(convertToTitleCase(userProfile.name))
-      expect(result.roles).toEqual(userProfile.roles)
-      expect(result.active).toEqual(userProfile.isActive)
-      expect(result.apArea).toEqual(userProfile.apArea)
+      expect(result.name).toEqual(approvedPremisesUser.deliusUsername)
+      expect(result.id).toEqual(approvedPremisesUser.id)
+      expect(result.displayName).toEqual(convertToTitleCase(approvedPremisesUser.name))
+      expect(result.roles).toEqual(approvedPremisesUser.roles)
+      expect(result.active).toEqual(approvedPremisesUser.isActive)
+      expect(result.apArea).toEqual(approvedPremisesUser.apArea)
     })
   })
 

--- a/server/testutils/factories/user.ts
+++ b/server/testutils/factories/user.ts
@@ -2,6 +2,7 @@ import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
 
 import type {
+  ProfileResponse,
   ApprovedPremisesUser as User,
   UserQualification,
   ApprovedPremisesUserRole as UserRole,
@@ -28,6 +29,11 @@ export const userWithWorkloadFactory = Factory.define<UserWithWorkload>(({ param
   numTasksPending: faker.number.int({ min: 0, max: 10 }),
   numTasksCompleted7Days: faker.number.int({ min: 0, max: 15 }),
   numTasksCompleted30Days: faker.number.int({ min: 0, max: 45 }),
+}))
+
+export const userProfileFactory = Factory.define<ProfileResponse>(() => ({
+  deliusUsername: faker.internet.userName(),
+  user: userFactory.build(),
 }))
 
 const roleFactory = Factory.define<UserRole>(() =>

--- a/server/views/deliusMissingStaffDetails.njk
+++ b/server/views/deliusMissingStaffDetails.njk
@@ -1,0 +1,10 @@
+{% extends "./partials/layout.njk" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">
+     Delius account missing staff details
+  </h1>
+  <p>
+    You are not currently able to use the service. Please complete the following form: <a class="govuk-link" href="https://forms.office.com/e/zBFKQbJtjU">Microsoft Forms</a> to request changes to your account.
+  </p>
+{% endblock %}


### PR DESCRIPTION
# Context

- https://dsdmoj.atlassian.net/browse/APS-597 
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
New user sees guidance if Delius acct missing staff details
## Screenshots of UI changes

### Before
### After
<img width="1728" alt="Screenshot 2024-06-25 at 11 29 14" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/b0833826-de81-431b-94bb-fc01d2212d53">

