### PR TITLE
Move build and Helm lint steps to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,9 +90,18 @@ jobs:
 workflows:
   build-test-and-deploy:
     jobs:
-      - build
+      - build:
+          name: build
+          filters:
+            branches:
+              only:
+                - main
       - hmpps/helm_lint:
           name: helm_lint
+          filters:
+            branches:
+              only:
+                - main
       - hmpps/build_docker:
           name: build_docker
           filters:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,25 @@ env:
   API_CLIENT_SECRET: clientsecret
 
 jobs:
+  build:
+    name: "Build 🛠️"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4.1.7
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4.0.3
+        with:
+          node-version-file: '.node-version'
+          cache: 'npm'
+
+      - name: Installing dependencies
+        run: npm ci
+
+      - name: Typechecking the code
+        run: npm run build
+
   type_checking:
     name: "Type check 🔎"
     runs-on: ubuntu-latest
@@ -52,6 +71,13 @@ jobs:
 
       - name: Running shell scripts linting checks
         run: npm run shellcheck
+
+  helm_lint:
+    name: "Helm config linting 🔎"
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/test_helm_lint.yml@v2
+    strategy:
+      matrix:
+        environments: [ 'dev', 'test', 'preprod', 'prod' ]
 
   unit_test:
     name: "Unit testing 🧪"


### PR DESCRIPTION
This ensures those steps are now run on GitHub for pushes to Pull Requests, but only run on CircleCI on the `main` branch.

https://dsdmoj.atlassian.net/browse/APS-1928