### PR TITLE
Introduce a E2E 'Person for AdHoc Booking'

### DIFF
--- a/e2e/pages/manage/premisesPage.ts
+++ b/e2e/pages/manage/premisesPage.ts
@@ -27,6 +27,10 @@ export class PremisesPage extends BasePage {
     await table.getByRole('link', { name: 'Manage' }).first().click()
   }
 
+  async clickGivenBooking(bookingId: string) {
+    await this.page.locator(`[data-cy-booking-id="${bookingId}"]`).first().click()
+  }
+
   async clickManageCurrentResident() {
     const table = this.page.getByRole('table', { name: 'Current residents' })
     await table.getByRole('link', { name: 'Manage' }).first().click()

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -9,6 +9,7 @@ export const test = base.extend<TestOptions>({
     },
     { option: true },
   ],
+  personForAdHocBooking: [{ crn: process.env.CAS1_E2E_PERSON_FOR_ADHOC_BOOKING_CRN }, { option: true }],
   user: [
     {
       name: (process.env.HMPPS_AUTH_NAME || 'Approved Premises E2ETester') as string,

--- a/e2e/types/index.d.ts
+++ b/e2e/types/index.d.ts
@@ -18,6 +18,9 @@ declare module '@approved-premises/e2e' {
       crn: string
       name: string
     }
+    personForAdHocBooking: {
+      crn: string
+    }
     userToAddAndDelete: {
       name: string
     }

--- a/server/utils/bookings/bookingActions.ts
+++ b/server/utils/bookings/bookingActions.ts
@@ -15,11 +15,23 @@ export const bookingActions = (user: UserDetails, booking: Booking): Array<Ident
 class MenuItems {
   constructor(public booking: Booking) {}
 
-  withdrawalLink = () => {
-    if (!this.booking?.applicationId) {
-      return paths.bookings.cancellations.new({ premisesId: this.booking.premises.id, bookingId: this.booking.id })
-    }
+  bookingCancellationPath = () => {
+    return paths.bookings.cancellations.new({ premisesId: this.booking.premises.id, bookingId: this.booking.id })
+  }
+
+  applicationWithdrawalPath = () => {
     return applyPaths.applications.withdraw.new({ id: this.booking?.applicationId })
+  }
+
+  bookingHasNoApplicationAssociatedByBothCrnAndEventNumber = () => {
+    return !this.booking?.applicationId
+  }
+
+  withdrawalLink = () => {
+    if (this.bookingHasNoApplicationAssociatedByBothCrnAndEventNumber()) {
+      return this.bookingCancellationPath()
+    }
+    return this.applicationWithdrawalPath()
   }
 
   items = {


### PR DESCRIPTION
The bookings page can offer 2 possibilities of "Withdraw placement" link:

1. where the booking has an associated application we use the **application withdrawal** path of `/applications/{id}/withdrawals/new`. In the case of adhoc bookings the association is made when an application is found matching the CRN and the Delius event number.

2. where there is no application for this combination of CRN and Delius event number, the booking will not have been associated with an application, and we use the **booking cancellation** path of  `premises/{id}/bookings/{id}/cancellations/new`

The "Mark a booking as cancelled" spec in `e2e/tests/manage.spec.ts` was inherently flaky as:

- a) the test exercises the *booking cancellation* path, and
- b) we can't easily ensure that the db has no existing pre-existing applications when the test is run

In this commit we:

### 1. Introduce a new person 
Our new CAS1 person (a "probation case" in AP-and-Delius language and an "offender" in CommunityAPI language) is for  use in scenarios where a manual or "ad hoc" booking is required.

The upstream API calls which we need to support to create an ad hoc booking are:

i) get info about the person from AP-and-Delius with `http://ap-and-delius/probation-cases/summaries`. See  [Probation Integration Services PE 3954][]

ii) get convictions from CommunityAPI with `http://community-api/secure/offenders/crn/X320811/convictions`. See [seeding at Community API]

### 2. Introduce a `navigateToGivenBooking(bookingId)` helper 
This allows us to reliably identify the ad-hoc booking which we've made. This isn't great BDD as we are using DOM attributes rather than human-readable links/buttons etc but this is a pragmatic choice to make these tests more resilient.

**NB**: We'll need to remember to add the new `CAS1_E2E_PERSON_FOR_ADHOC_BOOKING_CRN` environment variable to both the UI and API settings in Circle CI

[Probation Integration Services PE 3954]:
https://github.com/ministryofjustice/hmpps-probation-integration-services/pull/3954

[seeding at Community API]:
https://github.com/ministryofjustice/community-api/blob/736ac63ff7705a0c8d998ed2773d59563b0fdea4/src/main/resources/db/data/V1_9__offender_X320811_custody_status_data.sql#L1
