### PR TITLE
Prevent infinite loop for ineligible application

### DIFF
--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -678,7 +678,7 @@ export default class ApplyHelper {
     const notEligiblePage = Page.verifyOnPage(ApplyPages.EsapNotEligible, this.application)
 
     // When I click the continue button
-    notEligiblePage.clickSubmit()
+    notEligiblePage.clickContinueWithApplication()
 
     // Then I should be able to choose a different type of AP
     Page.verifyOnPage(ApplyPages.ApType, this.application)

--- a/integration_tests/pages/apply/esapNotEligible.ts
+++ b/integration_tests/pages/apply/esapNotEligible.ts
@@ -4,4 +4,8 @@ export default class EsapNotEligible extends Page {
   constructor() {
     super(`The person is not eligible for an Enhanced Security Approved Premises (ESAP) placement.`)
   }
+
+  clickContinueWithApplication() {
+    cy.get('a[role="button"]').contains('Continue with application').click()
+  }
 }

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapNotEligible.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapNotEligible.test.ts
@@ -16,11 +16,13 @@ describe('EsapNotEligible', () => {
 
   itShouldHavePreviousValue(page, 'esap-exceptional-case')
 
-  itShouldHaveNextValue(page, 'ap-type')
+  itShouldHaveNextValue(page, '')
 
   describe('errors', () => {
-    it('should return an empty object', () => {
-      expect(page.errors()).toEqual({})
+    it('should return an object with an error to prevent continuing with the application', () => {
+      expect(page.errors()).toEqual({
+        esapNotEligible: 'The person is not eligible for an Enhanced Security Approved Premises (ESAP) placement.',
+      })
     })
   })
 

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapNotEligible.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapNotEligible.ts
@@ -1,14 +1,17 @@
 import { ApprovedPremisesApplication as Application } from '@approved-premises/api'
+import type { TaskListErrors } from '@approved-premises/ui'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
 
-@Page({ name: 'not-esap-eligible', bodyProperties: [] })
+@Page({ name: 'not-esap-eligible', bodyProperties: ['esapNotEligible'] })
 export default class EsapNotEligible implements TasklistPage {
   title = `The person is not eligible for an Enhanced Security Approved Premises (ESAP) placement.`
 
   constructor(
-    readonly body: Record<string, never>,
+    readonly body: Partial<{
+      esapNotEligible: never
+    }>,
     readonly application: Application,
   ) {}
 
@@ -21,10 +24,14 @@ export default class EsapNotEligible implements TasklistPage {
   }
 
   next() {
-    return 'ap-type'
+    return ''
   }
 
   errors() {
-    return {}
+    const errors: TaskListErrors<this> = {}
+
+    errors.esapNotEligible = this.title
+
+    return errors
   }
 }

--- a/server/views/applications/pages/type-of-ap/not-esap-eligible.njk
+++ b/server/views/applications/pages/type-of-ap/not-esap-eligible.njk
@@ -7,42 +7,31 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
-  {{ govukBackLink({
-      text: "Back",
-      href: paths.applications.pages.show({ id: applicationId, task: task, page: page.previous() })
+    {{ govukBackLink({
+        text: "Back",
+        href: paths.applications.pages.show({ id: applicationId, task: task, page: page.previous() })
     }) }}
 {% endblock %}
 
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="{{ columnClasses | default("govuk-grid-column-two-thirds") }}">
-      <form action="{{ paths.applications.pages.update({ id: applicationId, task: task, page: page.name }) }}?_method=PUT" method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+    <div class="govuk-grid-row">
+        <div class="{{ columnClasses | default("govuk-grid-column-two-thirds") }}">
+          
+            <h1 class="govuk-heading-l">{{ page.title }}</h1>
 
-        <h1 class="govuk-heading-l">{{ page.title }}</h1>
+            <p>From the information you've provided this person is not eligible for an ESAP placement.</p>
 
-        <p>From the information you've provided this person is not eligible for an ESAP placement.</p>
+            <p>You can continue with an application for a standard Approved Premises placement. Or you can return to the
+                dashboard to withdraw your application.</p>
 
-        <p>You can continue with an application for a standard Approved Premises placement. Or you can return to the dashboard to withdraw your application.</p>
+            <div class="govuk-button-group">
+                {{ govukButton({
+                    text: "Continue with application",
+                    href: paths.applications.pages.show({ id: applicationId, task: task, page: 'ap-type' })
+                }) }}
 
-        <div class="govuk-button-group">
-          {{
-            govukButton({
-              text: "Continue with application",
-              preventDoubleClick: true
-            })
-          }}
-          {{
-            linkTo(
-              paths.applications.index,
-              {},
-              {
-                text: 'Back to dashboard'
-              }
-            ) | safe
-          }}
+                <a href="{{ paths.applications.index() }}">Back to dashboard</a>
+            </div>
         </div>
-      </form>
     </div>
-  </div>
 {% endblock %}


### PR DESCRIPTION
This prevents an infinite loop when ~~building the task list~~ generating the task statuses for a task list for an application that has the ESAP AP type selected but no agreement with CHPP. The loop was the result of the ineligibility page returning the user to the AP type selection page on submission. This works if the user then saves a different AP type straight away; however, should the user then exit the application, any further attempt to load the application would result in the loop.

To prevent this, the ESAP ineligibility page no longer posts, but simply offers a link to the AP Type selection.

In addition, to ensure the AP Type task is shown as 'In progress' in the above scenario, the ESAP ineligibility page always returns an error. This error is never shown, but prevents the loop from continuing with processing any further task when building the task list for the draft application.

# Context

https://dsdmoj.atlassian.net/browse/APS-1778

# Changes in this PR

The page that offers to continue with a Standard AP (or to choose another type of AP altogether) now uses a button as link to take the user to the AP type page. The 'Back to dashboard' link next to this button is also now fixed, as it was showing as `undefined` (and with a broken URL) due to an incorrect path.

## Screenshots of UI changes

### Before

(Broken URL shown below)

<img width="1087" alt="Screenshot 2025-01-07 at 18 26 47" src="https://github.com/user-attachments/assets/53b7399e-d8a2-4703-ab6e-4aead41a4354" />

### After

<img width="674" alt="Screenshot 2025-01-07 at 18 25 53" src="https://github.com/user-attachments/assets/1bd4b07e-c258-4a01-a938-611c4ecd052a" />
