### PR TITLE
CHORE: Install npm dependencies before starting E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,14 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
+          name: Install Dependencies
+          command: npm ci --no-audit
+      - save_cache:
+          key: dependency-cache-{{ checksum "package-lock.json" }}
+          paths:
+            - node_modules
+            - ~/.cache
+      - run:
           name: Install Playwright
           command: npx playwright install
       - run:


### PR DESCRIPTION
Since we have removed the orphaned `build` step, npm dependencies are no longer available to the E2E test runner -- this ensures they are installed first, before running the tests.

The E2E tests continued to run fine for a few merges, as they were restoring a cached version of the dependencies. There has since been a change to the dependencies, resulting in the cache becoming invalid, and the tests no longer having readily installed dependencies to use.
