### PR TITLE
APS-1413 Assign keyworker

### DIFF
--- a/integration_tests/mockApis/premises.ts
+++ b/integration_tests/mockApis/premises.ts
@@ -3,6 +3,7 @@ import type {
   ExtendedPremisesSummary,
   Premises,
   ApprovedPremisesSummary as PremisesSummary,
+  StaffMember,
 } from '@approved-premises/api'
 
 import { stubFor } from './setup'
@@ -69,9 +70,25 @@ const stubSinglePremises = (premises: Premises) =>
     },
   })
 
+const stubPremisesStaffMembers = (args: { premisesId: string; staffMembers: Array<StaffMember> }) =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: paths.premises.staffMembers.index({ premisesId: args.premisesId }),
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: args.staffMembers,
+    },
+  })
+
 export default {
   stubAllPremises,
   stubCas1AllPremises,
   stubPremisesSummary,
   stubSinglePremises,
+  stubPremisesStaffMembers,
 }

--- a/integration_tests/mockApis/spaceBooking.ts
+++ b/integration_tests/mockApis/spaceBooking.ts
@@ -79,4 +79,18 @@ export default {
         status: 200,
       },
     }),
+
+  stubSpaceBookingAssignKeyworker: placement =>
+    stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: paths.premises.placements.keyworker({
+          premisesId: placement.premises.id,
+          placementId: placement.id,
+        }),
+      },
+      response: {
+        status: 200,
+      },
+    }),
 }

--- a/integration_tests/pages/manage/placementShow.ts
+++ b/integration_tests/pages/manage/placementShow.ts
@@ -27,16 +27,16 @@ export default class PlacementShowPage extends Page {
   }
 
   shouldShowSummaryInformation(placement: Cas1SpaceBooking): void {
-    const removeGreyRows = row => !row.key.html
-    this.shouldContainSummaryListItems(placementSummary(placement).rows.filter(removeGreyRows))
-    this.shouldContainSummaryListItems(arrivalInformation(placement).rows.filter(removeGreyRows))
-    this.shouldContainSummaryListItems(departureInformation(placement).rows.filter(removeGreyRows))
+    const removeHiddenRows = row => row.key
+    this.shouldContainSummaryListItems(placementSummary(placement).rows.filter(removeHiddenRows))
+    this.shouldContainSummaryListItems(arrivalInformation(placement).rows.filter(removeHiddenRows))
+    this.shouldContainSummaryListItems(departureInformation(placement).rows.filter(removeHiddenRows))
   }
 
-  shouldShowGreyRows(placement: Cas1SpaceBooking, rows: Array<string>): void {
+  shouldNotShowUnpopulatedRows(placement: Cas1SpaceBooking, rows: Array<string>): void {
     rows.forEach(title => {
-      cy.contains(title).closest('.govuk-summary-list__row').should('contain', '-')
-      cy.contains(title).closest('.govuk-summary-list__row').should('contain', '-')
+      cy.contains(title).should('not.exist')
+      cy.contains(title).should('not.exist')
     })
   }
 

--- a/integration_tests/pages/manage/placementShow.ts
+++ b/integration_tests/pages/manage/placementShow.ts
@@ -36,7 +36,6 @@ export default class PlacementShowPage extends Page {
   shouldNotShowUnpopulatedRows(placement: Cas1SpaceBooking, rows: Array<string>): void {
     rows.forEach(title => {
       cy.contains(title).should('not.exist')
-      cy.contains(title).should('not.exist')
     })
   }
 

--- a/integration_tests/pages/manage/placements/keyworker.ts
+++ b/integration_tests/pages/manage/placements/keyworker.ts
@@ -1,9 +1,11 @@
-import type { Cas1SpaceBooking } from '@approved-premises/api'
+import type { Cas1SpaceBooking, StaffMember } from '@approved-premises/api'
 import Page from '../../page'
-// import { DateFormats } from '../../../../server/utils/dateUtils'
 
 export class KeyworkerAssignmentPage extends Page {
-  constructor(private readonly placement: Cas1SpaceBooking) {
+  constructor(
+    private readonly placement: Cas1SpaceBooking,
+    private readonly staffMembers: Array<StaffMember>,
+  ) {
     super('Edit keyworker details')
   }
 
@@ -20,7 +22,7 @@ export class KeyworkerAssignmentPage extends Page {
     cy.get('.govuk-error-summary__list').should('contain', 'You must select a keyworker')
   }
 
-  completeForm(keyworkerName: string): void {
-    this.getSelectInputByIdAndSelectAnEntry('keyworkerId', keyworkerName)
+  completeForm(): void {
+    this.getSelectInputByIdAndSelectAnEntry('staffCode', this.staffMembers[1].name)
   }
 }

--- a/integration_tests/pages/manage/placements/keyworker.ts
+++ b/integration_tests/pages/manage/placements/keyworker.ts
@@ -1,0 +1,26 @@
+import type { Cas1SpaceBooking } from '@approved-premises/api'
+import Page from '../../page'
+// import { DateFormats } from '../../../../server/utils/dateUtils'
+
+export class KeyworkerAssignmentPage extends Page {
+  constructor(private readonly placement: Cas1SpaceBooking) {
+    super('Edit keyworker details')
+  }
+
+  shouldShowKeyworkerList(placement: Cas1SpaceBooking): void {
+    this.shouldContainSummaryListItems([
+      {
+        key: { text: 'Keyworker' },
+        value: { text: placement.keyWorkerAllocation?.keyWorker?.name },
+      },
+    ])
+  }
+
+  shouldShowError(): void {
+    cy.get('.govuk-error-summary__list').should('contain', 'You must select a keyworker')
+  }
+
+  completeForm(keyworkerName: string): void {
+    this.getSelectInputByIdAndSelectAnEntry('keyworkerId', keyworkerName)
+  }
+}

--- a/integration_tests/tests/manage/placements.cy.ts
+++ b/integration_tests/tests/manage/placements.cy.ts
@@ -9,7 +9,6 @@ context('Placements', () => {
   describe('show', () => {
     const setup = (permissions: Array<ApprovedPremisesUserPermission>, placementParameters = {}) => {
       cy.task('reset')
-      // Given I am logged in with permission to view a placement
       signIn(['future_manager'], permissions)
       const placement = cas1SpaceBookingFactory.build(placementParameters)
       cy.task('stubSpaceBookingShow', placement)
@@ -17,8 +16,9 @@ context('Placements', () => {
         placement,
       }
     }
+
     it('should show a placement', () => {
-      // Given I am logged in with permission to view a placement and a mocked placement
+      // Given that I am logged in with permission to view a placement and a mocked placement
       const { placement } = setup(['cas1_space_booking_view'])
       // When I visit the placement page
       const placementShowPage = PlacementShowPage.visit(placement)
@@ -38,7 +38,7 @@ context('Placements', () => {
       // When I visit the placement page
       const placementShowPage = PlacementShowPage.visit(placement)
       // Then I should see greyed rows in the page tables
-      placementShowPage.shouldShowGreyRows(placement, ['Actual arrival date', 'Actual departure date'])
+      placementShowPage.shouldNotShowUnpopulatedRows(placement, ['Actual arrival date', 'Actual departure date'])
       placementShowPage.shouldShowSummaryInformation(placement)
     })
 

--- a/integration_tests/tests/manage/placements/keyworker.cy.ts
+++ b/integration_tests/tests/manage/placements/keyworker.cy.ts
@@ -28,7 +28,7 @@ context('Keyworker', () => {
     placementPage.clickAction('Assign keyworker')
 
     // Then I should open the keyworker assignment page
-    const page = new KeyworkerAssignmentPage(placement)
+    const page = new KeyworkerAssignmentPage(placement, staffMembers)
     page.shouldShowKeyworkerList(placement)
 
     // When I submit the form without selecting a keyworker
@@ -38,7 +38,7 @@ context('Keyworker', () => {
     page.shouldShowError()
 
     // When I select a keyworker and submit the form
-    page.completeForm(staffMembers[1].name)
+    page.completeForm()
     page.clickSubmit()
 
     // Then I should be shown the placement page with a confirmation message

--- a/integration_tests/tests/manage/placements/keyworker.cy.ts
+++ b/integration_tests/tests/manage/placements/keyworker.cy.ts
@@ -1,0 +1,48 @@
+import { signIn } from '../../signIn'
+import { KeyworkerAssignmentPage } from '../../../pages/manage/placements/keyworker'
+import {
+  cas1PremisesSummaryFactory,
+  cas1SpaceBookingFactory,
+  staffMemberFactory,
+} from '../../../../server/testutils/factories'
+import { PlacementShowPage } from '../../../pages/manage'
+
+context('Keyworker', () => {
+  it('Assigns a keyworker to a placement', () => {
+    const premises = cas1PremisesSummaryFactory.build()
+    const placement = cas1SpaceBookingFactory.build({ premises })
+    const staffMembers = staffMemberFactory.buildList(5, { keyWorker: true })
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSpaceBookingShow', placement)
+    cy.task('stubPremisesStaffMembers', { premisesId: premises.id, staffMembers })
+    cy.task('stubSpaceBookingAssignKeyworker', placement)
+
+    // Given I am logged in with the correct permissions
+    signIn([], ['cas1_space_booking_view', 'cas1_space_booking_record_keyworker'])
+
+    // And I am on the placement page
+    let placementPage = PlacementShowPage.visit(placement)
+
+    // When I click on option to assign a keyworker
+    placementPage.clickAction('Assign keyworker')
+
+    // Then I should open the keyworker assignment page
+    const page = new KeyworkerAssignmentPage(placement)
+    page.shouldShowKeyworkerList(placement)
+
+    // When I submit the form without selecting a keyworker
+    page.clickSubmit()
+
+    // Then I should see an error message
+    page.shouldShowError()
+
+    // When I select a keyworker and submit the form
+    page.completeForm(staffMembers[1].name)
+    page.clickSubmit()
+
+    // Then I should be shown the placement page with a confirmation message
+    placementPage = new PlacementShowPage(placement)
+    placementPage.shouldShowBanner('Keyworker assigned')
+  })
+})

--- a/server/@types/shared/models/Cas1SpaceBookingSummaryStatus.ts
+++ b/server/@types/shared/models/Cas1SpaceBookingSummaryStatus.ts
@@ -1,0 +1,5 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type Cas1SpaceBookingSummaryStatus = 'arrivingWithin6Weeks' | 'arrivingWithin2Weeks' | 'arrivingToday' | 'overdueArrival' | 'arrived' | 'notArrived' | 'departingWithin2Weeks' | 'departingToday' | 'overdueDeparture' | 'departed';

--- a/server/controllers/manage/index.ts
+++ b/server/controllers/manage/index.ts
@@ -12,6 +12,7 @@ import BedsController from './premises/bedsController'
 import OutOfServiceBedsController from './outOfServiceBedsController'
 import UpdateOutOfServiceBedsController from './updateOutOfServiceBedsController'
 import ArrivalsController from './premises/placements/arrivalsController'
+import KeyworkerController from './premises/placements/keyworkerController'
 
 export const controllers = (services: Services) => {
   const premisesController = new PremisesController(services.premisesService, services.apAreaService)
@@ -29,6 +30,7 @@ export const controllers = (services: Services) => {
   const dateChangesController = new DateChangesController(services.bookingService)
   const placementController = new PlacementController(services.premisesService)
   const arrivalsController = new ArrivalsController(services.premisesService, services.placementService)
+  const keyworkerController = new KeyworkerController(services.premisesService, services.placementService)
 
   return {
     premisesController,
@@ -41,13 +43,15 @@ export const controllers = (services: Services) => {
     dateChangesController,
     cancellationsController,
     placementController,
+    keyworkerController,
   }
 }
 
 export {
   PremisesController,
-  ArrivalsController,
   PlacementController,
+  ArrivalsController,
+  KeyworkerController,
   BedsController,
   OutOfServiceBedsController,
   UpdateOutOfServiceBedsController,

--- a/server/controllers/manage/premises/placements/keyworkerController.test.ts
+++ b/server/controllers/manage/premises/placements/keyworkerController.test.ts
@@ -1,0 +1,117 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+import type { ErrorsAndUserInput } from '@approved-premises/ui'
+import { when } from 'jest-when'
+import KeyworkerController from './keyworkerController'
+import { spaceBookingFactory } from '../../../../testutils/factories'
+import { PremisesService } from '../../../../services'
+import * as validationUtils from '../../../../utils/validation'
+import paths from '../../../../paths/manage'
+import PlacementService from '../../../../services/placementService'
+import { ValidationError } from '../../../../utils/errors'
+
+describe('keyworkerController', () => {
+  const token = 'SOME_TOKEN'
+
+  let request: DeepMocked<Request>
+  const response: DeepMocked<Response> = createMock<Response>()
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>()
+
+  const premisesService = createMock<PremisesService>()
+  const placementService = createMock<PlacementService>()
+  const keyworkerController = new KeyworkerController(premisesService, placementService)
+
+  const premisesId = 'premises-id'
+  const placement = spaceBookingFactory.build()
+  const testKeyworkerId = 'TestId'
+  const uiPlacementPagePath = paths.premises.placements.show({ premisesId, placementId: placement.id })
+  const uiKeyworkerPagePath = paths.premises.placements.keyworker({ premisesId, placementId: placement.id })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    premisesService.getPlacement.mockResolvedValue(placement)
+    request = createMock<Request>({ user: { token }, params: { premisesId, placementId: placement.id } })
+
+    jest.spyOn(validationUtils, 'fetchErrorsAndUserInput')
+    jest.spyOn(validationUtils, 'catchValidationErrorOrPropogate').mockReturnValue(undefined)
+  })
+
+  describe('new', () => {
+    it('should render the keyworker assignement form with a list of staff', async () => {
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+      when(validationUtils.fetchErrorsAndUserInput).calledWith(request).mockReturnValue(errorsAndUserInput)
+
+      const requestHandler = keyworkerController.new()
+
+      await requestHandler(request, response, next)
+
+      expect(premisesService.getPlacement).toHaveBeenCalledWith({ token, premisesId, placementId: placement.id })
+      expect(response.render).toHaveBeenCalledWith('manage/premises/placements/keyworker', {
+        placement,
+        currentKeyworkerName: placement.keyWorkerAllocation?.keyWorker?.name,
+        errors: errorsAndUserInput.errors,
+        errorSummary: errorsAndUserInput.errorSummary,
+        errorTitle: errorsAndUserInput.errorTitle,
+        ...errorsAndUserInput.userInput,
+      })
+    })
+  })
+
+  describe('assign', () => {
+    it('assigns the keyworker and returns to the placement details page', async () => {
+      const requestHandler = keyworkerController.assign()
+      request.body = { keyworkerId: testKeyworkerId }
+
+      await requestHandler(request, response, next)
+
+      expect(placementService.assignKeyworker).toHaveBeenCalledWith(token, premisesId, placement.id, {
+        staffCode: testKeyworkerId,
+      })
+      expect(request.flash).toHaveBeenCalledWith('success', 'Keyworker assigned')
+      expect(response.redirect).toHaveBeenCalledWith(uiPlacementPagePath)
+    })
+
+    it('returns error if page submitted without keyworker selected', async () => {
+      const requestHandler = keyworkerController.assign()
+
+      request.body = {}
+
+      await requestHandler(request, response, next)
+
+      expect(placementService.assignKeyworker).not.toHaveBeenCalled()
+      expect(validationUtils.catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+        request,
+        response,
+        new ValidationError({}),
+        uiKeyworkerPagePath,
+      )
+
+      const errorData = (validationUtils.catchValidationErrorOrPropogate as jest.Mock).mock.lastCall[2].data
+
+      expect(errorData).toEqual({
+        keyworkerId: 'You must select a keyworker',
+      })
+    })
+
+    describe('when errors are raised by the API', () => {
+      it('should call catchValidationErrorOrPropogate with a standard error', async () => {
+        const requestHandler = keyworkerController.assign()
+        request.body = { keyworkerId: testKeyworkerId }
+
+        const err = new Error()
+
+        placementService.assignKeyworker.mockRejectedValue(err)
+
+        await requestHandler(request, response, next)
+
+        expect(validationUtils.catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+          request,
+          response,
+          err,
+          uiKeyworkerPagePath,
+        )
+      })
+    })
+  })
+})

--- a/server/controllers/manage/premises/placements/keyworkerController.test.ts
+++ b/server/controllers/manage/premises/placements/keyworkerController.test.ts
@@ -23,7 +23,7 @@ describe('keyworkerController', () => {
 
   const premisesId = 'premises-id'
   const placement = spaceBookingFactory.build()
-  const testKeyworkerId = 'TestId'
+  const testStaffCode = 'TestId'
   const uiPlacementPagePath = paths.premises.placements.show({ premisesId, placementId: placement.id })
   const uiKeyworkerPagePath = paths.premises.placements.keyworker({ premisesId, placementId: placement.id })
 
@@ -61,12 +61,12 @@ describe('keyworkerController', () => {
   describe('assign', () => {
     it('assigns the keyworker and returns to the placement details page', async () => {
       const requestHandler = keyworkerController.assign()
-      request.body = { keyworkerId: testKeyworkerId }
+      request.body = { staffCode: testStaffCode }
 
       await requestHandler(request, response, next)
 
       expect(placementService.assignKeyworker).toHaveBeenCalledWith(token, premisesId, placement.id, {
-        staffCode: testKeyworkerId,
+        staffCode: testStaffCode,
       })
       expect(request.flash).toHaveBeenCalledWith('success', 'Keyworker assigned')
       expect(response.redirect).toHaveBeenCalledWith(uiPlacementPagePath)
@@ -90,14 +90,14 @@ describe('keyworkerController', () => {
       const errorData = (validationUtils.catchValidationErrorOrPropogate as jest.Mock).mock.lastCall[2].data
 
       expect(errorData).toEqual({
-        keyworkerId: 'You must select a keyworker',
+        staffCode: 'You must select a keyworker',
       })
     })
 
     describe('when errors are raised by the API', () => {
       it('should call catchValidationErrorOrPropogate with a standard error', async () => {
         const requestHandler = keyworkerController.assign()
-        request.body = { keyworkerId: testKeyworkerId }
+        request.body = { staffCode: testStaffCode }
 
         const err = new Error()
 

--- a/server/controllers/manage/premises/placements/keyworkerController.ts
+++ b/server/controllers/manage/premises/placements/keyworkerController.ts
@@ -1,0 +1,68 @@
+import { type Request, RequestHandler, type Response } from 'express'
+import { Cas1AssignKeyWorker, StaffMember } from '@approved-premises/api'
+import { PlacementService, PremisesService } from '../../../../services'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../../utils/validation'
+import managePaths from '../../../../paths/manage'
+import { ValidationError } from '../../../../utils/errors'
+
+export default class KeyworkerController {
+  constructor(
+    private readonly premisesService: PremisesService,
+    private readonly placementService: PlacementService,
+  ) {}
+
+  new(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { token } = req.user
+      const { premisesId, placementId } = req.params
+      const { errors, errorSummary, userInput, errorTitle } = fetchErrorsAndUserInput(req)
+
+      const placement = await this.premisesService.getPlacement({ token, premisesId, placementId })
+      const staffList: Array<StaffMember> = await this.premisesService.getStaff(token, premisesId)
+
+      return res.render('manage/premises/placements/keyworker', {
+        currentKeyworkerName: placement.keyWorkerAllocation?.keyWorker?.name || 'Not assigned',
+        staffList,
+        placement,
+        errors,
+        errorSummary,
+        errorTitle,
+        ...userInput,
+      })
+    }
+  }
+
+  assign(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, placementId } = req.params
+      try {
+        const { keyworkerId } = req.body
+
+        if (!keyworkerId) {
+          throw new ValidationError({
+            keyworkerId: 'You must select a keyworker',
+          })
+        }
+
+        const keyworkerAssignment: Cas1AssignKeyWorker = {
+          staffCode: keyworkerId,
+        }
+
+        await this.placementService.assignKeyworker(req.user.token, premisesId, placementId, keyworkerAssignment)
+
+        req.flash('success', 'Keyworker assigned')
+        return res.redirect(managePaths.premises.placements.show({ premisesId, placementId }))
+      } catch (error) {
+        return catchValidationErrorOrPropogate(
+          req,
+          res,
+          error as Error,
+          managePaths.premises.placements.keyworker({
+            premisesId,
+            placementId,
+          }),
+        )
+      }
+    }
+  }
+}

--- a/server/controllers/manage/premises/placements/keyworkerController.ts
+++ b/server/controllers/manage/premises/placements/keyworkerController.ts
@@ -1,5 +1,5 @@
 import { type Request, RequestHandler, type Response } from 'express'
-import { Cas1AssignKeyWorker, StaffMember } from '@approved-premises/api'
+import { StaffMember } from '@approved-premises/api'
 import { PlacementService, PremisesService } from '../../../../services'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../../utils/validation'
 import managePaths from '../../../../paths/manage'
@@ -36,19 +36,15 @@ export default class KeyworkerController {
     return async (req: Request, res: Response) => {
       const { premisesId, placementId } = req.params
       try {
-        const { keyworkerId } = req.body
+        const { staffCode } = req.body
 
-        if (!keyworkerId) {
+        if (!staffCode) {
           throw new ValidationError({
-            keyworkerId: 'You must select a keyworker',
+            staffCode: 'You must select a keyworker',
           })
         }
 
-        const keyworkerAssignment: Cas1AssignKeyWorker = {
-          staffCode: keyworkerId,
-        }
-
-        await this.placementService.assignKeyworker(req.user.token, premisesId, placementId, keyworkerAssignment)
+        await this.placementService.assignKeyworker(req.user.token, premisesId, placementId, { staffCode })
 
         req.flash('success', 'Keyworker assigned')
         return res.redirect(managePaths.premises.placements.show({ premisesId, placementId }))

--- a/server/data/placementClient.test.ts
+++ b/server/data/placementClient.test.ts
@@ -1,7 +1,7 @@
 import PlacementClient from './placementClient'
 import paths from '../paths/api'
 import { describeCas1NamespaceClient } from '../testutils/describeClient'
-import { newPlacementArrivalFactory } from '../testutils/factories/newPlacementArrival'
+import { cas1AssignKeyWorkerFactory, newPlacementArrivalFactory } from '../testutils/factories'
 
 describeCas1NamespaceClient('PlacementClient', provider => {
   let placementClient: PlacementClient
@@ -36,6 +36,32 @@ describeCas1NamespaceClient('PlacementClient', provider => {
       })
 
       const result = await placementClient.createArrival(premisesId, placementId, newPlacementArrival)
+
+      expect(result).toEqual({})
+    })
+  })
+
+  describe('assignKeyworker', () => {
+    it('assigns a keyworker to a given placement', async () => {
+      const keyworkerAssignment = cas1AssignKeyWorkerFactory.build()
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to assign a keyworker to a placement',
+        withRequest: {
+          method: 'POST',
+          path: paths.premises.placements.keyworker({ premisesId, placementId }),
+          body: keyworkerAssignment,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+        },
+      })
+
+      const result = await placementClient.assignKeyworker(premisesId, placementId, keyworkerAssignment)
 
       expect(result).toEqual({})
     })

--- a/server/data/placementClient.ts
+++ b/server/data/placementClient.ts
@@ -1,4 +1,4 @@
-import { Cas1NewArrival } from '@approved-premises/api'
+import { Cas1AssignKeyWorker, Cas1NewArrival } from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -14,6 +14,13 @@ export default class PlacementClient {
     return this.restClient.post({
       path: paths.premises.placements.arrival({ premisesId, placementId }),
       data: newPlacementArrival,
+    })
+  }
+
+  async assignKeyworker(premisesId: string, placementId: string, keyworkerAssignment: Cas1AssignKeyWorker) {
+    return this.restClient.post({
+      path: paths.premises.placements.keyworker({ premisesId, placementId }),
+      data: keyworkerAssignment,
     })
   }
 }

--- a/server/data/premisesClient.test.ts
+++ b/server/data/premisesClient.test.ts
@@ -1,4 +1,4 @@
-import { bedDetailFactory, bedSummaryFactory, premisesFactory } from '../testutils/factories'
+import { bedDetailFactory, bedSummaryFactory, premisesFactory, staffMemberFactory } from '../testutils/factories'
 import PremisesClient from './premisesClient'
 import paths from '../paths/api'
 import describeClient from '../testutils/describeClient'
@@ -61,6 +61,32 @@ describeClient('PremisesClient', provider => {
 
       const output = await premisesClient.getBed(premises.id, bed.id)
       expect(output).toEqual(bed)
+    })
+  })
+
+  describe('getStaff', () => {
+    it('should return a list of staff for a given premises', async () => {
+      const premises = premisesFactory.build()
+      const staffList = staffMemberFactory.buildList(5)
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get a list of staff for a premises',
+        withRequest: {
+          method: 'GET',
+          path: paths.premises.staffMembers.index({ premisesId: premises.id }),
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: staffList,
+        },
+      })
+
+      const output = await premisesClient.getStaff(premises.id)
+      expect(output).toEqual(staffList)
     })
   })
 })

--- a/server/data/premisesClient.ts
+++ b/server/data/premisesClient.ts
@@ -7,6 +7,7 @@ import type {
   Cas1SpaceBookingSummary,
   Cas1SpaceBookingSummarySortField,
   SortDirection,
+  StaffMember,
 } from '@approved-premises/api'
 import type { PaginatedResponse, PremisesFilters } from '@approved-premises/ui'
 import RestClient from './restClient'
@@ -59,5 +60,11 @@ export default class PremisesClient {
     return (await this.restClient.get({
       path: paths.premises.placements.show(args),
     })) as Cas1SpaceBooking
+  }
+
+  async getStaff(premisesId: string): Promise<Array<StaffMember>> {
+    return (await this.restClient.get({
+      path: paths.premises.staffMembers.index({ premisesId }),
+    })) as Array<StaffMember>
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -94,6 +94,7 @@ export default {
       index: cas1PremisesSingle.path('space-bookings'),
       show: cas1SpaceBookingSingle,
       arrival: cas1SpaceBookingSingle.path('arrival'),
+      keyworker: cas1SpaceBookingSingle.path('keyworker'),
     },
     calendar: premisesSingle.path('calendar'),
   },

--- a/server/paths/manage.ts
+++ b/server/paths/manage.ts
@@ -53,7 +53,7 @@ const deprecated = {
 const managePath = path('/manage')
 const premisesPath = managePath.path('premises')
 const singlePremisesPath = premisesPath.path(':premisesId')
-const singlePlacementPath = singlePremisesPath.path('placements/:placementId')
+const placementPath = singlePremisesPath.path('placements/:placementId')
 const bookingsPath = singlePremisesPath.path('bookings')
 const bookingPath = bookingsPath.path(':bookingId')
 const bedsPath = singlePremisesPath.path('beds')
@@ -72,10 +72,10 @@ const paths = {
       show: bedsPath.path(':bedId'),
     },
     placements: {
-      show: singlePlacementPath,
-      arrival: singlePlacementPath.path('arrival'),
-      departure: singlePlacementPath.path('departure'),
-      keyworker: singlePlacementPath.path('keyworker'),
+      show: placementPath,
+      arrival: placementPath.path('arrival'),
+      departure: placementPath.path('departure'),
+      keyworker: placementPath.path('keyworker'),
     },
   },
 

--- a/server/paths/manage.ts
+++ b/server/paths/manage.ts
@@ -53,7 +53,7 @@ const deprecated = {
 const managePath = path('/manage')
 const premisesPath = managePath.path('premises')
 const singlePremisesPath = premisesPath.path(':premisesId')
-const placementPath = singlePremisesPath.path('placements/:placementId')
+const singlePlacementPath = singlePremisesPath.path('placements/:placementId')
 const bookingsPath = singlePremisesPath.path('bookings')
 const bookingPath = bookingsPath.path(':bookingId')
 const bedsPath = singlePremisesPath.path('beds')
@@ -72,8 +72,10 @@ const paths = {
       show: bedsPath.path(':bedId'),
     },
     placements: {
-      show: placementPath,
-      arrival: placementPath.path('arrival'),
+      show: singlePlacementPath,
+      arrival: singlePlacementPath.path('arrival'),
+      departure: singlePlacementPath.path('departure'),
+      keyworker: singlePlacementPath.path('keyworker'),
     },
   },
 

--- a/server/routes/manage.test.ts
+++ b/server/routes/manage.test.ts
@@ -5,6 +5,7 @@ import {
   BedsController,
   BookingExtensionsController,
   BookingsController,
+  KeyworkerController,
   OutOfServiceBedsController,
   PlacementController,
   PremisesController,
@@ -38,6 +39,7 @@ describe('manage routes', () => {
 
   const cancellationsController: DeepMocked<CancellationsController> = createMock<CancellationsController>({})
   const redirectController: DeepMocked<RedirectController> = createMock<RedirectController>({})
+  const keyworkerController: DeepMocked<KeyworkerController> = createMock<KeyworkerController>({})
 
   const controllers: DeepMocked<Controllers> = createMock<Controllers>({
     bookingExtensionsController,
@@ -51,6 +53,7 @@ describe('manage routes', () => {
     cancellationsController,
     redirectController,
     placementController,
+    keyworkerController,
   })
   const services: DeepMocked<Services> = createMock<Services>({})
 

--- a/server/routes/manage.ts
+++ b/server/routes/manage.ts
@@ -23,6 +23,7 @@ export default function routes(controllers: Controllers, router: Router, service
     updateOutOfServiceBedsController,
     cancellationsController,
     redirectController,
+    keyworkerController,
   } = controllers
 
   // Deprecated paths, redirect to v2 equivalent
@@ -127,17 +128,31 @@ export default function routes(controllers: Controllers, router: Router, service
   })
   get(paths.premises.placements.arrival.pattern, arrivalsController.new(), {
     auditEvent: 'NEW_ARRIVAL',
-    allowedRoles: ['future_manager'], // TODO: use permissions instead of roles here
+    allowedPermissions: ['cas1_space_booking_record_arrival'],
   })
   post(paths.premises.placements.arrival.pattern, arrivalsController.create(), {
     auditEvent: 'CREATE_ARRIVAL_SUCCESS',
+    allowedPermissions: ['cas1_space_booking_record_arrival'],
     redirectAuditEventSpecs: [
       {
         path: paths.premises.placements.arrival.pattern,
         auditEvent: 'CREATE_ARRIVAL_FAILURE',
       },
     ],
-    allowedRoles: ['future_manager'], // TODO: use permissions instead of roles here
+  })
+  get(paths.premises.placements.keyworker.pattern, keyworkerController.new(), {
+    auditEvent: 'ASSIGN_KEYWORKER',
+    allowedPermissions: ['cas1_space_booking_record_keyworker'],
+  })
+  post(paths.premises.placements.keyworker.pattern, keyworkerController.assign(), {
+    auditEvent: 'ASSIGN_KEYWORKER_SUCCESS',
+    allowedPermissions: ['cas1_space_booking_record_keyworker'],
+    redirectAuditEventSpecs: [
+      {
+        path: paths.premises.placements.keyworker.pattern,
+        auditEvent: 'ASSIGN_KEYWORKER_FAILURE',
+      },
+    ],
   })
 
   // Bookings

--- a/server/services/placementService.test.ts
+++ b/server/services/placementService.test.ts
@@ -1,6 +1,6 @@
 import PlacementService from './placementService'
 import PlacementClient from '../data/placementClient'
-import { newPlacementArrivalFactory } from '../testutils/factories/newPlacementArrival'
+import { cas1AssignKeyWorkerFactory, newPlacementArrivalFactory } from '../testutils/factories'
 
 jest.mock('../data/placementClient')
 
@@ -31,6 +31,18 @@ describe('PlacementService', () => {
       expect(result).toEqual({})
       expect(placementClientFactory).toHaveBeenCalledWith(token)
       expect(placementClient.createArrival).toHaveBeenCalledWith(premisesId, placementId, newPlacementArrival)
+    })
+  })
+
+  describe('assignKeyworker', () => {
+    it('calls the assignKeyworker method of the placement client a response', async () => {
+      const assignKeyworker = cas1AssignKeyWorkerFactory.build()
+      placementClient.assignKeyworker.mockResolvedValue({})
+
+      const result = await service.assignKeyworker(token, premisesId, placementId, assignKeyworker)
+      expect(result).toEqual({})
+      expect(placementClientFactory).toHaveBeenCalledWith(token)
+      expect(placementClient.assignKeyworker).toHaveBeenCalledWith(premisesId, placementId, assignKeyworker)
     })
   })
 })

--- a/server/services/placementService.ts
+++ b/server/services/placementService.ts
@@ -1,4 +1,4 @@
-import { Cas1NewArrival } from '@approved-premises/api'
+import { Cas1AssignKeyWorker, Cas1NewArrival } from '@approved-premises/api'
 import type { RestClientBuilder } from '../data'
 import PlacementClient from '../data/placementClient'
 
@@ -9,5 +9,16 @@ export default class PlacementService {
     const placementClient = this.placementClientFactory(token)
 
     return placementClient.createArrival(premisesId, placementId, newPlacementArrival)
+  }
+
+  async assignKeyworker(
+    token: string,
+    premisesId: string,
+    placementId: string,
+    keyworkerAssignment: Cas1AssignKeyWorker,
+  ) {
+    const placementClient = this.placementClientFactory(token)
+
+    return placementClient.assignKeyworker(premisesId, placementId, keyworkerAssignment)
   }
 }

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -11,6 +11,7 @@ import {
   cas1SpaceBookingFactory,
   cas1SpaceBookingSummaryFactory,
   paginatedResponseFactory,
+  staffMemberFactory,
 } from '../testutils/factories'
 
 jest.mock('../data/premisesClient')
@@ -166,7 +167,6 @@ describe('PremisesService', () => {
   describe('getPlacement', () => {
     it('returns the details for a single placement', async () => {
       const placement = cas1SpaceBookingFactory.build()
-
       premisesClient.getPlacement.mockResolvedValue(placement)
 
       const result = await service.getPlacement({ token, premisesId, placementId: placement.id })
@@ -178,6 +178,20 @@ describe('PremisesService', () => {
         premisesId,
         placementId: placement.id,
       })
+    })
+  })
+
+  describe('getStaff', () => {
+    it('on success returns the list of staff in a premises', async () => {
+      const staffList = staffMemberFactory.buildList(5)
+      premisesClient.getStaff.mockResolvedValue(staffList)
+
+      const result = await service.getStaff(token, premisesId)
+
+      expect(result).toEqual(staffList)
+
+      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClient.getStaff).toHaveBeenCalledWith(premisesId)
     })
   })
 })

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -5,6 +5,7 @@ import type {
   Cas1PremisesSummary,
   Cas1SpaceBookingSummarySortField,
   SortDirection,
+  StaffMember,
 } from '@approved-premises/api'
 import type { PremisesFilters } from '@approved-premises/ui'
 import type { PremisesClient, RestClientBuilder } from '../data'
@@ -56,5 +57,10 @@ export default class PremisesService {
     const { token, ...remainingArgs } = args
     const premisesClient = this.premisesClientFactory(token)
     return premisesClient.getPlacement(remainingArgs)
+  }
+
+  async getStaff(token: string, premisesId: string): Promise<Array<StaffMember>> {
+    const premisesClient = this.premisesClientFactory(token)
+    return premisesClient.getStaff(premisesId)
   }
 }

--- a/server/testutils/factories/cas1AssignKeyWorker.ts
+++ b/server/testutils/factories/cas1AssignKeyWorker.ts
@@ -1,0 +1,7 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker'
+import { Cas1AssignKeyWorker } from '@approved-premises/api'
+
+export default Factory.define<Cas1AssignKeyWorker>(() => ({
+  staffCode: faker.string.alphanumeric(5),
+}))

--- a/server/testutils/factories/cas1SpaceBooking.ts
+++ b/server/testutils/factories/cas1SpaceBooking.ts
@@ -20,6 +20,14 @@ class Cas1SpaceBookingFactory extends Factory<Cas1SpaceBooking> {
       departureMoveOnCategory: undefined,
     })
   }
+
+  current() {
+    return this.params({
+      actualDepartureDate: undefined,
+      departureReason: undefined,
+      departureMoveOnCategory: undefined,
+    })
+  }
 }
 
 export default Cas1SpaceBookingFactory.define(() => {

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -82,6 +82,8 @@ import cas1PremisesBasicSummaryFactory from './cas1PremisesBasicSummary'
 import cas1SpaceBookingSummaryFactory from './cas1SpaceBookingSummary'
 import cas1SpaceBookingFactory from './cas1SpaceBooking'
 import cas1SpaceBookingDatesFactory from './cas1SpaceBookingDates'
+import cas1AssignKeyWorkerFactory from './cas1AssignKeyWorker'
+import newPlacementArrivalFactory from './newPlacementArrival'
 
 export {
   acctAlertFactory,
@@ -114,6 +116,8 @@ export {
   cas1SpaceBookingDatesFactory,
   cas1SpaceBookingFactory,
   cas1SpaceBookingSummaryFactory,
+  cas1AssignKeyWorkerFactory,
+  newPlacementArrivalFactory,
   clarificationNoteFactory,
   contingencyPlanPartnerFactory,
   contingencyPlanQuestionsBodyFactory,

--- a/server/testutils/factories/newPlacementArrival.ts
+++ b/server/testutils/factories/newPlacementArrival.ts
@@ -3,7 +3,7 @@ import { Cas1NewArrival } from '@approved-premises/api'
 import { faker } from '@faker-js/faker'
 import { DateFormats } from '../../utils/dateUtils'
 
-export const newPlacementArrivalFactory = Factory.define<Cas1NewArrival>(() => {
+export default Factory.define<Cas1NewArrival>(() => {
   const arrivalDateTime = faker.date.recent({ days: 1 })
   return {
     expectedDepartureDate: DateFormats.dateObjToIsoDate(faker.date.soon({ days: 365, refDate: arrivalDateTime })),

--- a/server/utils/placements/index.test.ts
+++ b/server/utils/placements/index.test.ts
@@ -1,7 +1,7 @@
-import type { FullPerson } from '@approved-premises/api'
-import { UserDetails } from '@approved-premises/ui'
+import type { Cas1SpaceBooking, FullPerson, StaffMember } from '@approved-premises/api'
+import { SelectOption } from '@approved-premises/ui'
 import { faker } from '@faker-js/faker/locale/en_GB'
-import { cas1SpaceBookingFactory, userDetailsFactory } from '../../testutils/factories'
+import { cas1SpaceBookingFactory, staffMemberFactory, userDetailsFactory } from '../../testutils/factories'
 import {
   actions,
   arrivalInformation,
@@ -10,6 +10,7 @@ import {
   getKeyDetail,
   otherBookings,
   placementSummary,
+  renderKeyworkersSelectOptions,
 } from '.'
 import { DateFormats } from '../dateUtils'
 
@@ -22,93 +23,99 @@ describe('placementUtils', () => {
         'cas1_space_booking_record_arrival',
         'cas1_space_booking_record_departure',
         'cas1_space_booking_record_keyworker',
-        'cas1_space_booking_view',
       ],
     })
-    it('should allow setting of keyworker when placement in initial state', () => {
-      const placement = cas1SpaceBookingFactory.build({
-        actualArrivalDate: undefined,
-        actualDepartureDate: undefined,
-        keyWorkerAllocation: undefined,
-      })
+    const placement = cas1SpaceBookingFactory.build()
+    const { actualDepartureDate: _, ...placementAfterArrival } = placement
+    const { actualArrivalDate: __, ...placementInitial } = placementAfterArrival
+    const placementAfterDeparture = placement
 
-      expect(actions(placement, userDetails)).toEqual([
-        { classes: 'govuk-button--secondary', href: '', text: 'Allocate keyworker' },
-        {
-          classes: 'govuk-button--secondary',
-          href: paths.premises.placements.arrival({ premisesId: placement.premises.id, placementId: placement.id }),
-          text: 'Record arrival',
-        },
-      ])
+    const arrivalOption = {
+      classes: 'govuk-button--secondary',
+      href: paths.premises.placements.arrival({ premisesId: placement.premises.id, placementId: placement.id }),
+      text: 'Record arrival',
+    }
+    const departureOption = {
+      classes: 'govuk-button--secondary',
+      href: paths.premises.placements.departure({ premisesId: placement.premises.id, placementId: placement.id }),
+      text: 'Record departure',
+    }
+    const keyworkerOption = {
+      classes: 'govuk-button--secondary',
+      href: paths.premises.placements.keyworker({ premisesId: placement.premises.id, placementId: placement.id }),
+      text: 'Assign keyworker',
+    }
+
+    it('should allow arrivals and assignment of keyworker when placement in initial state', () => {
+      expect(actions(placementInitial, userDetails)).toEqual([keyworkerOption, arrivalOption])
     })
 
-    it('should render record arrival option before arrival', () => {
-      const placement = cas1SpaceBookingFactory.build({ actualArrivalDate: undefined, actualDepartureDate: undefined })
-
-      expect(actions(placement, userDetails)).toEqual([
-        {
-          classes: 'govuk-button--secondary',
-          href: '',
-          text: 'Edit keyworker',
-        },
-        {
-          classes: 'govuk-button--secondary',
-          href: paths.premises.placements.arrival({ premisesId: placement.premises.id, placementId: placement.id }),
-          text: 'Record arrival',
-        },
-      ])
+    it('should allow departure and assigning keyworker after arrival', () => {
+      expect(actions(placementAfterArrival, userDetails)).toEqual([keyworkerOption, departureOption])
     })
 
-    it('should render record departure option after arrival', () => {
-      const placement = cas1SpaceBookingFactory.build({ actualDepartureDate: undefined })
-
-      expect(actions(placement, userDetails)).toEqual([
-        { classes: 'govuk-button--secondary', href: '', text: 'Edit keyworker' },
-        { classes: 'govuk-button--secondary', href: '', text: 'Record departure' },
-      ])
+    it('should allow only assigning keyworker after departure', () => {
+      expect(actions(placementAfterDeparture, userDetails)).toEqual([keyworkerOption])
     })
 
-    it('should allow change of keyworker as only option after departure', () => {
-      const placement = cas1SpaceBookingFactory.build()
-
-      expect(actions(placement, userDetails)).toEqual([
-        { classes: 'govuk-button--secondary', href: '', text: 'Edit keyworker' },
-      ])
+    it('should require correct permissions for arrival and keyworker', () => {
+      expect(
+        actions(
+          placementInitial,
+          userDetailsFactory.build({
+            permissions: [],
+          }),
+        ),
+      ).toEqual([])
+      expect(
+        actions(
+          placementInitial,
+          userDetailsFactory.build({
+            permissions: ['cas1_space_booking_record_keyworker'],
+          }),
+        ),
+      ).toEqual([keyworkerOption])
+      expect(
+        actions(
+          placementInitial,
+          userDetailsFactory.build({
+            permissions: ['cas1_space_booking_record_arrival'],
+          }),
+        ),
+      ).toEqual([arrivalOption])
     })
-    it('should require the correct permissions', () => {
-      const placement = cas1SpaceBookingFactory.build({
-        actualArrivalDate: undefined,
-        actualDepartureDate: undefined,
-        keyWorkerAllocation: undefined,
-      })
-      expect(actions(placement, { permissions: ['cas1_space_booking_record_arrival'] } as UserDetails)).toEqual([
-        {
-          classes: 'govuk-button--secondary',
-          href: paths.premises.placements.arrival({ premisesId: placement.premises.id, placementId: placement.id }),
-          text: 'Record arrival',
-        },
-      ])
-      expect(actions(placement, { permissions: ['cas1_space_booking_record_departure'] } as UserDetails)).toEqual([
-        { classes: 'govuk-button--secondary', href: '', text: 'Record departure' },
-      ])
-      expect(actions(placement, { permissions: ['cas1_space_booking_record_keyworker'] } as UserDetails)).toEqual([
-        { classes: 'govuk-button--secondary', href: '', text: 'Allocate keyworker' },
-      ])
+    it('should require correct permissions for arrival and keyworker', () => {
+      expect(
+        actions(
+          placementAfterArrival,
+          userDetailsFactory.build({
+            permissions: [],
+          }),
+        ),
+      ).toEqual([])
+      expect(
+        actions(
+          placementInitial,
+          userDetailsFactory.build({
+            permissions: ['cas1_space_booking_record_departure'],
+          }),
+        ),
+      ).toEqual([departureOption])
     })
   })
 
   describe('getBackLink', () => {
     it('should return the correct back link, given the referrer', () => {
-      const premesisId = faker.string.uuid()
-      const bareUrl = `/manage/premises/${premesisId}`
-      const urlWithQuery = `/manage/premises/${premesisId}?activeTab=historic&sortBy=canonicalArrivalDate`
+      const premisesId = faker.string.uuid()
+      const bareUrl = `/manage/premises/${premisesId}`
+      const urlWithQuery = `/manage/premises/${premisesId}?activeTab=historic&sortBy=canonicalArrivalDate`
       const urlOtherId = `/manage/premises/${faker.string.uuid()}`
-      expect(getBackLink(bareUrl, premesisId)).toEqual(bareUrl)
-      expect(getBackLink(urlWithQuery, premesisId)).toEqual(urlWithQuery)
-      expect(getBackLink('some string', premesisId)).toEqual(bareUrl)
-      expect(getBackLink('', premesisId)).toEqual(bareUrl)
-      expect(getBackLink(null, premesisId)).toEqual(bareUrl)
-      expect(getBackLink(urlOtherId, premesisId)).toEqual(bareUrl)
+      expect(getBackLink(bareUrl, premisesId)).toEqual(bareUrl)
+      expect(getBackLink(urlWithQuery, premisesId)).toEqual(urlWithQuery)
+      expect(getBackLink('some string', premisesId)).toEqual(bareUrl)
+      expect(getBackLink('', premisesId)).toEqual(bareUrl)
+      expect(getBackLink(null, premisesId)).toEqual(bareUrl)
+      expect(getBackLink(urlOtherId, premisesId)).toEqual(bareUrl)
     })
   })
 
@@ -168,14 +175,6 @@ describe('placementUtils', () => {
             key: { text: 'Arrival time' },
             value: { text: DateFormats.timeFromDate(DateFormats.isoToDateObj(placement.actualArrivalDate)) },
           },
-          {
-            key: { html: '<span class="text-grey">Non arrival reason</span>' },
-            value: { html: '<span class="text-grey">-</span>' },
-          },
-          {
-            key: { html: '<span class="text-grey">Non arrival any other information</span>' },
-            value: { html: '<span class="text-grey">-</span>' },
-          },
         ],
       })
     })
@@ -196,15 +195,7 @@ describe('placementUtils', () => {
             value: { text: DateFormats.timeFromDate(DateFormats.isoToDateObj(placement.actualDepartureDate)) },
           },
           { key: { text: 'Departure reason' }, value: { text: placement.departureReason?.name } },
-          {
-            key: { html: '<span class="text-grey">Breach or recall</span>' },
-            value: { html: '<span class="text-grey">-</span>' },
-          },
           { key: { text: 'Move on' }, value: { text: placement.departureMoveOnCategory?.name } },
-          {
-            key: { html: '<span class="text-grey">More information</span>' },
-            value: { html: '<span class="text-grey">-</span>' },
-          },
         ],
       })
     })
@@ -230,6 +221,24 @@ describe('placementUtils', () => {
           },
         ],
       })
+    })
+  })
+  describe('renderKeyworkersSelectOptions', () => {
+    it('should return a list of keyworker selection options', () => {
+      const staffList: Array<StaffMember> = staffMemberFactory.buildList(3, { keyWorker: true })
+      const placement: Cas1SpaceBooking = cas1SpaceBookingFactory.build()
+      const expected = [
+        { text: 'Select a keyworker', value: null } as SelectOption,
+        ...staffList.map(({ name, code }) => ({ text: name, value: code, selected: false })),
+      ]
+      const result = renderKeyworkersSelectOptions(staffList, placement)
+      expect(result).toEqual(expected)
+    })
+    it('should remove non-keyworkers', () => {
+      const staffList: Array<StaffMember> = staffMemberFactory.buildList(3, { keyWorker: false })
+      const placement: Cas1SpaceBooking = cas1SpaceBookingFactory.build()
+      const result = renderKeyworkersSelectOptions(staffList, placement)
+      expect(result).toEqual([{ text: 'Select a keyworker', value: null } as SelectOption])
     })
   })
 })

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -64,10 +64,11 @@ export const getBackLink = (referrer: string, premisesId: string): string => {
   return paths.premises.show({ premisesId })
 }
 
-const summaryRow = (key: string, value: string, excludeRow = false): SummaryListItem => ({
-  key: excludeRow ? null : textValue(key),
-  value: textValue(value),
-})
+const summaryRow = (key: string, value: string, excludeRow = false): SummaryListItem =>
+  value && {
+    key: excludeRow ? null : textValue(key),
+    value: textValue(value),
+  }
 
 export const placementSummary = (placement: Cas1SpaceBooking): SummaryList => {
   const { createdAt, actualArrivalDate, actualDepartureDate, keyWorkerAllocation, deliusEventNumber } = placement
@@ -92,7 +93,7 @@ export const placementSummary = (placement: Cas1SpaceBooking): SummaryList => {
       ),
       summaryRow('Key worker', keyWorkerAllocation?.keyWorker?.name || 'Not assigned'),
       summaryRow('Delius Event Number', deliusEventNumber, !deliusEventNumber),
-    ].filter(({ key }) => key),
+    ].filter(Boolean),
   }
 }
 
@@ -103,7 +104,7 @@ export const arrivalInformation = (placement: Cas1SpaceBooking): SummaryList => 
     summaryRow('Arrival time', formatTime(placement.actualArrivalDate), !placement.actualArrivalDate),
     summaryRow('Non arrival reason', null, true),
     summaryRow('Non arrival any other information', null, true),
-  ].filter(({ key }) => key),
+  ].filter(Boolean),
 })
 
 export const departureInformation = (placement: Cas1SpaceBooking): SummaryList => ({
@@ -115,7 +116,7 @@ export const departureInformation = (placement: Cas1SpaceBooking): SummaryList =
     summaryRow('Breach or recall', null, true),
     summaryRow('Move on', placement.departureMoveOnCategory?.name, !placement.departureMoveOnCategory?.name),
     summaryRow('More information', null, true),
-  ].filter(({ key }) => key),
+  ].filter(Boolean),
 })
 
 const listOtherBookings = (placement: Cas1SpaceBooking): string =>

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -64,9 +64,9 @@ export const getBackLink = (referrer: string, premisesId: string): string => {
   return paths.premises.show({ premisesId })
 }
 
-const summaryRow = (key: string, value: string, excludeRow = false): SummaryListItem =>
+const summaryRow = (key: string, value: string): SummaryListItem =>
   value && {
-    key: excludeRow ? null : textValue(key),
+    key: textValue(key),
     value: textValue(value),
   }
 
@@ -89,10 +89,9 @@ export const placementSummary = (placement: Cas1SpaceBooking): SummaryList => {
               ).number,
             ),
           ),
-        !actualArrivalDate || !actualDepartureDate,
       ),
       summaryRow('Key worker', keyWorkerAllocation?.keyWorker?.name || 'Not assigned'),
-      summaryRow('Delius Event Number', deliusEventNumber, !deliusEventNumber),
+      summaryRow('Delius Event Number', deliusEventNumber),
     ].filter(Boolean),
   }
 }
@@ -100,22 +99,22 @@ export const placementSummary = (placement: Cas1SpaceBooking): SummaryList => {
 export const arrivalInformation = (placement: Cas1SpaceBooking): SummaryList => ({
   rows: [
     summaryRow('Expected arrival date', formatDate(placement.expectedArrivalDate)),
-    summaryRow('Actual arrival date', formatDate(placement.actualArrivalDate), !placement.actualArrivalDate),
-    summaryRow('Arrival time', formatTime(placement.actualArrivalDate), !placement.actualArrivalDate),
-    summaryRow('Non arrival reason', null, true),
-    summaryRow('Non arrival any other information', null, true),
+    summaryRow('Actual arrival date', formatDate(placement.actualArrivalDate)),
+    summaryRow('Arrival time', formatTime(placement.actualArrivalDate)),
+    summaryRow('Non arrival reason', null),
+    summaryRow('Non arrival any other information', null),
   ].filter(Boolean),
 })
 
 export const departureInformation = (placement: Cas1SpaceBooking): SummaryList => ({
   rows: [
     summaryRow('Expected departure date', formatDate(placement.expectedDepartureDate)),
-    summaryRow('Actual departure date', formatDate(placement.actualDepartureDate), !placement.actualDepartureDate),
-    summaryRow('Departure time', formatTime(placement.actualDepartureDate), !placement.actualDepartureDate),
-    summaryRow('Departure reason', placement.departureReason?.name, !placement.departureReason?.name),
-    summaryRow('Breach or recall', null, true),
-    summaryRow('Move on', placement.departureMoveOnCategory?.name, !placement.departureMoveOnCategory?.name),
-    summaryRow('More information', null, true),
+    summaryRow('Actual departure date', formatDate(placement.actualDepartureDate)),
+    summaryRow('Departure time', formatTime(placement.actualDepartureDate)),
+    summaryRow('Departure reason', placement.departureReason?.name),
+    summaryRow('Breach or recall', null),
+    summaryRow('Move on', placement.departureMoveOnCategory?.name),
+    summaryRow('More information', null),
   ].filter(Boolean),
 })
 

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -1,5 +1,5 @@
-import type { Cas1SpaceBooking, Cas1SpaceBookingDates, FullPerson } from '@approved-premises/api'
-import { KeyDetailsArgs, SummaryList, UserDetails } from '@approved-premises/ui'
+import type { Cas1SpaceBooking, Cas1SpaceBookingDates, FullPerson, StaffMember } from '@approved-premises/api'
+import { KeyDetailsArgs, SelectOption, SummaryList, SummaryListItem, UserDetails } from '@approved-premises/ui'
 import { DateFormats, daysToWeeksAndDays } from '../dateUtils'
 import { htmlValue, textValue } from '../applications/helpers'
 import { isFullPerson, nameOrPlaceholderCopy } from '../personUtils'
@@ -11,9 +11,9 @@ export const actions = (placement: Cas1SpaceBooking, user: UserDetails) => {
 
   if (hasPermission(user, ['cas1_space_booking_record_keyworker'])) {
     out.push({
-      text: placement.keyWorkerAllocation ? 'Edit keyworker' : 'Allocate keyworker',
+      text: 'Assign keyworker',
       classes: 'govuk-button--secondary',
-      href: '',
+      href: paths.premises.placements.keyworker({ premisesId: placement.premises.id, placementId: placement.id }),
     })
   }
   if (!placement.actualArrivalDate && hasPermission(user, ['cas1_space_booking_record_arrival'])) {
@@ -26,7 +26,7 @@ export const actions = (placement: Cas1SpaceBooking, user: UserDetails) => {
     out.push({
       text: 'Record departure',
       classes: 'govuk-button--secondary',
-      href: '',
+      href: paths.premises.placements.departure({ premisesId: placement.premises.id, placementId: placement.id }),
     })
   }
   return out
@@ -51,22 +51,9 @@ export const getKeyDetail = (placement: Cas1SpaceBooking): KeyDetailsArgs => {
   }
 }
 
-const greyValue = (text: string) => htmlValue(`<span class="text-grey">${text}</span>`)
-
 const formatDate = (date: string | null) => date && DateFormats.isoDateToUIDate(date)
 
 const formatTime = (date: string | null) => date && DateFormats.timeFromDate(DateFormats.isoToDateObj(date))
-
-const summaryRow = (key: string, value: string, greyRow = false) =>
-  greyRow
-    ? {
-        key: greyValue(key),
-        value: greyValue('-'),
-      }
-    : {
-        key: textValue(key),
-        value: textValue(value),
-      }
 
 export const getBackLink = (referrer: string, premisesId: string): string => {
   const regString: string = `${paths.premises.show({ premisesId: '([0-9a-f-]{36})' })}[^/]*$`
@@ -76,6 +63,11 @@ export const getBackLink = (referrer: string, premisesId: string): string => {
   }
   return paths.premises.show({ premisesId })
 }
+
+const summaryRow = (key: string, value: string, excludeRow = false): SummaryListItem => ({
+  key: excludeRow ? null : textValue(key),
+  value: textValue(value),
+})
 
 export const placementSummary = (placement: Cas1SpaceBooking): SummaryList => {
   const { createdAt, actualArrivalDate, actualDepartureDate, keyWorkerAllocation, deliusEventNumber } = placement
@@ -100,7 +92,7 @@ export const placementSummary = (placement: Cas1SpaceBooking): SummaryList => {
       ),
       summaryRow('Key worker', keyWorkerAllocation?.keyWorker?.name || 'Not assigned'),
       summaryRow('Delius Event Number', deliusEventNumber, !deliusEventNumber),
-    ],
+    ].filter(({ key }) => key),
   }
 }
 
@@ -111,7 +103,7 @@ export const arrivalInformation = (placement: Cas1SpaceBooking): SummaryList => 
     summaryRow('Arrival time', formatTime(placement.actualArrivalDate), !placement.actualArrivalDate),
     summaryRow('Non arrival reason', null, true),
     summaryRow('Non arrival any other information', null, true),
-  ],
+  ].filter(({ key }) => key),
 })
 
 export const departureInformation = (placement: Cas1SpaceBooking): SummaryList => ({
@@ -123,7 +115,7 @@ export const departureInformation = (placement: Cas1SpaceBooking): SummaryList =
     summaryRow('Breach or recall', null, true),
     summaryRow('Move on', placement.departureMoveOnCategory?.name, !placement.departureMoveOnCategory?.name),
     summaryRow('More information', null, true),
-  ],
+  ].filter(({ key }) => key),
 })
 
 const listOtherBookings = (placement: Cas1SpaceBooking): string =>
@@ -142,3 +134,17 @@ export const otherBookings = (placement: Cas1SpaceBooking): SummaryList => ({
     },
   ],
 })
+
+export const renderKeyworkersSelectOptions = (
+  staffList: Array<StaffMember>,
+  placement: Cas1SpaceBooking,
+): Array<SelectOption> => [
+  { text: 'Select a keyworker', value: null },
+  ...staffList
+    .filter(({ keyWorker, code }) => keyWorker && placement.keyWorkerAllocation?.keyWorker?.code !== code)
+    .map(({ name, code }) => ({
+      text: `${name}`,
+      value: `${code}`,
+      selected: false,
+    })),
+]

--- a/server/views/manage/premises/placements/arrival.njk
+++ b/server/views/manage/premises/placements/arrival.njk
@@ -10,8 +10,8 @@
 {% extends "../../../partials/layout.njk" %}
 
 {% block header %}
-    {{ super() }}
-    {{ keyDetails(PlacementUtils.getKeyDetail(placement)) }}
+  {{ super() }}
+  {{ keyDetails(PlacementUtils.getKeyDetail(placement)) }}
 {% endblock %}
 
 {% block beforeContent %}
@@ -19,11 +19,6 @@
         text: "Back",
         href: paths.premises.placements.show({ premisesId: placement.premises.id, placementId: placement.id })
     }) }}
-{% endblock %}
-
-{% block header %}
-  {{ super() }}
-  {{ keyDetails(PlacementUtils.getKeyDetail(placement)) }}
 {% endblock %}
 
 {% block content %}

--- a/server/views/manage/premises/placements/arrival.njk
+++ b/server/views/manage/premises/placements/arrival.njk
@@ -5,7 +5,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% from "../../../components/keyDetails/macro.njk" import keyDetails %}
-
 {% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
 
 {% extends "../../../partials/layout.njk" %}
@@ -20,6 +19,11 @@
         text: "Back",
         href: paths.premises.placements.show({ premisesId: placement.premises.id, placementId: placement.id })
     }) }}
+{% endblock %}
+
+{% block header %}
+  {{ super() }}
+  {{ keyDetails(PlacementUtils.getKeyDetail(placement)) }}
 {% endblock %}
 
 {% block content %}

--- a/server/views/manage/premises/placements/keyworker.njk
+++ b/server/views/manage/premises/placements/keyworker.njk
@@ -51,8 +51,8 @@
                 text: "Select keyworker",
                 classes: "govuk-label--s"
             },
-            id: "keyworkerId",
-            name: "keyworkerId",
+            id: "staffCode",
+            name: "staffCode",
             items: PlacementUtils.renderKeyworkersSelectOptions(staffList, placement)
         }) }}
 

--- a/server/views/manage/premises/placements/keyworker.njk
+++ b/server/views/manage/premises/placements/keyworker.njk
@@ -1,0 +1,66 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "../../../components/keyDetails/macro.njk" import keyDetails %}
+{% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
+
+{%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        text: "Back",
+        href: paths.premises.placements.show({ premisesId: placement.premises.id, placementId: placement.id })
+    }) }}
+{% endblock %}
+
+{% block header %}
+  {{ super() }}
+  {{ keyDetails(PlacementUtils.getKeyDetail(placement)) }}
+{% endblock %}
+
+{% block content %}
+
+    <form action="{{ paths.premises.placements.keyworker({ premisesId: placement.premises.id, placementId: placement.id }) }}"
+          method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+        {{ showErrorSummary(errorSummary, errorTitle) }}
+
+        {% include "../../../_messages.njk" %}
+
+        <h1 class="govuk-heading-l">Edit keyworker details</h1>
+
+
+        {{ govukSummaryList({
+            rows: [{
+                key: {
+                    text: "Keyworker"
+                },
+                value: {
+                    text: currentKeyworkerName
+                }
+            }]
+        }) }}
+
+        {{ govukSelect({
+            label: {
+                text: "Select keyworker",
+                classes: "govuk-label--s"
+            },
+            id: "keyworkerId",
+            name: "keyworkerId",
+            items: PlacementUtils.renderKeyworkersSelectOptions(staffList, placement)
+        }) }}
+
+        {{ govukButton({
+            text: "Submit",
+            preventDoubleClick: true
+        }) }}
+    </form>
+
+{% endblock %}
+


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1413
This feature is available only for users with the `cas1_space_booking_record_keyworker` pernission
# Changes in this PR

Adds the ability to assign a keyworker to a placement

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

Placement page with open actions menu
![image](https://github.com/user-attachments/assets/0cc28b0d-14a8-4e8d-ae86-85f01e0872b5)

Assign keyworker page
![image](https://github.com/user-attachments/assets/88747531-09c5-4ed4-b1d3-4399cd41172a)

Error page - keyworker not selected
![image](https://github.com/user-attachments/assets/a8788dc7-f6a5-4bb6-b346-8f8d3e4ba7ca)

Placement page with notification and assigned keyworker
![image](https://github.com/user-attachments/assets/ece9a21b-d1b7-4ad1-ba4f-ce474bbc88c9)



