### PR TITLE
Add build step to setup script

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -16,3 +16,6 @@ if [ ! -f .env.test ]; then
 fi
 
 script/bootstrap
+
+echo "==> Build app..."
+npm run build


### PR DESCRIPTION
We don't run the build step (which compiles the SASS and copies across the views) in the setup script. This step is neccessary to ["set up a project in an initial
state"](https://github.com/github/scripts-to-rule-them-all?tab=readme-ov-file#scriptsetup) so should be included here
