### PR TITLE
APS-1561 Restrict space booking list based on premises

### DIFF
--- a/integration_tests/tests/manage/premises.cy.ts
+++ b/integration_tests/tests/manage/premises.cy.ts
@@ -93,6 +93,18 @@ context('Premises', () => {
         // Then the 'current' tab should be selected
         page.shouldHaveTabSelected('Current')
       })
+
+      it('should not show the placements list if space bookings are not enabled for the premises', () => {
+        // Given there is a premises in the database that does not support space bookings
+        const premises = cas1PremisesSummaryFactory.build({ supportsSpaceBookings: false })
+        cy.task('stubSinglePremises', premises)
+
+        // When I visit premises details page
+        const page = PremisesShowPage.visit(premises)
+
+        // Then I should not see a list of bookings
+        page.shouldNotShowPlacementsList()
+      })
     })
 
     it('should not show the placements list if the user lacks permission', () => {
@@ -109,6 +121,8 @@ context('Premises', () => {
 
       // When I visit premises details page
       const page = PremisesShowPage.visit(premises)
+
+      // Then I should not see a list of bookings
       page.shouldNotShowPlacementsList()
     })
   })

--- a/server/controllers/manage/premises/premisesController.ts
+++ b/server/controllers/manage/premises/premisesController.ts
@@ -35,6 +35,7 @@ export default class PremisesController {
       )
       const premises = await this.premisesService.find(req.user.token, req.params.premisesId)
       const paginatedPlacements =
+        premises.supportsSpaceBookings &&
         hasPermission(res.locals.user, ['cas1_space_booking_list']) &&
         (await this.premisesService.getPlacements({
           token: req.user.token,

--- a/server/utils/users/roles.ts
+++ b/server/utils/users/roles.ts
@@ -13,6 +13,7 @@ export const roles: ReadonlyArray<RoleInUse> = [
   'excluded_from_assess_allocation',
   'excluded_from_match_allocation',
   'excluded_from_placement_application_allocation',
+  'cru_member_find_and_book_beta',
   'appeals_manager',
   'report_viewer',
   'future_manager',

--- a/server/utils/users/roles.ts
+++ b/server/utils/users/roles.ts
@@ -13,7 +13,6 @@ export const roles: ReadonlyArray<RoleInUse> = [
   'excluded_from_assess_allocation',
   'excluded_from_match_allocation',
   'excluded_from_placement_application_allocation',
-  'cru_member_find_and_book_beta',
   'appeals_manager',
   'report_viewer',
   'future_manager',


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/APS-1561
<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Hides the list of placements from the premises details page if the premises doesn't support space bookings.
In test data - premises in SWSC region have the `supports_space_bookings` flag set, others don't.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes
![image](https://github.com/user-attachments/assets/936ce9d7-2599-404b-9519-25b49024258e)

![image](https://github.com/user-attachments/assets/27c38143-bbf0-4d34-9df4-5f3e4be486ad)


