### PR TITLE
updates for switch over to auto generated swagger docs

### DIFF
--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -2,14 +2,11 @@ import {
   ActiveOffence,
   Adjudication,
   ApprovedPremisesApplication as Application,
-  ArrayOfOASysOffenceDetailsQuestions,
-  ArrayOfOASysRiskManagementPlanQuestions,
-  ArrayOfOASysRiskOfSeriousHarmSummaryQuestions,
-  ArrayOfOASysRiskToSelfQuestions,
-  ArrayOfOASysSupportingInformationQuestions,
   Document,
   FullPerson,
+  OASysQuestion,
   OASysSection,
+  OASysSupportingInformationQuestion,
   Person,
   PersonAcctAlert,
   PrisonCaseNote,
@@ -63,15 +60,15 @@ export default class ApplyHelper {
 
   otherOasysSections: Array<OASysSection> = []
 
-  roshSummaries: ArrayOfOASysRiskOfSeriousHarmSummaryQuestions = []
+  roshSummaries: Array<OASysQuestion> = []
 
-  offenceDetailSummaries: ArrayOfOASysOffenceDetailsQuestions = []
+  offenceDetailSummaries: Array<OASysQuestion> = []
 
-  supportingInformationSummaries: ArrayOfOASysSupportingInformationQuestions = []
+  supportingInformationSummaries: Array<OASysSupportingInformationQuestion> = []
 
-  riskManagementPlanSummaries: ArrayOfOASysRiskManagementPlanQuestions = []
+  riskManagementPlanSummaries: Array<OASysQuestion> = []
 
-  riskToSelfSummaries: ArrayOfOASysRiskToSelfQuestions = []
+  riskToSelfSummaries: Array<OASysQuestion> = []
 
   selectedPrisonCaseNotes: Array<PrisonCaseNote> = []
 

--- a/integration_tests/helpers/index.ts
+++ b/integration_tests/helpers/index.ts
@@ -1,50 +1,37 @@
 import { add } from 'date-fns'
 import {
-  AnyValue,
   ApprovedPremisesApplication,
   ApprovedPremisesUserPermission,
-  ArrayOfOASysOffenceDetailsQuestions,
-  ArrayOfOASysRiskManagementPlanQuestions,
-  ArrayOfOASysRiskOfSeriousHarmSummaryQuestions,
-  ArrayOfOASysRiskToSelfQuestions,
-  ArrayOfOASysSupportingInformationQuestions,
+  OASysQuestion,
+  OASysSupportingInformationQuestion,
+  Unit,
   ApprovedPremisesUserRole as UserRole,
 } from '@approved-premises/api'
 import { TableCell, TableRow } from '@approved-premises/ui'
 
 import { DateFormats } from '../../server/utils/dateUtils'
 
-const roshSummariesFromApplication = (
-  application: ApprovedPremisesApplication,
-): ArrayOfOASysRiskOfSeriousHarmSummaryQuestions => {
-  return application.data['oasys-import']['rosh-summary'].roshSummaries as ArrayOfOASysRiskOfSeriousHarmSummaryQuestions
+const roshSummariesFromApplication = (application: ApprovedPremisesApplication): Array<OASysQuestion> => {
+  return application.data['oasys-import']['rosh-summary'].roshSummaries as Array<OASysQuestion>
 }
 
-const offenceDetailSummariesFromApplication = (
-  application: ApprovedPremisesApplication,
-): ArrayOfOASysOffenceDetailsQuestions => {
-  return application.data['oasys-import']['offence-details']
-    .offenceDetailsSummaries as ArrayOfOASysOffenceDetailsQuestions
+const offenceDetailSummariesFromApplication = (application: ApprovedPremisesApplication): Array<OASysQuestion> => {
+  return application.data['oasys-import']['offence-details'].offenceDetailsSummaries as Array<OASysQuestion>
 }
 
 const supportInformationFromApplication = (
   application: ApprovedPremisesApplication,
-): ArrayOfOASysSupportingInformationQuestions => {
+): Array<OASysSupportingInformationQuestion> => {
   return application.data['oasys-import']['supporting-information']
-    .supportingInformationSummaries as ArrayOfOASysSupportingInformationQuestions
+    .supportingInformationSummaries as Array<OASysSupportingInformationQuestion>
 }
 
-const riskManagementPlanFromApplication = (
-  application: ApprovedPremisesApplication,
-): ArrayOfOASysRiskManagementPlanQuestions => {
-  return application.data['oasys-import']['risk-management-plan']
-    .riskManagementSummaries as ArrayOfOASysRiskManagementPlanQuestions
+const riskManagementPlanFromApplication = (application: ApprovedPremisesApplication): Array<OASysQuestion> => {
+  return application.data['oasys-import']['risk-management-plan'].riskManagementSummaries as Array<OASysQuestion>
 }
 
-const riskToSelfSummariesFromApplication = (
-  application: ApprovedPremisesApplication,
-): ArrayOfOASysRiskToSelfQuestions => {
-  return application.data['oasys-import']['risk-to-self'].riskToSelfSummaries as ArrayOfOASysRiskToSelfQuestions
+const riskToSelfSummariesFromApplication = (application: ApprovedPremisesApplication): Array<OASysQuestion> => {
+  return application.data['oasys-import']['risk-to-self'].riskToSelfSummaries as Array<OASysQuestion>
 }
 
 const tableRowsToArrays = (tableRows: Array<TableRow>): Array<Array<string>> => {
@@ -78,7 +65,7 @@ const shouldShowTableRows = (tableRows: Array<TableRow>): void => {
   })
 }
 
-const updateApplicationReleaseDate = (data: AnyValue) => {
+const updateApplicationReleaseDate = (data: Unit) => {
   const releaseDate = add(new Date(), { months: 7 })
 
   return {

--- a/integration_tests/pages/apply/offenceDetails.ts
+++ b/integration_tests/pages/apply/offenceDetails.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesApplication, ArrayOfOASysOffenceDetailsQuestions } from '@approved-premises/api'
+import { ApprovedPremisesApplication, OASysQuestion } from '@approved-premises/api'
 import paths from '../../../server/paths/apply'
 
 import ApplyPage from './applyPage'
@@ -6,7 +6,7 @@ import ApplyPage from './applyPage'
 export default class OffenceDetails extends ApplyPage {
   constructor(
     application: ApprovedPremisesApplication,
-    private readonly offenceDetailSummaries: ArrayOfOASysOffenceDetailsQuestions,
+    private readonly offenceDetailSummaries: Array<OASysQuestion>,
     private readonly oasysMissing: boolean,
   ) {
     const title = oasysMissing ? 'Provide risk information' : 'Offence details'

--- a/integration_tests/pages/apply/riskManagementPlan.ts
+++ b/integration_tests/pages/apply/riskManagementPlan.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesApplication, ArrayOfOASysRiskManagementPlanQuestions } from '@approved-premises/api'
+import { ApprovedPremisesApplication, OASysQuestion } from '@approved-premises/api'
 import paths from '../../../server/paths/apply'
 
 import ApplyPage from './applyPage'
@@ -6,7 +6,7 @@ import ApplyPage from './applyPage'
 export default class RiskManagementPlan extends ApplyPage {
   constructor(
     application: ApprovedPremisesApplication,
-    private readonly riskRiskManagementPlanSummaries: ArrayOfOASysRiskManagementPlanQuestions,
+    private readonly riskRiskManagementPlanSummaries: Array<OASysQuestion>,
     private readonly oasysMissing: boolean,
   ) {
     const title = oasysMissing ? 'Provide risk information' : 'Risk management plan'

--- a/integration_tests/pages/apply/riskToSelf.ts
+++ b/integration_tests/pages/apply/riskToSelf.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesApplication, ArrayOfOASysRiskToSelfQuestions } from '@approved-premises/api'
+import { ApprovedPremisesApplication, OASysQuestion } from '@approved-premises/api'
 import paths from '../../../server/paths/apply'
 
 import ApplyPage from './applyPage'
@@ -6,7 +6,7 @@ import ApplyPage from './applyPage'
 export default class RiskToSelf extends ApplyPage {
   constructor(
     application: ApprovedPremisesApplication,
-    private readonly riskToSelfummaries: ArrayOfOASysRiskToSelfQuestions,
+    private readonly riskToSelfummaries: Array<OASysQuestion>,
     private readonly oasysMissing: boolean,
   ) {
     const title = oasysMissing ? 'Provide risk information' : 'Risk to self'

--- a/integration_tests/pages/apply/roshSummary.ts
+++ b/integration_tests/pages/apply/roshSummary.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesApplication, ArrayOfOASysRiskOfSeriousHarmSummaryQuestions } from '@approved-premises/api'
+import { ApprovedPremisesApplication, OASysQuestion } from '@approved-premises/api'
 import paths from '../../../server/paths/apply'
 
 import ApplyPage from './applyPage'
@@ -6,7 +6,7 @@ import ApplyPage from './applyPage'
 export default class RoshSummary extends ApplyPage {
   constructor(
     application: ApprovedPremisesApplication,
-    private readonly roshSummary: ArrayOfOASysRiskOfSeriousHarmSummaryQuestions,
+    private readonly roshSummary: Array<OASysQuestion>,
     private readonly oasysMissing: boolean,
   ) {
     const title = oasysMissing ? 'Provide risk information' : 'RoSH summary'

--- a/integration_tests/pages/apply/supportingInformation.ts
+++ b/integration_tests/pages/apply/supportingInformation.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesApplication, ArrayOfOASysSupportingInformationQuestions } from '@approved-premises/api'
+import { ApprovedPremisesApplication, OASysSupportingInformationQuestion } from '@approved-premises/api'
 import paths from '../../../server/paths/apply'
 
 import ApplyPage from './applyPage'
@@ -6,7 +6,7 @@ import ApplyPage from './applyPage'
 export default class SupportingInformation extends ApplyPage {
   constructor(
     application: ApprovedPremisesApplication,
-    private readonly supportingInformationSummaries: ArrayOfOASysSupportingInformationQuestions,
+    private readonly supportingInformationSummaries: Array<OASysSupportingInformationQuestion>,
     private readonly oasysMissing: boolean,
   ) {
     const title = oasysMissing ? 'Provide risk information' : 'Supporting information'

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -7,11 +7,6 @@ import {
   ApprovedPremisesAssessment,
   ApprovedPremisesUserPermission,
   ApprovedPremisesUserRole,
-  ArrayOfOASysOffenceDetailsQuestions,
-  ArrayOfOASysRiskManagementPlanQuestions,
-  ArrayOfOASysRiskOfSeriousHarmSummaryQuestions,
-  ArrayOfOASysRiskToSelfQuestions,
-  ArrayOfOASysSupportingInformationQuestions,
   ApprovedPremisesAssessmentSummary as AssessmentSummary,
   AssessmentTask,
   Cas1CruManagementArea,
@@ -331,12 +326,7 @@ export type GroupedMatchTasks = Record<PlacementRequestStatus, Array<PlacementRe
   placementApplications: Array<PlacementApplicationTask>
 }
 
-export type OasysImportArrays =
-  | ArrayOfOASysOffenceDetailsQuestions
-  | ArrayOfOASysRiskOfSeriousHarmSummaryQuestions
-  | ArrayOfOASysSupportingInformationQuestions
-  | ArrayOfOASysRiskToSelfQuestions
-  | ArrayOfOASysRiskManagementPlanQuestions
+export type OasysImportArrays = Array<OASysQuestion> | Array<OASysSupportingInformationQuestion>
 
 export type OasysSummariesSection = { [index: string]: OasysImportArrays }
 

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.ts
@@ -1,13 +1,13 @@
 import type { DataServices, OasysPage, PersonRisksUI } from '@approved-premises/ui'
 
-import type { ApprovedPremisesApplication, ArrayOfOASysOffenceDetailsQuestions } from '@approved-premises/api'
+import type { ApprovedPremisesApplication, OASysQuestion } from '@approved-premises/api'
 
 import { Page } from '../../../utils/decorators'
 import { getOasysSections, oasysImportReponse } from '../../../../utils/oasysImportUtils'
 
 type OffenceDetailsBody = {
   offenceDetailsAnswers: Record<string, string>
-  offenceDetailsSummaries: ArrayOfOASysOffenceDetailsQuestions
+  offenceDetailsSummaries: Array<OASysQuestion>
 }
 
 @Page({

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.ts
@@ -1,13 +1,13 @@
 import type { DataServices, OasysPage, PersonRisksUI } from '@approved-premises/ui'
 
-import type { ApprovedPremisesApplication, ArrayOfOASysRiskManagementQuestions } from '@approved-premises/api'
+import type { ApprovedPremisesApplication, OASysQuestion } from '@approved-premises/api'
 
 import { Page } from '../../../utils/decorators'
 import { getOasysSections, oasysImportReponse } from '../../../../utils/oasysImportUtils'
 
 type RiskManagementBody = {
   riskManagementAnswers: Record<string, string>
-  riskManagementSummaries: ArrayOfOASysRiskManagementQuestions
+  riskManagementSummaries: Array<OASysQuestion>
 }
 
 @Page({

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.ts
@@ -1,13 +1,13 @@
 import type { DataServices, OasysPage, PersonRisksUI } from '@approved-premises/ui'
 
-import type { ApprovedPremisesApplication, ArrayOfOASysRiskToSelfQuestions } from '@approved-premises/api'
+import type { ApprovedPremisesApplication, OASysQuestion } from '@approved-premises/api'
 
 import { Page } from '../../../utils/decorators'
 import { getOasysSections, oasysImportReponse } from '../../../../utils/oasysImportUtils'
 
 type RiskToSelfBody = {
   riskToSelfAnswers: Record<string, string>
-  riskToSelfSummaries: ArrayOfOASysRiskToSelfQuestions
+  riskToSelfSummaries: Array<OASysQuestion>
 }
 
 @Page({

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
@@ -1,14 +1,14 @@
 /* eslint-disable no-underscore-dangle */
 import type { DataServices, OasysPage, PersonRisksUI } from '@approved-premises/ui'
 
-import type { ApprovedPremisesApplication, ArrayOfOASysRiskOfSeriousHarmSummaryQuestions } from '@approved-premises/api'
+import type { ApprovedPremisesApplication, OASysQuestion } from '@approved-premises/api'
 
 import { Page } from '../../../utils/decorators'
 import { getOasysSections, oasysImportReponse } from '../../../../utils/oasysImportUtils'
 
 type RoshSummaryBody = {
   roshAnswers: Record<string, string>
-  roshSummaries: ArrayOfOASysRiskOfSeriousHarmSummaryQuestions
+  roshSummaries: Array<OASysQuestion>
 }
 
 @Page({

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.ts
@@ -1,13 +1,13 @@
 import type { DataServices, OasysPage, PersonRisksUI } from '@approved-premises/ui'
 
-import type { ApprovedPremisesApplication, ArrayOfOASysSupportingInformationQuestions } from '@approved-premises/api'
+import { ApprovedPremisesApplication, OASysSupportingInformationQuestion } from '@approved-premises/api'
 
 import { Page } from '../../../utils/decorators'
 import { fetchOptionalOasysSections, getOasysSections, oasysImportReponse } from '../../../../utils/oasysImportUtils'
 
 type SupportingInformationBody = {
   supportingInformationAnswers: Record<string, string>
-  supportingInformationSummaries: ArrayOfOASysSupportingInformationQuestions
+  supportingInformationSummaries: Array<OASysSupportingInformationQuestion>
 }
 
 @Page({


### PR DESCRIPTION
This PR updates the code so that we can successfully generate the UI code when using auto-generated swagger documentation. The changes are:

- The AnyValue class now generates as Unit, so this has been updated where used.
- There are a number of ArrayOfOasys.... classes that are just a wrapper for a list of OASysQuestion with different names, so these have renamed to use Array<OasysQuestion> (which is what the API uses... it does not use these wrappers)