### PR TITLE
Fix e2e test button matcher

### DIFF
--- a/e2e/pages/match/bookingPage.ts
+++ b/e2e/pages/match/bookingPage.ts
@@ -11,7 +11,7 @@ export class BookingPage extends BasePage {
   }
 
   async clickConfirm() {
-    await this.page.getByRole('button', { name: 'Confirm and submit' }).click()
+    await this.page.getByRole('button', { name: 'Confirm and book' }).click()
   }
 
   async shouldShowDatesOfPlacement(datesOfPlacement: E2EDatesOfPlacement) {


### PR DESCRIPTION
Fixes E2E tests failing on the 'Confirm booking' page -- submit button was changed last minute.