### PR TITLE
APS-1889 8 week view for occupancy views

### DIFF
--- a/server/utils/match/occupancy.test.ts
+++ b/server/utils/match/occupancy.test.ts
@@ -155,6 +155,7 @@ describe('durationSelectOptions', () => {
   const defaultOptions = [
     { text: 'Up to 1 week', value: '7' },
     { text: 'Up to 6 weeks', value: '42' },
+    { text: 'Up to 8 weeks', value: '56' },
     { text: 'Up to 12 weeks', value: '84' },
     { text: 'Up to 26 weeks', value: '182' },
     { text: 'Up to 52 weeks', value: '364' },
@@ -168,6 +169,8 @@ describe('durationSelectOptions', () => {
     ['Up to 1 week', 3],
     ['Up to 1 week', 7],
     ['Up to 6 weeks', 42],
+    ['Up to 8 weeks', 43],
+    ['Up to 8 weeks', 56],
     ['Up to 12 weeks', 80],
     ['Up to 12 weeks', 84],
     ['Up to 26 weeks', 85],

--- a/server/utils/match/occupancy.ts
+++ b/server/utils/match/occupancy.ts
@@ -72,6 +72,7 @@ export const dayAvailabilitySummaryListItems = (
 const durationOptionsMap: Record<number, string> = {
   '7': 'Up to 1 week',
   '42': 'Up to 6 weeks',
+  '56': 'Up to 8 weeks',
   '84': 'Up to 12 weeks',
   '182': 'Up to 26 weeks',
   '364': 'Up to 52 weeks',

--- a/server/utils/premises/occupancy.test.ts
+++ b/server/utils/premises/occupancy.test.ts
@@ -54,6 +54,7 @@ describe('apOccupancy utils', () => {
   const durationOptions: Array<SelectOption> = [
     { selected: undefined, text: '1 week', value: '7' },
     { selected: undefined, text: '6 weeks', value: '42' },
+    { selected: undefined, text: '8 weeks', value: '56' },
     { selected: undefined, text: '12 weeks', value: '84' },
     { selected: undefined, text: '26 weeks', value: '182' },
     { selected: undefined, text: '52 weeks', value: '364' },

--- a/server/utils/premises/occupancy.ts
+++ b/server/utils/premises/occupancy.ts
@@ -66,6 +66,7 @@ export const occupancyCalendar = (capacity: Array<Cas1PremiseCapacityForDay>, pr
 const durationOptionsMap: Record<number, string> = {
   '7': '1 week',
   '42': '6 weeks',
+  '56': '8 weeks',
   '84': '12 weeks',
   '182': '26 weeks',
   '364': '52 weeks',


### PR DESCRIPTION
# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

https://dsdmoj.atlassian.net/browse/APS-1889
# Changes in this PR

Add 8 week option to both the match occupancy view and the AP manage occupancy view

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/073596aa-7dfd-463f-9c87-415e3987cd42)

![image](https://github.com/user-attachments/assets/68d29c33-cf11-43c9-8e8e-a1b406bf0b07)
