### PR TITLE
E2E fix for Occupancy view page

### DIFF
--- a/e2e/pages/match/occupancyViewPage.ts
+++ b/e2e/pages/match/occupancyViewPage.ts
@@ -25,6 +25,6 @@ export class OccupancyViewPage extends MatchBasePage {
   }
 
   async shouldShowReleaseType(releaseType: ReleaseTypeLabel) {
-    await expect(this.page.locator('.govuk-details').getByText(releaseType)).toBeVisible()
+    await expect(this.page.locator('.govuk-details').getByText(releaseType, { exact: true })).toBeVisible()
   }
 }


### PR DESCRIPTION
# Context

JIRA: https://dsdmoj.atlassian.net/browse/APS-1624

# Changes in this PR

- E2E tests were failing due to finding 2 fields when expecting one
- This was due to me adding the `Licence expiry date` label and the e2e looking for the release type of `Licence` on the same page
- This slipped through the net as the `License expiry date` expectations were asserted into integration tests only and did not run e2e locally as no changes to them. Ooops!
