### PR TITLE
Remove step to generate types from CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Installing dependencies
         run: npm ci
 
-      - name: Pulling the latest type from the API repo
-        run: npm run generate-types
-
       - name: Typechecking the code
         run: npm run typecheck
 


### PR DESCRIPTION
This step is run separately, and updated types should only be brought in as and when they are needed.


