### PR TITLE
APS-1412 Record non-arrivals

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -10,7 +10,7 @@ import outOfServiceBed from './integration_tests/mockApis/outOfServiceBed'
 import person from './integration_tests/mockApis/person'
 import reports from './integration_tests/mockApis/reports'
 import applications from './integration_tests/mockApis/applications'
-import { stubJourney } from './integration_tests/mockApis/journeyUtils'
+import { stubJourney, verifyApiPost } from './integration_tests/mockApis/journeyUtils'
 import assessments from './integration_tests/mockApis/assessments'
 import users from './integration_tests/mockApis/users'
 import tasks from './integration_tests/mockApis/tasks'
@@ -57,6 +57,7 @@ export default defineConfig({
         ...spaceBookings,
         ...referenceData,
         stubJourney,
+        verifyApiPost,
       })
     },
     baseUrl: 'http://localhost:3007',

--- a/integration_tests/mockApis/journeyUtils.ts
+++ b/integration_tests/mockApis/journeyUtils.ts
@@ -4,7 +4,7 @@ import {
   ApprovedPremisesAssessment as Assessment,
 } from '@approved-premises/api'
 
-import { bulkStub } from './setup'
+import { bulkStub, getMatchingRequests } from './setup'
 import isAssessment from '../../server/utils/assessments/isAssessment'
 
 export const generateStubsForPage = (
@@ -150,6 +150,15 @@ export const copyCompleteTasksToData = ({ completeTasks, form }) => {
   })
 
   return data
+}
+
+export const verifyApiPost = async (path: string): Promise<Record<string, unknown>> => {
+  const result = await getMatchingRequests({
+    method: 'POST',
+    url: path,
+  })
+  const { requests } = result.body
+  return JSON.parse(requests[0].body)
 }
 
 export const stubJourney = (form: Application | Assessment): SuperAgentRequest => {

--- a/integration_tests/mockApis/referenceData.ts
+++ b/integration_tests/mockApis/referenceData.ts
@@ -1,7 +1,7 @@
 import { Response } from 'superagent'
-import { ApArea, Cas1CruManagementArea } from '@approved-premises/api'
+import { ApArea, Cas1CruManagementArea, NonArrivalReason } from '@approved-premises/api'
 import { stubFor } from './setup'
-import { apAreaFactory, cruManagementAreaFactory } from '../../server/testutils/factories'
+import { apAreaFactory, cruManagementAreaFactory, nonArrivalReasonsFactory } from '../../server/testutils/factories'
 
 export const stubApAreaReferenceData = (
   {
@@ -53,7 +53,24 @@ export const stubCruManagementAreaReferenceData = (
   })
 }
 
+export const stubNonArrivalReasonsReferenceData = (nonArrivalReasons: Array<NonArrivalReason>) => {
+  return stubFor({
+    request: {
+      method: 'GET',
+      url: '/reference-data/non-arrival-reasons',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: nonArrivalReasons || nonArrivalReasonsFactory.buildList(10),
+    },
+  })
+}
+
 export default {
   stubApAreaReferenceData,
   stubCruManagementAreaReferenceData,
+  stubNonArrivalReasonsReferenceData,
 }

--- a/integration_tests/mockApis/spaceBooking.ts
+++ b/integration_tests/mockApis/spaceBooking.ts
@@ -93,4 +93,18 @@ export default {
         status: 200,
       },
     }),
+
+  stubSpaceBookingNonArrival: placement =>
+    stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: paths.premises.placements.nonArrival({
+          premisesId: placement.premises.id,
+          placementId: placement.id,
+        }),
+      },
+      response: {
+        status: 200,
+      },
+    }),
 }

--- a/integration_tests/mockApis/spaceBooking.ts
+++ b/integration_tests/mockApis/spaceBooking.ts
@@ -107,4 +107,13 @@ export default {
         status: 200,
       },
     }),
+
+  getApiPost: async (path: string): Promise<Record<string, unknown>> => {
+    const result = await getMatchingRequests({
+      method: 'POST',
+      url: path,
+    })
+    const { requests } = result.body
+    return JSON.parse(requests[0].body)
+  },
 }

--- a/integration_tests/mockApis/spaceBooking.ts
+++ b/integration_tests/mockApis/spaceBooking.ts
@@ -107,13 +107,4 @@ export default {
         status: 200,
       },
     }),
-
-  getApiPost: async (path: string): Promise<Record<string, unknown>> => {
-    const result = await getMatchingRequests({
-      method: 'POST',
-      url: path,
-    })
-    const { requests } = result.body
-    return JSON.parse(requests[0].body)
-  },
 }

--- a/integration_tests/pages/manage/index.ts
+++ b/integration_tests/pages/manage/index.ts
@@ -1,7 +1,7 @@
 import CancellationCreatePage from './cancellationCreate'
 import PremisesListPage from './premisesList'
 import PremisesShowPage from './premisesShow'
-import PlacementShowPage from './placementShow'
+import PlacementShowPage from './placements/placementShow'
 import WithdrawConfirmPage from './withdrawConfirm'
 import UnableToMatchPage from './unableToMatch'
 

--- a/integration_tests/pages/manage/placements/arrival.ts
+++ b/integration_tests/pages/manage/placements/arrival.ts
@@ -1,6 +1,7 @@
-import type { Cas1SpaceBooking } from '@approved-premises/api'
+import type { Cas1NewArrival, Cas1SpaceBooking } from '@approved-premises/api'
 import Page from '../../page'
 import { DateFormats } from '../../../../server/utils/dateUtils'
+import apiPaths from '../../../../server/paths/api'
 
 export class ArrivalCreatePage extends Page {
   constructor(private readonly placement: Cas1SpaceBooking) {
@@ -21,5 +22,16 @@ export class ArrivalCreatePage extends Page {
   completeForm(): void {
     this.completeDateInputs('arrivalDateTime', this.placement.expectedArrivalDate)
     this.completeTextInput('arrivalTime', '9:45')
+  }
+
+  checkApiCalled(): void {
+    cy.task(
+      'getApiPost',
+      apiPaths.premises.placements.arrival({ premisesId: this.placement.premises.id, placementId: this.placement.id }),
+    ).then(body => {
+      const { arrivalDateTime, expectedDepartureDate } = body as Cas1NewArrival
+      expect(arrivalDateTime).equal(`${this.placement.expectedArrivalDate}T09:45:00.000Z`)
+      expect(expectedDepartureDate).equal(this.placement.expectedDepartureDate)
+    })
   }
 }

--- a/integration_tests/pages/manage/placements/arrival.ts
+++ b/integration_tests/pages/manage/placements/arrival.ts
@@ -29,9 +29,8 @@ export class ArrivalCreatePage extends Page {
       'verifyApiPost',
       apiPaths.premises.placements.arrival({ premisesId: this.placement.premises.id, placementId: this.placement.id }),
     ).then(body => {
-      const { arrivalDateTime, expectedDepartureDate } = body as Cas1NewArrival
+      const { arrivalDateTime } = body as Cas1NewArrival
       expect(arrivalDateTime).equal(`${this.placement.expectedArrivalDate}T09:45:00.000Z`)
-      expect(expectedDepartureDate).equal(this.placement.expectedDepartureDate)
     })
   }
 }

--- a/integration_tests/pages/manage/placements/arrival.ts
+++ b/integration_tests/pages/manage/placements/arrival.ts
@@ -26,7 +26,7 @@ export class ArrivalCreatePage extends Page {
 
   checkApiCalled(): void {
     cy.task(
-      'getApiPost',
+      'verifyApiPost',
       apiPaths.premises.placements.arrival({ premisesId: this.placement.premises.id, placementId: this.placement.id }),
     ).then(body => {
       const { arrivalDateTime, expectedDepartureDate } = body as Cas1NewArrival

--- a/integration_tests/pages/manage/placements/keyworker.ts
+++ b/integration_tests/pages/manage/placements/keyworker.ts
@@ -1,12 +1,21 @@
 import type { Cas1SpaceBooking, StaffMember } from '@approved-premises/api'
 import Page from '../../page'
+import paths from '../../../../server/paths/manage'
 
 export class KeyworkerAssignmentPage extends Page {
   constructor(
     private readonly placement: Cas1SpaceBooking,
     private readonly staffMembers: Array<StaffMember>,
+    title: string = 'Edit keyworker details',
   ) {
-    super('Edit keyworker details')
+    super(title)
+  }
+
+  static visitUnauthorised(placement: Cas1SpaceBooking): KeyworkerAssignmentPage {
+    cy.visit(paths.premises.placements.keyworker({ premisesId: placement.premises.id, placementId: placement.id }), {
+      failOnStatusCode: false,
+    })
+    return new KeyworkerAssignmentPage(null, null, `Authorisation Error`)
   }
 
   shouldShowKeyworkerList(placement: Cas1SpaceBooking): void {

--- a/integration_tests/pages/manage/placements/keyworker.ts
+++ b/integration_tests/pages/manage/placements/keyworker.ts
@@ -1,6 +1,7 @@
 import type { Cas1SpaceBooking, StaffMember } from '@approved-premises/api'
 import Page from '../../page'
 import paths from '../../../../server/paths/manage'
+import apiPaths from '../../../../server/paths/api'
 
 export class KeyworkerAssignmentPage extends Page {
   constructor(
@@ -33,5 +34,14 @@ export class KeyworkerAssignmentPage extends Page {
 
   completeForm(): void {
     this.getSelectInputByIdAndSelectAnEntry('staffCode', this.staffMembers[1].name)
+  }
+
+  checkApiCalled(placement: Cas1SpaceBooking): void {
+    cy.task(
+      'getApiPost',
+      apiPaths.premises.placements.keyworker({ premisesId: placement.premises.id, placementId: placement.id }),
+    ).then(body => {
+      expect(body).to.deep.equal({ staffCode: this.staffMembers[1].code })
+    })
   }
 }

--- a/integration_tests/pages/manage/placements/keyworker.ts
+++ b/integration_tests/pages/manage/placements/keyworker.ts
@@ -38,7 +38,7 @@ export class KeyworkerAssignmentPage extends Page {
 
   checkApiCalled(placement: Cas1SpaceBooking): void {
     cy.task(
-      'getApiPost',
+      'verifyApiPost',
       apiPaths.premises.placements.keyworker({ premisesId: placement.premises.id, placementId: placement.id }),
     ).then(body => {
       expect(body).to.deep.equal({ staffCode: this.staffMembers[1].code })

--- a/integration_tests/pages/manage/placements/nonArrival.ts
+++ b/integration_tests/pages/manage/placements/nonArrival.ts
@@ -1,0 +1,48 @@
+import { faker } from '@faker-js/faker'
+import type { Cas1SpaceBooking } from '@approved-premises/api'
+import Page from '../../page'
+import paths from '../../../../server/paths/manage'
+
+export class RecordNonArrivalPage extends Page {
+  constructor(title: string = 'Record someone as not arrived') {
+    super(title)
+  }
+
+  shouldShowReasonError(): void {
+    cy.get('.govuk-error-summary__list').should('contain', 'You must select a reason for non-arrival')
+  }
+
+  shouldShowTextError(): void {
+    cy.get('.govuk-error-summary__list').should('contain', 'You have exceeded 200 characters')
+  }
+
+  completeNotesBad(): void {
+    // Generate a text string of exactly 250 chars with no trailing space - so we have a repeatable error message
+    const words = faker.lorem.words(100).substring(0, 250).trim()
+    const text = words + 'abc'.substring(0, 250 - words.length)
+    this.completeTextArea('notes', text)
+  }
+
+  completeNotesGood(): void {
+    this.completeTextArea('notes', faker.lorem.words(20).substring(0, 200))
+  }
+
+  checkForCharacterCountError(): void {
+    cy.contains('You have 50 characters too many')
+  }
+
+  completeReason(): void {
+    cy.get('input[name=reason]')
+      .invoke('val')
+      .then(val => {
+        this.checkRadioByNameAndValue('reason', String(val))
+      })
+  }
+
+  static visitUnauthorised(placement: Cas1SpaceBooking): RecordNonArrivalPage {
+    cy.visit(paths.premises.placements.nonArrival({ premisesId: placement.premises.id, placementId: placement.id }), {
+      failOnStatusCode: false,
+    })
+    return new RecordNonArrivalPage(`Authorisation Error`)
+  }
+}

--- a/integration_tests/pages/manage/placements/nonArrival.ts
+++ b/integration_tests/pages/manage/placements/nonArrival.ts
@@ -47,7 +47,7 @@ export class RecordNonArrivalPage extends Page {
 
   checkApiCalled(placement: Cas1SpaceBooking): void {
     cy.task(
-      'getApiPost',
+      'verifyApiPost',
       apiPaths.premises.placements.nonArrival({ premisesId: placement.premises.id, placementId: placement.id }),
     ).then(body => {
       expect(body).to.deep.equal(this.nonArrivalDetails)

--- a/integration_tests/pages/manage/placements/placementShow.ts
+++ b/integration_tests/pages/manage/placements/placementShow.ts
@@ -1,8 +1,8 @@
 import { Cas1SpaceBooking } from '@approved-premises/api'
-import Page from '../page'
-import paths from '../../../server/paths/manage'
-import { DateFormats } from '../../../server/utils/dateUtils'
-import { arrivalInformation, departureInformation, placementSummary } from '../../../server/utils/placements'
+import Page from '../../page'
+import paths from '../../../../server/paths/manage'
+import { DateFormats } from '../../../../server/utils/dateUtils'
+import { arrivalInformation, departureInformation, placementSummary } from '../../../../server/utils/placements'
 
 export default class PlacementShowPage extends Page {
   constructor(placement: Cas1SpaceBooking | null, pageHeading?: string) {

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -146,6 +146,7 @@ export default abstract class Page {
   }
 
   completeTextArea(name: string, value: string): void {
+    cy.get(`textarea[name="${name}"]`).clear()
     cy.get(`textarea[name="${name}"]`).type(value)
   }
 
@@ -182,6 +183,10 @@ export default abstract class Page {
   clickAction(actionLabel: string): void {
     cy.get('.moj-button-menu > button').contains('Actions').click()
     cy.get('[role="menuitem"]').contains(actionLabel).click()
+  }
+
+  actionMenuShouldNotExist(): void {
+    cy.get('.moj-button-menu > button').should('not.exist')
   }
 
   shouldShowMappa = (): void => {

--- a/integration_tests/tests/manage/placements/arrivals.cy.ts
+++ b/integration_tests/tests/manage/placements/arrivals.cy.ts
@@ -36,5 +36,8 @@ context('Arrivals', () => {
     // Then I should be shown the placement page with a confirmation that the placement has been marked as arrived
     placementPage = new PlacementShowPage(placement)
     placementPage.shouldShowBanner('You have recorded this person as arrived')
+
+    // and the API should have been called with the correct data
+    arrivalCreatePage.checkApiCalled()
   })
 })

--- a/integration_tests/tests/manage/placements/keyworker.cy.ts
+++ b/integration_tests/tests/manage/placements/keyworker.cy.ts
@@ -1,23 +1,25 @@
 import { signIn } from '../../signIn'
 import { KeyworkerAssignmentPage } from '../../../pages/manage/placements/keyworker'
+import { PlacementShowPage } from '../../../pages/manage'
 import {
   cas1PremisesSummaryFactory,
   cas1SpaceBookingFactory,
   staffMemberFactory,
 } from '../../../../server/testutils/factories'
-import { PlacementShowPage } from '../../../pages/manage'
+
+const premises = cas1PremisesSummaryFactory.build()
+const placement = cas1SpaceBookingFactory.upcoming().build({ premises })
+const staffMembers = staffMemberFactory.buildList(5, { keyWorker: true })
 
 context('Keyworker', () => {
-  it('Assigns a keyworker to a placement', () => {
-    const premises = cas1PremisesSummaryFactory.build()
-    const placement = cas1SpaceBookingFactory.build({ premises })
-    const staffMembers = staffMemberFactory.buildList(5, { keyWorker: true })
-
+  beforeEach(() => {
     cy.task('stubSinglePremises', premises)
     cy.task('stubSpaceBookingShow', placement)
     cy.task('stubPremisesStaffMembers', { premisesId: premises.id, staffMembers })
     cy.task('stubSpaceBookingAssignKeyworker', placement)
+  })
 
+  it('Assigns a keyworker to a placement', () => {
     // Given I am logged in with the correct permissions
     signIn([], ['cas1_space_booking_view', 'cas1_space_booking_record_keyworker'])
 
@@ -44,5 +46,20 @@ context('Keyworker', () => {
     // Then I should be shown the placement page with a confirmation message
     placementPage = new PlacementShowPage(placement)
     placementPage.shouldShowBanner('Keyworker assigned')
+  })
+
+  it('Requires the correct permission to assign a keyworker', () => {
+    // Given I am logged in and have permission to view the placement, but not assign keyworker
+    signIn([], ['cas1_space_booking_view'])
+
+    // And I am on the placement page
+    const placementPage = PlacementShowPage.visit(placement)
+
+    // Then the record non-arrival option should not be present
+    placementPage.actionMenuShouldNotExist()
+
+    // When I navigate to the keyworker page directly
+    // Then I see an authorisation error
+    KeyworkerAssignmentPage.visitUnauthorised(placement)
   })
 })

--- a/integration_tests/tests/manage/placements/keyworker.cy.ts
+++ b/integration_tests/tests/manage/placements/keyworker.cy.ts
@@ -46,6 +46,9 @@ context('Keyworker', () => {
     // Then I should be shown the placement page with a confirmation message
     placementPage = new PlacementShowPage(placement)
     placementPage.shouldShowBanner('Keyworker assigned')
+
+    // And the API should have been called with the correct parameters
+    page.checkApiCalled(placement)
   })
 
   it('Requires the correct permission to assign a keyworker', () => {

--- a/integration_tests/tests/manage/placements/keyworker.cy.ts
+++ b/integration_tests/tests/manage/placements/keyworker.cy.ts
@@ -27,7 +27,7 @@ context('Keyworker', () => {
     let placementPage = PlacementShowPage.visit(placement)
 
     // When I click on option to assign a keyworker
-    placementPage.clickAction('Assign keyworker')
+    placementPage.clickAction('Edit keyworker')
 
     // Then I should open the keyworker assignment page
     const page = new KeyworkerAssignmentPage(placement, staffMembers)
@@ -51,8 +51,8 @@ context('Keyworker', () => {
     page.checkApiCalled(placement)
   })
 
-  it('Requires the correct permission to assign a keyworker', () => {
-    // Given I am logged in and have permission to view the placement, but not assign keyworker
+  it('Requires the correct permission to edit a keyworker', () => {
+    // Given I am logged in and have permission to view the placement, but not edit keyworker
     signIn([], ['cas1_space_booking_view'])
 
     // And I am on the placement page

--- a/integration_tests/tests/manage/placements/non-arrivals.cy.ts
+++ b/integration_tests/tests/manage/placements/non-arrivals.cy.ts
@@ -1,0 +1,82 @@
+import { signIn } from '../../signIn'
+import { cas1PremisesSummaryFactory, cas1SpaceBookingFactory } from '../../../../server/testutils/factories'
+import { PlacementShowPage } from '../../../pages/manage'
+import { RecordNonArrivalPage } from '../../../pages/manage/placements/nonArrival'
+
+context('Non-arrivals', () => {
+  let placement
+
+  beforeEach(() => {
+    const premises = cas1PremisesSummaryFactory.build()
+    placement = cas1SpaceBookingFactory.upcoming().build({ premises })
+    cy.task('stubNonArrivalReasonsReferenceData')
+    cy.task('stubSpaceBookingShow', placement)
+    cy.task('stubSpaceBookingNonArrival', placement)
+  })
+
+  it('Records a non-arrival against a placement', () => {
+    // Given I am logged in with the correct permissions
+    signIn([], ['cas1_space_booking_view', 'cas1_space_booking_record_non_arrival'])
+
+    // And I am on the placement page
+    let placementPage = PlacementShowPage.visit(placement)
+
+    // When I click on option to record a non-arrival
+    placementPage.clickAction('Record non-arrival')
+
+    // Then it should open the record non-arrival page
+    const page = new RecordNonArrivalPage()
+
+    // When I submit the form without selecting a non-arrival reason
+    page.clickSubmit()
+
+    // Then I should see an error message
+    page.shouldShowReasonError()
+
+    // When I type too much text into the notes box
+    page.completeNotesBad()
+
+    // Then I should see an in-page error
+    page.checkForCharacterCountError()
+
+    // When I submit the page
+    page.clickSubmit()
+
+    // Then I should see two errors
+    page.shouldShowReasonError()
+    page.shouldShowTextError()
+
+    // And the text should still be populated
+    page.checkForCharacterCountError()
+
+    // When I select a reason and submit the form
+    page.completeReason()
+    page.clickSubmit()
+
+    // Then I should see the text overflow error (but the reason should remain populated)
+    page.shouldShowTextError()
+
+    // When I fix the text overflow and submit the form (given that the reason remained populated)
+    page.completeNotesGood()
+    page.clickSubmit()
+
+    // Then I should be shown the placement page with a confirmation message
+    placementPage = new PlacementShowPage(placement)
+    placementPage.shouldShowBanner('You have recorded this person as not arrived')
+  })
+
+  it('Requires the correct permission to record a non-arrival against a placement', () => {
+    // Given I am logged in and have permission to view the placement, but not record non-arrival
+    signIn([], ['cas1_space_booking_view'])
+
+    // And I am on the placement page
+    const placementPage = PlacementShowPage.visit(placement)
+
+    // Then the record non-arrival option should not be present
+    placementPage.actionMenuShouldNotExist()
+
+    // When I navigate to the non-arrival page directly
+    // Then I see an authorisation error
+    RecordNonArrivalPage.visitUnauthorised(placement)
+  })
+})

--- a/integration_tests/tests/manage/placements/non-arrivals.cy.ts
+++ b/integration_tests/tests/manage/placements/non-arrivals.cy.ts
@@ -14,6 +14,11 @@ context('Non-arrivals', () => {
     cy.task('stubSpaceBookingNonArrival', placement)
   })
 
+  const errorMessages = {
+    notes: 'You have exceeded 200 characters',
+    reason: 'You must select a reason for non-arrival',
+  }
+
   it('Records a non-arrival against a placement', () => {
     // Given I am logged in with the correct permissions
     signIn([], ['cas1_space_booking_view', 'cas1_space_booking_record_non_arrival'])
@@ -31,7 +36,7 @@ context('Non-arrivals', () => {
     page.clickSubmit()
 
     // Then I should see an error message
-    page.shouldShowReasonError()
+    page.shouldShowErrorMessagesForFields(['reason'], errorMessages)
 
     // When I type too much text into the notes box
     page.completeNotesBad()
@@ -43,8 +48,7 @@ context('Non-arrivals', () => {
     page.clickSubmit()
 
     // Then I should see two errors
-    page.shouldShowReasonError()
-    page.shouldShowTextError()
+    page.shouldShowErrorMessagesForFields(['reason', 'notes'], errorMessages)
 
     // And the text should still be populated
     page.checkForCharacterCountError()
@@ -54,7 +58,7 @@ context('Non-arrivals', () => {
     page.clickSubmit()
 
     // Then I should see the text overflow error (but the reason should remain populated)
-    page.shouldShowTextError()
+    page.shouldShowErrorMessagesForFields(['notes'], errorMessages)
 
     // When I fix the text overflow and submit the form (given that the reason remained populated)
     page.completeNotesGood()
@@ -63,6 +67,9 @@ context('Non-arrivals', () => {
     // Then I should be shown the placement page with a confirmation message
     placementPage = new PlacementShowPage(placement)
     placementPage.shouldShowBanner('You have recorded this person as not arrived')
+
+    // And the booking details should have been sent to the API
+    page.checkApiCalled(placement)
   })
 
   it('Requires the correct permission to record a non-arrival against a placement', () => {

--- a/integration_tests/tests/manage/placements/viewPlacement.cy.ts
+++ b/integration_tests/tests/manage/placements/viewPlacement.cy.ts
@@ -1,9 +1,9 @@
 import { ApprovedPremisesUserPermission, Cas1SpaceBookingDates, FullPerson } from '@approved-premises/api'
-import { cas1SpaceBookingFactory } from '../../../server/testutils/factories'
+import { cas1SpaceBookingFactory } from '../../../../server/testutils/factories'
 
-import { PlacementShowPage } from '../../pages/manage'
+import { PlacementShowPage } from '../../../pages/manage'
 
-import { signIn } from '../signIn'
+import { signIn } from '../../signIn'
 
 context('Placements', () => {
   describe('show', () => {

--- a/server/controllers/manage/index.ts
+++ b/server/controllers/manage/index.ts
@@ -12,6 +12,7 @@ import BedsController from './premises/bedsController'
 import OutOfServiceBedsController from './outOfServiceBedsController'
 import UpdateOutOfServiceBedsController from './updateOutOfServiceBedsController'
 import ArrivalsController from './premises/placements/arrivalsController'
+import NonArrivalsController from './premises/placements/nonArrivalsController'
 import KeyworkerController from './premises/placements/keyworkerController'
 
 export const controllers = (services: Services) => {
@@ -30,11 +31,13 @@ export const controllers = (services: Services) => {
   const dateChangesController = new DateChangesController(services.bookingService)
   const placementController = new PlacementController(services.premisesService)
   const arrivalsController = new ArrivalsController(services.premisesService, services.placementService)
+  const nonArrivalsController = new NonArrivalsController(services.premisesService, services.placementService)
   const keyworkerController = new KeyworkerController(services.premisesService, services.placementService)
 
   return {
     premisesController,
     arrivalsController,
+    nonArrivalsController,
     bedsController,
     outOfServiceBedsController,
     updateOutOfServiceBedsController,
@@ -51,6 +54,7 @@ export {
   PremisesController,
   PlacementController,
   ArrivalsController,
+  NonArrivalsController,
   KeyworkerController,
   BedsController,
   OutOfServiceBedsController,

--- a/server/controllers/manage/premises/placements/arrivalsController.ts
+++ b/server/controllers/manage/premises/placements/arrivalsController.ts
@@ -17,7 +17,6 @@ export default class ArrivalsController {
     return async (req: Request, res: Response) => {
       const { premisesId, placementId } = req.params
       const { errors, errorSummary, userInput, errorTitle } = fetchErrorsAndUserInput(req)
-
       const placement = await this.premisesService.getPlacement({ token: req.user.token, premisesId, placementId })
 
       return res.render('manage/premises/placements/arrival', {

--- a/server/controllers/manage/premises/placements/nonArrivalsController.test.ts
+++ b/server/controllers/manage/premises/placements/nonArrivalsController.test.ts
@@ -1,0 +1,118 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+import type { ErrorsAndUserInput } from '@approved-premises/ui'
+import { when } from 'jest-when'
+import { NonArrivalReason } from '@approved-premises/api'
+import NonArrivalsController from './nonArrivalsController'
+import { referenceDataFactory, spaceBookingFactory } from '../../../../testutils/factories'
+import { PremisesService } from '../../../../services'
+import * as validationUtils from '../../../../utils/validation'
+import managePaths from '../../../../paths/manage'
+import PlacementService from '../../../../services/placementService'
+import { ValidationError } from '../../../../utils/errors'
+
+describe('nonArrivalsController', () => {
+  const token = 'SAMPLE_TOKEN'
+  const premisesId = 'premises-id'
+
+  let request: DeepMocked<Request>
+  const response: DeepMocked<Response> = createMock<Response>()
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>()
+
+  const premisesService = createMock<PremisesService>()
+  const placementService = createMock<PlacementService>()
+
+  const nonArrivalsController = new NonArrivalsController(premisesService, placementService)
+
+  const placement = spaceBookingFactory.build()
+  const uiPlacementPagePath = managePaths.premises.placements.show({ premisesId, placementId: placement.id })
+  const uiNonArrivalsPagePath = managePaths.premises.placements.nonArrival({ premisesId, placementId: placement.id })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    premisesService.getPlacement.mockResolvedValue(placement)
+    request = createMock<Request>({ user: { token }, params: { premisesId, placementId: placement.id } })
+
+    jest.spyOn(validationUtils, 'fetchErrorsAndUserInput')
+    jest.spyOn(validationUtils, 'catchValidationErrorOrPropogate').mockReturnValue(undefined)
+  })
+
+  describe('new', () => {
+    it('should render the non-arrivals form with a selection of reasons', async () => {
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+      when(validationUtils.fetchErrorsAndUserInput).calledWith(request).mockReturnValue(errorsAndUserInput)
+      const nonArrivalReasons: Array<NonArrivalReason> = referenceDataFactory.nonArrivalReason().buildList(20)
+      placementService.getNonArrivalReasons.mockResolvedValue(nonArrivalReasons)
+
+      const requestHandler = nonArrivalsController.new()
+
+      await requestHandler(request, response, next)
+
+      expect(premisesService.getPlacement).toHaveBeenCalledWith({ token, premisesId, placementId: placement.id })
+      expect(response.render).toHaveBeenCalledWith('manage/premises/placements/non-arrival', {
+        nonArrivalReasons,
+        placement,
+        errors: errorsAndUserInput.errors,
+        errorSummary: errorsAndUserInput.errorSummary,
+        errorTitle: errorsAndUserInput.errorTitle,
+        ...errorsAndUserInput.userInput,
+      })
+    })
+  })
+
+  describe('create', () => {
+    it(`Sets the placement's state to non-arrived and returns to the details page`, async () => {
+      const requestHandler = nonArrivalsController.create()
+      request.body = { reason: 'reason', notes: 'some dummy notes' }
+
+      await requestHandler(request, response, next)
+
+      expect(placementService.recordNonArrival).toHaveBeenCalledWith(token, premisesId, placement.id, request.body)
+      expect(request.flash).toHaveBeenCalledWith('success', 'You have recorded this person as not arrived')
+      expect(response.redirect).toHaveBeenCalledWith(uiPlacementPagePath)
+    })
+
+    it('returns error if page submitted without reason selected', async () => {
+      const requestHandler = nonArrivalsController.create()
+
+      request.body = {}
+
+      await requestHandler(request, response, next)
+
+      expect(placementService.recordNonArrival).not.toHaveBeenCalled()
+      expect(validationUtils.catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+        request,
+        response,
+        new ValidationError({}),
+        uiNonArrivalsPagePath,
+      )
+
+      const errorData = (validationUtils.catchValidationErrorOrPropogate as jest.Mock).mock.lastCall[2].data
+
+      expect(errorData).toEqual({
+        reason: 'You must select a reason for non-arrival',
+      })
+    })
+
+    describe('when errors are raised by the API', () => {
+      it('should call catchValidationErrorOrPropogate with a standard error', async () => {
+        const requestHandler = nonArrivalsController.create()
+        request.body = { reason: 'test' }
+
+        const err = new Error()
+
+        placementService.recordNonArrival.mockRejectedValue(err)
+
+        await requestHandler(request, response, next)
+
+        expect(validationUtils.catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+          request,
+          response,
+          err,
+          uiNonArrivalsPagePath,
+        )
+      })
+    })
+  })
+})

--- a/server/controllers/manage/premises/placements/nonArrivalsController.ts
+++ b/server/controllers/manage/premises/placements/nonArrivalsController.ts
@@ -19,7 +19,7 @@ export default class NonArrivalsController {
       const placement = await this.premisesService.getPlacement({ token, premisesId, placementId })
       const nonArrivalReasons: Array<NonArrivalReason> = await this.placementService.getNonArrivalReasons(token)
       return res.render('manage/premises/placements/non-arrival', {
-        nonArrivalReasons,
+        nonArrivalReasons: nonArrivalReasons.filter(({ isActive }) => isActive),
         placement,
         errors,
         errorSummary,

--- a/server/controllers/manage/premises/placements/nonArrivalsController.ts
+++ b/server/controllers/manage/premises/placements/nonArrivalsController.ts
@@ -1,0 +1,73 @@
+import { type Request, RequestHandler, type Response } from 'express'
+import { Cas1NonArrival, NonArrivalReason } from '@approved-premises/api'
+import { PlacementService, PremisesService } from '../../../../services'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../../utils/validation'
+import managePaths from '../../../../paths/manage'
+import { ValidationError } from '../../../../utils/errors'
+
+export default class NonArrivalsController {
+  constructor(
+    private readonly premisesService: PremisesService,
+    private readonly placementService: PlacementService,
+  ) {}
+
+  new(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { token } = req.user
+      const { premisesId, placementId } = req.params
+      const { errors, errorSummary, userInput, errorTitle } = fetchErrorsAndUserInput(req)
+      const placement = await this.premisesService.getPlacement({ token, premisesId, placementId })
+      const nonArrivalReasons: Array<NonArrivalReason> = await this.placementService.getNonArrivalReasons(token)
+      return res.render('manage/premises/placements/non-arrival', {
+        nonArrivalReasons: nonArrivalReasons.filter(({ isActive }) => isActive),
+        placement,
+        errors,
+        errorSummary,
+        errorTitle,
+        ...userInput,
+      })
+    }
+  }
+
+  create(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, placementId } = req.params
+      const errors: Record<string, string> = {}
+      try {
+        const { reason, notes } = req.body
+
+        if (!reason) {
+          errors.reason = 'You must select a reason for non-arrival'
+        }
+
+        if (notes?.length > 200) {
+          errors.notes = 'You have exceeded 200 characters'
+        }
+
+        if (Object.keys(errors).length) {
+          throw new ValidationError(errors)
+        }
+
+        const nonArrival: Cas1NonArrival = {
+          reason,
+          notes,
+        }
+
+        await this.placementService.recordNonArrival(req.user.token, premisesId, placementId, nonArrival)
+
+        req.flash('success', 'You have recorded this person as not arrived')
+        return res.redirect(managePaths.premises.placements.show({ premisesId, placementId }))
+      } catch (error) {
+        return catchValidationErrorOrPropogate(
+          req,
+          res,
+          error as Error,
+          managePaths.premises.placements.nonArrival({
+            premisesId,
+            placementId,
+          }),
+        )
+      }
+    }
+  }
+}

--- a/server/controllers/manage/premises/placements/nonArrivalsController.ts
+++ b/server/controllers/manage/premises/placements/nonArrivalsController.ts
@@ -19,7 +19,7 @@ export default class NonArrivalsController {
       const placement = await this.premisesService.getPlacement({ token, premisesId, placementId })
       const nonArrivalReasons: Array<NonArrivalReason> = await this.placementService.getNonArrivalReasons(token)
       return res.render('manage/premises/placements/non-arrival', {
-        nonArrivalReasons: nonArrivalReasons.filter(({ isActive }) => isActive),
+        nonArrivalReasons,
         placement,
         errors,
         errorSummary,

--- a/server/data/placementClient.test.ts
+++ b/server/data/placementClient.test.ts
@@ -1,7 +1,7 @@
 import PlacementClient from './placementClient'
 import paths from '../paths/api'
 import { describeCas1NamespaceClient } from '../testutils/describeClient'
-import { cas1AssignKeyWorkerFactory, newPlacementArrivalFactory } from '../testutils/factories'
+import { cas1AssignKeyWorkerFactory, cas1NonArrivalFactory, newPlacementArrivalFactory } from '../testutils/factories'
 
 describeCas1NamespaceClient('PlacementClient', provider => {
   let placementClient: PlacementClient
@@ -62,6 +62,32 @@ describeCas1NamespaceClient('PlacementClient', provider => {
       })
 
       const result = await placementClient.assignKeyworker(premisesId, placementId, keyworkerAssignment)
+
+      expect(result).toEqual({})
+    })
+  })
+
+  describe('recordNonArrival', () => {
+    it('records a non-arrival against a given placement', async () => {
+      const nonArrival = cas1NonArrivalFactory.build()
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to record a non-arrival',
+        withRequest: {
+          method: 'POST',
+          path: paths.premises.placements.nonArrival({ premisesId, placementId }),
+          body: nonArrival,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+        },
+      })
+
+      const result = await placementClient.recordNonArrival(premisesId, placementId, nonArrival)
 
       expect(result).toEqual({})
     })

--- a/server/data/placementClient.ts
+++ b/server/data/placementClient.ts
@@ -1,4 +1,4 @@
-import { Cas1AssignKeyWorker, Cas1NewArrival } from '@approved-premises/api'
+import { Cas1AssignKeyWorker, Cas1NewArrival, Cas1NonArrival } from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -14,6 +14,13 @@ export default class PlacementClient {
     return this.restClient.post({
       path: paths.premises.placements.arrival({ premisesId, placementId }),
       data: newPlacementArrival,
+    })
+  }
+
+  async recordNonArrival(premisesId: string, placementId: string, nonArrival: Cas1NonArrival) {
+    return this.restClient.post({
+      path: paths.premises.placements.nonArrival({ premisesId, placementId }),
+      data: nonArrival,
     })
   }
 

--- a/server/data/referenceDataClient.test.ts
+++ b/server/data/referenceDataClient.test.ts
@@ -10,7 +10,7 @@ import {
 import ReferenceDataClient from './referenceDataClient'
 import { probationRegionFactory, referenceDataFactory } from '../testutils/factories'
 import describeClient from '../testutils/describeClient'
-import { apAreaFactory } from '../testutils/factories/referenceData'
+import { apAreaFactory, nonArrivalReasonsFactory } from '../testutils/factories/referenceData'
 
 describeClient('ReferenceDataClient', provider => {
   let referenceDataClient: ReferenceDataClient
@@ -102,6 +102,31 @@ describeClient('ReferenceDataClient', provider => {
 
       const output = await referenceDataClient.getApAreas()
       expect(output).toEqual(apAreas)
+    })
+  })
+
+  describe('getNonArrivalReasons', () => {
+    it('should return an array of non-arrival reasons', async () => {
+      const nonArrivalReasons = nonArrivalReasonsFactory.buildList(5)
+
+      provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: `A request to get Non-arrival reasons`,
+        withRequest: {
+          method: 'GET',
+          path: `/reference-data/non-arrival-reasons`,
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: nonArrivalReasons,
+        },
+      })
+
+      const output = await referenceDataClient.getNonArrivalReasons()
+      expect(output).toEqual(nonArrivalReasons)
     })
   })
 })

--- a/server/data/referenceDataClient.ts
+++ b/server/data/referenceDataClient.ts
@@ -1,7 +1,7 @@
 import type { ReferenceData } from '@approved-premises/ui'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
-import { ApArea, ProbationRegion } from '../@types/shared'
+import { ApArea, NonArrivalReason, ProbationRegion } from '../@types/shared'
 
 export default class ReferenceDataClient {
   restClient: RestClient
@@ -20,5 +20,9 @@ export default class ReferenceDataClient {
 
   async getApAreas(): Promise<Array<ApArea>> {
     return (await this.restClient.get({ path: `/reference-data/ap-areas` })) as Array<ApArea>
+  }
+
+  async getNonArrivalReasons(): Promise<Array<NonArrivalReason>> {
+    return (await this.restClient.get({ path: `/reference-data/non-arrival-reasons` })) as Array<NonArrivalReason>
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -94,6 +94,7 @@ export default {
       index: cas1PremisesSingle.path('space-bookings'),
       show: cas1SpaceBookingSingle,
       arrival: cas1SpaceBookingSingle.path('arrival'),
+      nonArrival: cas1SpaceBookingSingle.path('non-arrival'),
       keyworker: cas1SpaceBookingSingle.path('keyworker'),
     },
     calendar: premisesSingle.path('calendar'),

--- a/server/paths/manage.ts
+++ b/server/paths/manage.ts
@@ -53,7 +53,7 @@ const deprecated = {
 const managePath = path('/manage')
 const premisesPath = managePath.path('premises')
 const singlePremisesPath = premisesPath.path(':premisesId')
-const placementPath = singlePremisesPath.path('placements/:placementId')
+const singlePlacementPath = singlePremisesPath.path('placements/:placementId')
 const bookingsPath = singlePremisesPath.path('bookings')
 const bookingPath = bookingsPath.path(':bookingId')
 const bedsPath = singlePremisesPath.path('beds')
@@ -72,10 +72,11 @@ const paths = {
       show: bedsPath.path(':bedId'),
     },
     placements: {
-      show: placementPath,
-      arrival: placementPath.path('arrival'),
-      departure: placementPath.path('departure'),
-      keyworker: placementPath.path('keyworker'),
+      show: singlePlacementPath,
+      arrival: singlePlacementPath.path('arrival'),
+      departure: singlePlacementPath.path('departure'),
+      keyworker: singlePlacementPath.path('keyworker'),
+      nonArrival: singlePlacementPath.path('non-arrival'),
     },
   },
 

--- a/server/routes/manage.test.ts
+++ b/server/routes/manage.test.ts
@@ -6,6 +6,7 @@ import {
   BookingExtensionsController,
   BookingsController,
   KeyworkerController,
+  NonArrivalsController,
   OutOfServiceBedsController,
   PlacementController,
   PremisesController,
@@ -30,6 +31,7 @@ describe('manage routes', () => {
   const bookingsController: DeepMocked<BookingsController> = createMock<BookingsController>({})
   const premisesController: DeepMocked<PremisesController> = createMock<PremisesController>({})
   const arrivalsController: DeepMocked<ArrivalsController> = createMock<ArrivalsController>({})
+  const nonArrivalsController: DeepMocked<NonArrivalsController> = createMock<NonArrivalsController>({})
   const placementController: DeepMocked<PlacementController> = createMock<PlacementController>({})
   const bedsController: DeepMocked<BedsController> = createMock<BedsController>({})
   const outOfServiceBedsController: DeepMocked<OutOfServiceBedsController> = createMock<OutOfServiceBedsController>({})
@@ -50,6 +52,7 @@ describe('manage routes', () => {
     dateChangesController,
     premisesController,
     arrivalsController,
+    nonArrivalsController,
     cancellationsController,
     redirectController,
     placementController,

--- a/server/routes/manage.ts
+++ b/server/routes/manage.ts
@@ -18,6 +18,7 @@ export default function routes(controllers: Controllers, router: Router, service
     premisesController,
     placementController,
     arrivalsController,
+    nonArrivalsController,
     bedsController,
     outOfServiceBedsController,
     updateOutOfServiceBedsController,
@@ -151,6 +152,20 @@ export default function routes(controllers: Controllers, router: Router, service
       {
         path: paths.premises.placements.keyworker.pattern,
         auditEvent: 'ASSIGN_KEYWORKER_FAILURE',
+      },
+    ],
+  })
+  get(paths.premises.placements.nonArrival.pattern, nonArrivalsController.new(), {
+    auditEvent: 'NON_ARRIVAL',
+    allowedPermissions: ['cas1_space_booking_record_non_arrival'],
+  })
+  post(paths.premises.placements.nonArrival.pattern, nonArrivalsController.create(), {
+    auditEvent: 'NON_ARRIVAL_SUCCESS',
+    allowedPermissions: ['cas1_space_booking_record_non_arrival'],
+    redirectAuditEventSpecs: [
+      {
+        path: paths.premises.placements.nonArrival.pattern,
+        auditEvent: 'NON_ARRIVAL_FAILURE',
       },
     ],
   })

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -47,7 +47,7 @@ export const services = () => {
   const userService = new UserService(userClientBuilder, referenceDataClientBuilder)
   const auditService = new AuditService(config.apis.audit as AuditConfig)
   const premisesService = new PremisesService(approvedPremisesClientBuilder)
-  const placementService = new PlacementService(placementClientBuilder)
+  const placementService = new PlacementService(placementClientBuilder, referenceDataClientBuilder)
   const personService = new PersonService(personClient)
   const bookingService = new BookingService(bookingClientBuilder)
   const cancellationService = new CancellationService(bookingClientBuilder, referenceDataClientBuilder)

--- a/server/services/placementService.test.ts
+++ b/server/services/placementService.test.ts
@@ -78,7 +78,7 @@ describe('PlacementService', () => {
 
       const result = await placementService.getNonArrivalReasons(token)
 
-      expect(result).toEqual(nonArrivalReasons)
+      expect(result).toEqual(nonArrivalReasons.filter(({ isActive }) => isActive))
     })
   })
 })

--- a/server/services/placementService.test.ts
+++ b/server/services/placementService.test.ts
@@ -1,23 +1,34 @@
 import PlacementService from './placementService'
 import PlacementClient from '../data/placementClient'
-import { cas1AssignKeyWorkerFactory, newPlacementArrivalFactory } from '../testutils/factories'
+import { ReferenceDataClient } from '../data'
+import {
+  cas1AssignKeyWorkerFactory,
+  cas1NonArrivalFactory,
+  newPlacementArrivalFactory,
+  nonArrivalReasonsFactory,
+} from '../testutils/factories'
 
 jest.mock('../data/placementClient')
+jest.mock('../data/referenceDataClient.ts')
 
 describe('PlacementService', () => {
   const placementClient = new PlacementClient(null) as jest.Mocked<PlacementClient>
+  const referenceDataClient = new ReferenceDataClient(null) as jest.Mocked<ReferenceDataClient>
 
   const placementClientFactory = jest.fn()
-
-  const service = new PlacementService(placementClientFactory)
+  const referenceDataClientFactory = jest.fn()
 
   const token = 'SOME_TOKEN'
   const premisesId = 'premisesId'
   const placementId = 'placementId'
 
+  let placementService: PlacementService
+
   beforeEach(() => {
     jest.resetAllMocks()
+    placementService = new PlacementService(placementClientFactory, referenceDataClientFactory)
     placementClientFactory.mockReturnValue(placementClient)
+    referenceDataClientFactory.mockReturnValue(referenceDataClient)
   })
 
   describe('createArrival', () => {
@@ -26,7 +37,7 @@ describe('PlacementService', () => {
 
       placementClient.createArrival.mockResolvedValue({})
 
-      const result = await service.createArrival(token, premisesId, placementId, newPlacementArrival)
+      const result = await placementService.createArrival(token, premisesId, placementId, newPlacementArrival)
 
       expect(result).toEqual({})
       expect(placementClientFactory).toHaveBeenCalledWith(token)
@@ -35,14 +46,34 @@ describe('PlacementService', () => {
   })
 
   describe('assignKeyworker', () => {
-    it('calls the assignKeyworker method of the placement client a response', async () => {
+    it('calls the assignKeyworker method of the placement client an returns a response', async () => {
       const assignKeyworker = cas1AssignKeyWorkerFactory.build()
       placementClient.assignKeyworker.mockResolvedValue({})
 
-      const result = await service.assignKeyworker(token, premisesId, placementId, assignKeyworker)
+      const result = await placementService.assignKeyworker(token, premisesId, placementId, assignKeyworker)
       expect(result).toEqual({})
       expect(placementClientFactory).toHaveBeenCalledWith(token)
       expect(placementClient.assignKeyworker).toHaveBeenCalledWith(premisesId, placementId, assignKeyworker)
+    })
+  })
+
+  describe('recordNonArrival', () => {
+    it('calls the recordNonArrival method of the placement client and returns a response', async () => {
+      const nonArrival = cas1NonArrivalFactory.build()
+      placementClient.recordNonArrival.mockResolvedValue({})
+      const result = await placementService.recordNonArrival(token, premisesId, placementId, nonArrival)
+      expect(result).toEqual({})
+      expect(placementClientFactory).toHaveBeenCalledWith(token)
+      expect(placementClient.recordNonArrival).toHaveBeenCalledWith(premisesId, placementId, nonArrival)
+    })
+  })
+
+  describe('getNonArrivalReasons', () => {
+    it('loads the non-arrival reasons from the reference data client', async () => {
+      const nonArrivalReasons = nonArrivalReasonsFactory.buildList(20)
+      referenceDataClient.getNonArrivalReasons.mockResolvedValue(nonArrivalReasons)
+      const result = await placementService.getNonArrivalReasons(token)
+      expect(result).toEqual(nonArrivalReasons)
     })
   })
 })

--- a/server/services/placementService.test.ts
+++ b/server/services/placementService.test.ts
@@ -51,6 +51,7 @@ describe('PlacementService', () => {
       placementClient.assignKeyworker.mockResolvedValue({})
 
       const result = await placementService.assignKeyworker(token, premisesId, placementId, assignKeyworker)
+
       expect(result).toEqual({})
       expect(placementClientFactory).toHaveBeenCalledWith(token)
       expect(placementClient.assignKeyworker).toHaveBeenCalledWith(premisesId, placementId, assignKeyworker)
@@ -61,7 +62,9 @@ describe('PlacementService', () => {
     it('calls the recordNonArrival method of the placement client and returns a response', async () => {
       const nonArrival = cas1NonArrivalFactory.build()
       placementClient.recordNonArrival.mockResolvedValue({})
+
       const result = await placementService.recordNonArrival(token, premisesId, placementId, nonArrival)
+
       expect(result).toEqual({})
       expect(placementClientFactory).toHaveBeenCalledWith(token)
       expect(placementClient.recordNonArrival).toHaveBeenCalledWith(premisesId, placementId, nonArrival)
@@ -72,7 +75,9 @@ describe('PlacementService', () => {
     it('loads the non-arrival reasons from the reference data client', async () => {
       const nonArrivalReasons = nonArrivalReasonsFactory.buildList(20)
       referenceDataClient.getNonArrivalReasons.mockResolvedValue(nonArrivalReasons)
+
       const result = await placementService.getNonArrivalReasons(token)
+
       expect(result).toEqual(nonArrivalReasons)
     })
   })

--- a/server/services/placementService.ts
+++ b/server/services/placementService.ts
@@ -27,7 +27,9 @@ export default class PlacementService {
 
   async getNonArrivalReasons(token: string): Promise<Array<NonArrivalReason>> {
     const client = this.referenceDataClientFactory(token)
-    return client.getNonArrivalReasons()
+    const allNonArrivalReasons = await client.getNonArrivalReasons()
+
+    return allNonArrivalReasons.filter(({ isActive }) => isActive)
   }
 
   async recordNonArrival(token: string, premisesId: string, placementId: string, nonArrival: Cas1NonArrival) {

--- a/server/services/placementService.ts
+++ b/server/services/placementService.ts
@@ -1,9 +1,12 @@
-import { Cas1AssignKeyWorker, Cas1NewArrival } from '@approved-premises/api'
-import type { RestClientBuilder } from '../data'
+import { Cas1AssignKeyWorker, Cas1NewArrival, Cas1NonArrival, NonArrivalReason } from '@approved-premises/api'
+import type { ReferenceDataClient, RestClientBuilder } from '../data'
 import PlacementClient from '../data/placementClient'
 
 export default class PlacementService {
-  constructor(private readonly placementClientFactory: RestClientBuilder<PlacementClient>) {}
+  constructor(
+    private readonly placementClientFactory: RestClientBuilder<PlacementClient>,
+    private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
+  ) {}
 
   async createArrival(token: string, premisesId: string, placementId: string, newPlacementArrival: Cas1NewArrival) {
     const placementClient = this.placementClientFactory(token)
@@ -20,5 +23,16 @@ export default class PlacementService {
     const placementClient = this.placementClientFactory(token)
 
     return placementClient.assignKeyworker(premisesId, placementId, keyworkerAssignment)
+  }
+
+  async getNonArrivalReasons(token: string): Promise<Array<NonArrivalReason>> {
+    const client = this.referenceDataClientFactory(token)
+    return client.getNonArrivalReasons()
+  }
+
+  async recordNonArrival(token: string, premisesId: string, placementId: string, nonArrival: Cas1NonArrival) {
+    const placementClient = this.placementClientFactory(token)
+
+    return placementClient.recordNonArrival(premisesId, placementId, nonArrival)
   }
 }

--- a/server/testutils/factories/cas1NonArrival.ts
+++ b/server/testutils/factories/cas1NonArrival.ts
@@ -6,5 +6,5 @@ import { DateFormats } from '../../utils/dateUtils'
 export default Factory.define<Cas1NonArrival>(() => ({
   reason: faker.string.uuid(),
   notes: faker.lorem.words(20),
-  confirmedAt: DateFormats.dateObjToIsoDateTime(new Date(faker.date.recent())),
+  confirmedAt: DateFormats.dateObjToIsoDateTime(faker.date.recent()),
 }))

--- a/server/testutils/factories/cas1NonArrival.ts
+++ b/server/testutils/factories/cas1NonArrival.ts
@@ -1,0 +1,12 @@
+import { Factory } from 'fishery'
+import { Cas1NonArrival } from '@approved-premises/api'
+import { faker } from '@faker-js/faker'
+import { DateFormats } from '../../utils/dateUtils'
+
+export default Factory.define<Cas1NonArrival>(() => ({
+  reason: faker.word.words(3),
+  notes: faker.lorem.words(50),
+  confirmedAt: DateFormats.dateObjToIsoDateTime(
+    new Date(faker.date.recent().getTime() + faker.number.int({ max: 1000 * 60 * 60 * 24 })),
+  ),
+}))

--- a/server/testutils/factories/cas1NonArrival.ts
+++ b/server/testutils/factories/cas1NonArrival.ts
@@ -4,9 +4,7 @@ import { faker } from '@faker-js/faker'
 import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<Cas1NonArrival>(() => ({
-  reason: faker.word.words(3),
-  notes: faker.lorem.words(50),
-  confirmedAt: DateFormats.dateObjToIsoDateTime(
-    new Date(faker.date.recent().getTime() + faker.number.int({ max: 1000 * 60 * 60 * 24 })),
-  ),
+  reason: faker.string.uuid(),
+  notes: faker.lorem.words(20),
+  confirmedAt: DateFormats.dateObjToIsoDateTime(new Date(faker.date.recent())),
 }))

--- a/server/testutils/factories/cas1SpaceBooking.ts
+++ b/server/testutils/factories/cas1SpaceBooking.ts
@@ -10,8 +10,6 @@ import staffMemberFactory from './staffMember'
 import { DateFormats } from '../../utils/dateUtils'
 import cas1SpaceBookingNonArrivalFactory from './cas1SpaceBookingNonArrival'
 
-const addTime = (date: Date): Date => new Date(date.getTime() + faker.number.int({ max: 60 * 60 * 24 * 1000 }))
-
 class Cas1SpaceBookingFactory extends Factory<Cas1SpaceBooking> {
   upcoming() {
     return this.params({
@@ -42,8 +40,8 @@ class Cas1SpaceBookingFactory extends Factory<Cas1SpaceBooking> {
 }
 
 export default Cas1SpaceBookingFactory.define(() => {
-  const startDateTime = addTime(faker.date.soon({ days: 90 }))
-  const endDateTime = addTime(faker.date.soon({ days: 365, refDate: startDateTime }))
+  const startDateTime = faker.date.soon({ days: 90 })
+  const endDateTime = faker.date.soon({ days: 365, refDate: startDateTime })
   const [actualArrivalDate, actualDepartureDate] = [startDateTime, endDateTime].map(DateFormats.dateObjToIsoDateTime)
   const [canonicalArrivalDate, canonicalDepartureDate] = [startDateTime, endDateTime].map(DateFormats.dateObjToIsoDate)
   const [expectedArrivalDate, expectedDepartureDate] = faker.date
@@ -70,7 +68,7 @@ export default Cas1SpaceBookingFactory.define(() => {
     canonicalDepartureDate,
     departureReason: { id: faker.string.uuid(), name: faker.word.noun() },
     departureMoveOnCategory: { id: faker.string.uuid(), name: faker.word.noun() },
-    createdAt: DateFormats.dateObjToIsoDateTime(addTime(faker.date.recent())),
+    createdAt: DateFormats.dateObjToIsoDateTime(faker.date.recent()),
     keyWorkerAllocation: { keyWorker: staffMemberFactory.build() } as Cas1KeyWorkerAllocation,
     otherBookingsInPremisesForCrn: cas1SpaceBookingDatesFactory.buildList(4),
     deliusEventNumber: String(faker.number.int()),

--- a/server/testutils/factories/cas1SpaceBooking.ts
+++ b/server/testutils/factories/cas1SpaceBooking.ts
@@ -8,6 +8,7 @@ import userFactory from './user'
 
 import staffMemberFactory from './staffMember'
 import { DateFormats } from '../../utils/dateUtils'
+import cas1SpaceBookingNonArrivalFactory from './cas1SpaceBookingNonArrival'
 
 const addTime = (date: Date): Date => new Date(date.getTime() + faker.number.int({ max: 60 * 60 * 24 * 1000 }))
 
@@ -26,6 +27,16 @@ class Cas1SpaceBookingFactory extends Factory<Cas1SpaceBooking> {
       actualDepartureDate: undefined,
       departureReason: undefined,
       departureMoveOnCategory: undefined,
+    })
+  }
+
+  nonArrival() {
+    return this.params({
+      actualArrivalDate: undefined,
+      actualDepartureDate: undefined,
+      departureReason: undefined,
+      departureMoveOnCategory: undefined,
+      nonArrival: cas1SpaceBookingNonArrivalFactory.build(),
     })
   }
 }

--- a/server/testutils/factories/cas1SpaceBookingNonArrival.ts
+++ b/server/testutils/factories/cas1SpaceBookingNonArrival.ts
@@ -1,0 +1,19 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker'
+import { type Cas1SpaceBookingNonArrival } from '@approved-premises/api'
+import { DateFormats } from '../../utils/dateUtils'
+
+class Cas1SpaceBookingNonArrivalFactory extends Factory<Cas1SpaceBookingNonArrival> {}
+
+export default Cas1SpaceBookingNonArrivalFactory.define(() => {
+  return {
+    notes: faker.word.words(20),
+    reason: {
+      id: faker.string.uuid(),
+      name: `${faker.word.noun()} ${faker.word.verb()}`,
+    },
+    confirmedAt: DateFormats.dateObjToIsoDate(
+      new Date(faker.date.recent().getTime() + faker.number.int({ max: 60 * 60 * 24 * 1000 })),
+    ),
+  }
+})

--- a/server/testutils/factories/cas1SpaceBookingNonArrival.ts
+++ b/server/testutils/factories/cas1SpaceBookingNonArrival.ts
@@ -12,6 +12,6 @@ export default Cas1SpaceBookingNonArrivalFactory.define(() => {
       id: faker.string.uuid(),
       name: `${faker.word.noun()} ${faker.word.verb()}`,
     },
-    confirmedAt: DateFormats.dateObjToIsoDateTime(new Date(faker.date.recent())),
+    confirmedAt: DateFormats.dateObjToIsoDateTime(faker.date.recent()),
   }
 })

--- a/server/testutils/factories/cas1SpaceBookingNonArrival.ts
+++ b/server/testutils/factories/cas1SpaceBookingNonArrival.ts
@@ -12,8 +12,6 @@ export default Cas1SpaceBookingNonArrivalFactory.define(() => {
       id: faker.string.uuid(),
       name: `${faker.word.noun()} ${faker.word.verb()}`,
     },
-    confirmedAt: DateFormats.dateObjToIsoDate(
-      new Date(faker.date.recent().getTime() + faker.number.int({ max: 60 * 60 * 24 * 1000 })),
-    ),
+    confirmedAt: DateFormats.dateObjToIsoDateTime(new Date(faker.date.recent())),
   }
 })

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -54,7 +54,7 @@ import premisesFactory from './premises'
 import premisesSummaryFactory from './premisesSummary'
 import prisonCaseNotesFactory from './prisonCaseNotes'
 import reallocationFactory from './reallocation'
-import referenceDataFactory, { apAreaFactory, probationRegionFactory } from './referenceData'
+import referenceDataFactory, { apAreaFactory, nonArrivalReasonsFactory, probationRegionFactory } from './referenceData'
 import cas1ReferenceDataFactory, { cruManagementAreaFactory } from './cas1ReferenceData'
 import requestForPlacementFactory from './requestForPlacement'
 import risksFactory, { tierEnvelopeFactory } from './risks'
@@ -84,6 +84,7 @@ import cas1SpaceBookingFactory from './cas1SpaceBooking'
 import cas1SpaceBookingDatesFactory from './cas1SpaceBookingDates'
 import cas1AssignKeyWorkerFactory from './cas1AssignKeyWorker'
 import newPlacementArrivalFactory from './newPlacementArrival'
+import cas1NonArrivalFactory from './cas1NonArrival'
 
 export {
   acctAlertFactory,
@@ -118,6 +119,7 @@ export {
   cas1SpaceBookingSummaryFactory,
   cas1AssignKeyWorkerFactory,
   newPlacementArrivalFactory,
+  cas1NonArrivalFactory,
   clarificationNoteFactory,
   contingencyPlanPartnerFactory,
   contingencyPlanQuestionsBodyFactory,
@@ -138,6 +140,7 @@ export {
   outOfServiceBedCancellationFactory,
   outOfServiceBedRevisionFactory,
   newOutOfServiceBedFactory,
+  nonArrivalReasonsFactory,
   paginatedResponseFactory,
   personFactory,
   personalTimelineFactory,

--- a/server/testutils/factories/referenceData.ts
+++ b/server/testutils/factories/referenceData.ts
@@ -10,7 +10,7 @@ import cancellationReasonsJson from '../referenceData/stubs/cancellation-reasons
 import lostBedReasonsJson from '../referenceData/stubs/lost-bed-reasons.json'
 import nonArrivalReasonsJson from '../referenceData/stubs/non-arrival-reasons.json'
 import probationRegionsJson from '../referenceData/stubs/probation-regions.json'
-import { ApArea, ProbationRegion } from '../../@types/shared'
+import { ApArea, NonArrivalReason, ProbationRegion } from '../../@types/shared'
 
 class ReferenceDataFactory extends Factory<ReferenceData> {
   departureReasons() {
@@ -64,4 +64,10 @@ export const apAreaFactory = Factory.define<ApArea>(() => ({
   id: faker.string.uuid(),
   name: faker.location.city(),
   identifier: faker.location.countryCode(),
+}))
+
+export const nonArrivalReasonsFactory = Factory.define<NonArrivalReason>(() => ({
+  id: faker.string.uuid(),
+  name: faker.word.words(2),
+  isActive: faker.datatype.boolean(),
 }))

--- a/server/utils/placements/index.test.ts
+++ b/server/utils/placements/index.test.ts
@@ -54,7 +54,7 @@ describe('placementUtils', () => {
     const keyworkerOption = {
       classes: 'govuk-button--secondary',
       href: paths.premises.placements.keyworker({ premisesId: premises.id, placementId }),
-      text: 'Assign keyworker',
+      text: 'Edit keyworker',
     }
     describe('when the placement is in its initial state', () => {
       const placementInitial = cas1SpaceBookingFactory.upcoming().build({ id: placementId, premises })

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -14,7 +14,7 @@ export const actions = (placement: Cas1SpaceBooking, user: UserDetails) => {
 
   if (!departed && !nonArrival && hasPermission(user, ['cas1_space_booking_record_keyworker'])) {
     actionList.push({
-      text: 'Assign keyworker',
+      text: 'Edit keyworker',
       classes: 'govuk-button--secondary',
       href: paths.premises.placements.keyworker({ premisesId: placement.premises.id, placementId: placement.id }),
     })

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -19,19 +19,20 @@ export const actions = (placement: Cas1SpaceBooking, user: UserDetails) => {
       href: paths.premises.placements.keyworker({ premisesId: placement.premises.id, placementId: placement.id }),
     })
   }
-  if (!arrived && !nonArrival && hasPermission(user, ['cas1_space_booking_record_arrival'])) {
-    actionList.push({
-      text: 'Record arrival',
-      classes: 'govuk-button--secondary',
-      href: paths.premises.placements.arrival({ premisesId: placement.premises.id, placementId: placement.id }),
-    })
-  }
-  if (!arrived && !nonArrival && !departed && hasPermission(user, ['cas1_space_booking_record_non_arrival'])) {
-    actionList.push({
-      text: 'Record non-arrival',
-      classes: 'govuk-button--secondary',
-      href: paths.premises.placements.nonArrival({ premisesId: placement.premises.id, placementId: placement.id }),
-    })
+  if (!arrived && !nonArrival) {
+    if (hasPermission(user, ['cas1_space_booking_record_arrival']))
+      actionList.push({
+        text: 'Record arrival',
+        classes: 'govuk-button--secondary',
+        href: paths.premises.placements.arrival({ premisesId: placement.premises.id, placementId: placement.id }),
+      })
+    if (hasPermission(user, ['cas1_space_booking_record_non_arrival'])) {
+      actionList.push({
+        text: 'Record non-arrival',
+        classes: 'govuk-button--secondary',
+        href: paths.premises.placements.nonArrival({ premisesId: placement.premises.id, placementId: placement.id }),
+      })
+    }
   }
   if (arrived && !nonArrival && !departed && hasPermission(user, ['cas1_space_booking_record_departure'])) {
     actionList.push({

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -34,7 +34,7 @@ export const actions = (placement: Cas1SpaceBooking, user: UserDetails) => {
       })
     }
   }
-  if (arrived && !nonArrival && !departed && hasPermission(user, ['cas1_space_booking_record_departure'])) {
+  if (arrived && !departed && hasPermission(user, ['cas1_space_booking_record_departure'])) {
     actionList.push({
       text: 'Record departure',
       classes: 'govuk-button--secondary',

--- a/server/views/manage/premises/placements/non-arrival.njk
+++ b/server/views/manage/premises/placements/non-arrival.njk
@@ -1,0 +1,76 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+{% from "../../../components/keyDetails/macro.njk" import keyDetails %}
+{% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
+
+{%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        text: "Back",
+        href: paths.premises.placements.show({ premisesId: placement.premises.id, placementId: placement.id })
+    }) }}
+{% endblock %}
+
+{% block header %}
+  {{ super() }}
+  {{ keyDetails(PlacementUtils.getKeyDetail(placement)) }}
+{% endblock %}
+
+{% block content %}
+
+    <form action="{{ paths.premises.placements.nonArrival({ premisesId: placement.premises.id, placementId: placement.id }) }}"
+          method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+        {{ showErrorSummary(errorSummary, errorTitle) }}
+
+        {% include "../../../_messages.njk" %}
+
+        <h1 class="govuk-heading-l">Record someone as not arrived</h1>
+
+
+        {{ govukSummaryList({
+            rows: [{
+                key: {
+                    text: "Expected arrival date"
+                },
+                value: {
+                    text: formatDate(placement.expectedArrivalDate)
+                }
+            }]
+        }) }}
+
+        {{ govukRadios({
+            idPrefix: "reason",
+            errorMessage: errors.reason,
+            name: "reason",
+                items: convertObjectsToRadioItems(nonArrivalReasons, 'name', 'id', 'reason',{reason:reason})
+            }) 
+        }}
+
+        {{ govukCharacterCount({
+            id: "notes",
+            name: "notes",
+            maxlength: 200,
+            value: notes,
+            label: {
+                text: "Any other information",
+                classes: "govuk-fieldset__legend--s"
+            },
+            errorMessage: errors.notes
+        }) }}
+
+        {{ govukButton({
+            text: "Submit",
+            preventDoubleClick: true
+        }) }}
+    </form>
+
+{% endblock %}
+

--- a/server/views/manage/premises/placements/non-arrival.njk
+++ b/server/views/manage/premises/placements/non-arrival.njk
@@ -30,8 +30,6 @@
 
         {{ showErrorSummary(errorSummary, errorTitle) }}
 
-        {% include "../../../_messages.njk" %}
-
         <h1 class="govuk-heading-l">Record someone as not arrived</h1>
 
 

--- a/server/views/manage/premises/placements/show.njk
+++ b/server/views/manage/premises/placements/show.njk
@@ -37,9 +37,7 @@
         title: {
             html: titleHtml
         },
-        menus: [{
-            items: PlacementUtils.actions(placement, user)
-        }]
+        menus: PlacementUtils.actions(placement, user)
     }) }}
 
     {{ govukSummaryList(PlacementUtils.placementSummary(placement)) }}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1412

# Changes in this PR

Adds 'Record non-arrival' action to placement details page.
The option and page routes require the permission `cas1_space_booking_record_non_arrival` to be enabled

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes
Placement detail page with open actions menu
![image](https://github.com/user-attachments/assets/547855a5-a4b1-4dd0-b93f-0da196776b22)

Record non-arrival page
![image](https://github.com/user-attachments/assets/223f46c5-a295-42c9-90c7-162a435ad9f0)

Checks on reason and character count
![image](https://github.com/user-attachments/assets/3d73ab57-44c5-487a-b76d-541014d26b86)

Completion showing confirmation and updated details
![image](https://github.com/user-attachments/assets/72f3f4b6-7439-4c1e-8eb4-8c758ecb4b1b)





