### PR TITLE
APS-1678 AP day summary view

### DIFF
--- a/integration_tests/mockApis/premises.ts
+++ b/integration_tests/mockApis/premises.ts
@@ -8,7 +8,7 @@ import type {
   StaffMember,
 } from '@approved-premises/api'
 
-import { stubFor } from './setup'
+import { getMatchingRequests, stubFor } from './setup'
 import paths from '../../server/paths/api'
 import { createQueryString } from '../../server/utils/utils'
 
@@ -111,21 +111,15 @@ const stubPremiseCapacity = (args: {
     },
   })
 
-const stubPremiseDaySummary = (args: {
+const stubPremisesDaySummary = (args: {
   premisesId: string
   date: string
   premisesDaySummary: Cas1PremisesDaySummary
-  sortBy?: string
-  sortDirection?: string
 }) => {
-  const queryString: string = createQueryString({
-    sortBy: args.sortBy || undefined,
-    sortDirection: args.sortDirection || undefined,
-  })
   return stubFor({
     request: {
       method: 'GET',
-      url: `${paths.premises.daySummary({ premisesId: args.premisesId, date: args.date })}${queryString ? `?${queryString}` : ''}`,
+      urlPath: paths.premises.daySummary({ premisesId: args.premisesId, date: args.date }),
     },
     response: {
       status: 200,
@@ -137,6 +131,14 @@ const stubPremiseDaySummary = (args: {
   })
 }
 
+const verifyPremisesDaySummaryRequest = async ({ premisesId, date }: { premisesId: string; date: string }) =>
+  (
+    await getMatchingRequests({
+      method: 'GET',
+      urlPath: paths.premises.daySummary({ premisesId, date }),
+    })
+  ).body.requests
+
 export default {
   stubAllPremises,
   stubCas1AllPremises,
@@ -144,5 +146,6 @@ export default {
   stubSinglePremises,
   stubPremisesStaffMembers,
   stubPremiseCapacity,
-  stubPremiseDaySummary,
+  stubPremisesDaySummary,
+  verifyPremisesDaySummaryRequest,
 }

--- a/integration_tests/pages/manage/occupancyDayView.ts
+++ b/integration_tests/pages/manage/occupancyDayView.ts
@@ -1,8 +1,15 @@
-import { Cas1PremisesBasicSummary, Cas1PremisesDaySummary } from '@approved-premises/api'
+import {
+  Cas1OutOfServiceBedSummary,
+  Cas1PremisesBasicSummary,
+  Cas1PremisesDaySummary,
+  Cas1SpaceBookingDaySummary,
+} from '@approved-premises/api'
 import Page from '../page'
 import { DateFormats } from '../../../server/utils/dateUtils'
 import paths from '../../../server/paths/manage'
 import { daySummaryRows } from '../../../server/utils/premises/occupancy'
+import { laoSummaryName } from '../../../server/utils/personUtils'
+import { spaceSearchCriteriaApLevelLabels } from '../../../server/utils/placementCriteriaUtils'
 
 export default class OccupancyDayViewPage extends Page {
   constructor(private pageTitle: string) {
@@ -14,6 +21,13 @@ export default class OccupancyDayViewPage extends Page {
     return new OccupancyDayViewPage(DateFormats.isoDateToUIDate(date))
   }
 
+  static visitUnauthorised(premises: Cas1PremisesBasicSummary, date: string): OccupancyDayViewPage {
+    cy.visit(paths.premises.occupancy.day({ premisesId: premises.id, date }), {
+      failOnStatusCode: false,
+    })
+    return new OccupancyDayViewPage(`Authorisation Error`)
+  }
+
   shouldShowDaySummaryDetails(premisesDaySummary: Cas1PremisesDaySummary) {
     this.shouldContainSummaryListItems(daySummaryRows(premisesDaySummary).rows)
   }
@@ -23,10 +37,32 @@ export default class OccupancyDayViewPage extends Page {
     cy.get('h1').contains(DateFormats.isoDateToUIDate(date))
   }
 
-  static visitUnauthorised(premises: Cas1PremisesBasicSummary, date: string): OccupancyDayViewPage {
-    cy.visit(paths.premises.occupancy.day({ premisesId: premises.id, date }), {
-      failOnStatusCode: false,
+  shouldShowListOfPlacements(placementSummaryList: Array<Cas1SpaceBookingDaySummary>) {
+    placementSummaryList.forEach(
+      ({ person, canonicalArrivalDate, canonicalDepartureDate, releaseType, essentialCharacteristics }) => {
+        cy.get('.govuk-table__body').contains(person.crn).closest('.govuk-table__row').as('row')
+        cy.get('@row').contains(laoSummaryName(person))
+        cy.get('@row').contains(DateFormats.isoDateToUIDate(canonicalArrivalDate, { format: 'short' }))
+        cy.get('@row').contains(DateFormats.isoDateToUIDate(canonicalDepartureDate, { format: 'short' }))
+        cy.get('@row').contains(releaseType)
+        essentialCharacteristics.forEach(characteristic => {
+          if (spaceSearchCriteriaApLevelLabels[characteristic])
+            cy.get('@row').contains(spaceSearchCriteriaApLevelLabels[characteristic])
+        })
+      },
+    )
+  }
+
+  shouldShowListOfOutOfServiceBeds(outOfServiceBedList: Array<Cas1OutOfServiceBedSummary>) {
+    outOfServiceBedList.forEach(({ roomName, startDate, endDate, reason, characteristics }) => {
+      cy.get('.govuk-table__body').contains(roomName).closest('.govuk-table__row').as('row')
+      cy.get('@row').contains(DateFormats.isoDateToUIDate(startDate, { format: 'short' }))
+      cy.get('@row').contains(DateFormats.isoDateToUIDate(endDate, { format: 'short' }))
+      cy.get('@row').contains(reason.name)
+      characteristics.forEach(characteristic => () => {
+        if (spaceSearchCriteriaApLevelLabels[characteristic])
+          cy.get('@row').contains(spaceSearchCriteriaApLevelLabels[characteristic])
+      })
     })
-    return new OccupancyDayViewPage(`Authorisation Error`)
   }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -535,6 +535,10 @@ export default abstract class Page {
     cy.get(`[value="${id}"]`).should('be.checked')
   }
 
+  shouldNotBeSelected(id: string): void {
+    cy.get(`[value="${id}"]`).should('not.be.checked')
+  }
+
   shouldShowApplicationTimeline(timelineEvents: Array<TimelineEvent>, index: number = 0) {
     const sortedTimelineEvents = timelineEvents.sort((a, b) => {
       return new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime()

--- a/server/controllers/manage/premises/apOccupancyViewController.test.ts
+++ b/server/controllers/manage/premises/apOccupancyViewController.test.ts
@@ -3,6 +3,7 @@ import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
 import { PremisesService } from 'server/services'
+import { ParsedQs } from 'qs'
 import ApOccupancyViewController from './apOccupancyViewController'
 
 import {
@@ -12,8 +13,19 @@ import {
 } from '../../../testutils/factories'
 
 import paths from '../../../paths/manage'
-import { daySummaryRows, generateDaySummaryText, occupancyCalendar } from '../../../utils/premises/occupancy'
+import {
+  daySummaryRows,
+  generateDaySummaryText,
+  occupancyCalendar,
+  outOfServiceBedColumnMap,
+  outOfServiceBedTableRows,
+  placementColumnMap,
+  placementTableRows,
+  tableHeader,
+} from '../../../utils/premises/occupancy'
 import { DateFormats } from '../../../utils/dateUtils'
+import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
+import { occupancyCriteriaMap } from '../../../utils/match/occupancy'
 
 describe('AP occupancyViewController', () => {
   const token = 'TEST_TOKEN'
@@ -115,13 +127,18 @@ describe('AP occupancyViewController', () => {
       expect(premisesService.getCapacity).not.toHaveBeenCalled()
     })
   })
+
   describe('dayView', () => {
-    const mockPremises = async (date: string = DateFormats.dateObjToIsoDate(new Date())) => {
+    const mockPremises = async (
+      date: string = DateFormats.dateObjToIsoDate(new Date()),
+      queryParameters: ParsedQs = {},
+    ) => {
       const premisesSummary: Cas1Premises = cas1PremisesFactory.build({ id: premisesId })
       const premisesDaySummary: Cas1PremisesDaySummary = cas1PremisesDaySummaryFactory.build({ forDate: date })
       premisesService.getDaySummary.mockResolvedValue(premisesDaySummary)
       premisesService.find.mockResolvedValue(premisesSummary)
       request.params.date = date
+      request.query = queryParameters
       const requestHandler = occupancyViewController.dayView()
       await requestHandler(request, response, next)
       return {
@@ -130,24 +147,70 @@ describe('AP occupancyViewController', () => {
       }
     }
 
-    it('should render the premises day summary', async () => {
+    it('should render the premises day summary with default sort and filter', async () => {
       const date = '2025-01-01'
       const { premisesSummary, premisesDaySummary } = await mockPremises(date)
 
-      expect(response.render).toHaveBeenCalledWith(
-        'manage/premises/occupancy/dayView',
+      expect(response.render).toHaveBeenCalledWith('manage/premises/occupancy/dayView', {
+        premises: premisesSummary,
+        pageHeading: DateFormats.isoDateToUIDate(date),
+        backLink: paths.premises.occupancy.view({ premisesId }),
+        previousDayLink: `${paths.premises.occupancy.day({ premisesId, date: '2024-12-31' })}`,
+        nextDayLink: `${paths.premises.occupancy.day({ premisesId, date: '2025-01-02' })}`,
+        daySummaryRows: daySummaryRows(premisesDaySummary),
+        daySummaryText: generateDaySummaryText(premisesDaySummary),
+        formattedDate: 'Wed 1 Jan 2025',
+        placementTableHeader: tableHeader(
+          placementColumnMap,
+          'personName',
+          'asc',
+          '/manage/premises/some-uuid/occupancy/day/2025-01-01',
+        ),
+        placementTableRows: placementTableRows(premisesId, premisesDaySummary.spaceBookings),
+        outOfServiceBedTableHeader: tableHeader(outOfServiceBedColumnMap, 'personName', 'asc', ''),
+        outOfServiceBedTableRows: outOfServiceBedTableRows(premisesId, premisesDaySummary.outOfServiceBeds),
+        criteriaOptions: convertKeyValuePairToCheckBoxItems(occupancyCriteriaMap, []),
+      })
+      expect(premisesService.find).toHaveBeenCalledWith(token, premisesId)
+      expect(premisesService.getDaySummary).toHaveBeenCalledWith({
+        token,
+        premisesId,
+        date,
+        bookingsSortBy: 'personName',
+        bookingsSortDirection: 'asc',
+      })
+    })
+
+    it('should render the premises day summary with specified sort and filter', async () => {
+      const date = '2025-01-01'
+      const { premisesSummary } = await mockPremises(date, {
+        sortBy: 'canonicalArrivalDate',
+        sortDirection: 'desc',
+        characteristics: ['hasEnsuite'],
+      })
+      const result = response.render.mock.calls[0][1]
+      expect(result).toEqual(
         expect.objectContaining({
           premises: premisesSummary,
-          pageHeading: DateFormats.isoDateToUIDate(date),
-          backLink: paths.premises.occupancy.view({ premisesId }),
-          previousDayLink: paths.premises.occupancy.day({ premisesId, date: '2024-12-31' }),
-          nextDayLink: paths.premises.occupancy.day({ premisesId, date: '2025-01-02' }),
-          daySummaryRows: daySummaryRows(premisesDaySummary),
-          daySummaryText: generateDaySummaryText(premisesDaySummary),
+          previousDayLink: `${paths.premises.occupancy.day({ premisesId, date: '2024-12-31' })}?sortBy=canonicalArrivalDate&sortDirection=desc&characteristics=hasEnsuite`,
+          nextDayLink: `${paths.premises.occupancy.day({ premisesId, date: '2025-01-02' })}?sortBy=canonicalArrivalDate&sortDirection=desc&characteristics=hasEnsuite`,
+          placementTableHeader: tableHeader(
+            placementColumnMap,
+            'canonicalArrivalDate',
+            'desc',
+            '/manage/premises/some-uuid/occupancy/day/2025-01-01?characteristics=hasEnsuite',
+          ),
         }),
       )
       expect(premisesService.find).toHaveBeenCalledWith(token, premisesId)
-      expect(premisesService.getDaySummary).toHaveBeenCalledWith({ token, premisesId, date })
+      expect(premisesService.getDaySummary).toHaveBeenCalledWith({
+        token,
+        premisesId,
+        date,
+        bookingsSortBy: 'canonicalArrivalDate',
+        bookingsSortDirection: 'desc',
+        bookingsCriteriaFilter: ['hasEnsuite'],
+      })
     })
   })
 })

--- a/server/data/premisesClient.test.ts
+++ b/server/data/premisesClient.test.ts
@@ -143,8 +143,8 @@ describeCas1NamespaceClient('PremisesCas1Client', provider => {
       const date = '2025-03-14'
       const premises = premisesFactory.build()
       const premiseCapacity = cas1PremisesDaySummaryFactory.build()
-      const sortDirection: SortDirection = 'asc'
-      const sortBy: Cas1SpaceBookingDaySummarySortField = 'personName'
+      const bookingsSortDirection: SortDirection = 'asc'
+      const bookingsSortBy: Cas1SpaceBookingDaySummarySortField = 'personName'
 
       await provider.addInteraction({
         state: 'Server is healthy',
@@ -153,8 +153,8 @@ describeCas1NamespaceClient('PremisesCas1Client', provider => {
           method: 'GET',
           path: paths.premises.daySummary({ premisesId: premises.id, date }),
           query: {
-            sortDirection,
-            sortBy,
+            bookingsSortDirection,
+            bookingsSortBy,
             bookingsCriteriaFilter: 'hasEnSuite',
           },
           headers: {
@@ -170,8 +170,8 @@ describeCas1NamespaceClient('PremisesCas1Client', provider => {
       const output = await premisesClient.getDaySummary({
         premisesId: premises.id,
         date,
-        sortDirection,
-        sortBy,
+        bookingsSortDirection,
+        bookingsSortBy,
         bookingsCriteriaFilter: ['hasEnSuite'],
       })
       expect(output).toEqual(premiseCapacity)

--- a/server/data/premisesClient.ts
+++ b/server/data/premisesClient.ts
@@ -55,13 +55,17 @@ export default class PremisesClient {
     premisesId: string
     date: string
     bookingsCriteriaFilter?: Array<Cas1SpaceBookingCharacteristic>
-    sortDirection?: SortDirection
-    sortBy?: Cas1SpaceBookingDaySummarySortField
+    bookingsSortDirection?: SortDirection
+    bookingsSortBy?: Cas1SpaceBookingDaySummarySortField
   }): Promise<Cas1PremisesDaySummary> {
-    const { premisesId, date, sortDirection, sortBy, bookingsCriteriaFilter } = args
+    const { premisesId, date, bookingsSortDirection, bookingsSortBy, bookingsCriteriaFilter } = args
     return (await this.restClient.get({
       path: paths.premises.daySummary({ premisesId, date }),
-      query: { sortDirection, sortBy, bookingsCriteriaFilter: bookingsCriteriaFilter?.join(',') },
+      query: {
+        bookingsSortDirection,
+        bookingsSortBy,
+        bookingsCriteriaFilter: bookingsCriteriaFilter?.join(','),
+      },
     })) as Cas1PremisesDaySummary
   }
 

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -1,5 +1,11 @@
 import type { ManWoman, PaginatedResponse } from '@approved-premises/ui'
-import type { Cas1SpaceBookingResidency, Cas1SpaceBookingSummary } from '@approved-premises/api'
+import type {
+  Cas1SpaceBookingCharacteristic,
+  Cas1SpaceBookingDaySummarySortField,
+  Cas1SpaceBookingResidency,
+  Cas1SpaceBookingSummary,
+  SortDirection,
+} from '@approved-premises/api'
 
 import PremisesService from './premisesService'
 import PremisesClient from '../data/premisesClient'
@@ -132,14 +138,23 @@ describe('PremisesService', () => {
 
   describe('getDaySummary', () => {
     it('should return the day summary for a premises', async () => {
-      const date = '2025-05-20'
       const daySummary = cas1PremisesDaySummaryFactory.build()
-      premisesClient.getDaySummary.mockResolvedValue(daySummary)
-      const result = await service.getDaySummary({ token, premisesId, date })
+      const params = {
+        premisesId,
+        date: '2025-05-20',
+        bookingsSortBy: 'canonicalArrivalDate' as Cas1SpaceBookingDaySummarySortField,
+        bookingsSortDirection: 'asc' as SortDirection,
+        bookingsCriteriaFilter: ['isSingle'] as Array<Cas1SpaceBookingCharacteristic>,
+      }
 
+      premisesClient.getDaySummary.mockResolvedValue(daySummary)
+      const result = await service.getDaySummary({
+        token,
+        ...params,
+      })
       expect(result).toEqual(daySummary)
       expect(premisesClientFactory).toHaveBeenCalledWith(token)
-      expect(premisesClient.getDaySummary).toHaveBeenCalledWith({ premisesId, date })
+      expect(premisesClient.getDaySummary).toHaveBeenCalledWith(params)
     })
   })
 

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -52,8 +52,8 @@ export default class PremisesService {
     premisesId: string
     date: string
     bookingsCriteriaFilter?: Array<Cas1SpaceBookingCharacteristic>
-    sortBy?: Cas1SpaceBookingDaySummarySortField
-    sortDirection?: SortDirection
+    bookingsSortBy?: Cas1SpaceBookingDaySummarySortField
+    bookingsSortDirection?: SortDirection
   }): Promise<Cas1PremisesDaySummary> {
     const { token, ...parameters } = args
     const premisesClient = this.premisesClientFactory(token)

--- a/server/testutils/factories/cas1OutOfServiceBedSummary.ts
+++ b/server/testutils/factories/cas1OutOfServiceBedSummary.ts
@@ -1,0 +1,30 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker'
+import {
+  Cas1OutOfServiceBedReason,
+  Cas1OutOfServiceBedSummary,
+  Cas1SpaceBookingCharacteristic,
+} from '@approved-premises/api'
+import { DateFormats } from '../../utils/dateUtils'
+import { spaceSearchCriteriaRoomLevelLabels } from '../../utils/placementCriteriaUtils'
+
+export default Factory.define<Cas1OutOfServiceBedSummary>(({ sequence }) => {
+  const reason: Cas1OutOfServiceBedReason = {
+    id: faker.string.uuid(),
+    name: `${faker.word.verb()} ${faker.word.preposition()} ${faker.word.noun()}`,
+    isActive: true,
+  }
+  const characteristics = faker.helpers.arrayElements(Object.keys(spaceSearchCriteriaRoomLevelLabels), {
+    min: 0,
+    max: 3,
+  }) as Array<Cas1SpaceBookingCharacteristic>
+  return {
+    id: faker.string.uuid(),
+    bedId: faker.string.uuid(),
+    roomName: `${faker.helpers.arrayElement(['Ground floor', 'First floor'])} rm ${faker.number.int({ min: 1, max: 9 })}-${sequence}`,
+    startDate: DateFormats.dateObjToIsoDate(faker.date.recent({ days: 10 })),
+    endDate: DateFormats.dateObjToIsoDate(faker.date.soon({ days: 10 })),
+    reason,
+    characteristics,
+  }
+})

--- a/server/testutils/factories/cas1PremiseCapacity.ts
+++ b/server/testutils/factories/cas1PremiseCapacity.ts
@@ -49,10 +49,22 @@ class CapacityForDayFactory extends Factory<Cas1PremiseCapacityForDay> {
     })
   }
 
-  overbooked() {
+  overbookedOrFull() {
     const totalBedCount = faker.number.int({ min: 6, max: 40 })
     const availableBedCount = faker.number.int({ min: totalBedCount - 5, max: totalBedCount })
     const bookingCount = faker.number.int({ min: availableBedCount, max: totalBedCount + 5 })
+
+    return this.params({
+      totalBedCount,
+      availableBedCount,
+      bookingCount,
+    })
+  }
+
+  strictlyOverbooked() {
+    const totalBedCount = faker.number.int({ min: 6, max: 40 })
+    const availableBedCount = faker.number.int({ min: totalBedCount - 5, max: totalBedCount })
+    const bookingCount = faker.number.int({ min: availableBedCount + 1, max: totalBedCount + 5 })
 
     return this.params({
       totalBedCount,

--- a/server/testutils/factories/cas1PremisesDaySummary.ts
+++ b/server/testutils/factories/cas1PremisesDaySummary.ts
@@ -5,19 +5,20 @@ import type { Cas1PremisesDaySummary } from '@approved-premises/api'
 import { addDays } from 'date-fns'
 import { DateFormats } from '../../utils/dateUtils'
 import { cas1PremiseCapacityForDayFactory } from './cas1PremiseCapacity'
+import cas1OutOfServiceBedSummaryFactory from './cas1OutOfServiceBedSummary'
+import cas1SpaceBookingDaySummaryFactory from './cas1SpaceBookingDaySummary'
 
 export default Factory.define<Cas1PremisesDaySummary>(({ params }) => {
   const forDate = params.forDate ? DateFormats.isoToDateObj(params.forDate) : faker.date.anytime()
   const capacity = cas1PremiseCapacityForDayFactory.build({
     date: DateFormats.dateObjToIsoDate(forDate),
   })
-  // const spaceBookings = cas1SpaceBookingDaySummaryFactory.buildList(20)
-  // TODO: Add the spacebookings and lost beds lists
-
   return {
     forDate: DateFormats.dateObjToIsoDate(forDate),
     previousDate: DateFormats.dateObjToIsoDate(addDays(forDate, -1)),
     nextDate: DateFormats.dateObjToIsoDate(addDays(forDate, 1)),
     capacity,
+    spaceBookings: cas1SpaceBookingDaySummaryFactory.buildList(5),
+    outOfServiceBeds: cas1OutOfServiceBedSummaryFactory.buildList(5),
   } as Cas1PremisesDaySummary
 })

--- a/server/testutils/factories/cas1SpaceBookingDaySummary.ts
+++ b/server/testutils/factories/cas1SpaceBookingDaySummary.ts
@@ -1,0 +1,21 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker'
+import { Cas1SpaceBookingCharacteristic, Cas1SpaceBookingDaySummary } from '@approved-premises/api'
+import { spaceSearchCriteriaRoomLevelLabels } from '../../utils/placementCriteriaUtils'
+import { fullPersonSummaryFactory } from './person'
+import { DateFormats } from '../../utils/dateUtils'
+
+export default Factory.define<Cas1SpaceBookingDaySummary>(() => {
+  const essentialCharacteristics = faker.helpers.arrayElements(
+    Object.keys(spaceSearchCriteriaRoomLevelLabels),
+  ) as Array<Cas1SpaceBookingCharacteristic>
+  return {
+    id: faker.string.uuid(),
+    person: fullPersonSummaryFactory.build(),
+    canonicalArrivalDate: DateFormats.dateObjToIsoDate(faker.date.recent({ days: 90 })),
+    canonicalDepartureDate: DateFormats.dateObjToIsoDate(faker.date.soon({ days: 90 })),
+    tier: faker.helpers.arrayElement(['A', 'B', 'C']),
+    releaseType: faker.helpers.arrayElement(['ROTL', 'HDC', 'PSS', 'Parole', 'Priority']),
+    essentialCharacteristics,
+  }
+})

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -84,6 +84,7 @@ import cas1PremisesFactory from './cas1Premises'
 import cas1PremisesBasicSummaryFactory from './cas1PremisesBasicSummary'
 import cas1PremiseCapacityFactory, { cas1PremiseCapacityForDayFactory } from './cas1PremiseCapacity'
 import cas1SpaceBookingSummaryFactory from './cas1SpaceBookingSummary'
+import cas1SpaceBookingDaySummaryFactory from './cas1SpaceBookingDaySummary'
 import cas1SpaceBookingFactory from './cas1SpaceBooking'
 import cas1SpaceBookingDatesFactory from './cas1SpaceBookingDates'
 import cas1AssignKeyWorkerFactory from './cas1AssignKeyWorker'
@@ -94,6 +95,7 @@ import cas1SpaceBookingDepartureFactory from './cas1SpaceBookingDeparture'
 import cas1KeyworkerAllocationFactory from './cas1KeyworkerAllocation'
 import cas1NewSpaceBookingCancellationFactory from './cas1NewSpaceBookingCancellation'
 import cas1PremisesDaySummaryFactory from './cas1PremisesDaySummary'
+import cas1OutOfServiceBedSummaryFactory from './cas1OutOfServiceBedSummary'
 
 export {
   acctAlertFactory,
@@ -118,6 +120,7 @@ export {
   bookingPremisesSummaryFactory,
   bookingNotMadeFactory,
   cancellationFactory,
+  cas1OutOfServiceBedSummaryFactory,
   cas1PremisesBasicSummaryFactory,
   cas1PremiseCapacityFactory,
   cas1PremiseCapacityForDayFactory,
@@ -128,6 +131,7 @@ export {
   cas1SpaceBookingDepartureFactory,
   cas1SpaceBookingFactory,
   cas1SpaceBookingSummaryFactory,
+  cas1SpaceBookingDaySummaryFactory,
   cas1AssignKeyWorkerFactory,
   cas1NewArrivalFactory,
   cas1NewDepartureFactory,

--- a/server/utils/match/occupancy.test.ts
+++ b/server/utils/match/occupancy.test.ts
@@ -76,7 +76,7 @@ describe('dayAvailabilityStatus', () => {
     })
 
     it('returns overbooked if there is no availability', () => {
-      const capacityForDay = cas1PremiseCapacityForDayFactory.overbooked().build()
+      const capacityForDay = cas1PremiseCapacityForDayFactory.overbookedOrFull().build()
 
       expect(dayAvailabilityStatus(capacityForDay)).toEqual('overbooked')
     })
@@ -102,7 +102,7 @@ describe('dayAvailabilityStatus', () => {
     })
 
     describe('if there is no general availability but availability for criteria', () => {
-      const overbookedCapacity = cas1PremiseCapacityForDayFactory.overbooked().build({
+      const overbookedCapacity = cas1PremiseCapacityForDayFactory.overbookedOrFull().build({
         characteristicAvailability: [
           premiseCharacteristicAvailability.available().build({ characteristic: 'isSuitedForSexOffenders' }),
           premiseCharacteristicAvailability.available().build({ characteristic: 'isSingle' }),

--- a/server/utils/match/occupancySummary.test.ts
+++ b/server/utils/match/occupancySummary.test.ts
@@ -6,9 +6,9 @@ describe('occupancySummary', () => {
     const capacity = [
       cas1PremiseCapacityForDayFactory.available().build({ date: '2025-02-12' }),
       cas1PremiseCapacityForDayFactory.available().build({ date: '2025-02-13' }),
-      cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-02-14' }),
-      cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-02-15' }),
-      cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-02-16' }),
+      cas1PremiseCapacityForDayFactory.overbookedOrFull().build({ date: '2025-02-14' }),
+      cas1PremiseCapacityForDayFactory.overbookedOrFull().build({ date: '2025-02-15' }),
+      cas1PremiseCapacityForDayFactory.overbookedOrFull().build({ date: '2025-02-16' }),
       cas1PremiseCapacityForDayFactory.available().build({ date: '2025-02-17' }),
     ]
 
@@ -24,7 +24,7 @@ describe('occupancySummary', () => {
   })
 
   it('returns only overbooked if no dates are available', () => {
-    const capacity = [cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-04-14' })]
+    const capacity = [cas1PremiseCapacityForDayFactory.overbookedOrFull().build({ date: '2025-04-14' })]
 
     const result = occupancySummary(capacity)
 

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -7,6 +7,7 @@ import {
   initialiseName,
   linebreaksToParagraphs,
   linkTo,
+  makeArrayOfType,
   mapApiPersonRisksForUi,
   numberToOrdinal,
   objectIfNotEmpty,
@@ -279,6 +280,16 @@ describe('resolvePath', () => {
     it('returns the object if it does have keys', () => {
       expect(objectIfNotEmpty({ key: 'value' })).toEqual({ key: 'value' })
     })
+  })
+})
+
+describe('makeArrayOfType', () => {
+  it('Should return an array, whatever is passed', () => {
+    type TestType = 'one' | 'two'
+    const result1: Array<TestType> = ['one']
+    expect(makeArrayOfType<TestType>('one') === result1)
+    expect(makeArrayOfType<TestType>(['one']) === result1)
+    expect(makeArrayOfType<TestType>(null) === undefined)
   })
 })
 

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -161,6 +161,18 @@ export const objectIfNotEmpty = <T>(object: Record<string, unknown> | T | undefi
   return undefined
 }
 
+/**
+ * Returns a typed array from either an object/string or an array. Useful for handling arrays of query parameters.
+ * @param input either an object or string or an array
+ * @returns an array or undefined if the input is falsey
+ */
+export const makeArrayOfType = <T>(input: unknown): Array<T> => {
+  if (input) {
+    return (Array.isArray(input) ? input : [input]) as Array<T>
+  }
+  return undefined
+}
+
 export const numberToOrdinal = (number: number | string): string =>
   ['First', 'Second', 'Third', 'Fourth', 'Fifth'][Number(number)]
 

--- a/server/views/manage/premises/occupancy/dayView.njk
+++ b/server/views/manage/premises/occupancy/dayView.njk
@@ -1,13 +1,9 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
-{% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
-
-{%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% extends "../../../partials/layout.njk" %}
 
@@ -43,6 +39,42 @@
         }) }}
     {% endif %}
     {{ govukSummaryList(daySummaryRows) }}
+
+    <div class="search-and-filter">
+        <form action="{{ selfPath }}"
+              method="get">
+            <h2 class="govuk-heading-m">Filter</h2>
+
+            <div class="search-and-filter__row">
+                {{ govukCheckboxes({
+                    name: "characteristics",
+                    classes: "govuk-checkboxes--small govuk-checkboxes--inline",
+                    items: criteriaOptions
+                }) }}
+                {{ govukButton({
+                    text: 'Apply filters',
+                    preventDoubleClick: true
+                }) }}
+            </div>
+        </form>
+    </div>
+
+    <section>
+        <h2 class="govuk-heading-m">People booked in on {{ formattedDate }}</h2>
+        {{ govukTable({
+            firstCellIsHeader: false,
+            head: placementTableHeader,
+            rows: placementTableRows
+        }) }}
+    </section>
+    <section>
+        <h2 class="govuk-heading-m">Out of service beds on {{ formattedDate }}</h2>
+        {{ govukTable({
+            firstCellIsHeader: false,
+            head: outOfServiceBedTableHeader,
+            rows: outOfServiceBedTableRows
+        }) }}
+    </section>
 
 {% endblock %}
 


### PR DESCRIPTION
# Context
[(https://dsdmoj.atlassian.net/browse/APS-1679)](https://dsdmoj.atlassian.net/browse/APS-1679)

# Changes in this PR

<!-- [] I have run the E2E tests locally and they passed -->
Adds a list of residents and out of service beds to the AP day summary page.
The residents list is sortable on all but one field. There is also a filter that allows the residents list to be filtered based on room characteristics.
The filters and sort orders are preserved if the user navigates forward and back through the days.
The residents list has links to the placement details page and the out of service bed list links to the oos bed details page. Both of these links will suffer from 'back button misdirection' but these issues will be resolved later.

## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/fd2b51ce-109e-4639-bb13-ca8f4093dfd2)
