### PR TITLE
APS-1603: occupancy filters

### DIFF
--- a/assets/sass/components/_calendar.scss
+++ b/assets/sass/components/_calendar.scss
@@ -5,10 +5,6 @@
     margin: 0;
     border-bottom: 1px solid $govuk-border-colour;
 
-    &:focus-within {
-      border-color: transparent;
-    }
-
     #calendar-key & {
       padding: govuk-spacing(2) 0;
     }
@@ -22,11 +18,17 @@
     padding: govuk-spacing(2) 0;
     text-decoration: none;
 
-    &:hover {
+    &:hover, &:focus {
       background: govuk-colour('blue');
       color: govuk-colour('white');
       text-decoration: underline;
       text-decoration-thickness: 2px;
+    }
+
+    &:focus {
+      outline: 3px solid govuk-colour('yellow');
+      outline-offset: -2px;
+      box-shadow: none;
     }
   }
 

--- a/assets/sass/components/_calendar.scss
+++ b/assets/sass/components/_calendar.scss
@@ -41,6 +41,10 @@
 
     dd {
       margin: 0;
+
+      &:only-of-type {
+        margin-bottom: govuk-spacing(4);
+      }
     }
   }
 

--- a/assets/sass/components/_search-and-filter.scss
+++ b/assets/sass/components/_search-and-filter.scss
@@ -28,5 +28,9 @@
     & .govuk-button {
       margin-bottom: 2px;
     }
+
+    & + & {
+      margin-top: govuk-spacing(4);
+    }
   }
 }

--- a/assets/sass/components/_search-and-filter.scss
+++ b/assets/sass/components/_search-and-filter.scss
@@ -1,20 +1,32 @@
 .search-and-filter {
-  &__wrapper {
-    @include govuk-responsive-padding(6);
-    @include govuk-responsive-margin(6, 'bottom');
+  @include govuk-responsive-padding(6);
+  @include govuk-responsive-margin(6, 'bottom');
 
-    background-color: govuk-colour('light-grey');
-  }
+  background-color: govuk-colour('light-grey');
 
   &__crn-label {
     &--small {
       @extend .govuk-heading-s;
       @include govuk-responsive-margin(1, 'bottom');
     }
+
     @extend .govuk-heading-m;
   }
 
-  &__submit {
-    @include govuk-responsive-margin(6, 'top');
+  &__row {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    justify-content: flex-start;
+    gap: govuk-spacing(4);
+
+    & .govuk-form-group {
+      margin-bottom: 0;
+    }
+
+    & .govuk-button {
+      margin-bottom: 2px;
+    }
   }
 }

--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -12,3 +12,14 @@
 
 [aria-sort] a
   display: inline-block
+
+.govuk-checkboxes--inline
+  display: flex
+  flex-wrap: wrap
+  gap: govuk-spacing(3)
+
+  & label
+    min-inline-size: fit-content
+
+    &:before
+      background: govuk-colour('white')

--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -1072,7 +1072,7 @@ export default class ApplyHelper {
 
     tasklistPage.shouldShowMissingCheckboxErrorMessage()
 
-    tasklistPage.checkCheckboxByLabel('submit')
+    tasklistPage.checkCheckboxByValue('submit')
     tasklistPage.clickSubmit()
   }
 }

--- a/integration_tests/helpers/assess.ts
+++ b/integration_tests/helpers/assess.ts
@@ -337,7 +337,7 @@ export default class AseessHelper {
 
     tasklistPage.shouldShowMissingCheckboxErrorMessage()
 
-    tasklistPage.checkCheckboxByLabel('confirmed')
+    tasklistPage.checkCheckboxByValue('confirmed')
     tasklistPage.clickSubmit()
     Page.verifyOnPage(SubmissionConfirmation, isSuitable)
   }

--- a/integration_tests/mockApis/premises.ts
+++ b/integration_tests/mockApis/premises.ts
@@ -1,8 +1,8 @@
 import type {
   Cas1PremiseCapacity,
   Cas1PremisesBasicSummary,
+  Cas1PremisesSummary,
   ExtendedPremisesSummary,
-  Premises,
   ApprovedPremisesSummary as PremisesSummary,
   StaffMember,
 } from '@approved-premises/api'
@@ -57,7 +57,7 @@ const stubPremisesSummary = (premises: ExtendedPremisesSummary) =>
     },
   })
 
-const stubSinglePremises = (premises: Premises) =>
+const stubSinglePremises = (premises: Cas1PremisesSummary) =>
   stubFor({
     request: {
       method: 'GET',
@@ -96,7 +96,10 @@ const stubPremiseCapacity = (args: {
   stubFor({
     request: {
       method: 'GET',
-      url: `${paths.premises.capacity({ premisesId: args.premiseCapacity.premise.id })}?${createQueryString({ startDate: args.startDate, endDate: args.endDate })}`,
+      url: `${paths.premises.capacity({ premisesId: args.premiseCapacity.premise.id })}?${createQueryString({
+        startDate: args.startDate,
+        endDate: args.endDate,
+      })}`,
     },
     response: {
       status: 200,

--- a/integration_tests/pages/admin/userManagement/showPage.ts
+++ b/integration_tests/pages/admin/userManagement/showPage.ts
@@ -30,19 +30,19 @@ export default class ShowPage extends Page {
   selectRoles(roles: ReadonlyArray<UserRole>): void {
     this.uncheckUsersPreviousRoles()
     roles.forEach(role => {
-      this.checkCheckboxByLabel(role)
+      this.checkCheckboxByValue(role)
     })
   }
 
   selectAllocationRoles(roles: ReadonlyArray<UserRole>): void {
     roles.forEach(role => {
-      this.checkCheckboxByLabel(role)
+      this.checkCheckboxByValue(role)
     })
   }
 
   selectUserQualifications(roles: ReadonlyArray<UserQualification>): void {
     roles.forEach(role => {
-      this.checkCheckboxByLabel(role)
+      this.checkCheckboxByValue(role)
     })
   }
 

--- a/integration_tests/pages/match/occupancyViewPage.ts
+++ b/integration_tests/pages/match/occupancyViewPage.ts
@@ -2,10 +2,10 @@ import {
   ApType,
   Cas1PremiseCapacity,
   Cas1PremisesSummary,
+  Cas1SpaceBookingCharacteristic,
   PlacementRequest,
   PlacementRequestDetail,
 } from '@approved-premises/api'
-import { OccupancyFilterCriteria } from '@approved-premises/ui'
 import Page from '../page'
 import { occupancySummary, occupancyViewSummaryListForMatchingDetails } from '../../../server/utils/match'
 import { createQueryString } from '../../../server/utils/utils'
@@ -65,7 +65,10 @@ export default class OccupancyViewPage extends Page {
     this.clickApplyFilter()
   }
 
-  shouldShowOccupancySummary(premiseCapacity: Cas1PremiseCapacity, criteria: Array<OccupancyFilterCriteria> = []) {
+  shouldShowOccupancySummary(
+    premiseCapacity: Cas1PremiseCapacity,
+    criteria: Array<Cas1SpaceBookingCharacteristic> = [],
+  ) {
     const summary = occupancySummary(premiseCapacity.capacity, criteria)
 
     if (!summary.overbooked) {
@@ -82,7 +85,10 @@ export default class OccupancyViewPage extends Page {
     cy.get('.calendar__availability').contains(copy).should('exist')
   }
 
-  shouldShowOccupancyCalendar(premiseCapacity: Cas1PremiseCapacity, criteria: Array<OccupancyFilterCriteria> = []) {
+  shouldShowOccupancyCalendar(
+    premiseCapacity: Cas1PremiseCapacity,
+    criteria: Array<Cas1SpaceBookingCharacteristic> = [],
+  ) {
     const firstMonth = DateFormats.isoDateToMonthAndYear(premiseCapacity.startDate)
     cy.get('.govuk-heading-m').contains(firstMonth).should('exist')
 

--- a/integration_tests/pages/match/occupancyViewPage.ts
+++ b/integration_tests/pages/match/occupancyViewPage.ts
@@ -39,14 +39,20 @@ export default class OccupancyViewPage extends Page {
       .should('exist')
   }
 
-  shouldShowFilters(startDate: string, selectedDuration: string) {
+  shouldShowFilters(startDate: string, selectedDuration: string, newCriteria: Array<string>) {
     this.dateInputsShouldContainDate('startDate', startDate)
     this.shouldHaveSelectText('durationDays', selectedDuration)
+    newCriteria.forEach(criteria => {
+      this.verifyCheckboxByLabel(criteria)
+    })
   }
 
-  filterForDateAndDuration(newStartDate: string, newDuration: string) {
+  filterAvailability(newStartDate: string, newDuration: string, newCriteria: Array<string>) {
     this.clearAndCompleteDateInputs('startDate', newStartDate)
     this.getSelectInputByIdAndSelectAnEntry('durationDays', newDuration)
+    newCriteria.forEach(criteria => {
+      this.checkCheckboxByLabel(criteria)
+    })
     this.clickApplyFilter()
   }
 
@@ -76,7 +82,7 @@ export default class OccupancyViewPage extends Page {
       this.shouldShowCalendarCell('Available')
     }
     if (availability === 'none' || availability === 'partial') {
-      this.shouldShowCalendarCell(/-?\d+ total/)
+      this.shouldShowCalendarCell(/-?\d+ in total/)
     }
   }
 

--- a/integration_tests/pages/match/occupancyViewPage.ts
+++ b/integration_tests/pages/match/occupancyViewPage.ts
@@ -52,12 +52,16 @@ export default class OccupancyViewPage extends Page {
     })
   }
 
-  filterAvailability(newStartDate: string, newDuration: string, newCriteria: Array<string>) {
+  filterAvailability(newStartDate: string, newDuration?: string, newCriteria?: Array<string>) {
     this.clearAndCompleteDateInputs('startDate', newStartDate)
-    this.getSelectInputByIdAndSelectAnEntry('durationDays', newDuration)
-    newCriteria.forEach(criteria => {
-      this.checkCheckboxByLabel(criteria)
-    })
+    if (newDuration) {
+      this.getSelectInputByIdAndSelectAnEntry('durationDays', newDuration)
+    }
+    if (newCriteria) {
+      newCriteria.forEach(criteria => {
+        this.checkCheckboxByLabel(criteria)
+      })
+    }
     this.clickApplyFilter()
   }
 

--- a/integration_tests/pages/match/occupancyViewPage.ts
+++ b/integration_tests/pages/match/occupancyViewPage.ts
@@ -34,7 +34,7 @@ export default class OccupancyViewPage extends Page {
     })
     cy.get('.govuk-heading-l')
       .contains(
-        `View availability and book your placement for ${DateFormats.formatDuration(daysToWeeksAndDays(durationDays))} from ${DateFormats.isoDateToUIDate(startDate, { format: 'short' })}`,
+        `View availability for ${DateFormats.formatDuration(daysToWeeksAndDays(durationDays))} from ${DateFormats.isoDateToUIDate(startDate, { format: 'short' })}`,
       )
       .should('exist')
   }

--- a/integration_tests/pages/match/occupancyViewPage.ts
+++ b/integration_tests/pages/match/occupancyViewPage.ts
@@ -1,4 +1,10 @@
-import { ApType, Cas1PremiseCapacity, PlacementRequest, PlacementRequestDetail, Premises } from '@approved-premises/api'
+import {
+  ApType,
+  Cas1PremiseCapacity,
+  Cas1PremisesSummary,
+  PlacementRequest,
+  PlacementRequestDetail,
+} from '@approved-premises/api'
 import { OccupancyFilterCriteria } from '@approved-premises/ui'
 import Page from '../page'
 import { occupancySummary, occupancyViewSummaryListForMatchingDetails } from '../../../server/utils/match'
@@ -11,16 +17,15 @@ export default class OccupancyViewPage extends Page {
     super(`View spaces in ${premisesName}`)
   }
 
-  static visit(
-    placementRequest: PlacementRequestDetail,
-    premisesName: Premises['name'],
-    premisesId: Premises['id'],
-    apType: ApType,
-  ) {
-    const queryString = createQueryString({ premisesName, premisesId, apType })
-    const path = `${paths.v2Match.placementRequests.spaceBookings.viewSpaces({ id: placementRequest.id })}?${queryString}`
+  static visit(placementRequest: PlacementRequestDetail, premises: Cas1PremisesSummary, apType: ApType) {
+    const path = `${paths.v2Match.placementRequests.search.occupancy({
+      id: placementRequest.id,
+      premisesId: premises.id,
+    })}?${createQueryString({ apType })}`
+
     cy.visit(path)
-    return new OccupancyViewPage(premisesName)
+
+    return new OccupancyViewPage(premises.name)
   }
 
   shouldShowMatchingDetails(

--- a/integration_tests/pages/match/searchPage.ts
+++ b/integration_tests/pages/match/searchPage.ts
@@ -5,6 +5,7 @@ import { placementRequestSummaryListForMatching, summaryCardRows } from '../../.
 import paths from '../../../server/paths/match'
 import { isFullPerson } from '../../../server/utils/personUtils'
 import { DateFormats } from '../../../server/utils/dateUtils'
+import { occupancyCriteriaMap } from '../../../server/utils/match/occupancy'
 
 export default class SearchPage extends Page {
   constructor() {
@@ -82,6 +83,19 @@ export default class SearchPage extends Page {
 
     newSearchParameters.requirements.spaceCharacteristics.forEach(requirement => {
       cy.get(`input[name="requirements[spaceCharacteristics][]"][value="${requirement}"]`).should('be.checked')
+    })
+  }
+
+  shouldHaveSearchParametersInLinks(newSearchParameters: SpaceSearchParametersUi): void {
+    cy.get('.govuk-summary-card__actions .govuk-link')
+      .invoke('attr', 'href')
+      .should('contain', `apType=${newSearchParameters.requirements.apType}`)
+
+    newSearchParameters.requirements.spaceCharacteristics.forEach(spaceCharacteristic => {
+      const isSpaceBookingCharacteristic = Object.keys(occupancyCriteriaMap).includes(spaceCharacteristic)
+      cy.get('.govuk-summary-card__actions .govuk-link')
+        .invoke('attr', 'href')
+        .should(isSpaceBookingCharacteristic ? 'contain' : 'not.contain', `criteria=${spaceCharacteristic}`)
     })
   }
 

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -156,25 +156,23 @@ export default abstract class Page {
   }
 
   completeDateInputs(prefix: string, date: string): void {
-    const parsedDate = DateFormats.isoToDateObj(date)
-    cy.get(`#${prefix}-day`).type(parsedDate.getDate().toString())
-    cy.get(`#${prefix}-month`).type(`${parsedDate.getMonth() + 1}`)
-    cy.get(`#${prefix}-year`).type(parsedDate.getFullYear().toString())
+    const [year, month, day] = date.split('-')
+
+    cy.get(`#${prefix}-day`).type(day)
+    cy.get(`#${prefix}-month`).type(month)
+    cy.get(`#${prefix}-year`).type(year)
   }
 
-  completeDateInputsByName(prefix: string, date: string): void {
-    const parsedDate = DateFormats.isoToDateObj(date)
-
-    cy.get(`[name="${prefix}[day]"`).type(parsedDate.getDate().toString())
-    cy.get(`[name="${prefix}[month]"`).type(`${parsedDate.getMonth() + 1}`)
-    cy.get(`[name="${prefix}[year]`).type(parsedDate.getFullYear().toString())
+  private stripLeadingZeros(value: string): string {
+    return value.replace(/^0+/, '')
   }
 
   dateInputsShouldContainDate(prefix: string, date: string): void {
-    const parsedDate = DateFormats.isoToDateObj(date)
-    cy.get(`#${prefix}-day`).should('have.value', parsedDate.getDate().toString())
-    cy.get(`#${prefix}-month`).should('have.value', `${parsedDate.getMonth() + 1}`)
-    cy.get(`#${prefix}-year`).should('have.value', parsedDate.getFullYear().toString())
+    const [year, month, day] = date.split('-').map(this.stripLeadingZeros)
+
+    cy.get(`#${prefix}-day`).invoke('val').then(this.stripLeadingZeros).should('equal', day)
+    cy.get(`#${prefix}-month`).invoke('val').then(this.stripLeadingZeros).should('equal', month)
+    cy.get(`#${prefix}-year`).invoke('val').then(this.stripLeadingZeros).should('equal', year)
   }
 
   clickSubmit(): void {

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -134,8 +134,12 @@ export default abstract class Page {
     cy.get(`input[name="${name}"][value="${option}"]`).check()
   }
 
-  checkCheckboxByLabel(option: string): void {
+  checkCheckboxByValue(option: string): void {
     cy.get(`input[value="${option}"]`).check()
+  }
+
+  checkCheckboxByLabel(label: string): void {
+    cy.get('label').contains(label).parent().find('input').check()
   }
 
   uncheckCheckboxbyNameAndValue(name: string, option: string): void {
@@ -373,6 +377,14 @@ export default abstract class Page {
 
   verifyRadioInputByName(name: string, value: string): void {
     cy.get(`[name="${name}"][value="${value}"]`).should('be.checked')
+  }
+
+  verifyCheckboxByLabel(label: string, checked = true) {
+    cy.get('label')
+      .contains(label)
+      .parent()
+      .find('input')
+      .should(checked ? 'be.checked' : 'not.be.checked')
   }
 
   clearAndCompleteTextInputById(id: string, text: string): void {

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -220,6 +220,14 @@ context('Placement Requests', () => {
     // And I should see an occupancy calendar
     occupancyViewPage.shouldShowOccupancyCalendar(premiseCapacity)
 
+    // When I filter with an invalid date
+    occupancyViewPage.filterAvailability('2025-02-35')
+
+    // Then I should see an error message
+    occupancyViewPage.shouldShowErrorMessagesForFields(['startDate'], {
+      startDate: 'Enter a valid date',
+    })
+
     // When I filter for a different date and duration
     const newStartDate = '2024-08-01'
     const newEndDate = '2024-08-08'

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -221,7 +221,7 @@ context('Placement Requests', () => {
     occupancyViewPage.shouldShowMatchingDetails(totalCapacity, startDate, durationDays, placementRequest)
 
     // And I should see the filter form with populated values
-    occupancyViewPage.shouldShowFilters(startDate, 'Up to 6 weeks')
+    occupancyViewPage.shouldShowFilters(startDate, 'Up to 6 weeks', [])
 
     // And I should see a summary of occupancy
     occupancyViewPage.shouldShowOccupancySummary(premiseCapacity)
@@ -233,6 +233,7 @@ context('Placement Requests', () => {
     const newStartDate = '2024-08-01'
     const newEndDate = '2024-08-08'
     const newDuration = 'Up to 1 week'
+    const newCriteria = ['Wheelchair accessible', 'Step-free']
     const newPremiseCapacity = cas1PremiseCapacityFactory.build({
       premise: { id: premisesId, bedCount: totalCapacity },
       startDate: newStartDate,
@@ -244,10 +245,10 @@ context('Placement Requests', () => {
       endDate: newEndDate,
       premiseCapacity: newPremiseCapacity,
     })
-    occupancyViewPage.filterForDateAndDuration(newStartDate, newDuration)
+    occupancyViewPage.filterAvailability(newStartDate, newDuration, newCriteria)
 
     // Then I should see the filter form with updated values
-    occupancyViewPage.shouldShowFilters(newStartDate, newDuration)
+    occupancyViewPage.shouldShowFilters(newStartDate, newDuration, newCriteria)
   })
 
   it('allows me to book a space', () => {

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -66,6 +66,9 @@ context('Placement Requests', () => {
     // And the new search criteria should be selected
     searchPage.shouldShowSearchParametersInInputs(newSearchParameters)
 
+    // And the results should have links with the correct AP type and criteria
+    searchPage.shouldHaveSearchParametersInLinks(newSearchParameters)
+
     // And the parameters should be submitted to the API
     cy.task('verifySearchSubmit').then(requests => {
       expect(requests).to.have.length(numberOfSearches)
@@ -91,7 +94,6 @@ context('Placement Requests', () => {
       })
 
       // And the second request to the API should contain the new criteria I submitted
-
       expect(secondSearchRequestBody).to.contain({
         applicationId: placementRequest.applicationId,
         durationInDays: placementRequest.duration,

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -11,6 +11,7 @@ import {
   AssessmentTask,
   Cas1CruManagementArea,
   Cas1PremisesBasicSummary,
+  type Cas1SpaceCharacteristic,
   Document,
   FlagsEnvelope,
   Gender,
@@ -472,4 +473,14 @@ export type DepartureFormSessionData = Partial<
     moveOnCategoryId: string
     notes: string
   }
+>
+
+export type OccupancyFilterCriteria = Extract<
+  Cas1SpaceCharacteristic,
+  | 'isArsonSuitable'
+  | 'hasEnSuite'
+  | 'isSingle'
+  | 'isStepFreeDesignated'
+  | 'isSuitedForSexOffenders'
+  | 'isWheelchairDesignated'
 >

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -11,7 +11,6 @@ import {
   AssessmentTask,
   Cas1CruManagementArea,
   Cas1PremisesBasicSummary,
-  type Cas1SpaceCharacteristic,
   Document,
   FlagsEnvelope,
   Gender,
@@ -473,14 +472,4 @@ export type DepartureFormSessionData = Partial<
     moveOnCategoryId: string
     notes: string
   }
->
-
-export type OccupancyFilterCriteria = Extract<
-  Cas1SpaceCharacteristic,
-  | 'isArsonSuitable'
-  | 'hasEnSuite'
-  | 'isSingle'
-  | 'isStepFreeDesignated'
-  | 'isSuitedForSexOffenders'
-  | 'isWheelchairDesignated'
 >

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -233,7 +233,7 @@ export interface ErrorSummary {
 export interface ErrorsAndUserInput {
   errorTitle?: string
   errors: ErrorMessages
-  errorSummary: Array<string>
+  errorSummary: Array<ErrorSummary>
   userInput: Record<string, unknown>
 }
 

--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -113,8 +113,8 @@ describe('OccupancyViewController', () => {
           premiseCapacity.premise.bedCount,
           placementRequestDetail,
         ),
-        occupancySummaryHtml: occupancySummary(premiseCapacity),
-        calendar: occupancyCalendar(premiseCapacity),
+        summary: occupancySummary(premiseCapacity.capacity),
+        calendar: occupancyCalendar(premiseCapacity.capacity),
         errors: {},
         errorSummary: [],
       })
@@ -219,6 +219,7 @@ describe('OccupancyViewController', () => {
           ],
           durationDays: 100,
           startDate: '2025-04-30',
+          summary: occupancySummary(premiseCapacity.capacity, ['isSingle', 'isWheelchairDesignated']),
           calendar: occupancyCalendar(premiseCapacity.capacity, ['isSingle', 'isWheelchairDesignated']),
         }),
       )

--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -104,6 +104,7 @@ describe('OccupancyViewController', () => {
           { value: 'isSuitedForSexOffenders', text: 'Suitable for sex offenders', checked: false },
           { value: 'isArsonSuitable', text: 'Designated arson room', checked: false },
         ],
+        criteria: undefined,
         matchingDetailsSummaryList: occupancyViewSummaryListForMatchingDetails(
           premiseCapacity.premise.bedCount,
           placementRequestDetail,
@@ -208,6 +209,7 @@ describe('OccupancyViewController', () => {
             { value: 'isSuitedForSexOffenders', text: 'Suitable for sex offenders', checked: false },
             { value: 'isArsonSuitable', text: 'Designated arson room', checked: false },
           ],
+          criteria: ['isSingle', 'isWheelchairDesignated'],
           durationDays: 100,
           startDate: '2025-04-30',
           'startDate-day': '30',
@@ -262,6 +264,7 @@ describe('OccupancyViewController', () => {
       apType,
       startDate,
       durationDays,
+      criteria: '',
       'arrivalDate-day': arrivalDay,
       'arrivalDate-month': arrivalMonth,
       'arrivalDate-year': arrivalYear,
@@ -290,6 +293,7 @@ describe('OccupancyViewController', () => {
       const body = {
         ...validBookingBody,
         'arrivalDate-day': emptyDay,
+        criteria: 'isWheelchairDesignated,isSuitedForSexOffenders',
       }
       const params = { id: placementRequestDetail.id, premisesId: premises.id }
 
@@ -303,7 +307,7 @@ describe('OccupancyViewController', () => {
         'arrivalDate',
       )
 
-      const expectedParams = `apType=${apType}&startDate=${startDate}&durationDays=${durationDays}`
+      const expectedParams = `apType=${apType}&startDate=${startDate}&durationDays=${durationDays}&criteria=isWheelchairDesignated&criteria=isSuitedForSexOffenders`
 
       expect(response.redirect).toHaveBeenCalledWith(
         `${matchPaths.v2Match.placementRequests.search.occupancy({

--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -1,18 +1,16 @@
 import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
-import type { Cas1PremiseCapacity, PlacementRequestDetail } from '@approved-premises/api'
 import { when } from 'jest-when'
 import { addDays } from 'date-fns'
 import { PlacementRequestService, PremisesService } from '../../../services'
-import { cas1PremiseCapacityFactory, placementRequestDetailFactory } from '../../../testutils/factories'
-import OccupancyViewController from './occupancyViewController'
 import {
-  filterOutAPTypes,
-  occupancySummary,
-  occupancyViewSummaryListForMatchingDetails,
-  placementDates,
-} from '../../../utils/match'
+  cas1PremiseCapacityFactory,
+  cas1PremisesSummaryFactory,
+  placementRequestDetailFactory,
+} from '../../../testutils/factories'
+import OccupancyViewController from './occupancyViewController'
+import { occupancySummary, occupancyViewSummaryListForMatchingDetails } from '../../../utils/match'
 import matchPaths from '../../../paths/match'
 import { occupancyCalendar } from '../../../utils/match/occupancyCalendar'
 import { addErrorMessageToFlash, fetchErrorsAndUserInput } from '../../../utils/validation'
@@ -31,24 +29,24 @@ describe('OccupancyViewController', () => {
   const premisesService = createMock<PremisesService>({})
 
   let occupancyViewController: OccupancyViewController
-  let placementRequestDetail: PlacementRequestDetail
-  let premiseCapacity: Cas1PremiseCapacity
+  const premises = cas1PremisesSummaryFactory.build()
+  const placementRequestDetail = placementRequestDetailFactory.build({ duration: 84 })
+  const premiseCapacity = cas1PremiseCapacityFactory.build()
   let request: Readonly<DeepMocked<Request>>
 
-  const premisesName = 'Hope House'
-  const premisesId = 'abc123'
   const apType = 'esap'
 
   beforeEach(() => {
     jest.resetAllMocks()
+
     occupancyViewController = new OccupancyViewController(placementRequestService, premisesService)
     request = createMock<Request>({
       user: { token },
       flash: flashSpy,
     })
-    placementRequestDetail = placementRequestDetailFactory.build({ duration: 84 })
-    premiseCapacity = cas1PremiseCapacityFactory.build()
+
     placementRequestService.getPlacementRequest.mockResolvedValue(placementRequestDetail)
+    premisesService.find.mockResolvedValue(premises)
     premisesService.getCapacity.mockResolvedValue(premiseCapacity)
 
     when(fetchErrorsAndUserInput as jest.Mock)
@@ -66,30 +64,28 @@ describe('OccupancyViewController', () => {
       const expectedDuration = placementRequestDetail.duration
 
       const query = {
-        premisesName,
-        premisesId,
         apType,
       }
 
-      const params = { id: placementRequestDetail.id }
+      const params = { id: placementRequestDetail.id, premisesId: premises.id }
 
       const requestHandler = occupancyViewController.view()
 
       await requestHandler({ ...request, params, query }, response, next)
 
       expect(placementRequestService.getPlacementRequest).toHaveBeenCalledWith(token, placementRequestDetail.id)
+      expect(premisesService.find).toHaveBeenCalledWith(token, premises.id)
       expect(premisesService.getCapacity).toHaveBeenCalledWith(
         token,
-        premisesId,
-        placementRequestDetail.expectedArrival,
-        DateFormats.dateObjToIsoDate(addDays(placementRequestDetail.expectedArrival, placementRequestDetail.duration)),
+        premises.id,
+        expectedStartDate,
+        DateFormats.dateObjToIsoDate(addDays(expectedStartDate, expectedDuration)),
       )
 
       expect(response.render).toHaveBeenCalledWith('match/placementRequests/occupancyView/view', {
-        pageHeading: `View spaces in ${premisesName}`,
+        pageHeading: `View spaces in ${premises.name}`,
         placementRequest: placementRequestDetail,
-        premisesName,
-        premisesId,
+        premises,
         apType,
         startDate: expectedStartDate,
         ...DateFormats.isoDateToDateInputs(expectedStartDate, 'startDate'),
@@ -122,12 +118,10 @@ describe('OccupancyViewController', () => {
 
     it('should render the occupancy view template with errors', async () => {
       const query = {
-        premisesName,
-        premisesId,
         apType,
       }
 
-      const params = { id: placementRequestDetail.id }
+      const params = { id: placementRequestDetail.id, premisesId: premises.id }
 
       const expectedErrors = {
         arrivalDate: {
@@ -182,8 +176,6 @@ describe('OccupancyViewController', () => {
 
     it('should render the occupancy view template with filtered start date, duration and criteria', async () => {
       const query = {
-        premisesName,
-        premisesId,
         apType,
         'startDate-day': '30',
         'startDate-month': '04',
@@ -192,13 +184,13 @@ describe('OccupancyViewController', () => {
         criteria: ['isSingle', 'isWheelchairDesignated'],
       }
 
-      const params = { id: placementRequestDetail.id }
+      const params = { id: placementRequestDetail.id, premisesId: premises.id }
 
       const requestHandler = occupancyViewController.view()
 
       await requestHandler({ ...request, params, query }, response, next)
 
-      expect(premisesService.getCapacity).toHaveBeenCalledWith(token, premisesId, '2025-04-30', '2025-08-08')
+      expect(premisesService.getCapacity).toHaveBeenCalledWith(token, premises.id, '2025-04-30', '2025-08-08')
       expect(response.render).toHaveBeenCalledWith(
         'match/placementRequests/occupancyView/view',
         expect.objectContaining({
@@ -234,8 +226,6 @@ describe('OccupancyViewController', () => {
     const arrivalYear = '2026'
 
     const validBookingBody = {
-      premisesId,
-      premisesName,
       apType,
       startDate,
       durationDays,
@@ -248,15 +238,14 @@ describe('OccupancyViewController', () => {
     }
 
     it(`should redirect to space-booking confirmation page when date validation succeeds`, async () => {
-      const params = { id: placementRequestDetail.id }
+      const params = { id: placementRequestDetail.id, premisesId: premises.id }
 
       const requestHandler = occupancyViewController.bookSpace()
       await requestHandler({ ...request, params, body: validBookingBody }, response, next)
 
-      const expectedPremisesName = encodeURIComponent(premisesName)
       const expectedDurationDays = 10
       const expectedStartDate = `${arrivalYear}-0${arrivalMonth}-${arrivalDay}`
-      const expectedParams = `premisesName=${expectedPremisesName}&premisesId=${premisesId}&apType=${apType}&startDate=${expectedStartDate}&durationDays=${expectedDurationDays}`
+      const expectedParams = `apType=${apType}&startDate=${expectedStartDate}&durationDays=${expectedDurationDays}`
       expect(response.redirect).toHaveBeenCalledWith(
         `${matchPaths.v2Match.placementRequests.spaceBookings.new({ id: placementRequestDetail.id })}?${expectedParams}`,
       )
@@ -268,17 +257,21 @@ describe('OccupancyViewController', () => {
         ...validBookingBody,
         'arrivalDate-day': emptyDay,
       }
-      const params = { id: placementRequestDetail.id }
+      const params = { id: placementRequestDetail.id, premisesId: premises.id }
 
       const requestHandler = occupancyViewController.bookSpace()
+
       await requestHandler({ ...request, params, body }, response, next)
 
       expect(addErrorMessageToFlash).toHaveBeenCalledWith(request, 'You must enter an arrival date', 'arrivalDate')
 
-      const expectedPremisesName = encodeURIComponent(premisesName)
-      const expectedParams = `premisesName=${expectedPremisesName}&premisesId=${premisesId}&apType=${apType}&startDate=${startDate}&durationDays=${durationDays}`
+      const expectedParams = `apType=${apType}&startDate=${startDate}&durationDays=${durationDays}`
+
       expect(response.redirect).toHaveBeenCalledWith(
-        `${matchPaths.v2Match.placementRequests.spaceBookings.viewSpaces({ id: placementRequestDetail.id })}?${expectedParams}`,
+        `${matchPaths.v2Match.placementRequests.search.occupancy({
+          id: placementRequestDetail.id,
+          premisesId: premises.id,
+        })}?${expectedParams}`,
       )
     })
   })

--- a/server/controllers/match/placementRequests/occupancyViewController.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.ts
@@ -1,7 +1,7 @@
 import { Request, Response, TypedRequestHandler } from 'express'
-import { ApType } from '@approved-premises/api'
+import type { ApType, Cas1SpaceBookingCharacteristic } from '@approved-premises/api'
 import { differenceInDays } from 'date-fns'
-import type { ObjectWithDateParts, OccupancyFilterCriteria } from '@approved-premises/ui'
+import type { ObjectWithDateParts } from '@approved-premises/ui'
 import { PlacementRequestService, PremisesService } from '../../../services'
 import {
   occupancySummary,
@@ -31,7 +31,7 @@ interface NewRequest extends Request {
   query: ObjectWithDateParts<'startDate'> & {
     durationDays: string
     apType: ApType
-    criteria: Array<OccupancyFilterCriteria> | OccupancyFilterCriteria
+    criteria: Array<Cas1SpaceBookingCharacteristic> | Cas1SpaceBookingCharacteristic
   }
 }
 
@@ -51,7 +51,7 @@ export default class {
       const placementRequest = await this.placementRequestService.getPlacementRequest(token, id)
       const premises = await this.premisesService.find(token, premisesId)
 
-      let criteriaAsArray: Array<OccupancyFilterCriteria>
+      let criteriaAsArray: Array<Cas1SpaceBookingCharacteristic>
       if (criteria) {
         criteriaAsArray = Array.isArray(criteria) ? criteria : [criteria]
       }

--- a/server/controllers/match/placementRequests/occupancyViewController.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.ts
@@ -102,6 +102,7 @@ export default class {
         durationDays,
         durationOptions: durationSelectOptions(durationDays),
         criteriaOptions: convertKeyValuePairToCheckBoxItems(occupancyCriteriaMap, criteriaAsArray),
+        criteria: criteriaAsArray,
         matchingDetailsSummaryList,
         summary,
         calendar,
@@ -123,13 +124,14 @@ export default class {
         if (errors.departureDate) {
           addErrorMessageToFlash(req, errors.departureDate, 'departureDate')
         }
-        const { startDate, durationDays, apType } = body
+        const { startDate, durationDays, apType, criteria } = body
         const redirectUrl = occupancyViewLink({
           placementRequestId: req.params.id,
           premisesId: req.params.premisesId,
           apType,
           startDate,
           durationDays,
+          spaceCharacteristics: criteria.split(','),
         })
         res.redirect(redirectUrl)
       } else {

--- a/server/controllers/match/placementRequests/occupancyViewController.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.ts
@@ -60,8 +60,8 @@ export default class {
         capacity.premise.bedCount,
         placementRequest,
       )
-      const occupancySummaryHtml = occupancySummary(capacity)
-      const calendar = occupancyCalendar(capacity, criteriaAsArray)
+      const summary = occupancySummary(capacity.capacity, criteriaAsArray)
+      const calendar = occupancyCalendar(capacity.capacity, criteriaAsArray)
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
       res.render('match/placementRequests/occupancyView/view', {
@@ -76,7 +76,7 @@ export default class {
         durationOptions: durationSelectOptions(durationDays),
         criteriaOptions: convertKeyValuePairToCheckBoxItems(occupancyCriteriaMap, criteriaAsArray),
         matchingDetailsSummaryList,
-        occupancySummaryHtml,
+        summary,
         calendar,
         errors,
         errorSummary,

--- a/server/paths/match.ts
+++ b/server/paths/match.ts
@@ -10,10 +10,10 @@ const v2Match = {
   placementRequests: {
     search: {
       spaces: v2PlacementRequestSearchPath.path('new'),
+      occupancy: v2PlacementRequestSearchPath.path('occupancy/:premisesId'),
     },
     spaceBookings: {
       new: v2SpaceBookingsPath.path('new'),
-      viewSpaces: v2SpaceBookingsPath.path('view-spaces'),
       create: v2SpaceBookingsPath,
     },
   },

--- a/server/routes/match.ts
+++ b/server/routes/match.ts
@@ -47,11 +47,11 @@ export default function routes(controllers: Controllers, router: Router, service
     auditEvent: 'NEW_SPACE_BOOKING',
   })
 
-  get(paths.v2Match.placementRequests.spaceBookings.viewSpaces.pattern, occupancyViewController.view(), {
+  get(paths.v2Match.placementRequests.search.occupancy.pattern, occupancyViewController.view(), {
     auditEvent: 'OCCUPANCY_VIEW',
   })
 
-  post(paths.v2Match.placementRequests.spaceBookings.viewSpaces.pattern, occupancyViewController.bookSpace(), {
+  post(paths.v2Match.placementRequests.search.occupancy.pattern, occupancyViewController.bookSpace(), {
     auditEvent: 'OCCUPANCY_VIEW_BOOK_SPACE',
   })
 

--- a/server/testutils/factories/cas1PremiseCapacity.ts
+++ b/server/testutils/factories/cas1PremiseCapacity.ts
@@ -7,9 +7,10 @@ import type {
   Cas1PremiseCharacteristicAvailability,
 } from '@approved-premises/api'
 import { addDays, differenceInDays } from 'date-fns'
+import { OccupancyFilterCriteria } from '@approved-premises/ui'
 import cas1PremisesSummaryFactory from './cas1PremisesSummary'
 import { DateFormats } from '../../utils/dateUtils'
-import { offenceAndRiskCriteria } from '../../utils/placementCriteriaUtils'
+import { occupancyCriteriaMap } from '../../utils/match/occupancy'
 
 export default Factory.define<Cas1PremiseCapacity>(({ params }) => {
   const startDate = params.startDate ? DateFormats.isoToDateObj(params.startDate) : faker.date.anytime()
@@ -69,12 +70,14 @@ export const cas1PremiseCapacityForDayFactory = CapacityForDayFactory.define(() 
     totalBedCount,
     availableBedCount: faker.number.int({ min: 0, max: totalBedCount }),
     bookingCount: faker.number.int({ min: 0, max: totalBedCount + 10 }),
-    characteristicAvailability: premiseCharacteristicAvailability.buildList(2),
+    characteristicAvailability: Object.keys(occupancyCriteriaMap).map(characteristic =>
+      premiseCharacteristicAvailability.build({ characteristic: characteristic as OccupancyFilterCriteria }),
+    ),
   }
 })
 
-const premiseCharacteristicAvailability = Factory.define<Cas1PremiseCharacteristicAvailability>(() => ({
-  characteristic: faker.helpers.arrayElement(offenceAndRiskCriteria),
+export const premiseCharacteristicAvailability = Factory.define<Cas1PremiseCharacteristicAvailability>(() => ({
+  characteristic: faker.helpers.arrayElement(Object.keys(occupancyCriteriaMap)) as OccupancyFilterCriteria,
   availableBedsCount: faker.number.int({ min: 0, max: 40 }),
   bookingsCount: faker.number.int({ min: 0, max: 45 }),
 }))

--- a/server/testutils/factories/cas1PremiseCapacity.ts
+++ b/server/testutils/factories/cas1PremiseCapacity.ts
@@ -5,9 +5,9 @@ import type {
   Cas1PremiseCapacity,
   Cas1PremiseCapacityForDay,
   Cas1PremiseCharacteristicAvailability,
+  Cas1SpaceBookingCharacteristic,
 } from '@approved-premises/api'
 import { addDays, differenceInDays } from 'date-fns'
-import { OccupancyFilterCriteria } from '@approved-premises/ui'
 import cas1PremisesSummaryFactory from './cas1PremisesSummary'
 import { DateFormats } from '../../utils/dateUtils'
 import { occupancyCriteriaMap } from '../../utils/match/occupancy'
@@ -71,13 +71,13 @@ export const cas1PremiseCapacityForDayFactory = CapacityForDayFactory.define(() 
     availableBedCount: faker.number.int({ min: 0, max: totalBedCount }),
     bookingCount: faker.number.int({ min: 0, max: totalBedCount + 10 }),
     characteristicAvailability: Object.keys(occupancyCriteriaMap).map(characteristic =>
-      premiseCharacteristicAvailability.build({ characteristic: characteristic as OccupancyFilterCriteria }),
+      premiseCharacteristicAvailability.build({ characteristic: characteristic as Cas1SpaceBookingCharacteristic }),
     ),
   }
 })
 
 export const premiseCharacteristicAvailability = Factory.define<Cas1PremiseCharacteristicAvailability>(() => ({
-  characteristic: faker.helpers.arrayElement(Object.keys(occupancyCriteriaMap)) as OccupancyFilterCriteria,
+  characteristic: faker.helpers.arrayElement(Object.keys(occupancyCriteriaMap)) as Cas1SpaceBookingCharacteristic,
   availableBedsCount: faker.number.int({ min: 0, max: 40 }),
   bookingsCount: faker.number.int({ min: 0, max: 45 }),
 }))

--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -247,7 +247,6 @@ describe('matchUtils', () => {
   describe('occupancyViewLink', () => {
     it('returns a link to the occupancy view page', () => {
       const placementRequestId = '123'
-      const premisesName = 'Hope House'
       const premisesId = 'abc'
       const apType = 'pipe'
       const startDate = '2025-04-14'
@@ -255,7 +254,6 @@ describe('matchUtils', () => {
 
       const result = occupancyViewLink({
         placementRequestId,
-        premisesName,
         premisesId,
         apType,
         startDate,
@@ -263,10 +261,11 @@ describe('matchUtils', () => {
       })
 
       expect(result).toEqual(
-        `${paths.v2Match.placementRequests.spaceBookings.viewSpaces({ id: placementRequestId })}${createQueryString(
+        `${paths.v2Match.placementRequests.search.occupancy({
+          id: placementRequestId,
+          premisesId,
+        })}${createQueryString(
           {
-            premisesName,
-            premisesId,
             apType,
             startDate,
             durationDays,

--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -250,12 +250,16 @@ describe('matchUtils', () => {
       const premisesName = 'Hope House'
       const premisesId = 'abc'
       const apType = 'pipe'
+      const startDate = '2025-04-14'
+      const durationDays = '84'
 
       const result = occupancyViewLink({
         placementRequestId,
         premisesName,
         premisesId,
         apType,
+        startDate,
+        durationDays,
       })
 
       expect(result).toEqual(
@@ -264,6 +268,8 @@ describe('matchUtils', () => {
             premisesName,
             premisesId,
             apType,
+            startDate,
+            durationDays,
           },
           { addQueryPrefix: true },
         )}`,

--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -250,18 +250,12 @@ describe('matchUtils', () => {
       const premisesName = 'Hope House'
       const premisesId = 'abc'
       const apType = 'pipe'
-      const startDate = '2022-01-01'
-      const durationWeeks = '4'
-      const durationDays = '1'
-      const durationInDays = Number(durationWeeks) * 7 + Number(durationDays)
 
       const result = occupancyViewLink({
         placementRequestId,
         premisesName,
         premisesId,
         apType,
-        startDate,
-        durationDays,
       })
 
       expect(result).toEqual(
@@ -270,8 +264,6 @@ describe('matchUtils', () => {
             premisesName,
             premisesId,
             apType,
-            startDate,
-            durationInDays,
           },
           { addQueryPrefix: true },
         )}`,

--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -1,10 +1,4 @@
-import type {
-  ApType,
-  ApprovedPremisesApplication,
-  Cas1SpaceCharacteristic,
-  FullPerson,
-  PlacementCriteria,
-} from '@approved-premises/api'
+import type { ApType, ApprovedPremisesApplication, FullPerson, PlacementCriteria } from '@approved-premises/api'
 import { when } from 'jest-when'
 import paths from '../../paths/match'
 import {
@@ -41,6 +35,7 @@ import {
   mapUiParamsForApi,
   occupancyViewLink,
   occupancyViewSummaryListForMatchingDetails,
+  placementDates,
   placementLength,
   placementLengthRow,
   placementRequestSummaryListForMatching,
@@ -361,33 +356,28 @@ describe('matchUtils', () => {
   })
 
   describe('occupancyViewSummaryListForMatchingDetails', () => {
-    const placementRequest = placementRequestDetailFactory.build({ releaseType: 'hdc' })
+    const placementRequest = placementRequestDetailFactory.build({
+      releaseType: 'hdc',
+      expectedArrival: '2025-10-02',
+      duration: 52,
+      essentialCriteria: ['hasTactileFlooring'],
+    })
+    const dates = placementDates(placementRequest.expectedArrival, placementRequest.duration)
     const totalCapacity = 120
 
-    const dates = {
-      startDate: '2025-10-02',
-      endDate: '2025-12-23',
-      placementLength: 52,
-    }
-    const essentialCharacteristics: Array<Cas1SpaceCharacteristic> = ['hasTactileFlooring']
-
     it('should call the correct row functions', () => {
-      expect(
-        occupancyViewSummaryListForMatchingDetails(totalCapacity, dates, placementRequest, essentialCharacteristics),
-      ).toEqual([
+      expect(occupancyViewSummaryListForMatchingDetails(totalCapacity, placementRequest)).toEqual([
         arrivalDateRow(dates.startDate),
         departureDateRow(dates.endDate),
         placementLengthRow(dates.placementLength),
         releaseTypeRow(placementRequest),
         totalCapacityRow(totalCapacity),
-        spaceRequirementsRow(essentialCharacteristics),
+        spaceRequirementsRow(filterOutAPTypes(placementRequest.essentialCriteria)),
       ])
     })
 
     it('should generate the expected matching details', () => {
-      expect(
-        occupancyViewSummaryListForMatchingDetails(totalCapacity, dates, placementRequest, essentialCharacteristics),
-      ).toEqual([
+      expect(occupancyViewSummaryListForMatchingDetails(totalCapacity, placementRequest)).toEqual([
         {
           key: {
             text: 'Expected arrival date',
@@ -401,7 +391,7 @@ describe('matchUtils', () => {
             text: 'Expected departure date',
           },
           value: {
-            text: 'Tue 23 Dec 2025',
+            text: 'Sun 23 Nov 2025',
           },
         },
         {

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -1,6 +1,7 @@
 import { addDays } from 'date-fns'
 import type {
   ApType,
+  Cas1SpaceCharacteristic,
   Gender,
   PlacementCriteria,
   PlacementRequest,
@@ -31,6 +32,7 @@ import { preferredApsRow } from '../placementRequests/preferredApsRow'
 import { placementRequirementsRow } from '../placementRequests/placementRequirementsRow'
 import { allReleaseTypes } from '../applications/releaseTypeUtils'
 import { placementDates } from './placementDates'
+import { occupancyCriteriaMap } from './occupancy'
 
 export { placementDates } from './placementDates'
 export { occupancySummary } from './occupancySummary'
@@ -87,13 +89,16 @@ export const occupancyViewLink = ({
   apType,
   startDate,
   durationDays,
+  spaceCharacteristics = [],
 }: {
   placementRequestId: string
   premisesId: string
   apType: string
   startDate: string
   durationDays: string
+  spaceCharacteristics: Array<Cas1SpaceCharacteristic>
 }): string => {
+  const criteria = spaceCharacteristics.filter(name => Object.keys(occupancyCriteriaMap).includes(name))
   return `${matchPaths.v2Match.placementRequests.search.occupancy({
     id: placementRequestId,
     premisesId,
@@ -102,8 +107,9 @@ export const occupancyViewLink = ({
       apType,
       startDate,
       durationDays,
+      criteria,
     },
-    { addQueryPrefix: true },
+    { addQueryPrefix: true, arrayFormat: 'repeat' },
   )}`
 }
 

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -86,17 +86,23 @@ export const occupancyViewLink = ({
   premisesName,
   premisesId,
   apType,
+  startDate,
+  durationDays,
 }: {
   placementRequestId: string
   premisesName: string
   premisesId: string
   apType: string
+  startDate: string
+  durationDays: string
 }): string => {
   return `${matchPaths.v2Match.placementRequests.spaceBookings.viewSpaces({ id: placementRequestId })}${createQueryString(
     {
       premisesName,
       premisesId,
       apType,
+      startDate,
+      durationDays,
     },
     { addQueryPrefix: true },
   )}`

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -30,6 +30,7 @@ import { isFullPerson } from '../personUtils'
 import { preferredApsRow } from '../placementRequests/preferredApsRow'
 import { placementRequirementsRow } from '../placementRequests/placementRequirementsRow'
 import { allReleaseTypes } from '../applications/releaseTypeUtils'
+import { placementDates } from './placementDates'
 
 export { placementDates } from './placementDates'
 export { occupancySummary } from './occupancySummary'
@@ -168,14 +169,15 @@ export const spaceBookingPersonNeedsSummaryCardRows = (
 
 export const occupancyViewSummaryListForMatchingDetails = (
   totalCapacity: number,
-  dates: PlacementDates,
   placementRequest: PlacementRequest,
-  essentialCharacteristics: Array<SpaceCharacteristic>,
 ): Array<SummaryListItem> => {
+  const placementRequestDates = placementDates(placementRequest.expectedArrival, placementRequest.duration)
+  const essentialCharacteristics = filterOutAPTypes(placementRequest.essentialCriteria)
+
   return [
-    arrivalDateRow(dates.startDate),
-    departureDateRow(dates.endDate),
-    placementLengthRow(dates.placementLength),
+    arrivalDateRow(placementRequestDates.startDate),
+    departureDateRow(placementRequestDates.endDate),
+    placementLengthRow(placementRequestDates.placementLength),
     releaseTypeRow(placementRequest),
     totalCapacityRow(totalCapacity),
     spaceRequirementsRow(essentialCharacteristics),

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -86,23 +86,17 @@ export const occupancyViewLink = ({
   premisesName,
   premisesId,
   apType,
-  startDate,
-  durationDays,
 }: {
   placementRequestId: string
   premisesName: string
   premisesId: string
   apType: string
-  startDate: string
-  durationDays: string
 }): string => {
   return `${matchPaths.v2Match.placementRequests.spaceBookings.viewSpaces({ id: placementRequestId })}${createQueryString(
     {
       premisesName,
       premisesId,
       apType,
-      startDate,
-      durationDays,
     },
     { addQueryPrefix: true },
   )}`

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -83,23 +83,22 @@ export const placementLength = (lengthInDays: number): string => {
 
 export const occupancyViewLink = ({
   placementRequestId,
-  premisesName,
   premisesId,
   apType,
   startDate,
   durationDays,
 }: {
   placementRequestId: string
-  premisesName: string
   premisesId: string
   apType: string
   startDate: string
   durationDays: string
 }): string => {
-  return `${matchPaths.v2Match.placementRequests.spaceBookings.viewSpaces({ id: placementRequestId })}${createQueryString(
+  return `${matchPaths.v2Match.placementRequests.search.occupancy({
+    id: placementRequestId,
+    premisesId,
+  })}${createQueryString(
     {
-      premisesName,
-      premisesId,
       apType,
       startDate,
       durationDays,

--- a/server/utils/match/occupancy.test.ts
+++ b/server/utils/match/occupancy.test.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker'
 import { cas1PremiseCapacityFactory, cas1PremiseCapacityForDayFactory } from '../../testutils/factories'
-import { dateRangeAvailability, dayAvailabilityCount, dayHasAvailability } from './occupancy'
+import { dateRangeAvailability, dayAvailabilityCount, dayHasAvailability, durationSelectOptions } from './occupancy'
 
 describe('dayAvailabilityCount', () => {
   it('returns the count of available spaces for the day', () => {
@@ -92,5 +92,35 @@ describe('dateRangeAvailability', () => {
     })
 
     expect(dateRangeAvailability(premisesCapacity)).toEqual('none')
+  })
+})
+
+describe('durationSelectOptions', () => {
+  const defaultOptions = [
+    { text: 'Up to 1 week', value: '7' },
+    { text: 'Up to 6 weeks', value: '42' },
+    { text: 'Up to 12 weeks', value: '84' },
+    { text: 'Up to 26 weeks', value: '182' },
+    { text: 'Up to 52 weeks', value: '364' },
+  ]
+
+  it('returns a list of duration options', () => {
+    expect(durationSelectOptions()).toEqual(defaultOptions)
+  })
+
+  it.each([
+    ['Up to 1 week', 3],
+    ['Up to 1 week', 7],
+    ['Up to 6 weeks', 42],
+    ['Up to 12 weeks', 80],
+    ['Up to 12 weeks', 84],
+    ['Up to 26 weeks', 85],
+    ['Up to 26 weeks', 182],
+    ['Up to 52 weeks', 183],
+    ['Up to 52 weeks', 500],
+  ])('selects the option "%s" for a duration of %s days', (selectedLabel, duration) => {
+    const result = durationSelectOptions(duration)
+
+    expect(result.find(option => option.selected === true).text).toEqual(selectedLabel)
   })
 })

--- a/server/utils/match/occupancy.test.ts
+++ b/server/utils/match/occupancy.test.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker'
 import { Cas1PremiseCapacityForDay } from '@approved-premises/api'
 import { cas1PremiseCapacityForDayFactory } from '../../testutils/factories'
-import { dayAvailabilityCount, dayHasAvailability, durationSelectOptions } from './occupancy'
+import { dayAvailabilityCount, durationSelectOptions } from './occupancy'
 import { premiseCharacteristicAvailability } from '../../testutils/factories/cas1PremiseCapacity'
 
 const capacityWithCriteria: Cas1PremiseCapacityForDay = cas1PremiseCapacityForDayFactory.build({
@@ -58,61 +58,6 @@ describe('dayAvailabilityCount', () => {
       expect(
         dayAvailabilityCount(capacityWithCriteria, ['hasEnSuite', 'isSuitedForSexOffenders', 'isWheelchairDesignated']),
       ).toEqual(-1)
-    })
-  })
-})
-
-describe('dayHasAvailability', () => {
-  it('returns true if the day has availability', () => {
-    const dayCapacity = cas1PremiseCapacityForDayFactory.build({
-      availableBedCount: 15,
-      bookingCount: 10,
-    })
-
-    expect(dayHasAvailability(dayCapacity)).toBe(true)
-  })
-
-  it('returns false if the day is overbooked', () => {
-    const dayCapacity = cas1PremiseCapacityForDayFactory.build({
-      availableBedCount: 15,
-      bookingCount: 20,
-    })
-
-    expect(dayHasAvailability(dayCapacity)).toBe(false)
-  })
-
-  it('returns false if the day is fully booked', () => {
-    const dayCapacity = cas1PremiseCapacityForDayFactory.build({
-      availableBedCount: 15,
-      bookingCount: 15,
-    })
-
-    expect(dayHasAvailability(dayCapacity)).toBe(false)
-  })
-
-  describe('when criteria are provided', () => {
-    it('returns true if the count of available spaces that match the criteria is more than 0', () => {
-      expect(dayHasAvailability(capacityWithCriteria, ['isSuitedForSexOffenders'])).toEqual(true)
-    })
-
-    it('returns false if the count of available spaces that match the criteria is 0', () => {
-      expect(dayHasAvailability(capacityWithCriteria, ['isStepFreeDesignated'])).toEqual(false)
-    })
-
-    it('returns false if the count of available spaces that match the criteria is less than', () => {
-      expect(dayHasAvailability(capacityWithCriteria, ['hasEnSuite'])).toEqual(false)
-    })
-
-    it('returns true if the lowest count that match any criteria is more than 0', () => {
-      expect(dayHasAvailability(capacityWithCriteria, ['isSuitedForSexOffenders', 'isWheelchairDesignated'])).toEqual(
-        true,
-      )
-    })
-
-    it('returns false if the lowest count that match any criteria is less than 0', () => {
-      expect(
-        dayHasAvailability(capacityWithCriteria, ['hasEnSuite', 'isSuitedForSexOffenders', 'isWheelchairDesignated']),
-      ).toEqual(false)
     })
   })
 })

--- a/server/utils/match/occupancy.ts
+++ b/server/utils/match/occupancy.ts
@@ -1,14 +1,14 @@
-import type { Cas1PremiseCapacityForDay } from '@approved-premises/api'
-import { OccupancyFilterCriteria, SelectOption } from '@approved-premises/ui'
+import { Cas1PremiseCapacityForDay, Cas1SpaceBookingCharacteristic } from '@approved-premises/api'
+import { SelectOption } from '@approved-premises/ui'
 
 export const dayAvailabilityCount = (
   dayCapacity: Cas1PremiseCapacityForDay,
-  criteria: Array<OccupancyFilterCriteria> = [],
+  criteria: Array<Cas1SpaceBookingCharacteristic> = [],
 ) => {
   return criteria.length
     ? Math.min(
         ...dayCapacity.characteristicAvailability
-          .filter(availability => criteria.includes(availability.characteristic as OccupancyFilterCriteria))
+          .filter(availability => criteria.includes(availability.characteristic as Cas1SpaceBookingCharacteristic))
           .map(availability => availability.availableBedsCount - availability.bookingsCount),
       )
     : dayCapacity.availableBedCount - dayCapacity.bookingCount
@@ -37,7 +37,7 @@ export const durationSelectOptions = (duration?: number): Array<SelectOption> =>
   }))
 }
 
-export const occupancyCriteriaMap: Record<OccupancyFilterCriteria, string> = {
+export const occupancyCriteriaMap: Record<Cas1SpaceBookingCharacteristic, string> = {
   isWheelchairDesignated: 'Wheelchair accessible',
   isSingle: 'Single room',
   isStepFreeDesignated: 'Step-free',

--- a/server/utils/match/occupancy.ts
+++ b/server/utils/match/occupancy.ts
@@ -1,4 +1,5 @@
 import { Cas1PremiseCapacity, Cas1PremiseCapacityForDay } from '@approved-premises/api'
+import { SelectOption } from '@approved-premises/ui'
 
 export const dayAvailabilityCount = (dayCapacity: Cas1PremiseCapacityForDay) => {
   return dayCapacity.availableBedCount - dayCapacity.bookingCount
@@ -14,4 +15,27 @@ export const dateRangeAvailability = (capacity: Cas1PremiseCapacity) => {
   if (availableDays.length === capacity.capacity.length) return 'available'
   if (availableDays.length === 0) return 'none'
   return 'partial'
+}
+
+const durationOptionsMap: Record<number, string> = {
+  '7': 'Up to 1 week',
+  '42': 'Up to 6 weeks',
+  '84': 'Up to 12 weeks',
+  '182': 'Up to 26 weeks',
+  '364': 'Up to 52 weeks',
+}
+
+export const durationSelectOptions = (duration?: number): Array<SelectOption> => {
+  let selected: string
+
+  if (duration) {
+    const values = Object.keys(durationOptionsMap)
+    selected = String(values.filter(value => Number(value) >= duration)[0] || values.slice(-1))
+  }
+
+  return Object.entries(durationOptionsMap).map(([value, label]) => ({
+    value,
+    text: label,
+    selected: selected === value || undefined,
+  }))
 }

--- a/server/utils/match/occupancy.ts
+++ b/server/utils/match/occupancy.ts
@@ -1,20 +1,24 @@
-import type { Cas1PremiseCapacity, Cas1PremiseCapacityForDay } from '@approved-premises/api'
+import type { Cas1PremiseCapacityForDay } from '@approved-premises/api'
 import { OccupancyFilterCriteria, SelectOption } from '@approved-premises/ui'
 
-export const dayAvailabilityCount = (dayCapacity: Cas1PremiseCapacityForDay) => {
-  return dayCapacity.availableBedCount - dayCapacity.bookingCount
+export const dayAvailabilityCount = (
+  dayCapacity: Cas1PremiseCapacityForDay,
+  criteria: Array<OccupancyFilterCriteria> = [],
+) => {
+  return criteria.length
+    ? Math.min(
+        ...dayCapacity.characteristicAvailability
+          .filter(availability => criteria.includes(availability.characteristic as OccupancyFilterCriteria))
+          .map(availability => availability.availableBedsCount - availability.bookingsCount),
+      )
+    : dayCapacity.availableBedCount - dayCapacity.bookingCount
 }
 
-export const dayHasAvailability = (dayCapacity: Cas1PremiseCapacityForDay) => {
-  return dayAvailabilityCount(dayCapacity) > 0
-}
-
-export const dateRangeAvailability = (capacity: Cas1PremiseCapacity) => {
-  const availableDays = capacity.capacity.filter(dayHasAvailability)
-
-  if (availableDays.length === capacity.capacity.length) return 'available'
-  if (availableDays.length === 0) return 'none'
-  return 'partial'
+export const dayHasAvailability = (
+  dayCapacity: Cas1PremiseCapacityForDay,
+  criteria: Array<OccupancyFilterCriteria> = [],
+) => {
+  return dayAvailabilityCount(dayCapacity, criteria) > 0
 }
 
 const durationOptionsMap: Record<number, string> = {

--- a/server/utils/match/occupancy.ts
+++ b/server/utils/match/occupancy.ts
@@ -1,5 +1,5 @@
-import { Cas1PremiseCapacity, Cas1PremiseCapacityForDay } from '@approved-premises/api'
-import { SelectOption } from '@approved-premises/ui'
+import type { Cas1PremiseCapacity, Cas1PremiseCapacityForDay } from '@approved-premises/api'
+import { OccupancyFilterCriteria, SelectOption } from '@approved-premises/ui'
 
 export const dayAvailabilityCount = (dayCapacity: Cas1PremiseCapacityForDay) => {
   return dayCapacity.availableBedCount - dayCapacity.bookingCount
@@ -38,4 +38,13 @@ export const durationSelectOptions = (duration?: number): Array<SelectOption> =>
     text: label,
     selected: selected === value || undefined,
   }))
+}
+
+export const occupancyCriteriaMap: Record<OccupancyFilterCriteria, string> = {
+  isWheelchairDesignated: 'Wheelchair accessible',
+  isSingle: 'Single room',
+  isStepFreeDesignated: 'Step-free',
+  hasEnSuite: 'En-suite',
+  isSuitedForSexOffenders: 'Suitable for sex offenders',
+  isArsonSuitable: 'Designated arson room',
 }

--- a/server/utils/match/occupancy.ts
+++ b/server/utils/match/occupancy.ts
@@ -14,13 +14,6 @@ export const dayAvailabilityCount = (
     : dayCapacity.availableBedCount - dayCapacity.bookingCount
 }
 
-export const dayHasAvailability = (
-  dayCapacity: Cas1PremiseCapacityForDay,
-  criteria: Array<OccupancyFilterCriteria> = [],
-) => {
-  return dayAvailabilityCount(dayCapacity, criteria) > 0
-}
-
 const durationOptionsMap: Record<number, string> = {
   '7': 'Up to 1 week',
   '42': 'Up to 6 weeks',

--- a/server/utils/match/occupancyCalendar.test.ts
+++ b/server/utils/match/occupancyCalendar.test.ts
@@ -1,38 +1,56 @@
 import { Cas1PremiseCapacityForDay } from '@approved-premises/api'
 import { occupancyCalendar } from './occupancyCalendar'
 import { cas1PremiseCapacityFactory, cas1PremiseCapacityForDayFactory } from '../../testutils/factories'
-import { dayAvailabilityCount } from './occupancy'
 import { premiseCharacteristicAvailability } from '../../testutils/factories/cas1PremiseCapacity'
 
 describe('occupancyCalendar', () => {
   it('returns a calendar from the start date to the end date', () => {
-    const premisesCapacity = cas1PremiseCapacityFactory.build({ startDate: '2024-12-30', endDate: '2025-01-02' })
+    const premisesCapacity = cas1PremiseCapacityFactory.build({
+      startDate: '2024-12-30',
+      endDate: '2025-01-02',
+      capacity: [
+        cas1PremiseCapacityForDayFactory.build({ date: '2024-12-30', availableBedCount: 10, bookingCount: 5 }),
+        cas1PremiseCapacityForDayFactory.build({ date: '2024-12-31', availableBedCount: 10, bookingCount: 5 }),
+        cas1PremiseCapacityForDayFactory.build({ date: '2025-01-01', availableBedCount: 10, bookingCount: 12 }),
+        cas1PremiseCapacityForDayFactory.build({ date: '2025-01-02', availableBedCount: 10, bookingCount: 5 }),
+      ],
+    })
 
     expect(occupancyCalendar(premisesCapacity.capacity)).toEqual([
       {
         name: 'December 2024',
         days: [
-          { name: 'Mon 30 Dec', bookableCount: dayAvailabilityCount(premisesCapacity.capacity[0]) },
-          { name: 'Tue 31 Dec', bookableCount: dayAvailabilityCount(premisesCapacity.capacity[1]) },
+          { name: 'Mon 30 Dec', bookableCount: 5, status: 'available' },
+          { name: 'Tue 31 Dec', bookableCount: 5, status: 'available' },
         ],
       },
       {
         name: 'January 2025',
         days: [
-          { name: 'Wed 1 Jan', bookableCount: dayAvailabilityCount(premisesCapacity.capacity[2]) },
-          { name: 'Thu 2 Jan', bookableCount: dayAvailabilityCount(premisesCapacity.capacity[3]) },
+          { name: 'Wed 1 Jan', bookableCount: -2, status: 'overbooked' },
+          { name: 'Thu 2 Jan', bookableCount: 5, status: 'available' },
         ],
       },
     ])
   })
 
   it('returns the calendar without criteria count if an empty list of criteria is provided', () => {
-    const premisesCapacity = cas1PremiseCapacityFactory.build({ startDate: '2024-12-30', endDate: '2024-12-30' })
+    const premisesCapacity = cas1PremiseCapacityFactory.build({
+      startDate: '2024-12-30',
+      endDate: '2024-12-30',
+      capacity: [
+        cas1PremiseCapacityForDayFactory.build({
+          date: '2024-12-30',
+          availableBedCount: 10,
+          bookingCount: 6,
+        }),
+      ],
+    })
 
     expect(occupancyCalendar(premisesCapacity.capacity, [])).toEqual([
       {
         name: 'December 2024',
-        days: [{ name: 'Mon 30 Dec', bookableCount: dayAvailabilityCount(premisesCapacity.capacity[0]) }],
+        days: [{ name: 'Mon 30 Dec', bookableCount: 4, status: 'available' }],
       },
     ])
   })
@@ -73,6 +91,7 @@ describe('occupancyCalendar', () => {
               name: 'Sun 2 Feb',
               bookableCount: -2,
               criteriaBookableCount: -1,
+              status: 'overbooked',
             },
           ],
         },
@@ -86,6 +105,7 @@ describe('occupancyCalendar', () => {
               name: 'Sun 2 Feb',
               bookableCount: -2,
               criteriaBookableCount: 3,
+              status: 'availableForCriteria',
             },
           ],
         },
@@ -99,6 +119,7 @@ describe('occupancyCalendar', () => {
               name: 'Sun 2 Feb',
               bookableCount: -2,
               criteriaBookableCount: 1,
+              status: 'availableForCriteria',
             },
           ],
         },
@@ -114,6 +135,25 @@ describe('occupancyCalendar', () => {
               name: 'Sun 2 Feb',
               bookableCount: -2,
               criteriaBookableCount: -1,
+              status: 'overbooked',
+            },
+          ],
+        },
+      ])
+    })
+
+    it('returns the correct availability status if the day is available with and without criteria applied', () => {
+      const capacityAvailable = [cas1PremiseCapacityForDayFactory.build({ ...capacity[0], bookingCount: 0 })]
+
+      expect(occupancyCalendar(capacityAvailable, ['isSuitedForSexOffenders'])).toEqual([
+        {
+          name: 'February 2025',
+          days: [
+            {
+              name: 'Sun 2 Feb',
+              bookableCount: 18,
+              criteriaBookableCount: 3,
+              status: 'available',
             },
           ],
         },

--- a/server/utils/match/occupancyCalendar.test.ts
+++ b/server/utils/match/occupancyCalendar.test.ts
@@ -1,11 +1,14 @@
+import { Cas1PremiseCapacityForDay } from '@approved-premises/api'
 import { occupancyCalendar } from './occupancyCalendar'
-import { cas1PremiseCapacityFactory } from '../../testutils/factories'
+import { cas1PremiseCapacityFactory, cas1PremiseCapacityForDayFactory } from '../../testutils/factories'
 import { dayAvailabilityCount } from './occupancy'
+import { premiseCharacteristicAvailability } from '../../testutils/factories/cas1PremiseCapacity'
 
 describe('occupancyCalendar', () => {
   it('returns a calendar from the start date to the end date', () => {
     const premisesCapacity = cas1PremiseCapacityFactory.build({ startDate: '2024-12-30', endDate: '2025-01-02' })
-    expect(occupancyCalendar(premisesCapacity)).toEqual([
+
+    expect(occupancyCalendar(premisesCapacity.capacity)).toEqual([
       {
         name: 'December 2024',
         days: [
@@ -21,5 +24,100 @@ describe('occupancyCalendar', () => {
         ],
       },
     ])
+  })
+
+  it('returns the calendar without criteria count if an empty list of criteria is provided', () => {
+    const premisesCapacity = cas1PremiseCapacityFactory.build({ startDate: '2024-12-30', endDate: '2024-12-30' })
+
+    expect(occupancyCalendar(premisesCapacity.capacity, [])).toEqual([
+      {
+        name: 'December 2024',
+        days: [{ name: 'Mon 30 Dec', bookableCount: dayAvailabilityCount(premisesCapacity.capacity[0]) }],
+      },
+    ])
+  })
+
+  describe('when a filter criteria is provided', () => {
+    const capacity: Array<Cas1PremiseCapacityForDay> = [
+      cas1PremiseCapacityForDayFactory.build({
+        date: '2025-02-02',
+        totalBedCount: 20,
+        availableBedCount: 18,
+        bookingCount: 20,
+        characteristicAvailability: [
+          premiseCharacteristicAvailability.build({
+            characteristic: 'hasEnSuite',
+            availableBedsCount: 1,
+            bookingsCount: 2,
+          }),
+          premiseCharacteristicAvailability.build({
+            characteristic: 'isSuitedForSexOffenders',
+            availableBedsCount: 5,
+            bookingsCount: 2,
+          }),
+          premiseCharacteristicAvailability.build({
+            characteristic: 'isWheelchairDesignated',
+            availableBedsCount: 2,
+            bookingsCount: 1,
+          }),
+        ],
+      }),
+    ]
+
+    it('returns the calendar with bookable count for the selected criteria', () => {
+      expect(occupancyCalendar(capacity, ['hasEnSuite'])).toEqual([
+        {
+          name: 'February 2025',
+          days: [
+            {
+              name: 'Sun 2 Feb',
+              bookableCount: -2,
+              criteriaBookableCount: -1,
+            },
+          ],
+        },
+      ])
+
+      expect(occupancyCalendar(capacity, ['isSuitedForSexOffenders'])).toEqual([
+        {
+          name: 'February 2025',
+          days: [
+            {
+              name: 'Sun 2 Feb',
+              bookableCount: -2,
+              criteriaBookableCount: 3,
+            },
+          ],
+        },
+      ])
+
+      expect(occupancyCalendar(capacity, ['isWheelchairDesignated'])).toEqual([
+        {
+          name: 'February 2025',
+          days: [
+            {
+              name: 'Sun 2 Feb',
+              bookableCount: -2,
+              criteriaBookableCount: 1,
+            },
+          ],
+        },
+      ])
+    })
+
+    it('returns the calendar with the lowest bookable count for all criteria', () => {
+      expect(occupancyCalendar(capacity, ['hasEnSuite', 'isSuitedForSexOffenders', 'isWheelchairDesignated'])).toEqual([
+        {
+          name: 'February 2025',
+          days: [
+            {
+              name: 'Sun 2 Feb',
+              bookableCount: -2,
+              criteriaBookableCount: -1,
+            },
+          ],
+        },
+      ])
+    })
   })
 })

--- a/server/utils/match/occupancyCalendar.test.ts
+++ b/server/utils/match/occupancyCalendar.test.ts
@@ -78,6 +78,11 @@ describe('occupancyCalendar', () => {
             availableBedsCount: 2,
             bookingsCount: 1,
           }),
+          premiseCharacteristicAvailability.build({
+            characteristic: 'isStepFreeDesignated',
+            availableBedsCount: 4,
+            bookingsCount: 4,
+          }),
         ],
       }),
     ]
@@ -124,6 +129,20 @@ describe('occupancyCalendar', () => {
           ],
         },
       ])
+
+      expect(occupancyCalendar(capacity, ['isStepFreeDesignated'])).toEqual([
+        {
+          name: 'February 2025',
+          days: [
+            {
+              name: 'Sun 2 Feb',
+              bookableCount: -2,
+              criteriaBookableCount: 0,
+              status: 'overbooked',
+            },
+          ],
+        },
+      ])
     })
 
     it('returns the calendar with the lowest bookable count for all criteria', () => {
@@ -154,6 +173,20 @@ describe('occupancyCalendar', () => {
               bookableCount: 18,
               criteriaBookableCount: 3,
               status: 'available',
+            },
+          ],
+        },
+      ])
+
+      expect(occupancyCalendar(capacityAvailable, ['isStepFreeDesignated'])).toEqual([
+        {
+          name: 'February 2025',
+          days: [
+            {
+              name: 'Sun 2 Feb',
+              bookableCount: 18,
+              criteriaBookableCount: 0,
+              status: 'overbooked',
             },
           ],
         },

--- a/server/utils/match/occupancyCalendar.ts
+++ b/server/utils/match/occupancyCalendar.ts
@@ -1,5 +1,4 @@
-import type { Cas1PremiseCapacityForDay } from '@approved-premises/api'
-import type { OccupancyFilterCriteria } from '@approved-premises/ui'
+import type { Cas1PremiseCapacityForDay, Cas1SpaceBookingCharacteristic } from '@approved-premises/api'
 import { DateFormats } from '../dateUtils'
 import { dayAvailabilityCount } from './occupancy'
 
@@ -19,7 +18,7 @@ export type Calendar = Array<CalendarMonth>
 
 export const occupancyCalendar = (
   capacity: Array<Cas1PremiseCapacityForDay>,
-  criteria: Array<OccupancyFilterCriteria> = [],
+  criteria: Array<Cas1SpaceBookingCharacteristic> = [],
 ): Calendar => {
   return capacity.reduce<Calendar>((calendar, day) => {
     const monthAndYear = DateFormats.isoDateToMonthAndYear(day.date)

--- a/server/utils/match/occupancyCalendar.ts
+++ b/server/utils/match/occupancyCalendar.ts
@@ -22,12 +22,12 @@ export const occupancyCalendar = (
   criteria: Array<OccupancyFilterCriteria> = [],
 ): Calendar => {
   return capacity.reduce<Calendar>((calendar, day) => {
-    const dayMonthAndYear = DateFormats.isoDateToMonthAndYear(day.date)
-    let currentMonth = calendar.find(month => month.name === dayMonthAndYear)
+    const monthAndYear = DateFormats.isoDateToMonthAndYear(day.date)
+    let currentMonth = calendar.find(month => month.name === monthAndYear)
 
     if (!currentMonth) {
       currentMonth = {
-        name: dayMonthAndYear,
+        name: monthAndYear,
         days: [],
       }
       calendar.push(currentMonth)

--- a/server/utils/match/occupancyCalendar.ts
+++ b/server/utils/match/occupancyCalendar.ts
@@ -15,7 +15,7 @@ type CalendarMonth = {
   name: string
   days: Array<CalendarDay>
 }
-type Calendar = Array<CalendarMonth>
+export type Calendar = Array<CalendarMonth>
 
 export const occupancyCalendar = (
   capacity: Array<Cas1PremiseCapacityForDay>,

--- a/server/utils/match/occupancyCalendar.ts
+++ b/server/utils/match/occupancyCalendar.ts
@@ -1,10 +1,12 @@
-import { Cas1PremiseCapacity } from '@approved-premises/api'
+import type { Cas1PremiseCapacityForDay } from '@approved-premises/api'
+import type { OccupancyFilterCriteria } from '@approved-premises/ui'
 import { DateFormats } from '../dateUtils'
 import { dayAvailabilityCount } from './occupancy'
 
 type CalendarDay = {
   name: string
   bookableCount: number
+  criteriaBookableCount?: number
 }
 type CalendarMonth = {
   name: string
@@ -12,10 +14,11 @@ type CalendarMonth = {
 }
 type Calendar = Array<CalendarMonth>
 
-export const occupancyCalendar = (capacity: Cas1PremiseCapacity) => {
-  const calendar: Calendar = []
-
-  capacity.capacity.forEach(day => {
+export const occupancyCalendar = (
+  capacity: Array<Cas1PremiseCapacityForDay>,
+  criteria: Array<OccupancyFilterCriteria> = [],
+): Calendar => {
+  return capacity.reduce<Calendar>((calendar, day) => {
     const dayMonthAndYear = DateFormats.isoDateToMonthAndYear(day.date)
     let currentMonth = calendar.find(month => month.name === dayMonthAndYear)
 
@@ -27,11 +30,21 @@ export const occupancyCalendar = (capacity: Cas1PremiseCapacity) => {
       calendar.push(currentMonth)
     }
 
-    currentMonth.days.push({
+    const calendarDay: CalendarDay = {
       name: DateFormats.isoDateToUIDate(day.date, { format: 'longNoYear' }),
       bookableCount: dayAvailabilityCount(day),
-    })
-  })
+    }
 
-  return calendar
+    if (criteria.length) {
+      calendarDay.criteriaBookableCount = Math.min(
+        ...day.characteristicAvailability
+          .filter(availability => criteria.includes(availability.characteristic as OccupancyFilterCriteria))
+          .map(availability => availability.availableBedsCount - availability.bookingsCount),
+      )
+    }
+
+    currentMonth.days.push(calendarDay)
+
+    return calendar
+  }, [])
 }

--- a/server/utils/match/occupancyCalendar.ts
+++ b/server/utils/match/occupancyCalendar.ts
@@ -1,7 +1,7 @@
 import type { Cas1PremiseCapacityForDay } from '@approved-premises/api'
 import type { OccupancyFilterCriteria } from '@approved-premises/ui'
 import { DateFormats } from '../dateUtils'
-import { dayAvailabilityCount, dayHasAvailability } from './occupancy'
+import { dayAvailabilityCount } from './occupancy'
 
 type CalendarDayStatus = 'available' | 'availableForCriteria' | 'overbooked'
 
@@ -33,16 +33,23 @@ export const occupancyCalendar = (
       calendar.push(currentMonth)
     }
 
+    const bookableCount = dayAvailabilityCount(day)
+
     const calendarDay: CalendarDay = {
       name: DateFormats.isoDateToUIDate(day.date, { format: 'longNoYear' }),
-      status: dayHasAvailability(day) ? 'available' : 'overbooked',
-      bookableCount: dayAvailabilityCount(day),
+      status: bookableCount > 0 ? 'available' : 'overbooked',
+      bookableCount,
     }
 
     if (criteria.length) {
-      calendarDay.criteriaBookableCount = dayAvailabilityCount(day, criteria)
-      if (dayHasAvailability(day, criteria) && calendarDay.status === 'overbooked') {
+      const criteriaBookableCount = dayAvailabilityCount(day, criteria)
+
+      calendarDay.criteriaBookableCount = criteriaBookableCount
+
+      if (criteriaBookableCount > 0 && calendarDay.status === 'overbooked') {
         calendarDay.status = 'availableForCriteria'
+      } else if (criteriaBookableCount <= 0) {
+        calendarDay.status = 'overbooked'
       }
     }
 

--- a/server/utils/match/occupancySummary.test.ts
+++ b/server/utils/match/occupancySummary.test.ts
@@ -1,5 +1,5 @@
 import { cas1PremiseCapacityForDayFactory } from '../../testutils/factories'
-import { DateRange, occupancySummary, renderDateRange } from './occupancySummary'
+import { occupancySummary } from './occupancySummary'
 
 describe('occupancySummary', () => {
   it('returns a list of available and overbooked time periods', () => {
@@ -14,76 +14,32 @@ describe('occupancySummary', () => {
 
     const result = occupancySummary(capacity)
 
-    expect(result).toMatchStringIgnoringWhitespace(`
-      <h3 class="govuk-heading-m">Available on:</h3>
-      <ul>
-        <li>Wed 12 Feb 2025 to Thu 13 Feb 2025 <strong>(2 days)</strong></li>
-        <li>Mon 17 Feb 2025 <strong>(1 day)</strong></li>
-      </ul>
-      <h3 class="govuk-heading-m">Overbooked on:</h3>
-      <ul>
-        <li>Fri 14 Feb 2025 to Sun 16 Feb 2025 <strong>(3 days)</strong></li>
-      </ul>
-    `)
+    expect(result).toEqual({
+      available: [
+        { from: '2025-02-12', to: '2025-02-13', duration: 2 },
+        { from: '2025-02-17', duration: 1 },
+      ],
+      overbooked: [{ from: '2025-02-14', to: '2025-02-16', duration: 3 }],
+    })
   })
 
-  it('returns null for available if no dates are available', () => {
+  it('returns only overbooked if no dates are available', () => {
     const capacity = [cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-04-14' })]
 
     const result = occupancySummary(capacity)
 
-    expect(result).toMatchStringIgnoringWhitespace(
-      `<p class="govuk-heading-m">There are no spaces available for the dates you have selected.</p>`,
-    )
+    expect(result).toEqual({
+      overbooked: [{ from: '2025-04-14', duration: 1 }],
+    })
   })
 
-  it('returns null for overbooked if no dates are overbooked', () => {
+  it('returns only available if no dates are overbooked', () => {
     const capacity = [cas1PremiseCapacityForDayFactory.available().build({ date: '2025-04-15' })]
 
     const result = occupancySummary(capacity)
 
-    expect(result).toMatchStringIgnoringWhitespace(
-      `<p class="govuk-heading-m">The placement dates you have selected are available.</p>`,
-    )
-  })
-
-  describe('renderDateRange', () => {
-    it.each([
-      ['1 day', { start: '2024-12-04', end: '2024-12-04' }, 'Wed 4 Dec 2024 <strong>(1 day)</strong>'],
-      [
-        '3 days',
-        {
-          start: '2024-12-04',
-          end: '2024-12-06',
-        },
-        'Wed 4 Dec 2024 to Fri 6 Dec 2024 <strong>(3 days)</strong>',
-      ],
-      [
-        '1 week',
-        {
-          start: '2024-12-04',
-          end: '2024-12-10',
-        },
-        'Wed 4 Dec 2024 to Tue 10 Dec 2024 <strong>(1 week)</strong>',
-      ],
-      [
-        '1 week and 4 days',
-        {
-          start: '2024-12-04',
-          end: '2024-12-14',
-        },
-        'Wed 4 Dec 2024 to Sat 14 Dec 2024 <strong>(1 week and 4 days)</strong>',
-      ],
-      [
-        '3 weeks and 1 day',
-        {
-          start: '2024-12-04',
-          end: '2024-12-25',
-        },
-        'Wed 4 Dec 2024 to Wed 25 Dec 2024 <strong>(3 weeks and 1 day)</strong>',
-      ],
-    ])('renders a date range spanning %s', (_, dateRange: DateRange, expected) => {
-      expect(renderDateRange(dateRange)).toEqual(expected)
+    expect(result).toEqual({
+      available: [{ from: '2025-04-15', duration: 1 }],
     })
   })
 })

--- a/server/utils/match/occupancySummary.test.ts
+++ b/server/utils/match/occupancySummary.test.ts
@@ -1,18 +1,17 @@
-import { cas1PremiseCapacityFactory, cas1PremiseCapacityForDayFactory } from '../../testutils/factories'
+import { cas1PremiseCapacityForDayFactory } from '../../testutils/factories'
 import { DateRange, occupancySummary, renderDateRange } from './occupancySummary'
 
 describe('occupancySummary', () => {
   it('returns a list of available and overbooked time periods', () => {
-    const capacity = cas1PremiseCapacityFactory.build({
-      capacity: [
-        cas1PremiseCapacityForDayFactory.available().build({ date: '2025-02-12' }),
-        cas1PremiseCapacityForDayFactory.available().build({ date: '2025-02-13' }),
-        cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-02-14' }),
-        cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-02-15' }),
-        cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-02-16' }),
-        cas1PremiseCapacityForDayFactory.available().build({ date: '2025-02-17' }),
-      ],
-    })
+    const capacity = [
+      cas1PremiseCapacityForDayFactory.available().build({ date: '2025-02-12' }),
+      cas1PremiseCapacityForDayFactory.available().build({ date: '2025-02-13' }),
+      cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-02-14' }),
+      cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-02-15' }),
+      cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-02-16' }),
+      cas1PremiseCapacityForDayFactory.available().build({ date: '2025-02-17' }),
+    ]
+
     const result = occupancySummary(capacity)
 
     expect(result).toMatchStringIgnoringWhitespace(`
@@ -29,9 +28,8 @@ describe('occupancySummary', () => {
   })
 
   it('returns null for available if no dates are available', () => {
-    const capacity = cas1PremiseCapacityFactory.build({
-      capacity: [cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-04-14' })],
-    })
+    const capacity = [cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-04-14' })]
+
     const result = occupancySummary(capacity)
 
     expect(result).toMatchStringIgnoringWhitespace(
@@ -40,9 +38,8 @@ describe('occupancySummary', () => {
   })
 
   it('returns null for overbooked if no dates are overbooked', () => {
-    const capacity = cas1PremiseCapacityFactory.build({
-      capacity: [cas1PremiseCapacityForDayFactory.available().build({ date: '2025-04-15' })],
-    })
+    const capacity = [cas1PremiseCapacityForDayFactory.available().build({ date: '2025-04-15' })]
+
     const result = occupancySummary(capacity)
 
     expect(result).toMatchStringIgnoringWhitespace(

--- a/server/utils/match/occupancySummary.test.ts
+++ b/server/utils/match/occupancySummary.test.ts
@@ -42,4 +42,30 @@ describe('occupancySummary', () => {
       available: [{ from: '2025-04-15', duration: 1 }],
     })
   })
+
+  it('can handle ranges spanning the GMT to BST clock change', () => {
+    const capacity = [
+      cas1PremiseCapacityForDayFactory.available().build({ date: '2025-03-30' }),
+      cas1PremiseCapacityForDayFactory.available().build({ date: '2025-03-31' }),
+    ]
+
+    const result = occupancySummary(capacity)
+
+    expect(result).toEqual({
+      available: [{ from: '2025-03-30', to: '2025-03-31', duration: 2 }],
+    })
+  })
+
+  it('can handle ranges spanning the BST to GMT clock change', () => {
+    const capacity = [
+      cas1PremiseCapacityForDayFactory.available().build({ date: '2025-10-26' }),
+      cas1PremiseCapacityForDayFactory.available().build({ date: '2025-10-27' }),
+    ]
+
+    const result = occupancySummary(capacity)
+
+    expect(result).toEqual({
+      available: [{ from: '2025-10-26', to: '2025-10-27', duration: 2 }],
+    })
+  })
 })

--- a/server/utils/match/occupancySummary.ts
+++ b/server/utils/match/occupancySummary.ts
@@ -10,26 +10,23 @@ type DateRange = {
 }
 
 const daysToRanges = (days: Array<Cas1PremiseCapacityForDay>): Array<DateRange> =>
-  days
-    .reduce((ranges: Array<Omit<DateRange, 'duration'>>, capacityForDay) => {
-      if (!ranges.length) {
-        ranges.push({ from: capacityForDay.date })
-      } else {
-        const lastRange = ranges[ranges.length - 1]
-        const previousDate = lastRange.to || lastRange.from
+  days.reduce((ranges: Array<DateRange>, capacityForDay) => {
+    const newRange = { from: capacityForDay.date, duration: 1 }
+    if (!ranges.length) {
+      ranges.push(newRange)
+    } else {
+      const lastRange = ranges[ranges.length - 1]
+      const previousDate = lastRange.to || lastRange.from
 
-        if (differenceInDays(capacityForDay.date, previousDate) === 1) {
-          lastRange.to = capacityForDay.date
-        } else {
-          ranges.push({ from: capacityForDay.date })
-        }
+      if (differenceInDays(capacityForDay.date, previousDate) < 2) {
+        lastRange.to = capacityForDay.date
+        lastRange.duration += 1
+      } else {
+        ranges.push(newRange)
       }
-      return ranges
-    }, [])
-    .map(range => ({
-      ...range,
-      duration: range.to ? differenceInDays(range.to, range.from) + 1 : 1,
-    }))
+    }
+    return ranges
+  }, [])
 
 type OccupancySummary = {
   available?: Array<DateRange>

--- a/server/utils/match/occupancySummary.ts
+++ b/server/utils/match/occupancySummary.ts
@@ -28,7 +28,7 @@ const daysToRanges = (days: Array<Cas1PremiseCapacityForDay>): Array<DateRange> 
     return ranges
   }, [])
 
-type OccupancySummary = {
+export type OccupancySummary = {
   available?: Array<DateRange>
   overbooked?: Array<DateRange>
 }

--- a/server/utils/match/occupancySummary.ts
+++ b/server/utils/match/occupancySummary.ts
@@ -1,7 +1,7 @@
 import type { Cas1PremiseCapacityForDay } from '@approved-premises/api'
 import { differenceInDays } from 'date-fns'
 import { OccupancyFilterCriteria } from '@approved-premises/ui'
-import { dayHasAvailability } from './occupancy'
+import { dayAvailabilityCount } from './occupancy'
 
 type DateRange = {
   from: string
@@ -41,7 +41,7 @@ export const occupancySummary = (
   const overbookedDays: Array<Cas1PremiseCapacityForDay> = []
 
   capacity.forEach(capacityForDay => {
-    if (dayHasAvailability(capacityForDay, criteria)) {
+    if (dayAvailabilityCount(capacityForDay, criteria) > 0) {
       availableDays.push(capacityForDay)
     } else {
       overbookedDays.push(capacityForDay)

--- a/server/utils/match/occupancySummary.ts
+++ b/server/utils/match/occupancySummary.ts
@@ -1,4 +1,4 @@
-import type { Cas1PremiseCapacity, Cas1PremiseCapacityForDay } from '@approved-premises/api'
+import type { Cas1PremiseCapacityForDay } from '@approved-premises/api'
 import { differenceInDays } from 'date-fns'
 import { DateFormats, daysToWeeksAndDays } from '../dateUtils'
 import { dayHasAvailability } from './occupancy'
@@ -38,11 +38,11 @@ export const renderDateRange = (dateRange: DateRange): string => {
   return render
 }
 
-export const occupancySummary = (premiseCapacity: Cas1PremiseCapacity): string => {
+export const occupancySummary = (capacity: Array<Cas1PremiseCapacityForDay>): string => {
   const availableDays: Array<Cas1PremiseCapacityForDay> = []
   const overbookedDays: Array<Cas1PremiseCapacityForDay> = []
 
-  premiseCapacity.capacity.forEach(capacityForDay => {
+  capacity.forEach(capacityForDay => {
     if (dayHasAvailability(capacityForDay)) {
       availableDays.push(capacityForDay)
     } else {

--- a/server/utils/match/occupancySummary.ts
+++ b/server/utils/match/occupancySummary.ts
@@ -1,6 +1,5 @@
-import type { Cas1PremiseCapacityForDay } from '@approved-premises/api'
+import type { Cas1PremiseCapacityForDay, Cas1SpaceBookingCharacteristic } from '@approved-premises/api'
 import { differenceInDays } from 'date-fns'
-import { OccupancyFilterCriteria } from '@approved-premises/ui'
 import { dayAvailabilityCount } from './occupancy'
 
 type DateRange = {
@@ -36,7 +35,7 @@ export type OccupancySummary = {
 
 export const occupancySummary = (
   capacity: Array<Cas1PremiseCapacityForDay>,
-  criteria: Array<OccupancyFilterCriteria> = [],
+  criteria: Array<Cas1SpaceBookingCharacteristic> = [],
 ): OccupancySummary => {
   const availableDays: Array<Cas1PremiseCapacityForDay> = []
   const overbookedDays: Array<Cas1PremiseCapacityForDay> = []

--- a/server/utils/match/occupancySummary.ts
+++ b/server/utils/match/occupancySummary.ts
@@ -10,16 +10,17 @@ type DateRange = {
 }
 
 const daysToRanges = (days: Array<Cas1PremiseCapacityForDay>): Array<DateRange> =>
-  days.reduce((ranges: Array<DateRange>, capacityForDay) => {
-    const newRange = { from: capacityForDay.date, duration: 1 }
+  days.reduce((ranges: Array<DateRange>, { date }) => {
+    const newRange = { from: date, duration: 1 }
+
     if (!ranges.length) {
       ranges.push(newRange)
     } else {
       const lastRange = ranges[ranges.length - 1]
       const previousDate = lastRange.to || lastRange.from
 
-      if (differenceInDays(capacityForDay.date, previousDate) < 2) {
-        lastRange.to = capacityForDay.date
+      if (differenceInDays(date, previousDate) < 2) {
+        lastRange.to = date
         lastRange.duration += 1
       } else {
         ranges.push(newRange)

--- a/server/utils/match/placementDates.ts
+++ b/server/utils/match/placementDates.ts
@@ -7,7 +7,7 @@ type PlacementDates = {
   endDate: string
 }
 
-export const placementDates = (startDateString: string, lengthInDays: string): PlacementDates => {
+export const placementDates = (startDateString: string, lengthInDays: string | number): PlacementDates => {
   const days = Number(lengthInDays)
   const startDate = DateFormats.isoToDateObj(startDateString)
   const endDate = addDays(startDate, days)

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -74,7 +74,7 @@ export const catchAPIErrorOrPropogate = (request: Request, response: Response, e
 
 export const fetchErrorsAndUserInput = (request: Request): ErrorsAndUserInput => {
   const errors = firstFlashItem(request, 'errors') || {}
-  const errorSummary = request.flash('errorSummary') || []
+  const errorSummary = (request.flash('errorSummary') as Array<ErrorSummary>) || []
   const userInput = firstFlashItem(request, 'userInput') || {}
   const errorTitle = firstFlashItem(request, 'errorTitle')
 

--- a/server/views/admin/cruDashboard/index.njk
+++ b/server/views/admin/cruDashboard/index.njk
@@ -20,68 +20,56 @@
             <p class="govuk-body">
                 {{ subheading }}
             </p>
-            <div class="search-and-filter__wrapper">
-                <form action="{{ paths.admin.cruDashboard.index({}) }}" method="get">
-                    <input type="hidden" name="status" value="{{ status }}">
-                    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+            
+            <form action="{{ paths.admin.cruDashboard.index({}) }}" method="get" class="search-and-filter">
+                <input type="hidden" name="status" value="{{ status }}">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-                    <div class="govuk-grid-row">
-                        <div class="govuk-grid-column-full">
-                            <h2 class="govuk-heading-m">Filters</h2>
-                        </div>
-                    </div>
+                <h2 class="govuk-heading-m">Filters</h2>
 
-                    <div class="govuk-grid-row">
-                        <div class="govuk-grid-column-one-third">
-                            {{ govukSelect({
-                                label: {
-                                    text: "AP Area",
-                                    classes: "govuk-label--s"
-                                },
-                                classes: "govuk-input--width-20",
-                                id: "cruManagementArea",
-                                name: "cruManagementArea",
-                                items: convertObjectsToSelectOptions(cruManagementAreas, 'All areas', 'name', 'id', 'cruManagementArea', 'all', context)
-                            }) }}
-                        </div>
-                        {% if status != "pendingPlacement" %}
-                            <div class="govuk-grid-column-one-third">
-                                {{ govukSelect({
-                                    label: {
-                                        text: "Request type",
-                                        classes: "govuk-label--s"
-                                    },
-                                    id: "requestType",
-                                    name: "requestType",
-                                    items: convertObjectsToSelectOptions(PlacementRequestUtils.requestTypes, 'All request types', 'name', 'value', 'requestType', '', context)
-                                }) }}
-                            </div>
-                        {% endif %}
-                        {% if status === "pendingPlacement" %}
-                            <div class="govuk-grid-column-one-third">
-                                {{ govukSelect({
-                                    label: {
-                                        text: "Release type",
-                                        classes: "govuk-label--s"
-                                    },
-                                    id: "releaseType",
-                                    name: "releaseType",
-                                    items: ApplyUtils.releaseTypeSelectOptions(releaseType)
-                                }) }}
-                            </div>
-                        {% endif %}
+                <div class="search-and-filter__row">
+                    {{ govukSelect({
+                        label: {
+                            text: "AP Area",
+                            classes: "govuk-label--s"
+                        },
+                        classes: "govuk-input--width-20",
+                        id: "cruManagementArea",
+                        name: "cruManagementArea",
+                        items: convertObjectsToSelectOptions(cruManagementAreas, 'All areas', 'name', 'id', 'cruManagementArea', 'all', context)
+                    }) }}
 
-                        <div class="govuk-grid-column-one-third">
-                            {{ govukButton({
-                                "name": "submit",
-                                "text": "Apply filters",
-                                "classes": "search-and-filter__submit",
-                                "preventDoubleClick": true
-                            }) }}
-                        </div>
-                    </div>
-                </form>
-            </div>
+                    {% if status != "pendingPlacement" %}
+                        {{ govukSelect({
+                            label: {
+                                text: "Request type",
+                                classes: "govuk-label--s"
+                            },
+                            id: "requestType",
+                            name: "requestType",
+                            items: convertObjectsToSelectOptions(PlacementRequestUtils.requestTypes, 'All request types', 'name', 'value', 'requestType', '', context)
+                        }) }}
+                    {% endif %}
+
+                    {% if status === "pendingPlacement" %}
+                        {{ govukSelect({
+                            label: {
+                                text: "Release type",
+                                classes: "govuk-label--s"
+                            },
+                            id: "releaseType",
+                            name: "releaseType",
+                            items: ApplyUtils.releaseTypeSelectOptions(releaseType)
+                        }) }}
+                    {% endif %}
+
+                    {{ govukButton({
+                        "name": "submit",
+                        "text": "Apply filters",
+                        "preventDoubleClick": true
+                    }) }}
+                </div>
+            </form>
 
             {{ navigation(status, cruManagementArea, requestType) }}
 

--- a/server/views/admin/cruDashboard/search.njk
+++ b/server/views/admin/cruDashboard/search.njk
@@ -10,119 +10,96 @@
 
 {% from "./_navigation.njk" import navigation %}
 
-{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body assessments--index" %}
 
 {% block content %}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full search-and-filter">
-      {% include "../../_messages.njk" %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            {% include "../../_messages.njk" %}
 
-      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+            <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
-      {{ navigation("search") }}
+            {{ navigation("search") }}
 
-      <div class="search-and-filter__wrapper">
 
-        <form action="{{ paths.admin.cruDashboard.search({}) }}" method="get">
+            <form action="{{ paths.admin.cruDashboard.search({}) }}" method="get" class="search-and-filter">
 
-          <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-              <div class="govuk-form-group">
-                <label class="search-and-filter__crn-label" for="crnOrName">
-                 Find a placement
-                </label>
 
-                <div id="crn-hint" class="govuk-hint moj-crn__hint ">
-                  You can search by CRN or name
+                <div class="govuk-form-group">
+                    <label class="search-and-filter__crn-label" for="crnOrName">
+                        Find a placement
+                    </label>
+
+                    <div id="crn-hint" class="govuk-hint moj-crn__hint ">
+                        You can search by CRN or name
+                    </div>
+
+                    <input class="govuk-input moj-search__input" id="crnOrName" name="crnOrName" type="search"
+                           aria-describedby="crn-hint" value="{{ crnOrName }}">
+
                 </div>
 
-                <input class="govuk-input moj-search__input" id="crnOrName" name="crnOrName" type="search" aria-describedby="crn-hint" value="{{ crnOrName }}">
-              </div>
-            </div>
-          </div>
+                <h2 class="govuk-heading-m">Filters</h2>
 
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-one-quarter">
-              <h2 class="govuk-heading-m">Filters</h2>
-            </div>
-          </div>
+                <div class="search-and-filter__row">
+                    {{ govukSelect({
+                        label: {
+                            text: "Tier",
+                            classes: "govuk-label--s"
+                        },
+                        id: "tier",
+                        name: "tier",
+                        items: FormUtils.tierSelectOptions(tier)
+                    }) }}
 
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-one-quarter">
-              {{
-                govukSelect({
-                  label: {
-                      text: "Tier",
-                      classes: "govuk-label--s"
-                  },
-                  id: "tier",
-                  name: "tier",
-                  items: FormUtils.tierSelectOptions(tier)
-                })
-              }}
-            </div>
-            <div class="govuk-grid-column-one-quarter">
-              {{
-                govukSelect({
-                  label: {
-                      text: "Status",
-                      classes: "govuk-label--s"
-                  },
-                  id: "status",
-                  name: "status",
-                  items: FormUtils.placementRequestStatusSelectOptions(status)
-                })
-              }}
-            </div>
-            <div class="govuk-grid-column-one-quarter">
-              <div class="govuk-form-group">
-                <label class="govuk-label govuk-label--s" for="arrivalDateStart">
-                  Arrival date from
-                </label>
+                    {{ govukSelect({
+                        label: {
+                            text: "Status",
+                            classes: "govuk-label--s"
+                        },
+                        id: "status",
+                        name: "status",
+                        items: FormUtils.placementRequestStatusSelectOptions(status)
+                    }) }}
 
-                <input type="date" id="arrivalDateStart" class="govuk-input" name="arrivalDateStart" placeholder="Date from" value="{{ arrivalDateStart }}"/>
-              </div>
-            </div>
-            <div class="govuk-grid-column-one-quarter">
-              <div class="govuk-form-group">
-                <label class="govuk-label govuk-label--s" for="arrivalDateEnd">
-                  Arrival date to
-                </label>
+                    <div class="govuk-form-group">
+                        <label class="govuk-label govuk-label--s" for="arrivalDateStart">
+                            Arrival date from
+                        </label>
 
-                <input type="date" id="arrivalDateEnd" class="govuk-input" name="arrivalDateEnd" placeholder="Date to" value="{{ arrivalDateEnd }}"/>
-              </div>
-            </div>
-          </div>
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-one-quarter">
-              {{
-                          govukButton({
-                            name: 'submit',
-                            text: 'Apply filters',
-                            classes: 'search-and-filter__submit',
-                            preventDoubleClick: true
-                          })
-                        }}
-            </div>
-          </div>
+                        <input type="date" id="arrivalDateStart" class="govuk-input" name="arrivalDateStart"
+                               placeholder="Date from" value="{{ arrivalDateStart }}" />
+                    </div>
 
-        </form>
-      </div>
+                    <div class="govuk-form-group">
+                        <label class="govuk-label govuk-label--s" for="arrivalDateEnd">
+                            Arrival date to
+                        </label>
 
-      {{
-        govukTable({
-            firstCellIsHeader: true,
-            head: PlacementRequestUtils.tableUtils.dashboardTableHeader(status, sortBy, sortDirection, hrefPrefix),
-            rows: PlacementRequestUtils.tableUtils.dashboardTableRows(placementRequests)
-          })
-      }}
+                        <input type="date" id="arrivalDateEnd" class="govuk-input" name="arrivalDateEnd"
+                               placeholder="Date to" value="{{ arrivalDateEnd }}" />
+                    </div>
 
-      {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
+                    {{ govukButton({
+                        name: 'submit',
+                        text: 'Apply filters',
+                        preventDoubleClick: true
+                    }) }}
+                </div>
+            </form>
 
+            {{ govukTable({
+                firstCellIsHeader: true,
+                head: PlacementRequestUtils.tableUtils.dashboardTableHeader(status, sortBy, sortDirection, hrefPrefix),
+                rows: PlacementRequestUtils.tableUtils.dashboardTableRows(placementRequests)
+            }) }}
+
+            {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
+
+        </div>
     </div>
-  </div>
 {% endblock %}

--- a/server/views/admin/users/index.njk
+++ b/server/views/admin/users/index.njk
@@ -11,7 +11,7 @@
 {% endblock %}
 {% block content %}
     {% include "../../_messages.njk" %}
-    <div class="govuk-width-container search-and-filter">
+    <div class="govuk-width-container">
         <div class="govuk-grid-row">
             <h1 class="govuk-heading-l govuk-grid-column-three-quarters">{{ pageHeading }}</h1>
             {{ govukButton({
@@ -21,90 +21,84 @@
                 preventDoubleClick: true
             }) }}
         </div>
-        <div class="search-and-filter__wrapper">
+
+        <div class="search-and-filter">
             <form action="{{ paths.admin.userManagement.search({}) }}" method="post">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-                <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-three-quarters">
-                        {{ govukInput({
-                            classes: "moj-search__input",
-                            label: {
-                                text: "Find a user",
-                                classes: "govuk-label--m"
-                            },
-                            id: 'search-by-name',
-                            hint: {
-                                text: "You can search for a person by name e.g. 'John' or 'smith' or 'john Smith'",
-                                classes: "moj-crn__hint"
-                            },
-                            name: "name",
-                            value: name,
-                            errorMessage: errors.name
-                        }) }}
-                    </div>
-                    <div class="govuk-grid-column-one-quarter govuk-!-margin-top-5 govuk-!-padding-left-0">
-                        {{ govukButton({
-                            "text": "Search",
-                            "type": "submit",
-                            "classes": "govuk-grid-column-one-quarter govuk-!-margin-top-9",
-                            "preventDoubleClick": true
-                        }) }}
-                    </div>
+
+                <div class="search-and-filter__row">
+                    {{ govukInput({
+                        classes: "moj-search__input",
+                        label: {
+                            text: "Find a user",
+                            classes: "govuk-label--m"
+                        },
+                        id: 'search-by-name',
+                        hint: {
+                            text: "You can search for a person by name e.g. 'John' or 'smith' or 'john Smith'",
+                            classes: "moj-crn__hint"
+                        },
+                        name: "name",
+                        value: name,
+                        errorMessage: errors.name
+                    }) }}
+
+
+                    {{ govukButton({
+                        "text": "Search",
+                        "type": "submit",
+                        "classes": "govuk-grid-column-one-quarter govuk-!-margin-top-9",
+                        "preventDoubleClick": true
+                    }) }}
                 </div>
             </form>
+
             <form action="{{ paths.admin.userManagement.index({}) }}" method="get">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-                <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-one-quarter">
-                        <h2 class="govuk-heading-m">Filters</h2>
-                    </div>
-                </div>
-                <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-one-quarter">
-                        {{ govukSelect({
-                            label: {
-                                text: "Role",
-                                classes: "govuk-label--s"
-                            },
-                            id: "role",
-                            name: "role",
-                            items: UserUtils.userRolesSelectOptions(selectedRole)
-                        }) }}
-                    </div>
-                    <div class="govuk-grid-column-one-quarter">
-                        {{ govukSelect({
-                            label: {
-                                text: "AP Area",
-                                classes: "govuk-label--s"
-                            },
-                            classes: "govuk-input--width-20",
-                            id: "area",
-                            name: "area",
-                            items: convertObjectsToSelectOptions(cruManagementAreas, 'All areas', 'name', 'id', 'selectedArea')
-                        }) }}
-                    </div>
-                    <div class="govuk-grid-column-one-quarter">
-                        {{ govukSelect({
-                            label: {
-                                text: "Allocation",
-                                classes: "govuk-label--s"
-                            },
-                            id: "qualification",
-                            name: "qualification",
-                            items: UserUtils.userQualificationsSelectOptions(selectedQualification)
-                        }) }}
-                    </div>
-                    <div class="govuk-grid-column-one-quarter">
-                        {{ govukButton({
-                            "name": "submit",
-                            "text": "Apply filters",
-                            "classes": "search-and-filter__submit",
-                            "preventDoubleClick": true
-                        }) }}
-                    </div>
+
+                <h2 class="govuk-heading-m govuk-!-margin-top-4">Filters</h2>
+
+                <div class="search-and-filter__row">
+                    {{ govukSelect({
+                        label: {
+                            text: "Role",
+                            classes: "govuk-label--s"
+                        },
+                        id: "role",
+                        name: "role",
+                        items: UserUtils.userRolesSelectOptions(selectedRole)
+                    }) }}
+
+                    {{ govukSelect({
+                        label: {
+                            text: "AP Area",
+                            classes: "govuk-label--s"
+                        },
+                        classes: "govuk-input--width-20",
+                        id: "area",
+                        name: "area",
+                        items: convertObjectsToSelectOptions(cruManagementAreas, 'All areas', 'name', 'id', 'selectedArea')
+                    }) }}
+
+                    {{ govukSelect({
+                        label: {
+                            text: "Allocation",
+                            classes: "govuk-label--s"
+                        },
+                        id: "qualification",
+                        name: "qualification",
+                        items: UserUtils.userQualificationsSelectOptions(selectedQualification)
+                    }) }}
+
+                    {{ govukButton({
+                        "name": "submit",
+                        "text": "Apply filters",
+                        "preventDoubleClick": true
+                    }) }}
                 </div>
             </form>
         </div>
+
         {{ govukTable({
             firstCellIsHeader: true,
             head: UserUtils.managementDashboardTableHeader(sortBy, sortDirection, hrefPrefix) ,

--- a/server/views/applications/dashboard.njk
+++ b/server/views/applications/dashboard.njk
@@ -9,87 +9,64 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
-  {% include "../_messages.njk" %}
+    {% include "../_messages.njk" %}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
 
-      <h1 class="govuk-heading-l">Approved Premises applications</h1>
+            <h1 class="govuk-heading-l">Approved Premises applications</h1>
 
-      {{ navigation('allApplications') }}
+            {{ navigation('allApplications') }}
 
-      <div class="search-and-filter__wrapper">
+            <form action="{{ paths.applications.dashboard({}) }}" method="get" class="search-and-filter">
+                <div class="govuk-form-group">
+                    <label class="search-and-filter__crn-label" for="crnOrName">
+                        Find an application
+                    </label>
 
-        <form action="{{ paths.applications.dashboard({}) }}" method="get">
+                    <div id="crn-hint" class="govuk-hint moj-crn__hint ">
+                        You can search by CRN or name
+                    </div>
 
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-              <div class="govuk-form-group">
-                <label class="search-and-filter__crn-label" for="crnOrName">
-                 Find an application
-                </label>
-
-                <div id="crn-hint" class="govuk-hint moj-crn__hint ">
-                  You can search by CRN or name
+                    <input class="govuk-input moj-search__input" id="crnOrName" name="crnOrName" type="search"
+                           aria-describedby="crn-hint" value="{{ crnOrName }}">
                 </div>
 
-                <input class="govuk-input moj-search__input" id="crnOrName" name="crnOrName" type="search" aria-describedby="crn-hint" value="{{ crnOrName }}">
-              </div>
-            </div>
-          </div>
+                <h2 class="govuk-heading-m govuk-!-margin-top-4">Filters</h2>
 
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-one-quarter">
-              <h2 class="govuk-heading-m">Filters</h2>
-            </div>
-          </div>
+                <div class="search-and-filter__row">
+                    {{ govukSelect({
+                        label: {
+                            text: "Statuses",
+                            classes: "govuk-label--s"
+                        },
+                        id: "status",
+                        name: "status",
+                        items: ApplyUtils.applicationStatusSelectOptions(status)
+                    }) }}
 
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-one-quarter">
-              {{
-                govukSelect({
-                  label: {
-                      text: "Statuses",
-                      classes: "govuk-label--s"
-                  },
-                  id: "status",
-                  name: "status",
-                  items: ApplyUtils.applicationStatusSelectOptions(status)
-                })
-              }}
-            </div>
-            <div class="govuk-grid-column-one-quarter">
-              {{
-                govukButton({
-                  name: 'submit',
-                  text: 'Apply filters',
-                  classes: 'search-and-filter__submit',
-                  preventDoubleClick: true
-                })
-              }}
-            </div>
-          </div>
+                    {{ govukButton({
+                        name: 'submit',
+                        text: 'Apply filters',
+                        preventDoubleClick: true
+                    }) }}
+                </div>
+            </form>
 
-        </form>
-      </div>
+            {{ govukTable({
+                caption: title,
+                captionClasses: "govuk-table__caption--m",
+                firstCellIsHeader: true,
+                head: ApplyUtils.dashboardTableHeader(sortBy, sortDirection, hrefPrefix),
+                rows: ApplyUtils.dashboardTableRows(applications, { linkInProgressApplications: false })
+            }) }}
 
-      {{
-        govukTable({
-          caption: title,
-          captionClasses: "govuk-table__caption--m",
-          firstCellIsHeader: true,
-          head: ApplyUtils.dashboardTableHeader(sortBy, sortDirection, hrefPrefix),
-          rows: ApplyUtils.dashboardTableRows(applications, { linkInProgressApplications: false })
-        })
-      }}
+            {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
 
-      {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
-
+        </div>
     </div>
-  </div>
-</div>
 {% endblock %}

--- a/server/views/manage/outOfServiceBeds/index.njk
+++ b/server/views/manage/outOfServiceBeds/index.njk
@@ -33,88 +33,75 @@
 {% endblock %}
 
 {% block content %}
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full-width">
-            <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-            <div class="search-and-filter__wrapper">
-                <form action="{{ paths.outOfServiceBeds.index({temporality: temporality}) }}" method="get"
-                      id="osbFilters">
-                    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-                    <div class="govuk-grid-row">
-                        <div class="govuk-grid-column-full">
-                            <h2 class="govuk-heading-m">Filters</h2>
-                        </div>
-                    </div>
+    <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
-                    <div class="govuk-grid-row">
-                        <div class="govuk-grid-column-one-third">
-                            {{ govukSelect({
-                                label: {
-                                    text: "AP Area",
-                                    classes: "govuk-label--s"
-                                },
-                                classes: "govuk-input--width-20",
-                                id: "apAreaId",
-                                name: "apAreaId",
-                                items: convertObjectsToSelectOptions(apAreas, 'All areas', 'name', 'id', 'apAreaId', 'all', context)
-                            }) }}
-                        </div>
-                        <div class="govuk-grid-column-one-third">
-                            {{ govukSelect({
-                                label: {
-                                    text: "Premises Name",
-                                    classes: "govuk-label--s"
-                                },
-                                id: "premisesId",
-                                name: "premisesId",
-                                disabled: disablePremisesSelect,
-                                items: premisesItems
-                            }) }}
-                        </div>
-                        <div class="govuk-grid-column-one-third" id="submitbutton">
-                            {{ govukButton({
-                                "name": "submit",
-                                "text": "Apply filters",
-                                "classes": "search-and-filter__submit",
-                                "preventDoubleClick": true
-                            }) }}
-                        </div>
-                    </div>
-                </form>
-            </div>
+    <form action="{{ paths.outOfServiceBeds.index({temporality: temporality}) }}" method="get"
+          id="osbFilters" class="search-and-filter">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-            {{ mojSubNavigation({
-                label: 'Sub navigation',
-                items: [{
-                    text: 'Current',
-                    href: paths.outOfServiceBeds.index({temporality: 'current'}) + areaAndPremisesParam,
-                    active: temporality === 'current'
-                }, {
-                    text: 'Future',
-                    href: paths.outOfServiceBeds.index({temporality: 'future'}) + areaAndPremisesParam,
-                    active: temporality === 'future'
-                }, {
-                    text: 'Historic',
-                    href: paths.outOfServiceBeds.index({temporality: 'past'}) + areaAndPremisesParam,
-                    active: temporality === 'past'
-                }]
+        <h2 class="govuk-heading-m">Filters</h2>
+
+        <div class="search-and-filter__row">
+            {{ govukSelect({
+                label: {
+                    text: "AP Area",
+                    classes: "govuk-label--s"
+                },
+                classes: "govuk-input--width-20",
+                id: "apAreaId",
+                name: "apAreaId",
+                items: convertObjectsToSelectOptions(apAreas, 'All areas', 'name', 'id', 'apAreaId', 'all', context)
             }) }}
 
-            {% if outOfServiceBeds %}
+            {{ govukSelect({
+                label: {
+                    text: "Premises Name",
+                    classes: "govuk-label--s"
+                },
+                id: "premisesId",
+                name: "premisesId",
+                disabled: disablePremisesSelect,
+                items: premisesItems
+            }) }}
 
-                {{ govukTable({
-                    caption: "Out of service beds",
-                    captionClasses: "govuk-table__caption--m",
-                    head: OutOfServiceBedUtils.allOutOfServiceBedsTableHeaders(sortBy, sortDirection, hrefPrefix),
-                    rows: OutOfServiceBedUtils.allOutOfServiceBedsTableRows(outOfServiceBeds)
-                }) }}
-
-                {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
-
-            {% endif %}
+            {{ govukButton({
+                "name": "submit",
+                "text": "Apply filters",
+                "preventDoubleClick": true
+            }) }}
         </div>
-    </div>
+    </form>
+
+    {{ mojSubNavigation({
+        label: 'Sub navigation',
+        items: [{
+            text: 'Current',
+            href: paths.outOfServiceBeds.index({temporality: 'current'}) + areaAndPremisesParam,
+            active: temporality === 'current'
+        }, {
+            text: 'Future',
+            href: paths.outOfServiceBeds.index({temporality: 'future'}) + areaAndPremisesParam,
+            active: temporality === 'future'
+        }, {
+            text: 'Historic',
+            href: paths.outOfServiceBeds.index({temporality: 'past'}) + areaAndPremisesParam,
+            active: temporality === 'past'
+        }]
+    }) }}
+
+    {% if outOfServiceBeds %}
+
+        {{ govukTable({
+            caption: "Out of service beds",
+            captionClasses: "govuk-table__caption--m",
+            head: OutOfServiceBedUtils.allOutOfServiceBedsTableHeaders(sortBy, sortDirection, hrefPrefix),
+            rows: OutOfServiceBedUtils.allOutOfServiceBedsTableRows(outOfServiceBeds)
+        }) }}
+
+        {{ govukPagination(pagination(pageNumber, totalPages, hrefPrefix)) }}
+
+    {% endif %}
 {% endblock %}
 
 {% block extraScripts %}

--- a/server/views/manage/premises/show.njk
+++ b/server/views/manage/premises/show.njk
@@ -55,12 +55,12 @@
             }) }}
 
             {% if activeTab === 'upcoming' or activeTab === 'current' %}
-                <div class="search-and-filter__wrapper">
-                    <form action="{{ hrefPrefix }}" method="get">
-                        <input type="hidden" name="activeTab" value="{{ activeTab }}" />
+                <form action="{{ hrefPrefix }}" method="get" class="search-and-filter">
+                    <input type="hidden" name="activeTab" value="{{ activeTab }}" />
 
-                        <h3 class="govuk-heading-m">Filters</h3>
+                    <h3 class="govuk-heading-m">Filters</h3>
 
+                    <div class="search-and-filter__row">
                         {{ govukSelect({
                             id: 'keyworker',
                             name: 'keyworker',
@@ -73,42 +73,36 @@
 
                         {{ govukButton({
                             text: 'Apply filters',
-                            classes: 'govuk-!-margin-bottom-0',
                             preventDoubleClick: true
                         }) }}
-                    </form>
-                </div>
+                    </div>
+                </form>
             {% endif %}
 
             {% if activeTab === 'search' %}
-                <div class="search-and-filter__wrapper">
-                    <form action="{{ hrefPrefix }}" method="get">
-                        <input type="hidden" name="activeTab" value="search" />
+                <form action="{{ hrefPrefix }}" method="get" class="search-and-filter">
+                    <input type="hidden" name="activeTab" value="search" />
 
-                        <div class="govuk-grid-row">
-                            <div class="govuk-grid-column-two-thirds">
-                                {{ govukInput({
-                                    label: {
-                                        text: 'Search for a booking',
-                                        classes: 'govuk-fieldset__legend--m'
-                                    },
-                                    hint: {
-                                        text: 'You can search for a person name or CRN'
-                                    },
-                                    id: 'crnOrName',
-                                    name: 'crnOrName',
-                                    value: crnOrName
-                                }) }}
+                    <div class="search-and-filter__row">
+                        {{ govukInput({
+                            label: {
+                                text: 'Search for a booking',
+                                classes: 'govuk-fieldset__legend--m'
+                            },
+                            hint: {
+                                text: 'You can search for a person name or CRN'
+                            },
+                            id: 'crnOrName',
+                            name: 'crnOrName',
+                            value: crnOrName
+                        }) }}
 
-                                {{ govukButton({
-                                    text: 'Search',
-                                    classes: 'govuk-!-margin-bottom-0',
-                                    preventDoubleClick: true
-                                }) }}
-                            </div>
-                        </div>
-                    </form>
-                </div>
+                        {{ govukButton({
+                            text: 'Search',
+                            preventDoubleClick: true
+                        }) }}
+                    </div>
+                </form>
             {% endif %}
 
 

--- a/server/views/match/placementRequests/occupancyView/partials/_occupancyCalendar.njk
+++ b/server/views/match/placementRequests/occupancyView/partials/_occupancyCalendar.njk
@@ -1,26 +1,41 @@
 {% macro occupancyCalendar(calendar) %}
     <div class="calendar">
         {% for month in calendar %}
-            <h3 class="govuk-heading-m">{{ month.name }}</h3>
-            <ul class="calendar__month govuk-list">
-                {% for day in month.days %}
-                    <li class="calendar__day calendar__day--{{ day.name.slice(0,3) | lower }}{% if day.bookableCount <= 0 %} govuk-tag--red{% endif %}">
-                        <a class="calendar__link" href="#">
-                            <time class="calendar__date" datetime="{{ day.date }}">{{ day.name }}</time>
+            <section>
+                <h3 class="govuk-heading-m">{{ month.name }}</h3>
 
-                            <dl class="calendar__availability">
-                                <dt class="govuk-visually-hidden">Availability:</dt>
+                <ul class="calendar__month govuk-list">
+                    {% for day in month.days %}
+                        <li class="calendar__day calendar__day--{{ day.name.slice(0,3) | lower }}{% if day.bookableCount <= 0 %} {{ 'govuk-tag--yellow' if day.criteriaBookableCount > 0 else 'govuk-tag--red' }}{% endif %}">
+                            <a class="calendar__link" href="#">
+                                <time class="calendar__date" datetime="{{ day.date }}">{{ day.name }}</time>
 
-                                {% if day.bookableCount > 0 %}
-                                    <dd>Available</dd>
-                                {% else %}
-                                    <dd><span class="govuk-!-font-weight-bold">{{ day.bookableCount }}</span> total</dd>
-                                {% endif %}
-                            </dl>
-                        </a>
-                    </li>
-                {% endfor %}
-            </ul>
+                                <dl class="calendar__availability">
+                                    <dt class="govuk-visually-hidden">Availability:</dt>
+
+                                    {% if day.bookableCount > 0 %}
+                                        <dd>Available</dd>
+                                    {% else %}
+                                        {% if day.criteriaBookableCount is defined %}
+                                            <dd>
+                                                <span class="govuk-!-font-weight-bold">{{ day.criteriaBookableCount }}</span>
+                                                <span class="govuk-visually-hidden">for</span>
+                                                your criteria
+                                            </dd>
+                                        {% endif %}
+
+                                        <dd>
+                                            <span class="govuk-!-font-weight-bold">{{ day.bookableCount }}</span>
+                                            <span class="govuk-visually-hidden">in</span>
+                                            total
+                                        </dd>
+                                    {% endif %}
+                                </dl>
+                            </a>
+                        </li>
+                    {% endfor %}
+                </ul>
+            </section>
         {% endfor %}
     </div>
 {% endmacro %}

--- a/server/views/match/placementRequests/occupancyView/partials/_occupancyCalendar.njk
+++ b/server/views/match/placementRequests/occupancyView/partials/_occupancyCalendar.njk
@@ -6,14 +6,14 @@
 
                 <ul class="calendar__month govuk-list">
                     {% for day in month.days %}
-                        <li class="calendar__day calendar__day--{{ day.name.slice(0,3) | lower }}{% if day.bookableCount <= 0 %} {{ 'govuk-tag--yellow' if day.criteriaBookableCount > 0 else 'govuk-tag--red' }}{% endif %}">
+                        <li class="calendar__day calendar__day--{{ day.name.slice(0,3) | lower }}{% if day.status !== 'available' %} {{ 'govuk-tag--yellow' if day.status === 'availableForCriteria' else 'govuk-tag--red' }}{% endif %}">
                             <a class="calendar__link" href="#">
                                 <time class="calendar__date" datetime="{{ day.date }}">{{ day.name }}</time>
 
                                 <dl class="calendar__availability">
                                     <dt class="govuk-visually-hidden">Availability:</dt>
 
-                                    {% if day.bookableCount > 0 %}
+                                    {% if day.status === 'available' %}
                                         <dd>Available</dd>
                                     {% else %}
                                         {% if day.criteriaBookableCount is defined %}

--- a/server/views/match/placementRequests/occupancyView/partials/_occupancySummary.njk
+++ b/server/views/match/placementRequests/occupancyView/partials/_occupancySummary.njk
@@ -1,0 +1,38 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{% macro dateRangeList(ranges) %}
+    <ul>
+        {% for range in ranges %}
+            <li>
+                {{ formatDate(range.from) }}
+                {% if range.to %} to {{ formatDate(range.to) }}{% endif %}
+                <strong>({{ formatDuration(range.duration) }})</strong>
+            </li>
+        {% endfor %}
+    </ul>
+{% endmacro %}
+
+{% macro occupancySummary(summary) %}
+    {% set bannerHtml %}
+        {% if summary.overbooked is not defined %}
+            <p class="govuk-heading-m">The placement dates you have selected are available.</p>
+        {% endif %}
+
+        {% if summary.available is not defined %}
+            <p class="govuk-heading-m">There are no spaces available for the dates you have selected.</p>
+        {% endif %}
+
+        {% if summary.available and summary.overbooked %}
+            <h3 class="govuk-heading-m">Available on:</h3>
+            {{ dateRangeList(summary.available) }}
+
+            <h3 class="govuk-heading-m">Overbooked on:</h3>
+            {{ dateRangeList(summary.overbooked) }}
+        {% endif %}
+    {% endset %}
+
+    {{ govukNotificationBanner({
+        html: bannerHtml,
+        classes: 'govuk-notification-banner--full-width-content'
+    }) }}
+{% endmacro %}

--- a/server/views/match/placementRequests/occupancyView/view.njk
+++ b/server/views/match/placementRequests/occupancyView/view.njk
@@ -137,6 +137,7 @@
                 <input type="hidden" name="apType" value="{{ apType }}" />
                 <input type="hidden" name="startDate" value="{{ startDate }}" />
                 <input type="hidden" name="durationDays" value="{{ durationDays }}" />
+                <input type="hidden" name="criteria" value="{{ criteria }}" />
 
                 {{ govukDateInput({
                     id: "arrivalDate",

--- a/server/views/match/placementRequests/occupancyView/view.njk
+++ b/server/views/match/placementRequests/occupancyView/view.njk
@@ -1,5 +1,7 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
@@ -42,6 +44,45 @@
     }) }}
 
     <section>
+        <div class="search-and-filter__wrapper">
+            <form action="{{ paths.v2Match.placementRequests.spaceBookings.viewSpaces({ id: placementRequest.id }) }}"
+                  method="get">
+                <h2 class="govuk-heading-m">Filters</h2>
+
+                <input type="hidden" name="premisesId" value="{{ premisesId }}">
+                <input type="hidden" name="premisesName" value="{{ premisesName }}">
+                <input type="hidden" name="apType" value="{{ apType }}">
+
+                {{ govukDateInput({
+                    id: "startDate",
+                    namePrefix: "startDate",
+                    fieldset: {
+                        legend: {
+                            text: "Availability start date",
+                            classes: "govuk-fieldset__legend--s"
+                        }
+                    },
+                    items: dateFieldValues('startDate', errors)
+                }) }}
+
+                {{ govukSelect({
+                    id: 'durationDays',
+                    name: 'durationDays',
+                    label: {
+                        text: 'Length of availability',
+                        classes: 'govuk-label--s'
+                    },
+                    items: durationOptions
+                }) }}
+
+                {{ govukButton({
+                    text: 'Apply filters',
+                    classes: 'govuk-!-margin-bottom-0',
+                    preventDoubleClick: true
+                }) }}
+            </form>
+        </div>
+
         <h2 class="govuk-heading-l">View availability and book your placement
             for {{ formatDuration(durationDays) }}
             from {{ formatDate(startDate, { format: 'short' }) }}</h2>

--- a/server/views/match/placementRequests/occupancyView/view.njk
+++ b/server/views/match/placementRequests/occupancyView/view.njk
@@ -187,13 +187,11 @@
             <h3 class="govuk-heading-m">If you are not booking this placement</h3>
             <p class="govuk-body">
                 <a href="{{ paths.v2Match.placementRequests.search.spaces({ id: placementRequest.id }) }}">Check for a
-                    space
-                    at another AP</a>
+                    space at another AP</a>
             </p>
             <p class="govuk-body">
                 <a href="{{ paths.placementRequests.bookingNotMade.confirm({id: placementRequest.id}) }}">Mark as unable
-                    to
-                    match</a>
+                    to match</a>
             </p>
         </section>
     {% endif %}

--- a/server/views/match/placementRequests/occupancyView/view.njk
+++ b/server/views/match/placementRequests/occupancyView/view.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
@@ -75,12 +76,27 @@
                         },
                         items: durationOptions
                     }) }}
+                </div>
 
+                <div class="search-and-filter__row">
+                    {{ govukCheckboxes({
+                        name: "criteria",
+                        classes: "govuk-checkboxes--small govuk-checkboxes--inline",
+                        fieldset: {
+                            legend: {
+                                text: "Select following criteria",
+                                classes: "govuk-fieldset__legend--s"
+                            }
+                        },
+                        items: criteriaOptions
+                    }) }}
+                </div>
+
+                <div class="search-and-filter__row">
                     {{ govukButton({
                         text: 'Apply filters',
                         preventDoubleClick: true
                     }) }}
-
                 </div>
             </form>
         </div>
@@ -100,6 +116,9 @@
             <ul class="calendar__month govuk-list">
                 <li class="calendar__day">
                     Available
+                </li>
+                <li class="calendar__day govuk-tag--yellow">
+                    Available for your criteria
                 </li>
                 <li class="calendar__day govuk-tag--red">
                     Full or overbooked

--- a/server/views/match/placementRequests/occupancyView/view.njk
+++ b/server/views/match/placementRequests/occupancyView/view.njk
@@ -45,10 +45,13 @@
     }) }}
 
     <section>
+        <h2 class="govuk-heading-l">View availability for {{ formatDuration(durationDays) }}
+            from {{ formatDate(startDate, { format: 'short' }) }}</h2>
+
         <div class="search-and-filter">
             <form action="{{ paths.v2Match.placementRequests.spaceBookings.viewSpaces({ id: placementRequest.id }) }}"
                   method="get">
-                <h2 class="govuk-heading-m">Filters</h2>
+                <h3 class="govuk-heading-m">Filters</h3>
 
                 <input type="hidden" name="premisesId" value="{{ premisesId }}">
                 <input type="hidden" name="premisesName" value="{{ premisesName }}">
@@ -100,10 +103,6 @@
                 </div>
             </form>
         </div>
-
-        <h2 class="govuk-heading-l">View availability and book your placement
-            for {{ formatDuration(durationDays) }}
-            from {{ formatDate(startDate, { format: 'short' }) }}</h2>
 
         {{ govukNotificationBanner({
             html: occupancySummaryHtml,

--- a/server/views/match/placementRequests/occupancyView/view.njk
+++ b/server/views/match/placementRequests/occupancyView/view.njk
@@ -1,3 +1,4 @@
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
@@ -22,16 +23,10 @@
     }) }}
 {% endblock %}
 
-{% block extraScripts %}
-    {# TODO: useful for debugging, remove once page complete! #}
-    <script type="text/javascript" nonce="{{ cspNonce }}">
-      console.log(JSON.parse('{{ calendar | dump | safe }}'))
-    </script>
-{% endblock %}
-
 {% block content %}
-    <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
     {{ showErrorSummary(errorSummary) }}
+
+    <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
     {% set detailsHTML %}
         {{ govukSummaryList({
@@ -47,15 +42,13 @@
 
     <section>
         <h2 class="govuk-heading-l">View availability for {{ formatDuration(durationDays) }}
-            from {{ formatDate(startDate, { format: 'short' }) }}</h2>
+            {% if startDate %}from {{ formatDate(startDate, { format: 'short' }) }}{% endif %}</h2>
 
         <div class="search-and-filter">
             <form action="{{ paths.v2Match.placementRequests.search.occupancy({ id: placementRequest.id, premisesId: premises.id }) }}"
                   method="get">
                 <h3 class="govuk-heading-m">Filters</h3>
 
-                <input type="hidden" name="premisesId" value="{{ premisesId }}">
-                <input type="hidden" name="premisesName" value="{{ premisesName }}">
                 <input type="hidden" name="apType" value="{{ apType }}">
 
                 <div class="search-and-filter__row">
@@ -68,7 +61,8 @@
                                 classes: "govuk-fieldset__legend--s"
                             }
                         },
-                        items: dateFieldValues('startDate', errors)
+                        items: dateFieldValues('startDate', errors),
+                        errorMessage: errors.startDate
                     }) }}
 
                     {{ govukSelect({
@@ -105,94 +99,101 @@
             </form>
         </div>
 
-        {{ occupancySummary(summary) }}
+        {% if not errors.startDate %}
 
-        <section id="calendar-key">
-            <h3 class="govuk-heading-m">Key</h3>
+            {{ occupancySummary(summary) }}
 
-            <ul class="calendar__month govuk-list">
-                <li class="calendar__day">
-                    Available
-                </li>
-                <li class="calendar__day govuk-tag--yellow">
-                    Available for your criteria
-                </li>
-                <li class="calendar__day govuk-tag--red">
-                    Full or overbooked
-                </li>
-            </ul>
-        </section>
+            <section id="calendar-key">
+                <h3 class="govuk-heading-m">Key</h3>
 
-        <section aria-describedby="calendar-key">
-            {{ occupancyCalendar(calendar) }}
-        </section>
+                <ul class="calendar__month govuk-list">
+                    <li class="calendar__day">
+                        Available
+                    </li>
+                    <li class="calendar__day govuk-tag--yellow">
+                        Available for your criteria
+                    </li>
+                    <li class="calendar__day govuk-tag--red">
+                        Full or overbooked
+                    </li>
+                </ul>
+            </section>
+
+            <section aria-describedby="calendar-key">
+                {{ occupancyCalendar(calendar) }}
+            </section>
+        {% endif %}
     </section>
 
-    <section>
-        <h2 class="govuk-heading-l">Book your placement</h2>
+    {% if not errors.startDate %}
+        <section>
+            <h2 class="govuk-heading-l">Book your placement</h2>
 
-        <form action="{{ paths.v2Match.placementRequests.search.occupancy({ id: placementRequest.id, premisesId: premises.id }) }}"
-              method="post">
-            <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-            <input type="hidden" name="premisesId" value="{{ premises.id }}" />
-            <input type="hidden" name="premisesName" value="{{ premises.name }}" />
-            <input type="hidden" name="apType" value="{{ apType }}" />
-            <input type="hidden" name="startDate" value="{{ startDate }}" />
-            <input type="hidden" name="durationDays" value="{{ durationDays }}" />
+            <form action="{{ paths.v2Match.placementRequests.search.occupancy({ id: placementRequest.id, premisesId: premises.id }) }}"
+                  method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+                <input type="hidden" name="premisesId" value="{{ premises.id }}" />
+                <input type="hidden" name="premisesName" value="{{ premises.name }}" />
+                <input type="hidden" name="apType" value="{{ apType }}" />
+                <input type="hidden" name="startDate" value="{{ startDate }}" />
+                <input type="hidden" name="durationDays" value="{{ durationDays }}" />
 
-            {{ govukDateInput({
-                id: "arrivalDate",
-                namePrefix: "arrivalDate",
-                fieldset: {
-                    legend: {
-                        text: "Arrival date",
-                        classes: "govuk-fieldset__legend--m"
-                    }
-                },
-                hint: {
-                    text: "For example, 17 5 2024"
-                },
-                items: dateFieldValues('arrivalDate', errors),
-                errorMessage: errors.arrivalDate
-            }) }}
-
-            {{ govukDateInput({
-                id: "departureDate",
-                namePrefix: "departureDate",
-                fieldset: {
-                    legend: {
-                        text: "Departure date",
-                        classes: "govuk-fieldset__legend--m"
-                    }
-                },
-                hint: {
-                    text: "For example, 17 5 2024"
-                },
-                items: dateFieldValues('departureDate', errors),
-                errorMessage: errors.departureDate
-            }) }}
-
-            <div class="govuk-button-group">
-                {{ govukButton({
-                    text: "Continue",
-                    preventDoubleClick: true
+                {{ govukDateInput({
+                    id: "arrivalDate",
+                    namePrefix: "arrivalDate",
+                    fieldset: {
+                        legend: {
+                            text: "Arrival date",
+                            classes: "govuk-fieldset__legend--m"
+                        }
+                    },
+                    hint: {
+                        text: "For example, 17 5 2024"
+                    },
+                    items: dateFieldValues('arrivalDate', errors),
+                    errorMessage: errors.arrivalDate
                 }) }}
-                {{ govukButton({
-                    text: "Cancel",
-                    classes: "govuk-button--secondary",
-                    href: paths.v2Match.placementRequests.search.spaces({ id: placementRequest.id }),
-                    preventDoubleClick: true
+
+                {{ govukDateInput({
+                    id: "departureDate",
+                    namePrefix: "departureDate",
+                    fieldset: {
+                        legend: {
+                            text: "Departure date",
+                            classes: "govuk-fieldset__legend--m"
+                        }
+                    },
+                    hint: {
+                        text: "For example, 17 5 2024"
+                    },
+                    items: dateFieldValues('departureDate', errors),
+                    errorMessage: errors.departureDate
                 }) }}
-            </div>
-        </form>
-        <h3 class="govuk-heading-m">If you are not booking this placement</h3>
-        <p class="govuk-body">
-            <a href="{{ paths.v2Match.placementRequests.search.spaces({ id: placementRequest.id }) }}">Check for a space
-                at another AP</a>
-        </p>
-        <p class="govuk-body">
-            <a href="{{ paths.placementRequests.bookingNotMade.confirm({id: placementRequest.id}) }}">Mark as unable to
-                match</a>
-        </p>
-    </section>
+
+                <div class="govuk-button-group">
+                    {{ govukButton({
+                        text: "Continue",
+                        preventDoubleClick: true
+                    }) }}
+                    {{ govukButton({
+                        text: "Cancel",
+                        classes: "govuk-button--secondary",
+                        href: paths.v2Match.placementRequests.search.spaces({ id: placementRequest.id }),
+                        preventDoubleClick: true
+                    }) }}
+                </div>
+            </form>
+            <h3 class="govuk-heading-m">If you are not booking this placement</h3>
+            <p class="govuk-body">
+                <a href="{{ paths.v2Match.placementRequests.search.spaces({ id: placementRequest.id }) }}">Check for a
+                    space
+                    at another AP</a>
+            </p>
+            <p class="govuk-body">
+                <a href="{{ paths.placementRequests.bookingNotMade.confirm({id: placementRequest.id}) }}">Mark as unable
+                    to
+                    match</a>
+            </p>
+        </section>
+    {% endif %}
 {% endblock %}

--- a/server/views/match/placementRequests/occupancyView/view.njk
+++ b/server/views/match/placementRequests/occupancyView/view.njk
@@ -50,7 +50,7 @@
             from {{ formatDate(startDate, { format: 'short' }) }}</h2>
 
         <div class="search-and-filter">
-            <form action="{{ paths.v2Match.placementRequests.spaceBookings.viewSpaces({ id: placementRequest.id }) }}"
+            <form action="{{ paths.v2Match.placementRequests.search.occupancy({ id: placementRequest.id, premisesId: premises.id }) }}"
                   method="get">
                 <h3 class="govuk-heading-m">Filters</h3>
 
@@ -131,10 +131,11 @@
     <section>
         <h2 class="govuk-heading-l">Book your placement</h2>
 
-        <form action="{{ paths.v2Match.placementRequests.spaceBookings.viewSpaces({ id: placementRequest.id }) }}" method="post">
+        <form action="{{ paths.v2Match.placementRequests.search.occupancy({ id: placementRequest.id, premisesId: premises.id }) }}"
+              method="post">
             <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-            <input type="hidden" name="premisesId" value="{{ premisesId }}" />
-            <input type="hidden" name="premisesName" value="{{ premisesName }}" />
+            <input type="hidden" name="premisesId" value="{{ premises.id }}" />
+            <input type="hidden" name="premisesName" value="{{ premises.name }}" />
             <input type="hidden" name="apType" value="{{ apType }}" />
             <input type="hidden" name="startDate" value="{{ startDate }}" />
             <input type="hidden" name="durationDays" value="{{ durationDays }}" />
@@ -186,10 +187,12 @@
         </form>
         <h3 class="govuk-heading-m">If you are not booking this placement</h3>
         <p class="govuk-body">
-            <a href="{{ paths.v2Match.placementRequests.search.spaces({ id: placementRequest.id }) }}">Check for a space at another AP</a>
+            <a href="{{ paths.v2Match.placementRequests.search.spaces({ id: placementRequest.id }) }}">Check for a space
+                at another AP</a>
         </p>
         <p class="govuk-body">
-            <a href="{{ paths.placementRequests.bookingNotMade.confirm({id: placementRequest.id}) }}">Mark as unable to match</a>
+            <a href="{{ paths.placementRequests.bookingNotMade.confirm({id: placementRequest.id}) }}">Mark as unable to
+                match</a>
         </p>
     </section>
 {% endblock %}

--- a/server/views/match/placementRequests/occupancyView/view.njk
+++ b/server/views/match/placementRequests/occupancyView/view.njk
@@ -7,6 +7,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "./partials/_occupancySummary.njk" import occupancySummary %}
 {% from "./partials/_occupancyCalendar.njk" import occupancyCalendar %}
 {% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
 
@@ -104,10 +105,7 @@
             </form>
         </div>
 
-        {{ govukNotificationBanner({
-            html: occupancySummaryHtml,
-            classes: 'govuk-notification-banner--full-width-content'
-        }) }}
+        {{ occupancySummary(summary) }}
 
         <section id="calendar-key">
             <h3 class="govuk-heading-m">Key</h3>
@@ -124,7 +122,6 @@
                 </li>
             </ul>
         </section>
-
 
         <section aria-describedby="calendar-key">
             {{ occupancyCalendar(calendar) }}

--- a/server/views/match/placementRequests/occupancyView/view.njk
+++ b/server/views/match/placementRequests/occupancyView/view.njk
@@ -44,7 +44,7 @@
     }) }}
 
     <section>
-        <div class="search-and-filter__wrapper">
+        <div class="search-and-filter">
             <form action="{{ paths.v2Match.placementRequests.spaceBookings.viewSpaces({ id: placementRequest.id }) }}"
                   method="get">
                 <h2 class="govuk-heading-m">Filters</h2>
@@ -53,33 +53,35 @@
                 <input type="hidden" name="premisesName" value="{{ premisesName }}">
                 <input type="hidden" name="apType" value="{{ apType }}">
 
-                {{ govukDateInput({
-                    id: "startDate",
-                    namePrefix: "startDate",
-                    fieldset: {
-                        legend: {
-                            text: "Availability start date",
-                            classes: "govuk-fieldset__legend--s"
-                        }
-                    },
-                    items: dateFieldValues('startDate', errors)
-                }) }}
+                <div class="search-and-filter__row">
+                    {{ govukDateInput({
+                        id: "startDate",
+                        namePrefix: "startDate",
+                        fieldset: {
+                            legend: {
+                                text: "Availability start date",
+                                classes: "govuk-fieldset__legend--s"
+                            }
+                        },
+                        items: dateFieldValues('startDate', errors)
+                    }) }}
 
-                {{ govukSelect({
-                    id: 'durationDays',
-                    name: 'durationDays',
-                    label: {
-                        text: 'Length of availability',
-                        classes: 'govuk-label--s'
-                    },
-                    items: durationOptions
-                }) }}
+                    {{ govukSelect({
+                        id: 'durationDays',
+                        name: 'durationDays',
+                        label: {
+                            text: 'Length of availability',
+                            classes: 'govuk-label--s'
+                        },
+                        items: durationOptions
+                    }) }}
 
-                {{ govukButton({
-                    text: 'Apply filters',
-                    classes: 'govuk-!-margin-bottom-0',
-                    preventDoubleClick: true
-                }) }}
+                    {{ govukButton({
+                        text: 'Apply filters',
+                        preventDoubleClick: true
+                    }) }}
+
+                </div>
             </form>
         </div>
 

--- a/server/views/match/placementRequests/spaceBookings/new.njk
+++ b/server/views/match/placementRequests/spaceBookings/new.njk
@@ -10,7 +10,7 @@
 {% block beforeContent %}
     {{ govukBackLink({
         text: "Back",
-        href: MatchUtils.occupancyViewLink({placementRequestId: placementRequest.id, premisesName: premisesName, premisesId: premisesId, apType: apType, startDate: startDate, durationDays: durationDays})
+        href: MatchUtils.occupancyViewLink({ placementRequestId: placementRequest.id, premisesName: premisesName, premisesId: premisesId, apType: apType })
     }) }}
 {% endblock %}
 

--- a/server/views/match/placementRequests/spaceBookings/new.njk
+++ b/server/views/match/placementRequests/spaceBookings/new.njk
@@ -10,7 +10,7 @@
 {% block beforeContent %}
     {{ govukBackLink({
         text: "Back",
-        href: MatchUtils.occupancyViewLink({ placementRequestId: placementRequest.id, premisesName: premisesName, premisesId: premisesId, apType: apType })
+        href: MatchUtils.occupancyViewLink({ placementRequestId: placementRequest.id, premisesId: premisesId, apType: apType })
     }) }}
 {% endblock %}
 

--- a/server/views/match/search.njk
+++ b/server/views/match/search.njk
@@ -145,7 +145,6 @@
                                     items: [{
                                         href: MatchUtils.occupancyViewLink({
                                             placementRequestId: placementRequest.id,
-                                            premisesName: spaceSearchResult.premises.name,
                                             premisesId: spaceSearchResult.premises.id,
                                             apType: spaceSearchResult.premises.apType
                                         }),

--- a/server/views/match/search.njk
+++ b/server/views/match/search.njk
@@ -15,158 +15,158 @@
 {% set context = fetchContext() %}
 
 {% block beforeContent %}
-	{{ govukBackLink({
-		text: "Back to dashboard",
-		href: paths.admin.placementRequests.show({id: placementRequest.id})
-	}) }}
+    {{ govukBackLink({
+        text: "Back to dashboard",
+        href: paths.admin.placementRequests.show({id: placementRequest.id})
+    }) }}
 {% endblock %}
 
 {% block content %}
-	<div class="govuk-grid-row">
-		<div class="govuk-width-container">
-			<div class="govuk-grid-column-full">
-				<h1 class="govuk-heading-l">Find a space in an Approved Premises</h1>
-				{% call govukDetails({summaryText: "Matching details", open: true}) %}
-				{{ govukSummaryList({
-					rows: MatchUtils.placementRequestSummaryListForMatching(placementRequest) 
-				})
-				}}
-				{%endcall%}
-			</div>
-		</div>
-		<div class="govuk-grid-row">
-			<div class="govuk-width-container">
-				<div class="govuk-grid-column-full">
-					<h2 class="govuk-heading-m">{{spaceSearchResults.resultsCount}} Approved Premises found</h2>
-				</div>
-			</div>
-		</div>
+<div class="govuk-grid-row">
+    <div class="govuk-width-container">
+        <div class="govuk-grid-column-full">
+            <h1 class="govuk-heading-l">Find a space in an Approved Premises</h1>
+            {% call govukDetails({summaryText: "Matching details", open: true}) %}
+                {{ govukSummaryList({
+                    rows: MatchUtils.placementRequestSummaryListForMatching(placementRequest)
+                }) }}
+            {% endcall %}
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-width-container">
+            <div class="govuk-grid-column-full">
+                <h2 class="govuk-heading-m">{{ spaceSearchResults.resultsCount }} Approved Premises found</h2>
+            </div>
+        </div>
+    </div>
 
-		<div class="govuk-grid-row">
-			<div class="govuk-width-container">
-				<div class="govuk-grid-column-one-third">
-					<form action="{{formPath}}" method="post">
-						<input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-						<input type="hidden" name="durationInDays" value="{{placementRequest.duration}}"/>
+    <div class="govuk-grid-row">
+        <div class="govuk-width-container">
+            <div class="govuk-grid-column-one-third">
+                <form action="{{ formPath }}" method="post">
+                    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+                    <input type="hidden" name="durationInDays" value="{{ placementRequest.duration }}" />
 
-						<div class="moj-filter">
-							<div class="moj-filter__header govuk-!-padding-left-2">
-								<h3 class="govuk-heading-m">Filters</h2>
-							</div>
-							<div class="space-search-inputs">
+                    <div class="moj-filter">
+                        <div class="moj-filter__header govuk-!-padding-left-2">
+                            <h3 class="govuk-heading-m">Filters</h2>
+                        </div>
+                        <div class="space-search-inputs">
 
-								{{ govukDateInput({
-								id: "startDate",
-								namePrefix: "startDate",
-								fieldset: {
-								legend: {
-									text: "Available from",
-									classes: "govuk-fieldset__legend--s"
-									}
-								},
-								items: dateFieldValues('startDate', errors),
-								errorMessage: errors.startDate
-							}) }}
+                            {{ govukDateInput({
+                                id: "startDate",
+                                namePrefix: "startDate",
+                                fieldset: {
+                                    legend: {
+                                        text: "Available from",
+                                        classes: "govuk-fieldset__legend--s"
+                                    }
+                                },
+                                items: dateFieldValues('startDate', errors),
+                                errorMessage: errors.startDate
+                            }) }}
 
-								{{ govukInput({
-								id: "targetPostcodeDistrict",
-								name: "targetPostcodeDistrict",
-								value: targetPostcodeDistrict,
-								label: {
-									text: "Preferred location",
-									classes: "govuk-fieldset__legend--s"
+                            {{ govukInput({
+                                id: "targetPostcodeDistrict",
+                                name: "targetPostcodeDistrict",
+                                value: targetPostcodeDistrict,
+                                label: {
+                                    text: "Preferred location",
+                                    classes: "govuk-fieldset__legend--s"
 
-								},
-								classes: "govuk-input--width-3"
-							}) }}
+                                },
+                                classes: "govuk-input--width-3"
+                            }) }}
 
-								{{ govukRadios({
-									name: "requirements[apType]",
-									classes: "govuk-radios--small",
-									fieldset: {
-										legend: {
-											text: 'AP Type',
-											classes: 'govuk-fieldset__legend--s',
-											isPageHeading: false
-										}
-									},
-									items: MatchUtils.apTypeLabelsForRadioInput(context['requirements']['apType'])
-								}) }}
+                            {{ govukRadios({
+                                name: "requirements[apType]",
+                                classes: "govuk-radios--small",
+                                fieldset: {
+                                    legend: {
+                                        text: 'AP Type',
+                                        classes: 'govuk-fieldset__legend--s',
+                                        isPageHeading: false
+                                    }
+                                },
+                                items: MatchUtils.apTypeLabelsForRadioInput(context['requirements']['apType'])
+                            }) }}
 
-								{% for title, details in MatchUtils.groupedCheckboxes() %}
-									{{
-											govukCheckboxes({
-												name: 'requirements[' + details.inputName + '][]',
-												classes: "govuk-checkboxes--small",
-												fieldset: {
-													legend: {
-														text: title,
-														isPageHeading: false,
-														classes: 'govuk-fieldset__legend--s'
-													}
-												},
-												items: MatchUtils.checkBoxesForCriteria(details.items, context['requirements'][details.inputName])
-											})
-										}}
-								{% endfor %}
+                            {% for title, details in MatchUtils.groupedCheckboxes() %}
+                                {{ govukCheckboxes({
+                                    name: 'requirements[' + details.inputName + '][]',
+                                    classes: "govuk-checkboxes--small",
+                                    fieldset: {
+                                        legend: {
+                                            text: title,
+                                            isPageHeading: false,
+                                            classes: 'govuk-fieldset__legend--s'
+                                        }
+                                    },
+                                    items: MatchUtils.checkBoxesForCriteria(details.items, context['requirements'][details.inputName])
+                                }) }}
+                            {% endfor %}
 
-								{{ govukRadios({
-									name: "requirements[gender]",
-									classes: "govuk-radios--small",
-									value: requirements.gender,
-									fieldset: {
-										legend: {
-											text: 'Gender',
-											classes: 'govuk-fieldset__legend--s',
-											isPageHeading: false
-										}
-									},
-									items: [{value: 'male', text: 'Male' }, {value: 'female', text: 'Female' }]
-								}) }}
+                            {{ govukRadios({
+                                name: "requirements[gender]",
+                                classes: "govuk-radios--small",
+                                value: requirements.gender,
+                                fieldset: {
+                                    legend: {
+                                        text: 'Gender',
+                                        classes: 'govuk-fieldset__legend--s',
+                                        isPageHeading: false
+                                    }
+                                },
+                                items: [{value: 'male', text: 'Male' }, {value: 'female', text: 'Female' }]
+                            }) }}
 
-								<div class="button">
-									{{ govukButton({
-									text: "Update",
-									preventDoubleClick: true
-								}) }}
-								</div>
-							</div>
-						</div>
-					</form>
-				</div>
+                            <div class="button">
+                                {{ govukButton({
+                                    text: "Update",
+                                    preventDoubleClick: true
+                                }) }}
+                            </div>
+                        </div>
+                    </div>
+                </form>
+            </div>
 
-				<div class="govuk-grid-column-two-thirds">
-					<div>
-						{% for spaceSearchResult in spaceSearchResults.results %}
-							{{ govukSummaryList({
-								card: {
-									title: {
-										text: spaceSearchResult.premises.name,
-										headingLevel: 3
-										},
-									actions: {
-										items: [
-											{
-												href: MatchUtils.occupancyViewLink({placementRequestId: placementRequest.id, premisesName: spaceSearchResult.premises.name, premisesId: spaceSearchResult.premises.id, apType: spaceSearchResult.premises.apType, startDate: startDate, durationDays: durationInDays}),
-												text: "View spaces",
-												visuallyHiddenText: "View spaces at " + spaceSearchResult.premises.name
-											}
-										]
-								}
-								},
-								rows: MatchUtils.summaryCardRows(spaceSearchResult, targetPostcodeDistrict)
-							}) }}
-						{% endfor %}
+            <div class="govuk-grid-column-two-thirds">
+                <div>
+                    {% for spaceSearchResult in spaceSearchResults.results %}
+                        {{ govukSummaryList({
+                            card: {
+                                title: {
+                                    text: spaceSearchResult.premises.name,
+                                    headingLevel: 3
+                                },
+                                actions: {
+                                    items: [{
+                                        href: MatchUtils.occupancyViewLink({
+                                            placementRequestId: placementRequest.id,
+                                            premisesName: spaceSearchResult.premises.name,
+                                            premisesId: spaceSearchResult.premises.id,
+                                            apType: spaceSearchResult.premises.apType
+                                        }),
+                                        text: "View spaces",
+                                        visuallyHiddenText: "View spaces at " + spaceSearchResult.premises.name
+                                    }]
+                                }
+                            },
+                            rows: MatchUtils.summaryCardRows(spaceSearchResult, targetPostcodeDistrict)
+                        }) }}
+                    {% endfor %}
 
-						<h3 class="govuk-heading-m">Mark this case as unable to match</h3>
-						<p>If there are no suitable results for your search, mark this case as unable to match.</p>
-						{{ govukButton({
-						text: "Unable to match",
-						href: paths.placementRequests.bookingNotMade.confirm({id: placementRequest.id}),
-						preventDoubleClick: true
-					}) }}
-					</div>
-				</div>
-			</div>
+                    <h3 class="govuk-heading-m">Mark this case as unable to match</h3>
+                    <p>If there are no suitable results for your search, mark this case as unable to match.</p>
+                    {{ govukButton({
+                        text: "Unable to match",
+                        href: paths.placementRequests.bookingNotMade.confirm({id: placementRequest.id}),
+                        preventDoubleClick: true
+                    }) }}
+                </div>
+            </div>
+        </div>
 
-		{% endblock %}
+        {% endblock %}

--- a/server/views/match/search.njk
+++ b/server/views/match/search.njk
@@ -22,150 +22,152 @@
 {% endblock %}
 
 {% block content %}
-<div class="govuk-grid-row">
-    <div class="govuk-width-container">
-        <div class="govuk-grid-column-full">
-            <h1 class="govuk-heading-l">Find a space in an Approved Premises</h1>
-            {% call govukDetails({summaryText: "Matching details", open: true}) %}
-                {{ govukSummaryList({
-                    rows: MatchUtils.placementRequestSummaryListForMatching(placementRequest)
-                }) }}
-            {% endcall %}
-        </div>
-    </div>
     <div class="govuk-grid-row">
         <div class="govuk-width-container">
             <div class="govuk-grid-column-full">
-                <h2 class="govuk-heading-m">{{ spaceSearchResults.resultsCount }} Approved Premises found</h2>
+                <h1 class="govuk-heading-l">Find a space in an Approved Premises</h1>
+                {% call govukDetails({summaryText: "Matching details", open: true}) %}
+                    {{ govukSummaryList({
+                        rows: MatchUtils.placementRequestSummaryListForMatching(placementRequest)
+                    }) }}
+                {% endcall %}
             </div>
         </div>
-    </div>
-
-    <div class="govuk-grid-row">
-        <div class="govuk-width-container">
-            <div class="govuk-grid-column-one-third">
-                <form action="{{ formPath }}" method="post">
-                    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-                    <input type="hidden" name="durationInDays" value="{{ placementRequest.duration }}" />
-
-                    <div class="moj-filter">
-                        <div class="moj-filter__header govuk-!-padding-left-2">
-                            <h3 class="govuk-heading-m">Filters</h2>
-                        </div>
-                        <div class="space-search-inputs">
-
-                            {{ govukDateInput({
-                                id: "startDate",
-                                namePrefix: "startDate",
-                                fieldset: {
-                                    legend: {
-                                        text: "Available from",
-                                        classes: "govuk-fieldset__legend--s"
-                                    }
-                                },
-                                items: dateFieldValues('startDate', errors),
-                                errorMessage: errors.startDate
-                            }) }}
-
-                            {{ govukInput({
-                                id: "targetPostcodeDistrict",
-                                name: "targetPostcodeDistrict",
-                                value: targetPostcodeDistrict,
-                                label: {
-                                    text: "Preferred location",
-                                    classes: "govuk-fieldset__legend--s"
-
-                                },
-                                classes: "govuk-input--width-3"
-                            }) }}
-
-                            {{ govukRadios({
-                                name: "requirements[apType]",
-                                classes: "govuk-radios--small",
-                                fieldset: {
-                                    legend: {
-                                        text: 'AP Type',
-                                        classes: 'govuk-fieldset__legend--s',
-                                        isPageHeading: false
-                                    }
-                                },
-                                items: MatchUtils.apTypeLabelsForRadioInput(context['requirements']['apType'])
-                            }) }}
-
-                            {% for title, details in MatchUtils.groupedCheckboxes() %}
-                                {{ govukCheckboxes({
-                                    name: 'requirements[' + details.inputName + '][]',
-                                    classes: "govuk-checkboxes--small",
-                                    fieldset: {
-                                        legend: {
-                                            text: title,
-                                            isPageHeading: false,
-                                            classes: 'govuk-fieldset__legend--s'
-                                        }
-                                    },
-                                    items: MatchUtils.checkBoxesForCriteria(details.items, context['requirements'][details.inputName])
-                                }) }}
-                            {% endfor %}
-
-                            {{ govukRadios({
-                                name: "requirements[gender]",
-                                classes: "govuk-radios--small",
-                                value: requirements.gender,
-                                fieldset: {
-                                    legend: {
-                                        text: 'Gender',
-                                        classes: 'govuk-fieldset__legend--s',
-                                        isPageHeading: false
-                                    }
-                                },
-                                items: [{value: 'male', text: 'Male' }, {value: 'female', text: 'Female' }]
-                            }) }}
-
-                            <div class="button">
-                                {{ govukButton({
-                                    text: "Update",
-                                    preventDoubleClick: true
-                                }) }}
-                            </div>
-                        </div>
-                    </div>
-                </form>
-            </div>
-
-            <div class="govuk-grid-column-two-thirds">
-                <div>
-                    {% for spaceSearchResult in spaceSearchResults.results %}
-                        {{ govukSummaryList({
-                            card: {
-                                title: {
-                                    text: spaceSearchResult.premises.name,
-                                    headingLevel: 3
-                                },
-                                actions: {
-                                    items: [{
-                                        href: MatchUtils.occupancyViewLink({
-                                            placementRequestId: placementRequest.id,
-                                            premisesId: spaceSearchResult.premises.id,
-                                            apType: spaceSearchResult.premises.apType
-                                        }),
-                                        text: "View spaces",
-                                        visuallyHiddenText: "View spaces at " + spaceSearchResult.premises.name
-                                    }]
-                                }
-                            },
-                            rows: MatchUtils.summaryCardRows(spaceSearchResult, targetPostcodeDistrict)
-                        }) }}
-                    {% endfor %}
-
-                    <h3 class="govuk-heading-m">Mark this case as unable to match</h3>
-                    <p>If there are no suitable results for your search, mark this case as unable to match.</p>
-                    {{ govukButton({
-                        text: "Unable to match",
-                        href: paths.placementRequests.bookingNotMade.confirm({id: placementRequest.id}),
-                        preventDoubleClick: true
-                    }) }}
+        <div class="govuk-grid-row">
+            <div class="govuk-width-container">
+                <div class="govuk-grid-column-full">
+                    <h2 class="govuk-heading-m">{{ spaceSearchResults.resultsCount }} Approved Premises found</h2>
                 </div>
             </div>
         </div>
 
-        {% endblock %}
+        <div class="govuk-grid-row">
+            <div class="govuk-width-container">
+                <div class="govuk-grid-column-one-third">
+                    <form action="{{ formPath }}" method="post">
+                        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+                        <input type="hidden" name="durationInDays" value="{{ placementRequest.duration }}" />
+
+                        <div class="moj-filter">
+                            <div class="moj-filter__header govuk-!-padding-left-2">
+                                <h3 class="govuk-heading-m">Filters</h3>
+                            </div>
+                            <div class="space-search-inputs">
+
+                                {{ govukDateInput({
+                                    id: "startDate",
+                                    namePrefix: "startDate",
+                                    fieldset: {
+                                        legend: {
+                                            text: "Available from",
+                                            classes: "govuk-fieldset__legend--s"
+                                        }
+                                    },
+                                    items: dateFieldValues('startDate', errors),
+                                    errorMessage: errors.startDate
+                                }) }}
+
+                                {{ govukInput({
+                                    id: "targetPostcodeDistrict",
+                                    name: "targetPostcodeDistrict",
+                                    value: targetPostcodeDistrict,
+                                    label: {
+                                        text: "Preferred location",
+                                        classes: "govuk-fieldset__legend--s"
+
+                                    },
+                                    classes: "govuk-input--width-3"
+                                }) }}
+
+                                {{ govukRadios({
+                                    name: "requirements[apType]",
+                                    classes: "govuk-radios--small",
+                                    fieldset: {
+                                        legend: {
+                                            text: 'AP Type',
+                                            classes: 'govuk-fieldset__legend--s',
+                                            isPageHeading: false
+                                        }
+                                    },
+                                    items: MatchUtils.apTypeLabelsForRadioInput(context['requirements']['apType'])
+                                }) }}
+
+                                {% for title, details in MatchUtils.groupedCheckboxes() %}
+                                    {{ govukCheckboxes({
+                                        name: 'requirements[' + details.inputName + '][]',
+                                        classes: "govuk-checkboxes--small",
+                                        fieldset: {
+                                            legend: {
+                                                text: title,
+                                                isPageHeading: false,
+                                                classes: 'govuk-fieldset__legend--s'
+                                            }
+                                        },
+                                        items: MatchUtils.checkBoxesForCriteria(details.items, context['requirements'][details.inputName])
+                                    }) }}
+                                {% endfor %}
+
+                                {{ govukRadios({
+                                    name: "requirements[gender]",
+                                    classes: "govuk-radios--small",
+                                    value: requirements.gender,
+                                    fieldset: {
+                                        legend: {
+                                            text: 'Gender',
+                                            classes: 'govuk-fieldset__legend--s',
+                                            isPageHeading: false
+                                        }
+                                    },
+                                    items: [{value: 'male', text: 'Male' }, {value: 'female', text: 'Female' }]
+                                }) }}
+
+                                <div class="button">
+                                    {{ govukButton({
+                                        text: "Update",
+                                        preventDoubleClick: true
+                                    }) }}
+                                </div>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+
+                <div class="govuk-grid-column-two-thirds">
+                    <div>
+                        {% for spaceSearchResult in spaceSearchResults.results %}
+                            {{ govukSummaryList({
+                                card: {
+                                    title: {
+                                        text: spaceSearchResult.premises.name,
+                                        headingLevel: 3
+                                    },
+                                    actions: {
+                                        items: [{
+                                            href: MatchUtils.occupancyViewLink({
+                                                placementRequestId: placementRequest.id,
+                                                premisesId: spaceSearchResult.premises.id,
+                                                apType: context.requirements.apType,
+                                                spaceCharacteristics: context.requirements.spaceCharacteristics
+                                            }),
+                                            text: "View spaces",
+                                            visuallyHiddenText: "View spaces at " + spaceSearchResult.premises.name
+                                        }]
+                                    }
+                                },
+                                rows: MatchUtils.summaryCardRows(spaceSearchResult, targetPostcodeDistrict)
+                            }) }}
+                        {% endfor %}
+
+                        <h3 class="govuk-heading-m">Mark this case as unable to match</h3>
+                        <p>If there are no suitable results for your search, mark this case as unable to match.</p>
+                        {{ govukButton({
+                            text: "Unable to match",
+                            href: paths.placementRequests.bookingNotMade.confirm({id: placementRequest.id}),
+                            preventDoubleClick: true
+                        }) }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/server/views/tasks/_filters.njk
+++ b/server/views/tasks/_filters.njk
@@ -38,61 +38,34 @@
     {{ govukButton({
         "name": "submit",
         "text": "Apply filters",
-        "classes": "search-and-filter__submit",
         preventDoubleClick: true
     }) }}
 {% endset %}
 
-<div class="search-and-filter__wrapper">
-    <form action="{{ paths.tasks.index({}) }}" method="get">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-        <input type="hidden" name="activeTab" value="{{ activeTab }}">
-        <input type="hidden" name="allocatedFilter" value="{{ allocatedFilter }}">
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-one-quarter">
-                <h2 class="govuk-heading-m">Filters</h2>
-            </div>
-        </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <div class="govuk-form-group">
-                    <label class="search-and-filter__crn-label--small" for="crnOrName">
-                        CRN or Name
-                    </label>
-                    <input class="govuk-input moj-search__input" id="crnOrName" name="crnOrName" type="search"
-                           aria-describedby="crn-hint" value="{{ crnOrName }}">
-                </div>
-            </div>
-        </div>
+<form action="{{ paths.tasks.index({}) }}" method="get" class="search-and-filter">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    <input type="hidden" name="activeTab" value="{{ activeTab }}">
+    <input type="hidden" name="allocatedFilter" value="{{ allocatedFilter }}">
+
+    <h2 class="govuk-heading-m">Filters</h2>
+
+    <div class="govuk-form-group">
+        <label class="search-and-filter__crn-label--small" for="crnOrName">
+            CRN or Name
+        </label>
+        <input class="govuk-input moj-search__input" id="crnOrName" name="crnOrName" type="search"
+               aria-describedby="crn-hint" value="{{ crnOrName }}">
+    </div>
+
+    <div class="search-and-filter__row">
+        {{ cruManagementAreaFilter | safe }}
+
         {% if activeTab == 'allocated' or activeTab == 'completed' %}
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-one-third">
-                    {{ cruManagementAreaFilter | safe }}
-                </div>
-                <div class="govuk-grid-column-one-third">
-                    {{ allocatedUserFilter | safe }}
-                </div>
-                <div class="govuk-grid-column-one-third">
-                    {{ qualificationsFilter | safe }}
-                </div>
-            </div>
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-one-third">
-                    {{ submitButton | safe }}
-                </div>
-            </div>
-            {% elif activeTab == 'unallocated' %}
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-one-third">
-                    {{ cruManagementAreaFilter | safe }}
-                </div>
-                <div class="govuk-grid-column-one-third">
-                    {{ qualificationsFilter | safe }}
-                </div>
-                <div class="govuk-grid-column-one-third">
-                    {{ submitButton | safe }}
-                </div>
-            </div>
+            {{ allocatedUserFilter | safe }}
         {% endif %}
-    </form>
-</div>
+
+        {{ qualificationsFilter | safe }}
+
+        {{ submitButton | safe }}
+    </div>
+</form>

--- a/server/views/tasks/show.njk
+++ b/server/views/tasks/show.njk
@@ -28,48 +28,40 @@
         </div>
     </div>
 
-    <div class="search-and-filter__wrapper">
-        <form action="{{ paths.tasks.show(TaskUtils.taskParams(task)) }}" method="get">
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-one-quarter">
-                    <h2 class="govuk-heading-m">Filters</h2>
-                </div>
-            </div>
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-one-quarter">
-                    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-                    {{ govukSelect({
-                        label: {
-                            text: "AP area",
-                            classes: "govuk-label--s"
-                        },
-                        id: "cruManagementAreaId",
-                        name: "cruManagementAreaId",
-                        items: convertObjectsToSelectOptions(cruManagementAreas, 'All areas', 'name', 'id', 'cruManagementAreaId')
-                    }) }}
-                </div>
-                <div class="govuk-grid-column-one-quarter">
-                    {{ govukSelect({
-                        label: {
-                            text: "Qualifications",
-                            classes: "govuk-label--s"
-                        },
-                        id: "qualification",
-                        name: "qualification",
-                        items: UserUtils.userQualificationsSelectOptions(qualification)
-                    }) }}
-                </div>
-                <div class="govuk-grid-column-one-quarter">
-                    {{ govukButton({
-                        "name": "submit",
-                        "text": "Apply filters",
-                        "classes": "search-and-filter__submit",
-                        "preventDoubleClick": true
-                    }) }}
-                </div>
-            </div>
-        </form>
-    </div>
+    <form action="{{ paths.tasks.show(TaskUtils.taskParams(task)) }}" method="get" class="search-and-filter">
+
+        <h2 class="govuk-heading-m">Filters</h2>
+
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+        <div class="search-and-filter__row">
+            {{ govukSelect({
+                label: {
+                    text: "AP area",
+                    classes: "govuk-label--s"
+                },
+                id: "cruManagementAreaId",
+                name: "cruManagementAreaId",
+                items: convertObjectsToSelectOptions(cruManagementAreas, 'All areas', 'name', 'id', 'cruManagementAreaId')
+            }) }}
+
+            {{ govukSelect({
+                label: {
+                    text: "Qualifications",
+                    classes: "govuk-label--s"
+                },
+                id: "qualification",
+                name: "qualification",
+                items: UserUtils.userQualificationsSelectOptions(qualification)
+            }) }}
+
+            {{ govukButton({
+                "name": "submit",
+                "text": "Apply filters",
+                "preventDoubleClick": true
+            }) }}
+        </div>
+    </form>
 
     {{ govukTable({
         attributes: {


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1603

# Changes in this PR

Adds the filters to the occupancy view screen:
- Start date
- Length of availability
- Criteria

Both the occupancy calendar and occupancy summary update based on criteria selected. 

The wording for the heading has been amended to match the section it represents ('Book your placement' is the section below). The heading has also been moved above the form to better reflect page hierarchy.

Includes a refactor of the Occupancy Summary banner to move the rendering to a new macro instead of generating HTML in the utility. 

## Screenshots of UI changes

<details><summary>All screenshots</summary>

### Updated focus style to match designs

<img width="305" alt="Screenshot 2024-12-12 at 12 07 30" src="https://github.com/user-attachments/assets/5a415eaf-f2ee-4bc8-bb2d-a1e90f8acafe" />

---

### Full availability, no criteria selected

<img width="497" alt="Screenshot 2024-12-12 at 11 59 08" src="https://github.com/user-attachments/assets/ce4eed5a-bcc0-4339-9cbe-e2579aeed668" />

---

### Partial availability, no criteria selected

<img width="506" alt="Screenshot 2024-12-12 at 11 53 03" src="https://github.com/user-attachments/assets/feb7aa1b-3e41-43e8-b2ab-4fd0e00be06c" />

---

### No availability, no criteria selected

<img width="502" alt="Screenshot 2024-12-12 at 11 53 37" src="https://github.com/user-attachments/assets/8e385299-0fed-4ded-a259-67c3749d9b2d" />

---

### Full availability for the criteria selected

<img width="499" alt="Screenshot 2024-12-12 at 12 03 19" src="https://github.com/user-attachments/assets/f58a1f00-488d-4bb5-9de8-c88413560255" />

---

### No availability for the criteria selected

<img width="502" alt="Screenshot 2024-12-12 at 11 53 37" src="https://github.com/user-attachments/assets/3eeff972-6c9f-44fd-bd6f-b150eba830b4" />

</details>