### PR TITLE
APS-1411: record placement arrival

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -70,5 +70,5 @@ export default defineConfig<TestOptions>({
       dependencies: ['setup-local'],
     },
   ],
-  testIgnore: ['/utils/*.ts'],
+  testIgnore: process.env.APPLICATION_TYPE ? [] : ['/utils/*.ts'],
 })

--- a/e2e/utils/createApplication.spec.ts
+++ b/e2e/utils/createApplication.spec.ts
@@ -1,9 +1,11 @@
 import { ApplicationType } from '@approved-premises/e2e'
 import { test } from '../test'
 import { createApplication } from '../steps/apply'
+import { signIn } from '../steps/signIn'
 
 const applicationType = process.env.APPLICATION_TYPE as ApplicationType
 
-test(`create ${applicationType} application`, async ({ page, person, oasysSections }) => {
+test(`create ${applicationType} application`, async ({ page, assessor, person, oasysSections }) => {
+  await signIn(page, assessor)
   await createApplication({ page, person, oasysSections, applicationType }, true, true)
 })

--- a/integration_tests/mockApis/spaceBooking.ts
+++ b/integration_tests/mockApis/spaceBooking.ts
@@ -31,7 +31,10 @@ export default {
     stubFor({
       request: {
         method: 'GET',
-        urlPattern: `${paths.premises.placements.show({ premisesId: placement.premises.id, placementId: placement.id })}`,
+        urlPattern: paths.premises.placements.show({
+          premisesId: placement.premises.id,
+          placementId: placement.id,
+        }),
       },
       response: {
         status: 200,
@@ -65,4 +68,15 @@ export default {
       },
     })
   },
+
+  stubSpaceBookingArrivalCreate: (args: { premisesId: string; placementId: string }) =>
+    stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: paths.premises.placements.arrival({ premisesId: args.premisesId, placementId: args.placementId }),
+      },
+      response: {
+        status: 200,
+      },
+    }),
 }

--- a/integration_tests/pages/manage/placementShow.ts
+++ b/integration_tests/pages/manage/placementShow.ts
@@ -5,23 +5,25 @@ import { DateFormats } from '../../../server/utils/dateUtils'
 import { arrivalInformation, departureInformation, placementSummary } from '../../../server/utils/placements'
 
 export default class PlacementShowPage extends Page {
-  constructor(pageHeading: string) {
-    super(pageHeading)
+  constructor(placement: Cas1SpaceBooking | null, pageHeading?: string) {
+    let title = pageHeading
+    if (placement) {
+      title = `${DateFormats.isoDateToUIDate(placement.canonicalArrivalDate, { format: 'short' })} to ${DateFormats.isoDateToUIDate(placement.canonicalDepartureDate, { format: 'short' })}`
+    }
+    super(title)
     this.checkPhaseBanner('Give us your feedback')
   }
 
   static visit(placement: Cas1SpaceBooking): PlacementShowPage {
     cy.visit(paths.premises.placements.show({ premisesId: placement.premises.id, placementId: placement.id }))
-    return new PlacementShowPage(
-      `${DateFormats.isoDateToUIDate(placement.canonicalArrivalDate, { format: 'short' })} to ${DateFormats.isoDateToUIDate(placement.canonicalDepartureDate, { format: 'short' })}`,
-    )
+    return new PlacementShowPage(placement)
   }
 
   static visitUnauthorised(placement: Cas1SpaceBooking): PlacementShowPage {
     cy.visit(paths.premises.placements.show({ premisesId: placement.premises.id, placementId: placement.id }), {
       failOnStatusCode: false,
     })
-    return new PlacementShowPage(`Authorisation Error`)
+    return new PlacementShowPage(null, `Authorisation Error`)
   }
 
   shouldShowPersonHeader(placement: Cas1SpaceBooking): void {

--- a/integration_tests/pages/manage/placements/arrival.ts
+++ b/integration_tests/pages/manage/placements/arrival.ts
@@ -1,0 +1,25 @@
+import type { Cas1SpaceBooking } from '@approved-premises/api'
+import Page from '../../page'
+import { DateFormats } from '../../../../server/utils/dateUtils'
+
+export class ArrivalCreatePage extends Page {
+  constructor(private readonly placement: Cas1SpaceBooking) {
+    super('Record someone as arrived')
+  }
+
+  shouldShowFormAndExpectedArrivalDate(): void {
+    this.shouldContainSummaryListItems([
+      {
+        key: { text: 'Expected arrival date' },
+        value: { text: DateFormats.isoDateToUIDate(this.placement.expectedArrivalDate) },
+      },
+    ])
+    this.getLegend('What is the arrival date?')
+    this.getLabel('What is the time of arrival?')
+  }
+
+  completeForm(): void {
+    this.completeDateInputs('arrivalDateTime', this.placement.expectedArrivalDate)
+    this.completeTextInput('arrivalTime', '9:45')
+  }
+}

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -141,6 +141,10 @@ export default abstract class Page {
     cy.get(`input[name="${name}"][value="${option}"]`).uncheck()
   }
 
+  completeTextInput(name: string, value: string): void {
+    cy.get(`input[name="${name}"]`).type(value)
+  }
+
   completeTextArea(name: string, value: string): void {
     cy.get(`textarea[name="${name}"]`).type(value)
   }
@@ -173,6 +177,11 @@ export default abstract class Page {
 
   clickBack(): void {
     cy.get('a').contains('Back').click()
+  }
+
+  clickAction(actionLabel: string): void {
+    cy.get('.moj-button-menu > button').contains('Actions').click()
+    cy.get('[role="menuitem"]').contains(actionLabel).click()
   }
 
   shouldShowMappa = (): void => {

--- a/integration_tests/tests/manage/placements/arrivals.cy.ts
+++ b/integration_tests/tests/manage/placements/arrivals.cy.ts
@@ -1,0 +1,38 @@
+import { signIn } from '../../signIn'
+import { ArrivalCreatePage } from '../../../pages/manage/placements/arrival'
+import { cas1PremisesSummaryFactory, cas1SpaceBookingFactory } from '../../../../server/testutils/factories'
+import { PlacementShowPage } from '../../../pages/manage'
+
+context('Arrivals', () => {
+  it('lets a future manager mark a placement as arrived', () => {
+    const premises = cas1PremisesSummaryFactory.build()
+    const placement = cas1SpaceBookingFactory.upcoming().build({
+      premises,
+    })
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSpaceBookingShow', placement)
+    cy.task('stubSpaceBookingArrivalCreate', { premisesId: premises.id, placementId: placement.id })
+
+    // Given I am logged in as a future manager
+    signIn(['future_manager'], ['cas1_space_booking_view', 'cas1_space_booking_record_arrival'])
+
+    // When I view a new placement
+    let placementPage = PlacementShowPage.visit(placement)
+
+    // And I click on the 'Arrived' action
+    placementPage.clickAction('Record arrival')
+
+    // Then I should see the form to record the arrival
+    const arrivalCreatePage = new ArrivalCreatePage(placement)
+    arrivalCreatePage.shouldShowFormAndExpectedArrivalDate()
+
+    // When I submit the form with the arrival details
+    arrivalCreatePage.completeForm()
+    arrivalCreatePage.clickSubmit()
+
+    // Then I should be shown the placement page with a confirmation that the placement has been marked as arrived
+    placementPage = new PlacementShowPage(placement)
+    placementPage.shouldShowBanner('You have recorded this person as arrived')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "clean": "rm -rf dist build node_modules stylesheets",
     "start-test-wiremock": "docker compose -f docker-compose-test.yml up -d",
     "generate-types": "script/generate-types",
-    "create-application:standard": "APPLICATION_TYPE='standard' npx playwright test --config ./e2e/playwright.config.ts --project=dev utils/createApplication.spec.ts",
-    "create-application:emergency": "APPLICATION_TYPE='emergency' npx playwright test --config ./e2e/playwright.config.ts --project=dev utils/createApplication.spec.ts",
-    "create-application:short-notice": "APPLICATION_TYPE='shortNotice' npx playwright test --config ./e2e/playwright.config.ts --project=dev utils/createApplication.spec.ts"
+    "create-application:standard": "APPLICATION_TYPE='standard' npx playwright test --config ./e2e/playwright.config.ts --project=local utils/createApplication.spec.ts",
+    "create-application:emergency": "APPLICATION_TYPE='emergency' npx playwright test --config ./e2e/playwright.config.ts --project=local utils/createApplication.spec.ts",
+    "create-application:short-notice": "APPLICATION_TYPE='shortNotice' npx playwright test --config ./e2e/playwright.config.ts --project=local utils/createApplication.spec.ts"
   },
   "engines": {
     "node": "^20.0.0",

--- a/server/controllers/manage/index.ts
+++ b/server/controllers/manage/index.ts
@@ -11,6 +11,7 @@ import PlacementController from './placementController'
 import BedsController from './premises/bedsController'
 import OutOfServiceBedsController from './outOfServiceBedsController'
 import UpdateOutOfServiceBedsController from './updateOutOfServiceBedsController'
+import ArrivalsController from './premises/placements/arrivalsController'
 
 export const controllers = (services: Services) => {
   const premisesController = new PremisesController(services.premisesService, services.apAreaService)
@@ -27,9 +28,11 @@ export const controllers = (services: Services) => {
   const cancellationsController = new CancellationsController(services.cancellationService, services.bookingService)
   const dateChangesController = new DateChangesController(services.bookingService)
   const placementController = new PlacementController(services.premisesService)
+  const arrivalsController = new ArrivalsController(services.premisesService, services.placementService)
 
   return {
     premisesController,
+    arrivalsController,
     bedsController,
     outOfServiceBedsController,
     updateOutOfServiceBedsController,
@@ -43,6 +46,7 @@ export const controllers = (services: Services) => {
 
 export {
   PremisesController,
+  ArrivalsController,
   PlacementController,
   BedsController,
   OutOfServiceBedsController,

--- a/server/controllers/manage/premises/placements/arrivalsController.test.ts
+++ b/server/controllers/manage/premises/placements/arrivalsController.test.ts
@@ -1,0 +1,100 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+import type { ErrorsAndUserInput } from '@approved-premises/ui'
+import { when } from 'jest-when'
+import ArrivalsController from './arrivalsController'
+import { spaceBookingFactory } from '../../../../testutils/factories'
+import { PremisesService } from '../../../../services'
+import * as validationUtils from '../../../../utils/validation'
+import paths from '../../../../paths/manage'
+import PlacementService from '../../../../services/placementService'
+
+describe('ArrivalsController', () => {
+  const token = 'SOME_TOKEN'
+
+  let request: DeepMocked<Request>
+  const response: DeepMocked<Response> = createMock<Response>()
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>()
+
+  const premisesService = createMock<PremisesService>()
+  const placementService = createMock<PlacementService>()
+  const arrivalsController = new ArrivalsController(premisesService, placementService)
+
+  const premisesId = 'premises-id'
+  const placement = spaceBookingFactory.build()
+
+  beforeEach(() => {
+    premisesService.getPlacement.mockResolvedValue(placement)
+    request = createMock<Request>({ user: { token }, params: { premisesId, placementId: placement.id } })
+    jest.spyOn(validationUtils, 'fetchErrorsAndUserInput')
+  })
+
+  describe('new', () => {
+    it('renders the form with placement information, errors and user input', async () => {
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+      when(validationUtils.fetchErrorsAndUserInput).calledWith(request).mockReturnValue(errorsAndUserInput)
+
+      const requestHandler = arrivalsController.new()
+
+      await requestHandler(request, response, next)
+
+      expect(premisesService.getPlacement).toHaveBeenCalledWith({ token, premisesId, placementId: placement.id })
+      expect(response.render).toHaveBeenCalledWith('manage/placements/arrivals/new', {
+        placement,
+        errors: errorsAndUserInput.errors,
+        errorSummary: errorsAndUserInput.errorSummary,
+        errorTitle: errorsAndUserInput.errorTitle,
+        ...errorsAndUserInput.userInput,
+      })
+    })
+  })
+
+  describe('create', () => {
+    it('creates the arrival and redirects to the placement page', async () => {
+      const requestHandler = arrivalsController.create()
+
+      request.body = {
+        expectedDepartureDate: '2025-04-01',
+        'arrivalDate-year': '2024',
+        'arrivalDate-month': '11',
+        'arrivalDate-day': '5',
+        arrivalTime: '10:45',
+      }
+
+      await requestHandler(request, response, next)
+
+      expect(placementService.createArrival).toHaveBeenCalledWith(token, premisesId, placement.id, {
+        expectedDepartureDate: '2025-04-01',
+        arrivalDateTime: '2024-11-05T10:45:00.000Z',
+      })
+      expect(request.flash).toHaveBeenCalledWith('success', 'You have recorded this person as arrived')
+      expect(response.redirect).toHaveBeenCalledWith(
+        paths.premises.placements.show({ premisesId, bookingId: placement.id }),
+      )
+    })
+
+    describe('when errors are raised', () => {
+      it('should call catchValidationErrorOrPropogate with a standard error', async () => {
+        jest.spyOn(validationUtils, 'catchValidationErrorOrPropogate').mockReturnValue(undefined)
+
+        const requestHandler = arrivalsController.create()
+
+        const err = new Error()
+
+        placementService.createArrival.mockRejectedValue(err)
+
+        await requestHandler(request, response, next)
+
+        expect(validationUtils.catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+          request,
+          response,
+          err,
+          paths.premises.placements.arrival({
+            premisesId: request.params.premisesId,
+            bookingId: request.params.placementId,
+          }),
+        )
+      })
+    })
+  })
+})

--- a/server/controllers/manage/premises/placements/arrivalsController.test.ts
+++ b/server/controllers/manage/premises/placements/arrivalsController.test.ts
@@ -44,7 +44,7 @@ describe('ArrivalsController', () => {
       await requestHandler(request, response, next)
 
       expect(premisesService.getPlacement).toHaveBeenCalledWith({ token, premisesId, placementId: placement.id })
-      expect(response.render).toHaveBeenCalledWith('manage/placements/arrivals/new', {
+      expect(response.render).toHaveBeenCalledWith('manage/premises/placements/arrival', {
         placement,
         errors: errorsAndUserInput.errors,
         errorSummary: errorsAndUserInput.errorSummary,
@@ -61,13 +61,13 @@ describe('ArrivalsController', () => {
       'arrivalDateTime-year': '2024',
       'arrivalDateTime-month': '11',
       'arrivalDateTime-day': '5',
-      'arrivalDateTime-time': '9:45',
+      arrivalTime: '9:45',
     }
 
     beforeEach(() => {
       arrivalPath = paths.premises.placements.arrival({
         premisesId: request.params.premisesId,
-        bookingId: request.params.placementId,
+        placementId: request.params.placementId,
       })
       request.body = validBody
     })
@@ -83,7 +83,7 @@ describe('ArrivalsController', () => {
       })
       expect(request.flash).toHaveBeenCalledWith('success', 'You have recorded this person as arrived')
       expect(response.redirect).toHaveBeenCalledWith(
-        paths.premises.placements.show({ premisesId, bookingId: placement.id }),
+        paths.premises.placements.show({ premisesId, placementId: placement.id }),
       )
     })
 
@@ -97,7 +97,7 @@ describe('ArrivalsController', () => {
 
         const expectedErrorData = {
           arrivalDateTime: 'You must enter an arrival date',
-          'arrivalDateTime-time': 'You must enter a time of arrival',
+          arrivalTime: 'You must enter a time of arrival',
         }
 
         expect(placementService.createArrival).not.toHaveBeenCalled()
@@ -121,14 +121,14 @@ describe('ArrivalsController', () => {
           'arrivalDateTime-year': '2024',
           'arrivalDateTime-month': '13',
           'arrivalDateTime-day': '34',
-          'arrivalDateTime-time': '9am',
+          arrivalTime: '9am',
         }
 
         await requestHandler(request, response, next)
 
         const expectedErrorData = {
           arrivalDateTime: 'You must enter a valid arrival date',
-          'arrivalDateTime-time': 'You must enter a valid time of arrival in 24hr format',
+          arrivalTime: 'You must enter a valid time of arrival in 24hr format',
         }
 
         expect(validationUtils.catchValidationErrorOrPropogate).toHaveBeenCalledWith(

--- a/server/controllers/manage/premises/placements/arrivalsController.ts
+++ b/server/controllers/manage/premises/placements/arrivalsController.ts
@@ -20,7 +20,7 @@ export default class ArrivalsController {
 
       const placement = await this.premisesService.getPlacement({ token: req.user.token, premisesId, placementId })
 
-      return res.render('manage/placements/arrivals/new', {
+      return res.render('manage/premises/placements/arrival', {
         placement,
         errors,
         errorSummary,
@@ -37,15 +37,21 @@ export default class ArrivalsController {
       try {
         const errors: Record<string, string> = {}
 
-        const arrivalTime = req.body['arrivalDateTime-time']
+        const { arrivalTime } = req.body
 
         if (!arrivalTime) {
-          errors['arrivalDateTime-time'] = 'You must enter a time of arrival'
+          errors.arrivalTime = 'You must enter a time of arrival'
         } else if (!timeIsValid24hrFormat(arrivalTime)) {
-          errors['arrivalDateTime-time'] = 'You must enter a valid time of arrival in 24hr format'
+          errors.arrivalTime = 'You must enter a valid time of arrival in 24hr format'
         }
 
-        const { arrivalDateTime } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'arrivalDateTime')
+        const { arrivalDateTime } = DateFormats.dateAndTimeInputsToIsoString(
+          {
+            ...req.body,
+            'arrivalDateTime-time': arrivalTime,
+          },
+          'arrivalDateTime',
+        )
 
         if (!arrivalDateTime) {
           errors.arrivalDateTime = 'You must enter an arrival date'
@@ -65,7 +71,7 @@ export default class ArrivalsController {
         await this.placementService.createArrival(req.user.token, premisesId, placementId, placementArrival)
 
         req.flash('success', 'You have recorded this person as arrived')
-        return res.redirect(paths.premises.placements.show({ premisesId, bookingId: placementId }))
+        return res.redirect(paths.premises.placements.show({ premisesId, placementId }))
       } catch (error) {
         return catchValidationErrorOrPropogate(
           req,
@@ -73,7 +79,7 @@ export default class ArrivalsController {
           error as Error,
           paths.premises.placements.arrival({
             premisesId,
-            bookingId: placementId,
+            placementId,
           }),
         )
       }

--- a/server/controllers/manage/premises/placements/arrivalsController.ts
+++ b/server/controllers/manage/premises/placements/arrivalsController.ts
@@ -1,0 +1,61 @@
+import { type Request, RequestHandler, type Response } from 'express'
+import { Cas1NewArrival } from '@approved-premises/api'
+import { PremisesService } from '../../../../services'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../../utils/validation'
+import PlacementService from '../../../../services/placementService'
+import paths from '../../../../paths/manage'
+import { DateFormats } from '../../../../utils/dateUtils'
+
+export default class ArrivalsController {
+  constructor(
+    private readonly premisesService: PremisesService,
+    private readonly placementService: PlacementService,
+  ) {}
+
+  new(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, placementId } = req.params
+      const { errors, errorSummary, userInput, errorTitle } = fetchErrorsAndUserInput(req)
+
+      const placement = await this.premisesService.getPlacement({ token: req.user.token, premisesId, placementId })
+
+      return res.render('manage/placements/arrivals/new', {
+        placement,
+        errors,
+        errorSummary,
+        errorTitle,
+        ...userInput,
+      })
+    }
+  }
+
+  create(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, placementId } = req.params
+
+      const { arrivalDate } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'arrivalDate')
+
+      const placementArrival: Cas1NewArrival = {
+        expectedDepartureDate: req.body.expectedDepartureDate,
+        arrivalDateTime: `${arrivalDate}T${req.body.arrivalTime}:00.000Z`,
+      }
+
+      try {
+        await this.placementService.createArrival(req.user.token, premisesId, placementId, placementArrival)
+
+        req.flash('success', 'You have recorded this person as arrived')
+        return res.redirect(paths.premises.placements.show({ premisesId, bookingId: placementId }))
+      } catch (error) {
+        return catchValidationErrorOrPropogate(
+          req,
+          res,
+          error as Error,
+          paths.premises.placements.arrival({
+            premisesId,
+            bookingId: placementId,
+          }),
+        )
+      }
+    }
+  }
+}

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -29,6 +29,7 @@ import BedClient from './spaceClient'
 import ReportClient from './reportClient'
 import AppealClient from './appealClient'
 import OutOfServiceBedClient from './outOfServiceBedClient'
+import PlacementClient from './placementClient'
 
 type RestClientBuilder<T> = (token: string) => T
 
@@ -36,6 +37,7 @@ export const dataAccess = () => ({
   appealClientBuilder: ((token: string) => new AppealClient(token)) as RestClientBuilder<AppealClient>,
   hmppsAuthClient: new HmppsAuthClient(new TokenStore(createRedisClient())),
   approvedPremisesClientBuilder: ((token: string) => new PremisesClient(token)) as RestClientBuilder<PremisesClient>,
+  placementClientBuilder: ((token: string) => new PlacementClient(token)) as RestClientBuilder<PlacementClient>,
   bookingClientBuilder: ((token: string) => new BookingClient(token)) as RestClientBuilder<BookingClient>,
   referenceDataClientBuilder: ((token: string) =>
     new ReferenceDataClient(token)) as RestClientBuilder<ReferenceDataClient>,

--- a/server/data/placementClient.test.ts
+++ b/server/data/placementClient.test.ts
@@ -1,0 +1,43 @@
+import PlacementClient from './placementClient'
+import paths from '../paths/api'
+import { describeCas1NamespaceClient } from '../testutils/describeClient'
+import { newPlacementArrivalFactory } from '../testutils/factories/newPlacementArrival'
+
+describeCas1NamespaceClient('PlacementClient', provider => {
+  let placementClient: PlacementClient
+
+  const token = 'SOME_TOKEN'
+
+  const placementId = 'placementId'
+  const premisesId = 'premisesId'
+
+  beforeEach(() => {
+    placementClient = new PlacementClient(token)
+  })
+
+  describe('createArrival', () => {
+    it('creates and returns an arrival for a given placement', async () => {
+      const newPlacementArrival = newPlacementArrivalFactory.build()
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to create a lost bed',
+        withRequest: {
+          method: 'POST',
+          path: paths.premises.placements.arrival({ premisesId, placementId }),
+          body: newPlacementArrival,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+        },
+      })
+
+      const result = await placementClient.createArrival(premisesId, placementId, newPlacementArrival)
+
+      expect(result).toEqual({})
+    })
+  })
+})

--- a/server/data/placementClient.ts
+++ b/server/data/placementClient.ts
@@ -1,0 +1,19 @@
+import { Cas1NewArrival } from '@approved-premises/api'
+import RestClient from './restClient'
+import config, { ApiConfig } from '../config'
+import paths from '../paths/api'
+
+export default class PlacementClient {
+  restClient: RestClient
+
+  constructor(token: string) {
+    this.restClient = new RestClient('placementClient', config.apis.approvedPremises as ApiConfig, token)
+  }
+
+  async createArrival(premisesId: string, placementId: string, newPlacementArrival: Cas1NewArrival) {
+    return this.restClient.post({
+      path: paths.premises.placements.arrival({ premisesId, placementId }),
+      data: newPlacementArrival,
+    })
+  }
+}

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -93,6 +93,7 @@ export default {
     placements: {
       index: cas1PremisesSingle.path('space-bookings'),
       show: cas1SpaceBookingSingle,
+      arrival: cas1SpaceBookingSingle.path('arrival'),
     },
     calendar: premisesSingle.path('calendar'),
   },

--- a/server/paths/manage.ts
+++ b/server/paths/manage.ts
@@ -53,6 +53,7 @@ const deprecated = {
 const managePath = path('/manage')
 const premisesPath = managePath.path('premises')
 const singlePremisesPath = premisesPath.path(':premisesId')
+const placementPath = singlePremisesPath.path('placements/:placementId')
 const bookingsPath = singlePremisesPath.path('bookings')
 const bookingPath = bookingsPath.path(':bookingId')
 const bedsPath = singlePremisesPath.path('beds')
@@ -71,7 +72,8 @@ const paths = {
       show: bedsPath.path(':bedId'),
     },
     placements: {
-      show: singlePremisesPath.path('placements').path(':placementId'),
+      show: placementPath,
+      arrival: placementPath.path('arrival'),
     },
   },
 

--- a/server/routes/manage.test.ts
+++ b/server/routes/manage.test.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import {
+  ArrivalsController,
   BedsController,
   BookingExtensionsController,
   BookingsController,
@@ -27,6 +28,7 @@ describe('manage routes', () => {
   )
   const bookingsController: DeepMocked<BookingsController> = createMock<BookingsController>({})
   const premisesController: DeepMocked<PremisesController> = createMock<PremisesController>({})
+  const arrivalsController: DeepMocked<ArrivalsController> = createMock<ArrivalsController>({})
   const placementController: DeepMocked<PlacementController> = createMock<PlacementController>({})
   const bedsController: DeepMocked<BedsController> = createMock<BedsController>({})
   const outOfServiceBedsController: DeepMocked<OutOfServiceBedsController> = createMock<OutOfServiceBedsController>({})
@@ -45,6 +47,7 @@ describe('manage routes', () => {
     updateOutOfServiceBedsController,
     dateChangesController,
     premisesController,
+    arrivalsController,
     cancellationsController,
     redirectController,
     placementController,

--- a/server/routes/manage.ts
+++ b/server/routes/manage.ts
@@ -17,6 +17,7 @@ export default function routes(controllers: Controllers, router: Router, service
     bookingExtensionsController,
     premisesController,
     placementController,
+    arrivalsController,
     bedsController,
     outOfServiceBedsController,
     updateOutOfServiceBedsController,
@@ -123,6 +124,20 @@ export default function routes(controllers: Controllers, router: Router, service
   get(paths.premises.placements.show.pattern, placementController.show(), {
     auditEvent: 'SHOW_PLACEMENT',
     allowedPermissions: ['cas1_space_booking_view'],
+  })
+  get(paths.premises.placements.arrival.pattern, arrivalsController.new(), {
+    auditEvent: 'NEW_ARRIVAL',
+    allowedRoles: ['future_manager'], // TODO: use permissions instead of roles here
+  })
+  post(paths.premises.placements.arrival.pattern, arrivalsController.create(), {
+    auditEvent: 'CREATE_ARRIVAL_SUCCESS',
+    redirectAuditEventSpecs: [
+      {
+        path: paths.premises.placements.arrival.pattern,
+        auditEvent: 'CREATE_ARRIVAL_FAILURE',
+      },
+    ],
+    allowedRoles: ['future_manager'], // TODO: use permissions instead of roles here
   })
 
   // Bookings

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -5,6 +5,7 @@ import { dataAccess } from '../data'
 import AuditService from './auditService'
 import UserService from './userService'
 import PremisesService from './premisesService'
+import PlacementService from './placementService'
 import PersonService from './personService'
 import BookingService from './bookingService'
 import CancellationService from './cancellationService'
@@ -26,6 +27,7 @@ export const services = () => {
   const {
     appealClientBuilder,
     approvedPremisesClientBuilder,
+    placementClientBuilder,
     bookingClientBuilder,
     cas1ReferenceDataClientBuilder,
     referenceDataClientBuilder,
@@ -45,6 +47,7 @@ export const services = () => {
   const userService = new UserService(userClientBuilder, referenceDataClientBuilder)
   const auditService = new AuditService(config.apis.audit as AuditConfig)
   const premisesService = new PremisesService(approvedPremisesClientBuilder)
+  const placementService = new PlacementService(placementClientBuilder)
   const personService = new PersonService(personClient)
   const bookingService = new BookingService(bookingClientBuilder)
   const cancellationService = new CancellationService(bookingClientBuilder, referenceDataClientBuilder)
@@ -67,6 +70,7 @@ export const services = () => {
     userService,
     auditService,
     premisesService,
+    placementService,
     personService,
     bookingService,
     cancellationService,
@@ -89,6 +93,7 @@ export {
   AppealService,
   UserService,
   PremisesService,
+  PlacementService,
   PersonService,
   CancellationService,
   BookingService,

--- a/server/services/placementService.test.ts
+++ b/server/services/placementService.test.ts
@@ -1,0 +1,36 @@
+import PlacementService from './placementService'
+import PlacementClient from '../data/placementClient'
+import { newPlacementArrivalFactory } from '../testutils/factories/newPlacementArrival'
+
+jest.mock('../data/placementClient')
+
+describe('PlacementService', () => {
+  const placementClient = new PlacementClient(null) as jest.Mocked<PlacementClient>
+
+  const placementClientFactory = jest.fn()
+
+  const service = new PlacementService(placementClientFactory)
+
+  const token = 'SOME_TOKEN'
+  const premisesId = 'premisesId'
+  const placementId = 'placementId'
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    placementClientFactory.mockReturnValue(placementClient)
+  })
+
+  describe('createArrival', () => {
+    it('calls the create method of the placement client and returns a response', async () => {
+      const newPlacementArrival = newPlacementArrivalFactory.build()
+
+      placementClient.createArrival.mockResolvedValue({})
+
+      const result = await service.createArrival(token, premisesId, placementId, newPlacementArrival)
+
+      expect(result).toEqual({})
+      expect(placementClientFactory).toHaveBeenCalledWith(token)
+      expect(placementClient.createArrival).toHaveBeenCalledWith(premisesId, placementId, newPlacementArrival)
+    })
+  })
+})

--- a/server/services/placementService.ts
+++ b/server/services/placementService.ts
@@ -1,0 +1,13 @@
+import { Cas1NewArrival } from '@approved-premises/api'
+import type { RestClientBuilder } from '../data'
+import PlacementClient from '../data/placementClient'
+
+export default class PlacementService {
+  constructor(private readonly placementClientFactory: RestClientBuilder<PlacementClient>) {}
+
+  async createArrival(token: string, premisesId: string, placementId: string, newPlacementArrival: Cas1NewArrival) {
+    const placementClient = this.placementClientFactory(token)
+
+    return placementClient.createArrival(premisesId, placementId, newPlacementArrival)
+  }
+}

--- a/server/testutils/factories/cas1SpaceBooking.ts
+++ b/server/testutils/factories/cas1SpaceBooking.ts
@@ -11,7 +11,18 @@ import { DateFormats } from '../../utils/dateUtils'
 
 const addTime = (date: Date): Date => new Date(date.getTime() + faker.number.int({ max: 60 * 60 * 24 * 1000 }))
 
-export default Factory.define<Cas1SpaceBooking>(() => {
+class Cas1SpaceBookingFactory extends Factory<Cas1SpaceBooking> {
+  upcoming() {
+    return this.params({
+      actualArrivalDate: undefined,
+      actualDepartureDate: undefined,
+      departureReason: undefined,
+      departureMoveOnCategory: undefined,
+    })
+  }
+}
+
+export default Cas1SpaceBookingFactory.define(() => {
   const startDateTime = addTime(faker.date.soon({ days: 90 }))
   const endDateTime = addTime(faker.date.soon({ days: 365, refDate: startDateTime }))
   const [actualArrivalDate, actualDepartureDate] = [startDateTime, endDateTime].map(DateFormats.dateObjToIsoDateTime)

--- a/server/testutils/factories/newPlacementArrival.ts
+++ b/server/testutils/factories/newPlacementArrival.ts
@@ -1,0 +1,12 @@
+import { Factory } from 'fishery'
+import { Cas1NewArrival } from '@approved-premises/api'
+import { faker } from '@faker-js/faker'
+import { DateFormats } from '../../utils/dateUtils'
+
+export const newPlacementArrivalFactory = Factory.define<Cas1NewArrival>(() => {
+  const arrivalDateTime = faker.date.recent({ days: 1 })
+  return {
+    expectedDepartureDate: DateFormats.dateObjToIsoDate(faker.date.soon({ days: 365, refDate: arrivalDateTime })),
+    arrivalDateTime: arrivalDateTime.toISOString(),
+  }
+})

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -20,6 +20,7 @@ import {
   daysToWeeksAndDays,
   isToday,
   monthOptions,
+  timeIsValid24hrFormat,
   uiDateOrDateEmptyMessage,
   yearOptions,
 } from './dateUtils'
@@ -149,6 +150,19 @@ describe('DateFormats', () => {
       const result = DateFormats.dateAndTimeInputsToIsoString(obj, 'date')
 
       expect(result.date).toEqual('2022-01-01T12:35:00.000Z')
+    })
+
+    it('pads the time', () => {
+      const obj: ObjectWithDateParts<'date'> = {
+        'date-year': '2022',
+        'date-month': '1',
+        'date-day': '1',
+        'date-time': '8:15',
+      }
+
+      const result = DateFormats.dateAndTimeInputsToIsoString(obj, 'date')
+
+      expect(result.date).toEqual('2022-01-01T08:15:00.000Z')
     })
 
     it('returns an empty string when given empty strings as input', () => {
@@ -494,4 +508,17 @@ describe('daysToWeeksAndDays', () => {
   it('should convert a string value to a number', () => {
     expect(daysToWeeksAndDays('7')).toEqual({ days: 0, weeks: 1 })
   })
+})
+
+describe('timeIsValid24hrFormat', () => {
+  it.each(['08:45', '11:20', '23:59', '00:00'])('returns true if the time is valid, like %s', time => {
+    expect(timeIsValid24hrFormat(time)).toEqual(true)
+  })
+
+  it.each(['8:30pm', '1am', '1.25pm', '08.35', '-1:00', '24:00', '13:78', 'foo', 'no:no', '', '9:4'])(
+    'returns false if the time is invalid, like %s',
+    time => {
+      expect(timeIsValid24hrFormat(time)).toEqual(false)
+    },
+  )
 })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -116,7 +116,7 @@ export class DateFormats {
     const day = `0${dateInputObj[`${key}-day`]}`.slice(-2)
     const month = `0${dateInputObj[`${key}-month`]}`.slice(-2)
     const year = dateInputObj[`${key}-year`]
-    const time = dateInputObj[`${key}-time`]
+    const time = dateInputObj[`${key}-time`] ? `0${dateInputObj[`${key}-time`]}`.slice(-5) : undefined
 
     const o: { [P in K]?: string } = dateInputObj
     if (day && month && year) {
@@ -338,4 +338,8 @@ export const daysToWeeksAndDays = (days: string | number): { days: number; weeks
     days: daysAsNumber - durationWeeks * 7,
     weeks: durationWeeks,
   }
+}
+
+export const timeIsValid24hrFormat = (time: string): Boolean => {
+  return /^(2[0-3]|[01]?[0-9]):[0-5][0-9]$/.test(time)
 }

--- a/server/utils/placements/index.test.ts
+++ b/server/utils/placements/index.test.ts
@@ -13,6 +13,8 @@ import {
 } from '.'
 import { DateFormats } from '../dateUtils'
 
+import paths from '../../paths/manage'
+
 describe('placementUtils', () => {
   describe('actions', () => {
     const userDetails = userDetailsFactory.build({
@@ -29,27 +31,46 @@ describe('placementUtils', () => {
         actualDepartureDate: undefined,
         keyWorkerAllocation: undefined,
       })
+
       expect(actions(placement, userDetails)).toEqual([
         { classes: 'govuk-button--secondary', href: '', text: 'Allocate keyworker' },
-        { classes: 'govuk-button--secondary', href: '', text: 'Record arrival' },
+        {
+          classes: 'govuk-button--secondary',
+          href: paths.premises.placements.arrival({ premisesId: placement.premises.id, placementId: placement.id }),
+          text: 'Record arrival',
+        },
       ])
     })
+
     it('should render record arrival option before arrival', () => {
       const placement = cas1SpaceBookingFactory.build({ actualArrivalDate: undefined, actualDepartureDate: undefined })
+
       expect(actions(placement, userDetails)).toEqual([
-        { classes: 'govuk-button--secondary', href: '', text: 'Edit keyworker' },
-        { classes: 'govuk-button--secondary', href: '', text: 'Record arrival' },
+        {
+          classes: 'govuk-button--secondary',
+          href: '',
+          text: 'Edit keyworker',
+        },
+        {
+          classes: 'govuk-button--secondary',
+          href: paths.premises.placements.arrival({ premisesId: placement.premises.id, placementId: placement.id }),
+          text: 'Record arrival',
+        },
       ])
     })
+
     it('should render record departure option after arrival', () => {
       const placement = cas1SpaceBookingFactory.build({ actualDepartureDate: undefined })
+
       expect(actions(placement, userDetails)).toEqual([
         { classes: 'govuk-button--secondary', href: '', text: 'Edit keyworker' },
         { classes: 'govuk-button--secondary', href: '', text: 'Record departure' },
       ])
     })
+
     it('should allow change of keyworker as only option after departure', () => {
       const placement = cas1SpaceBookingFactory.build()
+
       expect(actions(placement, userDetails)).toEqual([
         { classes: 'govuk-button--secondary', href: '', text: 'Edit keyworker' },
       ])
@@ -61,7 +82,11 @@ describe('placementUtils', () => {
         keyWorkerAllocation: undefined,
       })
       expect(actions(placement, { permissions: ['cas1_space_booking_record_arrival'] } as UserDetails)).toEqual([
-        { classes: 'govuk-button--secondary', href: '', text: 'Record arrival' },
+        {
+          classes: 'govuk-button--secondary',
+          href: paths.premises.placements.arrival({ premisesId: placement.premises.id, placementId: placement.id }),
+          text: 'Record arrival',
+        },
       ])
       expect(actions(placement, { permissions: ['cas1_space_booking_record_departure'] } as UserDetails)).toEqual([
         { classes: 'govuk-button--secondary', href: '', text: 'Record departure' },
@@ -90,6 +115,7 @@ describe('placementUtils', () => {
   describe('getKeyDetail', () => {
     it('should return the key information from the person in the placement', () => {
       const placement = cas1SpaceBookingFactory.build()
+
       expect(getKeyDetail(placement)).toEqual({
         header: { key: '', showKey: false, value: (placement.person as FullPerson).name },
         items: [
@@ -183,13 +209,13 @@ describe('placementUtils', () => {
       })
     })
   })
+
   describe('otherBookings', () => {
     it('should return a list of other bookings from a placement', () => {
       const placementList = [
         { id: 'id1', canonicalArrivalDate: '2024-09-10', canonicalDepartureDate: '2025-06-04' },
         { id: 'id2', canonicalArrivalDate: '2024-09-20', canonicalDepartureDate: '2025-03-20' },
       ]
-
       const placement = cas1SpaceBookingFactory.build({
         premises: { id: '1234' },
         otherBookingsInPremisesForCrn: placementList,

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -20,7 +20,7 @@ export const actions = (placement: Cas1SpaceBooking, user: UserDetails) => {
     out.push({
       text: 'Record arrival',
       classes: 'govuk-button--secondary',
-      href: '',
+      href: paths.premises.placements.arrival({ premisesId: placement.premises.id, placementId: placement.id }),
     })
   } else if (!placement.actualDepartureDate && hasPermission(user, ['cas1_space_booking_record_departure'])) {
     out.push({

--- a/server/utils/premises/index.ts
+++ b/server/utils/premises/index.ts
@@ -145,7 +145,10 @@ export const placementTableHeader = (
 export const placementTableRows = (premisesId: string, placements: Array<Cas1SpaceBookingSummary>): Array<TableRow> =>
   placements.map(({ id, person, tier, canonicalArrivalDate, canonicalDepartureDate, keyWorkerAllocation }) => [
     htmlValue(
-      `<a href="${managePaths.premises.placements.show({ premisesId, placementId: id })}" data-cy-id="${id}">${laoName(person as unknown as FullPerson)}, ${person.crn}</a>`,
+      `<a href="${managePaths.premises.placements.show({
+        premisesId,
+        placementId: id,
+      })}" data-cy-id="${id}">${laoName(person as unknown as FullPerson)}, ${person.crn}</a>`,
     ),
     htmlValue(getTierOrBlank(tier)),
     textValue(DateFormats.isoDateToUIDate(canonicalArrivalDate, { format: 'short' })),

--- a/server/views/_messages.njk
+++ b/server/views/_messages.njk
@@ -1,21 +1,21 @@
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% if infoMessages %}
-  {% for message in infoMessages %}
-    {{ govukNotificationBanner({
-      titleText: 'Important',
-      html: '<div class="govuk-heading-s">' + message + '</div>',
-      titleId: 'info-title'
-    }) }}
-  {% endfor %}
+    {% for message in infoMessages %}
+        {{ govukNotificationBanner({
+            titleText: 'Important',
+            html: '<div class="govuk-heading-s">' + message + '</div>',
+            titleId: 'info-title'
+        }) }}
+    {% endfor %}
 {% endif %}
 
 {% if successMessages %}
-  {% for message in successMessages %}
-    {{ govukNotificationBanner({
-      html: '<h3 class="govuk-!-margin-top-2">' + message + '</h3>',
-      type: 'success',
-      titleId: 'success-title'
-    }) }}
-  {% endfor %}
+    {% for message in successMessages %}
+        {{ govukNotificationBanner({
+            html: '<h3 class="govuk-notification-banner__heading">' + message + '</h3>',
+            type: 'success',
+            titleId: 'success-title'
+        }) }}
+    {% endfor %}
 {% endif %}

--- a/server/views/manage/premises/placements/arrival.njk
+++ b/server/views/manage/premises/placements/arrival.njk
@@ -1,0 +1,72 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        text: "Back",
+        href: paths.premises.placements.show({ premisesId: placement.premises.id, placementId: placement.id })
+    }) }}
+{% endblock %}
+
+{% block content %}
+    <form action="{{ paths.premises.placements.arrival({ premisesId: placement.premises.id, placementId: placement.id }) }}"
+          method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+        <input type="hidden" name="expectedDepartureDate" value="{{ placement.expectedDepartureDate }}" />
+
+        {{ showErrorSummary(errorSummary, errorTitle) }}
+
+        <h1 class="govuk-heading-l">Record someone as arrived</h1>
+
+        {{ govukSummaryList({
+            rows: [{
+                key: {
+                    text: "Expected arrival date"
+                },
+                value: {
+                    text: formatDate(placement.expectedArrivalDate)
+                }
+            }]
+        }) }}
+
+        {{ govukDateInput({
+            id: "arrivalDateTime",
+            namePrefix: "arrivalDateTime",
+            items: dateFieldValues('arrivalDateTime', errors),
+            errorMessage: errors.arrivalDateTime,
+            fieldset: {
+                legend: {
+                    text: "What is the arrival date?",
+                    classes: "govuk-fieldset__legend--m"
+                }
+            }
+        }) }}
+
+        {{ govukInput({
+            label: {
+                text: 'What is the time of arrival?',
+                classes: 'govuk-fieldset__legend--m'
+            },
+            hint: {
+                text: 'For example, 09:30 or 14:55.'
+            },
+            classes: 'govuk-input--width-5',
+            id: 'arrivalTime',
+            name: 'arrivalTime',
+            value: arrivalTime,
+            errorMessage: errors.arrivalTime
+        }) }}
+
+        {{ govukButton({
+            text: "Submit",
+            preventDoubleClick: true
+        }) }}
+    </form>
+{% endblock %}

--- a/server/views/manage/premises/placements/show.njk
+++ b/server/views/manage/premises/placements/show.njk
@@ -20,16 +20,18 @@
 {% endblock %}
 
 {% block header %}
-  {{ super() }}
-  {{ keyDetails(PlacementUtils.getKeyDetail(placement)) }}
+    {{ super() }}
+    {{ keyDetails(PlacementUtils.getKeyDetail(placement)) }}
 {% endblock %}
 
 {% set titleHtml %}
     <span class="govuk-caption-xl">{{ placement.premises.name }}</span>
-    <h1>{{pageHeading}}</h1>
+    <h1>{{ pageHeading }}</h1>
 {% endset %}
 
 {% block content %}
+
+    {% include "../../../_messages.njk" %}
 
     {{ mojIdentityBar({
         title: {


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1411

# Changes in this PR

Implements the 'Record arrival' flow from the placement screen. For now this uses the standard, GOVUK-style date input field -- the datepicker will be implemented in a separate ticket. The confirmation banner used is also consistent with the rest of the service and uses the GOVUK version, rather than the MoJ version shown in the design -- this has been agreed with the designer and will be reviewed service-wide at a later stage.

The 'Time of arrival' field is validated, and expects a valid 24hr-format time, with or without leading zero for the hours.

## Screenshots of UI changes

### Arrival form

<img width="545" alt="Screenshot 2024-11-07 at 10 17 17" src="https://github.com/user-attachments/assets/42386565-f477-483f-a230-f88ec3e0f151">

---

### Arrival form with 'empty' errors

<img width="962" alt="Screenshot 2024-11-07 at 10 17 33" src="https://github.com/user-attachments/assets/382f554a-87ed-4dba-ad07-1ffeb0fe05cd">

---

### Arrival form with 'invalid' errors

<img width="1002" alt="Screenshot 2024-11-07 at 10 18 14" src="https://github.com/user-attachments/assets/8f570856-9ac5-4b8b-86c6-e9bd91992836">

---

### Confirmation on placement screen

<img width="994" alt="Screenshot 2024-11-07 at 10 18 59" src="https://github.com/user-attachments/assets/0870dc2f-006f-4381-8fc8-00b7304bcc8e">
