### PR TITLE
APS-973: Dates shown multiple times on request for placement screen a…

### DIFF
--- a/server/testutils/factories/requestForPlacement.ts
+++ b/server/testutils/factories/requestForPlacement.ts
@@ -42,6 +42,14 @@ export default Factory.define<RequestForPlacement>(() => ({
         "Has the person's access or healthcare needs changed since the application was assessed?": 'No',
         "Has the person's location factors changed since the application was assessed?": 'No',
       },
+      {
+        'Dates of placement': [
+          {
+            'When will the person arrive?': 'Wed 22 Jan 2025',
+            'How long should the Approved Premises placement last?': '12 weeks',
+          },
+        ],
+      },
     ],
   },
   requestReviewedAt: faker.date.past().toISOString(),

--- a/server/utils/placementRequests/requestForPlacementSummaryCards.ts
+++ b/server/utils/placementRequests/requestForPlacementSummaryCards.ts
@@ -12,6 +12,8 @@ export class RequestForPlacementSummaryCards {
 
   private actionItems: Array<SummaryListActionItem> = []
 
+  private unusedQuestions = ['Dates of placement']
+
   constructor(
     private readonly requestForPlacement: RequestForPlacement,
     private readonly applicationId: Application['id'],
@@ -23,7 +25,8 @@ export class RequestForPlacementSummaryCards {
     const pageResponses = this.requestForPlacement?.document?.[taskName]
 
     pageResponses?.forEach((pageResponse: PageResponse) => {
-      const questionsAndAnswers = Object.entries(pageResponse)
+      const allQuestionsAndAnswers = Object.entries(pageResponse)
+      const questionsAndAnswers = allQuestionsAndAnswers.filter(([key]) => !this.unusedQuestions.includes(key))
 
       questionsAndAnswers.forEach(([question, answer]) => {
         const value =


### PR DESCRIPTION
…nd should show only placement dates

# Context

https://dsdmoj.atlassian.net/browse/APS-973
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Dates shown multiple times on request for placement screen and should show only placement dates
<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before
<img width="802" alt="image" src="https://github.com/user-attachments/assets/105bf994-3900-4693-bf20-0936925e00b5">

### After
<img width="1728" alt="Screenshot 2024-07-19 at 14 21 02" src="https://github.com/user-attachments/assets/7ac6bbca-10d7-4c2d-97b4-dff41e6b4d2e">

