### PR TITLE
Allow assessors to assess request for placements

### DIFF
--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -413,7 +413,7 @@ describe('utils', () => {
   })
 
   describe('assessmentsTabItems', () => {
-    it.each([['workflow_manager'], ['matcher']])(
+    it.each([['workflow_manager'], ['matcher'], ['assessor']])(
       `returns the all assessment tab items for user with role %s`,
       (role: ApprovedPremisesUserRole) => {
         const user = userDetailsFactory.build({ roles: [role] })
@@ -443,7 +443,7 @@ describe('utils', () => {
       },
     )
   })
-  it('returns the all assessment tab items except requests for placement for user with out roles workflow_manager and matcher ', () => {
+  it('returns the all assessment tab items except requests for placement for user with out roles workflow_manager, matcher or assessor', () => {
     const user = userDetailsFactory.build({ roles: ['manager'] })
 
     expect(assessmentsTabItems(user)).toEqual([

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -203,7 +203,7 @@ const assessmentsTabItems = (user: UserDetails, activeTab?: string): Array<TabIt
     active: activeTab === 'requests_for_placement',
   }
 
-  if (hasRole(user, 'workflow_manager') || hasRole(user, 'matcher')) {
+  if (hasRole(user, 'workflow_manager') || hasRole(user, 'matcher') || hasRole(user, 'assessor')) {
     tabItems.splice(1, 0, requestForPlacementTabItem)
   }
 


### PR DESCRIPTION
Previously this tab was only available to workflow_manager and matcher. This should also be available to assessors as the API will start to allow placement requests to be allocated to users with this role

# Context

Relates to JIRA ticket https://dsdmoj.atlassian.net/browse/APS-969

# Changes in this PR

## Screenshots of UI changes

Screenshots are when logged in as user with 'assessor' role

### Before

![Screenshot 2024-07-11 at 15 05 03](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22135634/45a2f9ef-0659-4667-81fd-35c3d067f3eb)

### After

![Screenshot 2024-07-11 at 15 06 50](https://github.com/ministryofjustice/hmpps-approved-premises-ui/assets/22135634/f746859a-cfb8-48aa-95d9-a8bdea8832cd)

