### PR TITLE
Fix update OOS bed E2E test

### DIFF
--- a/e2e/pages/manage/v2OutOfServiceBedPage.ts
+++ b/e2e/pages/manage/v2OutOfServiceBedPage.ts
@@ -12,7 +12,7 @@ export class OutOfServiceBedPage extends BasePage {
   }
 
   async shouldShowUpdatedDetails(update: Record<string, string>) {
-    await expect(this.page.getByText(update.referenceNumber)).toBeVisible()
+    await expect(this.page.getByText(update.referenceNumber, { exact: true })).toBeVisible()
     await expect(this.page.getByText(update.additionalInformation)).toBeVisible()
   }
 


### PR DESCRIPTION
# Changes in this PR

Fixes an issue whereby the UUID was matching both the reference number and the additional information fields, which caused the test to fail.
<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before

### After
