### PR TITLE
APS 912 - Out of Service bed timeline

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 # Changes in this PR
 
-- [] I have run the E2E tests locally and they passed
+<!-- [] I have run the E2E tests locally and they passed -->
 
 ## Screenshots of UI changes
 

--- a/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
+++ b/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
@@ -24,11 +24,16 @@ export class OutOfServiceBedShowPage extends Page {
 
   shouldShowOutOfServiceBedDetail(): void {
     const latestRevision = this.outOfServiceBed.revisionHistory[0]
-    this.assertDefinition('Start date', DateFormats.isoDateToUIDate(latestRevision.startDate, { format: 'long' }))
-    this.assertDefinition('End date', DateFormats.isoDateToUIDate(latestRevision.endDate, { format: 'long' }))
-    this.assertDefinition('Reason', latestRevision.reason.name)
-    this.assertDefinition('Reference number', latestRevision.referenceNumber)
-    this.assertDefinition('Additional information', latestRevision.notes)
+
+    if (latestRevision.startDate) {
+      this.assertDefinition('Start date', DateFormats.isoDateToUIDate(latestRevision.startDate, { format: 'long' }))
+    }
+    if (latestRevision.endDate) {
+      this.assertDefinition('End date', DateFormats.isoDateToUIDate(latestRevision.endDate, { format: 'long' }))
+    }
+    if (latestRevision.reason) this.assertDefinition('Reason', latestRevision.reason.name)
+    if (latestRevision.referenceNumber) this.assertDefinition('Reference number', latestRevision.referenceNumber)
+    if (latestRevision.notes) this.assertDefinition('Additional information', latestRevision.notes)
   }
 
   shouldShowCharacteristics(bed: BedDetail): void {

--- a/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
+++ b/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
@@ -35,4 +35,8 @@ export class OutOfServiceBedShowPage extends Page {
       cy.get('li').contains(characteristic.name)
     })
   }
+
+  clickTab(tab: 'Details' | 'Timeline'): void {
+    cy.get('.moj-sub-navigation__link').contains(tab).click()
+  }
 }

--- a/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
+++ b/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
@@ -3,6 +3,7 @@ import paths from '../../../../server/paths/manage'
 import Page from '../../page'
 import { DateFormats } from '../../../../server/utils/dateUtils'
 import { BedDetail, Cas1OutOfServiceBed as OutOfServiceBed, Premises } from '../../../../server/@types/shared'
+import { sentenceCase } from '../../../../server/utils/utils'
 
 export class OutOfServiceBedShowPage extends Page {
   constructor(private readonly outOfServiceBed: OutOfServiceBed) {
@@ -33,6 +34,64 @@ export class OutOfServiceBedShowPage extends Page {
   shouldShowCharacteristics(bed: BedDetail): void {
     bed.characteristics.forEach(characteristic => {
       cy.get('li').contains(characteristic.name)
+    })
+  }
+
+  shouldShowTimeline() {
+    const timelineEvents = this.outOfServiceBed.revisionHistory
+
+    cy.get('.moj-timeline').within(() => {
+      cy.get('.moj-timeline__item').should('have.length', timelineEvents.length)
+
+      cy.get('.moj-timeline__item').each(($el, i) => {
+        cy.wrap($el).within(() => {
+          // Revision type(s)
+          timelineEvents[i].revisionType.forEach(element => {
+            cy.get('.moj-timeline__header').should('contain', sentenceCase(element))
+          })
+
+          // Updated by
+          if (timelineEvents[i].updatedBy?.name) {
+            cy.get('.moj-timeline__header > .moj-timeline__byline').should('contain', timelineEvents[i].updatedBy.name)
+          }
+
+          // Date time
+          cy.get('time').should('have.attr', { time: timelineEvents[i].updatedAt })
+          cy.get('time').should('contain', DateFormats.isoDateTimeToUIDateTime(timelineEvents[i].updatedAt))
+
+          // Revision details
+          if (timelineEvents[i].startDate) {
+            cy.get('.govuk-summary-list__key').should('contain', 'Start date')
+            cy.get('.govuk-summary-list__value').should(
+              'contain',
+              DateFormats.isoDateToUIDate(timelineEvents[i].startDate, { format: 'long' }),
+            )
+          }
+
+          if (timelineEvents[i].endDate) {
+            cy.get('.govuk-summary-list__key').should('contain', 'End date')
+            cy.get('.govuk-summary-list__value').should(
+              'contain',
+              DateFormats.isoDateToUIDate(timelineEvents[i].endDate, { format: 'long' }),
+            )
+          }
+
+          if (timelineEvents[i].reason) {
+            cy.get('.govuk-summary-list__key').should('contain', 'Reason')
+            cy.get('.govuk-summary-list__value').should('contain', timelineEvents[i].reason.name)
+          }
+
+          if (timelineEvents[i].referenceNumber) {
+            cy.get('.govuk-summary-list__key').should('contain', 'Reference number')
+            cy.get('.govuk-summary-list__value').should('contain', timelineEvents[i].referenceNumber)
+          }
+
+          if (timelineEvents[i].notes) {
+            cy.get('.govuk-summary-list__key').should('contain', 'Notes')
+            cy.get('.govuk-summary-list__value').should('contain', timelineEvents[i].notes)
+          }
+        })
+      })
     })
   }
 

--- a/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
+++ b/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
@@ -135,6 +135,12 @@ context('OutOfServiceBeds', () => {
 
     // And I should see the bed characteristics
     page.shouldShowCharacteristics(bedDetail)
+
+    // When I click the 'Timeline' tab
+    page.clickTab('Timeline')
+
+    // Then I should see the timeline of that out of service bed's revision
+    page.shouldShowTimeline()
   })
 
   describe('CRU Member lists all OOS beds', () => {

--- a/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
+++ b/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
@@ -4,6 +4,7 @@ import {
   bookingFactory,
   extendedPremisesSummaryFactory,
   outOfServiceBedFactory,
+  outOfServiceBedRevisionFactory,
   premisesFactory,
 } from '../../../server/testutils/factories'
 import { sortOutOfServiceBedRevisionsByUpdatedAt } from '../../../server/utils/outOfServiceBedUtils'
@@ -113,34 +114,72 @@ context('OutOfServiceBeds', () => {
     page.shouldShowDateConflictErrorMessages(conflictingBooking, 'booking')
   })
 
-  it('should show a out of service bed', () => {
-    // Given I am signed in as a future manager
-    signIn(['future_manager'])
+  describe('for a new out of service bed with all nullable fields present in the initial OoS bed revision', () => {
+    it('should show a out of service bed', () => {
+      // Given I am signed in as a future manager
+      signIn(['future_manager'])
 
-    // And I have created a out of service bed
-    const bed = { name: 'abc', id: '123' }
-    const premises = premisesFactory.build()
-    const outOfServiceBed = outOfServiceBedFactory.build({ bed })
-    outOfServiceBed.revisionHistory = sortOutOfServiceBedRevisionsByUpdatedAt(outOfServiceBed.revisionHistory)
-    const bedDetail = bedDetailFactory.build({ id: bed.id })
+      // And I have created a out of service bed
+      const bed = { name: 'abc', id: '123' }
+      const premises = premisesFactory.build()
+      const outOfServiceBed = outOfServiceBedFactory.build({ bed })
+      outOfServiceBed.revisionHistory = sortOutOfServiceBedRevisionsByUpdatedAt(outOfServiceBed.revisionHistory)
+      const bedDetail = bedDetailFactory.build({ id: bed.id })
 
-    cy.task('stubOutOfServiceBed', { premisesId: premises.id, outOfServiceBed })
-    cy.task('stubBed', { premisesId: premises.id, bedDetail })
+      cy.task('stubOutOfServiceBed', { premisesId: premises.id, outOfServiceBed })
+      cy.task('stubBed', { premisesId: premises.id, bedDetail })
 
-    // And I visit that out of service bed's show page
-    const page = OutOfServiceBedShowPage.visit(premises.id, outOfServiceBed)
+      // And I visit that out of service bed's show page
+      const page = OutOfServiceBedShowPage.visit(premises.id, outOfServiceBed)
 
-    // Then I should see the latest details of that out of service bed
-    page.shouldShowOutOfServiceBedDetail()
+      // Then I should see the latest details of that out of service bed
+      page.shouldShowOutOfServiceBedDetail()
 
-    // And I should see the bed characteristics
-    page.shouldShowCharacteristics(bedDetail)
+      // And I should see the bed characteristics
+      page.shouldShowCharacteristics(bedDetail)
 
-    // When I click the 'Timeline' tab
-    page.clickTab('Timeline')
+      // When I click the 'Timeline' tab
+      page.clickTab('Timeline')
 
-    // Then I should see the timeline of that out of service bed's revision
-    page.shouldShowTimeline()
+      // Then I should see the timeline of that out of service bed's revision
+      page.shouldShowTimeline()
+    })
+  })
+
+  describe('for a legacy "lost bed" records migrated with all nullable fields not present in the initial OoS bed revision', () => {
+    it('should show a out of service bed', () => {
+      // Given I am signed in as a future manager
+      signIn(['future_manager'])
+
+      // And I have created a out of service bed
+      const bed = { name: 'abc', id: '123' }
+      const premises = premisesFactory.build()
+      const outOfServiceBedRevision = outOfServiceBedRevisionFactory.build({
+        updatedBy: undefined,
+        startDate: undefined,
+        endDate: undefined,
+        reason: undefined,
+        referenceNumber: undefined,
+        notes: undefined,
+      })
+      const outOfServiceBed = outOfServiceBedFactory.build({
+        bed,
+        revisionHistory: [outOfServiceBedRevision],
+      })
+      const bedDetail = bedDetailFactory.build({ id: bed.id })
+
+      cy.task('stubOutOfServiceBed', { premisesId: premises.id, outOfServiceBed })
+      cy.task('stubBed', { premisesId: premises.id, bedDetail })
+
+      // And I visit that out of service bed's show page
+      const page = OutOfServiceBedShowPage.visit(premises.id, outOfServiceBed)
+
+      // When I click the 'Timeline' tab
+      page.clickTab('Timeline')
+
+      // Then I should see the timeline of that out of service bed's revision
+      page.shouldShowTimeline()
+    })
   })
 
   describe('CRU Member lists all OOS beds', () => {

--- a/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
+++ b/integration_tests/tests/v2Manage/outOfServiceBeds.cy.ts
@@ -6,7 +6,7 @@ import {
   outOfServiceBedFactory,
   premisesFactory,
 } from '../../../server/testutils/factories'
-
+import { sortOutOfServiceBedRevisionsByUpdatedAt } from '../../../server/utils/outOfServiceBedUtils'
 import {
   OutOfServiceBedCreatePage,
   OutOfServiceBedIndexPage,
@@ -121,6 +121,7 @@ context('OutOfServiceBeds', () => {
     const bed = { name: 'abc', id: '123' }
     const premises = premisesFactory.build()
     const outOfServiceBed = outOfServiceBedFactory.build({ bed })
+    outOfServiceBed.revisionHistory = sortOutOfServiceBedRevisionsByUpdatedAt(outOfServiceBed.revisionHistory)
     const bedDetail = bedDetailFactory.build({ id: bed.id })
 
     cy.task('stubOutOfServiceBed', { premisesId: premises.id, outOfServiceBed })

--- a/server/controllers/v2Manage/outOfServiceBedsController.test.ts
+++ b/server/controllers/v2Manage/outOfServiceBedsController.test.ts
@@ -171,7 +171,7 @@ describe('OutOfServiceBedsController', () => {
       const errorsAndUserInput = createMock<ErrorsAndUserInput>()
       when(fetchErrorsAndUserInput).calledWith(request).mockReturnValue(errorsAndUserInput)
       when(outOfServiceBedService.getOutOfServiceBed)
-        .calledWith(request.user.token, request.params.premisesId, request.params.id)
+        .calledWith(request.user.token, premisesId, outOfServiceBed.id)
         .mockResolvedValue(outOfServiceBed)
 
       const requestHandler = outOfServiceBedController.show()

--- a/server/controllers/v2Manage/outOfServiceBedsController.ts
+++ b/server/controllers/v2Manage/outOfServiceBedsController.ts
@@ -11,6 +11,7 @@ import { DateFormats } from '../../utils/dateUtils'
 import { SanitisedError } from '../../sanitisedError'
 import { getPaginationDetails } from '../../utils/getPaginationDetails'
 import { OutOfServiceBedService, PremisesService } from '../../services'
+import { sortOutOfServiceBedRevisionsByUpdatedAt } from '../../utils/outOfServiceBedUtils'
 
 export default class OutOfServiceBedsController {
   constructor(
@@ -165,6 +166,9 @@ export default class OutOfServiceBedsController {
       const referrer = req.headers.referer
 
       const outOfServiceBed = await this.outOfServiceBedService.getOutOfServiceBed(req.user.token, premisesId, id)
+
+      outOfServiceBed.revisionHistory = sortOutOfServiceBedRevisionsByUpdatedAt(outOfServiceBed.revisionHistory)
+
       const { characteristics } = await this.premisesService.getBed(req.user.token, premisesId, bedId)
 
       return res.render('v2Manage/outOfServiceBeds/show', {

--- a/server/controllers/v2Manage/outOfServiceBedsController.ts
+++ b/server/controllers/v2Manage/outOfServiceBedsController.ts
@@ -161,8 +161,7 @@ export default class OutOfServiceBedsController {
 
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const activeTab = req.params.tab
-      const { premisesId, bedId, id } = req.params
+      const { premisesId, bedId, id, tab = 'details' } = req.params
       const referrer = req.headers.referer
 
       const outOfServiceBed = await this.outOfServiceBedService.getOutOfServiceBed(req.user.token, premisesId, id)
@@ -174,7 +173,7 @@ export default class OutOfServiceBedsController {
         bedId,
         id,
         referrer,
-        activeTab,
+        activeTab: tab,
         characteristics,
       })
     }

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -59,6 +59,7 @@ import {
   newOutOfServiceBedFactory,
   outOfServiceBedCancellationFactory,
   outOfServiceBedFactory,
+  outOfServiceBedRevisionFactory,
 } from './outOfServiceBed'
 import paginatedResponseFactory from './paginatedResponse'
 import { fullPersonFactory as personFactory, restrictedPersonFactory } from './person'
@@ -148,6 +149,7 @@ export {
   oasysSelectionFactory,
   outOfServiceBedFactory,
   outOfServiceBedCancellationFactory,
+  outOfServiceBedRevisionFactory,
   newOutOfServiceBedFactory,
   paginatedResponseFactory,
   personFactory,

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -226,6 +226,8 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addFilter('removeBlankSummaryListItems', removeBlankSummaryListItems)
   njkEnv.addFilter('sentenceCase', sentenceCase)
   njkEnv.addFilter('kebabCase', kebabCase)
+  njkEnv.addFilter('addCommasToList', (arg, notLastItem) => (notLastItem ? `${arg}, ` : arg))
+
   njkEnv.addFilter('linebreaksToParagraphs', linebreaksToParagraphs)
 
   njkEnv.addGlobal('numberToOrdinal', numberToOrdinal)

--- a/server/utils/outOfServiceBedUtils.test.ts
+++ b/server/utils/outOfServiceBedUtils.test.ts
@@ -9,6 +9,7 @@ import {
   outOfServiceBedTableHeaders,
   outOfServiceBedTableRows,
   referenceNumberCell,
+  sortOutOfServiceBedRevisionsByUpdatedAt,
 } from './outOfServiceBedUtils'
 import { getRandomInt } from './utils'
 import { ApprovedPremisesUserRole, Cas1OutOfServiceBedSortField as OutOfServiceBedSortField } from '../@types/shared'
@@ -191,6 +192,18 @@ describe('outOfServiceBedUtils', () => {
       expect(
         outOfServiceBedCountForToday([...outOfServiceBedsForToday, ...futureOutOfServiceBeds, ...pastOutOfServiceBeds]),
       ).toEqual(`${outOfServiceBedsForToday.length} beds`)
+    })
+  })
+  describe('sortOutOfServiceBedRevisionsByUpdatedAt', () => {
+    it('sorts revisions by updatedAt in descending order', () => {
+      const revisions = [
+        outOfServiceBedRevisionFactory.build({ updatedAt: '2024-01-01T00:00:00Z' }),
+        outOfServiceBedRevisionFactory.build({ updatedAt: '2024-01-02T00:00:00Z' }),
+        outOfServiceBedRevisionFactory.build({ updatedAt: '2024-01-03T00:00:00Z' }),
+      ]
+      const sortedRevisions = sortOutOfServiceBedRevisionsByUpdatedAt(revisions)
+
+      expect(sortedRevisions).toEqual([revisions[0], revisions[1], revisions[2]])
     })
   })
 })

--- a/server/utils/outOfServiceBedUtils.test.ts
+++ b/server/utils/outOfServiceBedUtils.test.ts
@@ -1,10 +1,11 @@
 import { add, sub } from 'date-fns'
-import { outOfServiceBedFactory, userDetailsFactory } from '../testutils/factories'
+import { outOfServiceBedFactory, outOfServiceBedRevisionFactory, userDetailsFactory } from '../testutils/factories'
 import { DateFormats } from './dateUtils'
 import {
   actionCell,
   allOutOfServiceBedsTableHeaders,
   allOutOfServiceBedsTableRows,
+  bedRevisionDetails,
   outOfServiceBedCountForToday,
   outOfServiceBedTableHeaders,
   outOfServiceBedTableRows,
@@ -194,6 +195,61 @@ describe('outOfServiceBedUtils', () => {
       ).toEqual(`${outOfServiceBedsForToday.length} beds`)
     })
   })
+
+  describe('bedRevisionDetails', () => {
+    it('adds a formatted start date the summary list', () => {
+      const startDate = new Date(2024, 2, 1)
+      const revision = outOfServiceBedRevisionFactory.build({
+        startDate: DateFormats.dateObjToIsoDate(startDate),
+      })
+
+      expect(bedRevisionDetails(revision)).toEqual(
+        expect.arrayContaining([
+          { key: { text: 'Start date' }, value: { text: DateFormats.dateObjtoUIDate(startDate) } },
+        ]),
+      )
+    })
+
+    it('adds a formatted end date the summary list', () => {
+      const endDate = new Date(2024, 2, 1)
+      const revision = outOfServiceBedRevisionFactory.build({
+        endDate: DateFormats.dateObjToIsoDate(endDate),
+      })
+
+      expect(bedRevisionDetails(revision)).toEqual(
+        expect.arrayContaining([{ key: { text: 'End date' }, value: { text: DateFormats.dateObjtoUIDate(endDate) } }]),
+      )
+    })
+
+    it('adds a reason the summary list', () => {
+      const revision = outOfServiceBedRevisionFactory.build({
+        reason: { id: 'reasonId', name: 'reasonName' },
+      })
+
+      expect(bedRevisionDetails(revision)).toEqual(
+        expect.arrayContaining([{ key: { text: 'Reason' }, value: { text: revision.reason.name } }]),
+      )
+    })
+
+    it('adds a reference the summary list', () => {
+      const revision = outOfServiceBedRevisionFactory.build({
+        referenceNumber: '123',
+      })
+
+      expect(bedRevisionDetails(revision)).toEqual(
+        expect.arrayContaining([{ key: { text: 'Reference number' }, value: { text: revision.referenceNumber } }]),
+      )
+    })
+
+    it('adds a notes item to the summary list', () => {
+      const revision = outOfServiceBedRevisionFactory.build({ notes: 'some note' })
+
+      expect(bedRevisionDetails(revision)).toEqual(
+        expect.arrayContaining([{ key: { text: 'Notes' }, value: { text: 'some note' } }]),
+      )
+    })
+  })
+
   describe('sortOutOfServiceBedRevisionsByUpdatedAt', () => {
     it('sorts revisions by updatedAt in descending order', () => {
       const revisions = [

--- a/server/utils/outOfServiceBedUtils.ts
+++ b/server/utils/outOfServiceBedUtils.ts
@@ -130,3 +130,8 @@ const bedLink = (bed: OutOfServiceBed, premisesId: Premises['id']): string =>
       attributes: { 'data-cy-bedId': bed.bed.id },
     },
   )
+export const sortOutOfServiceBedRevisionsByUpdatedAt = (revisions: Array<Cas1OutOfServiceBedRevision>) => {
+  return revisions.sort((a, b) => {
+    return a.updatedAt > b.updatedAt ? -1 : 1
+  })
+}

--- a/server/utils/outOfServiceBedUtils.ts
+++ b/server/utils/outOfServiceBedUtils.ts
@@ -1,10 +1,11 @@
 import {
+  Cas1OutOfServiceBedRevision,
   Cas1OutOfServiceBed as OutOfServiceBed,
   Cas1OutOfServiceBedSortField as OutOfServiceBedSortField,
   Premises,
   SortDirection,
 } from '@approved-premises/api'
-import { TableCell, UserDetails } from '@approved-premises/ui'
+import { SummaryList, SummaryListItem, TableCell, UserDetails } from '@approved-premises/ui'
 
 import { isWithinInterval } from 'date-fns'
 import paths from '../paths/manage'
@@ -130,6 +131,48 @@ const bedLink = (bed: OutOfServiceBed, premisesId: Premises['id']): string =>
       attributes: { 'data-cy-bedId': bed.bed.id },
     },
   )
+
+export const bedRevisionDetails = (revision: Cas1OutOfServiceBedRevision): SummaryList['rows'] => {
+  const summaryListItems: Array<SummaryListItem> = []
+
+  if (revision.startDate) {
+    summaryListItems.push({
+      key: textValue('Start date'),
+      value: textValue(DateFormats.isoDateToUIDate(revision.startDate, { format: 'long' })),
+    })
+  }
+
+  if (revision.endDate) {
+    summaryListItems.push({
+      key: textValue('End date'),
+      value: textValue(DateFormats.isoDateToUIDate(revision.endDate, { format: 'long' })),
+    })
+  }
+
+  if (revision.reason) {
+    summaryListItems.push({
+      key: textValue('Reason'),
+      value: textValue(revision.reason.name),
+    })
+  }
+
+  if (revision.referenceNumber) {
+    summaryListItems.push({
+      key: textValue('Reference number'),
+      value: textValue(revision.referenceNumber),
+    })
+  }
+
+  if (revision.notes) {
+    summaryListItems.push({
+      key: textValue('Notes'),
+      value: textValue(revision.notes),
+    })
+  }
+
+  return summaryListItems
+}
+
 export const sortOutOfServiceBedRevisionsByUpdatedAt = (revisions: Array<Cas1OutOfServiceBedRevision>) => {
   return revisions.sort((a, b) => {
     return a.updatedAt > b.updatedAt ? -1 : 1

--- a/server/views/v2Manage/outOfServiceBeds/partials/_bedDetails.njk
+++ b/server/views/v2Manage/outOfServiceBeds/partials/_bedDetails.njk
@@ -8,6 +8,9 @@
     {% endfor %}
   </ul>
   {%endset%}
+
+  {% set latestRevision = outOfServiceBed.revisionHistory[0] %}
+
   {{
         govukSummaryList({
           rows: [
@@ -16,7 +19,7 @@
                 text: "Start date"
               },
               value: {
-                text: formatDate(outOfServiceBed.revisionHistory[0].startDate, {format: 'long'})
+                text: formatDate(latestRevision.startDate, {format: 'long'}) if latestRevision.startDate else "None supplied"
               }
             },
             {
@@ -24,7 +27,7 @@
                 text: "End date"
               },
               value: {
-                text: formatDate(outOfServiceBed.revisionHistory[0].endDate, {format: 'long'})
+                text: formatDate(latestRevision.endDate, {format: 'long'}) if latestRevision.startDate else "None supplied"
               }
             },
             {
@@ -32,7 +35,7 @@
                 text: "Reason"
               },
               value: {
-                text: outOfServiceBed.revisionHistory[0].reason.name
+                text: latestRevision.reason.name if latestRevision.reason.name else "None supplied"
               }
             },
             {
@@ -40,7 +43,7 @@
                 text: "Reference number"
               },
               value: {
-                text: outOfServiceBed.revisionHistory[0].referenceNumber
+                text: latestRevision.referenceNumber if latestRevision.referenceNumber else "None supplied"
               }
             },
             {
@@ -48,7 +51,7 @@
                 text: "Additional information"
               },
               value: {
-                text: outOfServiceBed.revisionHistory[0].notes
+                text: latestRevision.notes if latestRevision.notes else "None supplied"
               }
             },
             {

--- a/server/views/v2Manage/outOfServiceBeds/partials/_bedDetails.njk
+++ b/server/views/v2Manage/outOfServiceBeds/partials/_bedDetails.njk
@@ -1,0 +1,66 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% macro outOfServiceBedDetails(outOfServiceBed, characteristics)%}
+  {% set characteristicsHtml%}
+  <ul>
+    {% for characteristic in characteristics %}
+      <li>{{characteristic.name}}</li>
+    {% endfor %}
+  </ul>
+  {%endset%}
+  {{
+        govukSummaryList({
+          rows: [
+            {
+              key: {
+                text: "Start date"
+              },
+              value: {
+                text: formatDate(outOfServiceBed.revisionHistory[0].startDate, {format: 'long'})
+              }
+            },
+            {
+              key: {
+                text: "End date"
+              },
+              value: {
+                text: formatDate(outOfServiceBed.revisionHistory[0].endDate, {format: 'long'})
+              }
+            },
+            {
+              key: {
+                text: "Reason"
+              },
+              value: {
+                text: outOfServiceBed.revisionHistory[0].reason.name
+              }
+            },
+            {
+              key: {
+                text: "Reference number"
+              },
+              value: {
+                text: outOfServiceBed.revisionHistory[0].referenceNumber
+              }
+            },
+            {
+              key: {
+                text: "Additional information"
+              },
+              value: {
+                text: outOfServiceBed.revisionHistory[0].notes
+              }
+            },
+            {
+              key: {
+                text: "Characteristics"
+              },
+              value: {
+                html: characteristicsHtml
+              }
+            }
+          ]
+        })
+      }}
+
+{% endmacro %}

--- a/server/views/v2Manage/outOfServiceBeds/partials/_timeline.njk
+++ b/server/views/v2Manage/outOfServiceBeds/partials/_timeline.njk
@@ -1,0 +1,3 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% macro outOfServiceBedTimeline(outOfServiceBedRevisions)%}{% endmacro %}

--- a/server/views/v2Manage/outOfServiceBeds/partials/_timeline.njk
+++ b/server/views/v2Manage/outOfServiceBeds/partials/_timeline.njk
@@ -22,6 +22,13 @@
         <p class="moj-timeline__date">
           <time datetime="{{revision.updatedAt}}">{{formatDateTime(revision.updatedAt)}}</time>
         </p>
+        <div class="moj-timeline__description">
+          {{
+            govukSummaryList({
+              rows:OutOfServiceBedUtils.bedRevisionDetails(revision)
+            })
+          }}
+        </div>
       </div>
     {% endfor %}
   </div>

--- a/server/views/v2Manage/outOfServiceBeds/partials/_timeline.njk
+++ b/server/views/v2Manage/outOfServiceBeds/partials/_timeline.njk
@@ -1,3 +1,28 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% macro outOfServiceBedTimeline(outOfServiceBedRevisions)%}{% endmacro %}
+{% macro outOfServiceBedTimeline(outOfServiceBedRevisions)%}
+  <div class="moj-timeline">
+    {% for revision in outOfServiceBedRevisions %}
+      <div class="moj-timeline__item">
+        <div class="moj-timeline__header">
+          <h3 class="moj-timeline__title">
+            {%for type in revision.revisionType %}
+              {{type | sentenceCase | addCommasToList(loop.revindex0) }}
+              {%endfor%}
+            </h3>
+
+            {% if revision.updatedBy %}
+              <p class="moj-timeline__byline">by {{revision.updatedBy.name}}</p>
+              {% if revision.updatedBy.email %}
+                <p class="moj-timeline__byline">{{revision.updatedBy.email}}</p>
+              {%endif%}
+            {%endif%}
+        </div>
+
+        <p class="moj-timeline__date">
+          <time datetime="{{revision.updatedAt}}">{{formatDateTime(revision.updatedAt)}}</time>
+        </p>
+      </div>
+    {% endfor %}
+  </div>
+{% endmacro %}

--- a/server/views/v2Manage/outOfServiceBeds/show.njk
+++ b/server/views/v2Manage/outOfServiceBeds/show.njk
@@ -1,20 +1,14 @@
-{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+
+{% from "./partials/_bedDetails.njk" import outOfServiceBedDetails %}
+{% from "./partials/_timeline.njk" import outOfServiceBedTimeline %}
 
 {% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body" %}
-
-{% set characteristicsHtml%}
-<ul>
-  {% for characteristic in characteristics %}
-    <li>{{characteristic.name}}</li>
-  {% endfor %}
-</ul>
-{%endset%}
 
 {% block beforeContent %}
   {% if referrer %}
@@ -60,71 +54,11 @@
         })
       }}
 
-      {{
-        govukSummaryList({
-          rows: [
-            {
-              key: {
-                text: "Start date"
-              },
-              value: {
-                text: formatDate(outOfServiceBed.revisionHistory[0].startDate, {format: 'long'})
-              }
-            },
-            {
-              key: {
-                text: "End date"
-              },
-              value: {
-                text: formatDate(outOfServiceBed.revisionHistory[0].endDate, {format: 'long'})
-              }
-            },
-            {
-              key: {
-                text: "Reason"
-              },
-              value: {
-                text: outOfServiceBed.revisionHistory[0].reason.name
-              }
-            },
-            {
-              key: {
-                text: "End date"
-              },
-              value: {
-                text: formatDate(outOfServiceBed.endDate, {format: 'long'})
-              }
-            },
-
-            {
-              key: {
-                text: "Reference number"
-              },
-              value: {
-                text: outOfServiceBed.revisionHistory[0].referenceNumber
-              }
-            },
-            {
-              key: {
-                text: "Additional information"
-              },
-              value: {
-                text: outOfServiceBed.revisionHistory[0].notes
-              }
-            },
-            {
-              key: {
-                text: "Characteristics"
-              },
-              value: {
-                html: characteristicsHtml
-              }
-            }
-          ]
-        })
-      }}
-
-      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+      {% if activeTab === 'timeline' %}
+        {{outOfServiceBedTimeline(outOfServiceBed.revisionHistory)}}
+      {% else %}
+        {{outOfServiceBedDetails(outOfServiceBed, characteristics)}}
+      {% endif %}
 
     </div>
   </div>


### PR DESCRIPTION
# Context
We need to display updates to an Out of Service (OoS) bed in order for users to understand the progress made.

# Changes in this PR
- Some refactoring to make 'tab' view on the OoS bed page cleaner
- Add the timeline tab

[JIRA](https://dsdmoj.atlassian.net/jira/software/c/projects/APS/boards/1328?assignee=62a050ba9f5d480069c97f49&selectedIssue=APS-912&sprints=6188) 

## Screenshots of UI changes
![out-of-service-bed-timeline](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/44123869/05fed20b-d84f-4c5b-adb2-2bd2b5150f75)

