### PR TITLE
bugfix: Ensure all date errors returned at once

### DIFF
--- a/server/utils/match/validateSpaceBooking.ts
+++ b/server/utils/match/validateSpaceBooking.ts
@@ -3,32 +3,32 @@ import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank, datetimeIsInT
 
 export const validateSpaceBooking = (body: ObjectWithDateParts<string>): Record<string, string> => {
   const errors: Record<string, string> = {}
+
   if (dateIsBlank(body, 'arrivalDate')) {
     errors.arrivalDate = 'You must enter an arrival date'
-    return errors
-  }
-  if (!dateAndTimeInputsAreValidDates(body as ObjectWithDateParts<'arrivalDate'>, 'arrivalDate')) {
+  } else if (!dateAndTimeInputsAreValidDates(body as ObjectWithDateParts<'arrivalDate'>, 'arrivalDate')) {
     errors.arrivalDate = 'The arrival date is an invalid date'
-    return errors
   }
+
   if (dateIsBlank(body, 'departureDate')) {
     errors.departureDate = 'You must enter a departure date'
-    return errors
-  }
-  if (!dateAndTimeInputsAreValidDates(body as ObjectWithDateParts<'departureDate'>, 'departureDate')) {
+  } else if (!dateAndTimeInputsAreValidDates(body as ObjectWithDateParts<'departureDate'>, 'departureDate')) {
     errors.departureDate = 'The departure date is an invalid date'
-    return errors
   }
-  const { arrivalDate } = DateFormats.dateAndTimeInputsToIsoString(
-    body as ObjectWithDateParts<'arrivalDate'>,
-    'arrivalDate',
-  )
-  const { departureDate } = DateFormats.dateAndTimeInputsToIsoString(
-    body as ObjectWithDateParts<'departureDate'>,
-    'departureDate',
-  )
-  if (datetimeIsInThePast(departureDate, arrivalDate) || departureDate === arrivalDate) {
-    errors.departureDate = 'The departure date must be after the arrival date'
+
+  if (!Object.keys(errors).length) {
+    const { arrivalDate } = DateFormats.dateAndTimeInputsToIsoString(
+      body as ObjectWithDateParts<'arrivalDate'>,
+      'arrivalDate',
+    )
+    const { departureDate } = DateFormats.dateAndTimeInputsToIsoString(
+      body as ObjectWithDateParts<'departureDate'>,
+      'departureDate',
+    )
+    if (datetimeIsInThePast(departureDate, arrivalDate) || departureDate === arrivalDate) {
+      errors.departureDate = 'The departure date must be after the arrival date'
+    }
   }
+
   return errors
 }


### PR DESCRIPTION
When submitting a new booking without an arrival or departure date, or with either of those invalid, only one error would be indicated for the first error field, with the other field ignored. This ensures all errors are returned at once.

A small refactor of the booking post handler makes it follow the more usual `try/catch` pattern.

## Screenshot of changes

<img width="988" alt="Screenshot 2025-01-13 at 16 20 06" src="https://github.com/user-attachments/assets/e089b3a9-00bc-4cd1-bd35-a63f7c486683" />
