### PR TITLE
APS-1435: Add women's AP qualification

### DIFF
--- a/server/@types/shared/models/UserQualification.ts
+++ b/server/@types/shared/models/UserQualification.ts
@@ -2,4 +2,12 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type UserQualification = 'pipe' | 'lao' | 'emergency' | 'esap' | 'recovery_focused' | 'mental_health_specialist';
+// TODO: this will be updated by the types generation when API work is done
+export type UserQualification =
+  'pipe'
+  | 'lao'
+  | 'emergency'
+  | 'esap'
+  | 'recovery_focused'
+  | 'mental_health_specialist'
+  | 'womens';

--- a/server/utils/tasks/index.test.ts
+++ b/server/utils/tasks/index.test.ts
@@ -194,6 +194,7 @@ describe('index', () => {
         { selected: false, text: 'PIPE', value: 'pipe' },
         { selected: false, text: 'Recovery-focused APs', value: 'recovery_focused' },
         { selected: false, text: 'Specialist Mental Health APs', value: 'mental_health_specialist' },
+        { selected: false, text: "Women's APs", value: 'womens' },
       ])
     })
 
@@ -205,6 +206,7 @@ describe('index', () => {
         { selected: false, text: 'PIPE', value: 'pipe' },
         { selected: false, text: 'Recovery-focused APs', value: 'recovery_focused' },
         { selected: false, text: 'Specialist Mental Health APs', value: 'mental_health_specialist' },
+        { selected: false, text: "Women's APs", value: 'womens' },
       ])
     })
   })

--- a/server/utils/users/roles.ts
+++ b/server/utils/users/roles.ts
@@ -45,6 +45,7 @@ export const qualifications: ReadonlyArray<UserQualification> = [
   'lao',
   'recovery_focused',
   'mental_health_specialist',
+  'womens',
 ]
 
 export type RoleLabel = { label: string; hint?: string }
@@ -98,6 +99,7 @@ export const qualificationDictionary: QualificationLabelDictionary = {
   pipe: 'PIPE',
   recovery_focused: 'Recovery-focused APs',
   mental_health_specialist: 'Specialist Mental Health APs',
+  womens: "Women's APs",
 }
 
 export const hasRole = (user: UserDetails, role: UserRole): boolean => {

--- a/server/utils/users/userManagement.test.ts
+++ b/server/utils/users/userManagement.test.ts
@@ -177,6 +177,7 @@ describe('userQualificationsSelectOptions', () => {
       { selected: false, text: 'PIPE', value: 'pipe' },
       { selected: false, text: 'Recovery-focused APs', value: 'recovery_focused' },
       { selected: false, text: 'Specialist Mental Health APs', value: 'mental_health_specialist' },
+      { selected: false, text: "Women's APs", value: 'womens' },
     ])
   })
 
@@ -189,6 +190,7 @@ describe('userQualificationsSelectOptions', () => {
       { selected: false, text: 'PIPE', value: 'pipe' },
       { selected: false, text: 'Recovery-focused APs', value: 'recovery_focused' },
       { selected: false, text: 'Specialist Mental Health APs', value: 'mental_health_specialist' },
+      { selected: false, text: "Women's APs", value: 'womens' },
     ])
   })
 })


### PR DESCRIPTION
# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

This adds the qualification to the task reallocation filters, as well as the user management, so it can be assigned to users.

## Todo

- [ ] Get types updated from API

## Screenshots of UI changes

### Before

### After

#### Task allocation filters:

<img width="1037" alt="Screenshot 2024-10-21 at 16 28 01" src="https://github.com/user-attachments/assets/0a0ac861-88cc-4ab8-8861-252b69d5d555">
 
---

<img width="711" alt="Screenshot 2024-10-21 at 16 25 40" src="https://github.com/user-attachments/assets/dafc76b2-90db-4998-b5e1-cc7432989dfd">


---

#### User management edit screen: 

<img width="670" alt="Screenshot 2024-10-21 at 16 25 58" src="https://github.com/user-attachments/assets/bc21dd86-ab5c-494f-a680-d6a63d7eebfc">
