### PR TITLE
APS-1831: Render timeline event payload based on template for Booking Changed event

### DIFF
--- a/server/testutils/factories/cas1Timeline.ts
+++ b/server/testutils/factories/cas1Timeline.ts
@@ -52,10 +52,10 @@ export const cas1TimelineEventFactory = Factory.define<Cas1TimelineEvent>(() => 
   triggerSource: faker.helpers.arrayElement(cas1TriggerSourceTypes),
 }))
 
-const cas1TimelineEventContentPayloadFactory = Factory.define<Cas1TimelineEventContentPayload>(() => ({
+export const cas1TimelineEventContentPayloadFactory = Factory.define<Cas1TimelineEventContentPayload>(() => ({
   type: faker.helpers.arrayElement(cas1TimelineEventTypes),
   premises: namedIdFactory.build(),
-  schemaVersion: 1,
+  schemaVersion: 2,
 }))
 
 const cas1TimelineEventUrlTypes: ReadonlyArray<Cas1TimelineEventUrlType> = [

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -51,8 +51,8 @@ import {
 import { journeyTypeFromArtifact } from '../journeyTypeFromArtifact'
 import { RestrictedPersonError } from '../errors'
 import { sortHeader } from '../sortHeader'
-import { escape } from '../formUtils'
 import { APPLICATION_SUITABLE, ApplicationStatusTag } from './statusTag'
+import { renderTimelineEventContent } from '../timeline'
 
 jest.mock('../placementRequests/placementApplicationSubmissionData')
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
@@ -726,7 +726,7 @@ describe('utils', () => {
           label: {
             text: eventTypeTranslations[timelineEvents[0].type],
           },
-          content: escape(timelineEvents[0].content),
+          content: renderTimelineEventContent(timelineEvents[0]),
           createdBy: timelineEvents[0].createdBy.name,
           associatedUrls: expect.arrayContaining(
             mapTimelineUrlsForUi([
@@ -752,7 +752,7 @@ describe('utils', () => {
           label: {
             text: eventTypeTranslations[timelineEvents[0].type],
           },
-          content: escape(timelineEvents[0].content),
+          content: renderTimelineEventContent(timelineEvents[0]),
           createdBy: timelineEvents[0].createdBy.name,
           associatedUrls: [],
         },
@@ -809,11 +809,14 @@ describe('utils', () => {
     })
 
     it('escapes any rogue HTML', () => {
-      const timelineEventWithRogueHTML = cas1TimelineEventFactory.build({ content: '<div>Hello!</div>' })
+      const timelineEventWithRogueHTML = cas1TimelineEventFactory.build({
+        content: '<div>Hello!</div>',
+        payload: undefined,
+      })
 
       const actual = mapApplicationTimelineEventsForUi([timelineEventWithRogueHTML])
 
-      expect(actual[0].content).toEqual('&lt;div&gt;Hello!&lt;/div&gt;')
+      expect(actual[0].content).toEqual('<p class="govuk-body">&lt;div&gt;Hello!&lt;/div&gt;</p>')
     })
 
     it('Sets createdBy to System if triggerSource is `system`', () => {
@@ -828,7 +831,7 @@ describe('utils', () => {
           label: {
             text: eventTypeTranslations[timelineEvents[0].type],
           },
-          content: escape(timelineEvents[0].content),
+          content: renderTimelineEventContent(timelineEvents[0]),
           createdBy: 'System',
           associatedUrls: expect.arrayContaining(
             mapTimelineUrlsForUi([

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -852,6 +852,7 @@ describe('utils', () => {
       ['assessment', 'assessment'],
       ['booking', 'placement'],
       ['assessmentAppeal', 'appeal'],
+      ['spaceBooking', 'placement'],
     ])('Translates a "%s" url type to "%s"', (urlType: Cas1TimelineEventUrlType, translation: string) => {
       const timelineUrl = { type: urlType, url: faker.internet.url() }
       expect(mapTimelineUrlsForUi([timelineUrl])).toEqual([{ url: timelineUrl.url, type: translation }])

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -22,7 +22,6 @@ import type {
   Cas1TimelineEventType,
   Cas1TimelineEventUrlType,
   SortDirection,
-  TimelineEventUrlType,
 } from '@approved-premises/api'
 import IsExceptionalCase from '../../form-pages/apply/reasons-for-placement/basic-information/isExceptionalCase'
 import paths from '../../paths/apply'
@@ -314,12 +313,12 @@ const mapPersonalTimelineForUi = (personalTimeline: Cas1PersonalTimeline) => {
 }
 
 const urlTypeForUi = (type: Cas1TimelineEventUrlType) => {
-  const translations: Record<TimelineEventUrlType, string> = {
+  const translations: Record<Cas1TimelineEventUrlType, string> = {
     application: 'application',
     assessment: 'assessment',
     booking: 'placement',
     assessmentAppeal: 'appeal',
-    cas1SpaceBooking: 'placement',
+    spaceBooking: 'placement',
   }
   return translations[type]
 }

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -43,8 +43,8 @@ import { RestrictedPersonError } from '../errors'
 import { sortHeader } from '../sortHeader'
 import { linkTo } from '../utils'
 import { createNameAnchorElement, getTierOrBlank, htmlValue, textValue } from './helpers'
-import { escape } from '../formUtils'
 import { APPLICATION_SUITABLE, ApplicationStatusTag } from './statusTag'
+import { renderTimelineEventContent } from '../timeline'
 
 export { withdrawableTypeRadioOptions, withdrawableRadioOptions } from './withdrawables'
 export { placementApplicationWithdrawalReasons } from './withdrawables/withdrawalReasons'
@@ -285,7 +285,7 @@ const mapApplicationTimelineEventsForUi = (timelineEvents: Array<Cas1TimelineEve
           timestamp: timelineEvent.occurredAt,
           date: timelineEvent.occurredAt ? DateFormats.isoDateTimeToUIDateTime(timelineEvent.occurredAt) : '',
         },
-        content: escape(timelineEvent.content),
+        content: renderTimelineEventContent(timelineEvent),
         associatedUrls: timelineEvent.associatedUrls ? mapTimelineUrlsForUi(timelineEvent.associatedUrls) : [],
       }
 

--- a/server/utils/characteristicsUtils.ts
+++ b/server/utils/characteristicsUtils.ts
@@ -1,5 +1,5 @@
 import { Cas1SpaceBookingCharacteristic, Cas1SpaceCharacteristic, CharacteristicPair } from '@approved-premises/api'
-import { makeArrayOfType } from './utils'
+import { joinWithCommas, makeArrayOfType } from './utils'
 
 export const roomCharacteristicMap: Record<Cas1SpaceBookingCharacteristic, string> = {
   isWheelchairDesignated: 'Wheelchair accessible',
@@ -22,3 +22,6 @@ export const characteristicsBulletList = (characteristics: Array<Cas1SpaceCharac
     .filter(characteristic => roomCharacteristicMap[characteristic])
     .map(characteristic => `<li>${roomCharacteristicMap[characteristic]}</li>`)
     .join('')}</ul>`
+
+export const characteristicsInlineList = (criteria: Array<Cas1SpaceCharacteristic>): string =>
+  joinWithCommas(criteria.map(characteristic => roomCharacteristicMap[characteristic].toLowerCase()))

--- a/server/utils/premises/occupancy.ts
+++ b/server/utils/premises/occupancy.ts
@@ -5,6 +5,7 @@ import {
   Cas1SpaceBookingCharacteristic,
   Cas1SpaceBookingDaySummary,
   Cas1SpaceBookingDaySummarySortField,
+  Cas1SpaceCharacteristic,
   SortDirection,
 } from '@approved-premises/api'
 import { SelectOption, SummaryListItem, TableCell, TableRow } from '@approved-premises/ui'
@@ -81,6 +82,9 @@ export const durationSelectOptions = (durationDays?: string): Array<SelectOption
     text: label,
     selected: value === durationDays || undefined,
   }))
+
+export const criteriaListInline = (criteria: Array<Cas1SpaceCharacteristic>): string =>
+  joinWithCommas(criteria.map(characteristic => roomCharacteristicMap[characteristic].toLowerCase()))
 
 export const generateDaySummaryText = (daySummary: Cas1PremisesDaySummary): string => {
   const {

--- a/server/utils/premises/occupancy.ts
+++ b/server/utils/premises/occupancy.ts
@@ -5,7 +5,6 @@ import {
   Cas1SpaceBookingCharacteristic,
   Cas1SpaceBookingDaySummary,
   Cas1SpaceBookingDaySummarySortField,
-  Cas1SpaceCharacteristic,
   SortDirection,
 } from '@approved-premises/api'
 import { SelectOption, SummaryListItem, TableCell, TableRow } from '@approved-premises/ui'
@@ -82,9 +81,6 @@ export const durationSelectOptions = (durationDays?: string): Array<SelectOption
     text: label,
     selected: value === durationDays || undefined,
   }))
-
-export const criteriaListInline = (criteria: Array<Cas1SpaceCharacteristic>): string =>
-  joinWithCommas(criteria.map(characteristic => roomCharacteristicMap[characteristic].toLowerCase()))
 
 export const generateDaySummaryText = (daySummary: Cas1PremisesDaySummary): string => {
   const {

--- a/server/utils/timeline.test.ts
+++ b/server/utils/timeline.test.ts
@@ -101,10 +101,7 @@ describe('timeline utilities', () => {
           `)
         })
 
-        it.each([
-          ['the same', ['hasEnSuite']],
-          ['both none', []],
-        ])('does not render room criteria changes if they are %s', (_, characteristics) => {
+        it('does not render the detailed changes if there is no previous value', () => {
           const timelineEvent = cas1TimelineEventFactory.build({
             payload: cas1TimelineEventContentPayloadFactory.build({
               type: 'booking_changed',
@@ -113,17 +110,23 @@ describe('timeline utilities', () => {
                 id: premises.id,
               },
               schemaVersion: 2,
-              characteristics,
-              previousCharacteristics: characteristics,
+              previousExpectedArrival: null,
+              previousExpectedDeparture: null,
+              previousCharacteristics: null,
+              expectedArrival: '2025-09-18',
+              expectedDeparture: '2025-12-18',
+              characteristics: ['isCatered', 'hasEnSuite'],
             } as Cas1TimelineEventContentPayload),
           })
 
           const result = renderTimelineEventContent(timelineEvent)
 
           expect(result).not.toContain('Room criteria changed from')
+          expect(result).not.toContain('Arrival date changed from')
+          expect(result).not.toContain('Departure date changed from')
         })
 
-        it('renders "none" if previous or current criteria were none', () => {
+        it('renders "none" if the previous room criteria were none', () => {
           const timelineEvent = cas1TimelineEventFactory.build({
             payload: cas1TimelineEventContentPayloadFactory.build({
               type: 'booking_changed',
@@ -140,6 +143,25 @@ describe('timeline utilities', () => {
           const result = renderTimelineEventContent(timelineEvent)
 
           expect(result).toContain('Room criteria changed from none to en-suite')
+        })
+
+        it('renders "none" if the updated room criteria are none', () => {
+          const timelineEvent = cas1TimelineEventFactory.build({
+            payload: cas1TimelineEventContentPayloadFactory.build({
+              type: 'booking_changed',
+              premises: {
+                name: premises.name,
+                id: premises.id,
+              },
+              schemaVersion: 2,
+              characteristics: [],
+              previousCharacteristics: ['isWheelchairDesignated', 'isSingle'],
+            } as Cas1TimelineEventContentPayload),
+          })
+
+          const result = renderTimelineEventContent(timelineEvent)
+
+          expect(result).toContain('Room criteria changed from wheelchair accessible and single room to none')
         })
       })
     })

--- a/server/utils/timeline.test.ts
+++ b/server/utils/timeline.test.ts
@@ -124,6 +124,7 @@ describe('timeline utilities', () => {
           expect(result).not.toContain('Room criteria changed from')
           expect(result).not.toContain('Arrival date changed from')
           expect(result).not.toContain('Departure date changed from')
+          expect(result).toContain('No change')
         })
 
         it('renders "none" if the previous room criteria were none', () => {

--- a/server/utils/timeline.test.ts
+++ b/server/utils/timeline.test.ts
@@ -1,0 +1,106 @@
+import { Cas1TimelineEventContentPayload } from '@approved-premises/api'
+import { faker } from '@faker-js/faker'
+import { cas1PremisesFactory, cas1TimelineEventFactory } from '../testutils/factories'
+import { cas1TimelineEventContentPayloadFactory } from '../testutils/factories/cas1Timeline'
+import { renderTimelineEventContent } from './timeline'
+
+describe('timeline utilities', () => {
+  describe('timeline event content renderer', () => {
+    describe('when there is no payload', () => {
+      it('renders nothing if there is no content', () => {
+        const timelineEvent = cas1TimelineEventFactory.build({
+          content: undefined,
+          payload: undefined,
+        })
+
+        expect(renderTimelineEventContent(timelineEvent)).toEqual(undefined)
+      })
+
+      it('renders the content in a paragraph', () => {
+        const timelineEvent = cas1TimelineEventFactory.build({
+          payload: undefined,
+          content: faker.lorem.sentences(),
+        })
+
+        expect(renderTimelineEventContent(timelineEvent)).toEqual(`<p class="govuk-body">${timelineEvent.content}</p>`)
+      })
+
+      it('escapes the content before rendering it', () => {
+        const timelineEvent = cas1TimelineEventFactory.build({
+          payload: undefined,
+          content: '<script src="bad.js"/> & Nope',
+        })
+
+        expect(renderTimelineEventContent(timelineEvent)).toEqual(
+          `<p class="govuk-body">&lt;script src=&quot;bad.js&quot;/&gt; &amp; Nope</p>`,
+        )
+      })
+    })
+
+    describe('when the event type is `booking_changed`', () => {
+      const premises = cas1PremisesFactory.build()
+
+      describe('if there is no schema version', () => {
+        it('renders a basic description of changes', () => {
+          const timelineEvent = cas1TimelineEventFactory.build({
+            type: 'booking_changed',
+            payload: cas1TimelineEventContentPayloadFactory.build({
+              type: 'booking_changed',
+              premises: {
+                name: premises.name,
+                id: premises.id,
+              },
+              schemaVersion: undefined,
+              arrivalOn: '2025-04-17',
+              departureOn: '2025-06-21',
+            } as Cas1TimelineEventContentPayload),
+          })
+
+          const result = renderTimelineEventContent(timelineEvent)
+
+          expect(result).toEqual(
+            `A placement at ${premises.name} had its arrival and/or departure date changed to Thu 17 Apr 2025 to Sat 21 Jun 2025.`,
+          )
+        })
+      })
+
+      describe('if the schema version is 2', () => {
+        it('renders the content with all changes', () => {
+          const timelineEvent = cas1TimelineEventFactory.build({
+            payload: cas1TimelineEventContentPayloadFactory.build({
+              type: 'booking_changed',
+              premises: {
+                name: premises.name,
+                id: premises.id,
+              },
+              expectedArrival: '2025-09-18',
+              expectedDeparture: '2025-12-18',
+              schemaVersion: 2,
+              previousExpectedArrival: '2025-09-16',
+              previousExpectedDeparture: '2025-09-20',
+              characteristics: [
+                'acceptsNonSexualChildOffenders',
+                'isCatered',
+                'hasEnSuite',
+                'isArsonSuitable',
+                'isWheelchairDesignated',
+              ],
+              previousCharacteristics: ['acceptsNonSexualChildOffenders', 'isCatered', 'hasEnSuite'],
+            } as Cas1TimelineEventContentPayload),
+          })
+
+          const result = renderTimelineEventContent(timelineEvent)
+
+          expect(result).toMatchStringIgnoringWhitespace(`
+            <p class="govuk-body">A placement at ${premises.name} has been changed:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>Arrival date changed from Tue 16 Sep 2025 to Thu 18 Sep 2025</li>
+              <li>Departure date changed from Sat 20 Sep 2025 to Thu 18 Dec 2025</li>
+              <li>Room criteria changed from en-suite to wheelchair accessible, en-suite and suitable for active arson risk</li>
+            </ul>
+          `)
+        })
+      })
+    })
+  })
+})

--- a/server/utils/timeline.test.ts
+++ b/server/utils/timeline.test.ts
@@ -122,6 +122,25 @@ describe('timeline utilities', () => {
 
           expect(result).not.toContain('Room criteria changed from')
         })
+
+        it('renders "none" if previous or current criteria were none', () => {
+          const timelineEvent = cas1TimelineEventFactory.build({
+            payload: cas1TimelineEventContentPayloadFactory.build({
+              type: 'booking_changed',
+              premises: {
+                name: premises.name,
+                id: premises.id,
+              },
+              schemaVersion: 2,
+              characteristics: ['hasEnSuite'],
+              previousCharacteristics: [],
+            } as Cas1TimelineEventContentPayload),
+          })
+
+          const result = renderTimelineEventContent(timelineEvent)
+
+          expect(result).toContain('Room criteria changed from none to en-suite')
+        })
       })
     })
   })

--- a/server/utils/timeline.test.ts
+++ b/server/utils/timeline.test.ts
@@ -59,7 +59,7 @@ describe('timeline utilities', () => {
           const result = renderTimelineEventContent(timelineEvent)
 
           expect(result).toEqual(
-            `A placement at ${premises.name} had its arrival and/or departure date changed to Thu 17 Apr 2025 to Sat 21 Jun 2025.`,
+            `The placement at ${premises.name} had its arrival and/or departure date changed to Thu 17 Apr 2025 to Sat 21 Jun 2025.`,
           )
         })
       })
@@ -92,7 +92,7 @@ describe('timeline utilities', () => {
           const result = renderTimelineEventContent(timelineEvent)
 
           expect(result).toMatchStringIgnoringWhitespace(`
-            <p class="govuk-body">A placement at ${premises.name} has been changed:</p>
+            <p class="govuk-body">The placement at ${premises.name} has been changed:</p>
             <ul class="govuk-list govuk-list--bullet">
               <li>Arrival date changed from Tue 16 Sep 2025 to Thu 18 Sep 2025</li>
               <li>Departure date changed from Sat 20 Sep 2025 to Thu 18 Dec 2025</li>

--- a/server/utils/timeline.test.ts
+++ b/server/utils/timeline.test.ts
@@ -100,6 +100,28 @@ describe('timeline utilities', () => {
             </ul>
           `)
         })
+
+        it.each([
+          ['the same', ['hasEnSuite']],
+          ['both none', []],
+        ])('does not render room criteria changes if they are %s', (_, characteristics) => {
+          const timelineEvent = cas1TimelineEventFactory.build({
+            payload: cas1TimelineEventContentPayloadFactory.build({
+              type: 'booking_changed',
+              premises: {
+                name: premises.name,
+                id: premises.id,
+              },
+              schemaVersion: 2,
+              characteristics,
+              previousCharacteristics: characteristics,
+            } as Cas1TimelineEventContentPayload),
+          })
+
+          const result = renderTimelineEventContent(timelineEvent)
+
+          expect(result).not.toContain('Room criteria changed from')
+        })
       })
     })
   })

--- a/server/utils/timeline.ts
+++ b/server/utils/timeline.ts
@@ -42,7 +42,7 @@ export const renderTimelineEventContent = (event: Cas1TimelineEvent): string => 
         const isoDateToUiDateOrUndefined = (isoDate: string) =>
           isoDate ? DateFormats.isoDateToUIDate(isoDate) : undefined
         const roomCriteriaOrNone = (criteria: Array<Cas1SpaceCharacteristic>) =>
-          criteriaListInline(filterRoomLevelCriteria(criteria || [])) || 'None'
+          criteriaListInline(filterRoomLevelCriteria(criteria || [])) || 'none'
 
         const context = {
           premises,

--- a/server/utils/timeline.ts
+++ b/server/utils/timeline.ts
@@ -5,7 +5,8 @@ import { escape } from './formUtils'
 import { linebreaksToParagraphs } from './utils'
 import { DateFormats } from './dateUtils'
 import { filterRoomLevelCriteria } from './match/spaceSearch'
-import { criteriaListInline } from './premises/occupancy'
+
+import { characteristicsInlineList } from './characteristicsUtils'
 
 type PayloadBookingChangedV1 = Cas1TimelineEventContentPayload & {
   schemaVersion: undefined
@@ -42,7 +43,7 @@ export const renderTimelineEventContent = (event: Cas1TimelineEvent): string => 
         const isoDateToUiDateOrUndefined = (isoDate: string) =>
           isoDate ? DateFormats.isoDateToUIDate(isoDate) : undefined
         const roomCriteriaOrNone = (criteria: Array<Cas1SpaceCharacteristic>) =>
-          criteriaListInline(filterRoomLevelCriteria(criteria || [])) || 'none'
+          characteristicsInlineList(filterRoomLevelCriteria(criteria || [])) || 'none'
 
         const context = {
           premises,

--- a/server/utils/timeline.ts
+++ b/server/utils/timeline.ts
@@ -1,0 +1,71 @@
+import { Cas1SpaceCharacteristic, Cas1TimelineEvent, Cas1TimelineEventContentPayload } from '@approved-premises/api'
+import nunjucks from 'nunjucks'
+import path from 'path'
+import { escape } from './formUtils'
+import { linebreaksToParagraphs } from './utils'
+import { DateFormats } from './dateUtils'
+import { filterRoomLevelCriteria } from './match/spaceSearch'
+import { criteriaListInline } from './premises/occupancy'
+
+type PayloadBookingChangedV1 = Cas1TimelineEventContentPayload & {
+  schemaVersion: undefined
+  arrivalOn: string
+  departureOn: string
+}
+
+type PayloadBookingChangedV2 = Cas1TimelineEventContentPayload & {
+  schemaVersion: 2
+  expectedArrival: string
+  expectedDeparture: string
+  previousExpectedArrival?: string
+  previousExpectedDeparture?: string
+  characteristics: Array<Cas1SpaceCharacteristic>
+  previousCharacteristics: Array<Cas1SpaceCharacteristic>
+}
+
+export const renderTimelineEventContent = (event: Cas1TimelineEvent): string => {
+  if (event.payload) {
+    if (event.payload.type === 'booking_changed') {
+      if (event.payload.schemaVersion === 2) {
+        nunjucks.configure(path.join(__dirname, '../views/partials/timelineEvents'))
+
+        const {
+          premises,
+          expectedArrival,
+          expectedDeparture,
+          previousExpectedArrival,
+          previousExpectedDeparture,
+          characteristics,
+          previousCharacteristics,
+        } = event.payload as PayloadBookingChangedV2
+
+        const isoDateToUiDateOrUndefined = (isoDate: string) =>
+          isoDate ? DateFormats.isoDateToUIDate(isoDate) : undefined
+        const roomCriteriaOrNone = (criteria: Array<Cas1SpaceCharacteristic>) =>
+          criteriaListInline(filterRoomLevelCriteria(criteria || [])) || 'None'
+
+        const context = {
+          premises,
+          expectedArrival: isoDateToUiDateOrUndefined(expectedArrival),
+          expectedDeparture: isoDateToUiDateOrUndefined(expectedDeparture),
+          previousExpectedArrival: isoDateToUiDateOrUndefined(previousExpectedArrival),
+          previousExpectedDeparture: isoDateToUiDateOrUndefined(previousExpectedDeparture),
+          characteristics: roomCriteriaOrNone(characteristics),
+          previousCharacteristics: roomCriteriaOrNone(previousCharacteristics),
+        }
+
+        return nunjucks.render('booking_changed.njk', context)
+      }
+
+      const {
+        premises: { name: premisesName },
+        arrivalOn,
+        departureOn,
+      } = event.payload as PayloadBookingChangedV1
+
+      return `A placement at ${premisesName} had its arrival and/or departure date changed to ${DateFormats.isoDateToUIDate(arrivalOn)} to ${DateFormats.isoDateToUIDate(departureOn)}.`
+    }
+  }
+
+  return event.content ? linebreaksToParagraphs(escape(event.content)) : undefined
+}

--- a/server/utils/timeline.ts
+++ b/server/utils/timeline.ts
@@ -17,10 +17,10 @@ type PayloadBookingChangedV2 = Cas1TimelineEventContentPayload & {
   schemaVersion: 2
   expectedArrival: string
   expectedDeparture: string
-  previousExpectedArrival?: string
-  previousExpectedDeparture?: string
   characteristics: Array<Cas1SpaceCharacteristic>
-  previousCharacteristics: Array<Cas1SpaceCharacteristic>
+  previousExpectedArrival: string | null
+  previousExpectedDeparture: string | null
+  previousCharacteristics: Array<Cas1SpaceCharacteristic> | null
 }
 
 export const renderTimelineEventContent = (event: Cas1TimelineEvent): string => {
@@ -51,7 +51,7 @@ export const renderTimelineEventContent = (event: Cas1TimelineEvent): string => 
           previousExpectedArrival: isoDateToUiDateOrUndefined(previousExpectedArrival),
           previousExpectedDeparture: isoDateToUiDateOrUndefined(previousExpectedDeparture),
           characteristics: roomCriteriaOrNone(characteristics),
-          previousCharacteristics: roomCriteriaOrNone(previousCharacteristics),
+          previousCharacteristics: previousCharacteristics ? roomCriteriaOrNone(previousCharacteristics) : undefined,
         }
 
         return nunjucks.render('booking_changed.njk', context)

--- a/server/utils/timeline.ts
+++ b/server/utils/timeline.ts
@@ -63,7 +63,7 @@ export const renderTimelineEventContent = (event: Cas1TimelineEvent): string => 
         departureOn,
       } = event.payload as PayloadBookingChangedV1
 
-      return `A placement at ${premisesName} had its arrival and/or departure date changed to ${DateFormats.isoDateToUIDate(arrivalOn)} to ${DateFormats.isoDateToUIDate(departureOn)}.`
+      return `The placement at ${premisesName} had its arrival and/or departure date changed to ${DateFormats.isoDateToUIDate(arrivalOn)} to ${DateFormats.isoDateToUIDate(departureOn)}.`
     }
   }
 

--- a/server/views/applications/partials/_timeline.njk
+++ b/server/views/applications/partials/_timeline.njk
@@ -4,25 +4,26 @@
 {% from "../../partials/_applicationTimeline.njk" import applicationTimeline %}
 {% macro timeline(timelineEvents, application, csrfToken) %}
 
-  <form action="{{ paths.applications.notes.new({id: application.id}) }}" method="post">
-    <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+    <form action="{{ paths.applications.notes.new({id: application.id}) }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-    {{ govukTextarea({
-          name: "note",
-          id: "note",
-          label: {
-            text: "Add a note to the application", 
-            classes: "govuk-label--m"
-          }
+        {{ govukTextarea({
+            name: "note",
+            id: "note",
+            label: {
+                text: "Add a note to the application",
+                classes: "govuk-label--m"
+            }
         }) }}
 
-    {{ govukButton({
-        text: "Add note",
-        preventDoubleClick: true
-    }) }}
-  </form>
+        {{ govukButton({
+            text: "Add note",
+            preventDoubleClick: true
+        }) }}
+    </form>
 
-  <h2 class="govuk-heading-m">Application history</h2>
-  {{applicationTimeline(timelineEvents)}}</div>
+    <h2 class="govuk-heading-m">Application history</h2>
+
+    {{ applicationTimeline(timelineEvents) }}
 
 {% endmacro %}

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -72,8 +72,11 @@
 
             <div class="govuk-grid-column-full">
                 {% if tab === ApplyUtils.applicationShowPageTabs.timeline %}
+
                     {{ timeline(ApplyUtils.mapApplicationTimelineEventsForUi(timelineEvents), application, csrfToken) }}
+
                     {% elif tab === ApplyUtils.applicationShowPageTabs.placementRequests %}
+
                     {{ requestAPlacement(requestsForPlacement, application, user, csrfToken) }}
                 {% else %}
                     {{ applicationReadonlyView(application) }}

--- a/server/views/partials/_applicationTimeline.njk
+++ b/server/views/partials/_applicationTimeline.njk
@@ -4,33 +4,36 @@
             <div class="moj-timeline__item">
 
                 <div class="moj-timeline__header">
-                    <h3 class="moj-timeline__title">{{event.label.text}}</h3>
+                    <h3 class="moj-timeline__title">{{ event.label.text }}</h3>
                     {% if event.createdBy %}
-                        <p class="moj-timeline__byline">by {{event.createdBy}}</p>
-                        {%endif%}
-                    </div>
-
-                    <p class="moj-timeline__date">
-                        <time datetime="{{event.datetime.timestamp}}">{{event.datetime.date}}</time>
-                    </p>
-
-                    {% if event.content %}
-                        <div class="moj-timeline__description">
-                            {{ event.content | linebreaksToParagraphs | safe }}
-                        </div>
-                        {%endif%}
-                        {% if event.associatedUrls %}
-                            {% for associatedUrl in event.associatedUrls %}
-                                <div class="moj-timeline__description">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li>
-                                            <a class="govuk-link" href="{{associatedUrl.url}}">View {{associatedUrl.type}}</a>
-                                        </li>
-                                    </ul>
-                                </div>
-                            {% endfor %}
-                            {%endif%}
-                        </div>
-                    {% endfor %}
+                        <p class="moj-timeline__byline">by {{ event.createdBy }}</p>
+                    {% endif %}
                 </div>
-                {%endmacro%}
+
+                <p class="moj-timeline__date">
+                    <time datetime="{{ event.datetime.timestamp }}">{{ event.datetime.date }}</time>
+                </p>
+
+                {% if event.content %}
+                    <div class="moj-timeline__description">
+                        {{ event.content | safe }}
+                    </div>
+                {% endif %}
+
+                {% if event.associatedUrls %}
+                    <div class="moj-timeline__description">
+                        <ul class="govuk-list govuk-list--bullet">
+                            {% for associatedUrl in event.associatedUrls %}
+                                <li>
+                                    <a class="govuk-link"
+                                       href="{{ associatedUrl.url }}">View {{ associatedUrl.type }}</a>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                {% endif %}
+            </div>
+
+        {% endfor %}
+    </div>
+{% endmacro %}

--- a/server/views/partials/timelineEvents/booking_changed.njk
+++ b/server/views/partials/timelineEvents/booking_changed.njk
@@ -1,0 +1,12 @@
+<p class="govuk-body">A placement at {{ premises.name }} has been changed:</p>
+<ul class="govuk-list govuk-list--bullet">
+    {% if previousExpectedArrival %}
+        <li>Arrival date changed from {{ previousExpectedArrival }} to {{ expectedArrival }}</li>
+    {% endif %}
+    {% if previousExpectedDeparture %}
+        <li>Departure date changed from {{ previousExpectedDeparture }} to {{ expectedDeparture }}</li>
+    {% endif %}
+    {% if previousCharacteristics !== 'None' or characteristics !== 'None' %}
+        <li>Room criteria changed from {{ previousCharacteristics }} to {{ characteristics }}</li>
+    {% endif %}
+</ul>

--- a/server/views/partials/timelineEvents/booking_changed.njk
+++ b/server/views/partials/timelineEvents/booking_changed.njk
@@ -1,4 +1,4 @@
-<p class="govuk-body">A placement at {{ premises.name }} has been changed:</p>
+<p class="govuk-body">The placement at {{ premises.name }} has been changed:</p>
 <ul class="govuk-list govuk-list--bullet">
     {% if previousExpectedArrival %}
         <li>Arrival date changed from {{ previousExpectedArrival }} to {{ expectedArrival }}</li>

--- a/server/views/partials/timelineEvents/booking_changed.njk
+++ b/server/views/partials/timelineEvents/booking_changed.njk
@@ -9,4 +9,7 @@
     {% if previousCharacteristics %}
         <li>Room criteria changed from {{ previousCharacteristics }} to {{ characteristics }}</li>
     {% endif %}
+    {% if not previousExpectedArrival and not previousExpectedDeparture and not previousCharacteristics %}
+        <li>No change</li>
+    {% endif %}
 </ul>

--- a/server/views/partials/timelineEvents/booking_changed.njk
+++ b/server/views/partials/timelineEvents/booking_changed.njk
@@ -6,7 +6,7 @@
     {% if previousExpectedDeparture %}
         <li>Departure date changed from {{ previousExpectedDeparture }} to {{ expectedDeparture }}</li>
     {% endif %}
-    {% if previousCharacteristics !== characteristics %}
+    {% if previousCharacteristics %}
         <li>Room criteria changed from {{ previousCharacteristics }} to {{ characteristics }}</li>
     {% endif %}
 </ul>

--- a/server/views/partials/timelineEvents/booking_changed.njk
+++ b/server/views/partials/timelineEvents/booking_changed.njk
@@ -6,7 +6,7 @@
     {% if previousExpectedDeparture %}
         <li>Departure date changed from {{ previousExpectedDeparture }} to {{ expectedDeparture }}</li>
     {% endif %}
-    {% if previousCharacteristics !== 'None' or characteristics !== 'None' %}
+    {% if previousCharacteristics !== characteristics %}
         <li>Room criteria changed from {{ previousCharacteristics }} to {{ characteristics }}</li>
     {% endif %}
 </ul>


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1831

# Changes in this PR

If the timeline event has a payload of type `booking_changed`, this now uses a template to render the content of the timeline event. I took some liberty to make the template more readable, by actually listing the changes next to bullet points.

This PR also tidies up the markup used for timelines, which had some incorrectly nested elements.

_NOTE: the API currently returns an empty list for `previousCharacteristics` when there has been no change to the room criteria. This means the UI is unable to determine whether there has been no change, or there has been a change from no criteria to a new set. https://dsdmoj.atlassian.net/browse/APS-2013 should eventually fix this, with no further change required to the UI._

## Screenshots of UI changes

<img width="978" alt="Screenshot 2025-02-20 at 15 43 07" src="https://github.com/user-attachments/assets/ae4d90aa-788c-4a82-80a3-631dd41e0681" />


