### PR TITLE
APS-1096: Remove 'status' from beds list and bed page

### DIFF
--- a/integration_tests/pages/v2Manage/bed/bedList.ts
+++ b/integration_tests/pages/v2Manage/bed/bedList.ts
@@ -3,7 +3,7 @@ import { BedDetail, BedSummary, Premises } from '../../../../server/@types/share
 import Page from '../../page'
 import paths from '../../../../server/paths/manage'
 
-import { bedTableRows } from '../../../../server/utils/bedUtils'
+import { v2BedTableRows } from '../../../../server/utils/bedUtils'
 
 export default class V2BedsListPage extends Page {
   constructor() {
@@ -16,7 +16,7 @@ export default class V2BedsListPage extends Page {
   }
 
   shouldShowBeds(beds: Array<BedSummary>, premisesId: Premises['id']): void {
-    const rows = bedTableRows(beds, premisesId)
+    const rows = v2BedTableRows(beds, premisesId)
     this.shouldContainTableRows(rows)
   }
 

--- a/integration_tests/pages/v2Manage/bed/bedList.ts
+++ b/integration_tests/pages/v2Manage/bed/bedList.ts
@@ -28,4 +28,11 @@ export default class V2BedsListPage extends Page {
     cy.get('.moj-button-menu__toggle-button').click()
     cy.get('a').contains('Manage out of service beds').click()
   }
+
+  shouldIncludeLinkToAllPremisesOutOfServiceBeds(premisesId: Premises['id']): void {
+    cy.get('.moj-button-menu__toggle-button').click()
+    cy.get(
+      `a[href="${paths.v2Manage.outOfServiceBeds.premisesIndex({ premisesId, temporality: 'current' })}"]`,
+    ).contains('Manage out of service beds')
+  }
 }

--- a/integration_tests/pages/v2Manage/bed/bedShow.ts
+++ b/integration_tests/pages/v2Manage/bed/bedShow.ts
@@ -3,7 +3,7 @@ import { BedDetail, ExtendedPremisesSummary, Premises } from '../../../../server
 import Page from '../../page'
 import paths from '../../../../server/paths/manage'
 
-import { bedDetails } from '../../../../server/utils/bedUtils'
+import { v2BedDetails } from '../../../../server/utils/bedUtils'
 
 export default class V2BedShowPage extends Page {
   constructor(private readonly bedName: string) {
@@ -18,7 +18,7 @@ export default class V2BedShowPage extends Page {
   shouldShowBedDetails(bed: BedDetail): void {
     cy.get('h1').contains(bed.roomName)
     cy.get('h1').contains(bed.name)
-    const details = bedDetails(bed)
+    const details = v2BedDetails(bed)
     this.shouldContainSummaryListItems(details)
   }
 

--- a/integration_tests/tests/v2Manage/future_manager/beds.cy.ts
+++ b/integration_tests/tests/v2Manage/future_manager/beds.cy.ts
@@ -33,6 +33,9 @@ context('Beds', () => {
     // Then I should see all of the beds listed
     v2BedsPage.shouldShowBeds(bedSummaries, premisesId)
 
+    // And I should have a link to view all of this premises' out-of-service beds
+    v2BedsPage.shouldIncludeLinkToAllPremisesOutOfServiceBeds(premisesId)
+
     // When I click on a bed
     v2BedsPage.clickBed(bedDetail)
 

--- a/integration_tests/tests/v2Manage/future_manager/beds.cy.ts
+++ b/integration_tests/tests/v2Manage/future_manager/beds.cy.ts
@@ -27,25 +27,25 @@ context('Beds', () => {
     // Given I am signed in as a workflow manager
     signIn(['future_manager'])
 
-    // When I visit the rooms page
-    const bedsPage = V2BedsListPage.visit(premisesId)
+    // When I visit the V2 beds page
+    const v2BedsPage = V2BedsListPage.visit(premisesId)
 
-    // Then I should see all of the rooms listed
-    bedsPage.shouldShowBeds(bedSummaries, premisesId)
+    // Then I should see all of the beds listed
+    v2BedsPage.shouldShowBeds(bedSummaries, premisesId)
 
     // When I click on a bed
-    bedsPage.clickBed(bedDetail)
+    v2BedsPage.clickBed(bedDetail)
 
     // Then I should be taken to the bed page
     Page.verifyOnPage(V2BedShowPage, bedDetail.name)
 
-    // Give I'm on the bed page
-    const bedPage = V2BedShowPage.visit(premisesId, bedDetail)
+    // Given I'm on the V2 bed page
+    const v2BedPage = V2BedShowPage.visit(premisesId, bedDetail)
 
     // Then I should see the room details
-    bedPage.shouldShowBedDetails(bedDetail)
+    v2BedPage.shouldShowBedDetails(bedDetail)
 
     // And I should see a link to the premises
-    bedPage.shouldLinkToPremises(premises)
+    v2BedPage.shouldLinkToPremises(premises)
   })
 })

--- a/server/controllers/v2Manage/premises/bedsController.test.ts
+++ b/server/controllers/v2Manage/premises/bedsController.test.ts
@@ -3,7 +3,7 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
 import PremisesService from '../../../services/premisesService'
 import BedsController from './bedsController'
-import { bedDetailFactory, extendedPremisesSummaryFactory } from '../../../testutils/factories'
+import { bedDetailFactory, bedSummaryFactory, extendedPremisesSummaryFactory } from '../../../testutils/factories'
 import paths from '../../../paths/manage'
 
 describe('V2BedsController', () => {
@@ -62,6 +62,27 @@ describe('V2BedsController', () => {
 
       expect(premisesService.getBed).toHaveBeenCalledWith(token, premises.id, bedId)
       expect(premisesService.getPremisesDetails).toHaveBeenCalledWith(token, premises.id)
+    })
+  })
+
+  describe('index', () => {
+    it('should return the beds to the template', async () => {
+      const beds = bedSummaryFactory.buildList(1)
+      const premisesId = 'premisesId'
+      request.params.premisesId = premisesId
+
+      premisesService.getBeds.mockResolvedValue(beds)
+
+      const requestHandler = bedsController.index()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('v2Manage/premises/beds/index', {
+        beds,
+        premisesId,
+        pageHeading: 'Manage beds',
+      })
+
+      expect(premisesService.getBeds).toHaveBeenCalledWith(token, premisesId)
     })
   })
 })

--- a/server/controllers/v2Manage/premises/bedsController.ts
+++ b/server/controllers/v2Manage/premises/bedsController.ts
@@ -6,6 +6,18 @@ import paths from '../../../paths/manage'
 export default class V2BedsController {
   constructor(private readonly premisesService: PremisesService) {}
 
+  index(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const beds = await this.premisesService.getBeds(req.user.token, req.params.premisesId)
+
+      return res.render('v2Manage/premises/beds/index', {
+        beds,
+        premisesId: req.params.premisesId,
+        pageHeading: 'Manage beds',
+      })
+    }
+  }
+
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId } = req.params

--- a/server/routes/v2Manage.ts
+++ b/server/routes/v2Manage.ts
@@ -37,7 +37,7 @@ export default function routes(controllers: Controllers, router: Router, service
   })
 
   // Beds
-  get(paths.v2Manage.premises.beds.index.pattern, bedsController.index(), {
+  get(paths.v2Manage.premises.beds.index.pattern, v2BedsController.index(), {
     auditEvent: 'LIST_BEDS',
     allowedRoles: ['future_manager'],
   })

--- a/server/utils/bedUtils.test.ts
+++ b/server/utils/bedUtils.test.ts
@@ -26,7 +26,9 @@ import {
   title,
   v1BedLink,
   v2BedActions,
+  v2BedDetails,
   v2BedLink,
+  v2BedTableRows,
 } from './bedUtils'
 import { DateFormats } from './dateUtils'
 
@@ -111,6 +113,18 @@ describe('bedUtils', () => {
     })
   })
 
+  describe('v2BedRows', () => {
+    const user = userDetailsFactory.build({ roles: ['manager'] })
+
+    it('returns the table rows given the rooms', () => {
+      const beds = [bed]
+
+      expect(v2BedTableRows(beds, premisesId, user)).toEqual([
+        [roomNameCell(bed), bedNameCell(bed), actionCell(bed, premisesId, user)],
+      ])
+    })
+  })
+
   describe('statusRow', () => {
     it('returns the status of an available room in sentence case', () => {
       bedDetail.status = 'available'
@@ -161,6 +175,12 @@ describe('bedUtils', () => {
   describe('bedDetails', () => {
     it('returns details for a bed', () => {
       expect(bedDetails(bedDetail)).toEqual([statusRow(bedDetail), characteristicsRow(bedDetail)])
+    })
+  })
+
+  describe('v2BedDetails', () => {
+    it('returns details for a bed', () => {
+      expect(v2BedDetails(bedDetail)).toEqual([characteristicsRow(bedDetail)])
     })
   })
 

--- a/server/utils/bedUtils.test.ts
+++ b/server/utils/bedUtils.test.ts
@@ -31,6 +31,7 @@ import {
   v2BedTableRows,
 } from './bedUtils'
 import { DateFormats } from './dateUtils'
+import { translateCharacteristic } from './characteristicsUtils'
 
 describe('bedUtils', () => {
   const premisesId = 'premisesId'
@@ -155,18 +156,21 @@ describe('bedUtils', () => {
   })
 
   describe('characteristicsRow', () => {
-    it('returns a list of characteristics', () => {
-      bedDetail.characteristics = [
-        apCharacteristicPairFactory.build({ propertyName: 'hasStepFreeAccessToCommunalAreas' }),
-        apCharacteristicPairFactory.build({ propertyName: 'isSuitedForSexOffenders' }),
-      ]
+    it('returns a list of translated characteristics', () => {
+      const characteristic1 = apCharacteristicPairFactory.build({ propertyName: 'hasStepFreeAccessToCommunalAreas' })
+      const characteristic2 = apCharacteristicPairFactory.build({ propertyName: 'isSuitedForSexOffenders' })
+
+      const translatedCharacteristic1 = translateCharacteristic(characteristic1)
+      const translatedCharacteristic2 = translateCharacteristic(characteristic2)
+
+      bedDetail.characteristics = [characteristic1, characteristic2]
 
       expect(characteristicsRow(bedDetail)).toEqual({
         key: { text: 'Characteristics' },
         value: {
           html:
             '<ul class="govuk-list govuk-list--bullet">\n' +
-            '  <li>Has step free access to communal areas</li> <li>Is suited for sex offenders</li></ul>',
+            `  <li>${translatedCharacteristic1}</li> <li>${translatedCharacteristic2}</li></ul>`,
         },
       })
     })

--- a/server/utils/bedUtils.ts
+++ b/server/utils/bedUtils.ts
@@ -11,6 +11,7 @@ import {
 import paths from '../paths/manage'
 import { DateFormats } from './dateUtils'
 import { linkTo, sentenceCase } from './utils'
+import { translateCharacteristic } from './characteristicsUtils'
 
 export class InvalidOverbookingDataException extends Error {}
 
@@ -49,7 +50,7 @@ export const characteristicsRow = (bed: BedDetail): SummaryListItem => ({
   key: { text: 'Characteristics' },
   value: {
     html: `<ul class="govuk-list govuk-list--bullet">
-  ${bed.characteristics.map(characteristic => `<li>${sentenceCase(characteristic.propertyName)}</li>`).join(' ')}</ul>`,
+  ${bed.characteristics.map(characteristic => `<li>${translateCharacteristic(characteristic)}</li>`).join(' ')}</ul>`,
   },
 })
 

--- a/server/utils/bedUtils.ts
+++ b/server/utils/bedUtils.ts
@@ -28,8 +28,16 @@ export const actionCell = (bed: BedSummary, premisesId: string, user?: UserDetai
   html: bedLinkForUser(bed, premisesId, user),
 })
 
+export const v2BedTableRows = (beds: Array<BedSummary>, premisesId: string, user?: UserDetails) => {
+  return beds.map(bed => [roomNameCell(bed), bedNameCell(bed), actionCell(bed, premisesId, user)])
+}
+
 export const bedDetails = (bed: BedDetail): Array<SummaryListItem> => {
   return [statusRow(bed), characteristicsRow(bed)]
+}
+
+export const v2BedDetails = (bed: BedDetail): Array<SummaryListItem> => {
+  return [characteristicsRow(bed)]
 }
 
 export const statusRow = (bed: BedDetail): SummaryListItem => ({

--- a/server/utils/premises/premisesActions.test.ts
+++ b/server/utils/premises/premisesActions.test.ts
@@ -119,11 +119,11 @@ describe('premisesActions', () => {
     const user = userDetails.build({ roles: ['future_manager'] })
     const premises = premisesFactory.build()
 
-    it('includes the MANAGE BEDS action', () => {
+    it('includes the V2 MANAGE BEDS action', () => {
       expect(premisesActions(user, premises)).toContainAction({
         text: 'Manage beds',
         classes: 'govuk-button--secondary',
-        href: paths.premises.beds.index({ premisesId: premises.id }),
+        href: paths.v2Manage.premises.beds.index({ premisesId: premises.id }),
       })
     })
 

--- a/server/utils/premises/premisesActions.ts
+++ b/server/utils/premises/premisesActions.ts
@@ -3,13 +3,17 @@ import { UserDetails } from '@approved-premises/ui'
 import paths from '../../paths/manage'
 
 export const premisesActions = (user: UserDetails, premises: Premises) => {
-  const actions = [
-    {
-      text: 'Manage beds',
-      classes: 'govuk-button--secondary',
-      href: paths.premises.beds.index({ premisesId: premises.id }),
-    },
-  ]
+  const actions = []
+
+  const premisesBedsPath = user.roles?.includes('future_manager')
+    ? paths.v2Manage.premises.beds.index({ premisesId: premises.id })
+    : paths.premises.beds.index({ premisesId: premises.id })
+
+  actions.push({
+    text: 'Manage beds',
+    classes: 'govuk-button--secondary',
+    href: premisesBedsPath,
+  })
 
   if (user.roles?.includes('future_manager')) {
     actions.push({

--- a/server/views/v2Manage/premises/beds/index.njk
+++ b/server/views/v2Manage/premises/beds/index.njk
@@ -26,7 +26,7 @@
           items: [ {
             text: "Manage out of service beds",
             classes: "govuk-button--secondary",
-            href: paths.lostBeds.index({premisesId: premisesId})
+            href: paths.v2Manage.outOfServiceBeds.premisesIndex({premisesId: premisesId, temporality: 'current'})
           }]
         }]
         })

--- a/server/views/v2Manage/premises/beds/index.njk
+++ b/server/views/v2Manage/premises/beds/index.njk
@@ -1,0 +1,61 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+		text: "Back",
+		href: paths.premises.show({ premisesId: premisesId })
+	}) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-width">
+      {{
+        mojIdentityBar({
+          title: {
+            html: "<h1>" + pageHeading + "</h1>"
+          },
+        menus: [{
+          items: [ {
+            text: "Manage out of service beds",
+            classes: "govuk-button--secondary",
+            href: paths.lostBeds.index({premisesId: premisesId})
+          }]
+        }]
+        })
+      }}
+
+      {{
+        govukTable({
+          captionClasses: "govuk-table__caption--m",
+          firstCellIsHeader: true,
+          head: [
+            {
+              text: "Room Name"
+            },
+            {
+              text: "Bed Name"
+            },
+            {
+              text: 'Action'
+            }
+          ],
+          rows: BedUtils.v2BedTableRows(beds, premisesId, user)
+        })
+      }}
+    </div>
+  </div>
+{% endblock %}
+
+{% block extraScripts %}
+  <script type="text/javascript" nonce="{{ cspNonce }}">
+    new MOJFrontend.ButtonMenu({container: $('.moj-button-menu'), mq: "(min-width: 200em)", buttonText: "Actions", menuClasses: "moj-button-menu__wrapper--right"});
+  </script>
+{% endblock %}

--- a/server/views/v2Manage/premises/beds/show.njk
+++ b/server/views/v2Manage/premises/beds/show.njk
@@ -41,7 +41,7 @@
     <div class="govuk-grid-column-two-thirds">
       {{
           govukSummaryList({
-            rows: BedUtils.bedDetails(bed)
+            rows: BedUtils.v2BedDetails(bed)
           })
         }}
     </div>


### PR DESCRIPTION


# Context

Bed "status" (indicating 'available', 'occupied', 'out-of-service') is not working. For now we remove it from both:

- the premises beds lists
- the individual bed page

## Screenshots of UI changes

### Before

#### Premises beds list

<img width="1069" alt="before_v1_premises_beds_list" src="https://github.com/user-attachments/assets/7aeb64ee-c359-4e8a-a27b-bea8b68548c2">

#### Bed page

<img width="1095" alt="before_bed_page" src="https://github.com/user-attachments/assets/25bf975c-c159-4e8f-bd68-16ac5ec6edc5">

### After

#### Premises beds list

![after_v2_premises_bed_list](https://github.com/user-attachments/assets/148cd268-a305-4f0b-8600-313c902c2ca4)

#### Bed page

<img width="1139" alt="after_bed_page" src="https://github.com/user-attachments/assets/08bc491a-a277-4e0f-b06f-55c7c2ae5ee2">


We also ensure that a "future manager" is given a link to the v2 Premises Beds list:

<img width="1069" alt="after_link_to_beds_list" src="https://github.com/user-attachments/assets/8609a07d-0762-4f64-a91b-ea78fe6b43d0">

