### PR TITLE
Remove temporality query param from OOS index path

### DIFF
--- a/server/controllers/v2Manage/outOfServiceBedsController.ts
+++ b/server/controllers/v2Manage/outOfServiceBedsController.ts
@@ -126,7 +126,6 @@ export default class OutOfServiceBedsController {
         req,
         paths.v2Manage.outOfServiceBeds.index({ temporality }),
         {
-          temporality,
           premisesId,
           apAreaId,
         },


### PR DESCRIPTION
This query parameter is repetitive as the temporality is already in the path as a path parameter.

# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- [] I have run the E2E tests locally and they passed

## Screenshots of UI changes

### Before

### After
