### PR TITLE
Use single branch and PR for types generation

### DIFF
--- a/.github/workflows/generate-types.yml
+++ b/.github/workflows/generate-types.yml
@@ -30,5 +30,4 @@ jobs:
           commit-message: 'Updating hmpps-approved-premises-api models from OpenAPI specification'
           body: 'Updating hmpps-approved-premises-api models from OpenAPI specification.  This PR was created automatically from the generate-types.yml Workflow'
           delete-branch: true
-          branch-suffix: timestamp
           branch: update-api-types


### PR DESCRIPTION
[Copied from CAS3](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/951)

The .github/workflow/generate-types.yml GitHub Actions Workflow uses the [Create Pull Request](https://github.com/peter-evans/create-pull-request) GitHub Action. The current configuration specifies a suffix for the branch created (the ['alternative strategy'](https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#alternative-strategy---always-create-a-new-pull-request-branch)). This results in a new branch and PR being created every time the types are updated. As a result:

A great number of PRs are generated, making managing them difficult
When the latest PR is reviewed and merged, the older ones usually conflict, and therefore cannot be rebased and closed automatically
This PR switches to using the [default behaviour](https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#action-behaviour), which should use a unique branch (update-api-types) which will be created, updated and deleted by the action when necessary. This should result in an easier workflow with only one of those PRs at any one time.