### PR TITLE
APS-1404 Update AP summary page

### DIFF
--- a/server/utils/premises/index.test.ts
+++ b/server/utils/premises/index.test.ts
@@ -172,6 +172,7 @@ describe('premisesUtils', () => {
         postcode: 'SW1A 1AA',
         bedCount: 20,
         availableBeds: 12,
+        outOfServiceBeds: 3,
       })
 
       expect(summaryListForPremises(premises)).toEqual({
@@ -191,6 +192,10 @@ describe('premisesUtils', () => {
           {
             key: textValue('Available Beds'),
             value: textValue('12'),
+          },
+          {
+            key: textValue('Out of Service Beds'),
+            value: textValue('3'),
           },
         ],
       })

--- a/server/utils/premises/index.ts
+++ b/server/utils/premises/index.ts
@@ -111,6 +111,10 @@ export const summaryListForPremises = (premises: Cas1PremisesSummary): SummaryLi
         key: textValue('Available Beds'),
         value: textValue(premises.availableBeds.toString()),
       },
+      {
+        key: textValue('Out of Service Beds'),
+        value: textValue(premises.outOfServiceBeds.toString()),
+      },
     ],
   }
 }


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1404

# Changes in this PR
Just adds out-of-service bedcount to the summary block at the top of the view Premises page.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### After
![image](https://github.com/user-attachments/assets/5455965f-e993-408f-87bc-bc05ff31454a)

