### PR TITLE
APS-1410 status in placement view

### DIFF
--- a/integration_tests/tests/manage/placements/viewPlacement.cy.ts
+++ b/integration_tests/tests/manage/placements/viewPlacement.cy.ts
@@ -32,8 +32,8 @@ context('Placements', () => {
       // Given I am logged in with permission to view a placement
       // And the mocked placement has missing data
       const { placement } = setup(['cas1_space_booking_view'], {
-        actualArrivalDate: undefined,
-        actualDepartureDate: undefined,
+        actualArrivalDateOnly: undefined,
+        actualDepartureDateOnly: undefined,
       })
       // When I visit the placement page
       const placementShowPage = PlacementShowPage.visit(placement)

--- a/server/controllers/manage/premises/placements/departuresController.test.ts
+++ b/server/controllers/manage/premises/placements/departuresController.test.ts
@@ -31,7 +31,8 @@ describe('DeparturesController', () => {
   const premisesId = 'premises-id'
   const TEST_DATE = new Date('2024-11-14T14:00:00.000Z')
   const placement = cas1SpaceBookingFactory.current().build({
-    actualArrivalDate: '2024-10-05T11:30:00.000Z',
+    actualArrivalDateOnly: '2024-10-05',
+    actualArrivalTime: '11:30',
   })
   const departureFormData = {
     departureDate: '2024-10-08',

--- a/server/controllers/match/placementRequests/spaceBookingsController.ts
+++ b/server/controllers/match/placementRequests/spaceBookingsController.ts
@@ -1,5 +1,5 @@
 import type { Request, RequestHandler, Response, TypedRequestHandler } from 'express'
-import type { ApType, Cas1NewSpaceBooking as NewSpaceBooking } from '@approved-premises/api'
+import type { ApType, Cas1NewSpaceBooking } from '@approved-premises/api'
 import { PlacementRequestService, SpaceService } from '../../../services'
 import { filterOutAPTypes, placementDates } from '../../../utils/match'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
@@ -47,7 +47,7 @@ export default class {
         body: { arrivalDate, departureDate, durationDays, premisesId, premisesName, essentialCharacteristics, apType },
       } = req
 
-      const newSpaceBooking: NewSpaceBooking = {
+      const newSpaceBooking: Cas1NewSpaceBooking = {
         arrivalDate,
         departureDate,
         premisesId,

--- a/server/testutils/factories/cas1SpaceBooking.ts
+++ b/server/testutils/factories/cas1SpaceBooking.ts
@@ -1,6 +1,11 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker'
-import { Cas1KeyWorkerAllocation, Cas1SpaceBooking, Person } from '@approved-premises/api'
+import type {
+  Cas1KeyWorkerAllocation,
+  Cas1SpaceBooking,
+  Cas1SpaceBookingSummaryStatus,
+  Person,
+} from '@approved-premises/api'
 import { fullPersonFactory } from './person'
 import cas1SpaceBookingDatesFactory from './cas1SpaceBookingDates'
 import cas1SpaceBookingRequirementsFactory from './spaceBookingRequirements'
@@ -16,26 +21,38 @@ import { BREACH_OR_RECALL_REASON_ID, PLANNED_MOVE_ON_REASON_ID } from '../../uti
 class Cas1SpaceBookingFactory extends Factory<Cas1SpaceBooking> {
   upcoming() {
     return this.params({
-      actualArrivalDate: undefined,
-      actualDepartureDate: undefined,
+      actualArrivalDateOnly: undefined,
+      actualArrivalTime: undefined,
+      actualDepartureDateOnly: undefined,
+      actualDepartureTime: undefined,
       departure: undefined,
+      status: faker.helpers.arrayElement([
+        'arrivingToday',
+        'arrivingWithin6Weeks',
+        'arrivingWithin2Weeks',
+      ] as Array<Cas1SpaceBookingSummaryStatus>),
     })
   }
 
   current() {
     return this.params({
-      actualArrivalDate: DateFormats.dateObjToIsoDateTime(faker.date.recent({ days: 180 })),
-      actualDepartureDate: undefined,
+      actualArrivalDateOnly: DateFormats.dateObjToIsoDate(faker.date.recent({ days: 180 })),
+      actualDepartureDateOnly: undefined,
+      actualDepartureTime: undefined,
       departure: undefined,
+      status: 'arrived',
     })
   }
 
   nonArrival() {
     return this.params({
-      actualArrivalDate: undefined,
-      actualDepartureDate: undefined,
+      actualArrivalDateOnly: undefined,
+      actualArrivalTime: undefined,
+      actualDepartureDateOnly: undefined,
+      actualDepartureTime: undefined,
       departure: undefined,
       nonArrival: cas1SpaceBookingNonArrivalFactory.build(),
+      status: 'notArrived',
     })
   }
 
@@ -44,8 +61,8 @@ class Cas1SpaceBookingFactory extends Factory<Cas1SpaceBooking> {
     const actualArrivalDate = faker.date.past({ years: 1, refDate: actualDepartureDate })
 
     return this.params({
-      actualArrivalDate: DateFormats.dateObjToIsoDateTime(actualArrivalDate),
-      actualDepartureDate: DateFormats.dateObjToIsoDateTime(actualDepartureDate),
+      actualArrivalDateOnly: DateFormats.dateObjToIsoDate(actualArrivalDate),
+      actualDepartureDateOnly: DateFormats.dateObjToIsoDate(actualDepartureDate),
       departure: cas1SpaceBookingDepartureFactory.build({
         moveOnCategory: undefined,
       }),
@@ -77,7 +94,10 @@ class Cas1SpaceBookingFactory extends Factory<Cas1SpaceBooking> {
 export default Cas1SpaceBookingFactory.define(() => {
   const startDateTime = faker.date.soon({ days: 90 })
   const endDateTime = faker.date.soon({ days: 365, refDate: startDateTime })
-  const [actualArrivalDate, actualDepartureDate] = [startDateTime, endDateTime].map(DateFormats.dateObjToIsoDateTime)
+  const [actualArrivalDateOnly, actualDepartureDateOnly] = [startDateTime, endDateTime].map(
+    DateFormats.dateObjToIsoDate,
+  )
+  const [actualArrivalTime, actualDepartureTime] = [startDateTime, endDateTime].map(DateFormats.dateObjTo24hrTime)
   const [canonicalArrivalDate, canonicalDepartureDate] = [startDateTime, endDateTime].map(DateFormats.dateObjToIsoDate)
   const [expectedArrivalDate, expectedDepartureDate] = faker.date
     .betweens({ from: startDateTime, to: endDateTime, count: 2 })
@@ -96,9 +116,11 @@ export default Cas1SpaceBookingFactory.define(() => {
     apArea: { id: faker.string.uuid(), name: `${faker.location.cardinalDirection()} ${faker.location.county()}` },
     bookedBy: userFactory.build(),
     expectedArrivalDate,
-    actualArrivalDate,
+    actualArrivalDateOnly,
+    actualArrivalTime,
     expectedDepartureDate,
-    actualDepartureDate,
+    actualDepartureDateOnly,
+    actualDepartureTime,
     canonicalArrivalDate,
     canonicalDepartureDate,
     departure: cas1SpaceBookingDepartureFactory.build(),
@@ -107,5 +129,6 @@ export default Cas1SpaceBookingFactory.define(() => {
     otherBookingsInPremisesForCrn: cas1SpaceBookingDatesFactory.buildList(4),
     deliusEventNumber: String(faker.number.int()),
     nonArrival: undefined,
+    status: 'departed' as Cas1SpaceBookingSummaryStatus,
   }
 })

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -13,6 +13,7 @@ import {
   dateIsToday,
   datetimeIsInThePast,
   daysToWeeksAndDays,
+  isoDateAndTimeToDateObj,
   monthOptions,
   timeIsValid24hrFormat,
   uiDateOrDateEmptyMessage,
@@ -542,4 +543,29 @@ describe('timeIsValid24hrFormat', () => {
       expect(timeIsValid24hrFormat(time)).toEqual(false)
     },
   )
+})
+
+describe('dateObjToIsoTime', () => {
+  it.each([
+    ['00:00', 0, 0, 0],
+    ['12:01', 12, 1, 1],
+    ['23:59', 23, 59, 59],
+  ])('returns the iso time part of the date with time like %s', (expected, h, m, s) => {
+    const date = new Date()
+    date.setUTCHours(h)
+    date.setUTCMinutes(m)
+    date.setUTCSeconds(s)
+    expect(DateFormats.dateObjTo24hrTime(date)).toBe(expected)
+  })
+})
+
+describe('isoDateAndTimeToDateObj', () => {
+  it.each([
+    ['2024-01-01', '05:22', '2024-01-01T05:22'],
+    ['2024-12-31', '13:22', '2024-12-31T13:22'],
+    ['2024-12-31', null, '2024-12-31'],
+  ])('returns a date from an iso date and time, %s %s', (dateStr, timeStr, expected) => {
+    const date = isoDateAndTimeToDateObj(dateStr, timeStr)
+    expect(date.getTime()).toEqual(DateFormats.isoToDateObj(expected).getTime())
+  })
 })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -52,6 +52,14 @@ export class DateFormats {
 
   /**
    * @param date JS Date object.
+   * @returns the time in the format '19:05'.
+   */
+  static dateObjTo24hrTime(date: Date) {
+    return formatISO(date, { representation: 'time' }).substring(0, 5)
+  }
+
+  /**
+   * @param date JS Date object.
    * @param options - options for the formatting
    * @param options.format - 'long' (default, e.g. "Thu 20 Dec 2012") or 'short' (e.g. "20 Dec 2012")
    * @returns the date in the to be shown in the UI.
@@ -336,8 +344,7 @@ export const bankHolidays = () => {
 
 export const todayAtMidnight = () => new Date(new Date().setHours(0, 0, 0, 0))
 
-export class InvalidDateStringError extends Error {
-}
+export class InvalidDateStringError extends Error {}
 
 export const daysToWeeksAndDays = (days: string | number): { days: number; weeks: number } => {
   const daysAsNumber = Number(days)
@@ -351,4 +358,13 @@ export const daysToWeeksAndDays = (days: string | number): { days: number; weeks
 
 export const timeIsValid24hrFormat = (time: string): Boolean => {
   return /^(2[0-3]|[01]?[0-9]):[0-5][0-9]$/.test(time)
+}
+
+export const isoDateAndTimeToDateObj = (isoDate:string,time:string):Date => {
+  const date = DateFormats.isoToDateObj(isoDate)
+  if(timeIsValid24hrFormat(time)) {
+    const [h,m] = time.split(':').map(Number)
+    date.setHours(h,m)
+  }
+  return date
 }

--- a/server/utils/placements/index.test.ts
+++ b/server/utils/placements/index.test.ts
@@ -168,8 +168,8 @@ describe('placementUtils', () => {
 
   describe('tabular information', () => {
     const placement = cas1SpaceBookingFactory.build({
-      actualArrivalDate: '2024-06-01',
-      actualDepartureDate: '2024-12-25',
+      actualArrivalDateOnly: '2024-06-01',
+      actualDepartureDateOnly: '2024-12-25',
     })
 
     it('should return the placement summary information', () => {
@@ -177,7 +177,7 @@ describe('placementUtils', () => {
         rows: [
           { key: { text: 'AP name' }, value: { text: placement.premises.name } },
           { key: { text: 'Date allocated' }, value: { text: DateFormats.isoDateToUIDate(placement.createdAt) } },
-          { key: { text: 'Status' }, value: { text: 'TBD' } },
+          { key: { text: 'Status' }, value: { text: 'Departed' } },
           {
             key: { text: 'Actual length of stay' },
             value: { text: '29 weeks, 4 days' },
@@ -197,11 +197,11 @@ describe('placementUtils', () => {
           },
           {
             key: { text: 'Actual arrival date' },
-            value: { text: DateFormats.isoDateToUIDate(placement.actualArrivalDate) },
+            value: { text: DateFormats.isoDateToUIDate(placement.actualArrivalDateOnly) },
           },
           {
             key: { text: 'Arrival time' },
-            value: { text: DateFormats.timeFromDate(DateFormats.isoToDateObj(placement.actualArrivalDate)) },
+            value: { text: (placement.actualArrivalTime || '')},
           },
         ],
       })
@@ -247,12 +247,12 @@ describe('placementUtils', () => {
             },
             {
               key: { text: 'Actual departure date' },
-              value: { text: DateFormats.isoDateToUIDate(departedPlacement.actualDepartureDate) },
+              value: { text: DateFormats.isoDateToUIDate(departedPlacement.actualDepartureDateOnly) },
             },
             {
               key: { text: 'Departure time' },
               value: {
-                text: DateFormats.timeFromDate(DateFormats.isoToDateObj(departedPlacement.actualDepartureDate)),
+                text: (departedPlacement.actualDepartureTime || '').substring(0, 5),
               },
             },
             { key: { text: 'Departure reason' }, value: { text: departedPlacement.departure?.reason?.name } },
@@ -272,12 +272,12 @@ describe('placementUtils', () => {
             },
             {
               key: { text: 'Actual departure date' },
-              value: { text: DateFormats.isoDateToUIDate(departedPlacement.actualDepartureDate) },
+              value: { text: DateFormats.isoDateToUIDate(departedPlacement.actualDepartureDateOnly) },
             },
             {
               key: { text: 'Departure time' },
               value: {
-                text: DateFormats.timeFromDate(DateFormats.isoToDateObj(departedPlacement.actualDepartureDate)),
+                text: (departedPlacement.actualDepartureTime || '').substring(0, 5),
               },
             },
             { key: { text: 'Departure reason' }, value: { text: departedPlacement.departure?.parentReason?.name } },
@@ -298,12 +298,12 @@ describe('placementUtils', () => {
             },
             {
               key: { text: 'Actual departure date' },
-              value: { text: DateFormats.isoDateToUIDate(departedPlacement.actualDepartureDate) },
+              value: { text: DateFormats.isoDateToUIDate(departedPlacement.actualDepartureDateOnly) },
             },
             {
               key: { text: 'Departure time' },
               value: {
-                text: DateFormats.timeFromDate(DateFormats.isoToDateObj(departedPlacement.actualDepartureDate)),
+                text: (departedPlacement.actualDepartureTime || '').substring(0, 5),
               },
             },
             { key: { text: 'Departure reason' }, value: { text: departedPlacement.departure?.reason?.name } },

--- a/server/utils/placements/index.test.ts
+++ b/server/utils/placements/index.test.ts
@@ -201,7 +201,7 @@ describe('placementUtils', () => {
           },
           {
             key: { text: 'Arrival time' },
-            value: { text: (placement.actualArrivalTime || '')},
+            value: { text: placement.actualArrivalTime || '' },
           },
         ],
       })


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/APS-1410
<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Adds the placement status to the placement details page.
Also, switches to use split date/time values for actual arrival/departure dates. Once this PR is merged, the deprecated values `actualArrivalDate` and `actualDepartureDate` are no longer used by the UI and can be removed.


<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/09b39411-b320-49df-9a12-f27ac9a9bc9c)
