### PR TITLE
Increase max POST body size and parameter count

### DIFF
--- a/server/middleware/setupRequestParsing.ts
+++ b/server/middleware/setupRequestParsing.ts
@@ -4,7 +4,7 @@ import trimInput from './trimInput'
 export default function setUpWebRequestParsing(): Router {
   const router = express.Router()
   router.use(express.json())
-  router.use(express.urlencoded({ extended: true }))
+  router.use(express.urlencoded({ extended: true, limit: '1mb', parameterLimit: 2500 }))
   router.use(trimInput())
   return router
 }


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1663

# Changes in this PR

This increases the max POST body size for form from the default of `100kb` to `1mb` (https://expressjs.com/en/resources/middleware/body-parser.html#bodyparserurlencodedoptions). It also increases the max parameter count to `2500` to cover rare cases where forms may have in excess of 1000 checkboxes.

## Screenshots of UI changes

n/a
