### PR TITLE
APS-1385: expired application

### DIFF
--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -1,6 +1,7 @@
 import type {
   ApprovedPremisesApplication as Application,
   ApplicationTimelineNote,
+  ApprovedPremisesApplicationStatus,
   FullPerson,
   RequestForPlacement,
 } from '@approved-premises/api'
@@ -12,7 +13,7 @@ import Page from '../page'
 import { ApplicationShowPageTab, applicationShowPageTab } from '../../../server/utils/applications/utils'
 import paths from '../../../server/paths/apply'
 import { isFullPerson } from '../../../server/utils/personUtils'
-import { mapRequestsForPlacementToSummaryCards } from '../../../server/utils/placementRequests/requestForPlacementSummaryCards'
+import { mapRequestsForPlacementToSummaryCards } from '../../../server/utils/placementRequests'
 
 export default class ShowPage extends Page {
   constructor(private readonly application: Application) {
@@ -60,7 +61,7 @@ export default class ShowPage extends Page {
   }
 
   shouldNotShowCreatePlacementButton() {
-    cy.get('Create request for placement').should('not.exist')
+    cy.contains('Create request for placement').should('not.exist')
   }
 
   shouldNotShowOfflineStatus() {
@@ -110,10 +111,6 @@ export default class ShowPage extends Page {
     this.shouldShowCheckYourAnswersResponses(this.application)
   }
 
-  shouldNotShowCreatePlacementRequestButton() {
-    cy.get('Create placement request').should('not.exist')
-  }
-
   clickTimelineTab() {
     cy.get('.moj-sub-navigation a').contains('Timeline').click()
   }
@@ -161,5 +158,9 @@ export default class ShowPage extends Page {
 
   showsNoteAddedConfirmationMessage() {
     this.shouldShowBanner('Note added')
+  }
+
+  shouldShowStatusTag(status: ApprovedPremisesApplicationStatus) {
+    cy.get(`.govuk-tag[data-cy-status="${status}"]`).should('exist')
   }
 }

--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -72,14 +72,32 @@ export default class ShowPage extends Page {
     cy.get('.govuk-tag').contains('Offline application').should('exist')
   }
 
-  shouldShowAssessmentDetails() {
+  shouldShowAssessmentDetails(expired = false) {
     cy.get('.govuk-inset-text')
       .contains(
         `Application was ${this.application.assessmentDecision} on ${DateFormats.isoDateToUIDate(
           this.application.assessmentDecisionDate,
-        )}`,
+        )}.`,
       )
       .should('exist')
+
+    if (expired) {
+      cy.get('.govuk-inset-text')
+        .contains(
+          'Applications expire 12 months after being assessed as suitable. You cannot submit any new requests for placement.',
+        )
+        .should('exist')
+      cy.get('.govuk-inset-text')
+        .contains('You’ll need to submit a new application for this person to be assessed.')
+        .should('exist')
+    } else {
+      cy.get('.govuk-inset-text')
+        .contains(
+          'Applications expire 12 months after being assessed as ‘suitable’. You’ll then need to submit a new application for this person to be assessed.',
+        )
+        .should('exist')
+      cy.get('.govuk-inset-text').contains('Booked placements are unaffected.').should('exist')
+    }
 
     cy.get(`a[data-cy-assessmentId="${this.application.assessmentId}"]`).should('exist')
   }
@@ -123,10 +141,6 @@ export default class ShowPage extends Page {
     cy.get(`[data-cy-placement-application-id="${placementRequestId}"]`).within(() => {
       cy.get('a').contains('Withdraw').click()
     })
-  }
-
-  verifyOnTimelineTab() {
-    cy.get('a').contains('Placement').should('contain', '[aria-page="current"]')
   }
 
   shouldShowRequestsForPlacement(

--- a/integration_tests/tests/apply/viewApplication.cy.ts
+++ b/integration_tests/tests/apply/viewApplication.cy.ts
@@ -67,8 +67,24 @@ context('show applications', () => {
     // Then I should see a read-only version of the application
     const showPage = ShowPage.visit(updatedApplication, 'application')
 
+    // And I should see a 'Withdrawn application' status tag
+    showPage.shouldShowStatusTag('withdrawn')
+
     // And I should see the application details
     showPage.shouldShowResponsesForUnsubmittedWithdrawnApplication()
+  })
+
+  it('shows a read-only version of an expired application', function test() {
+    // Given I have an expired application
+    const updatedApplication = { ...this.application, status: 'expired', document: undefined }
+    cy.task('stubApplicationGet', { application: updatedApplication })
+    cy.task('stubApplications', [updatedApplication])
+
+    // Then I should see a read-only version of the application
+    const showPage = ShowPage.visit(updatedApplication, 'application')
+
+    // And I should see an 'Expired application' status tag
+    showPage.shouldShowStatusTag('expired')
   })
 
   it('links to an assessment when an application has been assessed', function test() {
@@ -263,6 +279,6 @@ context('show applications', () => {
     const showPage = ShowPage.visit(application, 'placementRequests')
 
     // Then I should not see the "Create placement request" button
-    showPage.shouldNotShowCreatePlacementRequestButton()
+    showPage.shouldNotShowCreatePlacementButton()
   })
 })

--- a/integration_tests/tests/apply/viewApplication.cy.ts
+++ b/integration_tests/tests/apply/viewApplication.cy.ts
@@ -79,6 +79,9 @@ context('show applications', () => {
     // And I should see a 'Withdrawn application' status tag
     showPage.shouldShowStatusTag('withdrawn')
 
+    // And I should see a link to the assessment with guidance
+    showPage.shouldShowAssessmentDetails()
+
     // And I should see the application details
     showPage.shouldShowResponsesForUnsubmittedWithdrawnApplication()
 
@@ -112,6 +115,9 @@ context('show applications', () => {
 
     // And I should see an 'Expired application' status tag
     showPage.shouldShowStatusTag('expired')
+
+    // And I should see a link to the assessment with guidance
+    showPage.shouldShowAssessmentDetails(true)
 
     // When I click the 'Request for placement' tab
     cy.task('stubApplicationRequestsForPlacement', {

--- a/integration_tests/tests/apply/viewApplication.cy.ts
+++ b/integration_tests/tests/apply/viewApplication.cy.ts
@@ -5,6 +5,7 @@ import Page from '../../pages/page'
 import { setup } from './setup'
 import {
   applicationFactory,
+  assessmentFactory,
   noteFactory,
   placementApplicationFactory,
   requestForPlacementFactory,
@@ -53,16 +54,24 @@ context('show applications', () => {
     showPage.shouldHaveWithdrawalLink()
 
     // When I click on the 'Timeline' tab
-    // Then I should see timeline page
     showPage.clickTimelineTab()
+
+    // Then I should see timeline page
     showPage.shouldShowApplicationTimeline(timeline)
   })
 
   it('shows a read-only version of an unsubmitted withdrawn application', function test() {
     // Given I have a withdrawn unsubmitted application
-    const updatedApplication = { ...this.application, status: 'withdrawn', document: undefined }
+    const assessmentDecision = assessmentFactory.build({ decision: 'accepted' })
+    const updatedApplication = {
+      ...this.application,
+      status: 'withdrawn',
+      document: undefined,
+      assessmentDecision: assessmentDecision.decision,
+      assessmentDecisionDate: assessmentDecision.createdAt,
+      assessmentId: assessmentDecision.id,
+    }
     cy.task('stubApplicationGet', { application: updatedApplication })
-    cy.task('stubApplications', [updatedApplication])
 
     // Then I should see a read-only version of the application
     const showPage = ShowPage.visit(updatedApplication, 'application')
@@ -72,19 +81,47 @@ context('show applications', () => {
 
     // And I should see the application details
     showPage.shouldShowResponsesForUnsubmittedWithdrawnApplication()
+
+    // When I click the 'Request for placement' tab
+    const requestsForPlacement = requestForPlacementFactory.buildList(1, { status: 'request_withdrawn' })
+    cy.task('stubApplicationRequestsForPlacement', {
+      applicationId: updatedApplication.id,
+      requestsForPlacement,
+    })
+    showPage.clickRequestAPlacementTab()
+
+    // Then I do not see the 'Create request for placement' button
+    showPage.shouldNotShowCreatePlacementButton()
   })
 
   it('shows a read-only version of an expired application', function test() {
     // Given I have an expired application
-    const updatedApplication = { ...this.application, status: 'expired', document: undefined }
+    const assessmentDecision = assessmentFactory.build({ decision: 'accepted' })
+    const updatedApplication = {
+      ...this.application,
+      status: 'expired',
+      document: undefined,
+      assessmentDecision: assessmentDecision.decision,
+      assessmentDecisionDate: assessmentDecision.createdAt,
+      assessmentId: assessmentDecision.id,
+    }
     cy.task('stubApplicationGet', { application: updatedApplication })
-    cy.task('stubApplications', [updatedApplication])
 
     // Then I should see a read-only version of the application
     const showPage = ShowPage.visit(updatedApplication, 'application')
 
     // And I should see an 'Expired application' status tag
     showPage.shouldShowStatusTag('expired')
+
+    // When I click the 'Request for placement' tab
+    cy.task('stubApplicationRequestsForPlacement', {
+      applicationId: updatedApplication.id,
+      requestsForPlacement: [],
+    })
+    showPage.clickRequestAPlacementTab()
+
+    // Then I do not see the 'Create request for placement' button
+    showPage.shouldNotShowCreatePlacementButton()
   })
 
   it('links to an assessment when an application has been assessed', function test() {
@@ -261,24 +298,5 @@ context('show applications', () => {
       const body = JSON.parse(requests[0].body)
       expect(body).to.have.keys('note')
     })
-  })
-
-  it('should not show the "Create placement request" button if the application is withdrawn', function test() {
-    const application = {
-      ...this.application,
-      status: 'withdrawn',
-    }
-
-    cy.task('stubApplicationGet', { application })
-    cy.task('stubApplications', [application])
-    cy.task('stubApplicationRequestsForPlacement', {
-      applicationId: application.id,
-      requestsForPlacement: [],
-    })
-    // Given I am on the placement requests view on the application show page
-    const showPage = ShowPage.visit(application, 'placementRequests')
-
-    // Then I should not see the "Create placement request" button
-    showPage.shouldNotShowCreatePlacementButton()
   })
 })

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -320,28 +320,6 @@ describe('applicationsController', () => {
       })
     })
 
-    it('fetches the application from the API and renders the read only view if the application is submitted', async () => {
-      application.status = 'submitted'
-
-      const requestHandler = applicationsController.show()
-      const stubTaskList = jest.fn()
-
-      ;(TasklistService as jest.Mock).mockImplementation(() => {
-        return stubTaskList
-      })
-
-      await requestHandler(request, response, next)
-
-      expect(response.render).toHaveBeenCalledWith('applications/show', {
-        application,
-        referrer,
-        tab: 'application',
-        pageHeading: 'Approved Premises application',
-      })
-
-      expect(applicationService.findApplication).toHaveBeenCalledWith(token, application.id)
-    })
-
     describe('when there is an error in the flash', () => {
       const errorsAndUserInput = createMock<ErrorsAndUserInput>()
 

--- a/server/utils/applications/applicationIdentityBar.test.ts
+++ b/server/utils/applications/applicationIdentityBar.test.ts
@@ -43,6 +43,20 @@ describe('applicationIdentityBar', () => {
         <h3 class="govuk-caption-m govuk-!-margin-top-1">CRN: ${application.person.crn}</h3>
       `)
     })
+
+    it('should show a tag for an expired application', () => {
+      const person = personFactory.build()
+      const application = applicationFactory.build({ person, status: 'expired' })
+
+      expect(applicationTitle(application, 'heading')).toMatchStringIgnoringWhitespace(`
+        <h1 class="govuk-caption-l">heading</h1>
+        <h2 class="govuk-heading-l">
+          ${person.name}
+          <strong class="govuk-tag govuk-tag--red govuk-!-margin-5" data-cy-status="expired">Expired application</strong>
+        </h2>
+        <h3 class="govuk-caption-m govuk-!-margin-top-1">CRN: ${application.person.crn}</h3>
+      `)
+    })
   })
 
   describe('applicationMenuItems', () => {

--- a/server/utils/applications/applicationIdentityBar.ts
+++ b/server/utils/applications/applicationIdentityBar.ts
@@ -11,7 +11,7 @@ export const applicationTitle = (application: Application, pageHeading: string):
     heading += '<strong class="govuk-tag govuk-tag--grey govuk-!-margin-5">Offline application</strong>'
   }
 
-  if (application.status === 'withdrawn') {
+  if (application.status === 'withdrawn' || application.status === 'expired') {
     heading += new ApplicationStatusTag(application.status, { addLeftMargin: true }).html()
   }
 

--- a/server/utils/applications/statusTag.ts
+++ b/server/utils/applications/statusTag.ts
@@ -17,10 +17,8 @@ export class ApplicationStatusTag extends StatusTag<ApplicationStatus> {
     withdrawn: 'Application withdrawn',
     requestedFurtherInformation: 'Further information requested',
     pendingPlacementRequest: APPLICATION_SUITABLE,
-    expired: 'Application expired',
+    expired: 'Expired application',
   }
-
-  readonly applicationSuitableStatus: 'blue' = 'blue' as const
 
   static readonly colours: Record<ApplicationStatus, string> = {
     started: 'blue',

--- a/server/views/applications/partials/_request-a-placement.njk
+++ b/server/views/applications/partials/_request-a-placement.njk
@@ -6,14 +6,14 @@
     <div class="moj-page-header-actions__actions">
         <div class="moj-button-menu">
             <div class="moj-button-menu__wrapper">
-                {% if application.assessmentDecision === 'accepted' and application.status !== 'withdrawn' %}
-                    <form action="{{paths.placementApplications.create({}) }}" method="post">
-                        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-                        <input type="hidden" name="applicationId" value="{{ application.id }}"/>
+                {% if application.assessmentDecision === 'accepted' and application.status !== 'withdrawn' and application.status !== 'expired' %}
+                    <form action="{{ paths.placementApplications.create({}) }}" method="post">
+                        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+                        <input type="hidden" name="applicationId" value="{{ application.id }}" />
                         {{ govukButton({
-                    text: "Create request for placement",
-                    preventDoubleClick: true
-                  }) }}
+                            text: "Create request for placement",
+                            preventDoubleClick: true
+                        }) }}
                     </form>
                 {% endif %}
             </div>
@@ -34,9 +34,9 @@
     {% else %}
         {% for requestForPlacement in requestsForPlacement %}
 
-            {{govukSummaryList(requestForPlacement)}}
-            {%endfor%}
+            {{ govukSummaryList(requestForPlacement) }}
+        {% endfor %}
 
-        {% endif %}
+    {% endif %}
 
-        {%endmacro%}
+{% endmacro %}

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -14,65 +14,84 @@
 {% set mainClasses = "app-container govuk-body application--show" %}
 
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-width-container">
-      <div class="govuk-grid-column-full">
-        {{ mojIdentityBar(ApplyUtils.applicationIdentityBar(application, pageHeading, user)) }}
+    <div class="govuk-grid-row">
+        <div class="govuk-width-container">
+            <div class="govuk-grid-column-full">
+                {{ mojIdentityBar(ApplyUtils.applicationIdentityBar(application, pageHeading, user)) }}
 
-        {% include "../_messages.njk" %}
+                {% include "../_messages.njk" %}
 
-        {% if application.assessmentDecision %}
-          {% set html %}
-          <p class="govuk-body">Application was {{ application.assessmentDecision }} on {{ formatDate(application.assessmentDecisionDate) }}</p>
-          <p class="govuk-body">
-            <a href="{{paths.assessments.show({id: application.assessmentId})}}" data-cy-assessmentId="{{ application.assessmentId }}">View assessment</a>
-          </p>
-          {% endset %}
+                {% if application.assessmentDecision %}
+                    {% set html %}
+                        <p class="govuk-body">Application was {{ application.assessmentDecision }}
+                            on {{ formatDate(application.assessmentDecisionDate) }}.</p>
 
-          {{ govukInsetText({
-          html: html
-        }) }}
-        {% endif %}
+                        {% if application.status === 'expired' %}
+                            <p class="govuk-body">Applications expire 12 months after being assessed as suitable. You
+                                cannot submit any new requests for placement.</p>
+                            <p class="govuk-body">You’ll need to submit a new application for this person to be
+                                assessed.</p>
+                        {% else %}
+                            <p class="govuk-body">Applications expire 12 months after being assessed as ‘suitable’.
+                                You’ll then need to submit a new application for this person to be assessed.</p>
+                            <p class="govuk-body">Booked placements are unaffected.</p>
+                        {% endif %}
 
-      </div>
+                        <p class="govuk-body">
+                            <a href="{{ paths.assessments.show({id: application.assessmentId}) }}"
+                               data-cy-assessmentId="{{ application.assessmentId }}">View assessment</a>
+                        </p>
+                    {% endset %}
 
-      <div class="govuk-grid-column-full">
-        {{ mojSubNavigation({
-        items: [{
-          text: 'Application',
-          href: ApplyUtils.applicationShowPageTab(application.id, ApplyUtils.applicationShowPageTabs.application),
-          active: tab === ApplyUtils.applicationShowPageTabs.application
-        }, {
-          text: 'Timeline',
-          href:  ApplyUtils.applicationShowPageTab(application.id, ApplyUtils.applicationShowPageTabs.timeline),
-          active: tab === ApplyUtils.applicationShowPageTabs.timeline
-        },
-        {
-          text: 'Request for placement',
-          href: ApplyUtils.applicationShowPageTab(application.id, ApplyUtils.applicationShowPageTabs.placementRequests),
-          active: tab === ApplyUtils.applicationShowPageTabs.placementRequests
-        }
-        ]
-      }) }}
-      </div>
+                    {{ govukInsetText({
+                        html: html
+                    }) }}
+                {% endif %}
 
-      <div class="govuk-grid-column-full">
-        {% if tab === ApplyUtils.applicationShowPageTabs.timeline %}
-          {{ timeline(ApplyUtils.mapApplicationTimelineEventsForUi(timelineEvents), application, csrfToken) }}
-        {% elif tab === ApplyUtils.applicationShowPageTabs.placementRequests %}
-          {{ requestAPlacement(requestsForPlacement, application, user, csrfToken) }}
-        {% else %}
-          {{ applicationReadonlyView(application) }}
-        {% endif %}
-      </div>
+            </div>
+
+            <div class="govuk-grid-column-full">
+                {{ mojSubNavigation({
+                    items: [{
+                        text: 'Application',
+                        href: ApplyUtils.applicationShowPageTab(application.id, ApplyUtils.applicationShowPageTabs.application),
+                        active: tab === ApplyUtils.applicationShowPageTabs.application
+                    }, {
+                        text: 'Timeline',
+                        href:  ApplyUtils.applicationShowPageTab(application.id, ApplyUtils.applicationShowPageTabs.timeline),
+                        active: tab === ApplyUtils.applicationShowPageTabs.timeline
+                    },
+                        {
+                            text: 'Request for placement',
+                            href: ApplyUtils.applicationShowPageTab(application.id, ApplyUtils.applicationShowPageTabs.placementRequests),
+                            active: tab === ApplyUtils.applicationShowPageTabs.placementRequests
+                        }
+                    ]
+                }) }}
+            </div>
+
+            <div class="govuk-grid-column-full">
+                {% if tab === ApplyUtils.applicationShowPageTabs.timeline %}
+                    {{ timeline(ApplyUtils.mapApplicationTimelineEventsForUi(timelineEvents), application, csrfToken) }}
+                    {% elif tab === ApplyUtils.applicationShowPageTabs.placementRequests %}
+                    {{ requestAPlacement(requestsForPlacement, application, user, csrfToken) }}
+                {% else %}
+                    {{ applicationReadonlyView(application) }}
+                {% endif %}
+            </div>
+        </div>
     </div>
-  </div>
 {% endblock %}
 
 {% block extraScripts %}
-  <script type="text/javascript" nonce="{{ cspNonce }}">
-    if ($('.application-identity-bar .moj-button-menu').length) {
-      new MOJFrontend.ButtonMenu({container: $('.application-identity-bar .moj-button-menu'), mq: "(min-width: 200em)", buttonText: "Actions", menuClasses: "moj-button-menu__wrapper--right"});
-    }
-  </script>
+    <script type="text/javascript" nonce="{{ cspNonce }}">
+      if ($('.application-identity-bar .moj-button-menu').length) {
+        new MOJFrontend.ButtonMenu({
+          container: $('.application-identity-bar .moj-button-menu'),
+          mq: '(min-width: 200em)',
+          buttonText: 'Actions',
+          menuClasses: 'moj-button-menu__wrapper--right',
+        })
+      }
+    </script>
 {% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1385

# Changes in this PR

Lists of applications now shows an 'Expired application` status tag next to relevant applications. Actions still may include 'View placement request(s)' to retain ability to check historical data about the application.

The Application page now shows an 'Expired application' tag in the header. The guidance about when the assessment was accepted is updated to mention the 12 months limit on assessments. This guidance explains a new application needs to be submitted when it has expired. The 'Create a request for placement' is hidden under the 'Request for placement' tab for expired applications.

## Screenshots of UI changes

#### List of submitted applications

<img width="996" alt="Screenshot 2024-10-04 at 11 18 21" src="https://github.com/user-attachments/assets/92fb616f-7322-4381-ad16-c19dec0dace2">

---

#### Application page for expired application (showing 'Request for placement' tab -- other tabs' content unchanged)

<img width="962" alt="Screenshot 2024-10-04 at 10 32 27" src="https://github.com/user-attachments/assets/51ff687f-be26-4737-b2e2-aca4cd89e969">



