### PR TITLE
APS-1391: Only check user permissions if necessary

### DIFF
--- a/server/middleware/applicationAuthMiddleware.test.ts
+++ b/server/middleware/applicationAuthMiddleware.test.ts
@@ -79,4 +79,21 @@ describe('applicationAuthMiddleware', () => {
     expect(response.status).toHaveBeenCalledWith(401)
     expect(response.render).toHaveBeenCalledWith('roleError')
   })
+
+  it('redirects with an error if the user does not have the role and no required permissions are specified', async () => {
+    const user = userDetailsFactory.build({ roles: [], permissions: ['cas1_adhoc_booking_create'] })
+    const response = createMock<Response>({ locals: { user } })
+
+    const loggerSpy = jest.spyOn(logger, 'error')
+
+    const auditedhandler = applicationAuthMiddleware(handler, {
+      allowedRoles: ['future_manager'],
+    })
+
+    await auditedhandler(request, response, next)
+
+    expect(loggerSpy).toHaveBeenCalledWith('User is not authorised to access this')
+    expect(response.status).toHaveBeenCalledWith(401)
+    expect(response.render).toHaveBeenCalledWith('roleError')
+  })
 })

--- a/server/middleware/applicationAuthMiddleware.ts
+++ b/server/middleware/applicationAuthMiddleware.ts
@@ -1,15 +1,14 @@
 import type { NextFunction, Request, RequestHandler, Response } from 'express'
 import { MiddlewareSpec } from '../@types/ui'
-import { ApprovedPremisesUserRole } from '../@types/shared'
 import logger from '../../logger'
-import { hasPermission } from '../utils/users'
+import { hasPermission, hasRole } from '../utils/users'
 
 export default function applicationAuthMiddleware(requestHandler: RequestHandler, middlewareSpec?: MiddlewareSpec) {
   if (middlewareSpec?.allowedRoles || middlewareSpec?.allowedPermissions) {
     return async (req: Request, res: Response, next: NextFunction) => {
       if (
-        res.locals.user.roles.some((role: ApprovedPremisesUserRole) => middlewareSpec.allowedRoles.includes(role)) ||
-        hasPermission(res.locals.user, middlewareSpec.allowedPermissions)
+        (middlewareSpec?.allowedRoles || []).some(role => hasRole(res.locals.user, role)) ||
+        (middlewareSpec?.allowedPermissions && hasPermission(res.locals.user, middlewareSpec.allowedPermissions))
       ) {
         return requestHandler(req, res, next)
       }


### PR DESCRIPTION
There is no need to check the user's permissions if the middleware does not specify allowed permissions. This prevents passing an `undefined` list of permissions to `hasPermission`, which would result in the `TypeError` mentioned in the ticket.

Similarly, only check if the user has the role for each specified allowed role, not the other way round, for clarity.

https://dsdmoj.atlassian.net/browse/APS-1391
