### PR TITLE
Remove 'Create a placement' link entirely

### DIFF
--- a/server/utils/premises/premisesActions.test.ts
+++ b/server/utils/premises/premisesActions.test.ts
@@ -24,28 +24,6 @@ describe('premisesActions', () => {
       })
     })
 
-    describe('if the user doesnt have the future_manager role', () => {
-      it('includes the CREATE PLACEMENT action', () => {
-        expect(premisesActions(user, premises)).toContainAction({
-          text: 'Create a placement',
-          classes: 'govuk-button--secondary',
-          href: paths.bookings.new({ premisesId: premises.id }),
-        })
-      })
-    })
-
-    describe('if the user does have the future_manager role', () => {
-      it('does not include the CREATE PLACEMENT action', () => {
-        expect(
-          premisesActions(userDetails.build({ roles: ['workflow_manager', 'future_manager'] }), premises),
-        ).not.toContainAction({
-          text: 'Create a placement',
-          classes: 'govuk-button--secondary',
-          href: paths.bookings.new({ premisesId: premises.id }),
-        })
-      })
-    })
-
     it('includes the MANAGE BEDS action', () => {
       expect(premisesActions(user, premises)).toContainAction({
         text: 'Manage beds',

--- a/server/utils/premises/premisesActions.ts
+++ b/server/utils/premises/premisesActions.ts
@@ -23,14 +23,6 @@ export const premisesActions = (user: UserDetails, premises: Premises) => {
     })
   }
 
-  if (user.roles?.includes('workflow_manager') && !user.roles?.includes('future_manager')) {
-    actions.push({
-      text: 'Create a placement',
-      classes: 'govuk-button--secondary',
-      href: paths.bookings.new({ premisesId: premises.id }),
-    })
-  }
-
   if (user.roles?.includes('manager')) {
     actions.push({
       text: 'View calendar',


### PR DESCRIPTION
#2069 removed the 'Create a placement' link for users with the 'workflow_manager' role but without the 'future_manager' role. We now want to remove the link for all users.
