### PR TITLE
APS-1597 Prevent Keyworker rendering on historical tab

### DIFF
--- a/server/utils/premises/index.ts
+++ b/server/utils/premises/index.ts
@@ -144,16 +144,23 @@ export const placementTableHeader = (
   )
 }
 
-export const placementTableRows = (premisesId: string, placements: Array<Cas1SpaceBookingSummary>): Array<TableRow> =>
-  placements.map(({ id, person, tier, canonicalArrivalDate, canonicalDepartureDate, keyWorkerAllocation }) => [
-    htmlValue(
-      `<a href="${managePaths.premises.placements.show({
-        premisesId,
-        placementId: id,
-      })}" data-cy-id="${id}">${laoName(person as unknown as FullPerson)}, ${person.crn}</a>`,
-    ),
-    htmlValue(getTierOrBlank(tier)),
-    textValue(DateFormats.isoDateToUIDate(canonicalArrivalDate, { format: 'short' })),
-    textValue(DateFormats.isoDateToUIDate(canonicalDepartureDate, { format: 'short' })),
-    textValue(keyWorkerAllocation?.keyWorker?.name),
-  ])
+export const placementTableRows = (
+  activeTab: string,
+  premisesId: string,
+  placements: Array<Cas1SpaceBookingSummary>,
+): Array<TableRow> =>
+  placements.map(({ id, person, tier, canonicalArrivalDate, canonicalDepartureDate, keyWorkerAllocation }) => {
+    const fieldValues: Record<Cas1SpaceBookingSummarySortField, TableCell> = {
+      personName: htmlValue(
+        `<a href="${managePaths.premises.placements.show({
+          premisesId,
+          placementId: id,
+        })}" data-cy-id="${id}">${laoName(person as unknown as FullPerson)}, ${person.crn}</a>`,
+      ),
+      tier: htmlValue(getTierOrBlank(tier)),
+      canonicalArrivalDate: textValue(DateFormats.isoDateToUIDate(canonicalArrivalDate, { format: 'short' })),
+      canonicalDepartureDate: textValue(DateFormats.isoDateToUIDate(canonicalDepartureDate, { format: 'short' })),
+      keyWorkerName: textValue(keyWorkerAllocation?.keyWorker?.name),
+    }
+    return columnMap[activeTab].map(({ fieldName }: ColumnDefinition) => fieldValues[fieldName])
+  })

--- a/server/views/manage/premises/show.njk
+++ b/server/views/manage/premises/show.njk
@@ -89,7 +89,7 @@
                 {{ govukTable({
                     firstCellIsHeader: false,
                     head: PremisesUtils.placementTableHeader(activeTab, sortBy, sortDirection, hrefPrefix),
-                    rows: PremisesUtils.placementTableRows(premises.id, placements)
+                    rows: PremisesUtils.placementTableRows(activeTab, premises.id, placements)
                 }) }}
 
                 {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1597
<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

The rendering of the placement table contents on the premises details page now follows the same pattern as the header - mapping the same column definition structure.
 
<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/6ff4301a-5197-458b-b229-4c2f29d6684d)


### After
![image](https://github.com/user-attachments/assets/fc4221f7-d18d-4d03-b0f2-82f191be882b)

