### PR TITLE
Occupancy View - Add AP Manager to matching details

### DIFF
--- a/integration_tests/pages/match/occupancyViewPage.ts
+++ b/integration_tests/pages/match/occupancyViewPage.ts
@@ -33,9 +33,12 @@ export default class OccupancyViewPage extends Page {
     startDate: string,
     durationDays: number,
     placementRequest: PlacementRequest,
+    managerDetails: string,
   ) {
     cy.get('.govuk-details').within(() => {
-      this.shouldContainSummaryListItems(occupancyViewSummaryListForMatchingDetails(totalCapacity, placementRequest))
+      this.shouldContainSummaryListItems(
+        occupancyViewSummaryListForMatchingDetails(totalCapacity, placementRequest, managerDetails),
+      )
     })
     cy.get('.govuk-heading-l')
       .contains(

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -149,6 +149,7 @@ context('Placement Requests', () => {
     const startDate = '2024-07-23'
     const endDate = '2024-08-07'
     const totalCapacity = 10
+    const managerDetails = 'John Doe'
 
     // Given I am signed in as a cru_member
     signIn(['cru_member'], ['cas1_space_booking_create'])
@@ -162,7 +163,7 @@ context('Placement Requests', () => {
       duration: durationDays,
     })
     const premiseCapacity = cas1PremiseCapacityFactory.build({
-      premise: { id: premises.id, bedCount: totalCapacity },
+      premise: { id: premises.id, bedCount: totalCapacity, managerDetails },
       startDate,
       endDate,
     })
@@ -175,7 +176,13 @@ context('Placement Requests', () => {
     const occupancyViewPage = OccupancyViewPage.visit(placementRequest, premises, apType)
 
     // Then I should see the details of the case I am matching
-    occupancyViewPage.shouldShowMatchingDetails(totalCapacity, startDate, durationDays, placementRequest)
+    occupancyViewPage.shouldShowMatchingDetails(
+      totalCapacity,
+      startDate,
+      durationDays,
+      placementRequest,
+      managerDetails,
+    )
     return { occupancyViewPage, placementRequest, premiseCapacity, premises }
   }
 
@@ -185,6 +192,7 @@ context('Placement Requests', () => {
     const startDate = '2024-07-23'
     const endDate = '2024-08-07'
     const totalCapacity = 10
+    const managerDetails = 'John Doe'
 
     // Given I am signed in as a cru_member
     signIn(['cru_member'], ['cas1_space_booking_create'])
@@ -198,7 +206,7 @@ context('Placement Requests', () => {
       duration: durationDays,
     })
     const premiseCapacity = cas1PremiseCapacityFactory.build({
-      premise: { id: premises.id, bedCount: totalCapacity },
+      premise: { id: premises.id, bedCount: totalCapacity, managerDetails },
       startDate,
       endDate,
     })
@@ -211,7 +219,13 @@ context('Placement Requests', () => {
     const occupancyViewPage = OccupancyViewPage.visit(placementRequest, premises, apType)
 
     // Then I should see the details of the case I am matching
-    occupancyViewPage.shouldShowMatchingDetails(totalCapacity, startDate, durationDays, placementRequest)
+    occupancyViewPage.shouldShowMatchingDetails(
+      totalCapacity,
+      startDate,
+      durationDays,
+      placementRequest,
+      managerDetails,
+    )
 
     // And I should see the filter form with populated values
     occupancyViewPage.shouldShowFilters(startDate, 'Up to 6 weeks', [])
@@ -236,7 +250,7 @@ context('Placement Requests', () => {
     const newDuration = 'Up to 1 week'
     const newCriteria = ['Wheelchair accessible', 'Step-free']
     const newPremiseCapacity = cas1PremiseCapacityFactory.build({
-      premise: { id: premises.id, bedCount: totalCapacity },
+      premise: { id: premises.id, bedCount: totalCapacity, managerDetails },
       startDate: newStartDate,
       endDate: newEndDate,
     })

--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -108,6 +108,7 @@ describe('OccupancyViewController', () => {
         matchingDetailsSummaryList: occupancyViewSummaryListForMatchingDetails(
           premiseCapacity.premise.bedCount,
           placementRequestDetail,
+          premiseCapacity.premise.managerDetails,
         ),
         summary: occupancySummary(premiseCapacity.capacity),
         calendar: occupancyCalendar(premiseCapacity.capacity),

--- a/server/controllers/match/placementRequests/occupancyViewController.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.ts
@@ -100,10 +100,9 @@ export default class {
       const durationDays = filterDurationDays || placementRequest.duration
       const dateFieldValues = filterError ? filterUserInput : DateFormats.isoDateToDateInputs(startDate, 'startDate')
 
-      const matchingDetailsSummaryList = occupancyViewSummaryListForMatchingDetails(premises.bedCount, placementRequest)
       let summary: OccupancySummary
       let calendar: Calendar
-
+      let managerDetails: string
       if (!errors.startDate) {
         const capacityDates = placementDates(startDate, durationDays)
         const capacity = await this.premisesService.getCapacity(
@@ -115,6 +114,7 @@ export default class {
 
         summary = occupancySummary(capacity.capacity, filterCriteria)
         calendar = occupancyCalendar(capacity.capacity, filterCriteria)
+        managerDetails = capacity.premise.managerDetails
       }
 
       res.render('match/placementRequests/occupancyView/view', {
@@ -128,7 +128,11 @@ export default class {
         durationOptions: durationSelectOptions(durationDays),
         criteriaOptions: convertKeyValuePairToCheckBoxItems(occupancyCriteriaMap, filterCriteria),
         criteria: filterCriteria,
-        matchingDetailsSummaryList,
+        matchingDetailsSummaryList: occupancyViewSummaryListForMatchingDetails(
+          premises.bedCount,
+          placementRequest,
+          managerDetails,
+        ),
         summary,
         calendar,
         errors,

--- a/server/testutils/factories/cas1PremisesSummary.ts
+++ b/server/testutils/factories/cas1PremisesSummary.ts
@@ -6,7 +6,7 @@ import { apAreaFactory } from './referenceData'
 
 export default Factory.define<Cas1PremisesSummary>(() => ({
   id: faker.string.uuid(),
-  name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
+  name: `${faker.person}`,
   postcode: faker.location.zipCode(),
   apCode: `${faker.string.alpha(2)}`,
   bedCount: 50,
@@ -14,5 +14,6 @@ export default Factory.define<Cas1PremisesSummary>(() => ({
   outOfServiceBeds: faker.number.int({ min: 0, max: 50 }),
   apArea: apAreaFactory.build(),
   supportsSpaceBookings: true,
+  managerDetails: `${faker.person}`,
   overbookingSummary: [],
 }))

--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -19,6 +19,7 @@ import { DateFormats } from '../dateUtils'
 import {
   InvalidSpaceSearchDataException,
   addressRow,
+  apManagerDetailsRow,
   apTypeLabelsForRadioInput,
   apTypeRow,
   arrivalDateRow,
@@ -395,20 +396,22 @@ describe('matchUtils', () => {
     })
     const dates = placementDates(placementRequest.expectedArrival, placementRequest.duration)
     const totalCapacity = 120
+    const managerDetails = 'John Doe'
 
     it('should call the correct row functions', () => {
-      expect(occupancyViewSummaryListForMatchingDetails(totalCapacity, placementRequest)).toEqual([
+      expect(occupancyViewSummaryListForMatchingDetails(totalCapacity, placementRequest, managerDetails)).toEqual([
         arrivalDateRow(dates.startDate),
         departureDateRow(dates.endDate),
         placementLengthRow(dates.placementLength),
         releaseTypeRow(placementRequest),
         totalCapacityRow(totalCapacity),
+        apManagerDetailsRow(managerDetails),
         spaceRequirementsRow(filterOutAPTypes(placementRequest.essentialCriteria)),
       ])
     })
 
     it('should generate the expected matching details', () => {
-      expect(occupancyViewSummaryListForMatchingDetails(totalCapacity, placementRequest)).toEqual([
+      expect(occupancyViewSummaryListForMatchingDetails(totalCapacity, placementRequest, managerDetails)).toEqual([
         {
           key: {
             text: 'Expected arrival date',
@@ -447,6 +450,14 @@ describe('matchUtils', () => {
           },
           value: {
             text: '120 spaces',
+          },
+        },
+        {
+          key: {
+            text: 'AP manager details',
+          },
+          value: {
+            text: 'John Doe',
           },
         },
         {

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -175,6 +175,7 @@ export const spaceBookingPersonNeedsSummaryCardRows = (
 export const occupancyViewSummaryListForMatchingDetails = (
   totalCapacity: number,
   placementRequest: PlacementRequest,
+  managerDetails: string,
 ): Array<SummaryListItem> => {
   const placementRequestDates = placementDates(placementRequest.expectedArrival, placementRequest.duration)
   const essentialCharacteristics = filterOutAPTypes(placementRequest.essentialCriteria)
@@ -185,6 +186,7 @@ export const occupancyViewSummaryListForMatchingDetails = (
     placementLengthRow(placementRequestDates.placementLength),
     releaseTypeRow(placementRequest),
     totalCapacityRow(totalCapacity),
+    apManagerDetailsRow(managerDetails),
     spaceRequirementsRow(essentialCharacteristics),
   ]
 }
@@ -331,6 +333,15 @@ export const totalCapacityRow = (totalCapacity: number) => ({
   },
   value: {
     text: `${totalCapacity} spaces`,
+  },
+})
+
+export const apManagerDetailsRow = (apManagerDetails: string) => ({
+  key: {
+    text: 'AP manager details',
+  },
+  value: {
+    text: apManagerDetails,
   },
 })
 


### PR DESCRIPTION
# Context

* This relates to this ticket: https://dsdmoj.atlassian.net/browse/APS-1623
* We previously de-scoped including the `AP manager details` data from the `Matching details` section on the `Occupancy View` page because the data was not available from the API
* The `AP manager details` data has since been made available from the `GET /cas1/premises/a41ed4ca-d8f4-4712-9151-f02b2b0d4034/capacity` API endpoint

# Changes in this PR
- Add the `AP manager details` data into the `Matching details` section on the `Occupancy View`

## Screenshots of UI changes

### Before
<img width="1728" alt="before" src="https://github.com/user-attachments/assets/c22067bf-b98b-43b8-b963-7000bf70a4e8" />

### After
<img width="1728" alt="after" src="https://github.com/user-attachments/assets/739fc14e-2d87-4a27-aa62-511c37067622" />
