### PR TITLE
Separate person requirements from premises details on space booking page

### DIFF
--- a/integration_tests/pages/match/bookASpacePage.ts
+++ b/integration_tests/pages/match/bookASpacePage.ts
@@ -2,7 +2,6 @@ import { ApType, PlacementDates, PlacementRequestDetail, Premises } from '@appro
 import Page from '../page'
 import paths from '../../../server/paths/match'
 import { createQueryString, sentenceCase } from '../../../server/utils/utils'
-import { isFullPerson } from '../../../server/utils/personUtils'
 import { DateFormats } from '../../../server/utils/dateUtils'
 import {
   filterOutAPTypes,
@@ -38,7 +37,6 @@ export default class BookASpacePage extends Page {
     apType: ApType,
   ): void {
     const { endDate, placementLength } = placementDates(startDate, duration.toString())
-    cy.get('h2').contains(isFullPerson(placementRequest.person) && placementRequest.person.name)
     cy.get('dd').contains(apTypeLabels[apType])
     cy.get('dd').contains(DateFormats.isoDateToUIDate(startDate))
     cy.get('dd').contains(DateFormats.isoDateToUIDate(endDate))

--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -38,7 +38,8 @@ import {
   postcodeRow,
   premisesNameRow,
   requirementsHtmlString,
-  spaceBookingSummaryCardRows,
+  spaceBookingPersonNeedsSummaryCardRows,
+  spaceBookingPremisesSummaryCardRows,
   startDateObjFromParams,
   summaryCardLink,
   summaryCardRows,
@@ -277,11 +278,10 @@ describe('matchUtils', () => {
     })
   })
 
-  describe('spaceBookingSummaryCardRows', () => {
+  describe('spaceBookingPersonNeedsSummaryCardRows', () => {
     it('should call the correct row functions', () => {
-      const premisesName = 'Hope House'
       const gender = 'male'
-      const apType = 'pipe'
+
       const dates = {
         startDate: '2022-01-01',
         endDate: '2022-01-15',
@@ -291,23 +291,26 @@ describe('matchUtils', () => {
       const desirableCharacteristics: Array<PlacementCriteria> = ['hasBrailleSignage']
 
       expect(
-        spaceBookingSummaryCardRows(
-          premisesName,
-          apType,
-          dates,
-          gender,
-          essentialCharacteristics,
-          desirableCharacteristics,
-        ),
+        spaceBookingPersonNeedsSummaryCardRows(dates, gender, essentialCharacteristics, desirableCharacteristics),
       ).toEqual([
-        premisesNameRow(premisesName),
-        apTypeRow(apType),
         arrivalDateRow(dates.startDate),
         departureDateRow(dates.endDate),
         placementLengthRow(dates.placementLength),
         genderRow(gender),
         essentialCharacteristicsRow(essentialCharacteristics),
         desirableCharacteristicsRow(desirableCharacteristics),
+      ])
+    })
+  })
+
+  describe('spaceBookingPremisesSummaryCardRows', () => {
+    it('should call the correct row functions', () => {
+      const premisesName = 'Hope House'
+      const apType = 'pipe'
+
+      expect(spaceBookingPremisesSummaryCardRows(premisesName, apType)).toEqual([
+        premisesNameRow(premisesName),
+        apTypeRow(apType),
       ])
     })
   })

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -106,17 +106,17 @@ export const confirmationSummaryCardRows = (
   ]
 }
 
-export const spaceBookingSummaryCardRows = (
-  premisesName: string,
-  apType: ApType,
+export const spaceBookingPremisesSummaryCardRows = (premisesName: string, apType: ApType): Array<SummaryListItem> => {
+  return [premisesNameRow(premisesName), apTypeRow(apType)]
+}
+
+export const spaceBookingPersonNeedsSummaryCardRows = (
   dates: PlacementDates,
   gender: Gender,
   essentialCharacteristics: Array<PlacementCriteria>,
   desirableCharacteristics: Array<PlacementCriteria>,
 ): Array<SummaryListItem> => {
   return [
-    premisesNameRow(premisesName),
-    apTypeRow(apType),
     arrivalDateRow(dates.startDate),
     departureDateRow(dates.endDate),
     placementLengthRow(dates.placementLength),

--- a/server/views/match/placementRequests/spaceBookings/new.njk
+++ b/server/views/match/placementRequests/spaceBookings/new.njk
@@ -15,8 +15,25 @@
 
         {{
           govukSummaryList({
+            card: {
+              title: {
+                text: "Premises details"
+              }
+            },
             classes: 'govuk-summary-list--no-border',
-					  rows: MatchUtils.spaceBookingSummaryCardRows(premisesName, apType, dates, placementRequest.gender, essentialCharacteristics, desirableCharacteristics)
+					  rows: MatchUtils.spaceBookingPremisesSummaryCardRows(premisesName, apType)
+				  })
+        }}
+
+        {{
+          govukSummaryList({
+            card: {
+              title: {
+                text: "Booking requirements"
+              }
+            },
+            classes: 'govuk-summary-list--no-border',
+					  rows: MatchUtils.spaceBookingPersonNeedsSummaryCardRows(dates, placementRequest.gender, essentialCharacteristics, desirableCharacteristics)
 				  })
         }}
 

--- a/server/views/match/placementRequests/spaceBookings/new.njk
+++ b/server/views/match/placementRequests/spaceBookings/new.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% extends "../../../partials/layout.njk" %}
+{% extends "../../layout-with-details.njk" %}
 
 {% set pageTitle = applicationName + " - " + pageHeading %}
 
@@ -10,8 +10,6 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-
-        <h2 class="govuk-heading-m">{{ placementRequest.person.name }}</h2>
 
         {{
           govukSummaryList({


### PR DESCRIPTION
# Context

Jira ticket: https://dsdmoj.atlassian.net/browse/APS-1142. I've done this without designs and there may be a better way to display this, but this will do for now.

I've also included https://dsdmoj.atlassian.net/browse/APS-1140 (adding the blue key details banner we're using on the space search page) as it's a minor change.

# Changes in this PR

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before

![Placement Requests -- allows me to book a space (3)](https://github.com/user-attachments/assets/7bd1e65a-c4fe-42e2-a94a-f6c9f7d9692d)

### After

![Placement Requests -- allows me to book a space (3)](https://github.com/user-attachments/assets/b4581fbb-65e3-4a63-a363-ea3a3c367579)