### PR TITLE
APS-792 - Remove defunct ‘NAT’ filtering

### DIFF
--- a/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.test.ts
@@ -125,24 +125,6 @@ describe('ConfirmYourDetails', () => {
       expect(result).toEqual(expected)
       expect(result.userDetailsFromDelius).toEqual(deliusUserMappedForUi)
     })
-
-    it('excludes "NAT" from the areas', async () => {
-      const areasWithNat = [...areas, apAreaFactory.build({ name: 'NAT' })]
-      const getAreasMock = jest.fn().mockResolvedValue(areasWithNat)
-      const apAreaService: DeepMocked<ApAreaService> = createMock<ApAreaService>({
-        getApAreas: getAreasMock,
-      })
-
-      const result = await ConfirmYourDetails.initialize(
-        {},
-        application,
-        'token',
-        fromPartial({ userService, apAreaService }),
-      )
-
-      expect(result.body.areas).toEqual(areas)
-      expect(result.body.areas.find(bodyArea => bodyArea.name === 'NAT')).toBeUndefined()
-    })
   })
 
   describe('next', () => {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails.ts
@@ -117,7 +117,7 @@ export default class ConfirmYourDetails implements TasklistPage {
     dataServices: DataServices,
   ): Promise<ConfirmYourDetails> {
     const user = await dataServices.userService.getUserById(token, application.createdByUserId)
-    const areas = (await dataServices.apAreaService.getApAreas(token)).filter(area => area.name !== 'NAT')
+    const areas = await dataServices.apAreaService.getApAreas(token)
 
     const userForUi = {
       name: user.name,


### PR DESCRIPTION
As a stop gap for removing the ‘National’ AP Area we filtered it out of drop downs on the UI. This AP Area has now been removed in the backend, so the UI filtering is no longer required

![Screenshot 2025-02-04 at 12 54 35](https://github.com/user-attachments/assets/ef1e8db2-911a-49f3-9563-9d1e5b643f95)

