### PR TITLE
[APS-1078] Fix historic out-of-service beds not displaying in dashboard

### DIFF
--- a/integration_tests/tests/v2Manage/cru_member/viewsAllOutOfServiceBeds.cy.ts
+++ b/integration_tests/tests/v2Manage/cru_member/viewsAllOutOfServiceBeds.cy.ts
@@ -71,7 +71,7 @@ describe('CRU Member lists all OOS beds', () => {
     cy.task('stubOutOfServiceBedsList', {
       outOfServiceBeds: historicBeds,
       page: 1,
-      temporality: 'historic',
+      temporality: 'past',
     })
 
     // Given I'm on the out of service beds index page

--- a/server/controllers/v2Manage/outOfServiceBedsController.ts
+++ b/server/controllers/v2Manage/outOfServiceBedsController.ts
@@ -83,7 +83,7 @@ export default class OutOfServiceBedsController {
     return async (req: Request, res: Response) => {
       const { temporality, premisesId } = req.params as { temporality: Temporality; premisesId: string }
 
-      if (!['current', 'future', 'historic'].includes(temporality)) {
+      if (!['current', 'future', 'past'].includes(temporality)) {
         return res.redirect(paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId, temporality: 'current' }))
       }
 
@@ -120,7 +120,7 @@ export default class OutOfServiceBedsController {
     return async (req: Request, res: Response) => {
       const { temporality } = req.params as { temporality: Temporality }
 
-      if (!['current', 'future', 'historic'].includes(temporality)) {
+      if (!['current', 'future', 'past'].includes(temporality)) {
         return res.redirect(paths.v2Manage.outOfServiceBeds.index({ temporality: 'current' }))
       }
 

--- a/server/views/v2Manage/outOfServiceBeds/index.njk
+++ b/server/views/v2Manage/outOfServiceBeds/index.njk
@@ -35,8 +35,8 @@
               active: temporality === 'future'
             }, {
               text: 'Historic',
-              href: paths.v2Manage.outOfServiceBeds.index({temporality: 'historic'}),
-              active: temporality === 'historic'
+              href: paths.v2Manage.outOfServiceBeds.index({temporality: 'past'}),
+              active: temporality === 'past'
           }]
         })
       }}

--- a/server/views/v2Manage/outOfServiceBeds/premisesIndex.njk
+++ b/server/views/v2Manage/outOfServiceBeds/premisesIndex.njk
@@ -52,8 +52,8 @@
               active: temporality === 'future'
             }, {
               text: 'Historic',
-              href: paths.v2Manage.outOfServiceBeds.premisesIndex({premisesId: premisesId, temporality: 'historic'}),
-              active: temporality === 'historic'
+              href: paths.v2Manage.outOfServiceBeds.premisesIndex({premisesId: premisesId, temporality: 'past'}),
+              active: temporality === 'past'
           }]
         })
       }}


### PR DESCRIPTION
# Context

See [APS-1078 on the Approved Premises Jira board](https://dsdmoj.atlassian.net/browse/APS-1078).

# Changes in this PR

When using the `/manage/out-of-service-beds` dashboard, historic out-of-service beds are not displayed when the 'Historic' tab is selected.

This is because the UI is using the value `'historic'`, which is not a valid value for the `Temporality` type. The correct value is `'past'`, and using this value resolves the issue.

No user-facing changes have been made, so the tab still uses the 'Historic' label.

## Screenshots of UI changes
*No visual change.*
