### PR TITLE
Use OoS bed entity for bed details, not the revision

### DIFF
--- a/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
+++ b/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
@@ -23,17 +23,19 @@ export class OutOfServiceBedShowPage extends Page {
   }
 
   shouldShowOutOfServiceBedDetail(): void {
-    const latestRevision = this.outOfServiceBed.revisionHistory[0]
-
-    if (latestRevision.startDate) {
-      this.assertDefinition('Start date', DateFormats.isoDateToUIDate(latestRevision.startDate, { format: 'long' }))
+    if (this.outOfServiceBed.startDate) {
+      this.assertDefinition(
+        'Start date',
+        DateFormats.isoDateToUIDate(this.outOfServiceBed.startDate, { format: 'long' }),
+      )
     }
-    if (latestRevision.endDate) {
-      this.assertDefinition('End date', DateFormats.isoDateToUIDate(latestRevision.endDate, { format: 'long' }))
+    if (this.outOfServiceBed.endDate) {
+      this.assertDefinition('End date', DateFormats.isoDateToUIDate(this.outOfServiceBed.endDate, { format: 'long' }))
     }
-    if (latestRevision.reason) this.assertDefinition('Reason', latestRevision.reason.name)
-    if (latestRevision.referenceNumber) this.assertDefinition('Reference number', latestRevision.referenceNumber)
-    if (latestRevision.notes) this.assertDefinition('Additional information', latestRevision.notes)
+    if (this.outOfServiceBed.reason) this.assertDefinition('Reason', this.outOfServiceBed.reason.name)
+    if (this.outOfServiceBed.referenceNumber)
+      this.assertDefinition('Reference number', this.outOfServiceBed.referenceNumber)
+    if (this.outOfServiceBed.notes) this.assertDefinition('Additional information', this.outOfServiceBed.notes)
   }
 
   shouldShowCharacteristics(bed: BedDetail): void {

--- a/server/views/v2Manage/outOfServiceBeds/partials/_bedDetails.njk
+++ b/server/views/v2Manage/outOfServiceBeds/partials/_bedDetails.njk
@@ -9,8 +9,6 @@
   </ul>
   {%endset%}
 
-  {% set latestRevision = outOfServiceBed.revisionHistory[0] %}
-
   {{
         govukSummaryList({
           rows: [
@@ -19,7 +17,7 @@
                 text: "Start date"
               },
               value: {
-                text: formatDate(latestRevision.startDate, {format: 'long'}) if latestRevision.startDate else "None supplied"
+                text: formatDate(outOfServiceBed.startDate, {format: 'long'}) if outOfServiceBed.startDate else "None supplied"
               }
             },
             {
@@ -27,7 +25,7 @@
                 text: "End date"
               },
               value: {
-                text: formatDate(latestRevision.endDate, {format: 'long'}) if latestRevision.startDate else "None supplied"
+                text: formatDate(outOfServiceBed.endDate, {format: 'long'}) if outOfServiceBed.startDate else "None supplied"
               }
             },
             {
@@ -35,7 +33,7 @@
                 text: "Reason"
               },
               value: {
-                text: latestRevision.reason.name if latestRevision.reason.name else "None supplied"
+                text: outOfServiceBed.reason.name if outOfServiceBed.reason.name else "None supplied"
               }
             },
             {
@@ -43,7 +41,7 @@
                 text: "Reference number"
               },
               value: {
-                text: latestRevision.referenceNumber if latestRevision.referenceNumber else "None supplied"
+                text: outOfServiceBed.referenceNumber if outOfServiceBed.referenceNumber else "None supplied"
               }
             },
             {
@@ -51,7 +49,7 @@
                 text: "Additional information"
               },
               value: {
-                text: latestRevision.notes if latestRevision.notes else "None supplied"
+                text: outOfServiceBed.notes if outOfServiceBed.notes else "None supplied"
               }
             },
             {


### PR DESCRIPTION
Previously we were using the revision which only contains the updated details not the full details. The top level entity is automatically updated when revisions are made so it is safe to use here
