### PR TITLE
APS-1497 Placement details page - Handle offline apps

### DIFF
--- a/server/controllers/manage/placementController.ts
+++ b/server/controllers/manage/placementController.ts
@@ -32,13 +32,15 @@ export default class PlacementController {
       const { user } = res.locals
 
       const placement = await this.premisesService.getPlacement({ token: req.user.token, premisesId, placementId })
-      const tabItems = placementTabItems(placement, activeTab)
+      const isOfflineApplication = !placement.assessmentId
+      const tabItems = placementTabItems(placement, activeTab, isOfflineApplication)
       const backLink = getBackLink(req.headers.referer, premisesId)
       const pageHeading = `${DateFormats.isoDateToUIDate(placement.canonicalArrivalDate, { format: 'short' })} to ${DateFormats.isoDateToUIDate(placement.canonicalDepartureDate, { format: 'short' })}`
       let timelineEvents: Array<TimelineEvent> = []
       let application: ApprovedPremisesApplication = null
       let assessment: ApprovedPremisesAssessment = null
       let placementRequestDetail: PlacementRequestDetail = null
+
       if (activeTab === 'timeline') {
         timelineEvents = await this.placementService.getTimeline({ token: req.user.token, premisesId, placementId })
       }
@@ -70,6 +72,7 @@ export default class PlacementController {
         assessment,
         placementRequestDetail,
         showTitle: true,
+        isOfflineApplication,
       })
     }
   }

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -214,15 +214,19 @@ export const renderKeyworkersSelectOptions = (
 
 export type PlacementTab = 'application' | 'assessment' | 'placementRequest' | 'placement' | 'timeline'
 
-export const tabMap: Record<PlacementTab, { label: string; disableRestricted?: boolean }> = {
+export const tabMap: Record<PlacementTab, { label: string; disableRestricted?: boolean; disableOffline?: boolean }> = {
   application: { label: 'Application', disableRestricted: true },
-  assessment: { label: 'Assessment', disableRestricted: true },
-  placementRequest: { label: 'Request for placement' },
+  assessment: { label: 'Assessment', disableRestricted: true, disableOffline: true },
+  placementRequest: { label: 'Request for placement', disableOffline: true },
   placement: { label: 'Placement details' },
   timeline: { label: 'Timeline' },
 }
 
-export const placementTabItems = (placement: Cas1SpaceBooking, activeTab?: PlacementTab): Array<TabItem> => {
+export const placementTabItems = (
+  placement: Cas1SpaceBooking,
+  activeTab: PlacementTab,
+  isOfflineApplication: boolean = false,
+): Array<TabItem> => {
   const isPersonRestricted = placement.person.type === 'RestrictedPerson'
   const getSelfLink = (tab: PlacementTab): string => {
     const pathRoot = paths.premises.placements
@@ -241,13 +245,13 @@ export const placementTabItems = (placement: Cas1SpaceBooking, activeTab?: Place
         return pathRoot.show({ premisesId, placementId })
     }
   }
-  return Object.entries(tabMap).map(([key, { label, disableRestricted }]) => {
-    const isRestricted = isPersonRestricted && disableRestricted
+  return Object.entries(tabMap).map(([key, { label, disableRestricted, disableOffline }]) => {
+    const isDisabled = (isPersonRestricted && disableRestricted) || (isOfflineApplication && disableOffline)
     return {
       text: label,
       active: activeTab === key,
-      href: isRestricted ? null : getSelfLink(key as PlacementTab),
-      classes: isRestricted ? 'disabled' : '',
+      href: isDisabled ? null : getSelfLink(key as PlacementTab),
+      classes: isDisabled ? 'disabled' : '',
     }
   })
 }

--- a/server/views/manage/premises/placements/show.njk
+++ b/server/views/manage/premises/placements/show.njk
@@ -34,6 +34,11 @@
     <h1>{{ pageHeading }}</h1>
 {% endset %}
 
+{% set offlineAppContent %}
+    <span class="govuk-heading-s">This booking was imported from NDelius</span>
+    <span>As such, Assessment and Request for Placement information isn't available.</span>
+{% endset %}
+
 {% block content %}
 
     {% include "../../../_messages.njk" %}
@@ -44,6 +49,13 @@
         },
         menus: PlacementUtils.actions(placement, user)
     }) }}
+    {% if isOfflineApplication %}
+        {{ govukNotificationBanner({
+            html: offlineAppContent,
+            classes: 'govuk-notification-banner--full-width-content',
+            titleText: 'Information'
+        }) }}
+    {% endif %}
     {{ mojSubNavigation({
         label: 'Sub navigation',
         items: tabItems


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1497

# Changes in this PR
On the placement details page, if the application has been created as an offline application (where the assessment and placementRequest do not exist) the assessment and placement request tabs should be disabled. Also, there should be a banner to indicate to the user that this is an offline application.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/ff538b69-bcbe-4296-908b-b6eac27e8a95)

