### PR TITLE
APS-1440: Allow update of user CRU Management Area

### DIFF
--- a/integration_tests/mockApis/referenceData.ts
+++ b/integration_tests/mockApis/referenceData.ts
@@ -33,7 +33,7 @@ export const stubApAreaReferenceData = (
   })
 }
 
-export const stubCRUManagementAreaReferenceData = (
+export const stubCruManagementAreaReferenceData = (
   args: {
     cruManagementAreas?: Array<Cas1CruManagementArea>
   } = {},
@@ -55,5 +55,5 @@ export const stubCRUManagementAreaReferenceData = (
 
 export default {
   stubApAreaReferenceData,
-  stubCRUManagementAreaReferenceData,
+  stubCruManagementAreaReferenceData,
 }

--- a/integration_tests/pages/admin/userManagement/showPage.ts
+++ b/integration_tests/pages/admin/userManagement/showPage.ts
@@ -2,6 +2,7 @@ import Page from '../../page'
 import paths from '../../../../server/paths/admin'
 
 import {
+  Cas1CruManagementArea,
   ApprovedPremisesUser as User,
   UserQualification,
   ApprovedPremisesUserRole as UserRole,
@@ -49,14 +50,17 @@ export default class ShowPage extends Page {
     roles,
     allocationRoles,
     qualifications,
+    cruManagementArea,
   }: {
     roles: ReadonlyArray<UserRole>
     allocationRoles: ReadonlyArray<AllocationRole>
     qualifications: ReadonlyArray<UserQualification>
+    cruManagementArea: Readonly<Cas1CruManagementArea>
   }): void {
     this.selectRoles(roles)
     this.selectAllocationRoles(allocationRoles)
     this.selectUserQualifications(qualifications)
+    this.getSelectInputByIdAndSelectAnEntry('cruManagementAreaOverrideId', cruManagementArea.name)
   }
 
   clickRemoveAccess(): void {

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -77,7 +77,7 @@ context('Placement Requests', () => {
     cy.task('stubPlacementRequest', unmatchedPlacementRequest)
     cy.task('stubPlacementRequest', matchedPlacementRequest)
     cy.task('stubPlacementRequest', unableToMatchPlacementRequest)
-    cy.task('stubCRUManagementAreaReferenceData', { cruManagementAreas })
+    cy.task('stubCruManagementAreaReferenceData', { cruManagementAreas })
 
     const cas1premises = cas1PremisesBasicSummaryFactory.buildList(3)
     cy.task('stubCas1AllPremises', cas1premises)

--- a/integration_tests/tests/admin/userManagement.cy.ts
+++ b/integration_tests/tests/admin/userManagement.cy.ts
@@ -1,6 +1,6 @@
 import { ApprovedPremisesUserRole, UserQualification } from '@approved-premises/api'
 import paths from '../../../server/paths/admin'
-import { userFactory } from '../../../server/testutils/factories'
+import { cruManagementAreaFactory, userFactory } from '../../../server/testutils/factories'
 import ConfirmDeletionPage from '../../pages/admin/userManagement/confirmDeletionPage'
 import ConfirmUserDetailsPage from '../../pages/admin/userManagement/confirmUserDetailsPage'
 import ListPage from '../../pages/admin/userManagement/listPage'
@@ -20,12 +20,14 @@ context('User management', () => {
 
   it('allows the user to view and update users', () => {
     // Given there are users in the DB
-    const users = userFactory.buildList(10, { roles: ['assessor'] })
+    const users = userFactory.buildList(10, { roles: ['assessor'], cruManagementAreaOverride: undefined })
     const user = users[0]
+    const cruManagementAreas = cruManagementAreaFactory.buildList(5)
     const roles = ['matcher', 'workflow_manager']
     cy.task('stubFindUser', { user, id: user.id })
     cy.task('stubUsers', { users })
     cy.task('stubApAreaReferenceData')
+    cy.task('stubCRUManagementAreaReferenceData', { cruManagementAreas })
     cy.task('stubAuthUser', { roles })
 
     // When I visit the list page
@@ -45,7 +47,8 @@ context('User management', () => {
     showPage.checkForBackButton(paths.admin.userManagement.index({}))
     showPage.shouldShowUserDetails(user)
 
-    // When I update the user's roles and qualifications
+    // When I update the user's CRU management area, roles and qualifications
+    const updatedCruManagementArea = cruManagementAreas[1]
     const updatedRoles = {
       roles: ['matcher', 'workflow_manager'] as const,
       allocationRoles: [
@@ -59,11 +62,13 @@ context('User management', () => {
       roles: updatedRoles.roles,
       allocationRoles: updatedRoles.allocationRoles,
       qualifications: updatedRoles.qualifications,
+      cruManagementArea: updatedCruManagementArea,
     })
     const updatedUser = {
       ...user,
       roles: [...updatedRoles.roles, ...updatedRoles.allocationRoles],
       qualifications: [...updatedRoles.qualifications],
+      cruManagementAreaOverride: updatedCruManagementArea,
     }
     cy.task('stubUserUpdate', {
       user: updatedUser,
@@ -80,6 +85,7 @@ context('User management', () => {
       expect(body).to.deep.equal({
         roles: updatedUser.roles,
         qualifications: updatedRoles.qualifications,
+        cruManagementAreaOverrideId: updatedCruManagementArea.id,
       })
     })
 
@@ -118,6 +124,7 @@ context('User management', () => {
   it('enables adding a user from Delius', () => {
     const users = userFactory.buildList(10)
     cy.task('stubApAreaReferenceData')
+    cy.task('stubCRUManagementAreaReferenceData')
     cy.task('stubUsers', { users })
     // Given I am on the list page
     const listPage = ListPage.visit()
@@ -163,6 +170,7 @@ context('User management', () => {
     cy.task('stubUsers', { users })
     cy.task('stubFindUser', { user: userToDelete, id: userToDelete.id })
     cy.task('stubApAreaReferenceData')
+    cy.task('stubCRUManagementAreaReferenceData')
 
     // Given I am on a user's permissions page
     const permissionsPage = ShowPage.visit(userToDelete.id)

--- a/integration_tests/tests/admin/userManagement.cy.ts
+++ b/integration_tests/tests/admin/userManagement.cy.ts
@@ -27,7 +27,7 @@ context('User management', () => {
     cy.task('stubFindUser', { user, id: user.id })
     cy.task('stubUsers', { users })
     cy.task('stubApAreaReferenceData')
-    cy.task('stubCRUManagementAreaReferenceData', { cruManagementAreas })
+    cy.task('stubCruManagementAreaReferenceData', { cruManagementAreas })
     cy.task('stubAuthUser', { roles })
 
     // When I visit the list page
@@ -124,7 +124,7 @@ context('User management', () => {
   it('enables adding a user from Delius', () => {
     const users = userFactory.buildList(10)
     cy.task('stubApAreaReferenceData')
-    cy.task('stubCRUManagementAreaReferenceData')
+    cy.task('stubCruManagementAreaReferenceData')
     cy.task('stubUsers', { users })
     // Given I am on the list page
     const listPage = ListPage.visit()
@@ -170,7 +170,7 @@ context('User management', () => {
     cy.task('stubUsers', { users })
     cy.task('stubFindUser', { user: userToDelete, id: userToDelete.id })
     cy.task('stubApAreaReferenceData')
-    cy.task('stubCRUManagementAreaReferenceData')
+    cy.task('stubCruManagementAreaReferenceData')
 
     // Given I am on a user's permissions page
     const permissionsPage = ShowPage.visit(userToDelete.id)

--- a/integration_tests/tests/login.cy.ts
+++ b/integration_tests/tests/login.cy.ts
@@ -93,19 +93,17 @@ context('SignIn', () => {
     // When my user roles have been updated
     cy.task('stubAuthUser', { ...authUser, roles: ['role_admin', 'report_viewer'] })
     cy.task('stubFindUser', { user: authUser, id: authUser.id, userVersion: newUserVersion })
+    cy.task('stubCruManagementAreaReferenceData')
 
     // And I visit a page that calls the API
     const userPage = ShowPage.visit(authUser.id)
 
-    // Then I see no change for the current page load
-    userPage.shouldShowMenuItem('Reports', false)
-
-    // When I visit another page
+    // Then I visit another page
     userPage.clickMenuItem('Home')
 
     dashboardPage = Page.verifyOnPage(DashboardPage)
 
-    // Then the updated user roles have been fetched from the API
+    // Then the updated user roles have been fetched from the API and the UI is updated
     dashboardPage.shouldShowCard('reports')
   })
 })

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -24,7 +24,7 @@ context('Placement Requests', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubCRUManagementAreaReferenceData')
+    cy.task('stubCruManagementAreaReferenceData')
   })
 
   it('allows me to search for an available space', () => {

--- a/integration_tests/tests/tasks/allocations.cy.ts
+++ b/integration_tests/tests/tasks/allocations.cy.ts
@@ -74,7 +74,7 @@ context('Task Allocation', () => {
     cy.task('stubTaskGet', { application, task, users })
     cy.task('stubApplicationGet', { application })
     cy.task('stubApAreaReferenceData', { apArea })
-    cy.task('stubCRUManagementAreaReferenceData')
+    cy.task('stubCruManagementAreaReferenceData')
     cy.task('stubUserSummaryList', { users, roles: ['assessor', 'matcher'] })
     cy.task('stubUserList', { users, roles: ['assessor', 'matcher'] })
 

--- a/integration_tests/tests/tasks/list.cy.ts
+++ b/integration_tests/tests/tasks/list.cy.ts
@@ -24,7 +24,7 @@ context('Task Allocation', () => {
     cy.task('stubUserSummaryList', { users, roles: ['assessor', 'matcher'] })
     cy.task('stubAuthUser', { apArea })
     cy.task('stubApAreaReferenceData', { apArea, additionalAreas: [additionalArea] })
-    cy.task('stubCRUManagementAreaReferenceData', { cruManagementAreas })
+    cy.task('stubCruManagementAreaReferenceData', { cruManagementAreas })
 
     const me = userFactory.build({ apArea, cruManagementArea: cruManagementAreas[0] })
     cy.task('stubAuthUser', {

--- a/integration_tests/tests/withdrawals/withdrawals.cy.ts
+++ b/integration_tests/tests/withdrawals/withdrawals.cy.ts
@@ -24,7 +24,7 @@ context('Withdrawals', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
-    cy.task('stubCRUManagementAreaReferenceData')
+    cy.task('stubCruManagementAreaReferenceData')
   })
 
   describe('as a CRU user', () => {

--- a/server/controllers/admin/cruDashboardController.test.ts
+++ b/server/controllers/admin/cruDashboardController.test.ts
@@ -66,7 +66,7 @@ describe('CruDashboardController', () => {
     beforeEach(() => {
       placementRequestService.getDashboard.mockResolvedValue(paginatedResponse)
       ;(getPaginationDetails as jest.Mock).mockReturnValue(paginationDetails)
-      cruManagementAreaService.getCRUManagementAreas.mockResolvedValue(cruManagementAreas)
+      cruManagementAreaService.getCruManagementAreas.mockResolvedValue(cruManagementAreas)
     })
 
     it('should render the placement requests template with the users CRU management area filtered by default', async () => {
@@ -98,7 +98,7 @@ describe('CruDashboardController', () => {
         paginationDetails.sortDirection,
       )
 
-      expect(cruManagementAreaService.getCRUManagementAreas).toHaveBeenCalledWith(token)
+      expect(cruManagementAreaService.getCruManagementAreas).toHaveBeenCalledWith(token)
 
       expect(getPaginationDetails).toHaveBeenCalledWith(request, paths.admin.cruDashboard.index({}), {
         status: 'notMatched',

--- a/server/controllers/admin/cruDashboardController.test.ts
+++ b/server/controllers/admin/cruDashboardController.test.ts
@@ -4,7 +4,7 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import { when } from 'jest-when'
 import CruDashboardController from './cruDashboardController'
 
-import { ApplicationService, CRUManagementAreaService, PlacementRequestService } from '../../services'
+import { ApplicationService, CruManagementAreaService, PlacementRequestService } from '../../services'
 import {
   applicationSummaryFactory,
   cruManagementAreaFactory,
@@ -35,7 +35,7 @@ describe('CruDashboardController', () => {
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
   const placementRequestService = createMock<PlacementRequestService>({})
-  const cruManagementAreaService = createMock<CRUManagementAreaService>({})
+  const cruManagementAreaService = createMock<CruManagementAreaService>({})
   const applicationService = createMock<ApplicationService>({})
 
   let cruDashboardController: CruDashboardController

--- a/server/controllers/admin/cruDashboardController.ts
+++ b/server/controllers/admin/cruDashboardController.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
-import { ApplicationService, CRUManagementAreaService, PlacementRequestService } from '../../services'
+import { ApplicationService, CruManagementAreaService, PlacementRequestService } from '../../services'
 import {
   ApplicationSortField,
   Cas1CruManagementArea,
@@ -16,7 +16,7 @@ import { getSearchOptions } from '../../utils/getSearchOptions'
 export default class CruDashboardController {
   constructor(
     private readonly placementRequestService: PlacementRequestService,
-    private readonly cruManagementAreaService: CRUManagementAreaService,
+    private readonly cruManagementAreaService: CruManagementAreaService,
     private readonly applicationService: ApplicationService,
   ) {}
 

--- a/server/controllers/admin/cruDashboardController.ts
+++ b/server/controllers/admin/cruDashboardController.ts
@@ -22,7 +22,7 @@ export default class CruDashboardController {
 
   index(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
-      const cruManagementAreas = await this.cruManagementAreaService.getCRUManagementAreas(req.user.token)
+      const cruManagementAreas = await this.cruManagementAreaService.getCruManagementAreas(req.user.token)
       const viewArgs =
         req.query.status === 'pendingPlacement'
           ? await this.getPendingApplications(req, res)

--- a/server/controllers/admin/index.ts
+++ b/server/controllers/admin/index.ts
@@ -33,7 +33,11 @@ export const controllers = (services: Services) => {
   const placementRequestWithdrawalsController = new PlacementRequestsWithdrawalsController(placementRequestService)
   const reportsController = new ReportsController(reportService)
   const placementRequestUnableToMatchController = new PlacementRequestUnableToMatchController(placementRequestService)
-  const userManagementController = new UserManagementController(services.userService, apAreaService)
+  const userManagementController = new UserManagementController(
+    services.userService,
+    apAreaService,
+    cruManagementAreaService,
+  )
   const deliusUserController = new DeliusUserController(services.userService)
 
   return {

--- a/server/controllers/admin/userManagementController.test.ts
+++ b/server/controllers/admin/userManagementController.test.ts
@@ -268,7 +268,7 @@ describe('UserManagementController', () => {
       const updateUser = userFactory.build({ cruManagementAreaOverride: undefined })
 
       userService.getUserById.mockResolvedValue(updateUser)
-      cruManagementAreaService.getCRUManagementAreas.mockResolvedValue(cruManagementAreas)
+      cruManagementAreaService.getCruManagementAreas.mockResolvedValue(cruManagementAreas)
 
       const requestHandler = userManagementController.edit()
 
@@ -277,7 +277,7 @@ describe('UserManagementController', () => {
       await requestHandler(request, response, next)
 
       expect(userService.getUserById).toHaveBeenCalledWith(token, updateUser.id)
-      expect(cruManagementAreaService.getCRUManagementAreas).toHaveBeenCalledWith(token)
+      expect(cruManagementAreaService.getCruManagementAreas).toHaveBeenCalledWith(token)
       expect(response.render).toHaveBeenCalledWith('admin/users/edit', {
         pageHeading: 'Manage permissions',
         updateUser,
@@ -309,7 +309,7 @@ describe('UserManagementController', () => {
         const updateUser = userFactory.build({ cruManagementAreaOverride: cruManagementAreas[1] })
 
         userService.getUserById.mockResolvedValue(updateUser)
-        cruManagementAreaService.getCRUManagementAreas.mockResolvedValue(cruManagementAreas)
+        cruManagementAreaService.getCruManagementAreas.mockResolvedValue(cruManagementAreas)
 
         const requestHandler = userManagementController.edit()
 
@@ -354,12 +354,12 @@ describe('UserManagementController', () => {
         allocationRoles: ['excluded_from_assess_allocation'],
         roles: ['assessor', 'matcher'],
       }
-      const updatedCRUManagementArea = cruManagementAreaFactory.build()
+      const updatedCruManagementArea = cruManagementAreaFactory.build()
       const updatedUser = {
         ...user,
         qualifications: ['emergency'],
         roles: [...updatedRoles.roles, ...updatedRoles.allocationRoles],
-        cruManagementAreaOverride: updatedCRUManagementArea,
+        cruManagementAreaOverride: updatedCruManagementArea,
       }
       const flash = jest.fn()
 
@@ -372,7 +372,7 @@ describe('UserManagementController', () => {
             roles: updatedRoles.roles,
             allocationPreferences: updatedRoles.allocationRoles,
             qualifications: updatedUser.qualifications,
-            cruManagementAreaOverrideId: updatedCRUManagementArea.id,
+            cruManagementAreaOverrideId: updatedCruManagementArea.id,
           },
           params: { id: user.id },
         },
@@ -383,7 +383,7 @@ describe('UserManagementController', () => {
       expect(userService.updateUser).toHaveBeenCalledWith(token, user.id, {
         roles: [...updatedRoles.roles, ...updatedRoles.allocationRoles],
         qualifications: updatedUser.qualifications,
-        cruManagementAreaOverrideId: updatedCRUManagementArea.id,
+        cruManagementAreaOverrideId: updatedCruManagementArea.id,
       })
       expect(response.redirect).toHaveBeenCalledWith(paths.admin.userManagement.edit({ id: user.id }))
       expect(flash).toHaveBeenCalledWith('success', 'User updated')

--- a/server/controllers/admin/userManagementController.test.ts
+++ b/server/controllers/admin/userManagementController.test.ts
@@ -265,22 +265,22 @@ describe('UserManagementController', () => {
   describe('edit', () => {
     it('renders an individual user page', async () => {
       const cruManagementAreas = cruManagementAreaFactory.buildList(2)
-      const user = userFactory.build({ cruManagementAreaOverride: undefined })
+      const updateUser = userFactory.build({ cruManagementAreaOverride: undefined })
 
-      userService.getUserById.mockResolvedValue(user)
+      userService.getUserById.mockResolvedValue(updateUser)
       cruManagementAreaService.getCRUManagementAreas.mockResolvedValue(cruManagementAreas)
 
       const requestHandler = userManagementController.edit()
 
-      request.params = { id: user.id }
+      request.params = { id: updateUser.id }
 
       await requestHandler(request, response, next)
 
-      expect(userService.getUserById).toHaveBeenCalledWith(token, user.id)
+      expect(userService.getUserById).toHaveBeenCalledWith(token, updateUser.id)
       expect(cruManagementAreaService.getCRUManagementAreas).toHaveBeenCalledWith(token)
       expect(response.render).toHaveBeenCalledWith('admin/users/edit', {
         pageHeading: 'Manage permissions',
-        user,
+        updateUser,
         roles,
         qualifications,
         cruManagementAreasOptions: [
@@ -306,14 +306,14 @@ describe('UserManagementController', () => {
     describe('when the user has a CRU management area assigned', () => {
       it('renders the assigned CRU management area as selected', async () => {
         const cruManagementAreas = cruManagementAreaFactory.buildList(2)
-        const user = userFactory.build({ cruManagementAreaOverride: cruManagementAreas[1] })
+        const updateUser = userFactory.build({ cruManagementAreaOverride: cruManagementAreas[1] })
 
-        userService.getUserById.mockResolvedValue(user)
+        userService.getUserById.mockResolvedValue(updateUser)
         cruManagementAreaService.getCRUManagementAreas.mockResolvedValue(cruManagementAreas)
 
         const requestHandler = userManagementController.edit()
 
-        request.params = { id: user.id }
+        request.params = { id: updateUser.id }
 
         await requestHandler(request, response, next)
 

--- a/server/controllers/admin/userManagementController.ts
+++ b/server/controllers/admin/userManagementController.ts
@@ -1,15 +1,17 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 import { qualifications, roles } from '../../utils/users'
-import { ApAreaService, UserService } from '../../services'
+import { ApAreaService, CruManagementAreaService, UserService } from '../../services'
 import paths from '../../paths/admin'
 import { flattenCheckboxInput } from '../../utils/formUtils'
 import { UserQualification, ApprovedPremisesUserRole as UserRole, UserSortField } from '../../@types/shared'
 import { getPaginationDetails } from '../../utils/getPaginationDetails'
+import { userCRUManagementAreasSelectOptions } from '../../utils/users/userManagement'
 
 export default class UserController {
   constructor(
     private readonly userService: UserService,
     private readonly apAreaService: ApAreaService,
+    private readonly cruManagementAreaService: CruManagementAreaService,
   ) {}
 
   index(): TypedRequestHandler<Request, Response> {
@@ -55,8 +57,18 @@ export default class UserController {
   edit(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       const user = await this.userService.getUserById(req.user.token, req.params.id)
+      const cruManagementAreas = await this.cruManagementAreaService.getCRUManagementAreas(req.user.token)
 
-      res.render('admin/users/edit', { pageHeading: 'Manage permissions', user, roles, qualifications })
+      res.render('admin/users/edit', {
+        pageHeading: 'Manage permissions',
+        user,
+        cruManagementAreasOptions: userCRUManagementAreasSelectOptions(
+          cruManagementAreas,
+          user.cruManagementAreaOverride?.id,
+        ),
+        roles,
+        qualifications,
+      })
     }
   }
 
@@ -65,6 +77,7 @@ export default class UserController {
       await this.userService.updateUser(req.user.token, req.params.id, {
         roles: [...flattenCheckboxInput(req.body.roles), ...flattenCheckboxInput(req.body.allocationPreferences)],
         qualifications: flattenCheckboxInput(req.body.qualifications),
+        cruManagementAreaOverrideId: req.body.cruManagementAreaOverrideId,
       })
 
       req.flash('success', 'User updated')

--- a/server/controllers/admin/userManagementController.ts
+++ b/server/controllers/admin/userManagementController.ts
@@ -56,15 +56,15 @@ export default class UserController {
 
   edit(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
-      const user = await this.userService.getUserById(req.user.token, req.params.id)
+      const updateUser = await this.userService.getUserById(req.user.token, req.params.id)
       const cruManagementAreas = await this.cruManagementAreaService.getCRUManagementAreas(req.user.token)
 
       res.render('admin/users/edit', {
         pageHeading: 'Manage permissions',
-        user,
+        updateUser,
         cruManagementAreasOptions: userCRUManagementAreasSelectOptions(
           cruManagementAreas,
-          user.cruManagementAreaOverride?.id,
+          updateUser.cruManagementAreaOverride?.id,
         ),
         roles,
         qualifications,

--- a/server/controllers/admin/userManagementController.ts
+++ b/server/controllers/admin/userManagementController.ts
@@ -5,7 +5,7 @@ import paths from '../../paths/admin'
 import { flattenCheckboxInput } from '../../utils/formUtils'
 import { UserQualification, ApprovedPremisesUserRole as UserRole, UserSortField } from '../../@types/shared'
 import { getPaginationDetails } from '../../utils/getPaginationDetails'
-import { userCRUManagementAreasSelectOptions } from '../../utils/users/userManagement'
+import { userCruManagementAreasSelectOptions } from '../../utils/users/userManagement'
 
 export default class UserController {
   constructor(
@@ -57,12 +57,12 @@ export default class UserController {
   edit(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
       const updateUser = await this.userService.getUserById(req.user.token, req.params.id)
-      const cruManagementAreas = await this.cruManagementAreaService.getCRUManagementAreas(req.user.token)
+      const cruManagementAreas = await this.cruManagementAreaService.getCruManagementAreas(req.user.token)
 
       res.render('admin/users/edit', {
         pageHeading: 'Manage permissions',
         updateUser,
-        cruManagementAreasOptions: userCRUManagementAreasSelectOptions(
+        cruManagementAreasOptions: userCruManagementAreasSelectOptions(
           cruManagementAreas,
           updateUser.cruManagementAreaOverride?.id,
         ),

--- a/server/controllers/tasksController.test.ts
+++ b/server/controllers/tasksController.test.ts
@@ -64,7 +64,7 @@ describe('TasksController', () => {
     }
 
     beforeEach(() => {
-      when(cruManagementAreaService.getCRUManagementAreas).calledWith(token).mockResolvedValue(cruManagementAreas)
+      when(cruManagementAreaService.getCruManagementAreas).calledWith(token).mockResolvedValue(cruManagementAreas)
       when(taskService.getAll).calledWith(expect.anything()).mockResolvedValue(paginatedResponse)
       when(userService.getUserList).calledWith(token, ['assessor', 'matcher']).mockResolvedValue(users)
 

--- a/server/controllers/tasksController.test.ts
+++ b/server/controllers/tasksController.test.ts
@@ -14,7 +14,7 @@ import {
   userDetailsFactory,
   userFactory,
 } from '../testutils/factories'
-import { ApAreaService, ApplicationService, CRUManagementAreaService, TaskService, UserService } from '../services'
+import { ApAreaService, ApplicationService, CruManagementAreaService, TaskService, UserService } from '../services'
 import { fetchErrorsAndUserInput } from '../utils/validation'
 import { ErrorsAndUserInput, PaginatedResponse } from '../@types/ui'
 import paths from '../paths/api'
@@ -34,7 +34,7 @@ describe('TasksController', () => {
   const taskService = createMock<TaskService>({})
   const apAreaService: DeepMocked<ApAreaService> = createMock<ApAreaService>({})
   const userService: DeepMocked<UserService> = createMock<UserService>({})
-  const cruManagementAreaService: DeepMocked<CRUManagementAreaService> = createMock<CRUManagementAreaService>({})
+  const cruManagementAreaService: DeepMocked<CruManagementAreaService> = createMock<CruManagementAreaService>({})
 
   let tasksController: TasksController
 

--- a/server/controllers/tasksController.ts
+++ b/server/controllers/tasksController.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 import { convertToTitleCase, sentenceCase } from '../utils/utils'
-import { ApAreaService, ApplicationService, CRUManagementAreaService, TaskService, UserService } from '../services'
+import { ApAreaService, ApplicationService, CruManagementAreaService, TaskService, UserService } from '../services'
 import { fetchErrorsAndUserInput } from '../utils/validation'
 import { getPaginationDetails } from '../utils/getPaginationDetails'
 import paths from '../paths/api'
@@ -13,7 +13,7 @@ export default class TasksController {
     private readonly applicationService: ApplicationService,
     private readonly apAreaService: ApAreaService,
     private readonly userService: UserService,
-    private readonly cruManagementAreaService: CRUManagementAreaService,
+    private readonly cruManagementAreaService: CruManagementAreaService,
   ) {}
 
   index(): TypedRequestHandler<Request, Response> {

--- a/server/controllers/tasksController.ts
+++ b/server/controllers/tasksController.ts
@@ -59,7 +59,7 @@ export default class TasksController {
         isCompleted,
       })
 
-      const cruManagementAreas = await this.cruManagementAreaService.getCRUManagementAreas(req.user.token)
+      const cruManagementAreas = await this.cruManagementAreaService.getCruManagementAreas(req.user.token)
 
       res.render('tasks/index', {
         pageHeading: 'Task Allocation',

--- a/server/data/cas1ReferenceDataClient.test.ts
+++ b/server/data/cas1ReferenceDataClient.test.ts
@@ -44,7 +44,7 @@ describeCas1NamespaceClient('Cas1ReferenceDataClient', provider => {
     })
   })
 
-  describe('getCRUManagementAreas', () => {
+  describe('getCruManagementAreas', () => {
     it('should return an array of CRU management areas', async () => {
       const cruManagementAreas = cruManagementAreaFactory.buildList(5)
 
@@ -64,7 +64,7 @@ describeCas1NamespaceClient('Cas1ReferenceDataClient', provider => {
         },
       })
 
-      const output = await cas1ReferenceDataClient.getCRUManagementAreas()
+      const output = await cas1ReferenceDataClient.getCruManagementAreas()
       expect(output).toEqual(cruManagementAreas)
     })
   })

--- a/server/data/cas1ReferenceDataClient.ts
+++ b/server/data/cas1ReferenceDataClient.ts
@@ -14,7 +14,7 @@ export default class Cas1ReferenceDataClient {
     return (await this.restClient.get({ path: `/cas1/reference-data/${objectType}` })) as Array<Cas1ReferenceData>
   }
 
-  async getCRUManagementAreas(): Promise<Array<Cas1CruManagementArea>> {
+  async getCruManagementAreas(): Promise<Array<Cas1CruManagementArea>> {
     return (await this.restClient.get({
       path: `/cas1/reference-data/cru-management-areas`,
     })) as Array<Cas1CruManagementArea>

--- a/server/data/cas1UserClient.test.ts
+++ b/server/data/cas1UserClient.test.ts
@@ -1,0 +1,94 @@
+import { describeCas1NamespaceClient } from '../testutils/describeClient'
+import UserClient from './userClient'
+import { userFactory } from '../testutils/factories'
+import paths from '../paths/api'
+
+describeCas1NamespaceClient('Cas1UserClient', provider => {
+  let userClient: UserClient
+
+  const token = 'token-1'
+
+  beforeEach(() => {
+    userClient = new UserClient(token)
+  })
+
+  describe('getUser', () => {
+    const user = userFactory.build()
+    const id = 'SOME_ID'
+
+    it('should return a user', async () => {
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get a user',
+        withRequest: {
+          method: 'GET',
+          path: paths.users.show({ id }),
+          headers: {
+            authorization: `Bearer ${token}`,
+            'X-Service-Name': 'approved-premises',
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: user,
+        },
+      })
+
+      const output = await userClient.getUser(id)
+      expect(output).toEqual(user)
+    })
+  })
+
+  describe('updateUser', () => {
+    it('should update a user', async () => {
+      const user = userFactory.build()
+
+      const rolesAndQualifications = { roles: user.roles, qualifications: user.qualifications }
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to update a user',
+        withRequest: {
+          method: 'PUT',
+          path: paths.users.update({ id: user.id }),
+          headers: {
+            authorization: `Bearer ${token}`,
+            'X-Service-Name': 'approved-premises',
+          },
+          body: rolesAndQualifications,
+        },
+        willRespondWith: {
+          status: 200,
+          body: user,
+        },
+      })
+
+      const output = await userClient.updateUser(user.id, rolesAndQualifications)
+      expect(output).toEqual(user)
+    })
+  })
+
+  describe('delete', () => {
+    it('should delete a user', async () => {
+      const user = userFactory.build()
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to delete a user',
+        withRequest: {
+          method: 'DELETE',
+          path: paths.users.delete({ id: user.id }),
+          headers: {
+            authorization: `Bearer ${token}`,
+            'X-Service-Name': 'approved-premises',
+          },
+        },
+        willRespondWith: {
+          status: 200,
+        },
+      })
+
+      await userClient.delete(user.id)
+    })
+  })
+})

--- a/server/data/cas1UserClient.test.ts
+++ b/server/data/cas1UserClient.test.ts
@@ -1,3 +1,4 @@
+import { Cas1UpdateUser } from '@approved-premises/api'
 import { describeCas1NamespaceClient } from '../testutils/describeClient'
 import UserClient from './userClient'
 import { userFactory } from '../testutils/factories'
@@ -43,7 +44,11 @@ describeCas1NamespaceClient('Cas1UserClient', provider => {
     it('should update a user', async () => {
       const user = userFactory.build()
 
-      const rolesAndQualifications = { roles: user.roles, qualifications: user.qualifications }
+      const updateUserData: Cas1UpdateUser = {
+        roles: user.roles,
+        qualifications: user.qualifications,
+        cruManagementAreaOverrideId: 'foo-id',
+      }
 
       provider.addInteraction({
         state: 'Server is healthy',
@@ -55,7 +60,7 @@ describeCas1NamespaceClient('Cas1UserClient', provider => {
             authorization: `Bearer ${token}`,
             'X-Service-Name': 'approved-premises',
           },
-          body: rolesAndQualifications,
+          body: updateUserData,
         },
         willRespondWith: {
           status: 200,
@@ -63,7 +68,7 @@ describeCas1NamespaceClient('Cas1UserClient', provider => {
         },
       })
 
-      const output = await userClient.updateUser(user.id, rolesAndQualifications)
+      const output = await userClient.updateUser(user.id, updateUserData)
       expect(output).toEqual(user)
     })
   })

--- a/server/data/userClient.test.ts
+++ b/server/data/userClient.test.ts
@@ -12,33 +12,6 @@ describeClient('UserClient', provider => {
     userClient = new UserClient(token)
   })
 
-  describe('getUser', () => {
-    const user = userFactory.build()
-    const id = 'SOME_ID'
-
-    it('should return a user', async () => {
-      provider.addInteraction({
-        state: 'Server is healthy',
-        uponReceiving: 'A request to get a user',
-        withRequest: {
-          method: 'GET',
-          path: paths.users.show({ id }),
-          headers: {
-            authorization: `Bearer ${token}`,
-            'X-Service-Name': 'approved-premises',
-          },
-        },
-        willRespondWith: {
-          status: 200,
-          body: user,
-        },
-      })
-
-      const output = await userClient.getUser(id)
-      expect(output).toEqual(user)
-    })
-  })
-
   describe('getUserProfile', () => {
     const user = userFactory.build()
 
@@ -48,7 +21,7 @@ describeClient('UserClient', provider => {
         uponReceiving: 'A request to get a user profile',
         withRequest: {
           method: 'GET',
-          path: paths.users.v2profile({}),
+          path: paths.users.profile({}),
           headers: {
             authorization: `Bearer ${token}`,
             'X-Service-Name': 'approved-premises',
@@ -363,35 +336,6 @@ describeClient('UserClient', provider => {
     })
   })
 
-  describe('updateUser', () => {
-    it('should update a user', async () => {
-      const user = userFactory.build()
-
-      const rolesAndQualifications = { roles: user.roles, qualifications: user.qualifications }
-
-      provider.addInteraction({
-        state: 'Server is healthy',
-        uponReceiving: 'A request to update a user',
-        withRequest: {
-          method: 'PUT',
-          path: paths.users.update({ id: user.id }),
-          headers: {
-            authorization: `Bearer ${token}`,
-            'X-Service-Name': 'approved-premises',
-          },
-          body: rolesAndQualifications,
-        },
-        willRespondWith: {
-          status: 200,
-          body: user,
-        },
-      })
-
-      const output = await userClient.updateUser(user.id, rolesAndQualifications)
-      expect(output).toEqual(user)
-    })
-  })
-
   describe('search', () => {
     it('should search for a user', async () => {
       const users = userFactory.buildList(1)
@@ -449,30 +393,6 @@ describeClient('UserClient', provider => {
 
       const output = await userClient.searchDelius(name)
       expect(output).toEqual(user)
-    })
-  })
-
-  describe('delete', () => {
-    it('should delete a user', async () => {
-      const user = userFactory.build()
-
-      provider.addInteraction({
-        state: 'Server is healthy',
-        uponReceiving: 'A request to delete a user',
-        withRequest: {
-          method: 'DELETE',
-          path: paths.users.delete({ id: user.id }),
-          headers: {
-            authorization: `Bearer ${token}`,
-            'X-Service-Name': 'approved-premises',
-          },
-        },
-        willRespondWith: {
-          status: 200,
-        },
-      })
-
-      await userClient.delete(user.id)
     })
   })
 })

--- a/server/data/userClient.ts
+++ b/server/data/userClient.ts
@@ -1,10 +1,10 @@
 import type {
+  Cas1UpdateUser,
   ProfileResponse,
   SortDirection,
   ApprovedPremisesUser as User,
   UserQualification,
   ApprovedPremisesUserRole as UserRole,
-  UserRolesAndQualifications,
   UserSortField,
   UserSummary,
 } from '@approved-premises/api'
@@ -65,10 +65,10 @@ export default class UserClient {
     })
   }
 
-  async updateUser(userId: string, rolesAndQualifications: UserRolesAndQualifications): Promise<User> {
+  async updateUser(userId: string, data: Cas1UpdateUser): Promise<User> {
     return (await this.restClient.put({
       path: paths.users.update({ id: userId }),
-      data: rolesAndQualifications,
+      data,
     })) as User
   }
 

--- a/server/data/userClient.ts
+++ b/server/data/userClient.ts
@@ -26,7 +26,7 @@ export default class UserClient {
   }
 
   async getUserProfile(): Promise<ProfileResponse> {
-    return (await this.restClient.get({ path: paths.users.v2profile({}) })) as ProfileResponse
+    return (await this.restClient.get({ path: paths.users.profile({}) })) as ProfileResponse
   }
 
   async getUserList(roles: Array<UserRole> = []): Promise<Array<UserSummary>> {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -33,6 +33,7 @@ const person = people.path(':crn')
 const oasys = person.path('oasys')
 
 const users = path('/users')
+const cas1Users = cas1Namespace.path('users')
 
 const tasks = path('/tasks')
 const taskSingle = tasks.path(':taskType/:id')
@@ -180,11 +181,10 @@ export default {
     summary: users.path('summary'),
     search: users.path('search'),
     searchDelius: users.path('delius'),
-    show: users.path(':id'),
-    profile,
-    update: users.path(':id'),
-    delete: users.path(':id'),
-    v2profile: profile.path('v2'),
+    show: cas1Users.path(':id'),
+    update: cas1Users.path(':id'),
+    delete: cas1Users.path(':id'),
+    profile: profile.path('v2'),
   },
   reports: cas1Reports.path(':reportName'),
 }

--- a/server/services/cruManagementAreaService.test.ts
+++ b/server/services/cruManagementAreaService.test.ts
@@ -1,14 +1,14 @@
 import { Cas1ReferenceDataClient } from '../data'
-import CRUManagementAreaService from './cruManagementAreaService'
+import CruManagementAreaService from './cruManagementAreaService'
 import { cruManagementAreaFactory } from '../testutils/factories'
 
 jest.mock('../data/cas1ReferenceDataClient.ts')
 
-describe('CRUManagementAreaService', () => {
+describe('CruManagementAreaService', () => {
   const cas1ReferenceDataClient = new Cas1ReferenceDataClient(null) as jest.Mocked<Cas1ReferenceDataClient>
   const referenceDataClientFactory = jest.fn()
 
-  const service = new CRUManagementAreaService(referenceDataClientFactory)
+  const service = new CruManagementAreaService(referenceDataClientFactory)
 
   const token = 'SOME_TOKEN'
 
@@ -17,16 +17,16 @@ describe('CRUManagementAreaService', () => {
     referenceDataClientFactory.mockReturnValue(cas1ReferenceDataClient)
   })
 
-  describe('getCRUManagementAreas', () => {
-    it('calls the getCRUManagementAreas client method and returns the result', async () => {
+  describe('getCruManagementAreas', () => {
+    it('calls the getCruManagementAreas client method and returns the result', async () => {
       const cruManagementAreas = cruManagementAreaFactory.buildList(1)
 
-      cas1ReferenceDataClient.getCRUManagementAreas.mockResolvedValue(cruManagementAreas)
+      cas1ReferenceDataClient.getCruManagementAreas.mockResolvedValue(cruManagementAreas)
 
-      const result = await service.getCRUManagementAreas(token)
+      const result = await service.getCruManagementAreas(token)
 
       expect(referenceDataClientFactory).toHaveBeenCalledWith(token)
-      expect(cas1ReferenceDataClient.getCRUManagementAreas).toHaveBeenCalled()
+      expect(cas1ReferenceDataClient.getCruManagementAreas).toHaveBeenCalled()
       expect(result).toEqual(cruManagementAreas)
     })
   })

--- a/server/services/cruManagementAreaService.ts
+++ b/server/services/cruManagementAreaService.ts
@@ -2,12 +2,12 @@ import type { Cas1ReferenceDataClient, RestClientBuilder } from '../data'
 
 import { Cas1CruManagementArea } from '../@types/shared'
 
-export default class CRUManagementAreaService {
+export default class CruManagementAreaService {
   constructor(private readonly referenceDataClientFactory: RestClientBuilder<Cas1ReferenceDataClient>) {}
 
-  async getCRUManagementAreas(token: string): Promise<Array<Cas1CruManagementArea>> {
+  async getCruManagementAreas(token: string): Promise<Array<Cas1CruManagementArea>> {
     const client = this.referenceDataClientFactory(token)
 
-    return client.getCRUManagementAreas()
+    return client.getCruManagementAreas()
   }
 }

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -20,7 +20,7 @@ import PlacementApplicationService from './placementApplicationService'
 import SpaceService from './spaceService'
 import ReportService from './reportService'
 import ApAreaService from './apAreaService'
-import CRUManagementAreaService from './cruManagementAreaService'
+import CruManagementAreaService from './cruManagementAreaService'
 import AppealService from './appealService'
 
 import config, { AuditConfig } from '../config'
@@ -66,7 +66,7 @@ export const services = () => {
   const spaceService = new SpaceService(bedClientBuilder)
   const reportService = new ReportService(reportClientBuilder)
   const apAreaService = new ApAreaService(referenceDataClientBuilder)
-  const cruManagementAreaService = new CRUManagementAreaService(cas1ReferenceDataClientBuilder)
+  const cruManagementAreaService = new CruManagementAreaService(cas1ReferenceDataClientBuilder)
 
   return {
     appealService,
@@ -113,5 +113,5 @@ export {
   SpaceService,
   ReportService,
   ApAreaService,
-  CRUManagementAreaService,
+  CruManagementAreaService,
 }

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -120,6 +120,7 @@ describe('User service', () => {
       const result = await userService.updateUser(token, user.id, {
         roles: user.roles,
         qualifications: user.qualifications,
+        cruManagementAreaOverrideId: user.cruManagementAreaOverride.id,
       })
 
       expect(result).toEqual(user)
@@ -127,6 +128,7 @@ describe('User service', () => {
       expect(userClient.updateUser).toHaveBeenCalledWith(userId, {
         roles: user.roles,
         qualifications: user.qualifications,
+        cruManagementAreaOverrideId: user.cruManagementAreaOverride.id,
       })
     })
   })

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,10 +1,10 @@
 import {
+  Cas1UpdateUser,
   ProbationRegion,
   SortDirection,
   ApprovedPremisesUser as User,
   UserQualification,
   ApprovedPremisesUserRole as UserRole,
-  UserRolesAndQualifications,
   UserSortField,
   type UserSummary,
 } from '@approved-premises/api'
@@ -64,10 +64,10 @@ export default class UserService {
     return client.getUsers(areaId, roles, qualifications, page, sortBy, sortDirection)
   }
 
-  async updateUser(token: string, userId: string, rolesAndQualifications: UserRolesAndQualifications): Promise<User> {
+  async updateUser(token: string, userId: string, updateUserData: Cas1UpdateUser): Promise<User> {
     const client = this.userClientFactory(token)
 
-    return client.updateUser(userId, rolesAndQualifications)
+    return client.updateUser(userId, updateUserData)
   }
 
   async search(token: string, query: string): Promise<Array<User>> {

--- a/server/testutils/factories/user.ts
+++ b/server/testutils/factories/user.ts
@@ -27,6 +27,7 @@ const userFactory = Factory.define<User>(() => ({
   version: faker.number.int(),
   cruManagementArea: cruManagementAreaFactory.build(),
   cruManagementAreaDefault: cruManagementAreaFactory.build(),
+  cruManagementAreaOverride: cruManagementAreaFactory.build(),
 }))
 
 export const userSummaryFactory = Factory.define<UserSummary>(() => ({

--- a/server/testutils/jest.setup.ts
+++ b/server/testutils/jest.setup.ts
@@ -13,8 +13,11 @@ declare global {
   namespace jest {
     interface Matchers<R> {
       toContainAction(expected: Action): R
+
       toContainMenuItem(expected: IdentityBarMenuItem): R
+
       toMatchStringIgnoringWhitespace(expected: string): R
+
       toMatchOpenAPISpec({ cas1Namespace }: { cas1Namespace: boolean }): R
     }
   }
@@ -35,7 +38,8 @@ const apiSpecs = {
     sed -E 's@/spaces@/cas1/spaces@g' |
     sed -E 's@ /reference-data@ /cas1/reference-data@g' |
     sed -E 's@ /placement-requests@ /cas1/placement-requests@g' |
-    sed -E 's@/reports@/cas1/reports@g' > ${apiSpecPaths.cas1Spec}
+    sed -E 's@/reports@/cas1/reports@g' |
+    sed -E 's@ /users@ /cas1/users@g' > ${apiSpecPaths.cas1Spec}
   fi`,
     specPath: apiSpecPaths.cas1Spec,
   },

--- a/server/utils/users/userManagement.test.ts
+++ b/server/utils/users/userManagement.test.ts
@@ -1,6 +1,6 @@
 import { cruManagementAreaFactory, userFactory } from '../../testutils/factories'
 import {
-  userCRUManagementAreasSelectOptions,
+  userCruManagementAreasSelectOptions,
   userQualificationsSelectOptions,
   userRolesSelectOptions,
   userSummaryListItems,
@@ -200,11 +200,11 @@ describe('userQualificationsSelectOptions', () => {
   })
 })
 
-describe('userCRUManagementAreasSelectOptions', () => {
+describe('userCruManagementAreasSelectOptions', () => {
   const cruManagementAreas = cruManagementAreaFactory.buildList(2)
 
   it('returns a list of CRU management areas', () => {
-    expect(userCRUManagementAreasSelectOptions(cruManagementAreas)).toEqual([
+    expect(userCruManagementAreasSelectOptions(cruManagementAreas)).toEqual([
       {
         text: 'None',
         value: '',
@@ -224,7 +224,7 @@ describe('userCRUManagementAreasSelectOptions', () => {
   })
 
   it('returns a list of CRU management areas with one selected', () => {
-    expect(userCRUManagementAreasSelectOptions(cruManagementAreas, cruManagementAreas[1].id)).toEqual([
+    expect(userCruManagementAreasSelectOptions(cruManagementAreas, cruManagementAreas[1].id)).toEqual([
       {
         text: 'None',
         value: '',

--- a/server/utils/users/userManagement.test.ts
+++ b/server/utils/users/userManagement.test.ts
@@ -1,5 +1,10 @@
-import { userFactory } from '../../testutils/factories'
-import { userQualificationsSelectOptions, userRolesSelectOptions, userSummaryListItems } from './userManagement'
+import { cruManagementAreaFactory, userFactory } from '../../testutils/factories'
+import {
+  userCRUManagementAreasSelectOptions,
+  userQualificationsSelectOptions,
+  userRolesSelectOptions,
+  userSummaryListItems,
+} from './userManagement'
 
 describe('UserUtils', () => {
   it('returns the correct objects in an array when all the expected data is present', () => {
@@ -191,6 +196,50 @@ describe('userQualificationsSelectOptions', () => {
       { selected: false, text: 'PIPE', value: 'pipe' },
       { selected: false, text: 'Recovery-focused APs', value: 'recovery_focused' },
       { selected: false, text: 'Specialist Mental Health APs', value: 'mental_health_specialist' },
+    ])
+  })
+})
+
+describe('userCRUManagementAreasSelectOptions', () => {
+  const cruManagementAreas = cruManagementAreaFactory.buildList(2)
+
+  it('returns a list of CRU management areas', () => {
+    expect(userCRUManagementAreasSelectOptions(cruManagementAreas)).toEqual([
+      {
+        text: 'None',
+        value: '',
+        selected: true,
+      },
+      {
+        text: cruManagementAreas[0].name,
+        value: cruManagementAreas[0].id,
+        selected: false,
+      },
+      {
+        text: cruManagementAreas[1].name,
+        value: cruManagementAreas[1].id,
+        selected: false,
+      },
+    ])
+  })
+
+  it('returns a list of CRU management areas with one selected', () => {
+    expect(userCRUManagementAreasSelectOptions(cruManagementAreas, cruManagementAreas[1].id)).toEqual([
+      {
+        text: 'None',
+        value: '',
+        selected: false,
+      },
+      {
+        text: cruManagementAreas[0].name,
+        value: cruManagementAreas[0].id,
+        selected: false,
+      },
+      {
+        text: cruManagementAreas[1].name,
+        value: cruManagementAreas[1].id,
+        selected: true,
+      },
     ])
   })
 })

--- a/server/utils/users/userManagement.ts
+++ b/server/utils/users/userManagement.ts
@@ -102,7 +102,7 @@ export const userQualificationsSelectOptions = (
   return options
 }
 
-export const userCRUManagementAreasSelectOptions = (
+export const userCruManagementAreasSelectOptions = (
   cruManagementAreas: Array<Cas1CruManagementArea>,
   selected?: Cas1CruManagementArea['id'],
 ): Array<SelectOption> => [

--- a/server/utils/users/userManagement.ts
+++ b/server/utils/users/userManagement.ts
@@ -1,5 +1,10 @@
 import { SelectOption } from '@approved-premises/ui'
-import { ApprovedPremisesUserRole, ApprovedPremisesUser as User, UserQualification } from '../../@types/shared'
+import {
+  ApprovedPremisesUserRole,
+  Cas1CruManagementArea,
+  ApprovedPremisesUser as User,
+  UserQualification,
+} from '../../@types/shared'
 import { RoleInUse, qualificationDictionary } from './roles'
 
 export const userSummaryListItems = (user: User) => [
@@ -96,3 +101,19 @@ export const userQualificationsSelectOptions = (
 
   return options
 }
+
+export const userCRUManagementAreasSelectOptions = (
+  cruManagementAreas: Array<Cas1CruManagementArea>,
+  selected?: Cas1CruManagementArea['id'],
+): Array<SelectOption> => [
+  {
+    text: 'None',
+    value: '',
+    selected: !selected,
+  },
+  ...cruManagementAreas.map(area => ({
+    text: area.name,
+    value: area.id,
+    selected: selected === area.id,
+  })),
+]

--- a/server/views/admin/users/edit.njk
+++ b/server/views/admin/users/edit.njk
@@ -32,11 +32,11 @@
 
             <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
-            <form action="{{ paths.admin.userManagement.update({id: user.id}) }}?_method=PUT" method="post">
+            <form action="{{ paths.admin.userManagement.update({id: updateUser.id}) }}?_method=PUT" method="post">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
                 {{ govukSummaryList({
-                    rows: UserUtils.userSummaryListItems(user)
+                    rows: UserUtils.userSummaryListItems(updateUser)
                 }) }}
 
                 {{ govukSelect({
@@ -60,7 +60,7 @@
                     hint: {
                         text: "Select all that apply"
                     },
-                    items: UserUtils.rolesToCheckboxItems(roles, user.roles)
+                    items: UserUtils.rolesToCheckboxItems(roles, updateUser.roles)
                 }) }}
 
                 {{ govukCheckboxes({
@@ -74,7 +74,7 @@
                     hint: {
                         html: allocationPreferencesHint
                     },
-                    items: UserUtils.allocationRolesToCheckboxItems(roles, user.roles)
+                    items: UserUtils.allocationRolesToCheckboxItems(roles, updateUser.roles)
                 }) }}
 
                 {{ govukCheckboxes({
@@ -88,7 +88,7 @@
                     hint: {
                         html: qualificationsHint
                     },
-                    items: UserUtils.userQualificationsToCheckboxItems(qualifications, user.qualifications)
+                    items: UserUtils.userQualificationsToCheckboxItems(qualifications, updateUser.qualifications)
                 }) }}
 
                 <div class="govuk-button-group">
@@ -100,7 +100,7 @@
 
                     {{ govukButton({
                         text: "Remove access",
-                        href: paths.admin.userManagement.confirmDelete({id: user.id}),
+                        href: paths.admin.userManagement.confirmDelete({id: updateUser.id}),
                         classes: "govuk-button--warning",
                         preventDoubleClick: true
                     }) }}

--- a/server/views/admin/users/edit.njk
+++ b/server/views/admin/users/edit.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList -%}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
 
 {% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body assessments--index" %}
@@ -36,6 +37,16 @@
 
                 {{ govukSummaryList({
                     rows: UserUtils.userSummaryListItems(user)
+                }) }}
+
+                {{ govukSelect({
+                    label: {
+                        text: "CRU Management Area",
+                        classes: "govuk-label--m"
+                    },
+                    id: "cruManagementAreaOverrideId",
+                    name: "cruManagementAreaOverrideId",
+                    items: cruManagementAreasOptions
                 }) }}
 
                 {{ govukCheckboxes({


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1440

# Changes in this PR

This PR adds a select dropdown to update a user's CRU Management Area. The CRU management Area can be cleared by selecting 'None'.

## Screenshots of UI changes

<img width="716" alt="Screenshot 2024-10-23 at 16 21 20" src="https://github.com/user-attachments/assets/63faf6fc-90bb-4635-a3f6-ef2b0ecefcc3">
