### PR TITLE
APS-1581: Add CRU Member Beta (find and book) role

### DIFF
--- a/server/utils/users/roles.ts
+++ b/server/utils/users/roles.ts
@@ -10,6 +10,7 @@ export const roles: ReadonlyArray<RoleInUse> = [
   'matcher',
   'workflow_manager',
   'cru_member',
+  'cru_member_find_and_book_beta',
   'excluded_from_assess_allocation',
   'excluded_from_match_allocation',
   'excluded_from_placement_application_allocation',
@@ -20,13 +21,7 @@ export const roles: ReadonlyArray<RoleInUse> = [
   'janitor',
 ]
 
-export const unusedRoles = [
-  'applicant',
-  'manager',
-  'legacy_manager',
-  'role_admin',
-  'cru_member_find_and_book_beta',
-] as const
+export const unusedRoles = ['applicant', 'manager', 'legacy_manager', 'role_admin'] as const
 
 type UnusedRole = (typeof unusedRoles)[number]
 
@@ -71,6 +66,10 @@ export const roleLabelDictionary: RoleLabelDictionary = {
   cru_member: {
     label: 'CRU member',
     hint: 'Manage out of service beds across all premises and areas',
+  },
+  cru_member_find_and_book_beta: {
+    label: 'CRU member beta (find and book)',
+    hint: 'Create and amend space bookings',
   },
   report_viewer: {
     label: 'Report Viewer',

--- a/server/utils/users/userManagement.test.ts
+++ b/server/utils/users/userManagement.test.ts
@@ -118,6 +118,7 @@ describe('userRolesSelectOptions', () => {
         text: 'Excluded from placement application allocation',
         value: 'excluded_from_placement_application_allocation',
       },
+      { selected: false, text: 'CRU member beta (find and book)', value: 'cru_member_find_and_book_beta' },
       {
         selected: false,
         text: 'Appeals manager',
@@ -152,6 +153,7 @@ describe('userRolesSelectOptions', () => {
         text: 'Excluded from placement application allocation',
         value: 'excluded_from_placement_application_allocation',
       },
+      { selected: false, text: 'CRU member beta (find and book)', value: 'cru_member_find_and_book_beta' },
       {
         selected: false,
         text: 'Appeals manager',

--- a/server/utils/users/userManagement.ts
+++ b/server/utils/users/userManagement.ts
@@ -59,6 +59,7 @@ const userRoles: Record<RoleInUse, string> = {
   excluded_from_assess_allocation: 'Excluded from assess allocation',
   excluded_from_match_allocation: 'Excluded from match allocation',
   excluded_from_placement_application_allocation: 'Excluded from placement application allocation',
+  cru_member_find_and_book_beta: 'CRU member beta (find and book)',
   appeals_manager: 'Appeals manager',
   future_manager: 'Future manager',
   user_manager: 'User manager',


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1581

# Changes in this PR

Adds the "CRU member beta (find and book)" role to the user admin screen (mostly a revert of https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/2204/commits/c27d6873c9515dfaf9d0ae47da101f6c4077befd by @bobmeredith 😉)

## Screenshots of UI changes

<img width="600" alt="Screenshot 2024-11-20 at 15 36 35" src="https://github.com/user-attachments/assets/c0285bbe-1dae-43ea-acf9-1f4dbd7e778e">

