### PR TITLE
Reinstate short-notice-application test

### DIFF
--- a/e2e/pages/match/cruDashboard.ts
+++ b/e2e/pages/match/cruDashboard.ts
@@ -22,16 +22,18 @@ export class CruDashboard extends BasePage {
     applicationDate: string
     isParole: boolean
   }) {
+    const columns = [person.name, person.tier, lengthOfStay, applicationDate, isParole ? 'Parole' : 'Standard release']
+
+    if (arrivalDate) {
+      columns.push(arrivalDate)
+    }
+
     const placementRequestRow = this.page
       .getByRole('row')
       .filter({
         has:
-          this.page.getByRole('cell', { name: person.name }) &&
-          this.page.getByRole('cell', { name: person.tier }) &&
-          this.page.getByRole('cell', { name: arrivalDate }) &&
-          this.page.getByRole('cell', { name: lengthOfStay }) &&
-          this.page.getByRole('cell', { name: applicationDate }) &&
-          this.page.getByRole('cell', { name: isParole ? 'Parole' : 'Standard release' }),
+          columns.every(column => this.page.getByRole('cell', { name: column })) &&
+          this.page.getByRole('cell', { name: columns[columns.length] }),
       })
       .first()
     await placementRequestRow.getByRole('link').click()

--- a/e2e/pages/match/searchScreen.ts
+++ b/e2e/pages/match/searchScreen.ts
@@ -53,7 +53,7 @@ export class SearchScreen extends BasePage {
 
   async shouldShowDatesOfPlacement({ startDate, endDate }: E2EDatesOfPlacement, duration: string) {
     ;[startDate, endDate, duration].forEach(async date => {
-      await this.page.locator('.govuk-details').getByText(date).isVisible()
+      if (date) await this.page.locator('.govuk-details').getByText(date).isVisible()
     })
   }
 

--- a/e2e/steps/assess.ts
+++ b/e2e/steps/assess.ts
@@ -171,10 +171,12 @@ export const addMatchingInformation = async (page: Page) => {
   // Agree to the dates of placement
   await matchingInformationPage.checkRadio('Yes')
 
-  const [startDate, endDate] = (await page.locator('.dates-of-placement').textContent()).split(' - ') as [
-    string,
-    string,
-  ]
+  let startDate
+  let endDate
+
+  if (await page.locator('.dates-of-placement').isVisible()) {
+    ;[startDate, endDate] = (await page.locator('.dates-of-placement').textContent()).split(' - ') as [string, string]
+  }
   const duration = await page.locator('.placement-duration').textContent()
 
   await matchingInformationPage.clickSubmit()

--- a/e2e/tests/apply/short-notice-application.spec.ts
+++ b/e2e/tests/apply/short-notice-application.spec.ts
@@ -2,6 +2,8 @@ import { test } from '../../test'
 import { createApplication } from '../../steps/apply'
 import { assessApplication } from '../../steps/assess'
 import { signIn } from '../../steps/signIn'
+import { matchAndBookApplication } from '../../steps/match'
+import { DateFormats } from '../../../server/utils/dateUtils'
 
 test('Apply, assess, match and book an short notice application for an Approved Premises with a release date', async ({
   page,
@@ -11,23 +13,31 @@ test('Apply, assess, match and book an short notice application for an Approved 
   assessor,
 }) => {
   await signIn(page, assessor)
-  const { id } = await createApplication({ page, person, oasysSections, applicationType: 'shortNotice' }, true, true)
-  await assessApplication({ page, assessor, person }, id, {
-    applicationType: 'shortNotice',
-    acceptApplication: true,
-    allocatedUser: emergencyApplicationUser,
-  })
+  const { id, apType, preferredAps, preferredPostcode } = await createApplication(
+    { page, person, oasysSections, applicationType: 'shortNotice' },
+    true,
+    true,
+  )
+  const { duration, datesOfPlacement, placementCharacteristics } = await assessApplication(
+    { page, assessor, person },
+    id,
+    {
+      applicationType: 'shortNotice',
+      acceptApplication: true,
+      allocatedUser: emergencyApplicationUser,
+    },
+  )
 
-  // await matchAndBookApplication({
-  //   page,
-  //   person,
-  //   apType,
-  //   preferredAps,
-  //   datesOfPlacement,
-  //   duration,
-  //   preferredPostcode,
-  //   placementCharacteristics,
-  //   applicationDate: DateFormats.dateObjtoUIDate(new Date(), { format: 'short' }),
-  //   isParole: false,
-  // })
+  await matchAndBookApplication({
+    page,
+    person,
+    apType,
+    preferredAps,
+    datesOfPlacement,
+    duration,
+    preferredPostcode,
+    placementCharacteristics,
+    applicationDate: DateFormats.dateObjtoUIDate(new Date(), { format: 'short' }),
+    isParole: false,
+  })
 })


### PR DESCRIPTION
Previously we were trying to inspect the textContent of an element that was sometimes undefined which caused an error. Now we check if the item is defined before extracting the text content. 
This enables us to reinstate the short notice application test previously removed #2063 