### PR TITLE
CHORE: Remove CircleCI `build` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,36 +18,6 @@ parameters:
     default: 20.18-browsers
 
 jobs:
-  build:
-    executor:
-      name: hmpps/node
-      tag: << pipeline.parameters.node-version >>
-    steps:
-      - checkout
-      - run:
-          name: Update npm
-          command: 'sudo npm install -g npm@10.8.2'
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-      - run:
-          name: Install Dependencies
-          command: npm ci --no-audit
-      - save_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-          paths:
-            - node_modules
-            - ~/.cache
-      - run:
-          command: |
-            npm run build
-      - persist_to_workspace:
-          root: .
-          paths:
-            - node_modules
-            - build
-            - dist
-            - .cache/Cypress
-
   e2e_environment_test_on_merge:
     executor:
       name: hmpps/node
@@ -90,12 +60,6 @@ jobs:
 workflows:
   build-test-and-deploy:
     jobs:
-      - build:
-          name: build
-          filters:
-            branches:
-              only:
-                - main
       - hmpps/helm_lint:
           name: helm_lint
           filters:


### PR DESCRIPTION
No other step depends on it, as the Docker build does this internally. The validity of the build is checked in the Github Action run on main.
