### PR TITLE
 Use default replicaCount in test for load test

### DIFF
--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -2,8 +2,6 @@
 # Per environment values which override defaults in approved-premises-ui/values.yaml
 
 generic-service:
-  replicaCount: 2
-
   ingress:
     hosts:
       - approved-premises-test.hmpps.service.justice.gov.uk


### PR DESCRIPTION
This ensures that the test environment has the same number of replicas as production
