### PR TITLE
CHORE: Use one branch for bank holiday updates

### DIFF
--- a/.github/workflows/fetch-bank-holidays.yml
+++ b/.github/workflows/fetch-bank-holidays.yml
@@ -30,5 +30,4 @@ jobs:
           commit-message: 'Update bank holidays'
           body: 'This PR updates the bank holidays JSON file from the gov.uk API.'
           delete-branch: true
-          branch-suffix: timestamp
           branch: bank-holiday-updates


### PR DESCRIPTION
This stops the Bank Holiday update GitHub Action from creating multiple branches and multiple PRs for every run of the Bank Holiday updates.

