### PR TITLE
Remove UUID dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,8 +53,7 @@
         "static-path": "^0.0.4",
         "superagent": "^9.0.0",
         "underscore": "^1.13.6",
-        "url-value-parser": "^2.2.0",
-        "uuid": "^10.0.0"
+        "url-value-parser": "^2.2.0"
       },
       "devDependencies": {
         "@golevelup/ts-jest": "^0.5.0",
@@ -78,7 +77,6 @@
         "@types/superagent": "^8.0.0",
         "@types/supertest": "^6.0.0",
         "@types/underscore": "^1.11.4",
-        "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "audit-ci": "^7.0.0",
@@ -3876,13 +3874,6 @@
       "version": "1.11.15",
       "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.15.tgz",
       "integrity": "sha512-HP38xE+GuWGlbSRq9WrZkousaQ7dragtZCruBVMi0oX1migFZavZ3OROKHSkNp/9ouq82zrWtZpg18jFnVN96g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -15806,19 +15797,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/uuidjs": {

--- a/package.json
+++ b/package.json
@@ -162,8 +162,7 @@
     "static-path": "^0.0.4",
     "superagent": "^9.0.0",
     "underscore": "^1.13.6",
-    "url-value-parser": "^2.2.0",
-    "uuid": "^10.0.0"
+    "url-value-parser": "^2.2.0"
   },
   "devDependencies": {
     "@golevelup/ts-jest": "^0.5.0",
@@ -187,7 +186,6 @@
     "@types/superagent": "^8.0.0",
     "@types/supertest": "^6.0.0",
     "@types/underscore": "^1.11.4",
-    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "audit-ci": "^7.0.0",

--- a/server/middleware/setUpWebSession.ts
+++ b/server/middleware/setUpWebSession.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from 'uuid'
 import session from 'express-session'
 import RedisStore from 'connect-redis'
 import express, { Router } from 'express'
@@ -32,7 +31,7 @@ export default function setUpWebSession(): Router {
   router.use((req, res, next) => {
     const headerName = 'X-Request-Id'
     const oldValue = req.get(headerName)
-    const id = oldValue === undefined ? uuidv4() : oldValue
+    const id = oldValue === undefined ? crypto.randomUUID() : oldValue
 
     res.set(headerName, id)
     req.id = id


### PR DESCRIPTION


# Context
This dependency was removed from HMPPS Typescript template so this commit brings this codebase inline with the template.

See https://github.com/ministryofjustice/hmpps-template-typescript/pull/439
