### PR TITLE
APS-1632: Allow booking access with no specific role

### DIFF
--- a/integration_tests/tests/manage/booking.cy.ts
+++ b/integration_tests/tests/manage/booking.cy.ts
@@ -33,8 +33,8 @@ context('Booking', () => {
   })
 
   it('should allow me to see a booking', () => {
-    // Given I am signed in as a workflow manager
-    signIn(['workflow_manager'])
+    // Given I am signed in as a user with no specific role
+    signIn([])
 
     cy.task('stubBookingGet', { premisesId: premises.id, booking })
 

--- a/server/routes/manage.ts
+++ b/server/routes/manage.ts
@@ -210,7 +210,6 @@ export default function routes(controllers: Controllers, router: Router, service
   // Bookings
   get(paths.bookings.show.pattern, bookingsController.show(), {
     auditEvent: 'SHOW_BOOKING',
-    allowedRoles: ['workflow_manager', 'future_manager'],
   })
 
   // Booking date changes


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1632

# Changes in this PR

Enables access to legacy bookings details (`/manage/premises/{premisesId}/bookings/{bookingId}`) for PP and any user with no specific role.

