### PR TITLE
APS-1562 Legacy bookings only allow legacy premises

### DIFF
--- a/integration_tests/pages/admin/placementApplications/createPlacementPage.ts
+++ b/integration_tests/pages/admin/placementApplications/createPlacementPage.ts
@@ -35,4 +35,8 @@ export default class CreatePlacementPage extends Page {
       this.checkRadioByNameAndValue('premisesId', premises.id)
     }
   }
+
+  premisesShouldNotBeAvailable(premises: Cas1PremisesBasicSummary): void {
+    cy.get(`#area0 option:contains(${premises.apArea.name})`).should('not.exist')
+  }
 }

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -54,7 +54,7 @@ context('Placement Requests', () => {
     })
     const unableToMatchPlacementRequest = placementRequestDetailFactory.build({ ...unableToMatchPlacementRequests[0] })
 
-    const preferredAps = premisesFactory.buildList(3, {})
+    const preferredAps = premisesFactory.buildList(3)
 
     const cruManagementAreas = cruManagementAreaFactory.buildList(5)
     application = addResponseToFormArtifact(application, {

--- a/server/@types/shared/models/Cas1PremisesBasicSummary.ts
+++ b/server/@types/shared/models/Cas1PremisesBasicSummary.ts
@@ -9,5 +9,6 @@ export type Cas1PremisesBasicSummary = {
     apCode?: string;
     apArea: NamedId;
     bedCount: number;
+    supportsSpaceBookings: boolean;
 };
 

--- a/server/controllers/admin/placementRequests/bookingsController.test.ts
+++ b/server/controllers/admin/placementRequests/bookingsController.test.ts
@@ -37,17 +37,6 @@ describe('PlacementRequestsController', () => {
 
   describe('new', () => {
     const premises = cas1PremisesBasicSummaryFactory.buildList(2, { supportsSpaceBookings: false })
-    const expectedRenderParameters = {
-      pageHeading: 'Record an Approved Premises (AP) placement',
-      premises,
-      placementRequest,
-      errors: {},
-      errorSummary: [] as Array<unknown>,
-      errorTitle: undefined as string,
-      isWomensApplication: false,
-      ...DateFormats.isoDateToDateInputs(placementRequest.expectedArrival, 'arrivalDate'),
-      ...DateFormats.isoDateToDateInputs('2022-01-15', 'departureDate'),
-    }
     beforeEach(() => {
       jest.resetAllMocks()
       placementRequestService.getPlacementRequest.mockResolvedValue(placementRequest)
@@ -62,7 +51,17 @@ describe('PlacementRequestsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('admin/placementRequests/bookings/new', expectedRenderParameters)
+      expect(response.render).toHaveBeenCalledWith('admin/placementRequests/bookings/new', {
+        pageHeading: 'Record an Approved Premises (AP) placement',
+        premises,
+        placementRequest,
+        errors: {},
+        errorSummary: [] as Array<unknown>,
+        errorTitle: undefined as string,
+        isWomensApplication: false,
+        ...DateFormats.isoDateToDateInputs(placementRequest.expectedArrival, 'arrivalDate'),
+        ...DateFormats.isoDateToDateInputs('2022-01-15', 'departureDate'),
+      })
 
       expect(premisesService.getCas1All).toHaveBeenCalledWith(token, { gender: 'man' })
       expect(placementRequestService.getPlacementRequest).toHaveBeenCalledWith(token, placementRequest.id)
@@ -82,10 +81,12 @@ describe('PlacementRequestsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('admin/placementRequests/bookings/new', {
-        ...expectedRenderParameters,
-        premises: mixedPremises.filter(({ supportsSpaceBookings }) => !supportsSpaceBookings),
-      })
+      expect(response.render).toHaveBeenCalledWith(
+        'admin/placementRequests/bookings/new',
+        expect.objectContaining({
+          premises: mixedPremises.filter(({ supportsSpaceBookings }) => !supportsSpaceBookings),
+        }),
+      )
     })
 
     it(`should render the form for a women's AP with the premises and the placement request`, async () => {
@@ -96,11 +97,13 @@ describe('PlacementRequestsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('admin/placementRequests/bookings/new', {
-        ...expectedRenderParameters,
-        pageHeading: `Record a women’s Approved Premises placement`,
-        isWomensApplication: true,
-      })
+      expect(response.render).toHaveBeenCalledWith(
+        'admin/placementRequests/bookings/new',
+        expect.objectContaining({
+          pageHeading: `Record a women’s Approved Premises placement`,
+          isWomensApplication: true,
+        }),
+      )
 
       expect(premisesService.getCas1All).toHaveBeenCalledWith(token, { gender: 'woman' })
       expect(placementRequestService.getPlacementRequest).toHaveBeenCalledWith(token, placementRequest.id)

--- a/server/controllers/admin/placementRequests/bookingsController.ts
+++ b/server/controllers/admin/placementRequests/bookingsController.ts
@@ -20,10 +20,10 @@ export default class PlacementRequestsController {
 
       const placementRequest = await this.placementRequestService.getPlacementRequest(req.user.token, req.params.id)
       const { isWomensApplication } = placementRequest.application as ApprovedPremisesApplication
-      const premises = await this.premisesService.getCas1All(req.user.token, {
+      const allPremises = await this.premisesService.getCas1All(req.user.token, {
         gender: isWomensApplication ? 'woman' : 'man',
       })
-
+      const premises = allPremises.filter(({ supportsSpaceBookings }) => !supportsSpaceBookings)
       if (!Object.keys(userInput).length) {
         const dates = placementDates(placementRequest.expectedArrival, String(placementRequest.duration))
 

--- a/server/testutils/factories/cas1PremisesBasicSummary.ts
+++ b/server/testutils/factories/cas1PremisesBasicSummary.ts
@@ -10,4 +10,5 @@ export default Factory.define<Cas1PremisesBasicSummary>(() => ({
   apCode: `${faker.string.alpha(2)}`,
   bedCount: faker.number.int({ min: 10, max: 50 }),
   apArea: apAreaFactory.build(),
+  supportsSpaceBookings: true,
 }))


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1562
<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Filters out premises that have `supportsSpaceBookings` set true when on the legacy bookings creation page within CRU dashboard.

<!-- [] I have run the E2E tests locally and they passed -->

![image](https://github.com/user-attachments/assets/07d23ca0-2f6a-4ded-afa4-088fad102b41)
Note: the SWSC region has been removed because all its premises allow space bookings.


