### PR TITLE
APS-1066 - add e2e tests for oos beds

### DIFF
--- a/e2e/pages/manage/premisesPage.ts
+++ b/e2e/pages/manage/premisesPage.ts
@@ -44,4 +44,9 @@ export class PremisesPage extends BasePage {
     await this.clickActions()
     await this.page.getByRole('menuitem', { name: 'Create a placement' }).click()
   }
+
+  async viewOutOfServiceBedRecords() {
+    await this.page.getByRole('button', { name: 'Actions' }).click()
+    await this.page.getByRole('menuitem', { name: 'Manage out of service bed records' }).click()
+  }
 }

--- a/e2e/pages/manage/v2OutOfServiceBedPage.ts
+++ b/e2e/pages/manage/v2OutOfServiceBedPage.ts
@@ -1,0 +1,22 @@
+import { Page, expect } from '@playwright/test'
+import { BasePage } from '../basePage'
+
+export class OutOfServiceBedPage extends BasePage {
+  static async initialize(page: Page) {
+    await expect(page.locator('h1')).toContainText('Out of service bed record')
+    return new OutOfServiceBedPage(page)
+  }
+
+  async selectUpdateRecord() {
+    await this.page.getByRole('button', { name: 'Update record' }).click()
+  }
+
+  async shouldShowUpdatedDetails(update: Record<string, string>) {
+    await expect(this.page.getByText(update.referenceNumber)).toBeVisible()
+    await expect(this.page.getByText(update.additionalInformation)).toBeVisible()
+  }
+
+  async selectDetails() {
+    await this.page.getByRole('link', { name: 'Details', exact: true }).click()
+  }
+}

--- a/e2e/pages/manage/v2OutOfServiceBedsIndexPage.ts
+++ b/e2e/pages/manage/v2OutOfServiceBedsIndexPage.ts
@@ -1,0 +1,17 @@
+import { Page, expect } from '@playwright/test'
+import { BasePage } from '../basePage'
+
+export class OutOfServiceBedsPremisesListPage extends BasePage {
+  static async initialize(page: Page) {
+    await expect(page.locator('h1')).toContainText('Manage out of service beds')
+    return new OutOfServiceBedsPremisesListPage(page)
+  }
+
+  async selectFutureTab() {
+    await this.page.getByRole('link', { name: 'Future' }).click()
+  }
+
+  async selectOutOfServiceBed() {
+    await this.page.getByRole('link', { name: 'View' }).first().click()
+  }
+}

--- a/e2e/pages/manage/v2UpdateOutOfServiceBedPage.ts
+++ b/e2e/pages/manage/v2UpdateOutOfServiceBedPage.ts
@@ -1,0 +1,14 @@
+import { Page, expect } from '@playwright/test'
+import { BasePage } from '../basePage'
+
+export class UpdateOutOfServiceBedPage extends BasePage {
+  static async initialize(page: Page) {
+    await expect(page.locator('h1')).toContainText('Update out of service bed record')
+    return new UpdateOutOfServiceBedPage(page)
+  }
+
+  async updateBed(update: Record<string, string>) {
+    await this.page.getByLabel('Work order reference number').fill(update.referenceNumber)
+    await this.page.getByLabel('Provide additional information').fill(update.additionalInformation)
+  }
+}

--- a/e2e/tests/manage.spec.ts
+++ b/e2e/tests/manage.spec.ts
@@ -24,6 +24,7 @@ test.describe.configure({ mode: 'parallel' })
 
 const premisesName = 'Test AP 10'
 const apArea = 'South West & South Central'
+const roomName = 'Bed 101 - 1'
 
 const navigateToPremisesPage = async (page: Page, { filterPremisesPage } = { filterPremisesPage: false }) => {
   // Given I visit the dashboard
@@ -187,7 +188,7 @@ test('Mark a bed as out of service', async ({ page, legacyManager }) => {
   await bedsPage.viewAvailableBed()
 
   // Then I should be able to mark a bed as out of service
-  const bedPage = await BedPage.initialize(page, 'Manage beds')
+  const bedPage = await BedPage.initialize(page, roomName)
   await bedPage.clickMarkBedAsOutOfService()
 
   // When I fill in and submit the form


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/APS-1066

# Changes in this PR

Adds an E2E test for updating an out of service bed. Also fixes a broke v1 manage test.

<!-- [x] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before

### After
