### PR TITLE
APS 1146 - Extend E2Es to include Match

### DIFF
--- a/e2e/pages/assess/assessPage.ts
+++ b/e2e/pages/assess/assessPage.ts
@@ -9,7 +9,18 @@ export class AssessPage extends BasePage {
     return new AssessPage(page)
   }
 
+  checkListOfRequirements(
+    requirements: Array<string>,
+    relevancy: 'essential' | 'desirable' | 'notRelevant' | 'relevant',
+  ) {
+    return Promise.all(
+      requirements.map(async requirement => {
+        await this.checkRequirement(requirement, relevancy)
+      }),
+    )
+  }
+
   async checkRequirement(requirement: string, status: string) {
-    await this.page.getByLabel(`${requirement} ${status}`, { exact: true }).check()
+    await this.checkRadio(`${requirement} ${status}`)
   }
 }

--- a/e2e/pages/assess/listPage.ts
+++ b/e2e/pages/assess/listPage.ts
@@ -15,7 +15,7 @@ export class ListPage extends BasePage {
     const nextLink = this.page.getByRole('link', { name: 'Next' })
 
     try {
-      await expect(assessmentRow).toBeVisible()
+      await expect(assessmentRow).toBeVisible({ timeout: 1000 })
       await assessmentRow.click()
     } catch (err) {
       try {

--- a/e2e/pages/basePage.ts
+++ b/e2e/pages/basePage.ts
@@ -19,6 +19,10 @@ export class BasePage {
     await this.page.getByRole('button', { name: 'Withdraw' }).click()
   }
 
+  async clickActions() {
+    await this.page.getByRole('button', { name: 'Actions' }).click()
+  }
+
   async fillField(label: string, value: string) {
     await this.page.getByRole('textbox', { name: label }).fill(value)
   }

--- a/e2e/pages/basePage.ts
+++ b/e2e/pages/basePage.ts
@@ -1,4 +1,5 @@
 import { Page } from '@playwright/test'
+import { Premises } from '../../server/@types/shared'
 
 export class BasePage {
   constructor(public readonly page: Page) {}
@@ -64,14 +65,16 @@ export class BasePage {
     await this.page.getByLabel('Year', { exact: true }).first().fill(year)
   }
 
-  async selectFirstPremises(legend: string) {
+  async selectFirstPremises(legend: string): Promise<Premises['name']> {
     await this.page
       .getByRole('group', { name: legend })
       .getByRole('combobox', { name: 'Select an area' })
       .selectOption({ index: 1 })
-    await this.page
+    const selectedPremises = await this.page
       .getByRole('group', { name: legend })
       .getByRole('combobox', { name: 'Select a premises' })
       .selectOption({ index: 1 })
+
+    return selectedPremises[0]
   }
 }

--- a/e2e/pages/basePage.ts
+++ b/e2e/pages/basePage.ts
@@ -28,7 +28,7 @@ export class BasePage {
   }
 
   async checkRadio(label: string) {
-    await this.page.getByLabel(label, { exact: true }).check()
+    await this.page.getByLabel(label, { exact: true }).click()
   }
 
   async checkRadioInGroup(group: string, label: string) {

--- a/e2e/pages/dashboardPage.ts
+++ b/e2e/pages/dashboardPage.ts
@@ -17,8 +17,8 @@ export class DashboardPage extends BasePage {
     await this.page.getByRole('link', { name: 'Assess Approved Premises applications' }).click()
   }
 
-  async clickMatch() {
-    await this.page.getByRole('link', { name: 'Match people to Approved Premises placements' }).click()
+  async clickCruDashboard() {
+    await this.page.getByRole('link', { name: 'CRU Dashboard' }).click()
   }
 
   async clickManage() {

--- a/e2e/pages/manage/bedPage.ts
+++ b/e2e/pages/manage/bedPage.ts
@@ -9,10 +9,6 @@ export class BedPage extends BasePage {
     return new BedPage(page)
   }
 
-  async clickActions() {
-    await this.page.getByRole('button', { name: 'Actions' }).click()
-  }
-
   async clickBookBed() {
     await this.clickActions()
     await this.page.getByRole('menuitem', { name: 'Create a placement' }).click()

--- a/e2e/pages/manage/placementPage.ts
+++ b/e2e/pages/manage/placementPage.ts
@@ -9,10 +9,6 @@ export class PlacementPage extends BasePage {
     return new PlacementPage(page)
   }
 
-  async clickActions() {
-    await this.page.getByRole('button', { name: 'Actions' }).click()
-  }
-
   async clickMarkNotArrived() {
     await this.clickActions()
     await this.page.getByRole('menuitem', { name: 'Mark as not arrived' }).click()

--- a/e2e/pages/manage/premisesPage.ts
+++ b/e2e/pages/manage/premisesPage.ts
@@ -18,10 +18,6 @@ export class PremisesPage extends BasePage {
     await this.page.getByRole('heading', { name: 'Success' })
   }
 
-  async clickActions() {
-    await this.page.getByRole('button', { name: 'Actions' }).click()
-  }
-
   async clickManageTodaysArrival() {
     const table = this.page.getByRole('table', { name: 'Arriving Today' })
     await table.getByRole('link', { name: 'Manage' }).first().click()

--- a/e2e/pages/manage/v2BedPage.ts
+++ b/e2e/pages/manage/v2BedPage.ts
@@ -8,10 +8,6 @@ export class V2BedPage extends BasePage {
     return new V2BedPage(page)
   }
 
-  async clickActions() {
-    await this.page.getByRole('button', { name: 'Actions' }).click()
-  }
-
   async clickMarkBedAsOutOfService() {
     await this.clickActions()
     await this.page.getByRole('menuitem', { name: 'Create out of service bed record' }).click()

--- a/e2e/pages/match/cruDashboard.ts
+++ b/e2e/pages/match/cruDashboard.ts
@@ -1,0 +1,39 @@
+import { Page, expect } from '@playwright/test'
+import { TestOptions } from '@approved-premises/e2e'
+import { BasePage } from '../basePage'
+
+export class CruDashboard extends BasePage {
+  static async initialize(page: Page) {
+    await expect(page.locator('h1')).toContainText('CRU Dashboard')
+
+    return new CruDashboard(page)
+  }
+
+  async selectPlacementRequest({
+    person,
+    arrivalDate,
+    lengthOfStay,
+    applicationDate,
+    isParole,
+  }: {
+    person: TestOptions['person']
+    arrivalDate: string
+    lengthOfStay: string
+    applicationDate: string
+    isParole: boolean
+  }) {
+    const placementRequestRow = this.page
+      .getByRole('row')
+      .filter({
+        has:
+          this.page.getByRole('cell', { name: person.name }) &&
+          this.page.getByRole('cell', { name: person.tier }) &&
+          this.page.getByRole('cell', { name: arrivalDate }) &&
+          this.page.getByRole('cell', { name: lengthOfStay }) &&
+          this.page.getByRole('cell', { name: applicationDate }) &&
+          this.page.getByRole('cell', { name: isParole ? 'Parole' : 'Standard release' }),
+      })
+      .first()
+    await placementRequestRow.getByRole('link').click()
+  }
+}

--- a/e2e/pages/match/searchScreen.ts
+++ b/e2e/pages/match/searchScreen.ts
@@ -1,0 +1,72 @@
+import { Page, expect } from '@playwright/test'
+import { BasePage } from '../basePage'
+import { Premises } from '../../../server/@types/shared'
+import { ApTypeLabel } from '../../../server/utils/apTypeLabels'
+import { E2EDatesOfPlacement, E2EPlacementCharacteristics } from '../../steps/assess'
+
+export class SearchScreen extends BasePage {
+  static async initialize(page: Page) {
+    await expect(page.locator('h1')).toContainText('Find a space in an Approved Premises')
+
+    return new SearchScreen(page)
+  }
+
+  async clickUpdate() {
+    await this.page.getByRole('button', { name: 'Update' }).click()
+  }
+
+  shouldShowApplicationDetails({
+    preferredAps,
+    datesOfPlacement,
+    duration,
+    apType,
+    preferredPostcode,
+    placementCharacteristics,
+  }: {
+    preferredAps: Array<Premises['name']>
+    datesOfPlacement: E2EDatesOfPlacement
+    duration: string
+    apType: ApTypeLabel
+    preferredPostcode: string
+    placementCharacteristics: E2EPlacementCharacteristics
+  }): void {
+    this.shouldShowDatesOfPlacement(datesOfPlacement, duration)
+    this.shouldShowApType(apType)
+    this.shouldShowPreferredPostcode(preferredPostcode)
+    this.shouldShowPreferredAps(preferredAps)
+    this.shouldShowPlacementCharacteristics(placementCharacteristics)
+  }
+
+  async shouldShowPreferredAps(preferredAps: Array<Premises['name']>) {
+    preferredAps.forEach(async (preferredAp, index) => {
+      await this.page.getByText(preferredAp, { exact: true }).nth(index).isVisible()
+    })
+  }
+
+  async shouldShowApType(apType: ApTypeLabel) {
+    await this.page.locator('.govuk-details').getByText(apType).isVisible()
+  }
+
+  async shouldShowPreferredPostcode(postcode: string) {
+    await this.page.locator('.govuk-details').getByText(postcode).isVisible()
+  }
+
+  async shouldShowDatesOfPlacement({ startDate, endDate }: E2EDatesOfPlacement, duration: string) {
+    ;[startDate, endDate, duration].forEach(async date => {
+      await this.page.locator('.govuk-details').getByText(date).isVisible()
+    })
+  }
+
+  async shouldShowPlacementCharacteristics({
+    essentialCharacteristics,
+    desirableCharacteristics,
+  }: E2EPlacementCharacteristics) {
+    essentialCharacteristics.forEach(async characteristic => {
+      await this.page.locator('.govuk-details').getByText(characteristic).isVisible()
+    })
+
+    desirableCharacteristics.forEach(async characteristic => {
+      await this.page.locator('.govuk-details').getByText(characteristic).isVisible()
+    })
+  }
+}

--- a/e2e/pages/workflow/listPage.ts
+++ b/e2e/pages/workflow/listPage.ts
@@ -23,7 +23,7 @@ export class ListPage extends BasePage {
     const nextLink = this.page.getByRole('link', { name: 'Next' })
 
     try {
-      await expect(assessmentRow).toBeVisible()
+      await expect(assessmentRow).toBeVisible({ timeout: 1000 })
     } catch (err) {
       try {
         await expect(nextLink).toBeVisible()

--- a/e2e/pages/workflow/placementRequestPage.ts
+++ b/e2e/pages/workflow/placementRequestPage.ts
@@ -4,4 +4,9 @@ export class PlacementRequestPage extends BasePage {
   async selectStaffMember(userName: string) {
     await this.page.locator('select').selectOption(userName)
   }
+
+  async clickSearchForASpace() {
+    await this.clickActions()
+    await this.page.getByRole('menuitem', { name: 'Search for a space' }).click()
+  }
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -44,6 +44,7 @@ export default defineConfig<TestOptions>({
         person: {
           name: 'Aadland Bertrand',
           crn: 'X320741',
+          tier: 'D2',
         },
         indexOffenceRequired: true,
         oasysSections: [

--- a/e2e/steps/assess.ts
+++ b/e2e/steps/assess.ts
@@ -163,7 +163,15 @@ export const addMatchingInformation = async (page: Page) => {
 
   await matchingInformationPage.checkRadio('Yes')
 
+  const [startDate, endDate] = (await page.locator('.dates-of-placement').textContent()).split(' - ') as [
+    string,
+    string,
+  ]
+  const duration = await page.locator('.placement-duration').textContent()
+
   await matchingInformationPage.clickSubmit()
+
+  return { datesOfPlacement: { startDate, endDate }, duration, essentialCharacteristics, desirableCharacteristics }
 }
 
 export const checkAssessAnswers = async (page: Page) => {

--- a/e2e/steps/assess.ts
+++ b/e2e/steps/assess.ts
@@ -146,21 +146,29 @@ export const addMatchingInformation = async (page: Page) => {
 
   await matchingInformationPage.checkRadio('Standard AP')
 
-  await matchingInformationPage.checkRequirement('Is wheelchair designated', 'notRelevant')
-  await matchingInformationPage.checkRequirement('Is single', 'notRelevant')
-  await matchingInformationPage.checkRequirement('Is step free designated', 'notRelevant')
-  await matchingInformationPage.checkRequirement('Is catered', 'notRelevant')
-  await matchingInformationPage.checkRequirement('Has en suite', 'notRelevant')
-  await matchingInformationPage.checkRequirement('Is suited for sex offenders', 'notRelevant')
-  await matchingInformationPage.checkRequirement('Is arson designated', 'notRelevant')
+  const relevantRisksAndOffences = ['Is arson suitable']
+  const irrelevantRisksAndOffences = [
+    'Accepts sex offenders',
+    'Accepts non sexual child offenders',
+    'Is suitable for vulnerable',
+    'Accepts child sex offenders',
+    'Accepts hate crime offenders',
+    'Is arson designated',
+  ]
 
-  await matchingInformationPage.checkRequirement('Is suitable for vulnerable', 'notRelevant')
-  await matchingInformationPage.checkRequirement('Accepts sex offenders', 'notRelevant')
-  await matchingInformationPage.checkRequirement('Accepts child sex offenders', 'notRelevant')
-  await matchingInformationPage.checkRequirement('Accepts non sexual child offenders', 'notRelevant')
-  await matchingInformationPage.checkRequirement('Accepts hate crime offenders', 'notRelevant')
-  await matchingInformationPage.checkRequirement('Is arson suitable', 'notRelevant')
+  const essentialCharacteristics = ['Is wheelchair designated', 'Is single']
 
+  const desirableCharacteristics = ['Is catered', 'Has en suite']
+
+  const irrelevantCharacteristics = ['Is step free designated']
+
+  await matchingInformationPage.checkListOfRequirements(relevantRisksAndOffences, 'relevant')
+  await matchingInformationPage.checkListOfRequirements(irrelevantRisksAndOffences, 'notRelevant')
+  await matchingInformationPage.checkListOfRequirements(essentialCharacteristics, 'essential')
+  await matchingInformationPage.checkListOfRequirements(desirableCharacteristics, 'desirable')
+  await matchingInformationPage.checkListOfRequirements(irrelevantCharacteristics, 'notRelevant')
+
+  // Agree to the dates of placement
   await matchingInformationPage.checkRadio('Yes')
 
   const [startDate, endDate] = (await page.locator('.dates-of-placement').textContent()).split(' - ') as [
@@ -190,6 +198,16 @@ export const submitAssessment = async (page: Page) => {
 export const shouldSeeAssessmentConfirmationScreen = async (page: Page) => {
   const confirmationPage = new ConfirmationPage(page)
   await confirmationPage.shouldShowSuccessMessage()
+}
+
+export type E2EDatesOfPlacement = {
+  startDate: string
+  endDate: string
+}
+
+export type E2EPlacementCharacteristics = {
+  essentialCharacteristics: Array<string>
+  desirableCharacteristics: Array<string>
 }
 
 export const assessApplication = async (
@@ -255,8 +273,18 @@ export const assessApplication = async (
   await makeDecision(page, { acceptApplication })
 
   // And I provide matching information if application is accepted
+  let datesOfPlacement: undefined | E2EDatesOfPlacement
+  let duration: undefined | string
+  let placementCharacteristics: E2EPlacementCharacteristics
   if (acceptApplication) {
-    await addMatchingInformation(page)
+    const matchingInformation = await addMatchingInformation(page)
+
+    datesOfPlacement = matchingInformation.datesOfPlacement
+    duration = matchingInformation.duration
+    placementCharacteristics = {
+      essentialCharacteristics: matchingInformation.essentialCharacteristics,
+      desirableCharacteristics: matchingInformation.desirableCharacteristics,
+    }
   }
 
   // And I check my answers
@@ -267,6 +295,8 @@ export const assessApplication = async (
 
   // Then I should see a confirmation screen
   await shouldSeeAssessmentConfirmationScreen(page)
+
+  return { datesOfPlacement, duration, placementCharacteristics }
 }
 
 export const requestAndAddAdditionalInformation = async (

--- a/e2e/steps/match.ts
+++ b/e2e/steps/match.ts
@@ -2,6 +2,9 @@ import { Page } from '@playwright/test'
 import { TestOptions } from '@approved-premises/e2e'
 import { visitDashboard } from './apply'
 import { ConfirmPage, ConfirmationPage } from '../pages/match'
+import { CruDashboard } from '../pages/match/cruDashboard'
+import { E2EDatesOfPlacement } from './assess'
+import { PlacementRequestPage } from '../pages/workflow'
 
 export const confirmBooking = async (page: Page) => {
   const confirmPage = new ConfirmPage(page)
@@ -13,13 +16,37 @@ export const shouldShowBookingConfirmation = async (page: Page) => {
   await confirmationPage.shouldShowSuccessMessage()
 }
 
-export const matchAndBookApplication = async ({ page, person }: { page: Page; person: TestOptions['person'] }) => {
+export const matchAndBookApplication = async ({
+  page,
+  person,
+  datesOfPlacement,
+  duration,
+  isParole,
+  applicationDate,
+}: {
+  page: Page
+  person: TestOptions['person']
+  datesOfPlacement: E2EDatesOfPlacement
+  duration: string
+  isParole: boolean
+  applicationDate: string
+}) => {
   // Given I visit the Dashboard
   const dashboard = await visitDashboard(page)
 
   // And I click the link to the CRU Dashboard
   await dashboard.clickCruDashboard()
 
-  // And I confirm my booking
-  await confirmBooking(page)
+  const cruDashboard = new CruDashboard(page)
+
+  // And I select the placement request
+  cruDashboard.selectPlacementRequest({
+    applicationDate,
+    person,
+    arrivalDate: datesOfPlacement.startDate,
+    isParole,
+    lengthOfStay: duration,
+  })
+
+  const placementRequestPage = new PlacementRequestPage(page)
 }

--- a/e2e/steps/match.ts
+++ b/e2e/steps/match.ts
@@ -22,7 +22,4 @@ export const matchAndBookApplication = async ({ page, person }: { page: Page; pe
 
   // And I confirm my booking
   await confirmBooking(page)
-
-  // Then I should bee a confirmation screen
-  await shouldShowBookingConfirmation(page)
 }

--- a/e2e/steps/match.ts
+++ b/e2e/steps/match.ts
@@ -3,8 +3,11 @@ import { TestOptions } from '@approved-premises/e2e'
 import { visitDashboard } from './apply'
 import { ConfirmPage, ConfirmationPage } from '../pages/match'
 import { CruDashboard } from '../pages/match/cruDashboard'
-import { E2EDatesOfPlacement } from './assess'
+import { E2EDatesOfPlacement, E2EPlacementCharacteristics } from './assess'
 import { PlacementRequestPage } from '../pages/workflow'
+import { Premises } from '../../server/@types/shared'
+import { ApTypeLabel } from '../../server/utils/apTypeLabels'
+import { SearchScreen } from '../pages/match/searchScreen'
 
 export const confirmBooking = async (page: Page) => {
   const confirmPage = new ConfirmPage(page)
@@ -23,6 +26,10 @@ export const matchAndBookApplication = async ({
   duration,
   isParole,
   applicationDate,
+  apType,
+  preferredAps,
+  placementCharacteristics,
+  preferredPostcode,
 }: {
   page: Page
   person: TestOptions['person']
@@ -30,6 +37,10 @@ export const matchAndBookApplication = async ({
   duration: string
   isParole: boolean
   applicationDate: string
+  apType: ApTypeLabel
+  preferredAps: Array<Premises['name']>
+  preferredPostcode: string
+  placementCharacteristics: E2EPlacementCharacteristics
 }) => {
   // Given I visit the Dashboard
   const dashboard = await visitDashboard(page)
@@ -49,4 +60,33 @@ export const matchAndBookApplication = async ({
   })
 
   const placementRequestPage = new PlacementRequestPage(page)
+
+  // And I click the 'Search for a space' button
+  await placementRequestPage.clickSearchForASpace()
+
+  // Then I should see the search screen
+  const searchScreen = new SearchScreen(page)
+
+  // Should show details
+  searchScreen.shouldShowApplicationDetails({
+    preferredAps,
+    datesOfPlacement,
+    duration,
+    apType,
+    preferredPostcode,
+    placementCharacteristics,
+  })
+
+  // And I click the 'Update' button
+  await searchScreen.clickUpdate()
+
+  // Should show details again
+  searchScreen.shouldShowApplicationDetails({
+    preferredAps,
+    datesOfPlacement,
+    duration,
+    apType,
+    preferredPostcode,
+    placementCharacteristics,
+  })
 }

--- a/e2e/steps/match.ts
+++ b/e2e/steps/match.ts
@@ -1,23 +1,7 @@
 import { Page } from '@playwright/test'
 import { TestOptions } from '@approved-premises/e2e'
 import { visitDashboard } from './apply'
-import { ConfirmPage, ConfirmationPage, DetailsPage, ListPage, ResultsPage } from '../pages/match'
-
-export const searchForBed = async (page: Page, personName: string) => {
-  const dashboard = await visitDashboard(page)
-  await dashboard.clickMatch()
-
-  const listPage = new ListPage(page)
-  await listPage.clickFirstPlacementRequest(personName)
-
-  const detailsPage = new DetailsPage(page)
-  await detailsPage.clickSearch()
-}
-
-export const chooseBed = async (page: Page) => {
-  const resultsPage = new ResultsPage(page)
-  await resultsPage.chooseBed()
-}
+import { ConfirmPage, ConfirmationPage } from '../pages/match'
 
 export const confirmBooking = async (page: Page) => {
   const confirmPage = new ConfirmPage(page)
@@ -35,12 +19,6 @@ export const matchAndBookApplication = async ({ page, person }: { page: Page; pe
 
   // And I click the link to the CRU Dashboard
   await dashboard.clickCruDashboard()
-
-  // And I search for a bed
-  await searchForBed(page, person.name)
-
-  // And I select a matching bed
-  await chooseBed(page)
 
   // And I confirm my booking
   await confirmBooking(page)

--- a/e2e/steps/match.ts
+++ b/e2e/steps/match.ts
@@ -2,7 +2,6 @@ import { Page } from '@playwright/test'
 import { TestOptions } from '@approved-premises/e2e'
 import { visitDashboard } from './apply'
 import { ConfirmPage, ConfirmationPage, DetailsPage, ListPage, ResultsPage } from '../pages/match'
-import { assignPlacementRequestToMe } from './workflow'
 
 export const searchForBed = async (page: Page, personName: string) => {
   const dashboard = await visitDashboard(page)
@@ -34,8 +33,6 @@ export const matchAndBookApplication = async ({ page, person }: { page: Page; pe
   // Given I visit the Dashboard
   const dashboard = await visitDashboard(page)
 
-  // And I allocate the placement request to myself
-  await assignPlacementRequestToMe(dashboard, page, user.name, id)
 
   // And I search for a bed
   await searchForBed(page, person.name)

--- a/e2e/steps/match.ts
+++ b/e2e/steps/match.ts
@@ -30,10 +30,7 @@ export const shouldShowBookingConfirmation = async (page: Page) => {
   await confirmationPage.shouldShowSuccessMessage()
 }
 
-export const matchAndBookApplication = async (
-  { page, user, person }: { page: Page; user: TestOptions['user']; person: TestOptions['person'] },
-  id: string,
-) => {
+export const matchAndBookApplication = async ({ page, person }: { page: Page; person: TestOptions['person'] }) => {
   // Given I visit the Dashboard
   const dashboard = await visitDashboard(page)
 

--- a/e2e/steps/match.ts
+++ b/e2e/steps/match.ts
@@ -33,6 +33,8 @@ export const matchAndBookApplication = async ({ page, person }: { page: Page; pe
   // Given I visit the Dashboard
   const dashboard = await visitDashboard(page)
 
+  // And I click the link to the CRU Dashboard
+  await dashboard.clickCruDashboard()
 
   // And I search for a bed
   await searchForBed(page, person.name)

--- a/e2e/steps/placementApplication.ts
+++ b/e2e/steps/placementApplication.ts
@@ -107,7 +107,6 @@ export const reviewAndApprovePlacementApplication = async (
   await assignPlacementApplicationToMe(dashboard, page, user.name, applicationId)
 
   await visitDashboard(page)
-  await dashboard.clickMatch()
 
   const listPage = new MatchListPage(page)
   await listPage.clickPlacementApplications()

--- a/e2e/steps/workflow.ts
+++ b/e2e/steps/workflow.ts
@@ -1,7 +1,7 @@
 import { Page } from '@playwright/test'
 import { TestOptions } from '@approved-premises/e2e'
 import { DashboardPage } from '../pages/dashboardPage'
-import { AssessmentPage, ListPage, PlacementRequestPage } from '../pages/workflow'
+import { AssessmentPage, ListPage } from '../pages/workflow'
 
 export const assessmentShouldHaveCorrectDeadlineAndAllocatedUser = async (
   dashboard: DashboardPage,
@@ -27,20 +27,4 @@ export const assignAssessmentToMe = async (
 
   const assessmentPage = new AssessmentPage(page)
   await assessmentPage.selectStaffMember(userName)
-}
-
-export const assignPlacementRequestToMe = async (
-  dashboard: DashboardPage,
-  page: Page,
-  userName: string,
-  id: string,
-) => {
-  await dashboard.clickWorkflow()
-
-  const workflowListPage = new ListPage(page)
-  await workflowListPage.choosePlacementRequestWithId(id)
-
-  const placementRequestPage = new PlacementRequestPage(page)
-  await placementRequestPage.selectStaffMember(userName)
-  await placementRequestPage.clickSubmit()
 }

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -6,6 +6,7 @@ export const test = base.extend<TestOptions>({
     {
       name: 'Ben Davies',
       crn: 'X371199',
+      tier: 'D2S',
     },
     { option: true },
   ],

--- a/e2e/tests/apply/appeal.spec.ts
+++ b/e2e/tests/apply/appeal.spec.ts
@@ -11,7 +11,7 @@ import { signIn } from '../../steps/signIn'
 
 test('Record a successful appeal against a rejected application', async ({ page, person, oasysSections, assessor }) => {
   await signIn(page, assessor)
-  const id = await createApplication({ page, person, oasysSections, applicationType: 'standard' }, false, true)
+  const { id } = await createApplication({ page, person, oasysSections, applicationType: 'standard' }, false, true)
   await assessApplication({ page, assessor, person }, id, { acceptApplication: false })
   await recordAnAppealOnApplication(page, id, 'Appeal successful')
   await assessmentShouldBeAllocatedToCorrectUser(page, id, assessor.name)
@@ -25,7 +25,7 @@ test('Record an unsuccessful appeal against a rejected application', async ({
   assessor,
 }) => {
   await signIn(page, assessor)
-  const id = await createApplication({ page, person, oasysSections, applicationType: 'standard' }, false, true)
+  const { id } = await createApplication({ page, person, oasysSections, applicationType: 'standard' }, false, true)
   await assessApplication({ page, assessor, person }, id, { acceptApplication: false })
   await recordAnAppealOnApplication(page, id, 'Appeal unsuccessful')
   await verifyEmailSent(assessor.email, 'Approved Premises assessment appeal unsuccessful')

--- a/e2e/tests/apply/emergency-application.spec.ts
+++ b/e2e/tests/apply/emergency-application.spec.ts
@@ -13,11 +13,18 @@ test('Apply, assess, match and book an emergency application for an Approved Pre
   assessor,
 }) => {
   await signIn(page, assessor)
-  const id = await createApplication({ page, person, oasysSections, applicationType: 'emergency' }, true)
-  const { datesOfPlacement, duration } = await assessApplication({ page, assessor, person }, id, {
-    applicationType: 'emergency',
-    allocatedUser: emergencyApplicationUser,
-  })
+  const { id, preferredAps, apType, preferredPostcode } = await createApplication(
+    { page, person, oasysSections, applicationType: 'emergency' },
+    true,
+  )
+  const { datesOfPlacement, duration, placementCharacteristics } = await assessApplication(
+    { page, assessor, person },
+    id,
+    {
+      applicationType: 'emergency',
+      allocatedUser: emergencyApplicationUser,
+    },
+  )
 
   await matchAndBookApplication({
     page,
@@ -26,7 +33,9 @@ test('Apply, assess, match and book an emergency application for an Approved Pre
     duration,
     isParole: false,
     applicationDate: DateFormats.dateObjtoUIDate(new Date(), { format: 'short' }),
+    placementCharacteristics,
+    apType,
+    preferredAps,
+    preferredPostcode,
   })
-  // Skip match until it's back
-  // await matchAndBookApplication({ page, user, person }, id)
 })

--- a/e2e/tests/apply/emergency-application.spec.ts
+++ b/e2e/tests/apply/emergency-application.spec.ts
@@ -2,6 +2,8 @@ import { test } from '../../test'
 import { createApplication } from '../../steps/apply'
 import { assessApplication } from '../../steps/assess'
 import { signIn } from '../../steps/signIn'
+import { matchAndBookApplication } from '../../steps/match'
+import { DateFormats } from '../../../server/utils/dateUtils'
 
 test('Apply, assess, match and book an emergency application for an Approved Premises', async ({
   page,
@@ -12,9 +14,18 @@ test('Apply, assess, match and book an emergency application for an Approved Pre
 }) => {
   await signIn(page, assessor)
   const id = await createApplication({ page, person, oasysSections, applicationType: 'emergency' }, true)
-  await assessApplication({ page, assessor, person }, id, {
+  const { datesOfPlacement, duration } = await assessApplication({ page, assessor, person }, id, {
     applicationType: 'emergency',
     allocatedUser: emergencyApplicationUser,
+  })
+
+  await matchAndBookApplication({
+    page,
+    person,
+    datesOfPlacement,
+    duration,
+    isParole: false,
+    applicationDate: DateFormats.dateObjtoUIDate(new Date(), { format: 'short' }),
   })
   // Skip match until it's back
   // await matchAndBookApplication({ page, user, person }, id)

--- a/e2e/tests/apply/no-release-date.spec.ts
+++ b/e2e/tests/apply/no-release-date.spec.ts
@@ -17,8 +17,4 @@ test('Apply, assess, match and book an application for an Approved Premises with
   await assessApplication({ page, assessor, person }, id)
   await startAndCreatePlacementApplication({ page }, id)
   await withdrawPlacementApplication(page, id)
-
-  // Skip match until it's back
-  // await reviewAndApprovePlacementApplication({ page, user }, id)
-  // TODO: Match and book once approval is done
 })

--- a/e2e/tests/apply/no-release-date.spec.ts
+++ b/e2e/tests/apply/no-release-date.spec.ts
@@ -13,7 +13,7 @@ test('Apply, assess, match and book an application for an Approved Premises with
   assessor,
 }) => {
   await signIn(page, assessor)
-  const id = await createApplication({ page, person, oasysSections, applicationType: 'standard' }, false)
+  const { id } = await createApplication({ page, person, oasysSections, applicationType: 'standard' }, false)
   await assessApplication({ page, assessor, person }, id)
   await startAndCreatePlacementApplication({ page }, id)
   await withdrawPlacementApplication(page, id)

--- a/e2e/tests/apply/request-further-information.spec.ts
+++ b/e2e/tests/apply/request-further-information.spec.ts
@@ -11,6 +11,6 @@ test('Request further information on an Application, adds it and proceeds with t
   assessor,
 }) => {
   await signIn(page, assessor)
-  const id = await createApplication({ page, person, oasysSections, applicationType: 'standard' }, false)
+  const { id } = await createApplication({ page, person, oasysSections, applicationType: 'standard' }, false)
   await requestAndAddAdditionalInformation({ page, assessor, person }, id)
 })

--- a/e2e/tests/apply/short-notice-application.spec.ts
+++ b/e2e/tests/apply/short-notice-application.spec.ts
@@ -2,6 +2,8 @@ import { test } from '../../test'
 import { createApplication } from '../../steps/apply'
 import { assessApplication } from '../../steps/assess'
 import { signIn } from '../../steps/signIn'
+import { matchAndBookApplication } from '../../steps/match'
+import { DateFormats } from '../../../server/utils/dateUtils'
 
 test('Apply, assess, match and book an short notice application for an Approved Premises with a release date', async ({
   page,
@@ -12,10 +14,19 @@ test('Apply, assess, match and book an short notice application for an Approved 
 }) => {
   await signIn(page, assessor)
   const id = await createApplication({ page, person, oasysSections, applicationType: 'shortNotice' }, true, true)
-  await assessApplication({ page, assessor, person }, id, {
+  const { duration, datesOfPlacement } = await assessApplication({ page, assessor, person }, id, {
     applicationType: 'shortNotice',
     acceptApplication: true,
     allocatedUser: emergencyApplicationUser,
+  })
+
+  await matchAndBookApplication({
+    page,
+    person,
+    datesOfPlacement,
+    duration,
+    applicationDate: DateFormats.dateObjtoUIDate(new Date(), { format: 'short' }),
+    isParole: false,
   })
   // Skip match until it's back
   // await matchAndBookApplication({ page, user, person }, id)

--- a/e2e/tests/apply/short-notice-application.spec.ts
+++ b/e2e/tests/apply/short-notice-application.spec.ts
@@ -13,21 +13,31 @@ test('Apply, assess, match and book an short notice application for an Approved 
   assessor,
 }) => {
   await signIn(page, assessor)
-  const id = await createApplication({ page, person, oasysSections, applicationType: 'shortNotice' }, true, true)
-  const { duration, datesOfPlacement } = await assessApplication({ page, assessor, person }, id, {
-    applicationType: 'shortNotice',
-    acceptApplication: true,
-    allocatedUser: emergencyApplicationUser,
-  })
+  const { id, apType, preferredAps, preferredPostcode } = await createApplication(
+    { page, person, oasysSections, applicationType: 'shortNotice' },
+    true,
+    true,
+  )
+  const { duration, datesOfPlacement, placementCharacteristics } = await assessApplication(
+    { page, assessor, person },
+    id,
+    {
+      applicationType: 'shortNotice',
+      acceptApplication: true,
+      allocatedUser: emergencyApplicationUser,
+    },
+  )
 
   await matchAndBookApplication({
     page,
     person,
+    apType,
+    preferredAps,
     datesOfPlacement,
     duration,
+    preferredPostcode,
+    placementCharacteristics,
     applicationDate: DateFormats.dateObjtoUIDate(new Date(), { format: 'short' }),
     isParole: false,
   })
-  // Skip match until it's back
-  // await matchAndBookApplication({ page, user, person }, id)
 })

--- a/e2e/tests/apply/standard-application.spec.ts
+++ b/e2e/tests/apply/standard-application.spec.ts
@@ -2,6 +2,8 @@ import { test } from '../../test'
 import { createApplication } from '../../steps/apply'
 import { assessApplication } from '../../steps/assess'
 import { signIn } from '../../steps/signIn'
+import { matchAndBookApplication } from '../../steps/match'
+import { DateFormats } from '../../../server/utils/dateUtils'
 
 test('Apply, assess, match and book an application for an Approved Premises with a release date', async ({
   page,
@@ -11,7 +13,14 @@ test('Apply, assess, match and book an application for an Approved Premises with
 }) => {
   await signIn(page, assessor)
   const id = await createApplication({ page, person, oasysSections, applicationType: 'standard' }, true, true)
-  await assessApplication({ page, assessor, person }, id)
-  // Skip match until it's back
-  // await matchAndBookApplication({ page, user, person }, id)
+  const { datesOfPlacement, duration } = await assessApplication({ page, assessor, person }, id)
+  await matchAndBookApplication({
+    page,
+    person,
+    datesOfPlacement,
+    duration,
+
+    isParole: false,
+    applicationDate: DateFormats.dateObjtoUIDate(new Date(), { format: 'short' }),
+  })
 })

--- a/e2e/tests/apply/standard-application.spec.ts
+++ b/e2e/tests/apply/standard-application.spec.ts
@@ -12,14 +12,24 @@ test('Apply, assess, match and book an application for an Approved Premises with
   oasysSections,
 }) => {
   await signIn(page, assessor)
-  const id = await createApplication({ page, person, oasysSections, applicationType: 'standard' }, true, true)
-  const { datesOfPlacement, duration } = await assessApplication({ page, assessor, person }, id)
+  const { id, apType, preferredAps, preferredPostcode } = await createApplication(
+    { page, person, oasysSections, applicationType: 'standard' },
+    true,
+    true,
+  )
+  const { datesOfPlacement, duration, placementCharacteristics } = await assessApplication(
+    { page, assessor, person },
+    id,
+  )
   await matchAndBookApplication({
     page,
     person,
+    apType,
+    preferredAps,
     datesOfPlacement,
     duration,
-
+    preferredPostcode,
+    placementCharacteristics,
     isParole: false,
     applicationDate: DateFormats.dateObjtoUIDate(new Date(), { format: 'short' }),
   })

--- a/e2e/types/index.d.ts
+++ b/e2e/types/index.d.ts
@@ -17,6 +17,7 @@ declare module '@approved-premises/e2e' {
     person: {
       crn: string
       name: string
+      tier: string
     }
     personForAdHocBooking: {
       crn: string

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -181,7 +181,7 @@ export interface SummaryListActions {
 
 export interface SummaryListItem {
   key: TextItem | HtmlItem
-  value: TextItem | HtmlItem
+  value: (TextItem | HtmlItem) & { classes?: string }
   actions?: SummaryListActions
 }
 

--- a/server/form-pages/utils/matchingInformationUtils.test.ts
+++ b/server/form-pages/utils/matchingInformationUtils.test.ts
@@ -517,8 +517,11 @@ describe('matchingInformationUtils', () => {
 
           expect(suggestedStaySummaryListOptions(application)).toEqual({
             rows: [
-              { key: { text: 'Placement duration' }, value: { text: '1 week, 5 days' } },
-              { key: { text: 'Dates of placement' }, value: { text: 'Thu 7 Mar 2024 - Tue 19 Mar 2024' } },
+              { key: { text: 'Placement duration' }, value: { text: '1 week, 5 days', classes: 'placement-duration' } },
+              {
+                key: { text: 'Dates of placement' },
+                value: { text: 'Thu 7 Mar 2024 - Tue 19 Mar 2024', classes: 'dates-of-placement' },
+              },
             ],
           })
 
@@ -546,8 +549,11 @@ describe('matchingInformationUtils', () => {
 
           expect(suggestedStaySummaryListOptions(application)).toEqual({
             rows: [
-              { key: { text: 'Placement duration' }, value: { text: '1 week, 5 days' } },
-              { key: { text: 'Dates of placement' }, value: { text: 'Tue 7 May 2024 - Sun 19 May 2024' } },
+              { key: { text: 'Placement duration' }, value: { text: '1 week, 5 days', classes: 'placement-duration' } },
+              {
+                key: { text: 'Dates of placement' },
+                value: { text: 'Tue 7 May 2024 - Sun 19 May 2024', classes: 'dates-of-placement' },
+              },
             ],
           })
 
@@ -573,7 +579,9 @@ describe('matchingInformationUtils', () => {
           .mockReturnValue('no')
 
         expect(suggestedStaySummaryListOptions(application)).toEqual({
-          rows: [{ key: { text: 'Placement duration' }, value: { text: '1 week, 5 days' } }],
+          rows: [
+            { key: { text: 'Placement duration' }, value: { text: '1 week, 5 days', classes: 'placement-duration' } },
+          ],
         })
 
         expect(placementDurationFromApplication).toHaveBeenCalledWith(application)

--- a/server/form-pages/utils/matchingInformationUtils.ts
+++ b/server/form-pages/utils/matchingInformationUtils.ts
@@ -231,7 +231,9 @@ const defaultMatchingInformationValues = (
 const suggestedStaySummaryListOptions = (application: ApprovedPremisesApplication): SummaryList => {
   const duration = placementDurationFromApplication(application)
   const formattedDuration = DateFormats.formatDuration(daysToWeeksAndDays(duration))
-  const rows = [{ key: { text: 'Placement duration' }, value: { text: formattedDuration } }]
+  const rows: SummaryList['rows'] = [
+    { key: { text: 'Placement duration' }, value: { text: formattedDuration, classes: 'placement-duration' } },
+  ]
 
   const knownReleaseDate = retrieveQuestionResponseFromFormArtifact(application, ReleaseDate, 'knowReleaseDate')
 
@@ -249,7 +251,10 @@ const suggestedStaySummaryListOptions = (application: ApprovedPremisesApplicatio
     const placementDatesObject = placementDates(placementStartDate, duration.toString())
     const formattedStartDate = DateFormats.isoDateToUIDate(placementDatesObject.startDate)
     const formattedEndDate = DateFormats.isoDateToUIDate(placementDatesObject.endDate)
-    rows.push({ key: { text: 'Dates of placement' }, value: { text: `${formattedStartDate} - ${formattedEndDate}` } })
+    rows.push({
+      key: { text: 'Dates of placement' },
+      value: { text: `${formattedStartDate} - ${formattedEndDate}`, classes: 'dates-of-placement' },
+    })
   }
   return {
     rows,

--- a/server/utils/apTypeLabels.ts
+++ b/server/utils/apTypeLabels.ts
@@ -7,4 +7,6 @@ export const apTypeLabels: Record<ApType, string> = {
   rfap: 'Recovery Focused AP (RFAP)',
   mhapElliottHouse: 'Specialist Mental Health AP (Elliott House - Midlands)',
   mhapStJosephs: 'Specialist Mental Health AP (St Josephs - Greater Manchester)',
-}
+} as const
+
+export type ApTypeLabel = (typeof apTypeLabels)[ApType]


### PR DESCRIPTION
This reinstates and extends the Match transaction in the E2E tests. 
This transaction was previously disabled but now development work has started on it again. 
The search page filters don't currently function so these can't be tested.
What can be tested is the information shown when the matcher performs the search: 
<img width="1040" alt="image" src="https://github.com/user-attachments/assets/9c1cdb74-ae55-4401-9d44-22eb8a2c207b">
This information is pulled from Apply and Assess and we want to sure that it is populate correctly by the UI. This PR ensures that the information that is entered earlier in the journey is shown correctly. To do this we need to return the information from the earlier transactions and pass it to the Match transactions. This introduces a visible dependency between the tests but this existed previously it is just being made visible now. 

