### PR TITLE
Revert "Correct ordering of OoS bed revisions"

### DIFF
--- a/server/utils/outOfServiceBedUtils.test.ts
+++ b/server/utils/outOfServiceBedUtils.test.ts
@@ -252,14 +252,15 @@ describe('outOfServiceBedUtils', () => {
 
   describe('sortOutOfServiceBedRevisionsByUpdatedAt', () => {
     it('sorts revisions by updatedAt in descending order', () => {
-      const revisions = [
-        outOfServiceBedRevisionFactory.build({ updatedAt: '2024-01-02T00:00:00Z' }),
-        outOfServiceBedRevisionFactory.build({ updatedAt: '2024-01-03T00:00:00Z' }),
-        outOfServiceBedRevisionFactory.build({ updatedAt: '2024-01-01T00:00:00Z' }),
-      ]
-      const sortedRevisions = sortOutOfServiceBedRevisionsByUpdatedAt(revisions)
+      const earliestDate = outOfServiceBedRevisionFactory.build({ updatedAt: '2024-01-01T00:00:00Z' })
+      const middleDate = outOfServiceBedRevisionFactory.build({ updatedAt: '2024-01-02T00:00:00Z' })
+      const latestDate = outOfServiceBedRevisionFactory.build({ updatedAt: '2024-01-03T00:00:00Z' })
 
-      expect(sortedRevisions).toEqual([revisions[0], revisions[1], revisions[2]])
+      const unsortedRevisions = [earliestDate, latestDate, middleDate]
+
+      const sortedRevisions = sortOutOfServiceBedRevisionsByUpdatedAt(unsortedRevisions)
+
+      expect(sortedRevisions).toEqual([latestDate, middleDate, earliestDate])
     })
   })
 })

--- a/server/utils/outOfServiceBedUtils.ts
+++ b/server/utils/outOfServiceBedUtils.ts
@@ -175,6 +175,6 @@ export const bedRevisionDetails = (revision: Cas1OutOfServiceBedRevision): Summa
 
 export const sortOutOfServiceBedRevisionsByUpdatedAt = (revisions: Array<Cas1OutOfServiceBedRevision>) => {
   return revisions.sort((a, b) => {
-    return a.updatedAt < b.updatedAt ? -1 : 1
+    return a.updatedAt > b.updatedAt ? -1 : 1
   })
 }


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-approved-premises-ui#1981
It was the correct way around initially 