### PR TITLE
Correct backlink on beds index page

### DIFF
--- a/server/views/v2Manage/premises/beds/index.njk
+++ b/server/views/v2Manage/premises/beds/index.njk
@@ -10,7 +10,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
 		text: "Back",
-		href: paths.premises.show({ premisesId: premisesId })
+		href: paths.v2Manage.premises.show({ premisesId: premisesId })
 	}) }}
 {% endblock %}
 


### PR DESCRIPTION
This was using the backlink from v1 but it should be v2
