### PR TITLE
APS-1705 Default key-worker to 'Not assigned' on the premises view page placement list

### DIFF
--- a/server/utils/premises/index.test.ts
+++ b/server/utils/premises/index.test.ts
@@ -89,12 +89,12 @@ describe('premisesUtils', () => {
       ])
     })
 
-    it('should select the option whose id maches the premisesId field in the context', () => {
+    it('should select the option whose id matches the premisesId field in the context', () => {
       expect(
         groupCas1SummaryPremisesSelectOptions(premises, { premisesId: area1Premises[0].id })[0].items[0].selected,
       ).toBeTruthy()
     })
-    it('should select the option whose id maches the specified field in the context', () => {
+    it('should select the option whose id matches the specified field in the context', () => {
       expect(
         groupCas1SummaryPremisesSelectOptions(premises, { premises: area2Premises[1].id }, 'premises')[1].items[1]
           .selected,
@@ -119,7 +119,7 @@ describe('premisesUtils', () => {
         },
       ])
     })
-    it('should select the option whose id maches the specfied field in the context', () => {
+    it('should select the option whose id matches the specfied field in the context', () => {
       expect(
         cas1PremisesSummaryRadioOptions(premises, { premises: premises[1].id }, 'premises')[1].selected,
       ).toBeTruthy()
@@ -266,6 +266,7 @@ describe('premisesUtils', () => {
         const placements = [
           ...cas1SpaceBookingSummaryFactory.buildList(3, { tier: 'A' }),
           cas1SpaceBookingSummaryFactory.build({ tier: 'A', status: undefined }),
+          cas1SpaceBookingSummaryFactory.build({ tier: 'A', keyWorkerAllocation: undefined }),
         ]
 
         const tableRows = placementTableRows(activeTab, 'Test_Premises_Id', placements)
@@ -281,7 +282,7 @@ describe('premisesUtils', () => {
           ]
           return activeTab === 'historic'
             ? [...baseColumns, statusColumn]
-            : [...baseColumns, { text: placement.keyWorkerAllocation.keyWorker.name }, statusColumn]
+            : [...baseColumns, { text: placement.keyWorkerAllocation?.keyWorker?.name || 'Not assigned' }, statusColumn]
         })
         expect(tableRows).toEqual(expectedRows)
       },

--- a/server/utils/premises/index.ts
+++ b/server/utils/premises/index.ts
@@ -163,7 +163,7 @@ export const placementTableRows = (
       tier: htmlValue(getTierOrBlank(tier)),
       canonicalArrivalDate: textValue(DateFormats.isoDateToUIDate(canonicalArrivalDate, { format: 'short' })),
       canonicalDepartureDate: textValue(DateFormats.isoDateToUIDate(canonicalDepartureDate, { format: 'short' })),
-      keyWorkerName: textValue(keyWorkerAllocation?.keyWorker?.name),
+      keyWorkerName: textValue(keyWorkerAllocation?.keyWorker?.name || 'Not assigned'),
       status: textValue(statusTextMap[status]),
     }
     return columnMap[activeTab].map(({ fieldName }: ColumnDefinition) => fieldValues[fieldName])


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/APS-1705

# Changes in this PR
For placements where a key-worker is not assigned, show 'Not assigned' in the table rather than blank

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/ac742d6e-56d1-4a21-99dd-3b5b3ea189b6)

### After
![image](https://github.com/user-attachments/assets/091f7e74-d2be-4456-ad04-580ec374d159)

