### PR TITLE
APS-1815: Throw if page already visited

### DIFF
--- a/server/form-pages/utils/getTaskStatus.test.ts
+++ b/server/form-pages/utils/getTaskStatus.test.ts
@@ -144,4 +144,20 @@ describe('getTaskStatus', () => {
     expect(page3Instance.errors).toHaveBeenCalled()
     expect(page3Instance.next).toHaveBeenCalled()
   })
+
+  it('throws if the saved data creates an infinite loop', () => {
+    const application = applicationFactory.build({
+      data: { 'my-task': { 'page-1': { foo: 'bar' }, 'page-2': { foo: 'bar' }, 'page-3': { foo: 'bar' } } },
+    })
+
+    page1Instance.errors.mockReturnValue({})
+    page1Instance.next.mockReturnValue('page-2')
+
+    page2Instance.errors.mockReturnValue({})
+    page2Instance.next.mockReturnValue('page-1')
+
+    expect(() => getTaskStatus(task, application)).toThrow(
+      new Error('Page already visited while getting task status: page-1. Visited pages: page-1, page-2'),
+    )
+  })
 })

--- a/server/form-pages/utils/getTaskStatus.ts
+++ b/server/form-pages/utils/getTaskStatus.ts
@@ -23,7 +23,15 @@ const getTaskStatus = (task: UiTask, applicationOrAssessment: Application | Asse
     return 'not_started'
   }
 
+  const visited: Array<string> = []
+
   while (pageId) {
+    if (visited.includes(pageId)) {
+      throw new Error(`Page already visited while getting task status: ${pageId}. Visited pages: ${visited.join(', ')}`)
+    }
+
+    visited.push(pageId)
+
     const pageData = getPageData(applicationOrAssessment, task.id, pageId)
 
     // If there's no page data for this page, then we know it's incomplete

--- a/server/utils/applications/forPagesInTask.test.ts
+++ b/server/utils/applications/forPagesInTask.test.ts
@@ -199,4 +199,29 @@ describe('forPagesInTask', () => {
     expect(spy).toHaveBeenCalledWith(secondApplyPageInstance, 'second')
     expect(spy).toHaveBeenCalledTimes(1)
   })
+
+  it('throws if the saved data creates an infinite loop', () => {
+    ;(journeyTypeFromArtifact as jest.MockedFunction<typeof journeyTypeFromArtifact>).mockReturnValue('applications')
+
+    const firstApplyPageInstance = {
+      next: () => 'second',
+    }
+    const secondApplyPageInstance = {
+      next: () => 'first',
+    }
+
+    FirstApplyPage.mockReturnValue(firstApplyPageInstance)
+    SecondApplyPage.mockReturnValue(secondApplyPageInstance)
+    const spy = jest.fn()
+
+    const application = applicationFactory.build({
+      data: {
+        'first-apply-section-task-1': { first: { foo: 'bar' }, second: { bar: 'foo' } },
+      },
+    })
+
+    expect(() => forPagesInTask(application, applySection1Task1, spy)).toThrow(
+      new Error('Page already visited while building task list: first. Visited pages: first, second'),
+    )
+  })
 })

--- a/server/utils/applications/forPagesInTask.test.ts
+++ b/server/utils/applications/forPagesInTask.test.ts
@@ -8,6 +8,7 @@ import { forPagesInTask } from './forPagesInTask'
 jest.mock('../journeyTypeFromArtifact')
 const FirstApplyPage = jest.fn()
 const SecondApplyPage = jest.fn()
+const ThirdApplyPage = jest.fn()
 const AssessPage = jest.fn()
 const PlacementRequestPage = jest.fn()
 
@@ -32,6 +33,7 @@ const applySection1Task1 = {
   pages: {
     first: FirstApplyPage,
     second: SecondApplyPage,
+    third: ThirdApplyPage,
   },
 }
 const applySection1Task2 = {
@@ -72,6 +74,7 @@ Apply.sections = [applySection1, applySection2]
 Apply.pages['first-apply-section-task-1'] = {
   first: FirstApplyPage,
   second: SecondApplyPage,
+  third: ThirdApplyPage,
 }
 
 const assessSection1Task1 = {
@@ -223,5 +226,36 @@ describe('forPagesInTask', () => {
     expect(() => forPagesInTask(application, applySection1Task1, spy)).toThrow(
       new Error('Page already visited while building task list: first. Visited pages: first, second'),
     )
+  })
+
+  it('prevents a page being visited again through lack of previous page data', () => {
+    ;(journeyTypeFromArtifact as jest.MockedFunction<typeof journeyTypeFromArtifact>).mockReturnValue('applications')
+
+    const firstApplyPageInstance = {
+      next: () => 'third',
+    }
+    const secondApplyPageInstance = {
+      next: () => '',
+    }
+    const thirdApplyPageInstance = {
+      next: () => 'second',
+    }
+
+    FirstApplyPage.mockReturnValue(firstApplyPageInstance)
+    SecondApplyPage.mockReturnValue(secondApplyPageInstance)
+    ThirdApplyPage.mockReturnValue(thirdApplyPageInstance)
+    const spy = jest.fn()
+
+    const application = applicationFactory.build({
+      data: {
+        'first-apply-section-task-1': { first: { foo: 'bar' }, second: undefined, third: { bar: 'foo' } },
+      },
+    })
+
+    forPagesInTask(application, applySection1Task1, spy)
+
+    expect(spy).toHaveBeenCalledWith(firstApplyPageInstance, 'first')
+    expect(spy).toHaveBeenCalledWith(thirdApplyPageInstance, 'third')
+    expect(spy).toHaveBeenCalledTimes(2)
   })
 })

--- a/server/utils/applications/forPagesInTask.ts
+++ b/server/utils/applications/forPagesInTask.ts
@@ -21,6 +21,7 @@ export const forPagesInTask = (
     }
 
     visited.push(pageName)
+    pageNames.splice(pageNames.indexOf(pageName), 1)
 
     const Page = getPage(task.id, pageName, journeyTypeFromArtifact(formArtifact))
     const body = formArtifact?.data?.[task.id]?.[pageName]

--- a/server/utils/applications/forPagesInTask.ts
+++ b/server/utils/applications/forPagesInTask.ts
@@ -11,7 +11,17 @@ export const forPagesInTask = (
   const pageNames = Object.keys(task.pages)
   let pageName = pageNames?.[0]
 
+  const visited: Array<string> = []
+
   while (pageName && pageName !== 'check-your-answers') {
+    if (visited.includes(pageName)) {
+      throw new Error(
+        `Page already visited while building task list: ${pageName}. Visited pages: ${visited.join(', ')}`,
+      )
+    }
+
+    visited.push(pageName)
+
     const Page = getPage(task.id, pageName, journeyTypeFromArtifact(formArtifact))
     const body = formArtifact?.data?.[task.id]?.[pageName]
 


### PR DESCRIPTION
When building the main task list or fetching statuses for building un-submitted application summaries, some answer combinations may unintentionally produce an infinite loop due to how the next page to check is determined.

To prevent this, a simple trail of pages that have already been visited is built whenever such a loop is running. If a page has already been visited, an error is now thrown: this prevents the current process running indefinitely, and will alert us of the trail of pages that caused the infinite loop, so the issue can be remedied.

In addition, when no data has been saved against a given page, the loop attempts to check the next page as defined in the Task. Due to certain logic combinations, this page may already have been checked, which may also produce an infinite loop (or, thanks to the fix above, an error!). To prevent this, pages are removed from the pool as they are checked.

# Context

https://dsdmoj.atlassian.net/browse/APS-1815
