### PR TITLE
APS-1783 Future validation on arrival

### DIFF
--- a/integration_tests/pages/manage/placements/arrival.ts
+++ b/integration_tests/pages/manage/placements/arrival.ts
@@ -1,4 +1,5 @@
 import type { Cas1NewArrival, Cas1SpaceBooking } from '@approved-premises/api'
+import { faker } from '@faker-js/faker'
 import Page from '../../page'
 import { DateFormats } from '../../../../server/utils/dateUtils'
 import apiPaths from '../../../../server/paths/api'
@@ -7,6 +8,8 @@ export class ArrivalCreatePage extends Page {
   constructor(private readonly placement: Cas1SpaceBooking) {
     super('Record someone as arrived')
   }
+
+  private arrivalDateTime = DateFormats.dateObjToIsoDateTime(faker.date.recent())
 
   shouldShowFormAndExpectedArrivalDate(): void {
     this.shouldContainSummaryListItems([
@@ -20,8 +23,8 @@ export class ArrivalCreatePage extends Page {
   }
 
   completeForm(): void {
-    this.completeDateInputs('arrivalDateTime', this.placement.expectedArrivalDate)
-    this.completeTextInput('arrivalTime', '9:45')
+    this.completeDateInputs('arrivalDateTime', DateFormats.isoDateTimeToIsoDate(this.arrivalDateTime))
+    this.completeTextInput('arrivalTime', DateFormats.isoDateTimeToTime(this.arrivalDateTime))
   }
 
   checkApiCalled(): void {
@@ -29,8 +32,9 @@ export class ArrivalCreatePage extends Page {
       'verifyApiPost',
       apiPaths.premises.placements.arrival({ premisesId: this.placement.premises.id, placementId: this.placement.id }),
     ).then(body => {
-      const { arrivalDateTime } = body as Cas1NewArrival
-      expect(arrivalDateTime).equal(`${this.placement.expectedArrivalDate}T09:45:00.000Z`)
+      const { arrivalDate, arrivalTime } = body as Cas1NewArrival
+      expect(arrivalDate).equal(DateFormats.isoDateTimeToIsoDate(this.arrivalDateTime))
+      expect(arrivalTime).equal(DateFormats.isoDateTimeToTime(this.arrivalDateTime))
     })
   }
 }

--- a/server/testutils/factories/cas1NewArrival.ts
+++ b/server/testutils/factories/cas1NewArrival.ts
@@ -4,9 +4,10 @@ import { faker } from '@faker-js/faker'
 import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<Cas1NewArrival>(() => {
-  const arrivalDateTime = faker.date.recent({ days: 1 })
+  const arrivalDateTime = faker.date.recent({ days: 1 }).toISOString()
   return {
     expectedDepartureDate: DateFormats.dateObjToIsoDate(faker.date.soon({ days: 365, refDate: arrivalDateTime })),
-    arrivalDateTime: arrivalDateTime.toISOString(),
+    arrivalDate: DateFormats.isoDateTimeToIsoDate(arrivalDateTime),
+    arrivalTime: DateFormats.isoDateTimeToTime(arrivalDateTime),
   }
 })

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -585,3 +585,22 @@ describe('isoDateAndTimeToDateObj', () => {
     expect(date.getTime()).toEqual(DateFormats.isoToDateObj(expected).getTime())
   })
 })
+
+describe('isoDateTimeToIsoDate', () => {
+  it.each([
+    ['2025-02-01T12:15', '2025-02-01'],
+    ['2024-12-31', '2024-12-31'],
+  ])('returns an iso date only from an iso datetime, %s', (dateStr, expected) => {
+    expect(DateFormats.isoDateTimeToIsoDate(dateStr)).toEqual(expected)
+  })
+})
+
+describe('isoDateTimeToIsoTime', () => {
+  it.each([
+    ['2025-02-01T09:15', '09:15'],
+    ['2025-02-01T23:45', '23:45'],
+    ['2024-12-31', '00:00'],
+  ])('returns an iso time only from an iso datetime, %s', (dateStr, expected) => {
+    expect(DateFormats.isoDateTimeToTime(dateStr)).toEqual(expected)
+  })
+})

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -207,6 +207,14 @@ export class DateFormats {
     return DateFormats.dateObjectToDateInputs(DateFormats.isoToDateObj(isoDate), key)
   }
 
+  static isoDateTimeToIsoDate(isoDateTime: string): string {
+    return formatISO(this.isoToDateObj(isoDateTime), { representation: 'date' })
+  }
+
+  static isoDateTimeToTime(isoDateTime: string): string {
+    return formatISO(this.isoToDateObj(isoDateTime), { representation: 'time' }).substring(0, 5)
+  }
+
   static formatDuration(
     duration: DurationWithNumberOrString,
     durationFormat: Array<'weeks' | 'days'> = ['weeks', 'days'],
@@ -368,11 +376,11 @@ export const timeIsValid24hrFormat = (time: string): Boolean => {
   return /^(2[0-3]|[01]?[0-9]):[0-5][0-9]$/.test(time)
 }
 
-export const isoDateAndTimeToDateObj = (isoDate:string,time:string):Date => {
+export const isoDateAndTimeToDateObj = (isoDate: string, time: string): Date => {
   const date = DateFormats.isoToDateObj(isoDate)
-  if(timeIsValid24hrFormat(time)) {
-    const [h,m] = time.split(':').map(Number)
-    date.setHours(h,m)
+  if (timeIsValid24hrFormat(time)) {
+    const [h, m] = time.split(':').map(Number)
+    date.setHours(h, m)
   }
   return date
 }


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1783

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Adds validation to the arrivals journey that ensures that arrivals can only be dated in the past.
Validiation on this is split into two -
if the date == today, and the time is in the future, a validation message linked to the time input is shown.
If the date is in the future, a validation message linked to the date is shown.

Also, the deprecated `arrivalDateTime` is no longer sent to the arrivals endpoint and separate `arrivalDate` and `arrivalTime` values are sent instead.
 
It strikes me that the whole date/time validation with in-th-past check could be componentized with savings in code and improved consistency although we'd probably need to regularize the error message structure somewhat.  One for another day though.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes
<details>
  <summary>Date in future</summary>
<img src="https://github.com/user-attachments/assets/f60f3064-36e1-4f0a-843d-faa9b0a901c3"/>
</details>

<details>
  <summary>Date today and time in future</summary>
<img src="https://github.com/user-attachments/assets/ac54094b-bdd2-4f73-99d3-7587cb93d763"/>
</details>

