### PR TITLE
APS-1618 Licence expiry date

### DIFF
--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -55,6 +55,7 @@ context('Apply', () => {
         'caseManagerIsNotApplicant',
         'caseManagerUserDetails',
         'noticeType',
+        'licenseExpiryDate'
       )
       expect(body.data).to.deep.equal(this.applicationData)
     })
@@ -81,6 +82,7 @@ context('Apply', () => {
         'caseManagerIsNotApplicant',
         'caseManagerUserDetails',
         'noticeType',
+        'licenseExpiryDate',
       )
     })
 
@@ -340,6 +342,7 @@ context('Apply', () => {
         'caseManagerIsNotApplicant',
         'caseManagerUserDetails',
         'noticeType',
+        'licenseExpiryDate'
       )
 
       expect(body.data).to.deep.equal(this.applicationData)
@@ -367,6 +370,7 @@ context('Apply', () => {
         'caseManagerIsNotApplicant',
         'caseManagerUserDetails',
         'noticeType',
+        'licenseExpiryDate',
       )
     })
   })

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -55,7 +55,7 @@ context('Apply', () => {
         'caseManagerIsNotApplicant',
         'caseManagerUserDetails',
         'noticeType',
-        'licenseExpiryDate'
+        'licenseExpiryDate',
       )
       expect(body.data).to.deep.equal(this.applicationData)
     })
@@ -342,7 +342,7 @@ context('Apply', () => {
         'caseManagerIsNotApplicant',
         'caseManagerUserDetails',
         'noticeType',
-        'licenseExpiryDate'
+        'licenseExpiryDate',
       )
 
       expect(body.data).to.deep.equal(this.applicationData)

--- a/integration_tests/tests/apply/invalidations.cy.ts
+++ b/integration_tests/tests/apply/invalidations.cy.ts
@@ -35,7 +35,6 @@ context('Apply', () => {
     cy.task('verifyApplicationUpdate', this.application.id).then((requests: Array<{ body: string }>) => {
       expect(requests).to.have.length(1)
       const body = JSON.parse(requests[0].body)
-
       expect(body).to.have.keys(
         'data',
         'arrivalDate',
@@ -53,6 +52,7 @@ context('Apply', () => {
         'caseManagerIsNotApplicant',
         'caseManagerUserDetails',
         'noticeType',
+        'licenseExpiryDate',
       )
       expect(body.data).not.to.have.keys(['check-your-answers'])
     })
@@ -95,6 +95,7 @@ context('Apply', () => {
         'caseManagerIsNotApplicant',
         'caseManagerUserDetails',
         'noticeType',
+        'licenseExpiryDate',
       )
       expect(body.data).to.have.any.keys(['check-your-answers'])
     })

--- a/server/@types/shared/models/Cas1PremiseCharacteristicAvailability.ts
+++ b/server/@types/shared/models/Cas1PremiseCharacteristicAvailability.ts
@@ -2,12 +2,9 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { Cas1SpaceCharacteristic } from './Cas1SpaceCharacteristic';
-/**
- * Will only ever be returned for the following characteristics: 'isArsonSuitable', 'hasEnSuite', 'isSingle', 'isStepFreeDesignated', 'isSuitedForSexOffenders' or 'isWheelchairDesignated'
- */
+import type { Cas1SpaceBookingCharacteristic } from './Cas1SpaceBookingCharacteristic';
 export type Cas1PremiseCharacteristicAvailability = {
-    characteristic: Cas1SpaceCharacteristic;
+    characteristic: Cas1SpaceBookingCharacteristic;
     /**
      * the number of available beds with this characteristic
      */

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -1,5 +1,6 @@
 import { ReleaseTypeOption, SentenceTypeOption } from '@approved-premises/api'
 import { when } from 'jest-when'
+import { faker } from '@faker-js/faker/locale/en_GB'
 import { applicationFactory } from '../../testutils/factories'
 import { getApplicationSubmissionData, getApplicationUpdateData } from './getApplicationData'
 import {
@@ -12,6 +13,8 @@ import { isInapplicable } from './utils'
 import { isWomensApplication } from './isWomensApplication'
 import { reasonForShortNoticeDetails } from './reasonForShortNoticeDetails'
 import { applicationUserDetailsFactory } from '../../testutils/factories/application'
+import { DateFormats } from '../dateUtils'
+import { licenceExpiryDateFromApplication } from './licenceExpiryDateFromApplication'
 
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
 jest.mock('../applications/applicantAndCaseManagerDetails')
@@ -19,6 +22,7 @@ jest.mock('./arrivalDateFromApplication')
 jest.mock('./utils')
 jest.mock('./isWomensApplication')
 jest.mock('./reasonForShortNoticeDetails')
+jest.mock('./licenceExpiryDateFromApplication')
 
 const apAreaId = 'test-id'
 const applicantUserDetails = applicationUserDetailsFactory.build()
@@ -53,10 +57,12 @@ describe('getApplicationData', () => {
     const releaseType: ReleaseTypeOption = 'licence'
     const sentenceType: SentenceTypeOption = 'standardDeterminate'
     const arrivalDate = '2023-01-01'
+    const licenceExpiryDate = DateFormats.dateObjToIsoDate(faker.date.soon())
 
     beforeEach(() => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(arrivalDate)
       ;(isWomensApplication as jest.Mock).mockReturnValue(false)
+      ;(licenceExpiryDateFromApplication as jest.Mock).mockReturnValue(licenceExpiryDate)
       mockOptionalQuestionResponse({
         releaseType,
         sentenceType,
@@ -73,6 +79,7 @@ describe('getApplicationData', () => {
         translatedDocument: application.document,
         apType: 'normal',
         isWomensApplication: false,
+        licenseExpiryDate: licenceExpiryDate,
         releaseType,
         sentenceType,
         situation: null,
@@ -145,6 +152,14 @@ describe('getApplicationData', () => {
     it('returns correct data for a womens application', () => {
       ;(isWomensApplication as jest.Mock).mockReturnValue(true)
       expect(getApplicationSubmissionData(application)).toEqual(expect.objectContaining({ isWomensApplication: true }))
+    })
+
+    it('returns the licence expiry date', () => {
+      expect(getApplicationSubmissionData(application)).toEqual(
+        expect.objectContaining({
+          licenseExpiryDate: licenceExpiryDate,
+        }),
+      )
     })
   })
 

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -24,6 +24,7 @@ import ConfirmYourDetails from '../../form-pages/apply/reasons-for-placement/bas
 import { applicantAndCaseManagerDetails } from './applicantAndCaseManagerDetails'
 import { reasonForShortNoticeDetails } from './reasonForShortNoticeDetails'
 import { isWomensApplication } from './isWomensApplication'
+import { licenceExpiryDateFromApplication } from './licenceExpiryDateFromApplication'
 
 type FirstClassFields<T> = T extends UpdateApprovedPremisesApplication
   ? Omit<UpdateApprovedPremisesApplication, 'data'>
@@ -66,6 +67,7 @@ const firstClassFields = <T>(
   const { applicantUserDetails, caseManagerUserDetails, caseManagerIsNotApplicant } =
     applicantAndCaseManagerDetails(application)
   const { reasonForShortNotice, reasonForShortNoticeOther } = reasonForShortNoticeDetails(application)
+  const licenseExpiryDate = licenceExpiryDateFromApplication(application)
 
   return {
     isWomensApplication: isWomensApplication(application),
@@ -83,6 +85,7 @@ const firstClassFields = <T>(
     noticeType,
     reasonForShortNotice,
     reasonForShortNoticeOther,
+    licenseExpiryDate,
   } as FirstClassFields<T>
 }
 

--- a/server/utils/applications/licenceExpiryDateFromApplication.test.ts
+++ b/server/utils/applications/licenceExpiryDateFromApplication.test.ts
@@ -1,0 +1,34 @@
+import type { ApprovedPremisesApplication } from '@approved-premises/api'
+import { licenceExpiryDateFromApplication } from './licenceExpiryDateFromApplication'
+
+import { applicationFactory } from '../../testutils/factories'
+
+jest.mock('./arrivalDateFromApplication')
+
+describe('licenceExpiryDateFromApplication', () => {
+  let application: ApprovedPremisesApplication
+  const licenceExpiryDate = '2024-12-14'
+
+  beforeEach(() => {
+    application = applicationFactory.build({})
+  })
+
+  it('returns the licenceExpiryDate from the application if the licenceExpiryDate date has been selected', () => {
+    application.data = {
+      'basic-information': { 'relevant-dates': { licenceExpiryDate, selectedDates: ['licenceExpiryDate'] } },
+    }
+    expect(licenceExpiryDateFromApplication(application)).toEqual(licenceExpiryDate)
+  })
+  it('returns null from the application if the date has not been selected', () => {
+    application.data = {
+      'basic-information': { 'relevant-dates': { licenceExpiryDate, selectedDates: [] } },
+    }
+    expect(licenceExpiryDateFromApplication(application)).toEqual(null)
+  })
+  it('returns null from the application if the date has been selected but not populated', () => {
+    application.data = {
+      'basic-information': { 'relevant-dates': { selectedDates: ['licenceExpiryDate'] } },
+    }
+    expect(licenceExpiryDateFromApplication(application)).toEqual(null)
+  })
+})

--- a/server/utils/applications/licenceExpiryDateFromApplication.ts
+++ b/server/utils/applications/licenceExpiryDateFromApplication.ts
@@ -1,0 +1,16 @@
+import type { ApprovedPremisesApplication as Application } from '@approved-premises/api'
+
+export const licenceExpiryDateFromApplication = (application: Application): string | null => {
+  const basicInformation = application.data?.['basic-information']
+
+  if (!basicInformation) return null
+
+  const { licenceExpiryDate = '', selectedDates = [] } = {
+    ...basicInformation['relevant-dates'],
+  }
+
+  if (selectedDates.includes('licenceExpiryDate') && licenceExpiryDate) {
+    return licenceExpiryDate
+  }
+  return null
+}

--- a/server/utils/placementCriteriaUtils.ts
+++ b/server/utils/placementCriteriaUtils.ts
@@ -1,4 +1,4 @@
-import { ApType, Cas1SpaceBookingCharacteristic, PlacementCriteria } from '@approved-premises/api'
+import { ApType, PlacementCriteria } from '@approved-premises/api'
 import { filterByType } from './utils'
 import { apTypes } from '../form-pages/apply/reasons-for-placement/type-of-ap/apType'
 
@@ -35,14 +35,6 @@ export const prepopulatablePlacementRequirementCriteria = [
   'isSuitedForSexOffenders',
 ] as const
 export const nonPrepopulatablePlacementRequirementCriteria = ['isStepFreeDesignated', 'hasEnSuite'] as const
-export const spaceBookingCharacteristics: Array<Cas1SpaceBookingCharacteristic> = [
-  'hasEnSuite',
-  'isArsonSuitable',
-  'isSingle',
-  'isStepFreeDesignated',
-  'isSuitedForSexOffenders',
-  'isWheelchairDesignated',
-]
 export const placementRequirementCriteria = [
   ...prepopulatablePlacementRequirementCriteria,
   ...nonPrepopulatablePlacementRequirementCriteria,

--- a/server/utils/placementCriteriaUtils.ts
+++ b/server/utils/placementCriteriaUtils.ts
@@ -1,4 +1,4 @@
-import { ApType, PlacementCriteria } from '@approved-premises/api'
+import { ApType, Cas1SpaceBookingCharacteristic, PlacementCriteria } from '@approved-premises/api'
 import { filterByType } from './utils'
 import { apTypes } from '../form-pages/apply/reasons-for-placement/type-of-ap/apType'
 
@@ -35,6 +35,14 @@ export const prepopulatablePlacementRequirementCriteria = [
   'isSuitedForSexOffenders',
 ] as const
 export const nonPrepopulatablePlacementRequirementCriteria = ['isStepFreeDesignated', 'hasEnSuite'] as const
+export const spaceBookingCharacteristics: Array<Cas1SpaceBookingCharacteristic> = [
+  'hasEnSuite',
+  'isArsonSuitable',
+  'isSingle',
+  'isStepFreeDesignated',
+  'isSuitedForSexOffenders',
+  'isWheelchairDesignated',
+]
 export const placementRequirementCriteria = [
   ...prepopulatablePlacementRequirementCriteria,
   ...nonPrepopulatablePlacementRequirementCriteria,


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1618

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

This change makes `licenceExpiryDate` a first-class field in the `approved_premises_applications` table (`ApprovedPremisesApplication` object )
Note that the object type `SubmitApprovedPremisesApplication` uses the American spelling of `licenseExpiryDate` while everywhere else uses the English 'licence' spelling.
The field value is read from the application object and passed on application submission. The field is only populated if the user both populates the licence expiry date and selects it as a relevant date.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes
No UI change

