### PR TITLE
CHORE: Store failed integration tests artefacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,12 +159,14 @@ jobs:
           path: test_results/cypress
 
       - name: Store Integration tests videos
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: integration-tests-videos-${{ matrix.ci_node_index }}
           path: integration_tests/videos
 
       - name: Store Integration tests screenshots
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: integration-tests-screenshots-${{ matrix.ci_node_index }}


### PR DESCRIPTION
GitHub actions skips steps after failing ones by default, resulting in the steps to store artefacts not being run.

This ensure the steps to store any screenshots or videos from failed integration tests are always run.
