### PR TITLE
CHORE: Add option to assess to application create script

### DIFF
--- a/e2e/utils/createApplication.spec.ts
+++ b/e2e/utils/createApplication.spec.ts
@@ -2,10 +2,23 @@ import { ApplicationType } from '@approved-premises/e2e'
 import { test } from '../test'
 import { createApplication } from '../steps/apply'
 import { signIn } from '../steps/signIn'
+import { assessApplication } from '../steps/assess'
 
 const applicationType = process.env.APPLICATION_TYPE as ApplicationType
+const assess: string = process.env.ASSESS_APPLICATION
 
-test(`create ${applicationType} application`, async ({ page, assessor, person, oasysSections }) => {
+test(`create ${assess ? 'and assess ' : ''}${applicationType} application`, async ({
+  page,
+  assessor,
+  person,
+  oasysSections,
+  emergencyApplicationUser,
+}) => {
   await signIn(page, assessor)
-  await createApplication({ page, person, oasysSections, applicationType }, true, true)
+  const { id } = await createApplication({ page, person, oasysSections, applicationType }, true, true)
+
+  if (assess) {
+    const allocatedUser = applicationType !== 'standard' ? emergencyApplicationUser : undefined
+    await assessApplication({ page, assessor, person }, id, { applicationType, allocatedUser })
+  }
 })

--- a/package.json
+++ b/package.json
@@ -41,8 +41,11 @@
     "start-test-wiremock": "docker compose -f docker-compose-test.yml up -d",
     "generate-types": "script/generate-types",
     "create-application:standard": "APPLICATION_TYPE='standard' npx playwright test --config ./e2e/playwright.config.ts --project=local utils/createApplication.spec.ts",
+    "create-application:standard:assess": "ASSESS_APPLICATION='true' npm run create-application:standard",
     "create-application:emergency": "APPLICATION_TYPE='emergency' npx playwright test --config ./e2e/playwright.config.ts --project=local utils/createApplication.spec.ts",
-    "create-application:short-notice": "APPLICATION_TYPE='shortNotice' npx playwright test --config ./e2e/playwright.config.ts --project=local utils/createApplication.spec.ts"
+    "create-application:emergency:assess": "ASSESS_APPLICATION='true' npm run create-application:emergency",
+    "create-application:short-notice": "APPLICATION_TYPE='shortNotice' npx playwright test --config ./e2e/playwright.config.ts --project=local utils/createApplication.spec.ts",
+    "create-application:short-notice:assess": "ASSESS_APPLICATION='true' npm run create-application:short-notice"
   },
   "engines": {
     "node": "^20.0.0",


### PR DESCRIPTION
This adds the following scripts to help create test data locally:

- `create-application:standard:assess`
- `create-application:emergency:assess`
- `create-application:short-notice:assess`

In addition to creating the application like the existing scripts, these also go through the assessment so the application is ready to match under the CRU dashboard.

