### PR TITLE
APS-1602: calendar view

### DIFF
--- a/assets/sass/components/_calendar.scss
+++ b/assets/sass/components/_calendar.scss
@@ -1,123 +1,44 @@
-$colWidth: 22px;
-$colPadding: 2px;
+.calendar__month {
+  border-top: 1px solid $govuk-border-colour;
 
-$roomHeaderWidth: 100px;
-
-$calendarWidth: $roomHeaderWidth + (30 * ($colWidth + ($colPadding * 2)));
-
-.govuk-link {
-  &--booking {
-    &:link, &:visited {
-      color: govuk-colour("black");
-      font-weight: bold;
-    }
+  .calendar__day {
+    padding: govuk-spacing(2) 0;
+    border-bottom: 1px solid $govuk-border-colour;
   }
 
-  &--overbooking {
-    &:link, &:visited {
-      color: govuk-colour("white");
-      font-weight: bold;
-    }
-  }
-}
+  @include govuk-media-query($from: tablet) {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    grid-gap: 2px;
+    border-top: none;
 
-.govuk-pagination {
-  &--calendar {
-    padding-bottom: govuk-spacing(6);
-
-    .govuk-pagination__prev {
-      float: left;
+    .calendar__day {
+      margin: 0;
+      padding: govuk-spacing(2);
+      border: 1px solid $govuk-text-colour;
+      @include govuk-font-size(16);
     }
 
-    .govuk-pagination__next {
-      float: right;
-      border-top: none;
+    .calendar__day--mon {
+      grid-column-start: 1;
     }
-
-    .govuk-pagination__prev + .govuk-pagination__next {
-      border-top: none;
+    .calendar__day--tue {
+      grid-column-start: 2;
     }
-  }
-}
-
-.govuk-table {
-  &--calendar {
-    font-size: 0.9em;
-    width: $calendarWidth;
-    table-layout: fixed;
-    margin: 0 auto;
-
-    @for $i from 1 through 31 {
-      th[colspan="#{$i}"], td[colspan="#{$i}"] {
-        width: ($i * ($colWidth + ($colPadding * 2)));
-      }
+    .calendar__day--wed {
+      grid-column-start: 3;
     }
-  }
-
-  &__header {
-    &--calendar {
-      border: 1px solid $govuk-border-colour;
-      text-align: center;
-      width: $colWidth;
-      padding: $colPadding;
+    .calendar__day--thu {
+      grid-column-start: 4;
     }
-
-    &--calendar-room-header {
-      text-align: center;
-      width: 100px;
-      vertical-align: middle;
+    .calendar__day--fri {
+      grid-column-start: 5;
     }
-  }
-
-
-  &__cell {
-    &--calendar {
-      position: relative;
-      border: 1px solid $govuk-border-colour;
-      padding: $colPadding;
-
-      span {
-        white-space: nowrap;
-        overflow:hidden;
-        text-overflow: ellipsis;
-        display: block;
-
-        &.tooltip {
-          &:hover::before {
-            position: absolute;
-            bottom: -120%;
-            left: 10px;
-            z-index: 999;
-            content: attr(title);
-            opacity: 0.75;
-            background-color: govuk-colour("black");
-            color: govuk-colour("white");
-            padding: $colPadding;
-            border-radius: 3px;
-            display: block;
-            font-weight: normal;
-          }
-        }
-      }
+    .calendar__day--sat {
+      grid-column-start: 6;
     }
-
-    &--booking {
-      background-color: govuk-colour("light-blue");
-    }
-
-    &--lost_bed {
-      background-color: govuk-colour("light-grey");
-      font-weight: bold;
-    }
-
-    &--month {
-      text-align: center;
-    }
-
-    &--overbooking {
-      background-color: govuk-colour("black");
-      color: govuk-colour("white");
-      font-weight: bold;
+    .calendar__day--sun {
+      grid-column-start: 7;
     }
   }
 }

--- a/assets/sass/components/_calendar.scss
+++ b/assets/sass/components/_calendar.scss
@@ -2,8 +2,44 @@
   border-top: 1px solid $govuk-border-colour;
 
   .calendar__day {
-    padding: govuk-spacing(2) 0;
+    margin: 0;
     border-bottom: 1px solid $govuk-border-colour;
+
+    &:focus-within {
+      border-color: transparent;
+    }
+
+    #calendar-key & {
+      padding: govuk-spacing(2) 0;
+    }
+  }
+
+  .calendar__link {
+    display: flex;
+    flex-direction: row;
+    gap: govuk-spacing(4);
+    color: $govuk-text-colour;
+    padding: govuk-spacing(2) 0;
+    text-decoration: none;
+
+    &:hover {
+      background: govuk-colour('blue');
+      color: govuk-colour('white');
+      text-decoration: underline;
+      text-decoration-thickness: 2px;
+    }
+  }
+
+  .calendar__date {
+    min-width: 20%;
+  }
+
+  .calendar__availability {
+    margin: 0;
+
+    dd {
+      margin: 0;
+    }
   }
 
   @include govuk-media-query($from: tablet) {
@@ -12,10 +48,23 @@
     grid-gap: 2px;
     border-top: none;
 
+    #calendar-key & {
+      display: flex;
+    }
+
     .calendar__day {
-      margin: 0;
-      padding: govuk-spacing(2);
+      display: flex;
       border: 1px solid $govuk-text-colour;
+
+      #calendar-key & {
+        padding: govuk-spacing(2) govuk-spacing(6);
+      }
+    }
+
+    .calendar__link {
+      flex: 1;
+      flex-direction: column;
+      padding: govuk-spacing(2);
       @include govuk-font-size(16);
     }
 
@@ -39,6 +88,10 @@
     }
     .calendar__day--sun {
       grid-column-start: 7;
+    }
+
+    .calendar__date {
+      margin-bottom: auto;
     }
   }
 }

--- a/integration_tests/pages/match/occupancyViewPage.ts
+++ b/integration_tests/pages/match/occupancyViewPage.ts
@@ -14,6 +14,7 @@ import {
 } from '../../../server/utils/match'
 import { createQueryString } from '../../../server/utils/utils'
 import paths from '../../../server/paths/match'
+import { DateFormats, daysToWeeksAndDays } from '../../../server/utils/dateUtils'
 
 export default class OccupancyViewPage extends Page {
   constructor(premisesName: string) {
@@ -47,6 +48,11 @@ export default class OccupancyViewPage extends Page {
         occupancyViewSummaryListForMatchingDetails(totalCapacity, dates, placementRequest, essentialCharacteristics),
       )
     })
+    cy.get('.govuk-heading-l')
+      .contains(
+        `View availability and book your placement for ${DateFormats.formatDuration(daysToWeeksAndDays(durationDays))} from ${DateFormats.isoDateToUIDate(startDate, { format: 'short' })}`,
+      )
+      .should('exist')
   }
 
   shouldShowOccupancySummary(premiseCapacity: Cas1PremiseCapacity) {

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -140,6 +140,9 @@ context('Placement Requests', () => {
 
     // And I should see a summary of occupancy
     occupancyViewPage.shouldShowOccupancySummary(premiseCapacity)
+
+    // And I should see an occupancy calendar
+    occupancyViewPage.shouldShowOccupancyCalendar(premiseCapacity)
   })
 
   it('allows me to book a space', () => {

--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -10,6 +10,7 @@ import {
   occupancyViewSummaryListForMatchingDetails,
   placementDates,
 } from '../../../utils/match'
+import { occupancyCalendar } from '../../../utils/match/occupancyCalendar'
 
 describe('OccupancyViewController', () => {
   const token = 'SOME_TOKEN'
@@ -72,6 +73,7 @@ describe('OccupancyViewController', () => {
           filterOutAPTypes(placementRequestDetail.essentialCriteria),
         ),
         occupancySummaryHtml: occupancySummary(premiseCapacity),
+        calendar: occupancyCalendar(premiseCapacity),
       })
       expect(placementRequestService.getPlacementRequest).toHaveBeenCalledWith(token, placementRequestDetail.id)
     })

--- a/server/controllers/match/placementRequests/occupancyViewController.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.ts
@@ -7,6 +7,7 @@ import {
   occupancyViewSummaryListForMatchingDetails,
   placementDates,
 } from '../../../utils/match'
+import { occupancyCalendar } from '../../../utils/match/occupancyCalendar'
 
 interface NewRequest extends Request {
   params: { id: string }
@@ -35,6 +36,7 @@ export default class {
         essentialCharacteristics,
       )
       const occupancySummaryHtml = occupancySummary(capacity)
+      const calendar = occupancyCalendar(capacity)
 
       res.render('match/placementRequests/occupancyView/view', {
         pageHeading: `View spaces in ${premisesName}`,
@@ -46,6 +48,7 @@ export default class {
         durationDays,
         matchingDetailsSummaryList,
         occupancySummaryHtml,
+        calendar,
       })
     }
   }

--- a/server/testutils/factories/cas1PremiseCapacity.ts
+++ b/server/testutils/factories/cas1PremiseCapacity.ts
@@ -12,8 +12,13 @@ import { DateFormats } from '../../utils/dateUtils'
 import { offenceAndRiskCriteria } from '../../utils/placementCriteriaUtils'
 
 export default Factory.define<Cas1PremiseCapacity>(({ params }) => {
-  const startDate = DateFormats.isoToDateObj(params.startDate) || faker.date.anytime()
-  const endDate = DateFormats.isoToDateObj(params.endDate) || faker.date.soon({ days: 365, refDate: startDate })
+  const startDate = params.startDate ? DateFormats.isoToDateObj(params.startDate) : faker.date.anytime()
+  const endDate = params.endDate
+    ? DateFormats.isoToDateObj(params.endDate)
+    : faker.date.soon({
+        days: 365,
+        refDate: startDate,
+      })
   const days = differenceInDays(endDate, startDate) + 1
 
   const capacity = Array.from(Array(days).keys()).map(index =>
@@ -32,9 +37,9 @@ export default Factory.define<Cas1PremiseCapacity>(({ params }) => {
 
 class CapacityForDayFactory extends Factory<Cas1PremiseCapacityForDay> {
   available() {
-    const totalBedCount = faker.number.int({ min: 1, max: 40 })
-    const availableBedCount = faker.number.int({ min: 1, max: totalBedCount })
-    const bookingCount = totalBedCount - availableBedCount
+    const totalBedCount = faker.number.int({ min: 6, max: 40 })
+    const availableBedCount = faker.number.int({ min: totalBedCount - 5, max: totalBedCount })
+    const bookingCount = faker.number.int({ min: 0, max: availableBedCount - 1 })
 
     return this.params({
       totalBedCount,
@@ -44,12 +49,14 @@ class CapacityForDayFactory extends Factory<Cas1PremiseCapacityForDay> {
   }
 
   overbooked() {
-    const totalBedCount = faker.number.int({ min: 1, max: 40 })
-    const availableBedCount = 0
+    const totalBedCount = faker.number.int({ min: 6, max: 40 })
+    const availableBedCount = faker.number.int({ min: totalBedCount - 5, max: totalBedCount })
+    const bookingCount = faker.number.int({ min: availableBedCount, max: totalBedCount + 5 })
+
     return this.params({
       totalBedCount,
       availableBedCount,
-      bookingCount: faker.number.int({ min: totalBedCount, max: totalBedCount + 10 }),
+      bookingCount,
     })
   }
 }

--- a/server/testutils/factories/cas1PremiseCapacity.ts
+++ b/server/testutils/factories/cas1PremiseCapacity.ts
@@ -11,10 +11,10 @@ import cas1PremisesSummaryFactory from './cas1PremisesSummary'
 import { DateFormats } from '../../utils/dateUtils'
 import { offenceAndRiskCriteria } from '../../utils/placementCriteriaUtils'
 
-export default Factory.define<Cas1PremiseCapacity>(() => {
-  const startDate = faker.date.anytime()
-  const endDate = faker.date.soon({ days: 365, refDate: startDate })
-  const days = differenceInDays(endDate, startDate)
+export default Factory.define<Cas1PremiseCapacity>(({ params }) => {
+  const startDate = DateFormats.isoToDateObj(params.startDate) || faker.date.anytime()
+  const endDate = DateFormats.isoToDateObj(params.endDate) || faker.date.soon({ days: 365, refDate: startDate })
+  const days = differenceInDays(endDate, startDate) + 1
 
   const capacity = Array.from(Array(days).keys()).map(index =>
     cas1PremiseCapacityForDayFactory.build({

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -70,6 +70,13 @@ describe('DateFormats', () => {
       expect(DateFormats.isoDateToUIDate(date, { format: 'short' })).toEqual(expectedUiDate)
     })
 
+    it.each([
+      ['2022-11-09T00:00:00.000Z', 'Wed 9 Nov'],
+      ['2022-11-11T00:00:00.000Z', 'Fri 11 Nov'],
+    ])('converts ISO8601 date %s to a long format date with no year', (date, expectedUiDate) => {
+      expect(DateFormats.isoDateToUIDate(date, { format: 'longNoYear' })).toEqual(expectedUiDate)
+    })
+
     it('raises an error if the date is not a valid ISO8601 date string', () => {
       const date = '23/11/2022'
 
@@ -279,6 +286,15 @@ describe('DateFormats', () => {
   describe('formatDuration', () => {
     it('formats a duration with the given unit', () => {
       expect(DateFormats.formatDuration({ days: '4', weeks: '7' })).toEqual('7 weeks, 4 days')
+    })
+  })
+
+  describe('isoDateToMonthAndYear', () => {
+    it.each([
+      ['2024-12-04', 'December 2024'],
+      ['2025-01-01', 'January 2025'],
+    ])('returns the month and year for the date %s', (date, expected) => {
+      expect(DateFormats.isoDateToMonthAndYear(date)).toEqual(expected)
     })
   })
 })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -33,6 +33,13 @@ type DurationWithNumberOrString = {
   seconds?: number | string
 }
 
+const uiDateFormats = {
+  short: 'd MMM y',
+  long: 'ccc d MMM y',
+  longNoYear: 'ccc d MMM',
+}
+type UiDateFormat = keyof typeof uiDateFormats
+
 export class DateFormats {
   /**
    * @param date JS Date object.
@@ -64,11 +71,8 @@ export class DateFormats {
    * @param options.format - 'long' (default, e.g. "Thu 20 Dec 2012") or 'short' (e.g. "20 Dec 2012")
    * @returns the date in the to be shown in the UI.
    */
-  static dateObjtoUIDate(date: Date, options: { format: 'short' | 'long' } = { format: 'long' }) {
-    if (options.format === 'long') {
-      return format(date, 'ccc d MMM y')
-    }
-    return format(date, 'd MMM y')
+  static dateObjtoUIDate(date: Date, options: { format: UiDateFormat } = { format: 'long' }) {
+    return format(date, uiDateFormats[options.format])
   }
 
   /**
@@ -99,7 +103,7 @@ export class DateFormats {
    * @param options.format - 'long' (default, e.g. "Thu 20 Dec 2012") or 'short' (e.g. "20 Dec 2012")
    * @returns the date in the to be shown in the UI.
    */
-  static isoDateToUIDate(isoDate: string, options: { format: 'short' | 'long' } = { format: 'long' }) {
+  static isoDateToUIDate(isoDate: string, options: { format: UiDateFormat } = { format: 'long' }) {
     return DateFormats.dateObjtoUIDate(DateFormats.isoToDateObj(isoDate), options)
   }
 
@@ -226,9 +230,13 @@ export class DateFormats {
   static formatDurationBetweenTwoDates(
     date1: string,
     date2: string,
-    options: { format: 'short' | 'long' } = { format: 'long' },
+    options: { format: UiDateFormat } = { format: 'long' },
   ): string {
     return `${DateFormats.isoDateToUIDate(date1, { format: options.format })} - ${DateFormats.isoDateToUIDate(date2, { format: options.format })}`
+  }
+
+  static isoDateToMonthAndYear(date: string) {
+    return format(date, 'MMMM yyyy')
   }
 }
 

--- a/server/utils/match/occupancy.test.ts
+++ b/server/utils/match/occupancy.test.ts
@@ -1,0 +1,96 @@
+import { faker } from '@faker-js/faker'
+import { cas1PremiseCapacityFactory, cas1PremiseCapacityForDayFactory } from '../../testutils/factories'
+import { dateRangeAvailability, dayAvailabilityCount, dayHasAvailability } from './occupancy'
+
+describe('dayAvailabilityCount', () => {
+  it('returns the count of available spaces for the day', () => {
+    const availableBedCount = faker.number.int({ min: 1, max: 20 })
+    const bookingCount = faker.number.int({ min: 1, max: 30 })
+    const dayCapacity = cas1PremiseCapacityForDayFactory.build({
+      availableBedCount,
+      bookingCount,
+    })
+
+    expect(dayAvailabilityCount(dayCapacity)).toEqual(availableBedCount - bookingCount)
+  })
+})
+
+describe('dayHasAvailability', () => {
+  it('returns true if the day has availability', () => {
+    const dayCapacity = cas1PremiseCapacityForDayFactory.build({
+      availableBedCount: 15,
+      bookingCount: 10,
+    })
+
+    expect(dayHasAvailability(dayCapacity)).toBe(true)
+  })
+
+  it('returns false if the day is overbooked', () => {
+    const dayCapacity = cas1PremiseCapacityForDayFactory.build({
+      availableBedCount: 15,
+      bookingCount: 20,
+    })
+
+    expect(dayHasAvailability(dayCapacity)).toBe(false)
+  })
+
+  it('returns false if the day is fully booked', () => {
+    const dayCapacity = cas1PremiseCapacityForDayFactory.build({
+      availableBedCount: 15,
+      bookingCount: 15,
+    })
+
+    expect(dayHasAvailability(dayCapacity)).toBe(false)
+  })
+})
+
+describe('dateRangeAvailability', () => {
+  it('returns "available" if all dates have availability', () => {
+    const premisesCapacity = cas1PremiseCapacityFactory.build({
+      startDate: '2024-12-05',
+      endDate: '2024-12-05',
+      capacity: [
+        cas1PremiseCapacityForDayFactory.build({
+          availableBedCount: 15,
+          bookingCount: 0,
+        }),
+      ],
+    })
+
+    expect(dateRangeAvailability(premisesCapacity)).toEqual('available')
+  })
+
+  it('returns "partial" if only some of the dates have availability', () => {
+    const premisesCapacity = cas1PremiseCapacityFactory.build({
+      startDate: '2024-12-05',
+      endDate: '2024-12-05',
+      capacity: [
+        cas1PremiseCapacityForDayFactory.build({
+          availableBedCount: 15,
+          bookingCount: 0,
+        }),
+        cas1PremiseCapacityForDayFactory.build({
+          availableBedCount: 15,
+          bookingCount: 20,
+        }),
+      ],
+    })
+
+    expect(dateRangeAvailability(premisesCapacity)).toEqual('partial')
+  })
+
+  it('returns "none" if none of the dates have availability', () => {
+    const premisesCapacity = cas1PremiseCapacityFactory.build({
+      startDate: '2024-12-05',
+      endDate: '2024-12-05',
+      capacity: [
+        cas1PremiseCapacityForDayFactory.build({
+          availableBedCount: 15,
+          bookingCount: 20,
+        }),
+      ],
+    })
+
+    expect(dateRangeAvailability(premisesCapacity)).toEqual('none')
+  })
+})

--- a/server/utils/match/occupancy.ts
+++ b/server/utils/match/occupancy.ts
@@ -1,0 +1,17 @@
+import { Cas1PremiseCapacity, Cas1PremiseCapacityForDay } from '@approved-premises/api'
+
+export const dayAvailabilityCount = (dayCapacity: Cas1PremiseCapacityForDay) => {
+  return dayCapacity.availableBedCount - dayCapacity.bookingCount
+}
+
+export const dayHasAvailability = (dayCapacity: Cas1PremiseCapacityForDay) => {
+  return dayAvailabilityCount(dayCapacity) > 0
+}
+
+export const dateRangeAvailability = (capacity: Cas1PremiseCapacity) => {
+  const availableDays = capacity.capacity.filter(dayHasAvailability)
+
+  if (availableDays.length === capacity.capacity.length) return 'available'
+  if (availableDays.length === 0) return 'none'
+  return 'partial'
+}

--- a/server/utils/match/occupancyCalendar.test.ts
+++ b/server/utils/match/occupancyCalendar.test.ts
@@ -1,0 +1,24 @@
+import { occupancyCalendar } from './occupancyCalendar'
+import { cas1PremiseCapacityFactory } from '../../testutils/factories'
+
+describe('occupancyCalendar', () => {
+  it('returns a calendar from the start date to the end date', () => {
+    const premisesCapacity = cas1PremiseCapacityFactory.build({ startDate: '2024-12-30', endDate: '2025-01-02' })
+    expect(occupancyCalendar(premisesCapacity)).toEqual([
+      {
+        name: 'December 2024',
+        days: [
+          { name: 'Mon 30 Dec', ...premisesCapacity.capacity[0] },
+          { name: 'Tue 31 Dec', ...premisesCapacity.capacity[1] },
+        ],
+      },
+      {
+        name: 'January 2025',
+        days: [
+          { name: 'Wed 1 Jan', ...premisesCapacity.capacity[2] },
+          { name: 'Thu 2 Jan', ...premisesCapacity.capacity[3] },
+        ],
+      },
+    ])
+  })
+})

--- a/server/utils/match/occupancyCalendar.test.ts
+++ b/server/utils/match/occupancyCalendar.test.ts
@@ -1,5 +1,6 @@
 import { occupancyCalendar } from './occupancyCalendar'
 import { cas1PremiseCapacityFactory } from '../../testutils/factories'
+import { dayAvailabilityCount } from './occupancy'
 
 describe('occupancyCalendar', () => {
   it('returns a calendar from the start date to the end date', () => {
@@ -8,15 +9,15 @@ describe('occupancyCalendar', () => {
       {
         name: 'December 2024',
         days: [
-          { name: 'Mon 30 Dec', ...premisesCapacity.capacity[0] },
-          { name: 'Tue 31 Dec', ...premisesCapacity.capacity[1] },
+          { name: 'Mon 30 Dec', bookableCount: dayAvailabilityCount(premisesCapacity.capacity[0]) },
+          { name: 'Tue 31 Dec', bookableCount: dayAvailabilityCount(premisesCapacity.capacity[1]) },
         ],
       },
       {
         name: 'January 2025',
         days: [
-          { name: 'Wed 1 Jan', ...premisesCapacity.capacity[2] },
-          { name: 'Thu 2 Jan', ...premisesCapacity.capacity[3] },
+          { name: 'Wed 1 Jan', bookableCount: dayAvailabilityCount(premisesCapacity.capacity[2]) },
+          { name: 'Thu 2 Jan', bookableCount: dayAvailabilityCount(premisesCapacity.capacity[3]) },
         ],
       },
     ])

--- a/server/utils/match/occupancyCalendar.ts
+++ b/server/utils/match/occupancyCalendar.ts
@@ -1,8 +1,10 @@
-import { Cas1PremiseCapacity, Cas1PremiseCapacityForDay } from '@approved-premises/api'
+import { Cas1PremiseCapacity } from '@approved-premises/api'
 import { DateFormats } from '../dateUtils'
+import { dayAvailabilityCount } from './occupancy'
 
-type CalendarDay = Cas1PremiseCapacityForDay & {
+type CalendarDay = {
   name: string
+  bookableCount: number
 }
 type CalendarMonth = {
   name: string
@@ -27,7 +29,7 @@ export const occupancyCalendar = (capacity: Cas1PremiseCapacity) => {
 
     currentMonth.days.push({
       name: DateFormats.isoDateToUIDate(day.date, { format: 'longNoYear' }),
-      ...day,
+      bookableCount: dayAvailabilityCount(day),
     })
   })
 

--- a/server/utils/match/occupancyCalendar.ts
+++ b/server/utils/match/occupancyCalendar.ts
@@ -1,0 +1,35 @@
+import { Cas1PremiseCapacity, Cas1PremiseCapacityForDay } from '@approved-premises/api'
+import { DateFormats } from '../dateUtils'
+
+type CalendarDay = Cas1PremiseCapacityForDay & {
+  name: string
+}
+type CalendarMonth = {
+  name: string
+  days: Array<CalendarDay>
+}
+type Calendar = Array<CalendarMonth>
+
+export const occupancyCalendar = (capacity: Cas1PremiseCapacity) => {
+  const calendar: Calendar = []
+
+  capacity.capacity.forEach(day => {
+    const dayMonthAndYear = DateFormats.isoDateToMonthAndYear(day.date)
+    let currentMonth = calendar.find(month => month.name === dayMonthAndYear)
+
+    if (!currentMonth) {
+      currentMonth = {
+        name: dayMonthAndYear,
+        days: [],
+      }
+      calendar.push(currentMonth)
+    }
+
+    currentMonth.days.push({
+      name: DateFormats.isoDateToUIDate(day.date, { format: 'longNoYear' }),
+      ...day,
+    })
+  })
+
+  return calendar
+}

--- a/server/utils/match/occupancySummary.test.ts
+++ b/server/utils/match/occupancySummary.test.ts
@@ -16,17 +16,15 @@ describe('occupancySummary', () => {
     const result = occupancySummary(capacity)
 
     expect(result).toMatchStringIgnoringWhitespace(`
-      <div style="max-width: 100%">
-        <h3 class="govuk-heading-m">Available on:</h3>
-        <ul>
-          <li>Wed 12 Feb 2025 to Thu 13 Feb 2025 <strong>(2 days)</strong></li>
-          <li>Mon 17 Feb 2025 <strong>(1 day)</strong></li>
-        </ul>
-        <h3 class="govuk-heading-m">Overbooked on:</h3>
-        <ul>
-          <li>Fri 14 Feb 2025 to Sun 16 Feb 2025 <strong>(3 days)</strong></li>
-        </ul>
-      </div>
+      <h3 class="govuk-heading-m">Available on:</h3>
+      <ul>
+        <li>Wed 12 Feb 2025 to Thu 13 Feb 2025 <strong>(2 days)</strong></li>
+        <li>Mon 17 Feb 2025 <strong>(1 day)</strong></li>
+      </ul>
+      <h3 class="govuk-heading-m">Overbooked on:</h3>
+      <ul>
+        <li>Fri 14 Feb 2025 to Sun 16 Feb 2025 <strong>(3 days)</strong></li>
+      </ul>
     `)
   })
 

--- a/server/utils/match/occupancySummary.ts
+++ b/server/utils/match/occupancySummary.ts
@@ -1,6 +1,7 @@
 import type { Cas1PremiseCapacity, Cas1PremiseCapacityForDay } from '@approved-premises/api'
 import { differenceInDays } from 'date-fns'
 import { DateFormats, daysToWeeksAndDays } from '../dateUtils'
+import { dayHasAvailability } from './occupancy'
 
 export type DateRange = {
   start: string
@@ -42,7 +43,7 @@ export const occupancySummary = (premiseCapacity: Cas1PremiseCapacity): string =
   const overbookedDays: Array<Cas1PremiseCapacityForDay> = []
 
   premiseCapacity.capacity.forEach(capacityForDay => {
-    if (capacityForDay.availableBedCount > 0) {
+    if (dayHasAvailability(capacityForDay)) {
       availableDays.push(capacityForDay)
     } else {
       overbookedDays.push(capacityForDay)
@@ -60,15 +61,13 @@ export const occupancySummary = (premiseCapacity: Cas1PremiseCapacity): string =
   const overbookedRanges = daysToRanges(overbookedDays).map(renderDateRange)
 
   return `
-    <div style="max-width: 100%">
-        <h3 class="govuk-heading-m">Available on:</h3>
-        <ul>
-          ${availableRanges.map(range => `<li>${range}</li>`).join('')}
-        </ul>
-        <h3 class="govuk-heading-m">Overbooked on:</h3>
-        <ul>
-          ${overbookedRanges.map(range => `<li>${range}</li>`).join('')}
-        </ul>
-    </div>
+    <h3 class="govuk-heading-m">Available on:</h3>
+    <ul>
+      ${availableRanges.map(range => `<li>${range}</li>`).join('')}
+    </ul>
+    <h3 class="govuk-heading-m">Overbooked on:</h3>
+    <ul>
+      ${overbookedRanges.map(range => `<li>${range}</li>`).join('')}
+    </ul>
   `
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -33,7 +33,7 @@ import { navigationItems } from './navigationItems'
 
 import { StatusTagOptions } from './statusTag'
 import { ApplicationStatusTag } from './applications/statusTag'
-import { DateFormats, monthOptions, uiDateOrDateEmptyMessage, yearOptions } from './dateUtils'
+import { DateFormats, daysToWeeksAndDays, monthOptions, uiDateOrDateEmptyMessage, yearOptions } from './dateUtils'
 import { pagination } from './pagination'
 import { sortHeader } from './sortHeader'
 import { SumbmittedApplicationSummaryCards } from './applications/submittedApplicationSummaryCards'
@@ -121,6 +121,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('formatDate', (date: string, options: { format: 'short' | 'long' } = { format: 'long' }) =>
     DateFormats.isoDateToUIDate(date, options),
   )
+  njkEnv.addGlobal('formatDuration', (days: number) => DateFormats.formatDuration(daysToWeeksAndDays(days)))
   njkEnv.addGlobal('formatDateTime', (date: string) => DateFormats.isoDateTimeToUIDateTime(date))
   njkEnv.addGlobal('dateObjToUIDate', (date: Date) => DateFormats.dateObjtoUIDate(date))
   njkEnv.addGlobal(

--- a/server/views/match/placementRequests/occupancyView/partials/_occupancyCalendar.njk
+++ b/server/views/match/placementRequests/occupancyView/partials/_occupancyCalendar.njk
@@ -4,8 +4,20 @@
             <h3 class="govuk-heading-m">{{ month.name }}</h3>
             <ul class="calendar__month govuk-list">
                 {% for day in month.days %}
-                    <li class="calendar__day calendar__day--{{ day.name.slice(0,3) | lower }}">
-                        <time datetime="{{ day.date }}">{{ day.name }}</time>
+                    <li class="calendar__day calendar__day--{{ day.name.slice(0,3) | lower }}{% if day.bookableCount <= 0 %} govuk-tag--red{% endif %}">
+                        <a class="calendar__link" href="#">
+                            <time class="calendar__date" datetime="{{ day.date }}">{{ day.name }}</time>
+
+                            <dl class="calendar__availability">
+                                <dt class="govuk-visually-hidden">Availability:</dt>
+
+                                {% if day.bookableCount > 0 %}
+                                    <dd>Available</dd>
+                                {% else %}
+                                    <dd><span class="govuk-!-font-weight-bold">{{ day.bookableCount }}</span> total</dd>
+                                {% endif %}
+                            </dl>
+                        </a>
                     </li>
                 {% endfor %}
             </ul>

--- a/server/views/match/placementRequests/occupancyView/partials/_occupancyCalendar.njk
+++ b/server/views/match/placementRequests/occupancyView/partials/_occupancyCalendar.njk
@@ -1,0 +1,14 @@
+{% macro occupancyCalendar(calendar) %}
+    <div class="calendar">
+        {% for month in calendar %}
+            <h3 class="govuk-heading-m">{{ month.name }}</h3>
+            <ul class="calendar__month govuk-list">
+                {% for day in month.days %}
+                    <li class="calendar__day calendar__day--{{ day.name.slice(0,3) | lower }}">
+                        <time datetime="{{ day.date }}">{{ day.name }}</time>
+                    </li>
+                {% endfor %}
+            </ul>
+        {% endfor %}
+    </div>
+{% endmacro %}

--- a/server/views/match/placementRequests/occupancyView/view.njk
+++ b/server/views/match/placementRequests/occupancyView/view.njk
@@ -48,7 +48,23 @@
             classes: 'govuk-notification-banner--full-width-content'
         }) }}
 
-        {{ occupancyCalendar(calendar) }}
+        <section id="calendar-key">
+            <h3 class="govuk-heading-m">Key</h3>
+
+            <ul class="calendar__month govuk-list">
+                <li class="calendar__day">
+                    Available
+                </li>
+                <li class="calendar__day govuk-tag--red">
+                    Full or overbooked
+                </li>
+            </ul>
+        </section>
+
+
+        <section aria-describedby="calendar-key">
+            {{ occupancyCalendar(calendar) }}
+        </section>
     </section>
 
     <section>

--- a/server/views/match/placementRequests/occupancyView/view.njk
+++ b/server/views/match/placementRequests/occupancyView/view.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "./partials/_occupancyCalendar.njk" import occupancyCalendar %}
 
 {% extends "../../layout-with-details.njk" %}
 
@@ -13,6 +14,13 @@
         text: "Back to other APs",
         href: paths.v2Match.placementRequests.search.spaces({ id: placementRequest.id })
     }) }}
+{% endblock %}
+
+{% block extraScripts %}
+    {# TODO: useful for debugging, remove once page complete! #}
+    <script type="text/javascript" nonce="{{ cspNonce }}">
+      console.log(JSON.parse('{{ calendar | dump | safe }}'))
+    </script>
 {% endblock %}
 
 {% block content %}
@@ -39,6 +47,8 @@
             html: occupancySummaryHtml,
             classes: 'govuk-notification-banner--full-width-content'
         }) }}
+
+        {{ occupancyCalendar(calendar) }}
     </section>
 
     <section>

--- a/server/views/match/placementRequests/occupancyView/view.njk
+++ b/server/views/match/placementRequests/occupancyView/view.njk
@@ -30,13 +30,23 @@
         html: detailsHTML
     }) }}
 
-    {{ govukNotificationBanner({
-        html: occupancySummaryHtml,
-        classes: 'govuk-notification-banner--full-width-content'
-    }) }}
+    <section>
+        <h2 class="govuk-heading-l">View availability and book your placement
+            for {{ formatDuration(durationDays) }}
+            from {{ formatDate(startDate, { format: 'short' }) }}</h2>
 
-    <a class="govuk-button"
-       href="{{ MatchUtils.redirectToSpaceBookingsNew({placementRequestId: placementRequest.id, premisesName: premisesName, premisesId: premisesId, apType: apType, startDate: startDate, durationDays: durationDays }) }}">
-        Continue
-    </a>
+        {{ govukNotificationBanner({
+            html: occupancySummaryHtml,
+            classes: 'govuk-notification-banner--full-width-content'
+        }) }}
+    </section>
+
+    <section>
+        <h2 class="govuk-heading-l">Book your placement</h2>
+
+        <a class="govuk-button"
+           href="{{ MatchUtils.redirectToSpaceBookingsNew({placementRequestId: placementRequest.id, premisesName: premisesName, premisesId: premisesId, apType: apType, startDate: startDate, durationDays: durationDays }) }}">
+            Continue
+        </a>
+    </section>
 {% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1602

# Changes in this PR

Implement the calendar view on the occupancy view page.

This implements both the 'Available' and 'Fully booked' calendar days, but not the 'available for your criteria' type, as this requires the filtering to be in place.

Each cell currently links to `#`, as the day detail page isn't built either.

## Screenshots of UI changes

### Desktop calendar view

<img width="809" alt="Screenshot 2024-12-05 at 15 39 41" src="https://github.com/user-attachments/assets/e5911395-34f9-4899-be37-71e9e56c598d">

### Mobile view

<img width="527" alt="Screenshot 2024-12-05 at 15 58 07" src="https://github.com/user-attachments/assets/77aefd10-f7f7-48a6-8587-9ed8594a00ec">


