### PR TITLE
APS-1951 Pen-test fix - Type confusion through parameter tampering

### DIFF
--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -392,6 +392,17 @@ describe('dateAndTimeInputsAreValidDates', () => {
 
     expect(result).toEqual(false)
   })
+
+  it('returns false when the date is an array (Pen-test APS-1951)', () => {
+    const obj: ObjectWithDateParts<'date'> = {
+      // @ts-expect-error Simulate array query parameters
+      'date-year': ['2020', '2021', '2022', '2023'],
+      'date-month': '12',
+      'date-day': '11',
+    }
+
+    expect(dateAndTimeInputsAreValidDates(obj, 'date')).toEqual(false)
+  })
 })
 
 describe('dateIsBlank', () => {

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -278,7 +278,7 @@ export const dateAndTimeInputsAreValidDates = <K extends string | number>(
 ): boolean => {
   const inputYear = dateInputObj?.[`${key}-year`] as string
 
-  if (inputYear && inputYear.length !== 4) return false
+  if (typeof inputYear !== 'string' || inputYear?.length !== 4) return false
 
   const dateString = DateFormats.dateAndTimeInputsToIsoString(dateInputObj, key)
 


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1951
<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Add recommended change (test for type string on date parameter). Also added a test. 

Note: the test passes (date validation returns false) even without the fix so I don't think there was ever an actual vulnerability. 

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

No UI change
