### PR TITLE
APS-898 Add filters for AP Area and Premises Name to Out of service beds index page

### DIFF
--- a/server/controllers/v2Manage/index.ts
+++ b/server/controllers/v2Manage/index.ts
@@ -13,6 +13,7 @@ export const controllers = (services: Services) => {
   const v2OutOfServiceBedsController = new V2OutOfServiceBedsController(
     services.outOfServiceBedService,
     services.premisesService,
+    services.apAreaService,
   )
   const v2UpdateOutOfServiceBedsController = new V2UpdateOutOfServiceBedsController(
     services.outOfServiceBedService,

--- a/server/views/v2Manage/outOfServiceBeds/index.njk
+++ b/server/views/v2Manage/outOfServiceBeds/index.njk
@@ -2,6 +2,8 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
@@ -9,6 +11,19 @@
 {% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - " + pageHeading %}
+
+{% set premisesItems = convertObjectsToSelectOptions(premises, 'All premises', 'name', 'id', 'premisesId', 'all', context) %}
+
+{% set areaAndPremisesParam = '?apAreaId=' + apAreaId + '&premisesId=' + premisesId %}
+
+{% if disablePremisesSelect === true %}
+  {% set premisesItems = [
+    {
+    value: "selectApArea",
+    text: "Select an AP area"
+    }
+  ] %}
+{% endif %}
 
 {% block beforeContent %}
   {{ govukBackLink({
@@ -21,21 +36,67 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-width">
       <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+      <div class="search-and-filter__wrapper">
+        <form action="{{ paths.v2Manage.outOfServiceBeds.index({temporality: temporality}) }}" method="get" id="osbFilters">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+              <h2 class="govuk-heading-m">Filters</h2>
+            </div>
+          </div>
+
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-third">
+              {{ govukSelect({
+                label: {
+                  text: "AP Area",
+                  classes: "govuk-label--s"
+                },
+                classes: "govuk-input--width-20",
+                id: "apAreaId",
+                name: "apAreaId",
+                items: convertObjectsToSelectOptions(apAreas, 'All areas', 'name', 'id', 'apAreaId', 'all', context)
+              }) }}
+            </div>
+            <div class="govuk-grid-column-one-third">
+              {{ govukSelect({
+                label: {
+                  text: "Premises Name",
+                  classes: "govuk-label--s"
+                },
+                id: "premisesId",
+                name: "premisesId",
+                disabled: disablePremisesSelect,
+                items: premisesItems
+              }) }}
+            </div>
+            <div class="govuk-grid-column-one-third" id="submitbutton">
+              {{ govukButton({
+                "name": "submit",
+                "text": "Apply filters",
+                "classes": "search-and-filter__submit",
+                "preventDoubleClick": true
+              }) }}
+            </div>
+          </div>
+        </form>
+      </div>
 
       {{
         mojSubNavigation({
           label: 'Sub navigation',
           items: [{
               text: 'Current',
-              href: paths.v2Manage.outOfServiceBeds.index({temporality: 'current'}),
+              href: paths.v2Manage.outOfServiceBeds.index({temporality: 'current'}) + areaAndPremisesParam,
               active: temporality === 'current'
             }, {
               text: 'Future',
-              href: paths.v2Manage.outOfServiceBeds.index({temporality: 'future'}),
+              href: paths.v2Manage.outOfServiceBeds.index({temporality: 'future'}) + areaAndPremisesParam,
               active: temporality === 'future'
             }, {
               text: 'Historic',
-              href: paths.v2Manage.outOfServiceBeds.index({temporality: 'past'}),
+              href: paths.v2Manage.outOfServiceBeds.index({temporality: 'past'}) + areaAndPremisesParam,
               active: temporality === 'past'
           }]
         })
@@ -57,4 +118,51 @@
       {% endif %}
     </div>
   </div>
+{% endblock %}
+
+{% block extraScripts %}
+  <script type="text/javascript" nonce="{{ cspNonce }}">
+      document.addEventListener('DOMContentLoaded', function () {
+        const allPremises = {{ allPremises | dump | safe }};
+        const apAreaSelect = document.getElementById('apAreaId');
+        const premisesSelect = document.getElementById('premisesId');
+
+        apAreaSelect.addEventListener('change', function () {
+          const selectedArea = apAreaSelect.options[apAreaSelect.selectedIndex].text;
+          premisesSelect.innerHTML = '';
+
+          if (selectedArea === 'All areas') {
+            const disabledOption = document.createElement('option');
+            disabledOption.value = 'selectApArea';
+            disabledOption.text = 'Select an AP area';
+            premisesSelect.appendChild(disabledOption);
+            premisesSelect.disabled = true;
+          } else {
+            const filteredData = allPremises.filter(item => item.apArea === selectedArea);
+            if (filteredData.length > 0) {
+
+              premisesSelect.disabled = false;
+
+              const defaultOption = document.createElement('option');
+              defaultOption.value = 'all';
+              defaultOption.text = 'All premises';
+              premisesSelect.appendChild(defaultOption);
+
+              filteredData.forEach(item => {
+                const option = document.createElement('option');
+                option.value = item.id;
+                option.text = item.name;
+                premisesSelect.appendChild(option);
+              });
+            } else {
+              premisesSelect.disabled = true;
+              const defaultOption = document.createElement('option');
+              defaultOption.value = '';
+              defaultOption.text = 'No premises available';
+              premisesSelect.appendChild(defaultOption);
+            }
+          }
+        });
+      });
+  </script>
 {% endblock %}


### PR DESCRIPTION
Add filters for AP Area and Premises Name to Out of service beds index page

In order to focus on the particular category of OoS beds of interest users need to specify filter

Adds Ap area and Premises filter for the index page for Out of service beds


## Screenshots of UI changes

### Before
![Screenshot 2024-08-08 at 09 28 46](https://github.com/user-attachments/assets/6768ccca-343c-4867-b241-4a47d4cd1298)


### After

![Screenshot 2024-08-08 at 09 26 33](https://github.com/user-attachments/assets/48370865-0275-4977-a6c7-688652cd0483)

