### PR TITLE
APS-1334: task allocation Women's Estate

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -23,6 +23,7 @@ import beds from './integration_tests/mockApis/beds'
 import spaceSearch from './integration_tests/mockApis/spaces'
 import moveBooking from './integration_tests/mockApis/moveBooking'
 import spaceBookings from './integration_tests/mockApis/spaceBooking'
+import referenceData from './integration_tests/mockApis/referenceData'
 
 export default defineConfig({
   chromeWebSecurity: false,
@@ -62,6 +63,7 @@ export default defineConfig({
         ...moveBooking,
         ...reports,
         ...spaceBookings,
+        ...referenceData,
         stubJourney,
       })
     },

--- a/integration_tests/mockApis/referenceData.ts
+++ b/integration_tests/mockApis/referenceData.ts
@@ -1,0 +1,55 @@
+import { Response } from 'superagent'
+import { ApArea } from '@approved-premises/api'
+import { stubFor } from './setup'
+import { apAreaFactory } from '../../server/testutils/factories'
+
+export const stubApAreaReferenceData = (
+  {
+    apArea = null,
+    additionalAreas = [],
+  }: {
+    apArea: ApArea | null
+    additionalAreas: Array<ApArea>
+  } = { apArea: null, additionalAreas: [] },
+): Promise<Response> => {
+  const apAreas = [...additionalAreas.map(area => apAreaFactory.build(area)), ...apAreaFactory.buildList(10)]
+
+  if (apArea != null) {
+    apAreas.push(apAreaFactory.build(apArea))
+  }
+
+  return stubFor({
+    request: {
+      method: 'GET',
+      url: '/reference-data/ap-areas',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: apAreas,
+    },
+  })
+}
+
+export const stubCRUManagementAreaReferenceData = ({ cruManagementAreas }) => {
+  return stubFor({
+    request: {
+      method: 'GET',
+      url: '/cas1/reference-data/cru-management-areas',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: cruManagementAreas,
+    },
+  })
+}
+
+export default {
+  stubApAreaReferenceData,
+  stubCRUManagementAreaReferenceData,
+}

--- a/integration_tests/mockApis/tasks.ts
+++ b/integration_tests/mockApis/tasks.ts
@@ -15,7 +15,7 @@ export default {
     page = '1',
     sortDirection = 'asc',
     sortBy = 'createdAt',
-    apAreaId = '',
+    cruManagementAreaId = '',
     types = [],
     isCompleted = 'false',
   }: {
@@ -25,7 +25,7 @@ export default {
     allocatedToUserId: string
     sortDirection: SortDirection
     sortBy: TaskSortField
-    apAreaId: string
+    cruManagementAreaId: string
     types: Array<TaskType>
     isCompleted: string
   }): SuperAgentRequest => {
@@ -36,8 +36,8 @@ export default {
       allocatedFilter: {
         equalTo: allocatedFilter,
       },
-      apAreaId: {
-        equalTo: apAreaId,
+      cruManagementAreaId: {
+        equalTo: cruManagementAreaId,
       },
 
       allocatedToUserId: {

--- a/integration_tests/mockApis/users.ts
+++ b/integration_tests/mockApis/users.ts
@@ -1,16 +1,12 @@
 import {
-  ApArea,
   ApprovedPremisesUser as User,
   UserQualification,
   ApprovedPremisesUserRole as UserRole,
   UserSummary,
 } from '@approved-premises/api'
 import QueryString from 'qs'
-import { Response } from 'superagent'
 import { getMatchingRequests, stubFor } from './setup'
 import paths from '../../server/paths/api'
-import { probationRegions } from '../../server/testutils/referenceData/stubs/referenceDataStubs'
-import { apAreaFactory } from '../../server/testutils/factories'
 
 const stubFindUser = (args: { user: User; id: string; userVersion?: string }) =>
   stubFor({
@@ -225,38 +221,6 @@ const stubUserDelete = (args: { id: string }) =>
     },
   })
 
-const stubProbationRegionsReferenceData = (): Promise<Response> => stubFor(probationRegions)
-
-const stubApAreaReferenceData = (
-  {
-    apArea = null,
-    additionalAreas = [],
-  }: {
-    apArea: ApArea | null
-    additionalAreas: Array<ApArea>
-  } = { apArea: null, additionalAreas: [] },
-): Promise<Response> => {
-  const apAreas = [...additionalAreas.map(area => apAreaFactory.build(area)), ...apAreaFactory.buildList(10)]
-
-  if (apArea != null) {
-    apAreas.push(apAreaFactory.build(apArea))
-  }
-
-  return stubFor({
-    request: {
-      method: 'GET',
-      url: '/reference-data/ap-areas',
-    },
-    response: {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: apAreas,
-    },
-  })
-}
-
 const verifyUserUpdate = async (userId: string) =>
   (
     await getMatchingRequests({
@@ -277,6 +241,4 @@ export default {
   stubNotFoundDeliusUserSearch,
   verifyUserUpdate,
   verifyUsersRequest,
-  stubProbationRegionsReferenceData,
-  stubApAreaReferenceData,
 }

--- a/integration_tests/tests/tasks/allocations.cy.ts
+++ b/integration_tests/tests/tasks/allocations.cy.ts
@@ -1,9 +1,12 @@
+import { Cas1CruManagementArea } from '@approved-premises/api'
 import TaskListPage from '../../pages/tasks/listPage'
 import AllocationsPage from '../../pages/tasks/allocationPage'
 import Page from '../../pages/page'
 
 import {
+  apAreaFactory,
   applicationFactory,
+  cruManagementAreaFactory,
   personFactory,
   reallocationFactory,
   taskFactory,
@@ -20,13 +23,15 @@ context('Task Allocation', () => {
     cy.task('reset')
     cy.task('stubSignIn')
 
-    const apArea = {
-      id: '0544d95a-f6bb-43f8-9be7-aae66e3bf244',
-      name: 'Midlands',
-    }
+    const apArea = apAreaFactory.build()
+    const cruManagementArea = cruManagementAreaFactory.build()
+    const cruManagementAreas: Array<Cas1CruManagementArea> = [
+      ...cruManagementAreaFactory.buildList(3),
+      cruManagementArea,
+    ]
     const qualifications = qualificationFactory.buildList(2)
     // Given there are some users in the database
-    const users = [...userWithWorkloadFactory.buildList(3), userWithWorkloadFactory.build({ apArea, qualifications })]
+    const users = [...userWithWorkloadFactory.buildList(3), userWithWorkloadFactory.build({ qualifications })]
     const selectedUser = users[0]
 
     // And there is an allocated task
@@ -70,17 +75,17 @@ context('Task Allocation', () => {
       allocatedFilter: 'allocated',
       page: '1',
       sortDirection: 'asc',
-      apAreaId: apArea.id,
+      cruManagementAreaId: cruManagementArea.id,
     })
     cy.task('stubTaskGet', { application, task, users })
     cy.task('stubApplicationGet', { application })
     cy.task('stubApAreaReferenceData', { apArea })
+    cy.task('stubCRUManagementAreaReferenceData', { cruManagementAreas })
     cy.task('stubUserSummaryList', { users, roles: ['assessor', 'matcher'] })
     cy.task('stubUserList', { users, roles: ['assessor', 'matcher'] })
 
     // And I am logged in with the cas1 view manage tasks permission
-    const me = userFactory.build({ apArea })
-    cy.task('stubAuthUser', { roles: [], permissions: ['cas1_view_manage_tasks'], userId: me.id, apArea: me.apArea })
+    cy.task('stubAuthUser', { roles: [], permissions: ['cas1_view_manage_tasks'], cruManagementArea })
     cy.signIn()
 
     // When I visit the task list page
@@ -95,6 +100,7 @@ context('Task Allocation', () => {
     cy.wrap(application).as('application')
     cy.wrap(applicationForRestrictedPerson).as('applicationForRestrictedPerson')
     cy.wrap(apArea).as('apArea')
+    cy.wrap(cruManagementArea).as('cruManagementArea')
     cy.wrap(qualifications).as('qualification')
   })
 
@@ -193,8 +199,8 @@ context('Task Allocation', () => {
     allocationsPage.searchBy('apAreaId', this.apArea.id)
     allocationsPage.clickApplyFilter()
 
-    // Then I should be shown a list of users with that qualification and AP AreaId
-    expectedUsers = expectedUsers.filter(user => user.apArea.id === this.apArea.id)
+    // Then I should be shown a list of users with that qualification and CRU Management Area
+    expectedUsers = expectedUsers.filter(user => user.cruManagementArea.id === this.cruManagementArea.id)
     allocationsPage.shouldShowUserTable(expectedUsers, this.task)
   })
 

--- a/integration_tests/tests/tasks/list.cy.ts
+++ b/integration_tests/tests/tasks/list.cy.ts
@@ -1,6 +1,12 @@
 import ListPage from '../../pages/tasks/listPage'
 
-import { apAreaFactory, taskFactory, userFactory, userSummaryFactory } from '../../../server/testutils/factories'
+import {
+  apAreaFactory,
+  cruManagementAreaFactory,
+  taskFactory,
+  userFactory,
+  userSummaryFactory,
+} from '../../../server/testutils/factories'
 import { restrictedPersonSummaryTaskFactory } from '../../../server/testutils/factories/task'
 import { restrictedPersonSummaryAssessmentTaskFactory } from '../../../server/testutils/factories/assessmentTask'
 import paths from '../../../server/paths/tasks'
@@ -10,6 +16,7 @@ context('Task Allocation', () => {
   const users = userSummaryFactory.buildList(5)
   const apArea = apAreaFactory.build()
   const additionalArea = apAreaFactory.build()
+  const cruManagementAreas = cruManagementAreaFactory.buildList(5)
 
   beforeEach(() => {
     cy.task('reset')
@@ -17,9 +24,15 @@ context('Task Allocation', () => {
     cy.task('stubUserSummaryList', { users, roles: ['assessor', 'matcher'] })
     cy.task('stubAuthUser', { apArea })
     cy.task('stubApAreaReferenceData', { apArea, additionalAreas: [additionalArea] })
+    cy.task('stubCRUManagementAreaReferenceData', { cruManagementAreas })
 
-    const me = userFactory.build({ apArea })
-    cy.task('stubAuthUser', { roles: [], permissions: ['cas1_view_manage_tasks'], userId: me.id, apArea: me.apArea })
+    const me = userFactory.build({ apArea, cruManagementArea: cruManagementAreas[0] })
+    cy.task('stubAuthUser', {
+      roles: [],
+      permissions: ['cas1_view_manage_tasks'],
+      userId: me.id,
+      cruManagementArea: cruManagementAreas[0],
+    })
   })
 
   it('returns unauthorised if user does not have the cas1 view manage task permission', () => {
@@ -47,7 +60,7 @@ context('Task Allocation', () => {
       allocatedFilter: 'allocated',
       page: '1',
       sortDirection: 'asc',
-      apAreaId: apArea.id,
+      cruManagementAreaId: cruManagementAreas[0].id,
     })
 
     cy.task('stubGetAllTasks', {
@@ -55,7 +68,7 @@ context('Task Allocation', () => {
       allocatedFilter: 'unallocated',
       page: '1',
       sortDirection: 'asc',
-      apAreaId: apArea.id,
+      cruManagementAreaId: cruManagementAreas[0].id,
     })
 
     cy.task('stubGetAllTasks', {
@@ -64,7 +77,7 @@ context('Task Allocation', () => {
       page: '1',
       sortDirection: 'asc',
       isCompleted: 'true',
-      apAreaId: apArea.id,
+      cruManagementAreaId: cruManagementAreas[0].id,
     })
 
     // When I visit the tasks dashboard
@@ -103,7 +116,7 @@ context('Task Allocation', () => {
       allocatedFilter: 'allocated',
       page: '1',
       sortDirection: 'asc',
-      apAreaId: apArea.id,
+      cruManagementAreaId: cruManagementAreas[0].id,
     })
 
     cy.task('stubGetAllTasks', {
@@ -111,7 +124,7 @@ context('Task Allocation', () => {
       allocatedFilter: 'unallocated',
       page: '1',
       sortDirection: 'asc',
-      apAreaId: apArea.id,
+      cruManagementAreaId: cruManagementAreas[0].id,
     })
 
     // When I visit the tasks dashboard
@@ -144,21 +157,21 @@ context('Task Allocation', () => {
       tasks: allocatedTasksPage1,
       allocatedFilter: 'allocated',
       page: '1',
-      apAreaId: apArea.id,
+      cruManagementAreaId: cruManagementAreas[0].id,
     })
 
     cy.task('stubGetAllTasks', {
       tasks: allocatedTasksPage2,
       allocatedFilter: 'allocated',
       page: '2',
-      apAreaId: apArea.id,
+      cruManagementAreaId: cruManagementAreas[0].id,
     })
 
     cy.task('stubGetAllTasks', {
       tasks: allocatedTasksPage9,
       allocatedFilter: 'allocated',
       page: '9',
-      apAreaId: apArea.id,
+      cruManagementAreaId: cruManagementAreas[0].id,
     })
 
     // When I visit the tasks dashboard
@@ -202,7 +215,7 @@ context('Task Allocation', () => {
       allocatedFilter: 'allocated',
       sortDirection: 'asc',
       sortBy: 'createdAt',
-      apAreaId: apArea.id,
+      cruManagementAreaId: cruManagementAreas[0].id,
     })
 
     sortFields.forEach(sortField => {
@@ -212,7 +225,7 @@ context('Task Allocation', () => {
         page: '1',
         sortDirection: 'asc',
         sortBy: sortField,
-        apAreaId: apArea.id,
+        cruManagementAreaId: cruManagementAreas[0].id,
       })
 
       cy.task('stubGetAllTasks', {
@@ -221,7 +234,7 @@ context('Task Allocation', () => {
         page: '1',
         sortDirection: 'desc',
         sortBy: sortField,
-        apAreaId: apArea.id,
+        cruManagementAreaId: cruManagementAreas[0].id,
       })
     })
 
@@ -258,8 +271,8 @@ context('Task Allocation', () => {
 
   const filterOptions = {
     area: {
-      apiKey: 'apAreaId',
-      value: apArea.id,
+      apiKey: 'cruManagamentAreaId',
+      value: cruManagementAreas[0].id,
     },
     allocatedToUserId: {
       apiKey: 'allocatedToUserId',
@@ -289,7 +302,7 @@ context('Task Allocation', () => {
         tasks: allocatedTasks,
         allocatedFilter: 'allocated',
         page: '1',
-        apAreaId: apArea.id,
+        cruManagementAreaId: cruManagementAreas[0].id,
       })
 
       // When I visit the tasks dashboard
@@ -304,7 +317,7 @@ context('Task Allocation', () => {
         allocatedFilter: 'allocated',
         page: '1',
         sortDirection: 'asc',
-        apAreaId: apArea.id,
+        cruManagementAreaId: cruManagementAreas[0].id,
 
         [filterOptions[key].apiKey]: filterOptions[key].value,
       })
@@ -329,7 +342,12 @@ context('Task Allocation', () => {
     const allocatedTasksFiltered = restrictedPersonSummaryTaskFactory.buildList(1)
     const unallocatedTasks = restrictedPersonSummaryTaskFactory.buildList(1, { allocatedToStaffMember: undefined })
 
-    cy.task('stubGetAllTasks', { tasks: allocatedTasks, allocatedFilter: 'allocated', page: '1', apAreaId: apArea.id })
+    cy.task('stubGetAllTasks', {
+      tasks: allocatedTasks,
+      allocatedFilter: 'allocated',
+      page: '1',
+      cruManagementAreaId: cruManagementAreas[0].id,
+    })
 
     // When I visit the tasks dashboard
     const listPage = ListPage.visit(allocatedTasks, unallocatedTasks)
@@ -337,13 +355,13 @@ context('Task Allocation', () => {
     // Then I should see the tasks that are allocated
     listPage.shouldShowAllocatedTasks()
 
-    // When I filter by region
+    // When I filter by CRU Management area
     cy.task('stubGetAllTasks', {
       tasks: allocatedTasksFiltered,
       allocatedFilter: 'allocated',
       page: '1',
       sortDirection: 'asc',
-      apAreaId: additionalArea.id,
+      cruManagementAreaId: cruManagementAreas[1].id,
     })
 
     cy.task('stubGetAllTasks', {
@@ -351,10 +369,10 @@ context('Task Allocation', () => {
       allocatedFilter: 'unallocated',
       page: '1',
       sortDirection: 'asc',
-      apAreaId: additionalArea.id,
+      cruManagementAreaId: cruManagementAreas[1].id,
     })
 
-    listPage.searchBy('area', additionalArea.id)
+    listPage.searchBy('area', cruManagementAreas[1].id)
     listPage.clickApplyFilter()
 
     // Then the page should show the results
@@ -364,7 +382,7 @@ context('Task Allocation', () => {
     listPage.clickTab('Unallocated')
 
     // Then the page should keep the area filter
-    listPage.shouldHaveSelectText('area', additionalArea.name)
+    listPage.shouldHaveSelectText('area', cruManagementAreas[1].name)
   })
 
   it('retains the unallocated filter when applying other filters', () => {
@@ -382,7 +400,7 @@ context('Task Allocation', () => {
       allocatedFilter: 'unallocated',
       page: '1',
       sortDirection: 'asc',
-      apAreaId: apArea.id,
+      cruManagementAreaId: cruManagementAreas[0].id,
     })
 
     // Given I am on the tasks dashboard filtering by the unallocated tab
@@ -401,10 +419,10 @@ context('Task Allocation', () => {
       allocatedFilter: 'unallocated',
       page: '1',
       sortDirection: 'asc',
-      apAreaId: apArea.id,
+      cruManagementAreaId: cruManagementAreas[0].id,
     })
 
-    listPage.searchBy('area', apArea.id)
+    listPage.searchBy('area', cruManagementAreas[0].id)
     listPage.clickApplyFilter()
 
     // Then the status filter should be retained and allocated results should be shown
@@ -425,21 +443,21 @@ context('Task Allocation', () => {
       tasks: allocatedTasks,
       allocatedFilter: 'allocated',
       page: '1',
-      apAreaId: apArea.id,
+      cruManagementAreaId: cruManagementAreas[0].id,
     })
 
     cy.task('stubGetAllTasks', {
       tasks: allocatedTasksFiltered,
       allocatedFilter: 'allocated',
       page: '1',
-      apAreaId: '',
+      cruManagementAreaId: '',
     })
 
     cy.task('stubGetAllTasks', {
       tasks: allocatedTasksFilteredPage2,
       allocatedFilter: 'allocated',
       page: '2',
-      apAreaId: '',
+      cruManagementAreaId: '',
     })
 
     cy.task('stubGetAllTasks', {
@@ -448,7 +466,7 @@ context('Task Allocation', () => {
       sortDirection: 'asc',
       page: '1',
       sortBy: 'dueAt',
-      apAreaId: '',
+      cruManagementAreaId: '',
     })
 
     // When I visit the tasks dashboard
@@ -493,7 +511,7 @@ context('Task Allocation', () => {
         allocatedFilter: 'allocated',
         page: '1',
         sortDirection: 'asc',
-        apAreaId: apArea.id,
+        cruManagementAreaId: cruManagementAreas[0].id,
       })
       const completedTasks = restrictedPersonSummaryAssessmentTaskFactory.buildList(5)
       cy.task('stubGetAllTasks', {
@@ -503,7 +521,7 @@ context('Task Allocation', () => {
         sortDirection: 'asc',
         sortBy: 'createdAt',
         isCompleted: 'true',
-        apAreaId: apArea.id,
+        cruManagementAreaId: cruManagementAreas[0].id,
       })
       cy.task('stubGetAllTasks', {
         tasks: [...completedTasks],
@@ -512,7 +530,7 @@ context('Task Allocation', () => {
         sortDirection: 'asc',
         sortBy: sortField,
         isCompleted: 'true',
-        apAreaId: apArea.id,
+        cruManagementAreaId: cruManagementAreas[0].id,
       })
       cy.task('stubGetAllTasks', {
         tasks: [...completedTasks],
@@ -521,7 +539,7 @@ context('Task Allocation', () => {
         sortDirection: 'desc',
         sortBy: sortField,
         isCompleted: 'true',
-        apAreaId: apArea.id,
+        cruManagementAreaId: cruManagementAreas[0].id,
       })
 
       // When I visit the tasks dashboard

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -21,6 +21,7 @@ import {
   BedOccupancyOpenEntry,
   BedOccupancyRange,
   Booking,
+  Cas1CruManagementArea,
   Document,
   FlagsEnvelope,
   Gender,
@@ -375,6 +376,7 @@ export type UserDetails = {
   permissions: Array<ApprovedPremisesUserPermission>
   active: boolean
   apArea: ApArea
+  cruManagementArea: Cas1CruManagementArea
   version: string
 }
 

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -25,6 +25,7 @@ export const controllers = (services: Services) => {
     services.applicationService,
     services.apAreaService,
     services.userService,
+    services.cruManagementAreaService,
   )
   const allocationsController = new AllocationsController(services.taskService)
   const placementApplicationPagesController = new PagesController(

--- a/server/data/cas1ReferenceDataClient.test.ts
+++ b/server/data/cas1ReferenceDataClient.test.ts
@@ -1,7 +1,7 @@
 import { LostBedReason } from '@approved-premises/api'
 
 import Cas1ReferenceDataClient from './cas1ReferenceDataClient'
-import { cas1ReferenceDataFactory } from '../testutils/factories'
+import { cas1ReferenceDataFactory, cruManagementAreaFactory } from '../testutils/factories'
 import { describeCas1NamespaceClient } from '../testutils/describeClient'
 
 describeCas1NamespaceClient('Cas1ReferenceDataClient', provider => {
@@ -41,6 +41,31 @@ describeCas1NamespaceClient('Cas1ReferenceDataClient', provider => {
         const output = await cas1ReferenceDataClient.getReferenceData(key)
         expect(output).toEqual(data[key])
       })
+    })
+  })
+
+  describe('getCRUManagementAreas', () => {
+    it('should return an array of CRU management areas', async () => {
+      const cruManagementAreas = cruManagementAreaFactory.buildList(5)
+
+      await provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: `A request to get CRU management areas`,
+        withRequest: {
+          method: 'GET',
+          path: `/cas1/reference-data/cru-management-areas`,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: cruManagementAreas,
+        },
+      })
+
+      const output = await cas1ReferenceDataClient.getCRUManagementAreas()
+      expect(output).toEqual(cruManagementAreas)
     })
   })
 })

--- a/server/data/cas1ReferenceDataClient.ts
+++ b/server/data/cas1ReferenceDataClient.ts
@@ -1,4 +1,5 @@
 import type { Cas1ReferenceData } from '@approved-premises/ui'
+import { Cas1CruManagementArea } from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 
@@ -11,5 +12,11 @@ export default class Cas1ReferenceDataClient {
 
   async getReferenceData(objectType: string): Promise<Array<Cas1ReferenceData>> {
     return (await this.restClient.get({ path: `/cas1/reference-data/${objectType}` })) as Array<Cas1ReferenceData>
+  }
+
+  async getCRUManagementAreas(): Promise<Array<Cas1CruManagementArea>> {
+    return (await this.restClient.get({
+      path: `/cas1/reference-data/cru-management-areas`,
+    })) as Array<Cas1CruManagementArea>
   }
 }

--- a/server/data/taskClient.test.ts
+++ b/server/data/taskClient.test.ts
@@ -25,7 +25,7 @@ describeClient('taskClient', provider => {
     it('makes a get request to the tasks endpoint', async () => {
       const tasks = taskFactory.buildList(2)
 
-      const apAreaId = 'ap-area-id'
+      const cruManagementAreaId = 'cru-management-area-id'
       const userId = 'user-id'
       const taskTypes: Array<TaskType> = ['PlacementApplication', 'Assessment']
       const requiredQualification = 'emergency'
@@ -39,7 +39,7 @@ describeClient('taskClient', provider => {
           path: paths.tasks.index.pattern,
           query: {
             allocatedFilter: 'allocated',
-            apAreaId,
+            cruManagementAreaId,
             allocatedToUserId: userId,
             page: '1',
             sortDirection: 'asc',
@@ -67,7 +67,7 @@ describeClient('taskClient', provider => {
 
       const result = await taskClient.getAll({
         allocatedFilter: 'allocated',
-        apAreaId,
+        cruManagementAreaId,
         allocatedToUserId: userId,
         page: 1,
         sortDirection: 'asc',

--- a/server/data/taskClient.ts
+++ b/server/data/taskClient.ts
@@ -4,7 +4,7 @@ import RestClient from './restClient'
 import paths from '../paths/api'
 import {
   AllocatedFilter,
-  ApArea,
+  Cas1CruManagementArea,
   Reallocation,
   Task,
   TaskSortField,
@@ -22,7 +22,7 @@ export default class TaskClient {
 
   async getAll({
     allocatedFilter,
-    apAreaId,
+    cruManagementAreaId,
     allocatedToUserId,
     page,
     sortDirection,
@@ -33,7 +33,7 @@ export default class TaskClient {
     isCompleted = false,
   }: {
     allocatedFilter: AllocatedFilter
-    apAreaId: ApArea['id']
+    cruManagementAreaId: Cas1CruManagementArea['id']
     allocatedToUserId: string
     page: number
     sortDirection: string
@@ -54,7 +54,7 @@ export default class TaskClient {
         ...filters,
         allocatedFilter,
         allocatedToUserId,
-        apAreaId,
+        cruManagementAreaId,
         sortBy,
         sortDirection,
         requiredQualification,

--- a/server/data/userClient.ts
+++ b/server/data/userClient.ts
@@ -30,9 +30,10 @@ export default class UserClient {
   }
 
   async getUserList(roles: Array<UserRole> = []): Promise<Array<UserSummary>> {
-    return this.restClient.get({ path: paths.users.summary({}), query: { roles: roles.join(',') } }) as Promise<
-      Array<User>
-    >
+    return (await this.restClient.get({
+      path: paths.users.summary({}),
+      query: { roles: roles.join(',') },
+    })) as Promise<Array<User>>
   }
 
   async getUsers(

--- a/server/services/cruManagementAreaService.test.ts
+++ b/server/services/cruManagementAreaService.test.ts
@@ -1,0 +1,33 @@
+import { Cas1ReferenceDataClient } from '../data'
+import CRUManagementAreaService from './cruManagementAreaService'
+import { cruManagementAreaFactory } from '../testutils/factories'
+
+jest.mock('../data/cas1ReferenceDataClient.ts')
+
+describe('CRUManagementAreaService', () => {
+  const cas1ReferenceDataClient = new Cas1ReferenceDataClient(null) as jest.Mocked<Cas1ReferenceDataClient>
+  const referenceDataClientFactory = jest.fn()
+
+  const service = new CRUManagementAreaService(referenceDataClientFactory)
+
+  const token = 'SOME_TOKEN'
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    referenceDataClientFactory.mockReturnValue(cas1ReferenceDataClient)
+  })
+
+  describe('getCRUManagementAreas', () => {
+    it('calls the getCRUManagementAreas client method and returns the result', async () => {
+      const cruManagementAreas = cruManagementAreaFactory.buildList(1)
+
+      cas1ReferenceDataClient.getCRUManagementAreas.mockResolvedValue(cruManagementAreas)
+
+      const result = await service.getCRUManagementAreas(token)
+
+      expect(referenceDataClientFactory).toHaveBeenCalledWith(token)
+      expect(cas1ReferenceDataClient.getCRUManagementAreas).toHaveBeenCalled()
+      expect(result).toEqual(cruManagementAreas)
+    })
+  })
+})

--- a/server/services/cruManagementAreaService.ts
+++ b/server/services/cruManagementAreaService.ts
@@ -1,0 +1,13 @@
+import type { Cas1ReferenceDataClient, RestClientBuilder } from '../data'
+
+import { Cas1CruManagementArea } from '../@types/shared'
+
+export default class CRUManagementAreaService {
+  constructor(private readonly referenceDataClientFactory: RestClientBuilder<Cas1ReferenceDataClient>) {}
+
+  async getCRUManagementAreas(token: string): Promise<Array<Cas1CruManagementArea>> {
+    const client = this.referenceDataClientFactory(token)
+
+    return client.getCRUManagementAreas()
+  }
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -20,6 +20,7 @@ import PlacementApplicationService from './placementApplicationService'
 import SpaceService from './spaceService'
 import ReportService from './reportService'
 import ApAreaService from './apAreaService'
+import CRUManagementAreaService from './cruManagementAreaService'
 import AppealService from './appealService'
 
 import config, { AuditConfig } from '../config'
@@ -65,6 +66,7 @@ export const services = () => {
   const spaceService = new SpaceService(bedClientBuilder)
   const reportService = new ReportService(reportClientBuilder)
   const apAreaService = new ApAreaService(referenceDataClientBuilder)
+  const cruManagementAreaService = new CRUManagementAreaService(cas1ReferenceDataClientBuilder)
 
   return {
     appealService,
@@ -86,6 +88,7 @@ export const services = () => {
     spaceService,
     reportService,
     apAreaService,
+    cruManagementAreaService,
   }
 }
 
@@ -110,4 +113,5 @@ export {
   SpaceService,
   ReportService,
   ApAreaService,
+  CRUManagementAreaService,
 }

--- a/server/services/taskService.test.ts
+++ b/server/services/taskService.test.ts
@@ -41,7 +41,7 @@ describe('taskService', () => {
         sortBy: 'createdAt',
         sortDirection: 'asc',
         page: 1,
-        apAreaId: 'testAreaId',
+        cruManagementAreaId: 'testAreaId',
         taskTypes: ['PlacementApplication', 'Assessment'],
         requiredQualification: 'emergency',
         crnOrName: 'CRN123',
@@ -58,7 +58,7 @@ describe('taskService', () => {
       expect(taskClientFactory).toHaveBeenCalledWith(token)
       expect(taskClient.getAll).toHaveBeenCalledWith({
         allocatedFilter: 'allocated',
-        apAreaId: 'testAreaId',
+        cruManagementAreaId: 'testAreaId',
         allocatedToUserId: '',
         page: 1,
         sortDirection: 'asc',

--- a/server/services/taskService.ts
+++ b/server/services/taskService.ts
@@ -24,7 +24,7 @@ export default class TaskService {
     sortBy,
     sortDirection,
     page = 1,
-    apAreaId = '',
+    cruManagementAreaId = '',
     taskTypes,
     requiredQualification,
     crnOrName,
@@ -36,7 +36,7 @@ export default class TaskService {
     sortBy: TaskSortField
     sortDirection: SortDirection
     page: number
-    apAreaId?: string
+    cruManagementAreaId?: string
     taskTypes?: Array<TaskType>
     requiredQualification?: TaskSearchQualification
     crnOrName?: string
@@ -44,10 +44,10 @@ export default class TaskService {
   }): Promise<PaginatedResponse<Task>> {
     const taskClient = this.taskClientFactory(token)
 
-    const tasks = await taskClient.getAll({
+    return taskClient.getAll({
       allocatedFilter,
       allocatedToUserId,
-      apAreaId,
+      cruManagementAreaId,
       page,
       sortDirection,
       sortBy,
@@ -56,8 +56,6 @@ export default class TaskService {
       crnOrName,
       isCompleted,
     })
-
-    return tasks
   }
 
   async getMatchTasks(token: string): Promise<GroupedMatchTasks> {

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -45,6 +45,7 @@ describe('User service', () => {
       expect(result.roles).toEqual(approvedPremisesUser.roles)
       expect(result.active).toEqual(approvedPremisesUser.isActive)
       expect(result.apArea).toEqual(approvedPremisesUser.apArea)
+      expect(result.cruManagementArea).toEqual(approvedPremisesUser.cruManagementArea)
     })
   })
 

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -35,6 +35,7 @@ export default class UserService {
       roles: user.roles,
       active: user.isActive,
       apArea: user.apArea,
+      cruManagementArea: user.cruManagementArea,
       version: user.version.toString(),
     }
   }

--- a/server/testutils/factories/cas1ReferenceData.ts
+++ b/server/testutils/factories/cas1ReferenceData.ts
@@ -3,6 +3,7 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 
 import type { Cas1ReferenceData } from '@approved-premises/ui'
 
+import { Cas1CruManagementArea } from '@approved-premises/api'
 import outOfServiceBedReasonsJson from '../referenceData/stubs/cas1/out-of-service-bed-reasons.json'
 
 class Cas1ReferenceDataFactory extends Factory<Cas1ReferenceData> {
@@ -16,4 +17,9 @@ export default Cas1ReferenceDataFactory.define(() => ({
   id: faker.string.uuid(),
   name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
   isActive: true,
+}))
+
+export const cruManagementAreaFactory = Factory.define<Cas1CruManagementArea>(() => ({
+  id: faker.string.uuid(),
+  name: faker.location.city(),
 }))

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -70,7 +70,7 @@ import premisesSummaryFactory from './premisesSummary'
 import prisonCaseNotesFactory from './prisonCaseNotes'
 import reallocationFactory from './reallocation'
 import referenceDataFactory, { apAreaFactory, probationRegionFactory } from './referenceData'
-import cas1ReferenceDataFactory from './cas1ReferenceData'
+import cas1ReferenceDataFactory, { cruManagementAreaFactory } from './cas1ReferenceData'
 import requestForPlacementFactory from './requestForPlacement'
 import risksFactory, { tierEnvelopeFactory } from './risks'
 import roomFactory from './room'
@@ -132,6 +132,7 @@ export {
   clarificationNoteFactory,
   contingencyPlanPartnerFactory,
   contingencyPlanQuestionsBodyFactory,
+  cruManagementAreaFactory,
   dateChangeFactory,
   dateCapacityFactory,
   departureFactory,

--- a/server/testutils/factories/user.ts
+++ b/server/testutils/factories/user.ts
@@ -10,6 +10,7 @@ import type {
   UserWithWorkload,
 } from '@approved-premises/api'
 import { apAreaFactory } from './referenceData'
+import { cruManagementAreaFactory } from './cas1ReferenceData'
 
 const userFactory = Factory.define<User>(() => ({
   name: faker.person.fullName(),
@@ -24,8 +25,8 @@ const userFactory = Factory.define<User>(() => ({
   isActive: true,
   apArea: apAreaFactory.build(),
   version: faker.number.int(),
-  cruManagementArea: { id: faker.string.uuid(), name: faker.location.state() },
-  cruManagementAreaDefault: { id: faker.string.uuid(), name: faker.location.state() },
+  cruManagementArea: cruManagementAreaFactory.build(),
+  cruManagementAreaDefault: cruManagementAreaFactory.build(),
 }))
 
 export const userSummaryFactory = Factory.define<UserSummary>(() => ({

--- a/server/testutils/factories/userDetails.ts
+++ b/server/testutils/factories/userDetails.ts
@@ -3,6 +3,7 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 
 import type { UserDetails } from '@approved-premises/ui'
 import { apAreaFactory } from './referenceData'
+import { cruManagementAreaFactory } from './cas1ReferenceData'
 
 export default Factory.define<UserDetails>(() => ({
   id: faker.string.uuid(),
@@ -12,5 +13,6 @@ export default Factory.define<UserDetails>(() => ({
   roles: [],
   permissions: [],
   apArea: apAreaFactory.build(),
+  cruManagementArea: cruManagementAreaFactory.build(),
   version: faker.number.int().toString(),
 }))

--- a/server/views/tasks/_filters.njk
+++ b/server/views/tasks/_filters.njk
@@ -1,97 +1,98 @@
-{% set apAreaFilter %}
-  {{ govukSelect({
-    label: {
-      text: "AP Areas",
-      classes: "govuk-label--s"
-    },
-    id: "area",
-    name: "area",
-    items: convertObjectsToSelectOptions(apAreas, 'All areas', 'name', 'id', 'apArea', 'all', context)
-  }) }}
+{% set cruManagementAreaFilter %}
+    {{ govukSelect({
+        label: {
+            text: "AP Areas",
+            classes: "govuk-label--s"
+        },
+        id: "area",
+        name: "area",
+        items: convertObjectsToSelectOptions(cruManagementAreas, 'All areas', 'name', 'id', 'cruManagementArea', 'all', context)
+    }) }}
 {% endset %}
 
 {% set allocatedUserFilter %}
-  {{ govukSelect({
-    label: {
-      text: "Allocated user",
-      classes: "govuk-label--s"
-    },
-    id: "allocatedToUserId",
-    name: "allocatedToUserId",
-    items: convertObjectsToSelectOptions(users, 'All users', 'name', 'id', 'allocatedToUserId', '', context)
-  }) }}
+    {{ govukSelect({
+        label: {
+            text: "Allocated user",
+            classes: "govuk-label--s"
+        },
+        id: "allocatedToUserId",
+        name: "allocatedToUserId",
+        items: convertObjectsToSelectOptions(users, 'All users', 'name', 'id', 'allocatedToUserId', '', context)
+    }) }}
 {% endset %}
 
 {% set qualificationsFilter %}
-  {{ govukSelect({
-    label: {
-      text: "Required qualification",
-      classes: "govuk-label--s"
-    },
-    id: "requiredQualification",
-    name: "requiredQualification",
-    items: TaskUtils.userQualificationsSelectOptions(requiredQualification)
-  }) }}
+    {{ govukSelect({
+        label: {
+            text: "Required qualification",
+            classes: "govuk-label--s"
+        },
+        id: "requiredQualification",
+        name: "requiredQualification",
+        items: TaskUtils.userQualificationsSelectOptions(requiredQualification)
+    }) }}
 {% endset %}
 
 {% set submitButton %}
-  {{ govukButton({
-      "name": "submit",
-      "text": "Apply filters",
-      "classes": "search-and-filter__submit",
-      preventDoubleClick: true
-  }) }}
+    {{ govukButton({
+        "name": "submit",
+        "text": "Apply filters",
+        "classes": "search-and-filter__submit",
+        preventDoubleClick: true
+    }) }}
 {% endset %}
 
 <div class="search-and-filter__wrapper">
-  <form action="{{ paths.tasks.index({}) }}" method="get">
-    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-    <input type="hidden" name="activeTab" value="{{ activeTab }}">
-    <input type="hidden" name="allocatedFilter" value="{{ allocatedFilter }}">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-quarter">
-        <h2 class="govuk-heading-m">Filters</h2>
-      </div>
-    </div>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <div class="govuk-form-group">
-          <label class="search-and-filter__crn-label--small" for="crnOrName">
-            CRN or Name
-          </label>
-          <input class="govuk-input moj-search__input" id="crnOrName" name="crnOrName" type="search" aria-describedby="crn-hint" value="{{ crnOrName }}">
+    <form action="{{ paths.tasks.index({}) }}" method="get">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+        <input type="hidden" name="activeTab" value="{{ activeTab }}">
+        <input type="hidden" name="allocatedFilter" value="{{ allocatedFilter }}">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-quarter">
+                <h2 class="govuk-heading-m">Filters</h2>
+            </div>
         </div>
-      </div>
-    </div>
-    {% if activeTab == 'allocated' or activeTab == 'completed' %}
-       <div class="govuk-grid-row">
-         <div class="govuk-grid-column-one-third">
-            {{ apAreaFilter | safe }}
-         </div>
-         <div class="govuk-grid-column-one-third">
-            {{ allocatedUserFilter | safe }}
-         </div>
-         <div class="govuk-grid-column-one-third">
-            {{ qualificationsFilter | safe }}
-         </div>
-       </div>
-       <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-third">
-          {{ submitButton | safe }}
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+                <div class="govuk-form-group">
+                    <label class="search-and-filter__crn-label--small" for="crnOrName">
+                        CRN or Name
+                    </label>
+                    <input class="govuk-input moj-search__input" id="crnOrName" name="crnOrName" type="search"
+                           aria-describedby="crn-hint" value="{{ crnOrName }}">
+                </div>
+            </div>
         </div>
-      </div>
-    {% elif activeTab == 'unallocated' %}
-       <div class="govuk-grid-row">
-         <div class="govuk-grid-column-one-third">
-            {{ apAreaFilter | safe }}
-         </div>
-         <div class="govuk-grid-column-one-third">
-            {{ qualificationsFilter | safe }}
-         </div>
-         <div class="govuk-grid-column-one-third">
-            {{ submitButton | safe }}
-         </div>
-       </div>
-    {% endif %}
-  </form>
+        {% if activeTab == 'allocated' or activeTab == 'completed' %}
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-one-third">
+                    {{ cruManagementAreaFilter | safe }}
+                </div>
+                <div class="govuk-grid-column-one-third">
+                    {{ allocatedUserFilter | safe }}
+                </div>
+                <div class="govuk-grid-column-one-third">
+                    {{ qualificationsFilter | safe }}
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-one-third">
+                    {{ submitButton | safe }}
+                </div>
+            </div>
+            {% elif activeTab == 'unallocated' %}
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-one-third">
+                    {{ cruManagementAreaFilter | safe }}
+                </div>
+                <div class="govuk-grid-column-one-third">
+                    {{ qualificationsFilter | safe }}
+                </div>
+                <div class="govuk-grid-column-one-third">
+                    {{ submitButton | safe }}
+                </div>
+            </div>
+        {% endif %}
+    </form>
 </div>

--- a/server/views/tasks/_filters.njk
+++ b/server/views/tasks/_filters.njk
@@ -1,7 +1,7 @@
 {% set cruManagementAreaFilter %}
     {{ govukSelect({
         label: {
-            text: "AP Areas",
+            text: "AP area",
             classes: "govuk-label--s"
         },
         id: "area",


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1334

# Changes in this PR

Fetches the list of CRU management areas instead of AP areas for the 'AP area' filter on the Task allocation page. This lets the user filter the list for applications to the Women's Estate only.

The new CAS1-specific Reference Data endpoint has been added as a service, and CRU information has been added to the user's session data to enable pre-selecting the filter.

The label for the filter has been changed to singular form for consistency with other filters.

## Screenshots of UI changes

### Before

### After

#### Showing _Women's Estate_ option in AP area filter

<img width="988" alt="Screenshot 2024-10-09 at 09 26 45" src="https://github.com/user-attachments/assets/01737cd3-414f-4bc7-8760-4583e7037f5f">


