### PR TITLE
APS-1883: Hide Available beds on premises that don't support space bookings

### DIFF
--- a/server/controllers/manage/premises/premisesController.test.ts
+++ b/server/controllers/manage/premises/premisesController.test.ts
@@ -14,7 +14,7 @@ import {
   paginatedResponseFactory,
   staffMemberFactory,
 } from '../../../testutils/factories'
-import { premisesOverbookingSummary } from '../../../utils/premises'
+import { premisesOverbookingSummary, summaryListForPremises } from '../../../utils/premises'
 
 describe('V2PremisesController', () => {
   const token = 'SOME_TOKEN'
@@ -72,6 +72,7 @@ describe('V2PremisesController', () => {
 
       expect(response.render).toHaveBeenCalledWith('manage/premises/show', {
         premises: premisesSummary,
+        summaryList: summaryListForPremises(premisesSummary),
         showPlacements: true,
         sortBy: 'canonicalArrivalDate',
         sortDirection: 'asc',

--- a/server/controllers/manage/premises/premisesController.ts
+++ b/server/controllers/manage/premises/premisesController.ts
@@ -5,7 +5,7 @@ import { ApAreaService, PremisesService } from '../../../services'
 import managePaths from '../../../paths/manage'
 import { getPaginationDetails } from '../../../utils/getPaginationDetails'
 import { hasPermission } from '../../../utils/users'
-import { PremisesTab, premisesOverbookingSummary } from '../../../utils/premises'
+import { PremisesTab, premisesOverbookingSummary, summaryListForPremises } from '../../../utils/premises'
 
 type TabSettings = {
   pageSize: number
@@ -58,6 +58,7 @@ export default class PremisesController {
 
       return res.render('manage/premises/show', {
         premises,
+        summaryList: summaryListForPremises(premises),
         showPlacements,
         activeTab,
         crnOrName,

--- a/server/utils/premises/index.test.ts
+++ b/server/utils/premises/index.test.ts
@@ -1,4 +1,5 @@
 import type { Cas1OverbookingRange, Cas1SpaceBookingResidency } from '@approved-premises/api'
+import { TextItem } from '@approved-premises/ui'
 import {
   cas1PremisesBasicSummaryFactory,
   cas1PremisesFactory,
@@ -63,6 +64,17 @@ describe('premisesUtils', () => {
           },
         ],
       })
+    })
+
+    it('should not show available beds count if the premises does not support space bookings', () => {
+      const premises = cas1PremisesFactory.build({
+        supportsSpaceBookings: false,
+      })
+
+      const summaryList = summaryListForPremises(premises)
+
+      expect(summaryList.rows).toHaveLength(4)
+      expect(summaryList.rows.find(row => (row.key as TextItem).text === 'Available Beds')).toBeUndefined()
     })
   })
 

--- a/server/utils/premises/index.ts
+++ b/server/utils/premises/index.ts
@@ -35,15 +35,17 @@ export const summaryListForPremises = (premises: Cas1Premises): SummaryList => {
         key: textValue('Number of Beds'),
         value: textValue(premises.bedCount.toString()),
       },
-      {
-        key: textValue('Available Beds'),
-        value: textValue(premises.availableBeds.toString()),
-      },
+      premises.supportsSpaceBookings
+        ? {
+            key: textValue('Available Beds'),
+            value: textValue(premises.availableBeds.toString()),
+          }
+        : null,
       {
         key: textValue('Out of Service Beds'),
         value: textValue(premises.outOfServiceBeds.toString()),
       },
-    ],
+    ].filter(Boolean),
   }
 }
 

--- a/server/views/manage/premises/show.njk
+++ b/server/views/manage/premises/show.njk
@@ -46,9 +46,7 @@
         }]
     }) }}
 
-    {{ govukSummaryList(
-        PremisesUtils.summaryListForPremises(premises)
-    ) }}
+    {{ govukSummaryList(summaryList) }}
 
     {% if showPlacements %}
         <section>


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1883

# Changes in this PR

Hides the 'Available beds' summary list item for premises that do not support space bookings.

## Screenshots of UI changes

<img width="988" alt="Screenshot 2025-02-13 at 11 27 45" src="https://github.com/user-attachments/assets/f0bbaa14-74ae-466d-b579-137ffefb0cbf" />
