### PR TITLE
Add bed page heading macro and link to premises page

### DIFF
--- a/integration_tests/pages/v2Manage/bed/bedList.ts
+++ b/integration_tests/pages/v2Manage/bed/bedList.ts
@@ -1,0 +1,31 @@
+import { BedDetail, BedSummary, Premises } from '../../../../server/@types/shared'
+
+import Page from '../../page'
+import paths from '../../../../server/paths/manage'
+
+import { bedTableRows } from '../../../../server/utils/bedUtils'
+
+export default class V2BedsListPage extends Page {
+  constructor() {
+    super('Manage beds')
+  }
+
+  static visit(premisesId: Premises['id']): V2BedsListPage {
+    cy.visit(paths.v2Manage.premises.beds.index({ premisesId }))
+    return new V2BedsListPage()
+  }
+
+  shouldShowBeds(beds: Array<BedSummary>, premisesId: Premises['id']): void {
+    const rows = bedTableRows(beds, premisesId)
+    this.shouldContainTableRows(rows)
+  }
+
+  clickBed(bed: BedDetail): void {
+    cy.get(`a[data-cy-bedid="${bed.id}"]`).click()
+  }
+
+  clickManageOutOfServiceBeds(): void {
+    cy.get('.moj-button-menu__toggle-button').click()
+    cy.get('a').contains('Manage out of service beds').click()
+  }
+}

--- a/integration_tests/pages/v2Manage/bed/bedShow.ts
+++ b/integration_tests/pages/v2Manage/bed/bedShow.ts
@@ -1,22 +1,18 @@
-import { BedDetail, Premises } from '../../../../server/@types/shared'
+import { BedDetail, ExtendedPremisesSummary, Premises } from '../../../../server/@types/shared'
 
 import Page from '../../page'
 import paths from '../../../../server/paths/manage'
 
 import { bedDetails } from '../../../../server/utils/bedUtils'
 
-export default class BedShowPage extends Page {
+export default class V2BedShowPage extends Page {
   constructor(private readonly bedName: string) {
     super(`Bed ${bedName}`)
   }
 
-  static visit(premisesId: Premises['id'], bed: BedDetail): BedShowPage {
+  static visit(premisesId: Premises['id'], bed: BedDetail): V2BedShowPage {
     cy.visit(paths.v2Manage.premises.beds.show({ premisesId, bedId: bed.id }))
-    return new BedShowPage(bed.name)
-  }
-
-  shouldShowPremisesName(premisesName: string): void {
-    cy.get('span').contains(premisesName)
+    return new V2BedShowPage(bed.name)
   }
 
   shouldShowBedDetails(bed: BedDetail): void {
@@ -26,13 +22,9 @@ export default class BedShowPage extends Page {
     this.shouldContainSummaryListItems(details)
   }
 
-  clickOutOfServiceBedOption() {
-    cy.get('.moj-button-menu__toggle-button').click()
-    cy.get('a').contains('Create out of service bed record').click()
-  }
-
-  clickCreateBookingOption() {
-    cy.get('.moj-button-menu__toggle-button').click()
-    cy.get('a').contains('Create a placement').click()
+  shouldLinkToPremises(premises: ExtendedPremisesSummary): void {
+    cy.get('a')
+      .contains(premises.name)
+      .should('have.attr', 'href', paths.v2Manage.premises.show({ premisesId: premises.id }))
   }
 }

--- a/integration_tests/tests/v2Manage/future_manager/beds.cy.ts
+++ b/integration_tests/tests/v2Manage/future_manager/beds.cy.ts
@@ -1,0 +1,51 @@
+import Page from '../../../pages/page'
+import { signIn } from '../../signIn'
+import V2BedsListPage from '../../../pages/v2Manage/bed/bedList'
+import V2BedShowPage from '../../../pages/v2Manage/bed/bedShow'
+import {
+  bedDetailFactory,
+  bedSummaryFactory,
+  extendedPremisesSummaryFactory,
+} from '../../../../server/testutils/factories'
+
+context('Beds', () => {
+  const premisesId = 'premisesId'
+  const bedSummaries = bedSummaryFactory.buildList(5)
+  const bedDetail = bedDetailFactory.build({ ...bedSummaries[0] })
+  const premises = extendedPremisesSummaryFactory.build({ id: premisesId })
+
+  beforeEach(() => {
+    cy.task('reset')
+
+    // Given there are beds in the database
+    cy.task('stubBeds', { premisesId, bedSummaries })
+    cy.task('stubBed', { premisesId, bedDetail })
+    cy.task('stubPremisesSummary', premises)
+  })
+
+  it('should allow me to visit a bed from the bed list page', () => {
+    // Given I am signed in as a workflow manager
+    signIn(['future_manager'])
+
+    // When I visit the rooms page
+    const bedsPage = V2BedsListPage.visit(premisesId)
+
+    // Then I should see all of the rooms listed
+    bedsPage.shouldShowBeds(bedSummaries, premisesId)
+
+    // When I click on a bed
+    bedsPage.clickBed(bedDetail)
+
+    // Then I should be taken to the bed page
+    Page.verifyOnPage(V2BedShowPage, bedDetail.name)
+
+    // Give I'm on the bed page
+    const bedPage = V2BedShowPage.visit(premisesId, bedDetail)
+
+    // Then I should see the room details
+    bedPage.shouldShowBedDetails(bedDetail)
+
+    // And I should see a link to the premises
+    bedPage.shouldLinkToPremises(premises)
+  })
+})

--- a/server/views/v2Manage/premises/beds/partials/_pageHeading.njk
+++ b/server/views/v2Manage/premises/beds/partials/_pageHeading.njk
@@ -1,0 +1,7 @@
+{% macro bedPageHeading(title, bed, premises)%}
+  <span class="govuk-caption-l">
+    <a href="{{paths.v2Manage.premises.show({premisesId: premises.id})}}">{{premises.name}}</a>
+  </span>
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l">Room {{bed.roomName}}</span>{{title}}</h1>
+  {%endmacro%}

--- a/server/views/v2Manage/premises/beds/show.njk
+++ b/server/views/v2Manage/premises/beds/show.njk
@@ -4,6 +4,7 @@
 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList -%}
 {%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+{% from "./partials/_pageHeading.njk" import bedPageHeading %}
 
 {% extends "../../../partials/layout.njk" %}
 
@@ -25,7 +26,7 @@
         {{
           mojIdentityBar({
             title: {
-              html: '<span class="govuk-caption-l">' + premises.name + '</span> <h1 class="govuk-heading-l"><span class="govuk-caption-l">Room ' + bed.roomName + '</span>' + pageHeading + '</h1>'
+              html: bedPageHeading(pageHeading, bed, premises)
             },
             menus: [BedUtils.v2BedActions(bed, premises.id)]
           })


### PR DESCRIPTION
Following the out of service bed page pattern, we create a macro for this purpose. This will help to keep the code cleaner and clearer.

# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before

### After
