### PR TITLE
APS-1028 : Implement Assessment Appeals Manager Role

### DIFF
--- a/integration_tests/helpers/index.ts
+++ b/integration_tests/helpers/index.ts
@@ -2,6 +2,7 @@ import { add } from 'date-fns'
 import {
   AnyValue,
   ApprovedPremisesApplication,
+  ApprovedPremisesUserPermission,
   ArrayOfOASysOffenceDetailsQuestions,
   ArrayOfOASysRiskManagementPlanQuestions,
   ArrayOfOASysRiskOfSeriousHarmSummaryQuestions,
@@ -93,8 +94,8 @@ const updateApplicationReleaseDate = (data: AnyValue) => {
   }
 }
 
-const signInWithRoles = (roles: Array<UserRole>) => {
-  cy.task('stubAuthUser', { roles })
+const signInWithRolesAndPermissions = (roles: Array<UserRole>, permissions?: Array<ApprovedPremisesUserPermission>) => {
+  cy.task('stubAuthUser', { roles, permissions })
   cy.signIn()
 }
 
@@ -108,5 +109,5 @@ export {
   updateApplicationReleaseDate,
   shouldShowTableRows,
   uiObjectValue,
-  signInWithRoles,
+  signInWithRolesAndPermissions,
 }

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -2,7 +2,12 @@ import jwt from 'jsonwebtoken'
 import { Response } from 'superagent'
 import { faker } from '@faker-js/faker'
 
-import { ApArea, ProfileResponse, ApprovedPremisesUserRole as UserRole } from '../../server/@types/shared'
+import {
+  ApArea,
+  ApprovedPremisesUserPermission,
+  ProfileResponse,
+  ApprovedPremisesUserRole as UserRole,
+} from '../../server/@types/shared'
 
 import { getMatchingRequests, stubFor } from './setup'
 import tokenVerification from './tokenVerification'
@@ -146,7 +151,14 @@ export default {
   stubSignIn: (): Promise<[Response, Response, Response, Response, Response, Response]> =>
     Promise.all([favicon(), redirect(), signOut(), manageDetails(), token(), tokenVerification.stubVerifyToken()]),
   stubAuthUser: (
-    args: { name?: string; userId?: string; roles?: Array<UserRole>; apArea?: ApArea; profile?: ProfileResponse } = {},
+    args: {
+      name?: string
+      userId?: string
+      roles?: Array<UserRole>
+      apArea?: ApArea
+      profile?: ProfileResponse
+      permissions?: Array<ApprovedPremisesUserPermission>
+    } = {},
   ): Promise<Response> =>
     stubProfile(
       args.profile ||
@@ -155,6 +167,7 @@ export default {
             name: args.name || faker.person.fullName(),
             id: args.userId || defaultUserId,
             roles: args.roles || [],
+            permissions: args.permissions || [],
             apArea: args.apArea || apAreaFactory.build(),
             isActive: true,
           }),

--- a/integration_tests/tests/apply/appeals.cy.ts
+++ b/integration_tests/tests/apply/appeals.cy.ts
@@ -9,7 +9,7 @@ context('Appeals', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser', { roles: ['appeals_manager'] })
+    cy.task('stubAuthUser', { roles: ['appeals_manager'], permissions: ['cas1_process_an_appeal'] })
 
     // Given I am logged in
     cy.signIn()

--- a/integration_tests/tests/dashboard.cy.ts
+++ b/integration_tests/tests/dashboard.cy.ts
@@ -1,4 +1,4 @@
-import { signInWithRoles } from '../helpers'
+import { signInWithRolesAndPermissions } from '../helpers'
 import DashboardPage from '../pages/dashboard'
 
 context('Dashboard', () => {
@@ -7,8 +7,8 @@ context('Dashboard', () => {
     cy.task('stubSignIn')
   })
 
-  it('displays all services when a user has all roles', () => {
-    signInWithRoles(['assessor', 'manager'])
+  it('displays all services when a user has all roles and permissions', () => {
+    signInWithRolesAndPermissions(['assessor', 'manager'], ['cas1_view_assigned_assessments'])
 
     const dashboardPage = DashboardPage.visit()
 
@@ -17,8 +17,8 @@ context('Dashboard', () => {
     dashboardPage.shouldShowCard('manage')
   })
 
-  it('only displays the apply and assess services to assessors', () => {
-    signInWithRoles(['assessor'])
+  it('only displays the apply and assess services to users with "cas1_view_assigned_assessments" permission', () => {
+    signInWithRolesAndPermissions([], ['cas1_view_assigned_assessments'])
 
     const dashboardPage = DashboardPage.visit()
 
@@ -29,7 +29,7 @@ context('Dashboard', () => {
   })
 
   it('only displays the apply service when someone has no roles', () => {
-    signInWithRoles([])
+    signInWithRolesAndPermissions([])
 
     const dashboardPage = DashboardPage.visit()
 
@@ -40,7 +40,7 @@ context('Dashboard', () => {
   })
 
   it('only displays the apply and manage services to managers', () => {
-    signInWithRoles(['manager'])
+    signInWithRolesAndPermissions(['manager'])
 
     const dashboardPage = DashboardPage.visit()
 
@@ -51,7 +51,7 @@ context('Dashboard', () => {
   })
 
   it('displays the apply and user management services to users with "role_admin"', () => {
-    signInWithRoles(['role_admin'])
+    signInWithRolesAndPermissions(['role_admin'])
 
     const dashboardPage = DashboardPage.visit()
 

--- a/server/@types/shared/index.d.ts
+++ b/server/@types/shared/index.d.ts
@@ -25,6 +25,7 @@ export type { ApprovedPremisesAssessmentStatus } from './models/ApprovedPremises
 export type { ApprovedPremisesAssessmentSummary } from './models/ApprovedPremisesAssessmentSummary';
 export type { ApprovedPremisesBedSearchParameters } from './models/ApprovedPremisesBedSearchParameters';
 export type { ApprovedPremisesBedSearchResult } from './models/ApprovedPremisesBedSearchResult';
+export type { ApprovedPremisesPermission } from './models/ApprovedPremisesPermission';
 export type { ApprovedPremisesSummary } from './models/ApprovedPremisesSummary';
 export type { ApprovedPremisesUser } from './models/ApprovedPremisesUser';
 export type { ApprovedPremisesUserPermission } from './models/ApprovedPremisesUserPermission';

--- a/server/@types/shared/models/ApprovedPremisesPermission.ts
+++ b/server/@types/shared/models/ApprovedPremisesPermission.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApprovedPremisesPermission =
+  'cas1_view_assigned_assessments' |
+  'cas1_process_an_appeal'|
+  'cas1_assess_placement_application' |
+  'cas1_assess_placement_request' |
+  'cas1_assess_application' |
+  'cas1_assess_appealed_application';

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -6,6 +6,7 @@ import {
   ApprovedPremisesApplication,
   ApprovedPremisesApplicationStatus,
   ApprovedPremisesAssessment,
+  ApprovedPremisesPermission,
   ApprovedPremisesUserRole,
   ArrayOfOASysOffenceDetailsQuestions,
   ArrayOfOASysRiskManagementPlanQuestions,
@@ -369,6 +370,7 @@ export type UserDetails = {
   name: string
   displayName: string
   roles: Array<UserRole>
+  permissions: Array<ApprovedPremisesPermission>
   active: boolean
   apArea: ApArea
 }

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -30,6 +30,7 @@ export default class UserService {
       name: user.deliusUsername,
       id: user.id,
       displayName: convertToTitleCase(user.name),
+      permissions: user.permissions,
       roles: user.roles,
       active: user.isActive,
       apArea: user.apArea,

--- a/server/testutils/factories/userDetails.ts
+++ b/server/testutils/factories/userDetails.ts
@@ -10,5 +10,6 @@ export default Factory.define<UserDetails>(() => ({
   displayName: faker.person.fullName(),
   active: true,
   roles: [],
+  permissions: [],
   apArea: apAreaFactory.build(),
 }))

--- a/server/utils/applications/applicationIdentityBar.test.ts
+++ b/server/utils/applications/applicationIdentityBar.test.ts
@@ -78,9 +78,11 @@ describe('applicationIdentityBar', () => {
       })
     })
 
-    it('should return an appeals link when userRoles includes appeals_manager and the application has been rejected', () => {
+    it('should return an appeals link when user has cas1 process an appeal permission and the application has been rejected', () => {
       const application = applicationFactory.build({ status: 'rejected', createdByUserId: userId })
-      expect(applicationMenuItems(application, fromPartial({ roles: ['appeals_manager'], id: userId }))).toEqual([
+      expect(
+        applicationMenuItems(application, fromPartial({ permissions: ['cas1_process_an_appeal'], id: userId })),
+      ).toEqual([
         {
           text: 'Withdraw application or placement request',
           href: paths.applications.withdraw.new({ id: application.id }),
@@ -100,9 +102,11 @@ describe('applicationIdentityBar', () => {
       ])
     })
 
-    it('should not return an appeals link when userRoles includes appeals_manager and the application has not been rejected', () => {
+    it('should not return an appeals link when user has cas1 process an appeal permission and the application has not been rejected', () => {
       const application = applicationFactory.build({ status: 'assesmentInProgress', createdByUserId: userId })
-      expect(applicationMenuItems(application, fromPartial({ roles: ['appeals_manager'], id: userId }))).toEqual([
+      expect(
+        applicationMenuItems(application, fromPartial({ permissions: ['cas1_process_an_appeal'], id: userId })),
+      ).toEqual([
         {
           text: 'Withdraw application or placement request',
           href: paths.applications.withdraw.new({ id: application.id }),
@@ -114,9 +118,9 @@ describe('applicationIdentityBar', () => {
       ])
     })
 
-    it('should not return an appeals link when userRoles does not include appeals_manager and the application has been rejected', () => {
+    it('should not return an appeals link when user does not have cas1 process an appeal permission and the application has been rejected', () => {
       const application = applicationFactory.build({ status: 'rejected', createdByUserId: userId })
-      expect(applicationMenuItems(application, fromPartial({ roles: ['assessor'], id: userId }))).toEqual([
+      expect(applicationMenuItems(application, fromPartial({ permissions: [], id: userId }))).toEqual([
         {
           text: 'Withdraw application or placement request',
           href: paths.applications.withdraw.new({ id: application.id }),

--- a/server/utils/applications/applicationIdentityBar.ts
+++ b/server/utils/applications/applicationIdentityBar.ts
@@ -2,6 +2,7 @@ import { ApprovedPremisesApplication as Application, FullPerson } from '../../@t
 import { IdentityBar, IdentityBarMenuItem, UserDetails } from '../../@types/ui'
 import paths from '../../paths/apply'
 import { ApplicationStatusTag } from './statusTag'
+import { hasPermission } from '../users'
 
 export const applicationTitle = (application: Application, pageHeading: string): string => {
   let heading = (application.person as FullPerson).name
@@ -35,7 +36,7 @@ export const applicationMenuItems = (application: Application, user: UserDetails
     })
   }
 
-  if (user.roles.includes('appeals_manager') && application.status === 'rejected') {
+  if (hasPermission(user, ['cas1_process_an_appeal']) && application.status === 'rejected') {
     items.push({
       text: 'Process an appeal',
       href: paths.applications.appeals.new({ id: application.id }),

--- a/server/utils/users/homePageDashboard.test.ts
+++ b/server/utils/users/homePageDashboard.test.ts
@@ -1,5 +1,5 @@
 import { userDetailsFactory } from '../../testutils/factories'
-import { hasRole, sections, sectionsForUser } from './homePageDashboard'
+import { hasPermission, hasRole, sections, sectionsForUser } from './homePageDashboard'
 
 describe('homePageDashboard', () => {
   describe('hasRole', () => {
@@ -16,6 +16,20 @@ describe('homePageDashboard', () => {
     })
   })
 
+  describe('hasPermission', () => {
+    it('returns true when the user has the permission', () => {
+      const user = userDetailsFactory.build({ permissions: ['cas1_view_assigned_assessments'] })
+
+      expect(hasPermission(user, ['cas1_view_assigned_assessments'])).toEqual(true)
+    })
+
+    it('returns false when the user does not have the permission', () => {
+      const user = userDetailsFactory.build({ permissions: ['cas1_view_assigned_assessments'] })
+
+      expect(hasPermission(user, ['cas1_process_an_appeal'])).toEqual(false)
+    })
+  })
+
   describe('sectionsForUser', () => {
     it('should return Apply for a user with no roles', () => {
       const user = userDetailsFactory.build({ roles: [] })
@@ -23,8 +37,8 @@ describe('homePageDashboard', () => {
       expect(sectionsForUser(user)).toEqual([sections.apply])
     })
 
-    it('should return Apply and Assess sections for a user with an assessor role', () => {
-      const user = userDetailsFactory.build({ roles: ['assessor'] })
+    it('should return Apply and Assess sections for a user with cas1 view assigned assessments permission', () => {
+      const user = userDetailsFactory.build({ permissions: ['cas1_view_assigned_assessments'] })
 
       expect(sectionsForUser(user)).toEqual([sections.apply, sections.assess])
     })
@@ -68,9 +82,10 @@ describe('homePageDashboard', () => {
       expect(sectionsForUser(user)).toEqual([sections.apply])
     })
 
-    it('should return all except match sections for a user with all roles', () => {
+    it('should return all except match sections for a user with all roles and user permissions', () => {
       const user = userDetailsFactory.build({
         roles: ['assessor', 'manager', 'matcher', 'workflow_manager', 'report_viewer'],
+        permissions: ['cas1_view_assigned_assessments'],
       })
 
       expect(sectionsForUser(user)).toEqual([

--- a/server/utils/users/homePageDashboard.ts
+++ b/server/utils/users/homePageDashboard.ts
@@ -8,6 +8,7 @@ import taskPaths from '../../paths/tasks'
 import adminPaths from '../../paths/admin'
 import peoplePaths from '../../paths/people'
 import { retrieveFeatureFlag } from '../retrieveFeatureFlag'
+import { ApprovedPremisesPermission } from '../../@types/shared/models/ApprovedPremisesPermission'
 
 export const sections = {
   apply: {
@@ -96,6 +97,10 @@ export const hasRole = (user: UserDetails, role: UserRole): boolean => {
   return (user.roles || []).includes(role)
 }
 
+export const hasPermission = (user: UserDetails, requiredPermissions: Array<ApprovedPremisesPermission>): boolean => {
+  return (user.permissions || []).filter(userPermission => requiredPermissions.includes(userPermission)).length >= 1
+}
+
 export const sectionsForUser = (user: UserDetails): Array<ServiceSection> => {
   const items = [sections.apply]
 
@@ -103,7 +108,7 @@ export const sectionsForUser = (user: UserDetails): Array<ServiceSection> => {
     items.push(sections.personalTimeline)
   }
 
-  if (hasRole(user, 'assessor')) {
+  if (hasPermission(user, ['cas1_view_assigned_assessments'])) {
     items.push(sections.assess)
   }
 


### PR DESCRIPTION
Add user permissions to cas1 roles to allow functionality to be governed by distinct permissions

Displaying Assess Approved Premises applications tile is governed by `cas1_view_assigned_assessments` permission 

Process An Appeal action link is governed by` cas1_process_an_appeal `permission 

Only users with `cas1_assess_appealed_application` permission can be allocated appealed assessments (governed by API response)

# Context

Link to [ticket](https://dsdmoj.atlassian.net/browse/APS-1028) in Jira. 

# Changes in this PR

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### “Assess Approved Premises applications” tile isn’t shown when a suitable role (with permission) is not found

<img width="1049" alt="tile_no_roles" src="https://github.com/user-attachments/assets/56643fda-d861-4b47-a008-056c0cb53df0">

### “Assess Approved Premises applications” tile is shown for the Assessor role.

<img width="1046" alt="tile_assessor_role" src="https://github.com/user-attachments/assets/356fdee3-db90-4c56-bbef-00c2da6989c7">

### “Assess Approved Premises applications” tile is shown for the Janitor role.

<img width="1059" alt="tile_janitor_role" src="https://github.com/user-attachments/assets/50f2c281-7208-4382-9921-e3fdc60b33b0">

### “Assess Approved Premises applications” tile is shown for the Appeals Manager role.

<img width="1038" alt="tile_appeals_manager_role" src="https://github.com/user-attachments/assets/d3b94ccc-10da-4168-88b1-00bac165c839">



### No option to ‘Process an appeal’ when a suitable role is not present.

<img width="1110" alt="appeals_no_role" src="https://github.com/user-attachments/assets/9e7a0bc6-183a-4509-bf68-ef90487c3eee">

### Option to ‘Process an appeal’ for the Janitor role.

<img width="1046" alt="appeals_janitor_role" src="https://github.com/user-attachments/assets/09725614-33be-4048-a07e-51feb5b82438">

### Option to ‘Process an appeal’ for the Appeals Manager role.

<img width="1037" alt="appeal_appeals_manager_role" src="https://github.com/user-attachments/assets/3908307a-be75-4db7-88cc-b7913bd1eaeb">



### No suitable users available to allocate a previously rejected assessment to.

<img width="1073" alt="reallocate_no_matching_roles" src="https://github.com/user-attachments/assets/914d4b9a-6bfe-4b4a-a664-dfd2ddb1eb9e">

### Users with Appeals Manager role can be assigned a previously rejected assessment. 

<img width="1055" alt="reallocate_cas1_appeals_manager" src="https://github.com/user-attachments/assets/12730842-e8f3-4db3-8f6d-77b8e7f9c4af">

### Users with Assessor role can be assigned a previously rejected assessment.

<img width="1055" alt="reallocate_cas1_assessor" src="https://github.com/user-attachments/assets/cf4e4f39-7a8c-416a-9079-674250107f05">






