### PR TITLE
APS-1893: Update booking confirmation message

### DIFF
--- a/integration_tests/pages/admin/placementApplications/listPage.ts
+++ b/integration_tests/pages/admin/placementApplications/listPage.ts
@@ -26,8 +26,8 @@ export default class ListPage extends Page {
 
   shouldShowSpaceBookingConfirmation(crn: string, premisesName: string) {
     this.shouldShowBanner(
-      `Place booked for ${crn} at ${premisesName}`,
-      'A confirmation email will be sent to the AP and probation practitioner.',
+      `Place booked for ${crn} at ${premisesName} 
+      A confirmation email will be sent to the AP and probation practitioner.`,
     )
   }
 

--- a/integration_tests/pages/admin/placementApplications/listPage.ts
+++ b/integration_tests/pages/admin/placementApplications/listPage.ts
@@ -24,9 +24,9 @@ export default class ListPage extends Page {
     return new ListPage()
   }
 
-  shouldShowSpaceBookingConfirmation() {
+  shouldShowSpaceBookingConfirmation(crn: string, premisesName: string) {
     this.shouldShowBanner(
-      'You have now booked a place in this AP for this person. An email will be sent to the AP, to inform them of the booking.',
+      `You have now booked a place for ${crn} at ${premisesName}. A confirmation email will be sent to the AP and probation practitioner.`,
     )
   }
 

--- a/integration_tests/pages/admin/placementApplications/listPage.ts
+++ b/integration_tests/pages/admin/placementApplications/listPage.ts
@@ -26,7 +26,8 @@ export default class ListPage extends Page {
 
   shouldShowSpaceBookingConfirmation(crn: string, premisesName: string) {
     this.shouldShowBanner(
-      `You have now booked a place for ${crn} at ${premisesName}. A confirmation email will be sent to the AP and probation practitioner.`,
+      `Place booked for ${crn} at ${premisesName}`,
+      'A confirmation email will be sent to the AP and probation practitioner.',
     )
   }
 

--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -152,7 +152,7 @@ export default class ShowPage extends Page {
   }
 
   showsWithdrawalConfirmationMessage() {
-    this.shouldShowBanner('Request for placement')
+    this.shouldShowBanner('Request for placement for ', { exact: false })
   }
 
   showsNoteAddedConfirmationMessage() {

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -104,8 +104,11 @@ export default abstract class Page {
     })
   }
 
-  shouldShowBanner(copy: string): void {
-    cy.get('.govuk-notification-banner').contains(copy)
+  shouldShowBanner(heading: string, body?: string): void {
+    cy.get('.govuk-notification-banner').contains(heading)
+    if (body) {
+      cy.get('.govuk-notification-banner').contains(body)
+    }
   }
 
   shouldNotShowBanner(): void {

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -104,11 +104,16 @@ export default abstract class Page {
     })
   }
 
-  shouldShowBanner(heading: string, body?: string): void {
-    cy.get('.govuk-notification-banner').contains(heading)
-    if (body) {
-      cy.get('.govuk-notification-banner').contains(body)
-    }
+  shouldShowBanner(text: string, options: { exact: boolean } = { exact: true }): void {
+    cy.get('.govuk-notification-banner__content').then(bannerElement => {
+      const { actual, expected } = parseHtml(bannerElement, text)
+
+      if (options.exact) {
+        expect(actual).to.equal(expected)
+      } else {
+        expect(actual).to.contain(expected)
+      }
+    })
   }
 
   shouldNotShowBanner(): void {

--- a/integration_tests/pages/shared/occupancyFilterPage.ts
+++ b/integration_tests/pages/shared/occupancyFilterPage.ts
@@ -56,8 +56,8 @@ export default class OccupancyFilterPage extends Page {
     } else if (!summary.available) {
       this.shouldShowBanner('There are no spaces available for the dates you have selected.')
     } else {
-      this.shouldShowBanner('Available on:')
-      this.shouldShowBanner('Overbooked on:')
+      this.shouldShowBanner('Available on:', { exact: false })
+      this.shouldShowBanner('Overbooked on:', { exact: false })
     }
   }
 

--- a/integration_tests/support/helpers.ts
+++ b/integration_tests/support/helpers.ts
@@ -37,7 +37,7 @@ const withdrawPlacementRequestOrApplication = async (
   confirmationPage.clickConfirm()
 
   // And I should see the confirmation message
-  showPage.shouldShowBanner('Request for placement')
+  showPage.shouldShowBanner('Request for placement for ', { exact: false })
 }
 
 export { withdrawPlacementRequestOrApplication }

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -257,7 +257,7 @@ context('Placement Requests', () => {
     createPage.clickSubmit()
 
     // Then I should see a confirmation message
-    showPage.shouldShowBanner('Placement created')
+    showPage.shouldShowBanner('Placement created for ', { exact: false })
 
     // And the booking details should have been sent to the API
     cy.task('verifyBookingFromPlacementRequest', unmatchedPlacementRequest).then(requests => {
@@ -299,7 +299,7 @@ context('Placement Requests', () => {
     createPage.clickSubmit()
 
     // Then I should see a confirmation message
-    showPage.shouldShowBanner('Placement created')
+    showPage.shouldShowBanner('Placement created for ', { exact: false })
 
     // And the booking details should have been sent to the API
     cy.task('verifyBookingFromPlacementRequest', unmatchedPlacementRequest).then(requests => {

--- a/integration_tests/tests/manage/occupancyView.cy.ts
+++ b/integration_tests/tests/manage/occupancyView.cy.ts
@@ -226,7 +226,7 @@ context('Premises day occupancy', () => {
         // I should see the occupancy summary for the day
         summaryPage.shouldShowDaySummaryDetails(premisesDaySummary)
         // And I should see a warning banner
-        summaryPage.shouldShowBanner('This AP is overbooked on: single room and en-suite')
+        summaryPage.shouldShowBanner('This AP is overbooked on: single room and en-suite.')
       })
 
       it('should allow navigation to the next day and back again', () => {

--- a/integration_tests/tests/manage/placements/viewPlacement.cy.ts
+++ b/integration_tests/tests/manage/placements/viewPlacement.cy.ts
@@ -131,7 +131,10 @@ context('Placements', () => {
       // When I visit the placement page
       const placementShowPage = PlacementShowPage.visit(placement)
       // Then I should see the offline application warning banner
-      placementShowPage.shouldShowBanner('This booking was imported from NDelius')
+      placementShowPage.shouldShowBanner(
+        `This booking was imported from NDelius
+        As such, Assessment and Request for Placement information isn't available.`,
+      )
       // Then I wil be on the placement details tab
       placementShowPage.shouldHaveActiveTab('Placement details')
       // When I click on the assessment tab

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -351,7 +351,7 @@ context('Placement Requests', () => {
     const cruDashboard = Page.verifyOnPage(ListPage)
 
     // And I should see a success message
-    cruDashboard.shouldShowSpaceBookingConfirmation()
+    cruDashboard.shouldShowSpaceBookingConfirmation(spaceBooking.person.crn, spaceBooking.premises.name)
 
     // And the booking details should have been sent to the API
     cy.task('verifyApiPost', apiPaths.placementRequests.spaceBookings.create({ id: placementRequest.id })).then(

--- a/server/controllers/match/placementRequests/spaceBookingsController.test.ts
+++ b/server/controllers/match/placementRequests/spaceBookingsController.test.ts
@@ -130,7 +130,7 @@ describe('SpaceBookingsController', () => {
       )
       expect(flash).toHaveBeenCalledWith(
         'success',
-        `You have now booked a place in this AP for this person. An email will be sent to the AP, to inform them of the booking.`,
+        `You have now booked a place for ${spaceBooking.person.crn} at ${spaceBooking.premises.name}. A confirmation email will be sent to the AP and probation practitioner.`,
       )
       expect(mockSessionSave).toHaveBeenCalled()
       expect(response.redirect).toHaveBeenCalledWith(`${paths.admin.cruDashboard.index({})}?status=matched`)

--- a/server/controllers/match/placementRequests/spaceBookingsController.test.ts
+++ b/server/controllers/match/placementRequests/spaceBookingsController.test.ts
@@ -128,10 +128,10 @@ describe('SpaceBookingsController', () => {
         placementRequestDetail.id,
         newSpaceBooking,
       )
-      expect(flash).toHaveBeenCalledWith(
-        'success',
-        `You have now booked a place for ${spaceBooking.person.crn} at ${spaceBooking.premises.name}. A confirmation email will be sent to the AP and probation practitioner.`,
-      )
+      expect(flash).toHaveBeenCalledWith('success', {
+        heading: `Place booked for ${spaceBooking.person.crn} at ${spaceBooking.premises.name}`,
+        body: `<p>A confirmation email will be sent to the AP and probation practitioner.</p>`,
+      })
       expect(mockSessionSave).toHaveBeenCalled()
       expect(response.redirect).toHaveBeenCalledWith(`${paths.admin.cruDashboard.index({})}?status=matched`)
     })

--- a/server/controllers/match/placementRequests/spaceBookingsController.ts
+++ b/server/controllers/match/placementRequests/spaceBookingsController.ts
@@ -82,10 +82,10 @@ export default class {
 
       try {
         const placement = await this.spaceSearchService.createSpaceBooking(token, id, newSpaceBooking)
-        req.flash(
-          'success',
-          `You have now booked a place for ${placement.person.crn} at ${placement.premises.name}. A confirmation email will be sent to the AP and probation practitioner.`,
-        )
+        req.flash('success', {
+          heading: `Place booked for ${placement.person.crn} at ${placement.premises.name}`,
+          body: '<p>A confirmation email will be sent to the AP and probation practitioner.</p>',
+        })
         this.spaceSearchService.removeSpaceSearchState(id, req.session)
 
         return req.session.save(() => {

--- a/server/controllers/match/placementRequests/spaceBookingsController.ts
+++ b/server/controllers/match/placementRequests/spaceBookingsController.ts
@@ -81,10 +81,10 @@ export default class {
       }
 
       try {
-        await this.spaceSearchService.createSpaceBooking(token, id, newSpaceBooking)
+        const placement = await this.spaceSearchService.createSpaceBooking(token, id, newSpaceBooking)
         req.flash(
           'success',
-          'You have now booked a place in this AP for this person. An email will be sent to the AP, to inform them of the booking.',
+          `You have now booked a place for ${placement.person.crn} at ${placement.premises.name}. A confirmation email will be sent to the AP and probation practitioner.`,
         )
         this.spaceSearchService.removeSpaceSearchState(id, req.session)
 

--- a/server/views/_messages.njk
+++ b/server/views/_messages.njk
@@ -13,7 +13,7 @@
 {% if successMessages %}
     {% for message in successMessages %}
         {{ govukNotificationBanner({
-            html: '<h3 class="govuk-notification-banner__heading">' + message + '</h3>',
+            html: '<h3 class="govuk-notification-banner__heading">' + (message.heading or message) + '</h3>' + (message.body or ''),
             type: 'success',
             titleId: 'success-title'
         }) }}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1893

# Changes in this PR

This updates the booking success message to include the CRN of the person and the name of the premises the booking was made for. The content is now split into heading and an extra paragraph to aid with readability.

## Screenshots of UI changes

<img width="986" alt="Screenshot 2025-02-12 at 12 25 56" src="https://github.com/user-attachments/assets/1637a88e-bc63-4f05-a071-e6db9007293d" />

