### PR TITLE
APS-1912 Extend booking

### DIFF
--- a/integration_tests/pages/manage/placements/changes/new.ts
+++ b/integration_tests/pages/manage/placements/changes/new.ts
@@ -1,20 +1,31 @@
 import { Cas1SpaceBooking } from '@approved-premises/api'
 import OccupancyFilterPage from '../../../shared/occupancyFilterPage'
 import { placementOverviewSummary } from '../../../../../server/utils/placements'
+import paths from '../../../../../server/paths/manage'
+import { DateFormats, daysToWeeksAndDays } from '../../../../../server/utils/dateUtils'
 
 export class ChangePlacementPage extends OccupancyFilterPage {
   constructor(private readonly placement: Cas1SpaceBooking) {
-    super('Change placement')
+    super(placement.actualArrivalDateOnly ? 'Extend placement' : 'Change placement')
+  }
+
+  static visit(placement: Cas1SpaceBooking): ChangePlacementPage {
+    cy.visit(paths.premises.placements.changes.new({ placementId: placement.id, premisesId: placement.premises.id }))
+    return new ChangePlacementPage(placement)
   }
 
   shouldShowPlacementOverview() {
     this.shouldContainSummaryListItems(placementOverviewSummary(this.placement).rows)
   }
 
+  shouldShowCalendarHeading(startDate, durationDays) {
+    cy.get('h2').contains(
+      `View availability for ${DateFormats.formatDuration(daysToWeeksAndDays(durationDays))} from ${DateFormats.isoDateToUIDate(startDate, { format: 'short' })}`,
+    )
+  }
+
   completeForm(arrivalDate: string, departureDate: string) {
-    this.clearDateInputs('arrivalDate')
-    this.completeDateInputs('arrivalDate', arrivalDate)
-    this.clearDateInputs('departureDate')
-    this.completeDateInputs('departureDate', departureDate)
+    this.clearAndCompleteDateInputs('arrivalDate', arrivalDate)
+    this.clearAndCompleteDateInputs('departureDate', departureDate)
   }
 }

--- a/integration_tests/tests/manage/placements/changes.cy.ts
+++ b/integration_tests/tests/manage/placements/changes.cy.ts
@@ -17,6 +17,8 @@ import { DateFormats } from '../../../../server/utils/dateUtils'
 import ChangePlacementConfirmPage from '../../../pages/manage/placements/changes/confirm'
 import apiPaths from '../../../../server/paths/api'
 import { roomCharacteristicMap } from '../../../../server/utils/characteristicsUtils'
+import { Cas1SpaceBooking } from '../../../../server/@types/shared/models/Cas1SpaceBooking'
+import { Cas1UpdateSpaceBooking } from '../../../../server/@types/shared/models/Cas1UpdateSpaceBooking'
 
 context('Change Placement', () => {
   const expectedArrivalDate = DateFormats.dateObjToIsoDate(faker.date.soon())
@@ -24,18 +26,27 @@ context('Change Placement', () => {
 
   const person = fullPersonFactory.build()
   const premises = cas1PremisesFactory.build()
-  const placement = cas1SpaceBookingFactory.upcoming().build({
-    premises: { name: premises.name, id: premises.id },
-    expectedArrivalDate,
-    expectedDepartureDate,
-  })
-  const placementRequestDetail = placementRequestDetailFactory.build({
-    person,
-    status: 'matched',
-    booking: bookingSummaryFactory.fromSpaceBooking(placement).build(),
-  })
-  placement.requestForPlacementId = placementRequestDetail.id
-  const capacity = cas1PremiseCapacityFactory.build()
+
+  const setupMocks = (placement: Cas1SpaceBooking, startDate?: string, endDate?: string) => {
+    const placementRequestDetail = placementRequestDetailFactory.build({
+      person,
+      status: 'matched',
+      booking: bookingSummaryFactory.fromSpaceBooking(placement).build(),
+    })
+    placement.requestForPlacementId = placementRequestDetail.id
+    const capacity = cas1PremiseCapacityFactory.build()
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubPremiseCapacity', {
+      premisesId: premises.id,
+      premiseCapacity: capacity,
+      startDate: startDate || placement.expectedArrivalDate,
+      endDate: endDate || placement.expectedDepartureDate,
+    })
+    cy.task('stubPlacementRequest', placementRequestDetail)
+    cy.task('stubSpaceBookingGetWithoutPremises', placement)
+    cy.task('stubSpaceBookingUpdate', { premisesId: premises.id, placementId: placement.id })
+    return { placement, placementRequestDetail }
+  }
 
   beforeEach(() => {
     cy.task('reset')
@@ -44,21 +55,15 @@ context('Change Placement', () => {
 
     // Given I am signed in
     signIn(['workflow_manager', 'future_manager'], ['cas1_space_booking_create'])
-
-    cy.task('stubSinglePremises', premises)
-    cy.task('stubPremiseCapacity', {
-      premisesId: premises.id,
-      premiseCapacity: capacity,
-      startDate: placement.expectedArrivalDate,
-      endDate: placement.expectedDepartureDate,
-      excludeSpaceBookingId: placement.id,
-    })
-    cy.task('stubPlacementRequest', placementRequestDetail)
-    cy.task('stubSpaceBookingGetWithoutPremises', placement)
-    cy.task('stubSpaceBookingUpdate', { premisesId: premises.id, placementId: placement.id })
   })
 
   it('allows me to change the dates and criteria of a space booking', () => {
+    const placement = cas1SpaceBookingFactory.upcoming().build({
+      premises: { name: premises.name, id: premises.id },
+      expectedArrivalDate,
+      expectedDepartureDate,
+    })
+    const { placementRequestDetail } = setupMocks(placement)
     // When I visit a placement request
     const placementRequestPage = ShowPage.visit(placementRequestDetail)
 
@@ -72,7 +77,7 @@ context('Change Placement', () => {
     changePlacementPage.shouldShowPlacementOverview()
 
     // And I should see the filter form with default populated values from the placement
-    const selectedCriteria = filterRoomLevelCriteria(placement.requirements.essentialCharacteristics)
+    const selectedCriteria = filterRoomLevelCriteria(placement.characteristics)
     const selectedCriteriaLabels = selectedCriteria.map(criterion => roomCharacteristicMap[criterion])
     changePlacementPage.shouldShowFilters(placement.expectedArrivalDate, 'Up to 12 weeks', selectedCriteriaLabels)
 
@@ -82,11 +87,11 @@ context('Change Placement', () => {
     // And I can see the current placement dates in the hints
     changePlacementPage.shouldShowDateFieldHint(
       'arrivalDate',
-      `Expected arrival date: ${DateFormats.isoDateToUIDate(placement.expectedArrivalDate, { format: 'dateFieldHint' })}`,
+      `Current arrival date: ${DateFormats.isoDateToUIDate(placement.expectedArrivalDate, { format: 'dateFieldHint' })}`,
     )
     changePlacementPage.shouldShowDateFieldHint(
       'departureDate',
-      `Expected departure date: ${DateFormats.isoDateToUIDate(placement.expectedDepartureDate, { format: 'dateFieldHint' })}`,
+      `Current departure date: ${DateFormats.isoDateToUIDate(placement.expectedDepartureDate, { format: 'dateFieldHint' })}`,
     )
 
     // When I submit the filters with an invalid date
@@ -152,6 +157,77 @@ context('Change Placement', () => {
         departureDate,
         characteristics: criteria,
       })
+    })
+  })
+
+  it('allows me to extend the end date of placement after arrival', () => {
+    const actualArrivalDateOnly = DateFormats.dateObjToIsoDate(addDays(expectedArrivalDate, 20))
+    const arrivedPlacement = cas1SpaceBookingFactory.upcoming().build({
+      premises: { name: premises.name, id: premises.id },
+      expectedArrivalDate,
+      expectedDepartureDate: DateFormats.dateObjToIsoDate(addDays(expectedArrivalDate, 45)),
+      actualArrivalDateOnly,
+    })
+    const newDepartureDate = DateFormats.dateObjToIsoDate(addDays(arrivedPlacement.expectedDepartureDate, 5))
+
+    const { placementRequestDetail } = setupMocks(
+      arrivedPlacement,
+      actualArrivalDateOnly,
+      DateFormats.dateObjToIsoDate(addDays(actualArrivalDateOnly, 56)),
+    )
+    // When I visit a placement request
+
+    const placementRequestPage = ShowPage.visit(placementRequestDetail)
+
+    // When I click on the amend booking button
+    placementRequestPage.clickAction('Change placement')
+
+    // Then I should see the Change Placement page
+    const page = Page.verifyOnPage(ChangePlacementPage, arrivedPlacement)
+
+    // And I should see an overview of the placement
+    page.shouldShowPlacementOverview()
+
+    // And I can see the calendar for the rounded-up period in the duration selector, from the actual arrival date
+    page.shouldShowCalendarHeading(actualArrivalDateOnly, 56)
+
+    // And I can see the current placement dates in the departure date hint
+    page.shouldShowDateFieldHint(
+      'departureDate',
+      `Current departure date: ${DateFormats.isoDateToUIDate(arrivedPlacement.expectedDepartureDate, { format: 'dateFieldHint' })}`,
+    )
+    // And I should only be able to change the departure date
+    cy.get('h2').contains('Change placement')
+
+    // When I set a new departure date and submit
+    page.clearAndCompleteDateInputs('departureDate', newDepartureDate)
+    page.clickContinue()
+
+    // Then I should see the confirmation page with the correct dates
+    const confirmPage = Page.verifyOnPage(ChangePlacementConfirmPage, premises, {
+      arrivalDate: arrivedPlacement.expectedArrivalDate,
+      departureDate: DateFormats.dateObjToIsoDate(addDays(arrivedPlacement.expectedDepartureDate, 5)),
+      criteria: arrivedPlacement.characteristics.filter(characteristic => roomCharacteristicMap[characteristic]),
+    })
+    confirmPage.shouldShowProposedChanges()
+
+    // When I submit the confirmation page
+    confirmPage.clickSubmit()
+
+    // Then I should see the placement request page again with a success banner
+    Page.verifyOnPage(ShowPage, placementRequestDetail)
+
+    placementRequestPage.shouldShowBanner('Booking changed successfully')
+
+    // And the booking changes should have been sent to the API
+    cy.task('verifyApiPatch', apiPaths.premises.placements.show).then(body => {
+      const { characteristics, arrivalDate, departureDate } = body as Cas1UpdateSpaceBooking
+
+      expect(arrivalDate).equal(undefined)
+      expect(departureDate).equal(newDepartureDate)
+      expect(characteristics.sort()).to.deep.equal(
+        arrivedPlacement.characteristics.filter(characteristic => roomCharacteristicMap[characteristic]).sort(),
+      )
     })
   })
 })

--- a/server/controllers/manage/premises/placements/changesController.test.ts
+++ b/server/controllers/manage/premises/placements/changesController.test.ts
@@ -61,7 +61,7 @@ describe('changesController', () => {
       const requestHandler = changesController.new()
       await requestHandler(request, response, next)
 
-      const expectedCriteria = filterRoomLevelCriteria(placement.requirements.essentialCharacteristics)
+      const expectedCriteria = filterRoomLevelCriteria(placement.characteristics)
       const expectedPlaceholderDayUrl = `${matchPaths.v2Match.placementRequests.search.dayOccupancy({
         id: placement.requestForPlacementId,
         premisesId: premises.id,
@@ -80,8 +80,8 @@ describe('changesController', () => {
         pageHeading: 'Change placement',
         placement,
         selectedCriteria: expectedCriteria.map(criterion => roomCharacteristicMap[criterion]).join(', '),
-        arrivalDateHint: `Expected arrival date: ${DateFormats.isoDateToUIDate(placement.expectedArrivalDate, { format: 'dateFieldHint' })}`,
-        departureDateHint: `Expected departure date: ${DateFormats.isoDateToUIDate(placement.expectedDepartureDate, { format: 'dateFieldHint' })}`,
+        arrivalDateHint: `Current arrival date: ${DateFormats.isoDateToUIDate(placement.expectedArrivalDate, { format: 'dateFieldHint' })}`,
+        departureDateHint: `Current departure date: ${DateFormats.isoDateToUIDate(placement.expectedDepartureDate, { format: 'dateFieldHint' })}`,
         placementSummary: placementOverviewSummary(placement),
         durationOptions: durationSelectOptions(expectedDuration),
         criteriaOptions: convertKeyValuePairToCheckBoxItems(roomCharacteristicMap, expectedCriteria),

--- a/server/controllers/manage/premises/placements/changesController.ts
+++ b/server/controllers/manage/premises/placements/changesController.ts
@@ -21,7 +21,7 @@ import { createQueryString, makeArrayOfType } from '../../../../utils/utils'
 import { DateFormats, dateAndTimeInputsAreValidDates } from '../../../../utils/dateUtils'
 import { CriteriaQuery } from '../../../match/placementRequests/occupancyViewController'
 import { convertKeyValuePairToCheckBoxItems } from '../../../../utils/formUtils'
-import { durationSelectOptions } from '../../../../utils/match/occupancy'
+import { durationSelectOptions, getClosestDuration } from '../../../../utils/match/occupancy'
 import { OccupancySummary } from '../../../../utils/match/occupancySummary'
 import managePaths from '../../../../paths/manage'
 import matchPaths from '../../../../paths/match'
@@ -43,6 +43,7 @@ interface ViewRequest extends Request {
   body: ObjectWithDateParts<'arrivalDate'> &
     ObjectWithDateParts<'departureDate'> & {
       criteria: string
+      actualArrivalDate: string
     }
 }
 
@@ -80,13 +81,19 @@ export default class ChangesController {
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
       const placement = await this.placementService.getPlacement(token, placementId)
-
+      let pageHeading = 'Change placement'
       let startDate = placement.expectedArrivalDate
       let endDate = placement.expectedDepartureDate
       let durationDays = differenceInDays(endDate, startDate)
-      let criteria: Array<Cas1SpaceBookingCharacteristic> = filterRoomLevelCriteria(
-        placement.requirements.essentialCharacteristics,
-      )
+
+      if (placement.actualArrivalDateOnly) {
+        startDate = placement.actualArrivalDateOnly
+        endDate = DateFormats.dateObjToIsoDate(addDays(startDate, getClosestDuration(durationDays)))
+        durationDays = differenceInDays(endDate, startDate)
+        pageHeading = 'Extend placement'
+      }
+
+      let criteria: Array<Cas1SpaceBookingCharacteristic> = filterRoomLevelCriteria(placement.characteristics)
 
       if (queryDurationDays) {
         durationDays = Number(queryDurationDays)
@@ -131,11 +138,11 @@ export default class ChangesController {
 
       return res.render('manage/premises/placements/changes/new', {
         backlink: adminPaths.admin.placementRequests.show({ id: placement.requestForPlacementId }),
-        pageHeading: 'Change placement',
+        pageHeading,
         placement,
         selectedCriteria: (criteria || []).map(criterion => roomCharacteristicMap[criterion]).join(', '),
-        arrivalDateHint: `Expected arrival date: ${DateFormats.isoDateToUIDate(placement.expectedArrivalDate, { format: 'dateFieldHint' })}`,
-        departureDateHint: `Expected departure date: ${DateFormats.isoDateToUIDate(placement.expectedDepartureDate, { format: 'dateFieldHint' })}`,
+        arrivalDateHint: `Current arrival date: ${DateFormats.isoDateToUIDate(placement.expectedArrivalDate, { format: 'dateFieldHint' })}`,
+        departureDateHint: `Current departure date: ${DateFormats.isoDateToUIDate(placement.expectedDepartureDate, { format: 'dateFieldHint' })}`,
         startDate,
         ...DateFormats.isoDateToDateInputs(startDate, 'startDate'),
         durationDays,
@@ -200,7 +207,6 @@ export default class ChangesController {
         this.premisesService.find(token, premisesId),
         this.placementService.getPlacement(token, placementId),
       ])
-
       const backlink = `${managePaths.premises.placements.changes.new(req.params)}${createQueryString(req.query, {
         arrayFormat: 'repeat',
         addQueryPrefix: true,
@@ -212,7 +218,7 @@ export default class ChangesController {
         placement,
         summaryListRows: spaceBookingConfirmationSummaryListRows(
           premises,
-          arrivalDate,
+          arrivalDate || placement.expectedArrivalDate,
           departureDate,
           makeArrayOfType<Cas1SpaceBookingCharacteristic>(criteria) || [],
         ),

--- a/server/utils/match/occupancy.ts
+++ b/server/utils/match/occupancy.ts
@@ -54,13 +54,13 @@ const durationOptionsMap: Record<number, string> = {
   '364': 'Up to 52 weeks',
 }
 
-export const durationSelectOptions = (duration?: number): Array<SelectOption> => {
-  let selected: string
+export const getClosestDuration = (duration: number): number => {
+  const values = Object.keys(durationOptionsMap)
+  return duration && Number(values.filter(value => Number(value) >= duration)[0] || values.slice(-1))
+}
 
-  if (duration) {
-    const values = Object.keys(durationOptionsMap)
-    selected = String(values.filter(value => Number(value) >= duration)[0] || values.slice(-1))
-  }
+export const durationSelectOptions = (duration?: number): Array<SelectOption> => {
+  const selected: string = String(getClosestDuration(duration))
 
   return Object.entries(durationOptionsMap).map(([value, label]) => ({
     value,

--- a/server/utils/match/validateSpaceBooking.ts
+++ b/server/utils/match/validateSpaceBooking.ts
@@ -3,13 +3,14 @@ import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank, datetimeIsInT
 
 export const validateSpaceBooking = (body: ObjectWithDateParts<string>): Record<string, string> => {
   const errors: Record<string, string> = {}
-
-  if (dateIsBlank(body, 'arrivalDate')) {
-    errors.arrivalDate = 'You must enter an arrival date'
-  } else if (!dateAndTimeInputsAreValidDates(body as ObjectWithDateParts<'arrivalDate'>, 'arrivalDate')) {
-    errors.arrivalDate = 'The arrival date is an invalid date'
+  const { actualArrivalDate } = body
+  if (!actualArrivalDate) {
+    if (dateIsBlank(body, 'arrivalDate')) {
+      errors.arrivalDate = 'You must enter an arrival date'
+    } else if (!dateAndTimeInputsAreValidDates(body as ObjectWithDateParts<'arrivalDate'>, 'arrivalDate')) {
+      errors.arrivalDate = 'The arrival date is an invalid date'
+    }
   }
-
   if (dateIsBlank(body, 'departureDate')) {
     errors.departureDate = 'You must enter a departure date'
   } else if (!dateAndTimeInputsAreValidDates(body as ObjectWithDateParts<'departureDate'>, 'departureDate')) {
@@ -25,7 +26,8 @@ export const validateSpaceBooking = (body: ObjectWithDateParts<string>): Record<
       body as ObjectWithDateParts<'departureDate'>,
       'departureDate',
     )
-    if (datetimeIsInThePast(departureDate, arrivalDate) || departureDate === arrivalDate) {
+    const textArrivalDate = actualArrivalDate || arrivalDate
+    if (datetimeIsInThePast(departureDate, textArrivalDate) || departureDate === textArrivalDate) {
       errors.departureDate = 'The departure date must be after the arrival date'
     }
   }

--- a/server/utils/placements/index.test.ts
+++ b/server/utils/placements/index.test.ts
@@ -160,9 +160,7 @@ describe('placementUtils', () => {
       actualArrivalDateOnly: '2024-06-01',
       actualDepartureDateOnly: '2024-12-25',
       createdAt: '2024-03-03',
-      requirements: {
-        essentialCharacteristics: ['isESAP', 'acceptsNonSexualChildOffenders', 'hasEnSuite'],
-      },
+      characteristics: ['isESAP', 'acceptsNonSexualChildOffenders', 'hasEnSuite'],
     })
 
     it('should return the placement summary information', () => {
@@ -181,17 +179,41 @@ describe('placementUtils', () => {
       })
     })
 
-    it('should return an overview of the placement summary information', () => {
-      const expectedSpaceTypeHtml = `<ul class="govuk-list govuk-list--bullet"><li>En-suite</li></ul>`
+    describe('Overview placement summary', () => {
+      it('should return an overview of the placement summary information before arrival', () => {
+        const unarrivedPlacement: Cas1SpaceBooking = {
+          ...placement,
+          actualArrivalDateOnly: undefined,
+          actualDepartureDateOnly: undefined,
+        }
 
-      expect(placementOverviewSummary(placement)).toEqual({
-        rows: [
-          { key: { text: 'Approved premises' }, value: { text: placement.premises.name } },
-          { key: { text: 'Date of match' }, value: { text: 'Sun 3 Mar 2024' } },
-          { key: { text: 'Expected arrival date' }, value: { text: 'Thu 30 May 2024' } },
-          { key: { text: 'Expected departure date' }, value: { text: 'Tue 24 Dec 2024' } },
-          { key: { text: 'Room criteria' }, value: { html: expectedSpaceTypeHtml } },
-        ],
+        expect(placementOverviewSummary(unarrivedPlacement)).toEqual({
+          rows: [
+            { key: { text: 'Approved premises' }, value: { text: unarrivedPlacement.premises.name } },
+            { key: { text: 'Date of match' }, value: { text: 'Sun 3 Mar 2024' } },
+            { key: { text: 'Expected arrival date' }, value: { text: 'Thu 30 May 2024' } },
+            { key: { text: 'Expected departure date' }, value: { text: 'Tue 24 Dec 2024' } },
+            {
+              key: { text: 'Room criteria' },
+              value: { html: `<ul class="govuk-list govuk-list--bullet"><li>En-suite</li></ul>` },
+            },
+          ],
+        })
+      })
+
+      it('should return an overview of the placement summary information after arrival', () => {
+        const expectedSpaceTypeHtml = `<ul class="govuk-list govuk-list--bullet"><li>En-suite</li></ul>`
+
+        expect(placementOverviewSummary(placement)).toEqual({
+          rows: [
+            { key: { text: 'Approved premises' }, value: { text: placement.premises.name } },
+            { key: { text: 'Date of match' }, value: { text: 'Sun 3 Mar 2024' } },
+            { key: { text: 'Expected arrival date' }, value: { text: 'Thu 30 May 2024' } },
+            { key: { text: 'Actual arrival date' }, value: { text: 'Sat 1 Jun 2024' } },
+            { key: { text: 'Expected departure date' }, value: { text: 'Tue 24 Dec 2024' } },
+            { key: { text: 'Room criteria' }, value: { html: expectedSpaceTypeHtml } },
+          ],
+        })
       })
     })
 
@@ -339,9 +361,7 @@ describe('placementUtils', () => {
     describe('requirements information', () => {
       it('should be returned for a placement in a standard AP', () => {
         const placementStandardAp = cas1SpaceBookingFactory.build({
-          requirements: {
-            essentialCharacteristics: ['acceptsChildSexOffenders', 'acceptsNonSexualChildOffenders', 'hasEnSuite'],
-          },
+          characteristics: ['acceptsChildSexOffenders', 'acceptsNonSexualChildOffenders', 'hasEnSuite'],
         })
 
         expect(requirementsInformation(placementStandardAp)).toEqual({
@@ -358,9 +378,7 @@ describe('placementUtils', () => {
 
       it('should be returned for a placement in a specialist AP', () => {
         const placementSpecialistAp = cas1SpaceBookingFactory.build({
-          requirements: {
-            essentialCharacteristics: ['isESAP', 'acceptsChildSexOffenders', 'hasEnSuite', 'isWheelchairAccessible'],
-          },
+          characteristics: ['isESAP', 'acceptsChildSexOffenders', 'hasEnSuite', 'isWheelchairAccessible'],
         })
 
         expect(requirementsInformation(placementSpecialistAp)).toEqual({
@@ -380,9 +398,7 @@ describe('placementUtils', () => {
 
       it('should be returned for a placement with no requirements', () => {
         const placementNoRequirements = cas1SpaceBookingFactory.build({
-          requirements: {
-            essentialCharacteristics: [],
-          },
+          characteristics: [],
         })
 
         expect(requirementsInformation(placementNoRequirements)).toEqual({

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -138,13 +138,10 @@ export const placementOverviewSummary = (placement: Cas1SpaceBooking): SummaryLi
     summaryRow('Approved premises', placement.premises.name),
     summaryRow('Date of match', formatDate(placement.createdAt)),
     summaryRow('Expected arrival date', formatDate(placement.expectedArrivalDate)),
+    summaryRow('Actual arrival date', formatDate(placement.actualArrivalDateOnly)),
     summaryRow('Expected departure date', formatDate(placement.expectedDepartureDate)),
-    summaryListItem(
-      'Room criteria',
-      requirementsHtmlString(placement.requirements.essentialCharacteristics, roomCharacteristicMap),
-      'html',
-    ),
-  ],
+    summaryListItem('Room criteria', requirementsHtmlString(placement.characteristics, roomCharacteristicMap), 'html'),
+  ].filter(Boolean),
 })
 
 export const arrivalInformation = (placement: Cas1SpaceBooking): SummaryList => {
@@ -188,7 +185,7 @@ export const departureInformation = (placement: Cas1SpaceBooking): SummaryList =
 }
 
 export const requirementsInformation = (placement: Cas1SpaceBooking): SummaryList => {
-  const requirements = placement.requirements.essentialCharacteristics
+  const requirements = placement.characteristics
   const apType =
     apTypeCriteriaLabels[requirements.find(requirement => specialistApTypeCriteria.includes(requirement)) || 'normal']
   const apRequirements = filterApLevelCriteria(requirements)

--- a/server/views/manage/premises/placements/changes/new.njk
+++ b/server/views/manage/premises/placements/changes/new.njk
@@ -133,7 +133,7 @@
 
     {% if not errors.startDate %}
         <section>
-            <h2 class="govuk-heading-l">Change placement dates</h2>
+            <h2 class="govuk-heading-l">Change placement</h2>
 
             <p><strong>Room criteria:</strong> {{ selectedCriteria }}</p>
 
@@ -141,29 +141,32 @@
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
                 <input type="hidden" name="criteria" value="{{ criteria }}" />
-
-                {{ govukDateInput({
-                    id: "arrivalDate",
-                    namePrefix: "arrivalDate",
-                    fieldset: {
-                        legend: {
-                            text: "Arrival date",
-                            classes: "govuk-fieldset__legend--m"
-                        }
-                    },
-                    hint: {
-                        text: arrivalDateHint
-                    },
-                    items: dateFieldValues('arrivalDate', errors),
-                    errorMessage: errors.arrivalDate
-                }) }}
+                {% if not placement.actualArrivalDateOnly %}
+                    {{ govukDateInput({
+                        id: "arrivalDate",
+                        namePrefix: "arrivalDate",
+                        fieldset: {
+                            legend: {
+                                text: "New arrival date",
+                                classes: "govuk-fieldset__legend--m"
+                            }
+                        },
+                        hint: {
+                            text: arrivalDateHint
+                        },
+                        items: dateFieldValues('arrivalDate', errors),
+                        errorMessage: errors.arrivalDate
+                    }) }}
+                {% else %}
+                    <input type="hidden" name="actualArrivalDate" value="{{ placement.actualArrivalDateOnly }}" />
+                {% endif %}
 
                 {{ govukDateInput({
                     id: "departureDate",
                     namePrefix: "departureDate",
                     fieldset: {
                         legend: {
-                            text: "Departure date",
+                            text: "New departure date",
                             classes: "govuk-fieldset__legend--m"
                         }
                     },


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1912

# Changes in this PR

Handles the 'Extend booking' journey - an amend on a placement post arrival (i.e. the actualArrivalDate is populated). This involved changes to the `changes` form.

- Added 'Actual arrival date' to the top summary.  I left the 'Expected arrival date' in place so the user can relate this to the arrival date shown on the confirmation page - which will not be changed.
- Removed the Arrival date input from the bottom form. 
- I re-titled the bottom section to 'Change placement' as it can change more than just dates, and changed the field labels to 'New arrival date' and 'New departure date' with the hints re-labelled as 'Current arrival date' and 'Current departure date'. This means that the form works well in both amend (both arrival and departure) and Extend (departure only) modes.
- The calendar displays from the actual arrival date, rather than the expected arrival date.
- Given that the departure is being extended, it's likely that the end date will be after the current end date. This means that the user will probably need to use the duration control in the filter to advance the period - but the current behaviour is odd in that the calendar is only shown up until the departure date, regardless of the rounding-up that occurs in the duration selector. To make the behaviour of the form slightly more logical, I forced the calendar end-date to use the rounded-up duration shown in the duration selector on the filter.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

<details>
  <summary>Occupancy view page</summary>
<img src="https://github.com/user-attachments/assets/e0450723-66f5-4cde-8331-f16a726aae1c"/>
</details>

<details>
  <summary>Error - departure must be after arrival</summary>
<img src="https://github.com/user-attachments/assets/3a2c9f5b-bd9d-47c7-abed-77f3cb78f5fd"/>
</details>
