### PR TITLE
Remove deprecated reports

### DIFF
--- a/e2e/pages/admin/reports.ts
+++ b/e2e/pages/admin/reports.ts
@@ -8,18 +8,13 @@ export class ReportsPage extends BasePage {
     return new ReportsPage(page)
   }
 
-  async downloadLostBedsReports({ month, year }: { month: string; year: string }) {
-    await this.checkRadio('Lost beds (no longer in use)')
+  async downloadOutOfServiceBedsReports({ month, year }: { month: string; year: string }) {
+    await this.checkRadio('Out of service beds')
     return this.downloadReports({ month, year })
   }
 
-  async downloadApplicationsReports({ month, year }: { month: string; year: string }) {
-    await this.checkRadio('Raw combined applications and placement requests')
-    return this.downloadReports({ month, year })
-  }
-
-  async downloadRawRequestsForPlacementsReports({ month, year }: { month: string; year: string }) {
-    await this.checkRadio('Raw requests for placement')
+  async downloadDailyMetricsReports({ month, year }: { month: string; year: string }) {
+    await this.checkRadio('Daily metrics')
     return this.downloadReports({ month, year })
   }
 

--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -26,15 +26,15 @@ test('download reports', async ({ page, reportViewer }) => {
   const month = '01'
   const year = '2023'
 
-  // When I download the lost beds report
-  const lostBedsDownload = await reportsPage.downloadLostBedsReports({ month, year })
+  // When I download the out of service beds report
+  const lostBedsDownload = await reportsPage.downloadOutOfServiceBedsReports({ month, year })
   // Then the file should be downloaded with the correct suggested name
-  expect(lostBedsDownload.suggestedFilename()).toMatch(/lost-beds-2023-01-[0-9_]*.xlsx/)
+  expect(lostBedsDownload.suggestedFilename()).toMatch(/out-of-service-beds-2023-01-[0-9_]*.xlsx/)
 
-  // When I download the applications report
-  const applicationsDownload = await reportsPage.downloadRawRequestsForPlacementsReports({ month, year })
+  // When I download the daily metrics report
+  const applicationsDownload = await reportsPage.downloadDailyMetricsReports({ month, year })
   // Then the file should be downloaded with the correct suggested name
-  expect(applicationsDownload.suggestedFilename()).toMatch(/placement-applications-2023-01-[0-9_]*.xlsx/)
+  expect(applicationsDownload.suggestedFilename()).toMatch(/daily-metrics-2023-01-[0-9_]*.xlsx/)
 })
 
 test('manage users', async ({ page, userToAddAndDelete, administrator }) => {

--- a/server/utils/reportUtils.test.ts
+++ b/server/utils/reportUtils.test.ts
@@ -5,34 +5,6 @@ describe('reportUtils', () => {
     it('should return a list of report options', () => {
       expect(reportOptions).toEqual([
         {
-          value: 'applications',
-          text: 'Raw Applications',
-          hint: {
-            text: 'A raw data extract for applications submitted within the month. Includes data up to the point of assessment completion.',
-          },
-        },
-        {
-          value: 'placementApplications',
-          text: 'Raw requests for placement',
-          hint: {
-            text: 'A raw data extract for request for placements created within the month. Includes application data, but does not include matching or booking data.',
-          },
-        },
-        {
-          value: 'placementMatchingOutcomes',
-          text: 'Raw data for Placement matching outcomes',
-          hint: {
-            text: 'A raw data extract to help identify placement matching outcomes. This downloads Match requests based on the Expected Arrival Date.',
-          },
-        },
-        {
-          value: 'lostBeds',
-          text: 'Lost beds (no longer in use)',
-          hint: {
-            text: 'This report provides information on lost beds recorded before out of service beds functionality was enabled. This will be removed in the near future.',
-          },
-        },
-        {
           value: 'outOfServiceBeds',
           text: 'Out of service beds',
           hint: {

--- a/server/utils/reportUtils.ts
+++ b/server/utils/reportUtils.ts
@@ -32,7 +32,12 @@ export const reportInputLabels = {
 
 export type ReportType = (keyof typeof reportInputLabels)[number]
 
-export const unusedReports = [] as Array<string>
+export const unusedReports = [
+  'applications',
+  'placementApplications',
+  'placementMatchingOutcomes',
+  'lostBeds',
+] as Array<string>
 
 export const reportOptions = Object.entries(reportInputLabels)
   .filter(([reportName]) => {


### PR DESCRIPTION
This commit removes reports that should no longer be used as they have been superseded by newer versions

## Screenshots of UI changes

### Before

![Screenshot 2025-02-19 at 08 35 10](https://github.com/user-attachments/assets/00c378dc-e6ae-43cd-8a2a-f494629b2db9)

### After

![Screenshot 2025-02-18 at 12 48 25](https://github.com/user-attachments/assets/f9f6493f-0d5c-4658-856e-411f718e88c9)
