### PR TITLE
APS-1920 Remove root backlinks

### DIFF
--- a/integration_tests/tests/admin/userManagement.cy.ts
+++ b/integration_tests/tests/admin/userManagement.cy.ts
@@ -31,7 +31,6 @@ context('User management', () => {
 
     // When I visit the list page
     const listPage = ListPage.visit()
-    listPage.checkForBackButton('/')
 
     // Then I should see the users and their details
     listPage.shouldShowUsers(users)
@@ -106,7 +105,6 @@ context('User management', () => {
 
     // When I visit the list page
     const page = ListPage.visit()
-    page.checkForBackButton('/')
 
     // Then I should see the users and their details
     page.shouldShowUsers(initialUsers)
@@ -303,7 +301,6 @@ context('User management', () => {
 
     // When I visit the list page
     const page = ListPage.visit()
-    page.checkForBackButton('/')
 
     // Then I should see the users and their details
     page.shouldShowUsers(initialUsers)

--- a/server/views/admin/users/index.njk
+++ b/server/views/admin/users/index.njk
@@ -7,8 +7,7 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body assessments--index" %}
-{% block beforeContent %}{{ govukBackLink({"text": "Back", "href": "/"}) }}
-{% endblock %}
+
 {% block content %}
     {% include "../../_messages.njk" %}
     <div class="govuk-width-container">

--- a/server/views/manage/outOfServiceBeds/index.njk
+++ b/server/views/manage/outOfServiceBeds/index.njk
@@ -25,13 +25,6 @@
     ] %}
 {% endif %}
 
-{% block beforeContent %}
-    {{ govukBackLink({
-        text: "Back",
-        href: '/'
-    }) }}
-{% endblock %}
-
 {% block content %}
 
     <h1 class="govuk-heading-l">{{ pageHeading }}</h1>


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1920

# Changes in this PR

Removes pointless backlinks from two pages that are accessed directly from the root menu.

- Out of service beds listing for all premises.
- User management

[x] I have run the E2E tests locally and they passed

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/0421f885-cbe9-4896-aef3-a006c182f63c)
![image](https://github.com/user-attachments/assets/b0ed4bf6-5a07-45e1-b937-f3f4992a2144)


### After
![image](https://github.com/user-attachments/assets/b650ed87-f761-4e76-9c0f-f549b819615c)
![image](https://github.com/user-attachments/assets/8e1c1cb6-aed4-4acc-8017-f0218e0910da)

