### PR TITLE
APS-1227 Conflict error for out-of-service beds with correct link

### DIFF
--- a/integration_tests/components/bedspaceConflictErrorComponent.ts
+++ b/integration_tests/components/bedspaceConflictErrorComponent.ts
@@ -3,17 +3,18 @@ import errorLookups from '../../server/i18n/en/errors.json'
 import Page from '../pages/page'
 import BookingShowPage from '../pages/manage/booking/show'
 import { OutOfServiceBedShowPage } from '../pages/v2Manage/outOfServiceBeds/outOfServiceBedShow'
+import { EntityType } from '../../server/@types/ui'
 
 export default class BedspaceConflictErrorComponent {
   constructor(
     private readonly premisesId: string,
-    private readonly source: 'booking' | 'lost-bed',
+    private readonly source: EntityType,
   ) {}
 
   shouldShowDateConflictErrorMessages(
     fields: Array<string>,
     conflictingEntity: Booking | LostBed | Cas1OutOfServiceBed,
-    conflictingEntityType: 'booking' | 'lost-bed',
+    conflictingEntityType: EntityType,
   ): void {
     fields.forEach(field => {
       cy.get(`[data-cy-error-${field}]`).should('contain', errorLookups[field].conflict)
@@ -36,7 +37,7 @@ export default class BedspaceConflictErrorComponent {
     cy.go('back')
   }
 
-  private getTitle(fields: Array<string>, conflictingEntityType: 'booking' | 'lost-bed'): string {
+  private getTitle(fields: Array<string>, conflictingEntityType: EntityType): string {
     return (
       conflictingEntityType === 'lost-bed'
         ? 'Out of service bed record cannot be created for the $date$ entered'
@@ -44,7 +45,7 @@ export default class BedspaceConflictErrorComponent {
     ).replace('$date$', fields.length === 1 ? 'date' : 'dates')
   }
 
-  private getMessage(fields: Array<string>, conflictingEntityType: 'booking' | 'lost-bed'): string {
+  private getMessage(fields: Array<string>, conflictingEntityType: EntityType): string {
     const noun = conflictingEntityType === 'booking' ? 'booking' : 'out of service beds record'
 
     return fields.length === 1 ? `It conflicts with an existing ${noun}` : `They conflict with an existing ${noun}`

--- a/integration_tests/components/bedspaceConflictErrorComponent.ts
+++ b/integration_tests/components/bedspaceConflictErrorComponent.ts
@@ -30,7 +30,7 @@ export default class BedspaceConflictErrorComponent {
     if (conflictingEntityType === 'booking') {
       Page.verifyOnPage(BookingShowPage, [this.premisesId, conflictingEntity as Booking])
     } else {
-      Page.verifyOnPage(OutOfServiceBedShowPage, this.premisesId, conflictingEntity as OutOfServiceBed)
+      Page.verifyOnPage(OutOfServiceBedShowPage, this.premisesId, conflictingEntity as Cas1OutOfServiceBed)
     }
 
     cy.go('back')

--- a/integration_tests/components/bedspaceConflictErrorComponent.ts
+++ b/integration_tests/components/bedspaceConflictErrorComponent.ts
@@ -2,7 +2,7 @@ import type { Booking, Cas1OutOfServiceBed, LostBed } from '@approved-premises/a
 import errorLookups from '../../server/i18n/en/errors.json'
 import Page from '../pages/page'
 import BookingShowPage from '../pages/manage/booking/show'
-import LostBedShowPage from '../pages/manage/lostBedShow'
+import { OutOfServiceBedShowPage } from '../pages/v2Manage/outOfServiceBeds/outOfServiceBedShow'
 
 export default class BedspaceConflictErrorComponent {
   constructor(
@@ -19,7 +19,7 @@ export default class BedspaceConflictErrorComponent {
       cy.get(`[data-cy-error-${field}]`).should('contain', errorLookups[field].conflict)
     })
 
-    const title = this.getTitle(fields)
+    const title = this.getTitle(fields, conflictingEntityType)
     const message = this.getMessage(fields, conflictingEntityType)
 
     cy.get('.govuk-error-summary h2').should('contain', title)
@@ -30,20 +30,22 @@ export default class BedspaceConflictErrorComponent {
     if (conflictingEntityType === 'booking') {
       Page.verifyOnPage(BookingShowPage, [this.premisesId, conflictingEntity as Booking])
     } else {
-      Page.verifyOnPage(LostBedShowPage, conflictingEntity as LostBed)
+      Page.verifyOnPage(OutOfServiceBedShowPage, this.premisesId, conflictingEntity as OutOfServiceBed)
     }
 
     cy.go('back')
   }
 
-  private getTitle(fields: Array<string>): string {
-    return fields.length === 1
-      ? 'This bedspace is not available for the date entered'
-      : 'This bedspace is not available for the dates entered'
+  private getTitle(fields: Array<string>, conflictingEntityType: 'booking' | 'lost-bed'): string {
+    return (
+      conflictingEntityType === 'lost-bed'
+        ? 'Out of service bed record cannot be created for the $date$ entered'
+        : 'This bedspace is not available for the $date$ entered'
+    ).replace('$date$', fields.length === 1 ? 'date' : 'dates')
   }
 
   private getMessage(fields: Array<string>, conflictingEntityType: 'booking' | 'lost-bed'): string {
-    const noun = conflictingEntityType === 'booking' ? 'booking' : 'lost bed'
+    const noun = conflictingEntityType === 'booking' ? 'booking' : 'out of service beds record'
 
     return fields.length === 1 ? `It conflicts with an existing ${noun}` : `They conflict with an existing ${noun}`
   }

--- a/integration_tests/mockApis/booking.ts
+++ b/integration_tests/mockApis/booking.ts
@@ -1,5 +1,6 @@
 import type { Booking } from '@approved-premises/api'
 
+import { EntityType } from '../../server/@types/ui'
 import { getMatchingRequests, stubFor } from './setup'
 import { bedspaceConflictResponseBody, errorStub } from './utils'
 import paths from '../../server/paths/api'
@@ -22,7 +23,7 @@ export default {
   stubBookingCreateConflictError: (args: {
     premisesId: string
     conflictingEntityId: string
-    conflictingEntityType: 'booking' | 'lost-bed'
+    conflictingEntityType: EntityType
   }) =>
     stubFor({
       request: {

--- a/integration_tests/mockApis/lostBed.ts
+++ b/integration_tests/mockApis/lostBed.ts
@@ -6,6 +6,7 @@ import { getMatchingRequests, stubFor } from './setup'
 import { bedspaceConflictResponseBody, errorStub } from './utils'
 import { lostBedReasons } from '../../server/testutils/referenceData/stubs/referenceDataStubs'
 import paths from '../../server/paths/api'
+import { EntityType } from '../../server/@types/ui'
 
 export default {
   stubLostBedCreate: (args: { premisesId: string; lostBed: LostBed }): SuperAgentRequest =>
@@ -86,7 +87,7 @@ export default {
   stubLostBedConflictError: (args: {
     premisesId: string
     conflictingEntityId: string
-    conflictingEntityType: 'booking' | 'lost-bed'
+    conflictingEntityType: EntityType
   }) =>
     stubFor({
       request: {

--- a/integration_tests/mockApis/utils.ts
+++ b/integration_tests/mockApis/utils.ts
@@ -54,7 +54,7 @@ const errorStub = (fields: Array<string>, pattern: string, method: 'PUT' | 'POST
 const bedspaceConflictResponseBody = (entityId: string | LostBed, entityType: 'booking' | 'lost-bed') => ({
   title: 'Conflict',
   status: 409,
-  detail: `${entityType === 'booking' ? 'Booking' : 'Lost Bed'}: ${entityId}`,
+  detail: `${entityType === 'booking' ? 'Booking' : 'out-of-service bed'}: ${entityId}`,
 })
 
 export { getCombinations, errorStub, bedspaceConflictResponseBody }

--- a/integration_tests/mockApis/utils.ts
+++ b/integration_tests/mockApis/utils.ts
@@ -1,4 +1,5 @@
 import { LostBed } from '@approved-premises/api'
+import { EntityType } from '../../server/@types/ui'
 
 const getCombinations = (arr: Array<string>) => {
   const result: Array<Array<string>> = []
@@ -51,7 +52,7 @@ const errorStub = (fields: Array<string>, pattern: string, method: 'PUT' | 'POST
   }
 }
 
-const bedspaceConflictResponseBody = (entityId: string | LostBed, entityType: 'booking' | 'lost-bed') => ({
+const bedspaceConflictResponseBody = (entityId: string | LostBed, entityType: EntityType) => ({
   title: 'Conflict',
   status: 409,
   detail: `${entityType === 'booking' ? 'Booking' : 'out-of-service bed'}: ${entityId}`,

--- a/integration_tests/pages/manage/booking/new.ts
+++ b/integration_tests/pages/manage/booking/new.ts
@@ -2,6 +2,7 @@ import type { ActiveOffence, Booking, FullPerson, LostBed } from '@approved-prem
 import BedspaceConflictErrorComponent from '../../../components/bedspaceConflictErrorComponent'
 import Page, { PageElement } from '../../page'
 import paths from '../../../../server/paths/manage'
+import { EntityType } from '../../../../server/@types/ui'
 
 export default class BookingNewPage extends Page {
   private readonly bedspaceConflictErrorComponent: BedspaceConflictErrorComponent
@@ -80,10 +81,7 @@ export default class BookingNewPage extends Page {
     cy.get(`input[name="eventNumber"][value="${offence.deliusEventNumber}"]`).click()
   }
 
-  shouldShowDateConflictErrorMessages(
-    conflictingEntity: Booking | LostBed,
-    conflictingEntityType: 'booking' | 'lost-bed',
-  ): void {
+  shouldShowDateConflictErrorMessages(conflictingEntity: Booking | LostBed, conflictingEntityType: EntityType): void {
     this.bedspaceConflictErrorComponent.shouldShowDateConflictErrorMessages(
       ['arrivalDate', 'departureDate'],
       conflictingEntity,

--- a/integration_tests/pages/manage/lostBedCreate.ts
+++ b/integration_tests/pages/manage/lostBedCreate.ts
@@ -3,6 +3,7 @@ import paths from '../../../server/paths/manage'
 
 import Page from '../page'
 import BedspaceConflictErrorComponent from '../../components/bedspaceConflictErrorComponent'
+import { EntityType } from '../../../server/@types/ui'
 
 export default class LostBedCreatePage extends Page {
   private readonly bedspaceConflictErrorComponent: BedspaceConflictErrorComponent
@@ -41,10 +42,7 @@ export default class LostBedCreatePage extends Page {
     cy.get('[name="lostBed[submit]"]').click()
   }
 
-  shouldShowDateConflictErrorMessages(
-    conflictingEntity: Booking | LostBed,
-    conflictingEntityType: 'booking' | 'lost-bed',
-  ): void {
+  shouldShowDateConflictErrorMessages(conflictingEntity: Booking | LostBed, conflictingEntityType: EntityType): void {
     this.bedspaceConflictErrorComponent.shouldShowDateConflictErrorMessages(
       ['startDate', 'endDate'],
       conflictingEntity,

--- a/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedCreate.ts
+++ b/integration_tests/pages/v2Manage/outOfServiceBeds/outOfServiceBedCreate.ts
@@ -3,6 +3,7 @@ import paths from '../../../../server/paths/manage'
 
 import Page from '../../page'
 import BedspaceConflictErrorComponent from '../../../components/bedspaceConflictErrorComponent'
+import { EntityType } from '../../../../server/@types/ui'
 
 export class OutOfServiceBedCreatePage extends Page {
   private readonly bedspaceConflictErrorComponent: BedspaceConflictErrorComponent
@@ -44,7 +45,7 @@ export class OutOfServiceBedCreatePage extends Page {
 
   shouldShowDateConflictErrorMessages(
     conflictingEntity: Booking | OutOfServiceBed,
-    conflictingEntityType: 'booking' | 'lost-bed',
+    conflictingEntityType: EntityType,
   ): void {
     this.bedspaceConflictErrorComponent.shouldShowDateConflictErrorMessages(
       ['startDate', 'endDate'],

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -513,3 +513,5 @@ export type KeyDetailsArgs = {
 export type TaskSearchQualification = Exclude<UserQualification, 'lao'>
 
 export type BackwardsCompatibleApplyApType = ApType | 'standard'
+
+export type EntityType = 'booking' | 'lost-bed'

--- a/server/utils/bookings/index.test.ts
+++ b/server/utils/bookings/index.test.ts
@@ -196,9 +196,9 @@ describe('bookingUtils', () => {
   })
 
   describe('generateConflictBespokeError', () => {
-    const bookingId = 'bookingId'
-    const bedId = 'bedId'
-    const lostBedId = 'lostBedId'
+    const bookingId = 'booking-id'
+    const bedId = 'bed-id'
+    const lostBedId = 'lost-bed-id'
 
     it('generates a bespoke error when there is a conflicting booking', () => {
       const err = {
@@ -220,22 +220,23 @@ describe('bookingUtils', () => {
       })
     })
 
-    it('generates a bespoke error when there is a conflicting lost bed', () => {
+    it('generates a bespoke error when there is a conflicting out-of-service bed', () => {
       const err = {
         data: {
-          detail: `Conflicting Lost Bed: ${lostBedId}`,
+          detail: `Conflicting out-of-service bed: ${lostBedId}`,
         },
       }
 
       expect(generateConflictBespokeError(err as SanitisedError, premisesId, 'plural', bedId)).toEqual({
-        errorTitle: 'This bedspace is not available for the dates entered',
+        errorTitle: 'Out of service bed record cannot be created for the dates entered',
         errorSummary: [
           {
-            html: `They conflict with an <a href="${paths.lostBeds.show({
+            html: `They conflict with an <a href="${paths.v2Manage.outOfServiceBeds.show({
               premisesId,
               bedId,
               id: lostBedId,
-            })}">existing lost bed</a>`,
+              tab: 'details',
+            })}">existing out of service beds record</a>`,
           },
         ],
       })

--- a/server/utils/bookings/index.test.ts
+++ b/server/utils/bookings/index.test.ts
@@ -223,7 +223,7 @@ describe('bookingUtils', () => {
     it('generates a bespoke error when there is a conflicting out-of-service bed', () => {
       const err = {
         data: {
-          detail: `Conflicting out-of-service bed: ${lostBedId}`,
+          detail: `An out-of-service bed already exists for dates from 2024-10-05 to 2024-10-20 which overlaps with the desired dates: ${lostBedId}`,
         },
       }
 

--- a/server/utils/bookings/index.ts
+++ b/server/utils/bookings/index.ts
@@ -192,7 +192,7 @@ export const generateConflictBespokeError = (
 
   const link =
     conflictingEntityType === ConflictingEntityType.lostBed && bedId
-      ? `<a href="${paths.v2Manage.outOfServiceBeds.show({ premisesId: premisesId, bedId: bedId, id: conflictingEntityId, tab: 'details' })}">existing out of service beds record</a>`
+      ? `<a href="${paths.v2Manage.outOfServiceBeds.show({ premisesId, bedId, id: conflictingEntityId, tab: 'details' })}">existing out of service beds record</a>`
       : `<a href="${paths.bookings.show({
           premisesId,
           bookingId: conflictingEntityId,

--- a/server/utils/bookings/index.ts
+++ b/server/utils/bookings/index.ts
@@ -21,10 +21,7 @@ import { bookingActions, v1BookingActions, v2BookingActions } from './bookingAct
 
 const UPCOMING_WINDOW_IN_DAYS = 365 * 10
 
-enum ConflictingEntityType {
-  booking,
-  lostBed,
-}
+type ConflictingEntityType = 'booking' | 'lostBed'
 
 type ParsedConflictError = {
   conflictingEntityId: string
@@ -185,13 +182,13 @@ export const generateConflictBespokeError = (
   const { conflictingEntityId, conflictingEntityType } = parseConflictError(detail)
 
   const title = (
-    conflictingEntityType === ConflictingEntityType.lostBed
+    conflictingEntityType === 'lostBed'
       ? 'Out of service bed record cannot be created for the $date$ entered'
       : 'This bedspace is not available for the $date$ entered'
   ).replace('$date$', datesGrammaticalNumber === 'plural' ? 'dates' : 'date')
 
   const link =
-    conflictingEntityType === ConflictingEntityType.lostBed && bedId
+    conflictingEntityType === 'lostBed' && bedId
       ? `<a href="${paths.v2Manage.outOfServiceBeds.show({ premisesId, bedId, id: conflictingEntityId, tab: 'details' })}">existing out of service beds record</a>`
       : `<a href="${paths.bookings.show({
           premisesId,
@@ -208,10 +205,9 @@ const parseConflictError = (detail: string): ParsedConflictError => {
    *  @param detail - string is text containing the entity id at the end preceded by ': '
    *    e.g. "An out-of-service bed already exists for dates from 2024-10-01 to 2024-10-14 which overlaps with the desired dates: 220a71da-bf5c-424d-94ff-254ecac5b857"
    */
-  const matchResult = /([0-9a-z-]*)$/.exec(detail)
-  const conflictingEntityId = matchResult && matchResult[1]
+  const conflictingEntityId = detail.split(': ').at(-1)
   const isOutOfServiceBedEntity = /(?:lost bed)|(?:out-of-service bed)/i.test(detail)
-  const conflictingEntityType = isOutOfServiceBedEntity ? ConflictingEntityType.lostBed : ConflictingEntityType.booking
+  const conflictingEntityType = isOutOfServiceBedEntity ? 'lostBed' : 'booking'
   return { conflictingEntityId, conflictingEntityType }
 }
 

--- a/server/utils/bookings/index.ts
+++ b/server/utils/bookings/index.ts
@@ -205,9 +205,8 @@ const parseConflictError = (detail: string): ParsedConflictError => {
    *  @param detail - string is text containing the entity id at the end preceded by ': '
    *    e.g. "An out-of-service bed already exists for dates from 2024-10-01 to 2024-10-14 which overlaps with the desired dates: 220a71da-bf5c-424d-94ff-254ecac5b857"
    */
-  const conflictingEntityId = detail.split(': ').at(-1)
-  const isOutOfServiceBedEntity = /(?:lost bed)|(?:out-of-service bed)/i.test(detail)
-  const conflictingEntityType = isOutOfServiceBedEntity ? 'lostBed' : 'booking'
+  const [message, conflictingEntityId] = detail.split(':').map((s: string) => s.trim())
+  const conflictingEntityType = message.includes('out-of-service bed') ? 'lostBed' : 'booking'
   return { conflictingEntityId, conflictingEntityType }
 }
 

--- a/server/utils/bookings/index.ts
+++ b/server/utils/bookings/index.ts
@@ -21,9 +21,14 @@ import { bookingActions, v1BookingActions, v2BookingActions } from './bookingAct
 
 const UPCOMING_WINDOW_IN_DAYS = 365 * 10
 
+enum ConflictingEntityType {
+  booking,
+  lostBed,
+}
+
 type ParsedConflictError = {
   conflictingEntityId: string
-  conflictingEntityType: 'booking' | 'lost-bed'
+  conflictingEntityType: ConflictingEntityType
 }
 
 export { bookingActions, v1BookingActions, v2BookingActions }
@@ -179,33 +184,34 @@ export const generateConflictBespokeError = (
   const { detail } = err.data as { detail: string }
   const { conflictingEntityId, conflictingEntityType } = parseConflictError(detail)
 
-  const title =
-    datesGrammaticalNumber === 'plural'
-      ? 'This bedspace is not available for the dates entered'
-      : 'This bedspace is not available for the date entered'
+  const title = (
+    conflictingEntityType === ConflictingEntityType.lostBed
+      ? 'Out of service bed record cannot be created for the $date$ entered'
+      : 'This bedspace is not available for the $date$ entered'
+  ).replace('$date$', datesGrammaticalNumber === 'plural' ? 'dates' : 'date')
 
   const link =
-    conflictingEntityType === 'lost-bed' && bedId
-      ? `<a href="${paths.lostBeds.show({
-          premisesId,
-          bedId,
-          id: conflictingEntityId,
-        })}">existing lost bed</a>`
+    conflictingEntityType === ConflictingEntityType.lostBed && bedId
+      ? `<a href="${paths.v2Manage.outOfServiceBeds.show({ premisesId: premisesId, bedId: bedId, id: conflictingEntityId, tab: 'details' })}">existing out of service beds record</a>`
       : `<a href="${paths.bookings.show({
           premisesId,
           bookingId: conflictingEntityId,
         })}">existing booking</a>`
-
   const message = datesGrammaticalNumber === 'plural' ? `They conflict with an ${link}` : `It conflicts with an ${link}`
 
   return { errorTitle: title, errorSummary: [{ html: message }] }
 }
 
 const parseConflictError = (detail: string): ParsedConflictError => {
-  const detailWords = detail.split(' ')
-  const conflictingEntityId = detailWords[detailWords.length - 1]
-  const conflictingEntityType = detail.includes('Lost Bed') ? 'lost-bed' : 'booking'
-
+  /**
+   *  Return the entity type and id by parsing an error detail string
+   *  @param detail - string is text containing the entity id at the end preceded by ': '
+   *    e.g. "An out-of-service bed already exists for dates from 2024-10-01 to 2024-10-14 which overlaps with the desired dates: 220a71da-bf5c-424d-94ff-254ecac5b857"
+   */
+  const matchResult = /([0-9a-z-]*)$/.exec(detail)
+  const conflictingEntityId = matchResult && matchResult[1]
+  const isOutOfServiceBedEntity = /(?:lost bed)|(?:out-of-service bed)/i.test(detail)
+  const conflictingEntityType = isOutOfServiceBedEntity ? ConflictingEntityType.lostBed : ConflictingEntityType.booking
   return { conflictingEntityId, conflictingEntityType }
 }
 

--- a/server/utils/bookings/index.ts
+++ b/server/utils/bookings/index.ts
@@ -18,10 +18,11 @@ import { isFullPerson, laoName } from '../personUtils'
 import { convertObjectsToRadioItems } from '../formUtils'
 import { StatusTag, StatusTagOptions } from '../statusTag'
 import { bookingActions, v1BookingActions, v2BookingActions } from './bookingActions'
+import { EntityType } from '../../@types/ui'
 
 const UPCOMING_WINDOW_IN_DAYS = 365 * 10
 
-type ConflictingEntityType = 'booking' | 'lostBed'
+type ConflictingEntityType = EntityType
 
 type ParsedConflictError = {
   conflictingEntityId: string
@@ -182,13 +183,13 @@ export const generateConflictBespokeError = (
   const { conflictingEntityId, conflictingEntityType } = parseConflictError(detail)
 
   const title = (
-    conflictingEntityType === 'lostBed'
+    conflictingEntityType === 'lost-bed'
       ? 'Out of service bed record cannot be created for the $date$ entered'
       : 'This bedspace is not available for the $date$ entered'
   ).replace('$date$', datesGrammaticalNumber === 'plural' ? 'dates' : 'date')
 
   const link =
-    conflictingEntityType === 'lostBed' && bedId
+    conflictingEntityType === 'lost-bed' && bedId
       ? `<a href="${paths.v2Manage.outOfServiceBeds.show({ premisesId, bedId, id: conflictingEntityId, tab: 'details' })}">existing out of service beds record</a>`
       : `<a href="${paths.bookings.show({
           premisesId,
@@ -206,7 +207,7 @@ const parseConflictError = (detail: string): ParsedConflictError => {
    *    e.g. "An out-of-service bed already exists for dates from 2024-10-01 to 2024-10-14 which overlaps with the desired dates: 220a71da-bf5c-424d-94ff-254ecac5b857"
    */
   const [message, conflictingEntityId] = detail.split(':').map((s: string) => s.trim())
-  const conflictingEntityType = message.includes('out-of-service bed') ? 'lostBed' : 'booking'
+  const conflictingEntityType = message.includes('out-of-service bed') ? 'lost-bed' : 'booking'
   return { conflictingEntityId, conflictingEntityType }
 }
 


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1227
<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

The handling errors in this area appears to be a bit sensitive to changes. There is code that detects the entity causing the conflict and the id of that entity by parsing the returned error details. It seems that the error details have changed from citing 'Lost beds' to 'out-of-service beds' which caused the error handling to default to its 'bookings' mode.
Also, the path needed updating for M&M v2.

I switched to regexp to do the parsing and switched some literal strings to enums, but this whole mechanism remains a bit fragile.

Note, the error texts on the date fields are wrong, but this was not mentioned in the ticket so I'll create a new ticket for this fix.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### After
![chrome-capture-2024-9-16](https://github.com/user-attachments/assets/893bf56b-c888-4c21-bf62-ab2f4e1a68b5)

