### PR TITLE
APS-853 Enable Updated App and Placement Reports in Prod

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -22,7 +22,6 @@ generic-service:
     FLIPT_ENABLED: true
     FLIPT_URL: 'https://feature-flags-dev.hmpps.service.justice.gov.uk'
     FLIPT_NAMESPACE: 'community-accommodation'
-    PROVIDE_PERFORMANCE_HUB_REPORTS: false
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -20,7 +20,6 @@ generic-service:
     FLIPT_ENABLED: true
     FLIPT_URL: 'https://feature-flags-preprod.hmpps.service.justice.gov.uk'
     FLIPT_NAMESPACE: 'community-accommodation'
-    PROVIDE_PERFORMANCE_HUB_REPORTS: true
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -20,7 +20,6 @@ generic-service:
     FLIPT_ENABLED: true
     FLIPT_URL: 'https://feature-flags.hmpps.service.justice.gov.uk'
     FLIPT_NAMESPACE: 'community-accommodation'
-    PROVIDE_PERFORMANCE_HUB_REPORTS: false
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -22,7 +22,6 @@ generic-service:
     FLIPT_ENABLED: true
     FLIPT_URL: 'https://feature-flags-dev.hmpps.service.justice.gov.uk'
     FLIPT_NAMESPACE: 'community-accommodation'
-    PROVIDE_PERFORMANCE_HUB_REPORTS: false
 
   allowlist: null
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -48,7 +48,6 @@ export default {
   fliptEnabled,
   flags: {
     oasysDisabled: process.env.OASYS_DISABLED || false,
-    providePerformanceHubReports: get('PROVIDE_PERFORMANCE_HUB_REPORTS', false),
   },
   environment: process.env.ENVIRONMENT || 'local',
   sentry: {

--- a/server/utils/reportUtils.test.ts
+++ b/server/utils/reportUtils.test.ts
@@ -39,6 +39,20 @@ describe('reportUtils', () => {
             text: 'Counts of key actions across the service grouped by day.',
           },
         },
+        {
+          value: 'applicationsV2',
+          text: 'Raw Applications for Performance Hub',
+          hint: {
+            text: 'A raw data extract for applications submitted or withdrawn within the month. Does not include any PII.',
+          },
+        },
+        {
+          value: 'requestsForPlacement',
+          text: 'Raw Requests for Placement for Performance Hub',
+          hint: {
+            text: 'A raw data extract for requests for placements created or withdrawn within the month. Does not include any PII.',
+          },
+        },
       ])
     })
   })

--- a/server/utils/reportUtils.ts
+++ b/server/utils/reportUtils.ts
@@ -1,5 +1,3 @@
-import config from '../config'
-
 export const reportInputLabels = {
   applications: {
     text: 'Raw Applications',
@@ -30,10 +28,7 @@ export const reportInputLabels = {
 
 export type ReportType = (keyof typeof reportInputLabels)[number]
 
-export const unusedReports =
-  config.flags.providePerformanceHubReports === 'true'
-    ? ([] as Array<string>)
-    : ['applicationsV2', 'requestsForPlacement']
+export const unusedReports = [] as Array<string>
 
 export const reportOptions = Object.entries(reportInputLabels)
   .filter(([reportName]) => {


### PR DESCRIPTION
These reports were disabled in production via commit d2bcf00b89890fcefa49c892ccf5b85463195446 because the required data had not been backfilled.

This data has now been backfilled, so these reports can be enabled
