### PR TITLE
Remove v2 heading from v1 e2e test

### DIFF
--- a/e2e/tests/manage.spec.ts
+++ b/e2e/tests/manage.spec.ts
@@ -24,7 +24,6 @@ test.describe.configure({ mode: 'parallel' })
 
 const premisesName = 'Test AP 10'
 const apArea = 'South West & South Central'
-const roomName = 'Bed 101 - 1'
 
 const navigateToPremisesPage = async (page: Page, { filterPremisesPage } = { filterPremisesPage: false }) => {
   // Given I visit the dashboard
@@ -188,7 +187,7 @@ test('Mark a bed as out of service', async ({ page, legacyManager }) => {
   await bedsPage.viewAvailableBed()
 
   // Then I should be able to mark a bed as out of service
-  const bedPage = await BedPage.initialize(page, roomName)
+  const bedPage = await BedPage.initialize(page, 'Manage beds')
   await bedPage.clickMarkBedAsOutOfService()
 
   // When I fill in and submit the form


### PR DESCRIPTION
# Changes in this PR

This reverts a change that was made based on a failing local e2e test, which was presumably failing because of local permissions. In dev the v1 manage E2E tests are completed by a user without v2 permissions, which means we need to retain the v1 heading.

## Screenshots of UI changes

### Before

### After
