### PR TITLE
Bugfix/APS-1694: validate CRN format

### DIFF
--- a/server/controllers/people/peopleController.test.ts
+++ b/server/controllers/people/peopleController.test.ts
@@ -76,10 +76,25 @@ describe('PeopleController', () => {
       expect(flashSpy).toHaveBeenCalledWith('errorSummary', [errorSummary('crn', 'You must enter a CRN')])
     })
 
+    it('sends an error to the flash if the crn provided is invalid', async () => {
+      request.body = {
+        crn: 'Not a CRN',
+      }
+
+      const requestHandler = peopleController.find()
+
+      await requestHandler(request, response, next)
+
+      expect(response.redirect).toHaveBeenCalledWith('some-referrer/')
+
+      expect(flashSpy).toHaveBeenCalledWith('errors', { crn: errorMessage('crn', 'Enter a CRN in the correct format') })
+      expect(flashSpy).toHaveBeenCalledWith('errorSummary', [errorSummary('crn', 'Enter a CRN in the correct format')])
+    })
+
     describe('if the service throws', () => {
       it('calls crnErrorHandling ', async () => {
         jest.spyOn(peopleUtils, 'crnErrorHandling')
-        const crn = 'SOME_CRN'
+        const crn = 'X333444'
         const requestHandler = peopleController.find()
 
         const err = { data: {}, status: 404 }
@@ -107,11 +122,11 @@ describe('PeopleController', () => {
         throw err
       })
 
-      request.body.crn = 'SOME_CRN'
+      request.body.crn = 'C555666'
 
       await requestHandler(request, response, next)
 
-      expect(peopleUtils.crnErrorHandling).toHaveBeenCalledWith(request, err, 'SOME_CRN')
+      expect(peopleUtils.crnErrorHandling).toHaveBeenCalledWith(request, err, 'C555666')
       expect(response.redirect).toHaveBeenCalledWith('some-referrer/')
     })
   })

--- a/server/controllers/people/peopleController.test.ts
+++ b/server/controllers/people/peopleController.test.ts
@@ -49,6 +49,21 @@ describe('PeopleController', () => {
       expect(flashSpy).toHaveBeenCalledWith('crn', person.crn)
     })
 
+    it('trims and makes the CRN uppercase', async () => {
+      const person = personFactory.build()
+      personService.findByCrn.mockResolvedValue(person)
+
+      const requestHandler = peopleController.find()
+
+      request.body.crn = `  ${person.crn.toLowerCase()} `
+
+      await requestHandler(request, response, next)
+
+      expect(response.redirect).toHaveBeenCalledWith('some-referrer/')
+      expect(personService.findByCrn).toHaveBeenCalledWith(token, person.crn, false)
+      expect(flashSpy).toHaveBeenCalledWith('crn', person.crn)
+    })
+
     it('should send checkCaseload to the service if it is set', async () => {
       const person = personFactory.build()
       personService.findByCrn.mockResolvedValue(person)

--- a/server/controllers/people/peopleController.ts
+++ b/server/controllers/people/peopleController.ts
@@ -13,7 +13,7 @@ export default class PeopleController {
   find(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { crn: postCrn, checkCaseload } = req.body
-      const crn = postCrn?.trim()
+      const crn = postCrn?.trim().toUpperCase()
 
       if (!crn) {
         addErrorMessageToFlash(req, 'You must enter a CRN', 'crn')

--- a/server/controllers/people/timelineController.test.ts
+++ b/server/controllers/people/timelineController.test.ts
@@ -79,7 +79,7 @@ describe('TimelineController', () => {
 
   describe('show', () => {
     it('renders the timeline view', async () => {
-      const crn = 'CRN'
+      const crn = 'X123456'
       const timeline = personalTimelineFactory.build()
 
       personService.getTimeline.mockResolvedValue(timeline)
@@ -99,14 +99,14 @@ describe('TimelineController', () => {
     it('trims the input', async () => {
       const requestHandler = timelineController.show()
 
-      await requestHandler({ ...request, query: { crn: ' test ' } }, response, next)
+      await requestHandler({ ...request, query: { crn: ' X123456 ' } }, response, next)
 
-      expect(personService.getTimeline).toHaveBeenCalledWith(token, 'test')
+      expect(personService.getTimeline).toHaveBeenCalledWith(token, 'X123456')
     })
 
     describe('when there the person service throws an error', () => {
       it('catches the error and redirects to the find page', async () => {
-        const crn = 'CRN'
+        const crn = 'X456123'
         const error = new Error('Some error')
 
         personService.getTimeline.mockRejectedValue(error)
@@ -128,6 +128,17 @@ describe('TimelineController', () => {
         await requestHandler({ ...request, query: { crn: ' ' } }, response, next)
 
         expect(addErrorMessageToFlash).toHaveBeenCalledWith(request, 'You must enter a CRN', 'crn')
+        expect(response.redirect).toHaveBeenCalledWith(paths.timeline.find({}))
+      })
+    })
+
+    describe('when the CRN does not follow the correct format', () => {
+      it('adds error message to flash and redirects to show', async () => {
+        const requestHandler = timelineController.show()
+
+        await requestHandler({ ...request, query: { crn: 'not a CRN' } }, response, next)
+
+        expect(addErrorMessageToFlash).toHaveBeenCalledWith(request, 'Enter a CRN in the correct format', 'crn')
         expect(response.redirect).toHaveBeenCalledWith(paths.timeline.find({}))
       })
     })

--- a/server/controllers/people/timelineController.ts
+++ b/server/controllers/people/timelineController.ts
@@ -25,20 +25,21 @@ export default class TimelineController {
 
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const crn = (req?.query?.crn as string)?.trim()
+      const crn = req?.query?.crn as string
+      const formattedCRN = crn?.trim().toUpperCase()
 
-      if (!crn) {
-        addErrorMessageToFlash(req, 'You must enter a CRN', 'crn')
+      if (!formattedCRN) {
+        addErrorMessageToFlash({ ...req, body: { crn } } as Request, 'You must enter a CRN', 'crn')
         return res.redirect(paths.timeline.find({}))
       }
-      if (!isValidCrn(crn)) {
-        addErrorMessageToFlash(req, 'Enter a CRN in the correct format', 'crn')
+      if (!isValidCrn(formattedCRN)) {
+        addErrorMessageToFlash({ ...req, body: { crn } } as Request, 'Enter a CRN in the correct format', 'crn')
         return res.redirect(paths.timeline.find({}))
       }
 
       try {
-        const timeline = await this.personService.getTimeline(req.user.token, crn)
-        return res.render('people/timeline/show', { timeline, crn, pageHeading: `Timeline for ${crn}` })
+        const timeline = await this.personService.getTimeline(req.user.token, formattedCRN)
+        return res.render('people/timeline/show', { timeline, crn, pageHeading: `Timeline for ${formattedCRN}` })
       } catch (error) {
         crnErrorHandling(req, error, crn)
         return res.redirect(paths.timeline.find({}))

--- a/server/utils/crn.test.ts
+++ b/server/utils/crn.test.ts
@@ -1,11 +1,14 @@
 import { isValidCrn } from './crn'
 
 describe('CRN utils', () => {
-  it.each(['foo', '', 'X123', 'C6783456', '999888', ' X123456 '])(`considers "%s" an invalid CRN`, testCrn => {
-    expect(isValidCrn(testCrn)).toEqual(false)
-  })
+  it.each(['foo', '', 'X123', 'C6783456', '999888', ' X123456 ', 'x320741'])(
+    `considers "%s" an invalid CRN`,
+    testCrn => {
+      expect(isValidCrn(testCrn)).toEqual(false)
+    },
+  )
 
-  it.each(['C456123', 'X678543', 'x320741'])('considers "%s" a valid CRN', testCrn => {
+  it.each(['C456123', 'X678543'])('considers "%s" a valid CRN', testCrn => {
     expect(isValidCrn(testCrn)).toEqual(true)
   })
 })

--- a/server/utils/crn.test.ts
+++ b/server/utils/crn.test.ts
@@ -1,0 +1,11 @@
+import { isValidCrn } from './crn'
+
+describe('CRN utils', () => {
+  it.each(['foo', '', 'X123', 'C6783456', '999888', ' X123456 '])(`considers "%s" an invalid CRN`, testCrn => {
+    expect(isValidCrn(testCrn)).toEqual(false)
+  })
+
+  it.each(['C456123', 'X678543', 'x320741'])('considers "%s" a valid CRN', testCrn => {
+    expect(isValidCrn(testCrn)).toEqual(true)
+  })
+})

--- a/server/utils/crn.ts
+++ b/server/utils/crn.ts
@@ -1,3 +1,3 @@
 export const isValidCrn = (crn: string) => {
-  return Boolean(crn.match(/^[A-Za-z][0-9]{6}$/))
+  return Boolean(crn.match(/^[A-Z][0-9]{6}$/))
 }

--- a/server/utils/crn.ts
+++ b/server/utils/crn.ts
@@ -1,0 +1,3 @@
+export const isValidCrn = (crn: string) => {
+  return Boolean(crn.match(/^[A-Za-z][0-9]{6}$/))
+}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1694

# Changes in this PR

This adds some validation to the CRN format to prevent CRN searches based on pasted data (sometimes PII).

In addition, the CRN fields are now normalised to ensure using a lowercase CRN does return results for the uppercase version (API is case-sensitive, but CRNs shouldn't be).

## Screenshots of UI changes

### After

#### Timeline search screen:

<img width="663" alt="Screenshot 2025-01-13 at 17 50 29" src="https://github.com/user-attachments/assets/2906eb12-416a-48ae-913b-11bbcfc7337a" />

#### Application start screen:

<img width="688" alt="Screenshot 2025-01-13 at 17 50 44" src="https://github.com/user-attachments/assets/da92564c-a106-42e8-a6d4-084fd2c89e30" />
