### PR TITLE
APS-1275 enable legacy placements alongside space booking

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -17,7 +17,7 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_SERVICE_NAME: approved-premises
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
     COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
-    ENABLE_V2_MATCH: false
+    ENABLE_V2_MATCH: true
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/server/utils/placementRequests/adminIdentityBar.ts
+++ b/server/utils/placementRequests/adminIdentityBar.ts
@@ -62,12 +62,12 @@ export const adminActions = (
         href: matchPaths.v2Match.placementRequests.search.spaces({ id: placementRequest.id }),
         text: 'Search for a space',
       })
-    } else {
-      actions.unshift({
-        href: adminPaths.admin.placementRequests.bookings.new({ id: placementRequest.id }),
-        text: 'Create placement',
-      })
     }
+
+    actions.unshift({
+      href: adminPaths.admin.placementRequests.bookings.new({ id: placementRequest.id }),
+      text: 'Create placement',
+    })
   }
 
   return actions


### PR DESCRIPTION
# Context

# Changes in this PR

Whilst we develop the ‘search a space functionality’, we should ensure that the ‘Create placement’ functionality is always available to allow us to test the functionality that is currently in production

Given this change, we can now enable match and manage v2 functionality in pre-production, as it no longer blocks access to the placement functionality provided in production

## Screenshots of UI changes

### Before

![Screenshot 2024-09-09 at 15 27 34](https://github.com/user-attachments/assets/a9f448fd-6186-47c6-aff3-1de20cf2a29c)

### After

![Screenshot 2024-09-09 at 15 20 28](https://github.com/user-attachments/assets/858891cc-7389-4589-a696-d9a50e46a583)
