### PR TITLE
APS-1704 default tab on premises page

### DIFF
--- a/e2e/steps/manage.ts
+++ b/e2e/steps/manage.ts
@@ -35,6 +35,9 @@ export const manageBooking = async ({
   // Then I see the page for the given premises
   const premisesPage = await PremisesPage.initialize(page, premisesName)
 
+  // And I select the upcoming tab
+  await premisesPage.clickTab('Upcoming')
+
   // And I can see the placement in the list of upcoming placements
   const bookingRow = await premisesPage.findRowWithValues([
     DateFormats.isoDateToUIDate(datesOfPlacement.startDate, { format: 'short' }),

--- a/server/controllers/manage/premises/premisesController.test.ts
+++ b/server/controllers/manage/premises/premisesController.test.ts
@@ -64,8 +64,10 @@ describe('V2PremisesController', () => {
       }
     }
 
-    it('should render the premises detail and list of placements on the default ("upcoming") tab', async () => {
-      const { premisesSummary, paginatedPlacements, keyworkersList } = await mockSummaryAndPlacements({})
+    it('should render the premises detail and list of placements on the "upcoming" tab', async () => {
+      const { premisesSummary, paginatedPlacements, keyworkersList } = await mockSummaryAndPlacements({
+        activeTab: 'upcoming',
+      })
 
       expect(response.render).toHaveBeenCalledWith('manage/premises/show', {
         premises: premisesSummary,
@@ -92,10 +94,8 @@ describe('V2PremisesController', () => {
       })
     })
 
-    it('should render the premises detail and list of placements on the "current" tab', async () => {
-      const { premisesSummary, paginatedPlacements, keyworkersList } = await mockSummaryAndPlacements({
-        activeTab: 'current',
-      })
+    it('should render the premises detail and list of placements on the default ("current") tab', async () => {
+      const { premisesSummary, paginatedPlacements, keyworkersList } = await mockSummaryAndPlacements({})
 
       expect(response.render).toHaveBeenCalledWith('manage/premises/show', {
         premises: premisesSummary,
@@ -264,12 +264,12 @@ describe('V2PremisesController', () => {
       expect(response.render).toHaveBeenCalledWith('manage/premises/show', {
         premises: premisesSummary,
         showPlacements: false,
-        sortBy: 'canonicalArrivalDate',
+        sortBy: 'canonicalDepartureDate',
         sortDirection: 'asc',
-        activeTab: 'upcoming',
+        activeTab: 'current',
         pageNumber: undefined,
         totalPages: undefined,
-        hrefPrefix: '/manage/premises/some-uuid?activeTab=upcoming&',
+        hrefPrefix: '/manage/premises/some-uuid?activeTab=current&',
         placements: undefined,
       })
       expect(premisesService.find).toHaveBeenCalledWith(token, premisesId)

--- a/server/controllers/manage/premises/premisesController.ts
+++ b/server/controllers/manage/premises/premisesController.ts
@@ -27,7 +27,7 @@ export default class PremisesController {
         historic: { pageSize: 20, sortBy: 'canonicalDepartureDate', sortDirection: 'desc' },
         search: { pageSize: 20, sortBy: 'canonicalArrivalDate', sortDirection: 'desc' },
       }
-      const { crnOrName, keyworker, activeTab = 'upcoming' } = req.query as Record<string, string>
+      const { crnOrName, keyworker, activeTab = 'current' } = req.query as Record<string, string>
       const { pageNumber, sortBy, sortDirection, hrefPrefix } = getPaginationDetails<Cas1SpaceBookingSummarySortField>(
         req,
         managePaths.premises.show({ premisesId: req.params.premisesId }),


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1704

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Change the default tab on the premises detail page to 'Current' rather than 'Upcoming'.
A trivial change but the impact on tests is surprisingly large

There is no UI change as such - just that the initial landing tab selection is different.
[x] I have run the E2E tests locally and they passed

