### PR TITLE
APS-1898 Remove arson offences questions

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -280,9 +280,6 @@
       "response": "yes"
     },
     "date-of-offence": {
-      "arsonOffence": [
-        "current"
-      ],
       "hateCrime": [
         "previous"
       ],

--- a/integration_tests/pages/apply/dateOfOffence.ts
+++ b/integration_tests/pages/apply/dateOfOffence.ts
@@ -19,7 +19,6 @@ export default class DateOfOffence extends ApplyPage {
   }
 
   completeForm(): void {
-    this.checkCheckboxesFromPageBody('arsonOffence')
     this.checkCheckboxesFromPageBody('hateCrime')
     this.checkCheckboxesFromPageBody('nonSexualOffencesAgainstChildren')
     this.checkCheckboxesFromPageBody('contactSexualOffencesAgainstAdults')

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/convictedOffences.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/convictedOffences.test.ts
@@ -43,7 +43,7 @@ describe('ConvictedOffences', () => {
       const page = new ConvictedOffences({ response: 'yes' })
 
       expect(page.response()).toEqual({
-        'Has the person ever been convicted of any arson offences, sexual offences, hate crimes or non-sexual offences against children?':
+        'Has the person ever been convicted of any sexual offences, hate crimes or non-sexual offences against children?':
           'Yes',
       })
     })

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/convictedOffences.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/convictedOffences.ts
@@ -16,7 +16,7 @@ export default class ConvictedOffences implements TasklistPage {
 
   furtherDetails = `This includes any spent or unspent convictions over their lifetime.`
 
-  offences = ['Arson offences', 'Sexual offences', 'Hate crimes', 'Non-sexual offences against children']
+  offences = ['Sexual offences', 'Hate crimes', 'Non-sexual offences against children']
 
   constructor(public body: { response?: YesOrNo }) {}
 

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/dateOfOffence.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/dateOfOffence.test.ts
@@ -6,9 +6,8 @@ jest.mock('../../../../utils/formUtils')
 
 describe('DateOfOffence', () => {
   const body = {
-    arsonOffence: 'current',
     hateCrime: 'previous',
-    nonSexualOffencesAgainstChildren: ['current', 'previous'],
+    nonSexualOffencesAgainstChildren: 'current',
     contactSexualOffencesAgainstAdults: ['current', 'previous'],
     nonContactSexualOffencesAgainstAdults: ['current', 'previous'],
     contactSexualOffencesAgainstChildren: ['current', 'previous'],
@@ -19,7 +18,7 @@ describe('DateOfOffence', () => {
     it('should set the body', () => {
       const page = new DateOfOffence(body)
 
-      expect(page.body).toEqual({ ...body, arsonOffence: ['current'], hateCrime: ['previous'] })
+      expect(page.body).toEqual({ ...body, hateCrime: ['previous'], nonSexualOffencesAgainstChildren: ['current'] })
     })
   })
 
@@ -29,12 +28,12 @@ describe('DateOfOffence', () => {
 
   describe('errors', () => {
     it('should return an empty object if the time period for one offence is present', () => {
-      const page = new DateOfOffence({ arsonOffence: 'current' })
+      const page = new DateOfOffence({ hateCrime: 'current' })
       expect(page.errors()).toEqual({})
     })
-    it('should return an error object there is no reponsess', () => {
+    it('should return an error object there is no responses', () => {
       const page = new DateOfOffence({})
-      expect(page.errors()).toEqual({ arsonOffence: 'You must enter a time period for one or more offence' })
+      expect(page.errors()).toEqual({ hateCrime: 'You must enter a time period for one or more offence' })
     })
   })
 
@@ -43,13 +42,12 @@ describe('DateOfOffence', () => {
       const page = new DateOfOffence(body)
 
       expect(page.response()).toEqual({
-        'Is the arson offence current or previous?': 'Current',
         'Is the hate crime current or previous?': 'Previous',
         'Is the contact sexual offences against adults current or previous?': 'Current and previous',
         'Is the contact sexual offences against children current or previous?': 'Current and previous',
         'Is the non contact sexual offences against adults current or previous?': 'Current and previous',
         'Is the non contact sexual offences against children current or previous?': 'Current and previous',
-        'Is the non sexual offences against children current or previous?': 'Current and previous',
+        'Is the non sexual offences against children current or previous?': 'Current',
       })
     })
   })
@@ -78,11 +76,11 @@ describe('DateOfOffence', () => {
 
   describe('renderTableRow', () => {
     it('returns a table row', () => {
-      const result = new DateOfOffence({ arsonOffence: ['previous'] }).renderTableRow('arsonOffence')
+      const result = new DateOfOffence({ hateCrime: ['previous'] }).renderTableRow('hateCrime')
       expect(result).toEqual([
-        { text: 'Arson offence' },
-        DateOfOffence.checkbox('arsonOffence', 'current', false),
-        DateOfOffence.checkbox('arsonOffence', 'previous', true),
+        { text: 'Hate crime' },
+        DateOfOffence.checkbox('hateCrime', 'current', false),
+        DateOfOffence.checkbox('hateCrime', 'previous', true),
       ])
     })
   })
@@ -91,7 +89,6 @@ describe('DateOfOffence', () => {
     it('returns the table body', () => {
       const result = new DateOfOffence({}).renderTableBody()
       expect(result).toEqual([
-        new DateOfOffence({}).renderTableRow('arsonOffence'),
         new DateOfOffence({}).renderTableRow('hateCrime'),
         new DateOfOffence({}).renderTableRow('nonSexualOffencesAgainstChildren'),
         new DateOfOffence({}).renderTableRow('contactSexualOffencesAgainstAdults'),
@@ -104,12 +101,12 @@ describe('DateOfOffence', () => {
 
   describe('checkbox', () => {
     it('it renders the markup for a unselected checkbox', () => {
-      expect(DateOfOffence.checkbox('arsonOffence', 'current', false)).toEqual({
+      expect(DateOfOffence.checkbox('hateCrime', 'current', false)).toEqual({
         html: `<div class="govuk-checkboxes" data-module="govuk-checkboxes">
           <div class="govuk-checkboxes__item">
-          <input class="govuk-checkboxes__input" id="arsonOffence-current" name="arsonOffence" type="checkbox" value="current" >
-              <label class="govuk-label govuk-checkboxes__label" for="arsonOffence-current">
-                <span class="govuk-visually-hidden">Arson offence: current</span>
+          <input class="govuk-checkboxes__input" id="hateCrime-current" name="hateCrime" type="checkbox" value="current" >
+              <label class="govuk-label govuk-checkboxes__label" for="hateCrime-current">
+                <span class="govuk-visually-hidden">Hate crime: current</span>
               </label>
           </div>
         </div>`,
@@ -117,12 +114,12 @@ describe('DateOfOffence', () => {
     })
 
     it('it renders the markup for a selected checkbox', () => {
-      expect(DateOfOffence.checkbox('arsonOffence', 'previous', true)).toEqual({
+      expect(DateOfOffence.checkbox('hateCrime', 'previous', true)).toEqual({
         html: `<div class="govuk-checkboxes" data-module="govuk-checkboxes">
           <div class="govuk-checkboxes__item">
-          <input class="govuk-checkboxes__input" id="arsonOffence-previous" name="arsonOffence" type="checkbox" value="previous" checked>
-              <label class="govuk-label govuk-checkboxes__label" for="arsonOffence-previous">
-                <span class="govuk-visually-hidden">Arson offence: previous</span>
+          <input class="govuk-checkboxes__input" id="hateCrime-previous" name="hateCrime" type="checkbox" value="previous" checked>
+              <label class="govuk-label govuk-checkboxes__label" for="hateCrime-previous">
+                <span class="govuk-visually-hidden">Hate crime: previous</span>
               </label>
           </div>
         </div>`,

--- a/server/form-pages/apply/risk-and-need-factors/risk-management-features/dateOfOffence.ts
+++ b/server/form-pages/apply/risk-and-need-factors/risk-management-features/dateOfOffence.ts
@@ -5,7 +5,6 @@ import { lowerCase, sentenceCase } from '../../../../utils/utils'
 import TasklistPage from '../../../tasklistPage'
 
 const offences = {
-  arsonOffence: 'Arson offence',
   hateCrime: 'Hate crime',
   nonSexualOffencesAgainstChildren: 'Non-sexual offences against children',
   contactSexualOffencesAgainstAdults: 'Contact sexual offences against adults',
@@ -72,7 +71,7 @@ export default class DateOfOffence implements TasklistPage {
     const errors: TaskListErrors<this> = {}
 
     if (!Object.keys(this.body).find(key => !!this.body[key])) {
-      errors.arsonOffence = 'You must enter a time period for one or more offence'
+      errors.hateCrime = 'You must enter a time period for one or more offence'
     }
 
     return errors

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -31,7 +31,6 @@ const defaultArguments = {
   acceptsChildSexOffenders: 'relevant',
   acceptsNonSexualChildOffenders: 'relevant',
   acceptsHateCrimeOffenders: 'relevant',
-  isArsonSuitable: 'relevant',
   isSuitedForSexOffenders: 'notRelevant',
   lengthOfStayAgreed: 'yes',
   cruInformation: 'Some info',
@@ -44,7 +43,6 @@ const defaultMatchingInformationValuesReturnValue: Partial<MatchingInformationBo
   acceptsSexOffenders: 'relevant',
   apType: 'isPIPE',
   isArsonDesignated: 'essential',
-  isArsonSuitable: 'relevant',
   isCatered: 'essential',
   isSingle: 'desirable',
   isSuitableForVulnerable: 'relevant',
@@ -127,7 +125,6 @@ describe('MatchingInformation', () => {
         'Sexual offences against children': 'Relevant',
         'Non sexual offences against children': 'Relevant',
         'Hate based offences': 'Relevant',
-        'Arson offences': 'Relevant',
         'Do you agree with the suggested length of stay?': 'Yes',
         'Information for Central Referral Unit (CRU) manager': 'Some info',
       })

--- a/server/form-pages/utils/matchingInformationUtils.test.ts
+++ b/server/form-pages/utils/matchingInformationUtils.test.ts
@@ -43,7 +43,6 @@ describe('matchingInformationUtils', () => {
       cruInformation: undefined,
       hasEnSuite: undefined,
       isArsonDesignated: undefined,
-      isArsonSuitable: undefined,
       isCatered: undefined,
       isSingle: undefined,
       isStepFreeDesignated: undefined,
@@ -114,7 +113,6 @@ describe('matchingInformationUtils', () => {
         acceptsSexOffenders: 'relevant',
         apType: 'isPIPE',
         isArsonDesignated: 'essential',
-        isArsonSuitable: 'relevant',
         isCatered: 'essential',
         isSingle: 'essential',
         isSuitableForVulnerable: 'relevant',
@@ -133,7 +131,6 @@ describe('matchingInformationUtils', () => {
           acceptsSexOffenders: 'relevant',
           apType: 'isPIPE',
           isArsonDesignated: 'desirable',
-          isArsonSuitable: 'relevant',
           isCatered: 'desirable',
           isSingle: 'desirable',
           isSuitableForVulnerable: 'relevant',
@@ -295,30 +292,6 @@ describe('matchingInformationUtils', () => {
 
             expect(defaultMatchingInformationValues(bodyWithUndefinedValues, application)).toEqual(
               expect.objectContaining({ isArsonDesignated: 'notRelevant' }),
-            )
-          })
-        })
-
-        describe('isArsonSuitable', () => {
-          truthyCurrentPreviousValues.forEach(value => {
-            it(`is set to 'relevant' when \`arsonOffence\` === ['${value.join("', '")}']`, () => {
-              when(retrieveOptionalQuestionResponseFromFormArtifact)
-                .calledWith(application, DateOfOffence, 'arsonOffence')
-                .mockReturnValue(value)
-
-              expect(defaultMatchingInformationValues(bodyWithUndefinedValues, application)).toEqual(
-                expect.objectContaining({ isArsonSuitable: 'relevant' }),
-              )
-            })
-          })
-
-          it("is set to 'notRelevant' when `arsonOffence` === undefined", () => {
-            when(retrieveOptionalQuestionResponseFromFormArtifact)
-              .calledWith(application, DateOfOffence, 'arsonOffence')
-              .mockReturnValue(undefined)
-
-            expect(defaultMatchingInformationValues(bodyWithUndefinedValues, application)).toEqual(
-              expect.objectContaining({ isArsonSuitable: 'notRelevant' }),
             )
           })
         })

--- a/server/form-pages/utils/matchingInformationUtils.ts
+++ b/server/form-pages/utils/matchingInformationUtils.ts
@@ -158,15 +158,6 @@ const defaultMatchingInformationValues = (
       'essential',
       'notRelevant',
     ),
-    isArsonSuitable: getValue<GetValueOffenceAndRisk>(
-      body,
-      'isArsonSuitable',
-      application,
-      [{ name: 'arsonOffence', page: DateOfOffence, optional: true }],
-      ['current', 'previous'],
-      'relevant',
-      'notRelevant',
-    ),
     isCatered: getValue<GetValuePlacementRequirement>(
       body,
       'isCatered',

--- a/server/utils/placementCriteriaUtils.ts
+++ b/server/utils/placementCriteriaUtils.ts
@@ -27,7 +27,6 @@ export const offenceAndRiskCriteria = [
   'acceptsChildSexOffenders',
   'acceptsNonSexualChildOffenders',
   'acceptsHateCrimeOffenders',
-  'isArsonSuitable',
 ] as const
 export const prepopulatablePlacementRequirementCriteria = [
   'isWheelchairDesignated',


### PR DESCRIPTION
This PR also allows the ‘arsonOffences’ criteria to be displayed when viewing a placement request, allowing us to show case where this was captured in previous assessments (the change to populate this value is being managed in the API). We use the description as the exiting ‘isArsonSuitable’, which will be renamed in a future commit to better reflect its purpose.

Notes from manual testing:

I tried the following scenarios:

1. unsubmitted application with arson offences before change
2. unsubmitted application without arson offences before change 
3. submitted application with arson offences, no assessment
4. draft assessment with arson offences already selected
5. draft assessment without arson offences already selected

These all worked without issue other than scenario 1. In this case when clicking on check your answers the user was forced to go back through the 'managing risks and needs' section. Once they'd completed that section they could access 'check your answers'. I think this is why I had to make [this change](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/2326/commits/adbda929aaa1899f69c4f5f4aab63b290856d0f7#diff-20850bda939c9f7e65026112399508e166406a1c6cf84c83dc1da8b90bda0c54) to make the integration tests pass

# UI Before

## Apply

![Screenshot 2025-02-06 at 12 39 50](https://github.com/user-attachments/assets/49a2939c-0ecf-4e91-b497-cdd5551145fe)

![Screenshot 2025-02-06 at 12 40 31](https://github.com/user-attachments/assets/9896e049-0c32-4da3-990a-728fd7c491a0)

## Assessment

![Screenshot 2025-02-04 at 10 09 03](https://github.com/user-attachments/assets/b168d0f7-a781-436c-b6c9-683cd9039948)

# UI After

## Apply

![Screenshot 2025-02-06 at 12 41 58](https://github.com/user-attachments/assets/341cc1fc-6e14-4b2f-bfa1-46f7e30eb150)

![Screenshot 2025-02-06 at 12 51 38](https://github.com/user-attachments/assets/713e0447-1f32-4137-a364-66c855a61ca9)

## Assessment

![Screenshot 2025-02-14 at 14 14 37](https://github.com/user-attachments/assets/2c753ad6-bd99-4b21-a165-6379ca2b5b23)


