### PR TITLE
APS-1578: Occupancy summary box

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -18,8 +18,9 @@ $path: "/assets/images/"
 @import './components/sortable-table'
 @import './components/search-and-filter'
 @import './components/key-details-bar'
-@import './components/moj-identity-bar.scss'
-@import './components/status-tag.scss'
+@import './components/moj-identity-bar'
+@import './components/status-tag'
+@import './components/notification-banner'
 
 @import './pages/assessments-index'
 @import './pages/applications-pages-attach-document'

--- a/assets/sass/components/_notification-banner.scss
+++ b/assets/sass/components/_notification-banner.scss
@@ -1,0 +1,3 @@
+.govuk-notification-banner--full-width-content .govuk-notification-banner__content > * {
+  max-width: 100%;
+}

--- a/integration_tests/pages/match/occupancyViewPage.ts
+++ b/integration_tests/pages/match/occupancyViewPage.ts
@@ -1,4 +1,11 @@
-import { ApType, PlacementDates, PlacementRequest, PlacementRequestDetail, Premises } from '@approved-premises/api'
+import {
+  ApType,
+  Cas1PremiseCapacity,
+  PlacementDates,
+  PlacementRequest,
+  PlacementRequestDetail,
+  Premises,
+} from '@approved-premises/api'
 import Page from '../page'
 import {
   filterOutAPTypes,
@@ -40,5 +47,16 @@ export default class OccupancyViewPage extends Page {
         occupancyViewSummaryListForMatchingDetails(totalCapacity, dates, placementRequest, essentialCharacteristics),
       )
     })
+  }
+
+  shouldShowOccupancySummary(premiseCapacity: Cas1PremiseCapacity) {
+    if (premiseCapacity.capacity.every(day => day.availableBedCount > 0)) {
+      this.shouldShowBanner('The placement dates you have selected are available.')
+    } else if (premiseCapacity.capacity.every(day => day.availableBedCount <= 0)) {
+      this.shouldShowBanner('There are no spaces available for the dates you have selected.')
+    } else {
+      this.shouldShowBanner('Available on:')
+      this.shouldShowBanner('Overbooked on:')
+    }
   }
 }

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -123,8 +123,8 @@ context('Placement Requests', () => {
     cy.task('stubPlacementRequest', placementRequest)
     cy.task('stubPremiseCapacity', { premisesId: premiseCapacity.premise.id, startDate, endDate, premiseCapacity })
 
-    // When I visit the search page
-    const searchPage = OccupancyViewPage.visit(
+    // When I visit the occupancy view page
+    const occupancyViewPage = OccupancyViewPage.visit(
       placementRequest,
       startDate,
       durationDays,
@@ -134,7 +134,10 @@ context('Placement Requests', () => {
     )
 
     // Then I should see the details of the case I am matching
-    searchPage.shouldShowMatchingDetails(totalCapacity, startDate, durationDays, placementRequest)
+    occupancyViewPage.shouldShowMatchingDetails(totalCapacity, startDate, durationDays, placementRequest)
+
+    // And I should see a summary of occupancy
+    occupancyViewPage.shouldShowOccupancySummary(premiseCapacity)
   })
 
   it('allows me to book a space', () => {

--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -4,7 +4,12 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import { PlacementRequestService, PremisesService } from '../../../services'
 import { cas1PremiseCapacityFactory, personFactory, placementRequestDetailFactory } from '../../../testutils/factories'
 import OccupancyViewController from './occupancyViewController'
-import { filterOutAPTypes, occupancyViewSummaryListForMatchingDetails, placementDates } from '../../../utils/match'
+import {
+  filterOutAPTypes,
+  occupancySummary,
+  occupancyViewSummaryListForMatchingDetails,
+  placementDates,
+} from '../../../utils/match'
 
 describe('OccupancyViewController', () => {
   const token = 'SOME_TOKEN'
@@ -66,6 +71,7 @@ describe('OccupancyViewController', () => {
           placementRequestDetail,
           filterOutAPTypes(placementRequestDetail.essentialCriteria),
         ),
+        occupancySummaryHtml: occupancySummary(premiseCapacity),
       })
       expect(placementRequestService.getPlacementRequest).toHaveBeenCalledWith(token, placementRequestDetail.id)
     })

--- a/server/controllers/match/placementRequests/occupancyViewController.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.ts
@@ -1,7 +1,12 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 import { ApType } from '@approved-premises/api'
 import { PlacementRequestService, PremisesService } from '../../../services'
-import { filterOutAPTypes, occupancyViewSummaryListForMatchingDetails, placementDates } from '../../../utils/match'
+import {
+  filterOutAPTypes,
+  occupancySummary,
+  occupancyViewSummaryListForMatchingDetails,
+  placementDates,
+} from '../../../utils/match'
 
 interface NewRequest extends Request {
   params: { id: string }
@@ -29,6 +34,8 @@ export default class {
         placementRequest,
         essentialCharacteristics,
       )
+      const occupancySummaryHtml = occupancySummary(capacity)
+
       res.render('match/placementRequests/occupancyView/view', {
         pageHeading: `View spaces in ${premisesName}`,
         placementRequest,
@@ -38,6 +45,7 @@ export default class {
         startDate,
         durationDays,
         matchingDetailsSummaryList,
+        occupancySummaryHtml,
       })
     }
   }

--- a/server/testutils/factories/cas1PremiseCapacity.ts
+++ b/server/testutils/factories/cas1PremiseCapacity.ts
@@ -1,35 +1,73 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
 
-import {
+import type {
   Cas1PremiseCapacity,
-  type Cas1PremiseCapacityForDay,
+  Cas1PremiseCapacityForDay,
   Cas1PremiseCharacteristicAvailability,
 } from '@approved-premises/api'
+import { addDays, differenceInDays } from 'date-fns'
 import cas1PremisesSummaryFactory from './cas1PremisesSummary'
 import { DateFormats } from '../../utils/dateUtils'
 import { offenceAndRiskCriteria } from '../../utils/placementCriteriaUtils'
 
 export default Factory.define<Cas1PremiseCapacity>(() => {
   const startDate = faker.date.anytime()
+  const endDate = faker.date.soon({ days: 365, refDate: startDate })
+  const days = differenceInDays(endDate, startDate)
+
+  const capacity = Array.from(Array(days).keys()).map(index =>
+    cas1PremiseCapacityForDayFactory.build({
+      date: DateFormats.dateObjToIsoDate(addDays(startDate, index)),
+    }),
+  )
+
   return {
     premise: cas1PremisesSummaryFactory.build(),
     startDate: DateFormats.dateObjToIsoDate(startDate),
-    endDate: DateFormats.dateObjToIsoDate(faker.date.soon({ days: 365, refDate: startDate })),
-    capacity: premiseCapacityForDayFactory.buildList(2),
+    endDate: DateFormats.dateObjToIsoDate(endDate),
+    capacity,
   }
 })
 
-const premiseCapacityForDayFactory = Factory.define<Cas1PremiseCapacityForDay>(() => ({
-  date: DateFormats.dateObjToIsoDate(faker.date.anytime()),
-  totalBedCount: faker.number.int(),
-  availableBedCount: faker.number.int(),
-  bookingCount: faker.number.int(),
-  characteristicAvailability: premiseCharacteristicAvailability.buildList(2),
-}))
+class CapacityForDayFactory extends Factory<Cas1PremiseCapacityForDay> {
+  available() {
+    const totalBedCount = faker.number.int({ min: 1, max: 40 })
+    const availableBedCount = faker.number.int({ min: 1, max: totalBedCount })
+    const bookingCount = totalBedCount - availableBedCount
+
+    return this.params({
+      totalBedCount,
+      availableBedCount,
+      bookingCount,
+    })
+  }
+
+  overbooked() {
+    const totalBedCount = faker.number.int({ min: 1, max: 40 })
+    const availableBedCount = 0
+    return this.params({
+      totalBedCount,
+      availableBedCount,
+      bookingCount: faker.number.int({ min: totalBedCount, max: totalBedCount + 10 }),
+    })
+  }
+}
+
+export const cas1PremiseCapacityForDayFactory = CapacityForDayFactory.define(() => {
+  const totalBedCount = faker.number.int({ min: 0, max: 40 })
+
+  return {
+    date: DateFormats.dateObjToIsoDate(faker.date.future()),
+    totalBedCount,
+    availableBedCount: faker.number.int({ min: 0, max: totalBedCount }),
+    bookingCount: faker.number.int({ min: 0, max: totalBedCount + 10 }),
+    characteristicAvailability: premiseCharacteristicAvailability.buildList(2),
+  }
+})
 
 const premiseCharacteristicAvailability = Factory.define<Cas1PremiseCharacteristicAvailability>(() => ({
   characteristic: faker.helpers.arrayElement(offenceAndRiskCriteria),
-  availableBedsCount: faker.number.int(),
-  bookingsCount: faker.number.int(),
+  availableBedsCount: faker.number.int({ min: 0, max: 40 }),
+  bookingsCount: faker.number.int({ min: 0, max: 45 }),
 }))

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -83,7 +83,7 @@ import spaceSearchResultFactory from './spaceSearchResult'
 import spaceSearchResultsFactory from './spaceSearchResults'
 import cas1PremisesSummaryFactory from './cas1PremisesSummary'
 import cas1PremisesBasicSummaryFactory from './cas1PremisesBasicSummary'
-import cas1PremiseCapacityFactory from './cas1PremiseCapacity'
+import cas1PremiseCapacityFactory, { cas1PremiseCapacityForDayFactory } from './cas1PremiseCapacity'
 import cas1SpaceBookingSummaryFactory from './cas1SpaceBookingSummary'
 import cas1SpaceBookingFactory from './cas1SpaceBooking'
 import cas1SpaceBookingDatesFactory from './cas1SpaceBookingDates'
@@ -122,6 +122,7 @@ export {
   cancellationFactory,
   cas1PremisesBasicSummaryFactory,
   cas1PremiseCapacityFactory,
+  cas1PremiseCapacityForDayFactory,
   cas1PremisesSummaryFactory,
   cas1ReferenceDataFactory,
   cas1SpaceBookingDatesFactory,

--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ApType,
   ApprovedPremisesApplication,
   Cas1SpaceCharacteristic,

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -1,5 +1,5 @@
 import { addDays } from 'date-fns'
-import {
+import type {
   ApType,
   Gender,
   PlacementCriteria,
@@ -8,8 +8,13 @@ import {
   Cas1SpaceCharacteristic as SpaceCharacteristic,
   Cas1SpaceSearchParameters as SpaceSearchParameters,
   Cas1SpaceSearchResult as SpaceSearchResult,
-} from '../../@types/shared'
-import { KeyDetailsArgs, ObjectWithDateParts, SpaceSearchParametersUi, SummaryListItem } from '../../@types/ui'
+} from '@approved-premises/api'
+import type {
+  KeyDetailsArgs,
+  ObjectWithDateParts,
+  SpaceSearchParametersUi,
+  SummaryListItem,
+} from '@approved-premises/ui'
 import { DateFormats, daysToWeeksAndDays } from '../dateUtils'
 import { createQueryString, sentenceCase } from '../utils'
 import matchPaths from '../../paths/match'
@@ -27,6 +32,7 @@ import { placementRequirementsRow } from '../placementRequests/placementRequirem
 import { allReleaseTypes } from '../applications/releaseTypeUtils'
 
 export { placementDates } from './placementDates'
+export { occupancySummary } from './occupancySummary'
 
 type PlacementDates = {
   placementLength: number

--- a/server/utils/match/occupancySummary.test.ts
+++ b/server/utils/match/occupancySummary.test.ts
@@ -1,0 +1,94 @@
+import { cas1PremiseCapacityFactory, cas1PremiseCapacityForDayFactory } from '../../testutils/factories'
+import { DateRange, occupancySummary, renderDateRange } from './occupancySummary'
+
+describe('occupancySummary', () => {
+  it('returns a list of available and overbooked time periods', () => {
+    const capacity = cas1PremiseCapacityFactory.build({
+      capacity: [
+        cas1PremiseCapacityForDayFactory.available().build({ date: '2025-02-12' }),
+        cas1PremiseCapacityForDayFactory.available().build({ date: '2025-02-13' }),
+        cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-02-14' }),
+        cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-02-15' }),
+        cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-02-16' }),
+        cas1PremiseCapacityForDayFactory.available().build({ date: '2025-02-17' }),
+      ],
+    })
+    const result = occupancySummary(capacity)
+
+    expect(result).toMatchStringIgnoringWhitespace(`
+      <div style="max-width: 100%">
+        <h3 class="govuk-heading-m">Available on:</h3>
+        <ul>
+          <li>Wed 12 Feb 2025 to Thu 13 Feb 2025 <strong>(2 days)</strong></li>
+          <li>Mon 17 Feb 2025 <strong>(1 day)</strong></li>
+        </ul>
+        <h3 class="govuk-heading-m">Overbooked on:</h3>
+        <ul>
+          <li>Fri 14 Feb 2025 to Sun 16 Feb 2025 <strong>(3 days)</strong></li>
+        </ul>
+      </div>
+    `)
+  })
+
+  it('returns null for available if no dates are available', () => {
+    const capacity = cas1PremiseCapacityFactory.build({
+      capacity: [cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-04-14' })],
+    })
+    const result = occupancySummary(capacity)
+
+    expect(result).toMatchStringIgnoringWhitespace(
+      `<p class="govuk-heading-m">There are no spaces available for the dates you have selected.</p>`,
+    )
+  })
+
+  it('returns null for overbooked if no dates are overbooked', () => {
+    const capacity = cas1PremiseCapacityFactory.build({
+      capacity: [cas1PremiseCapacityForDayFactory.available().build({ date: '2025-04-15' })],
+    })
+    const result = occupancySummary(capacity)
+
+    expect(result).toMatchStringIgnoringWhitespace(
+      `<p class="govuk-heading-m">The placement dates you have selected are available.</p>`,
+    )
+  })
+
+  describe('renderDateRange', () => {
+    it.each([
+      ['1 day', { start: '2024-12-04', end: '2024-12-04' }, 'Wed 4 Dec 2024 <strong>(1 day)</strong>'],
+      [
+        '3 days',
+        {
+          start: '2024-12-04',
+          end: '2024-12-06',
+        },
+        'Wed 4 Dec 2024 to Fri 6 Dec 2024 <strong>(3 days)</strong>',
+      ],
+      [
+        '1 week',
+        {
+          start: '2024-12-04',
+          end: '2024-12-10',
+        },
+        'Wed 4 Dec 2024 to Tue 10 Dec 2024 <strong>(1 week)</strong>',
+      ],
+      [
+        '1 week and 4 days',
+        {
+          start: '2024-12-04',
+          end: '2024-12-14',
+        },
+        'Wed 4 Dec 2024 to Sat 14 Dec 2024 <strong>(1 week and 4 days)</strong>',
+      ],
+      [
+        '3 weeks and 1 day',
+        {
+          start: '2024-12-04',
+          end: '2024-12-25',
+        },
+        'Wed 4 Dec 2024 to Wed 25 Dec 2024 <strong>(3 weeks and 1 day)</strong>',
+      ],
+    ])('renders a date range spanning %s', (_, dateRange: DateRange, expected) => {
+      expect(renderDateRange(dateRange)).toEqual(expected)
+    })
+  })
+})

--- a/server/utils/match/occupancySummary.ts
+++ b/server/utils/match/occupancySummary.ts
@@ -1,0 +1,74 @@
+import type { Cas1PremiseCapacity, Cas1PremiseCapacityForDay } from '@approved-premises/api'
+import { differenceInDays } from 'date-fns'
+import { DateFormats, daysToWeeksAndDays } from '../dateUtils'
+
+export type DateRange = {
+  start: string
+  end: string
+}
+
+const daysToRanges = (days: Array<Cas1PremiseCapacityForDay>) =>
+  days.reduce((ranges: Array<DateRange>, capacityForDay) => {
+    if (!ranges.length) {
+      ranges.push({ start: capacityForDay.date, end: capacityForDay.date })
+    } else {
+      const lastRange = ranges[ranges.length - 1]
+      if (differenceInDays(capacityForDay.date, lastRange.end) === 1) {
+        lastRange.end = capacityForDay.date
+      } else {
+        ranges.push({ start: capacityForDay.date, end: capacityForDay.date })
+      }
+    }
+    return ranges
+  }, [])
+
+export const renderDateRange = (dateRange: DateRange): string => {
+  let render = `${DateFormats.isoDateToUIDate(dateRange.start)}`
+
+  const totalDays =
+    differenceInDays(DateFormats.isoToDateObj(dateRange.end), DateFormats.isoToDateObj(dateRange.start)) + 1
+  if (totalDays > 1) {
+    render += ` to ${DateFormats.isoDateToUIDate(dateRange.end)}`
+  }
+
+  const duration = DateFormats.formatDuration(daysToWeeksAndDays(totalDays)).replace(', ', ' and ')
+  render += ` <strong>(${duration})</strong>`
+
+  return render
+}
+
+export const occupancySummary = (premiseCapacity: Cas1PremiseCapacity): string => {
+  const availableDays: Array<Cas1PremiseCapacityForDay> = []
+  const overbookedDays: Array<Cas1PremiseCapacityForDay> = []
+
+  premiseCapacity.capacity.forEach(capacityForDay => {
+    if (capacityForDay.availableBedCount > 0) {
+      availableDays.push(capacityForDay)
+    } else {
+      overbookedDays.push(capacityForDay)
+    }
+  })
+
+  if (availableDays.length === 0) {
+    return `<p class="govuk-heading-m">There are no spaces available for the dates you have selected.</p>`
+  }
+  if (overbookedDays.length === 0) {
+    return `<p class="govuk-heading-m">The placement dates you have selected are available.</p>`
+  }
+
+  const availableRanges = daysToRanges(availableDays).map(renderDateRange)
+  const overbookedRanges = daysToRanges(overbookedDays).map(renderDateRange)
+
+  return `
+    <div style="max-width: 100%">
+        <h3 class="govuk-heading-m">Available on:</h3>
+        <ul>
+          ${availableRanges.map(range => `<li>${range}</li>`).join('')}
+        </ul>
+        <h3 class="govuk-heading-m">Overbooked on:</h3>
+        <ul>
+          ${overbookedRanges.map(range => `<li>${range}</li>`).join('')}
+        </ul>
+    </div>
+  `
+}

--- a/server/views/match/placementRequests/occupancyView/view.njk
+++ b/server/views/match/placementRequests/occupancyView/view.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% extends "../../layout-with-details.njk" %}
 
@@ -16,17 +17,26 @@
 
 {% block content %}
     <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
     {% set detailsHTML %}
         {{ govukSummaryList({
             rows: matchingDetailsSummaryList
         }) }}
     {% endset %}
+
     {{ govukDetails({
         summaryText: "Matching details",
         open: true,
         html: detailsHTML
     }) }}
-    <a class="govuk-button" href="{{ MatchUtils.redirectToSpaceBookingsNew({placementRequestId: placementRequest.id, premisesName: premisesName, premisesId: premisesId, apType: apType, startDate: startDate, durationDays: durationDays }) }}">
+
+    {{ govukNotificationBanner({
+        html: occupancySummaryHtml,
+        classes: 'govuk-notification-banner--full-width-content'
+    }) }}
+
+    <a class="govuk-button"
+       href="{{ MatchUtils.redirectToSpaceBookingsNew({placementRequestId: placementRequest.id, premisesName: premisesName, premisesId: premisesId, apType: apType, startDate: startDate, durationDays: durationDays }) }}">
         Continue
     </a>
 {% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1578

# Changes in this PR

Adds the occupancy summary banner to the occupancy view page. 

## Screenshots of UI changes

### Dates available

<img width="942" alt="Screenshot 2024-12-04 at 11 37 13" src="https://github.com/user-attachments/assets/45827678-9377-4646-a6e0-5ae568e1c904">

---

### No dates available

<img width="941" alt="Screenshot 2024-12-04 at 11 36 40" src="https://github.com/user-attachments/assets/73022a3e-a24b-425b-a7f6-424edb157339">

---

### Mix of available and overbooked

<img width="948" alt="Screenshot 2024-12-04 at 11 33 30" src="https://github.com/user-attachments/assets/e2701ca5-8581-48f8-8906-d763a222b16c">
