### PR TITLE
APS-1888: Hide occupancy summary

### DIFF
--- a/server/views/manage/premises/placements/changes/new.njk
+++ b/server/views/manage/premises/placements/changes/new.njk
@@ -99,7 +99,9 @@
 
         {% if not errors.startDate %}
 
-            {{ occupancySummary(summary) }}
+            <section class="govuk-visually-hidden">
+                {{ occupancySummary(summary) }}
+            </section>
 
             <section id="calendar-key">
                 <h3 class="govuk-heading-m">Key</h3>

--- a/server/views/match/placementRequests/occupancyView/partials/_occupancySummary.njk
+++ b/server/views/match/placementRequests/occupancyView/partials/_occupancySummary.njk
@@ -33,6 +33,7 @@
 
     {{ govukNotificationBanner({
         html: bannerHtml,
+        titleHeadingLevel: 3,
         classes: 'govuk-notification-banner--full-width-content'
     }) }}
 {% endmacro %}

--- a/server/views/match/placementRequests/occupancyView/view.njk
+++ b/server/views/match/placementRequests/occupancyView/view.njk
@@ -91,7 +91,9 @@
 
         {% if not errors.startDate %}
 
-            {{ occupancySummary(summary) }}
+            <section class="govuk-visually-hidden">
+                {{ occupancySummary(summary) }}
+            </section>
 
             <section id="calendar-key">
                 <h3 class="govuk-heading-m">Key</h3>


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1888

# Changes in this PR

This removes the 'Important' banner containing the occupancy summary from view on the 'occupancy' views for both the 'Find and book' and the 'Change placement' journeys. The element remains accessible to screen readers. Headings hierarchy has been tweaked to ease landmark-based navigation for assistive technologies.

## Screenshots of UI changes

<img width="994" alt="Screenshot 2025-02-10 at 18 02 42" src="https://github.com/user-attachments/assets/a8b3670c-523c-4a2f-9248-db6ba146b7be" />
