### PR TITLE
APS 888 - update view OOS bed page

### DIFF
--- a/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedIndex.ts
+++ b/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedIndex.ts
@@ -44,7 +44,12 @@ export class OutOfServiceBedIndexPage extends Page {
               cy.get('a').should(
                 'have.attr',
                 'href',
-                paths.v2Manage.outOfServiceBeds.show({ id: item.id, premisesId: item.premises.id, bedId: item.bed.id }),
+                paths.v2Manage.outOfServiceBeds.show({
+                  id: item.id,
+                  premisesId: item.premises.id,
+                  bedId: item.bed.id,
+                  tab: 'details',
+                }),
               )
             })
         })

--- a/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
+++ b/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
@@ -2,28 +2,38 @@ import paths from '../../../../server/paths/manage'
 
 import Page from '../../page'
 import { DateFormats } from '../../../../server/utils/dateUtils'
-import { Cas1OutOfServiceBed as OutOfServiceBed, Premises } from '../../../../server/@types/shared'
+import { BedDetail, Cas1OutOfServiceBed as OutOfServiceBed, Premises } from '../../../../server/@types/shared'
 
 export class OutOfServiceBedShowPage extends Page {
   constructor(private readonly outOfServiceBed: OutOfServiceBed) {
-    super('Manage out of service bed')
+    super('View out of service bed record')
   }
 
   static visit(premisesId: Premises['id'], outOfServiceBed: OutOfServiceBed): OutOfServiceBedShowPage {
     cy.visit(
-      paths.v2Manage.outOfServiceBeds.show({ premisesId, id: outOfServiceBed.id, bedId: outOfServiceBed.bed.id }),
+      paths.v2Manage.outOfServiceBeds.show({
+        premisesId,
+        id: outOfServiceBed.id,
+        bedId: outOfServiceBed.bed.id,
+        tab: 'details',
+      }),
     )
     return new OutOfServiceBedShowPage(outOfServiceBed)
   }
 
   shouldShowOutOfServiceBedDetail(): void {
-    this.assertDefinition('Room number', this.outOfServiceBed.room.name)
-    this.assertDefinition('Bed number', this.outOfServiceBed.bed.name)
-    this.assertDefinition('Start date', DateFormats.isoDateToUIDate(this.outOfServiceBed.startDate, { format: 'long' }))
-    this.assertDefinition('End date', DateFormats.isoDateToUIDate(this.outOfServiceBed.endDate, { format: 'long' }))
-    if (this.outOfServiceBed.referenceNumber) {
-      this.assertDefinition('Reference number', this.outOfServiceBed.referenceNumber)
-    }
+    const latestRevision = this.outOfServiceBed.revisionHistory[0]
+    this.assertDefinition('Start date', DateFormats.isoDateToUIDate(latestRevision.startDate, { format: 'long' }))
+    this.assertDefinition('End date', DateFormats.isoDateToUIDate(latestRevision.endDate, { format: 'long' }))
+    this.assertDefinition('Reason', latestRevision.reason.name)
+    this.assertDefinition('Reference number', latestRevision.referenceNumber)
+    this.assertDefinition('Additional information', latestRevision.notes)
+  }
+
+  shouldShowCharacteristics(bed: BedDetail): void {
+    bed.characteristics.forEach(characteristic => {
+      cy.get('li').contains(characteristic.name)
+    })
   }
 
   public completeForm(endDate: OutOfServiceBed['endDate'], notes: OutOfServiceBed['notes']): void {

--- a/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
+++ b/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
@@ -35,18 +35,4 @@ export class OutOfServiceBedShowPage extends Page {
       cy.get('li').contains(characteristic.name)
     })
   }
-
-  public completeForm(endDate: OutOfServiceBed['endDate'], notes: OutOfServiceBed['notes']): void {
-    super.completeDateInputs('endDate', endDate)
-
-    cy.get('textarea[name="notes"]').type(String(notes))
-  }
-
-  clickSubmit(): void {
-    cy.get('button[name="submit"]').click()
-  }
-
-  clickCancel(): void {
-    cy.get('button').contains('Cancel out of service bed').click()
-  }
 }

--- a/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
+++ b/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
@@ -1,5 +1,6 @@
 import DashboardPage from '../../pages/dashboard'
 import {
+  bedDetailFactory,
   bookingFactory,
   extendedPremisesSummaryFactory,
   outOfServiceBedCancellationFactory,
@@ -119,16 +120,22 @@ context('OutOfServiceBeds', () => {
     signIn(['future_manager'])
 
     // And I have created a out of service bed
+    const bed = { name: 'abc', id: '123' }
     const premises = premisesFactory.build()
-    const outOfServiceBed = outOfServiceBedFactory.build()
+    const outOfServiceBed = outOfServiceBedFactory.build({ bed })
+    const bedDetail = bedDetailFactory.build({ id: bed.id })
 
     cy.task('stubOutOfServiceBed', { premisesId: premises.id, outOfServiceBed })
+    cy.task('stubBed', { premisesId: premises.id, bedDetail })
 
     // And I visit that out of service bed's show page
     const page = OutOfServiceBedShowPage.visit(premises.id, outOfServiceBed)
 
-    // Then I should see the details of that out of service bed
+    // Then I should see the latest details of that out of service bed
     page.shouldShowOutOfServiceBedDetail()
+
+    // And I should see the bed characteristics
+    page.shouldShowCharacteristics(bedDetail)
   })
 
   describe('managing out of service beds', () => {

--- a/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
+++ b/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
@@ -3,7 +3,6 @@ import {
   bedDetailFactory,
   bookingFactory,
   extendedPremisesSummaryFactory,
-  outOfServiceBedCancellationFactory,
   outOfServiceBedFactory,
   premisesFactory,
 } from '../../../server/testutils/factories'
@@ -11,7 +10,6 @@ import {
 import {
   OutOfServiceBedCreatePage,
   OutOfServiceBedIndexPage,
-  OutOfServiceBedListPage,
   OutOfServiceBedShowPage,
 } from '../../pages/v2Manage/outOfServiceBeds'
 import Page from '../../pages/page'
@@ -136,174 +134,6 @@ context('OutOfServiceBeds', () => {
 
     // And I should see the bed characteristics
     page.shouldShowCharacteristics(bedDetail)
-  })
-
-  describe('managing out of service beds', () => {
-    beforeEach(() => {
-      cy.task('reset')
-      // Given I am signed in as a future manager
-      signIn(['future_manager'])
-    })
-
-    it('should allow me to update an out of service bed', () => {
-      const premisesId = 'premisesId'
-
-      // And there is a out of service bed in the database
-      const outOfServiceBed = outOfServiceBedFactory.build()
-      cy.task('stubOutOfServiceBed', { premisesId, outOfServiceBed })
-      cy.task('stubOutOfServiceBedsList', {
-        premisesId,
-        outOfServiceBeds: [outOfServiceBed],
-        perPage: 50,
-      })
-      cy.task('stubOutOfServiceBedUpdate', { premisesId, outOfServiceBed })
-
-      // When I visit the out of service bed index page
-      const outOfServiceBedListPage = OutOfServiceBedListPage.visit(premisesId, 'current')
-
-      // // And I click manage on a bed
-      outOfServiceBedListPage.clickManageBed(outOfServiceBed)
-
-      // // Then I should see the out of service bed manage form
-      const outOfServiceBedShowPage = Page.verifyOnPage(OutOfServiceBedShowPage, outOfServiceBed)
-      outOfServiceBedShowPage.shouldShowOutOfServiceBedDetail()
-
-      // // When I fill in the form and submit
-      const newEndDate = '2023-10-12'
-      const newNote = 'example'
-      outOfServiceBedShowPage.completeForm(newEndDate, newNote)
-      outOfServiceBedShowPage.clickSubmit()
-
-      // // Then I am taken back to the list of out of service beds
-      Page.verifyOnPage(OutOfServiceBedListPage)
-
-      // // Then a out of service bed should have been updated in the API
-      cy.task('verifyOutOfServiceBedUpdate', {
-        premisesId,
-        outOfServiceBed,
-      }).then(requests => {
-        expect(requests).to.have.length(1)
-        const requestBody = JSON.parse(requests[0].body)
-
-        expect(requestBody.startDate).equal(outOfServiceBed.startDate)
-        expect(requestBody.endDate).equal(newEndDate)
-        expect(requestBody.notes).equal(newNote)
-        expect(requestBody.referenceNumber).equal(outOfServiceBed.referenceNumber)
-      })
-
-      // // And I should be navigated to the premises detail page and see the confirmation message
-      outOfServiceBedShowPage.shouldShowBanner('Bed updated')
-    })
-
-    it('should show an error when there are validation errors', () => {
-      const premisesId = 'premisesId'
-
-      // And there is a out of service bed in the database
-      const outOfServiceBed = outOfServiceBedFactory.build()
-      cy.task('stubOutOfServiceBed', { premisesId, outOfServiceBed })
-      cy.task('stubOutOfServiceBedsList', { premisesId, outOfServiceBeds: [outOfServiceBed] })
-
-      // And I miss required fields
-      cy.task('stubUpdateOutOfServiceBedErrors', {
-        outOfServiceBed,
-        premisesId,
-        params: [
-          {
-            propertyName: `$.endDate`,
-            errorType: 'empty',
-          },
-        ],
-      })
-
-      // When I visit the out of service bed show page
-      const outOfServiceBedShowPage = OutOfServiceBedShowPage.visit(premisesId, outOfServiceBed)
-      outOfServiceBedShowPage.shouldShowOutOfServiceBedDetail()
-
-      // When I try to submit
-      outOfServiceBedShowPage.clickSubmit()
-
-      // Then I should see an error message
-      outOfServiceBedShowPage.shouldShowErrorMessagesForFields(['endDate'])
-    })
-
-    it('should allow me to cancel a out of service bed', () => {
-      const premisesId = 'premisesId'
-
-      // And there is a out of service bed in the database
-      const outOfServiceBed = outOfServiceBedFactory.build()
-      const outOfServiceBedCancellation = outOfServiceBedCancellationFactory.build()
-      cy.task('stubOutOfServiceBed', { premisesId, outOfServiceBed })
-      cy.task('stubOutOfServiceBedsList', { premisesId, outOfServiceBeds: [outOfServiceBed], perPage: 50 })
-      cy.task('stubCancelOutOfServiceBed', {
-        premisesId,
-        outOfServiceBedId: outOfServiceBed.id,
-        outOfServiceBedCancellation,
-      })
-
-      // Given I visit the out of service bed show page
-      const outOfServiceBedShowPage = OutOfServiceBedShowPage.visit(premisesId, outOfServiceBed)
-
-      // When I try to submit
-      outOfServiceBedShowPage.clickCancel()
-
-      cy.task('verifyOutOfServiceBedCancel', {
-        premisesId,
-        outOfServiceBedId: outOfServiceBed.id,
-      }).then(requests => {
-        expect(requests).to.have.length(1)
-      })
-
-      // Then I am redirected to the out of service bed list page and see the confirmation message
-      const listPage = Page.verifyOnPage(OutOfServiceBedListPage)
-      listPage.shouldShowBanner('Bed cancelled')
-    })
-  })
-
-  describe('list all OOS beds for a given AP', () => {
-    const premisesId = 'abc123'
-    const outOfServiceBeds = outOfServiceBedFactory.buildList(10)
-
-    beforeEach(() => {
-      cy.task('reset')
-      // Given I am signed in as a future manager
-      signIn(['future_manager'])
-    })
-
-    it('allows me to view all out of service beds for a premises', () => {
-      // And there are out of service beds in the database
-      cy.task('stubOutOfServiceBedsList', { premisesId, outOfServiceBeds, page: 1, perPage: 50 })
-
-      // When I visit the out of service bed index page for a premises
-      const outOfServiceBedListPage = OutOfServiceBedListPage.visit(premisesId, 'current')
-
-      // Then I see the out of service beds for that premises
-      outOfServiceBedListPage.shouldShowOutOfServiceBeds(outOfServiceBeds)
-    })
-
-    it('supports pagination', () => {
-      cy.task('stubOutOfServiceBedsList', { outOfServiceBeds, page: 1, premisesId, perPage: 50 })
-      cy.task('stubOutOfServiceBedsList', { outOfServiceBeds, page: 2, premisesId, perPage: 50 })
-      cy.task('stubOutOfServiceBedsList', { outOfServiceBeds, page: 9, premisesId, perPage: 50 })
-
-      // When I visit the OOS beds index page for a premises
-      const page = OutOfServiceBedListPage.visit(premisesId, 'current')
-
-      // And I click next
-      page.clickNext()
-
-      // Then the API should have received a request for the next page
-      cy.task('verifyOutOfServiceBedsDashboard', { page: 2, premisesId, perPage: 50 }).then(requests => {
-        expect(requests).to.have.length(1)
-      })
-
-      // When I click on a page number
-      page.clickPageNumber('9')
-
-      // Then the API should have received a request for the that page number
-      cy.task('verifyOutOfServiceBedsDashboard', { page: 9, premisesId, perPage: 50 }).then(requests => {
-        expect(requests).to.have.length(1)
-      })
-    })
   })
 
   describe('CRU Member lists all OOS beds', () => {

--- a/server/controllers/v2Manage/index.ts
+++ b/server/controllers/v2Manage/index.ts
@@ -9,7 +9,10 @@ import type { Services } from '../../services'
 export const controllers = (services: Services) => {
   const v2PremisesController = new V2PremisesController(services.premisesService)
   const v2BedsController = new V2BedsController(services.premisesService)
-  const v2OutOfServiceBedsController = new V2OutOfServiceBedsController(services.outOfServiceBedService)
+  const v2OutOfServiceBedsController = new V2OutOfServiceBedsController(
+    services.outOfServiceBedService,
+    services.premisesService,
+  )
 
   return {
     v2PremisesController,

--- a/server/paths/manage.ts
+++ b/server/paths/manage.ts
@@ -131,7 +131,7 @@ const v2Manage = {
     create: outOfServiceBedsPath,
     premisesIndex: v2SinglePremisesPath.path('out-of-service-beds').path(':temporality'),
     index: outOfServiceBedsIndexPath.path(':temporality'),
-    show: outOfServiceBedsPath.path(':id'),
+    show: outOfServiceBedsPath.path(':id').path(':tab'),
     update: singlePremisesPath.path('out-of-service-beds').path(':id'),
     cancel: singlePremisesPath.path('out-of-service-beds').path(':id').path('cancellations'),
   },

--- a/server/utils/outOfServiceBedUtils.ts
+++ b/server/utils/outOfServiceBedUtils.ts
@@ -123,7 +123,7 @@ export const outOfServiceBedCountForToday = (outOfServiceBeds: Array<OutOfServic
 const bedLink = (bed: OutOfServiceBed, premisesId: Premises['id']): string =>
   linkTo(
     paths.v2Manage.outOfServiceBeds.show,
-    { id: bed.id, bedId: bed.bed.id, premisesId },
+    { id: bed.id, bedId: bed.bed.id, premisesId, tab: 'details' },
     {
       text: 'View',
       hiddenText: `Out of service bed ${bed.bed.name}`,

--- a/server/views/v2Manage/outOfServiceBeds/show.njk
+++ b/server/views/v2Manage/outOfServiceBeds/show.njk
@@ -1,18 +1,20 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
-{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "govuk/components/input/macro.njk" import govukInput %}
-
-{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+{%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
 
 {% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body" %}
+
+{% set characteristicsHtml%}
+<ul>
+  {% for characteristic in characteristics %}
+    <li>{{characteristic.name}}</li>
+  {% endfor %}
+</ul>
+{%endset%}
 
 {% block beforeContent %}
   {% if referrer %}
@@ -25,36 +27,64 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-full-width">
 
-      <h1 class="govuk-heading-l">Manage out of service bed</h1>
+      {{
+          mojIdentityBar({
+            title: {
+              html: '<span class="govuk-caption-l">' + outOfServiceBed.premises.name + '</span><span class="govuk-caption-l">Room ' + outOfServiceBed.room.name + ' | Bed ' + outOfServiceBed.bed.name + '</span> <h1 class="govuk-heading-l">View out of service bed record</h1>'
+            },
+            menus: [{
+              items: [
+                {
+                  text: "Update record",
+                  href: paths.v2Manage.outOfServiceBeds.update({premisesId: premisesId, id: id})
+                }
+              ]
+            }]
+          })
+        }}
+
+      {{
+        mojSubNavigation({
+          label: 'Sub navigation',
+          items: [{
+            text: 'Details',
+            href: paths.v2Manage.outOfServiceBeds.show({ premisesId: premisesId, bedId: bedId, id: id, tab: 'details' }),
+            active: activeTab === 'details'
+          }, {
+            text: 'Timeline',
+            href: paths.v2Manage.outOfServiceBeds.show({ premisesId: premisesId, bedId: bedId, id: id, tab: 'timeline' }),
+            active: activeTab === 'timeline'
+          }]
+        })
+      }}
 
       {{
         govukSummaryList({
-          classes: 'govuk-summary-list--no-border',
           rows: [
-            {
-              key: {
-                text: "Room number"
-              },
-              value: {
-                text: outOfServiceBed.room.name
-              }
-            },
-            {
-              key: {
-                text: "Bed number"
-              },
-              value: {
-                text: outOfServiceBed.bed.name
-              }
-            },
             {
               key: {
                 text: "Start date"
               },
               value: {
-                text: formatDate(outOfServiceBed.startDate, {format: 'long'})
+                text: formatDate(outOfServiceBed.revisionHistory[0].startDate, {format: 'long'})
+              }
+            },
+            {
+              key: {
+                text: "End date"
+              },
+              value: {
+                text: formatDate(outOfServiceBed.revisionHistory[0].endDate, {format: 'long'})
+              }
+            },
+            {
+              key: {
+                text: "Reason"
+              },
+              value: {
+                text: outOfServiceBed.revisionHistory[0].reason.name
               }
             },
             {
@@ -71,7 +101,23 @@
                 text: "Reference number"
               },
               value: {
-                text: outOfServiceBed.referenceNumber
+                text: outOfServiceBed.revisionHistory[0].referenceNumber
+              }
+            },
+            {
+              key: {
+                text: "Additional information"
+              },
+              value: {
+                text: outOfServiceBed.revisionHistory[0].notes
+              }
+            },
+            {
+              key: {
+                text: "Characteristics"
+              },
+              value: {
+                html: characteristicsHtml
               }
             }
           ]
@@ -79,55 +125,6 @@
       }}
 
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
-      <form action="{{ paths.v2Manage.outOfServiceBeds.update({ id: outOfServiceBed.id, bedId: outOfServiceBed.bedId, premisesId: premisesId }) }}" method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-        <input type="hidden" name="startDate" value="{{ outOfServiceBed.startDate }}"/>
-        <input type="hidden" name="referenceNumber" value="{{ outOfServiceBed.referenceNumber }}"/>
-
-        {{ showErrorSummary(errorSummary, errorTitle) }}
-
-        {{ govukDateInput({
-        id: "endDate",
-        namePrefix: "endDate",
-        items: dateFieldValues('endDate', errors),
-        errorMessage: errors.endDate,
-        hint: {
-        text: "For example, 27 3 2007"
-        },
-        fieldset: {
-          legend: {
-            text: "End date",
-            classes: "govuk-fieldset__legend--s"
-          }
-        }
-        }) }}
-
-        {{ govukTextarea({
-        id: "notes",
-        name: "notes",
-        label: {
-          text: "Can you provide more detail?",
-          classes: "govuk-fieldset__legend--s"
-        },
-        errorMessage: errors.notes
-        }) }}
-
-        {{ govukButton({
-          text: "Save and continue",
-          name: "submit",
-          preventDoubleClick: true
-        }) }}
-
-        {{ govukButton({
-          text: "Cancel out of service bed",
-          name: "cancel",
-          value: '1',
-          classes: "govuk-button--secondary govuk-!-margin-left-3",
-          preventDoubleClick: true
-        }) }}
-
-      </form>
 
     </div>
   </div>


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/APS-888

# Changes in this PR

Updates v2 show OOS bed page to show details of the 'latest revision', as well as the bed characteristics. Also removes the now redundant form from that page.

- [] I have run the E2E tests locally and they passed

## Screenshots of UI changes

### Before

![OutOfServiceBeds -- should show a out of service bed](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/70749355/0754e462-7fa3-491b-9f90-481a7974a507)

### After

![OutOfServiceBeds -- should show an out of service bed](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/70749355/82484b7c-e4f5-42ef-99d7-da5815ee10e6)