### PR TITLE
APS-1715: Remove usages of `Cas1PremiseCapacity.premise`

### DIFF
--- a/integration_tests/mockApis/premises.ts
+++ b/integration_tests/mockApis/premises.ts
@@ -96,7 +96,7 @@ const stubPremiseCapacity = (args: {
   stubFor({
     request: {
       method: 'GET',
-      url: `${paths.premises.capacity({ premisesId: args.premiseCapacity.premise.id })}?${createQueryString({
+      url: `${paths.premises.capacity({ premisesId: args.premisesId })}?${createQueryString({
         startDate: args.startDate,
         endDate: args.endDate,
       })}`,

--- a/integration_tests/tests/manage/occupancyView.cy.ts
+++ b/integration_tests/tests/manage/occupancyView.cy.ts
@@ -20,9 +20,9 @@ context('Premises occupancy', () => {
 
     const startDate = DateFormats.dateObjToIsoDate(startDateObj)
     const endDate = DateFormats.dateObjToIsoDate(endDateObj)
+    const premises = cas1PremisesFactory.build()
     const premisesCapacity = cas1PremiseCapacityFactory.build({ startDate, endDate })
 
-    const premises = premisesCapacity.premise
     const placements = cas1SpaceBookingSummaryFactory.buildList(30)
     const keyworkers = staffMemberFactory.keyworker().buildList(5)
 

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -199,7 +199,6 @@ context('Placement Requests', () => {
   ) => {
     const dayCapacity = occupancyViewPage.getOccupancyForDate(date, premiseCapacity)
     const premiseCapacityForDay = cas1PremiseCapacityFactory.build({
-      premise: premiseCapacity.premise,
       startDate: dayCapacity.date,
       endDate: dayCapacity.date,
       capacity: [dayCapacity],


### PR DESCRIPTION
This property is unnecessary, as it is only every called in a context where another Premises instance is available. The API can now remove it.

# Context

https://dsdmoj.atlassian.net/browse/APS-1715

# Changes in this PR

This fully removes any use of the `Cas1PremiseCapacity.premise` property.
