### PR TITLE
APS-1332: apply changes Women's Estate

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -5,14 +5,27 @@
       "name": "Bob Smith",
       "phoneNumber": "01234567890",
       "area": "5e44b880-df20-4751-938f-a14be5fe609d",
-      "areas": [{ "id": "5e44b880-df20-4751-938f-a14be5fe609d", "name": "Greater Manchester" }],
-      "detailsToUpdate": ["phoneNumber", "emailAddress", "name", "area"],
+      "areas": [
+        {
+          "id": "5e44b880-df20-4751-938f-a14be5fe609d",
+          "name": "Greater Manchester"
+        }
+      ],
+      "detailsToUpdate": [
+        "phoneNumber",
+        "emailAddress",
+        "name",
+        "area"
+      ],
       "caseManagementResponsibility": "no",
       "userDetailsFromDelius": {
         "name": "Frank",
         "emailAddress": "frank@test.com",
         "phoneNumber": "01234567890",
-        "area": { "name": "Greater Manchester", "id": "5e44b880-df20-4751-938f-a14be5fe609d" }
+        "area": {
+          "name": "Greater Manchester",
+          "id": "5e44b880-df20-4751-938f-a14be5fe609d"
+        }
       }
     },
     "case-manager-information": {
@@ -69,7 +82,6 @@
     "sentence-type": {
       "sentenceType": "communityOrder"
     },
-
     "situation": {
       "situation": "riskManagement"
     },
@@ -84,7 +96,10 @@
       "startDateSameAsReleaseDate": "yes"
     },
     "placement-purpose": {
-      "placementPurposes": ["drugAlcoholMonitoring", "otherReason"],
+      "placementPurposes": [
+        "drugAlcoholMonitoring",
+        "otherReason"
+      ],
       "otherReason": "Reason"
     }
   },
@@ -102,8 +117,18 @@
   "oasys-import": {
     "optional-oasys-sections": {
       "needsLinkedToReoffending": [
-        { "section": 1, "name": "accommodation", "linkedToHarm": false, "linkedToReOffending": true },
-        { "section": 2, "name": "relationships", "linkedToHarm": false, "linkedToReOffending": true }
+        {
+          "section": 1,
+          "name": "accommodation",
+          "linkedToHarm": false,
+          "linkedToReOffending": true
+        },
+        {
+          "section": 2,
+          "name": "relationships",
+          "linkedToHarm": false,
+          "linkedToReOffending": true
+        }
       ],
       "otherNeeds": [
         {
@@ -250,14 +275,36 @@
       "response": "yes"
     },
     "date-of-offence": {
-      "arsonOffence": ["current"],
-      "hateCrime": ["previous"],
-      "nonSexualOffencesAgainstChildren": ["current", "previous"],
-      "contactSexualOffencesAgainstAdults": ["current", "previous"],
-      "nonContactSexualOffencesAgainstAdults": ["current", "previous"],
-      "contactSexualOffencesAgainstChildren": ["current", "previous"],
-      "nonContactSexualOffencesAgainstChildren": ["current", "previous"],
-      "otherSexualOffences": ["current", "previous"]
+      "arsonOffence": [
+        "current"
+      ],
+      "hateCrime": [
+        "previous"
+      ],
+      "nonSexualOffencesAgainstChildren": [
+        "current",
+        "previous"
+      ],
+      "contactSexualOffencesAgainstAdults": [
+        "current",
+        "previous"
+      ],
+      "nonContactSexualOffencesAgainstAdults": [
+        "current",
+        "previous"
+      ],
+      "contactSexualOffencesAgainstChildren": [
+        "current",
+        "previous"
+      ],
+      "nonContactSexualOffencesAgainstChildren": [
+        "current",
+        "previous"
+      ],
+      "otherSexualOffences": [
+        "current",
+        "previous"
+      ]
     },
     "rehabilitative-interventions": {
       "rehabilitativeInterventions": [
@@ -278,7 +325,10 @@
   },
   "prison-information": {
     "case-notes": {
-      "caseNoteIds": ["a30173ca-061f-42c9-a1a2-28c70b282d3f", "4a477187-b77f-4fcc-a919-43a6633ee868"],
+      "caseNoteIds": [
+        "a30173ca-061f-42c9-a1a2-28c70b282d3f",
+        "4a477187-b77f-4fcc-a919-43a6633ee868"
+      ],
       "selectedCaseNotes": [
         {
           "authorName": "Denise Collins",
@@ -363,16 +413,33 @@
       "preferredAp4": "",
       "preferredAp5": "",
       "selectedAps": [
-        { "text": "Ap One", "value": "1" },
-        { "text": "Ap Two", "value": "2" },
-        { "text": "Ap Three", "value": "3" },
-        { "text": "No preference", "value": "" }
+        {
+          "text": "Ap One",
+          "value": "1"
+        },
+        {
+          "text": "Ap Two",
+          "value": "2"
+        },
+        {
+          "text": "Ap Three",
+          "value": "3"
+        },
+        {
+          "text": "No preference",
+          "value": ""
+        }
       ]
     }
   },
   "access-and-healthcare": {
     "access-needs": {
-      "additionalNeeds": ["mobility", "learningDisability", "neurodivergentConditions", "pregnancy"],
+      "additionalNeeds": [
+        "mobility",
+        "learningDisability",
+        "neurodivergentConditions",
+        "pregnancy"
+      ],
       "religiousOrCulturalNeeds": "yes",
       "religiousOrCulturalNeedsDetail": "sunt at minus",
       "needsInterpreter": "yes",
@@ -388,6 +455,9 @@
       "prescribedMedication": "yes",
       "prescribedMedicationDetail": "Some detail",
       "isPersonPregnant": "yes",
+      "additionalAdjustments": "Some detail"
+    },
+    "pregnancy": {
       "expectedDeliveryDate": "2023-12-31",
       "expectedDeliveryDate-year": "2023",
       "expectedDeliveryDate-month": "12",
@@ -396,8 +466,7 @@
       "socialCareInvolvementDetail": "Some detail",
       "otherPregnancyConsiderations": "yes",
       "otherPregnancyConsiderationsDetail": "some considerations",
-      "childRemoved": "decisionPending",
-      "additionalAdjustments": "Some detail"
+      "childRemoved": "decisionPending"
     },
     "covid": {
       "boosterEligibility": "yes",

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -454,8 +454,7 @@
       "healthConditionsDetail": "Some detail",
       "prescribedMedication": "yes",
       "prescribedMedicationDetail": "Some detail",
-      "isPersonPregnant": "yes",
-      "additionalAdjustments": "Some detail"
+      "isPersonPregnant": "yes"
     },
     "pregnancy": {
       "expectedDeliveryDate": "2023-12-31",
@@ -467,6 +466,9 @@
       "otherPregnancyConsiderations": "yes",
       "otherPregnancyConsiderationsDetail": "some considerations",
       "childRemoved": "decisionPending"
+    },
+    "access-needs-additional-details": {
+      "additionalAdjustments": "Some detail"
     },
     "covid": {
       "boosterEligibility": "yes",

--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -838,11 +838,15 @@ export default class ApplyHelper {
     accessNeedsFurtherQuestionsPage.completeForm()
     accessNeedsFurtherQuestionsPage.clickSubmit()
 
+    const pregnancyPage = new ApplyPages.PregnancyPage(this.application)
+    pregnancyPage.completeForm()
+    pregnancyPage.clickSubmit()
+
     const covidPage = new ApplyPages.CovidPage(this.application)
     covidPage.completeForm()
     covidPage.clickSubmit()
 
-    this.pages.accessAndHealthcare = [accessNeedsPage, accessNeedsFurtherQuestionsPage, covidPage]
+    this.pages.accessAndHealthcare = [accessNeedsPage, accessNeedsFurtherQuestionsPage, pregnancyPage, covidPage]
 
     // Then I should be taken back to the task list
     const tasklistPage = Page.verifyOnPage(ApplyPages.TaskListPage)

--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -842,11 +842,21 @@ export default class ApplyHelper {
     pregnancyPage.completeForm()
     pregnancyPage.clickSubmit()
 
+    const accessNeedsAdditionalDetailsPage = new ApplyPages.AccessNeedsAdditionalDetailsPage(this.application)
+    accessNeedsAdditionalDetailsPage.completeForm()
+    accessNeedsAdditionalDetailsPage.clickSubmit()
+
     const covidPage = new ApplyPages.CovidPage(this.application)
     covidPage.completeForm()
     covidPage.clickSubmit()
 
-    this.pages.accessAndHealthcare = [accessNeedsPage, accessNeedsFurtherQuestionsPage, pregnancyPage, covidPage]
+    this.pages.accessAndHealthcare = [
+      accessNeedsPage,
+      accessNeedsFurtherQuestionsPage,
+      pregnancyPage,
+      accessNeedsAdditionalDetailsPage,
+      covidPage,
+    ]
 
     // Then I should be taken back to the task list
     const tasklistPage = Page.verifyOnPage(ApplyPages.TaskListPage)

--- a/integration_tests/pages/apply/accessNeeds.ts
+++ b/integration_tests/pages/apply/accessNeeds.ts
@@ -18,12 +18,12 @@ export default class AccessNeedsPage extends ApplyPage {
     this.checkCheckboxesFromPageBody('additionalNeeds')
   }
 
-  checkingAdditionalNeedsOtherDisablesOtherCheckBoxes() {
+  checkingAdditionalNeedsNoneDeselectsOtherCheckBoxes() {
     this.checkAdditionalNeedsBoxes()
 
     this.checkCheckboxByNameAndValue('additionalNeeds', 'none')
 
-    cy.get('input[name="additionalNeeds"]:not([value="none"])').should('be.disabled')
+    cy.get('input[name="additionalNeeds"]:not([value="none"])').should('not.be.checked')
 
     this.uncheckCheckboxbyNameAndValue('additionalNeeds', 'none')
   }
@@ -44,7 +44,7 @@ export default class AccessNeedsPage extends ApplyPage {
   }
 
   completeForm() {
-    this.checkingAdditionalNeedsOtherDisablesOtherCheckBoxes()
+    this.checkingAdditionalNeedsNoneDeselectsOtherCheckBoxes()
     this.checkAdditionalNeedsBoxes()
     this.completeReligiousOrCulturalNeedsSection()
     this.completeNeedsInterpreterSection()

--- a/integration_tests/pages/apply/accessNeedsAdditionalDetails.ts
+++ b/integration_tests/pages/apply/accessNeedsAdditionalDetails.ts
@@ -1,0 +1,23 @@
+import { ApprovedPremisesApplication } from '@approved-premises/api'
+import paths from '../../../server/paths/apply'
+
+import ApplyPage from './applyPage'
+
+export default class AccessNeedsAdditionalDetailsPage extends ApplyPage {
+  constructor(application: ApprovedPremisesApplication) {
+    super(
+      'Access, cultural and healthcare needs',
+      application,
+      'access-and-healthcare',
+      'access-needs-additional-details',
+      paths.applications.pages.show({ id: application.id, task: 'access-and-healthcare', page: 'pregnancy' }),
+    )
+    cy.get('.govuk-form-group').contains(
+      /Specify any additional details and adjustments required for the person's (.*) needs \(optional\)/,
+    )
+  }
+
+  completeForm() {
+    this.completeTextInputFromPageBody('additionalAdjustments')
+  }
+}

--- a/integration_tests/pages/apply/accessNeedsFurtherQuestions.ts
+++ b/integration_tests/pages/apply/accessNeedsFurtherQuestions.ts
@@ -22,6 +22,5 @@ export default class AccessNeedsFurtherQuestionsPage extends ApplyPage {
     this.checkRadioButtonFromPageBody('prescribedMedication')
     this.completeTextInputFromPageBody('prescribedMedicationDetail')
     this.checkRadioButtonFromPageBody('isPersonPregnant')
-    this.completeTextInputFromPageBody('additionalAdjustments')
   }
 }

--- a/integration_tests/pages/apply/accessNeedsFurtherQuestions.ts
+++ b/integration_tests/pages/apply/accessNeedsFurtherQuestions.ts
@@ -22,12 +22,6 @@ export default class AccessNeedsFurtherQuestionsPage extends ApplyPage {
     this.checkRadioButtonFromPageBody('prescribedMedication')
     this.completeTextInputFromPageBody('prescribedMedicationDetail')
     this.checkRadioButtonFromPageBody('isPersonPregnant')
-    this.completeDateInputsFromPageBody('expectedDeliveryDate')
-    this.checkRadioButtonFromPageBody('socialCareInvolvement')
-    this.completeTextInputFromPageBody('socialCareInvolvementDetail')
-    this.checkRadioButtonFromPageBody('otherPregnancyConsiderations')
-    this.completeTextInputFromPageBody('otherPregnancyConsiderationsDetail')
-    this.checkRadioButtonFromPageBody('childRemoved')
     this.completeTextInputFromPageBody('additionalAdjustments')
   }
 }

--- a/integration_tests/pages/apply/index.ts
+++ b/integration_tests/pages/apply/index.ts
@@ -40,6 +40,7 @@ import PlacementPurposePage from './placementPurpose'
 import PlacementStartPage from './placementDate'
 import PlansInPlacePage from './plansInPlace'
 import PreferredAps from './preferredAps'
+import PregnancyPage from './pregnancy'
 import PreviousPlacements from './previousPlacements'
 import ReasonForShortNoticePage from './reasonForShortNoticePage'
 import RehabilitativeInterventions from './rehabilitativeInterventions'
@@ -109,6 +110,7 @@ export {
   PlacementStartPage,
   PlansInPlacePage,
   PreferredAps,
+  PregnancyPage,
   PreviousPlacements,
   ReasonForShortNoticePage,
   RehabilitativeInterventions,

--- a/integration_tests/pages/apply/index.ts
+++ b/integration_tests/pages/apply/index.ts
@@ -1,3 +1,4 @@
+import AccessNeedsAdditionalDetailsPage from './accessNeedsAdditionalDetails'
 import AccessNeedsFurtherQuestionsPage from './accessNeedsFurtherQuestions'
 import AccessNeedsPage from './accessNeeds'
 import AdditionalCircumstancesPage from './additionalCircumstances'
@@ -67,6 +68,7 @@ import VulnerabilityPage from './vulnerability'
 import NoOffencePage from './noOffence'
 
 export {
+  AccessNeedsAdditionalDetailsPage,
   AccessNeedsFurtherQuestionsPage,
   AccessNeedsPage,
   AdditionalCircumstancesPage,

--- a/integration_tests/pages/apply/pregnancy.ts
+++ b/integration_tests/pages/apply/pregnancy.ts
@@ -1,0 +1,29 @@
+import { ApprovedPremisesApplication } from '@approved-premises/api'
+import ApplyPage from './applyPage'
+import paths from '../../../server/paths/apply'
+
+export default class PregnancyPage extends ApplyPage {
+  constructor(application: ApprovedPremisesApplication) {
+    super(
+      'Access, cultural and healthcare needs',
+      application,
+      'access-and-healthcare',
+      'pregnancy',
+      paths.applications.pages.show({
+        id: application.id,
+        task: 'access-and-healthcare',
+        page: 'access-needs-further-questions',
+      }),
+    )
+    cy.get('.govuk-form-group').contains(`What is their expected date of delivery?`)
+  }
+
+  completeForm() {
+    this.completeDateInputsFromPageBody('expectedDeliveryDate')
+    this.checkRadioButtonFromPageBody('socialCareInvolvement')
+    this.completeTextInputFromPageBody('socialCareInvolvementDetail')
+    this.checkRadioButtonFromPageBody('otherPregnancyConsiderations')
+    this.completeTextInputFromPageBody('otherPregnancyConsiderationsDetail')
+    this.checkRadioButtonFromPageBody('childRemoved')
+  }
+}

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -142,6 +142,7 @@ export type CheckBoxItem =
       hint?: {
         text: string
       }
+      behaviour?: 'exclusive'
     }
   | CheckBoxDivider
 

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeeds.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeeds.test.ts
@@ -110,7 +110,7 @@ describe('AccessNeeds', () => {
       const page = new AccessNeeds({ additionalNeeds: ['mobility', 'neurodivergentConditions'] })
 
       expect(page.needsCheckboxes()).toEqual(
-        convertKeyValuePairToCheckBoxItems(additionalNeeds, ['mobility', 'neurodivergentConditions']),
+        convertKeyValuePairToCheckBoxItems(additionalNeeds, ['mobility', 'neurodivergentConditions'], true),
       )
     })
   })

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeeds.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeeds.ts
@@ -129,7 +129,7 @@ export default class AccessNeeds implements TasklistPage {
   }
 
   needsCheckboxes() {
-    return convertKeyValuePairToCheckBoxItems(additionalNeeds, this.body.additionalNeeds as Array<AdditionalNeed>)
+    return convertKeyValuePairToCheckBoxItems(additionalNeeds, this.body.additionalNeeds as Array<AdditionalNeed>, true)
   }
 }
 

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsAdditionalDetails.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsAdditionalDetails.test.ts
@@ -1,0 +1,128 @@
+import { when } from 'jest-when'
+import { applicationFactory } from '../../../../testutils/factories'
+import AccessNeedsAdditionalDetails, { AccessNeedsAdditionalDetailsBody } from './accessNeedsAdditionalDetails'
+import { retrieveOptionalQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
+import AccessNeeds from './accessNeeds'
+import AccessNeedsFurtherQuestions from './accessNeedsFurtherQuestions'
+
+jest.mock('../../../../utils/retrieveQuestionResponseFromFormArtifact')
+
+describe('AccessNeedsAdditionalDetails', () => {
+  const application = applicationFactory.build()
+
+  const body: AccessNeedsAdditionalDetailsBody = {
+    additionalAdjustments: 'Adjustments',
+  }
+
+  beforeEach(() => {
+    when(retrieveOptionalQuestionResponseFromFormArtifact)
+      .calledWith(application, AccessNeeds, 'additionalNeeds')
+      .mockReturnValue([])
+    when(retrieveOptionalQuestionResponseFromFormArtifact)
+      .calledWith(application, AccessNeedsFurtherQuestions, 'isPersonPregnant')
+      .mockReturnValue('yes')
+  })
+
+  describe('title', () => {
+    it('should return the title', () => {
+      expect(new AccessNeedsAdditionalDetails({}, application).title).toBe('Access, cultural and healthcare needs')
+    })
+  })
+
+  describe('body', () => {
+    it('should set the body', () => {
+      const page = new AccessNeedsAdditionalDetails(body, application)
+
+      expect(page.body).toEqual({
+        additionalAdjustments: 'Adjustments',
+      })
+    })
+  })
+
+  describe('next', () => {
+    it('returns the correct next page', () => {
+      expect(new AccessNeedsAdditionalDetails({}, application).next()).toBe('covid')
+    })
+  })
+
+  describe('previous', () => {
+    describe('if the person is pregnant', () => {
+      it('returns the pregnancy page', () => {
+        expect(new AccessNeedsAdditionalDetails(body, application).previous()).toBe('pregnancy')
+      })
+    })
+
+    describe('if the person is not pregnant', () => {
+      beforeEach(() => {
+        when(retrieveOptionalQuestionResponseFromFormArtifact)
+          .calledWith(application, AccessNeedsFurtherQuestions, 'isPersonPregnant')
+          .mockReturnValue('no')
+      })
+
+      it('returns the Access Needs Further Questions page', () => {
+        expect(new AccessNeedsAdditionalDetails(body, application).previous()).toBe('access-needs-further-questions')
+      })
+    })
+
+    describe('if the question about pregnancy was not asked', () => {
+      beforeEach(() => {
+        when(retrieveOptionalQuestionResponseFromFormArtifact)
+          .calledWith(application, AccessNeedsFurtherQuestions, 'isPersonPregnant')
+          .mockReturnValue(undefined)
+      })
+
+      it('returns the Access Needs Further Questions page', () => {
+        expect(new AccessNeedsAdditionalDetails(body, application).previous()).toBe('access-needs-further-questions')
+      })
+    })
+  })
+
+  describe('errors', () => {
+    it('should not require an answer for additional details', () => {
+      expect(new AccessNeedsAdditionalDetails({}, application).errors()).toEqual({})
+    })
+  })
+
+  describe('listOfNeeds', () => {
+    it('should return null when no needs are selected', () => {
+      const page = new AccessNeedsAdditionalDetails(body, application)
+
+      expect(page.listOfNeeds).toEqual(null)
+    })
+
+    it('should return a single need when one is selected', () => {
+      when(retrieveOptionalQuestionResponseFromFormArtifact)
+        .calledWith(application, AccessNeeds, 'additionalNeeds')
+        .mockReturnValue(['mobility'])
+
+      const page = new AccessNeedsAdditionalDetails(body, application)
+
+      expect(page.listOfNeeds).toEqual('mobility needs')
+    })
+
+    it('should return a list of needs', () => {
+      when(retrieveOptionalQuestionResponseFromFormArtifact)
+        .calledWith(application, AccessNeeds, 'additionalNeeds')
+        .mockReturnValue(['learningDisability', 'neurodivergentConditions', 'healthcare'])
+
+      const page = new AccessNeedsAdditionalDetails(body, application)
+
+      expect(page.listOfNeeds).toEqual('learning disability, neurodivergent conditions or healthcare needs')
+    })
+  })
+
+  describe('response', () => {
+    it('returns the correct plain english response for the question', () => {
+      when(retrieveOptionalQuestionResponseFromFormArtifact)
+        .calledWith(application, AccessNeeds, 'additionalNeeds')
+        .mockReturnValue(['mobility', 'pregnancy'])
+
+      const page = new AccessNeedsAdditionalDetails(body, application)
+
+      expect(page.response()).toEqual({
+        "Specify any additional details and adjustments required for the person's mobility or pregnancy needs":
+          'Adjustments',
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsAdditionalDetails.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsAdditionalDetails.ts
@@ -1,0 +1,77 @@
+import { PageResponse, type TaskListErrors } from '@approved-premises/ui'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
+import TasklistPage from '../../../tasklistPage'
+import { Page } from '../../../utils/decorators'
+import { retrieveOptionalQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
+import AccessNeedsFurtherQuestions from './accessNeedsFurtherQuestions'
+import { lowerCase } from '../../../../utils/utils'
+import AccessNeeds, { AdditionalNeed, additionalNeeds } from './accessNeeds'
+
+export type AccessNeedsAdditionalDetailsBody = {
+  additionalAdjustments: string
+}
+
+@Page({
+  name: 'access-needs-additional-details',
+  bodyProperties: ['additionalAdjustments'],
+})
+export default class AccessNeedsAdditionalDetails implements TasklistPage {
+  title = 'Access, cultural and healthcare needs'
+
+  questions = {
+    additionalAdjustments: `Specify any additional details and adjustments required for the person's ${this.listOfNeeds}`,
+  }
+
+  constructor(
+    public body: Partial<AccessNeedsAdditionalDetailsBody>,
+    private readonly application: ApprovedPremisesApplication,
+  ) {}
+
+  previous(): string {
+    if (
+      retrieveOptionalQuestionResponseFromFormArtifact(
+        this.application,
+        AccessNeedsFurtherQuestions,
+        'isPersonPregnant',
+      ) === 'yes'
+    ) {
+      return 'pregnancy'
+    }
+
+    return 'access-needs-further-questions'
+  }
+
+  next(): string {
+    return 'covid'
+  }
+
+  errors(): Partial<Record<keyof this['body'], unknown>> {
+    return {} as TaskListErrors<this>
+  }
+
+  response(): PageResponse {
+    return {
+      [this.questions.additionalAdjustments]: this.body.additionalAdjustments,
+    }
+  }
+
+  public get additionalNeeds(): Array<AdditionalNeed> {
+    return retrieveOptionalQuestionResponseFromFormArtifact(this.application, AccessNeeds, 'additionalNeeds')
+  }
+
+  public get listOfNeeds(): string {
+    const needs = this.additionalNeeds.map(need => additionalNeeds[need])
+
+    if (needs.length > 0) {
+      if (needs.length === 1) {
+        return lowerCase(`${needs[0]} needs`)
+      }
+
+      const lastNeed = needs.splice(-1)
+
+      return lowerCase(`${needs.join(', ')} or ${lastNeed} needs`)
+    }
+
+    return null
+  }
+}

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsFurtherQuestions.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsFurtherQuestions.test.ts
@@ -1,8 +1,8 @@
 import { fromPartial } from '@total-typescript/shoehorn'
+import { YesOrNo } from '@approved-premises/ui'
 import AccessNeedsFurtherQuestions, { AccessNeedsFurtherQuestionsBody } from './accessNeedsFurtherQuestions'
 
 import { applicationFactory } from '../../../../testutils/factories'
-import { DateFormats } from '../../../../utils/dateUtils'
 import { retrieveOptionalQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 
 jest.mock('../../../../utils/retrieveQuestionResponseFromFormArtifact')
@@ -10,26 +10,18 @@ jest.mock('../../../../utils/retrieveQuestionResponseFromFormArtifact')
 describe('AccessNeedsFurtherQuestions', () => {
   const application = applicationFactory.build()
 
-  const expectedDeliveryDate = new Date(2023, 1, 19)
   const body: AccessNeedsFurtherQuestionsBody = {
     needsWheelchair: 'yes',
     healthConditions: 'yes',
     healthConditionsDetail: 'Some detail',
     prescribedMedication: 'yes',
     prescribedMedicationDetail: 'Some detail',
-    expectedDeliveryDate: DateFormats.dateObjToIsoDate(expectedDeliveryDate),
-    ...DateFormats.dateObjectToDateInputs(expectedDeliveryDate, 'expectedDeliveryDate'),
-    otherPregnancyConsiderations: 'yes',
-    otherPregnancyConsiderationsDetail: 'Some detail',
-    socialCareInvolvement: 'yes',
-    socialCareInvolvementDetail: 'Some detail',
-    childRemoved: 'no',
     isPersonPregnant: 'yes',
     additionalAdjustments: 'Adjustments',
   }
 
   beforeEach(() => {
-    ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue([''])
+    ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue([])
   })
 
   describe('title', () => {
@@ -41,6 +33,7 @@ describe('AccessNeedsFurtherQuestions', () => {
   describe('body', () => {
     it('should set the body', () => {
       const page = new AccessNeedsFurtherQuestions(body, application)
+
       expect(page.body).toEqual({
         needsWheelchair: 'yes',
         healthConditions: 'yes',
@@ -48,23 +41,26 @@ describe('AccessNeedsFurtherQuestions', () => {
         prescribedMedication: 'yes',
         prescribedMedicationDetail: 'Some detail',
         isPersonPregnant: 'yes',
-        expectedDeliveryDate: DateFormats.dateObjToIsoDate(expectedDeliveryDate),
-        'expectedDeliveryDate-year': '2023',
-        'expectedDeliveryDate-month': '2',
-        'expectedDeliveryDate-day': '19',
-        otherPregnancyConsiderations: 'yes',
-        otherPregnancyConsiderationsDetail: 'Some detail',
-        socialCareInvolvement: 'yes',
-        socialCareInvolvementDetail: 'Some detail',
-        childRemoved: 'no',
         additionalAdjustments: 'Adjustments',
       })
     })
   })
 
   describe('next', () => {
-    it('returns the correct next page', () => {
-      expect(new AccessNeedsFurtherQuestions({}, application).next()).toBe('covid')
+    describe('if the person is pregnant', () => {
+      const bodyPregnancyYes = { ...body }
+
+      it('returns the pregnancy page', () => {
+        expect(new AccessNeedsFurtherQuestions(bodyPregnancyYes, application).next()).toBe('pregnancy')
+      })
+    })
+
+    describe('if the person is not pregnant', () => {
+      const bodyPregnancyNo = { ...body, isPersonPregnant: 'no' as YesOrNo }
+
+      it('returns the covid page', () => {
+        expect(new AccessNeedsFurtherQuestions(bodyPregnancyNo, application).next()).toBe('covid')
+      })
     })
   })
 
@@ -76,8 +72,6 @@ describe('AccessNeedsFurtherQuestions', () => {
 
   describe('errors', () => {
     it('should return errors if there are no responses to needsWheelchair question', () => {
-      ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue([])
-
       const page = new AccessNeedsFurtherQuestions({ ...body, needsWheelchair: undefined }, application)
 
       expect(page.errors()).toEqual({
@@ -86,7 +80,6 @@ describe('AccessNeedsFurtherQuestions', () => {
     })
 
     it('should return errors if there is no response to the healthConditions question', () => {
-      ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue([])
       const page = new AccessNeedsFurtherQuestions({ ...body, healthConditions: undefined }, application)
 
       expect(page.errors()).toEqual({
@@ -95,8 +88,6 @@ describe('AccessNeedsFurtherQuestions', () => {
     })
 
     it('should return errors if the person answers "yes" to the healthConditions question but does not provide details', () => {
-      ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue([])
-
       const page = new AccessNeedsFurtherQuestions(
         { ...body, healthConditions: 'yes', healthConditionsDetail: undefined },
         application,
@@ -114,52 +105,10 @@ describe('AccessNeedsFurtherQuestions', () => {
         isPersonPregnant: `You must confirm if the person is pregnant`,
       })
     })
-
-    it('should return errors if there are no responses to expectedDeliveryDate or childRemoved question and isPersonPregnant is yes', () => {
-      ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue(['pregnancy'])
-
-      const page = new AccessNeedsFurtherQuestions(
-        {
-          ...body,
-          isPersonPregnant: 'yes',
-          expectedDeliveryDate: undefined,
-          'expectedDeliveryDate-year': undefined,
-          'expectedDeliveryDate-month': undefined,
-          'expectedDeliveryDate-day': undefined,
-          childRemoved: undefined,
-          socialCareInvolvement: undefined,
-        },
-        application,
-      )
-      expect(page.errors()).toEqual({
-        expectedDeliveryDate: 'You must enter the expected delivery date',
-        childRemoved: 'You must confirm if the child will be removed at birth',
-        socialCareInvolvement: 'You must confirm if there is social care involvement',
-      })
-    })
-
-    it('should return a socialCareInvolvementDetail error if the person is pregnant and socialCareInvolvement is yes and socialCareInvolvementDetail is blank', () => {
-      ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue(['pregnancy'])
-
-      const page = new AccessNeedsFurtherQuestions(
-        {
-          ...body,
-          isPersonPregnant: 'yes',
-          socialCareInvolvement: 'yes',
-          socialCareInvolvementDetail: undefined,
-        },
-        application,
-      )
-      expect(page.errors()).toEqual({
-        socialCareInvolvementDetail: 'You must provide details of any social care involvement',
-      })
-    })
   })
 
   describe('listOfNeeds', () => {
     it('should return null when no needs are selected', () => {
-      ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue([])
-
       const page = new AccessNeedsFurtherQuestions(body, application)
 
       expect(page.listOfNeeds).toEqual(null)
@@ -197,10 +146,6 @@ describe('AccessNeedsFurtherQuestions', () => {
         'Does the person have any known health conditions?': 'Yes - Some detail',
         'Does the person have any prescribed medication?': 'Yes - Some detail',
         'Is the person pregnant?': 'Yes',
-        'Is there social care involvement?': 'Yes - Some detail',
-        'What is their expected date of delivery?': DateFormats.dateAndTimeInputsToUiDate(body, 'expectedDeliveryDate'),
-        "Will the child be removed from the person's care at birth?": 'No',
-        'Are there any pregnancy related issues relevant to placement?': 'Yes - Some detail',
         "Specify any additional details and adjustments required for the person's pregnancy needs": 'Adjustments',
       })
     })

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsFurtherQuestions.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsFurtherQuestions.test.ts
@@ -17,7 +17,6 @@ describe('AccessNeedsFurtherQuestions', () => {
     prescribedMedication: 'yes',
     prescribedMedicationDetail: 'Some detail',
     isPersonPregnant: 'yes',
-    additionalAdjustments: 'Adjustments',
   }
 
   beforeEach(() => {
@@ -41,7 +40,6 @@ describe('AccessNeedsFurtherQuestions', () => {
         prescribedMedication: 'yes',
         prescribedMedicationDetail: 'Some detail',
         isPersonPregnant: 'yes',
-        additionalAdjustments: 'Adjustments',
       })
     })
   })
@@ -58,8 +56,10 @@ describe('AccessNeedsFurtherQuestions', () => {
     describe('if the person is not pregnant', () => {
       const bodyPregnancyNo = { ...body, isPersonPregnant: 'no' as YesOrNo }
 
-      it('returns the covid page', () => {
-        expect(new AccessNeedsFurtherQuestions(bodyPregnancyNo, application).next()).toBe('covid')
+      it('returns the Access Needs Additional Details page', () => {
+        expect(new AccessNeedsFurtherQuestions(bodyPregnancyNo, application).next()).toBe(
+          'access-needs-additional-details',
+        )
       })
     })
   })
@@ -97,41 +97,13 @@ describe('AccessNeedsFurtherQuestions', () => {
       })
     })
 
-    it('should return errors if the person answered "yes" to pregancy healthcare questions but doesnt respond to pregnancy question', () => {
+    it('should return errors if the person answered "yes" to pregnancy healthcare questions but doesnt respond to pregnancy question', () => {
       ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue(['pregnancy'])
 
       const page = new AccessNeedsFurtherQuestions({ ...body, isPersonPregnant: undefined }, application)
       expect(page.errors()).toEqual({
         isPersonPregnant: `You must confirm if the person is pregnant`,
       })
-    })
-  })
-
-  describe('listOfNeeds', () => {
-    it('should return null when no needs are selected', () => {
-      const page = new AccessNeedsFurtherQuestions(body, application)
-
-      expect(page.listOfNeeds).toEqual(null)
-    })
-
-    it('should return a single need when one is selected', () => {
-      ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue(['mobility'])
-
-      const page = new AccessNeedsFurtherQuestions(body, application)
-
-      expect(page.listOfNeeds).toEqual('mobility needs')
-    })
-
-    it('should return a list of needs', () => {
-      ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue([
-        'learningDisability',
-        'neurodivergentConditions',
-        'healthcare',
-      ])
-
-      const page = new AccessNeedsFurtherQuestions(body, application)
-
-      expect(page.listOfNeeds).toEqual('learning disability, neurodivergent conditions or healthcare needs')
     })
   })
 
@@ -146,7 +118,6 @@ describe('AccessNeedsFurtherQuestions', () => {
         'Does the person have any known health conditions?': 'Yes - Some detail',
         'Does the person have any prescribed medication?': 'Yes - Some detail',
         'Is the person pregnant?': 'Yes',
-        "Specify any additional details and adjustments required for the person's pregnancy needs": 'Adjustments',
       })
     })
 
@@ -159,7 +130,6 @@ describe('AccessNeedsFurtherQuestions', () => {
         'Does the person require the use of a wheelchair?': 'Yes',
         'Does the person have any known health conditions?': 'Yes - Some detail',
         'Does the person have any prescribed medication?': 'Yes - Some detail',
-        "Specify any additional details and adjustments required for the person's mobility needs": 'Adjustments',
       })
     })
   })

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsFurtherQuestions.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsFurtherQuestions.ts
@@ -1,17 +1,16 @@
 import type { TaskListErrors, YesNoOrIDKWithDetail, YesOrNo, YesOrNoWithDetail } from '@approved-premises/ui'
 import { ApprovedPremisesApplication } from '@approved-premises/api'
-import { lowerCase, sentenceCase } from '../../../../utils/utils'
+import { sentenceCase } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
 import { yesNoOrDontKnowResponseWithDetail, yesOrNoResponseWithDetailForYes } from '../../../utils'
 
 import TasklistPage from '../../../tasklistPage'
 import { retrieveOptionalQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
-import AccessNeeds, { AdditionalNeed, additionalNeeds } from './accessNeeds'
+import AccessNeeds, { AdditionalNeed } from './accessNeeds'
 
 export type AccessNeedsFurtherQuestionsBody = {
   needsWheelchair: YesOrNo
   isPersonPregnant?: YesOrNo
-  additionalAdjustments: string
 } & YesOrNoWithDetail<'healthConditions'> &
   YesNoOrIDKWithDetail<'prescribedMedication'>
 
@@ -24,7 +23,6 @@ export type AccessNeedsFurtherQuestionsBody = {
     'prescribedMedication',
     'prescribedMedicationDetail',
     'isPersonPregnant',
-    'additionalAdjustments',
   ],
 })
 export default class AccessNeedsFurtherQuestions implements TasklistPage {
@@ -37,7 +35,6 @@ export default class AccessNeedsFurtherQuestions implements TasklistPage {
     prescribedMedication: `Does the person have any prescribed medication?`,
     prescribedMedicationDetail: 'Provide details',
     isPersonPregnant: `Is the person pregnant?`,
-    additionalAdjustments: `Specify any additional details and adjustments required for the person's ${this.listOfNeeds}`,
   }
 
   yesToPregnancyHealthcareQuestion: boolean = this.answeredYesToPregnancyHealthcareQuestion()
@@ -52,27 +49,11 @@ export default class AccessNeedsFurtherQuestions implements TasklistPage {
   }
 
   next() {
-    return this.body.isPersonPregnant === 'yes' ? 'pregnancy' : 'covid'
+    return this.body.isPersonPregnant === 'yes' ? 'pregnancy' : 'access-needs-additional-details'
   }
 
   public get additionalNeeds(): Array<AdditionalNeed> {
     return retrieveOptionalQuestionResponseFromFormArtifact(this.application, AccessNeeds, 'additionalNeeds')
-  }
-
-  public get listOfNeeds(): string {
-    const needs = this.additionalNeeds.map(need => additionalNeeds[need])
-
-    if (needs.length > 0) {
-      if (needs.length === 1) {
-        return lowerCase(`${needs[0]} needs`)
-      }
-
-      const lastNeed = needs.splice(-1)
-
-      return lowerCase(`${needs.join(', ')} or ${lastNeed} needs`)
-    }
-
-    return null
   }
 
   answeredYesToPregnancyHealthcareQuestion() {
@@ -89,8 +70,6 @@ export default class AccessNeedsFurtherQuestions implements TasklistPage {
     if (this.answeredYesToPregnancyHealthcareQuestion()) {
       response[this.questions.isPersonPregnant] = sentenceCase(this.body.isPersonPregnant)
     }
-
-    response[this.questions.additionalAdjustments] = this.body.additionalAdjustments
 
     return response
   }

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsFurtherQuestions.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/accessNeedsFurtherQuestions.ts
@@ -1,30 +1,19 @@
-import type {
-  ObjectWithDateParts,
-  TaskListErrors,
-  YesNoOrIDKWithDetail,
-  YesOrNo,
-  YesOrNoWithDetail,
-} from '@approved-premises/ui'
-import { ApprovedPremisesApplication } from '../../../../@types/shared'
+import type { TaskListErrors, YesNoOrIDKWithDetail, YesOrNo, YesOrNoWithDetail } from '@approved-premises/ui'
+import { ApprovedPremisesApplication } from '@approved-premises/api'
 import { lowerCase, sentenceCase } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
 import { yesNoOrDontKnowResponseWithDetail, yesOrNoResponseWithDetailForYes } from '../../../utils'
 
 import TasklistPage from '../../../tasklistPage'
-import { DateFormats } from '../../../../utils/dateUtils'
 import { retrieveOptionalQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 import AccessNeeds, { AdditionalNeed, additionalNeeds } from './accessNeeds'
 
 export type AccessNeedsFurtherQuestionsBody = {
   needsWheelchair: YesOrNo
   isPersonPregnant?: YesOrNo
-  childRemoved?: YesOrNo | 'decisionPending'
   additionalAdjustments: string
-} & ObjectWithDateParts<'expectedDeliveryDate'> &
-  YesOrNoWithDetail<'healthConditions'> &
-  YesNoOrIDKWithDetail<'prescribedMedication'> &
-  YesNoOrIDKWithDetail<'socialCareInvolvement'> &
-  YesOrNoWithDetail<'otherPregnancyConsiderations'>
+} & YesOrNoWithDetail<'healthConditions'> &
+  YesNoOrIDKWithDetail<'prescribedMedication'>
 
 @Page({
   name: 'access-needs-further-questions',
@@ -35,15 +24,6 @@ export type AccessNeedsFurtherQuestionsBody = {
     'prescribedMedication',
     'prescribedMedicationDetail',
     'isPersonPregnant',
-    'childRemoved',
-    'expectedDeliveryDate',
-    'expectedDeliveryDate-year',
-    'expectedDeliveryDate-month',
-    'expectedDeliveryDate-day',
-    'socialCareInvolvement',
-    'socialCareInvolvementDetail',
-    'otherPregnancyConsiderations',
-    'otherPregnancyConsiderationsDetail',
     'additionalAdjustments',
   ],
 })
@@ -57,47 +37,22 @@ export default class AccessNeedsFurtherQuestions implements TasklistPage {
     prescribedMedication: `Does the person have any prescribed medication?`,
     prescribedMedicationDetail: 'Provide details',
     isPersonPregnant: `Is the person pregnant?`,
-    expectedDeliveryDate: 'What is their expected date of delivery?',
-    otherPregnancyConsiderationsDetail: 'Provide details',
-    socialCareInvolvement: 'Is there social care involvement?',
-    socialCareInvolvementDetail: 'Provide details',
-    otherPregnancyConsiderations: 'Are there any pregnancy related issues relevant to placement?',
-    childRemoved: `Will the child be removed from the person's care at birth?`,
     additionalAdjustments: `Specify any additional details and adjustments required for the person's ${this.listOfNeeds}`,
   }
 
   yesToPregnancyHealthcareQuestion: boolean = this.answeredYesToPregnancyHealthcareQuestion()
 
   constructor(
-    private _body: Partial<AccessNeedsFurtherQuestionsBody>,
+    public body: Partial<AccessNeedsFurtherQuestionsBody>,
     private readonly application: ApprovedPremisesApplication,
   ) {}
-
-  public set body(value: Partial<AccessNeedsFurtherQuestionsBody>) {
-    if (value.isPersonPregnant === 'yes') {
-      this._body = {
-        ...value,
-        'expectedDeliveryDate-year': value['expectedDeliveryDate-year'] as string,
-        'expectedDeliveryDate-month': value['expectedDeliveryDate-month'] as string,
-        'expectedDeliveryDate-day': value['expectedDeliveryDate-day'] as string,
-        expectedDeliveryDate: DateFormats.dateAndTimeInputsToIsoString(
-          value as ObjectWithDateParts<'expectedDeliveryDate'>,
-          'expectedDeliveryDate',
-        ).expectedDeliveryDate,
-      }
-    }
-  }
-
-  public get body(): AccessNeedsFurtherQuestionsBody {
-    return this._body as AccessNeedsFurtherQuestionsBody
-  }
 
   previous() {
     return 'access-needs'
   }
 
   next() {
-    return 'covid'
+    return this.body.isPersonPregnant === 'yes' ? 'pregnancy' : 'covid'
   }
 
   public get additionalNeeds(): Array<AdditionalNeed> {
@@ -133,20 +88,6 @@ export default class AccessNeedsFurtherQuestions implements TasklistPage {
 
     if (this.answeredYesToPregnancyHealthcareQuestion()) {
       response[this.questions.isPersonPregnant] = sentenceCase(this.body.isPersonPregnant)
-
-      if (this.body.isPersonPregnant === 'yes') {
-        response[this.questions.expectedDeliveryDate] = DateFormats.isoDateToUIDate(this.body.expectedDeliveryDate)
-        response[this.questions.childRemoved] = sentenceCase(this.body.childRemoved)
-        response[this.questions.socialCareInvolvement] = yesNoOrDontKnowResponseWithDetail(
-          'socialCareInvolvement',
-          this.body,
-        )
-      }
-
-      response[this.questions.otherPregnancyConsiderations] = yesOrNoResponseWithDetailForYes(
-        'otherPregnancyConsiderations',
-        this.body,
-      )
     }
 
     response[this.questions.additionalAdjustments] = this.body.additionalAdjustments
@@ -180,26 +121,6 @@ export default class AccessNeedsFurtherQuestions implements TasklistPage {
     if (this.answeredYesToPregnancyHealthcareQuestion()) {
       if (!this.body.isPersonPregnant) {
         errors.isPersonPregnant = `You must confirm if the person is pregnant`
-      }
-
-      if (this.body.isPersonPregnant === 'yes') {
-        if (!this.body.expectedDeliveryDate) {
-          errors.expectedDeliveryDate = 'You must enter the expected delivery date'
-        }
-        if (!this.body.childRemoved) {
-          errors.childRemoved = 'You must confirm if the child will be removed at birth'
-        }
-        if (!this.body.socialCareInvolvement) {
-          errors.socialCareInvolvement = 'You must confirm if there is social care involvement'
-        }
-        if (this.body.socialCareInvolvement === 'yes' && !this.body.socialCareInvolvementDetail) {
-          errors.socialCareInvolvementDetail = 'You must provide details of any social care involvement'
-        }
-      }
-
-      if (this.body.otherPregnancyConsiderations === 'yes' && !this.body.otherPregnancyConsiderationsDetail) {
-        errors.otherPregnancyConsiderationsDetail =
-          'You must provide details of any pregnancy related issues relevant to the placement'
       }
     }
 

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/index.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/index.ts
@@ -1,5 +1,6 @@
 import AccessNeeds from './accessNeeds'
 import AccessNeedsFurtherQuestions from './accessNeedsFurtherQuestions'
+import Pregnancy from './pregnancy'
 import Covid from './covid'
 
 import { Task } from '../../../utils/decorators'
@@ -7,6 +8,6 @@ import { Task } from '../../../utils/decorators'
 @Task({
   name: 'Add access, cultural and healthcare needs',
   slug: 'access-and-healthcare',
-  pages: [AccessNeeds, AccessNeedsFurtherQuestions, Covid],
+  pages: [AccessNeeds, AccessNeedsFurtherQuestions, Pregnancy, Covid],
 })
 export default class AccessAndHealthcare {}

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/index.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/index.ts
@@ -1,6 +1,7 @@
 import AccessNeeds from './accessNeeds'
 import AccessNeedsFurtherQuestions from './accessNeedsFurtherQuestions'
 import Pregnancy from './pregnancy'
+import AccessNeedsAdditionalDetails from './accessNeedsAdditionalDetails'
 import Covid from './covid'
 
 import { Task } from '../../../utils/decorators'
@@ -8,6 +9,6 @@ import { Task } from '../../../utils/decorators'
 @Task({
   name: 'Add access, cultural and healthcare needs',
   slug: 'access-and-healthcare',
-  pages: [AccessNeeds, AccessNeedsFurtherQuestions, Pregnancy, Covid],
+  pages: [AccessNeeds, AccessNeedsFurtherQuestions, Pregnancy, AccessNeedsAdditionalDetails, Covid],
 })
 export default class AccessAndHealthcare {}

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/pregnancy.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/pregnancy.test.ts
@@ -85,8 +85,8 @@ describe('AccessNeeds', () => {
       const page = new Pregnancy(body)
 
       expect(page.response()).toEqual({
-        'Is there social care involvement?': 'Yes - Some detail',
         'What is their expected date of delivery?': DateFormats.dateAndTimeInputsToUiDate(body, 'expectedDeliveryDate'),
+        'Is there social care involvement?': 'Yes - Some detail',
         "Will the child be removed from the person's care at birth?": 'No',
         'Are there any pregnancy related issues relevant to placement?': 'Yes - Some detail',
       })

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/pregnancy.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/pregnancy.test.ts
@@ -1,0 +1,95 @@
+import Pregnancy, { PregnancyBody } from './pregnancy'
+import { DateFormats } from '../../../../utils/dateUtils'
+
+describe('AccessNeeds', () => {
+  const expectedDeliveryDate = new Date(2023, 1, 19)
+  const body: PregnancyBody = {
+    expectedDeliveryDate: DateFormats.dateObjToIsoDate(expectedDeliveryDate),
+    ...DateFormats.dateObjectToDateInputs(expectedDeliveryDate, 'expectedDeliveryDate'),
+    otherPregnancyConsiderations: 'yes',
+    otherPregnancyConsiderationsDetail: 'Some detail',
+    socialCareInvolvement: 'yes',
+    socialCareInvolvementDetail: 'Some detail',
+    childRemoved: 'no',
+  }
+
+  describe('title', () => {
+    it('should return the title', () => {
+      expect(new Pregnancy({}).title).toBe('Access, cultural and healthcare needs')
+    })
+  })
+
+  describe('body', () => {
+    it('should set the body', () => {
+      const page = new Pregnancy(body)
+
+      expect(page.body).toEqual({
+        expectedDeliveryDate: DateFormats.dateObjToIsoDate(expectedDeliveryDate),
+        'expectedDeliveryDate-year': '2023',
+        'expectedDeliveryDate-month': '2',
+        'expectedDeliveryDate-day': '19',
+        otherPregnancyConsiderations: 'yes',
+        otherPregnancyConsiderationsDetail: 'Some detail',
+        socialCareInvolvement: 'yes',
+        socialCareInvolvementDetail: 'Some detail',
+        childRemoved: 'no',
+      })
+    })
+  })
+
+  describe('next', () => {
+    it('returns the correct next page', () => {
+      expect(new Pregnancy({}).next()).toBe('covid')
+    })
+  })
+
+  describe('previous', () => {
+    it('returns the correct previous page', () => {
+      expect(new Pregnancy({}).previous()).toBe('access-needs-further-questions')
+    })
+  })
+
+  describe('errors', () => {
+    it('should return errors if there are no responses to expectedDeliveryDate or childRemoved question', () => {
+      const page = new Pregnancy({
+        expectedDeliveryDate: undefined,
+        'expectedDeliveryDate-year': undefined,
+        'expectedDeliveryDate-month': undefined,
+        'expectedDeliveryDate-day': undefined,
+        childRemoved: undefined,
+        socialCareInvolvement: undefined,
+      })
+
+      expect(page.errors()).toEqual({
+        expectedDeliveryDate: 'You must enter the expected delivery date',
+        childRemoved: 'You must confirm if the child will be removed at birth',
+        socialCareInvolvement: 'You must confirm if there is social care involvement',
+      })
+    })
+
+    it('should return a socialCareInvolvementDetail error if socialCareInvolvement is yes and socialCareInvolvementDetail is blank', () => {
+      const page = new Pregnancy({
+        ...body,
+        socialCareInvolvement: 'yes',
+        socialCareInvolvementDetail: undefined,
+      })
+
+      expect(page.errors()).toEqual({
+        socialCareInvolvementDetail: 'You must provide details of any social care involvement',
+      })
+    })
+  })
+
+  describe('response', () => {
+    it('returns the correct plain english responses for the questions', () => {
+      const page = new Pregnancy(body)
+
+      expect(page.response()).toEqual({
+        'Is there social care involvement?': 'Yes - Some detail',
+        'What is their expected date of delivery?': DateFormats.dateAndTimeInputsToUiDate(body, 'expectedDeliveryDate'),
+        "Will the child be removed from the person's care at birth?": 'No',
+        'Are there any pregnancy related issues relevant to placement?': 'Yes - Some detail',
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/pregnancy.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/pregnancy.test.ts
@@ -39,7 +39,7 @@ describe('AccessNeeds', () => {
 
   describe('next', () => {
     it('returns the correct next page', () => {
-      expect(new Pregnancy({}).next()).toBe('covid')
+      expect(new Pregnancy({}).next()).toBe('access-needs-additional-details')
     })
   })
 

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/pregnancy.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/pregnancy.ts
@@ -88,7 +88,7 @@ export default class Pregnancy implements TasklistPage {
   }
 
   next(): string {
-    return 'covid'
+    return 'access-needs-additional-details'
   }
 
   previous(): string {

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/pregnancy.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/pregnancy.ts
@@ -1,0 +1,109 @@
+import {
+  type ObjectWithDateParts,
+  PageResponse,
+  TaskListErrors,
+  type YesNoOrIDKWithDetail,
+  type YesOrNo,
+  type YesOrNoWithDetail,
+} from '@approved-premises/ui'
+import TasklistPage from '../../../tasklistPage'
+import { Page } from '../../../utils/decorators'
+import { DateFormats } from '../../../../utils/dateUtils'
+import { sentenceCase } from '../../../../utils/utils'
+import { yesNoOrDontKnowResponseWithDetail, yesOrNoResponseWithDetailForYes } from '../../../utils'
+
+export type PregnancyBody = {
+  childRemoved?: YesOrNo | 'decisionPending'
+} & ObjectWithDateParts<'expectedDeliveryDate'> &
+  YesNoOrIDKWithDetail<'socialCareInvolvement'> &
+  YesOrNoWithDetail<'otherPregnancyConsiderations'>
+
+@Page({
+  name: 'pregnancy',
+  bodyProperties: [
+    'childRemoved',
+    'expectedDeliveryDate',
+    'expectedDeliveryDate-year',
+    'expectedDeliveryDate-month',
+    'expectedDeliveryDate-day',
+    'socialCareInvolvement',
+    'socialCareInvolvementDetail',
+    'otherPregnancyConsiderations',
+    'otherPregnancyConsiderationsDetail',
+  ],
+})
+export default class Pregnancy implements TasklistPage {
+  title = 'Access, cultural and healthcare needs'
+
+  questions = {
+    expectedDeliveryDate: 'What is their expected date of delivery?',
+    otherPregnancyConsiderationsDetail: 'Provide details',
+    socialCareInvolvement: 'Is there social care involvement?',
+    socialCareInvolvementDetail: 'Provide details',
+    otherPregnancyConsiderations: 'Are there any pregnancy related issues relevant to placement?',
+    childRemoved: `Will the child be removed from the person's care at birth?`,
+  }
+
+  constructor(private _body: Partial<PregnancyBody>) {}
+
+  public set body(value: Partial<PregnancyBody>) {
+    this._body = {
+      ...value,
+      'expectedDeliveryDate-year': value['expectedDeliveryDate-year'] as string,
+      'expectedDeliveryDate-month': value['expectedDeliveryDate-month'] as string,
+      'expectedDeliveryDate-day': value['expectedDeliveryDate-day'] as string,
+      expectedDeliveryDate: DateFormats.dateAndTimeInputsToIsoString(
+        value as ObjectWithDateParts<'expectedDeliveryDate'>,
+        'expectedDeliveryDate',
+      ).expectedDeliveryDate,
+    }
+  }
+
+  public get body(): PregnancyBody {
+    return this._body as PregnancyBody
+  }
+
+  errors(): TaskListErrors<this> {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.expectedDeliveryDate) {
+      errors.expectedDeliveryDate = 'You must enter the expected delivery date'
+    }
+    if (!this.body.childRemoved) {
+      errors.childRemoved = 'You must confirm if the child will be removed at birth'
+    }
+    if (!this.body.socialCareInvolvement) {
+      errors.socialCareInvolvement = 'You must confirm if there is social care involvement'
+    }
+    if (this.body.socialCareInvolvement === 'yes' && !this.body.socialCareInvolvementDetail) {
+      errors.socialCareInvolvementDetail = 'You must provide details of any social care involvement'
+    }
+
+    if (this.body.otherPregnancyConsiderations === 'yes' && !this.body.otherPregnancyConsiderationsDetail) {
+      errors.otherPregnancyConsiderationsDetail =
+        'You must provide details of any pregnancy related issues relevant to the placement'
+    }
+
+    return errors
+  }
+
+  next(): string {
+    return 'covid'
+  }
+
+  previous(): string {
+    return 'access-needs-further-questions'
+  }
+
+  response(): PageResponse {
+    return {
+      [this.questions.expectedDeliveryDate]: DateFormats.isoDateToUIDate(this.body.expectedDeliveryDate),
+      [this.questions.childRemoved]: sentenceCase(this.body.childRemoved),
+      [this.questions.socialCareInvolvement]: yesNoOrDontKnowResponseWithDetail('socialCareInvolvement', this.body),
+      [this.questions.otherPregnancyConsiderations]: yesOrNoResponseWithDetailForYes(
+        'otherPregnancyConsiderations',
+        this.body,
+      ),
+    }
+  }
+}

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/pregnancy.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/pregnancy.ts
@@ -21,13 +21,13 @@ export type PregnancyBody = {
 @Page({
   name: 'pregnancy',
   bodyProperties: [
-    'childRemoved',
     'expectedDeliveryDate',
     'expectedDeliveryDate-year',
     'expectedDeliveryDate-month',
     'expectedDeliveryDate-day',
     'socialCareInvolvement',
     'socialCareInvolvementDetail',
+    'childRemoved',
     'otherPregnancyConsiderations',
     'otherPregnancyConsiderationsDetail',
   ],
@@ -37,11 +37,11 @@ export default class Pregnancy implements TasklistPage {
 
   questions = {
     expectedDeliveryDate: 'What is their expected date of delivery?',
-    otherPregnancyConsiderationsDetail: 'Provide details',
     socialCareInvolvement: 'Is there social care involvement?',
     socialCareInvolvementDetail: 'Provide details',
-    otherPregnancyConsiderations: 'Are there any pregnancy related issues relevant to placement?',
     childRemoved: `Will the child be removed from the person's care at birth?`,
+    otherPregnancyConsiderations: 'Are there any pregnancy related issues relevant to placement?',
+    otherPregnancyConsiderationsDetail: 'Provide details',
   }
 
   constructor(private _body: Partial<PregnancyBody>) {}
@@ -98,8 +98,8 @@ export default class Pregnancy implements TasklistPage {
   response(): PageResponse {
     return {
       [this.questions.expectedDeliveryDate]: DateFormats.isoDateToUIDate(this.body.expectedDeliveryDate),
-      [this.questions.childRemoved]: sentenceCase(this.body.childRemoved),
       [this.questions.socialCareInvolvement]: yesNoOrDontKnowResponseWithDetail('socialCareInvolvement', this.body),
+      [this.questions.childRemoved]: sentenceCase(this.body.childRemoved),
       [this.questions.otherPregnancyConsiderations]: yesOrNoResponseWithDetailForYes(
         'otherPregnancyConsiderations',
         this.body,

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -299,6 +299,25 @@ describe('formUtils', () => {
         },
       ])
     })
+
+    it('should separate the exclusive option', () => {
+      expect(convertKeyValuePairToCheckBoxItems(obj, [], true)).toEqual([
+        {
+          value: 'foo',
+          text: 'Foo',
+          checked: false,
+        },
+        {
+          divider: 'or',
+        },
+        {
+          value: 'bar',
+          text: 'Bar',
+          checked: false,
+          behaviour: 'exclusive',
+        },
+      ])
+    })
   })
 
   describe('convertKeyValuePairToRadioItems', () => {

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -108,14 +108,19 @@ export function convertKeyValuePairToRadioItems<T extends object>(
 export function convertKeyValuePairToCheckBoxItems<T extends object>(
   object: T,
   checkedItems: Array<string> = [],
+  exclusiveLastOption = false,
 ): Array<CheckBoxItem> {
-  return Object.keys(object).map(key => {
-    return {
-      value: key,
-      text: object[key],
-      checked: checkedItems.includes(key),
-    }
-  })
+  const items: Array<CheckBoxItem> = Object.keys(object).map(key => ({
+    value: key,
+    text: object[key],
+    checked: checkedItems.includes(key),
+  }))
+
+  if (exclusiveLastOption) {
+    items.splice(-1, 1, { divider: 'or' }, { ...items.at(-1), behaviour: 'exclusive' })
+  }
+
+  return items
 }
 
 export function convertArrayToRadioItems<T extends string>(

--- a/server/views/applications/pages/access-and-healthcare/access-needs-additional-details.njk
+++ b/server/views/applications/pages/access-and-healthcare/access-needs-additional-details.njk
@@ -1,0 +1,37 @@
+{% extends "../layout.njk" %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{% block questions %}
+    <h1 class="govuk-heading-l">{{ page.title }}</h1>
+
+    {% set hintHtml %}
+        <details class="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                    What adjustments can be made?
+                </span>
+            </summary>
+            <div class="govuk-details__text">
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>Step-free access for reduced mobility</li>
+                    <li>Wheelchair accessibility</li>
+                    <li>En-suite bedroom</li>
+                    <li>Signs in braille, tactile and directional flooring</li>
+                    <li>Hearing loop</li>
+                </ul>
+            </div>
+        </details>
+    {% endset %}
+
+    {{ formPageTextarea({
+        fieldName: "additionalAdjustments",
+        label: {
+            text: page.questions.additionalAdjustments + ' (optional)',
+            classes: "govuk-label--m"
+        },
+        hint: {
+            html: hintHtml
+        }
+    }, fetchContext()) }}
+
+{% endblock %}

--- a/server/views/applications/pages/access-and-healthcare/access-needs-further-questions.njk
+++ b/server/views/applications/pages/access-and-healthcare/access-needs-further-questions.njk
@@ -2,257 +2,148 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% block questions %}
-  <h1 class="govuk-heading-l">Access, cultural and healthcare needs</h1>
-  <p class="govuk-body">Specify any additional details and the adjustments required</p>
+    <h1 class="govuk-heading-l">Access, cultural and healthcare needs</h1>
+    <p class="govuk-body">Specify any additional details and the adjustments required</p>
 
-  {{ formPageRadios({
-      fieldName: "needsWheelchair",
-      fieldset: {
-        legend: {
-          text: page.questions.wheelchair,
-          classes: "govuk-fieldset__legend--m"
-        }
-      },
-      hint: {
-        html: '<p>If the person requires use of a wheelchair around the Approved Premises select yes.</p>'
-      },
-      items: [
-        {
-          value: "yes",
-          text: "Yes"
-        },
-        {
-          value: "no",
-          text: "No"
-        }
-      ]
-    }, fetchContext()) }}
-
-  {% set healthConditionsDetail %}
-  {{ formPageTextarea({
-        fieldName: "healthConditionsDetail",
-        label: {
-          text: page.questions.healthConditionsDetail
-        }
-    }, fetchContext()) }}
-  {% endset -%}
-
-  {{ formPageRadios({
-      fieldName: "healthConditions",
-      fieldset: {
-        legend: {
-          text: page.questions.healthConditions,
-          classes: "govuk-fieldset__legend--m"
-        }
-      },
-      items: [
-        {
-          value: "yes",
-          text: "Yes",
-          conditional: {
-            html: healthConditionsDetail
-          }
-        },
-        {
-          value: "no",
-          text: "No"
-        }
-      ]
-    }, fetchContext()) }}
-
-  {% set prescribedMedicationDetail %}
-  {{ formPageTextarea({
-        fieldName: "prescribedMedicationDetail",
-        label: {
-          text: page.questions.prescribedMedicationDetail
-        }
-    }, fetchContext()) }}
-  {% endset -%}
-
-  {{ formPageRadios({
-      fieldName: "prescribedMedication",
-      fieldset: {
-        legend: {
-          text: page.questions.prescribedMedication,
-          classes: "govuk-fieldset__legend--m"
-        }
-      },
-      items: [
-        {
-          value: "yes",
-          text: "Yes",
-          conditional: {
-            html: prescribedMedicationDetail
-          }
-        },
-        {
-          value: "no",
-          text: "No"
-        }
-      ]
-    }, fetchContext()) }}
-
-  {% set additionalPregnancyQuestions %}
-  {{
-    formPageDateInput(
-        {
-          fieldName: "expectedDeliveryDate",
-          fieldset: {
+    {{ formPageRadios({
+        fieldName: "needsWheelchair",
+        fieldset: {
             legend: {
-              text: page.questions.expectedDeliveryDate
+                text: page.questions.wheelchair,
+                classes: "govuk-fieldset__legend--m"
             }
-          },
-          items: dateFieldValues('expectedDeliveryDate', errors)
-        },
-        fetchContext()
-      )
-  }}
-  {% endset -%}
-
-  {% if page.yesToPregnancyHealthcareQuestion %}
-    {{ formPageRadios({
-      fieldName: "isPersonPregnant",
-      fieldset: {
-        legend: {
-          text: page.questions.isPersonPregnant,
-          classes: "govuk-fieldset__legend--m"
-        }
-      },
-      items: [
-        {
-          value: "yes",
-          text: "Yes",
-          conditional: {
-            html: additionalPregnancyQuestions
-          }
-        },
-        {
-          value: "no",
-          text: "No"
-        }
-      ]
-    }, fetchContext()) }}
-
-    {{ formPageRadios({
-      fieldName: "childRemoved",
-      fieldset: {
-        legend: {
-          text: page.questions.childRemoved,
-          classes: "govuk-fieldset__legend--m"
-        }
-      },
-      hint: {
-        text: "This will help determine a person's move on plan. Someone cannot stay at an Approved Premises with a child."
-      },
-      items: [
-        {
-          value: "yes",
-          text: "Yes"
-        },
-        {
-          value: "no",
-          text: "No"
-        },
-        {
-          value: "decisionPending",
-          text: "Decision pending"
-        }
-      ]
-    }, fetchContext()) }}
-
-    {% set socialCareInvolvementDetail %}
-    {{ formPageTextarea({
-        fieldName: "socialCareInvolvementDetail",
-        label: {
-          text: page.questions.socialCareInvolvementDetail
-        }
-    }, fetchContext()) }}
-    {% endset -%}
-
-    {{ formPageRadios({
-      fieldName: "socialCareInvolvement",
-      fieldset: {
-        legend: {
-          text: page.questions.socialCareInvolvement,
-          classes: "govuk-fieldset__legend--m"
-        }
-      },
-      items: [
-        {
-          value: "yes",
-          text: "Yes",
-          conditional: {
-            html: socialCareInvolvementDetail
-          }
-        },
-        {
-          value: "no",
-          text: "No"
-        }
-      ]
-    }, fetchContext()) }}
-
-    {% set otherPregnancyConsiderationsDetail %}
-    {{ formPageTextarea({
-        fieldName: "otherPregnancyConsiderationsDetail",
-        label: {
-          text: page.questions.otherPregnancyConsiderationsDetail
-        }
-    }, fetchContext()) }}
-    {% endset -%}
-
-    {{ formPageRadios({
-      fieldName: "otherPregnancyConsiderations",
-      fieldset: {
-        legend: {
-          text: page.questions.otherPregnancyConsiderations,
-          classes: "govuk-fieldset__legend--m"
-        }
-      },
-      items: [
-        {
-          value: "yes",
-          text: "Yes",
-          conditional: {
-            html: otherPregnancyConsiderationsDetail
-          }
-        },
-        {
-          value: "no",
-          text: "No"
-        }
-      ]
-    }, fetchContext()) }}
-
-  {% endif %}
-
-  {% set hintHtml %}
-  <details class="govuk-details">
-    <summary class="govuk-details__summary">
-      <span class="govuk-details__summary-text">
-                What adjustments can be made?
-              </span>
-    </summary>
-    <div class="govuk-details__text">
-      <ul class="govuk-list govuk-list--bullet">
-        <li>Step-free access for reduced mobility</li>
-        <li>Wheelchair accessibility</li>
-        <li>En-suite bedroom</li>
-        <li>Signs in braille, tactile and directional flooring</li>
-        <li>Hearing loop</li>
-      </ul>
-    </div>
-  </details>
-  {% endset %}
-
-  {{ formPageTextarea({
-        fieldName: "additionalAdjustments",
-        label: {
-          text: page.questions.additionalAdjustments,
-          classes: "govuk-label--m"
         },
         hint: {
-          html: hintHtml
+            html: '<p>If the person requires use of a wheelchair around the Approved Premises select yes.</p>'
+        },
+        items: [
+            {
+                value: "yes",
+                text: "Yes"
+            },
+            {
+                value: "no",
+                text: "No"
+            }
+        ]
+    }, fetchContext()) }}
+
+    {% set healthConditionsDetail %}
+        {{ formPageTextarea({
+            fieldName: "healthConditionsDetail",
+            label: {
+                text: page.questions.healthConditionsDetail
+            }
+        }, fetchContext()) }}
+    {% endset -%}
+
+    {{ formPageRadios({
+        fieldName: "healthConditions",
+        fieldset: {
+            legend: {
+                text: page.questions.healthConditions,
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+        items: [
+            {
+                value: "yes",
+                text: "Yes",
+                conditional: {
+                html: healthConditionsDetail
+            }
+            },
+            {
+                value: "no",
+                text: "No"
+            }
+        ]
+    }, fetchContext()) }}
+
+    {% set prescribedMedicationDetail %}
+        {{ formPageTextarea({
+            fieldName: "prescribedMedicationDetail",
+            label: {
+                text: page.questions.prescribedMedicationDetail
+            }
+        }, fetchContext()) }}
+    {% endset -%}
+
+    {{ formPageRadios({
+        fieldName: "prescribedMedication",
+        fieldset: {
+            legend: {
+                text: page.questions.prescribedMedication,
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+        items: [
+            {
+                value: "yes",
+                text: "Yes",
+                conditional: {
+                html: prescribedMedicationDetail
+            }
+            },
+            {
+                value: "no",
+                text: "No"
+            }
+        ]
+    }, fetchContext()) }}
+
+    {% if page.yesToPregnancyHealthcareQuestion %}
+        {{ formPageRadios({
+            fieldName: "isPersonPregnant",
+            fieldset: {
+                legend: {
+                    text: page.questions.isPersonPregnant,
+                    classes: "govuk-fieldset__legend--m"
+                }
+            },
+            items: [
+                {
+                    value: "yes",
+                    text: "Yes",
+                    conditional: {
+                    html: additionalPregnancyQuestions
+                }
+                },
+                {
+                    value: "no",
+                    text: "No"
+                }
+            ]
+        }, fetchContext()) }}
+    {% endif %}
+
+    {% set hintHtml %}
+        <details class="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                    What adjustments can be made?
+                </span>
+            </summary>
+            <div class="govuk-details__text">
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>Step-free access for reduced mobility</li>
+                    <li>Wheelchair accessibility</li>
+                    <li>En-suite bedroom</li>
+                    <li>Signs in braille, tactile and directional flooring</li>
+                    <li>Hearing loop</li>
+                </ul>
+            </div>
+        </details>
+    {% endset %}
+
+    {{ formPageTextarea({
+        fieldName: "additionalAdjustments",
+        label: {
+            text: page.questions.additionalAdjustments,
+            classes: "govuk-label--m"
+        },
+        hint: {
+            html: hintHtml
         }
     }, fetchContext()) }}
 

--- a/server/views/applications/pages/access-and-healthcare/access-needs-further-questions.njk
+++ b/server/views/applications/pages/access-and-healthcare/access-needs-further-questions.njk
@@ -1,8 +1,7 @@
 {% extends "../layout.njk" %}
-{% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% block questions %}
-    <h1 class="govuk-heading-l">Access, cultural and healthcare needs</h1>
+    <h1 class="govuk-heading-l">{{ page.title }}</h1>
     <p class="govuk-body">Specify any additional details and the adjustments required</p>
 
     {{ formPageRadios({
@@ -116,35 +115,5 @@
             ]
         }, fetchContext()) }}
     {% endif %}
-
-    {% set hintHtml %}
-        <details class="govuk-details">
-            <summary class="govuk-details__summary">
-                <span class="govuk-details__summary-text">
-                    What adjustments can be made?
-                </span>
-            </summary>
-            <div class="govuk-details__text">
-                <ul class="govuk-list govuk-list--bullet">
-                    <li>Step-free access for reduced mobility</li>
-                    <li>Wheelchair accessibility</li>
-                    <li>En-suite bedroom</li>
-                    <li>Signs in braille, tactile and directional flooring</li>
-                    <li>Hearing loop</li>
-                </ul>
-            </div>
-        </details>
-    {% endset %}
-
-    {{ formPageTextarea({
-        fieldName: "additionalAdjustments",
-        label: {
-            text: page.questions.additionalAdjustments,
-            classes: "govuk-label--m"
-        },
-        hint: {
-            html: hintHtml
-        }
-    }, fetchContext()) }}
 
 {% endblock %}

--- a/server/views/applications/pages/access-and-healthcare/access-needs.njk
+++ b/server/views/applications/pages/access-and-healthcare/access-needs.njk
@@ -4,174 +4,154 @@
 
 {% block questions %}
 
-  <h1 class="govuk-heading-l">{{page.title}}</h1>
+    <h1 class="govuk-heading-l">{{ page.title }}</h1>
 
-  {{ formPageCheckboxes({
-      fieldName: "additionalNeeds",
-      hint: {
-        text: page.questions.needs.hint
-      },
-      fieldset: {
-        legend: {
-          text: page.questions.needs.question,
-          classes: "govuk-fieldset__legend--m"
-        }
-      },
-      items: page.needsCheckboxes()
+    {{ formPageCheckboxes({
+        fieldName: "additionalNeeds",
+        hint: {
+            text: page.questions.needs.hint
+        },
+        fieldset: {
+            legend: {
+                text: page.questions.needs.question,
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+        items: page.needsCheckboxes()
     }, fetchContext()) }}
 
-  {% set culturalNeeds %}
-  {{ formPageTextarea({
-      fieldName: 'religiousOrCulturalNeedsDetail',
-      spellcheck: false,
-      label: {
-        text: "Provide details"
-      }
-    },fetchContext()) }}
-  {% endset %}
+    {% set culturalNeeds %}
+        {{ formPageTextarea({
+            fieldName: 'religiousOrCulturalNeedsDetail',
+            spellcheck: false,
+            label: {
+                text: "Provide details"
+            }
+        }, fetchContext()) }}
+    {% endset %}
 
-  {{ formPageRadios({
-      fieldName: "religiousOrCulturalNeeds",
-      fieldset: {
-        legend: {
-          text: page.questions.religiousOrCulturalNeeds.question,
-          classes: "govuk-fieldset__legend--m"
-        }
-      },
-      items: [
-        {
-          value: "yes",
-          text: "Yes",
-          conditional: {
-            html: culturalNeeds
-          }
+    {{ formPageRadios({
+        fieldName: "religiousOrCulturalNeeds",
+        fieldset: {
+            legend: {
+                text: page.questions.religiousOrCulturalNeeds.question,
+                classes: "govuk-fieldset__legend--m"
+            }
         },
-        {
-          value: "no",
-          text: "No"
-        }
-      ]
-    },fetchContext()) }}
+        items: [
+            {
+                value: "yes",
+                text: "Yes",
+                conditional: {
+                html: culturalNeeds
+            }
+            },
+            {
+                value: "no",
+                text: "No"
+            }
+        ]
+    }, fetchContext()) }}
 
-  {% set needInterpreter %}
-  {{ formPageInput({
-        fieldName: "interpreterLanguage",
-        label: {
-          text: page.questions.interpreter.language
-        }
-      },fetchContext()) }}
-  {% endset -%}
+    {% set needInterpreter %}
+        {{ formPageInput({
+            fieldName: "interpreterLanguage",
+            label: {
+                text: page.questions.interpreter.language
+            }
+        }, fetchContext()) }}
+    {% endset -%}
 
-  {% set careAndSupportNeeds %}
-  {{ formPageTextarea({
-      fieldName: 'careAndSupportNeedsDetail',
-      label: {
-        text: page.questions.careAndSupportNeeds.hint
-      }
-      },fetchContext()) }}
-  {% endset %}
+    {% set careAndSupportNeeds %}
+        {{ formPageTextarea({
+            fieldName: 'careAndSupportNeedsDetail',
+            label: {
+                text: page.questions.careAndSupportNeeds.hint
+            }
+        }, fetchContext()) }}
+    {% endset %}
 
-  {{ formPageRadios({
-      fieldName: "careAndSupportNeeds",
-      fieldset: {
-        legend: {
-          text: page.questions.careAndSupportNeeds.question,
-          classes: "govuk-fieldset__legend--m"
-        }
-      },
-      items: [
-        {
-          value: "yes",
-          text: "Yes",
-          conditional: {
-            html: careAndSupportNeeds
-          }
+    {{ formPageRadios({
+        fieldName: "careAndSupportNeeds",
+        fieldset: {
+            legend: {
+                text: page.questions.careAndSupportNeeds.question,
+                classes: "govuk-fieldset__legend--m"
+            }
         },
-        {
-          value: "no",
-          text: "No"
-        }
-      ]
-    },fetchContext()) }}
+        items: [
+            {
+                value: "yes",
+                text: "Yes",
+                conditional: {
+                html: careAndSupportNeeds
+            }
+            },
+            {
+                value: "no",
+                text: "No"
+            }
+        ]
+    }, fetchContext()) }}
 
-  {% set bannerHTML %}
-  {% set html %}
-  <p>Upload Care Act assessments to NDelius. You cannot upload these within the service.</p>
-  {% endset %}
+    {% set bannerHTML %}
+        {% set html %}
+            <p>Upload Care Act assessments to NDelius. You cannot upload these within the service.</p>
+        {% endset %}
 
-  {{ govukNotificationBanner({
-        html: html
-    }) }}
-  {% endset -%}
+        {{ govukNotificationBanner({
+            html: html
+        }) }}
+    {% endset -%}
 
-  {{ formPageRadios({
+    {{ formPageRadios({
         fieldName: "needsInterpreter",
         fieldset: {
-          legend: {
-            text: page.questions.interpreter.question,
-            classes: "govuk-fieldset__legend--m"
-          }
+            legend: {
+                text: page.questions.interpreter.question,
+                classes: "govuk-fieldset__legend--m"
+            }
         },
         items: [
-          {
-            value: "yes",
-            text: "Yes",
-            conditional: {
-              html: needInterpreter
+            {
+                value: "yes",
+                text: "Yes",
+                conditional: {
+                html: needInterpreter
             }
-          },
-          {
-            value: "no",
-            text: "No"
-          }
+            },
+            {
+                value: "no",
+                text: "No"
+            }
         ]
-      },fetchContext()) }}
+    }, fetchContext()) }}
 
-  {{ formPageRadios({
+    {{ formPageRadios({
         fieldName: "careActAssessmentCompleted",
         fieldset: {
-          legend: {
-            text: page.questions.careActAssessmentCompleted,
-            classes: "govuk-fieldset__legend--m"
-          }
+            legend: {
+                text: page.questions.careActAssessmentCompleted,
+                classes: "govuk-fieldset__legend--m"
+            }
         },
         items: [
-          {
-            value: "yes",
-            text: "Yes",
-            conditional: {
-              html: bannerHTML
+            {
+                value: "yes",
+                text: "Yes",
+                conditional: {
+                html: bannerHTML
             }
-          },
-          {
-            value: "no",
-            text: "No"
-          },
-          {
-            value: "iDontKnow",
-            text: "I don't know"
-          }
+            },
+            {
+                value: "no",
+                text: "No"
+            },
+            {
+                value: "iDontKnow",
+                text: "I don't know"
+            }
         ]
-      },fetchContext()) }}
+    }, fetchContext()) }}
 
-{% endblock %}
-
-{% block extraScripts %}
-  <script type="text/javascript" nonce="{{ cspNonce }}">
-    var none = document.querySelector('input[name="additionalNeeds"][value="none"]')
-    var checkBoxes = document.querySelectorAll('input[name="additionalNeeds"]:not([value="none"])')
-
-    none.addEventListener('change', function () {
-      if (this.checked) {
-        for (let i = 0; i < checkBoxes.length; i++) {
-          checkBoxes[i].checked = false
-          checkBoxes[i].setAttribute('disabled', true)
-        }
-      } else {
-        for (let i = 0; i < checkBoxes.length; i++) {
-          checkBoxes[i].removeAttribute('disabled')
-        }
-      }
-    });
-  </script>
 {% endblock %}

--- a/server/views/applications/pages/access-and-healthcare/pregnancy.njk
+++ b/server/views/applications/pages/access-and-healthcare/pregnancy.njk
@@ -4,7 +4,7 @@
     <h1 class="govuk-heading-l">Access, cultural and healthcare needs</h1>
 
     <p>Provide details about the person's pregnancy</p>
-    
+
     {{ formPageDateInput(
         {
             fieldName: "expectedDeliveryDate",
@@ -18,33 +18,6 @@
         },
         fetchContext()
     ) }}
-
-    {{ formPageRadios({
-        fieldName: "childRemoved",
-        fieldset: {
-            legend: {
-                text: page.questions.childRemoved,
-                classes: "govuk-fieldset__legend--m"
-            }
-        },
-        hint: {
-            text: "This will help determine a person's move on plan. Someone cannot stay at an Approved Premises with a child."
-        },
-        items: [
-            {
-                value: "yes",
-                text: "Yes"
-            },
-            {
-                value: "no",
-                text: "No"
-            },
-            {
-                value: "decisionPending",
-                text: "Decision pending"
-            }
-        ]
-    }, fetchContext()) }}
 
     {% set socialCareInvolvementDetail %}
         {{ formPageTextarea({
@@ -74,6 +47,33 @@
             {
                 value: "no",
                 text: "No"
+            }
+        ]
+    }, fetchContext()) }}
+
+    {{ formPageRadios({
+        fieldName: "childRemoved",
+        fieldset: {
+            legend: {
+                text: page.questions.childRemoved,
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+        hint: {
+            text: "This will help determine a person's move on plan. Someone cannot stay at an Approved Premises with a child."
+        },
+        items: [
+            {
+                value: "yes",
+                text: "Yes"
+            },
+            {
+                value: "no",
+                text: "No"
+            },
+            {
+                value: "decisionPending",
+                text: "Decision pending"
             }
         ]
     }, fetchContext()) }}

--- a/server/views/applications/pages/access-and-healthcare/pregnancy.njk
+++ b/server/views/applications/pages/access-and-healthcare/pregnancy.njk
@@ -1,0 +1,112 @@
+{% extends "../layout.njk" %}
+
+{% block questions %}
+    <h1 class="govuk-heading-l">Access, cultural and healthcare needs</h1>
+
+    <p>Provide details about the person's pregnancy</p>
+    
+    {{ formPageDateInput(
+        {
+            fieldName: "expectedDeliveryDate",
+            fieldset: {
+            legend: {
+                text: page.questions.expectedDeliveryDate,
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+            items: dateFieldValues('expectedDeliveryDate', errors)
+        },
+        fetchContext()
+    ) }}
+
+    {{ formPageRadios({
+        fieldName: "childRemoved",
+        fieldset: {
+            legend: {
+                text: page.questions.childRemoved,
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+        hint: {
+            text: "This will help determine a person's move on plan. Someone cannot stay at an Approved Premises with a child."
+        },
+        items: [
+            {
+                value: "yes",
+                text: "Yes"
+            },
+            {
+                value: "no",
+                text: "No"
+            },
+            {
+                value: "decisionPending",
+                text: "Decision pending"
+            }
+        ]
+    }, fetchContext()) }}
+
+    {% set socialCareInvolvementDetail %}
+        {{ formPageTextarea({
+            fieldName: "socialCareInvolvementDetail",
+            label: {
+                text: page.questions.socialCareInvolvementDetail
+            }
+        }, fetchContext()) }}
+    {% endset -%}
+
+    {{ formPageRadios({
+        fieldName: "socialCareInvolvement",
+        fieldset: {
+            legend: {
+                text: page.questions.socialCareInvolvement,
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+        items: [
+            {
+                value: "yes",
+                text: "Yes",
+                conditional: {
+                html: socialCareInvolvementDetail
+            }
+            },
+            {
+                value: "no",
+                text: "No"
+            }
+        ]
+    }, fetchContext()) }}
+
+    {% set otherPregnancyConsiderationsDetail %}
+        {{ formPageTextarea({
+            fieldName: "otherPregnancyConsiderationsDetail",
+            label: {
+                text: page.questions.otherPregnancyConsiderationsDetail
+            }
+        }, fetchContext()) }}
+    {% endset -%}
+
+    {{ formPageRadios({
+        fieldName: "otherPregnancyConsiderations",
+        fieldset: {
+            legend: {
+                text: page.questions.otherPregnancyConsiderations,
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+        items: [
+            {
+                value: "yes",
+                text: "Yes",
+                conditional: {
+                html: otherPregnancyConsiderationsDetail
+            }
+            },
+            {
+                value: "no",
+                text: "No"
+            }
+        ]
+    }, fetchContext()) }}
+{% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1332

# Changes in this PR

This PR splits the pregnancy-related health needs questions into their own screen, as well as providing the 'Additional adjustments' question its own screen too.

## Screenshots of UI changes

### After

#### Access Needs - Further questions, showing only the question about whether the person is pregnant

<img width="773" alt="Screenshot 2024-10-15 at 17 17 06" src="https://github.com/user-attachments/assets/5c9c36b3-98b0-46cc-a8d7-06d9780cd357">

---

#### New pregnancy screen, with questions following new order

<img width="533" alt="Screenshot 2024-10-15 at 17 17 48" src="https://github.com/user-attachments/assets/f5342e45-a5d1-4e90-81bb-21c219ddb9a8">

---

#### New screen for Additional Adjustments question

<img width="498" alt="Screenshot 2024-10-15 at 17 18 00" src="https://github.com/user-attachments/assets/dc18caef-0301-4d51-aaef-b4e784815d9e">

---

#### Check your answers showing new order

<img width="775" alt="Screenshot 2024-10-15 at 17 16 47" src="https://github.com/user-attachments/assets/e6b1dd8c-400a-4cb0-98cb-fd540b21a461">




