### PR TITLE
APS-1891: Add requested/expected dates to input fields hints

### DIFF
--- a/integration_tests/pages/shared/occupancyFilterPage.ts
+++ b/integration_tests/pages/shared/occupancyFilterPage.ts
@@ -112,4 +112,8 @@ export default class OccupancyFilterPage extends Page {
 
     return Object.values(dates).filter(Boolean)
   }
+
+  shouldShowDateFieldHint(fieldName: string, hint: string) {
+    cy.get(`#${fieldName}-hint`).should('contain', hint)
+  }
 }

--- a/integration_tests/tests/manage/placements/changes.cy.ts
+++ b/integration_tests/tests/manage/placements/changes.cy.ts
@@ -77,6 +77,16 @@ context('Change Placement', () => {
     )
     changePlacementPage.shouldShowFilters(placement.expectedArrivalDate, 'Up to 12 weeks', selectedCriteria)
 
+    // And I can see the current placement dates in the hints
+    changePlacementPage.shouldShowDateFieldHint(
+      'arrivalDate',
+      `Expected arrival date: ${DateFormats.isoDateToUIDate(placement.expectedArrivalDate, { format: 'dateFieldHint' })}`,
+    )
+    changePlacementPage.shouldShowDateFieldHint(
+      'departureDate',
+      `Expected departure date: ${DateFormats.isoDateToUIDate(placement.expectedDepartureDate, { format: 'dateFieldHint' })}`,
+    )
+
     // When I submit the filters with an invalid date
     changePlacementPage.filterAvailability({ newStartDate: '2025-14-45', newDuration: 'Up to 1 week' }, 'criteria')
 

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -34,6 +34,8 @@ import {
 } from '../../../server/utils/match/spaceSearch'
 import { apType } from '../../../server/utils/placementCriteriaUtils'
 import premisesSearchResultSummary from '../../../server/testutils/factories/cas1PremisesSearchResultSummary'
+import { DateFormats } from '../../../server/utils/dateUtils'
+import { placementDates } from '../../../server/utils/match'
 
 context('Placement Requests', () => {
   beforeEach(() => {
@@ -175,6 +177,10 @@ context('Placement Requests', () => {
         licenceExpiryDate,
       }),
     })
+    const { startDate: requestedArrivalDate, endDate: requestedDepartureDate } = placementDates(
+      placementRequest.expectedArrival,
+      placementRequest.duration,
+    )
     const searchState = initialiseSearchState(placementRequest)
     const premiseCapacity = cas1PremiseCapacityFactory.build({
       startDate,
@@ -204,7 +210,16 @@ context('Placement Requests', () => {
     // Then I should see the details of the case I am matching
     occupancyViewPage.shouldShowMatchingDetails(startDate, durationDays, placementRequest)
 
-    return { occupancyViewPage, placementRequest, premiseCapacity, premises, startDate, searchState }
+    return {
+      occupancyViewPage,
+      placementRequest,
+      premiseCapacity,
+      premises,
+      startDate,
+      searchState,
+      requestedArrivalDate,
+      requestedDepartureDate,
+    }
   }
 
   const shouldShowDayDetailsAndReturn = (
@@ -292,11 +307,21 @@ context('Placement Requests', () => {
   })
 
   it('allows me to book a space', () => {
-    const { occupancyViewPage, premises, placementRequest, searchState } =
+    const { occupancyViewPage, premises, placementRequest, searchState, requestedArrivalDate, requestedDepartureDate } =
       shouldVisitOccupancyViewPageAndShowMatchingDetails(defaultLicenceExpiryDate)
 
     const arrivalDate = '2024-07-23'
     const departureDate = '2024-08-08'
+
+    // Then I can see the requested dates in the hints
+    occupancyViewPage.shouldShowDateFieldHint(
+      'arrivalDate',
+      `Requested arrival date: ${DateFormats.isoDateToUIDate(requestedArrivalDate, { format: 'dateFieldHint' })}`,
+    )
+    occupancyViewPage.shouldShowDateFieldHint(
+      'departureDate',
+      `Requested departure date: ${DateFormats.isoDateToUIDate(requestedDepartureDate, { format: 'dateFieldHint' })}`,
+    )
 
     // And I fill in the requested arrival and departure dates
     occupancyViewPage.completeForm(arrivalDate, departureDate)

--- a/server/controllers/manage/premises/placements/changesController.test.ts
+++ b/server/controllers/manage/premises/placements/changesController.test.ts
@@ -78,6 +78,8 @@ describe('changesController', () => {
         backlink: adminPaths.admin.placementRequests.show({ id: placement.requestForPlacementId }),
         pageHeading: 'Change placement',
         placement,
+        arrivalDateHint: `Expected arrival date: ${DateFormats.isoDateToUIDate(placement.expectedArrivalDate, { format: 'dateFieldHint' })}`,
+        departureDateHint: `Expected departure date: ${DateFormats.isoDateToUIDate(placement.expectedDepartureDate, { format: 'dateFieldHint' })}`,
         placementSummary: placementOverviewSummary(placement),
         durationOptions: durationSelectOptions(expectedDuration),
         criteriaOptions: convertKeyValuePairToCheckBoxItems(occupancyCriteriaMap, expectedCriteria),

--- a/server/controllers/manage/premises/placements/changesController.test.ts
+++ b/server/controllers/manage/premises/placements/changesController.test.ts
@@ -14,7 +14,7 @@ import { occupancyCalendar } from '../../../../utils/match/occupancyCalendar'
 import matchPaths from '../../../../paths/match'
 import managePaths from '../../../../paths/manage'
 import adminPaths from '../../../../paths/admin'
-import { placementDatesSummary, placementOverviewSummary } from '../../../../utils/placements'
+import { placementOverviewSummary } from '../../../../utils/placements'
 import { filterRoomLevelCriteria } from '../../../../utils/match/spaceSearch'
 import { createQueryString, makeArrayOfType } from '../../../../utils/utils'
 import { durationSelectOptions, occupancyCriteriaMap } from '../../../../utils/match/occupancy'
@@ -79,7 +79,6 @@ describe('changesController', () => {
         pageHeading: 'Change placement',
         placement,
         placementSummary: placementOverviewSummary(placement),
-        placementDatesSummary: placementDatesSummary(placement),
         durationOptions: durationSelectOptions(expectedDuration),
         criteriaOptions: convertKeyValuePairToCheckBoxItems(occupancyCriteriaMap, expectedCriteria),
         startDate: placement.expectedArrivalDate,

--- a/server/controllers/manage/premises/placements/changesController.ts
+++ b/server/controllers/manage/premises/placements/changesController.ts
@@ -15,7 +15,7 @@ import {
   validateSpaceBooking,
 } from '../../../../utils/match'
 import { Calendar, occupancyCalendar } from '../../../../utils/match/occupancyCalendar'
-import { placementDatesSummary, placementOverviewSummary } from '../../../../utils/placements'
+import { placementOverviewSummary } from '../../../../utils/placements'
 import { filterRoomLevelCriteria } from '../../../../utils/match/spaceSearch'
 import { createQueryString, makeArrayOfType } from '../../../../utils/utils'
 import { DateFormats, dateAndTimeInputsAreValidDates } from '../../../../utils/dateUtils'
@@ -137,7 +137,6 @@ export default class ChangesController {
         durationDays,
         criteria,
         placementSummary: placementOverviewSummary(placement),
-        placementDatesSummary: placementDatesSummary(placement),
         durationOptions: durationSelectOptions(durationDays),
         criteriaOptions: convertKeyValuePairToCheckBoxItems(occupancyCriteriaMap, criteria),
         summary,

--- a/server/controllers/manage/premises/placements/changesController.ts
+++ b/server/controllers/manage/premises/placements/changesController.ts
@@ -132,6 +132,8 @@ export default class ChangesController {
         backlink: adminPaths.admin.placementRequests.show({ id: placement.requestForPlacementId }),
         pageHeading: 'Change placement',
         placement,
+        arrivalDateHint: `Expected arrival date: ${DateFormats.isoDateToUIDate(placement.expectedArrivalDate, { format: 'dateFieldHint' })}`,
+        departureDateHint: `Expected departure date: ${DateFormats.isoDateToUIDate(placement.expectedDepartureDate, { format: 'dateFieldHint' })}`,
         startDate,
         ...DateFormats.isoDateToDateInputs(startDate, 'startDate'),
         durationDays,

--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -13,7 +13,7 @@ import {
   spaceSearchStateFactory,
 } from '../../../testutils/factories'
 import OccupancyViewController from './occupancyViewController'
-import { occupancySummary } from '../../../utils/match'
+import { occupancySummary, placementDates } from '../../../utils/match'
 import matchPaths from '../../../paths/match'
 import { occupancyCalendar } from '../../../utils/match/occupancyCalendar'
 import * as validationUtils from '../../../utils/validation'
@@ -86,6 +86,11 @@ describe('OccupancyViewController', () => {
       const requestHandler = occupancyViewController.view()
       await requestHandler(request, response, next)
 
+      const { startDate: requestedArrivalDate, endDate: requestedDepartureDate } = placementDates(
+        placementRequestDetail.expectedArrival,
+        placementRequestDetail.duration,
+      )
+
       expect(spaceSearchService.getSpaceSearchState).toHaveBeenCalledWith(placementRequestDetail.id, request.session)
       expect(placementRequestService.getPlacementRequest).toHaveBeenCalledWith(token, placementRequestDetail.id)
       expect(premisesService.find).toHaveBeenCalledWith(token, premises.id)
@@ -97,6 +102,8 @@ describe('OccupancyViewController', () => {
       expect(response.render).toHaveBeenCalledWith('match/placementRequests/occupancyView/view', {
         pageHeading: `View spaces in ${premises.name}`,
         placementRequest: placementRequestDetail,
+        requestedArrivalDate,
+        requestedDepartureDate,
         premises,
         ...searchState,
         ...DateFormats.isoDateToDateInputs(searchState.startDate, 'startDate'),

--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -86,7 +86,7 @@ describe('OccupancyViewController', () => {
       const requestHandler = occupancyViewController.view()
       await requestHandler(request, response, next)
 
-      const { startDate: requestedArrivalDate, endDate: requestedDepartureDate } = placementDates(
+      const { startDate, endDate } = placementDates(
         placementRequestDetail.expectedArrival,
         placementRequestDetail.duration,
       )
@@ -102,8 +102,8 @@ describe('OccupancyViewController', () => {
       expect(response.render).toHaveBeenCalledWith('match/placementRequests/occupancyView/view', {
         pageHeading: `View spaces in ${premises.name}`,
         placementRequest: placementRequestDetail,
-        requestedArrivalDate,
-        requestedDepartureDate,
+        arrivalDateHint: `Requested arrival date: ${DateFormats.isoDateToUIDate(startDate, { format: 'dateFieldHint' })}`,
+        departureDateHint: `Requested departure date: ${DateFormats.isoDateToUIDate(endDate, { format: 'dateFieldHint' })}`,
         premises,
         ...searchState,
         ...DateFormats.isoDateToDateInputs(searchState.startDate, 'startDate'),

--- a/server/controllers/match/placementRequests/occupancyViewController.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.ts
@@ -77,10 +77,7 @@ export default class {
       }
 
       const placementRequest = await this.placementRequestService.getPlacementRequest(token, id)
-      const { startDate: requestedArrivalDate, endDate: requestedDepartureDate } = placementDates(
-        placementRequest.expectedArrival,
-        placementRequest.duration,
-      )
+      const { startDate, endDate } = placementDates(placementRequest.expectedArrival, placementRequest.duration)
       const premises = await this.premisesService.find(token, premisesId)
 
       let summary: OccupancySummary
@@ -111,8 +108,8 @@ export default class {
       return res.render('match/placementRequests/occupancyView/view', {
         pageHeading: `View spaces in ${premises.name}`,
         placementRequest,
-        requestedArrivalDate,
-        requestedDepartureDate,
+        arrivalDateHint: `Requested arrival date: ${DateFormats.isoDateToUIDate(startDate, { format: 'dateFieldHint' })}`,
+        departureDateHint: `Requested departure date: ${DateFormats.isoDateToUIDate(endDate, { format: 'dateFieldHint' })}`,
         premises,
         ...formValues,
         ...DateFormats.isoDateToDateInputs(formValues.startDate, 'startDate'),

--- a/server/controllers/match/placementRequests/occupancyViewController.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.ts
@@ -77,6 +77,10 @@ export default class {
       }
 
       const placementRequest = await this.placementRequestService.getPlacementRequest(token, id)
+      const { startDate: requestedArrivalDate, endDate: requestedDepartureDate } = placementDates(
+        placementRequest.expectedArrival,
+        placementRequest.duration,
+      )
       const premises = await this.premisesService.find(token, premisesId)
 
       let summary: OccupancySummary
@@ -107,6 +111,8 @@ export default class {
       return res.render('match/placementRequests/occupancyView/view', {
         pageHeading: `View spaces in ${premises.name}`,
         placementRequest,
+        requestedArrivalDate,
+        requestedDepartureDate,
         premises,
         ...formValues,
         ...DateFormats.isoDateToDateInputs(formValues.startDate, 'startDate'),

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -77,6 +77,13 @@ describe('DateFormats', () => {
       expect(DateFormats.isoDateToUIDate(date, { format: 'longNoYear' })).toEqual(expectedUiDate)
     })
 
+    it.each([
+      ['2022-11-09T00:00:00.000Z', '9 11 2022'],
+      ['2022-04-11T00:00:00.000Z', '11 4 2022'],
+    ])('converts ISO8601 date %s to a date field hint format date', (date, expectedUiDate) => {
+      expect(DateFormats.isoDateToUIDate(date, { format: 'dateFieldHint' })).toEqual(expectedUiDate)
+    })
+
     it('raises an error if the date is not a valid ISO8601 date string', () => {
       const date = '23/11/2022'
 

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -37,6 +37,7 @@ const uiDateFormats = {
   short: 'd MMM y',
   long: 'ccc d MMM y',
   longNoYear: 'ccc d MMM',
+  dateFieldHint: 'd M y',
 }
 type UiDateFormat = keyof typeof uiDateFormats
 

--- a/server/utils/placements/index.test.ts
+++ b/server/utils/placements/index.test.ts
@@ -13,7 +13,6 @@ import {
   getKeyDetail,
   injectRadioConditionalHtml,
   otherBookings,
-  placementDatesSummary,
   placementOverviewSummary,
   placementSummary,
   renderKeyworkersSelectOptions,
@@ -178,15 +177,6 @@ describe('placementUtils', () => {
           },
           { key: { text: 'Key worker' }, value: { text: placement.keyWorkerAllocation?.keyWorker?.name } },
           { key: { text: 'Delius Event Number' }, value: { text: placement.deliusEventNumber } },
-        ],
-      })
-    })
-
-    it('should return the placement dates summary information', () => {
-      expect(placementDatesSummary(placement)).toEqual({
-        rows: [
-          { key: { text: 'Expected arrival date' }, value: { text: 'Thu 30 May 2024' } },
-          { key: { text: 'Expected departure date' }, value: { text: 'Tue 24 Dec 2024' } },
         ],
       })
     })

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -136,13 +136,6 @@ export const placementSummary = (placement: Cas1SpaceBooking): SummaryList => {
   }
 }
 
-export const placementDatesSummary = (placement: Cas1SpaceBooking): SummaryList => ({
-  rows: [
-    summaryRow('Expected arrival date', formatDate(placement.expectedArrivalDate)),
-    summaryRow('Expected departure date', formatDate(placement.expectedDepartureDate)),
-  ],
-})
-
 export const placementOverviewSummary = (placement: Cas1SpaceBooking): SummaryList => ({
   rows: [
     summaryRow('Approved premises', placement.premises.name),

--- a/server/views/manage/premises/placements/changes/new.njk
+++ b/server/views/manage/premises/placements/changes/new.njk
@@ -144,7 +144,7 @@
                         }
                     },
                     hint: {
-                        text: 'Expected arrival date: ' + formatDate(placement.expectedArrivalDate, { format: 'dateFieldHint' })
+                        text: arrivalDateHint
                     },
                     items: dateFieldValues('arrivalDate', errors),
                     errorMessage: errors.arrivalDate
@@ -160,7 +160,7 @@
                         }
                     },
                     hint: {
-                        text: 'Expected departure date: ' + formatDate(placement.expectedDepartureDate, { format: 'dateFieldHint' })
+                        text: departureDateHint
                     },
                     items: dateFieldValues('departureDate', errors),
                     errorMessage: errors.departureDate

--- a/server/views/manage/premises/placements/changes/new.njk
+++ b/server/views/manage/premises/placements/changes/new.njk
@@ -129,8 +129,6 @@
         <section>
             <h2 class="govuk-heading-l">Change placement dates</h2>
 
-            {{ govukSummaryList(placementDatesSummary) }}
-
             <form action="{{ currentUrl }}" method="post">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 

--- a/server/views/manage/premises/placements/changes/new.njk
+++ b/server/views/manage/premises/placements/changes/new.njk
@@ -146,7 +146,7 @@
                         }
                     },
                     hint: {
-                        text: "For example, 17 5 2024"
+                        text: 'Expected arrival date: ' + formatDate(placement.expectedArrivalDate, { format: 'dateFieldHint' })
                     },
                     items: dateFieldValues('arrivalDate', errors),
                     errorMessage: errors.arrivalDate
@@ -162,7 +162,7 @@
                         }
                     },
                     hint: {
-                        text: "For example, 17 5 2024"
+                        text: 'Expected departure date: ' + formatDate(placement.expectedDepartureDate, { format: 'dateFieldHint' })
                     },
                     items: dateFieldValues('departureDate', errors),
                     errorMessage: errors.departureDate

--- a/server/views/match/placementRequests/occupancyView/view.njk
+++ b/server/views/match/placementRequests/occupancyView/view.njk
@@ -137,7 +137,7 @@
                         }
                     },
                     hint: {
-                        text: "For example, 17 5 2024"
+                        text: 'Requested arrival date: ' + formatDate(requestedArrivalDate, { format: 'dateFieldHint' })
                     },
                     items: dateFieldValues('arrivalDate', errors),
                     errorMessage: errors.arrivalDate
@@ -153,7 +153,7 @@
                         }
                     },
                     hint: {
-                        text: "For example, 17 5 2024"
+                        text: 'Requested departure date: ' + formatDate(requestedDepartureDate, { format: 'dateFieldHint' })
                     },
                     items: dateFieldValues('departureDate', errors),
                     errorMessage: errors.departureDate

--- a/server/views/match/placementRequests/occupancyView/view.njk
+++ b/server/views/match/placementRequests/occupancyView/view.njk
@@ -137,7 +137,7 @@
                         }
                     },
                     hint: {
-                        text: 'Requested arrival date: ' + formatDate(requestedArrivalDate, { format: 'dateFieldHint' })
+                        text: arrivalDateHint
                     },
                     items: dateFieldValues('arrivalDate', errors),
                     errorMessage: errors.arrivalDate
@@ -153,7 +153,7 @@
                         }
                     },
                     hint: {
-                        text: 'Requested departure date: ' + formatDate(requestedDepartureDate, { format: 'dateFieldHint' })
+                        text: departureDateHint
                     },
                     items: dateFieldValues('departureDate', errors),
                     errorMessage: errors.departureDate


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1891

# Changes in this PR

This adds the requested or expected dates to the input field hints on the occupancy view and 'Amend placement' forms. The summary of expected dates is removed from the 'Amend booking' form, to remove duplication of this information.

## Screenshots of UI changes

<details><summary>Occupancy view form</summary>

<img width="689" alt="Screenshot 2025-02-11 at 10 47 51" src="https://github.com/user-attachments/assets/6b46df11-fe36-4fb3-a766-de8478f2e18e" />

</details>

<details><summary>Change placement form</summary>

<img width="595" alt="Screenshot 2025-02-11 at 10 47 30" src="https://github.com/user-attachments/assets/a68a5344-979f-4d52-afcf-7bb4420960d7" />

</details>
