### PR TITLE
APS-1606: Day availability details

### DIFF
--- a/assets/sass/components/_summary-list.scss
+++ b/assets/sass/components/_summary-list.scss
@@ -25,3 +25,12 @@
   color: govuk-colour("dark-grey");
 }
 
+.govuk-summary-list--swap-bolding {
+  .govuk-summary-list__key {
+    font-weight: normal;
+  }
+
+  .govuk-summary-list__value {
+    font-weight: 700;
+  }
+}

--- a/integration_tests/pages/match/dayAvailabilityPage.ts
+++ b/integration_tests/pages/match/dayAvailabilityPage.ts
@@ -1,0 +1,71 @@
+import { Cas1PremiseCapacityForDay, Cas1SpaceBookingCharacteristic } from '@approved-premises/api'
+import Page from '../page'
+import { dayAvailabilityCount, occupancyCriteriaMap } from '../../../server/utils/match/occupancy'
+import { DateFormats } from '../../../server/utils/dateUtils'
+
+type Availability = 'Available' | 'Overbooked' | 'Available for your criteria'
+
+export default class DayAvailabilityPage extends Page {
+  availability: Availability
+
+  constructor(
+    private readonly dayCapacity: Cas1PremiseCapacityForDay,
+    private readonly criteria: Array<Cas1SpaceBookingCharacteristic> = [],
+  ) {
+    let availability: Availability = dayAvailabilityCount(dayCapacity) > 0 ? 'Available' : 'Overbooked'
+
+    if (criteria.length) {
+      if (dayAvailabilityCount(dayCapacity, criteria) > 0 && availability === 'Overbooked') {
+        availability = 'Available for your criteria'
+      }
+    }
+
+    super(availability)
+
+    this.availability = availability
+  }
+
+  shouldShowDayAvailability() {
+    const uiDate = DateFormats.isoDateToUIDate(this.dayCapacity.date, { format: 'long' })
+    cy.get('h2').should('contain.text', uiDate)
+
+    if (this.availability === 'Available') {
+      cy.get('p').should('contain.text', 'The space you require is available.')
+    } else if (this.availability === 'Overbooked') {
+      cy.get('p').should('contain.text', 'This AP is full or overbooked. The space you require is not available.')
+    } else if (this.availability === 'Available for your criteria') {
+      cy.get('p').should(
+        'contain.text',
+        'This AP is full or overbooked, but the space you require is available as it is occupied by someone who does not need it.',
+      )
+    }
+
+    const summaryList = {
+      'AP capacity': this.dayCapacity.totalBedCount,
+      'Booked spaces': this.dayCapacity.bookingCount,
+    }
+
+    if (this.criteria.length) {
+      this.criteria.forEach(criteria => {
+        const criteriaLabel = occupancyCriteriaMap[criteria]
+        const criteriaAvailability = this.dayCapacity.characteristicAvailability.find(
+          characteristic => characteristic.characteristic === criteria,
+        )
+        summaryList[`${criteriaLabel} spaces available`] =
+          criteriaAvailability.availableBedsCount - criteriaAvailability.bookingsCount
+      })
+    } else {
+      summaryList['Available spaces'] = dayAvailabilityCount(this.dayCapacity)
+    }
+    this.shouldContainAvailabilitySummary(summaryList)
+  }
+
+  shouldContainAvailabilitySummary(items: Record<string, string | number>) {
+    Object.entries(items).forEach(([key, value]) => {
+      cy.get('.govuk-summary-list__key')
+        .contains(key)
+        .siblings('.govuk-summary-list__value')
+        .should('contain.text', value)
+    })
+  }
+}

--- a/integration_tests/pages/match/occupancyViewPage.ts
+++ b/integration_tests/pages/match/occupancyViewPage.ts
@@ -1,6 +1,7 @@
 import {
   ApType,
   Cas1PremiseCapacity,
+  Cas1PremiseCapacityForDay,
   Cas1PremisesSummary,
   Cas1SpaceBookingCharacteristic,
   PlacementRequestDetail,
@@ -111,5 +112,15 @@ export default class OccupancyViewPage extends Page {
   shouldShowErrorSummaryAndErrorMessage(message: string): void {
     cy.get('.govuk-error-summary').should('contain', message)
     cy.get(`.govuk-error-message`).should('contain', message)
+  }
+
+  getOccupancyForDate(date: Date, capacity: Cas1PremiseCapacity): Cas1PremiseCapacityForDay {
+    return capacity.capacity.find(day => day.date === DateFormats.dateObjToIsoDate(date))
+  }
+
+  clickCalendarDay(date: string) {
+    const calendarDate = DateFormats.isoDateToUIDate(date, { format: 'longNoYear' })
+
+    cy.get('.calendar__day').contains(calendarDate).click()
   }
 }

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -256,11 +256,11 @@ context('Placement Requests', () => {
     // And I should see an occupancy calendar
     occupancyViewPage.shouldShowOccupancyCalendar(premiseCapacity)
 
-    // Then I should see the calendar again
-    occupancyViewPage.shouldShowOccupancyCalendar(premiseCapacity)
-
     // And I should be able to see the day's availability details
     shouldShowDayDetailsAndReturn(occupancyViewPage, addDays(startDate, 10), premises, premiseCapacity)
+
+    // Then I should see the calendar again
+    occupancyViewPage.shouldShowOccupancyCalendar(premiseCapacity)
 
     // When I filter with an invalid date
     occupancyViewPage.filterAvailability('2025-02-35')

--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -53,6 +53,9 @@ describe('OccupancyViewController', () => {
     request = createMock<Request>({
       user: { token },
       flash: flashSpy,
+      headers: {
+        referer: '/referrerPath',
+      },
     })
 
     placementRequestService.getPlacementRequest.mockResolvedValue(placementRequestDetail)
@@ -364,9 +367,11 @@ describe('OccupancyViewController', () => {
 
       expect(premisesService.getCapacity).toHaveBeenCalledWith('SOME_TOKEN', premises.id, date)
       expect(response.render).toHaveBeenCalledWith('match/placementRequests/occupancyView/viewDay', {
+        backlink: '/referrerPath',
         pageHeading: dayAvailabilityStatusMap[expectedStatus],
         placementRequest: placementRequestDetail,
         premises,
+        date,
         status: expectedStatus,
         availabilitySummaryListItems: dayAvailabilitySummaryListItems(dayCapacity, criteria),
       })

--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -17,7 +17,11 @@ import matchPaths from '../../../paths/match'
 import { occupancyCalendar } from '../../../utils/match/occupancyCalendar'
 import * as validationUtils from '../../../utils/validation'
 import { DateFormats } from '../../../utils/dateUtils'
-import { dayAvailabilityStatus, dayAvailabilityStatusMap } from '../../../utils/match/occupancy'
+import {
+  dayAvailabilityStatus,
+  dayAvailabilityStatusMap,
+  dayAvailabilitySummaryListItems,
+} from '../../../utils/match/occupancy'
 
 describe('OccupancyViewController', () => {
   const token = 'SOME_TOKEN'
@@ -356,6 +360,7 @@ describe('OccupancyViewController', () => {
         placementRequest: placementRequestDetail,
         premises,
         status: expectedStatus,
+        availabilitySummaryListItems: dayAvailabilitySummaryListItems(dayCapacity, criteria),
       })
     })
   })

--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -40,6 +40,11 @@ describe('OccupancyViewController', () => {
   let request: Readonly<DeepMocked<Request>>
 
   const apType = 'esap'
+  const placeholderDetailsUrl = matchPaths.v2Match.placementRequests.search.dayOccupancy({
+    id: placementRequestDetail.id,
+    premisesId: premises.id,
+    date: ':date',
+  })
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -118,7 +123,7 @@ describe('OccupancyViewController', () => {
           premiseCapacity.premise.managerDetails,
         ),
         summary: occupancySummary(premiseCapacity.capacity),
-        calendar: occupancyCalendar(premiseCapacity.capacity),
+        calendar: occupancyCalendar(premiseCapacity.capacity, placeholderDetailsUrl),
         errors: {},
         errorSummary: [],
       })
@@ -177,7 +182,7 @@ describe('OccupancyViewController', () => {
           'departureDate-day': '1',
           'departureDate-month': '5',
           'departureDate-year': '2026',
-          calendar: occupancyCalendar(premiseCapacity.capacity),
+          calendar: occupancyCalendar(premiseCapacity.capacity, placeholderDetailsUrl),
           summary: occupancySummary(premiseCapacity.capacity),
         }),
       )
@@ -226,7 +231,10 @@ describe('OccupancyViewController', () => {
           'startDate-month': '4',
           'startDate-year': '2025',
           summary: occupancySummary(premiseCapacity.capacity, ['isSingle', 'isWheelchairDesignated']),
-          calendar: occupancyCalendar(premiseCapacity.capacity, ['isSingle', 'isWheelchairDesignated']),
+          calendar: occupancyCalendar(premiseCapacity.capacity, placeholderDetailsUrl, [
+            'isSingle',
+            'isWheelchairDesignated',
+          ]),
         }),
       )
     })

--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -17,7 +17,7 @@ import matchPaths from '../../../paths/match'
 import { occupancyCalendar } from '../../../utils/match/occupancyCalendar'
 import * as validationUtils from '../../../utils/validation'
 import { DateFormats } from '../../../utils/dateUtils'
-import { dayAvailabilityStatus } from '../../../utils/match/occupancy'
+import { dayAvailabilityStatus, dayAvailabilityStatusMap } from '../../../utils/match/occupancy'
 
 describe('OccupancyViewController', () => {
   const token = 'SOME_TOKEN'
@@ -348,11 +348,14 @@ describe('OccupancyViewController', () => {
 
       await requestHandler({ ...request, params, query }, response, next)
 
+      const expectedStatus = dayAvailabilityStatus(dayCapacity, criteria)
+
       expect(premisesService.getCapacity).toHaveBeenCalledWith('SOME_TOKEN', premises.id, date)
       expect(response.render).toHaveBeenCalledWith('match/placementRequests/occupancyView/viewDay', {
+        pageHeading: dayAvailabilityStatusMap[expectedStatus],
         placementRequest: placementRequestDetail,
         premises,
-        status: dayAvailabilityStatus(dayCapacity, criteria),
+        status: expectedStatus,
       })
     })
   })

--- a/server/controllers/match/placementRequests/occupancyViewController.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.ts
@@ -19,7 +19,12 @@ import {
 } from '../../../utils/validation'
 import { type Calendar, occupancyCalendar } from '../../../utils/match/occupancyCalendar'
 import { DateFormats, dateAndTimeInputsAreValidDates } from '../../../utils/dateUtils'
-import { dayAvailabilityStatus, durationSelectOptions, occupancyCriteriaMap } from '../../../utils/match/occupancy'
+import {
+  dayAvailabilityStatus,
+  dayAvailabilityStatusMap,
+  durationSelectOptions,
+  occupancyCriteriaMap,
+} from '../../../utils/match/occupancy'
 import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
 import { OccupancySummary } from '../../../utils/match/occupancySummary'
 
@@ -216,9 +221,11 @@ export default class {
       const placementRequest = await this.placementRequestService.getPlacementRequest(token, id)
       const premises = await this.premisesService.find(token, premisesId)
       const premisesCapacity = await this.premisesService.getCapacity(token, premisesId, date)
-      const status = dayAvailabilityStatus(premisesCapacity.capacity[0], this.criteriaAsArray(criteria))
+      const dayCapacity = premisesCapacity.capacity[0]
+      const status = dayAvailabilityStatus(dayCapacity, this.criteriaAsArray(criteria))
 
       res.render('match/placementRequests/occupancyView/viewDay', {
+        pageHeading: dayAvailabilityStatusMap[status],
         placementRequest,
         premises,
         status,

--- a/server/controllers/match/placementRequests/occupancyViewController.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.ts
@@ -22,6 +22,7 @@ import { DateFormats, dateAndTimeInputsAreValidDates } from '../../../utils/date
 import {
   dayAvailabilityStatus,
   dayAvailabilityStatusMap,
+  dayAvailabilitySummaryListItems,
   durationSelectOptions,
   occupancyCriteriaMap,
 } from '../../../utils/match/occupancy'
@@ -229,6 +230,7 @@ export default class {
         placementRequest,
         premises,
         status,
+        availabilitySummaryListItems: dayAvailabilitySummaryListItems(dayCapacity, this.criteriaAsArray(criteria)),
       })
     }
   }

--- a/server/controllers/match/placementRequests/occupancyViewController.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.ts
@@ -28,10 +28,13 @@ import {
 } from '../../../utils/match/occupancy'
 import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
 import { OccupancySummary } from '../../../utils/match/occupancySummary'
+import paths from '../../../paths/match'
+
+type CriteriaQuery = Array<Cas1SpaceBookingCharacteristic> | Cas1SpaceBookingCharacteristic
 
 type FilterUserInput = ObjectWithDateParts<'startDate'> & {
   durationDays: string
-  criteria: Array<Cas1SpaceBookingCharacteristic> | Cas1SpaceBookingCharacteristic
+  criteria: CriteriaQuery
 }
 
 interface ViewRequest extends Request {
@@ -50,7 +53,9 @@ interface ViewDayRequest extends Request {
     premisesId: string
     date: string
   }
-  query: FilterUserInput
+  query: {
+    criteria: CriteriaQuery
+  }
 }
 
 export default class {
@@ -132,9 +137,14 @@ export default class {
           capacityDates.startDate,
           capacityDates.endDate,
         )
+        const placeholderDetailsUrl = paths.v2Match.placementRequests.search.dayOccupancy({
+          id,
+          premisesId,
+          date: ':date',
+        })
 
         summary = occupancySummary(capacity.capacity, filterCriteria)
-        calendar = occupancyCalendar(capacity.capacity, filterCriteria)
+        calendar = occupancyCalendar(capacity.capacity, placeholderDetailsUrl, filterCriteria)
         managerDetails = capacity.premise.managerDetails
       }
 

--- a/server/controllers/match/placementRequests/occupancyViewController.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.ts
@@ -229,6 +229,7 @@ export default class {
       const { id, premisesId, date } = req.params
       const { criteria } = req.query
 
+      const backlink = req.headers.referer
       const placementRequest = await this.placementRequestService.getPlacementRequest(token, id)
       const premises = await this.premisesService.find(token, premisesId)
       const premisesCapacity = await this.premisesService.getCapacity(token, premisesId, date)
@@ -236,9 +237,11 @@ export default class {
       const status = dayAvailabilityStatus(dayCapacity, this.criteriaAsArray(criteria))
 
       res.render('match/placementRequests/occupancyView/viewDay', {
+        backlink,
         pageHeading: dayAvailabilityStatusMap[status],
         placementRequest,
         premises,
+        date,
         status,
         availabilitySummaryListItems: dayAvailabilitySummaryListItems(dayCapacity, this.criteriaAsArray(criteria)),
       })

--- a/server/paths/match.ts
+++ b/server/paths/match.ts
@@ -4,13 +4,15 @@ const v2MatchPath = path('/match')
 const v2PlacementRequestsPath = v2MatchPath.path('placement-requests')
 const v2PlacementRequestPath = v2PlacementRequestsPath.path(':id')
 const v2PlacementRequestSearchPath = v2PlacementRequestPath.path('space-search')
+const v2PlacementRequestSearchOccupancyPath = v2PlacementRequestSearchPath.path('occupancy/:premisesId')
 const v2SpaceBookingsPath = v2PlacementRequestPath.path('space-bookings')
 
 const v2Match = {
   placementRequests: {
     search: {
       spaces: v2PlacementRequestSearchPath.path('new'),
-      occupancy: v2PlacementRequestSearchPath.path('occupancy/:premisesId'),
+      occupancy: v2PlacementRequestSearchOccupancyPath,
+      dayOccupancy: v2PlacementRequestSearchOccupancyPath.path('date/:date'),
     },
     spaceBookings: {
       new: v2SpaceBookingsPath.path('new'),

--- a/server/routes/match.ts
+++ b/server/routes/match.ts
@@ -50,9 +50,12 @@ export default function routes(controllers: Controllers, router: Router, service
   get(paths.v2Match.placementRequests.search.occupancy.pattern, occupancyViewController.view(), {
     auditEvent: 'OCCUPANCY_VIEW',
   })
-
   post(paths.v2Match.placementRequests.search.occupancy.pattern, occupancyViewController.bookSpace(), {
     auditEvent: 'OCCUPANCY_VIEW_BOOK_SPACE',
+  })
+
+  get(paths.v2Match.placementRequests.search.dayOccupancy.pattern, occupancyViewController.viewDay(), {
+    auditEvent: 'OCCUPANCY_VIEW_DAY',
   })
 
   post(paths.v2Match.placementRequests.spaceBookings.create.pattern, spaceBookingsController.create(), {

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -110,6 +110,23 @@ describe('PremisesService', () => {
       expect(premisesClientFactory).toHaveBeenCalledWith(token)
       expect(premisesClient.getCapacity).toHaveBeenCalledWith(premisesId, startDate, endDate)
     })
+
+    it('returns capacity for one day if no end date provided', async () => {
+      const startDate = '2025-05-20'
+
+      const premiseCapacity = cas1PremiseCapacityFactory.build({
+        startDate,
+        endDate: startDate,
+      })
+      premisesClient.getCapacity.mockResolvedValue(premiseCapacity)
+
+      const result = await service.getCapacity(token, premisesId, startDate)
+
+      expect(result).toEqual(premiseCapacity)
+
+      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClient.getCapacity).toHaveBeenCalledWith(premisesId, startDate, startDate)
+    })
   })
 
   describe('find', () => {

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -37,11 +37,11 @@ export default class PremisesService {
     token: string,
     premisesId: string,
     startDate: string,
-    endDate: string,
+    endDate?: string,
   ): Promise<Cas1PremiseCapacity> {
     const premisesClient = this.premisesClientFactory(token)
 
-    return premisesClient.getCapacity(premisesId, startDate, endDate)
+    return premisesClient.getCapacity(premisesId, startDate, endDate || startDate)
   }
 
   async find(token: string, id: string): Promise<Cas1PremisesSummary> {

--- a/server/testutils/factories/cas1PremiseCapacity.ts
+++ b/server/testutils/factories/cas1PremiseCapacity.ts
@@ -76,7 +76,29 @@ export const cas1PremiseCapacityForDayFactory = CapacityForDayFactory.define(() 
   }
 })
 
-export const premiseCharacteristicAvailability = Factory.define<Cas1PremiseCharacteristicAvailability>(() => ({
+class PremisesCharacteristicAvailability extends Factory<Cas1PremiseCharacteristicAvailability> {
+  available() {
+    const availableBedsCount = faker.number.int({ min: 5, max: 20 })
+    const bookingsCount = faker.number.int({ min: 0, max: availableBedsCount - 1 })
+
+    return this.params({
+      availableBedsCount,
+      bookingsCount,
+    })
+  }
+
+  overbooked() {
+    const availableBedsCount = faker.number.int({ min: 5, max: 20 })
+    const bookingsCount = faker.number.int({ min: availableBedsCount, max: 30 })
+
+    return this.params({
+      availableBedsCount,
+      bookingsCount,
+    })
+  }
+}
+
+export const premiseCharacteristicAvailability = PremisesCharacteristicAvailability.define(() => ({
   characteristic: faker.helpers.arrayElement(Object.keys(occupancyCriteriaMap)) as Cas1SpaceBookingCharacteristic,
   availableBedsCount: faker.number.int({ min: 0, max: 40 }),
   bookingsCount: faker.number.int({ min: 0, max: 45 }),

--- a/server/utils/match/occupancy.test.ts
+++ b/server/utils/match/occupancy.test.ts
@@ -1,14 +1,19 @@
 import { faker } from '@faker-js/faker'
 import { Cas1PremiseCapacityForDay } from '@approved-premises/api'
 import { cas1PremiseCapacityForDayFactory } from '../../testutils/factories'
-import { dayAvailabilityCount, dayAvailabilityStatus, durationSelectOptions } from './occupancy'
+import {
+  dayAvailabilityCount,
+  dayAvailabilityStatus,
+  dayAvailabilitySummaryListItems,
+  durationSelectOptions,
+} from './occupancy'
 import { premiseCharacteristicAvailability } from '../../testutils/factories/cas1PremiseCapacity'
 
 const capacityWithCriteria: Cas1PremiseCapacityForDay = cas1PremiseCapacityForDayFactory.build({
   date: '2025-02-02',
   totalBedCount: 20,
   availableBedCount: 18,
-  bookingCount: 20,
+  bookingCount: 21,
   characteristicAvailability: [
     premiseCharacteristicAvailability.build({
       characteristic: 'hasEnSuite',
@@ -112,6 +117,36 @@ describe('dayAvailabilityStatus', () => {
       it('returns overbooked if there is no availability for the given criteria', () => {
         expect(dayAvailabilityStatus(overbookedCapacity, ['hasEnSuite'])).toEqual('overbooked')
       })
+    })
+  })
+})
+
+describe('dayAvailabilitySummaryListItems', () => {
+  describe('when no criteria is provided', () => {
+    it('returns a summary list with main availability for the day', () => {
+      const summaryList = dayAvailabilitySummaryListItems(capacityWithCriteria)
+
+      expect(summaryList).toEqual([
+        { key: { text: 'AP capacity' }, value: { text: '20' } },
+        { key: { text: 'Booked spaces' }, value: { text: '21' } },
+        { key: { text: 'Available spaces' }, value: { text: '-3' } },
+      ])
+    })
+  })
+
+  describe('when criteria is provided', () => {
+    it('returns a summary list with detailed availability for the selected criteria', () => {
+      const summaryList = dayAvailabilitySummaryListItems(capacityWithCriteria, [
+        'isSuitedForSexOffenders',
+        'isStepFreeDesignated',
+      ])
+
+      expect(summaryList).toEqual([
+        { key: { text: 'AP capacity' }, value: { text: '20' } },
+        { key: { text: 'Booked spaces' }, value: { text: '21' } },
+        { key: { text: 'Suitable for sex offenders spaces available' }, value: { text: '3' } },
+        { key: { text: 'Step-free spaces available' }, value: { text: '0' } },
+      ])
     })
   })
 })

--- a/server/utils/match/occupancy.test.ts
+++ b/server/utils/match/occupancy.test.ts
@@ -62,7 +62,7 @@ describe('dayAvailabilityCount', () => {
   })
 })
 
-describe('dayOccupancyStatus', () => {
+describe('dayAvailabilityStatus', () => {
   describe('when no criteria is provided', () => {
     it('returns available if there is availability', () => {
       const capacityForDay = cas1PremiseCapacityForDayFactory.available().build()

--- a/server/utils/match/occupancy.test.ts
+++ b/server/utils/match/occupancy.test.ts
@@ -68,7 +68,7 @@ describe('dayAvailabilityCount', () => {
 })
 
 describe('dayAvailabilityStatus', () => {
-  describe('when no criteria is provided', () => {
+  describe('when no criteria are provided', () => {
     it('returns available if there is availability', () => {
       const capacityForDay = cas1PremiseCapacityForDayFactory.available().build()
 
@@ -82,7 +82,7 @@ describe('dayAvailabilityStatus', () => {
     })
   })
 
-  describe('when criteria is provided', () => {
+  describe('when criteria are provided', () => {
     describe('if there is general availability', () => {
       const availableCapacity = cas1PremiseCapacityForDayFactory.available().build({
         characteristicAvailability: [
@@ -122,7 +122,7 @@ describe('dayAvailabilityStatus', () => {
 })
 
 describe('dayAvailabilitySummaryListItems', () => {
-  describe('when no criteria is provided', () => {
+  describe('when no criteria are provided', () => {
     it('returns a summary list with main availability for the day', () => {
       const summaryList = dayAvailabilitySummaryListItems(capacityWithCriteria)
 
@@ -134,7 +134,7 @@ describe('dayAvailabilitySummaryListItems', () => {
     })
   })
 
-  describe('when criteria is provided', () => {
+  describe('when criteria are provided', () => {
     it('returns a summary list with detailed availability for the selected criteria', () => {
       const summaryList = dayAvailabilitySummaryListItems(capacityWithCriteria, [
         'isSuitedForSexOffenders',

--- a/server/utils/match/occupancy.ts
+++ b/server/utils/match/occupancy.ts
@@ -14,6 +14,28 @@ export const dayAvailabilityCount = (
     : dayCapacity.availableBedCount - dayCapacity.bookingCount
 }
 
+export type DayAvailabilityStatus = 'available' | 'availableForCriteria' | 'overbooked'
+
+export const dayAvailabilityStatus = (
+  dayCapacity: Cas1PremiseCapacityForDay,
+  criteria: Array<Cas1SpaceBookingCharacteristic> = [],
+): DayAvailabilityStatus => {
+  let status: DayAvailabilityStatus =
+    dayCapacity.availableBedCount > dayCapacity.bookingCount ? 'available' : 'overbooked'
+
+  if (criteria.length) {
+    const criteriaBookableCount = dayAvailabilityCount(dayCapacity, criteria)
+
+    if (criteriaBookableCount > 0 && status === 'overbooked') {
+      status = 'availableForCriteria'
+    } else if (criteriaBookableCount <= 0) {
+      status = 'overbooked'
+    }
+  }
+
+  return status
+}
+
 const durationOptionsMap: Record<number, string> = {
   '7': 'Up to 1 week',
   '42': 'Up to 6 weeks',

--- a/server/utils/match/occupancy.ts
+++ b/server/utils/match/occupancy.ts
@@ -36,6 +36,12 @@ export const dayAvailabilityStatus = (
   return status
 }
 
+export const dayAvailabilityStatusMap: Record<DayAvailabilityStatus, string> = {
+  available: 'Available',
+  availableForCriteria: 'Available for criteria',
+  overbooked: 'Overbooked',
+}
+
 const durationOptionsMap: Record<number, string> = {
   '7': 'Up to 1 week',
   '42': 'Up to 6 weeks',

--- a/server/utils/match/occupancy.ts
+++ b/server/utils/match/occupancy.ts
@@ -1,5 +1,5 @@
 import { Cas1PremiseCapacityForDay, Cas1SpaceBookingCharacteristic } from '@approved-premises/api'
-import { SelectOption } from '@approved-premises/ui'
+import { SelectOption, SummaryListItem } from '@approved-premises/ui'
 
 export const dayAvailabilityCount = (
   dayCapacity: Cas1PremiseCapacityForDay,
@@ -40,6 +40,33 @@ export const dayAvailabilityStatusMap: Record<DayAvailabilityStatus, string> = {
   available: 'Available',
   availableForCriteria: 'Available for criteria',
   overbooked: 'Overbooked',
+}
+
+export const dayAvailabilitySummaryListItems = (
+  dayCapacity: Cas1PremiseCapacityForDay,
+  criteria: Array<Cas1SpaceBookingCharacteristic> = [],
+): Array<SummaryListItem> => {
+  const rows = [
+    { key: { text: 'AP capacity' }, value: { text: `${dayCapacity.totalBedCount}` } },
+    { key: { text: 'Booked spaces' }, value: { text: `${dayCapacity.bookingCount}` } },
+  ]
+
+  if (!criteria.length) {
+    rows.push({ key: { text: 'Available spaces' }, value: { text: `${dayAvailabilityCount(dayCapacity)}` } })
+  } else {
+    criteria.forEach(criterion => {
+      const dayCharacteristic = dayCapacity.characteristicAvailability.find(
+        characteristic => characteristic.characteristic === criterion,
+      )
+
+      rows.push({
+        key: { text: `${occupancyCriteriaMap[criterion]} spaces available` },
+        value: { text: `${dayCharacteristic.availableBedsCount - dayCharacteristic.bookingsCount}` },
+      })
+    })
+  }
+
+  return rows
 }
 
 const durationOptionsMap: Record<number, string> = {

--- a/server/utils/match/occupancyCalendar.test.ts
+++ b/server/utils/match/occupancyCalendar.test.ts
@@ -20,15 +20,15 @@ describe('occupancyCalendar', () => {
       {
         name: 'December 2024',
         days: [
-          { name: 'Mon 30 Dec', bookableCount: 5, status: 'available' },
-          { name: 'Tue 31 Dec', bookableCount: 5, status: 'available' },
+          { date: '2024-12-30', name: 'Mon 30 Dec', bookableCount: 5, status: 'available' },
+          { date: '2024-12-31', name: 'Tue 31 Dec', bookableCount: 5, status: 'available' },
         ],
       },
       {
         name: 'January 2025',
         days: [
-          { name: 'Wed 1 Jan', bookableCount: -2, status: 'overbooked' },
-          { name: 'Thu 2 Jan', bookableCount: 5, status: 'available' },
+          { date: '2025-01-01', name: 'Wed 1 Jan', bookableCount: -2, status: 'overbooked' },
+          { date: '2025-01-02', name: 'Thu 2 Jan', bookableCount: 5, status: 'available' },
         ],
       },
     ])
@@ -50,7 +50,7 @@ describe('occupancyCalendar', () => {
     expect(occupancyCalendar(premisesCapacity.capacity, [])).toEqual([
       {
         name: 'December 2024',
-        days: [{ name: 'Mon 30 Dec', bookableCount: 4, status: 'available' }],
+        days: [{ date: '2024-12-30', name: 'Mon 30 Dec', bookableCount: 4, status: 'available' }],
       },
     ])
   })
@@ -93,6 +93,7 @@ describe('occupancyCalendar', () => {
           name: 'February 2025',
           days: [
             {
+              date: '2025-02-02',
               name: 'Sun 2 Feb',
               bookableCount: -2,
               criteriaBookableCount: -1,
@@ -107,6 +108,7 @@ describe('occupancyCalendar', () => {
           name: 'February 2025',
           days: [
             {
+              date: '2025-02-02',
               name: 'Sun 2 Feb',
               bookableCount: -2,
               criteriaBookableCount: 3,
@@ -121,6 +123,7 @@ describe('occupancyCalendar', () => {
           name: 'February 2025',
           days: [
             {
+              date: '2025-02-02',
               name: 'Sun 2 Feb',
               bookableCount: -2,
               criteriaBookableCount: 1,
@@ -135,6 +138,7 @@ describe('occupancyCalendar', () => {
           name: 'February 2025',
           days: [
             {
+              date: '2025-02-02',
               name: 'Sun 2 Feb',
               bookableCount: -2,
               criteriaBookableCount: 0,
@@ -151,6 +155,7 @@ describe('occupancyCalendar', () => {
           name: 'February 2025',
           days: [
             {
+              date: '2025-02-02',
               name: 'Sun 2 Feb',
               bookableCount: -2,
               criteriaBookableCount: -1,
@@ -169,6 +174,7 @@ describe('occupancyCalendar', () => {
           name: 'February 2025',
           days: [
             {
+              date: '2025-02-02',
               name: 'Sun 2 Feb',
               bookableCount: 18,
               criteriaBookableCount: 3,
@@ -183,6 +189,7 @@ describe('occupancyCalendar', () => {
           name: 'February 2025',
           days: [
             {
+              date: '2025-02-02',
               name: 'Sun 2 Feb',
               bookableCount: 18,
               criteriaBookableCount: 0,

--- a/server/utils/match/occupancyCalendar.test.ts
+++ b/server/utils/match/occupancyCalendar.test.ts
@@ -16,19 +16,43 @@ describe('occupancyCalendar', () => {
       ],
     })
 
-    expect(occupancyCalendar(premisesCapacity.capacity)).toEqual([
+    expect(occupancyCalendar(premisesCapacity.capacity, 'path/:date')).toEqual([
       {
         name: 'December 2024',
         days: [
-          { date: '2024-12-30', name: 'Mon 30 Dec', bookableCount: 5, status: 'available' },
-          { date: '2024-12-31', name: 'Tue 31 Dec', bookableCount: 5, status: 'available' },
+          {
+            date: '2024-12-30',
+            name: 'Mon 30 Dec',
+            bookableCount: 5,
+            status: 'available',
+            link: 'path/2024-12-30',
+          },
+          {
+            date: '2024-12-31',
+            name: 'Tue 31 Dec',
+            bookableCount: 5,
+            status: 'available',
+            link: 'path/2024-12-31',
+          },
         ],
       },
       {
         name: 'January 2025',
         days: [
-          { date: '2025-01-01', name: 'Wed 1 Jan', bookableCount: -2, status: 'overbooked' },
-          { date: '2025-01-02', name: 'Thu 2 Jan', bookableCount: 5, status: 'available' },
+          {
+            date: '2025-01-01',
+            name: 'Wed 1 Jan',
+            bookableCount: -2,
+            status: 'overbooked',
+            link: 'path/2025-01-01',
+          },
+          {
+            date: '2025-01-02',
+            name: 'Thu 2 Jan',
+            bookableCount: 5,
+            status: 'available',
+            link: 'path/2025-01-02',
+          },
         ],
       },
     ])
@@ -47,10 +71,18 @@ describe('occupancyCalendar', () => {
       ],
     })
 
-    expect(occupancyCalendar(premisesCapacity.capacity, [])).toEqual([
+    expect(occupancyCalendar(premisesCapacity.capacity, 'foo/:date', [])).toEqual([
       {
         name: 'December 2024',
-        days: [{ date: '2024-12-30', name: 'Mon 30 Dec', bookableCount: 4, status: 'available' }],
+        days: [
+          {
+            date: '2024-12-30',
+            name: 'Mon 30 Dec',
+            bookableCount: 4,
+            status: 'available',
+            link: 'foo/2024-12-30',
+          },
+        ],
       },
     ])
   })
@@ -88,7 +120,7 @@ describe('occupancyCalendar', () => {
     ]
 
     it('returns the calendar with bookable count for the selected criteria', () => {
-      expect(occupancyCalendar(capacity, ['hasEnSuite'])).toEqual([
+      expect(occupancyCalendar(capacity, 'foo/:date', ['hasEnSuite'])).toEqual([
         {
           name: 'February 2025',
           days: [
@@ -98,12 +130,13 @@ describe('occupancyCalendar', () => {
               bookableCount: -2,
               criteriaBookableCount: -1,
               status: 'overbooked',
+              link: 'foo/2025-02-02?criteria=hasEnSuite',
             },
           ],
         },
       ])
 
-      expect(occupancyCalendar(capacity, ['isSuitedForSexOffenders'])).toEqual([
+      expect(occupancyCalendar(capacity, 'foo/:date', ['isSuitedForSexOffenders'])).toEqual([
         {
           name: 'February 2025',
           days: [
@@ -113,12 +146,13 @@ describe('occupancyCalendar', () => {
               bookableCount: -2,
               criteriaBookableCount: 3,
               status: 'availableForCriteria',
+              link: 'foo/2025-02-02?criteria=isSuitedForSexOffenders',
             },
           ],
         },
       ])
 
-      expect(occupancyCalendar(capacity, ['isWheelchairDesignated'])).toEqual([
+      expect(occupancyCalendar(capacity, 'foo/:date', ['isWheelchairDesignated'])).toEqual([
         {
           name: 'February 2025',
           days: [
@@ -128,12 +162,13 @@ describe('occupancyCalendar', () => {
               bookableCount: -2,
               criteriaBookableCount: 1,
               status: 'availableForCriteria',
+              link: 'foo/2025-02-02?criteria=isWheelchairDesignated',
             },
           ],
         },
       ])
 
-      expect(occupancyCalendar(capacity, ['isStepFreeDesignated'])).toEqual([
+      expect(occupancyCalendar(capacity, 'foo/:date', ['isStepFreeDesignated'])).toEqual([
         {
           name: 'February 2025',
           days: [
@@ -143,6 +178,7 @@ describe('occupancyCalendar', () => {
               bookableCount: -2,
               criteriaBookableCount: 0,
               status: 'overbooked',
+              link: 'foo/2025-02-02?criteria=isStepFreeDesignated',
             },
           ],
         },
@@ -150,7 +186,9 @@ describe('occupancyCalendar', () => {
     })
 
     it('returns the calendar with the lowest bookable count for all criteria', () => {
-      expect(occupancyCalendar(capacity, ['hasEnSuite', 'isSuitedForSexOffenders', 'isWheelchairDesignated'])).toEqual([
+      expect(
+        occupancyCalendar(capacity, 'foo/:date', ['hasEnSuite', 'isSuitedForSexOffenders', 'isWheelchairDesignated']),
+      ).toEqual([
         {
           name: 'February 2025',
           days: [
@@ -160,6 +198,7 @@ describe('occupancyCalendar', () => {
               bookableCount: -2,
               criteriaBookableCount: -1,
               status: 'overbooked',
+              link: 'foo/2025-02-02?criteria=hasEnSuite&criteria=isSuitedForSexOffenders&criteria=isWheelchairDesignated',
             },
           ],
         },
@@ -169,7 +208,7 @@ describe('occupancyCalendar', () => {
     it('returns the correct availability status if the day is available with and without criteria applied', () => {
       const capacityAvailable = [cas1PremiseCapacityForDayFactory.build({ ...capacity[0], bookingCount: 0 })]
 
-      expect(occupancyCalendar(capacityAvailable, ['isSuitedForSexOffenders'])).toEqual([
+      expect(occupancyCalendar(capacityAvailable, 'foo/:date', ['isSuitedForSexOffenders'])).toEqual([
         {
           name: 'February 2025',
           days: [
@@ -179,12 +218,13 @@ describe('occupancyCalendar', () => {
               bookableCount: 18,
               criteriaBookableCount: 3,
               status: 'available',
+              link: 'foo/2025-02-02?criteria=isSuitedForSexOffenders',
             },
           ],
         },
       ])
 
-      expect(occupancyCalendar(capacityAvailable, ['isStepFreeDesignated'])).toEqual([
+      expect(occupancyCalendar(capacityAvailable, 'foo/:date', ['isStepFreeDesignated'])).toEqual([
         {
           name: 'February 2025',
           days: [
@@ -194,6 +234,7 @@ describe('occupancyCalendar', () => {
               bookableCount: 18,
               criteriaBookableCount: 0,
               status: 'overbooked',
+              link: 'foo/2025-02-02?criteria=isStepFreeDesignated',
             },
           ],
         },

--- a/server/utils/match/occupancyCalendar.ts
+++ b/server/utils/match/occupancyCalendar.ts
@@ -1,6 +1,7 @@
 import type { Cas1PremiseCapacityForDay, Cas1SpaceBookingCharacteristic } from '@approved-premises/api'
 import { DateFormats } from '../dateUtils'
 import { dayAvailabilityCount, dayAvailabilityStatus } from './occupancy'
+import { createQueryString } from '../utils'
 
 type CalendarDayStatus = 'available' | 'availableForCriteria' | 'overbooked'
 
@@ -10,6 +11,7 @@ type CalendarDay = {
   status: CalendarDayStatus
   bookableCount: number
   criteriaBookableCount?: number
+  link: string
 }
 type CalendarMonth = {
   name: string
@@ -19,6 +21,7 @@ export type Calendar = Array<CalendarMonth>
 
 export const occupancyCalendar = (
   capacity: Array<Cas1PremiseCapacityForDay>,
+  placeholderLink: string,
   criteria: Array<Cas1SpaceBookingCharacteristic> = [],
 ): Calendar => {
   return capacity.reduce<Calendar>((calendar, day) => {
@@ -40,6 +43,13 @@ export const occupancyCalendar = (
       name: DateFormats.isoDateToUIDate(day.date, { format: 'longNoYear' }),
       status: dayAvailabilityStatus(day, criteria),
       bookableCount,
+      link: `${placeholderLink.replace(':date', day.date)}${createQueryString(
+        { criteria },
+        {
+          addQueryPrefix: true,
+          arrayFormat: 'repeat',
+        },
+      )}`,
     }
 
     if (criteria.length) {

--- a/server/utils/match/occupancyCalendar.ts
+++ b/server/utils/match/occupancyCalendar.ts
@@ -1,10 +1,11 @@
 import type { Cas1PremiseCapacityForDay, Cas1SpaceBookingCharacteristic } from '@approved-premises/api'
 import { DateFormats } from '../dateUtils'
-import { dayAvailabilityCount } from './occupancy'
+import { dayAvailabilityCount, dayAvailabilityStatus } from './occupancy'
 
 type CalendarDayStatus = 'available' | 'availableForCriteria' | 'overbooked'
 
 type CalendarDay = {
+  date: string
   name: string
   status: CalendarDayStatus
   bookableCount: number
@@ -35,21 +36,14 @@ export const occupancyCalendar = (
     const bookableCount = dayAvailabilityCount(day)
 
     const calendarDay: CalendarDay = {
+      date: day.date,
       name: DateFormats.isoDateToUIDate(day.date, { format: 'longNoYear' }),
-      status: bookableCount > 0 ? 'available' : 'overbooked',
+      status: dayAvailabilityStatus(day, criteria),
       bookableCount,
     }
 
     if (criteria.length) {
-      const criteriaBookableCount = dayAvailabilityCount(day, criteria)
-
-      calendarDay.criteriaBookableCount = criteriaBookableCount
-
-      if (criteriaBookableCount > 0 && calendarDay.status === 'overbooked') {
-        calendarDay.status = 'availableForCriteria'
-      } else if (criteriaBookableCount <= 0) {
-        calendarDay.status = 'overbooked'
-      }
+      calendarDay.criteriaBookableCount = dayAvailabilityCount(day, criteria)
     }
 
     currentMonth.days.push(calendarDay)

--- a/server/views/match/placementRequests/occupancyView/viewDay.njk
+++ b/server/views/match/placementRequests/occupancyView/viewDay.njk
@@ -3,5 +3,5 @@
 {% set pageTitle = applicationName + " - " + pageHeading %}
 
 {% block content %}
-    <h1 class="govuk-heading-l">{{ status }}</h1>
+    <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 {% endblock %}

--- a/server/views/match/placementRequests/occupancyView/viewDay.njk
+++ b/server/views/match/placementRequests/occupancyView/viewDay.njk
@@ -1,0 +1,7 @@
+{% extends "../../layout-with-details.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading %}
+
+{% block content %}
+    <h1 class="govuk-heading-l">{{ status }}</h1>
+{% endblock %}

--- a/server/views/match/placementRequests/occupancyView/viewDay.njk
+++ b/server/views/match/placementRequests/occupancyView/viewDay.njk
@@ -1,7 +1,13 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
 {% extends "../../layout-with-details.njk" %}
 
 {% set pageTitle = applicationName + " - " + pageHeading %}
 
 {% block content %}
     <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+    {{ govukSummaryList({
+        rows: availabilitySummaryListItems
+    }) }}
 {% endblock %}

--- a/server/views/match/placementRequests/occupancyView/viewDay.njk
+++ b/server/views/match/placementRequests/occupancyView/viewDay.njk
@@ -31,6 +31,7 @@
             {% endif %}
 
             {{ govukSummaryList({
+                classes: 'govuk-summary-list--swap-bolding',
                 rows: availabilitySummaryListItems
             }) }}
 

--- a/server/views/match/placementRequests/occupancyView/viewDay.njk
+++ b/server/views/match/placementRequests/occupancyView/viewDay.njk
@@ -1,13 +1,39 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% extends "../../layout-with-details.njk" %}
 
 {% set pageTitle = applicationName + " - " + pageHeading %}
 
-{% block content %}
-    <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-
-    {{ govukSummaryList({
-        rows: availabilitySummaryListItems
+{% block beforeContent %}
+    {{ govukBackLink({
+        text: "Back",
+        href: backlink
     }) }}
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+            <h2 class="govuk-heading-m">{{ formatDate(date) }}</h2>
+
+            {% if status === 'available' %}
+                <p>The space you require is available.</p>
+            {% endif %}
+            {% if status === 'availableForCriteria' %}
+                <p>This AP is full or overbooked, but the space you require is available as it is occupied by someone
+                    who does not need it.</p>
+            {% endif %}
+            {% if status === 'overbooked' %}
+                <p>This AP is full or overbooked. The space you require is not available.</p>
+            {% endif %}
+
+            {{ govukSummaryList({
+                rows: availabilitySummaryListItems
+            }) }}
+
+        </div>
+    </div>
 {% endblock %}

--- a/server/views/partials/_calendar.njk
+++ b/server/views/partials/_calendar.njk
@@ -7,7 +7,7 @@
                 <ul class="calendar__month govuk-list">
                     {% for day in month.days %}
                         <li class="calendar__day calendar__day--{{ day.name.slice(0,3) | lower }}{% if day.status !== 'available' %} {{ 'govuk-tag--yellow' if day.status in ['availableForCriteria','full'] else 'govuk-tag--red' }}{% endif %}">
-                            <a class="calendar__link" href="{% if day.link %}{{ day.link }}{% else %}#{% endif %}">
+                            <a class="calendar__link" {% if day.link %}href="{{ day.link }}"{% endif %}>
                                 <time class="calendar__date" datetime="{{ day.date }}">{{ day.name }}</time>
 
                                 <dl class="calendar__availability">


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1606

# Changes in this PR

Implements the day availability detailed view. Calendar on occupancy view now links to this.

It has been assumed that the numbers shown on that page should match those shown on the calendar view, so this may return negative numbers when there is no availability for a given criteria (or globally).

## Screenshots of UI changes

<img width="741" alt="Screenshot 2024-12-19 at 15 37 12" src="https://github.com/user-attachments/assets/77bfd624-107c-44a0-93fe-a539a2c83e0d" />

<img width="735" alt="Screenshot 2024-12-19 at 15 38 29" src="https://github.com/user-attachments/assets/21f6c9f9-eef0-4eb0-8723-65e65f0dc270" />

<img width="747" alt="Screenshot 2024-12-19 at 15 39 11" src="https://github.com/user-attachments/assets/b4c833d7-6c3b-4c60-b986-3be228a16714" />

