### PR TITLE
APS-1885 First class fields in short-notice assessment

### DIFF
--- a/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness.ts
@@ -24,6 +24,12 @@ export type ApplicationDetails = {
   arrivalDate: string
 }
 
+export type ApplicationTimelinessBody = {
+  agreeWithShortNoticeReason: YesOrNo
+  agreeWithShortNoticeReasonComments?: string
+  reasonForLateApplication: ShortNoticeReasons
+}
+
 @Page({
   name: 'application-timeliness',
   bodyProperties: ['agreeWithShortNoticeReason', 'agreeWithShortNoticeReasonComments', 'reasonForLateApplication'],
@@ -45,11 +51,7 @@ export default class ApplicationTimeliness implements TasklistPage {
   }))
 
   constructor(
-    public body: {
-      agreeWithShortNoticeReason: YesOrNo
-      agreeWithShortNoticeReasonComments?: string
-      reasonForLateApplication: ShortNoticeReasons
-    },
+    public body: ApplicationTimelinessBody,
     private readonly assessment: Assessment,
   ) {
     this.applicationDetails = this.retrieveShortNoticeApplicationDetails()

--- a/server/utils/assessments/acceptanceData.ts
+++ b/server/utils/assessments/acceptanceData.ts
@@ -6,6 +6,7 @@ import {
   PlacementDates,
   PlacementRequirements,
 } from '@approved-premises/api'
+import { ShortNoticeReasons } from '../../form-pages/apply/reasons-for-placement/basic-information/reasonForShortNotice'
 import { pageDataFromApplicationOrAssessment } from '../../form-pages/utils'
 import {
   retrieveOptionalQuestionResponseFromFormArtifact,
@@ -26,6 +27,8 @@ import {
 } from '../placementCriteriaUtils'
 import { placementDurationFromApplication } from './placementDurationFromApplication'
 import { getResponses } from '../applications/getResponses'
+import ApplicationTimeliness from '../../form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness'
+import type { ApplicationTimelinessBody } from '../../form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness'
 
 export const acceptanceData = (assessment: Assessment): AssessmentAcceptance => {
   const notes = retrieveOptionalQuestionResponseFromFormArtifact(assessment, MatchingInformation, 'cruInformation')
@@ -36,6 +39,7 @@ export const acceptanceData = (assessment: Assessment): AssessmentAcceptance => 
     placementDates: placementDates(assessment),
     notes,
     apType: apTypeFromAssessment(assessment),
+    ...timelinessDataFromAssessment(assessment),
   }
 }
 
@@ -59,6 +63,25 @@ export const placementDates = (assessment: Assessment): PlacementDates | null =>
 export const apTypeFromAssessment = (assessment: Assessment): ApType => {
   const assessApType = retrieveQuestionResponseFromFormArtifact(assessment, MatchingInformation, 'apType')
   return apType(assessApType)
+}
+
+export const timelinessDataFromAssessment = (
+  assessment: Assessment,
+): {
+  agreeWithShortNoticeReasonComments?: string
+  agreeWithShortNoticeReason?: boolean
+  reasonForLateApplication?: ShortNoticeReasons
+} => {
+  const { agreeWithShortNoticeReason, agreeWithShortNoticeReasonComments, reasonForLateApplication } =
+    pageDataFromApplicationOrAssessment(ApplicationTimeliness, assessment) as ApplicationTimelinessBody
+  let data = {}
+  if (agreeWithShortNoticeReason) {
+    data = { agreeWithShortNoticeReasonComments, agreeWithShortNoticeReason: agreeWithShortNoticeReason === 'yes' }
+    if (agreeWithShortNoticeReason === 'no') {
+      data = { ...data, reasonForLateApplication }
+    }
+  }
+  return data
 }
 
 export const placementRequestData = (assessment: Assessment): PlacementRequirements => {


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1885

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Adds the fields     `agreeWithShortNoticeReason`, `agreeWithShortNoticeReasonComments` and `reasonForLateApplication` to the assessmentAcceptance.
`reasonForLateApplication` will only be included if `agreeWithShortNoticeReason` is false, i.e. the user answered 'no'.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

No UI changes

