### PR TITLE
APS-856 - Add Placement Matching Outcomes Report v2

### DIFF
--- a/server/utils/reportUtils.test.ts
+++ b/server/utils/reportUtils.test.ts
@@ -53,6 +53,13 @@ describe('reportUtils', () => {
             text: 'A raw data extract for requests for placements created or withdrawn within the month. Does not include any PII.',
           },
         },
+        {
+          value: 'placementMatchingOutcomesV2',
+          text: 'Raw Placement Matching Outcomes Reports (V2)',
+          hint: {
+            text: 'A raw data extract to help identify placement matching outcomes. This downloads placement requests based on the Expected Arrival Date. Does not include any PII.',
+          },
+        },
       ])
     })
   })

--- a/server/utils/reportUtils.ts
+++ b/server/utils/reportUtils.ts
@@ -24,6 +24,10 @@ export const reportInputLabels = {
     text: 'Raw Requests for Placement for Performance Hub',
     hint: 'A raw data extract for requests for placements created or withdrawn within the month. Does not include any PII.',
   },
+  placementMatchingOutcomesV2: {
+    text: 'Raw Placement Matching Outcomes Reports (V2)',
+    hint: 'A raw data extract to help identify placement matching outcomes. This downloads placement requests based on the Expected Arrival Date. Does not include any PII.',
+  },
 } as const
 
 export type ReportType = (keyof typeof reportInputLabels)[number]


### PR DESCRIPTION
# Context

# Changes in this PR

Adds a new option to download the V2 version of the placement matching outcomes reports.

We can't currently remove the 'v1' version of the report as we don't have authorisation to add PII into the new report. So in the meantime, we provide both.

## Screenshots of UI changes

### Before

![Screenshot 2024-07-08 at 16 48 32](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22135634/90f015ed-8f5c-4dba-842f-b85ec4cb950b)

### After

![Screenshot 2024-07-08 at 16 46 46](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22135634/5f96f77b-ead2-4538-b0e5-cae9d0e3c554)
