### PR TITLE
APS-965: Show CRN for LAO's on the Task List

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ assets
 cypress.json
 reporter-config.json
 dist/
+playwright-report

--- a/integration_tests/tests/tasks/list.cy.ts
+++ b/integration_tests/tests/tasks/list.cy.ts
@@ -1,6 +1,8 @@
 import ListPage from '../../pages/tasks/listPage'
 
-import { apAreaFactory, assessmentTaskFactory, taskFactory, userFactory } from '../../../server/testutils/factories'
+import { apAreaFactory, userFactory } from '../../../server/testutils/factories'
+import { restrictedPersonSummaryTaskFactory } from '../../../server/testutils/factories/task'
+import { restrictedPersonSummaryAssessmentTaskFactory } from '../../../server/testutils/factories/assessmentTask'
 
 context('Task Allocation', () => {
   const users = userFactory.buildList(5)
@@ -19,9 +21,9 @@ context('Task Allocation', () => {
     // Given I am logged in
     cy.signIn()
 
-    const allocatedTasks = taskFactory.buildList(5)
-    const unallocatedTasks = taskFactory.buildList(5, { allocatedToStaffMember: undefined })
-    const completedTasks = assessmentTaskFactory.buildList(5)
+    const allocatedTasks = restrictedPersonSummaryTaskFactory.buildList(5)
+    const unallocatedTasks = restrictedPersonSummaryTaskFactory.buildList(5, { allocatedToStaffMember: undefined })
+    const completedTasks = restrictedPersonSummaryAssessmentTaskFactory.buildList(5)
 
     cy.task('stubGetAllTasks', {
       tasks: allocatedTasks,
@@ -73,10 +75,10 @@ context('Task Allocation', () => {
     // Given I am logged in
     cy.signIn()
 
-    const allocatedTasksPage1 = taskFactory.buildList(10)
-    const allocatedTasksPage2 = taskFactory.buildList(10)
-    const allocatedTasksPage9 = taskFactory.buildList(10)
-    const unallocatedTasks = taskFactory.buildList(1, { allocatedToStaffMember: undefined })
+    const allocatedTasksPage1 = restrictedPersonSummaryTaskFactory.buildList(10)
+    const allocatedTasksPage2 = restrictedPersonSummaryTaskFactory.buildList(10)
+    const allocatedTasksPage9 = restrictedPersonSummaryTaskFactory.buildList(10)
+    const unallocatedTasks = restrictedPersonSummaryTaskFactory.buildList(1, { allocatedToStaffMember: undefined })
 
     cy.task('stubGetAllTasks', {
       tasks: allocatedTasksPage1,
@@ -133,7 +135,7 @@ context('Task Allocation', () => {
     // Given I am logged in
     cy.signIn()
 
-    const tasks = taskFactory.buildList(10)
+    const tasks = restrictedPersonSummaryTaskFactory.buildList(10)
 
     cy.task('stubGetAllTasks', {
       tasks,
@@ -219,9 +221,9 @@ context('Task Allocation', () => {
       // Given I am logged in
       cy.signIn()
 
-      const allocatedTasks = taskFactory.buildList(10)
-      const allocatedTasksFiltered = taskFactory.buildList(1)
-      const unallocatedTasks = taskFactory.buildList(1, { allocatedToStaffMember: undefined })
+      const allocatedTasks = restrictedPersonSummaryTaskFactory.buildList(10)
+      const allocatedTasksFiltered = restrictedPersonSummaryTaskFactory.buildList(1)
+      const unallocatedTasks = restrictedPersonSummaryTaskFactory.buildList(1, { allocatedToStaffMember: undefined })
 
       cy.task('stubGetAllTasks', {
         tasks: allocatedTasks,
@@ -263,9 +265,9 @@ context('Task Allocation', () => {
     // Given I am logged in
     cy.signIn()
 
-    const allocatedTasks = taskFactory.buildList(10)
-    const allocatedTasksFiltered = taskFactory.buildList(1)
-    const unallocatedTasks = taskFactory.buildList(1, { allocatedToStaffMember: undefined })
+    const allocatedTasks = restrictedPersonSummaryTaskFactory.buildList(10)
+    const allocatedTasksFiltered = restrictedPersonSummaryTaskFactory.buildList(1)
+    const unallocatedTasks = restrictedPersonSummaryTaskFactory.buildList(1, { allocatedToStaffMember: undefined })
 
     cy.task('stubGetAllTasks', { tasks: allocatedTasks, allocatedFilter: 'allocated', page: '1', apAreaId: apArea.id })
 
@@ -309,9 +311,11 @@ context('Task Allocation', () => {
     // Given I am logged in
     cy.signIn()
 
-    const allocatedTasks = taskFactory.buildList(10)
-    const unallocatedTasks = taskFactory.buildList(10, { allocatedToStaffMember: undefined })
-    const unallocatedTasksFiltered = taskFactory.buildList(1, { allocatedToStaffMember: undefined })
+    const allocatedTasks = restrictedPersonSummaryTaskFactory.buildList(10)
+    const unallocatedTasks = restrictedPersonSummaryTaskFactory.buildList(10, { allocatedToStaffMember: undefined })
+    const unallocatedTasksFiltered = restrictedPersonSummaryTaskFactory.buildList(1, {
+      allocatedToStaffMember: undefined,
+    })
 
     cy.task('stubGetAllTasks', {
       tasks: unallocatedTasks,
@@ -352,10 +356,10 @@ context('Task Allocation', () => {
     // Given I am signed in
     cy.signIn()
 
-    const allocatedTasks = taskFactory.buildList(1)
-    const allocatedTasksFiltered = taskFactory.buildList(10)
-    const allocatedTasksFilteredPage2 = taskFactory.buildList(10)
-    const unallocatedTasks = taskFactory.buildList(1, { allocatedToStaffMember: undefined })
+    const allocatedTasks = restrictedPersonSummaryTaskFactory.buildList(1)
+    const allocatedTasksFiltered = restrictedPersonSummaryTaskFactory.buildList(10)
+    const allocatedTasksFilteredPage2 = restrictedPersonSummaryTaskFactory.buildList(10)
+    const unallocatedTasks = restrictedPersonSummaryTaskFactory.buildList(1, { allocatedToStaffMember: undefined })
 
     cy.task('stubGetAllTasks', {
       tasks: allocatedTasks,
@@ -431,7 +435,7 @@ context('Task Allocation', () => {
         sortDirection: 'asc',
         apAreaId: apArea.id,
       })
-      const completedTasks = assessmentTaskFactory.buildList(5)
+      const completedTasks = restrictedPersonSummaryAssessmentTaskFactory.buildList(5)
       cy.task('stubGetAllTasks', {
         tasks: [...completedTasks],
         allocatedFilter: 'allocated',

--- a/server/testutils/factories/assessmentTask.ts
+++ b/server/testutils/factories/assessmentTask.ts
@@ -3,10 +3,17 @@ import { Factory } from 'fishery'
 import type { AssessmentTask } from '@approved-premises/api'
 
 import { faker } from '@faker-js/faker/locale/en_GB'
-import taskFactory from './task'
+import taskFactory, { restrictedPersonSummaryTaskFactory } from './task'
 
 export default Factory.define<AssessmentTask>(() => ({
   ...taskFactory.build(),
+  taskType: 'Assessment',
+  createdFromAppeal: false,
+  outcome: faker.helpers.arrayElement(['accepted', 'rejected']),
+}))
+
+export const restrictedPersonSummaryAssessmentTaskFactory = Factory.define<AssessmentTask>(() => ({
+  ...restrictedPersonSummaryTaskFactory.build(),
   taskType: 'Assessment',
   createdFromAppeal: false,
   outcome: faker.helpers.arrayElement(['accepted', 'rejected']),

--- a/server/testutils/factories/person.ts
+++ b/server/testutils/factories/person.ts
@@ -2,10 +2,12 @@ import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
 
 import type { FullPerson, PersonSummary, RestrictedPerson } from '@approved-premises/api'
+import { FullPersonSummary } from '@approved-premises/api'
 import { DateFormats } from '../../utils/dateUtils'
 
+export const getCrn = () => `C${faker.number.int({ min: 100000, max: 999999 })}`
 export const fullPersonFactory = Factory.define<FullPerson>(() => ({
-  crn: `C${faker.number.int({ min: 100000, max: 999999 })}`,
+  crn: getCrn(),
   name: faker.person.fullName(),
   dateOfBirth: DateFormats.dateObjToIsoDate(faker.date.past()),
   sex: faker.helpers.arrayElement(['Male', 'Female', 'Other', 'Prefer not to say']),
@@ -19,11 +21,22 @@ export const fullPersonFactory = Factory.define<FullPerson>(() => ({
 }))
 
 export const restrictedPersonFactory = Factory.define<RestrictedPerson>(() => ({
-  crn: `C${faker.number.int({ min: 100000, max: 999999 })}`,
+  crn: getCrn(),
   type: 'RestrictedPerson',
 }))
 
 export const personSummaryFactory = Factory.define<PersonSummary>(() => ({
-  crn: `C${faker.number.int({ min: 100000, max: 999999 })}`,
+  crn: getCrn(),
   personType: faker.helpers.arrayElement(['FullPersonSummary', 'RestrictedPersonSummary', 'UnknownPersonSummary']),
+}))
+
+export const restrictedPersonSummaryFactory = Factory.define<PersonSummary>(() => ({
+  crn: getCrn(),
+  personType: 'RestrictedPersonSummary',
+}))
+
+export const fullPersonSummaryFactory = Factory.define<FullPersonSummary>(() => ({
+  crn: getCrn(),
+  personType: 'FullPersonSummary',
+  name: faker.person.fullName(),
 }))

--- a/server/testutils/factories/risks.ts
+++ b/server/testutils/factories/risks.ts
@@ -4,12 +4,13 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 import type { PersonRisks, RiskEnvelopeStatus, RiskTierLevel } from '@approved-premises/api'
 import { RiskLevel, TierLetter, TierNumber } from '@approved-premises/ui'
 import { DateFormats } from '../../utils/dateUtils'
+import { getCrn } from './person'
 
 const riskLevels: Array<RiskLevel> = ['Low', 'Medium', 'High', 'Very High']
 const riskEnvelopeStatuses: Array<RiskEnvelopeStatus> = ['retrieved', 'not_found', 'error']
 
 export default Factory.define<PersonRisks>(() => ({
-  crn: `C${faker.number.int({ min: 100000, max: 999999 })}`,
+  crn: getCrn(),
   roshRisks: roshRisksFactory.build(),
   mappa: mappaFactory.build(),
   flags: flagsFactory.build(),

--- a/server/testutils/factories/task.ts
+++ b/server/testutils/factories/task.ts
@@ -6,7 +6,7 @@ import { DateFormats } from '../../utils/dateUtils'
 
 import UserFactory from './user'
 import { apAreaFactory } from './referenceData'
-import { personSummaryFactory } from './person'
+import { getCrn, personSummaryFactory, restrictedPersonSummaryFactory } from './person'
 
 export default Factory.define<Task>(() => ({
   id: faker.string.uuid(),
@@ -17,8 +17,23 @@ export default Factory.define<Task>(() => ({
   status: faker.helpers.arrayElement(['not_started', 'in_progress', 'complete']),
   taskType: faker.helpers.arrayElement(['Assessment', 'PlacementRequest', 'BookingAppeal']),
   personName: faker.person.fullName(),
-  crn: `C${faker.number.int({ min: 100000, max: 999999 })}`,
+  crn: getCrn(),
   apArea: apAreaFactory.build(),
   outcomeRecordedAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
   personSummary: personSummaryFactory.build(),
+}))
+
+export const restrictedPersonSummaryTaskFactory = Factory.define<Task>(() => ({
+  id: faker.string.uuid(),
+  allocatedToStaffMember: UserFactory.build(),
+  applicationId: faker.string.uuid(),
+  dueDate: DateFormats.dateObjToIsoDate(faker.date.future()),
+  dueAt: DateFormats.dateObjToIsoDateTime(faker.date.future()),
+  status: faker.helpers.arrayElement(['not_started', 'in_progress', 'complete']),
+  taskType: faker.helpers.arrayElement(['Assessment', 'PlacementRequest', 'BookingAppeal']),
+  personName: faker.person.fullName(),
+  crn: getCrn(),
+  apArea: apAreaFactory.build(),
+  outcomeRecordedAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
+  personSummary: restrictedPersonSummaryFactory.build(),
 }))

--- a/server/utils/tasks/listTable.test.ts
+++ b/server/utils/tasks/listTable.test.ts
@@ -28,6 +28,7 @@ import { TaskSortField } from '../../@types/shared'
 import paths from '../../paths/tasks'
 import { daysUntilDueCell } from '../tableUtils'
 import { TaskStatusTag } from './statusTag'
+import { fullPersonSummaryFactory } from '../../testutils/factories/person'
 
 describe('table', () => {
   beforeEach(() => {
@@ -197,16 +198,52 @@ describe('table', () => {
   })
 
   describe('nameAnchorCell', () => {
-    it('returns the cell when there is a person present in the task', () => {
+    it('returns the name when the person summary is FullPersonSummary  in the task', () => {
+      const personSummary = fullPersonSummaryFactory.build()
       const task = taskFactory.build({
         taskType: 'Assessment',
+        personSummary,
       })
       expect(nameAnchorCell(task)).toEqual({
         html: linkTo(
           paths.tasks.show,
           { id: task.id, taskType: kebabCase(task.taskType) },
           {
-            text: task.personName,
+            text: personSummary.name,
+            attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
+          },
+        ),
+      })
+    })
+    it('returns the Limited Access Offender (LAO) CRN when the person summary is RestrictedPersonSummary in the task', () => {
+      const personSummary = fullPersonSummaryFactory.build({ personType: 'RestrictedPersonSummary' })
+      const task = taskFactory.build({
+        taskType: 'Assessment',
+        personSummary,
+      })
+      expect(nameAnchorCell(task)).toEqual({
+        html: linkTo(
+          paths.tasks.show,
+          { id: task.id, taskType: kebabCase(task.taskType) },
+          {
+            text: `LAO CRN: ${personSummary.crn}`,
+            attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
+          },
+        ),
+      })
+    })
+    it('returns the not found CRN when the person summary is UnknownPersonSummary  in the task', () => {
+      const personSummary = fullPersonSummaryFactory.build({ personType: 'UnknownPersonSummary' })
+      const task = taskFactory.build({
+        taskType: 'Assessment',
+        personSummary,
+      })
+      expect(nameAnchorCell(task)).toEqual({
+        html: linkTo(
+          paths.tasks.show,
+          { id: task.id, taskType: kebabCase(task.taskType) },
+          {
+            text: `Not Found CRN: ${personSummary.crn}`,
             attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
           },
         ),

--- a/server/utils/tasks/listTable.ts
+++ b/server/utils/tasks/listTable.ts
@@ -1,6 +1,8 @@
 import { isAssessmentTask, isPlacementApplicationTask, isPlacementRequestTask } from './assertions'
 import {
   AssessmentDecision,
+  FullPersonSummary,
+  PersonSummary,
   PlacementApplicationDecision,
   PlacementRequestTaskOutcome,
   SortDirection,
@@ -89,9 +91,22 @@ const allocationCell = (task: Task): TableCell => ({
   text: task.allocatedToStaffMember?.name,
 })
 
+const getPersonName = (personSummary: PersonSummary): string => {
+  switch (personSummary.personType) {
+    case 'FullPersonSummary':
+      return (personSummary as FullPersonSummary).name
+    case 'RestrictedPersonSummary':
+      return `LAO CRN: ${personSummary.crn}`
+    case 'UnknownPersonSummary':
+      return `Not Found CRN: ${personSummary.crn}`
+    default:
+      return ''
+  }
+}
+
 const nameAnchorCell = (task: Task): TableCell => ({
   html: linkTo(paths.tasks.show, taskParams(task), {
-    text: task.personName,
+    text: getPersonName(task.personSummary),
     attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
   }),
 })
@@ -102,7 +117,6 @@ const apAreaCell = (task: Task): TableCell => ({
 
 const allocatedTableRows = (tasks: Array<Task>): Array<TableRow> => {
   const rows: Array<TableRow> = []
-
   tasks.forEach(task => {
     rows.push([
       nameAnchorCell(task),


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-965
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Show CRN for LAO's on the Task List as per below

- For FullPersonSummary the name can be shown as normal
- For RestrictedPersonSummary the name should be shown as ‘LRN CRN: crn’
- For UnknownPersonSummary the name should be shown as ‘Not Found CRN: crn’

- [] I have run the E2E tests locally and they passed

## Screenshots of UI changes

### Before

<img width="1728" alt="Screenshot 2024-07-05 at 18 37 20" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/51b14c07-aa43-47bc-a393-cd71c76bac1c">

### After
<img width="1728" alt="Screenshot 2024-07-05 at 18 34 35" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22200925/7afd0c17-4583-478f-a23c-5854307d2ad7">
