### PR TITLE
APS-1910: Show booking requirements on placement details

### DIFF
--- a/integration_tests/pages/manage/placements/placementShow.ts
+++ b/integration_tests/pages/manage/placements/placementShow.ts
@@ -7,6 +7,7 @@ import {
   arrivalInformation,
   departureInformation,
   placementSummary,
+  requirementsInformation,
 } from '../../../../server/utils/placements'
 import { placementDates, placementLength } from '../../../../server/utils/match'
 
@@ -53,6 +54,7 @@ export default class PlacementShowPage extends Page {
     this.shouldContainSummaryListItems(placementSummary(placement).rows.filter(removeHiddenRows))
     this.shouldContainSummaryListItems(arrivalInformation(placement).rows.filter(removeHiddenRows))
     this.shouldContainSummaryListItems(departureInformation(placement).rows.filter(removeHiddenRows))
+    this.shouldContainSummaryListItems(requirementsInformation(placement).rows)
   }
 
   shouldNotShowUnpopulatedRows(placement: Cas1SpaceBooking, rows: Array<string>): void {

--- a/server/utils/match/spaceSearch.ts
+++ b/server/utils/match/spaceSearch.ts
@@ -1,4 +1,9 @@
-import { Cas1SpaceSearchParameters, PlacementCriteria, PlacementRequestDetail } from '@approved-premises/api'
+import {
+  Cas1SpaceCharacteristic,
+  Cas1SpaceSearchParameters,
+  PlacementCriteria,
+  PlacementRequestDetail,
+} from '@approved-premises/api'
 import { CheckBoxItem, RadioItem } from '@approved-premises/ui'
 import { filterByType } from '../utils'
 import {
@@ -63,10 +68,10 @@ export const initialiseSearchState = (placementRequest: PlacementRequestDetail):
   }
 }
 
-export const filterApLevelCriteria = (criteria: Array<PlacementCriteria>) =>
+export const filterApLevelCriteria = (criteria: Array<PlacementCriteria | Cas1SpaceCharacteristic>) =>
   Object.keys(filterByType(criteria, spaceSearchCriteriaApLevelLabels)) as Array<SpaceSearchApCriteria>
 
-export const filterRoomLevelCriteria = (criteria: Array<PlacementCriteria>) =>
+export const filterRoomLevelCriteria = (criteria: Array<PlacementCriteria | Cas1SpaceCharacteristic>) =>
   Object.keys(filterByType(criteria, spaceSearchCriteriaRoomLevelLabels)) as Array<SpaceSearchRoomCriteria>
 
 export const spaceSearchStateToApiPayload = (state: SpaceSearchState): Cas1SpaceSearchParameters => {

--- a/server/utils/placements/index.test.ts
+++ b/server/utils/placements/index.test.ts
@@ -15,10 +15,12 @@ import {
   otherBookings,
   placementSummary,
   renderKeyworkersSelectOptions,
+  requirementsInformation,
 } from '.'
 import { DateFormats } from '../dateUtils'
 
 import paths from '../../paths/manage'
+import { requirementsHtmlString } from '../match'
 
 describe('placementUtils', () => {
   describe('actions', () => {
@@ -308,6 +310,65 @@ describe('placementUtils', () => {
                 html: `<span class="govuk-summary-list__textblock">${departedPlacement.departure?.notes}</span>`,
               },
             },
+          ],
+        })
+      })
+    })
+
+    describe('requirements information', () => {
+      it('should be returned for a placement in a standard AP', () => {
+        const placementStandardAp = cas1SpaceBookingFactory.build({
+          requirements: {
+            essentialCharacteristics: ['acceptsChildSexOffenders', 'acceptsNonSexualChildOffenders', 'hasEnSuite'],
+          },
+        })
+
+        expect(requirementsInformation(placementStandardAp)).toEqual({
+          rows: [
+            { key: { text: 'AP type' }, value: { text: 'Standard AP' } },
+            {
+              key: { text: 'AP requirements' },
+              value: { html: requirementsHtmlString(['acceptsChildSexOffenders', 'acceptsNonSexualChildOffenders']) },
+            },
+            { key: { text: 'Room requirements' }, value: { html: requirementsHtmlString(['hasEnSuite']) } },
+          ],
+        })
+      })
+
+      it('should be returned for a placement in a specialist AP', () => {
+        const placementSpecialistAp = cas1SpaceBookingFactory.build({
+          requirements: {
+            essentialCharacteristics: ['isESAP', 'acceptsChildSexOffenders', 'hasEnSuite', 'isWheelchairAccessible'],
+          },
+        })
+
+        expect(requirementsInformation(placementSpecialistAp)).toEqual({
+          rows: [
+            { key: { text: 'AP type' }, value: { text: 'Enhanced Security AP (ESAP)' } },
+            {
+              key: { text: 'AP requirements' },
+              value: { html: requirementsHtmlString(['acceptsChildSexOffenders']) },
+            },
+            {
+              key: { text: 'Room requirements' },
+              value: { html: requirementsHtmlString(['hasEnSuite', 'isWheelchairAccessible']) },
+            },
+          ],
+        })
+      })
+
+      it('should be returned for a placement with no requirements', () => {
+        const placementNoRequirements = cas1SpaceBookingFactory.build({
+          requirements: {
+            essentialCharacteristics: [],
+          },
+        })
+
+        expect(requirementsInformation(placementNoRequirements)).toEqual({
+          rows: [
+            { key: { text: 'AP type' }, value: { text: 'Standard AP' } },
+            { key: { text: 'AP requirements' }, value: { html: `<span class="text-grey">None</span>` } },
+            { key: { text: 'Room requirements' }, value: { html: `<span class="text-grey">None</span>` } },
           ],
         })
       })

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -20,6 +20,9 @@ import paths from '../../paths/manage'
 import { hasPermission } from '../users'
 import { TabItem } from '../tasks/listTable'
 import { summaryListItem } from '../formUtils'
+import { requirementsHtmlString } from '../match'
+import { apTypeCriteriaLabels, specialistApTypeCriteria } from '../placementCriteriaUtils'
+import { filterApLevelCriteria, filterRoomLevelCriteria } from '../match/spaceSearch'
 
 export const statusTextMap: Record<Cas1SpaceBookingSummaryStatus, string> = {
   arrivingWithin6Weeks: 'Arriving within 6 weeks',
@@ -166,6 +169,32 @@ export const departureInformation = (placement: Cas1SpaceBooking): SummaryList =
       summaryRow('Move on', placement.departure?.moveOnCategory?.name),
       summaryListItem('More information', placement.departure?.notes, 'textBlock', true),
     ].filter(Boolean),
+  }
+}
+
+export const requirementsInformation = (placement: Cas1SpaceBooking): SummaryList => {
+  const requirements = placement.requirements.essentialCharacteristics
+  const apType =
+    apTypeCriteriaLabels[requirements.find(requirement => specialistApTypeCriteria.includes(requirement)) || 'normal']
+  const apRequirements = filterApLevelCriteria(requirements)
+  const roomRequirements = filterRoomLevelCriteria(requirements)
+
+  const noneSelected = `<span class="text-grey">None</span>`
+
+  return {
+    rows: [
+      summaryListItem('AP type', apType),
+      summaryListItem(
+        'AP requirements',
+        apRequirements.length ? requirementsHtmlString(apRequirements) : noneSelected,
+        'html',
+      ),
+      summaryListItem(
+        'Room requirements',
+        roomRequirements.length ? requirementsHtmlString(roomRequirements) : noneSelected,
+        'html',
+      ),
+    ],
   }
 }
 

--- a/server/views/manage/premises/placements/show.njk
+++ b/server/views/manage/premises/placements/show.njk
@@ -56,34 +56,42 @@
             titleText: 'Information'
         }) }}
     {% endif %}
+
     {{ mojSubNavigation({
         label: 'Sub navigation',
         items: tabItems
     }) }}
+
     {% if activeTab=='timeline' %}
+
         <h2 class="govuk-heading-m">Placement timeline</h2>
-        {{applicationTimeline(timelineEvents)}}
+        {{ applicationTimeline(timelineEvents) }}
+
     {% elseif activeTab==='application' %}
+
         {{ applicationReadonlyView(application) }}
+
     {% elseif activeTab==='assessment' %}
-      {% for section in SummaryListUtils.summaryListSections(assessment, false) %}
-        <h2 class="govuk-heading-l">{{ section.title }}</h2>
-        {% for task in section.tasks %}
-          {{
-            govukSummaryList(task)
-          }}
+
+        {% for section in SummaryListUtils.summaryListSections(assessment, false) %}
+            <h2 class="govuk-heading-l">{{ section.title }}</h2>
+            {% for task in section.tasks %}
+                {{ govukSummaryList(task) }}
+            {% endfor %}
         {% endfor %}
-      {% endfor %}
+
     {% elseif activeTab==='placementRequest' %}
+
         {{ govukSummaryList({
             attributes: {
-            'data-cy-section': "placement-request-summary"
+                'data-cy-section': "placement-request-summary"
             },
             rows:PlacementRequestUtils.adminSummary(placementRequestDetail).rows
-            })
-        }}
+        }) }}
         {{ govukSummaryList(PlacementRequestUtils.matchingInformationSummary(placementRequestDetail)) }}
+
     {% else %}
+
         {{ govukSummaryList(PlacementUtils.placementSummary(placement)) }}
 
         <h2 class="govuk-heading-m">Arrival information</h2>
@@ -91,23 +99,28 @@
 
         <h2 class="govuk-heading-m">Departure information</h2>
         {{ govukSummaryList(PlacementUtils.departureInformation(placement)) }}
+
+        <h2 class="govuk-heading-m">Booking requirements</h2>
+        {{ govukSummaryList(PlacementUtils.requirementsInformation(placement)) }}
+
         {% if placement.otherBookingsInPremisesForCrn and placement.otherBookingsInPremisesForCrn.length %}
             <h2 class="govuk-heading-m">Other</h2>
             {{ govukSummaryList(PlacementUtils.otherBookings(placement)) }}
         {% endif %}
+
     {% endif %}
 {% endblock %}
 
 {% block extraScripts %}
-   <script type="text/javascript" nonce="{{ cspNonce }}">
-     const container = $('.moj-button-menu')
-     if(container?.length) {
-         new MOJFrontend.ButtonMenu({
-           container: container,
-            mq: '(min-width: 200em)',
-            buttonText: 'Actions',
-            menuClasses: 'moj-button-menu__wrapper--right',
-         })
-     }
-   </script>
+    <script type="text/javascript" nonce="{{ cspNonce }}">
+      const container = $('.moj-button-menu')
+      if (container?.length) {
+        new MOJFrontend.ButtonMenu({
+          container: container,
+          mq: '(min-width: 200em)',
+          buttonText: 'Actions',
+          menuClasses: 'moj-button-menu__wrapper--right',
+        })
+      }
+    </script>
 {% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1910

# Changes in this PR

This shows the requirements for the booking exactly as they were selected during the Find and book journey.

To be explicit about the booking made, when no requirements have been selected, the text 'None' is shown in a slightly greyed out hue.

## Screenshots of UI changes

### New section on placement details tab

<img width="990" alt="Screenshot 2025-02-06 at 15 21 40" src="https://github.com/user-attachments/assets/31235785-1c02-44a5-85c8-4576ebb1814b" />
