### PR TITLE
APS-979: Treat 'UnknownPerson' as Not found

### DIFF
--- a/server/utils/applications/helpers.test.ts
+++ b/server/utils/applications/helpers.test.ts
@@ -2,7 +2,7 @@ import { when } from 'jest-when'
 import { applicationSummaryFactory, personFactory } from '../../testutils/factories'
 import { createNameAnchorElement, getTierOrBlank, htmlValue, textValue } from './helpers'
 import paths from '../../paths/apply'
-import { isFullPerson, nameOrPlaceholderCopy, tierBadge } from '../personUtils'
+import { isFullPerson, isUnknownPerson, nameOrPlaceholderCopy, tierBadge } from '../personUtils'
 
 jest.mock('../personUtils')
 
@@ -32,6 +32,16 @@ describe('helpers', () => {
       const person = personFactory.build()
 
       when(isFullPerson).calledWith(person).mockReturnValue(false)
+
+      expect(createNameAnchorElement(person, applicationSummary)).toEqual(textValue(`LAO CRN: ${person.crn}`))
+    })
+
+    it('returns an LAO Not Found for person type Unknown', () => {
+      const applicationSummary = applicationSummaryFactory.build()
+      const person = personFactory.build()
+
+      when(isFullPerson).calledWith(person).mockReturnValue(false)
+      when(isUnknownPerson).calledWith(person).mockReturnValue(false)
 
       expect(createNameAnchorElement(person, applicationSummary)).toEqual(textValue(`LAO CRN: ${person.crn}`))
     })

--- a/server/utils/applications/helpers.ts
+++ b/server/utils/applications/helpers.ts
@@ -1,5 +1,5 @@
 import { ApprovedPremisesApplicationSummary as ApplicationSummary, Person } from '../../@types/shared'
-import { isFullPerson, nameOrPlaceholderCopy, tierBadge } from '../personUtils'
+import { isFullPerson, isUnknownPerson, nameOrPlaceholderCopy, tierBadge } from '../personUtils'
 import paths from '../../paths/apply'
 
 export const createNameAnchorElement = (
@@ -8,7 +8,7 @@ export const createNameAnchorElement = (
   { linkInProgressApplications }: { linkInProgressApplications: boolean } = { linkInProgressApplications: true },
 ) => {
   if (!linkInProgressApplications && applicationSummary.status === 'started') {
-    return textValue(nameOrPlaceholderCopy(person, `LAO: ${person.crn}`))
+    return textValue(nameOrPlaceholderCopy(person, isUnknownPerson(person) ? 'LAO: Not Found' : `LAO: ${person.crn}`))
   }
 
   return isFullPerson(person)
@@ -17,7 +17,7 @@ export const createNameAnchorElement = (
           person.name
         }</a>`,
       )
-    : textValue(`LAO CRN: ${person.crn}`)
+    : textValue(isUnknownPerson(person) ? 'LAO CRN: Not Found' : `LAO CRN: ${person.crn}`)
 }
 
 export const textValue = (value: string) => {

--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -1,5 +1,12 @@
 import { fullPersonFactory, restrictedPersonFactory } from '../testutils/factories/person'
-import { isApplicableTier, isFullPerson, laoName, nameOrPlaceholderCopy, tierBadge } from './personUtils'
+import {
+  isApplicableTier,
+  isFullPerson,
+  isUnknownPerson,
+  laoName,
+  nameOrPlaceholderCopy,
+  tierBadge,
+} from './personUtils'
 
 describe('personUtils', () => {
   describe('tierBadge', () => {
@@ -79,6 +86,16 @@ describe('personUtils', () => {
     it('does not include limited access offender text if showLaoLabel true and person is not restricted to others', () => {
       const person = fullPersonFactory.build({ isRestricted: false })
       expect(nameOrPlaceholderCopy(person, 'the person', true)).toEqual(person.name)
+    })
+  })
+
+  describe('isUnknownPerson', () => {
+    it('returns true if the person is a Unknown person', () => {
+      expect(isUnknownPerson(fullPersonFactory.build({ type: 'UnknownPerson' }))).toEqual(true)
+    })
+
+    it('returns false if the person is not Unknown person', () => {
+      expect(isUnknownPerson(restrictedPersonFactory.build())).toEqual(false)
     })
   })
 })

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -19,6 +19,8 @@ const isApplicableTier = (sex: string, tier: string): boolean => {
 
 const isFullPerson = (person?: Person): person is FullPerson => (person as FullPerson)?.name !== undefined
 
+const isUnknownPerson = (person?: Person): boolean => person?.type === 'UnknownPerson'
+
 const laoName = (person: FullPerson) => (person.isRestricted ? `LAO: ${person.name}` : person.name)
 
 /**
@@ -42,4 +44,4 @@ const nameText = (person: FullPerson, showLaoLabel: boolean) => {
   return name
 }
 
-export { tierBadge, isApplicableTier, isFullPerson, nameOrPlaceholderCopy, laoName }
+export { tierBadge, isApplicableTier, isFullPerson, nameOrPlaceholderCopy, laoName, isUnknownPerson }

--- a/server/utils/placementRequests/table.test.ts
+++ b/server/utils/placementRequests/table.test.ts
@@ -108,6 +108,15 @@ describe('tableUtils', () => {
         },
       )
     })
+
+    it('returns the crn cell if the person is a unknown person', () => {
+      const unknownPersonTask = placementRequestFactory.build()
+      unknownPersonTask.person = restrictedPersonFactory.build({ type: 'UnknownPerson' })
+
+      expect(nameCell(unknownPersonTask)).toEqual({
+        text: `LAO: Not Found`,
+      })
+    })
   })
 
   describe('expectedArrivalDateCell', () => {

--- a/server/utils/placementRequests/table.ts
+++ b/server/utils/placementRequests/table.ts
@@ -14,7 +14,7 @@ import { linkTo } from '../utils'
 import { crnCell, tierCell } from '../tableUtils'
 import { allReleaseTypes } from '../applications/releaseTypeUtils'
 import { sortHeader } from '../sortHeader'
-import { isFullPerson, laoName } from '../personUtils'
+import { isFullPerson, isUnknownPerson, laoName } from '../personUtils'
 import { placementRequestStatus } from '../formUtils'
 
 export const DIFFERENCE_IN_DAYS_BETWEEN_DUE_DATE_AND_ARRIVAL_DATE = 7
@@ -120,7 +120,7 @@ export const nameCell = (item: PlacementRequestTask | PlacementRequest): TableCe
 
   if ('person' in item && item.person && !isFullPerson(item.person)) {
     return {
-      text: `LAO: ${item.person.crn}`,
+      text: isUnknownPerson(item.person) ? 'LAO: Not Found' : `LAO: ${item.person.crn}`,
     }
   }
 


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/APS-979 
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
UI treats 'UnknownPerson' as 'RestrictedPerson' and make UnknownPerson as Not Found
## Screenshots of UI changes

### Before

### After
<img width="1728" alt="Screenshot 2024-07-02 at 12 17 44" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/8ed7f3e7-8627-4f45-908b-aca53315dac6">
<img width="1728" alt="Screenshot 2024-07-01 at 16 27 49" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/511554cd-eb02-418b-acff-980af5af64f1">
