### PR TITLE
APS-1341 WE - Record a placement

### DIFF
--- a/integration_tests/pages/admin/placementApplications/createPlacementPage.ts
+++ b/integration_tests/pages/admin/placementApplications/createPlacementPage.ts
@@ -1,10 +1,18 @@
-import { Cas1PremisesSummary, PlacementRequestDetail } from '../../../../server/@types/shared'
+import {
+  ApprovedPremisesApplication,
+  Cas1PremisesSummary,
+  PlacementRequestDetail,
+} from '../../../../server/@types/shared'
 import { placementDates } from '../../../../server/utils/match'
 import Page from '../../page'
 
 export default class CreatePlacementPage extends Page {
   constructor(private readonly placementRequest: PlacementRequestDetail) {
-    super('Record an Approved Premises (AP) placement')
+    super(
+      (placementRequest.application as ApprovedPremisesApplication).isWomensApplication
+        ? `Record a women’s Approved Premises placement`
+        : 'Record an Approved Premises (AP) placement',
+    )
   }
 
   dateInputsShouldBePrepopulated(): void {
@@ -20,7 +28,11 @@ export default class CreatePlacementPage extends Page {
 
     this.clearDateInputs('departureDate')
     this.completeDateInputs('departureDate', endDate)
-    this.getSelectInputByIdAndSelectAnEntry('area0', premises.apArea.name)
-    this.getSelectInputByIdAndSelectAnEntry('premisesId', premises.id)
+    if (!(this.placementRequest.application as ApprovedPremisesApplication).isWomensApplication) {
+      this.getSelectInputByIdAndSelectAnEntry('area0', premises.apArea.name)
+      this.getSelectInputByIdAndSelectAnEntry('premisesId', premises.id)
+    } else {
+      this.checkRadioByNameAndValue('premisesId', premises.id)
+    }
   }
 }

--- a/server/utils/premises/index.test.ts
+++ b/server/utils/premises/index.test.ts
@@ -6,6 +6,7 @@ import {
   premisesSummaryFactory,
 } from '../../testutils/factories'
 import {
+  cas1PremisesSummaryRadioOptions,
   groupCas1SummaryPremisesSelectOptions,
   mapApiOccupancyEntryToUiOccupancyEntry,
   mapApiOccupancyToUiOccupancy,
@@ -229,6 +230,30 @@ describe('premisesUtils', () => {
       expect(
         groupCas1SummaryPremisesSelectOptions(premises, { premises: area2Premises[1].id }, 'premises')[1].items[1]
           .selected,
+      ).toBeTruthy()
+    })
+  })
+
+  describe('cas1PremisesSummaryRadioOptions', () => {
+    const premises = cas1PremisesSummaryFactory.buildList(2)
+
+    it('should map premises summary list into a set of radio buttons', () => {
+      expect(cas1PremisesSummaryRadioOptions(premises, {})).toEqual([
+        {
+          text: `${premises[0].name} (${premises[0].apArea.name})`,
+          value: premises[0].id,
+          selected: false,
+        },
+        {
+          text: `${premises[1].name} (${premises[1].apArea.name})`,
+          value: premises[1].id,
+          selected: false,
+        },
+      ])
+    })
+    it('should select the option whose id maches the specfied field in the context', () => {
+      expect(
+        cas1PremisesSummaryRadioOptions(premises, { premises: premises[1].id }, 'premises')[1].selected,
       ).toBeTruthy()
     })
   })

--- a/server/utils/premises/index.ts
+++ b/server/utils/premises/index.ts
@@ -5,7 +5,7 @@ import type {
   DateCapacity,
   ApprovedPremisesSummary as PremisesSummary,
 } from '@approved-premises/api'
-import { BedOccupancyRangeUi, SelectGroup, SummaryList } from '@approved-premises/ui'
+import { BedOccupancyRangeUi, SelectGroup, SelectOption, SummaryList } from '@approved-premises/ui'
 import { DateFormats } from '../dateUtils'
 import { addOverbookingsToSchedule } from '../addOverbookingsToSchedule'
 import { htmlValue, textValue } from '../applications/helpers'
@@ -136,6 +136,19 @@ export const groupCas1SummaryPremisesSelectOptions = (
       })),
   }))
 }
+
+export const cas1PremisesSummaryRadioOptions = (
+  premises: Array<Cas1PremisesSummary>,
+  context: Record<string, unknown>,
+  fieldName: string = 'premisesId',
+): Array<SelectOption> =>
+  premises.map(({ id, name, apArea }) => {
+    return {
+      value: id,
+      text: `${name} (${apArea.name})`,
+      selected: context[fieldName] === id,
+    }
+  })
 
 export const premisesTableRows = (premisesSummaries: Array<PremisesSummary>) => {
   return premisesSummaries

--- a/server/views/admin/placementRequests/bookings/new.njk
+++ b/server/views/admin/placementRequests/bookings/new.njk
@@ -6,6 +6,7 @@
 {% from "../../../components/formFields/form-page-input/macro.njk" import formPageInput %}
 {% from "../../../components/formFields/form-page-date-input/macro.njk" import formPageDateInput %}
 {% from "../../../components/formFields/selectWithOptgroup.njk" import govukSelectWithOptgroup %}
+{% from "../../../components/formFields/form-page-radios/macro.njk" import formPageRadios %}
 
 {% extends "../../../partials/layout.njk" %}
 
@@ -19,6 +20,7 @@
 	}) }}
 {% endblock %}
 
+
 {% block content %}
   {% include "../../../_messages.njk" %}
 
@@ -30,28 +32,43 @@
           {{ pageHeading }}
         </h1>
 
+        {{ showErrorSummary(errorSummary) }}
+        {% if isWomensApplication %}
+          {{ 
+            formPageRadios(
+              {
+                fieldName: "premisesId",
+                fieldset: {
+                  legend: {
+                    text: "Select a property"
+                  }
+                },
+                items: PremisesUtils.cas1PremisesSummaryRadioOptions(premises,fetchContext())
+              },
+              fetchContext()
+            ) 
+          }}
+        {% else %}
         <p class="govuk-body">
           Provide details for an AP placement that has been confirmed by the receiving AP
         </p>
-
-        {{ showErrorSummary(errorSummary) }}
-
-        {{
-          govukSelectWithOptgroup({
-            label: {
-              classes: "govuk-fieldset__legend--m",
-              html: 'Select an Approved Premises'
-            },
-            attributes: {
-              "data-premises-with-areas": true
-            },
-            prompt: "Select a premises",
-            id: "premisesId",
-            name: "premisesId",
-            items: PremisesUtils.groupCas1SummaryPremisesSelectOptions(premises, fetchContext()),
-            errorMessage: errors.premisesId
-          })
-        }}
+          {{       
+            govukSelectWithOptgroup({
+              label: {
+                classes: "govuk-fieldset__legend--m",
+                html: 'Select an Approved Premises'
+              },
+              attributes: {
+                "data-premises-with-areas": true
+              },
+              prompt: "Select a premises",
+              id: "premisesId",
+              name: "premisesId",
+              items: PremisesUtils.groupCas1SummaryPremisesSelectOptions(premises, fetchContext()),
+              errorMessage: errors.premisesId
+            }) 
+          }}
+        {% endif %}
 
         {{
           formPageDateInput(


### PR DESCRIPTION
# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->
https://dsdmoj.atlassian.net/browse/APS-1341

# Changes in this PR
In the create placement flow, if the `isWomensApplication` flag is set on the associated application, the AP/date selection page shows only women's estate APs and displays them as a set of radio buttons, rather than a nested drop-down. If the application is not a women's application, the page is unchanged but only men's APs are shown in the nested select.  

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before

![image](https://github.com/user-attachments/assets/c06ed7bf-05ff-44ae-8257-c0dbfc5908a7)

### After

![image](https://github.com/user-attachments/assets/f6d1ad45-c6ae-45a5-a184-4ecceab0d4d9)



