### PR TITLE
Fixup up E2E test to no longer use bed status

### DIFF
--- a/e2e/pages/manage/v2BedsPage.ts
+++ b/e2e/pages/manage/v2BedsPage.ts
@@ -1,0 +1,19 @@
+import { Page, expect } from '@playwright/test'
+import { BasePage } from '../basePage'
+
+export class V2BedsPage extends BasePage {
+  static async initialize(page: Page, title?: string) {
+    if (title) {
+      await expect(page.locator('h1')).toContainText(title)
+    }
+    return new V2BedsPage(page)
+  }
+
+  async viewBed() {
+    const rowLocator = this.page.locator('tr')
+
+    const bedRows = rowLocator.filter({ hasText: 'Manage' })
+
+    await bedRows.first().getByRole('link', { name: 'Manage' }).click()
+  }
+}

--- a/e2e/tests/v2Manage.spec.ts
+++ b/e2e/tests/v2Manage.spec.ts
@@ -7,7 +7,7 @@ import { test } from '../test'
 import { visitDashboard } from '../steps/apply'
 import { PremisesListPage } from '../pages/manage/premisesListPage'
 import { PremisesPage } from '../pages/manage/premisesPage'
-import { BedsPage } from '../pages/manage/bedsPage'
+import { V2BedsPage } from '../pages/manage/v2BedsPage'
 import { V2BedPage } from '../pages/manage/v2BedPage'
 import { V2MarkBedAsOutOfServicePage } from '../pages/manage/v2MarkBedAsOutOfServicePage'
 import { signIn } from '../steps/signIn'
@@ -34,10 +34,10 @@ const markABedAsOutOfService = async (page: Page, futureManager: UserLoginDetail
 
   // When I choose to manage its beds
   await premisesPage.viewRooms()
-  const manageBedsPage = await BedsPage.initialize(page, 'Manage beds')
+  const manageBedsPage = await V2BedsPage.initialize(page, 'Manage beds')
 
   // And I pick a particular bed to manage
-  await manageBedsPage.viewAvailableBed()
+  await manageBedsPage.viewBed()
 
   // Then I see the V2 Bed page
   const v2BedPage = await V2BedPage.initialize(page, premisesName)


### PR DESCRIPTION
The "Future manager creates/updates Out-of-service bed" tests (E2E) were picking a bed with the "available" status.

The "Future manager" no longer sees the status column on the new V2 bed page.
