### PR TITLE
APS 1049 - link to premises and bed from OOS bed page

### DIFF
--- a/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
+++ b/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedShow.ts
@@ -85,4 +85,18 @@ export class OutOfServiceBedShowPage extends Page {
   clickUpdateRecord(): void {
     cy.get('a').contains('Update record').click()
   }
+
+  shouldLinkToPremisesAndBed(outOfServiceBed: OutOfServiceBed) {
+    cy.get('a')
+      .contains(outOfServiceBed.premises.name)
+      .should('have.attr', 'href', paths.v2Manage.premises.show({ premisesId: outOfServiceBed.premises.id }))
+
+    cy.get('a')
+      .contains(outOfServiceBed.bed.name)
+      .should(
+        'have.attr',
+        'href',
+        paths.v2Manage.premises.beds.show({ premisesId: outOfServiceBed.premises.id, bedId: outOfServiceBed.bed.id }),
+      )
+  }
 }

--- a/integration_tests/tests/v2Manage/future_manager/viewsOutOfServiceBed.cy.ts
+++ b/integration_tests/tests/v2Manage/future_manager/viewsOutOfServiceBed.cy.ts
@@ -38,6 +38,9 @@ context('OutOfServiceBeds', () => {
       // And I should see the bed characteristics
       page.shouldShowCharacteristics(bedDetail)
 
+      // And I should see links to the premises and bed in the page heading
+      page.shouldLinkToPremisesAndBed(outOfServiceBed)
+
       // When I click the 'Timeline' tab
       page.clickTab('Timeline')
 

--- a/server/views/v2Manage/outOfServiceBeds/partials/_pageHeading.njk
+++ b/server/views/v2Manage/outOfServiceBeds/partials/_pageHeading.njk
@@ -1,5 +1,8 @@
 {% macro outOfServiceBedPageHeading(title, outOfServiceBed)%}
-    <span class="govuk-caption-l">{{outOfServiceBed.premises.name}}</span>
-    <span class="govuk-caption-l">Room {{outOfServiceBed.room.name}} | Bed {{outOfServiceBed.bed.name}}</span>
+    <span class="govuk-caption-l">
+        <a href="{{paths.v2Manage.premises.show({premisesId: outOfServiceBed.premises.id})}}">{{outOfServiceBed.premises.name}}</a>
+    </span>
+    <span class="govuk-caption-l">Room {{outOfServiceBed.room.name}} | <a href="{{paths.v2Manage.premises.beds.show({premisesId: outOfServiceBed.premises.id, bedId: outOfServiceBed.bed.id})}}">Bed {{outOfServiceBed.bed.name}}</a>
+    </span>
     <h1 class="govuk-heading-l">{{title}}</h1>
     {%endmacro%}


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/APS-1049

# Changes in this PR

Adds links to the out of service bed page heading, so that the user can navigate to the premises and bed pages.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before

### After
