### PR TITLE
Remove 'Create a placement' link for users with future_manager role

### DIFF
--- a/server/utils/premises/premisesActions.test.ts
+++ b/server/utils/premises/premisesActions.test.ts
@@ -24,11 +24,25 @@ describe('premisesActions', () => {
       })
     })
 
-    it('includes the CREATE PLACEMENT action', () => {
-      expect(premisesActions(user, premises)).toContainAction({
-        text: 'Create a placement',
-        classes: 'govuk-button--secondary',
-        href: paths.bookings.new({ premisesId: premises.id }),
+    describe('if the user doesnt have the future_manager role', () => {
+      it('includes the CREATE PLACEMENT action', () => {
+        expect(premisesActions(user, premises)).toContainAction({
+          text: 'Create a placement',
+          classes: 'govuk-button--secondary',
+          href: paths.bookings.new({ premisesId: premises.id }),
+        })
+      })
+    })
+
+    describe('if the user does have the future_manager role', () => {
+      it('does not include the CREATE PLACEMENT action', () => {
+        expect(
+          premisesActions(userDetails.build({ roles: ['workflow_manager', 'future_manager'] }), premises),
+        ).not.toContainAction({
+          text: 'Create a placement',
+          classes: 'govuk-button--secondary',
+          href: paths.bookings.new({ premisesId: premises.id }),
+        })
       })
     })
 

--- a/server/utils/premises/premisesActions.ts
+++ b/server/utils/premises/premisesActions.ts
@@ -23,7 +23,7 @@ export const premisesActions = (user: UserDetails, premises: Premises) => {
     })
   }
 
-  if (user.roles?.includes('workflow_manager')) {
+  if (user.roles?.includes('workflow_manager') && !user.roles?.includes('future_manager')) {
     actions.push({
       text: 'Create a placement',
       classes: 'govuk-button--secondary',


### PR DESCRIPTION
This link was showing in 'V2 Manage' which isn't needed and could be confusing to users.
We need to remove it.
Only users with the role 'future_manager' will see V2 Manage and those with that role will only see V2 Manage and not V1 so this logic should work for what we need.
