### PR TITLE
APS-1402 Women's estate - Preferred AP selection

### DIFF
--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -217,9 +217,9 @@ export default class ApplyHelper {
   }
 
   private stubCas1PremisesEndpoint() {
-    const premises1 = cas1PremisesSummaryFactory.build({ id: '1', apArea: { id: 1, name: 'area1' } })
-    const premises2 = cas1PremisesSummaryFactory.build({ id: '2', apArea: { id: 2, name: 'area2' } })
-    const premises3 = cas1PremisesSummaryFactory.build({ id: '3', apArea: { id: 3, name: 'area3' } })
+    const premises1 = cas1PremisesSummaryFactory.build({ id: '1', apArea: { id: '1', name: 'area1' } })
+    const premises2 = cas1PremisesSummaryFactory.build({ id: '2', apArea: { id: '2', name: 'area2' } })
+    const premises3 = cas1PremisesSummaryFactory.build({ id: '3', apArea: { id: '3', name: 'area3' } })
     cy.task('stubCas1AllPremises', [premises1, premises2, premises3])
   }
 

--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -31,6 +31,7 @@ import Page from '../pages'
 import {
   acctAlertFactory,
   adjudicationFactory,
+  cas1PremisesSummaryFactory,
   contingencyPlanPartnerFactory,
   contingencyPlanQuestionsBodyFactory,
   documentFactory,
@@ -98,6 +99,7 @@ export default class ApplyHelper {
     this.stubPersonEndpoints()
     this.stubApplicationEndpoints()
     this.stubPremisesEndpoint()
+    this.stubCas1PremisesEndpoint()
     if (oasysMissing) {
       this.stubOasys404()
     } else {
@@ -212,6 +214,13 @@ export default class ApplyHelper {
     const premises2 = premisesSummaryFactory.build({ id: '2', apArea: 'area2' })
     const premises3 = premisesSummaryFactory.build({ id: '3', apArea: 'area3' })
     cy.task('stubAllPremises', [premises1, premises2, premises3])
+  }
+
+  private stubCas1PremisesEndpoint() {
+    const premises1 = cas1PremisesSummaryFactory.build({ id: '1', apArea: { id: 1, name: 'area1' } })
+    const premises2 = cas1PremisesSummaryFactory.build({ id: '2', apArea: { id: 2, name: 'area2' } })
+    const premises3 = cas1PremisesSummaryFactory.build({ id: '3', apArea: { id: 3, name: 'area3' } })
+    cy.task('stubCas1AllPremises', [premises1, premises2, premises3])
   }
 
   private stubPersonEndpoints() {

--- a/integration_tests/mockApis/premises.ts
+++ b/integration_tests/mockApis/premises.ts
@@ -3,6 +3,7 @@ import type { Response, SuperAgentRequest } from 'superagent'
 import type {
   BedOccupancyRange,
   Booking,
+  Cas1PremisesSummary,
   ExtendedPremisesSummary,
   Premises,
   ApprovedPremisesSummary as PremisesSummary,
@@ -28,6 +29,22 @@ const stubAllPremises = (premises: Array<PremisesSummary>) =>
       jsonBody: premises,
     },
   })
+
+const stubCas1AllPremises = (premises: Array<Cas1PremisesSummary>) => {
+  return stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/cas1/premises/summary.*',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: premises,
+    },
+  })
+}
 
 const stubPremisesSummary = (premises: ExtendedPremisesSummary) =>
   stubFor({
@@ -61,6 +78,7 @@ const stubSinglePremises = (premises: Premises) =>
 
 export default {
   stubAllPremises,
+  stubCas1AllPremises,
   stubPremisesSummary,
   stubSinglePremises,
   stubPremisesWithBookings: (args: { premises: Premises; bookings: Array<Booking> }): Promise<[Response, Response]> =>

--- a/integration_tests/pages/admin/placementApplications/createPlacementPage.ts
+++ b/integration_tests/pages/admin/placementApplications/createPlacementPage.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesSummary, PlacementRequestDetail } from '../../../../server/@types/shared'
+import { Cas1PremisesSummary, PlacementRequestDetail } from '../../../../server/@types/shared'
 import { placementDates } from '../../../../server/utils/match'
 import Page from '../../page'
 
@@ -14,13 +14,13 @@ export default class CreatePlacementPage extends Page {
     this.dateInputsShouldContainDate('departureDate', dates.endDate)
   }
 
-  completeForm(startDate: string, endDate: string, premises: ApprovedPremisesSummary): void {
+  completeForm(startDate: string, endDate: string, premises: Cas1PremisesSummary): void {
     this.clearDateInputs('arrivalDate')
     this.completeDateInputs('arrivalDate', startDate)
 
     this.clearDateInputs('departureDate')
     this.completeDateInputs('departureDate', endDate)
-    this.getSelectInputByIdAndSelectAnEntry('area0', premises.apArea)
+    this.getSelectInputByIdAndSelectAnEntry('area0', premises.apArea.name)
     this.getSelectInputByIdAndSelectAnEntry('premisesId', premises.id)
   }
 }

--- a/integration_tests/pages/apply/preferredAps.ts
+++ b/integration_tests/pages/apply/preferredAps.ts
@@ -4,9 +4,14 @@ import paths from '../../../server/paths/apply'
 import ApplyPage from './applyPage'
 
 export default class PreferredAps extends ApplyPage {
+  isWomensApplication: boolean
+
   constructor(application: ApprovedPremisesApplication) {
+    this.isWomensApplication = application.isWomensApplication
     super(
-      'Select a preferred AP',
+      this.isWomensApplication
+        ? 'Select all preferred properties for your women’s AP application'
+        : 'Select a preferred AP',
       application,
       'location-factors',
       'preferred-aps',
@@ -19,11 +24,17 @@ export default class PreferredAps extends ApplyPage {
   }
 
   completeForm() {
-    this.getSelectInputByIdAndSelectAnEntry('area0', 'area1')
-    this.selectSelectOptionFromPageBody('preferredAp1')
-    this.getSelectInputByIdAndSelectAnEntry('area1', 'area2')
-    this.selectSelectOptionFromPageBody('preferredAp2')
-    this.getSelectInputByIdAndSelectAnEntry('area2', 'area3')
-    this.selectSelectOptionFromPageBody('preferredAp3')
+    if (this.isWomensApplication) {
+      this.selectSelectOptionFromPageBody('preferredAp1')
+      this.selectSelectOptionFromPageBody('preferredAp2')
+      this.selectSelectOptionFromPageBody('preferredAp3')
+    } else {
+      this.getSelectInputByIdAndSelectAnEntry('area0', 'area1')
+      this.selectSelectOptionFromPageBody('preferredAp1')
+      this.getSelectInputByIdAndSelectAnEntry('area1', 'area2')
+      this.selectSelectOptionFromPageBody('preferredAp2')
+      this.getSelectInputByIdAndSelectAnEntry('area2', 'area3')
+      this.selectSelectOptionFromPageBody('preferredAp3')
+    }
   }
 }

--- a/integration_tests/pages/apply/preferredAps.ts
+++ b/integration_tests/pages/apply/preferredAps.ts
@@ -4,9 +4,7 @@ import paths from '../../../server/paths/apply'
 import ApplyPage from './applyPage'
 
 export default class PreferredAps extends ApplyPage {
-  private readonly isWomensApplication: boolean
-
-  constructor(application: ApprovedPremisesApplication) {
+  constructor(private readonly application: ApprovedPremisesApplication) {
     super(
       application.isWomensApplication
         ? 'Select all preferred properties for your women’s AP application'
@@ -20,11 +18,10 @@ export default class PreferredAps extends ApplyPage {
         page: 'describe-location-factors',
       }),
     )
-    this.isWomensApplication = application.isWomensApplication
   }
 
   completeForm() {
-    if (this.isWomensApplication) {
+    if (this.application.isWomensApplication) {
       this.selectSelectOptionFromPageBody('preferredAp1')
       this.selectSelectOptionFromPageBody('preferredAp2')
       this.selectSelectOptionFromPageBody('preferredAp3')

--- a/integration_tests/pages/apply/preferredAps.ts
+++ b/integration_tests/pages/apply/preferredAps.ts
@@ -7,9 +7,8 @@ export default class PreferredAps extends ApplyPage {
   isWomensApplication: boolean
 
   constructor(application: ApprovedPremisesApplication) {
-    this.isWomensApplication = application.isWomensApplication
     super(
-      this.isWomensApplication
+      application.isWomensApplication
         ? 'Select all preferred properties for your women’s AP application'
         : 'Select a preferred AP',
       application,
@@ -21,6 +20,7 @@ export default class PreferredAps extends ApplyPage {
         page: 'describe-location-factors',
       }),
     )
+    this.isWomensApplication = application.isWomensApplication
   }
 
   completeForm() {

--- a/integration_tests/pages/apply/preferredAps.ts
+++ b/integration_tests/pages/apply/preferredAps.ts
@@ -4,7 +4,7 @@ import paths from '../../../server/paths/apply'
 import ApplyPage from './applyPage'
 
 export default class PreferredAps extends ApplyPage {
-  isWomensApplication: boolean
+  private readonly isWomensApplication: boolean
 
   constructor(application: ApprovedPremisesApplication) {
     super(

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -1,6 +1,4 @@
 Cypress.Commands.add('signIn', (options = { failOnStatusCode: true }) => {
-  cy.task('stubAllPremises', [])
-  cy.task('stubCas1AllPremises', [])
   cy.request('/')
   return cy.task('getSignInUrl').then((url: string) => cy.visit(url, options))
 })

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -1,5 +1,6 @@
 Cypress.Commands.add('signIn', (options = { failOnStatusCode: true }) => {
   cy.task('stubAllPremises', [])
+  cy.task('stubCas1AllPremises', [])
   cy.request('/')
   return cy.task('getSignInUrl').then((url: string) => cy.visit(url, options))
 })

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -6,12 +6,12 @@ import {
   applicationFactory,
   applicationSummaryFactory,
   bookingFactory,
+  cas1PremisesSummaryFactory,
   cruManagementAreaFactory,
   newCancellationFactory,
   placementRequestDetailFactory,
   placementRequestWithFullPersonFactory,
   premisesFactory,
-  premisesSummaryFactory,
   withdrawableFactory,
 } from '../../../server/testutils/factories'
 import Page from '../../pages/page'
@@ -162,8 +162,8 @@ context('Placement Requests', () => {
   })
 
   it('allows me to create a booking', () => {
-    const premises = premisesSummaryFactory.buildList(3)
-    cy.task('stubAllPremises', premises)
+    const premises = cas1PremisesSummaryFactory.buildList(3)
+    cy.task('stubCas1AllPremises', premises)
     cy.task('stubBookingFromPlacementRequest', unmatchedPlacementRequest)
 
     // When I visit the tasks dashboard
@@ -206,8 +206,8 @@ context('Placement Requests', () => {
   })
 
   it('allows me to amend a booking', () => {
-    const premises = premisesFactory.buildList(3)
-    cy.task('stubAllPremises', premises)
+    const premises = cas1PremisesSummaryFactory.buildList(3)
+    cy.task('stubCas1AllPremises', premises)
     cy.task('stubBookingFromPlacementRequest', matchedPlacementRequest)
     cy.task('stubDateChange', {
       premisesId: matchedPlacementRequest.booking.premisesId,
@@ -257,10 +257,9 @@ context('Placement Requests', () => {
   })
 
   it('allows me to cancel a booking', () => {
-    const premises = premisesFactory.buildList(3)
-    const cancellation = newCancellationFactory.build()
+    const premises = cas1PremisesSummaryFactory.buildList(3)
+    cy.task('stubCas1AllPremises', premises)
     const withdrawable = withdrawableFactory.build({ id: matchedPlacementRequest.booking.id, type: 'booking' })
-    cy.task('stubAllPremises', premises)
     cy.task('stubBookingFromPlacementRequest', matchedPlacementRequest)
     cy.task('stubCancellationCreate', {
       premisesId: matchedPlacementRequest.booking.premisesId,

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -8,6 +8,7 @@ import {
   bookingFactory,
   cas1PremisesSummaryFactory,
   cruManagementAreaFactory,
+  newCancellationFactory,
   placementRequestDetailFactory,
   placementRequestWithFullPersonFactory,
   premisesFactory,
@@ -257,6 +258,7 @@ context('Placement Requests', () => {
 
   it('allows me to cancel a booking', () => {
     const premises = cas1PremisesSummaryFactory.buildList(3)
+    const cancellation = newCancellationFactory.build()
     cy.task('stubCas1AllPremises', premises)
     const withdrawable = withdrawableFactory.build({ id: matchedPlacementRequest.booking.id, type: 'booking' })
     cy.task('stubBookingFromPlacementRequest', matchedPlacementRequest)

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -8,7 +8,6 @@ import {
   bookingFactory,
   cas1PremisesSummaryFactory,
   cruManagementAreaFactory,
-  newCancellationFactory,
   placementRequestDetailFactory,
   placementRequestWithFullPersonFactory,
   premisesFactory,

--- a/integration_tests/tests/manage/cru_member/viewsAllOutOfServiceBeds.cy.ts
+++ b/integration_tests/tests/manage/cru_member/viewsAllOutOfServiceBeds.cy.ts
@@ -39,6 +39,7 @@ describe('CRU Member with permission to view out of service bed tile lists all O
     signIn(['cru_member'], ['cas1_view_out_of_service_beds'])
     cy.task('stubApAreaReferenceData', { apArea: apArea1, additionalAreas: [apArea2] })
     cy.task('stubAllPremises', allPremises)
+    cy.task('stubCas1AllPremises', allPremises)
   })
 
   const outOfServiceBeds = outOfServiceBedFactory.buildList(10, {

--- a/integration_tests/tests/manage/cru_member/viewsAllOutOfServiceBeds.cy.ts
+++ b/integration_tests/tests/manage/cru_member/viewsAllOutOfServiceBeds.cy.ts
@@ -1,4 +1,8 @@
-import { apAreaFactory, outOfServiceBedFactory, premisesSummaryFactory } from '../../../../server/testutils/factories'
+import {
+  apAreaFactory,
+  cas1PremisesSummaryFactory,
+  outOfServiceBedFactory,
+} from '../../../../server/testutils/factories'
 import DashboardPage from '../../../pages/dashboard'
 import Page from '../../../pages/page'
 import { OutOfServiceBedIndexPage } from '../../../pages/manage/outOfServiceBeds'
@@ -15,19 +19,19 @@ describe('CRU Member with permission to view out of service bed tile lists all O
     name: 'Test Area 2',
   })
 
-  const premises1 = premisesSummaryFactory.build({
-    apArea: apArea1.name,
+  const premises1 = cas1PremisesSummaryFactory.build({
+    apArea: apArea1,
     name: 'Premises 1',
     id: 'premises-1-id',
   })
 
-  const premises2 = premisesSummaryFactory.build({
-    apArea: apArea1.name,
+  const premises2 = cas1PremisesSummaryFactory.build({
+    apArea: apArea1,
     name: 'Premises 2',
   })
 
-  const premises3 = premisesSummaryFactory.build({
-    apArea: apArea2.name,
+  const premises3 = cas1PremisesSummaryFactory.build({
+    apArea: apArea2,
     name: 'Premises 3',
   })
 
@@ -38,7 +42,6 @@ describe('CRU Member with permission to view out of service bed tile lists all O
     // Given I am signed in as a CRU Member with the permission to view the out of service beds tile
     signIn(['cru_member'], ['cas1_view_out_of_service_beds'])
     cy.task('stubApAreaReferenceData', { apArea: apArea1, additionalAreas: [apArea2] })
-    cy.task('stubAllPremises', allPremises)
     cy.task('stubCas1AllPremises', allPremises)
   })
 

--- a/integration_tests/tests/manage/departure.cy.ts
+++ b/integration_tests/tests/manage/departure.cy.ts
@@ -32,7 +32,6 @@ context('Departures', () => {
       moveOnCategory,
     })
 
-    cy.task('stubAllPremises', premises)
     cy.task('stubCas1AllPremises', premises)
     cy.task('stubBookingGet', { premisesId: premises[0].id, booking })
     cy.task('stubDepartureCreate', { premisesId: premises[0].id, bookingId: booking.id, departure })
@@ -64,7 +63,6 @@ context('Departures', () => {
     const premises = premisesFactory.buildList(5)
     const booking = bookingFactory.build()
 
-    cy.task('stubAllPremises', premises)
     cy.task('stubCas1AllPremises', premises)
     cy.task('stubBookingGet', { premisesId: premises[0].id, booking })
 

--- a/integration_tests/tests/manage/departure.cy.ts
+++ b/integration_tests/tests/manage/departure.cy.ts
@@ -33,6 +33,7 @@ context('Departures', () => {
     })
 
     cy.task('stubAllPremises', premises)
+    cy.task('stubCas1AllPremises', premises)
     cy.task('stubBookingGet', { premisesId: premises[0].id, booking })
     cy.task('stubDepartureCreate', { premisesId: premises[0].id, bookingId: booking.id, departure })
 
@@ -64,6 +65,7 @@ context('Departures', () => {
     const booking = bookingFactory.build()
 
     cy.task('stubAllPremises', premises)
+    cy.task('stubCas1AllPremises', premises)
     cy.task('stubBookingGet', { premisesId: premises[0].id, booking })
 
     // When I visit the departure page

--- a/integration_tests/tests/manage/premises.cy.ts
+++ b/integration_tests/tests/manage/premises.cy.ts
@@ -15,6 +15,7 @@ context('Premises', () => {
     it('should list all premises', () => {
       const premises = premisesSummaryFactory.buildList(5)
       cy.task('stubAllPremises', premises)
+      cy.task('stubCas1AllPremises', premises)
       cy.task('stubApAreaReferenceData')
 
       // When I visit the premises page

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -286,7 +286,12 @@ export type GroupedListofBookings = {
   [K in 'arrivingToday' | 'departingToday' | 'upcomingArrivals' | 'upcomingDepartures']: Array<Booking>
 }
 
-export type ManWoman = 'man' | 'woman'
+type ManWoman = 'man' | 'woman'
+
+export interface PremisesFilters {
+  gender?: ManWoman
+  apAreaId?: string
+}
 
 export type DataServices = Partial<{
   personService: {
@@ -306,7 +311,7 @@ export type DataServices = Partial<{
   }
   premisesService: {
     getAll: (token: string) => Promise<Array<Premises>>
-    getCas1All: (token: string, gender: ManWoman) => Promise<Array<Cas1PremisesSummary>>
+    getCas1All: (token: string, filters: PremisesFilters) => Promise<Array<Cas1PremisesSummary>>
   }
   assessmentService: {
     createClarificationNote: (

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -22,6 +22,7 @@ import {
   BedOccupancyRange,
   Booking,
   Cas1CruManagementArea,
+  Cas1PremisesSummary,
   Document,
   FlagsEnvelope,
   Gender,
@@ -285,6 +286,8 @@ export type GroupedListofBookings = {
   [K in 'arrivingToday' | 'departingToday' | 'upcomingArrivals' | 'upcomingDepartures']: Array<Booking>
 }
 
+export type ManWoman = 'man' | 'woman'
+
 export type DataServices = Partial<{
   personService: {
     getPrisonCaseNotes: (token: string, crn: string) => Promise<Array<PrisonCaseNote>>
@@ -303,6 +306,7 @@ export type DataServices = Partial<{
   }
   premisesService: {
     getAll: (token: string) => Promise<Array<Premises>>
+    getCas1All: (token: string, gender: ManWoman) => Promise<Array<Cas1PremisesSummary>>
   }
   assessmentService: {
     createClarificationNote: (

--- a/server/controllers/admin/placementRequests/bookingsController.test.ts
+++ b/server/controllers/admin/placementRequests/bookingsController.test.ts
@@ -5,9 +5,9 @@ import BookingsController from './bookingsController'
 
 import { PlacementRequestService, PremisesService } from '../../../services'
 import {
+  cas1PremisesSummaryFactory,
   newPlacementRequestBookingConfirmationFactory,
   placementRequestDetailFactory,
-  premisesSummaryFactory,
 } from '../../../testutils/factories'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import { ErrorsAndUserInput } from '../../../@types/ui'
@@ -35,11 +35,11 @@ describe('PlacementRequestsController', () => {
   })
 
   describe('new', () => {
-    const premises = premisesSummaryFactory.buildList(2)
+    const premises = cas1PremisesSummaryFactory.buildList(2)
 
     beforeEach(() => {
       placementRequestService.getPlacementRequest.mockResolvedValue(placementRequest)
-      premisesService.getAll.mockResolvedValue(premises)
+      premisesService.getCas1All.mockResolvedValue(premises)
     })
 
     it('should render the form with the premises and the placement request', async () => {
@@ -60,7 +60,7 @@ describe('PlacementRequestsController', () => {
         ...DateFormats.isoDateToDateInputs('2022-01-15', 'departureDate'),
       })
 
-      expect(premisesService.getAll).toHaveBeenCalledWith(token)
+      expect(premisesService.getCas1All).toHaveBeenCalledWith(token)
       expect(placementRequestService.getPlacementRequest).toHaveBeenCalledWith(token, placementRequest.id)
     })
 

--- a/server/controllers/admin/placementRequests/bookingsController.ts
+++ b/server/controllers/admin/placementRequests/bookingsController.ts
@@ -17,7 +17,7 @@ export default class PlacementRequestsController {
       let { userInput } = errorsAndUserInput
       const { errors, errorSummary, errorTitle } = errorsAndUserInput
 
-      const premises = await this.premisesService.getAll(req.user.token)
+      const premises = await this.premisesService.getCas1All(req.user.token)
       const placementRequest = await this.placementRequestService.getPlacementRequest(req.user.token, req.params.id)
 
       if (!Object.keys(userInput).length) {

--- a/server/controllers/manage/outOfServiceBedsController.test.ts
+++ b/server/controllers/manage/outOfServiceBedsController.test.ts
@@ -394,16 +394,16 @@ describe('OutOfServiceBedsController', () => {
 
       const allApAreas = [apArea1, apArea2]
 
-      const premises1 = premisesSummaryFactory.build({
-        apArea: apArea1.name,
+      const premises1 = cas1PremisesSummaryFactory.build({
+        apArea: apArea1,
       })
 
-      const premises2 = premisesSummaryFactory.build({
-        apArea: apArea1.name,
+      const premises2 = cas1PremisesSummaryFactory.build({
+        apArea: apArea1,
       })
 
-      const premises3 = premisesSummaryFactory.build({
-        apArea: apArea2.name,
+      const premises3 = cas1PremisesSummaryFactory.build({
+        apArea: apArea2,
       })
 
       const allPremises = [premises1, premises2, premises3]
@@ -417,7 +417,7 @@ describe('OutOfServiceBedsController', () => {
       apAreaService.getApAreas.mockResolvedValue(allApAreas)
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      premisesService.getAll.mockResolvedValue(allPremises)
+      premisesService.getCas1All.mockResolvedValue(allPremises)
 
       outOfServiceBedService.getAllOutOfServiceBeds.mockResolvedValue(paginatedResponse)
       ;(getPaginationDetails as jest.Mock).mockReturnValue({})

--- a/server/controllers/manage/outOfServiceBedsController.ts
+++ b/server/controllers/manage/outOfServiceBedsController.ts
@@ -124,7 +124,7 @@ export default class OutOfServiceBedsController {
     return async (req: Request, res: Response) => {
       const { temporality } = req.params as { temporality: Temporality }
       const apAreas = await this.apAreaService.getApAreas(req.user.token)
-      let premises = await this.premisesService.getAll(req.user.token)
+      let premises = await this.premisesService.getCas1All(req.user.token)
       let { apAreaId = '', premisesId = '' } = req.query as {
         apAreaId: string
         premisesId: string
@@ -140,7 +140,7 @@ export default class OutOfServiceBedsController {
       if (apAreaId) {
         if (apAreaId !== 'all') {
           const apAreaSelected = apAreas.find(apArea => apArea.id === apAreaId)
-          premises = premises.filter(item => item.apArea === apAreaSelected.name)
+          premises = premises.filter(item => item.apArea.name === apAreaSelected.name)
           disablePremisesSelect = false
         }
       }

--- a/server/data/cas1PremisesClient.test.ts
+++ b/server/data/cas1PremisesClient.test.ts
@@ -2,7 +2,7 @@ import PremisesClient from './premisesClient'
 import paths from '../paths/api'
 
 import { describeCas1NamespaceClient } from '../testutils/describeClient'
-import { premisesFactory } from '../testutils/factories'
+import { cas1PremisesSummaryFactory, premisesFactory } from '../testutils/factories'
 
 describeCas1NamespaceClient('Cas1PremisesClient', provider => {
   let premisesClient: PremisesClient
@@ -35,6 +35,34 @@ describeCas1NamespaceClient('Cas1PremisesClient', provider => {
 
       const output = await premisesClient.find(premises.id)
       expect(output).toEqual(premises)
+    })
+  })
+
+  describe('allCas1', () => {
+    it('should get all premises', async () => {
+      const gender = 'man'
+      const premisesSummaries = cas1PremisesSummaryFactory.buildList(5)
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get all CAS1 premises summaries',
+        withRequest: {
+          method: 'GET',
+          path: paths.premises.indexCas1({ gender }),
+          headers: {
+            authorization: `Bearer ${sampleToken}`,
+            'X-Service-Name': 'approved-premises',
+          },
+          query: { gender },
+        },
+        willRespondWith: {
+          status: 200,
+          body: premisesSummaries,
+        },
+      })
+
+      const output = await premisesClient.allCas1(gender)
+      expect(output).toEqual(premisesSummaries)
     })
   })
 })

--- a/server/data/cas1PremisesClient.test.ts
+++ b/server/data/cas1PremisesClient.test.ts
@@ -61,7 +61,7 @@ describeCas1NamespaceClient('Cas1PremisesClient', provider => {
         },
       })
 
-      const output = await premisesClient.allCas1(gender)
+      const output = await premisesClient.allCas1({ gender })
       expect(output).toEqual(premisesSummaries)
     })
   })

--- a/server/data/premisesClient.ts
+++ b/server/data/premisesClient.ts
@@ -9,7 +9,7 @@ import type {
   Room,
   StaffMember,
 } from '@approved-premises/api'
-import type { ManWoman } from '@approved-premises/ui'
+import type { PremisesFilters } from '@approved-premises/ui'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -29,11 +29,10 @@ export default class PremisesClient {
     })) as Array<PremisesSummary>
   }
 
-  async allCas1(gender: ManWoman = null): Promise<Array<Cas1PremisesSummary>> {
-    const query = gender ? { gender } : {}
+  async allCas1(filters: PremisesFilters): Promise<Array<Cas1PremisesSummary>> {
     return (await this.restClient.get({
       path: paths.premises.indexCas1({}),
-      query,
+      query: { ...filters },
     })) as Array<Cas1PremisesSummary>
   }
 

--- a/server/data/premisesClient.ts
+++ b/server/data/premisesClient.ts
@@ -9,6 +9,7 @@ import type {
   Room,
   StaffMember,
 } from '@approved-premises/api'
+import type { ManWoman } from '@approved-premises/ui'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -26,6 +27,14 @@ export default class PremisesClient {
       path: paths.premises.index({}),
       query,
     })) as Array<PremisesSummary>
+  }
+
+  async allCas1(gender: ManWoman = null): Promise<Array<Cas1PremisesSummary>> {
+    const query = gender ? { gender } : {}
+    return (await this.restClient.get({
+      path: paths.premises.indexCas1({}),
+      query,
+    })) as Array<Cas1PremisesSummary>
   }
 
   async find(id: string): Promise<Cas1PremisesSummary> {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/maleAp.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/maleAp.ts
@@ -23,7 +23,9 @@ export default class MaleAp implements TasklistPage {
   }
 
   next() {
-    return this.body.shouldPersonBePlacedInMaleAp === 'yes' ? 'relevant-dates' : 'refer-to-delius'
+    return this.body.shouldPersonBePlacedInMaleAp === 'yes' || config.flags.weEnabled
+      ? 'relevant-dates'
+      : 'refer-to-delius'
   }
 
   response() {

--- a/server/form-pages/apply/risk-and-need-factors/location-factors/preferredAps.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/preferredAps.test.ts
@@ -3,18 +3,18 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import { fromPartial } from '@total-typescript/shoehorn'
 import PreferredAps from './preferredAps'
 import { PremisesService } from '../../../../services'
-import { applicationFactory, premisesFactory } from '../../../../testutils/factories'
+import { applicationFactory, cas1PremisesSummaryFactory } from '../../../../testutils/factories'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
 describe('PreferredAps', () => {
   let premisesService: DeepMocked<PremisesService>
   const application = applicationFactory.build()
 
-  const ap1 = premisesFactory.build({ id: '1', name: 'AP 1' })
-  const ap2 = premisesFactory.build({ id: '2', name: 'AP 2' })
-  const ap3 = premisesFactory.build({ id: '3', name: 'AP 3' })
-  const ap4 = premisesFactory.build({ id: '4', name: 'AP 4' })
-  const ap5 = premisesFactory.build({ id: '5', name: 'AP 5' })
+  const ap1 = cas1PremisesSummaryFactory.build({ id: '1', name: 'AP 1' })
+  const ap2 = cas1PremisesSummaryFactory.build({ id: '2', name: 'AP 2' })
+  const ap3 = cas1PremisesSummaryFactory.build({ id: '3', name: 'AP 3' })
+  const ap4 = cas1PremisesSummaryFactory.build({ id: '4', name: 'AP 4' })
+  const ap5 = cas1PremisesSummaryFactory.build({ id: '5', name: 'AP 5' })
 
   const allAps = [ap1, ap2, ap3, ap4, ap5]
 
@@ -36,12 +36,12 @@ describe('PreferredAps', () => {
   })
 
   describe('initialize', () => {
-    const getAll = jest.fn().mockResolvedValue(allAps)
+    const getCas1All = jest.fn().mockResolvedValue(allAps)
     const token = 'token'
 
     beforeEach(() => {
       premisesService = createMock<PremisesService>({
-        getAll,
+        getCas1All,
       })
     })
 
@@ -49,7 +49,7 @@ describe('PreferredAps', () => {
       const page = await PreferredAps.initialize(body, application, token, fromPartial({ premisesService }))
 
       expect(page.allPremises).toEqual(allAps)
-      expect(getAll).toHaveBeenCalledWith(token)
+      expect(getCas1All).toHaveBeenCalledWith(token, application.isWomensApplication ? 'woman' : 'man')
     })
 
     it('should convert the selectedAps from strings to objects containing text and value properties', async () => {

--- a/server/form-pages/apply/risk-and-need-factors/location-factors/preferredAps.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/preferredAps.test.ts
@@ -49,7 +49,7 @@ describe('PreferredAps', () => {
       const page = await PreferredAps.initialize(body, application, token, fromPartial({ premisesService }))
 
       expect(page.allPremises).toEqual(allAps)
-      expect(getCas1All).toHaveBeenCalledWith(token, application.isWomensApplication ? 'woman' : 'man')
+      expect(getCas1All).toHaveBeenCalledWith(token, { gender: application.isWomensApplication ? 'woman' : 'man' })
     })
 
     it('should convert the selectedAps from strings to objects containing text and value properties', async () => {

--- a/server/form-pages/apply/risk-and-need-factors/location-factors/preferredAps.ts
+++ b/server/form-pages/apply/risk-and-need-factors/location-factors/preferredAps.ts
@@ -34,8 +34,6 @@ export default class PreferredAps implements TasklistPage {
 
   preferredApLabels = this.preferredApOptions.map((_, i) => `${numberToOrdinal(i)} choice AP`)
 
-  isWomensAp: boolean
-
   selectorAttributes: SelectorAttributes
 
   body: PreferredApsBody
@@ -49,7 +47,7 @@ export default class PreferredAps implements TasklistPage {
     { premisesService }: DataServices,
   ) {
     const { isWomensApplication } = application
-    const allPremises = await premisesService.getCas1All(token, isWomensApplication ? 'woman' : 'man')
+    const allPremises = await premisesService.getCas1All(token, { gender: isWomensApplication ? 'woman' : 'man' })
 
     const selectedAps: Array<Cas1PremisesSummary> = []
     preferredAps.forEach(id => {
@@ -67,7 +65,6 @@ export default class PreferredAps implements TasklistPage {
     page.title = isWomensApplication
       ? 'Select all preferred properties for your women’s AP application'
       : 'Select a preferred AP'
-    page.isWomensAp = !isWomensApplication
     page.selectorAttributes = isWomensApplication
       ? {}
       : {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -65,6 +65,7 @@ export default {
   premises: {
     show: cas1PremisesSingle,
     index: premises.path('summary'),
+    indexCas1: cas1Premises.path('summary'),
     capacity: premisesSingle.path('capacity'),
     summary: premisesSingle.path('summary'),
     lostBeds: {

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -82,10 +82,10 @@ describe('PremisesService', () => {
       const premises = cas1PremisesSummaryFactory.buildList(2)
 
       premisesClient.allCas1.mockResolvedValue(premises)
-      await service.getCas1All(token, requestGender)
+      await service.getCas1All(token, { gender: requestGender })
 
       expect(premisesClientFactory).toHaveBeenCalledWith(token)
-      expect(premisesClient.allCas1).toHaveBeenCalledWith(requestGender)
+      expect(premisesClient.allCas1).toHaveBeenCalledWith({ gender: requestGender })
     })
 
     it('sorts the premises returned by name', async () => {

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -1,3 +1,4 @@
+import type { ManWoman } from '@approved-premises/ui'
 import PremisesService from './premisesService'
 import PremisesClient from '../data/premisesClient'
 import {
@@ -59,6 +60,41 @@ describe('PremisesService', () => {
       premisesClient.all.mockResolvedValue([premisesB, premisesA])
 
       const result = await service.getAll(token)
+
+      expect(result).toEqual([premisesA, premisesB])
+    })
+  })
+
+  describe('getCas1All', () => {
+    it('calls the all method of the premises client and returns the response', async () => {
+      const premises = cas1PremisesSummaryFactory.buildList(2)
+      premisesClient.allCas1.mockResolvedValue(premises)
+
+      const result = await service.getCas1All(token)
+
+      expect(result).toEqual(premises)
+      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClient.allCas1).toHaveBeenCalled()
+    })
+
+    it('supports optional gender parameter', async () => {
+      const requestGender: ManWoman = 'man'
+      const premises = cas1PremisesSummaryFactory.buildList(2)
+
+      premisesClient.allCas1.mockResolvedValue(premises)
+      await service.getCas1All(token, requestGender)
+
+      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClient.allCas1).toHaveBeenCalledWith(requestGender)
+    })
+
+    it('sorts the premises returned by name', async () => {
+      const premisesA = cas1PremisesSummaryFactory.build({ name: 'A' })
+      const premisesB = cas1PremisesSummaryFactory.build({ name: 'B' })
+
+      premisesClient.allCas1.mockResolvedValue([premisesB, premisesA])
+
+      const result = await service.getCas1All(token)
 
       expect(result).toEqual([premisesA, premisesB])
     })

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -19,45 +19,14 @@ export default class PremisesService {
     const premisesClient = this.premisesClientFactory(token)
     const premises = await premisesClient.all(selectedAreaId)
 
-    return premises.sort((a, b) => {
-      if (a.name < b.name) {
-        return -1
-      }
-      if (a.name > b.name) {
-        return 1
-      }
-      return 0
-    })
+    return premises.sort((a, b) => (a.name < b.name ? -1 : 1))
   }
 
   async getCas1All(token: string, gender: ManWoman = null): Promise<Array<Cas1PremisesSummary>> {
     const premisesClient = this.premisesClientFactory(token)
     const premises = await premisesClient.allCas1(gender)
 
-    return premises.sort((a, b) => {
-      if (a.name < b.name) {
-        return -1
-      }
-      if (a.name > b.name) {
-        return 1
-      }
-      return 0
-    })
-  }
-
-  async getSummary(token: string, selectedAreaId = ''): Promise<Array<ApprovedPremisesSummary>> {
-    const premisesClient = this.premisesClientFactory(token)
-    const premises = await premisesClient.all(selectedAreaId)
-
-    return premises.sort((a, b) => {
-      if (a.name < b.name) {
-        return -1
-      }
-      if (a.name > b.name) {
-        return 1
-      }
-      return 0
-    })
+    return premises.sort((a, b) => (a.name < b.name ? -1 : 1))
   }
 
   async getStaffMembers(token: string, premisesId: string): Promise<Array<StaffMember>> {

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -7,7 +7,7 @@ import type {
   Room,
   StaffMember,
 } from '@approved-premises/api'
-import type { ManWoman } from '@approved-premises/ui'
+import type { PremisesFilters } from '@approved-premises/ui'
 import type { PremisesClient, RestClientBuilder } from '../data'
 
 import { mapApiOccupancyToUiOccupancy } from '../utils/premises'
@@ -19,14 +19,14 @@ export default class PremisesService {
     const premisesClient = this.premisesClientFactory(token)
     const premises = await premisesClient.all(selectedAreaId)
 
-    return premises.sort((a, b) => (a.name < b.name ? -1 : 1))
+    return premises.sort((a, b) => a.name.localeCompare(b.name))
   }
 
-  async getCas1All(token: string, gender: ManWoman = null): Promise<Array<Cas1PremisesSummary>> {
+  async getCas1All(token: string, filters: PremisesFilters = {}): Promise<Array<Cas1PremisesSummary>> {
     const premisesClient = this.premisesClientFactory(token)
-    const premises = await premisesClient.allCas1(gender)
+    const premises = await premisesClient.allCas1(filters)
 
-    return premises.sort((a, b) => (a.name < b.name ? -1 : 1))
+    return premises.sort((a, b) => a.name.localeCompare(b.name))
   }
 
   async getStaffMembers(token: string, premisesId: string): Promise<Array<StaffMember>> {

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -7,6 +7,7 @@ import type {
   Room,
   StaffMember,
 } from '@approved-premises/api'
+import type { ManWoman } from '@approved-premises/ui'
 import type { PremisesClient, RestClientBuilder } from '../data'
 
 import { mapApiOccupancyToUiOccupancy } from '../utils/premises'
@@ -15,6 +16,36 @@ export default class PremisesService {
   constructor(private readonly premisesClientFactory: RestClientBuilder<PremisesClient>) {}
 
   async getAll(token: string, selectedAreaId = ''): Promise<Array<ApprovedPremisesSummary>> {
+    const premisesClient = this.premisesClientFactory(token)
+    const premises = await premisesClient.all(selectedAreaId)
+
+    return premises.sort((a, b) => {
+      if (a.name < b.name) {
+        return -1
+      }
+      if (a.name > b.name) {
+        return 1
+      }
+      return 0
+    })
+  }
+
+  async getCas1All(token: string, gender: ManWoman = null): Promise<Array<Cas1PremisesSummary>> {
+    const premisesClient = this.premisesClientFactory(token)
+    const premises = await premisesClient.allCas1(gender)
+
+    return premises.sort((a, b) => {
+      if (a.name < b.name) {
+        return -1
+      }
+      if (a.name > b.name) {
+        return 1
+      }
+      return 0
+    })
+  }
+
+  async getSummary(token: string, selectedAreaId = ''): Promise<Array<ApprovedPremisesSummary>> {
     const premisesClient = this.premisesClientFactory(token)
     const premises = await premisesClient.all(selectedAreaId)
 

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -139,6 +139,11 @@ describe('getApplicationData', () => {
         }),
       )
     })
+
+    it('returns correct data for a womens application', () => {
+      ;(isWomensApplication as jest.Mock).mockReturnValue(true)
+      expect(getApplicationSubmissionData(application)).toEqual(expect.objectContaining({ isWomensApplication: true }))
+    })
   })
 
   describe('getApplicationUpdateData', () => {

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -8,7 +8,7 @@ import {
   mockQuestionResponse,
 } from '../../testutils/mockQuestionResponse'
 import { arrivalDateFromApplication } from './arrivalDateFromApplication'
-import { isInapplicable, isWomensAp } from './utils'
+import { isInapplicable, isWomensApplication } from './utils'
 import { reasonForShortNoticeDetails } from './reasonForShortNoticeDetails'
 import { applicationUserDetailsFactory } from '../../testutils/factories/application'
 
@@ -54,7 +54,7 @@ describe('getApplicationData', () => {
 
     beforeEach(() => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(arrivalDate)
-      ;(isWomensAp as jest.Mock).mockReturnValue(false)
+      ;(isWomensApplication as jest.Mock).mockReturnValue(false)
       mockOptionalQuestionResponse({
         releaseType,
         sentenceType,
@@ -145,7 +145,7 @@ describe('getApplicationData', () => {
     it('returns empty attributes for a new application', () => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(undefined)
       ;(isInapplicable as jest.Mock).mockReturnValue(false)
-      ;(isWomensAp as jest.Mock).mockReturnValue(false)
+      ;(isWomensApplication as jest.Mock).mockReturnValue(false)
       mockOptionalQuestionResponse({})
 
       expect(getApplicationUpdateData(application)).toEqual({
@@ -170,7 +170,7 @@ describe('getApplicationData', () => {
     it('returns all the defined attributes', () => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2023-01-01')
       ;(isInapplicable as jest.Mock).mockReturnValue(false)
-      ;(isWomensAp as jest.Mock).mockReturnValue(false)
+      ;(isWomensApplication as jest.Mock).mockReturnValue(false)
       mockOptionalQuestionResponse({
         type: 'normal',
         releaseType: 'license',

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -8,7 +8,7 @@ import {
   mockQuestionResponse,
 } from '../../testutils/mockQuestionResponse'
 import { arrivalDateFromApplication } from './arrivalDateFromApplication'
-import { isInapplicable } from './utils'
+import { isInapplicable, isWomensAp } from './utils'
 import { reasonForShortNoticeDetails } from './reasonForShortNoticeDetails'
 import { applicationUserDetailsFactory } from '../../testutils/factories/application'
 
@@ -54,6 +54,7 @@ describe('getApplicationData', () => {
 
     beforeEach(() => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(arrivalDate)
+      ;(isWomensAp as jest.Mock).mockReturnValue(false)
       mockOptionalQuestionResponse({
         releaseType,
         sentenceType,
@@ -144,6 +145,7 @@ describe('getApplicationData', () => {
     it('returns empty attributes for a new application', () => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(undefined)
       ;(isInapplicable as jest.Mock).mockReturnValue(false)
+      ;(isWomensAp as jest.Mock).mockReturnValue(false)
       mockOptionalQuestionResponse({})
 
       expect(getApplicationUpdateData(application)).toEqual({
@@ -168,6 +170,7 @@ describe('getApplicationData', () => {
     it('returns all the defined attributes', () => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2023-01-01')
       ;(isInapplicable as jest.Mock).mockReturnValue(false)
+      ;(isWomensAp as jest.Mock).mockReturnValue(false)
       mockOptionalQuestionResponse({
         type: 'normal',
         releaseType: 'license',

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -16,7 +16,7 @@ import {
 } from '../retrieveQuestionResponseFromFormArtifact'
 import DescribeLocationFactors from '../../form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors'
 import { arrivalDateFromApplication } from './arrivalDateFromApplication'
-import { isInapplicable, isWomensAp } from './utils'
+import { isInapplicable, isWomensApplication } from './utils'
 import { BackwardsCompatibleApplyApType, FormArtifact } from '../../@types/ui'
 import { noticeTypeFromApplication } from './noticeTypeFromApplication'
 import Situation from '../../form-pages/apply/reasons-for-placement/basic-information/situation'
@@ -51,7 +51,6 @@ const firstClassFields = <T>(
   application: Application,
   retrieveQuestionResponse: QuestionResponseFunction,
 ): FirstClassFields<T> => {
-  const isWomensApplication = isWomensAp(application)
   const noticeType = noticeTypeFromApplication(application)
   const apTypeResponse = retrieveQuestionResponse(application, SelectApType, 'type') as BackwardsCompatibleApplyApType
   const apType = apTypeResponse === 'standard' ? 'normal' : apTypeResponse
@@ -68,7 +67,7 @@ const firstClassFields = <T>(
   const { reasonForShortNotice, reasonForShortNoticeOther } = reasonForShortNoticeDetails(application)
 
   return {
-    isWomensApplication,
+    isWomensApplication: isWomensApplication(application),
     apType,
     targetLocation,
     releaseType,

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -16,7 +16,7 @@ import {
 } from '../retrieveQuestionResponseFromFormArtifact'
 import DescribeLocationFactors from '../../form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors'
 import { arrivalDateFromApplication } from './arrivalDateFromApplication'
-import { isInapplicable } from './utils'
+import { isInapplicable, isWomensAp } from './utils'
 import { BackwardsCompatibleApplyApType, FormArtifact } from '../../@types/ui'
 import { noticeTypeFromApplication } from './noticeTypeFromApplication'
 import Situation from '../../form-pages/apply/reasons-for-placement/basic-information/situation'
@@ -51,6 +51,7 @@ const firstClassFields = <T>(
   application: Application,
   retrieveQuestionResponse: QuestionResponseFunction,
 ): FirstClassFields<T> => {
+  const isWomensApplication = isWomensAp(application)
   const noticeType = noticeTypeFromApplication(application)
   const apTypeResponse = retrieveQuestionResponse(application, SelectApType, 'type') as BackwardsCompatibleApplyApType
   const apType = apTypeResponse === 'standard' ? 'normal' : apTypeResponse
@@ -67,7 +68,7 @@ const firstClassFields = <T>(
   const { reasonForShortNotice, reasonForShortNoticeOther } = reasonForShortNoticeDetails(application)
 
   return {
-    isWomensApplication: false,
+    isWomensApplication,
     apType,
     targetLocation,
     releaseType,

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -41,7 +41,7 @@ import {
   getApplicationType,
   getSections,
   isInapplicable,
-  isWomensAp,
+  isWomensApplication,
   lengthOfStayForUI,
   mapApplicationTimelineEventsForUi,
   mapPersonalTimelineForUi,
@@ -603,20 +603,20 @@ describe('utils', () => {
     })
   })
 
-  describe('isWomensAp', () => {
-    it(`should return true if the person from nDelius has a sex of 'Male'`, () => {
+  describe('isWomensApplication', () => {
+    it(`should return false if the person from NDelius has a sex of 'Male'`, () => {
       const application = applicationFactory.build()
       const fp = application.person as FullPerson
       fp.sex = 'Male'
 
-      expect(isWomensAp(application)).toEqual(false)
+      expect(isWomensApplication(application)).toEqual(false)
     })
-    it(`should return false if the person from nDelius has a sex of 'Female'`, () => {
+    it(`should return true if the person from NDelius has a sex of 'Female'`, () => {
       const application = applicationFactory.build()
       const fp = application.person as FullPerson
       fp.sex = 'Female'
 
-      expect(isWomensAp(application)).toEqual(true)
+      expect(isWomensApplication(application)).toEqual(true)
     })
 
     it('should return true if the person is Male but the applicant answered no to the shouldPersonBePlacedInMaleAp question', () => {
@@ -625,7 +625,7 @@ describe('utils', () => {
       fp.sex = 'Male'
 
       mockOptionalQuestionResponse({ shouldPersonBePlacedInMaleAp: 'no' })
-      expect(isWomensAp(application)).toEqual(true)
+      expect(isWomensApplication(application)).toEqual(true)
     })
   })
 

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -2,6 +2,7 @@ import {
   ApType,
   ApplicationSortField,
   ApprovedPremisesApplicationStatus as ApplicationStatus,
+  FullPerson,
   TimelineEventUrlType,
 } from '@approved-premises/api'
 import { isAfter } from 'date-fns'
@@ -40,6 +41,7 @@ import {
   getApplicationType,
   getSections,
   isInapplicable,
+  isWomensAp,
   lengthOfStayForUI,
   mapApplicationTimelineEventsForUi,
   mapPersonalTimelineForUi,
@@ -594,22 +596,36 @@ describe('utils', () => {
       expect(isInapplicable(application)).toEqual(false)
     })
 
-    it('should return true if the applicant has answered no to the shouldPersonBePlacedInMaleAp question', () => {
-      mockOptionalQuestionResponse({ shouldPersonBePlacedInMaleAp: 'no' })
-
-      expect(isInapplicable(application)).toEqual(true)
-    })
-
-    it('should return false if the applicant has answered yes to the shouldPersonBePlacedInMaleAp question', () => {
-      mockOptionalQuestionResponse({ shouldPersonBePlacedInMaleAp: 'yes' })
-
-      expect(isInapplicable(application)).toEqual(false)
-    })
-
     it('should return false if the applicant has not answered the isExceptionalCase question', () => {
       mockOptionalQuestionResponse({})
 
       expect(isInapplicable(application)).toEqual(false)
+    })
+  })
+
+  describe('isWomensAp', () => {
+    it(`should return true if the person from nDelius has a sex of 'Male'`, () => {
+      const application = applicationFactory.build()
+      const fp = application.person as FullPerson
+      fp.sex = 'Male'
+
+      expect(isWomensAp(application)).toEqual(false)
+    })
+    it(`should return false if the person from nDelius has a sex of 'Female'`, () => {
+      const application = applicationFactory.build()
+      const fp = application.person as FullPerson
+      fp.sex = 'Female'
+
+      expect(isWomensAp(application)).toEqual(true)
+    })
+
+    it('should return true if the person is Male but the applicant answered no to the shouldPersonBePlacedInMaleAp question', () => {
+      const application = applicationFactory.build()
+      const fp = application.person as FullPerson
+      fp.sex = 'Male'
+
+      mockOptionalQuestionResponse({ shouldPersonBePlacedInMaleAp: 'no' })
+      expect(isWomensAp(application)).toEqual(true)
     })
   })
 

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -16,6 +16,7 @@ import type {
   ApplicationSortField,
   ApprovedPremisesApplicationStatus as ApplicationStatus,
   ApprovedPremisesApplicationSummary as ApplicationSummary,
+  FullPerson,
   PersonalTimeline,
   SortDirection,
   TimelineEvent,
@@ -185,12 +186,6 @@ const isInapplicable = (application: Application): boolean => {
     'agreedCaseWithManager',
   )
 
-  const shouldPersonBePlacedInMaleAp = retrieveOptionalQuestionResponseFromFormArtifact(
-    application,
-    MaleAp,
-    'shouldPersonBePlacedInMaleAp',
-  )
-
   if (isExceptionalCase === 'no') {
     return true
   }
@@ -199,11 +194,17 @@ const isInapplicable = (application: Application): boolean => {
     return true
   }
 
-  if (shouldPersonBePlacedInMaleAp === 'no') {
-    return true
-  }
-
   return false
+}
+
+const isWomensAp = (application: Application): boolean => {
+  const { sex } = application.person as FullPerson
+  const shouldPersonBePlacedInMaleAp = retrieveOptionalQuestionResponseFromFormArtifact(
+    application,
+    MaleAp,
+    'shouldPersonBePlacedInMaleAp',
+  )
+  return sex === 'Female' || shouldPersonBePlacedInMaleAp === 'no'
 }
 
 const tierQualificationPage = (application: Application) => {
@@ -430,6 +431,7 @@ export {
   arrivalDateFromApplication,
   getApplicationType,
   isInapplicable,
+  isWomensAp,
   mapApplicationTimelineEventsForUi,
   mapTimelineUrlsForUi,
   mapPersonalTimelineForUi,

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -197,7 +197,7 @@ const isInapplicable = (application: Application): boolean => {
   return false
 }
 
-const isWomensAp = (application: Application): boolean => {
+const isWomensApplication = (application: Application): boolean => {
   const { sex } = application.person as FullPerson
   const shouldPersonBePlacedInMaleAp = retrieveOptionalQuestionResponseFromFormArtifact(
     application,
@@ -431,7 +431,7 @@ export {
   arrivalDateFromApplication,
   getApplicationType,
   isInapplicable,
-  isWomensAp,
+  isWomensApplication,
   mapApplicationTimelineEventsForUi,
   mapTimelineUrlsForUi,
   mapPersonalTimelineForUi,

--- a/server/utils/premises/index.test.ts
+++ b/server/utils/premises/index.test.ts
@@ -7,7 +7,6 @@ import {
 } from '../../testutils/factories'
 import {
   groupCas1SummaryPremisesSelectOptions,
-  groupedSelectOptions,
   mapApiOccupancyEntryToUiOccupancyEntry,
   mapApiOccupancyToUiOccupancy,
   overcapacityMessage,
@@ -197,61 +196,17 @@ describe('premisesUtils', () => {
     })
   })
 
-  describe('groupedSelectOptions', () => {
-    const area1Premises = premisesSummaryFactory.buildList(2, { apArea: 'Area 1' })
-    const area2Premises = premisesSummaryFactory.buildList(2, { apArea: 'Area 2' })
-    const premises = [...area1Premises, ...area2Premises]
-
-    it('should group premises by region', () => {
-      expect(groupedSelectOptions(premises, { premisesId: area1Premises[1].id })).toEqual([
-        {
-          items: [
-            { selected: false, text: area1Premises[0].name, value: area1Premises[0].id },
-            { selected: true, text: area1Premises[1].name, value: area1Premises[1].id },
-          ],
-          label: 'Area 1',
-        },
-        {
-          items: [
-            { selected: false, text: area2Premises[0].name, value: area2Premises[0].id },
-            { selected: false, text: area2Premises[1].name, value: area2Premises[1].id },
-          ],
-          label: 'Area 2',
-        },
-      ])
-    })
-
-    it('should support a field name', () => {
-      expect(groupedSelectOptions(premises, { premises: area2Premises[1].id }, 'premises')).toEqual([
-        {
-          items: [
-            { selected: false, text: area1Premises[0].name, value: area1Premises[0].id },
-            { selected: false, text: area1Premises[1].name, value: area1Premises[1].id },
-          ],
-          label: 'Area 1',
-        },
-        {
-          items: [
-            { selected: false, text: area2Premises[0].name, value: area2Premises[0].id },
-            { selected: true, text: area2Premises[1].name, value: area2Premises[1].id },
-          ],
-          label: 'Area 2',
-        },
-      ])
-    })
-  })
-
   describe('groupCas1SummaryPremisesSelectOptions', () => {
     const area1Premises = cas1PremisesSummaryFactory.buildList(2, { apArea: { id: 'a1', name: 'Area 1' } })
     const area2Premises = cas1PremisesSummaryFactory.buildList(2, { apArea: { id: 'a2', name: 'Area 2' } })
     const premises = [...area1Premises, ...area2Premises]
 
-    it('should group premises by region', () => {
-      expect(groupCas1SummaryPremisesSelectOptions(premises, { premisesId: area1Premises[1].id })).toEqual([
+    it('should group premises by AP area', () => {
+      expect(groupCas1SummaryPremisesSelectOptions(premises, {})).toEqual([
         {
           items: [
             { selected: false, text: area1Premises[0].name, value: area1Premises[0].id },
-            { selected: true, text: area1Premises[1].name, value: area1Premises[1].id },
+            { selected: false, text: area1Premises[1].name, value: area1Premises[1].id },
           ],
           label: 'Area 1',
         },
@@ -265,23 +220,16 @@ describe('premisesUtils', () => {
       ])
     })
 
-    it('should support a field name', () => {
-      expect(groupCas1SummaryPremisesSelectOptions(premises, { premises: area2Premises[1].id }, 'premises')).toEqual([
-        {
-          items: [
-            { selected: false, text: area1Premises[0].name, value: area1Premises[0].id },
-            { selected: false, text: area1Premises[1].name, value: area1Premises[1].id },
-          ],
-          label: 'Area 1',
-        },
-        {
-          items: [
-            { selected: false, text: area2Premises[0].name, value: area2Premises[0].id },
-            { selected: true, text: area2Premises[1].name, value: area2Premises[1].id },
-          ],
-          label: 'Area 2',
-        },
-      ])
+    it('should select the option whose id maches the premisesId field in the context', () => {
+      expect(
+        groupCas1SummaryPremisesSelectOptions(premises, { premisesId: area1Premises[0].id })[0].items[0].selected,
+      ).toBeTruthy()
+    })
+    it('should select the option whose id maches the specified field in the context', () => {
+      expect(
+        groupCas1SummaryPremisesSelectOptions(premises, { premises: area2Premises[1].id }, 'premises')[1].items[1]
+          .selected,
+      ).toBeTruthy()
     })
   })
 

--- a/server/utils/premises/index.test.ts
+++ b/server/utils/premises/index.test.ts
@@ -6,6 +6,7 @@ import {
   premisesSummaryFactory,
 } from '../../testutils/factories'
 import {
+  groupCas1SummaryPremisesSelectOptions,
   groupedSelectOptions,
   mapApiOccupancyEntryToUiOccupancyEntry,
   mapApiOccupancyToUiOccupancy,
@@ -222,6 +223,50 @@ describe('premisesUtils', () => {
 
     it('should support a field name', () => {
       expect(groupedSelectOptions(premises, { premises: area2Premises[1].id }, 'premises')).toEqual([
+        {
+          items: [
+            { selected: false, text: area1Premises[0].name, value: area1Premises[0].id },
+            { selected: false, text: area1Premises[1].name, value: area1Premises[1].id },
+          ],
+          label: 'Area 1',
+        },
+        {
+          items: [
+            { selected: false, text: area2Premises[0].name, value: area2Premises[0].id },
+            { selected: true, text: area2Premises[1].name, value: area2Premises[1].id },
+          ],
+          label: 'Area 2',
+        },
+      ])
+    })
+  })
+
+  describe('groupCas1SummaryPremisesSelectOptions', () => {
+    const area1Premises = cas1PremisesSummaryFactory.buildList(2, { apArea: { id: 'a1', name: 'Area 1' } })
+    const area2Premises = cas1PremisesSummaryFactory.buildList(2, { apArea: { id: 'a2', name: 'Area 2' } })
+    const premises = [...area1Premises, ...area2Premises]
+
+    it('should group premises by region', () => {
+      expect(groupCas1SummaryPremisesSelectOptions(premises, { premisesId: area1Premises[1].id })).toEqual([
+        {
+          items: [
+            { selected: false, text: area1Premises[0].name, value: area1Premises[0].id },
+            { selected: true, text: area1Premises[1].name, value: area1Premises[1].id },
+          ],
+          label: 'Area 1',
+        },
+        {
+          items: [
+            { selected: false, text: area2Premises[0].name, value: area2Premises[0].id },
+            { selected: false, text: area2Premises[1].name, value: area2Premises[1].id },
+          ],
+          label: 'Area 2',
+        },
+      ])
+    })
+
+    it('should support a field name', () => {
+      expect(groupCas1SummaryPremisesSelectOptions(premises, { premises: area2Premises[1].id }, 'premises')).toEqual([
         {
           items: [
             { selected: false, text: area1Premises[0].name, value: area1Premises[0].id },

--- a/server/utils/premises/index.ts
+++ b/server/utils/premises/index.ts
@@ -116,24 +116,6 @@ export const summaryListForPremises = (premises: Cas1PremisesSummary): SummaryLi
   }
 }
 
-export const groupedSelectOptions = (
-  premises: Array<ApprovedPremisesSummary>,
-  context: Record<string, unknown>,
-  fieldName: string = 'premisesId',
-): Array<SelectGroup> => {
-  const apAreas = [...new Set(premises.map(item => item.apArea))]
-  return apAreas.map(apArea => ({
-    label: apArea,
-    items: premises
-      .filter(item => item.apArea === apArea)
-      .map(item => ({
-        text: item.name,
-        value: item.id,
-        selected: context[fieldName] === item.id,
-      })),
-  }))
-}
-
 export const groupCas1SummaryPremisesSelectOptions = (
   premises: Array<Cas1PremisesSummary>,
   context: Record<string, unknown>,

--- a/server/utils/premises/index.ts
+++ b/server/utils/premises/index.ts
@@ -134,6 +134,27 @@ export const groupedSelectOptions = (
   }))
 }
 
+export const groupCas1SummaryPremisesSelectOptions = (
+  premises: Array<Cas1PremisesSummary>,
+  context: Record<string, unknown>,
+  fieldName: string = 'premisesId',
+): Array<SelectGroup> => {
+  const apAreas = premises.reduce((map, { apArea }) => {
+    map[apArea.id] = apArea
+    return map
+  }, {})
+  return Object.values(apAreas).map(({ id, name }) => ({
+    label: name,
+    items: premises
+      .filter(item => item.apArea.id === id)
+      .map(item => ({
+        text: item.name,
+        value: item.id,
+        selected: context[fieldName] === item.id,
+      })),
+  }))
+}
+
 export const premisesTableRows = (premisesSummaries: Array<PremisesSummary>) => {
   return premisesSummaries
     .sort((a, b) => a.name.localeCompare(b.name))

--- a/server/views/admin/placementRequests/bookings/new.njk
+++ b/server/views/admin/placementRequests/bookings/new.njk
@@ -48,7 +48,7 @@
             prompt: "Select a premises",
             id: "premisesId",
             name: "premisesId",
-            items: PremisesUtils.groupedSelectOptions(premises, fetchContext()),
+            items: PremisesUtils.groupCas1SummaryPremisesSelectOptions(premises, fetchContext()),
             errorMessage: errors.premisesId
           })
         }}

--- a/server/views/applications/pages/location-factors/preferred-aps.njk
+++ b/server/views/applications/pages/location-factors/preferred-aps.njk
@@ -1,6 +1,5 @@
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "../../../components/formFields/form-page-select-with-optgroup/macro.njk" import formPageSelectWithOptgroup %}
-{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% extends "../layout.njk" %}
 

--- a/server/views/applications/pages/location-factors/preferred-aps.njk
+++ b/server/views/applications/pages/location-factors/preferred-aps.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "../../../components/formFields/form-page-select-with-optgroup/macro.njk" import formPageSelectWithOptgroup %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% extends "../layout.njk" %}
 
@@ -8,33 +9,28 @@
   <h1 class="govuk-heading-l">
     {{ page.title }}
   </h1>
-
   {% for preferredAp in page.preferredApOptions %}
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
         {{page.preferredApLabels[loop.index0]}}
       </legend>
-
       {{
       formPageSelectWithOptgroup({
         label: {
           classes: "govuk-fieldset__legend--s",
           html: "Select a premises"
         },
-        attributes: {
-          "data-premises-with-areas": true,
-          "data-region-prompt": "No preference"
-        },
+        attributes:  page.selectorAttributes,
         prompt: "No preference",
         fieldName: preferredAp,
-        items: PremisesUtils.groupedSelectOptions(page.allPremises, fetchContext(), preferredAp)
+        items: PremisesUtils.groupCas1SummaryPremisesSelectOptions(page.allPremises, fetchContext(), preferredAp)
       })
     }}
 
     </fieldset>
 
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-    {%endfor%}
+  {%endfor%}
 
   {% endblock %}
 

--- a/server/views/manage/outOfServiceBeds/index.njk
+++ b/server/views/manage/outOfServiceBeds/index.njk
@@ -135,7 +135,7 @@
             premisesSelect.appendChild(disabledOption)
             premisesSelect.disabled = true
           } else {
-            const filteredData = allPremises.filter(item => item.apArea === selectedArea)
+            const filteredData = allPremises.filter(item => item.apArea.name === selectedArea)
             if (filteredData.length > 0) {
 
               premisesSelect.disabled = false


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/APS-1402

As discussed in the ticket, this PR does not implement the checkbox page indicated in the design, but rather applies only a slight modification to the `Preferred AP` page for the women's estate.

- The title is modified as per the design
- The two-level selects are not applied. i.e. the user will see all the Women's estate APS in each select rather than being pre-filtered by area. This is because there are relatively few APs in the women's estate.

The ticket also implements two features needed to drive the above:

- The field **isWomensApplication** in the application is populated using the sex of the applicant and the selection of the Men's AP or Women's AP from the exceptional case board findings.
- The field **isInApplicable** in the application is no longer set if the exceptional case board find for a woman's AP, nor if the person's sex is female.
- Following from the exceptional case board findings page, the application will no longer abort with the 'refer to delius' page if the WE feature flag is set.

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before

### After

![image](https://github.com/user-attachments/assets/82a48c3c-6fda-4d71-b72a-1e91f36ee5d7)

![image](https://github.com/user-attachments/assets/f30ac494-3dcf-4d87-b0a9-f454907154bf)

