### PR TITLE
Correct ordering of OoS bed revisions

### DIFF
--- a/server/utils/outOfServiceBedUtils.test.ts
+++ b/server/utils/outOfServiceBedUtils.test.ts
@@ -253,9 +253,9 @@ describe('outOfServiceBedUtils', () => {
   describe('sortOutOfServiceBedRevisionsByUpdatedAt', () => {
     it('sorts revisions by updatedAt in descending order', () => {
       const revisions = [
-        outOfServiceBedRevisionFactory.build({ updatedAt: '2024-01-01T00:00:00Z' }),
         outOfServiceBedRevisionFactory.build({ updatedAt: '2024-01-02T00:00:00Z' }),
         outOfServiceBedRevisionFactory.build({ updatedAt: '2024-01-03T00:00:00Z' }),
+        outOfServiceBedRevisionFactory.build({ updatedAt: '2024-01-01T00:00:00Z' }),
       ]
       const sortedRevisions = sortOutOfServiceBedRevisionsByUpdatedAt(revisions)
 

--- a/server/utils/outOfServiceBedUtils.ts
+++ b/server/utils/outOfServiceBedUtils.ts
@@ -175,6 +175,6 @@ export const bedRevisionDetails = (revision: Cas1OutOfServiceBedRevision): Summa
 
 export const sortOutOfServiceBedRevisionsByUpdatedAt = (revisions: Array<Cas1OutOfServiceBedRevision>) => {
   return revisions.sort((a, b) => {
-    return a.updatedAt > b.updatedAt ? -1 : 1
+    return a.updatedAt < b.updatedAt ? -1 : 1
   })
 }


### PR DESCRIPTION
I missed this at the time but this function was ordering the revisions in the incorrect order
