### PR TITLE
Chore: Ensure test values are keyworkers

### DIFF
--- a/integration_tests/tests/manage/premises.cy.ts
+++ b/integration_tests/tests/manage/premises.cy.ts
@@ -33,14 +33,14 @@ context('Premises', () => {
   describe('show', () => {
     const premises = cas1PremisesSummaryFactory.build()
     const placements = cas1SpaceBookingSummaryFactory.buildList(30)
-    const staffMembers = staffMemberFactory.buildList(5)
+    const keyworkers = staffMemberFactory.keyworker().buildList(5)
 
     beforeEach(() => {
       cy.task('reset')
 
       // Given there is a premises in the database
       cy.task('stubSinglePremises', premises)
-      cy.task('stubPremisesStaffMembers', { premisesId: premises.id, staffMembers })
+      cy.task('stubPremisesStaffMembers', { premisesId: premises.id, staffMembers: keyworkers })
 
       // And it has a list of upcoming placements
       cy.task('stubSpaceBookingSummaryList', { premisesId: premises.id, placements, residency: 'upcoming' })
@@ -105,7 +105,7 @@ context('Premises', () => {
       })
 
       it('should let the user filter by keyworker', () => {
-        const testKeyworker = staffMembers[2]
+        const testKeyworker = keyworkers[2]
         const placementsWithKeyworker = cas1SpaceBookingSummaryFactory.buildList(6, {
           keyWorkerAllocation: cas1KeyworkerAllocationFactory.build({
             keyWorker: testKeyworker,

--- a/server/testutils/factories/staffMember.ts
+++ b/server/testutils/factories/staffMember.ts
@@ -3,7 +3,15 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 
 import type { StaffMember } from '@approved-premises/api'
 
-export default Factory.define<StaffMember>(() => ({
+class StaffMemberFactory extends Factory<StaffMember> {
+  keyworker() {
+    return this.params({
+      keyWorker: true,
+    })
+  }
+}
+
+export default StaffMemberFactory.define(() => ({
   id: faker.number.int(),
   name: faker.person.fullName(),
   code: faker.string.uuid(),


### PR DESCRIPTION
This fixes a flaky integration test, by ensuring mock values for staff members are definitely keyworkers.