### PR TITLE
APS-1405: search for booking

### DIFF
--- a/integration_tests/pages/manage/premisesShow.ts
+++ b/integration_tests/pages/manage/premisesShow.ts
@@ -70,8 +70,12 @@ export default class PremisesShowPage extends Page {
     cy.get('.moj-sub-navigation__list').contains(tabTitle).click()
   }
 
-  shouldNotShowPlacementsList(): void {
+  shouldNotShowPlacementsSection(): void {
+    cy.contains('All bookings').should('not.exist')
     cy.get('.moj-sub-navigation__list').should('not.exist')
+  }
+
+  shouldNotShowPlacementsResultsTable(): void {
     cy.get('.govuk-table').should('not.exist')
   }
 

--- a/integration_tests/pages/manage/premisesShow.ts
+++ b/integration_tests/pages/manage/premisesShow.ts
@@ -74,4 +74,21 @@ export default class PremisesShowPage extends Page {
     cy.get('.moj-sub-navigation__list').should('not.exist')
     cy.get('.govuk-table').should('not.exist')
   }
+
+  shouldShowSearchForm(crnOrName?: string) {
+    this.getLabel('Search for a booking')
+
+    if (crnOrName) {
+      this.verifyTextInputContentsById('crnOrName', crnOrName)
+    }
+  }
+
+  searchByCrnOrName(crnOrName: string) {
+    this.clearAndCompleteTextInputById('crnOrName', crnOrName)
+    cy.get('button').contains('Search').click()
+  }
+
+  shouldShowNoResults() {
+    cy.get('p').contains('There are no results for your search.').should('exist')
+  }
 }

--- a/integration_tests/tests/manage/premises.cy.ts
+++ b/integration_tests/tests/manage/premises.cy.ts
@@ -113,6 +113,9 @@ context('Premises', () => {
         // And I should see the search form
         page.shouldShowSearchForm()
 
+        // And I should not see the results list
+        page.shouldNotShowPlacementsResultsTable()
+
         // When I submit a search using the form
         page.searchByCrnOrName('Aadland')
 
@@ -139,7 +142,7 @@ context('Premises', () => {
         page.shouldShowNoResults()
       })
 
-      it('should not show the placements list if space bookings are not enabled for the premises', () => {
+      it('should not show the placements section if space bookings are not enabled for the premises', () => {
         // Given there is a premises in the database that does not support space bookings
         const premises = cas1PremisesSummaryFactory.build({ supportsSpaceBookings: false })
         cy.task('stubSinglePremises', premises)
@@ -147,17 +150,19 @@ context('Premises', () => {
         // When I visit premises details page
         const page = PremisesShowPage.visit(premises)
 
-        // Then I should not see a list of bookings
-        page.shouldNotShowPlacementsList()
+        // Then I should not see the placements section
+        page.shouldNotShowPlacementsSection()
       })
     })
 
-    it('should not show the placements list if the user lacks permission', () => {
+    it('should not show the placements section if the user lacks permission', () => {
       cy.task('reset')
       // Given I am logged in as a user without access to the booking list
       signIn(['future_manager'])
       // Given there is a premises in the database
-      const premises = cas1PremisesSummaryFactory.build()
+      const premises = cas1PremisesSummaryFactory.build({
+        supportsSpaceBookings: true,
+      })
       cy.task('stubSinglePremises', premises)
 
       // And it has a list of placements
@@ -168,7 +173,7 @@ context('Premises', () => {
       const page = PremisesShowPage.visit(premises)
 
       // Then I should not see a list of bookings
-      page.shouldNotShowPlacementsList()
+      page.shouldNotShowPlacementsSection()
     })
   })
 })

--- a/integration_tests/tests/manage/premises.cy.ts
+++ b/integration_tests/tests/manage/premises.cy.ts
@@ -94,6 +94,51 @@ context('Premises', () => {
         page.shouldHaveTabSelected('Current')
       })
 
+      it('should let the user search for placements by CRN or name', () => {
+        // Given there is a premises in the database
+        const premises = cas1PremisesSummaryFactory.build()
+        cy.task('stubSinglePremises', premises)
+        const placements = cas1SpaceBookingSummaryFactory.buildList(1)
+        cy.task('stubSpaceBookingSummaryList', { premisesId: premises.id, placements, pageSize: 9 })
+
+        // When I visit premises details page
+        const page = PremisesShowPage.visit(premises)
+
+        // And I select to the 'search' tab
+        page.shouldSelectTab('Search for a booking')
+
+        // Then the 'search' tab should be selected
+        page.shouldHaveTabSelected('Search for a booking')
+
+        // And I should see the search form
+        page.shouldShowSearchForm()
+
+        // When I submit a search using the form
+        page.searchByCrnOrName('Aadland')
+
+        // Then the 'search' tab should be selected
+        page.shouldHaveTabSelected('Search for a booking')
+
+        // And the search form should be populated with my search term
+        page.shouldShowSearchForm('Aadland')
+
+        // And I should see the results
+        page.shouldShowListOfPlacements(placements)
+
+        // When I search for a name that returns no results
+        cy.task('stubSpaceBookingSummaryList', { premisesId: premises.id, placements: [] })
+        page.searchByCrnOrName('No results for this query')
+
+        // Then the 'search' tab should be selected
+        page.shouldHaveTabSelected('Search for a booking')
+
+        // And the search form should be populated with my search term
+        page.shouldShowSearchForm('No results for this query')
+
+        // Then I should see a message that there are no results
+        page.shouldShowNoResults()
+      })
+
       it('should not show the placements list if space bookings are not enabled for the premises', () => {
         // Given there is a premises in the database that does not support space bookings
         const premises = cas1PremisesSummaryFactory.build({ supportsSpaceBookings: false })

--- a/integration_tests/tests/manage/premises.cy.ts
+++ b/integration_tests/tests/manage/premises.cy.ts
@@ -160,9 +160,7 @@ context('Premises', () => {
       // Given I am logged in as a user without access to the booking list
       signIn(['future_manager'])
       // Given there is a premises in the database
-      const premises = cas1PremisesSummaryFactory.build({
-        supportsSpaceBookings: true,
-      })
+      const premises = cas1PremisesSummaryFactory.build()
       cy.task('stubSinglePremises', premises)
 
       // And it has a list of placements

--- a/server/controllers/manage/premises/premisesController.test.ts
+++ b/server/controllers/manage/premises/premisesController.test.ts
@@ -64,6 +64,7 @@ describe('V2PremisesController', () => {
 
       expect(response.render).toHaveBeenCalledWith('manage/premises/show', {
         premises: premisesSummary,
+        showPlacements: true,
         sortBy: 'canonicalArrivalDate',
         sortDirection: 'asc',
         activeTab: 'upcoming',
@@ -89,6 +90,7 @@ describe('V2PremisesController', () => {
 
       expect(response.render).toHaveBeenCalledWith('manage/premises/show', {
         premises: premisesSummary,
+        showPlacements: true,
         sortBy: 'canonicalDepartureDate',
         sortDirection: 'asc',
         activeTab: 'current',
@@ -114,6 +116,7 @@ describe('V2PremisesController', () => {
 
       expect(response.render).toHaveBeenCalledWith('manage/premises/show', {
         premises: premisesSummary,
+        showPlacements: true,
         sortBy: 'canonicalDepartureDate',
         sortDirection: 'desc',
         activeTab: 'historic',
@@ -143,6 +146,7 @@ describe('V2PremisesController', () => {
 
       expect(response.render).toHaveBeenCalledWith('manage/premises/show', {
         premises: premisesSummary,
+        showPlacements: true,
         ...queryParameters,
         hrefPrefix: `/manage/premises/some-uuid?activeTab=historic&sortBy=personName&sortDirection=asc&`,
         pageNumber: 1,
@@ -161,32 +165,63 @@ describe('V2PremisesController', () => {
       })
     })
 
-    it('should render the premises detail and list of placements when on the "search" tab', async () => {
-      const { premisesSummary, paginatedPlacements } = await mockSummaryAndPlacements({
-        activeTab: 'search',
-        crnOrName: 'X123456',
-      })
+    describe('when viewing the "search" tab', () => {
+      it.each([
+        ['', '/manage/premises/some-uuid?activeTab=search&crnOrName=&'],
+        [undefined, '/manage/premises/some-uuid?activeTab=search&'],
+      ])(
+        'should render the premises detail without fetching the placements when no search has been performed',
+        async (crnOrName, hrefPrefix) => {
+          const { premisesSummary } = await mockSummaryAndPlacements({
+            activeTab: 'search',
+            crnOrName,
+          })
 
-      expect(response.render).toHaveBeenCalledWith('manage/premises/show', {
-        premises: premisesSummary,
-        sortBy: 'canonicalArrivalDate',
-        sortDirection: 'desc',
-        activeTab: 'search',
-        crnOrName: 'X123456',
-        pageNumber: 1,
-        totalPages: 1,
-        hrefPrefix: `/manage/premises/some-uuid?activeTab=search&crnOrName=X123456&`,
-        placements: paginatedPlacements.data,
-      })
-      expect(premisesService.find).toHaveBeenCalledWith(token, premisesId)
-      expect(premisesService.getPlacements).toHaveBeenCalledWith({
-        token,
-        premisesId,
-        page: 1,
-        perPage: 20,
-        sortBy: 'canonicalArrivalDate',
-        sortDirection: 'desc',
-        crnOrName: 'X123456',
+          expect(response.render).toHaveBeenCalledWith('manage/premises/show', {
+            premises: premisesSummary,
+            showPlacements: true,
+            sortBy: 'canonicalArrivalDate',
+            sortDirection: 'desc',
+            activeTab: 'search',
+            crnOrName,
+            pageNumber: undefined,
+            totalPages: undefined,
+            hrefPrefix,
+            placements: undefined,
+          })
+          expect(premisesService.find).toHaveBeenCalledWith(token, premisesId)
+          expect(premisesService.getPlacements).not.toHaveBeenCalled()
+        },
+      )
+
+      it('should render the premises detail and list of placements when a search query is present', async () => {
+        const { premisesSummary, paginatedPlacements } = await mockSummaryAndPlacements({
+          activeTab: 'search',
+          crnOrName: 'X123456',
+        })
+
+        expect(response.render).toHaveBeenCalledWith('manage/premises/show', {
+          premises: premisesSummary,
+          showPlacements: true,
+          sortBy: 'canonicalArrivalDate',
+          sortDirection: 'desc',
+          activeTab: 'search',
+          crnOrName: 'X123456',
+          pageNumber: 1,
+          totalPages: 1,
+          hrefPrefix: `/manage/premises/some-uuid?activeTab=search&crnOrName=X123456&`,
+          placements: paginatedPlacements.data,
+        })
+        expect(premisesService.find).toHaveBeenCalledWith(token, premisesId)
+        expect(premisesService.getPlacements).toHaveBeenCalledWith({
+          token,
+          premisesId,
+          page: 1,
+          perPage: 20,
+          sortBy: 'canonicalArrivalDate',
+          sortDirection: 'desc',
+          crnOrName: 'X123456',
+        })
       })
     })
 
@@ -198,11 +233,12 @@ describe('V2PremisesController', () => {
 
       expect(response.render).toHaveBeenCalledWith('manage/premises/show', {
         premises: premisesSummary,
+        showPlacements: false,
         sortBy: 'canonicalArrivalDate',
         sortDirection: 'asc',
         activeTab: 'upcoming',
-        pageNumber: NaN,
-        totalPages: NaN,
+        pageNumber: undefined,
+        totalPages: undefined,
         hrefPrefix: '/manage/premises/some-uuid?activeTab=upcoming&',
         placements: undefined,
       })

--- a/server/controllers/manage/premises/premisesController.test.ts
+++ b/server/controllers/manage/premises/premisesController.test.ts
@@ -135,18 +135,16 @@ describe('V2PremisesController', () => {
     })
 
     it('should render the premises detail and list of placements with specified sort and pagination criteria', async () => {
-      const hrefPrefix = `/manage/premises/${premisesId}?activeTab=historic&sortBy=personName&sortDirection=asc&`
       const queryParameters = { sortDirection: 'asc', sortBy: 'personName', activeTab: 'historic' }
       const { premisesSummary, paginatedPlacements } = await mockSummaryAndPlacements({
         ...queryParameters,
-        hrefPrefix,
         page: '2',
       })
 
       expect(response.render).toHaveBeenCalledWith('manage/premises/show', {
         premises: premisesSummary,
         ...queryParameters,
-        hrefPrefix,
+        hrefPrefix: `/manage/premises/some-uuid?activeTab=historic&sortBy=personName&sortDirection=asc&`,
         pageNumber: 1,
         totalPages: 1,
         placements: paginatedPlacements.data,
@@ -162,6 +160,36 @@ describe('V2PremisesController', () => {
         sortDirection: 'asc',
       })
     })
+
+    it('should render the premises detail and list of placements when on the "search" tab', async () => {
+      const { premisesSummary, paginatedPlacements } = await mockSummaryAndPlacements({
+        activeTab: 'search',
+        crnOrName: 'X123456',
+      })
+
+      expect(response.render).toHaveBeenCalledWith('manage/premises/show', {
+        premises: premisesSummary,
+        sortBy: 'canonicalArrivalDate',
+        sortDirection: 'desc',
+        activeTab: 'search',
+        crnOrName: 'X123456',
+        pageNumber: 1,
+        totalPages: 1,
+        hrefPrefix: `/manage/premises/some-uuid?activeTab=search&crnOrName=X123456&`,
+        placements: paginatedPlacements.data,
+      })
+      expect(premisesService.find).toHaveBeenCalledWith(token, premisesId)
+      expect(premisesService.getPlacements).toHaveBeenCalledWith({
+        token,
+        premisesId,
+        page: 1,
+        perPage: 20,
+        sortBy: 'canonicalArrivalDate',
+        sortDirection: 'desc',
+        crnOrName: 'X123456',
+      })
+    })
+
     it('should not render the list of placements if the premises does not support space bookings', async () => {
       const { premisesSummary } = await mockSummaryAndPlacements(
         {},

--- a/server/controllers/manage/premises/premisesController.ts
+++ b/server/controllers/manage/premises/premisesController.ts
@@ -35,9 +35,11 @@ export default class PremisesController {
       )
 
       const premises = await this.premisesService.find(req.user.token, req.params.premisesId)
+      const showPlacements =
+        premises.supportsSpaceBookings && hasPermission(res.locals.user, ['cas1_space_booking_list'])
       const paginatedPlacements =
-        premises.supportsSpaceBookings &&
-        hasPermission(res.locals.user, ['cas1_space_booking_list']) &&
+        showPlacements &&
+        (activeTab !== 'search' || Boolean(crnOrName)) &&
         (await this.premisesService.getPlacements({
           token: req.user.token,
           premisesId: req.params.premisesId,
@@ -51,14 +53,15 @@ export default class PremisesController {
 
       return res.render('manage/premises/show', {
         premises,
+        showPlacements,
         activeTab,
         crnOrName,
         placements: paginatedPlacements?.data,
         hrefPrefix,
         sortBy: sortBy || tabSettings[activeTab].sortBy,
         sortDirection: sortDirection || tabSettings[activeTab].sortDirection,
-        pageNumber: Number(paginatedPlacements?.pageNumber),
-        totalPages: Number(paginatedPlacements?.totalPages),
+        pageNumber: Number(paginatedPlacements?.pageNumber) || undefined,
+        totalPages: Number(paginatedPlacements?.totalPages) || undefined,
       })
     }
   }

--- a/server/data/premisesClient.ts
+++ b/server/data/premisesClient.ts
@@ -42,17 +42,18 @@ export default class PremisesClient {
 
   async getPlacements(args: {
     premisesId: string
-    status: string
+    status?: string
+    crnOrName?: string
     page: number
     perPage: number
     sortBy: Cas1SpaceBookingSummarySortField
     sortDirection: SortDirection
   }): Promise<PaginatedResponse<Cas1SpaceBookingSummary>> {
-    const { premisesId, status, page, perPage, sortBy, sortDirection } = args
+    const { premisesId, status, crnOrName, page, perPage, sortBy, sortDirection } = args
     return this.restClient.getPaginatedResponse<Cas1SpaceBookingSummary>({
       path: paths.premises.placements.index({ premisesId }),
       page: page.toString(),
-      query: { residency: status, sortBy, sortDirection, perPage },
+      query: { residency: status, crnOrName, sortBy, sortDirection, perPage },
     })
   }
 

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -42,7 +42,8 @@ export default class PremisesService {
   async getPlacements(args: {
     token: string
     premisesId: string
-    status: string
+    status?: string
+    crnOrName?: string
     page: number
     perPage: number
     sortBy: Cas1SpaceBookingSummarySortField

--- a/server/utils/getPaginationDetails.test.ts
+++ b/server/utils/getPaginationDetails.test.ts
@@ -5,7 +5,7 @@ import { getPaginationDetails } from './getPaginationDetails'
 describe('getPaginationDetails', () => {
   const hrefPrefix = 'http://localhost/example'
 
-  it('should return the hrefPrefix with a query string prefix if there are no query parameters', () => {
+  it('should return the hrefPrefix with a query string suffix if there are no query parameters', () => {
     const request = createMock<Request>({})
 
     expect(getPaginationDetails(request, hrefPrefix)).toEqual({
@@ -27,7 +27,7 @@ describe('getPaginationDetails', () => {
     })
   })
 
-  it('should append additonal parameters to the hrefPrefix', () => {
+  it('should append additional parameters to the hrefPrefix', () => {
     const request = createMock<Request>({ query: { page: '1', sortBy: 'something', sortDirection: 'asc' } })
 
     expect(getPaginationDetails(request, hrefPrefix, { foo: 'bar' })).toEqual({

--- a/server/utils/premises/index.test.ts
+++ b/server/utils/premises/index.test.ts
@@ -211,6 +211,11 @@ describe('premisesUtils', () => {
           href: `/manage/premises/${premises.id}?activeTab=historic`,
           text: 'Historical',
         },
+        {
+          active: false,
+          href: `/manage/premises/${premises.id}?activeTab=search`,
+          text: 'Search for a booking',
+        },
       ]
       const tabSet = premisesTabItems(premises, 'upcoming')
       expect(tabSet).toEqual(expectedTabs)

--- a/server/utils/premises/index.ts
+++ b/server/utils/premises/index.ts
@@ -1,4 +1,5 @@
 import type {
+  ApArea,
   Cas1PremisesBasicSummary,
   Cas1PremisesSummary,
   Cas1SpaceBookingResidency,
@@ -50,7 +51,7 @@ export const groupCas1SummaryPremisesSelectOptions = (
   context: Record<string, unknown>,
   fieldName: string = 'premisesId',
 ): Array<SelectGroup> => {
-  const apAreas = premises.reduce((map, { apArea }) => {
+  const apAreas: Record<string, ApArea> = premises.reduce((map, { apArea }) => {
     map[apArea.id] = apArea
     return map
   }, {})
@@ -94,20 +95,20 @@ export const premisesTableRows = (premisesSummaries: Array<Cas1PremisesBasicSumm
     })
 }
 
-export const tabTextMap: Record<Cas1SpaceBookingResidency, string> = {
+export type PremisesTab = Cas1SpaceBookingResidency | 'search'
+
+export const tabTextMap: Record<PremisesTab, string> = {
   upcoming: 'Upcoming',
   current: 'Current',
   historic: 'Historical',
+  search: 'Search for a booking',
 }
 
-export const premisesTabItems = (premises: Cas1PremisesSummary, activeTab?: string): Array<TabItem> => {
+export const premisesTabItems = (premises: Cas1PremisesSummary, activeTab?: PremisesTab): Array<TabItem> => {
   const getSelfLink = (tab: string): string =>
-    `${managePaths.premises.show({ premisesId: premises.id })}${createQueryString(
-      {
-        activeTab: tab,
-      },
-      { addQueryPrefix: true },
-    )}`
+    `${managePaths.premises.show({ premisesId: premises.id })}?${createQueryString({
+      activeTab: tab,
+    })}`
   return Object.entries(tabTextMap).map(([key, label]) => {
     return { text: label, active: activeTab === key, href: getSelfLink(key) }
   })
@@ -125,10 +126,11 @@ const baseColumns: Array<ColumnDefinition> = [
 ]
 const keyWorkerColumn: ColumnDefinition = { title: 'Key worker', fieldName: 'keyWorkerName' }
 
-const columnMap: Record<Cas1SpaceBookingResidency, Array<ColumnDefinition>> = {
+const columnMap: Record<PremisesTab, Array<ColumnDefinition>> = {
   upcoming: [...baseColumns, keyWorkerColumn],
   current: [...baseColumns, keyWorkerColumn],
   historic: baseColumns,
+  search: [...baseColumns, keyWorkerColumn],
 }
 
 export const placementTableHeader = (

--- a/server/views/manage/premises/show.njk
+++ b/server/views/manage/premises/show.njk
@@ -5,6 +5,8 @@
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
@@ -42,19 +44,58 @@
         PremisesUtils.summaryListForPremises(premises)
     ) }}
 
+    <h2 class="govuk-heading-m">All bookings</h2>
+
     {% if placements %}
         {{ mojSubNavigation({
             label: 'Sub navigation',
             items: PremisesUtils.premisesTabItems(premises, activeTab)
         }) }}
 
-        {{ govukTable({
-            firstCellIsHeader: false,
-            head: PremisesUtils.placementTableHeader(activeTab, sortBy, sortDirection, hrefPrefix),
-            rows: PremisesUtils.placementTableRows(premises.id, placements)
-        }) }}
+        {% if activeTab === 'search' %}
+            <div class="search-and-filter__wrapper">
+                <form action="{{ hrefPrefix }}" method="get">
+                    <input type="hidden" name="activeTab" value="search" />
 
-        {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
+                    <div class="govuk-grid-row">
+                        <div class="govuk-grid-column-two-thirds">
+                            {{ govukInput({
+                                label: {
+                                    text: 'Search for a booking',
+                                    classes: 'govuk-fieldset__legend--m'
+                                },
+                                hint: {
+                                    text: 'You can search for a person name or CRN'
+                                },
+                                id: 'crnOrName',
+                                name: 'crnOrName',
+                                value: crnOrName
+                            }) }}
+
+                            {{ govukButton({
+                                text: 'Search',
+                                classes: 'govuk-!-margin-bottom-0',
+                                preventDoubleClick: true
+                            }) }}
+                        </div>
+                    </div>
+                </form>
+            </div>
+        {% endif %}
+
+        {% if activeTab === 'search' and placements | length === 0 %}
+            <p>There are no results for your search.</p>
+        {% else %}
+            {{ govukTable({
+                firstCellIsHeader: false,
+                head: PremisesUtils.placementTableHeader(activeTab, sortBy, sortDirection, hrefPrefix),
+                rows: PremisesUtils.placementTableRows(premises.id, placements)
+            }) }}
+
+            {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
+        {% endif %}
+
+
     {% endif %}
 
 {% endblock %}

--- a/server/views/manage/premises/show.njk
+++ b/server/views/manage/premises/show.njk
@@ -44,58 +44,60 @@
         PremisesUtils.summaryListForPremises(premises)
     ) }}
 
-    <h2 class="govuk-heading-m">All bookings</h2>
+    {% if showPlacements %}
+        <section>
+            <h2 class="govuk-heading-m">All bookings</h2>
 
-    {% if placements %}
-        {{ mojSubNavigation({
-            label: 'Sub navigation',
-            items: PremisesUtils.premisesTabItems(premises, activeTab)
-        }) }}
-
-        {% if activeTab === 'search' %}
-            <div class="search-and-filter__wrapper">
-                <form action="{{ hrefPrefix }}" method="get">
-                    <input type="hidden" name="activeTab" value="search" />
-
-                    <div class="govuk-grid-row">
-                        <div class="govuk-grid-column-two-thirds">
-                            {{ govukInput({
-                                label: {
-                                    text: 'Search for a booking',
-                                    classes: 'govuk-fieldset__legend--m'
-                                },
-                                hint: {
-                                    text: 'You can search for a person name or CRN'
-                                },
-                                id: 'crnOrName',
-                                name: 'crnOrName',
-                                value: crnOrName
-                            }) }}
-
-                            {{ govukButton({
-                                text: 'Search',
-                                classes: 'govuk-!-margin-bottom-0',
-                                preventDoubleClick: true
-                            }) }}
-                        </div>
-                    </div>
-                </form>
-            </div>
-        {% endif %}
-
-        {% if activeTab === 'search' and placements | length === 0 %}
-            <p>There are no results for your search.</p>
-        {% else %}
-            {{ govukTable({
-                firstCellIsHeader: false,
-                head: PremisesUtils.placementTableHeader(activeTab, sortBy, sortDirection, hrefPrefix),
-                rows: PremisesUtils.placementTableRows(premises.id, placements)
+            {{ mojSubNavigation({
+                label: 'Sub navigation',
+                items: PremisesUtils.premisesTabItems(premises, activeTab)
             }) }}
 
-            {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
-        {% endif %}
+            {% if activeTab === 'search' %}
+                <div class="search-and-filter__wrapper">
+                    <form action="{{ hrefPrefix }}" method="get">
+                        <input type="hidden" name="activeTab" value="search" />
+
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                {{ govukInput({
+                                    label: {
+                                        text: 'Search for a booking',
+                                        classes: 'govuk-fieldset__legend--m'
+                                    },
+                                    hint: {
+                                        text: 'You can search for a person name or CRN'
+                                    },
+                                    id: 'crnOrName',
+                                    name: 'crnOrName',
+                                    value: crnOrName
+                                }) }}
+
+                                {{ govukButton({
+                                    text: 'Search',
+                                    classes: 'govuk-!-margin-bottom-0',
+                                    preventDoubleClick: true
+                                }) }}
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            {% endif %}
 
 
+            {% if activeTab !== 'search' or placements | length > 0 %}
+                {{ govukTable({
+                    firstCellIsHeader: false,
+                    head: PremisesUtils.placementTableHeader(activeTab, sortBy, sortDirection, hrefPrefix),
+                    rows: PremisesUtils.placementTableRows(premises.id, placements)
+                }) }}
+
+                {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
+            {% elseif crnOrName and placements | length === 0 %}
+                <p>There are no results for your search.</p>
+            {% endif %}
+
+        </section>
     {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1405

# Changes in this PR

Adds the 'Search for a booking' tab to the premises view.

By default, without a search term, the tab shows all bookings (any status, with pagination) ordered by canonical arrival date descending. This could be changed to show nothing instead -- TBC.

Adds the 'All bookings' heading shown in the designs above the tabs.

_Note: as with other views, for the time being we are not showing the 'Status' column._

## Screenshots of UI changes

### Initial view

<img width="988" alt="Screenshot 2024-11-19 at 18 21 46" src="https://github.com/user-attachments/assets/f731738d-4740-438a-ae37-b5087fd27108">


---

### With results

<img width="994" alt="Screenshot 2024-11-19 at 18 22 36" src="https://github.com/user-attachments/assets/0a5bfafb-d44d-4e70-87c2-b01e083d9870">


---

### No results

<img width="985" alt="Screenshot 2024-11-19 at 18 22 09" src="https://github.com/user-attachments/assets/a459be78-7858-4979-9232-6d008e767268">


