### PR TITLE
Chore rename page titles

### DIFF
--- a/e2e/pages/manage/v2BedPage.ts
+++ b/e2e/pages/manage/v2BedPage.ts
@@ -3,7 +3,7 @@ import { BasePage } from '../basePage'
 
 export class V2BedPage extends BasePage {
   static async initialize(page: Page, premisesName: string) {
-    await expect(page.locator('h1')).toContainText('View bed information')
+    await expect(page.locator('h1')).toContainText('Bed ')
     await expect(page.locator('.moj-identity-bar__title')).toContainText(premisesName)
     return new V2BedPage(page)
   }

--- a/e2e/tests/manage.spec.ts
+++ b/e2e/tests/manage.spec.ts
@@ -296,5 +296,5 @@ test('View all out of service beds', async ({ page, cruMember }) => {
   dashboard.clickOutOfServiceBeds()
 
   // Then I am taken to the out of service beds page
-  await OutOfServiceBedsPage.initialize(page, 'View out of service beds')
+  await OutOfServiceBedsPage.initialize(page, 'Out of service beds')
 })

--- a/integration_tests/pages/v2Manage/bed/bedShow.ts
+++ b/integration_tests/pages/v2Manage/bed/bedShow.ts
@@ -6,13 +6,13 @@ import paths from '../../../../server/paths/manage'
 import { bedDetails } from '../../../../server/utils/bedUtils'
 
 export default class BedShowPage extends Page {
-  constructor() {
-    super('View bed information')
+  constructor(private readonly bedName: string) {
+    super(`Bed ${bedName}`)
   }
 
   static visit(premisesId: Premises['id'], bed: BedDetail): BedShowPage {
     cy.visit(paths.v2Manage.premises.beds.show({ premisesId, bedId: bed.id }))
-    return new BedShowPage()
+    return new BedShowPage(bed.name)
   }
 
   shouldShowPremisesName(premisesName: string): void {

--- a/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedIndex.ts
+++ b/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedIndex.ts
@@ -6,7 +6,7 @@ import { DateFormats } from '../../../../server/utils/dateUtils'
 
 export class OutOfServiceBedIndexPage extends Page {
   constructor() {
-    super('View out of service beds')
+    super('Out of service beds')
   }
 
   static visit(temporality: Temporality): OutOfServiceBedIndexPage {

--- a/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
+++ b/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
@@ -7,7 +7,7 @@ import { sentenceCase } from '../../../../server/utils/utils'
 
 export class OutOfServiceBedShowPage extends Page {
   constructor(private readonly outOfServiceBed: OutOfServiceBed) {
-    super('View out of service bed record')
+    super('Out of service bed record')
   }
 
   static visit(premisesId: Premises['id'], outOfServiceBed: OutOfServiceBed): OutOfServiceBedShowPage {

--- a/integration_tests/tests/v2Manage/future_manager/createsOutOfServiceBed.cy.ts
+++ b/integration_tests/tests/v2Manage/future_manager/createsOutOfServiceBed.cy.ts
@@ -17,6 +17,7 @@ context('OutOfServiceBeds', () => {
   })
 
   it('should allow me to create an out of service bed', () => {
+    const bedName = '12 - 2'
     const premises = extendedPremisesSummaryFactory.build()
     cy.task('stubPremisesSummary', premises)
 
@@ -27,7 +28,7 @@ context('OutOfServiceBeds', () => {
     cy.task('stubOutOfServiceBedCreate', { premisesId: premises.id, outOfServiceBed })
 
     // stub ultimate API call when redirecting to bed page
-    const bedDetail = bedDetailFactory.build({ id: outOfServiceBed.bed.id })
+    const bedDetail = bedDetailFactory.build({ id: outOfServiceBed.bed.id, name: bedName })
     cy.task('stubBed', { premisesId: premises.id, bedDetail })
 
     // Given I am signed in as a future manager
@@ -56,7 +57,7 @@ context('OutOfServiceBeds', () => {
     })
 
     // And I should be redirected to the v2 bed page
-    const v2BedPage = Page.verifyOnPage(BedShowPage)
+    const v2BedPage = Page.verifyOnPage(BedShowPage, bedName)
 
     // And I should see the confirmation message
     v2BedPage.shouldShowBanner('The out of service bed has been recorded')

--- a/server/controllers/v2Manage/outOfServiceBedsController.test.ts
+++ b/server/controllers/v2Manage/outOfServiceBedsController.test.ts
@@ -282,7 +282,7 @@ describe('OutOfServiceBedsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('v2Manage/outOfServiceBeds/index', {
         outOfServiceBeds: paginatedResponse.data,
-        pageHeading: 'View out of service beds',
+        pageHeading: 'Out of service beds',
         pageNumber: Number(paginatedResponse.pageNumber),
         totalPages: Number(paginatedResponse.totalPages),
         hrefPrefix: paginationDetails.hrefPrefix,

--- a/server/controllers/v2Manage/outOfServiceBedsController.ts
+++ b/server/controllers/v2Manage/outOfServiceBedsController.ts
@@ -148,7 +148,7 @@ export default class OutOfServiceBedsController {
       })
 
       return res.render('v2Manage/outOfServiceBeds/index', {
-        pageHeading: 'View out of service beds',
+        pageHeading: 'Out of service beds',
         outOfServiceBeds: outOfServiceBeds.data,
         pageNumber: Number(outOfServiceBeds.pageNumber),
         totalPages: Number(outOfServiceBeds.totalPages),

--- a/server/controllers/v2Manage/premises/bedsController.test.ts
+++ b/server/controllers/v2Manage/premises/bedsController.test.ts
@@ -38,7 +38,7 @@ describe('V2BedsController', () => {
       expect(response.render).toHaveBeenCalledWith('v2Manage/premises/beds/show', {
         bed,
         premises,
-        pageHeading: 'View bed information',
+        pageHeading: `Bed ${bed.name}`,
         backLink: paths.premises.beds.index({ premisesId: premises.id }),
       })
 
@@ -56,7 +56,7 @@ describe('V2BedsController', () => {
       expect(response.render).toHaveBeenCalledWith('v2Manage/premises/beds/show', {
         bed,
         premises,
-        pageHeading: 'View bed information',
+        pageHeading: `Bed ${bed.name}`,
         backLink: paths.premises.calendar({ premisesId: premises.id }),
       })
 

--- a/server/controllers/v2Manage/premises/bedsController.ts
+++ b/server/controllers/v2Manage/premises/bedsController.ts
@@ -23,7 +23,7 @@ export default class V2BedsController {
       return res.render('v2Manage/premises/beds/show', {
         bed,
         premises,
-        pageHeading: 'View bed information',
+        pageHeading: `Bed ${bed.name}`,
         backLink,
       })
     }

--- a/server/views/v2Manage/outOfServiceBeds/show.njk
+++ b/server/views/v2Manage/outOfServiceBeds/show.njk
@@ -24,7 +24,7 @@
       {{
           mojIdentityBar({
             title: {
-              html: '<span class="govuk-caption-l">' + outOfServiceBed.premises.name + '</span><span class="govuk-caption-l">Room ' + outOfServiceBed.room.name + ' | Bed ' + outOfServiceBed.bed.name + '</span> <h1 class="govuk-heading-l">View out of service bed record</h1>'
+              html: '<span class="govuk-caption-l">' + outOfServiceBed.premises.name + '</span><span class="govuk-caption-l">Room ' + outOfServiceBed.room.name + ' | Bed ' + outOfServiceBed.bed.name + '</span> <h1 class="govuk-heading-l">Out of service bed record</h1>'
             },
             menus: [{
               items: [

--- a/server/views/v2Manage/premises/beds/show.njk
+++ b/server/views/v2Manage/premises/beds/show.njk
@@ -25,7 +25,7 @@
         {{
           mojIdentityBar({
             title: {
-              html: '<span class="govuk-caption-l">' + premises.name + '</span> <h1 class="govuk-heading-l"><span class="govuk-caption-l">Room ' + bed.roomName + ', Bed ' + bed.name + '</span>' + pageHeading + '</h1>'
+              html: '<span class="govuk-caption-l">' + premises.name + '</span> <h1 class="govuk-heading-l"><span class="govuk-caption-l">Room ' + bed.roomName + '</span>' + pageHeading + '</h1>'
             },
             menus: [BedUtils.v2BedActions(bed, premises.id)]
           })


### PR DESCRIPTION
# Changes in this PR

In this PR we improve the page titles of:

- All OOSB list
- Individual OOSB page
- Individual bed page

See commits for details.

<!-- [x I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Individual OOSB page
![oosb_page_title](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/20245/dec58e8e-e5b4-4316-8963-613396cdd928)

### All OOSB list
![all_oosbs_page_title](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/20245/051845b9-b8b8-402b-9462-42a508e63f7f)

###  Individual bed page
![bed_page_title](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/20245/773e1026-46cc-43c5-88cb-03ef72473d57)

### After
