### PR TITLE
Remove redundant placementRequestId from newSpaceBooking

### DIFF
--- a/server/controllers/match/placementRequests/spaceBookingsController.test.ts
+++ b/server/controllers/match/placementRequests/spaceBookingsController.test.ts
@@ -84,7 +84,6 @@ describe('SpaceBookingsController', () => {
         arrivalDate: newSpaceBooking.arrivalDate,
         departureDate: newSpaceBooking.departureDate,
         premisesId: newSpaceBooking.premisesId,
-        placementRequestId: id,
         apType: newSpaceBooking.requirements.apType,
         essentialCharacteristics: newSpaceBooking.requirements.essentialCharacteristics.toString(),
         desirableCharacteristics: newSpaceBooking.requirements.desirableCharacteristics.toString(),


### PR DESCRIPTION
As we also pass this as a URL param, it is redundant in the newSpaceBooking.

# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before

### After
