### PR TITLE
APS-1117: UI Implement User Version

### DIFF
--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -1,17 +1,11 @@
 import jwt from 'jsonwebtoken'
 import { Response } from 'superagent'
-import { faker } from '@faker-js/faker'
 
-import {
-  ApArea,
-  ApprovedPremisesUserPermission,
-  ProfileResponse,
-  ApprovedPremisesUserRole as UserRole,
-} from '../../server/@types/shared'
+import { ProfileResponse, User } from '@approved-premises/api'
 
 import { getMatchingRequests, stubFor } from './setup'
 import tokenVerification from './tokenVerification'
-import { apAreaFactory, userFactory } from '../../server/testutils/factories'
+import { userFactory } from '../../server/testutils/factories'
 import { userProfileFactory } from '../../server/testutils/factories/user'
 
 const createToken = () => {
@@ -151,24 +145,15 @@ export default {
   stubSignIn: (): Promise<[Response, Response, Response, Response, Response, Response]> =>
     Promise.all([favicon(), redirect(), signOut(), manageDetails(), token(), tokenVerification.stubVerifyToken()]),
   stubAuthUser: (
-    args: {
-      name?: string
-      userId?: string
-      roles?: Array<UserRole>
-      apArea?: ApArea
+    args: Partial<User> & {
       profile?: ProfileResponse
-      permissions?: Array<ApprovedPremisesUserPermission>
     } = {},
   ): Promise<Response> =>
     stubProfile(
       args.profile ||
         userProfileFactory.build({
           user: userFactory.build({
-            name: args.name || faker.person.fullName(),
-            id: args.userId || defaultUserId,
-            roles: args.roles || [],
-            permissions: args.permissions || [],
-            apArea: args.apArea || apAreaFactory.build(),
+            ...args,
             isActive: true,
           }),
         }),

--- a/integration_tests/mockApis/users.ts
+++ b/integration_tests/mockApis/users.ts
@@ -12,7 +12,7 @@ import paths from '../../server/paths/api'
 import { probationRegions } from '../../server/testutils/referenceData/stubs/referenceDataStubs'
 import { apAreaFactory } from '../../server/testutils/factories'
 
-const stubFindUser = (args: { user: User; id: string }) =>
+const stubFindUser = (args: { user: User; id: string; userVersion?: string }) =>
   stubFor({
     request: {
       method: 'GET',
@@ -22,7 +22,8 @@ const stubFindUser = (args: { user: User; id: string }) =>
       status: 200,
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
-        'x-cas-user-version': '321',
+        'x-cas-user-version': args.userVersion,
+        'x-cas-user-id': args.userVersion ? args.id : undefined,
       },
       jsonBody: args.user,
     },
@@ -115,7 +116,6 @@ const stubUsers = (args: {
       status: 200,
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
-        'x-cas-user-version': '123',
         'X-Pagination-TotalPages': '10',
         'X-Pagination-TotalResults': '100',
         'X-Pagination-PageSize': '10',
@@ -251,7 +251,6 @@ const stubApAreaReferenceData = (
       status: 200,
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
-        'x-cas-user-version': '123',
       },
       jsonBody: apAreas,
     },

--- a/integration_tests/mockApis/users.ts
+++ b/integration_tests/mockApis/users.ts
@@ -22,6 +22,7 @@ const stubFindUser = (args: { user: User; id: string }) =>
       status: 200,
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
+        'x-cas-user-version': '321',
       },
       jsonBody: args.user,
     },
@@ -114,6 +115,7 @@ const stubUsers = (args: {
       status: 200,
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
+        'x-cas-user-version': '123',
         'X-Pagination-TotalPages': '10',
         'X-Pagination-TotalResults': '100',
         'X-Pagination-PageSize': '10',
@@ -249,6 +251,7 @@ const stubApAreaReferenceData = (
       status: 200,
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
+        'x-cas-user-version': '123',
       },
       jsonBody: apAreas,
     },

--- a/integration_tests/pages/admin/userManagement/listPage.ts
+++ b/integration_tests/pages/admin/userManagement/listPage.ts
@@ -51,4 +51,8 @@ export default class ListPage extends Page {
   clickApplyFilter(): void {
     cy.get('button').contains('Apply filters').click()
   }
+
+  shouldShowReportsMenu(): void {
+    cy.get('a').contains('Reports')
+  }
 }

--- a/integration_tests/pages/admin/userManagement/listPage.ts
+++ b/integration_tests/pages/admin/userManagement/listPage.ts
@@ -51,8 +51,4 @@ export default class ListPage extends Page {
   clickApplyFilter(): void {
     cy.get('button').contains('Apply filters').click()
   }
-
-  shouldShowReportsMenu(): void {
-    cy.get('a').contains('Reports')
-  }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -554,4 +554,12 @@ export default abstract class Page {
       cy.get('.govuk-summary-list__value').should('contain', bedDetails.notes)
     }
   }
+
+  shouldShowMenuItem(label: string, visible = true): void {
+    cy.get('[aria-label="Primary navigation"] a').should(visible ? 'contain' : 'not.contain', label)
+  }
+
+  clickMenuItem(label: string): void {
+    cy.get('[aria-label="Primary navigation"] a').contains(label).click()
+  }
 }

--- a/integration_tests/tests/admin/userManagement.cy.ts
+++ b/integration_tests/tests/admin/userManagement.cy.ts
@@ -335,4 +335,27 @@ context('User management', () => {
     // Then the page should show the results for the second page
     page.shouldShowUsers(usersForResultsPage2)
   })
+
+  it('retrieve the updated user from api if version not matched to user in session and shows the new role added report viewer', () => {
+    // Given there are users in the DB
+    const users = userFactory.buildList(10, { roles: ['assessor'] })
+    const user = userFactory.build({ version: 345, roles: ['report_viewer'] })
+    const roles = ['manager', 'matcher', 'workflow_manager']
+    cy.task('stubFindUser', { user, id: users[0].id })
+    cy.task('stubUsers', { users })
+    cy.task('stubApAreaReferenceData')
+    cy.task('stubAuthUser', { roles })
+
+    // When I visit the list page
+    const listPage = ListPage.visit()
+
+    // Then I should see the users and their details
+    listPage.shouldShowUsers(users)
+
+    // And I click on user
+    listPage.clickUser(users[0].name)
+
+    // Then I should see the user with new report role
+    listPage.shouldShowReportsMenu()
+  })
 })

--- a/integration_tests/tests/admin/userManagement.cy.ts
+++ b/integration_tests/tests/admin/userManagement.cy.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesUserRole, UserQualification } from '../../../server/@types/shared'
+import { ApprovedPremisesUserRole, UserQualification } from '@approved-premises/api'
 import paths from '../../../server/paths/admin'
 import { userFactory } from '../../../server/testutils/factories'
 import ConfirmDeletionPage from '../../pages/admin/userManagement/confirmDeletionPage'
@@ -334,28 +334,5 @@ context('User management', () => {
 
     // Then the page should show the results for the second page
     page.shouldShowUsers(usersForResultsPage2)
-  })
-
-  it('retrieve the updated user from api if version not matched to user in session and shows the new role added report viewer', () => {
-    // Given there are users in the DB
-    const users = userFactory.buildList(10, { roles: ['assessor'] })
-    const user = userFactory.build({ version: 345, roles: ['report_viewer'] })
-    const roles = ['manager', 'matcher', 'workflow_manager']
-    cy.task('stubFindUser', { user, id: users[0].id })
-    cy.task('stubUsers', { users })
-    cy.task('stubApAreaReferenceData')
-    cy.task('stubAuthUser', { roles })
-
-    // When I visit the list page
-    const listPage = ListPage.visit()
-
-    // Then I should see the users and their details
-    listPage.shouldShowUsers(users)
-
-    // And I click on user
-    listPage.clickUser(users[0].name)
-
-    // Then I should see the user with new report role
-    listPage.shouldShowReportsMenu()
   })
 })

--- a/integration_tests/tests/apply/setup.ts
+++ b/integration_tests/tests/apply/setup.ts
@@ -12,7 +12,7 @@ import { defaultUserId } from '../../mockApis/auth'
 export const setup = () => {
   cy.task('reset')
   cy.task('stubSignIn')
-  cy.task('stubAuthUser', { userId: defaultUserId })
+  cy.task('stubAuthUser', { id: defaultUserId })
 
   // Given I am logged in
   cy.signIn()

--- a/integration_tests/tests/assess/list.cy.ts
+++ b/integration_tests/tests/assess/list.cy.ts
@@ -7,7 +7,7 @@ context('List assessments', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser', { roles: ['workflow_manager'] })
+    cy.task('stubAuthUser', { id: defaultUserId, roles: ['workflow_manager'] })
   })
 
   it('should list assessments', () => {

--- a/integration_tests/tests/match/placementApplications.cy.ts
+++ b/integration_tests/tests/match/placementApplications.cy.ts
@@ -32,7 +32,7 @@ context('Placement Applications', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser', { userId: defaultUserId, roles: ['workflow_manager'] })
+    cy.task('stubAuthUser', { id: defaultUserId, roles: ['workflow_manager'] })
   })
 
   beforeEach(() => {

--- a/integration_tests/tests/tasks/list.cy.ts
+++ b/integration_tests/tests/tasks/list.cy.ts
@@ -25,7 +25,7 @@ context('Task Allocation', () => {
   it('returns unauthorised if user does not have the cas1 view manage task permission', () => {
     // Given I am logged in without the required permissions
     const me = userFactory.build({ apArea })
-    cy.task('stubAuthUser', { roles: [], permissions: [], userId: me.id, apArea: me.apArea })
+    cy.task('stubAuthUser', { roles: [], permissions: [], id: me.id, apArea: me.apArea })
     cy.signIn()
 
     const path = paths.tasks.index({})

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "install-playwright": "npx playwright install",
     "security_audit": "npx audit-ci --config audit-ci.json",
     "int-test": "cypress run --config video=false",
-    "int-test-ui": "cypress open --e2e --browser chrome",
+    "int-test-ui": "cypress open --e2e --browser electron",
     "clean": "rm -rf dist build node_modules stylesheets",
     "start-test-wiremock": "docker-compose -f docker-compose-test.yml up -d",
     "generate-types": "script/generate-types",

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -45,6 +45,7 @@ import {
 interface TasklistPage {
   body: Record<string, unknown>
 }
+
 interface PersonService {}
 
 // A utility type that allows us to define an object with a date attribute split into
@@ -374,7 +375,7 @@ export type UserDetails = {
   permissions: Array<ApprovedPremisesUserPermission>
   active: boolean
   apArea: ApArea
-  version: number
+  version: string
 }
 
 export type PartnerAgencyDetails = {

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -374,6 +374,7 @@ export type UserDetails = {
   permissions: Array<ApprovedPremisesUserPermission>
   active: boolean
   apArea: ApArea
+  version: number
 }
 
 export type PartnerAgencyDetails = {

--- a/server/controllers/admin/userManagementController.test.ts
+++ b/server/controllers/admin/userManagementController.test.ts
@@ -5,7 +5,7 @@ import { ApAreaService, UserService } from '../../services'
 
 import UserManagementController from './userManagementController'
 import { qualifications, roles } from '../../utils/users'
-import { apAreaFactory, paginatedResponseFactory, userDetailsFactory, userFactory } from '../../testutils/factories'
+import { apAreaFactory, paginatedResponseFactory, userFactory } from '../../testutils/factories'
 import paths from '../../paths/admin'
 import { PaginatedResponse } from '../../@types/ui'
 import { ApprovedPremisesUser } from '../../@types/shared'
@@ -292,10 +292,6 @@ describe('UserManagementController', () => {
         qualifications: ['emergency'],
         roles: [...updatedRoles.roles, ...updatedRoles.allocationRoles],
       }
-      request.session.user = user
-      const userDetails = userDetailsFactory.build()
-      userService.getUserById.mockResolvedValue(user)
-      userService.getActingUser.mockResolvedValue(userDetails)
       const flash = jest.fn()
 
       const requestHandler = userManagementController.update()
@@ -320,7 +316,6 @@ describe('UserManagementController', () => {
       })
       expect(response.redirect).toHaveBeenCalledWith(paths.admin.userManagement.edit({ id: user.id }))
       expect(flash).toHaveBeenCalledWith('success', 'User updated')
-      expect(response.locals.user.roles).toEqual(userDetails.roles)
     })
   })
 

--- a/server/controllers/admin/userManagementController.ts
+++ b/server/controllers/admin/userManagementController.ts
@@ -66,9 +66,6 @@ export default class UserController {
         roles: [...flattenCheckboxInput(req.body.roles), ...flattenCheckboxInput(req.body.allocationPreferences)],
         qualifications: flattenCheckboxInput(req.body.qualifications),
       })
-      const user = await this.userService.getActingUser(res.locals.user.token)
-      req.session.user = user
-      res.locals.user = { ...user, ...res.locals.user }
 
       req.flash('success', 'User updated')
       res.redirect(paths.admin.userManagement.edit({ id: req.params.id }))

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -12,6 +12,7 @@ import type { UnsanitisedError } from '../sanitisedError'
 import { restClientMetricsMiddleware } from './restClientMetricsMiddleware'
 import { createQueryString } from '../utils/utils'
 import { PaginatedResponse } from '../@types/ui'
+import { userVersionMiddleware } from './userVersionMiddleware'
 
 interface GetRequest {
   path?: string
@@ -74,6 +75,7 @@ export default class RestClient {
         .get(`${this.apiUrl()}${path}`)
         .agent(this.agent)
         .use(restClientMetricsMiddleware)
+        .use(userVersionMiddleware)
         .retry(2, (err, res) => {
           if (res && res.statusCode === 503) {
             logger.info('Received 503, Not retrying')
@@ -87,7 +89,6 @@ export default class RestClient {
         .set({ ...this.defaultHeaders, ...headers })
         .responseType(responseType)
         .timeout(this.timeoutConfig())
-
       return raw ? result : result.body
     } catch (error) {
       const sanitisedError = sanitiseError(error as UnsanitisedError)
@@ -111,6 +112,7 @@ export default class RestClient {
         .delete(`${this.apiUrl()}${path}`)
         .agent(this.agent)
         .use(restClientMetricsMiddleware)
+        .use(userVersionMiddleware)
         .auth(this.token, { type: 'bearer' })
         .set({ ...this.defaultHeaders })
         .timeout(this.timeoutConfig())
@@ -131,6 +133,7 @@ export default class RestClient {
         .agent(this.agent)
         .auth(this.token, { type: 'bearer' })
         .use(restClientMetricsMiddleware)
+        .use(userVersionMiddleware)
         .retry(2, (err, res) => {
           if (res && res.statusCode === 503) {
             logger.info('Received 503, Not retrying')
@@ -168,6 +171,7 @@ export default class RestClient {
         .agent(this.agent)
         .auth(this.token, { type: 'bearer' })
         .use(restClientMetricsMiddleware)
+        .use(userVersionMiddleware)
         .retry(2, (err, res) => {
           if (res && res.statusCode === 503) {
             logger.info('Received 503, Not retrying')
@@ -236,6 +240,7 @@ export default class RestClient {
         .send(this.filterBlanksFromData(data))
         .agent(this.agent)
         .use(restClientMetricsMiddleware)
+        .use(userVersionMiddleware)
         .auth(this.token, { type: 'bearer' })
         .set({ ...this.defaultHeaders, ...headers })
         .responseType(responseType)

--- a/server/data/userClient.test.ts
+++ b/server/data/userClient.test.ts
@@ -34,7 +34,7 @@ describeClient('UserClient', provider => {
         },
       })
 
-      const output = await userClient.getActingUser(id)
+      const output = await userClient.getUser(id)
       expect(output).toEqual(user)
     })
   })

--- a/server/data/userClient.ts
+++ b/server/data/userClient.ts
@@ -21,7 +21,7 @@ export default class UserClient {
     this.restClient = new RestClient('userClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
-  async getActingUser(id: string): Promise<User> {
+  async getUser(id: string): Promise<User> {
     return (await this.restClient.get({ path: paths.users.show({ id }) })) as User
   }
 

--- a/server/data/userVersionMiddleware.test.ts
+++ b/server/data/userVersionMiddleware.test.ts
@@ -1,22 +1,34 @@
 import superagent from 'superagent'
 import nock from 'nock'
+import { faker } from '@faker-js/faker'
 import { userVersionMiddleware } from './userVersionMiddleware'
-import InMemoryStore from '../inMemoryStore'
+import inMemoryStore from '../inMemoryStore'
 
 describe('userVersionMiddleware', () => {
   afterEach(() => {
     jest.clearAllMocks()
+    inMemoryStore.users = {}
   })
 
-  describe('response headers', () => {
-    it('headers handling for x-cas-user-version to store in InMemoryStore for later retrieval', async () => {
-      const fakeApi = nock('https://httpbin.org/')
-      fakeApi.get('/', '').reply(200, {}, { 'x-cas-user-version': 'test' })
+  it('stores the user version in memory to compare it with session later', async () => {
+    const userId = faker.string.uuid()
+    const userVersion = faker.string.alphanumeric(8)
+    const fakeApi = nock('https://httpbin.org/')
+    fakeApi.get('/', '').reply(200, {}, { 'x-cas-user-id': userId, 'x-cas-user-version': userVersion })
 
-      const res = await superagent.get('https://httpbin.org/').use(userVersionMiddleware).set('accept', 'json')
+    await superagent.get('https://httpbin.org/').use(userVersionMiddleware).set('accept', 'json')
 
-      expect(res.headers['x-cas-user-version']).toBe(InMemoryStore.userVersion)
-      nock.cleanAll()
-    })
+    expect(inMemoryStore.users[userId]).toEqual(userVersion)
+    nock.cleanAll()
+  })
+
+  it('ignores responses without the user version headers', async () => {
+    const fakeApi = nock('https://httpbin.org/')
+    fakeApi.get('/', '').reply(200, {})
+
+    await superagent.get('https://httpbin.org/').use(userVersionMiddleware).set('accept', 'json')
+
+    expect(inMemoryStore.users).toEqual({})
+    nock.cleanAll()
   })
 })

--- a/server/data/userVersionMiddleware.test.ts
+++ b/server/data/userVersionMiddleware.test.ts
@@ -1,0 +1,22 @@
+import superagent from 'superagent'
+import nock from 'nock'
+import { userVersionMiddleware } from './userVersionMiddleware'
+import InMemoryStore from '../inMemoryStore'
+
+describe('userVersionMiddleware', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('response headers', () => {
+    it('headers handling for x-cas-user-version to store in InMemoryStore for later retrieval', async () => {
+      const fakeApi = nock('https://httpbin.org/')
+      fakeApi.get('/', '').reply(200, {}, { 'x-cas-user-version': 'test' })
+
+      const res = await superagent.get('https://httpbin.org/').use(userVersionMiddleware).set('accept', 'json')
+
+      expect(res.headers['x-cas-user-version']).toBe(InMemoryStore.userVersion)
+      nock.cleanAll()
+    })
+  })
+})

--- a/server/data/userVersionMiddleware.ts
+++ b/server/data/userVersionMiddleware.ts
@@ -1,0 +1,18 @@
+/* istanbul ignore file */
+
+import { Response, SuperAgentRequest } from 'superagent'
+import inMemoryStore from '../inMemoryStore'
+
+function userVersionMiddleware(agent: SuperAgentRequest) {
+  agent.on('request', ({ req }) => {
+    req.on('response', (res: Response, err: Error) => {
+      res.on('end', () => {
+        inMemoryStore.userVersion = res.headers['x-cas-user-version']
+      })
+    })
+  })
+
+  return agent
+}
+
+export { userVersionMiddleware }

--- a/server/data/userVersionMiddleware.ts
+++ b/server/data/userVersionMiddleware.ts
@@ -7,7 +7,9 @@ function userVersionMiddleware(agent: SuperAgentRequest) {
   agent.on('request', ({ req }) => {
     req.on('response', (res: Response, err: Error) => {
       res.on('end', () => {
-        inMemoryStore.userVersion = res.headers['x-cas-user-version']
+        if (res.headers['x-cas-user-id'] && res.headers['x-cas-user-version']) {
+          inMemoryStore.users[res.headers['x-cas-user-id']] = res.headers['x-cas-user-version']
+        }
       })
     })
   })

--- a/server/inMemoryStore.ts
+++ b/server/inMemoryStore.ts
@@ -1,0 +1,8 @@
+interface InMemoryStore {
+  userVersion: string
+}
+// will be used for data storage from api response that needed to be used later in the app
+const inMemoryStore: InMemoryStore = {
+  userVersion: '',
+}
+export default inMemoryStore

--- a/server/inMemoryStore.ts
+++ b/server/inMemoryStore.ts
@@ -1,8 +1,13 @@
+import { UserDetails } from '@approved-premises/ui'
+
 interface InMemoryStore {
-  userVersion: string
+  users: Record<UserDetails['id'], UserDetails['version']>
 }
-// will be used for data storage from api response that needed to be used later in the app
+
+// the in-memory store can be used for data that needs to persist across several sessions,
+// or where the session store cannot be used.
 const inMemoryStore: InMemoryStore = {
-  userVersion: '',
+  users: {},
 }
+
 export default inMemoryStore

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -21,7 +21,7 @@ export default function populateCurrentUser(userService: UserService): RequestHa
           }
         }
 
-        res.locals.user = { ...user, ...res.locals.user }
+        res.locals.user = { ...res.locals.user, ...user }
 
         if (!user) {
           logger.info('No user available')

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -53,13 +53,13 @@ describe('User service', () => {
       const id = 'SOME_ID'
       const user = userFactory.build()
 
-      userClient.getActingUser.mockResolvedValue(user)
+      userClient.getUser.mockResolvedValue(user)
 
       const result = await userService.getUserById(token, id)
 
       expect(result).toEqual(user)
 
-      expect(userClient.getActingUser).toHaveBeenCalledWith(id)
+      expect(userClient.getUser).toHaveBeenCalledWith(id)
     })
   })
 

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -35,7 +35,7 @@ export default class UserService {
       roles: user.roles,
       active: user.isActive,
       apArea: user.apArea,
-      version: user.version,
+      version: user.version.toString(),
     }
   }
 

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -35,6 +35,7 @@ export default class UserService {
       roles: user.roles,
       active: user.isActive,
       apArea: user.apArea,
+      version: user.version,
     }
   }
 

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -42,7 +42,7 @@ export default class UserService {
   async getUserById(token: string, id: string): Promise<User> {
     const client = this.userClientFactory(token)
 
-    return client.getActingUser(id)
+    return client.getUser(id)
   }
 
   async getUserList(token: string, roles: Array<UserRole> = []): Promise<Array<UserSummary>> {

--- a/server/testutils/factories/user.ts
+++ b/server/testutils/factories/user.ts
@@ -23,6 +23,7 @@ const userFactory = Factory.define<User>(() => ({
   service: 'ApprovedPremises',
   isActive: true,
   apArea: apAreaFactory.build(),
+  version: faker.number.int(),
 }))
 
 export const userSummaryFactory = Factory.define<UserSummary>(() => ({

--- a/server/testutils/factories/userDetails.ts
+++ b/server/testutils/factories/userDetails.ts
@@ -12,4 +12,5 @@ export default Factory.define<UserDetails>(() => ({
   roles: [],
   permissions: [],
   apArea: apAreaFactory.build(),
+  version: faker.number.int(),
 }))

--- a/server/testutils/factories/userDetails.ts
+++ b/server/testutils/factories/userDetails.ts
@@ -12,5 +12,5 @@ export default Factory.define<UserDetails>(() => ({
   roles: [],
   permissions: [],
   apArea: apAreaFactory.build(),
-  version: faker.number.int(),
+  version: faker.number.int().toString(),
 }))


### PR DESCRIPTION
This PR forces the currently logged in user details to be fetched from the API if a call to the API returns a changed version hash for this user. The version and user id are returned from the API for any call as the `x-cas-user-version` and `x-cas-user-version` headers.

Note that, due to the user authentication and session setup happening _before_ any call to the API, it is impossible to force a user refresh on the same request cycle as the API call that returns the new version. Instead, this cycle completes, then the user is updated on the next request.

# Context

https://dsdmoj.atlassian.net/browse/APS-1117
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes
No uI changes
### Before

### After
