### PR TITLE
Enable reports with PII role on admin ui

### DIFF
--- a/integration_tests/tests/admin/reports.cy.ts
+++ b/integration_tests/tests/admin/reports.cy.ts
@@ -5,7 +5,7 @@ context('Reports', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubAuthUser', { permissions: ['cas1_reports_view_with_pii'] })
 
     // Given I am logged in
     cy.signIn()

--- a/server/utils/reportUtils.test.ts
+++ b/server/utils/reportUtils.test.ts
@@ -1,9 +1,11 @@
 import { reportOptions } from './reportUtils'
+import { userDetailsFactory } from '../testutils/factories'
 
 describe('reportUtils', () => {
   describe('reportOptions', () => {
-    it('should return a list of report options', () => {
-      expect(reportOptions).toEqual([
+    it('should return a list of report options, excluding pii by default', () => {
+      const user = userDetailsFactory.build({ permissions: [] })
+      expect(reportOptions(user)).toEqual([
         {
           value: 'outOfServiceBeds',
           text: 'Out of service beds',
@@ -22,21 +24,85 @@ describe('reportUtils', () => {
           value: 'applicationsV2',
           text: 'Raw Applications for Performance Hub',
           hint: {
-            text: 'A raw data extract for applications submitted or withdrawn within the month. Excludes PII.',
+            text: 'A raw data extract for applications submitted or withdrawn within the month.',
           },
         },
         {
           value: 'requestsForPlacement',
           text: 'Raw Requests for Placement for Performance Hub',
           hint: {
-            text: 'A raw data extract for requests for placements created or withdrawn within the month. Excludes PII.',
+            text: 'A raw data extract for requests for placements created or withdrawn within the month.',
           },
         },
         {
           value: 'placementMatchingOutcomesV2',
-          text: 'Raw Placement Matching Outcomes Reports (V2)',
+          text: 'Raw Placement Matching Outcomes Reports V2',
           hint: {
-            text: 'A raw data extract providing placement matching outcomes for placement requests with an expected arrival within the month. Excludes PII.',
+            text: 'A raw data extract providing placement matching outcomes for placement requests with an expected arrival within the month.',
+          },
+        },
+      ])
+    })
+
+    it('should return a list of report options, including pii if user has permission', () => {
+      const userWithPiiPermissions = userDetailsFactory.build({
+        permissions: ['cas1_reports_view_with_pii'],
+      })
+      expect(reportOptions(userWithPiiPermissions)).toEqual([
+        {
+          value: 'outOfServiceBeds',
+          text: 'Out of service beds',
+          hint: {
+            text: 'A report of all out of service beds within the month and how long they were unavailable for.',
+          },
+        },
+        {
+          value: 'dailyMetrics',
+          text: 'Daily metrics',
+          hint: {
+            text: 'Counts of key actions across the service grouped by day.',
+          },
+        },
+        {
+          value: 'applicationsV2',
+          text: 'Raw Applications for Performance Hub',
+          hint: {
+            text: 'A raw data extract for applications submitted or withdrawn within the month.',
+          },
+        },
+        {
+          value: 'applicationsV2WithPii',
+          text: 'Raw Applications for Performance Hub (PII)',
+          hint: {
+            text: 'A raw data extract for applications submitted or withdrawn within the month, including PII.',
+          },
+        },
+        {
+          value: 'requestsForPlacement',
+          text: 'Raw Requests for Placement for Performance Hub',
+          hint: {
+            text: 'A raw data extract for requests for placements created or withdrawn within the month.',
+          },
+        },
+        {
+          value: 'requestsForPlacementWithPii',
+          text: 'Raw Requests for Placement for Performance Hub (PII)',
+          hint: {
+            text: 'A raw data extract for requests for placements created or withdrawn within the month, including PII.',
+          },
+        },
+        {
+          value: 'placementMatchingOutcomesV2',
+          text: 'Raw Placement Matching Outcomes Reports V2',
+          hint: {
+            text: 'A raw data extract providing placement matching outcomes for placement requests with an expected arrival within the month.',
+          },
+        },
+        {
+          value: 'placementMatchingOutcomesV2WithPii',
+          text: 'Raw Placement Matching Outcomes Reports V2 (PII)',
+          hint: {
+            text: 'A raw data extract providing placement matching outcomes for placement requests with an expected arrival within the month, including PII.',
           },
         },
       ])

--- a/server/utils/reportUtils.ts
+++ b/server/utils/reportUtils.ts
@@ -1,3 +1,6 @@
+import { UserDetails } from '@approved-premises/ui'
+import { hasPermission } from './users'
+
 export const reportInputLabels = {
   applications: {
     text: 'Raw Applications',
@@ -19,18 +22,33 @@ export const reportInputLabels = {
     text: 'Out of service beds',
     hint: 'A report of all out of service beds within the month and how long they were unavailable for.',
   },
-  dailyMetrics: { text: 'Daily metrics', hint: 'Counts of key actions across the service grouped by day.' },
+  dailyMetrics: {
+    text: 'Daily metrics',
+    hint: 'Counts of key actions across the service grouped by day.',
+  },
   applicationsV2: {
     text: 'Raw Applications for Performance Hub',
-    hint: 'A raw data extract for applications submitted or withdrawn within the month. Excludes PII.',
+    hint: 'A raw data extract for applications submitted or withdrawn within the month.',
+  },
+  applicationsV2WithPii: {
+    text: 'Raw Applications for Performance Hub (PII)',
+    hint: 'A raw data extract for applications submitted or withdrawn within the month, including PII.',
   },
   requestsForPlacement: {
     text: 'Raw Requests for Placement for Performance Hub',
-    hint: 'A raw data extract for requests for placements created or withdrawn within the month. Excludes PII.',
+    hint: 'A raw data extract for requests for placements created or withdrawn within the month.',
+  },
+  requestsForPlacementWithPii: {
+    text: 'Raw Requests for Placement for Performance Hub (PII)',
+    hint: 'A raw data extract for requests for placements created or withdrawn within the month, including PII.',
   },
   placementMatchingOutcomesV2: {
-    text: 'Raw Placement Matching Outcomes Reports (V2)',
-    hint: 'A raw data extract providing placement matching outcomes for placement requests with an expected arrival within the month. Excludes PII.',
+    text: 'Raw Placement Matching Outcomes Reports V2',
+    hint: 'A raw data extract providing placement matching outcomes for placement requests with an expected arrival within the month.',
+  },
+  placementMatchingOutcomesV2WithPii: {
+    text: 'Raw Placement Matching Outcomes Reports V2 (PII)',
+    hint: 'A raw data extract providing placement matching outcomes for placement requests with an expected arrival within the month, including PII.',
   },
 } as const
 
@@ -43,12 +61,23 @@ export const unusedReports = [
   'lostBeds',
 ] as Array<string>
 
-export const reportOptions = Object.entries(reportInputLabels)
-  .filter(([reportName]) => {
-    return !unusedReports.includes(reportName)
-  })
-  .map(([reportName, reportLabel]) => ({
-    value: reportName,
-    text: reportLabel.text,
-    hint: { text: reportLabel.hint },
-  }))
+export const piiReports = [
+  'applicationsV2WithPii',
+  'requestsForPlacementWithPii',
+  'placementMatchingOutcomesV2WithPii',
+] as Array<string>
+
+export const reportOptions = (user: UserDetails): Array<{ value: string; text: string; hint: { text: string } }> => {
+  return Object.entries(reportInputLabels)
+    .filter(([reportName]) => {
+      return !unusedReports.includes(reportName)
+    })
+    .filter(([reportName]) => {
+      return !piiReports.includes(reportName) || hasPermission(user, ['cas1_reports_view_with_pii'])
+    })
+    .map(([reportName, reportLabel]) => ({
+      value: reportName,
+      text: reportLabel.text,
+      hint: { text: reportLabel.hint },
+    }))
+}

--- a/server/utils/users/roles.ts
+++ b/server/utils/users/roles.ts
@@ -17,6 +17,7 @@ export const roles: ReadonlyArray<RoleInUse> = [
   'excluded_from_placement_application_allocation',
   'appeals_manager',
   'report_viewer',
+  'report_viewer_with_pii',
   'future_manager',
   'user_manager',
   'janitor',

--- a/server/views/admin/reports/new.njk
+++ b/server/views/admin/reports/new.njk
@@ -30,7 +30,7 @@
                       classes: "govuk-fieldset__legend--m"
                   }
               },
-              items: ReportUtils.reportOptions,
+              items: ReportUtils.reportOptions(user),
               errorMessage: errors.reportType
           }) }}
 


### PR DESCRIPTION
# Changes in this PR

* Make the 'report viewer with PII' role available on the user admin page
* Show reports that include PII on the reports page if the user has the required permission

## Screenshots of UI changes

### After

New role option

<img width="708" alt="Screenshot 2025-02-21 at 15 53 19" src="https://github.com/user-attachments/assets/f36f8925-88a9-45d7-bbbd-e750b0527fe7" />

Reports screen without PII role

<img width="736" alt="Screenshot 2025-02-21 at 16 28 33" src="https://github.com/user-attachments/assets/48bb9e96-313f-478d-9eda-317e60ee4745" />

Reports screen with PII role

<img width="712" alt="Screenshot 2025-02-21 at 16 30 43" src="https://github.com/user-attachments/assets/a3c010b7-c960-48eb-825d-a1347408289b" />
