### PR TITLE
APS-1957 Occupancy view filter crash

### DIFF
--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -256,6 +256,23 @@ describe('OccupancyViewController', () => {
       expect(response.redirect).toHaveBeenCalledWith(occupancyViewUrl)
     })
 
+    it('saves an array of a single room criterion if only one is selected and is posted as a string (APS-1957)', async () => {
+      const filterBodyOneCriterion: Request['body'] = {
+        ...filterBody,
+        roomCriteria: 'isArsonSuitable',
+      }
+      const requestHandler = occupancyViewController.filterView()
+      await requestHandler({ ...request, body: filterBodyOneCriterion }, response, next)
+
+      expect(spaceSearchService.setSpaceSearchState).toHaveBeenCalledWith(
+        placementRequestDetail.id,
+        request.session,
+        expect.objectContaining({
+          roomCriteria: ['isArsonSuitable'],
+        }),
+      )
+    })
+
     it('clears the selected room criteria when none are selected', async () => {
       const filterBodyNoCriteria: Request['body'] = {
         ...filterBody,

--- a/server/controllers/match/placementRequests/occupancyViewController.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.ts
@@ -132,7 +132,7 @@ export default class {
       const occupancyUrl = paths.v2Match.placementRequests.search.occupancy({ id, premisesId })
 
       try {
-        const { roomCriteria = [], durationDays, ...startDateInput } = req.body
+        const { roomCriteria, durationDays, ...startDateInput } = req.body
 
         if (dateIsBlank(startDateInput, 'startDate') || !dateAndTimeInputsAreValidDates(startDateInput, 'startDate')) {
           throw new ValidationError({
@@ -146,7 +146,7 @@ export default class {
         )
 
         this.spaceSearchService.setSpaceSearchState(id, req.session, {
-          roomCriteria,
+          roomCriteria: makeArrayOfType<Cas1SpaceBookingCharacteristic>(roomCriteria) || [],
           startDate,
           durationDays: Number(durationDays),
         })


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1957
<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
On the M&M occupancy view calendar page, if the filter is updated with a single room criterion, the post contains a string rather than an array. This is stored in the session and the view controller tries to do a `.map` causing the error.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes
No UI changes
