### PR TITLE
APS-1821 Placement action updates

### DIFF
--- a/assets/sass/components/_summary-list.scss
+++ b/assets/sass/components/_summary-list.scss
@@ -34,3 +34,6 @@
     font-weight: 700;
   }
 }
+.govuk-summary-list__textblock {
+  white-space: pre-line;
+}

--- a/integration_tests/pages/manage/placements/nonArrival.ts
+++ b/integration_tests/pages/manage/placements/nonArrival.ts
@@ -3,6 +3,7 @@ import type { Cas1NonArrival, Cas1SpaceBooking } from '@approved-premises/api'
 import Page from '../../page'
 import paths from '../../../../server/paths/manage'
 import apiPaths from '../../../../server/paths/api'
+import { NON_ARRIVAL_REASON_OTHER_ID } from '../../../../server/utils/placements'
 
 export class RecordNonArrivalPage extends Page {
   constructor(title: string = 'Record someone as not arrived') {
@@ -11,7 +12,7 @@ export class RecordNonArrivalPage extends Page {
 
   nonArrivalDetails: Cas1NonArrival = {
     notes: faker.lorem.words(20).substring(0, 200),
-    reason: null,
+    reason: NON_ARRIVAL_REASON_OTHER_ID,
   }
 
   completeNotesBad(): void {
@@ -27,15 +28,6 @@ export class RecordNonArrivalPage extends Page {
 
   checkForCharacterCountError(): void {
     cy.contains('You have 50 characters too many')
-  }
-
-  completeReason(): void {
-    cy.get('input[name=reason]')
-      .invoke('val')
-      .then(val => {
-        this.nonArrivalDetails.reason = String(val)
-        this.checkRadioByNameAndValue('reason', String(val))
-      })
   }
 
   static visitUnauthorised(placement: Cas1SpaceBooking): RecordNonArrivalPage {

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -457,5 +457,6 @@ export type DepartureFormSessionData = Partial<
     breachOrRecallReasonId: string
     moveOnCategoryId: string
     notes: string
+    apName: string
   }
 >

--- a/server/controllers/manage/premises/placements/nonArrivalsController.test.ts
+++ b/server/controllers/manage/premises/placements/nonArrivalsController.test.ts
@@ -10,6 +10,7 @@ import * as validationUtils from '../../../../utils/validation'
 import managePaths from '../../../../paths/manage'
 import PlacementService from '../../../../services/placementService'
 import { ValidationError } from '../../../../utils/errors'
+import { NON_ARRIVAL_REASON_OTHER_ID } from '../../../../utils/placements'
 
 describe('nonArrivalsController', () => {
   const token = 'SAMPLE_TOKEN'
@@ -92,6 +93,28 @@ describe('nonArrivalsController', () => {
 
       expect(errorData).toEqual({
         reason: 'You must select a reason for non-arrival',
+      })
+    })
+
+    it('returns error if "other" selected but no descriptive text', async () => {
+      const requestHandler = nonArrivalsController.create()
+
+      request.body = { reason: NON_ARRIVAL_REASON_OTHER_ID }
+
+      await requestHandler(request, response, next)
+
+      expect(placementService.recordNonArrival).not.toHaveBeenCalled()
+      expect(validationUtils.catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+        request,
+        response,
+        new ValidationError({}),
+        uiNonArrivalsPagePath,
+      )
+
+      const errorData = (validationUtils.catchValidationErrorOrPropogate as jest.Mock).mock.lastCall[2].data
+
+      expect(errorData).toEqual({
+        notes: 'You must provide the reason for non-arrival',
       })
     })
 

--- a/server/testutils/referenceData/stubs/cas1/move-on-categories.json
+++ b/server/testutils/referenceData/stubs/cas1/move-on-categories.json
@@ -10,5 +10,5 @@
   { "id": "e1863cc4-dbc8-4c02-8ff7-08c0c9952ba1", "name": "Owner Occupied", "isActive": true },
   { "id": "c6d3c3e3-d05b-4828-b393-9cfddc5daa6b", "name": "Private Rented", "isActive": true },
   { "id": "8f35e009-cdf8-4a70-9ca4-97d99609893e", "name": "Supported Housing", "isActive": true },
-  { "id": "29c0c4e8-6899-4471-832b-883cea522128", "name": "Transferred to different AP", "isActive": true }
+  { "id": "6b1f6645-dc1c-489d-8312-cab9a4a6b2a7", "name": "Transferred to different AP", "isActive": true }
 ]

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -14,6 +14,7 @@ import {
   flattenCheckboxInput,
   isStringOrArrayOfStrings,
   placementRequestStatusSelectOptions,
+  summaryListItem,
   tierSelectOptions,
   validPostcodeArea,
 } from './formUtils'
@@ -602,6 +603,26 @@ describe('formUtils', () => {
           },
         },
       ])
+    })
+  })
+
+  describe('SummaryListItem', () => {
+    const label = 'label'
+    const value = 'test value'
+
+    it('should return a summary list item', () => {
+      expect(summaryListItem(label, value)).toEqual({ key: { text: label }, value: { text: value } })
+      expect(summaryListItem(label, value, 'html')).toEqual({ key: { text: label }, value: { html: value } })
+      expect(summaryListItem(label, value, 'textBlock')).toEqual({
+        key: { text: label },
+        value: { html: `<span class="govuk-summary-list__textblock">${value}</span>` },
+      })
+      expect(summaryListItem(label, undefined)).toEqual({ key: { text: label }, value: { text: undefined } })
+    })
+
+    it('should return undefined if value is falsey and blank suppression enabled', () => {
+      expect(summaryListItem(label, '', 'text')).toEqual({ key: { text: label }, value: { text: '' } })
+      expect(summaryListItem(label, '', 'text', true)).toEqual(undefined)
     })
   })
 

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -175,11 +175,17 @@ export function convertKeyValuePairsToSummaryListItems<T extends object>(
 export const summaryListItem = (
   label: string,
   value: string,
-  renderAs: keyof TextItem | keyof HtmlItem = 'text',
-): SummaryListItem => ({
-  key: { text: label },
-  value: renderAs === 'text' ? { text: value } : { html: value },
-})
+  renderAs: keyof TextItem | keyof HtmlItem | 'textBlock' = 'text',
+  supressBlank = false,
+): SummaryListItem => {
+  const htmlValue = renderAs === 'textBlock' ? `<span class="govuk-summary-list__textblock">${value}</span>` : value
+  return !supressBlank || value
+    ? {
+        key: { text: label },
+        value: renderAs === 'text' ? { text: value } : { html: htmlValue },
+      }
+    : undefined
+}
 
 /**
  * Performs validation on the area of a postcode (IE the first three or four characters)

--- a/server/utils/placements/index.test.ts
+++ b/server/utils/placements/index.test.ts
@@ -1,5 +1,5 @@
 import type { Cas1SpaceBooking, FullPerson, StaffMember } from '@approved-premises/api'
-import { SelectOption } from '@approved-premises/ui'
+import { RadioItem, SelectOption } from '@approved-premises/ui'
 import { faker } from '@faker-js/faker/locale/en_GB'
 import {
   cas1PremisesFactory,
@@ -13,6 +13,7 @@ import {
   departureInformation,
   getBackLink,
   getKeyDetail,
+  injectRadioConditionalHtml,
   otherBookings,
   placementSummary,
   renderKeyworkersSelectOptions,
@@ -256,7 +257,12 @@ describe('placementUtils', () => {
               },
             },
             { key: { text: 'Departure reason' }, value: { text: departedPlacement.departure?.reason?.name } },
-            { key: { text: 'More information' }, value: { text: departedPlacement.departure?.notes } },
+            {
+              key: { text: 'More information' },
+              value: {
+                html: `<span class="govuk-summary-list__textblock">${departedPlacement.departure?.notes}</span>`,
+              },
+            },
           ],
         })
       })
@@ -282,7 +288,12 @@ describe('placementUtils', () => {
             },
             { key: { text: 'Departure reason' }, value: { text: departedPlacement.departure?.parentReason?.name } },
             { key: { text: 'Breach or recall' }, value: { text: departedPlacement.departure?.reason?.name } },
-            { key: { text: 'More information' }, value: { text: departedPlacement.departure?.notes } },
+            {
+              key: { text: 'More information' },
+              value: {
+                html: `<span class="govuk-summary-list__textblock">${departedPlacement.departure?.notes}</span>`,
+              },
+            },
           ],
         })
       })
@@ -308,7 +319,12 @@ describe('placementUtils', () => {
             },
             { key: { text: 'Departure reason' }, value: { text: departedPlacement.departure?.reason?.name } },
             { key: { text: 'Move on' }, value: { text: departedPlacement.departure?.moveOnCategory?.name } },
-            { key: { text: 'More information' }, value: { text: departedPlacement.departure?.notes } },
+            {
+              key: { text: 'More information' },
+              value: {
+                html: `<span class="govuk-summary-list__textblock">${departedPlacement.departure?.notes}</span>`,
+              },
+            },
           ],
         })
       })
@@ -364,6 +380,20 @@ describe('placementUtils', () => {
         selectBlankOption,
         ...[staffList[0], staffList[2]].map(({ name, code }) => ({ text: name, value: code, selected: false })),
       ])
+    })
+  })
+
+  describe('injectRadioConditionalHtml', () => {
+    it('should inject the supplied html into the radio list as a condtional', () => {
+      const radioList: Array<RadioItem> = [
+        { text: 'One', value: 'one' },
+        { text: 'Two', value: 'two' },
+        { text: 'Three', value: 'three' },
+      ]
+      const testHtml = 'test HTML'
+      expect(injectRadioConditionalHtml(radioList, 'two', testHtml)).toEqual(
+        expect.arrayContaining([{ text: 'Two', value: 'two', conditional: { html: testHtml } }]),
+      )
     })
   })
 })

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -5,7 +5,14 @@ import type {
   FullPerson,
   StaffMember,
 } from '@approved-premises/api'
-import { KeyDetailsArgs, SelectOption, SummaryList, SummaryListItem, UserDetails } from '@approved-premises/ui'
+import {
+  KeyDetailsArgs,
+  RadioItem,
+  SelectOption,
+  SummaryList,
+  SummaryListItem,
+  UserDetails,
+} from '@approved-premises/ui'
 import { DateFormats, daysToWeeksAndDays } from '../dateUtils'
 import { htmlValue, textValue } from '../applications/helpers'
 import { isFullPerson, nameOrPlaceholderCopy } from '../personUtils'
@@ -170,7 +177,7 @@ export const departureInformation = (placement: Cas1SpaceBooking): SummaryList =
       summaryRow('Departure reason', reason),
       summaryRow('Breach or recall', breachOrRecall),
       summaryRow('Move on', placement.departure?.moveOnCategory?.name),
-      summaryRow('More information', placement.departure?.notes),
+      summaryListItem('More information', placement.departure?.notes, 'textBlock', true),
     ].filter(Boolean),
   }
 }
@@ -253,5 +260,17 @@ export const placementTabItems = (
   })
 }
 
+type IdAndName = { id: string; name: string }
+export const processReferenceData = <T>(input: Array<IdAndName>, subst: IdAndName): Array<T> => {
+  return input.map(item => (item.id === subst.id ? subst : item)) as Array<T>
+}
+
+export const injectRadioConditionalHtml = (input: Array<RadioItem>, value: string, html: string): Array<RadioItem> =>
+  input.map((row: RadioItem) => (row.value === value ? { ...row, conditional: { html } } : row))
+
 export const BREACH_OR_RECALL_REASON_ID = 'd3e43ec3-02f4-4b96-a464-69dc74099259'
 export const PLANNED_MOVE_ON_REASON_ID = '1bfe5cdf-348e-4a6e-8414-177a92a53d26'
+export const LICENCE_EXPIRED_REASON_ID = '9c848d97-afe7-4da9-bd8b-f01897330e62'
+export const NON_ARRIVAL_REASON_OTHER_ID = '3635c76e-8e4b-4c0e-8b92-149dc1ff0855'
+export const MOVE_TO_AP_REASON_ID = '6b1f6645-dc1c-489d-8312-cab9a4a6b2a7'
+export const BED_WITHDRAWN_REASON_ID = '0f856559-26c0-4184-96fe-00d446e91da2'

--- a/server/views/manage/premises/placements/departure/move-on-category.njk
+++ b/server/views/manage/premises/placements/departure/move-on-category.njk
@@ -1,7 +1,20 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
 
 {% extends "./partials/layout.njk" %}
+{% set conditionalHtml %}
+    {{ govukSelect({
+        label: {
+            text: "Select destination AP",
+            classes: "govuk-label--m"
+        },
+        id: "apName",
+        name: "apName",
+        items: convertObjectsToSelectOptions(premisesSummaries, 'Select an AP', 'name', 'name', 'apName'),
+        errorMessage:errors.apName
+    }) }}
+{% endset %}
 
 {% block formContent %}
     {{ govukRadios({
@@ -12,7 +25,9 @@
                 classes: "govuk-fieldset__legend--m"
             }
         },
-        items: convertObjectsToRadioItems(moveOnCategories, 'name', 'id', 'moveOnCategoryId'),
+        items: PlacementUtils.injectRadioConditionalHtml(
+            convertObjectsToRadioItems(moveOnCategories, 'name', 'id', 'moveOnCategoryId'),
+            MOVE_TO_AP_REASON_ID,conditionalHtml),
         value: moveOnCategoryId,
         errorMessage: errors.moveOnCategoryId
     }) }}


### PR DESCRIPTION
# Context

(https://dsdmoj.atlassian.net/browse/APS-1821)

# Changes in this PR
As detailed in PR.

## Non Arrival Reasons

When the ‘other’ non arrival reason is selected the notes text box is mandatory

The ‘other’ non arrival reason label is overridden in the UI to ‘Other - provide reasons’. This is to allow the API to keep the same name.

## Departures

‘Order / licence expired’ and 'Bed Withdrawn’ go to the move-on reasons screen like 'Planned move-on'

## Move On

‘Transferred to different AP’ injects a Selection box to choose the destination AP. This is mandatory if the move-on reason is selected.
The selected AP is added to the 'notes' when the departure is saved.


<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before

### After

<details>
  <summary>AP selection</summary>
<img src="https://github.com/user-attachments/assets/a0ca4a69-d5b0-47b7-956e-f2590fe1cad3"/>
</details>

<details>
  <summary>AP selection - error</summary>
<img src="https://github.com/user-attachments/assets/d5f132f6-7f29-45d1-be07-a186090b6fc9"/>
</details>

<details>
  <summary>Mandatory notes - error</summary>
<img src="https://github.com/user-attachments/assets/506e26a0-1839-42b3-907c-60b0e2a84e8f"/>
</details>

<details>
  <summary>Rendering of linefeeds in notes</summary>
<img src="https://github.com/user-attachments/assets/0ff37c76-00b0-48e7-a78f-3e084b7c1fe1"/>
</details>


