### PR TITLE
Re-add the v1 placement matching outcomes report

### DIFF
--- a/server/utils/reportUtils.test.ts
+++ b/server/utils/reportUtils.test.ts
@@ -19,6 +19,13 @@ describe('reportUtils', () => {
           },
         },
         {
+          value: 'placementMatchingOutcomes',
+          text: 'Raw data for Placement matching outcomes',
+          hint: {
+            text: 'A raw data extract to help identify placement matching outcomes. This downloads Match requests based on the Expected Arrival Date.',
+          },
+        },
+        {
           value: 'lostBeds',
           text: 'Lost beds (no longer in use)',
           hint: {

--- a/server/utils/reportUtils.ts
+++ b/server/utils/reportUtils.ts
@@ -7,6 +7,10 @@ export const reportInputLabels = {
     text: 'Raw requests for placement',
     hint: 'A raw data extract for request for placements created within the month. Includes application data, but does not include matching or booking data.',
   },
+  placementMatchingOutcomes: {
+    text: 'Raw data for Placement matching outcomes',
+    hint: 'A raw data extract to help identify placement matching outcomes. This downloads Match requests based on the Expected Arrival Date.',
+  },
   lostBeds: {
     text: 'Lost beds (no longer in use)',
     hint: 'This report provides information on lost beds recorded before out of service beds functionality was enabled. This will be removed in the near future.',


### PR DESCRIPTION
This is still in use, so is being readded

# Context

# Changes in this PR

## Screenshots of UI changes

### After

![Screenshot 2024-12-03 at 11 11 27](https://github.com/user-attachments/assets/94b48d93-8d79-4393-acaa-762b0fd5d81b)
