### PR TITLE
APS-1751 Criteria transfer to space booking

### DIFF
--- a/integration_tests/pages/match/bookASpacePage.ts
+++ b/integration_tests/pages/match/bookASpacePage.ts
@@ -1,13 +1,16 @@
-import { ApType, PlacementDates, PlacementRequestDetail, Premises } from '@approved-premises/api'
+import {
+  ApType,
+  Cas1SpaceBookingCharacteristic,
+  Cas1SpaceCharacteristic,
+  PlacementDates,
+  PlacementRequestDetail,
+  Premises,
+} from '@approved-premises/api'
 import Page from '../page'
 import paths from '../../../server/paths/match'
 import { createQueryString, sentenceCase } from '../../../server/utils/utils'
 import { DateFormats } from '../../../server/utils/dateUtils'
-import {
-  filterOutAPTypes,
-  placementDates,
-  placementLength as placementLengthInDaysAndWeeks,
-} from '../../../server/utils/match'
+import { placementDates, placementLength as placementLengthInDaysAndWeeks } from '../../../server/utils/match'
 import { placementCriteriaLabels } from '../../../server/utils/placementCriteriaUtils'
 import { apTypeLabels } from '../../../server/utils/apTypeLabels'
 
@@ -23,8 +26,9 @@ export default class BookASpacePage extends Page {
     premisesName: Premises['name'],
     premisesId: Premises['id'],
     apType: ApType,
+    criteria: Array<Cas1SpaceBookingCharacteristic>,
   ) {
-    const queryString = createQueryString({ startDate, durationDays, premisesName, premisesId, apType })
+    const queryString = createQueryString({ startDate, durationDays, premisesName, premisesId, apType, criteria })
     const path = `${paths.v2Match.placementRequests.spaceBookings.new({ id: placementRequest.id })}?${queryString}`
     cy.visit(path)
     return new BookASpacePage(premisesName)
@@ -35,6 +39,7 @@ export default class BookASpacePage extends Page {
     startDate: string,
     duration: PlacementDates['duration'],
     apType: ApType,
+    criteria?: Array<Cas1SpaceCharacteristic>,
   ): void {
     const { endDate, placementLength } = placementDates(startDate, duration.toString())
     cy.get('dd').contains(apTypeLabels[apType])
@@ -42,10 +47,7 @@ export default class BookASpacePage extends Page {
     cy.get('dd').contains(DateFormats.isoDateToUIDate(endDate))
     cy.get('dd').contains(placementLengthInDaysAndWeeks(placementLength))
     cy.get('dd').contains(sentenceCase(placementRequest.gender))
-    filterOutAPTypes(placementRequest.essentialCriteria).forEach(requirement => {
-      cy.get('li').contains(placementCriteriaLabels[requirement])
-    })
-    filterOutAPTypes(placementRequest.desirableCriteria).forEach(requirement => {
+    ;(criteria || []).forEach(requirement => {
       cy.get('li').contains(placementCriteriaLabels[requirement])
     })
   }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -25,7 +25,6 @@ import {
   RiskTier,
   RiskTierLevel,
   RoshRisks,
-  Cas1SpaceCharacteristic as SpaceCharacteristic,
   ApprovedPremisesUser as User,
   UserQualification,
   ApprovedPremisesUserRole as UserRole,
@@ -386,7 +385,7 @@ export interface SpaceSearchParametersUi {
   requirements: {
     apType: ApType
     gender: Gender
-    spaceCharacteristics: Array<SpaceCharacteristic>
+    spaceCharacteristics: Array<Cas1SpaceCharacteristic>
   }
 }
 

--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -301,7 +301,7 @@ describe('OccupancyViewController', () => {
 
       const expectedDurationDays = 10
       const expectedStartDate = `${arrivalYear}-0${arrivalMonth}-${arrivalDay}`
-      const expectedParams = `apType=${apType}&startDate=${expectedStartDate}&durationDays=${expectedDurationDays}&criteria=`
+      const expectedParams = `apType=${apType}&startDate=${expectedStartDate}&durationDays=${expectedDurationDays}`
       expect(response.redirect).toHaveBeenCalledWith(
         `${matchPaths.v2Match.placementRequests.spaceBookings.new({ id: placementRequestDetail.id })}?${expectedParams}`,
       )

--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -301,7 +301,7 @@ describe('OccupancyViewController', () => {
 
       const expectedDurationDays = 10
       const expectedStartDate = `${arrivalYear}-0${arrivalMonth}-${arrivalDay}`
-      const expectedParams = `apType=${apType}&startDate=${expectedStartDate}&durationDays=${expectedDurationDays}`
+      const expectedParams = `apType=${apType}&startDate=${expectedStartDate}&durationDays=${expectedDurationDays}&criteria=`
       expect(response.redirect).toHaveBeenCalledWith(
         `${matchPaths.v2Match.placementRequests.spaceBookings.new({ id: placementRequestDetail.id })}?${expectedParams}`,
       )

--- a/server/controllers/match/placementRequests/occupancyViewController.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.ts
@@ -213,6 +213,7 @@ export default class {
             DateFormats.isoToDateObj(departureDate),
             DateFormats.isoToDateObj(arrivalDate),
           ).toString(),
+          criteria: body.criteria,
         })
         res.redirect(redirectUrl)
       }

--- a/server/controllers/match/placementRequests/occupancyViewController.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.ts
@@ -213,7 +213,7 @@ export default class {
             DateFormats.isoToDateObj(departureDate),
             DateFormats.isoToDateObj(arrivalDate),
           ).toString(),
-          criteria: body.criteria,
+          criteria: body.criteria ? body.criteria : undefined,
         })
         res.redirect(redirectUrl)
       }

--- a/server/testutils/factories/spaceSearchParameters.ts
+++ b/server/testutils/factories/spaceSearchParameters.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 
 import type { Cas1SpaceSearchParameters, Cas1SpaceSearchRequirements } from '@approved-premises/api'
 import { DateFormats } from '../../utils/dateUtils'
-import { filterOutAPTypes } from '../../utils/match'
+import { filterOutAPTypes, filterToSpaceBookingCharacteristics } from '../../utils/match'
 import { placementCriteria } from './placementRequest'
 import postcodeAreas from '../../etc/postcodeAreas.json'
 import { SpaceSearchParametersUi } from '../../@types/ui'
@@ -35,7 +35,7 @@ export const spaceSearchParametersUiFactory = Factory.define<SpaceSearchParamete
     durationInDays: faker.number.int({ max: 100, min: 1 }).toString(),
     requirements: {
       apType: faker.helpers.arrayElement(['pipe', 'esap', 'rfap', 'mhapStJosephs', 'mhapElliottHouse']),
-      spaceCharacteristics: faker.helpers.arrayElements(filterOutAPTypes(placementCriteria)),
+      spaceCharacteristics: faker.helpers.arrayElements(filterToSpaceBookingCharacteristics(placementCriteria)),
       gender: faker.helpers.arrayElement(['male', 'female']),
     },
     ...startDateInputsValues,

--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -1,6 +1,7 @@
 import type {
   ApType,
   ApprovedPremisesApplication,
+  Cas1SpaceBookingCharacteristic,
   Cas1SpaceCharacteristic,
   FullPerson,
   PlacementCriteria,
@@ -35,6 +36,7 @@ import {
   encodeSpaceSearchResult,
   essentialCharacteristicsRow,
   filterOutAPTypes,
+  filterToSpaceBookingCharacteristics,
   genderRow,
   groupedCheckboxes,
   groupedCriteria,
@@ -260,7 +262,7 @@ describe('matchUtils', () => {
       const apType = 'pipe'
       const startDate = '2025-04-14'
       const durationDays = '84'
-      const spaceCharacteristics: Array<Cas1SpaceCharacteristic> = ['isWheelchairDesignated', 'isSingle']
+      const spaceCharacteristics: Array<Cas1SpaceBookingCharacteristic> = ['isWheelchairDesignated', 'isSingle']
 
       const result = occupancyViewLink({
         placementRequestId,
@@ -285,14 +287,16 @@ describe('matchUtils', () => {
       const apType = 'pipe'
       const startDate = '2025-04-14'
       const durationDays = '84'
-      const spaceCharacteristics: Array<Cas1SpaceCharacteristic> = [
+      const spaceCharacteristics: Array<PlacementCriteria> = [
+        'isPIPE',
+        'isESAP',
+        'isMHAPStJosephs',
+        'isMHAPElliottHouse',
+        'isSemiSpecialistMentalHealth',
+        'isRecoveryFocussed',
         'isWheelchairDesignated',
-        'isIAP',
-        'hasArsonInsuranceConditions',
         'isSingle',
-        'acceptsHateCrimeOffenders',
         'hasEnSuite',
-        'isArsonDesignated',
         'isArsonSuitable',
       ]
 
@@ -302,7 +306,7 @@ describe('matchUtils', () => {
         apType,
         startDate,
         durationDays,
-        spaceCharacteristics,
+        spaceCharacteristics: filterToSpaceBookingCharacteristics(spaceCharacteristics),
       })
 
       expect(result).toEqual(
@@ -322,6 +326,7 @@ describe('matchUtils', () => {
       const apType = 'pipe'
       const startDate = '2022-01-01'
       const durationDays = '1'
+      const criteria: Array<Cas1SpaceCharacteristic> = ['acceptsHateCrimeOffenders', 'hasEnSuite']
 
       const result = redirectToSpaceBookingsNew({
         placementRequestId,
@@ -330,6 +335,7 @@ describe('matchUtils', () => {
         apType,
         startDate,
         durationDays,
+        criteria,
       })
 
       expect(result).toEqual(
@@ -340,6 +346,7 @@ describe('matchUtils', () => {
             apType,
             startDate,
             durationDays,
+            criteria,
           },
           { addQueryPrefix: true, arrayFormat: 'repeat' },
         )}`,

--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -2,7 +2,6 @@ import type {
   ApType,
   ApprovedPremisesApplication,
   Cas1SpaceBookingCharacteristic,
-  Cas1SpaceCharacteristic,
   FullPerson,
   PlacementCriteria,
 } from '@approved-premises/api'
@@ -326,7 +325,7 @@ describe('matchUtils', () => {
       const apType = 'pipe'
       const startDate = '2022-01-01'
       const durationDays = '1'
-      const criteria: Array<Cas1SpaceCharacteristic> = ['acceptsHateCrimeOffenders', 'hasEnSuite']
+      const criteria: Array<Cas1SpaceBookingCharacteristic> = ['hasEnSuite', 'isArsonSuitable']
 
       const result = redirectToSpaceBookingsNew({
         placementRequestId,
@@ -341,12 +340,12 @@ describe('matchUtils', () => {
       expect(result).toEqual(
         `${paths.v2Match.placementRequests.spaceBookings.new({ id: placementRequestId })}${createQueryString(
           {
-            premisesName,
-            premisesId,
-            apType,
-            startDate,
-            durationDays,
-            criteria,
+            premisesName: 'Hope House',
+            premisesId: 'abc',
+            apType: 'pipe',
+            startDate: '2022-01-01',
+            durationDays: '1',
+            criteria: ['hasEnSuite', 'isArsonSuitable'],
           },
           { addQueryPrefix: true, arrayFormat: 'repeat' },
         )}`,

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -2,6 +2,7 @@ import { addDays } from 'date-fns'
 import type {
   ApType,
   ApprovedPremisesApplication,
+  Cas1SpaceBookingCharacteristic,
   Cas1SpaceCharacteristic,
   Gender,
   PlacementCriteria,
@@ -97,10 +98,9 @@ export const occupancyViewLink = ({
   apType: string
   startDate: string
   durationDays: string
-  spaceCharacteristics: Array<Cas1SpaceCharacteristic>
-}): string => {
-  const criteria = spaceCharacteristics.filter(name => Object.keys(occupancyCriteriaMap).includes(name))
-  return `${matchPaths.v2Match.placementRequests.search.occupancy({
+  spaceCharacteristics: Array<Cas1SpaceBookingCharacteristic>
+}): string =>
+  `${matchPaths.v2Match.placementRequests.search.occupancy({
     id: placementRequestId,
     premisesId,
   })}${createQueryString(
@@ -108,11 +108,10 @@ export const occupancyViewLink = ({
       apType,
       startDate,
       durationDays,
-      criteria,
+      criteria: spaceCharacteristics,
     },
     { addQueryPrefix: true, arrayFormat: 'repeat' },
   )}`
-}
 
 export const redirectToSpaceBookingsNew = ({
   placementRequestId,
@@ -121,6 +120,7 @@ export const redirectToSpaceBookingsNew = ({
   apType,
   startDate,
   durationDays,
+  criteria,
 }: {
   placementRequestId: string
   premisesName: string
@@ -128,6 +128,7 @@ export const redirectToSpaceBookingsNew = ({
   apType: string
   startDate: string
   durationDays: string
+  criteria: Array<Cas1SpaceCharacteristic>
 }): string => {
   return `${matchPaths.v2Match.placementRequests.spaceBookings.new({ id: placementRequestId })}${createQueryString(
     {
@@ -136,8 +137,9 @@ export const redirectToSpaceBookingsNew = ({
       apType,
       startDate,
       durationDays,
+      criteria,
     },
-    { addQueryPrefix: true },
+    { addQueryPrefix: true, arrayFormat: 'repeat' },
   )}`
 }
 
@@ -206,6 +208,15 @@ export const filterOutAPTypes = (requirements: Array<PlacementCriteria>): Array<
         'isSemiSpecialistMentalHealth',
       ].includes(requirement),
   ) as Array<SpaceCharacteristic>
+}
+
+export const filterToSpaceBookingCharacteristics = (
+  requirements: Array<PlacementCriteria>,
+): Array<Cas1SpaceBookingCharacteristic> => {
+  const characteristics = Object.keys(occupancyCriteriaMap)
+  return requirements.filter(requirement =>
+    characteristics.includes(requirement),
+  ) as Array<Cas1SpaceBookingCharacteristic>
 }
 
 export const requirementsHtmlString = (requirements: Array<SpaceCharacteristic | PlacementCriteria>): string => {

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -3,7 +3,6 @@ import type {
   ApType,
   ApprovedPremisesApplication,
   Cas1SpaceBookingCharacteristic,
-  Cas1SpaceCharacteristic,
   Gender,
   PlacementCriteria,
   PlacementRequest,
@@ -128,7 +127,7 @@ export const redirectToSpaceBookingsNew = ({
   apType: string
   startDate: string
   durationDays: string
-  criteria: Array<Cas1SpaceCharacteristic>
+  criteria: Array<Cas1SpaceBookingCharacteristic>
 }): string => {
   return `${matchPaths.v2Match.placementRequests.spaceBookings.new({ id: placementRequestId })}${createQueryString(
     {

--- a/server/views/match/placementRequests/spaceBookings/new.njk
+++ b/server/views/match/placementRequests/spaceBookings/new.njk
@@ -10,7 +10,7 @@
 {% block beforeContent %}
     {{ govukBackLink({
         text: "Back",
-        href: MatchUtils.occupancyViewLink({ placementRequestId: placementRequest.id, premisesId: premisesId, apType: apType })
+        href: backLink
     }) }}
 {% endblock %}
 


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1751

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

When a user creates a space booking from the occupancy view page, the essential criteria in the booking should be populated with the criteria that have been set as filters on the occupancy view page.
These filters are defaulted to the filters that are set on the suitability search page, which in turn are defaulted to the matching criteria on the assessment.
The selected criteria are passed into the booking confirmation page as a set of query parameters.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/2c8c3780-df80-4192-ae9a-8f5861da46ca)

![image](https://github.com/user-attachments/assets/0074ee88-7878-42fd-86c6-01e358691fea)

