### PR TITLE
APS-1410 Status in placements table

### DIFF
--- a/integration_tests/pages/manage/premisesShow.ts
+++ b/integration_tests/pages/manage/premisesShow.ts
@@ -4,6 +4,7 @@ import { DateFormats } from '../../../server/utils/dateUtils'
 import Page from '../page'
 import paths from '../../../server/paths/manage'
 import { laoName } from '../../../server/utils/personUtils'
+import { statusTextMap } from '../../../server/utils/placements'
 
 export default class PremisesShowPage extends Page {
   constructor(private readonly premises: Cas1PremisesSummary) {
@@ -45,12 +46,13 @@ export default class PremisesShowPage extends Page {
     ;['Name and CRN', 'Arrival date', 'Departure date', 'Key worker'].forEach(heading => {
       cy.get('.govuk-table .govuk-table__head').contains(heading)
     })
-    placements.forEach(({ person, canonicalArrivalDate, canonicalDepartureDate, tier }) => {
+    placements.forEach(({ person, canonicalArrivalDate, canonicalDepartureDate, tier, status }) => {
       cy.get('.govuk-table__body').contains(person.crn).closest('.govuk-table__row').as('row')
       cy.get('@row').contains(DateFormats.isoDateToUIDate(canonicalArrivalDate, { format: 'short' }))
       cy.get('@row').contains(DateFormats.isoDateToUIDate(canonicalDepartureDate, { format: 'short' }))
       cy.get('@row').contains(tier)
       cy.get('@row').contains(laoName(person as unknown as FullPerson))
+      cy.get('@row').contains(statusTextMap[status])
     })
   }
 

--- a/server/testutils/factories/cas1SpaceBookingSummary.ts
+++ b/server/testutils/factories/cas1SpaceBookingSummary.ts
@@ -1,15 +1,9 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker'
-import {
-  Cas1KeyWorkerAllocation,
-  Cas1SpaceBookingSummary,
-  Cas1SpaceBookingSummaryStatus,
-  PersonSummary,
-} from '@approved-premises/api'
+import { Cas1SpaceBookingSummary, Cas1SpaceBookingSummaryStatus, PersonSummary } from '@approved-premises/api'
 import { fullPersonSummaryFactory } from './person'
 import { DateFormats } from '../../utils/dateUtils'
 import cas1KeyworkerAllocationFactory from './cas1KeyworkerAllocation'
-import { staffMemberFactory } from '.'
 
 const statuses: Array<Cas1SpaceBookingSummaryStatus> = [
   'arrived',

--- a/server/testutils/factories/cas1SpaceBookingSummary.ts
+++ b/server/testutils/factories/cas1SpaceBookingSummary.ts
@@ -1,10 +1,28 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker'
-import { Cas1SpaceBookingSummary, PersonSummary } from '@approved-premises/api'
+import {
+  Cas1KeyWorkerAllocation,
+  Cas1SpaceBookingSummary,
+  Cas1SpaceBookingSummaryStatus,
+  PersonSummary,
+} from '@approved-premises/api'
 import { fullPersonSummaryFactory } from './person'
 import { DateFormats } from '../../utils/dateUtils'
 import cas1KeyworkerAllocationFactory from './cas1KeyworkerAllocation'
+import { staffMemberFactory } from '.'
 
+const statuses: Array<Cas1SpaceBookingSummaryStatus> = [
+  'arrived',
+  'notArrived',
+  'arrivingWithin2Weeks',
+  'arrivingWithin6Weeks',
+  'departingWithin2Weeks',
+  'departed',
+  'arrivingToday',
+  'departingToday',
+  'overdueArrival',
+  'overdueDeparture',
+]
 export default Factory.define<Cas1SpaceBookingSummary>(() => {
   const canonicalArrivalDate = DateFormats.dateObjToIsoDate(faker.date.soon({ days: 90 }))
   const canonicalDepartureDate = DateFormats.dateObjToIsoDate(
@@ -17,5 +35,6 @@ export default Factory.define<Cas1SpaceBookingSummary>(() => {
     canonicalDepartureDate,
     tier: faker.helpers.arrayElement(['A', 'B', 'C']),
     keyWorkerAllocation: cas1KeyworkerAllocationFactory.build(),
+    status: faker.helpers.arrayElement(statuses),
   }
 })

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -1,10 +1,29 @@
-import type { Cas1SpaceBooking, Cas1SpaceBookingDates, FullPerson, StaffMember } from '@approved-premises/api'
+import type {
+  Cas1SpaceBooking,
+  Cas1SpaceBookingDates,
+  Cas1SpaceBookingSummaryStatus,
+  FullPerson,
+  StaffMember,
+} from '@approved-premises/api'
 import { KeyDetailsArgs, SelectOption, SummaryList, SummaryListItem, UserDetails } from '@approved-premises/ui'
 import { DateFormats, daysToWeeksAndDays } from '../dateUtils'
 import { htmlValue, textValue } from '../applications/helpers'
 import { isFullPerson, nameOrPlaceholderCopy } from '../personUtils'
 import paths from '../../paths/manage'
 import { hasPermission } from '../users'
+
+export const statusTextMap: Record<Cas1SpaceBookingSummaryStatus, string> = {
+  arrivingWithin6Weeks: 'Arriving within 6 weeks',
+  arrivingWithin2Weeks: 'Arriving within 2 weeks',
+  arrivingToday: 'Arriving today',
+  overdueArrival: 'Overdue arrival',
+  arrived: 'Arrived',
+  notArrived: 'Not arrived',
+  departingWithin2Weeks: 'Departing within 2 weeks',
+  departingToday: 'Departing today',
+  overdueDeparture: 'Overdue departure',
+  departed: 'Departed',
+}
 
 export const actions = (placement: Cas1SpaceBooking, user: UserDetails) => {
   const actionList = []


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1410

# Changes in this PR
Adds a status column to the ends of the placement table in the premises details view for match&manage.
The statuses are translated to text via a lookup table so that the UI can be changed in the future although the current status keys could be transformed programatically at the moment

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/b25dbace-8899-4cb6-8f82-60aefceb07b6)

![image](https://github.com/user-attachments/assets/0877a364-1eb3-48c7-a61e-e2dfdeb328fe)

