### PR TITLE
Add filtering and pagination to OOS bed list for a given premises

### DIFF
--- a/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedList.ts
+++ b/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedList.ts
@@ -1,4 +1,4 @@
-import type { Cas1OutOfServiceBed as OutOfServiceBed, Premises } from '@approved-premises/api'
+import type { Cas1OutOfServiceBed as OutOfServiceBed, Premises, Temporality } from '@approved-premises/api'
 import paths from '../../../../server/paths/manage'
 
 import Page from '../../page'
@@ -8,8 +8,8 @@ export class OutOfServiceBedListPage extends Page {
     super('Manage out of service beds')
   }
 
-  static visit(premisesId: Premises['id']): OutOfServiceBedListPage {
-    cy.visit(paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId }))
+  static visit(premisesId: Premises['id'], temporality: Temporality): OutOfServiceBedListPage {
+    cy.visit(paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId, temporality }))
     return new OutOfServiceBedListPage()
   }
 

--- a/server/controllers/manage/index.ts
+++ b/server/controllers/manage/index.ts
@@ -11,7 +11,6 @@ import LostBedsController from './lostBedsController'
 import MoveBedsController from './moveBedsController'
 import BedsController from './premises/bedsController'
 import DateChangesController from './dateChangesController'
-import OutOfServiceBedsController from './outOfServiceBedsController'
 
 import type { Services } from '../../services'
 
@@ -24,7 +23,6 @@ export const controllers = (services: Services) => {
   const departuresController = new DeparturesController(services.departureService, services.bookingService)
   const cancellationsController = new CancellationsController(services.cancellationService, services.bookingService)
   const lostBedsController = new LostBedsController(services.lostBedService)
-  const outOfServiceBedsController = new OutOfServiceBedsController(services.outOfServiceBedService)
   const bedsController = new BedsController(services.premisesService)
   const moveBedsController = new MoveBedsController(services.bookingService, services.premisesService)
   const dateChangesController = new DateChangesController(services.bookingService)
@@ -39,7 +37,6 @@ export const controllers = (services: Services) => {
     departuresController,
     cancellationsController,
     lostBedsController,
-    outOfServiceBedsController,
     bedsController,
     moveBedsController,
   }
@@ -49,7 +46,6 @@ export {
   PremisesController,
   BookingsController,
   BookingExtensionsController,
-  OutOfServiceBedsController,
   ArrivalsController,
   NonArrivalsController,
   DeparturesController,

--- a/server/controllers/v2Manage/index.ts
+++ b/server/controllers/v2Manage/index.ts
@@ -2,17 +2,20 @@
 
 import V2PremisesController from './premises/premisesController'
 import V2BedsController from './premises/bedsController'
+import V2OutOfServiceBedsController from './outOfServiceBedsController'
 
 import type { Services } from '../../services'
 
 export const controllers = (services: Services) => {
   const v2PremisesController = new V2PremisesController(services.premisesService)
   const v2BedsController = new V2BedsController(services.premisesService)
+  const v2OutOfServiceBedsController = new V2OutOfServiceBedsController(services.outOfServiceBedService)
 
   return {
     v2PremisesController,
     v2BedsController,
+    v2OutOfServiceBedsController,
   }
 }
 
-export { V2PremisesController, V2BedsController }
+export { V2PremisesController, V2BedsController, V2OutOfServiceBedsController }

--- a/server/controllers/v2Manage/outOfServiceBedsController.test.ts
+++ b/server/controllers/v2Manage/outOfServiceBedsController.test.ts
@@ -185,18 +185,53 @@ describe('OutOfServiceBedsController', () => {
   })
 
   describe('premisesIndex', () => {
-    it('shows a list of outOfService beds for a premises', async () => {
-      outOfServiceBedService.getOutOfServiceBedsForAPremises.mockResolvedValue([outOfServiceBed])
-      const requestHandler = outOfServiceBedController.premisesIndex()
+    it('requests a paginated list of outOfService beds for a premises and renders the template', async () => {
+      const temporality = 'current'
 
-      await requestHandler({ ...request, params: { premisesId } }, response, next)
+      const paginatedResponse = paginatedResponseFactory.build({
+        data: outOfServiceBedFactory.buildList(1),
+      }) as PaginatedResponse<OutOfServiceBed>
+      const paginationDetails = {
+        hrefPrefix: `${paths.v2Manage.outOfServiceBeds.premisesIndex.pattern}?${createQueryString({ temporality, premisesId })}`,
+        pageNumber: 1,
+      }
+
+      outOfServiceBedService.getAllOutOfServiceBeds.mockResolvedValue(paginatedResponse)
+      ;(getPaginationDetails as jest.Mock).mockReturnValue(paginationDetails)
+
+      const req = { ...request, query: { premisesId }, params: { temporality } }
+
+      const requestHandler = outOfServiceBedController.premisesIndex()
+      await requestHandler({ ...req, params: { premisesId, temporality } }, response, next)
 
       expect(response.render).toHaveBeenCalledWith('v2Manage/outOfServiceBeds/premisesIndex', {
-        outOfServiceBeds: [outOfServiceBed],
+        outOfServiceBeds: paginatedResponse.data,
         pageHeading: 'Manage out of service beds',
         premisesId,
+        hrefPrefix: paginationDetails.hrefPrefix,
+        temporality,
+        pageNumber: Number(paginatedResponse.pageNumber),
+        totalPages: Number(paginatedResponse.totalPages),
       })
-      expect(outOfServiceBedService.getOutOfServiceBedsForAPremises).toHaveBeenCalledWith(token, premisesId)
+      expect(outOfServiceBedService.getAllOutOfServiceBeds).toHaveBeenCalledWith({
+        token,
+        page: paginationDetails.pageNumber,
+        temporality,
+        premisesId,
+        perPage: 50,
+      })
+    })
+
+    it('redirects to the current temporality if a stray temporal URL parameter is entered', async () => {
+      const indexRequest = { ...request, params: { premisesId, temporality: 'abc' } }
+
+      const requestHandler = outOfServiceBedController.premisesIndex()
+
+      await requestHandler(indexRequest, response, next)
+
+      expect(response.redirect).toHaveBeenCalledWith(
+        paths.v2Manage.outOfServiceBeds.premisesIndex({ temporality: 'current', premisesId }),
+      )
     })
   })
 
@@ -290,7 +325,10 @@ describe('OutOfServiceBedsController', () => {
       )
       expect(request.flash).toHaveBeenCalledWith('success', 'Bed updated')
       expect(response.redirect).toHaveBeenCalledWith(
-        paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId: request.params.premisesId }),
+        paths.v2Manage.outOfServiceBeds.premisesIndex({
+          premisesId: request.params.premisesId,
+          temporality: 'current',
+        }),
       )
     })
 
@@ -342,7 +380,10 @@ describe('OutOfServiceBedsController', () => {
         )
         expect(request.flash).toHaveBeenCalledWith('success', 'Bed cancelled')
         expect(response.redirect).toHaveBeenCalledWith(
-          paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId: request.params.premisesId }),
+          paths.v2Manage.outOfServiceBeds.premisesIndex({
+            premisesId: request.params.premisesId,
+            temporality: 'current',
+          }),
         )
       })
     })

--- a/server/controllers/v2Manage/outOfServiceBedsController.test.ts
+++ b/server/controllers/v2Manage/outOfServiceBedsController.test.ts
@@ -64,7 +64,7 @@ describe('OutOfServiceBedsController', () => {
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith(
-        'outOfServiceBeds/new',
+        'v2Manage/outOfServiceBeds/new',
         expect.objectContaining({ premisesId, bedId: request.params.bedId }),
       )
     })
@@ -79,7 +79,7 @@ describe('OutOfServiceBedsController', () => {
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith(
-        'outOfServiceBeds/new',
+        'v2Manage/outOfServiceBeds/new',
         expect.objectContaining({
           errors: errorsAndUserInput.errors,
           errorSummary: errorsAndUserInput.errorSummary,
@@ -178,7 +178,7 @@ describe('OutOfServiceBedsController', () => {
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith(
-        'outOfServiceBeds/show',
+        'v2Manage/outOfServiceBeds/show',
         expect.objectContaining({ outOfServiceBed }),
       )
     })
@@ -191,7 +191,7 @@ describe('OutOfServiceBedsController', () => {
 
       await requestHandler({ ...request, params: { premisesId } }, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('outOfServiceBeds/premisesIndex', {
+      expect(response.render).toHaveBeenCalledWith('v2Manage/outOfServiceBeds/premisesIndex', {
         outOfServiceBeds: [outOfServiceBed],
         pageHeading: 'Manage out of service beds',
         premisesId,
@@ -224,7 +224,7 @@ describe('OutOfServiceBedsController', () => {
 
       await requestHandler(indexRequest, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('outOfServiceBeds/index', {
+      expect(response.render).toHaveBeenCalledWith('v2Manage/outOfServiceBeds/index', {
         outOfServiceBeds: paginatedResponse.data,
         pageHeading: 'View out of service beds',
         pageNumber: Number(paginatedResponse.pageNumber),

--- a/server/controllers/v2Manage/outOfServiceBedsController.ts
+++ b/server/controllers/v2Manage/outOfServiceBedsController.ts
@@ -172,14 +172,14 @@ export default class OutOfServiceBedsController {
 
           req.flash('success', 'Bed cancelled')
 
-          return res.redirect(paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId }))
+          return res.redirect(paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId, temporality: 'current' }))
         }
 
         await this.outOfServiceBedService.updateOutOfServiceBed(req.user.token, id, premisesId, req.body)
 
         req.flash('success', 'Bed updated')
 
-        return res.redirect(paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId }))
+        return res.redirect(paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId, temporality: 'current' }))
       } catch (error) {
         const redirectPath = req.headers.referer
 
@@ -198,7 +198,7 @@ export default class OutOfServiceBedsController {
 
         req.flash('success', 'Bed cancelled')
 
-        return res.redirect(paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId }))
+        return res.redirect(paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId, temporality: 'current' }))
       } catch (error) {
         return catchValidationErrorOrPropogate(
           req,

--- a/server/controllers/v2Manage/outOfServiceBedsController.ts
+++ b/server/controllers/v2Manage/outOfServiceBedsController.ts
@@ -20,7 +20,7 @@ export default class OutOfServiceBedsController {
       const { premisesId, bedId } = req.params
       const { errors, errorSummary, userInput, errorTitle } = fetchErrorsAndUserInput(req)
 
-      return res.render('outOfServiceBeds/new', {
+      return res.render('v2Manage/outOfServiceBeds/new', {
         premisesId,
         bedId,
         errors,
@@ -122,7 +122,7 @@ export default class OutOfServiceBedsController {
         apAreaId,
       })
 
-      return res.render('outOfServiceBeds/index', {
+      return res.render('v2Manage/outOfServiceBeds/index', {
         pageHeading: 'View out of service beds',
         outOfServiceBeds: outOfServiceBeds.data,
         pageNumber: Number(outOfServiceBeds.pageNumber),
@@ -146,7 +146,7 @@ export default class OutOfServiceBedsController {
 
       const outOfServiceBed = await this.outOfServiceBedService.getOutOfServiceBed(req.user.token, premisesId, id)
 
-      return res.render('outOfServiceBeds/show', {
+      return res.render('v2Manage/outOfServiceBeds/show', {
         errors,
         errorSummary,
         outOfServiceBed,

--- a/server/data/outOfServiceBedClient.test.ts
+++ b/server/data/outOfServiceBedClient.test.ts
@@ -105,10 +105,11 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
   })
 
   describe('get', () => {
-    it('makes a request to the outOfServiceBeds endpoint with a page number, sort and filter options', async () => {
+    it('makes a request to the outOfServiceBeds endpoint with a page number, perPage, sort and filter options', async () => {
       const outOfServiceBeds = outOfServiceBedFactory.buildList(2)
 
       const pageNumber = 3
+      const perPage = 20
       const sortBy = 'roomName'
       const sortDirection = 'asc'
       const temporality = 'future'
@@ -120,7 +121,14 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.manage.outOfServiceBeds.index({}),
-          query: { page: pageNumber.toString(), sortBy, sortDirection, temporality, apAreaId },
+          query: {
+            page: pageNumber.toString(),
+            sortBy,
+            sortDirection,
+            temporality,
+            apAreaId,
+            perPage: perPage.toString(),
+          },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -129,9 +137,9 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
           status: 200,
           body: outOfServiceBeds,
           headers: {
-            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalPages': '5',
             'X-Pagination-TotalResults': '100',
-            'X-Pagination-PageSize': '10',
+            'X-Pagination-PageSize': '20',
           },
         },
       })
@@ -142,14 +150,15 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
         sortDirection,
         temporality,
         apAreaId,
+        perPage,
       })
 
       expect(result).toEqual({
         data: outOfServiceBeds,
         pageNumber: pageNumber.toString(),
-        totalPages: '10',
+        totalPages: '5',
         totalResults: '100',
-        pageSize: '10',
+        pageSize: '20',
       })
     })
   })

--- a/server/data/outOfServiceBedClient.ts
+++ b/server/data/outOfServiceBedClient.ts
@@ -53,17 +53,19 @@ export default class OutOfServiceBedClient {
     temporality,
     premisesId,
     apAreaId,
+    perPage,
   }: {
     page: number
-    sortBy: OutOfServiceBedSortField
-    sortDirection: SortDirection
     temporality: Temporality
+    sortBy?: OutOfServiceBedSortField
+    sortDirection?: SortDirection
     premisesId?: string
     apAreaId?: string
+    perPage?: number
   }): Promise<PaginatedResponse<OutOfServiceBed>> {
     const response = (await this.restClient.get({
       path: paths.manage.outOfServiceBeds.index({}),
-      query: createQueryString({ page, sortBy, sortDirection, temporality, premisesId, apAreaId }),
+      query: createQueryString({ page, sortBy, sortDirection, temporality, premisesId, apAreaId, perPage }),
       raw: true,
     })) as superagent.Response
 

--- a/server/paths/manage.ts
+++ b/server/paths/manage.ts
@@ -129,7 +129,7 @@ const v2Manage = {
   outOfServiceBeds: {
     new: outOfServiceBedsPath.path('new'),
     create: outOfServiceBedsPath,
-    premisesIndex: singlePremisesPath.path('out-of-service-beds'),
+    premisesIndex: v2SinglePremisesPath.path('out-of-service-beds').path(':temporality'),
     index: outOfServiceBedsIndexPath.path(':temporality'),
     show: outOfServiceBedsPath.path(':id'),
     update: singlePremisesPath.path('out-of-service-beds').path(':id'),

--- a/server/routes/v2Manage.ts
+++ b/server/routes/v2Manage.ts
@@ -16,10 +16,10 @@ export default function routes(controllers: Controllers, router: Router, service
     premisesController,
     bookingsController,
     bookingExtensionsController,
-    outOfServiceBedsController,
     bedsController,
     v2PremisesController,
     v2BedsController,
+    v2OutOfServiceBedsController,
   } = controllers
 
   // Premises
@@ -93,11 +93,11 @@ export default function routes(controllers: Controllers, router: Router, service
   get(paths.v2Manage.bookings.extensions.confirm.pattern, bookingExtensionsController.confirm())
 
   // Out of service beds
-  get(paths.v2Manage.outOfServiceBeds.new.pattern, outOfServiceBedsController.new(), {
+  get(paths.v2Manage.outOfServiceBeds.new.pattern, v2OutOfServiceBedsController.new(), {
     auditEvent: 'NEW_OUT_OF_SERVICE_BED',
     allowedRoles: ['future_manager'],
   })
-  post(paths.v2Manage.outOfServiceBeds.create.pattern, outOfServiceBedsController.create(), {
+  post(paths.v2Manage.outOfServiceBeds.create.pattern, v2OutOfServiceBedsController.create(), {
     auditEvent: 'CREATE_OUT_OF_SERVICE_BED_SUCCESS',
     redirectAuditEventSpecs: [
       {
@@ -107,15 +107,15 @@ export default function routes(controllers: Controllers, router: Router, service
     ],
     allowedRoles: ['future_manager'],
   })
-  get(paths.v2Manage.outOfServiceBeds.premisesIndex.pattern, outOfServiceBedsController.premisesIndex(), {
+  get(paths.v2Manage.outOfServiceBeds.premisesIndex.pattern, v2OutOfServiceBedsController.premisesIndex(), {
     auditEvent: 'LIST_OUT_OF_SERVICE_BEDS_FOR_A_PREMISES',
     allowedRoles: ['future_manager'],
   })
-  get(paths.v2Manage.outOfServiceBeds.show.pattern, outOfServiceBedsController.show(), {
+  get(paths.v2Manage.outOfServiceBeds.show.pattern, v2OutOfServiceBedsController.show(), {
     auditEvent: 'SHOW_OUT_OF_SERVICE_BED',
     allowedRoles: ['future_manager'],
   })
-  post(paths.v2Manage.outOfServiceBeds.update.pattern, outOfServiceBedsController.update(), {
+  post(paths.v2Manage.outOfServiceBeds.update.pattern, v2OutOfServiceBedsController.update(), {
     auditEvent: 'UPDATE_OUT_OF_SERVICE_BED_SUCCESS',
     auditBodyParams: ['cancel'],
     redirectAuditEventSpecs: [
@@ -126,7 +126,7 @@ export default function routes(controllers: Controllers, router: Router, service
     ],
     allowedRoles: ['future_manager'],
   })
-  get(paths.v2Manage.outOfServiceBeds.index.pattern, outOfServiceBedsController.index(), {
+  get(paths.v2Manage.outOfServiceBeds.index.pattern, v2OutOfServiceBedsController.index(), {
     auditEvent: 'LIST_ALL_OUT_OF_SERVICE_BEDS',
     allowedRoles: ['cru_member'],
   })

--- a/server/services/outOfServiceBedService.test.ts
+++ b/server/services/outOfServiceBedService.test.ts
@@ -76,8 +76,9 @@ describe('OutOfServiceBedService', () => {
   describe('getAllOutOfServiceBeds', () => {
     const token = 'SOME_TOKEN'
 
-    it('calls the get method on the outOfServiceBedClient with a page and sort and filter options', async () => {
+    it('calls the get method on the outOfServiceBedClient with a page, perPage, sort and filter options', async () => {
       const pageNumber = 3
+      const perPage = 20
       const sortBy = 'roomName'
       const sortDirection = 'asc'
       const temporality = 'future'
@@ -96,6 +97,7 @@ describe('OutOfServiceBedService', () => {
         temporality,
         apAreaId,
         premisesId,
+        perPage,
       })
 
       expect(outOfServiceBeds).toEqual(response)
@@ -107,10 +109,11 @@ describe('OutOfServiceBedService', () => {
         temporality,
         apAreaId,
         premisesId,
+        perPage,
       })
     })
 
-    it('defaults to filtering for current items only with no area or premises filter, sorted by "from date" ascending', async () => {
+    it('uses default values for page, temporality and perPage', async () => {
       const response = paginatedResponseFactory.build({
         data: outOfServiceBedFactory.buildList(1),
       }) as PaginatedResponse<OutOfServiceBed>
@@ -120,9 +123,8 @@ describe('OutOfServiceBedService', () => {
 
       expect(outOfServiceBedClient.get).toHaveBeenCalledWith({
         page: 1,
-        sortBy: 'startDate',
-        sortDirection: 'asc',
         temporality: 'current',
+        perPage: 10,
       })
     })
   })

--- a/server/services/outOfServiceBedService.ts
+++ b/server/services/outOfServiceBedService.ts
@@ -62,11 +62,12 @@ export default class OutOfServiceBedService {
   async getAllOutOfServiceBeds({
     token,
     page = 1,
-    sortBy = 'startDate',
-    sortDirection = 'asc',
     temporality = 'current',
+    sortBy,
+    sortDirection,
     premisesId,
     apAreaId,
+    perPage = 10,
   }: {
     token: string
     page?: number
@@ -75,6 +76,7 @@ export default class OutOfServiceBedService {
     temporality?: Temporality
     premisesId?: string
     apAreaId?: string
+    perPage?: number
   }): Promise<PaginatedResponse<OutOfServiceBed>> {
     const outOfServiceBedClient = this.outOfServiceBedClientFactory(token)
     const outOfServiceBeds = await outOfServiceBedClient.get({
@@ -84,6 +86,7 @@ export default class OutOfServiceBedService {
       temporality,
       premisesId,
       apAreaId,
+      perPage,
     })
 
     return outOfServiceBeds

--- a/server/utils/outOfServiceBedUtils.test.ts
+++ b/server/utils/outOfServiceBedUtils.test.ts
@@ -169,7 +169,7 @@ describe('outOfServiceBedUtils', () => {
 
   describe('outOfServiceBedCountForToday', () => {
     it('returns the correct number of out of service beds for today', () => {
-      const outOfServiceBedsForToday = [...Array(getRandomInt(1, 10))].map(() =>
+      const outOfServiceBedsForToday = [...Array(getRandomInt(2, 10))].map(() =>
         outOfServiceBedFactory.build({
           startDate: DateFormats.dateObjToIsoDate(sub(Date.now(), { days: getRandomInt(1, 10) })),
           endDate: DateFormats.dateObjToIsoDate(add(Date.now(), { days: getRandomInt(1, 10) })),
@@ -190,7 +190,7 @@ describe('outOfServiceBedUtils', () => {
 
       expect(
         outOfServiceBedCountForToday([...outOfServiceBedsForToday, ...futureOutOfServiceBeds, ...pastOutOfServiceBeds]),
-      ).toEqual(outOfServiceBedsForToday.length)
+      ).toEqual(`${outOfServiceBedsForToday.length} beds`)
     })
   })
 })

--- a/server/utils/outOfServiceBedUtils.ts
+++ b/server/utils/outOfServiceBedUtils.ts
@@ -109,13 +109,15 @@ export const actionCell = (bed: OutOfServiceBed, premisesId: Premises['id']): Ta
   html: bedLink(bed, premisesId),
 })
 
-export const outOfServiceBedCountForToday = (outOfServiceBeds: Array<OutOfServiceBed>): number => {
-  return outOfServiceBeds.filter(outOfServiceBed =>
+export const outOfServiceBedCountForToday = (outOfServiceBeds: Array<OutOfServiceBed>): string => {
+  const count = outOfServiceBeds.filter(outOfServiceBed =>
     isWithinInterval(Date.now(), {
       start: DateFormats.isoToDateObj(outOfServiceBed.startDate),
       end: DateFormats.isoToDateObj(outOfServiceBed.endDate),
     }),
   ).length
+
+  return count === 1 ? '1 bed' : `${count} beds`
 }
 
 const bedLink = (bed: OutOfServiceBed, premisesId: Premises['id']): string =>

--- a/server/utils/premises/premisesActions.test.ts
+++ b/server/utils/premises/premisesActions.test.ts
@@ -12,7 +12,7 @@ describe('premisesActions', () => {
       expect(premisesActions(user, premises)).not.toContainManageAction({
         text: 'Manage out of service bed records',
         classes: 'govuk-button--secondary',
-        href: paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId: premises.id }),
+        href: paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId: premises.id, temporality: 'current' }),
       })
     })
 
@@ -49,7 +49,7 @@ describe('premisesActions', () => {
       expect(premisesActions(user, premises)).not.toContainManageAction({
         text: 'Manage out of service bed records',
         classes: 'govuk-button--secondary',
-        href: paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId: premises.id }),
+        href: paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId: premises.id, temporality: 'current' }),
       })
     })
 
@@ -86,7 +86,7 @@ describe('premisesActions', () => {
       expect(premisesActions(user, premises)).not.toContainManageAction({
         text: 'Manage out of service bed records',
         classes: 'govuk-button--secondary',
-        href: paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId: premises.id }),
+        href: paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId: premises.id, temporality: 'current' }),
       })
     })
 
@@ -147,7 +147,7 @@ describe('premisesActions', () => {
       expect(premisesActions(user, premises)).toContainManageAction({
         text: 'Manage out of service bed records',
         classes: 'govuk-button--secondary',
-        href: paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId: premises.id }),
+        href: paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId: premises.id, temporality: 'current' }),
       })
     })
   })
@@ -160,7 +160,7 @@ describe('premisesActions', () => {
       expect(premisesActions(user, premises)).not.toContainManageAction({
         text: 'Manage out of service bed records',
         classes: 'govuk-button--secondary',
-        href: paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId: premises.id }),
+        href: paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId: premises.id, temporality: 'current' }),
       })
     })
 

--- a/server/utils/premises/premisesActions.ts
+++ b/server/utils/premises/premisesActions.ts
@@ -15,7 +15,7 @@ export const premisesActions = (user: UserDetails, premises: Premises) => {
     actions.push({
       text: 'Manage out of service bed records',
       classes: 'govuk-button--secondary',
-      href: paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId: premises.id }),
+      href: paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId: premises.id, temporality: 'current' }),
     })
   }
 

--- a/server/views/v2Manage/outOfServiceBeds/index.njk
+++ b/server/views/v2Manage/outOfServiceBeds/index.njk
@@ -6,7 +6,7 @@
 {%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 
-{% extends "../partials/layout.njk" %}
+{% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - " + pageHeading %}
 

--- a/server/views/v2Manage/outOfServiceBeds/new.njk
+++ b/server/views/v2Manage/outOfServiceBeds/new.njk
@@ -4,9 +4,9 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 
-{% extends "../partials/layout.njk" %}
+{% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - Mark a bed as out of service" %}
 {% set mainClasses = "app-container govuk-body" %}

--- a/server/views/v2Manage/outOfServiceBeds/premisesIndex.njk
+++ b/server/views/v2Manage/outOfServiceBeds/premisesIndex.njk
@@ -4,7 +4,7 @@
 
 {%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
 
-{% extends "../partials/layout.njk" %}
+{% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - " + pageHeading %}
 
@@ -18,7 +18,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-width">
-      {% include "../_messages.njk" %}
+      {% include "../../_messages.njk" %}
 
       <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 

--- a/server/views/v2Manage/outOfServiceBeds/premisesIndex.njk
+++ b/server/views/v2Manage/outOfServiceBeds/premisesIndex.njk
@@ -1,8 +1,10 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
 
 {%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -27,13 +29,32 @@
           classes: 'govuk-summary-list--no-border',
           rows: [            {
               key: {
-                text: "Out of service"
+                text: "Current out of service beds"
               },
               value: {
                 text: OutOfServiceBedUtils.outOfServiceBedCountForToday(outOfServiceBeds)
               }
             }
           ]
+        })
+      }}
+
+      {{
+        mojSubNavigation({
+          label: 'Sub navigation',
+          items: [{
+              text: 'Current',
+              href: paths.v2Manage.outOfServiceBeds.premisesIndex({premisesId: premisesId, temporality: 'current'}),
+              active: temporality === 'current'
+            }, {
+              text: 'Future',
+              href: paths.v2Manage.outOfServiceBeds.premisesIndex({premisesId: premisesId, temporality: 'future'}),
+              active: temporality === 'future'
+            }, {
+              text: 'Historic',
+              href: paths.v2Manage.outOfServiceBeds.premisesIndex({premisesId: premisesId, temporality: 'historic'}),
+              active: temporality === 'historic'
+          }]
         })
       }}
 
@@ -47,6 +68,8 @@
             rows: OutOfServiceBedUtils.outOfServiceBedTableRows(outOfServiceBeds, premisesId, user)
           })
         }}
+
+        {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
 
       {% endif %}
     </div>

--- a/server/views/v2Manage/outOfServiceBeds/show.njk
+++ b/server/views/v2Manage/outOfServiceBeds/show.njk
@@ -7,9 +7,9 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% from "../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 
-{% extends "../partials/layout.njk" %}
+{% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body" %}


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/APS-887

# Changes in this PR

Adds filtering by temporality to the OOS beds page for a single premises. Also adds pagination, which is set to 50 per page by default. This is to all but ensure that all currently OOS beds will appear on a single page for any given AP.

## Screenshots of UI changes

### Before

![OutOfServiceBeds -- managing out of service beds -- should allow me to update an out of service bed](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/70749355/2d415913-5707-458e-a90c-5bee80ea27e5)

### After

![OutOfServiceBeds -- list all OOS beds for a given AP -- supports pagination](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/70749355/703b68eb-4aed-41d6-93d3-702689526cf8)