### PR TITLE
APS-1361: Prevent error if selected oasys section is null

### DIFF
--- a/server/utils/oasysImportUtils.test.ts
+++ b/server/utils/oasysImportUtils.test.ts
@@ -329,13 +329,13 @@ describe('OASysImportUtils', () => {
   })
 
   describe('sectionCheckBoxes', () => {
-    it('it returns needs as checkbox items', () => {
-      const needLinkedToReoffendingA = oasysSelectionFactory
-        .needsLinkedToReoffending()
-        .build({ section: 1, name: 'emotional' })
-      const needLinkedToReoffendingB = oasysSelectionFactory.needsLinkedToReoffending().build({ section: 2 })
-      const needLinkedToReoffendingC = oasysSelectionFactory.needsLinkedToReoffending().build({ section: 3 })
+    const needLinkedToReoffendingA = oasysSelectionFactory
+      .needsLinkedToReoffending()
+      .build({ section: 1, name: 'emotional' })
+    const needLinkedToReoffendingB = oasysSelectionFactory.needsLinkedToReoffending().build({ section: 2 })
+    const needLinkedToReoffendingC = oasysSelectionFactory.needsLinkedToReoffending().build({ section: 3 })
 
+    it('it returns needs as checkbox items', () => {
       const items = sectionCheckBoxes(
         [needLinkedToReoffendingA, needLinkedToReoffendingB, needLinkedToReoffendingC],
         [needLinkedToReoffendingA],
@@ -356,6 +356,18 @@ describe('OASysImportUtils', () => {
           checked: false,
           text: `3. ${sentenceCase(needLinkedToReoffendingC.name)}`,
           value: '3',
+        },
+      ])
+    })
+
+    it('does not throw if some selected sections are null', () => {
+      const items = sectionCheckBoxes([needLinkedToReoffendingA], [null])
+
+      expect(items).toEqual([
+        {
+          checked: false,
+          text: `1. ${sentenceCase(needLinkedToReoffendingA.name)}`,
+          value: '1',
         },
       ])
     })

--- a/server/utils/oasysImportUtils.ts
+++ b/server/utils/oasysImportUtils.ts
@@ -160,7 +160,10 @@ export const sectionCheckBoxes = (fullList: Array<OASysSection>, selectedList: A
     return {
       value: need.section.toString(),
       text: sectionAndName,
-      checked: selectedList.map(n => n.section).includes(need.section),
+      checked: selectedList
+        .filter(Boolean)
+        .map(n => n.section)
+        .includes(need.section),
     }
   })
 }


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1361

# Changes in this PR

This stops the user seeing an error if the application contains some `null` values in the optional Oasys sections. When submitting the page again, those null sections are then fully cleared.