### PR TITLE
CHORE: Remove `check_outdated` CI security job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,28 +154,6 @@ jobs:
       - store_artifacts:
           path: integration_tests/screenshots
 
-  check_outdated:
-    executor:
-      name: hmpps/node
-      tag: << pipeline.parameters.node-version >>
-    steps:
-      - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-      - run:
-          name: install-npm
-          command: 'npm ci --no-audit'
-      - run:
-          name: Check version
-          command: 'npm --version'
-      - run:
-          name: Run check
-          command: 'npm outdated typescript govuk-frontend'
-      - slack/notify:
-          event: fail
-          channel: << pipeline.parameters.alerts-slack-channel >>
-          template: basic_fail_1
-
   e2e_environment_test_on_merge:
     executor:
       name: hmpps/node
@@ -327,9 +305,6 @@ workflows:
               only:
                 - main
     jobs:
-      - check_outdated:
-          context:
-            - hmpps-common-vars
       - hmpps/npm_security_audit:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:


### PR DESCRIPTION
This job does not provide any useful output beyond what the npm security audit does. The maintainers of the Typescript template have now removed it from the template itself [1]

[1] https://github.com/ministryofjustice/hmpps-template-typescript/pull/388

