### PR TITLE
APS-1167 Enable out of service beds report

### DIFF
--- a/server/utils/reportUtils.test.ts
+++ b/server/utils/reportUtils.test.ts
@@ -27,9 +27,16 @@ describe('reportUtils', () => {
         },
         {
           value: 'lostBeds',
-          text: 'Lost beds',
+          text: 'Lost beds (no longer in use)',
           hint: {
-            text: 'A report on all lost beds for that month and how long they were unavailable for.',
+            text: 'This report provides information on lost beds recorded before out of service beds functionality was enabled. This will be removed in the near future.',
+          },
+        },
+        {
+          value: 'outOfServiceBeds',
+          text: 'Out of service beds',
+          hint: {
+            text: 'A report of all out of service beds within the month and how long they were unavailable for.',
           },
         },
         {

--- a/server/utils/reportUtils.ts
+++ b/server/utils/reportUtils.ts
@@ -12,8 +12,12 @@ export const reportInputLabels = {
     hint: 'A raw data extract to help identify placement matching outcomes. This downloads Match requests based on the Expected Arrival Date.',
   },
   lostBeds: {
-    text: 'Lost beds',
-    hint: 'A report on all lost beds for that month and how long they were unavailable for.',
+    text: 'Lost beds (no longer in use)',
+    hint: 'This report provides information on lost beds recorded before out of service beds functionality was enabled. This will be removed in the near future.',
+  },
+  outOfServiceBeds: {
+    text: 'Out of service beds',
+    hint: 'A report of all out of service beds within the month and how long they were unavailable for.',
   },
   dailyMetrics: { text: 'Daily metrics', hint: 'Counts of key actions across the service grouped by day.' },
   applicationsV2: {


### PR DESCRIPTION
The out of service beds report will replace lost beds. As such, we have deprecated that report in this commit.

# Context

# Changes in this PR

## Screenshots of UI changes

### Before

![Screenshot 2024-08-09 at 09 18 52](https://github.com/user-attachments/assets/e5c17f35-139b-4ab8-83a0-69b448652ba5)

### After

![Screenshot 2024-08-09 at 09 17 42](https://github.com/user-attachments/assets/c1a5fae5-8c29-4e68-9d8c-b4a723f871ee)

