### PR TITLE
AP1246 Fix E2E tests

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -48,7 +48,6 @@ export default defineConfig<TestOptions>({
         },
         indexOffenceRequired: true,
         oasysSections: [
-          '5. Finance',
           '6. Relationships',
           '7. Lifestyle',
           '10. Emotional',


### PR DESCRIPTION
# Context

Fixes a break in the E2E tests. The finance section is no longer an optional OASys section on the checkbox page of apply.

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

[x] I have run the E2E tests locally and they passed

## Screenshots of UI changes

### Before

### After
