### PR TITLE
APS-1321: Remove references to genderForAp

### DIFF
--- a/integration_tests/tests/tasks/allocations.cy.ts
+++ b/integration_tests/tests/tasks/allocations.cy.ts
@@ -40,7 +40,6 @@ context('Task Allocation', () => {
       apType: 'pipe',
       isWomensApplication: false,
     })
-    application.genderForAp = 'male'
 
     const task = taskFactory.build({
       allocatedToStaffMember: userFactory.build(),

--- a/server/utils/tasks/index.test.ts
+++ b/server/utils/tasks/index.test.ts
@@ -79,8 +79,8 @@ describe('index', () => {
             value: { text: 'Unallocated' },
           },
           {
-            key: { text: 'Gender for AP' },
-            value: { text: 'Male' },
+            key: { text: 'AP gender' },
+            value: { text: 'Men' },
           },
         ])
       })
@@ -91,12 +91,12 @@ describe('index', () => {
         application.isWomensApplication = true
       })
 
-      it('renders the Gender for AP accordingly', () => {
+      it('renders the AP gender accordingly', () => {
         expect(taskSummary(task, application)).toEqual(
           expect.arrayContaining([
             {
-              key: { text: 'Gender for AP' },
-              value: { text: 'Female' },
+              key: { text: 'AP gender' },
+              value: { text: 'Women' },
             },
           ]),
         )

--- a/server/utils/tasks/index.test.ts
+++ b/server/utils/tasks/index.test.ts
@@ -59,7 +59,7 @@ describe('index', () => {
             value: { text: 'Not provided' },
           },
           {
-            key: { text: 'Application Type' },
+            key: { text: 'Application type' },
             value: { text: getApplicationType(application) },
             actions: {
               items: [
@@ -71,7 +71,7 @@ describe('index', () => {
             },
           },
           {
-            key: { text: 'AP Area' },
+            key: { text: 'AP area' },
             value: { text: application.apArea.name },
           },
           {
@@ -151,7 +151,7 @@ describe('index', () => {
         expect(taskSummary(task, application)).toEqual(
           expect.arrayContaining([
             {
-              key: { text: 'Case Manager' },
+              key: { text: 'Case manager' },
               value: { text: `${caseManager.name} (${caseManager.email})` },
             },
           ]),

--- a/server/utils/tasks/index.ts
+++ b/server/utils/tasks/index.ts
@@ -130,8 +130,8 @@ const taskSummary = (task: Task, application: Application): Array<SummaryListIte
   }
 
   summary.push({
-    key: { text: 'Gender for AP' },
-    value: { text: application.isWomensApplication ? 'Female' : 'Male' },
+    key: { text: 'AP gender' },
+    value: { text: application.isWomensApplication ? 'Women' : 'Men' },
   })
 
   if (task.probationDeliveryUnit) {

--- a/server/utils/tasks/index.ts
+++ b/server/utils/tasks/index.ts
@@ -19,7 +19,6 @@ import {
 import { userTableHeader, userTableRows } from './usersTable'
 import paths from '../../paths/apply'
 import { isPlacementApplicationTask } from './assertions'
-import { sentenceCase } from '../utils'
 import { qualificationDictionary } from '../users'
 
 type GroupedTasks = {
@@ -49,7 +48,7 @@ const getArrivalDate = (task: Task, application: Application) => {
   return arrivalDateFromApplication(application)
 }
 
-const getFormattedNameAndEmail = (name: string, email: string) => {
+const getFormattedNameAndEmail = (name: string, email?: string) => {
   if (email) {
     return `${name} (${email})`
   }
@@ -116,26 +115,24 @@ const taskSummary = (task: Task, application: Application): Array<SummaryListIte
     },
   ]
 
-  if (applicantUserDetails && applicantUserDetails.name) {
+  if (applicantUserDetails) {
     summary.push({
       key: { text: 'Applicant' },
       value: { text: getFormattedNameAndEmail(applicantUserDetails.name, applicantUserDetails.email) },
     })
   }
 
-  if (caseManagerIsNotApplicant && caseManagerUserDetails.name) {
+  if (caseManagerIsNotApplicant && caseManagerUserDetails) {
     summary.push({
       key: { text: 'Case Manager' },
       value: { text: getFormattedNameAndEmail(caseManagerUserDetails.name, caseManagerUserDetails.email) },
     })
   }
 
-  if (application.genderForAp) {
-    summary.push({
-      key: { text: 'Gender for AP' },
-      value: { text: sentenceCase(application.genderForAp) },
-    })
-  }
+  summary.push({
+    key: { text: 'Gender for AP' },
+    value: { text: application.isWomensApplication ? 'Female' : 'Male' },
+  })
 
   if (task.probationDeliveryUnit) {
     summary.push({

--- a/server/utils/tasks/index.ts
+++ b/server/utils/tasks/index.ts
@@ -87,7 +87,7 @@ const taskSummary = (task: Task, application: Application): Array<SummaryListIte
     },
     {
       key: {
-        text: 'Application Type',
+        text: 'Application type',
       },
       value: {
         text: getApplicationType(application),
@@ -103,7 +103,7 @@ const taskSummary = (task: Task, application: Application): Array<SummaryListIte
     },
     {
       key: {
-        text: 'AP Area',
+        text: 'AP area',
       },
       value: {
         text: application.apArea?.name,
@@ -124,7 +124,7 @@ const taskSummary = (task: Task, application: Application): Array<SummaryListIte
 
   if (caseManagerIsNotApplicant && caseManagerUserDetails) {
     summary.push({
-      key: { text: 'Case Manager' },
+      key: { text: 'Case manager' },
       value: { text: getFormattedNameAndEmail(caseManagerUserDetails.name, caseManagerUserDetails.email) },
     })
   }


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1321

# Changes in this PR

Removes the use of `Application.genderForAp`, converting any logic to using `Application.isWomensApplication` instead. Refactor of Task. utilities tests.

_Note: for now the wording has not been changed, so the task allocation screen shows 'Gender for AP: Male/Female' This will need to be updated._

# To-do

- [x] Update wording

## Screenshots of UI changes

n/a
