### PR TITLE
AP-1246 Fix e2e tests on ci

### DIFF
--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -53,6 +53,6 @@ export const test = base.extend<TestOptions>({
     },
     { option: true },
   ],
-  oasysSections: [['3. Accommodation', '13. Health', '4. Education, training and employment'], { option: true }],
+  oasysSections: [['3. Accommodation', '13. Health'], { option: true }],
   emergencyApplicationUser: [process.env.CAS1_E2E_EMERGENCY_ASSESSOR_NAME_TO_ALLOCATE_TO, { option: true }],
 })


### PR DESCRIPTION
# Changes in this PR

Fix e2e tests in CI. The config (list of OAsys sections) differs between local and dev - as the mocked oasys sections differ.


<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before

### After
