### PR TITLE
APS-1229: Trim user input strings

### DIFF
--- a/server/middleware/setupRequestParsing.ts
+++ b/server/middleware/setupRequestParsing.ts
@@ -1,8 +1,10 @@
 import express, { Router } from 'express'
+import trimInput from './trimInput'
 
 export default function setUpWebRequestParsing(): Router {
   const router = express.Router()
   router.use(express.json())
   router.use(express.urlencoded({ extended: true }))
+  router.use(trimInput())
   return router
 }

--- a/server/middleware/trimInput.test.ts
+++ b/server/middleware/trimInput.test.ts
@@ -1,0 +1,74 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+import trimInput from './trimInput'
+
+describe('trimInput middleware', () => {
+  const token = 'SOME_TOKEN'
+  const dirtyData = {
+    foo: '  spaces and tabs and new lines  \n\n   ',
+    bar: '  ',
+  }
+  const cleanData = {
+    foo: 'spaces and tabs and new lines',
+    bar: '',
+  }
+
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  let next: DeepMocked<NextFunction>
+
+  beforeEach(() => {
+    request = createMock<Request>({})
+    response = createMock<Response>({ locals: { user: { token } } })
+    next = jest.fn()
+
+    jest.resetAllMocks()
+  })
+
+  it('trims the body properties for POST requests', async () => {
+    request.body = dirtyData
+    const middleware = trimInput()
+
+    await middleware(request, response, next)
+
+    expect(request.body).toEqual(cleanData)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('ignores non-string or nested properties', async () => {
+    const noStrings = {
+      foo: 123,
+      bar: { one: '  ' },
+    }
+    request.body = noStrings
+    const middleware = trimInput()
+
+    await middleware(request, response, next)
+
+    expect(request.body).toEqual(noStrings)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('trims the query params for GET requests', async () => {
+    request.query = dirtyData
+    const middleware = trimInput()
+
+    await middleware(request, response, next)
+
+    expect(request.query).toEqual(cleanData)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('ignores requests with no body or query params', async () => {
+    request.body = undefined
+    request.query = {}
+
+    const middleware = trimInput()
+
+    await middleware(request, response, next)
+
+    expect(request.body).toBeUndefined()
+    expect(request.query).toEqual({})
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/server/middleware/trimInput.ts
+++ b/server/middleware/trimInput.ts
@@ -1,0 +1,17 @@
+import { RequestHandler } from 'express'
+
+const trimStringValues = (body?: Record<string, unknown>) =>
+  body
+    ? Object.entries(body).forEach(([key, value]) => {
+        body[key] = typeof value === 'string' ? value.trim() : value
+      })
+    : undefined
+
+export default function trimInput(): RequestHandler {
+  return async (req, res, next) => {
+    trimStringValues(req.body)
+    trimStringValues(req.query)
+
+    next()
+  }
+}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1229

# Changes in this PR

This implements a new middleware to ensure blank strings (spaces, etc) cannot be used to bypass form input required validation, by actively trimming any string user input provided in GET or POST requests.

## Screenshots of UI changes

n/a
