### PR TITLE
Translate characteristic.propertyName to a positive statement

### DIFF
--- a/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
+++ b/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
@@ -2,6 +2,7 @@ import paths from '../../../../server/paths/manage'
 
 import Page from '../../page'
 import { DateFormats } from '../../../../server/utils/dateUtils'
+import { translateCharacteristic } from '../../../../server/utils/characteristicsUtils'
 import { BedDetail, Cas1OutOfServiceBed as OutOfServiceBed, Premises } from '../../../../server/@types/shared'
 import { sentenceCase } from '../../../../server/utils/utils'
 
@@ -40,7 +41,7 @@ export class OutOfServiceBedShowPage extends Page {
 
   shouldShowCharacteristics(bed: BedDetail): void {
     bed.characteristics.forEach(characteristic => {
-      cy.get('li').contains(characteristic.name)
+      cy.get('li').contains(translateCharacteristic(characteristic))
     })
   }
 

--- a/server/controllers/v2Manage/outOfServiceBedsController.test.ts
+++ b/server/controllers/v2Manage/outOfServiceBedsController.test.ts
@@ -17,6 +17,7 @@ import paths from '../../paths/manage'
 import { bedDetailFactory, outOfServiceBedFactory, paginatedResponseFactory } from '../../testutils/factories'
 import { getPaginationDetails } from '../../utils/getPaginationDetails'
 import { createQueryString } from '../../utils/utils'
+import { translateCharacteristic } from '../../utils/characteristicsUtils'
 import { OutOfServiceBedService, PremisesService } from '../../services'
 
 jest.mock('../../utils/validation')
@@ -163,6 +164,9 @@ describe('OutOfServiceBedsController', () => {
     it('shows the outOfService bed', async () => {
       const activeTab = 'details'
       const bed = bedDetailFactory.build({ id: outOfServiceBed.bed.id })
+      const translatedCharacteristics = bed.characteristics.map(characteristic =>
+        translateCharacteristic(characteristic),
+      )
       premisesService.getBed.mockResolvedValue(bed)
 
       const errorsAndUserInput = createMock<ErrorsAndUserInput>()
@@ -194,7 +198,7 @@ describe('OutOfServiceBedsController', () => {
         id: outOfServiceBed.id,
         referrer,
         activeTab,
-        characteristics: bed.characteristics,
+        characteristics: translatedCharacteristics,
         pageHeading: `Out of service bed ${outOfServiceBed.room.name} ${outOfServiceBed.bed.name}`,
       })
     })

--- a/server/controllers/v2Manage/outOfServiceBedsController.ts
+++ b/server/controllers/v2Manage/outOfServiceBedsController.ts
@@ -12,6 +12,7 @@ import { SanitisedError } from '../../sanitisedError'
 import { getPaginationDetails } from '../../utils/getPaginationDetails'
 import { OutOfServiceBedService, PremisesService } from '../../services'
 import { sortOutOfServiceBedRevisionsByUpdatedAt } from '../../utils/outOfServiceBedUtils'
+import { translateCharacteristic } from '../../utils/characteristicsUtils'
 
 export default class OutOfServiceBedsController {
   constructor(
@@ -172,6 +173,7 @@ export default class OutOfServiceBedsController {
       outOfServiceBed.revisionHistory = sortOutOfServiceBedRevisionsByUpdatedAt(outOfServiceBed.revisionHistory)
 
       const { characteristics } = await this.premisesService.getBed(req.user.token, premisesId, bedId)
+      const translatedCharacteristics = characteristics.map(characteristic => translateCharacteristic(characteristic))
 
       return res.render('v2Manage/outOfServiceBeds/show', {
         outOfServiceBed,
@@ -180,7 +182,7 @@ export default class OutOfServiceBedsController {
         id,
         referrer,
         activeTab: tab,
-        characteristics,
+        characteristics: translatedCharacteristics,
         pageHeading: `Out of service bed ${outOfServiceBed.room.name} ${outOfServiceBed.bed.name}`,
       })
     }

--- a/server/i18n/en/characteristics.json
+++ b/server/i18n/en/characteristics.json
@@ -1,0 +1,23 @@
+{
+  "isSingle": "Single room",
+  "isFullyFm": "All furnishings and bedding supplied by FM",
+  "hasCrib7Bedding": "Crib 7 rated bedding",
+  "hasSmokeDetector": "Smoke/heat detector",
+  "isTopFloorVulnerable": "On top floor and vulnerable",
+  "isGroundFloorNrOffice": "On ground floor close to office",
+  "hasNearbySprinkler": "Near to sprinkler",
+  "isArsonSuitable": "Suitable for arson risks",
+  "isArsonDesignated": "Designated arson room",
+  "hasArsonInsuranceConditions": "Not insured for arson risk",
+  "isSuitedForSexOffenders": "Suitable for sex offenders",
+  "hasEnSuite": "En suite",
+  "isWheelchairAccessible": "Can be accessed in wheelchair",
+  "hasWideDoor": "Door 90cm or wider",
+  "hasStepFreeAccess": "Step-free access",
+  "hasFixedMobilityAids": "Mobility aids",
+  "hasTurningSpace": "Turning space (1.5m x 1.5m)",
+  "hasCallForAssistance": "Personal / fall alarm",
+  "isWheelchairDesignated": "Designated wheelchair room",
+  "isStepFreeDesignated": "Designated step-free",
+  "isGroundFloor": "Ground floor"
+}

--- a/server/utils/characteristicsUtils.test.ts
+++ b/server/utils/characteristicsUtils.test.ts
@@ -1,0 +1,29 @@
+import { translateCharacteristic } from './characteristicsUtils'
+import { CharacteristicPair } from '../@types/shared'
+
+describe('characteristicsUtils.translateCharacteristic(CharacteristicPair)', () => {
+  describe('when the propertyName is found', () => {
+    const propertyNameFoundInTranslation = 'isSingle'
+    const successfulTranslation = 'Single room'
+    const characteristicWithTranslation = <CharacteristicPair>{
+      propertyName: propertyNameFoundInTranslation,
+      name: 'Is this a single room?',
+    }
+
+    it('returns the translation (in the form of a statement) for the characteristic', () => {
+      expect(translateCharacteristic(characteristicWithTranslation)).toEqual(successfulTranslation)
+    })
+  })
+
+  describe('when the propertyName is NOT found', () => {
+    const propertyNameNotFoundInTranslation = 'isRed'
+    const characteristicWithoutTranslation = <CharacteristicPair>{
+      propertyName: propertyNameNotFoundInTranslation,
+      name: 'Is this a a red room?',
+    }
+
+    it('returns the propertyName as a (just) human-readable fallback', () => {
+      expect(translateCharacteristic(characteristicWithoutTranslation)).toEqual('isRed')
+    })
+  })
+})

--- a/server/utils/characteristicsUtils.ts
+++ b/server/utils/characteristicsUtils.ts
@@ -1,0 +1,6 @@
+import { CharacteristicPair } from '@approved-premises/api'
+import characteristicLookup from '../i18n/en/characteristics.json'
+
+export const translateCharacteristic = (characteristic: CharacteristicPair): string => {
+  return characteristicLookup[characteristic.propertyName] || characteristic.propertyName
+}

--- a/server/views/v2Manage/outOfServiceBeds/partials/_bedDetails.njk
+++ b/server/views/v2Manage/outOfServiceBeds/partials/_bedDetails.njk
@@ -3,8 +3,8 @@
 {% macro outOfServiceBedDetails(outOfServiceBed, characteristics)%}
   {% set characteristicsHtml%}
   <ul>
-    {% for characteristic in characteristics %}
-      <li>{{characteristic.name}}</li>
+    {% for translatedCharacteristicName in characteristics %}
+      <li>{{translatedCharacteristicName}}</li>
     {% endfor %}
   </ul>
   {%endset%}


### PR DESCRIPTION
[Jira APS-1059](https://dsdmoj.atlassian.net/browse/APS-1059)

### Before

<img width="1176" alt="before_question" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/20245/0c112821-8146-4bba-be5e-d15b8a7b3187">

### After

<img width="1091" alt="after_statement" src="https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/20245/76e76ac1-3959-409c-b53c-dbd3e4e0708a">


Previously we were using `Characteristic.name` which is a string posing a question such as:

> Is this a single room?

or

> Is there a smoke/heat detector in the room?

With this commit we introduce a

```
characteristicUtils.translateCharacteristic(CharacteristicPair)
```

function which attempts to lookup `Characteristic.propertyName` in a JSON translation file (`i18n/en/characteristics.json`) to find a label for the characteristic which is cast in the form of a positive statement form, e.g.

> Single room

or

> Smoke/heat detector

If a translation for the given `propertyName` isn't found we return the `propertyName`. These are (just about) human readable e.g.

- `acceptsSexOffenders`
- `acceptsChildSexOffenders`


