### PR TITLE
CHORE: Fix flaky occupancy test

### DIFF
--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -57,7 +57,7 @@ describe('OccupancyViewController', () => {
     id: placementRequestDetail.id,
     premisesId: premises.id,
     date: ':date',
-  })}?${createQueryString({ criteria: searchState.roomCriteria }, { arrayFormat: 'repeat' })}`
+  })}${createQueryString({ criteria: searchState.roomCriteria }, { arrayFormat: 'repeat', addQueryPrefix: true })}`
 
   beforeEach(() => {
     jest.clearAllMocks()


### PR DESCRIPTION
The test setup may create a mocked placement request which does nto contain any room-level requirements. When this is the case, no criteria is added to the placeholder URL used to generate calendar links.

However, the test setup always specified the query string prefix for this placeholder URL, resulting in intermittent failures.
