### PR TITLE
APS-1174 - Replace the content on the AP list page with a link to the new destination

### DIFF
--- a/integration_tests/tests/manage/premises.cy.ts
+++ b/integration_tests/tests/manage/premises.cy.ts
@@ -5,11 +5,10 @@ import {
   dateCapacityFactory,
   extendedPremisesSummaryFactory,
   premisesBookingFactory,
-  premisesSummaryFactory,
 } from '../../../server/testutils/factories'
 import { DateFormats } from '../../../server/utils/dateUtils'
 
-import { CalendarPage, PremisesListPage, PremisesShowPage } from '../../pages/manage'
+import { CalendarPage, PremisesShowPage } from '../../pages/manage'
 import OverbookingPage from '../../pages/manage/overbooking'
 import { signIn } from '../signIn'
 import { fullPersonFactory } from '../../../server/testutils/factories/person'
@@ -17,23 +16,6 @@ import { fullPersonFactory } from '../../../server/testutils/factories/person'
 context('Premises', () => {
   beforeEach(() => {
     cy.task('reset')
-  })
-
-  describe('list', () => {
-    it('should list all premises', () => {
-      // Given I am logged in as legacy manager
-      signIn(['legacy_manager'])
-
-      const premises = premisesSummaryFactory.buildList(5)
-      cy.task('stubAllPremises', premises)
-      cy.task('stubApAreaReferenceData')
-
-      // When I visit the premises page
-      const page = PremisesListPage.visit()
-
-      // Then I should see all of the premises listed
-      page.shouldShowPremises(premises)
-    })
   })
 
   it('should show a single premises', () => {

--- a/server/views/premises/index.njk
+++ b/server/views/premises/index.njk
@@ -1,65 +1,12 @@
-{% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/select/macro.njk" import govukSelect %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Home" %}
+{% set pageTitle = applicationName + " - This page has been moved" %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-width">
-
-      <h1 class="govuk-heading-l">List of Approved Premises</h1>
-    </div>
-
-    <form action="{{ paths.premises.index({}) }}" method="post">
-      <div class="govuk-grid-column-one-quarter">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-
-        {{ govukSelect({
-              label: {
-              text: "Areas",
-              classes: "govuk-label--s"
-              },
-              classes: "govuk-input--width-20",
-              id: "selectedArea",
-              name: "selectedArea",
-              items: convertObjectsToSelectOptions(areas, 'All areas', 'name', 'id', 'selectedArea', '', context)
-          }) }}
-      </div>
-
-      <div class="govuk-grid-column-one-quarter">
-        {{ govukButton({
-                  "text": "Apply filter",
-                  "type": "submit",
-                  classes: "govuk-!-margin-top-6",
-                  preventDoubleClick: true
-              }) }}
-      </div>
-    </form>
-
-    <div class="govuk-grid-column-full-width">
-      {{
-      govukTable({
-        captionClasses: "govuk-table__caption--m",
-        firstCellIsHeader: true,
-        head: [
-          {
-            text: "Name"
-          },
-          {
-            text: "Code"
-          },
-          {
-            text: "Number of beds"
-          },
-          {
-            html: '<span class="govuk-visually-hidden">Actions</span>'
-          }
-        ],
-        rows: PremisesUtils.premisesTableRows(premisesSummaries)
-      })
-    }}
+      <h1 class="govuk-heading-l">This page has been moved</h1>
+      <p class="govuk-body"><a class="govuk-link" href="{{paths.v2Manage.premises.index({})}}">Please click this link to go to the new location</a></p>
     </div>
   </div>
 {% endblock %}

--- a/server/views/v2Manage/premises/index.njk
+++ b/server/views/v2Manage/premises/index.njk
@@ -12,7 +12,7 @@
       <h1 class="govuk-heading-l">List of Approved Premises</h1>
     </div>
 
-    <form action="{{ paths.premises.index({}) }}" method="post">
+    <form action="{{ paths.v2Manage.premises.index({}) }}" method="post">
       <div class="govuk-grid-column-one-quarter">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 


### PR DESCRIPTION
Replace the content on the AP list page with a link to the new destination

# Context
We do not want anyone to access the old screens
We cannot guarantee that users will not find the link to the old screen via bookmarks, browser history, or shared links
Instead of a redirect we’re using a link so that users know that things have moved and changed

# Changes in this PR
Updated view content
Removed integration tests as it is not needed and same test is run in another test with the new url


<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before
![Screenshot 2024-08-22 at 15 54 26](https://github.com/user-attachments/assets/af570aae-614e-45a2-81a6-882a3b96b88f)

### After
![Screenshot 2024-08-22 at 15 54 37](https://github.com/user-attachments/assets/2fa91018-4e9f-48a3-8f55-47fcb8ad5a04)
