### PR TITLE
Occupancy View - add license expiry date to matching details section

### DIFF
--- a/integration_tests/pages/match/occupancyViewPage.ts
+++ b/integration_tests/pages/match/occupancyViewPage.ts
@@ -3,7 +3,6 @@ import {
   Cas1PremiseCapacity,
   Cas1PremisesSummary,
   Cas1SpaceBookingCharacteristic,
-  PlacementRequest,
   PlacementRequestDetail,
 } from '@approved-premises/api'
 import Page from '../page'
@@ -32,7 +31,7 @@ export default class OccupancyViewPage extends Page {
     totalCapacity: number,
     startDate: string,
     durationDays: number,
-    placementRequest: PlacementRequest,
+    placementRequest: PlacementRequestDetail,
     managerDetails: string,
   ) {
     cy.get('.govuk-details').within(() => {

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -159,5 +159,6 @@ export default ApplicationFactory.define(() => ({
   caseManagerIsNotApplicant: faker.datatype.boolean(),
   caseManagerUserDetails: applicationUserDetailsFactory.build(),
   applicantUserDetails: applicationUserDetailsFactory.build(),
+  licenceExpiryDate: DateFormats.dateObjToIsoDateTime(faker.date.future()),
   ...apTypeField(),
 }))

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -1,6 +1,7 @@
 import { addDays } from 'date-fns'
 import type {
   ApType,
+  ApprovedPremisesApplication,
   Cas1SpaceCharacteristic,
   Gender,
   PlacementCriteria,
@@ -174,17 +175,19 @@ export const spaceBookingPersonNeedsSummaryCardRows = (
 
 export const occupancyViewSummaryListForMatchingDetails = (
   totalCapacity: number,
-  placementRequest: PlacementRequest,
+  placementRequest: PlacementRequestDetail,
   managerDetails: string,
 ): Array<SummaryListItem> => {
   const placementRequestDates = placementDates(placementRequest.expectedArrival, placementRequest.duration)
   const essentialCharacteristics = filterOutAPTypes(placementRequest.essentialCriteria)
+  const application = placementRequest.application as ApprovedPremisesApplication
 
   return [
     arrivalDateRow(placementRequestDates.startDate),
     departureDateRow(placementRequestDates.endDate),
     placementLengthRow(placementRequestDates.placementLength),
     releaseTypeRow(placementRequest),
+    licenceExpiryDateRow(application),
     totalCapacityRow(totalCapacity),
     apManagerDetailsRow(managerDetails),
     spaceRequirementsRow(essentialCharacteristics),
@@ -360,6 +363,15 @@ export const releaseTypeRow = (placementRequest: PlacementRequest) => ({
   },
   value: {
     text: allReleaseTypes[placementRequest.releaseType],
+  },
+})
+
+export const licenceExpiryDateRow = (application: ApprovedPremisesApplication) => ({
+  key: {
+    text: 'Licence expiry date',
+  },
+  value: {
+    text: application.licenceExpiryDate ? DateFormats.isoDateToUIDate(application.licenceExpiryDate) : '',
   },
 })
 


### PR DESCRIPTION
# Context

* This relates to this ticket: https://dsdmoj.atlassian.net/browse/APS-1624
* We previously de-scoped including the `Licence expiry date` data from the `Matching details` section on the `Occupancy View` page because the data was not available from the API
* The `Licence expiry date` data has since been made available from the `GET /placement-requests/{id}` API endpoint

# Changes in this PR
- Add the `Licence expiry date` data into the `Matching details` section on the `Occupancy View`

## Screenshots of UI changes

### Before
<img width="2048" alt="before" src="https://github.com/user-attachments/assets/b1d571d7-32d2-4607-89cd-48692a0b7b89" />

### After
<img width="2048" alt="after" src="https://github.com/user-attachments/assets/22d0af93-8fea-4bad-99f9-45de5302de67" />
