### PR TITLE
APS-1339: Use CRU Management data to populate CRU dashboard area filter

### DIFF
--- a/integration_tests/mockApis/referenceData.ts
+++ b/integration_tests/mockApis/referenceData.ts
@@ -1,7 +1,7 @@
 import { Response } from 'superagent'
-import { ApArea } from '@approved-premises/api'
+import { ApArea, Cas1CruManagementArea } from '@approved-premises/api'
 import { stubFor } from './setup'
-import { apAreaFactory } from '../../server/testutils/factories'
+import { apAreaFactory, cruManagementAreaFactory } from '../../server/testutils/factories'
 
 export const stubApAreaReferenceData = (
   {
@@ -33,7 +33,11 @@ export const stubApAreaReferenceData = (
   })
 }
 
-export const stubCRUManagementAreaReferenceData = ({ cruManagementAreas }) => {
+export const stubCRUManagementAreaReferenceData = (
+  args: {
+    cruManagementAreas?: Array<Cas1CruManagementArea>
+  } = {},
+) => {
   return stubFor({
     request: {
       method: 'GET',
@@ -44,7 +48,7 @@ export const stubCRUManagementAreaReferenceData = ({ cruManagementAreas }) => {
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
       },
-      jsonBody: cruManagementAreas,
+      jsonBody: args.cruManagementAreas || cruManagementAreaFactory.buildList(5),
     },
   })
 }

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -3,10 +3,10 @@ import ShowPage from '../../pages/admin/placementApplications/showPage'
 import NewWithdrawalPage from '../../pages/apply/newWithdrawal'
 
 import {
-  apAreaFactory,
   applicationFactory,
   applicationSummaryFactory,
   bookingFactory,
+  cruManagementAreaFactory,
   newCancellationFactory,
   placementRequestDetailFactory,
   placementRequestWithFullPersonFactory,
@@ -55,7 +55,7 @@ context('Placement Requests', () => {
 
   const preferredAps = premisesFactory.buildList(3)
 
-  const apArea = apAreaFactory.build()
+  const cruManagementAreas = cruManagementAreaFactory.buildList(5)
 
   beforeEach(() => {
     cy.task('reset')
@@ -82,7 +82,7 @@ context('Placement Requests', () => {
     cy.task('stubPlacementRequest', unmatchedPlacementRequest)
     cy.task('stubPlacementRequest', matchedPlacementRequest)
     cy.task('stubPlacementRequest', unableToMatchPlacementRequest)
-    cy.task('stubApAreaReferenceData', { apArea })
+    cy.task('stubCRUManagementAreaReferenceData', { cruManagementAreas })
   })
 
   it('allows me to view a placement request', () => {
@@ -506,13 +506,12 @@ context('Placement Requests', () => {
       sortDirection: 'asc',
     })
     cy.task('stubPlacementRequestsDashboard', { placementRequests: matchedPlacementRequests, status: 'matched' })
-    cy.task('stubApAreaReferenceData', { apArea })
 
     // Given I am on the placement request dashboard
     const listPage = ListPage.visit()
 
     // When I filter by AP area and request type
-    listPage.getSelectInputByIdAndSelectAnEntry('apArea', apArea.name)
+    listPage.getSelectInputByIdAndSelectAnEntry('cruManagementArea', cruManagementAreas[1].name)
     listPage.getSelectInputByIdAndSelectAnEntry('requestType', 'parole')
     listPage.clickApplyFilters()
 
@@ -521,9 +520,9 @@ context('Placement Requests', () => {
       status: 'notMatched',
     }).then(requests => {
       expect(requests).to.have.length(2)
-      const { apAreaId, requestType } = requests[1].queryParams
+      const { cruManagementAreaId, requestType } = requests[1].queryParams
 
-      expect(apAreaId.values).to.deep.equal([apArea.id])
+      expect(cruManagementAreaId.values).to.deep.equal([cruManagementAreas[1].id])
       expect(requestType.values).to.deep.equal(['parole'])
     })
 
@@ -531,7 +530,7 @@ context('Placement Requests', () => {
     listPage.clickMatched()
 
     // Then the page should retain the area and request type filter
-    listPage.shouldHaveSelectText('apArea', apArea.name)
+    listPage.shouldHaveSelectText('cruManagementArea', cruManagementAreas[1].name)
     listPage.shouldHaveSelectText('requestType', 'Parole')
   })
 
@@ -546,13 +545,12 @@ context('Placement Requests', () => {
       sortBy: 'created_at',
       sortDirection: 'asc',
     })
-    cy.task('stubApAreaReferenceData', { apArea })
 
     // Given I am on the placement request dashboard filtering by the unableToMatch status
     const listPage = ListPage.visit('status=unableToMatch')
 
     // When I filter by AP area and request type
-    listPage.getSelectInputByIdAndSelectAnEntry('apArea', apArea.name)
+    listPage.getSelectInputByIdAndSelectAnEntry('cruManagementArea', cruManagementAreas[2].name)
     listPage.getSelectInputByIdAndSelectAnEntry('requestType', 'parole')
     listPage.clickApplyFilters()
 
@@ -579,24 +577,24 @@ context('Placement Requests', () => {
     listPage.shouldNotShowRequestTypeFilter()
 
     // When I filter by AP area
-    const apAreaApplications = applicationSummaryFactory.buildList(2)
+    const areaApplications = applicationSummaryFactory.buildList(2)
     cy.task('stubAllApplications', {
-      applications: apAreaApplications,
+      applications: areaApplications,
       page: '1',
       sortDirection: 'asc',
-      searchOptions: { apAreaId: apArea.id, releaseType: 'rotl' },
+      searchOptions: { cruManagementAreaId: cruManagementAreas[3].id, releaseType: 'rotl' },
     })
-    listPage.getSelectInputByIdAndSelectAnEntry('apArea', apArea.name)
+    listPage.getSelectInputByIdAndSelectAnEntry('cruManagementArea', cruManagementAreas[3].name)
     listPage.getSelectInputByIdAndSelectAnEntry('releaseType', allReleaseTypes.rotl)
     listPage.clickApplyFilters()
 
     // Then I should see a list of applications with no placement requests for that area
-    listPage.shouldShowApplications(apAreaApplications)
+    listPage.shouldShowApplications(areaApplications)
 
     cy.task('verifyDashboardRequest', {
       status: 'pendingPlacementRequest',
       sortDirection: 'asc',
-      searchOptions: { apAreaId: apArea.id, releaseType: 'rotl' },
+      searchOptions: { cruManagementAreaId: cruManagementAreas[3].id, releaseType: 'rotl' },
     }).then(requests => {
       expect(requests).to.have.length(1)
     })

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -1,3 +1,4 @@
+import { Cas1SpaceSearchParameters, PlacementCriteria } from '@approved-premises/api'
 import SearchPage from '../../pages/match/searchPage'
 import UnableToMatchPage from '../../pages/match/unableToMatchPage'
 
@@ -13,7 +14,6 @@ import Page from '../../pages/page'
 import { signIn } from '../signIn'
 
 import ListPage from '../../pages/admin/placementApplications/listPage'
-import { Cas1SpaceSearchParameters, PlacementCriteria } from '../../../server/@types/shared'
 import { filterOutAPTypes, placementDates } from '../../../server/utils/match'
 import BookASpacePage from '../../pages/match/bookASpacePage'
 
@@ -24,7 +24,7 @@ context('Placement Requests', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubApAreaReferenceData')
+    cy.task('stubCRUManagementAreaReferenceData')
   })
 
   it('allows me to search for an available space', () => {

--- a/integration_tests/tests/tasks/allocations.cy.ts
+++ b/integration_tests/tests/tasks/allocations.cy.ts
@@ -1,4 +1,3 @@
-import { Cas1CruManagementArea } from '@approved-premises/api'
 import TaskListPage from '../../pages/tasks/listPage'
 import AllocationsPage from '../../pages/tasks/allocationPage'
 import Page from '../../pages/page'
@@ -25,10 +24,6 @@ context('Task Allocation', () => {
 
     const apArea = apAreaFactory.build()
     const cruManagementArea = cruManagementAreaFactory.build()
-    const cruManagementAreas: Array<Cas1CruManagementArea> = [
-      ...cruManagementAreaFactory.buildList(3),
-      cruManagementArea,
-    ]
     const qualifications = qualificationFactory.buildList(2)
     // Given there are some users in the database
     const users = [...userWithWorkloadFactory.buildList(3), userWithWorkloadFactory.build({ qualifications })]
@@ -80,7 +75,7 @@ context('Task Allocation', () => {
     cy.task('stubTaskGet', { application, task, users })
     cy.task('stubApplicationGet', { application })
     cy.task('stubApAreaReferenceData', { apArea })
-    cy.task('stubCRUManagementAreaReferenceData', { cruManagementAreas })
+    cy.task('stubCRUManagementAreaReferenceData')
     cy.task('stubUserSummaryList', { users, roles: ['assessor', 'matcher'] })
     cy.task('stubUserList', { users, roles: ['assessor', 'matcher'] })
 

--- a/integration_tests/tests/withdrawals/withdrawals.cy.ts
+++ b/integration_tests/tests/withdrawals/withdrawals.cy.ts
@@ -20,13 +20,17 @@ import paths from '../../../server/paths/apply'
 import withdrawablesFactory from '../../../server/testutils/factories/withdrawablesFactory'
 
 context('Withdrawals', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+    cy.task('stubCRUManagementAreaReferenceData')
+  })
+
   describe('as a CRU user', () => {
     const userRoles: Array<ApprovedPremisesUserRole> = ['workflow_manager']
 
     beforeEach(() => {
-      cy.task('reset')
-      cy.task('stubSignIn')
-      cy.task('stubAuthUser')
       // Given I am logged in
       signIn(userRoles)
     })
@@ -172,10 +176,8 @@ context('Withdrawals', () => {
 
   describe('as a non-CRU user', () => {
     const userRoles: Array<ApprovedPremisesUserRole> = ['applicant']
+
     beforeEach(() => {
-      cy.task('reset')
-      cy.task('stubSignIn')
-      cy.task('stubAuthUser')
       // Given I am logged in
       signIn(userRoles)
     })

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -496,7 +496,7 @@ export type PlacementRequestDashboardSearchOptions = {
 export type ApplicationDashboardSearchOptions = {
   crnOrName?: string
   status?: ApprovedPremisesApplicationStatus | ReadonlyArray<ApprovedPremisesApplicationStatus>
-  apAreaId?: string
+  cruManagementAreaId?: Cas1CruManagementArea['id'] | 'all'
   releaseType?: ReleaseTypeOption
 }
 

--- a/server/controllers/admin/index.ts
+++ b/server/controllers/admin/index.ts
@@ -12,9 +12,20 @@ import CruDashboardController from './cruDashboardController'
 import type { Services } from '../../services'
 
 export const controllers = (services: Services) => {
-  const { placementRequestService, premisesService, reportService, apAreaService, applicationService } = services
+  const {
+    placementRequestService,
+    premisesService,
+    reportService,
+    apAreaService,
+    cruManagementAreaService,
+    applicationService,
+  } = services
   const adminPlacementRequestsController = new AdminPlacementRequestsController(placementRequestService)
-  const cruDashboardController = new CruDashboardController(placementRequestService, apAreaService, applicationService)
+  const cruDashboardController = new CruDashboardController(
+    placementRequestService,
+    cruManagementAreaService,
+    applicationService,
+  )
   const placementRequestsBookingsController = new PlacementRequestsBookingsController(
     placementRequestService,
     premisesService,

--- a/server/data/placementRequestClient.test.ts
+++ b/server/data/placementRequestClient.test.ts
@@ -1,3 +1,4 @@
+import { WithdrawPlacementRequestReason } from '@approved-premises/api'
 import PlacementRequestClient from './placementRequestClient'
 import paths from '../paths/api'
 
@@ -10,7 +11,6 @@ import {
 } from '../testutils/factories'
 import describeClient from '../testutils/describeClient'
 import { normaliseCrn } from '../utils/normaliseCrn'
-import { WithdrawPlacementRequestReason } from '../@types/shared/models/WithdrawPlacementRequestReason'
 
 describeClient('placementRequestClient', provider => {
   let placementRequestClient: PlacementRequestClient
@@ -85,7 +85,7 @@ describeClient('placementRequestClient', provider => {
     })
 
     it('makes a get request to the placementRequests dashboard endpoint for matched requests ', async () => {
-      const apAreaId = 'area-id'
+      const cruManagementAreaId = 'area-id'
       const requestType = 'standardRelease'
       const status = 'matched'
 
@@ -95,7 +95,7 @@ describeClient('placementRequestClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.placementRequests.dashboard.pattern,
-          query: { page: '1', sortBy: 'created_at', sortDirection: 'asc', requestType, apAreaId, status },
+          query: { page: '1', sortBy: 'created_at', sortDirection: 'asc', requestType, cruManagementAreaId, status },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -111,7 +111,7 @@ describeClient('placementRequestClient', provider => {
         },
       })
 
-      const result = await placementRequestClient.dashboard({ apAreaId, requestType, status })
+      const result = await placementRequestClient.dashboard({ cruManagementAreaId, requestType, status })
 
       expect(result).toEqual({
         data: placementRequests,

--- a/server/data/placementRequestClient.ts
+++ b/server/data/placementRequestClient.ts
@@ -1,6 +1,6 @@
 import {
-  ApArea,
   BookingNotMade,
+  Cas1CruManagementArea,
   NewBookingNotMade,
   NewPlacementRequestBooking,
   NewPlacementRequestBookingConfirmation,
@@ -10,20 +10,20 @@ import {
   PlacementRequestSortField,
   PlacementRequestStatus,
   SortDirection,
+  WithdrawPlacementRequestReason,
 } from '@approved-premises/api'
 import config, { ApiConfig } from '../config'
 import RestClient from './restClient'
 import paths from '../paths/api'
 import { PaginatedResponse, PlacementRequestDashboardSearchOptions } from '../@types/ui'
 import { normaliseCrn } from '../utils/normaliseCrn'
-import { WithdrawPlacementRequestReason } from '../@types/shared/models/WithdrawPlacementRequestReason'
 
 type DashboardQueryParams = DashboardFilters & PlacementRequestDashboardSearchOptions
 
 export type DashboardFilters = {
   status?: PlacementRequestStatus
   requestType?: PlacementRequestRequestType | ''
-  apAreaId?: ApArea['id']
+  cruManagementAreaId?: Cas1CruManagementArea['id']
 }
 
 export default class PlacementRequestClient {
@@ -43,7 +43,7 @@ export default class PlacementRequestClient {
     allParams: DashboardQueryParams = {
       status: 'notMatched',
       requestType: '',
-      apAreaId: '',
+      cruManagementAreaId: '',
     },
     page = 1,
     sortBy: PlacementRequestSortField = 'created_at',

--- a/server/services/placementRequestService.test.ts
+++ b/server/services/placementRequestService.test.ts
@@ -1,4 +1,4 @@
-import { PlacementRequest, PlacementRequestDetail } from '@approved-premises/api'
+import { PlacementRequest, PlacementRequestDetail, WithdrawPlacementRequestReason } from '@approved-premises/api'
 import PlacementRequestClient, { DashboardFilters } from '../data/placementRequestClient'
 import {
   bookingNotMadeFactory,
@@ -9,7 +9,6 @@ import {
 } from '../testutils/factories'
 import PlacementRequestService from './placementRequestService'
 import { PaginatedResponse } from '../@types/ui'
-import { WithdrawPlacementRequestReason } from '../@types/shared/models/WithdrawPlacementRequestReason'
 
 jest.mock('../data/placementRequestClient.ts')
 
@@ -30,7 +29,7 @@ describe('placementRequestService', () => {
     const defaultFilters: DashboardFilters = {
       status: 'notMatched',
       requestType: 'standardRelease',
-      apAreaId: '',
+      cruManagementAreaId: '',
     }
 
     it('calls the find method on the placementRequest client', async () => {

--- a/server/utils/placementRequests/utils.test.ts
+++ b/server/utils/placementRequests/utils.test.ts
@@ -87,25 +87,25 @@ describe('utils', () => {
 
   describe('placementRequestTabItems', () => {
     it('returns placement request tab items', () => {
-      expect(placementRequestTabItems('notMatched', 'apArea', 'parole')).toEqual([
+      expect(placementRequestTabItems('notMatched', 'cru-management-area-id', 'parole')).toEqual([
         {
           active: false,
           text: 'Pending Request for Placement',
-          href: `/admin/cru-dashboard?apArea=apArea&status=pendingPlacement`,
+          href: `/admin/cru-dashboard?cruManagementArea=cru-management-area-id&status=pendingPlacement`,
         },
         {
           active: true,
-          href: '/admin/cru-dashboard?apArea=apArea&requestType=parole',
+          href: '/admin/cru-dashboard?cruManagementArea=cru-management-area-id&requestType=parole',
           text: 'Ready to match',
         },
         {
           active: false,
-          href: '/admin/cru-dashboard?apArea=apArea&requestType=parole&status=unableToMatch',
+          href: '/admin/cru-dashboard?cruManagementArea=cru-management-area-id&requestType=parole&status=unableToMatch',
           text: 'Unable to match',
         },
         {
           active: false,
-          href: '/admin/cru-dashboard?apArea=apArea&requestType=parole&status=matched',
+          href: '/admin/cru-dashboard?cruManagementArea=cru-management-area-id&requestType=parole&status=matched',
           text: 'Matched',
         },
         {

--- a/server/utils/placementRequests/utils.ts
+++ b/server/utils/placementRequests/utils.ts
@@ -51,27 +51,57 @@ export const requestTypes = [
 export const withdrawalMessage = (duration: number, expectedArrivalDate: string) =>
   `Request for placement for ${placementLength(Number(duration))} starting on ${DateFormats.isoDateToUIDate(expectedArrivalDate, { format: 'short' })} withdrawn successfully`
 
-export const placementRequestTabItems = (activeTab?: string, apArea?: string, requestType?: string): Array<TabItem> => {
+export const placementRequestTabItems = (
+  activeTab?: string,
+  cruManagementArea?: string,
+  requestType?: string,
+): Array<TabItem> => {
   return [
     {
       text: 'Pending Request for Placement',
       active: activeTab === 'pendingPlacement',
-      href: `${pathsAdmin.admin.cruDashboard.index({})}${createQueryString({ apArea, status: 'pendingPlacement' }, { addQueryPrefix: true })}`,
+      href: `${pathsAdmin.admin.cruDashboard.index({})}${createQueryString(
+        {
+          cruManagementArea,
+          status: 'pendingPlacement',
+        },
+        { addQueryPrefix: true },
+      )}`,
     },
     {
       text: 'Ready to match',
       active: activeTab === 'notMatched' || activeTab === undefined || activeTab?.length === 0,
-      href: `${pathsAdmin.admin.cruDashboard.index({})}${createQueryString({ apArea, requestType }, { addQueryPrefix: true })}`,
+      href: `${pathsAdmin.admin.cruDashboard.index({})}${createQueryString(
+        {
+          cruManagementArea,
+          requestType,
+        },
+        { addQueryPrefix: true },
+      )}`,
     },
     {
       text: 'Unable to match',
       active: activeTab === 'unableToMatch',
-      href: `${pathsAdmin.admin.cruDashboard.index({})}${createQueryString({ apArea, requestType, status: 'unableToMatch' }, { addQueryPrefix: true })}`,
+      href: `${pathsAdmin.admin.cruDashboard.index({})}${createQueryString(
+        {
+          cruManagementArea,
+          requestType,
+          status: 'unableToMatch',
+        },
+        { addQueryPrefix: true },
+      )}`,
     },
     {
       text: 'Matched',
       active: activeTab === 'matched',
-      href: `${pathsAdmin.admin.cruDashboard.index({})}${createQueryString({ apArea, requestType, status: 'matched' }, { addQueryPrefix: true })}`,
+      href: `${pathsAdmin.admin.cruDashboard.index({})}${createQueryString(
+        {
+          cruManagementArea,
+          requestType,
+          status: 'matched',
+        },
+        { addQueryPrefix: true },
+      )}`,
     },
     {
       text: 'Search',

--- a/server/views/admin/cruDashboard/_navigation.njk
+++ b/server/views/admin/cruDashboard/_navigation.njk
@@ -1,10 +1,8 @@
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 
-{% macro navigation(activeTab, apArea, requestType) %}
-  {{
-    mojSubNavigation({
-      label: 'Sub navigation',
-      items: PlacementRequestUtils.placementRequestTabItems(activeTab, apArea, requestType)
-    })
-  }}
+{% macro navigation(activeTab, cruManagementArea, requestType) %}
+    {{ mojSubNavigation({
+        label: 'Sub navigation',
+        items: PlacementRequestUtils.placementRequestTabItems(activeTab, cruManagementArea, requestType)
+    }) }}
 {% endmacro %}

--- a/server/views/admin/cruDashboard/index.njk
+++ b/server/views/admin/cruDashboard/index.njk
@@ -6,105 +6,101 @@
 
 {% from "./_navigation.njk" import navigation %}
 
-{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body assessments--index" %}
 
 {% block content %}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      {% include "../../_messages.njk" %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            {% include "../../_messages.njk" %}
 
-      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+            <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
-      <p class="govuk-body">
-        {{ subheading }}
-      </p>
-      <div class="search-and-filter__wrapper">
-        <form action="{{ paths.admin.cruDashboard.index({}) }}" method="get">
-          <input type="hidden" name="status" value="{{ status }}">
-          <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+            <p class="govuk-body">
+                {{ subheading }}
+            </p>
+            <div class="search-and-filter__wrapper">
+                <form action="{{ paths.admin.cruDashboard.index({}) }}" method="get">
+                    <input type="hidden" name="status" value="{{ status }}">
+                    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-              <h2 class="govuk-heading-m">Filters</h2>
+                    <div class="govuk-grid-row">
+                        <div class="govuk-grid-column-full">
+                            <h2 class="govuk-heading-m">Filters</h2>
+                        </div>
+                    </div>
+
+                    <div class="govuk-grid-row">
+                        <div class="govuk-grid-column-one-third">
+                            {{ govukSelect({
+                                label: {
+                                    text: "AP Area",
+                                    classes: "govuk-label--s"
+                                },
+                                classes: "govuk-input--width-20",
+                                id: "cruManagementArea",
+                                name: "cruManagementArea",
+                                items: convertObjectsToSelectOptions(cruManagementAreas, 'All areas', 'name', 'id', 'cruManagementArea', 'all', context)
+                            }) }}
+                        </div>
+                        {% if status != "pendingPlacement" %}
+                            <div class="govuk-grid-column-one-third">
+                                {{ govukSelect({
+                                    label: {
+                                        text: "Request type",
+                                        classes: "govuk-label--s"
+                                    },
+                                    id: "requestType",
+                                    name: "requestType",
+                                    items: convertObjectsToSelectOptions(PlacementRequestUtils.requestTypes, 'All request types', 'name', 'value', 'requestType', '', context)
+                                }) }}
+                            </div>
+                        {% endif %}
+                        {% if status === "pendingPlacement" %}
+                            <div class="govuk-grid-column-one-third">
+                                {{ govukSelect({
+                                    label: {
+                                        text: "Release type",
+                                        classes: "govuk-label--s"
+                                    },
+                                    id: "releaseType",
+                                    name: "releaseType",
+                                    items: ApplyUtils.releaseTypeSelectOptions(releaseType)
+                                }) }}
+                            </div>
+                        {% endif %}
+
+                        <div class="govuk-grid-column-one-third">
+                            {{ govukButton({
+                                "name": "submit",
+                                "text": "Apply filters",
+                                "classes": "search-and-filter__submit",
+                                "preventDoubleClick": true
+                            }) }}
+                        </div>
+                    </div>
+                </form>
             </div>
-          </div>
 
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-one-third">
-              {{ govukSelect({
-                  label: {
-                    text: "AP Area",
-                    classes: "govuk-label--s"
-                  },
-                  classes: "govuk-input--width-20",
-                  id: "apArea",
-                  name: "apArea",
-                  items: convertObjectsToSelectOptions(apAreas, 'All areas', 'name', 'id', 'apArea', 'all', context)
+            {{ navigation(status, cruManagementArea, requestType) }}
+
+            {% if status == "pendingPlacement" %}
+                {{ govukTable({
+                    firstCellIsHeader: true,
+                    head: ApplyUtils.pendingPlacementRequestTableHeader(sortBy, sortDirection, hrefPrefix),
+                    rows: ApplyUtils.pendingPlacementRequestTableRows(applications)
                 }) }}
-            </div>
-            {% if status != "pendingPlacement" %}
-              <div class="govuk-grid-column-one-third">
-                {{ govukSelect({
-                    label: {
-                    text: "Request type",
-                    classes: "govuk-label--s"
-                    },
-                    id: "requestType",
-                    name: "requestType",
-                    items: convertObjectsToSelectOptions(PlacementRequestUtils.requestTypes, 'All request types', 'name', 'value', 'requestType', '', context)
-                  }) }}
-              </div>
-            {% endif %}
-            {% if status === "pendingPlacement" %}
-              <div class="govuk-grid-column-one-third">
-                {{ govukSelect({
-                   label: {
-                   text: "Release type",
-                   classes: "govuk-label--s"
-                   },
-                   id: "releaseType",
-                   name: "releaseType",
-                   items: ApplyUtils.releaseTypeSelectOptions(releaseType)
-                 }) }}
-              </div>
+            {% else %}
+                {{ govukTable({
+                    firstCellIsHeader: true,
+                    head: PlacementRequestUtils.tableUtils.dashboardTableHeader(status, sortBy, sortDirection, hrefPrefix),
+                    rows: PlacementRequestUtils.tableUtils.dashboardTableRows(placementRequests, status)
+                }) }}
             {% endif %}
 
-            <div class="govuk-grid-column-one-third">
-              {{ govukButton({
-                  "name": "submit",
-                  "text": "Apply filters",
-                  "classes": "search-and-filter__submit",
-                  "preventDoubleClick": true
-              }) }}
-            </div>
-          </div>
-        </form>
-      </div>
+            {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
 
-      {{ navigation(status, apArea, requestType) }}
-
-      {% if status == "pendingPlacement" %}
-        {{
-          govukTable({
-              firstCellIsHeader: true,
-              head: ApplyUtils.pendingPlacementRequestTableHeader(sortBy, sortDirection, hrefPrefix),
-              rows: ApplyUtils.pendingPlacementRequestTableRows(applications)
-            })
-        }}
-      {% else %}
-        {{
-          govukTable({
-              firstCellIsHeader: true,
-              head: PlacementRequestUtils.tableUtils.dashboardTableHeader(status, sortBy, sortDirection, hrefPrefix),
-              rows: PlacementRequestUtils.tableUtils.dashboardTableRows(placementRequests, status)
-            })
-        }}
-      {% endif %}
-
-      {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
-
+        </div>
     </div>
-  </div>
 {% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1339

# Changes in this PR

On the CRU dashboard, populate the AP area filter using CRU management areas instead of simply AP areas, so the applications can be filtered for Women's Estate.

## Screenshots of UI changes

### After

#### Showing _Women's Estate_ option in AP area filter

<img width="995" alt="Screenshot 2024-10-09 at 16 47 15" src="https://github.com/user-attachments/assets/d47e9122-e819-492d-bed2-82f96380bf4d">
