### PR TITLE
APS-1775: Update booking confirmation screen

### DIFF
--- a/e2e/pages/match/bookingPage.ts
+++ b/e2e/pages/match/bookingPage.ts
@@ -1,12 +1,11 @@
 import { Page, expect } from '@playwright/test'
 import { E2EDatesOfPlacement } from 'e2e/steps/assess'
 import { BasePage } from '../basePage'
-import { Premises } from '../../../server/@types/shared'
 import { DateFormats } from '../../../server/utils/dateUtils'
 
 export class BookingPage extends BasePage {
-  static async initialize(page: Page, premisesName: Premises['name']) {
-    await expect(page.locator('h1')).toContainText(`Book space in ${premisesName}`)
+  static async initialize(page: Page) {
+    await expect(page.locator('h1')).toContainText('Confirm booking')
 
     return new BookingPage(page)
   }

--- a/e2e/steps/match.ts
+++ b/e2e/steps/match.ts
@@ -99,7 +99,7 @@ export const matchAndBookApplication = async ({
   await occupancyViewPage.clickContinue()
 
   // Then I should see the booking screen for that AP
-  const bookingPage = await BookingPage.initialize(page, premisesName)
+  const bookingPage = await BookingPage.initialize(page)
 
   // Should show the booking details (inc. new dates)
   const newDatesOfPlacement: E2EDatesOfPlacement = {
@@ -109,7 +109,7 @@ export const matchAndBookApplication = async ({
   await bookingPage.shouldShowDatesOfPlacement(newDatesOfPlacement)
 
   // And I confirm the booking
-  const premisesId = page.url().match(/premisesId=(.[^&]*)/)[1] // premisesId=338e22f3-70be-4519-97ab-f08c6c2dfb0b
+  const premisesId = page.url().match(/space-bookings\/(.[^/]*)/)[1] // Path: /match/placement-requests/:id/space-bookings/:premisesId/new
   await bookingPage.clickConfirm()
 
   // Then I should see the Matched tab on the CRU dashboard

--- a/integration_tests/mockApis/spaceBooking.ts
+++ b/integration_tests/mockApis/spaceBooking.ts
@@ -2,7 +2,6 @@ import type {
   Cas1SpaceBooking,
   Cas1SpaceBookingResidency,
   Cas1SpaceBookingSummary,
-  PlacementRequest,
   TimelineEvent,
 } from '@approved-premises/api'
 
@@ -25,14 +24,6 @@ export default {
         jsonBody: args.spaceBooking,
       },
     }),
-
-  verifySpaceBookingCreate: async (placementRequest: PlacementRequest) =>
-    (
-      await getMatchingRequests({
-        method: 'POST',
-        url: paths.placementRequests.spaceBookings.create({ id: placementRequest.id }),
-      })
-    ).body.requests,
 
   stubSpaceBookingShow: (placement: Cas1SpaceBooking) =>
     stubFor({

--- a/integration_tests/pages/admin/placementApplications/listPage.ts
+++ b/integration_tests/pages/admin/placementApplications/listPage.ts
@@ -24,8 +24,10 @@ export default class ListPage extends Page {
     return new ListPage()
   }
 
-  shouldShowSpaceBookingConfirmation(premisesName: string, personName: string) {
-    this.shouldShowBanner(`Space booked for ${personName} in ${premisesName}`)
+  shouldShowSpaceBookingConfirmation() {
+    this.shouldShowBanner(
+      'You have now booked a place in this AP for this person. An email will be sent to the AP, to inform them of the booking.',
+    )
   }
 
   shouldShowPlacementRequests(placementRequests: Array<PlacementRequest>, status?: PlacementRequestStatus): void {

--- a/integration_tests/pages/match/bookASpacePage.ts
+++ b/integration_tests/pages/match/bookASpacePage.ts
@@ -39,7 +39,7 @@ export default class BookASpacePage extends Page {
   ): void {
     this.shouldContainSummaryListItems([
       { key: { text: 'Approved Premises' }, value: { text: premises.name } },
-      // { key: { text: 'Address' }, value: { text: premises.fullAddress } },
+      { key: { text: 'Address' }, value: { text: premises.fullAddress } },
       { key: { text: 'Space type' }, value: { html: requirementsHtmlString(criteria) } },
       { key: { text: 'Arrival date' }, value: { text: DateFormats.isoDateToUIDate(arrivalDate) } },
       { key: { text: 'Departure date' }, value: { text: DateFormats.isoDateToUIDate(departureDate) } },

--- a/integration_tests/pages/match/searchPage.ts
+++ b/integration_tests/pages/match/searchPage.ts
@@ -73,10 +73,6 @@ export default class SearchPage extends Page {
   }
 
   shouldHaveSearchParametersInLinks(newSearchParameters: SpaceSearchParametersUi): void {
-    cy.get('.govuk-summary-card__actions .govuk-link')
-      .invoke('attr', 'href')
-      .should('contain', `apType=${newSearchParameters.requirements.apType}`)
-
     newSearchParameters.requirements.spaceCharacteristics.forEach(spaceCharacteristic => {
       const isSpaceBookingCharacteristic = Object.keys(occupancyCriteriaMap).includes(spaceCharacteristic)
       cy.get('.govuk-summary-card__actions .govuk-link')

--- a/server/controllers/match/index.ts
+++ b/server/controllers/match/index.ts
@@ -19,7 +19,7 @@ export const controllers = (services: Services) => {
   )
   const spaceSearchController = new SpaceSearchController(spaceService, placementRequestService)
   const placementRequestBookingsController = new BookingsController(placementRequestService)
-  const spaceBookingsController = new SpaceBookingsController(placementRequestService, spaceService)
+  const spaceBookingsController = new SpaceBookingsController(placementRequestService, premisesService, spaceService)
   const occupancyViewController = new OccupancyViewController(placementRequestService, premisesService)
 
   return {

--- a/server/controllers/match/placementRequests/spaceBookingsController.test.ts
+++ b/server/controllers/match/placementRequests/spaceBookingsController.test.ts
@@ -1,7 +1,6 @@
 import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
-import { when } from 'jest-when'
 import { Cas1SpaceBookingCharacteristic } from '@approved-premises/api'
 import SpaceBookingsController from './spaceBookingsController'
 
@@ -38,19 +37,10 @@ describe('SpaceBookingsController', () => {
   beforeEach(() => {
     jest.resetAllMocks()
     spaceBookingsController = new SpaceBookingsController(placementRequestService, premisesService, spaceService)
-    request = createMock<Request>({ user: { token } })
+    request = createMock<Request>({ user: { token }, flash: jest.fn() })
 
     placementRequestService.getPlacementRequest.mockResolvedValue(placementRequestDetail)
     premisesService.find.mockResolvedValue(premises)
-
-    jest.spyOn(validationUtils, 'fetchErrorsAndUserInput')
-    when(validationUtils.fetchErrorsAndUserInput as jest.Mock)
-      .calledWith(request)
-      .mockReturnValue({
-        errors: {},
-        errorSummary: [],
-        userInput: {},
-      })
   })
 
   describe('new', () => {

--- a/server/controllers/match/placementRequests/spaceBookingsController.test.ts
+++ b/server/controllers/match/placementRequests/spaceBookingsController.test.ts
@@ -1,98 +1,103 @@
 import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
-import { faker } from '@faker-js/faker'
+import { when } from 'jest-when'
 import { Cas1SpaceBookingCharacteristic } from '@approved-premises/api'
 import SpaceBookingsController from './spaceBookingsController'
 
-import { PlacementRequestService, SpaceService } from '../../../services'
+import { PlacementRequestService, PremisesService, SpaceService } from '../../../services'
 import {
+  cas1PremisesFactory,
   cas1SpaceBookingFactory,
   newSpaceBookingFactory,
-  personFactory,
   placementRequestDetailFactory,
   spaceBookingRequirementsFactory,
 } from '../../../testutils/factories'
-import { filterOutAPTypes, occupancyViewLink, placementDates } from '../../../utils/match'
 import paths from '../../../paths/admin'
-import { fetchErrorsAndUserInput } from '../../../utils/validation'
-import { occupancyCriteriaMap } from '../../../utils/match/occupancy'
+import matchPaths from '../../../paths/match'
+import * as validationUtils from '../../../utils/validation'
+import { createQueryString } from '../../../utils/utils'
+import { spaceBookingConfirmationSummaryListRows } from '../../../utils/match'
 
-jest.mock('../../../utils/validation')
 describe('SpaceBookingsController', () => {
   const token = 'SOME_TOKEN'
 
-  const request: DeepMocked<Request> = createMock<Request>({ user: { token } })
+  let request: Readonly<DeepMocked<Request>>
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
   const placementRequestService = createMock<PlacementRequestService>({})
+  const premisesService = createMock<PremisesService>({})
   const spaceService = createMock<SpaceService>({})
+
+  const premises = cas1PremisesFactory.build()
+  const placementRequestDetail = placementRequestDetailFactory.build({ duration: 84 })
 
   let spaceBookingsController: SpaceBookingsController
 
   beforeEach(() => {
     jest.resetAllMocks()
-    spaceBookingsController = new SpaceBookingsController(placementRequestService, spaceService)
+    spaceBookingsController = new SpaceBookingsController(placementRequestService, premisesService, spaceService)
+    request = createMock<Request>({ user: { token } })
+
+    placementRequestService.getPlacementRequest.mockResolvedValue(placementRequestDetail)
+    premisesService.find.mockResolvedValue(premises)
+
+    jest.spyOn(validationUtils, 'fetchErrorsAndUserInput')
+    when(validationUtils.fetchErrorsAndUserInput as jest.Mock)
+      .calledWith(request)
+      .mockReturnValue({
+        errors: {},
+        errorSummary: [],
+        userInput: {},
+      })
   })
 
   describe('new', () => {
-    it('should render the new space booking template', async () => {
-      const person = personFactory.build({ name: 'John Wayne' })
-      const placementRequestDetail = placementRequestDetailFactory.build({ person })
-      const startDate = '2024-07-26'
-      const durationDays = '40'
-      const premisesName = 'Hope House'
-      const premisesId = 'abc123'
-      const apType = 'esap'
-      const criteria = faker.helpers.arrayElements(Object.keys(occupancyCriteriaMap), {
-        min: 0,
-        max: 3,
-      }) as Array<Cas1SpaceBookingCharacteristic>
-      const backLink = occupancyViewLink({
-        placementRequestId: placementRequestDetail.id,
-        premisesId,
-        apType,
-        startDate,
-        durationDays,
-        spaceCharacteristics: criteria,
-      })
-      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: [], errorSummary: {}, userInput: {} })
-      placementRequestService.getPlacementRequest.mockResolvedValue(placementRequestDetail)
+    it('should render the new space booking confirmation template', async () => {
+      const startDate = '2024-07-20'
+      const durationDays = '84'
+      const criteria: Array<Cas1SpaceBookingCharacteristic> = ['hasEnSuite', 'isArsonSuitable']
+      const arrivalDate = '2024-07-26'
+      const departureDate = '2024-09-04' // 40 days later
 
       const query = {
         startDate,
         durationDays,
-        premisesName,
-        premisesId,
-        apType,
-        criteria: criteria.join(','),
+        criteria,
+        arrivalDate,
+        departureDate,
       }
 
-      const params = { id: placementRequestDetail.id }
+      const params = { id: placementRequestDetail.id, premisesId: premises.id }
 
       const requestHandler = spaceBookingsController.new()
-      request.params = params
-      request.query = query
 
-      await requestHandler(request, response, next)
+      await requestHandler({ ...request, params, query }, response, next)
+
+      const expectedSubmitLink = `${matchPaths.v2Match.placementRequests.spaceBookings.create(params)}?startDate=2024-07-20&durationDays=84&criteria=hasEnSuite&criteria=isArsonSuitable&arrivalDate=2024-07-26&departureDate=2024-09-04`
+      const expectedBackLink = `${matchPaths.v2Match.placementRequests.search.occupancy(params)}?startDate=2024-07-20&durationDays=84&criteria=hasEnSuite&criteria=isArsonSuitable`
 
       expect(response.render).toHaveBeenCalledWith('match/placementRequests/spaceBookings/new', {
-        pageHeading: `Book space in ${premisesName}`,
+        backLink: expectedBackLink,
+        submitLink: expectedSubmitLink,
         placementRequest: placementRequestDetail,
-        premisesName,
-        premisesId,
-        apType,
-        startDate,
-        durationDays,
-        errorSummary: {},
-        errors: [],
-        dates: placementDates(startDate, durationDays),
-        essentialCharacteristics: criteria,
-        desirableCharacteristics: filterOutAPTypes(placementRequestDetail.desirableCriteria),
-        backLink,
+        premises,
+        arrivalDate,
+        departureDate,
+        criteria,
+        summaryListRows: spaceBookingConfirmationSummaryListRows(
+          placementRequestDetail,
+          premises,
+          arrivalDate,
+          departureDate,
+          criteria,
+        ),
+        errorSummary: [],
+        errors: {},
       })
       expect(placementRequestService.getPlacementRequest).toHaveBeenCalledWith(token, placementRequestDetail.id)
+      expect(premisesService.find).toHaveBeenCalledWith(token, premises.id)
     })
   })
 
@@ -101,24 +106,18 @@ describe('SpaceBookingsController', () => {
       ['empty', { essentialCharacteristics: [] }],
       ['populated', {}],
     ])(
-      'should call the createSpaceBooking method on the spaceService and redirect the user to the CRU dashboard with characteristics %1',
-      async (text, requirementsOverride) => {
-        const personName = 'John Doe'
-        const premisesName = 'Hope House'
-        const id = 'placement-request-id'
+      'should call the createSpaceBooking method on the spaceService and redirect the user to the CRU dashboard with characteristics %s',
+      async (_, requirementsOverride) => {
         const requirements = spaceBookingRequirementsFactory.build(requirementsOverride)
-        const newSpaceBooking = newSpaceBookingFactory.build({ requirements })
+        const newSpaceBooking = newSpaceBookingFactory.build({ premisesId: premises.id, requirements })
         const spaceBooking = cas1SpaceBookingFactory.build()
 
         const body = {
           arrivalDate: newSpaceBooking.arrivalDate,
           departureDate: newSpaceBooking.departureDate,
-          premisesId: newSpaceBooking.premisesId,
-          essentialCharacteristics: newSpaceBooking.requirements.essentialCharacteristics.toString(),
-          personName,
-          premisesName,
+          criteria: newSpaceBooking.requirements.essentialCharacteristics.toString(),
         }
-        const params = { id }
+        const params = { id: placementRequestDetail.id, premisesId: premises.id }
 
         spaceService.createSpaceBooking.mockResolvedValue(spaceBooking)
         const flash = jest.fn()
@@ -126,10 +125,43 @@ describe('SpaceBookingsController', () => {
         const requestHandler = spaceBookingsController.create()
         await requestHandler({ ...request, flash, params, body }, response, next)
 
-        expect(spaceService.createSpaceBooking).toHaveBeenCalledWith(token, id, newSpaceBooking)
-        expect(flash).toHaveBeenCalledWith('success', `Space booked for ${personName} in ${premisesName}`)
+        expect(spaceService.createSpaceBooking).toHaveBeenCalledWith(token, placementRequestDetail.id, newSpaceBooking)
+        expect(flash).toHaveBeenCalledWith(
+          'success',
+          `You have now booked a place in this AP for this person. An email will be sent to the AP, to inform them of the booking.`,
+        )
         expect(response.redirect).toHaveBeenCalledWith(`${paths.admin.cruDashboard.index({})}?status=matched`)
       },
     )
+
+    describe('when errors are raised by the API', () => {
+      beforeEach(() => {
+        jest.spyOn(validationUtils, 'catchValidationErrorOrPropogate').mockReturnValue()
+      })
+
+      it('redirects to the confirm screen maintaining the query string', async () => {
+        const body = newSpaceBookingFactory.build()
+        const params = { id: placementRequestDetail.id, premisesId: premises.id }
+        const query = { startDate: '2025-06-12', durationDays: '84', criteria: ['hasEnSuite'] }
+
+        const apiError = new Error()
+        spaceService.createSpaceBooking.mockRejectedValue(apiError)
+
+        const requestHandler = spaceBookingsController.create()
+        await requestHandler({ ...request, params, query, body }, response, next)
+
+        const expectedRedirect = `${matchPaths.v2Match.placementRequests.spaceBookings.new({
+          id: placementRequestDetail.id,
+          premisesId: premises.id,
+        })}?${createQueryString(query)}`
+
+        expect(validationUtils.catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+          request,
+          response,
+          apiError,
+          expectedRedirect,
+        )
+      })
+    })
   })
 })

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -13,7 +13,7 @@ const cas1OutOfServiceBedsSingle = cas1OutOfServiceBeds.path(':id')
 const cas1SpaceBookingSingle = cas1PremisesSingle.path('space-bookings/:placementId')
 const cas1Capacity = cas1PremisesSingle.path('capacity')
 
-const cas1SpaceBookings = cas1Namespace.path('/placement-requests/:id/space-bookings')
+const cas1SpaceBookings = cas1Namespace.path('placement-requests/:id/space-bookings')
 
 const cas1Reports = cas1Namespace.path('reports')
 

--- a/server/paths/match.ts
+++ b/server/paths/match.ts
@@ -5,7 +5,7 @@ const v2PlacementRequestsPath = v2MatchPath.path('placement-requests')
 const v2PlacementRequestPath = v2PlacementRequestsPath.path(':id')
 const v2PlacementRequestSearchPath = v2PlacementRequestPath.path('space-search')
 const v2PlacementRequestSearchOccupancyPath = v2PlacementRequestSearchPath.path('occupancy/:premisesId')
-const v2SpaceBookingsPath = v2PlacementRequestPath.path('space-bookings')
+const v2SpaceBookingsPath = v2PlacementRequestPath.path('space-bookings/:premisesId')
 
 const v2Match = {
   placementRequests: {

--- a/server/routes/match.ts
+++ b/server/routes/match.ts
@@ -38,10 +38,6 @@ export default function routes(controllers: Controllers, router: Router, service
     auditEvent: 'SPACE_SEARCH',
   })
 
-  get(paths.v2Match.placementRequests.spaceBookings.new.pattern, spaceBookingsController.new(), {
-    auditEvent: 'NEW_SPACE_BOOKING',
-  })
-
   get(paths.v2Match.placementRequests.search.occupancy.pattern, occupancyViewController.view(), {
     auditEvent: 'OCCUPANCY_VIEW',
   })
@@ -53,6 +49,9 @@ export default function routes(controllers: Controllers, router: Router, service
     auditEvent: 'OCCUPANCY_VIEW_DAY',
   })
 
+  get(paths.v2Match.placementRequests.spaceBookings.new.pattern, spaceBookingsController.new(), {
+    auditEvent: 'NEW_SPACE_BOOKING',
+  })
   post(paths.v2Match.placementRequests.spaceBookings.create.pattern, spaceBookingsController.create(), {
     auditEvent: 'CREATE_SPACE_BOOKING',
   })

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -1,6 +1,14 @@
 import * as nunjucks from 'nunjucks'
 
-import type { CheckBoxItem, ErrorMessages, RadioItem, SelectOption, SummaryListItem } from '@approved-premises/ui'
+import type {
+  CheckBoxItem,
+  ErrorMessages,
+  HtmlItem,
+  RadioItem,
+  SelectOption,
+  SummaryListItem,
+  TextItem,
+} from '@approved-premises/ui'
 import type { RiskTierLevel } from '@approved-premises/api'
 import { PlacementRequestStatus } from '@approved-premises/api'
 import { resolvePath, sentenceCase } from './utils'
@@ -161,17 +169,17 @@ export function convertKeyValuePairsToSummaryListItems<T extends object>(
   values: T,
   titles: Record<string, string>,
 ): Array<SummaryListItem> {
-  return Object.keys(values).map(key => {
-    return {
-      key: {
-        text: titles[key],
-      },
-      value: {
-        text: values[key],
-      },
-    }
-  })
+  return Object.keys(values).map(key => summaryListItem(titles[key], values[key]))
 }
+
+export const summaryListItem = (
+  label: string,
+  value: string,
+  renderAs: keyof TextItem | keyof HtmlItem = 'text',
+): SummaryListItem => ({
+  key: { text: label },
+  value: renderAs === 'text' ? { text: value } : { html: value },
+})
 
 /**
  * Performs validation on the area of a postcode (IE the first three or four characters)

--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -502,7 +502,7 @@ describe('matchUtils', () => {
         spaceBookingConfirmationSummaryListRows(placementRequest, premises, arrivalDate, departureDate, criteria),
       ).toEqual([
         { key: { text: 'Approved Premises' }, value: { text: premises.name } },
-        // { key: { text: 'Address' }, value: { text: premises.fullAddress } },
+        { key: { text: 'Address' }, value: { text: premises.fullAddress } },
         {
           key: { text: 'Space type' },
           value: { html: '<ul class="govuk-list"><li>En-suite bathroom</li><li>Arson offences</li></ul>' },

--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -9,6 +9,7 @@ import { when } from 'jest-when'
 import type { SummaryListItem } from '@approved-premises/ui'
 import paths from '../../paths/match'
 import {
+  cas1PremisesFactory,
   personFactory,
   placementRequestDetailFactory,
   premisesFactory,
@@ -51,6 +52,7 @@ import {
   redirectToSpaceBookingsNew,
   releaseTypeRow,
   requirementsHtmlString,
+  spaceBookingConfirmationSummaryListRows,
   spaceBookingPersonNeedsSummaryCardRows,
   spaceBookingPremisesSummaryCardRows,
   spaceRequirementsRow,
@@ -59,7 +61,6 @@ import {
   totalCapacityRow,
 } from '.'
 import { placementCriteriaLabels } from '../placementCriteriaUtils'
-import { createQueryString } from '../utils'
 import * as formUtils from '../formUtils'
 import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
 import PreferredAps from '../../form-pages/apply/risk-and-need-factors/location-factors/preferredAps'
@@ -68,6 +69,7 @@ import { textValue } from '../applications/helpers'
 import { preferredApsRow } from '../placementRequests/preferredApsRow'
 import { placementRequirementsRow } from '../placementRequests/placementRequirementsRow'
 import applicationFactory from '../../testutils/factories/application'
+import { allReleaseTypes } from '../applications/releaseTypeUtils'
 
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
 
@@ -230,7 +232,6 @@ describe('matchUtils', () => {
     it('returns a link to the occupancy view page', () => {
       const placementRequestId = '123'
       const premisesId = 'abc'
-      const apType = 'pipe'
       const startDate = '2025-04-14'
       const durationDays = '84'
       const spaceCharacteristics: Array<Cas1SpaceBookingCharacteristic> = ['isWheelchairDesignated', 'isSingle']
@@ -238,7 +239,6 @@ describe('matchUtils', () => {
       const result = occupancyViewLink({
         placementRequestId,
         premisesId,
-        apType,
         startDate,
         durationDays,
         spaceCharacteristics,
@@ -248,14 +248,13 @@ describe('matchUtils', () => {
         `${paths.v2Match.placementRequests.search.occupancy({
           id: placementRequestId,
           premisesId,
-        })}?apType=pipe&startDate=2025-04-14&durationDays=84&criteria=isWheelchairDesignated&criteria=isSingle`,
+        })}?startDate=2025-04-14&durationDays=84&criteria=isWheelchairDesignated&criteria=isSingle`,
       )
     })
 
     it('filters out non booking-specific search criteria', () => {
       const placementRequestId = '123'
       const premisesId = 'abc'
-      const apType = 'pipe'
       const startDate = '2025-04-14'
       const durationDays = '84'
       const spaceCharacteristics: Array<PlacementCriteria> = [
@@ -274,7 +273,6 @@ describe('matchUtils', () => {
       const result = occupancyViewLink({
         placementRequestId,
         premisesId,
-        apType,
         startDate,
         durationDays,
         spaceCharacteristics: filterToSpaceBookingCharacteristics(spaceCharacteristics),
@@ -284,43 +282,39 @@ describe('matchUtils', () => {
         `${paths.v2Match.placementRequests.search.occupancy({
           id: placementRequestId,
           premisesId,
-        })}?apType=pipe&startDate=2025-04-14&durationDays=84&criteria=isWheelchairDesignated&criteria=isSingle&criteria=hasEnSuite&criteria=isArsonSuitable`,
+        })}?startDate=2025-04-14&durationDays=84&criteria=isWheelchairDesignated&criteria=isSingle&criteria=hasEnSuite&criteria=isArsonSuitable`,
       )
     })
   })
 
   describe('redirectToSpaceBookingsNew', () => {
-    it('returns a link to the confirm page with the premises name and bed', () => {
+    it('returns a link to the confirm booking page with dates, criteria and existing query parameters', () => {
       const placementRequestId = '123'
-      const premisesName = 'Hope House'
       const premisesId = 'abc'
-      const apType = 'pipe'
-      const startDate = '2022-01-01'
-      const durationDays = '1'
-      const criteria: Array<Cas1SpaceBookingCharacteristic> = ['hasEnSuite', 'isArsonSuitable']
+      const arrivalDate = '2022-01-01'
+      const departureDate = '2022-03-05'
+      const criteria: Array<Cas1SpaceBookingCharacteristic> = ['hasEnSuite', 'isWheelchairDesignated']
+      const existingQuery = {
+        foo: 'bar',
+      }
 
       const result = redirectToSpaceBookingsNew({
         placementRequestId,
-        premisesName,
         premisesId,
-        apType,
-        startDate,
-        durationDays,
+        arrivalDate,
+        departureDate,
         criteria,
+        ...existingQuery,
       })
 
+      const expectedQueryString =
+        'arrivalDate=2022-01-01&departureDate=2022-03-05&criteria=hasEnSuite&criteria=isWheelchairDesignated&foo=bar'
+
       expect(result).toEqual(
-        `${paths.v2Match.placementRequests.spaceBookings.new({ id: placementRequestId })}${createQueryString(
-          {
-            premisesName: 'Hope House',
-            premisesId: 'abc',
-            apType: 'pipe',
-            startDate: '2022-01-01',
-            durationDays: '1',
-            criteria: ['hasEnSuite', 'isArsonSuitable'],
-          },
-          { addQueryPrefix: true, arrayFormat: 'repeat' },
-        )}`,
+        `${paths.v2Match.placementRequests.spaceBookings.new({
+          id: placementRequestId,
+          premisesId,
+        })}?${expectedQueryString}`,
       )
     })
   })
@@ -492,6 +486,31 @@ describe('matchUtils', () => {
       expect(spaceBookingPremisesSummaryCardRows(premisesName, apType)).toEqual([
         premisesNameRow(premisesName),
         apTypeRow(apType),
+      ])
+    })
+  })
+
+  describe('spaceBookingConfirmationSummaryListRows', () => {
+    it('returns summary list items for the space booking confirmation screen', () => {
+      const placementRequest = placementRequestDetailFactory.build()
+      const premises = cas1PremisesFactory.build()
+      const arrivalDate = '2025-05-23'
+      const departureDate = '2025-07-18'
+      const criteria: Array<Cas1SpaceBookingCharacteristic> = ['hasEnSuite', 'isArsonSuitable']
+
+      expect(
+        spaceBookingConfirmationSummaryListRows(placementRequest, premises, arrivalDate, departureDate, criteria),
+      ).toEqual([
+        { key: { text: 'Approved Premises' }, value: { text: premises.name } },
+        // { key: { text: 'Address' }, value: { text: premises.fullAddress } },
+        {
+          key: { text: 'Space type' },
+          value: { html: '<ul class="govuk-list"><li>En-suite bathroom</li><li>Arson offences</li></ul>' },
+        },
+        { key: { text: 'Arrival date' }, value: { text: 'Fri 23 May 2025' } },
+        { key: { text: 'Departure date' }, value: { text: 'Fri 18 Jul 2025' } },
+        { key: { text: 'Length of stay' }, value: { text: '8 weeks' } },
+        { key: { text: 'Release type' }, value: { text: allReleaseTypes[placementRequest.releaseType] } },
       ])
     })
   })

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -28,7 +28,7 @@ import {
   placementRequirementCriteriaLabels,
 } from '../placementCriteriaUtils'
 import { apTypeLabels } from '../apTypeLabels'
-import { convertKeyValuePairToRadioItems } from '../formUtils'
+import { convertKeyValuePairToRadioItems, summaryListItem } from '../formUtils'
 import { textValue } from '../applications/helpers'
 import { isFullPerson } from '../personUtils'
 import { preferredApsRow } from '../placementRequests/preferredApsRow'
@@ -171,16 +171,6 @@ export const occupancyViewSummaryListForMatchingDetails = (
   ]
 }
 
-export const textRow = (label: string, value: string): SummaryListItem => ({
-  key: { text: label },
-  value: { text: value },
-})
-
-export const htmlRow = (label: string, value: string): SummaryListItem => ({
-  key: { text: label },
-  value: { html: value },
-})
-
 export const spaceBookingConfirmationSummaryListRows = (
   placementRequest: PlacementRequestDetail,
   premises: Cas1Premises,
@@ -189,16 +179,16 @@ export const spaceBookingConfirmationSummaryListRows = (
   criteria: Array<Cas1SpaceBookingCharacteristic>,
 ): Array<SummaryListItem> => {
   return [
-    textRow('Approved Premises', premises.name),
-    textRow('Address', premises.fullAddress),
-    htmlRow('Space type', requirementsHtmlString(criteria)),
-    textRow('Arrival date', DateFormats.isoDateToUIDate(arrivalDate)),
-    textRow('Departure date', DateFormats.isoDateToUIDate(departureDate)),
-    textRow(
+    summaryListItem('Approved Premises', premises.name),
+    summaryListItem('Address', premises.fullAddress),
+    summaryListItem('Space type', requirementsHtmlString(criteria), 'html'),
+    summaryListItem('Arrival date', DateFormats.isoDateToUIDate(arrivalDate)),
+    summaryListItem('Departure date', DateFormats.isoDateToUIDate(departureDate)),
+    summaryListItem(
       'Length of stay',
       DateFormats.formatDuration(daysToWeeksAndDays(differenceInDays(departureDate, arrivalDate))),
     ),
-    textRow('Release type', allReleaseTypes[placementRequest.releaseType]),
+    summaryListItem('Release type', allReleaseTypes[placementRequest.releaseType]),
   ]
 }
 

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -190,7 +190,7 @@ export const spaceBookingConfirmationSummaryListRows = (
 ): Array<SummaryListItem> => {
   return [
     textRow('Approved Premises', premises.name),
-    // textRow('Address', premises.fullAddress),
+    textRow('Address', premises.fullAddress),
     htmlRow('Space type', requirementsHtmlString(criteria)),
     textRow('Arrival date', DateFormats.isoDateToUIDate(arrivalDate)),
     textRow('Departure date', DateFormats.isoDateToUIDate(departureDate)),

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -1,7 +1,8 @@
-import { addDays } from 'date-fns'
+import { addDays, differenceInDays } from 'date-fns'
 import type {
   ApType,
   ApprovedPremisesApplication,
+  Cas1Premises,
   Cas1SpaceBookingCharacteristic,
   Gender,
   PlacementCriteria,
@@ -17,6 +18,7 @@ import type {
   SpaceSearchParametersUi,
   SummaryListItem,
 } from '@approved-premises/ui'
+import { ParsedQs } from 'qs'
 import { DateFormats, daysToWeeksAndDays } from '../dateUtils'
 import { createQueryString, sentenceCase } from '../utils'
 import matchPaths from '../../paths/match'
@@ -68,14 +70,12 @@ export const placementLength = (lengthInDays: number): string => {
 export const occupancyViewLink = ({
   placementRequestId,
   premisesId,
-  apType,
   startDate,
   durationDays,
   spaceCharacteristics = [],
 }: {
   placementRequestId: string
   premisesId: string
-  apType: string
   startDate: string
   durationDays: string
   spaceCharacteristics: Array<Cas1SpaceBookingCharacteristic>
@@ -85,7 +85,6 @@ export const occupancyViewLink = ({
     premisesId,
   })}${createQueryString(
     {
-      apType,
       startDate,
       durationDays,
       criteria: spaceCharacteristics,
@@ -95,31 +94,27 @@ export const occupancyViewLink = ({
 
 export const redirectToSpaceBookingsNew = ({
   placementRequestId,
-  premisesName,
   premisesId,
-  apType,
-  startDate,
-  durationDays,
+  arrivalDate,
+  departureDate,
   criteria,
-}: {
+  ...existingQuery
+}: ParsedQs & {
   placementRequestId: string
-  premisesName: string
   premisesId: string
-  apType: string
-  startDate: string
-  durationDays: string
+  arrivalDate: string
+  departureDate: string
   criteria: Array<Cas1SpaceBookingCharacteristic>
 }): string => {
-  return `${matchPaths.v2Match.placementRequests.spaceBookings.new({ id: placementRequestId })}${createQueryString(
+  return `${matchPaths.v2Match.placementRequests.spaceBookings.new({
+    id: placementRequestId,
+    premisesId,
+  })}${createQueryString(
+    { arrivalDate, departureDate, criteria, ...existingQuery },
     {
-      premisesName,
-      premisesId,
-      apType,
-      startDate,
-      durationDays,
-      criteria,
+      addQueryPrefix: true,
+      arrayFormat: 'repeat',
     },
-    { addQueryPrefix: true, arrayFormat: 'repeat' },
   )}`
 }
 
@@ -173,6 +168,37 @@ export const occupancyViewSummaryListForMatchingDetails = (
     totalCapacityRow(totalCapacity),
     apManagerDetailsRow(managerDetails),
     spaceRequirementsRow(essentialCharacteristics),
+  ]
+}
+
+export const textRow = (label: string, value: string): SummaryListItem => ({
+  key: { text: label },
+  value: { text: value },
+})
+
+export const htmlRow = (label: string, value: string): SummaryListItem => ({
+  key: { text: label },
+  value: { html: value },
+})
+
+export const spaceBookingConfirmationSummaryListRows = (
+  placementRequest: PlacementRequestDetail,
+  premises: Cas1Premises,
+  arrivalDate: string,
+  departureDate: string,
+  criteria: Array<Cas1SpaceBookingCharacteristic>,
+): Array<SummaryListItem> => {
+  return [
+    textRow('Approved Premises', premises.name),
+    // textRow('Address', premises.fullAddress),
+    htmlRow('Space type', requirementsHtmlString(criteria)),
+    textRow('Arrival date', DateFormats.isoDateToUIDate(arrivalDate)),
+    textRow('Departure date', DateFormats.isoDateToUIDate(departureDate)),
+    textRow(
+      'Length of stay',
+      DateFormats.formatDuration(daysToWeeksAndDays(differenceInDays(departureDate, arrivalDate))),
+    ),
+    textRow('Release type', allReleaseTypes[placementRequest.releaseType]),
   ]
 }
 

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -12,6 +12,7 @@ import { isFullPerson, nameOrPlaceholderCopy } from '../personUtils'
 import paths from '../../paths/manage'
 import { hasPermission } from '../users'
 import { TabItem } from '../tasks/listTable'
+import { summaryListItem } from '../formUtils'
 
 export const statusTextMap: Record<Cas1SpaceBookingSummaryStatus, string> = {
   arrivingWithin6Weeks: 'Arriving within 6 weeks',
@@ -105,11 +106,7 @@ export const getBackLink = (referrer: string, premisesId: string): string => {
   return null
 }
 
-const summaryRow = (key: string, value: string): SummaryListItem =>
-  value && {
-    key: textValue(key),
-    value: textValue(value),
-  }
+const summaryRow = (key: string, value: string): SummaryListItem => value && summaryListItem(key, value)
 
 export const placementSummary = (placement: Cas1SpaceBooking): SummaryList => {
   const { createdAt, actualArrivalDateOnly, actualDepartureDateOnly, keyWorkerAllocation, deliusEventNumber, status } =

--- a/server/views/match/placementRequests/occupancyView/view.njk
+++ b/server/views/match/placementRequests/occupancyView/view.njk
@@ -129,14 +129,9 @@
         <section>
             <h2 class="govuk-heading-l">Book your placement</h2>
 
-            <form action="{{ paths.v2Match.placementRequests.search.occupancy({ id: placementRequest.id, premisesId: premises.id }) }}"
-                  method="post">
+            <form action="{{ currentUrl }}" method="post">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-                <input type="hidden" name="premisesId" value="{{ premises.id }}" />
-                <input type="hidden" name="premisesName" value="{{ premises.name }}" />
-                <input type="hidden" name="apType" value="{{ apType }}" />
-                <input type="hidden" name="startDate" value="{{ startDate }}" />
-                <input type="hidden" name="durationDays" value="{{ durationDays }}" />
+
                 <input type="hidden" name="criteria" value="{{ criteria }}" />
 
                 {{ govukDateInput({

--- a/server/views/match/placementRequests/spaceBookings/new.njk
+++ b/server/views/match/placementRequests/spaceBookings/new.njk
@@ -30,9 +30,14 @@
         <input type="hidden" name="departureDate" value="{{ departureDate }}" />
         <input type="hidden" name="criteria" value="{{ criteria }}" />
 
-        {{ govukButton({
-            text: "Confirm and submit",
-            preventDoubleClick: true
-        }) }}
+        <div class="govuk-button-group">
+            {{ govukButton({
+                text: "Confirm and book",
+                preventDoubleClick: true
+            }) }}
+
+            <a href="{{ backLink }}" class="govuk-button govuk-button--secondary">Cancel</a>
+        </div>
+
     </form>
 {% endblock %}

--- a/server/views/match/placementRequests/spaceBookings/new.njk
+++ b/server/views/match/placementRequests/spaceBookings/new.njk
@@ -16,52 +16,23 @@
 
 {% block content %}
     {{ showErrorSummary(errorSummary, errorTitle) }}
-    <div class="govuk-width-container">
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-                <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
-                {{ govukSummaryList({
-                    card: {
-                        title: {
-                            text: "Premises details"
-                        }
-                    },
-                    classes: 'govuk-summary-list--no-border',
-                    rows: MatchUtils.spaceBookingPremisesSummaryCardRows(premisesName, apType)
-                }) }}
+    <h1 class="govuk-heading-l">Confirm booking</h1>
 
-                {{ govukSummaryList({
-                    card: {
-                        title: {
-                            text: "Booking request"
-                        }
-                    },
-                    classes: 'govuk-summary-list--no-border',
-                    rows: MatchUtils.spaceBookingPersonNeedsSummaryCardRows(dates, placementRequest.gender, essentialCharacteristics, desirableCharacteristics)
-                }) }}
+    {{ govukSummaryList({
+        rows: summaryListRows
+    }) }}
 
-                <p>This booking will be sent to {{ premisesName }} Approved Premises for confirmation.</p>
+    <form action="{{ submitLink }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-                <form action="{{ paths.v2Match.placementRequests.spaceBookings.create({ id: placementRequest.id }) }}"
-                      method="post">
-                    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+        <input type="hidden" name="arrivalDate" value="{{ arrivalDate }}" />
+        <input type="hidden" name="departureDate" value="{{ departureDate }}" />
+        <input type="hidden" name="criteria" value="{{ criteria }}" />
 
-                    <input type="hidden" name="arrivalDate" value="{{ dates.startDate }}" />
-                    <input type="hidden" name="departureDate" value="{{ dates.endDate }}" />
-                    <input type="hidden" name="durationDays" value="{{ dates.placementLength }}" />
-                    <input type="hidden" name="premisesId" value="{{ premisesId }}" />
-                    <input type="hidden" name="premisesName" value="{{ premisesName }}" />
-                    <input type="hidden" name="apType" value="{{ apType }}" />
-                    <input type="hidden" name="essentialCharacteristics" value="{{ essentialCharacteristics }}" />
-                    <input type="hidden" name="personName" value="{{ placementRequest.person.name }}" />
-
-                    {{ govukButton({
-                        text: "Confirm and submit",
-                        preventDoubleClick: true
-                    }) }}
-                </form>
-            </div>
-        </div>
-    </div>
+        {{ govukButton({
+            text: "Confirm and submit",
+            preventDoubleClick: true
+        }) }}
+    </form>
 {% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1775

# Changes in this PR

Implements design and content updates to the 'Confirm booking' page.

Under the hood, this ensures the booking flow relies on the arrival and departure dates entered on the Occupancy view page, rather than recalculating those based on a start date and duration. The path for the confirmation screen has been rewritten to include the premises ID, which ensures a 404 is returned if this ID is invalid/doesn't exist.

The occupancy filter query parameters are carried over to the confirmation page to ensure the back link functions correctly.

The `apType` parameter is now removed, as it is no longer used beyond the initial suitability search.

## Screenshots of UI changes

### Before

<img width="729" alt="Screenshot 2025-01-09 at 15 32 18" src="https://github.com/user-attachments/assets/338a3f46-1690-4db7-8f93-6ceaff5e99c5" />

### After

<img width="984" alt="Screenshot 2025-01-09 at 15 29 25" src="https://github.com/user-attachments/assets/17e6600c-110a-4224-8a74-19244aea6039" />
