### PR TITLE
APS-946: Prevent users from changing the start and end date of a book…

### DIFF
--- a/integration_tests/tests/manage/dateChanges.cy.ts
+++ b/integration_tests/tests/manage/dateChanges.cy.ts
@@ -101,4 +101,23 @@ context('Date Changes', () => {
     // And the back link should be populated correctly
     dateChangePage.shouldHaveCorrectBacklink()
   })
+
+  it('show errors when the user chooses to change a date, but does not change dates', () => {
+    const bookingDateChange = bookingFactory.build({ arrivalDate: '2023-01-01', departureDate: '2023-03-02' })
+    // And I have a booking for a premises
+    cy.task('stubBookingGet', { premisesId: premises.id, booking: bookingDateChange })
+    cy.task('stubDateChange', { premisesId: premises.id, bookingId: bookingDateChange.id })
+
+    // And I visit the date change page
+    const dateChangePage = NewDateChangePage.visit(premises.id, bookingDateChange.id)
+
+    // And I change the date of my booking
+    dateChangePage.completeForm('2023-01-01', '2023-03-02')
+    dateChangePage.clickSubmit()
+
+    // Then I should see errors
+    dateChangePage.shouldShowErrorMessagesForFields(['datesToChange'], {
+      datesToChange: 'You must change the selected dates to submit',
+    })
+  })
 })

--- a/server/controllers/manage/dateChangesController.test.ts
+++ b/server/controllers/manage/dateChangesController.test.ts
@@ -266,6 +266,103 @@ describe('dateChangesController', () => {
           }),
         )
       })
+
+      it('should catch the validation errors when new departure date is selected to change and not changed', async () => {
+        const previousBooking = bookingFactory.build({ departureDate: '2022-01-01' })
+        bookingService.find.mockResolvedValue(previousBooking)
+        const requestHandler = controller.create()
+
+        request = createMock<Request>(requestParams)
+
+        await requestHandler(
+          {
+            ...request,
+            body: {
+              datesToChange: ['newDepartureDate'],
+              ...DateFormats.isoDateToDateInputs('2022-01-01', 'newDepartureDate'),
+            },
+          },
+          response,
+          next,
+        )
+
+        expect(addErrorMessageToFlash).toHaveBeenCalledWith(
+          request,
+          'You must change the selected dates to submit',
+          'datesToChange',
+        )
+        expect(response.redirect).toHaveBeenCalledWith(
+          paths.bookings.dateChanges.new({
+            bookingId,
+            premisesId,
+          }),
+        )
+      })
+
+      it('should catch the validation errors when new arrival date is selected to change and not changed', async () => {
+        const previousBooking = bookingFactory.build({ arrivalDate: '2022-01-01' })
+        bookingService.find.mockResolvedValue(previousBooking)
+        const requestHandler = controller.create()
+
+        request = createMock<Request>(requestParams)
+
+        await requestHandler(
+          {
+            ...request,
+            body: {
+              datesToChange: ['newArrivalDate'],
+              ...DateFormats.isoDateToDateInputs('2022-01-01', 'newArrivalDate'),
+            },
+          },
+          response,
+          next,
+        )
+
+        expect(addErrorMessageToFlash).toHaveBeenCalledWith(
+          request,
+          'You must change the selected dates to submit',
+          'datesToChange',
+        )
+        expect(response.redirect).toHaveBeenCalledWith(
+          paths.bookings.dateChanges.new({
+            bookingId,
+            premisesId,
+          }),
+        )
+      })
+
+      it('should catch the validation errors when new arrival date and departure dates are selected to change and not changed', async () => {
+        const previousBooking = bookingFactory.build({ arrivalDate: '2022-01-01', departureDate: '2022-01-02' })
+        bookingService.find.mockResolvedValue(previousBooking)
+        const requestHandler = controller.create()
+
+        request = createMock<Request>(requestParams)
+
+        await requestHandler(
+          {
+            ...request,
+            body: {
+              datesToChange: ['newArrivalDate', 'newDepartureDate'],
+              ...DateFormats.isoDateToDateInputs('2022-01-01', 'newArrivalDate'),
+              ...DateFormats.isoDateToDateInputs('2022-01-02', 'newDepartureDate'),
+            },
+          },
+          response,
+          next,
+        )
+
+        expect(addErrorMessageToFlash).toHaveBeenCalledWith(
+          request,
+          'You must change the selected dates to submit',
+          'datesToChange',
+        )
+        expect(response.redirect).toHaveBeenCalledWith(
+          paths.bookings.dateChanges.new({
+            bookingId,
+            premisesId,
+          }),
+        )
+      })
     })
   })
 })

--- a/server/controllers/manage/dateChangesController.ts
+++ b/server/controllers/manage/dateChangesController.ts
@@ -73,6 +73,21 @@ export default class DateChangeController {
           }
         })
 
+        if (payload.newArrivalDate || payload.newDepartureDate) {
+          const booking = await this.bookingService.find(req.user.token, premisesId, bookingId)
+          const datesNotChanged =
+            payload.newArrivalDate === booking.arrivalDate || payload.newDepartureDate === booking.departureDate
+          if (datesNotChanged) {
+            addErrorMessageToFlash(req, 'You must change the selected dates to submit', 'datesToChange')
+            return res.redirect(
+              paths.bookings.dateChanges.new({
+                bookingId,
+                premisesId,
+              }),
+            )
+          }
+        }
+
         if (emptyDates.length) {
           const errorData = emptyDates.map((key: keyof NewDateChange) => ({
             propertyName: `$.${key}`,


### PR DESCRIPTION


# Context

https://dsdmoj.atlassian.net/browse/APS-946 
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Prevent users from changing the arrival and departure date of a booking, when both dates remain the same as the current dates
## Screenshots of UI changes

### Before
The form will be submitted even though the arrival and departure dates are selected for change but didn't changed of a booking
### After
<img width="1728" alt="Screenshot 2024-06-27 at 14 07 25" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/70c32132-a853-4488-8004-825916e8d843">
