### PR TITLE
APS-1014 Back link handler

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -20,6 +20,7 @@ declare module 'express-session' {
     messages: Array<string>
     departureForms: Record<Cas1SpaceBooking['id'], DepartureFormSessionData>
     spaceSearch: Record<PlacementRequestDetail['id'], SpaceSearchState>
+    pageReferers: Record<string, string>
   }
 }
 

--- a/server/controllers/apply/applications/withdrawalsController.ts
+++ b/server/controllers/apply/applications/withdrawalsController.ts
@@ -1,19 +1,23 @@
 import type { Request, RequestHandler, Response } from 'express'
 
-import ApplicationService from '../../../services/applicationService'
 import {
   addErrorMessageToFlash,
   catchValidationErrorOrPropogate,
   fetchErrorsAndUserInput,
 } from '../../../utils/validation'
 import paths from '../../../paths/apply'
+import adminPaths from '../../../paths/admin'
 import { NewWithdrawal } from '../../../@types/shared'
 import { SelectedWithdrawableType } from '../../../utils/applications/withdrawables'
+import { ApplicationService, SessionService } from '../../../services'
 
 export const tasklistPageHeading = 'Apply for an Approved Premises (AP) placement'
 
 export default class WithdrawalsController {
-  constructor(private readonly applicationService: ApplicationService) {}
+  constructor(
+    private readonly applicationService: ApplicationService,
+    private readonly sessionService: SessionService,
+  ) {}
 
   new(): RequestHandler {
     return async (req: Request, res: Response) => {
@@ -35,12 +39,18 @@ export default class WithdrawalsController {
         })
       }
 
+      const backLink = this.sessionService.getPageBackLink(paths.applications.withdraw.new.pattern, req, [
+        adminPaths.admin.placementRequests.show.pattern,
+        paths.applications.show.pattern,
+        paths.applications.index.pattern,
+      ])
+
       if (!selectedWithdrawableType) {
         return res.render('applications/withdrawables/new', {
           pageHeading: 'What do you want to withdraw?',
           id,
           withdrawables: withdrawables.withdrawables,
-          referer: req.headers.referer,
+          backLink,
           notes: withdrawables.notes,
         })
       }

--- a/server/controllers/apply/index.ts
+++ b/server/controllers/apply/index.ts
@@ -21,6 +21,7 @@ export const controllers = (services: Services) => {
     bookingService,
     appealService,
     placementService,
+    sessionService,
   } = services
   const applicationsController = new ApplicationsController(applicationService, personService)
   const pagesController = new PagesController(applicationService, {
@@ -32,7 +33,7 @@ export const controllers = (services: Services) => {
   })
   const offencesController = new OffencesController(personService)
   const documentsController = new DocumentsController(personService)
-  const withdrawalsController = new WithdrawalsController(applicationService)
+  const withdrawalsController = new WithdrawalsController(applicationService, sessionService)
   const notesController = new NotesController(applicationService)
   const withdrawablesController = new WithdrawablesController(applicationService, bookingService, placementService)
   const appealsController = new AppealsController(appealService, applicationService)

--- a/server/controllers/manage/index.ts
+++ b/server/controllers/manage/index.ts
@@ -24,6 +24,7 @@ export const controllers = (services: Services) => {
     services.outOfServiceBedService,
     services.premisesService,
     services.apAreaService,
+    services.sessionService,
   )
   const updateOutOfServiceBedsController = new UpdateOutOfServiceBedsController(services.outOfServiceBedService)
 
@@ -41,6 +42,7 @@ export const controllers = (services: Services) => {
     services.placementRequestService,
     services.placementService,
     services.premisesService,
+    services.sessionService,
   )
   const arrivalsController = new ArrivalsController(services.premisesService, services.placementService)
   const nonArrivalsController = new NonArrivalsController(services.premisesService, services.placementService)

--- a/server/controllers/manage/placementController.test.ts
+++ b/server/controllers/manage/placementController.test.ts
@@ -15,6 +15,7 @@ import type {
   PlacementRequestService,
   PlacementService,
   PremisesService,
+  SessionService,
 } from '../../services'
 import PlacementController from './placementController'
 import { mapApplicationTimelineEventsForUi } from '../../utils/applications/utils'
@@ -28,12 +29,14 @@ describe('placementController', () => {
   const assessmentService = createMock<AssessmentService>({})
   const placementRequestService = createMock<PlacementRequestService>({})
   const premisesService = createMock<PremisesService>({})
+  const sessionService = createMock<SessionService>({})
   const placementController = new PlacementController(
     applicationService,
     assessmentService,
     placementRequestService,
     placementService,
     premisesService,
+    sessionService,
   )
 
   const premisesId = 'premises-id'
@@ -63,12 +66,12 @@ describe('placementController', () => {
     placementRequestService.getPlacementRequest.mockResolvedValue(placementRequestDetail)
     premisesService.getPlacement.mockResolvedValue(placement)
     placementService.getTimeline.mockResolvedValue(timeLine)
+    sessionService.getPageBackLink.mockReturnValue(referrer)
 
     const response: DeepMocked<Response> = createMock<Response>({ locals: { user } })
     const request: DeepMocked<Request> = createMock<Request>({
       user: { token },
       params: { premisesId, placementId: placement.id },
-      headers: { referer: referrer },
     })
     return { application, assessment, placementRequestDetail, timeLine, placement, request, response }
   }
@@ -85,7 +88,7 @@ describe('placementController', () => {
           placement,
           pageHeading: '16 Nov 2024 to 26 Mar 2025',
           user,
-          backLink: null,
+          backLink: referrer,
           activeTab: 'placement',
         }),
       )
@@ -94,6 +97,16 @@ describe('placementController', () => {
       expect(assessmentService.findAssessment).not.toHaveBeenCalled()
       expect(placementRequestService.getPlacementRequest).not.toHaveBeenCalled()
       expect(placementService.getTimeline).not.toHaveBeenCalled()
+      expect(sessionService.getPageBackLink).toHaveBeenCalledWith(
+        '/manage/premises/:premisesId/placements/:placementId',
+        {},
+        [
+          '/manage/premises/:premisesId',
+          '/manage/premises/:premisesId/occupancy/day/:date',
+          '/applications/:id',
+          '/people/timeline/show',
+        ],
+      )
     })
 
     it('should render the placement view (on the application tab)', async () => {
@@ -191,7 +204,7 @@ describe('placementController', () => {
           placement,
           pageHeading: '16 Nov 2024 to 26 Mar 2025',
           user,
-          backLink: null,
+          backLink: referrer,
           activeTab: 'placement',
           isOfflineApplication: true,
         }),

--- a/server/controllers/manage/placementController.ts
+++ b/server/controllers/manage/placementController.ts
@@ -11,11 +11,15 @@ import {
   PlacementRequestService,
   PlacementService,
   PremisesService,
+  SessionService,
 } from '../../services'
 
 import { DateFormats } from '../../utils/dateUtils'
-import { PlacementTab, getBackLink, placementTabItems } from '../../utils/placements'
+import { PlacementTab, placementTabItems } from '../../utils/placements'
 import { mapApplicationTimelineEventsForUi } from '../../utils/applications/utils'
+import paths from '../../paths/manage'
+import applicationPaths from '../../paths/apply'
+import peoplePaths from '../../paths/people'
 
 export default class PlacementController {
   constructor(
@@ -24,6 +28,7 @@ export default class PlacementController {
     private readonly placementRequestService: PlacementRequestService,
     private readonly placementService: PlacementService,
     private readonly premisesService: PremisesService,
+    private readonly sessionService: SessionService,
   ) {}
 
   show(activeTab: PlacementTab = 'placement'): RequestHandler {
@@ -34,7 +39,12 @@ export default class PlacementController {
       const placement = await this.premisesService.getPlacement({ token: req.user.token, premisesId, placementId })
       const isOfflineApplication = !placement.assessmentId
       const tabItems = placementTabItems(placement, activeTab, isOfflineApplication)
-      const backLink = getBackLink(req.headers.referer, premisesId)
+      const backLink = this.sessionService.getPageBackLink(paths.premises.placements.show.pattern, req, [
+        paths.premises.show.pattern,
+        paths.premises.occupancy.day.pattern,
+        applicationPaths.applications.show.pattern,
+        peoplePaths.timeline.show.pattern,
+      ])
       const pageHeading = `${DateFormats.isoDateToUIDate(placement.canonicalArrivalDate, { format: 'short' })} to ${DateFormats.isoDateToUIDate(placement.canonicalDepartureDate, { format: 'short' })}`
       let timelineEvents: Array<TimelineEvent> = []
       let application: ApprovedPremisesApplication = null

--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -428,7 +428,7 @@ describe('OccupancyViewController', () => {
       expect(spaceSearchService.getSpaceSearchState).toHaveBeenCalledWith(placementRequestDetail.id, request.session)
       expect(premisesService.getCapacity).toHaveBeenCalledWith('SOME_TOKEN', premises.id, date)
       expect(response.render).toHaveBeenCalledWith('match/placementRequests/occupancyView/viewDay', {
-        backlink: occupancyViewUrl,
+        backLink: occupancyViewUrl,
         pageHeading: dayAvailabilityStatusMap[expectedStatus],
         placementRequest: placementRequestDetail,
         premises,

--- a/server/controllers/match/placementRequests/occupancyViewController.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.ts
@@ -197,7 +197,7 @@ export default class {
         return res.redirect(paths.v2Match.placementRequests.search.spaces({ id }))
       }
 
-      const backlink = paths.v2Match.placementRequests.search.occupancy({ id, premisesId })
+      const backLink = paths.v2Match.placementRequests.search.occupancy({ id, premisesId })
       const placementRequest = await this.placementRequestService.getPlacementRequest(token, id)
       const premises = await this.premisesService.find(token, premisesId)
       const premisesCapacity = await this.premisesService.getCapacity(token, premisesId, date)
@@ -205,7 +205,7 @@ export default class {
       const status = dayAvailabilityStatus(dayCapacity, searchState.roomCriteria)
 
       return res.render('match/placementRequests/occupancyView/viewDay', {
-        backlink,
+        backLink,
         pageHeading: dayAvailabilityStatusMap[status],
         placementRequest,
         premises,

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -20,6 +20,7 @@ import ReportService from './reportService'
 import ApAreaService from './apAreaService'
 import CruManagementAreaService from './cruManagementAreaService'
 import AppealService from './appealService'
+import SessionService from './sessionService'
 
 import config, { AuditConfig } from '../config'
 
@@ -64,6 +65,7 @@ export const services = () => {
   const reportService = new ReportService(reportClientBuilder)
   const apAreaService = new ApAreaService(referenceDataClientBuilder)
   const cruManagementAreaService = new CruManagementAreaService(cas1ReferenceDataClientBuilder)
+  const sessionService = new SessionService()
 
   return {
     appealService,
@@ -84,6 +86,7 @@ export const services = () => {
     reportService,
     apAreaService,
     cruManagementAreaService,
+    sessionService,
   }
 }
 
@@ -107,4 +110,5 @@ export {
   ReportService,
   ApAreaService,
   CruManagementAreaService,
+  SessionService,
 }

--- a/server/services/sessionService.test.ts
+++ b/server/services/sessionService.test.ts
@@ -1,0 +1,44 @@
+import { Request } from 'express'
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import { Session } from 'express-session'
+import SessionService from './sessionService'
+
+describe('SessionService', () => {
+  const service = new SessionService()
+
+  describe('getPageBackLink', () => {
+    const matchList = ['/pattern1/:param', '/pattern2/']
+    const pagePattern = 'page-Pattern'
+
+    const mockRequest = (referer: string, lastStoredReferer: string): DeepMocked<Request> =>
+      createMock<Request>({
+        headers: { referer },
+        session: {
+          pageReferers: {
+            [pagePattern]: lastStoredReferer,
+          },
+        },
+      })
+
+    const matchingReferer = 'http://domain/pattern1/112233445566'
+    const nonMatchingReferer = 'http://domain/pattern3/someParameter'
+    const lastStoredReferer = 'http://last/stored/222333444555'
+
+    it('should return the referer if it matches a provided path', () => {
+      const request = mockRequest(matchingReferer, undefined)
+      expect(service.getPageBackLink(pagePattern, request, matchList)).toEqual(matchingReferer)
+      expect(request.session.pageReferers[pagePattern]).toEqual(matchingReferer)
+    })
+
+    it('should return the stored referer if the current referer does not match a path', () => {
+      const request = mockRequest(nonMatchingReferer, lastStoredReferer)
+      expect(service.getPageBackLink(pagePattern, request, matchList)).toEqual(lastStoredReferer)
+    })
+
+    it('should return a homepage link if there is no stored referer and the current referer does not match a path', () => {
+      const request = mockRequest(null, null)
+      request.session = {} as Session
+      expect(service.getPageBackLink(pagePattern, request, matchList)).toEqual('/')
+    })
+  })
+})

--- a/server/services/sessionService.ts
+++ b/server/services/sessionService.ts
@@ -1,0 +1,31 @@
+import type { Request } from 'express'
+import { Path, match } from 'path-to-regexp'
+
+export default class SessionService {
+  constructor() {}
+
+  /**
+   * Provides referer links for pages with multiple routes
+   * A set of match path patterns are provided. If the referer in the request matches one of these paths,
+   * the referer is returned and stored in the session against this page pattern.
+   * If no match, the last stored referer for this page is returned
+   * @param pagePattern a unique id for the page being rendered - typically the pattern of the path.
+   * @param req the page request object
+   * @param matchList an array of path.pattern strings to match against the referer in the request
+   * @return the url to use as the backlink for the page.
+   */
+  getPageBackLink = (pagePattern: string, req: Request, matchList: Array<Path>): string => {
+    const {
+      session,
+      headers: { referer },
+    } = req
+    const refererPath = (referer && new URL(referer).pathname) || ''
+    const foundReferer = matchList.find(path => match(path)(refererPath))
+    const lastReferer = session.pageReferers?.[pagePattern]
+    if (foundReferer && lastReferer !== referer) {
+      session.pageReferers = session.pageReferers || {}
+      session.pageReferers[pagePattern] = referer
+    }
+    return foundReferer ? referer : lastReferer || '/'
+  }
+}

--- a/server/utils/placements/index.test.ts
+++ b/server/utils/placements/index.test.ts
@@ -1,6 +1,5 @@
 import type { Cas1SpaceBooking, FullPerson, StaffMember } from '@approved-premises/api'
 import { RadioItem, SelectOption } from '@approved-premises/ui'
-import { faker } from '@faker-js/faker/locale/en_GB'
 import {
   cas1PremisesFactory,
   cas1SpaceBookingFactory,
@@ -11,7 +10,6 @@ import {
   actions,
   arrivalInformation,
   departureInformation,
-  getBackLink,
   getKeyDetail,
   injectRadioConditionalHtml,
   otherBookings,
@@ -129,21 +127,6 @@ describe('placementUtils', () => {
       it('should allow nothing', () => {
         expect(actions(placementAfterDeparture, userDetails)).toEqual(null)
       })
-    })
-  })
-
-  describe('getBackLink', () => {
-    it('should return the correct back link, given the referrer', () => {
-      const premisesId = faker.string.uuid()
-      const bareUrl = `/manage/premises/${premisesId}`
-      const urlWithQuery = `/manage/premises/${premisesId}?activeTab=historic&sortBy=canonicalArrivalDate`
-      const urlOtherId = `/manage/premises/${faker.string.uuid()}`
-      expect(getBackLink(bareUrl, premisesId)).toEqual(bareUrl)
-      expect(getBackLink(urlWithQuery, premisesId)).toEqual(urlWithQuery)
-      expect(getBackLink('some string', premisesId)).toEqual(null)
-      expect(getBackLink('', premisesId)).toEqual(null)
-      expect(getBackLink(null, premisesId)).toEqual(null)
-      expect(getBackLink(urlOtherId, premisesId)).toEqual(null)
     })
   })
 

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -100,19 +100,6 @@ const formatTime = (time: string) => {
   return time ? DateFormats.timeFromDate(new Date(`2024-01-01T${time}`)) : ''
 }
 
-export const getBackLink = (referrer: string, premisesId: string): string => {
-  const premisesShowPagePathRegex = paths.premises.show({ premisesId: '([0-9a-f-]{36})' })
-  const premisesViewMatch = new RegExp(`${premisesShowPagePathRegex}[^/]*$`).exec(referrer)
-  if (premisesViewMatch && premisesViewMatch[1] === premisesId) {
-    return referrer
-  }
-  const premisesChildMatch = new RegExp(premisesShowPagePathRegex).exec(referrer)
-  if (premisesChildMatch && premisesChildMatch[1] === premisesId) {
-    return paths.premises.show({ premisesId })
-  }
-  return null
-}
-
 const summaryRow = (key: string, value: string): SummaryListItem => value && summaryListItem(key, value)
 
 export const placementSummary = (placement: Cas1SpaceBooking): SummaryList => {

--- a/server/views/applications/withdrawables/new.njk
+++ b/server/views/applications/withdrawables/new.njk
@@ -11,7 +11,7 @@
 {% block beforeContent %}
     {{ govukBackLink({
 		text: "Back",
-		href: referer
+		href: backLink
 	}) }}
 {% endblock %}
 

--- a/server/views/manage/outOfServiceBeds/premisesIndex.njk
+++ b/server/views/manage/outOfServiceBeds/premisesIndex.njk
@@ -13,7 +13,7 @@
 {% block beforeContent %}
     {{ govukBackLink({
         text: "Back",
-        href: paths.premises.beds.index({ premisesId: premises.id })
+        href: backLink
     }) }}
 {% endblock %}
 

--- a/server/views/manage/outOfServiceBeds/show.njk
+++ b/server/views/manage/outOfServiceBeds/show.njk
@@ -14,7 +14,7 @@
 {% block beforeContent %}
     {{ govukBackLink({
         text: "Back",
-        href: paths.outOfServiceBeds.premisesIndex({premisesId: premisesId, temporality: 'current'})
+        href: backLink
     }) }}
 {% endblock %}
 

--- a/server/views/match/placementRequests/occupancyView/viewDay.njk
+++ b/server/views/match/placementRequests/occupancyView/viewDay.njk
@@ -8,7 +8,7 @@
 {% block beforeContent %}
     {{ govukBackLink({
         text: "Back",
-        href: backlink
+        href: backLink
     }) }}
 {% endblock %}
 


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1014

# Changes in this PR

Adds a utility to supply back-links for problematic pages.
The fn takes the request, a list of acceptable parent paths and the path of the page. If the request referrer matches one of the parent paths, the referrer is returned and stored in the session. If the referrer doesn't match a parent path, the last stored parent referrer is returned instead.
This means. that a page that can be called from multiple points can always have a back-link to the page it last came from even if there are page transitions on that page e.g. if the user changes tab, alters filters or follows an 'action' journey.  

This PR adds the above functionality to:

- Placement view page
- Out of service bed listing page
- Out of service bed details page
- New withdrawal page 


<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

No UI change
