### PR TITLE
Remove ‘manager’ and ‘legacy_manager’ options

### DIFF
--- a/e2e/pages/admin/editUser.ts
+++ b/e2e/pages/admin/editUser.ts
@@ -8,13 +8,11 @@ export type Qualification = (typeof qualifications)[number]
 export const roles = [
   'Administrator',
   'Assessor',
-  'Manage an Approved Premises',
   'Matcher',
   'Workflow manager',
   'Appeals manager',
   'Report viewer',
   'Future manager',
-  'Legacy manager',
   'Stop assessment allocations',
   'Stop match allocations',
   'Stop placement request allocations',

--- a/integration_tests/tests/admin/userManagement.cy.ts
+++ b/integration_tests/tests/admin/userManagement.cy.ts
@@ -22,7 +22,7 @@ context('User management', () => {
     // Given there are users in the DB
     const users = userFactory.buildList(10, { roles: ['assessor'] })
     const user = users[0]
-    const roles = ['manager', 'matcher', 'workflow_manager']
+    const roles = ['matcher', 'workflow_manager']
     cy.task('stubFindUser', { user, id: user.id })
     cy.task('stubUsers', { users })
     cy.task('stubApAreaReferenceData')
@@ -47,7 +47,7 @@ context('User management', () => {
 
     // When I update the user's roles and qualifications
     const updatedRoles = {
-      roles: ['manager', 'matcher', 'workflow_manager'] as const,
+      roles: ['matcher', 'workflow_manager'] as const,
       allocationRoles: [
         'excluded_from_assess_allocation',
         'excluded_from_match_allocation',

--- a/server/testutils/factories/user.ts
+++ b/server/testutils/factories/user.ts
@@ -40,7 +40,6 @@ const roleFactory = Factory.define<UserRole>(() =>
   faker.helpers.arrayElement([
     'assessor',
     'matcher',
-    'manager',
     'workflow_manager',
     'applicant',
     'role_admin',

--- a/server/utils/users/roleCheckboxes/index.test.ts
+++ b/server/utils/users/roleCheckboxes/index.test.ts
@@ -8,14 +8,14 @@ describe('roleCheckboxUtils', () => {
           [
             'assessor',
             'matcher',
-            'manager',
+            'janitor',
             'excluded_from_assess_allocation',
             'excluded_from_match_allocation',
             'excluded_from_placement_application_allocation',
           ],
           { returnOnlyAllocationRoles: false },
         ),
-      ).toEqual(['assessor', 'matcher', 'manager'])
+      ).toEqual(['assessor', 'matcher', 'janitor'])
     })
 
     it('when passed returnOnlyAllocationRoles = false filters out the non-allocation preferences roles', () => {
@@ -24,7 +24,7 @@ describe('roleCheckboxUtils', () => {
           [
             'assessor',
             'matcher',
-            'manager',
+            'janitor',
             'excluded_from_assess_allocation',
             'excluded_from_match_allocation',
             'excluded_from_placement_application_allocation',
@@ -42,23 +42,23 @@ describe('roleCheckboxUtils', () => {
   describe('roleCheckboxItem', () => {
     it('returns a checkbox object without a hint ', () => {
       expect(
-        roleCheckboxItem('manager', { manager: { label: 'test label' } } as RoleLabelDictionary, ['manager']),
+        roleCheckboxItem('janitor', { janitor: { label: 'test label' } } as RoleLabelDictionary, ['janitor']),
       ).toEqual({
         checked: true,
         text: 'test label',
-        value: 'manager',
+        value: 'janitor',
       })
     })
 
     it('returns a checkbox object with a hint', () => {
       expect(
-        roleCheckboxItem('manager', { manager: { label: 'test label', hint: 'test hint' } } as RoleLabelDictionary, [
-          'manager',
+        roleCheckboxItem('janitor', { janitor: { label: 'test label', hint: 'test hint' } } as RoleLabelDictionary, [
+          'janitor',
         ]),
       ).toEqual({
         checked: true,
         text: 'test label',
-        value: 'manager',
+        value: 'janitor',
         hint: { text: 'test hint' },
       })
     })

--- a/server/utils/users/roleCheckboxes/index.ts
+++ b/server/utils/users/roleCheckboxes/index.ts
@@ -4,10 +4,6 @@ import { CheckBoxItem } from '../../../@types/ui'
 export const roleLabelDictionary: RoleLabelDictionary = {
   role_admin: { label: 'Administrator' },
   assessor: { label: 'Assessor', hint: 'Assess Approved Premises applications' },
-  manager: {
-    label: 'Manage an Approved Premises (AP)',
-    hint: 'Mark arrivals, departures, and manage placements at an AP',
-  },
   matcher: { label: 'Matcher', hint: 'Match a person to a suitable AP for placement' },
   workflow_manager: {
     label: 'Workflow manager',
@@ -25,10 +21,6 @@ export const roleLabelDictionary: RoleLabelDictionary = {
     label: 'Report Viewer',
     hint: 'View and download reports',
   },
-  legacy_manager: {
-    label: 'Legacy manager',
-    hint: 'Manage an approved premises',
-  },
   future_manager: {
     label: 'Future manager',
     hint: 'For digital team use only',
@@ -45,7 +37,7 @@ export const allocationRoleLabelDictionary: AllocationRoleLabelDictionary = {
   excluded_from_placement_application_allocation: { label: 'Stop placement request allocations' },
 }
 
-type UnusedRoles = 'applicant' | 'user_manager'
+type UnusedRoles = 'applicant' | 'user_manager' | 'manager' | 'legacy_manager'
 export type RolesInUse = Exclude<UserRole, UnusedRoles>
 
 type RolesForCheckboxes = Exclude<UserRole, AllocationRole | UnusedRoles>
@@ -60,7 +52,6 @@ type AllocationRolesForCheckboxes = Exclude<UserRole, RolesForCheckboxes | Unuse
 export const roles: ReadonlyArray<RolesInUse> = [
   'role_admin',
   'assessor',
-  'manager',
   'matcher',
   'workflow_manager',
   'cru_member',
@@ -70,7 +61,6 @@ export const roles: ReadonlyArray<RolesInUse> = [
   'appeals_manager',
   'report_viewer',
   'future_manager',
-  'legacy_manager',
   'janitor',
 ]
 
@@ -80,7 +70,7 @@ export const allocationRoles = [
   'excluded_from_placement_application_allocation',
 ] as const
 
-export const unusedRoles = ['applicant'] as const
+export const unusedRoles = ['applicant', 'manager', 'legacy_manager'] as const
 
 export type AllocationRole = (typeof allocationRoles)[number]
 

--- a/server/utils/users/tableUtils.test.ts
+++ b/server/utils/users/tableUtils.test.ts
@@ -80,7 +80,6 @@ describe('tableUtils', () => {
         roles: [
           'assessor',
           'matcher',
-          'manager',
           'workflow_manager',
           'role_admin',
 
@@ -90,7 +89,7 @@ describe('tableUtils', () => {
         ],
       })
       expect(roleCell(user)).toEqual({
-        text: 'Assessor, Matcher, Manage an Approved Premises (AP), Workflow manager, Administrator',
+        text: 'Assessor, Matcher, Workflow manager, Administrator',
       })
     })
   })
@@ -101,7 +100,6 @@ describe('tableUtils', () => {
         roles: [
           'assessor',
           'matcher',
-          'manager',
           'workflow_manager',
           'applicant',
           'role_admin',

--- a/server/utils/users/userManagement.test.ts
+++ b/server/utils/users/userManagement.test.ts
@@ -103,7 +103,6 @@ describe('userRolesSelectOptions', () => {
       { selected: true, text: 'All roles', value: '' },
       { selected: false, text: 'Assessor', value: 'assessor' },
       { selected: false, text: 'Matcher', value: 'matcher' },
-      { selected: false, text: 'Manager', value: 'manager' },
       { selected: false, text: 'Workflow manager', value: 'workflow_manager' },
       { selected: false, text: 'CRU member', value: 'cru_member' },
       { selected: false, text: 'Role admin', value: 'role_admin' },
@@ -119,11 +118,6 @@ describe('userRolesSelectOptions', () => {
         selected: false,
         text: 'Appeals manager',
         value: 'appeals_manager',
-      },
-      {
-        selected: false,
-        text: 'Legacy manager',
-        value: 'legacy_manager',
       },
       {
         selected: false,
@@ -143,7 +137,6 @@ describe('userRolesSelectOptions', () => {
       { selected: false, text: 'All roles', value: '' },
       { selected: true, text: 'Assessor', value: 'assessor' },
       { selected: false, text: 'Matcher', value: 'matcher' },
-      { selected: false, text: 'Manager', value: 'manager' },
       { selected: false, text: 'Workflow manager', value: 'workflow_manager' },
       { selected: false, text: 'CRU member', value: 'cru_member' },
       { selected: false, text: 'Role admin', value: 'role_admin' },
@@ -159,11 +152,6 @@ describe('userRolesSelectOptions', () => {
         selected: false,
         text: 'Appeals manager',
         value: 'appeals_manager',
-      },
-      {
-        selected: false,
-        text: 'Legacy manager',
-        value: 'legacy_manager',
       },
       {
         selected: false,

--- a/server/utils/users/userManagement.ts
+++ b/server/utils/users/userManagement.ts
@@ -48,7 +48,6 @@ export const userSummaryListItems = (user: User) => [
 const userRoles: Record<RolesInUse, string> = {
   assessor: 'Assessor',
   matcher: 'Matcher',
-  manager: 'Manager',
   workflow_manager: 'Workflow manager',
   cru_member: 'CRU member',
   role_admin: 'Role admin',
@@ -57,7 +56,6 @@ const userRoles: Record<RolesInUse, string> = {
   excluded_from_match_allocation: 'Excluded from match allocation',
   excluded_from_placement_application_allocation: 'Excluded from placement application allocation',
   appeals_manager: 'Appeals manager',
-  legacy_manager: 'Legacy manager',
   future_manager: 'Future manager',
   janitor: 'Janitor',
 }


### PR DESCRIPTION
These two roles should no longer be used going forward. This commit removes them as options from the manage user page to ensure they are no longer assigned to users. Once this change is in production the roles will be removed from the API and we can then remove all references to them in the UI code.

# Context

# Changes in this PR

## Screenshots of UI changes

### Before

![Screenshot 2024-08-21 at 14 40 54](https://github.com/user-attachments/assets/c2e87d58-0c73-4090-b771-561a44df9a55)

### After

![Screenshot 2024-08-21 at 14 39 35](https://github.com/user-attachments/assets/a9289b95-9f6f-491e-acfe-72fa46a4966e)