### PR TITLE
Refactor placement-request page information

### DIFF
--- a/integration_tests/pages/admin/placementApplications/showPage.ts
+++ b/integration_tests/pages/admin/placementApplications/showPage.ts
@@ -1,25 +1,16 @@
+import { ApprovedPremises, PlacementRequest, PlacementRequestDetail } from '@approved-premises/api'
 import Page from '../../page'
 
-import {
-  ApprovedPremises,
-  FullPerson,
-  PlacementRequest,
-  PlacementRequestDetail,
-} from '../../../../server/@types/shared'
-import { adminSummary, matchingInformationSummary } from '../../../../server/utils/placementRequests'
 import { bookingSummaryList } from '../../../../server/utils/bookings'
+import { placementRequestSummaryList } from '../../../../server/utils/placementRequests/placementRequestSummaryList'
 
 export default class ShowPage extends Page {
   constructor(private readonly placementRequest: PlacementRequestDetail) {
-    super((placementRequest.person as FullPerson).name)
+    super('Placement request')
   }
 
   shouldShowSummary(): void {
-    this.shouldContainSummaryListItems(adminSummary(this.placementRequest).rows)
-  }
-
-  shouldShowMatchingInformationSummary(): void {
-    this.shouldContainSummaryListItems(matchingInformationSummary(this.placementRequest).rows)
+    this.shouldContainSummaryListItems(placementRequestSummaryList(this.placementRequest).rows)
   }
 
   clickPlacementRequest(placementRequest: PlacementRequest): void {

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -113,7 +113,6 @@ context('Placement Requests', () => {
       unmatchedPlacementRequests,
       unableToMatchPlacementRequests,
       matchedPlacementRequests,
-      preferredAps,
       matchedPlacementRequest,
       parolePlacementRequest,
     } = stubArtifacts()
@@ -149,8 +148,6 @@ context('Placement Requests', () => {
 
     // And I should see the information about the placement request
     showPage.shouldShowSummary()
-    showPage.shouldShowMatchingInformationSummary()
-    showPage.shouldShowPreferredAps(preferredAps)
 
     // And I should not see any booking information
     showPage.shouldNotShowBookingInformation()
@@ -173,7 +170,6 @@ context('Placement Requests', () => {
 
     // And I should see the information about the placement request
     showPage.shouldShowSummary()
-    showPage.shouldShowMatchingInformationSummary()
 
     showPage.shouldNotShowCreateBookingOption()
     showPage.shouldShowAmendBookingOption()

--- a/server/controllers/admin/placementRequests/placementRequestsController.test.ts
+++ b/server/controllers/admin/placementRequests/placementRequestsController.test.ts
@@ -6,6 +6,7 @@ import PlacementRequestsController from './placementRequestsController'
 import { PlacementRequestService } from '../../../services'
 import { userDetailsFactory } from '../../../testutils/factories'
 import placementRequestDetail from '../../../testutils/factories/placementRequestDetail'
+import { placementRequestSummaryList } from '../../../utils/placementRequests/placementRequestSummaryList'
 
 jest.mock('../../../utils/applications/utils')
 jest.mock('../../../utils/applications/getResponses')
@@ -41,6 +42,7 @@ describe('PlacementRequestsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('admin/placementRequests/show', {
         placementRequest,
+        placementRequestSummaryList: placementRequestSummaryList(placementRequest),
       })
       expect(placementRequestService.getPlacementRequest).toHaveBeenCalledWith(token, 'some-uuid')
     })

--- a/server/controllers/admin/placementRequests/placementRequestsController.ts
+++ b/server/controllers/admin/placementRequests/placementRequestsController.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 import { PlacementRequestService } from '../../../services'
+import { placementRequestSummaryList } from '../../../utils/placementRequests/placementRequestSummaryList'
 
 export default class PlacementRequestsController {
   constructor(private readonly placementRequestService: PlacementRequestService) {}
@@ -10,6 +11,7 @@ export default class PlacementRequestsController {
 
       res.render('admin/placementRequests/show', {
         placementRequest,
+        placementRequestSummaryList: placementRequestSummaryList(placementRequest),
       })
     }
   }

--- a/server/testutils/factories/offlineApplication.ts
+++ b/server/testutils/factories/offlineApplication.ts
@@ -1,0 +1,16 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+import type { OfflineApplication } from '@approved-premises/api'
+
+import { fullPersonFactory, restrictedPersonFactory } from './person'
+import { DateFormats } from '../../utils/dateUtils'
+
+class OfflineApplicationFactory extends Factory<OfflineApplication> {}
+
+export default OfflineApplicationFactory.define(() => ({
+  type: 'CAS1',
+  id: faker.string.uuid(),
+  person: faker.helpers.arrayElement([fullPersonFactory.build(), restrictedPersonFactory.build()]),
+  createdAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
+}))

--- a/server/utils/placementRequests/adminIdentityBar.test.ts
+++ b/server/utils/placementRequests/adminIdentityBar.test.ts
@@ -1,18 +1,12 @@
 import { fromPartial } from '@total-typescript/shoehorn'
 import { ApprovedPremisesUserPermission } from '@approved-premises/api'
-import {
-  personFactory,
-  placementRequestDetailFactory,
-  restrictedPersonFactory,
-  userDetailsFactory,
-} from '../../testutils/factories'
+import { personFactory, placementRequestDetailFactory, userDetailsFactory } from '../../testutils/factories'
 import { adminActions, adminIdentityBar, title } from './adminIdentityBar'
 
 import managePaths from '../../paths/manage'
 import matchPaths from '../../paths/match'
 import adminPaths from '../../paths/admin'
 import applyPaths from '../../paths/apply'
-import { nameOrPlaceholderCopy } from '../personUtils'
 import { fullPersonFactory } from '../../testutils/factories/person'
 import config from '../../config'
 
@@ -139,31 +133,7 @@ describe('adminIdentityBar', () => {
       const placementRequestDetail = placementRequestDetailFactory.build({ person: personFactory.build() })
 
       expect(title(placementRequestDetail)).toMatchStringIgnoringWhitespace(`
-      <span class="govuk-caption-l">Placement request</span>
-      <h1 class="govuk-heading-l">${nameOrPlaceholderCopy(placementRequestDetail.person)}</h1>
-      `)
-    })
-
-    it('should return Not Found if the person is unknown person', () => {
-      const placementRequestDetailWithRestrictedAccessOffender = placementRequestDetailFactory.build()
-      placementRequestDetailWithRestrictedAccessOffender.person = restrictedPersonFactory.build({
-        type: 'UnknownPerson',
-      })
-
-      expect(title(placementRequestDetailWithRestrictedAccessOffender)).toMatchStringIgnoringWhitespace(`
-      <span class="govuk-caption-l">Placement request</span>
-      <h1 class="govuk-heading-l">Not Found CRN: ${placementRequestDetailWithRestrictedAccessOffender.person.crn}</h1>
-      `)
-    })
-
-    it('should return Limited Access Offender if the person has no name', () => {
-      const placementRequestDetailWithRestrictedAccessOffender = placementRequestDetailFactory.build()
-      const person = personFactory.build({ isRestricted: true })
-      placementRequestDetailWithRestrictedAccessOffender.person = person
-
-      expect(title(placementRequestDetailWithRestrictedAccessOffender)).toMatchStringIgnoringWhitespace(`
-      <span class="govuk-caption-l">Placement request</span>
-      <h1 class="govuk-heading-l"> ${person.name}</h1>
+      <h1 class="govuk-heading-l">Placement request</h1>
       `)
     })
 
@@ -174,9 +144,8 @@ describe('adminIdentityBar', () => {
       })
 
       expect(title(placementRequestDetail)).toMatchStringIgnoringWhitespace(`
-<span class="govuk-caption-l">Placement request</span>
 <h1 class="govuk-heading-l">
-${nameOrPlaceholderCopy(placementRequestDetail.person)}
+Placement request
 <strong class="govuk-tag govuk-tag--red govuk-!-margin-5">Request for placement withdrawn</strong>
 </h1>
       `)

--- a/server/utils/placementRequests/adminIdentityBar.ts
+++ b/server/utils/placementRequests/adminIdentityBar.ts
@@ -5,7 +5,6 @@ import managePaths from '../../paths/manage'
 import matchPaths from '../../paths/match'
 import applyPaths from '../../paths/apply'
 import adminPaths from '../../paths/admin'
-import { isUnknownPerson, nameOrPlaceholderCopy } from '../personUtils'
 import config from '../../config'
 import { hasPermission } from '../users'
 
@@ -76,13 +75,9 @@ export const adminActions = (
 }
 
 export const title = (placementRequest: PlacementRequestDetail) => {
-  const { person } = placementRequest
-  let heading = nameOrPlaceholderCopy(
-    person,
-    isUnknownPerson(person) ? `Not Found CRN: ${person.crn}` : `LAO: ${person.crn}`,
-  )
+  let heading = ''
   if (placementRequest.isWithdrawn) {
     heading += `<strong class="govuk-tag govuk-tag--red govuk-!-margin-5">Request for placement withdrawn</strong>`
   }
-  return `<span class="govuk-caption-l">Placement request</span><h1 class="govuk-heading-l">${heading}</h1>`
+  return `<h1 class="govuk-heading-l">Placement request${heading}</h1>`
 }

--- a/server/utils/placementRequests/matchingInformationSummaryList.ts
+++ b/server/utils/placementRequests/matchingInformationSummaryList.ts
@@ -1,9 +1,20 @@
 import { PlacementRequestDetail } from '@approved-premises/api'
-import { SummaryListWithCard } from '@approved-premises/ui'
+import { SummaryListItem, SummaryListWithCard } from '@approved-premises/ui'
 import { preferredApsRow } from './preferredApsRow'
 import { placementRequirementsRow } from './placementRequirementsRow'
 
 export const matchingInformationSummary = (placementRequest: PlacementRequestDetail): SummaryListWithCard => {
+  return {
+    card: {
+      title: {
+        text: 'Information for Matching',
+      },
+    },
+    rows: matchingInformationSummaryRows(placementRequest),
+  }
+}
+
+export const matchingInformationSummaryRows = (placementRequest: PlacementRequestDetail): Array<SummaryListItem> => {
   const rows = []
 
   const preferredAps = preferredApsRow(placementRequest)
@@ -25,13 +36,5 @@ export const matchingInformationSummary = (placementRequest: PlacementRequestDet
       },
     })
   }
-
-  return {
-    card: {
-      title: {
-        text: 'Information for Matching',
-      },
-    },
-    rows,
-  }
+  return rows
 }

--- a/server/utils/placementRequests/placementRequestSummaryList.test.ts
+++ b/server/utils/placementRequests/placementRequestSummaryList.test.ts
@@ -1,0 +1,219 @@
+import { Application } from '@approved-premises/api'
+import { SummaryListItem } from '@approved-premises/ui'
+import { applicationFactory, placementRequestDetailFactory } from '../../testutils/factories'
+import offlineApplicationFactory from '../../testutils/factories/offlineApplication'
+import { placementRequestSummaryList } from './placementRequestSummaryList'
+import { DateFormats } from '../dateUtils'
+import { apTypeLabels } from '../apTypeLabels'
+
+describe('placementRequestSummaryList', () => {
+  const application = applicationFactory.build({
+    licenceExpiryDate: '2030-11-23',
+  })
+  const placementRequest = placementRequestDetailFactory.build({
+    releaseType: 'hdc',
+    expectedArrival: '2025-10-02',
+    duration: 52,
+    essentialCriteria: ['hasTactileFlooring'],
+    application,
+    notes: 'Test notes',
+  })
+
+  it('should generate the expected summary list', () => {
+    expect(placementRequestSummaryList(placementRequest).rows).toEqual(
+      expectedSummaryListItems({
+        isWithdrawn: false,
+        expectedApplicationId: placementRequest.application.id,
+        expectedLicenceExpiryDate: application.licenceExpiryDate,
+        expectedPostcode: placementRequest.location,
+      }),
+    )
+  })
+
+  it('should generate the expected summary list when is withdrawn', () => {
+    const isWithdrawn = true
+    const withdrawnPlacementRequest = {
+      ...placementRequest,
+      isWithdrawn,
+    }
+    expect(placementRequestSummaryList(withdrawnPlacementRequest).rows).toEqual(
+      expectedSummaryListItems({
+        isWithdrawn,
+        expectedApplicationId: placementRequest.application.id,
+        expectedLicenceExpiryDate: application.licenceExpiryDate,
+        expectedPostcode: placementRequest.location,
+      }),
+    )
+  })
+
+  it(`should generate the expected summary list when placement-request's application is undefined`, () => {
+    const undefinedApplication: Application = undefined
+    const placementRequestWithoutLicenceExpiry = {
+      ...placementRequest,
+      application: undefinedApplication,
+    }
+    expect(placementRequestSummaryList(placementRequestWithoutLicenceExpiry).rows).toEqual(
+      expectedSummaryListItems({
+        isWithdrawn: false,
+        expectedApplicationId: undefined,
+        expectedLicenceExpiryDate: '',
+        expectedPostcode: placementRequest.location,
+      }),
+    )
+  })
+
+  it(`should generate the expected summary list when placement-request's application is not of type ApprovedPremisesApplication`, () => {
+    const placementRequestWithOfflineApplication = {
+      ...placementRequest,
+      application: offlineApplicationFactory.build(),
+    }
+    expect(placementRequestSummaryList(placementRequestWithOfflineApplication).rows).toEqual(
+      expectedSummaryListItems({
+        isWithdrawn: false,
+        expectedApplicationId: placementRequestWithOfflineApplication.application.id,
+        expectedLicenceExpiryDate: '',
+        expectedPostcode: placementRequest.location,
+      }),
+    )
+  })
+
+  it(`should generate the expected summary list with blank licence expiry date when applications license-expiry date is not set`, () => {
+    const placementRequestWithoutLicenceExpiry = {
+      ...placementRequest,
+      application: applicationFactory.build({
+        licenceExpiryDate: undefined,
+      }),
+    }
+    expect(placementRequestSummaryList(placementRequestWithoutLicenceExpiry).rows).toEqual(
+      expectedSummaryListItems({
+        isWithdrawn: false,
+        expectedApplicationId: placementRequestWithoutLicenceExpiry.application.id,
+        expectedLicenceExpiryDate: '',
+        expectedPostcode: placementRequest.location,
+      }),
+    )
+  })
+
+  const expectedSummaryListItems = (options: {
+    isWithdrawn: boolean
+    expectedApplicationId: string
+    expectedLicenceExpiryDate: string
+    expectedPostcode: string
+  }): Array<SummaryListItem> => {
+    const apTypeListItem = generateApTypeListItem(options.expectedApplicationId)
+    const rows = [
+      {
+        key: {
+          text: 'Requested arrival date',
+        },
+        value: {
+          text: 'Thu 2 Oct 2025',
+        },
+      },
+      {
+        key: {
+          text: 'Expected departure date',
+        },
+        value: {
+          text: 'Sun 23 Nov 2025',
+        },
+      },
+      {
+        key: {
+          text: 'Length of stay',
+        },
+        value: {
+          text: '7 weeks, 3 days',
+        },
+      },
+      {
+        key: {
+          text: 'Release type',
+        },
+        value: {
+          text: 'Home detention curfew (HDC)',
+        },
+      },
+      {
+        key: {
+          text: 'Licence expiry date',
+        },
+        value: {
+          text: options.expectedLicenceExpiryDate ? DateFormats.isoDateToUIDate(options.expectedLicenceExpiryDate) : '',
+        },
+      },
+      apTypeListItem,
+      {
+        key: {
+          text: 'Preferred postcode',
+        },
+        value: {
+          text: options.expectedPostcode,
+        },
+      },
+      {
+        key: {
+          text: 'Essential Criteria',
+        },
+        value: {
+          html: '<ul class="govuk-list"><li>Tactile flooring</li></ul>',
+        },
+      },
+      {
+        key: {
+          text: 'Desirable Criteria',
+        },
+        value: {
+          html: '<ul class="govuk-list"></ul>',
+        },
+      },
+      {
+        key: {
+          text: 'Observations from assessor',
+        },
+        value: {
+          text: 'Test notes',
+        },
+      },
+    ]
+    if (options.isWithdrawn) {
+      const statusRow = {
+        key: {
+          text: 'Status',
+        },
+        value: {
+          html: `<strong class="govuk-tag govuk-tag--timeline-tag govuk-tag--red">
+        Withdrawn
+      </strong>`,
+        },
+      }
+      rows.splice(7, 0, statusRow)
+    }
+    return rows
+  }
+
+  const generateApTypeListItem = (expectedApplicationId: string) => {
+    const apTypeListItem = {
+      key: {
+        text: 'Type of AP',
+      },
+      value: {
+        text: apTypeLabels[placementRequest.type],
+      },
+    }
+    if (expectedApplicationId) {
+      return {
+        ...apTypeListItem,
+        actions: {
+          items: [
+            {
+              href: `/applications/${expectedApplicationId}?tab=timeline`,
+              text: 'View timeline',
+            },
+          ],
+        },
+      }
+    }
+    return apTypeListItem
+  }
+})

--- a/server/utils/placementRequests/placementRequestSummaryList.ts
+++ b/server/utils/placementRequests/placementRequestSummaryList.ts
@@ -1,0 +1,34 @@
+import { PlacementRequestDetail } from '../../@types/shared'
+import { SummaryList, SummaryListItem } from '../../@types/ui'
+import { withdrawnStatusTag } from '../applications/utils'
+import {
+  apTypeWithViewTimelineActionRow,
+  departureDateRow,
+  lengthOfStayRow,
+  licenceExpiryDateRow,
+  placementDates,
+  preferredPostcodeRow,
+  releaseTypeRow,
+  requestedOrEstimatedArrivalDateRow,
+} from '../match'
+import { matchingInformationSummaryRows } from './matchingInformationSummaryList'
+
+export const placementRequestSummaryList = (placementRequest: PlacementRequestDetail): SummaryList => {
+  const dates = placementDates(placementRequest.expectedArrival, String(placementRequest.duration))
+  const rows: Array<SummaryListItem> = [
+    requestedOrEstimatedArrivalDateRow(placementRequest.isParole, dates.startDate),
+    departureDateRow(dates.endDate),
+    lengthOfStayRow(placementRequest.duration),
+    releaseTypeRow(placementRequest),
+    licenceExpiryDateRow(placementRequest),
+    apTypeWithViewTimelineActionRow(placementRequest),
+    preferredPostcodeRow(placementRequest.location),
+  ]
+
+  if (placementRequest.isWithdrawn) {
+    rows.push(withdrawnStatusTag)
+  }
+
+  const matchingInformationRows = matchingInformationSummaryRows(placementRequest)
+  return { rows: rows.concat(matchingInformationRows) }
+}

--- a/server/views/admin/placementRequests/show.njk
+++ b/server/views/admin/placementRequests/show.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% from "../../components/keyDetails/macro.njk" import keyDetails %}
 {% extends "../../partials/layout.njk" %}
@@ -10,6 +11,13 @@
 {% block header %}
     {{ super() }}
     {{ keyDetails(MatchUtils.keyDetails(placementRequest)) }}
+{% endblock %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        text: "Back",
+        href: paths.admin.cruDashboard.index({})
+    }) }}
 {% endblock %}
 
 {% block content %}
@@ -23,7 +31,7 @@
         </div>
         <div class="govuk-grid-row">
             <div class="govuk-width-container">
-                <div class="govuk-grid-column-two-thirds">
+                <div class="govuk-grid-column-full">
                     {% if placementRequest.isParole %}
                         {% set html %}
                             <p class="govuk-notification-banner__heading">
@@ -49,7 +57,7 @@
                         }) }}
                     {% endif %}
 
-                    <ul class="govuk-list govuk-!-padding-bottom-3">
+                    <ul class="govuk-list govuk-!-padding-top-3 govuk-!-padding-bottom-3">
                         <li>
                             <a href="{{ paths.applications.show({id: placementRequest.applicationId}) }}">View
                                 application</a>
@@ -62,9 +70,7 @@
                         </li>
                     </ul>
 
-                    {{ govukSummaryList(PlacementRequestUtils.adminSummary(placementRequest)) }}
-
-                    {{ govukSummaryList(PlacementRequestUtils.matchingInformationSummary(placementRequest)) }}
+                    {{ govukSummaryList(placementRequestSummaryList) }}
 
                     {% if placementRequest.status === 'matched' %}
                         <h2 class="govuk-heading-m">Booked Placement</h2>


### PR DESCRIPTION
# Context

* Related JIRA: https://dsdmoj.atlassian.net/browse/APS-1693
* This PR makes changes to the Summary information on the `Placement request` page in the `Find and Book` flow. This includes removing the data that overlaps with thre blue banner and moving the rest of the data to a summary list. 

# Changes in this PR

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before
<img width="2048" alt="placement_request_before" src="https://github.com/user-attachments/assets/ccc67e58-8425-4567-b182-20f68ad3273e" />

### After
<img width="2048" alt="placement_request_after" src="https://github.com/user-attachments/assets/3836af7a-3350-4f72-8d9d-c35f737dd8d7" />


