### PR TITLE
APS-1713 - Remove incorrect use of out of service bed permission

### DIFF
--- a/integration_tests/tests/manage/future_manager/beds.cy.ts
+++ b/integration_tests/tests/manage/future_manager/beds.cy.ts
@@ -21,7 +21,7 @@ context('Beds', () => {
 
   it('should allow me to visit a bed from the bed list page', () => {
     // Given I am signed in as a workflow manager
-    signIn(['future_manager'])
+    signIn(['future_manager'], ['cas1_premises_view'])
 
     // When I visit the beds page
     const bedsPage = BedsListPage.visit(premisesId)

--- a/integration_tests/tests/manage/future_manager/createsOutOfServiceBed.cy.ts
+++ b/integration_tests/tests/manage/future_manager/createsOutOfServiceBed.cy.ts
@@ -32,7 +32,7 @@ context('OutOfServiceBeds', () => {
     cy.task('stubBed', { premisesId: premises.id, bedDetail })
 
     // Given I am signed in with permissions to view and create out of service beds
-    signIn([], ['cas1_out_of_service_bed_create', 'cas1_view_out_of_service_beds'])
+    signIn([], ['cas1_premises_view', 'cas1_out_of_service_bed_create', 'cas1_view_out_of_service_beds'])
 
     // When I navigate to the out of service bed form
     const page = OutOfServiceBedCreatePage.visit(premises.id, outOfServiceBed.bed.id)

--- a/server/routes/manage.test.ts
+++ b/server/routes/manage.test.ts
@@ -67,13 +67,12 @@ describe('manage routes', () => {
   const postSpy = jest.fn()
   ;(actions as jest.Mock).mockReturnValue({ get: getSpy, post: postSpy, put: jest.fn(), delete: jest.fn() })
 
-  it('should allow a user with role cru_member to view a bed', () => {
+  it('should allow a user with permission cas1_premises_view to view a bed', () => {
     manageRoutes(controllers, router, services)
 
     expect(getSpy).toHaveBeenCalledWith(paths.premises.beds.show.pattern, bedsController.show(), {
       auditEvent: 'SHOW_BED',
-      allowedRoles: ['future_manager', 'cru_member'],
-      allowedPermissions: ['cas1_out_of_service_bed_create'],
+      allowedPermissions: ['cas1_premises_view'],
     })
   })
 

--- a/server/routes/manage.ts
+++ b/server/routes/manage.ts
@@ -119,8 +119,7 @@ export default function routes(controllers: Controllers, router: Router, service
   })
   get(paths.premises.beds.show.pattern, bedsController.show(), {
     auditEvent: 'SHOW_BED',
-    allowedRoles: ['future_manager', 'cru_member'],
-    allowedPermissions: ['cas1_out_of_service_bed_create'],
+    allowedPermissions: ['cas1_premises_view'],
   })
 
   // Placements


### PR DESCRIPTION
This commit removes usage of `cas1_out_of_service_bed_create` permisson to determine if a user can view a bed, replacing it with the new `cas1_premises_view` permission which is assigned to CRU Members and Future Managers

I've tested this by ensuring a future manager can still view a bed