### PR TITLE
APS-1275 - Reinstate placement E2E tests

### DIFF
--- a/e2e/pages/manage/cancellationPage.ts
+++ b/e2e/pages/manage/cancellationPage.ts
@@ -1,0 +1,15 @@
+import { Page, expect } from '@playwright/test'
+import { BasePage } from '../basePage'
+
+export class CancellationPage extends BasePage {
+  static async initialize(page: Page, title?: string) {
+    if (title) {
+      await expect(page.locator('h1')).toContainText(title)
+    }
+    return new CancellationPage(page)
+  }
+
+  async completeForm() {
+    await this.checkRadio('Probation Practitioner requested it')
+  }
+}

--- a/e2e/pages/manage/changePlacementDates.ts
+++ b/e2e/pages/manage/changePlacementDates.ts
@@ -1,0 +1,51 @@
+import { addMonths, getDate, getMonth, getYear } from 'date-fns'
+import { Page, expect } from '@playwright/test'
+import { BasePage } from '../basePage'
+
+export class ChangePlacementDatesPage extends BasePage {
+  static async initialize(page: Page, title?: string) {
+    if (title) {
+      await expect(page.locator('h1')).toContainText(title)
+    }
+    return new ChangePlacementDatesPage(page)
+  }
+
+  async selectAndEnterNewArrivalDate() {
+    const newDate = addMonths(new Date(), 2)
+    await this.page.getByLabel('Arrival date').check()
+    await this.page
+      .getByRole('group', { name: 'What is the new arrival date?' })
+      .getByLabel('Day')
+      .fill(getDate(newDate).toString())
+    await this.page
+      .getByRole('group', { name: 'What is the new arrival date?' })
+      .getByLabel('Month')
+      .fill((getMonth(newDate) + 1).toString())
+    await this.page
+      .getByRole('group', { name: 'What is the new arrival date?' })
+      .getByLabel('Year')
+      .fill(getYear(newDate).toString())
+  }
+
+  async selectAndEnterNewDepartureDate() {
+    const newDate = addMonths(new Date(), 3)
+    await this.page.getByLabel('Departure date').check()
+    await this.page
+      .getByRole('group', { name: 'What is the new departure date?' })
+      .getByLabel('Day')
+      .fill(getDate(newDate).toString())
+    await this.page
+      .getByRole('group', { name: 'What is the new departure date?' })
+      .getByLabel('Month')
+      .fill((getMonth(newDate) + 1).toString())
+    await this.page
+      .getByRole('group', { name: 'What is the new departure date?' })
+      .getByLabel('Year')
+      .fill(getYear(newDate).toString())
+  }
+
+  async completeForm() {
+    await this.selectAndEnterNewDepartureDate()
+    await this.selectAndEnterNewArrivalDate()
+  }
+}

--- a/e2e/pages/manage/confirmationPage.ts
+++ b/e2e/pages/manage/confirmationPage.ts
@@ -1,0 +1,16 @@
+import { expect } from '@playwright/test'
+import { BasePage } from '../basePage'
+
+export class ConfirmationPage extends BasePage {
+  async shouldShowPlacementSuccessMessage() {
+    await expect(this.page.locator('h1.govuk-panel__title')).toContainText('Placement confirmed')
+  }
+
+  async shouldShowBookingChangeSuccessMessage() {
+    await expect(this.page.locator('h3')).toContainText('Booking changed successfully')
+  }
+
+  async shouldShowDepartureDateChangedMessage() {
+    await expect(this.page.locator('h1.govuk-panel__title')).toContainText('Departure date updated')
+  }
+}

--- a/e2e/pages/manage/createPlacementPage.ts
+++ b/e2e/pages/manage/createPlacementPage.ts
@@ -1,0 +1,45 @@
+import { addDays, getDate, getMonth, getYear } from 'date-fns'
+import { BasePage } from '../basePage'
+
+export class CreatePlacementPage extends BasePage {
+  async enterArrivalDate() {
+    await this.page
+      .getByRole('group', { name: 'What is their expected arrival date?' })
+      .getByLabel('Day')
+      .fill(getDate(new Date()).toString())
+    await this.page
+      .getByRole('group', { name: 'What is their expected arrival date?' })
+      .getByLabel('Month')
+      .fill((getMonth(new Date()) + 1).toString())
+    await this.page
+      .getByRole('group', { name: 'What is their expected arrival date?' })
+      .getByLabel('Year')
+      .fill(getYear(new Date()).toString())
+  }
+
+  async enterExpectedDepartureDate() {
+    await this.page
+      .getByRole('group', { name: 'What is their expected departure date?' })
+      .getByLabel('Day')
+      .fill(getDate(addDays(new Date(), 1)).toString())
+
+    await this.page
+      .getByRole('group', { name: 'What is their expected departure date?' })
+      .getByLabel('Month')
+      .fill((getMonth(addDays(new Date(), 1)) + 1).toString())
+    await this.page
+      .getByRole('group', { name: 'What is their expected departure date?' })
+      .getByLabel('Year')
+      .fill(getYear(addDays(new Date(), 1)).toString())
+  }
+
+  async chooseIndexOffence() {
+    await this.page.getByRole('group', { name: 'Select an index offence' }).getByRole('radio').first().click()
+  }
+
+  async completeForm() {
+    await this.chooseIndexOffence()
+    await this.enterArrivalDate()
+    await this.enterExpectedDepartureDate()
+  }
+}

--- a/e2e/pages/manage/placementPage.ts
+++ b/e2e/pages/manage/placementPage.ts
@@ -1,0 +1,53 @@
+import { Page, expect } from '@playwright/test'
+import { BasePage } from '../basePage'
+
+export class PlacementPage extends BasePage {
+  static async initialize(page: Page, title?: string) {
+    if (title) {
+      await expect(page.locator('h1')).toContainText(title)
+    }
+    return new PlacementPage(page)
+  }
+
+  async clickMarkNotArrived() {
+    await this.clickActions()
+    await this.page.getByRole('menuitem', { name: 'Mark as not arrived' }).click()
+  }
+
+  async clickMovePersonToANewBed() {
+    await this.clickActions()
+    await this.page.getByRole('menuitem', { name: 'Move person to a new bed' }).click()
+  }
+
+  async clickMarkArrived() {
+    await this.clickActions()
+    await this.page.getByRole('menuitem', { name: 'Mark as arrived' }).click()
+  }
+
+  async clickMarkCancelled() {
+    await this.clickActions()
+    await this.page.getByRole('menuitem', { name: 'Withdraw placement' }).click()
+  }
+
+  async showsCancellationLoggedMessage() {
+    await this.page.waitForSelector('text=Booking withdrawn')
+  }
+
+  async clickChangePlacementDates() {
+    await this.clickActions()
+    await this.page.getByRole('menuitem', { name: 'Change placement dates' }).click()
+  }
+
+  async clickChangeDepartureDate() {
+    await this.clickActions()
+    await this.page.getByRole('menuitem', { name: 'Update departure date' }).click()
+  }
+
+  async showsNonArrivalLoggedMessage() {
+    await this.page.waitForSelector('text=Non-arrival logged')
+  }
+
+  async showsBedMoveLoggedMessage() {
+    await this.page.waitForSelector('text=Bed move logged')
+  }
+}

--- a/e2e/pages/manage/premisesListPage.ts
+++ b/e2e/pages/manage/premisesListPage.ts
@@ -12,4 +12,8 @@ export class PremisesListPage extends BasePage {
   async choosePremises(premisesName: string) {
     await this.page.getByRole('link', { name: `View about ${premisesName}`, exact: true }).click()
   }
+
+  async filterPremises(apArea: string) {
+    await this.page.getByLabel('Areas').selectOption({ label: apArea })
+  }
 }

--- a/e2e/pages/manage/premisesPage.ts
+++ b/e2e/pages/manage/premisesPage.ts
@@ -14,6 +14,33 @@ export class PremisesPage extends BasePage {
     await this.page.getByRole('menuitem', { name: 'Manage beds' }).click()
   }
 
+  async showsLostBedLoggedMessage() {
+    await this.page.getByRole('heading', { name: 'Success' })
+  }
+
+  async clickManageTodaysArrival() {
+    const table = this.page.getByRole('table', { name: 'Arriving Today' })
+    await table.getByRole('link', { name: 'Manage' }).first().click()
+  }
+
+  async clickGivenBooking(bookingId: string) {
+    await this.page.locator(`[data-cy-booking-id="${bookingId}"]`).first().click()
+  }
+
+  async clickManageCurrentResident() {
+    const table = this.page.getByRole('table', { name: 'Current residents' })
+    await table.getByRole('link', { name: 'Manage' }).first().click()
+  }
+
+  async showsArrivalLoggedMessage() {
+    await this.page.waitForSelector('text=Arrival logged')
+  }
+
+  async clickCreatePlacement() {
+    await this.clickActions()
+    await this.page.getByRole('menuitem', { name: 'Create a placement' }).click()
+  }
+
   async viewOutOfServiceBedRecords() {
     await this.page.getByRole('button', { name: 'Actions' }).click()
     await this.page.getByRole('menuitem', { name: 'Manage out of service bed records' }).click()

--- a/e2e/tests/manage-v1/create-and-manage-placements.spec.ts
+++ b/e2e/tests/manage-v1/create-and-manage-placements.spec.ts
@@ -1,0 +1,144 @@
+import { Page } from '@playwright/test'
+import { TestOptions } from '@approved-premises/e2e'
+import { test } from '../../test'
+import { visitDashboard } from '../../steps/apply'
+import { PremisesListPage } from '../../pages/manage/premisesListPage'
+import { PremisesPage } from '../../pages/manage/premisesPage'
+import { PlacementPage } from '../../pages/manage/placementPage'
+import { CancellationPage } from '../../pages/manage/cancellationPage'
+import { ConfirmationPage } from '../../pages/manage/confirmationPage'
+import { CRNPage } from '../../pages/apply'
+import { CreatePlacementPage } from '../../pages/manage/createPlacementPage'
+import { ChangePlacementDatesPage } from '../../pages/manage/changePlacementDates'
+import { signIn } from '../../steps/signIn'
+
+test.describe.configure({ mode: 'parallel' })
+
+const premisesName = 'Test AP 10'
+const apArea = 'South West & South Central'
+
+const navigateToPremisesPage = async (page: Page, { filterPremisesPage } = { filterPremisesPage: false }) => {
+  // Given I visit the dashboard
+  const dashboard = await visitDashboard(page)
+
+  // When I click the Manage link
+  await dashboard.clickManage()
+
+  // Then I should see the a list of premises
+  const listPage = await PremisesListPage.initialize(page, 'List of Approved Premises')
+
+  if (filterPremisesPage) {
+    await listPage.filterPremises(apArea)
+  }
+
+  // When I click on a Premises' 'View' link
+  await listPage.choosePremises(premisesName)
+}
+
+const navigateToGivenBooking = async (page: Page, bookingId: string) => {
+  await navigateToPremisesPage(page)
+
+  const premisesPage = await PremisesPage.initialize(page, premisesName)
+
+  await page.goto(`${premisesPage.page.url()}/bookings/${bookingId}`)
+}
+
+const manuallyBookPlacement = async ({
+  page,
+  person,
+  filterPremisesPage,
+}: {
+  page: Page
+  person: TestOptions['personForAdHocBooking']
+  filterPremisesPage?: boolean
+}) => {
+  const bookingId = () => {
+    const url = page.url()
+    return url.match(/bookings\/(.+)\/confirmation/)[1]
+  }
+
+  await navigateToPremisesPage(page, { filterPremisesPage })
+
+  // Then I should see the premises view page
+  const premisesPage = await PremisesPage.initialize(page, premisesName)
+
+  // And I navigate to create a placement
+  premisesPage.clickCreatePlacement()
+
+  // Given I am on the CRN entry page
+  const crnPage = new CRNPage(page)
+  // When I enter a CRN
+  await crnPage.enterCrn(person.crn)
+  await crnPage.clickSearch()
+
+  // Then I should see the placement page
+  // Given I am on the placement page
+  const createPlacementPage = new CreatePlacementPage(page)
+  // When I complete the form
+  await createPlacementPage.completeForm()
+  createPlacementPage.clickSubmit()
+
+  // Then I should be taken to the confirmation page
+  const confirmationPage = new ConfirmationPage(page)
+  await confirmationPage.shouldShowPlacementSuccessMessage()
+
+  return bookingId()
+}
+
+test('Manually create a placement', async ({ page, person, legacyManager }) => {
+  // Given I am signed in as a legacy manager
+  await signIn(page, legacyManager)
+
+  await manuallyBookPlacement({ page, person, filterPremisesPage: true })
+})
+
+test('Cancel a manually created placement', async ({ page, legacyManager, personForAdHocBooking }) => {
+  // Given I am signed in as a legacy manager
+  await signIn(page, legacyManager)
+
+  // And there is a placement for today
+  const bookingId = await manuallyBookPlacement({ page, person: personForAdHocBooking, filterPremisesPage: true })
+
+  await navigateToGivenBooking(page, bookingId)
+  // And I am on the placement's page
+  const placementPage = await PlacementPage.initialize(page, 'Placement details')
+
+  // When I click the 'Mark cancelled' link
+  await placementPage.clickMarkCancelled()
+
+  // Then I should see the cancellation form
+  const cancellationFormPage = await CancellationPage.initialize(page, 'Confirm withdrawn placement')
+
+  // When I complete the form
+  await cancellationFormPage.completeForm()
+  await cancellationFormPage.clickWithdraw()
+
+  // Then I should see the placement page with a banner
+  await placementPage.showsCancellationLoggedMessage()
+})
+
+test('Change placement dates', async ({ page, person, legacyManager }) => {
+  // Given I am signed in as a legacy manager
+  await signIn(page, legacyManager)
+
+  const bookingId = await manuallyBookPlacement({ page, person })
+
+  await navigateToGivenBooking(page, bookingId)
+
+  // And I am on the placement's page
+  const placementPage = await PlacementPage.initialize(page, 'Placement details')
+
+  // When I click the 'Extend' link
+  await placementPage.clickChangePlacementDates()
+
+  // Then I should see the extension form
+  const extensionFormPage = await ChangePlacementDatesPage.initialize(page, 'Update placement date')
+
+  // When I complete the form
+  await extensionFormPage.completeForm()
+  await extensionFormPage.clickSubmit()
+
+  // Then I should see the placement page with a banner
+  const confirmationPage = new ConfirmationPage(page)
+  await confirmationPage.shouldShowBookingChangeSuccessMessage()
+})


### PR DESCRIPTION
Last week some E2E tests related to placements were removed as changes to roles/permissions in the API and changes to screens in the UI meant they no longer worked (e.g. we no longer list placements when viewing a premise)

This commit reinstates tests that are still functionaly relevant and changes how they work to deal with the UI updates. It also moves them into a manage-v1 folder to differentiate them from the new manage-v2 functionality.

# Context

## Screenshots of UI changes

![Screenshot 2024-09-10 at 09 04 50](https://github.com/user-attachments/assets/1b954078-82da-4043-910f-933f275b4da0)

