### PR TITLE
APS-1277 - Re-instate change booking date on view placement

### DIFF
--- a/server/utils/bookings/bookingActions.ts
+++ b/server/utils/bookings/bookingActions.ts
@@ -81,12 +81,23 @@ class MenuItems {
 export const v2BookingActions = (user: UserDetails, booking: Booking): Array<IdentityBarMenu> => {
   const menuItems = new MenuItems(booking)
 
-  if (booking.status === 'awaiting-arrival' && hasPermission(user, ['cas1_booking_withdraw']))
+  if (booking.status === 'awaiting-arrival') {
+    const items = []
+
+    if (hasPermission(user, ['cas1_booking_withdraw'])) {
+      items.push(menuItems.item('withdrawPlacement'))
+    }
+
+    if (hasPermission(user, ['cas1_booking_change_dates'])) {
+      items.push(menuItems.item('changeDates'))
+    }
+
     return [
       {
-        items: [menuItems.item('withdrawPlacement')],
+        items,
       },
     ]
+  }
 
   return []
 }
@@ -111,7 +122,7 @@ export const v1BookingActions = (user: UserDetails, booking: Booking): Array<Ide
         items.push(menuItems.item('withdrawPlacement'))
       }
 
-      if (usersRoles.includes('manager') || usersRoles.includes('legacy_manager')) {
+      if (hasPermission(user, ['cas1_booking_change_dates'])) {
         items.push(menuItems.item('changeDates'))
       }
     }

--- a/server/utils/bookings/bookingActionsByRole.test.ts
+++ b/server/utils/bookings/bookingActionsByRole.test.ts
@@ -69,9 +69,10 @@ describe('bookingUtils bookingActions by role', () => {
       })
     })
 
-    describe('when the user has the "manager" role', () => {
+    describe('when the user has the "manager" role and "cas1_booking_change_dates" permission', () => {
       const user = userDetailsFactory.build({
         roles: ['manager'],
+        permissions: ['cas1_booking_change_dates'],
       })
       const booking = bookingFactory.build()
 
@@ -132,9 +133,10 @@ describe('bookingUtils bookingActions by role', () => {
       })
     })
 
-    describe('when the user has the "legacy_manager" role', () => {
+    describe('when the user has the "legacy_manager" role and "cas1_booking_change_dates" permission', () => {
       const user = userDetailsFactory.build({
         roles: ['legacy_manager'],
+        permissions: ['cas1_booking_change_dates'],
       })
       const booking = bookingFactory.build()
 
@@ -190,6 +192,25 @@ describe('bookingUtils bookingActions by role', () => {
               premisesId: arrivedBooking.premises.id,
               bookingId: arrivedBooking.id,
             }),
+          })
+        })
+      })
+    })
+
+    describe('when the user has the "future_manager" role and the "cas1_booking_change_dates" permission', () => {
+      const user = userDetailsFactory.build({
+        roles: ['future_manager'],
+        permissions: ['cas1_booking_change_dates'],
+      })
+
+      describe('when booking has NOT arrived', () => {
+        const booking = bookingFactory.build()
+
+        it('includes the CHANGE DATES action', () => {
+          expect(bookingActions(user, booking)).toContainMenuItem({
+            text: 'Change placement dates',
+            classes: 'govuk-button--secondary',
+            href: paths.bookings.dateChanges.new({ premisesId: booking?.premises.id, bookingId: booking?.id }),
           })
         })
       })


### PR DESCRIPTION
This was removed as part of migration to future manager. This is still a required function so has been re-added via a permission assigned to future manager. Note that this functonality can also be accessed via the CRU Dashboard Placement Request View

# Context

## Screenshots of UI changes

### Before

![Screenshot 2024-09-10 at 08 52 57](https://github.com/user-attachments/assets/7c3f5932-8f49-4bca-9d3b-6a9d3ed692a4)

### After

![Screenshot 2024-09-10 at 08 51 00](https://github.com/user-attachments/assets/9330fc32-0333-4aab-96c5-4cfa42aa5869)
