### PR TITLE
Only rebase Renovate branches when conflicted

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,10 @@
 {
-  "extends": ["github>ministryofjustice/arn-renovate-config"],
-  "ignoreDeps": ["@playwright/test", "applicationinsights"]
+  "extends": [
+    "github>ministryofjustice/arn-renovate-config"
+  ],
+  "ignoreDeps": [
+    "@playwright/test",
+    "applicationinsights"
+  ],
+  "rebaseWhen": "conflicted"
 }


### PR DESCRIPTION
This should prevent excessive test/CI runs due to Renovate branches rebasing whenever an update to `main` is done. Instead, only conflicts with main will trigger a rebase and a test run, which shoudl be rare, given dependencies are seldom updated manually.
