### PR TITLE
APS-1858: LAO display

### DIFF
--- a/integration_tests/pages/apply/appeals/new.ts
+++ b/integration_tests/pages/apply/appeals/new.ts
@@ -1,10 +1,11 @@
-import type { ApprovedPremisesApplication as Application, FullPerson, NewAppeal } from '@approved-premises/api'
+import type { ApprovedPremisesApplication as Application, NewAppeal } from '@approved-premises/api'
 import Page from '../../page'
 import paths from '../../../../server/paths/apply'
+import { displayName } from '../../../../server/utils/personUtils'
 
 export default class AppealsNewPage extends Page {
-  constructor(private readonly application: Application) {
-    super((application.person as FullPerson).name)
+  constructor(readonly application: Application) {
+    super(displayName(application.person))
   }
 
   static visit(application: Application): AppealsNewPage {

--- a/integration_tests/pages/apply/list.ts
+++ b/integration_tests/pages/apply/list.ts
@@ -5,7 +5,7 @@ import {
   ApprovedPremisesApplication as Application,
   ApprovedPremisesApplicationSummary,
 } from '../../../server/@types/shared'
-import { nameOrPlaceholderCopy } from '../../../server/utils/personUtils'
+import { displayName } from '../../../server/utils/personUtils'
 
 export default class ListPage extends Page {
   constructor(
@@ -68,7 +68,7 @@ export default class ListPage extends Page {
 
   private shouldShowApplications(applications: Array<ApprovedPremisesApplicationSummary>, status: string): void {
     applications.forEach(application => {
-      const name = nameOrPlaceholderCopy(application.person)
+      const name = displayName(application.person)
       cy.contains(name)
         .should('have.attr', 'href', paths.applications.show({ id: application.id }))
         .parent()

--- a/integration_tests/pages/apply/showPage.ts
+++ b/integration_tests/pages/apply/showPage.ts
@@ -12,13 +12,13 @@ import { DateFormats } from '../../../server/utils/dateUtils'
 import Page from '../page'
 import { ApplicationShowPageTab, applicationShowPageTab } from '../../../server/utils/applications/utils'
 import paths from '../../../server/paths/apply'
-import { isFullPerson } from '../../../server/utils/personUtils'
+import { displayName } from '../../../server/utils/personUtils'
 import { mapRequestsForPlacementToSummaryCards } from '../../../server/utils/placementRequests'
 
 export default class ShowPage extends Page {
   constructor(private readonly application: Application) {
     super('Approved Premises application')
-    cy.get('h2').contains(isFullPerson(application.person) && application.person.name)
+    cy.get('h2').contains(displayName(application.person))
   }
 
   static visit(application: Application, tab?: ApplicationShowPageTab) {

--- a/integration_tests/pages/manage/occupancyDayView.ts
+++ b/integration_tests/pages/manage/occupancyDayView.ts
@@ -8,7 +8,7 @@ import Page from '../page'
 import { DateFormats } from '../../../server/utils/dateUtils'
 import paths from '../../../server/paths/manage'
 import { daySummaryRows } from '../../../server/utils/premises/occupancy'
-import { laoSummaryName } from '../../../server/utils/personUtils'
+import { displayName } from '../../../server/utils/personUtils'
 import { spaceSearchCriteriaApLevelLabels } from '../../../server/utils/match/spaceSearch'
 
 export default class OccupancyDayViewPage extends Page {
@@ -41,7 +41,7 @@ export default class OccupancyDayViewPage extends Page {
     placementSummaryList.forEach(
       ({ person, canonicalArrivalDate, canonicalDepartureDate, releaseType, essentialCharacteristics }) => {
         cy.get('.govuk-table__body').contains(person.crn).closest('.govuk-table__row').as('row')
-        cy.get('@row').contains(laoSummaryName(person))
+        cy.get('@row').contains(displayName(person))
         cy.get('@row').contains(DateFormats.isoDateToUIDate(canonicalArrivalDate, { format: 'short' }))
         cy.get('@row').contains(DateFormats.isoDateToUIDate(canonicalDepartureDate, { format: 'short' }))
         cy.get('@row').contains(releaseType)

--- a/integration_tests/pages/manage/premisesShow.ts
+++ b/integration_tests/pages/manage/premisesShow.ts
@@ -1,10 +1,10 @@
-import type { Cas1OverbookingRange, Cas1Premises, Cas1SpaceBookingSummary, FullPerson } from '@approved-premises/api'
+import type { Cas1OverbookingRange, Cas1Premises, Cas1SpaceBookingSummary } from '@approved-premises/api'
 import { differenceInDays, formatDuration } from 'date-fns'
 import { DateFormats } from '../../../server/utils/dateUtils'
 
 import Page from '../page'
 import paths from '../../../server/paths/manage'
-import { laoName } from '../../../server/utils/personUtils'
+import { displayName } from '../../../server/utils/personUtils'
 import { statusTextMap } from '../../../server/utils/placements'
 import { cas1OverbookingRangeFactory } from '../../../server/testutils/factories'
 
@@ -55,7 +55,7 @@ export default class PremisesShowPage extends Page {
       cy.get('@row').contains(DateFormats.isoDateToUIDate(canonicalArrivalDate, { format: 'short' }))
       cy.get('@row').contains(DateFormats.isoDateToUIDate(canonicalDepartureDate, { format: 'short' }))
       cy.get('@row').contains(tier)
-      cy.get('@row').contains(laoName(person as unknown as FullPerson))
+      cy.get('@row').contains(displayName(person))
       cy.get('@row').contains(statusTextMap[status])
     })
   }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -22,7 +22,7 @@ import { sentenceCase } from '../../server/utils/utils'
 import { SumbmittedApplicationSummaryCards } from '../../server/utils/applications/submittedApplicationSummaryCards'
 import { eventTypeTranslations } from '../../server/utils/applications/utils'
 import { oasysSectionsToExclude } from '../../server/utils/oasysImportUtils'
-import { isFullPerson } from '../../server/utils/personUtils'
+import { displayName, isFullPerson } from '../../server/utils/personUtils'
 
 export type PageElement = Cypress.Chainable<JQuery>
 
@@ -588,7 +588,7 @@ export default abstract class Page {
 
   shouldShowPersonDetails(person: FullPerson, expectedStatus?: PersonStatus): void {
     cy.get('dl[data-cy-person-info],div[data-cy-section="person-details"]').within(() => {
-      this.assertDefinition('Name', person.name)
+      this.assertDefinition('Name', displayName(person, { laoAsSuffix: true }))
       this.assertDefinition('CRN', person.crn)
       this.assertDefinition('Date of Birth', DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }))
       this.assertDefinition('NOMIS Number', person.nomsNumber)
@@ -655,7 +655,7 @@ export default abstract class Page {
       const { person } = placementRequest
       if (!isFullPerson(person)) throw new Error('test requires a Full Person')
 
-      cy.get('span').contains(person.name)
+      cy.get('span').contains(displayName(person))
       cy.get('span').contains(`CRN: ${person.crn}`)
       cy.get('span').contains(`Tier: ${placementRequest?.risks?.tier?.value.level}`)
       cy.get('span').contains(`Date of birth: ${DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' })}`)

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -588,7 +588,7 @@ export default abstract class Page {
 
   shouldShowPersonDetails(person: FullPerson, expectedStatus?: PersonStatus): void {
     cy.get('dl[data-cy-person-info],div[data-cy-section="person-details"]').within(() => {
-      this.assertDefinition('Name', displayName(person, { laoAsSuffix: true }))
+      this.assertDefinition('Name', displayName(person, { laoSuffix: true }))
       this.assertDefinition('CRN', person.crn)
       this.assertDefinition('Date of Birth', DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }))
       this.assertDefinition('NOMIS Number', person.nomsNumber)

--- a/integration_tests/pages/people/timeline/show.ts
+++ b/integration_tests/pages/people/timeline/show.ts
@@ -7,7 +7,7 @@ export class ShowPage extends Page {
   timeline: Cas1PersonalTimeline
 
   constructor(timeline: Cas1PersonalTimeline, person: FullPerson) {
-    super(`Application history for ${displayName(person, { laoAsSuffix: true })}`)
+    super(`Application history for ${displayName(person, { laoPrefix: false })}`)
     this.timeline = timeline
   }
 

--- a/integration_tests/pages/people/timeline/show.ts
+++ b/integration_tests/pages/people/timeline/show.ts
@@ -1,12 +1,13 @@
 import { Cas1PersonalTimeline, FullPerson } from '@approved-premises/api'
 import Page from '../../page'
 import { ApplicationStatusTag } from '../../../../server/utils/applications/statusTag'
+import { displayName } from '../../../../server/utils/personUtils'
 
 export class ShowPage extends Page {
   timeline: Cas1PersonalTimeline
 
   constructor(timeline: Cas1PersonalTimeline, person: FullPerson) {
-    super(`Application history for ${person.name}`)
+    super(`Application history for ${displayName(person, { laoAsSuffix: true })}`)
     this.timeline = timeline
   }
 

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -323,7 +323,7 @@ context('Placement Requests', () => {
     })
     cy.task('stubBookingGet', {
       premisesId: matchedPlacementRequestWithLegacyBooking.booking.premisesId,
-      booking: matchedPlacementRequestWithLegacyBooking.booking,
+      booking: bookingFactory.build({ id: matchedPlacementRequestWithLegacyBooking.booking.id }),
     })
 
     // When I visit the tasks dashboard
@@ -376,7 +376,7 @@ context('Placement Requests', () => {
     })
     cy.task('stubBookingGet', {
       premisesId: matchedPlacementRequest.booking.premisesId,
-      booking: matchedPlacementRequest.booking,
+      booking: bookingFactory.build({ id: matchedPlacementRequest.booking.id }),
     })
     cy.task('stubCancellationReferenceData')
     const withdrawables = withdrawablesFactory.build({ withdrawables: [withdrawable] })

--- a/integration_tests/tests/apply/list.cy.ts
+++ b/integration_tests/tests/apply/list.cy.ts
@@ -2,8 +2,8 @@ import { ListPage, StartPage } from '../../pages/apply'
 
 import {
   applicationSummaryFactory,
+  personFactory,
   placementApplicationFactory,
-  restrictedPersonFactory,
 } from '../../../server/testutils/factories'
 import Page from '../../pages/page'
 import ReasonForPlacementPage from '../../pages/match/placementRequestForm/reasonForPlacement'
@@ -68,7 +68,7 @@ context('Applications dashboard', () => {
     // And there are applications in the database
     const inProgressApplications = applicationSummaryFactory.buildList(1, {
       status: 'started',
-      person: restrictedPersonFactory.build(),
+      person: personFactory.build({ isRestricted: true }),
     })
     const submittedApplications = applicationSummaryFactory.buildList(5, { status: 'submitted' })
     const requestedFurtherInformationApplications = applicationSummaryFactory.buildList(5, {

--- a/integration_tests/tests/people/timeline.cy.ts
+++ b/integration_tests/tests/people/timeline.cy.ts
@@ -37,5 +37,24 @@ context('Application timeline', () => {
       timelinePage.shouldShowTimeline()
       timelinePage.shouldShowPersonDetails(person)
     })
+
+    it('shows the timeline for a Limited access offender', () => {
+      const person = personFactory.build({ isRestricted: true })
+      const timeline = personalTimelineFactory.build({ person })
+
+      cy.task('stubPersonalTimeline', { timeline, person })
+      cy.visit(paths.timeline.find({}))
+
+      // Given I am on the timeline find page
+      const findPage = Page.verifyOnPage(FindPage, person)
+
+      // When I enter a CRN
+      findPage.enterCrn()
+      // And click submit
+      findPage.clickSubmit()
+
+      // Then I should be on the timeline show page
+      Page.verifyOnPage(ShowPage, timeline, person)
+    })
   })
 })

--- a/server/testutils/factories/person.ts
+++ b/server/testutils/factories/person.ts
@@ -1,7 +1,7 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
 
-import type { FullPerson, PersonSummary, RestrictedPerson } from '@approved-premises/api'
+import type { FullPerson, PersonSummary, RestrictedPerson, UnknownPerson } from '@approved-premises/api'
 import { FullPersonSummary } from '@approved-premises/api'
 import { DateFormats } from '../../utils/dateUtils'
 
@@ -23,6 +23,11 @@ export const fullPersonFactory = Factory.define<FullPerson>(() => ({
 export const restrictedPersonFactory = Factory.define<RestrictedPerson>(() => ({
   crn: getCrn(),
   type: 'RestrictedPerson',
+}))
+
+export const unknownPersonFactory = Factory.define<UnknownPerson>(() => ({
+  crn: getCrn(),
+  type: 'UnknownPerson',
 }))
 
 export const personSummaryFactory = Factory.define<PersonSummary>(() => ({

--- a/server/utils/applications/applicationIdentityBar.test.ts
+++ b/server/utils/applications/applicationIdentityBar.test.ts
@@ -2,6 +2,7 @@ import { fromPartial } from '@total-typescript/shoehorn'
 import { applicationFactory, personFactory } from '../../testutils/factories'
 import { applicationIdentityBar, applicationMenuItems, applicationTitle } from './applicationIdentityBar'
 import paths from '../../paths/apply'
+import { displayName } from '../personUtils'
 
 describe('applicationIdentityBar', () => {
   describe('applicationTitle', () => {
@@ -11,7 +12,7 @@ describe('applicationIdentityBar', () => {
 
       expect(applicationTitle(application, 'heading')).toMatchStringIgnoringWhitespace(`
         <h1 class="govuk-caption-l">heading</h1>
-        <h2 class="govuk-heading-l">${person.name}</h2>
+        <h2 class="govuk-heading-l">${displayName(person)}</h2>
         <h3 class="govuk-caption-m govuk-!-margin-top-1">CRN: ${application.person.crn}</h3>
       `)
     })
@@ -23,7 +24,7 @@ describe('applicationIdentityBar', () => {
       expect(applicationTitle(application, 'heading')).toMatchStringIgnoringWhitespace(`
         <h1 class="govuk-caption-l">heading</h1>
         <h2 class="govuk-heading-l">
-          ${person.name}
+          ${displayName(person)}
           <strong class="govuk-tag govuk-tag--grey govuk-!-margin-5" >Offline application</strong>
         </h2>
         <h3 class="govuk-caption-m govuk-!-margin-top-1">CRN: ${application.person.crn}</h3>
@@ -37,7 +38,7 @@ describe('applicationIdentityBar', () => {
       expect(applicationTitle(application, 'heading')).toMatchStringIgnoringWhitespace(`
         <h1 class="govuk-caption-l">heading</h1>
         <h2 class="govuk-heading-l">
-          ${person.name}
+          ${displayName(person)}
           <strong class="govuk-tag govuk-tag--red govuk-!-margin-5" data-cy-status="withdrawn">Application withdrawn</strong>
         </h2>
         <h3 class="govuk-caption-m govuk-!-margin-top-1">CRN: ${application.person.crn}</h3>
@@ -51,7 +52,7 @@ describe('applicationIdentityBar', () => {
       expect(applicationTitle(application, 'heading')).toMatchStringIgnoringWhitespace(`
         <h1 class="govuk-caption-l">heading</h1>
         <h2 class="govuk-heading-l">
-          ${person.name}
+          ${displayName(person)}
           <strong class="govuk-tag govuk-tag--red govuk-!-margin-5" data-cy-status="expired">Expired application</strong>
         </h2>
         <h3 class="govuk-caption-m govuk-!-margin-top-1">CRN: ${application.person.crn}</h3>

--- a/server/utils/applications/applicationIdentityBar.ts
+++ b/server/utils/applications/applicationIdentityBar.ts
@@ -1,11 +1,12 @@
-import { ApprovedPremisesApplication as Application, FullPerson } from '../../@types/shared'
+import { ApprovedPremisesApplication as Application } from '../../@types/shared'
 import { IdentityBar, IdentityBarMenuItem, UserDetails } from '../../@types/ui'
 import paths from '../../paths/apply'
 import { ApplicationStatusTag } from './statusTag'
 import { hasPermission } from '../users'
+import { displayName } from '../personUtils'
 
 export const applicationTitle = (application: Application, pageHeading: string): string => {
-  let heading = (application.person as FullPerson).name
+  let heading = displayName(application.person)
 
   if (application.type === 'Offline') {
     heading += '<strong class="govuk-tag govuk-tag--grey govuk-!-margin-5">Offline application</strong>'

--- a/server/utils/applications/helpers.ts
+++ b/server/utils/applications/helpers.ts
@@ -1,28 +1,31 @@
 import { ApprovedPremisesApplicationSummary as ApplicationSummary, Person } from '../../@types/shared'
-import { isFullPerson, isUnknownPerson, nameOrPlaceholderCopy, tierBadge } from '../personUtils'
+import { displayName, isFullPerson, tierBadge } from '../personUtils'
 import paths from '../../paths/apply'
 
 export const createNameAnchorElement = (
   person: Person,
   applicationSummary: ApplicationSummary,
-  { linkInProgressApplications }: { linkInProgressApplications: boolean } = { linkInProgressApplications: true },
+  {
+    linkInProgressApplications,
+    showCrn,
+  }: {
+    linkInProgressApplications?: boolean
+    showCrn?: boolean
+  } = { linkInProgressApplications: true, showCrn: false },
 ) => {
+  const name = displayName(person, showCrn)
+
   if (!linkInProgressApplications && applicationSummary.status === 'started') {
-    return textValue(
-      nameOrPlaceholderCopy(
-        person,
-        isUnknownPerson(person) ? `Not Found CRN: ${person.crn}` : `LAO CRN: ${person.crn}`,
-      ),
-    )
+    return textValue(name)
   }
 
   return isFullPerson(person)
     ? htmlValue(
         `<a href=${paths.applications.show({ id: applicationSummary.id })} data-cy-id="${applicationSummary.id}">${
-          person.name
+          name
         }</a>`,
       )
-    : textValue(isUnknownPerson(person) ? `Not Found CRN: ${person.crn}` : `LAO CRN: ${person.crn}`)
+    : textValue(name)
 }
 
 export const textValue = (value: string) => {

--- a/server/utils/applications/helpers.ts
+++ b/server/utils/applications/helpers.ts
@@ -13,7 +13,7 @@ export const createNameAnchorElement = (
     showCrn?: boolean
   } = { linkInProgressApplications: true, showCrn: false },
 ) => {
-  const name = displayName(person, showCrn)
+  const name = displayName(person, { showCrn })
 
   if (!linkInProgressApplications && applicationSummary.status === 'started') {
     return textValue(name)

--- a/server/utils/applications/pendingPlacementRequestTable.test.ts
+++ b/server/utils/applications/pendingPlacementRequestTable.test.ts
@@ -43,13 +43,13 @@ describe('pendingPlacementRequestTable', () => {
 
       expect(pendingPlacementRequestTableRows(summaries)).toEqual([
         [
-          createNameAnchorElement(summaries[0].person, summaries[0]),
+          createNameAnchorElement(summaries[0].person, summaries[0], { showCrn: true }),
           htmlValue(getTierOrBlank(summaries[0].risks?.tier?.value?.level)),
           textValue(DateFormats.isoDateToUIDate(summaries[0].createdAt, { format: 'short' })),
           textValue(allReleaseTypes[summaries[0].releaseType]),
         ],
         [
-          createNameAnchorElement(summaries[1].person, summaries[1]),
+          createNameAnchorElement(summaries[1].person, summaries[1], { showCrn: true }),
           htmlValue(getTierOrBlank(summaries[1].risks?.tier?.value?.level)),
           textValue(DateFormats.isoDateToUIDate(summaries[1].createdAt, { format: 'short' })),
           textValue(''),

--- a/server/utils/applications/pendingPlacementRequestTable.ts
+++ b/server/utils/applications/pendingPlacementRequestTable.ts
@@ -27,7 +27,7 @@ export const pendingPlacementRequestTableHeader = (
 
 export const pendingPlacementRequestTableRows = (applications: Array<ApplicationSummary>): Array<TableRow> => {
   return applications.map(application => [
-    createNameAnchorElement(application.person, application),
+    createNameAnchorElement(application.person, application, { showCrn: true }),
     htmlValue(getTierOrBlank(application.risks?.tier?.value?.level)),
     textValue(DateFormats.isoDateToUIDate(application.createdAt, { format: 'short' })),
     textValue(application.releaseType ? allReleaseTypes[application.releaseType] : ''),

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -26,7 +26,7 @@ import Apply from '../../form-pages/apply'
 import Assess from '../../form-pages/assess'
 import PlacementRequest from '../../form-pages/placement-application'
 import { DateFormats } from '../dateUtils'
-import { isApplicableTier, isFullPerson, nameOrPlaceholderCopy, tierBadge } from '../personUtils'
+import * as personUtils from '../personUtils'
 
 import {
   actionsLink,
@@ -74,8 +74,6 @@ jest.mock('../../form-pages/assess', () => {
     pages: { 'assess-page': {} },
   }
 })
-
-jest.mock('../personUtils')
 
 const applySection1Task1 = {
   id: 'first-apply-section-task-1',
@@ -178,16 +176,14 @@ PlacementRequest.pages['placement-request-page'] = {
 describe('utils', () => {
   beforeEach(() => {
     jest.resetAllMocks()
+    jest.spyOn(personUtils, 'tierBadge')
   })
 
   describe('applicationTableRows', () => {
     const arrivalDate = DateFormats.dateObjToIsoDate(new Date(2021, 0, 3))
-    const person = personFactory.build({ name: 'My name' })
+    const person = personFactory.build()
 
     it('returns an array of applications as table rows', async () => {
-      ;(tierBadge as jest.Mock).mockReturnValue('TIER_BADGE')
-      ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
-
       const applicationA = applicationSummaryFactory.build({
         arrivalDate: undefined,
         person,
@@ -202,8 +198,6 @@ describe('utils', () => {
 
       const result = applicationTableRows([applicationA, applicationB])
 
-      expect(tierBadge).toHaveBeenCalledWith('A1')
-
       expect(result).toEqual([
         [
           {
@@ -215,7 +209,7 @@ describe('utils', () => {
             text: applicationA.person.crn,
           },
           {
-            html: 'TIER_BADGE',
+            html: personUtils.tierBadge('A1'),
           },
           {
             text: 'N/A',
@@ -256,9 +250,6 @@ describe('utils', () => {
 
     describe('when tier is undefined', () => {
       it('returns a blank tier badge', async () => {
-        ;(tierBadge as jest.Mock).mockClear()
-        ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
-
         const application = applicationSummaryFactory.build({
           arrivalDate,
           person,
@@ -268,7 +259,7 @@ describe('utils', () => {
 
         const result = applicationTableRows([application])
 
-        expect(tierBadge).not.toHaveBeenCalled()
+        expect(personUtils.tierBadge).not.toHaveBeenCalled()
 
         expect(result[0][2]).toEqual({
           html: '',
@@ -278,9 +269,6 @@ describe('utils', () => {
 
     describe('when risks is undefined', () => {
       it('returns a blank tier badge', async () => {
-        ;(tierBadge as jest.Mock).mockClear()
-        ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
-
         const application = applicationSummaryFactory.build({
           arrivalDate,
           person,
@@ -289,7 +277,7 @@ describe('utils', () => {
 
         const result = applicationTableRows([application])
 
-        expect(tierBadge).not.toHaveBeenCalled()
+        expect(personUtils.tierBadge).not.toHaveBeenCalled()
 
         expect(result[0][2]).toEqual({
           html: '',
@@ -329,9 +317,6 @@ describe('utils', () => {
     const person = personFactory.build({ name: 'A' })
 
     it('returns an array of applications as table rows', async () => {
-      ;(tierBadge as jest.Mock).mockReturnValue('TIER_BADGE')
-      ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
-
       const applicationA = applicationSummaryFactory.build({
         arrivalDate: undefined,
         person,
@@ -348,8 +333,6 @@ describe('utils', () => {
 
       const result = dashboardTableRows([applicationA, applicationB])
 
-      expect(tierBadge).toHaveBeenCalledWith('A1')
-
       expect(result).toEqual([
         [
           {
@@ -361,7 +344,7 @@ describe('utils', () => {
             text: applicationA.person.crn,
           },
           {
-            html: 'TIER_BADGE',
+            html: personUtils.tierBadge('A1'),
           },
           {
             text: 'N/A',
@@ -406,9 +389,6 @@ describe('utils', () => {
 
     describe('when tier is undefined', () => {
       it('returns a blank tier badge', async () => {
-        ;(tierBadge as jest.Mock).mockClear()
-        ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
-
         const application = applicationSummaryFactory.build({
           arrivalDate,
           person,
@@ -418,7 +398,7 @@ describe('utils', () => {
 
         const result = dashboardTableRows([application])
 
-        expect(tierBadge).not.toHaveBeenCalled()
+        expect(personUtils.tierBadge).not.toHaveBeenCalled()
 
         expect(result[0][2]).toEqual({
           html: '',
@@ -428,9 +408,6 @@ describe('utils', () => {
 
     describe('when risks is undefined', () => {
       it('returns a blank tier badge', async () => {
-        ;(tierBadge as jest.Mock).mockClear()
-        ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
-
         const application = applicationSummaryFactory.build({
           arrivalDate,
           person,
@@ -439,7 +416,7 @@ describe('utils', () => {
 
         const result = dashboardTableRows([application])
 
-        expect(tierBadge).not.toHaveBeenCalled()
+        expect(personUtils.tierBadge).not.toHaveBeenCalled()
 
         expect(result[0][2]).toEqual({
           html: '',
@@ -449,11 +426,7 @@ describe('utils', () => {
 
     describe('when linkInProgressApplications is false', () => {
       it('returns the rows with the name cell without linking to the application', () => {
-        ;(tierBadge as jest.Mock).mockReturnValue('TIER_BADGE')
-        ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
-        ;(nameOrPlaceholderCopy as jest.MockedFunction<typeof nameOrPlaceholderCopy>).mockReturnValue(person.name)
-
-        const application = applicationSummaryFactory.build()
+        const application = applicationSummaryFactory.build({ person })
 
         const result = dashboardTableRows([application], { linkInProgressApplications: false })
 
@@ -466,7 +439,7 @@ describe('utils', () => {
               text: application.person.crn,
             },
             {
-              html: 'TIER_BADGE',
+              html: personUtils.tierBadge(application.tier),
             },
             {
               text: DateFormats.isoDateToUIDate(application.arrivalDate, { format: 'short' }),
@@ -520,19 +493,18 @@ describe('utils', () => {
 
   describe('firstPageOfApplicationJourney', () => {
     it('returns the sentence type page for an applicable application', () => {
-      ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
-      ;(isApplicableTier as jest.Mock).mockReturnValue(true)
+      jest.spyOn(personUtils, 'isApplicableTier').mockReturnValue(true)
       const application = applicationFactory.withFullPerson().build()
+
       expect(firstPageOfApplicationJourney(application)).toEqual(
         paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'confirm-your-details' }),
       )
     })
 
     it('returns the "enter risk level" page for an application for a person without a tier', () => {
-      const application = applicationFactory.withFullPerson().build()
-      ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
-
-      application.risks = undefined
+      const application = applicationFactory.withFullPerson().build({
+        risks: undefined,
+      })
 
       expect(firstPageOfApplicationJourney(application)).toEqual(
         paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'enter-risk-level' }),
@@ -540,9 +512,7 @@ describe('utils', () => {
     })
 
     it('returns the is exceptional case page for an application with an unsuitable tier', () => {
-      ;(isApplicableTier as jest.Mock).mockReturnValue(false)
-      ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
-
+      jest.spyOn(personUtils, 'isApplicableTier').mockReturnValue(false)
       const application = applicationFactory.withFullPerson().build()
 
       expect(firstPageOfApplicationJourney(application)).toEqual(
@@ -551,8 +521,6 @@ describe('utils', () => {
     })
 
     it('throws an error if the person is not a Full Person', () => {
-      ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(false)
-
       const restrictedPerson = restrictedPersonFactory.build()
       const application = applicationFactory.build({ person: restrictedPerson })
 
@@ -977,17 +945,16 @@ describe('utils', () => {
 
   describe('tierQualificationPage', () => {
     it('returns undefined for valid tier', () => {
-      ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
-      ;(isApplicableTier as jest.Mock).mockReturnValue(true)
+      jest.spyOn(personUtils, 'isApplicableTier').mockReturnValue(true)
       const application = applicationFactory.withFullPerson().build()
+
       expect(tierQualificationPage(application)).toBe(undefined)
     })
 
     it('returns the "enter risk level" page for an application for a person without a tier', () => {
-      const application = applicationFactory.withFullPerson().build()
-      ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
-
-      application.risks = undefined
+      const application = applicationFactory.withFullPerson().build({
+        risks: undefined,
+      })
 
       expect(tierQualificationPage(application)).toEqual(
         paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'enter-risk-level' }),
@@ -995,9 +962,7 @@ describe('utils', () => {
     })
 
     it('returns the is exceptional case page for an application with an unsuitable tier', () => {
-      ;(isApplicableTier as jest.Mock).mockReturnValue(false)
-      ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(true)
-
+      jest.spyOn(personUtils, 'isApplicableTier').mockReturnValue(false)
       const application = applicationFactory.withFullPerson().build()
 
       expect(tierQualificationPage(application)).toEqual(
@@ -1006,8 +971,6 @@ describe('utils', () => {
     })
 
     it('throws an error if the person is not a Full Person', () => {
-      ;(isFullPerson as jest.MockedFunction<typeof isFullPerson>).mockReturnValue(false)
-
       const restrictedPerson = restrictedPersonFactory.build()
       const application = applicationFactory.build({ person: restrictedPerson })
 

--- a/server/utils/assessments/tableUtils.test.ts
+++ b/server/utils/assessments/tableUtils.test.ts
@@ -16,7 +16,7 @@ import { crnCell, daysUntilDueCell, tierCell } from '../tableUtils'
 import { AssessmentSortField, ApprovedPremisesAssessmentSummary as AssessmentSummary } from '../../@types/shared'
 import { sortHeader } from '../sortHeader'
 import { linkTo } from '../utils'
-import { laoName } from '../personUtils'
+import { displayName } from '../personUtils'
 import { AssessmentStatusTag } from './statusTag'
 
 jest.mock('../applications/arrivalDateFromApplication')
@@ -35,7 +35,7 @@ describe('tableUtils', () => {
     it('returns a link to an assessment', () => {
       expect(assessmentLink(assessment, person)).toBe(
         linkTo(paths.assessments.show({ id: assessment.id }), {
-          text: laoName(person),
+          text: displayName(person),
           attributes: { 'data-cy-assessmentId': assessment.id, 'data-cy-applicationId': assessment.applicationId },
         }),
       )

--- a/server/utils/assessments/tableUtils.ts
+++ b/server/utils/assessments/tableUtils.ts
@@ -10,13 +10,13 @@ import { linkTo } from '../utils'
 import { daysSinceInfoRequest, daysSinceReceived, formatDays, formattedArrivalDate } from './dateUtils'
 import paths from '../../paths/assess'
 import { crnCell, daysUntilDueCell, tierCell } from '../tableUtils'
-import { isFullPerson, laoName } from '../personUtils'
+import { displayName, isFullPerson } from '../personUtils'
 import { sortHeader } from '../sortHeader'
 import { AssessmentStatusTag } from './statusTag'
 
 const assessmentLink = (assessment: AssessmentSummary, person: FullPerson, linkText = '', hiddenText = ''): string => {
   return linkTo(paths.assessments.show({ id: assessment.id }), {
-    text: linkText || laoName(person),
+    text: linkText || displayName(person),
     hiddenText,
     attributes: { 'data-cy-assessmentId': assessment.id, 'data-cy-applicationId': assessment.applicationId },
   })

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -32,7 +32,7 @@ import {
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
 import { applicationAccepted, decisionFromAssessment } from './decisionUtils'
 import { getResponseForPage } from '../applications/getResponseForPage'
-import { nameOrPlaceholderCopy } from '../personUtils'
+import { displayName } from '../personUtils'
 import { DateFormats } from '../dateUtils'
 import { linkTo } from '../utils'
 import applyPaths from '../../paths/apply'
@@ -350,7 +350,7 @@ describe('utils', () => {
       expect(keyDetails(assessment)).toEqual({
         header: {
           key: 'Name',
-          value: nameOrPlaceholderCopy(person),
+          value: displayName(person),
           showKey: false,
         },
         items: [
@@ -383,7 +383,7 @@ describe('utils', () => {
       expect(keyDetails(assessment)).toEqual({
         header: {
           key: 'Name',
-          value: nameOrPlaceholderCopy(person),
+          value: displayName(person),
           showKey: false,
         },
         items: [

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -15,7 +15,7 @@ import { getApplicationType } from '../applications/utils'
 import { applicationAccepted, decisionFromAssessment } from './decisionUtils'
 import { formattedArrivalDate } from './dateUtils'
 import { getResponseForPage } from '../applications/getResponseForPage'
-import { nameOrPlaceholderCopy } from '../personUtils'
+import { displayName } from '../personUtils'
 import { DateFormats } from '../dateUtils'
 import applyPaths from '../../paths/apply'
 import { TabItem } from '../tasks/listTable'
@@ -150,7 +150,7 @@ const keyDetails = (assessment: Assessment): KeyDetailsArgs => {
   return {
     header: {
       key: 'Name',
-      value: nameOrPlaceholderCopy(assessment.application.person),
+      value: displayName(assessment.application.person),
       showKey: false,
     },
     items: [

--- a/server/utils/bookings/index.test.ts
+++ b/server/utils/bookings/index.test.ts
@@ -15,7 +15,6 @@ import {
   departingTodayOrLate,
   generateConflictBespokeError,
   manageBookingLink,
-  nameCell,
   upcomingArrivals,
   upcomingDepartures,
 } from '.'
@@ -29,14 +28,14 @@ import {
   departureFactory,
   personFactory,
   premisesBookingFactory,
-  restrictedPersonFactory,
 } from '../../testutils/factories'
 import paths from '../../paths/manage'
 import assessPaths from '../../paths/assess'
 import applyPaths from '../../paths/apply'
 import { DateFormats } from '../dateUtils'
 import { linebreaksToParagraphs, linkTo } from '../utils'
-import { BookingStatus, FullPerson } from '../../@types/shared'
+import { BookingStatus } from '../../@types/shared'
+import { displayName } from '../personUtils'
 
 describe('bookingUtils', () => {
   const premisesId = 'e8f29a4a-dd4d-40a2-aa58-f3f60245c8fc'
@@ -103,7 +102,9 @@ describe('bookingUtils', () => {
     it('casts a group of bookings to table rows with the arrival date', () => {
       expect(bookingsToTableRows(bookings, premisesId, 'arrival')).toEqual([
         [
-          nameCell(bookings[0]),
+          {
+            text: displayName(bookings[0].person),
+          },
           {
             text: bookings[0].person.crn,
           },
@@ -118,7 +119,9 @@ describe('bookingUtils', () => {
           },
         ],
         [
-          nameCell(bookings[1]),
+          {
+            text: displayName(bookings[1].person),
+          },
           {
             text: bookings[1].person.crn,
           },
@@ -138,7 +141,9 @@ describe('bookingUtils', () => {
     it('casts a group of bookings to table rows with the departure date', () => {
       expect(bookingsToTableRows(bookings, premisesId, 'departure')).toEqual([
         [
-          nameCell(bookings[0]),
+          {
+            text: displayName(bookings[0].person),
+          },
           {
             text: bookings[0].person.crn,
           },
@@ -153,7 +158,9 @@ describe('bookingUtils', () => {
           },
         ],
         [
-          nameCell(bookings[1]),
+          {
+            text: displayName(bookings[1].person),
+          },
           {
             text: bookings[1].person.crn,
           },
@@ -169,29 +176,6 @@ describe('bookingUtils', () => {
           },
         ],
       ])
-    })
-  })
-
-  describe('nameCell', () => {
-    it('returns the persons name if they are a full person', () => {
-      const fullPerson = personFactory.build()
-      expect(nameCell(bookingFactory.build({ person: fullPerson }))).toEqual({ text: fullPerson.name })
-    })
-
-    it('returns "Limited access offender" if they are a restricted person', () => {
-      const booking = bookingFactory.build()
-      booking.person = restrictedPersonFactory.build()
-      expect(nameCell(booking)).toEqual({
-        text: `LAO: ${booking.person.crn}`,
-      })
-    })
-
-    it('returns the persons name prefixed with "LAO: " if they are a FullPerson but have the isRestricted flag', () => {
-      const booking = bookingFactory.build()
-      booking.person = personFactory.build({ isRestricted: true })
-      expect(nameCell(booking)).toEqual({
-        text: `LAO: ${(booking.person as FullPerson).name}`,
-      })
     })
   })
 
@@ -392,7 +376,9 @@ describe('bookingUtils', () => {
           key: {
             text: 'Name',
           },
-          value: nameCell(booking),
+          value: {
+            text: displayName(booking.person),
+          },
         },
         {
           key: {

--- a/server/utils/bookings/index.ts
+++ b/server/utils/bookings/index.ts
@@ -1,11 +1,4 @@
-import type {
-  BespokeError,
-  SelectOption,
-  SummaryList,
-  SummaryListItem,
-  TableCell,
-  TableRow,
-} from '@approved-premises/ui'
+import type { BespokeError, SelectOption, SummaryList, SummaryListItem, TableRow } from '@approved-premises/ui'
 import type {
   BedSummary,
   Booking,
@@ -20,7 +13,7 @@ import assessPaths from '../../paths/assess'
 import { DateFormats, todayAtMidnight } from '../dateUtils'
 import { SanitisedError } from '../../sanitisedError'
 import { linebreaksToParagraphs, linkTo } from '../utils'
-import { isFullPerson, laoName } from '../personUtils'
+import { displayName } from '../personUtils'
 import { convertObjectsToRadioItems } from '../formUtils'
 import { StatusTag, StatusTagOptions } from '../statusTag'
 import { bookingActions, v1BookingActions, v2BookingActions } from './bookingActions'
@@ -160,7 +153,9 @@ export const bookingsToTableRows = (
   type: 'arrival' | 'departure',
 ): Array<TableRow> => {
   return bookings.map(booking => [
-    nameCell(booking),
+    {
+      text: displayName(booking.person),
+    },
     {
       text: booking.person.crn,
     },
@@ -175,9 +170,6 @@ export const bookingsToTableRows = (
     },
   ])
 }
-
-export const nameCell = (booking: PremisesBooking): TableCell =>
-  isFullPerson(booking.person) ? { text: laoName(booking.person) } : { text: `LAO: ${booking.person.crn}` }
 
 export const generateConflictBespokeError = (
   err: SanitisedError,
@@ -236,7 +228,9 @@ export const bookingPersonRows = (booking: Booking): Array<SummaryListItem> => {
       key: {
         text: 'Name',
       },
-      value: nameCell(booking),
+      value: {
+        text: displayName(booking.person),
+      },
     },
     {
       key: {

--- a/server/utils/bookings/index.ts
+++ b/server/utils/bookings/index.ts
@@ -229,7 +229,7 @@ export const bookingPersonRows = (booking: Booking): Array<SummaryListItem> => {
         text: 'Name',
       },
       value: {
-        text: displayName(booking.person, { laoAsSuffix: true }),
+        text: displayName(booking.person, { laoSuffix: true }),
       },
     },
     {

--- a/server/utils/bookings/index.ts
+++ b/server/utils/bookings/index.ts
@@ -229,7 +229,7 @@ export const bookingPersonRows = (booking: Booking): Array<SummaryListItem> => {
         text: 'Name',
       },
       value: {
-        text: displayName(booking.person),
+        text: displayName(booking.person, { laoAsSuffix: true }),
       },
     },
     {

--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -31,6 +31,7 @@ import { apTypeLabels } from '../apTypeLabels'
 import { textValue } from '../applications/helpers'
 import { allReleaseTypes } from '../applications/releaseTypeUtils'
 import { roomCharacteristicMap } from '../characteristicsUtils'
+import { displayName } from '../personUtils'
 
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
 
@@ -328,7 +329,7 @@ describe('matchUtils', () => {
       expect(details).toEqual({
         header: {
           key: 'Name',
-          value: (placementRequest.person as FullPerson).name,
+          value: displayName(placementRequest.person),
           showKey: false,
         },
         items: [

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -19,7 +19,7 @@ import { placementCriteriaLabels } from '../placementCriteriaUtils'
 import { apTypeLabels } from '../apTypeLabels'
 import { summaryListItem } from '../formUtils'
 import { textValue } from '../applications/helpers'
-import { isFullPerson } from '../personUtils'
+import { displayName, isFullPerson } from '../personUtils'
 import { allReleaseTypes } from '../applications/releaseTypeUtils'
 import paths from '../../paths/apply'
 import { spaceSearchResultsCharacteristicsLabels } from './spaceSearch'
@@ -226,7 +226,7 @@ export const keyDetails = (placementRequest: PlacementRequestDetail): KeyDetails
   return {
     header: {
       key: 'Name',
-      value: person.name,
+      value: displayName(person),
       showKey: false,
     },
     items: [

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -75,6 +75,7 @@ import config from '../config'
 import { withdrawalRadioOptions } from './applications/withdrawalReasons'
 import { PersonStatusTag } from './people/personStatusTag'
 import { TaskStatusTag } from './tasks/statusTag'
+import { displayName } from './personUtils'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -117,6 +118,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   )
 
   njkEnv.addFilter('initialiseName', initialiseName)
+  njkEnv.addGlobal('displayName', displayName)
   njkEnv.addGlobal('dateFieldValues', dateFieldValues)
   njkEnv.addGlobal('formatDate', (date: string, options: { format: 'short' | 'long' } = { format: 'long' }) =>
     DateFormats.isoDateToUIDate(date, options),

--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -72,7 +72,7 @@ describe('personUtils', () => {
       it('returns the name suffixed with "(Limited access offender)" if restricted and LAO as suffix specified', () => {
         const person = fullPersonFactory.build({ isRestricted: true })
 
-        expect(displayName(person, { laoAsSuffix: true })).toEqual(`${person.name} (Limited access offender)`)
+        expect(displayName(person, { laoSuffix: true })).toEqual(`${person.name} (Limited access offender)`)
       })
     })
 
@@ -83,10 +83,24 @@ describe('personUtils', () => {
         expect(displayName(person)).toEqual(person.name)
       })
 
-      it('returns the name prefixed with "LAO:" if restricted', () => {
-        const person = fullPersonSummaryFactory.build({ isRestricted: true })
+      describe('with a restricted person', () => {
+        it('returns the name prefixed with "LAO:" by default', () => {
+          const person = fullPersonSummaryFactory.build({ isRestricted: true })
 
-        expect(displayName(person)).toEqual(`LAO: ${person.name}`)
+          expect(displayName(person)).toEqual(`LAO: ${person.name}`)
+        })
+
+        it('returns the name suffixed with " (Limited access offender)" if specified', () => {
+          const person = fullPersonSummaryFactory.build({ isRestricted: true })
+
+          expect(displayName(person, { laoSuffix: true })).toEqual(`${person.name} (Limited access offender)`)
+        })
+
+        it('returns the name with no prefix or suffix', () => {
+          const person = fullPersonSummaryFactory.build({ isRestricted: true })
+
+          expect(displayName(person, { laoPrefix: false })).toEqual(person.name)
+        })
       })
     })
 

--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -3,6 +3,7 @@ import {
   fullPersonSummaryFactory,
   restrictedPersonFactory,
   restrictedPersonSummaryFactory,
+  unknownPersonFactory,
   unknownPersonSummaryFactory,
 } from '../testutils/factories/person'
 import {
@@ -106,9 +107,15 @@ describe('personUtils', () => {
     it('returns "the person" if passed a restrictedPerson', () => {
       expect(nameOrPlaceholderCopy(restrictedPersonFactory.build())).toEqual('the person')
     })
+
     it('returns the persons name if passed a fullPerson', () => {
       const person = fullPersonFactory.build()
       expect(nameOrPlaceholderCopy(person)).toContain(person.name)
+    })
+
+    it('returns Unknown if the person is unknown', () => {
+      const person = unknownPersonFactory.build()
+      expect(nameOrPlaceholderCopy(person)).toEqual(`Unknown person`)
     })
 
     it('includes limited access offender text if showLaoLabel true and person is restricted to others', () => {

--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -6,15 +6,7 @@ import {
   unknownPersonFactory,
   unknownPersonSummaryFactory,
 } from '../testutils/factories/person'
-import {
-  isApplicableTier,
-  isFullPerson,
-  isUnknownPerson,
-  laoName,
-  laoSummaryName,
-  nameOrPlaceholderCopy,
-  tierBadge,
-} from './personUtils'
+import { displayName, isApplicableTier, isFullPerson, isUnknownPerson, tierBadge } from './personUtils'
 
 describe('personUtils', () => {
   describe('tierBadge', () => {
@@ -63,69 +55,81 @@ describe('personUtils', () => {
     })
   })
 
-  describe('laoName', () => {
-    it('if the person is not restricted it returns their name', () => {
-      const person = fullPersonFactory.build({ isRestricted: false })
+  describe('displayName', () => {
+    describe('with a Full Person', () => {
+      it('returns the name if not restricted', () => {
+        const person = fullPersonFactory.build({ isRestricted: false })
 
-      expect(laoName(person)).toEqual(person.name)
+        expect(displayName(person)).toEqual(person.name)
+      })
+
+      it('returns the name prefixed with "LAO:" if restricted', () => {
+        const person = fullPersonFactory.build({ isRestricted: true })
+
+        expect(displayName(person)).toEqual(`LAO: ${person.name}`)
+      })
     })
 
-    it('if the person is restricted it returns their name prefixed with LAO: ', () => {
-      const person = fullPersonFactory.build({ isRestricted: true })
+    describe('with a Full Person Summary', () => {
+      it('returns the name if not restricted', () => {
+        const person = fullPersonSummaryFactory.build({ isRestricted: false })
 
-      expect(laoName(person)).toEqual(`LAO: ${person.name}`)
-    })
-  })
+        expect(displayName(person)).toEqual(person.name)
+      })
 
-  describe('laoSummaryName', () => {
-    it('if the person is not restricted it returns their name', () => {
-      const person = fullPersonSummaryFactory.build({ isRestricted: false })
+      it('returns the name prefixed with "LAO:" if restricted', () => {
+        const person = fullPersonSummaryFactory.build({ isRestricted: true })
 
-      expect(laoSummaryName(person)).toEqual(person.name)
-    })
-
-    it('if the person is restricted but the API returns a full person summary, it returns their name prefixed with LAO:', () => {
-      const person = fullPersonSummaryFactory.build({ isRestricted: true })
-
-      expect(laoSummaryName(person)).toEqual(`LAO: ${person.name}`)
+        expect(displayName(person)).toEqual(`LAO: ${person.name}`)
+      })
     })
 
-    it('if the person is restricted and the API returns a restrictedPersonSummary, it returns LAO ', () => {
+    describe('with a Restricted Person', () => {
+      const person = restrictedPersonFactory.build()
+
+      it('returns "Limited Access Offender" without CRN', () => {
+        expect(displayName(person)).toEqual('Limited Access Offender')
+      })
+
+      it('returns "LAO: {crn}" with CRN', () => {
+        expect(displayName(person, true)).toEqual(`LAO: ${person.crn}`)
+      })
+    })
+
+    describe('with a Restricted Person Summary', () => {
       const person = restrictedPersonSummaryFactory.build()
 
-      expect(laoSummaryName(person)).toEqual(`LAO`)
+      it('returns "Limited Access Offender" without CRN', () => {
+        expect(displayName(person)).toEqual('Limited Access Offender')
+      })
+
+      it('returns "LAO: {crn}" with CRN', () => {
+        expect(displayName(person, true)).toEqual(`LAO: ${person.crn}`)
+      })
     })
 
-    it('if the person is unknown and the API returns an unknownPersonSummary, it returns Unknown ', () => {
+    describe('with an Unknown Person', () => {
+      const person = unknownPersonFactory.build()
+
+      it('returns "Unknown person" without CRN', () => {
+        expect(displayName(person)).toEqual('Unknown person')
+      })
+
+      it('returns "Unknown: {crn}" with CRN', () => {
+        expect(displayName(person, true)).toEqual(`Unknown: ${person.crn}`)
+      })
+    })
+
+    describe('with an Unknown Person Summary', () => {
       const person = unknownPersonSummaryFactory.build()
 
-      expect(laoSummaryName(person)).toEqual(`Unknown`)
-    })
-  })
+      it('returns "Unknown person" without CRN', () => {
+        expect(displayName(person)).toEqual('Unknown person')
+      })
 
-  describe('nameOrPlaceholderCopy', () => {
-    it('returns "the person" if passed a restrictedPerson', () => {
-      expect(nameOrPlaceholderCopy(restrictedPersonFactory.build())).toEqual('the person')
-    })
-
-    it('returns the persons name if passed a fullPerson', () => {
-      const person = fullPersonFactory.build()
-      expect(nameOrPlaceholderCopy(person)).toContain(person.name)
-    })
-
-    it('returns Unknown if the person is unknown', () => {
-      const person = unknownPersonFactory.build()
-      expect(nameOrPlaceholderCopy(person)).toEqual(`Unknown person`)
-    })
-
-    it('includes limited access offender text if showLaoLabel true and person is restricted to others', () => {
-      const person = fullPersonFactory.build({ isRestricted: true })
-      expect(nameOrPlaceholderCopy(person, 'the person', true)).toEqual(`${person.name} (Limited access offender)`)
-    })
-
-    it('does not include limited access offender text if showLaoLabel true and person is not restricted to others', () => {
-      const person = fullPersonFactory.build({ isRestricted: false })
-      expect(nameOrPlaceholderCopy(person, 'the person', true)).toEqual(person.name)
+      it('returns "Unknown: {crn}" with CRN', () => {
+        expect(displayName(person, true)).toEqual(`Unknown: ${person.crn}`)
+      })
     })
   })
 

--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -68,6 +68,12 @@ describe('personUtils', () => {
 
         expect(displayName(person)).toEqual(`LAO: ${person.name}`)
       })
+
+      it('returns the name suffixed with "(Limited access offender)" if restricted and LAO as suffix specified', () => {
+        const person = fullPersonFactory.build({ isRestricted: true })
+
+        expect(displayName(person, { laoAsSuffix: true })).toEqual(`${person.name} (Limited access offender)`)
+      })
     })
 
     describe('with a Full Person Summary', () => {
@@ -92,7 +98,7 @@ describe('personUtils', () => {
       })
 
       it('returns "LAO: {crn}" with CRN', () => {
-        expect(displayName(person, true)).toEqual(`LAO: ${person.crn}`)
+        expect(displayName(person, { showCrn: true })).toEqual(`LAO: ${person.crn}`)
       })
     })
 
@@ -104,7 +110,7 @@ describe('personUtils', () => {
       })
 
       it('returns "LAO: {crn}" with CRN', () => {
-        expect(displayName(person, true)).toEqual(`LAO: ${person.crn}`)
+        expect(displayName(person, { showCrn: true })).toEqual(`LAO: ${person.crn}`)
       })
     })
 
@@ -116,7 +122,7 @@ describe('personUtils', () => {
       })
 
       it('returns "Unknown: {crn}" with CRN', () => {
-        expect(displayName(person, true)).toEqual(`Unknown: ${person.crn}`)
+        expect(displayName(person, { showCrn: true })).toEqual(`Unknown: ${person.crn}`)
       })
     })
 
@@ -128,7 +134,7 @@ describe('personUtils', () => {
       })
 
       it('returns "Unknown: {crn}" with CRN', () => {
-        expect(displayName(person, true)).toEqual(`Unknown: ${person.crn}`)
+        expect(displayName(person, { showCrn: true })).toEqual(`Unknown: ${person.crn}`)
       })
     })
   })

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -17,7 +17,7 @@ const isApplicableTier = (sex: string, tier: string): boolean => {
   return applicableTiers.includes(tier)
 }
 
-const isFullPerson = (person?: Person): person is FullPerson => (person as FullPerson)?.name !== undefined
+const isFullPerson = (person?: Person): person is FullPerson => (person as FullPerson)?.type === 'FullPerson'
 
 const isUnknownPerson = (person?: Person): boolean => person?.type === 'UnknownPerson'
 
@@ -32,16 +32,22 @@ const laoSummaryName = (personSummary: PersonSummary) => {
 }
 
 /**
- * Returns the person's name if they are a FullPerson, otherwise returns 'the person'
- * @param {Person} person
- * @returns 'the person' | person.name
+ * Returns the person's name if they are a FullPerson, 'the person' or any other copy provided if they are LAO, or
+ * 'Unknown person' if they are unknown.
+ * @param {Person}    person
+ * @param {string}    copyForRestrictedPerson the copy to use instead of the person's name if the person is LAO
+ * @param {boolean}   showLaoLabel append ' (Limited access offender)' if the person is LAO
+ * @returns {string}  The name or text to display
  */
 const nameOrPlaceholderCopy = (
   person: Person,
-  copyForRestrictedPerson = 'the person',
-  showLaoLabel = false,
+  copyForRestrictedPerson: string = 'the person',
+  showLaoLabel: boolean = false,
 ): string => {
-  return isFullPerson(person) ? nameText(person, showLaoLabel) : copyForRestrictedPerson
+  if (isFullPerson(person)) {
+    return nameText(person, showLaoLabel)
+  }
+  return person.type === 'RestrictedPerson' ? copyForRestrictedPerson : 'Unknown person'
 }
 
 const nameText = (person: FullPerson, showLaoLabel: boolean) => {

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -29,7 +29,12 @@ const isFullPerson = (person?: Person): person is FullPerson => (person as FullP
 
 const isUnknownPerson = (person?: Person): person is Person => person?.type === 'UnknownPerson'
 
-const fullPersonName = (person: FullPerson) => (person.isRestricted ? `LAO: ${person.name}` : person.name)
+const fullPersonName = (person: FullPerson, laoAsSuffix = false) => {
+  if (person.isRestricted) {
+    return laoAsSuffix ? `${person.name} (Limited access offender)` : `LAO: ${person.name}`
+  }
+  return person.name
+}
 
 const restrictedPersonName = (person: RestrictedPerson | RestrictedPersonSummary, showCrn = false) =>
   showCrn ? `LAO: ${person.crn}` : 'Limited Access Offender'
@@ -41,10 +46,15 @@ const unknownPersonName = (person: UnknownPerson | UnknownPersonSummary, showCrn
  * Returns the person's name if they are a Full Person, 'Limited Access Offender' if they are a Restricted
  * Person, or 'Unknown person' if they are an Unknown Person. This handles 'summary' types.
  * @param {Person}    person The person whose name needs to be displayed
- * @param {boolean}   showCrn Whether to show the CRN when the person name cannot be shown
+ * @param options
+ * @param {boolean}   options.showCrn Whether to show the CRN when the person name cannot be shown
+ * @param {boolean}   options.lasoAsSuffix Shows a full person with the LAO mark as a suffix instead of prefix
  * @returns {string}  The name or text to display
  */
-const displayName = (person: Person | PersonSummary, showCrn: boolean = false): string => {
+const displayName = (
+  person: Person | PersonSummary,
+  options: { showCrn?: boolean; laoAsSuffix?: boolean } = { showCrn: false, laoAsSuffix: false },
+): string => {
   let typeKey: 'type' | 'personType'
 
   if ('type' in person) {
@@ -56,12 +66,12 @@ const displayName = (person: Person | PersonSummary, showCrn: boolean = false): 
   switch (person[typeKey]) {
     case 'FullPerson':
     case 'FullPersonSummary':
-      return fullPersonName(person as FullPerson)
+      return fullPersonName(person as FullPerson, options.laoAsSuffix)
     case 'RestrictedPerson':
     case 'RestrictedPersonSummary':
-      return restrictedPersonName(person, showCrn)
+      return restrictedPersonName(person, options.showCrn)
     default:
-      return unknownPersonName(person, showCrn)
+      return unknownPersonName(person, options.showCrn)
   }
 }
 

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -29,10 +29,22 @@ const isFullPerson = (person?: Person): person is FullPerson => (person as FullP
 
 const isUnknownPerson = (person?: Person): person is Person => person?.type === 'UnknownPerson'
 
-const fullPersonName = (person: FullPerson, laoAsSuffix = false) => {
+const fullPersonName = (
+  person: FullPerson,
+  options: { laoPrefix?: boolean; laoSuffix?: boolean } = {
+    laoPrefix: true,
+    laoSuffix: false,
+  },
+) => {
   if (person.isRestricted) {
-    return laoAsSuffix ? `${person.name} (Limited access offender)` : `LAO: ${person.name}`
+    if (options.laoSuffix) {
+      return `${person.name} (Limited access offender)`
+    }
+    if (options.laoPrefix) {
+      return `LAO: ${person.name}`
+    }
   }
+
   return person.name
 }
 
@@ -47,14 +59,17 @@ const unknownPersonName = (person: UnknownPerson | UnknownPersonSummary, showCrn
  * Person, or 'Unknown person' if they are an Unknown Person. This handles 'summary' types.
  * @param {Person}    person The person whose name needs to be displayed
  * @param options
- * @param {boolean}   options.showCrn Whether to show the CRN when the person name cannot be shown
- * @param {boolean}   options.lasoAsSuffix Shows a full person with the LAO mark as a suffix instead of prefix
+ * @param {boolean}   options.showCrn Show the CRN when the person name cannot be shown
+ * @param {boolean}   options.laoPrefix Prefix person name with 'LAO: ' if restricted (default true)
+ * @param {boolean}   options.laoSuffix Append ' (Limited access offender)' to person name if restricted
  * @returns {string}  The name or text to display
  */
 const displayName = (
   person: Person | PersonSummary,
-  options: { showCrn?: boolean; laoAsSuffix?: boolean } = { showCrn: false, laoAsSuffix: false },
+  options: { showCrn?: boolean; laoPrefix?: boolean; laoSuffix?: boolean } = {},
 ): string => {
+  const { showCrn = false, laoPrefix = true, laoSuffix = false } = options
+
   let typeKey: 'type' | 'personType'
 
   if ('type' in person) {
@@ -66,12 +81,12 @@ const displayName = (
   switch (person[typeKey]) {
     case 'FullPerson':
     case 'FullPersonSummary':
-      return fullPersonName(person as FullPerson, options.laoAsSuffix)
+      return fullPersonName(person as FullPerson, { laoPrefix, laoSuffix })
     case 'RestrictedPerson':
     case 'RestrictedPersonSummary':
-      return restrictedPersonName(person, options.showCrn)
+      return restrictedPersonName(person, showCrn)
     default:
-      return unknownPersonName(person, options.showCrn)
+      return unknownPersonName(person, showCrn)
   }
 }
 

--- a/server/utils/placementRequests/table.test.ts
+++ b/server/utils/placementRequests/table.test.ts
@@ -26,8 +26,8 @@ import { DateFormats } from '../dateUtils'
 import { allReleaseTypes } from '../applications/releaseTypeUtils'
 import { crnCell, tierCell } from '../tableUtils'
 import { sortHeader } from '../sortHeader'
-import { laoName } from '../personUtils'
-import { FullPerson, PlacementRequestSortField } from '../../@types/shared'
+import { displayName } from '../personUtils'
+import { PlacementRequestSortField } from '../../@types/shared'
 import { linkTo } from '../utils'
 import adminPaths from '../../paths/admin'
 
@@ -45,7 +45,7 @@ describe('tableUtils', () => {
       nameCell(placementRequest)
 
       expect(linkTo).toHaveBeenCalledWith(adminPaths.admin.placementRequests.show({ id: placementRequest.id }), {
-        text: laoName(placementRequest.person as FullPerson),
+        text: displayName(placementRequest.person),
         attributes: {
           'data-cy-placementRequestId': placementRequest.id,
           'data-cy-applicationId': placementRequest.applicationId,
@@ -53,15 +53,7 @@ describe('tableUtils', () => {
       })
     })
 
-    it('returns an empty cell if the personName is not present', () => {
-      const task = placementRequestFactory.build({ person: undefined })
-
-      expect(nameCell(task)).toEqual({
-        html: '',
-      })
-    })
-
-    it('returns the crn cell if the person is a restrictedPerson', () => {
+    it('returns the crn cell with no link if the person is a restrictedPerson', () => {
       const restrictedPersonTask = placementRequestFactory.build()
       restrictedPersonTask.person = restrictedPersonFactory.build()
 
@@ -77,7 +69,7 @@ describe('tableUtils', () => {
       nameCell(restrictedPersonTask)
 
       expect(linkTo).toHaveBeenCalledWith(adminPaths.admin.placementRequests.show({ id: restrictedPersonTask.id }), {
-        text: laoName(restrictedPersonTask.person as FullPerson),
+        text: displayName(restrictedPersonTask.person),
         attributes: {
           'data-cy-placementRequestId': restrictedPersonTask.id,
           'data-cy-applicationId': restrictedPersonTask.applicationId,
@@ -90,7 +82,7 @@ describe('tableUtils', () => {
       unknownPersonTask.person = restrictedPersonFactory.build({ type: 'UnknownPerson' })
 
       expect(nameCell(unknownPersonTask)).toEqual({
-        text: `Not Found CRN: ${unknownPersonTask.person.crn}`,
+        text: `Unknown: ${unknownPersonTask.person.crn}`,
       })
     })
   })

--- a/server/utils/placementRequests/table.ts
+++ b/server/utils/placementRequests/table.ts
@@ -89,7 +89,7 @@ export const applicationDateCell = (item: PlacementRequest): TableCell => ({
 })
 
 export const nameCell = (item: PlacementRequest): TableCell => {
-  const name = displayName(item.person, true)
+  const name = displayName(item.person, { showCrn: true })
 
   if (isFullPerson(item.person)) {
     return {

--- a/server/utils/placementRequests/table.ts
+++ b/server/utils/placementRequests/table.ts
@@ -7,7 +7,7 @@ import { linkTo } from '../utils'
 import { crnCell, tierCell } from '../tableUtils'
 import { allReleaseTypes } from '../applications/releaseTypeUtils'
 import { sortHeader } from '../sortHeader'
-import { isFullPerson, isUnknownPerson, laoName } from '../personUtils'
+import { displayName, isFullPerson } from '../personUtils'
 import { placementRequestStatus } from '../formUtils'
 
 export const DIFFERENCE_IN_DAYS_BETWEEN_DUE_DATE_AND_ARRIVAL_DATE = 7
@@ -89,22 +89,20 @@ export const applicationDateCell = (item: PlacementRequest): TableCell => ({
 })
 
 export const nameCell = (item: PlacementRequest): TableCell => {
-  if ('person' in item && item.person && isFullPerson(item.person)) {
+  const name = displayName(item.person, true)
+
+  if (isFullPerson(item.person)) {
     return {
       html: linkTo(adminPaths.admin.placementRequests.show({ id: item.id }), {
-        text: laoName(item.person),
+        text: name,
         attributes: { 'data-cy-placementRequestId': item.id, 'data-cy-applicationId': item.applicationId },
       }),
     }
   }
 
-  if ('person' in item && item.person && !isFullPerson(item.person)) {
-    return {
-      text: isUnknownPerson(item.person) ? `Not Found CRN: ${item.person.crn}` : `LAO: ${item.person.crn}`,
-    }
+  return {
+    text: name,
   }
-
-  return { html: '' }
 }
 
 export const releaseTypeCell = (task: PlacementRequest) => {

--- a/server/utils/placements/index.test.ts
+++ b/server/utils/placements/index.test.ts
@@ -3,6 +3,7 @@ import { RadioItem, SelectOption } from '@approved-premises/ui'
 import {
   cas1PremisesFactory,
   cas1SpaceBookingFactory,
+  restrictedPersonFactory,
   staffMemberFactory,
   userDetailsFactory,
 } from '../../testutils/factories'
@@ -22,6 +23,7 @@ import { DateFormats } from '../dateUtils'
 
 import paths from '../../paths/manage'
 import { requirementsHtmlString } from '../match'
+import { fullPersonFactory, unknownPersonFactory } from '../../testutils/factories/person'
 
 describe('placementUtils', () => {
   describe('actions', () => {
@@ -148,6 +150,46 @@ describe('placementUtils', () => {
               text: DateFormats.isoDateToUIDate((placement.person as FullPerson).dateOfBirth, { format: 'short' }),
             },
           },
+        ],
+      })
+    })
+
+    it('should prefix the name with LAO if the person is LAO', () => {
+      const placement = cas1SpaceBookingFactory.build({
+        person: fullPersonFactory.build({
+          isRestricted: true,
+        }),
+      })
+
+      const result = getKeyDetail(placement)
+
+      expect(result.header.value).toEqual(`LAO: ${(placement.person as FullPerson).name}`)
+    })
+
+    it('should not show the name or date of birth for a restricted person', () => {
+      const placement = cas1SpaceBookingFactory.build({
+        person: restrictedPersonFactory.build(),
+      })
+
+      expect(getKeyDetail(placement)).toEqual({
+        header: { key: '', showKey: false, value: 'Limited Access Offender' },
+        items: [
+          { key: { text: 'CRN' }, value: { text: placement.person.crn } },
+          { key: { text: 'Tier' }, value: { text: placement.tier } },
+        ],
+      })
+    })
+
+    it('should not show the name or date of birth for an unknown person', () => {
+      const placement = cas1SpaceBookingFactory.build({
+        person: unknownPersonFactory.build(),
+      })
+
+      expect(getKeyDetail(placement)).toEqual({
+        header: { key: '', showKey: false, value: 'Unknown person' },
+        items: [
+          { key: { text: 'CRN' }, value: { text: placement.person.crn } },
+          { key: { text: 'Tier' }, value: { text: placement.tier } },
         ],
       })
     })

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -2,7 +2,6 @@ import type {
   Cas1SpaceBooking,
   Cas1SpaceBookingDates,
   Cas1SpaceBookingSummaryStatus,
-  FullPerson,
   StaffMember,
 } from '@approved-premises/api'
 import {
@@ -15,7 +14,7 @@ import {
 } from '@approved-premises/ui'
 import { DateFormats, daysToWeeksAndDays } from '../dateUtils'
 import { htmlValue, textValue } from '../applications/helpers'
-import { isFullPerson, nameOrPlaceholderCopy } from '../personUtils'
+import { displayName, isFullPerson } from '../personUtils'
 import paths from '../../paths/manage'
 import { hasPermission } from '../users'
 import { TabItem } from '../tasks/listTable'
@@ -79,18 +78,18 @@ export const actions = (placement: Cas1SpaceBooking, user: UserDetails) => {
 export const getKeyDetail = (placement: Cas1SpaceBooking): KeyDetailsArgs => {
   const { person, tier } = placement
   return {
-    header: { value: nameOrPlaceholderCopy(person), key: '', showKey: false },
+    header: { value: displayName(person), key: '', showKey: false },
     items: [
       { key: textValue('CRN'), value: textValue(person.crn) },
       { key: { text: 'Tier' }, value: { text: tier } },
-      {
-        key: { text: 'Date of birth' },
-        value: {
-          text: isFullPerson(person)
-            ? DateFormats.isoDateToUIDate((person as FullPerson).dateOfBirth, { format: 'short' })
-            : '-',
-        },
-      },
+      isFullPerson(person)
+        ? {
+            key: { text: 'Date of birth' },
+            value: {
+              text: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
+            },
+          }
+        : undefined,
     ],
   }
 }

--- a/server/utils/premises/index.test.ts
+++ b/server/utils/premises/index.test.ts
@@ -20,7 +20,7 @@ import { statusTextMap } from '../placements'
 import { textValue } from '../applications/helpers'
 import paths from '../../paths/manage'
 import { linkTo } from '../utils'
-import { laoSummaryName } from '../personUtils'
+import { displayName } from '../personUtils'
 import { DateFormats } from '../dateUtils'
 
 describe('premisesUtils', () => {
@@ -287,7 +287,7 @@ describe('premisesUtils', () => {
           const statusColumn = { text: statusTextMap[placement.status] }
           const baseColumns = [
             {
-              html: `<a href="/manage/premises/Test_Premises_Id/placements/${placement.id}" data-cy-id="${placement.id}">${laoSummaryName(placement.person)}, ${placement.person.crn}</a>`,
+              html: `<a href="/manage/premises/Test_Premises_Id/placements/${placement.id}" data-cy-id="${placement.id}">${displayName(placement.person)}, ${placement.person.crn}</a>`,
             },
             { html: `<span class="moj-badge moj-badge--red">${placement.tier}</span>` },
             { text: DateFormats.isoDateToUIDate(placement.canonicalArrivalDate, { format: 'short' }) },

--- a/server/utils/premises/index.ts
+++ b/server/utils/premises/index.ts
@@ -16,7 +16,7 @@ import managePaths from '../../paths/manage'
 import { createQueryString, linkTo } from '../utils'
 import { TabItem } from '../tasks/listTable'
 import { sortHeader } from '../sortHeader'
-import { laoSummaryName } from '../personUtils'
+import { displayName } from '../personUtils'
 import { statusTextMap } from '../placements'
 
 export { premisesActions } from './premisesActions'
@@ -162,7 +162,7 @@ export const placementTableRows = (
         `<a href="${managePaths.premises.placements.show({
           premisesId,
           placementId: id,
-        })}" data-cy-id="${id}">${laoSummaryName(person)}, ${person.crn}</a>`,
+        })}" data-cy-id="${id}">${displayName(person)}, ${person.crn}</a>`,
       ),
       tier: htmlValue(getTierOrBlank(tier)),
       canonicalArrivalDate: textValue(DateFormats.isoDateToUIDate(canonicalArrivalDate, { format: 'short' })),

--- a/server/utils/premises/occupancy.test.ts
+++ b/server/utils/premises/occupancy.test.ts
@@ -28,7 +28,7 @@ import {
 import { DateFormats } from '../dateUtils'
 import { premiseCharacteristicAvailability } from '../../testutils/factories/cas1PremiseCapacity'
 import { getTierOrBlank } from '../applications/helpers'
-import { laoSummaryName } from '../personUtils'
+import { displayName } from '../personUtils'
 import config from '../../config'
 import { roomCharacteristicMap } from '../characteristicsUtils'
 
@@ -294,7 +294,7 @@ describe('apOccupancy utils', () => {
   describe('placementTableRows', () => {
     const checkRow = (placement: Cas1SpaceBookingDaySummary, row: Array<{ text?: string; html?: string }>) => {
       expect(row[0].html).toMatchStringIgnoringWhitespace(
-        `<a href="/manage/premises/premises-Id/placements/${placement.id}" data-cy-id="${placement.id}">${laoSummaryName(placement.person)}, ${placement.person.crn}</a>`,
+        `<a href="/manage/premises/premises-Id/placements/${placement.id}" data-cy-id="${placement.id}">${displayName(placement.person)}, ${placement.person.crn}</a>`,
       )
       expect(row[1].html).toEqual(getTierOrBlank(placement.tier))
       expect(row[2].text).toEqual(DateFormats.isoDateToUIDate(placement.canonicalArrivalDate, { format: 'short' }))

--- a/server/utils/premises/occupancy.ts
+++ b/server/utils/premises/occupancy.ts
@@ -13,7 +13,7 @@ import { getTierOrBlank, htmlValue, textValue } from '../applications/helpers'
 import managePaths from '../../paths/manage'
 import { summaryListItem } from '../formUtils'
 import { sortHeader } from '../sortHeader'
-import { laoSummaryName } from '../personUtils'
+import { displayName } from '../personUtils'
 import { joinWithCommas, pluralize } from '../utils'
 import { placementCriteriaLabels } from '../placementCriteriaUtils'
 import config from '../../config'
@@ -255,7 +255,7 @@ export const placementTableRows = (
           `<a href="${managePaths.premises.placements.show({
             premisesId,
             placementId: id,
-          })}" data-cy-id="${id}">${laoSummaryName(person)}, ${person.crn}</a>`,
+          })}" data-cy-id="${id}">${displayName(person)}, ${person.crn}</a>`,
         ),
         tier: htmlValue(getTierOrBlank(tier)),
         canonicalArrivalDate: textValue(DateFormats.isoDateToUIDate(canonicalArrivalDate, { format: 'short' })),

--- a/server/utils/tasks/index.test.ts
+++ b/server/utils/tasks/index.test.ts
@@ -1,5 +1,5 @@
 import { groupByAllocation, taskSummary, userQualificationsSelectOptions } from '.'
-import { type ApprovedPremisesApplication, FullPerson, Task } from '../../@types/shared'
+import { type ApprovedPremisesApplication, Task } from '../../@types/shared'
 import { applicationFactory, placementDatesFactory, taskFactory, userFactory } from '../../testutils/factories'
 import { fullPersonFactory } from '../../testutils/factories/person'
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
@@ -7,6 +7,7 @@ import { getApplicationType } from '../applications/utils'
 import paths from '../../paths/apply'
 import placementApplicationTask from '../../testutils/factories/placementApplicationTask'
 import { applicationUserDetailsFactory } from '../../testutils/factories/application'
+import { displayName } from '../personUtils'
 
 jest.mock('../applications/arrivalDateFromApplication')
 
@@ -48,7 +49,7 @@ describe('index', () => {
         expect(taskSummary(task, application)).toEqual([
           {
             key: { text: 'Name' },
-            value: { text: (application.person as FullPerson).name },
+            value: { text: displayName(application.person) },
           },
           {
             key: { text: 'CRN' },
@@ -83,6 +84,15 @@ describe('index', () => {
             value: { text: 'Men' },
           },
         ])
+      })
+
+      it('indicates if the person is a Limited access offender', () => {
+        const laoPerson = fullPersonFactory.build({ isRestricted: true })
+        const laoApplication = { ...application, person: laoPerson }
+
+        expect(taskSummary(task, laoApplication)[0].value).toEqual({
+          text: `${laoPerson.name} (Limited access offender)`,
+        })
       })
     })
 

--- a/server/utils/tasks/index.ts
+++ b/server/utils/tasks/index.ts
@@ -66,7 +66,7 @@ const taskSummary = (task: Task, application: Application): Array<SummaryListIte
         text: 'Name',
       },
       value: {
-        text: displayName(application.person, { laoAsSuffix: true }),
+        text: displayName(application.person, { laoSuffix: true }),
       },
     },
     {

--- a/server/utils/tasks/index.ts
+++ b/server/utils/tasks/index.ts
@@ -5,7 +5,7 @@ import { SelectOption, SummaryListItem, TaskSearchQualification } from '../../@t
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
 import { getApplicationType } from '../applications/utils'
 import { DateFormats } from '../dateUtils'
-import { nameOrPlaceholderCopy } from '../personUtils'
+import { displayName } from '../personUtils'
 import {
   allocatedTableRows,
   completedTableHeader,
@@ -66,7 +66,7 @@ const taskSummary = (task: Task, application: Application): Array<SummaryListIte
         text: 'Name',
       },
       value: {
-        text: nameOrPlaceholderCopy(application.person, `LAO: ${application.person.crn}`, true),
+        text: displayName(application.person),
       },
     },
     {

--- a/server/utils/tasks/index.ts
+++ b/server/utils/tasks/index.ts
@@ -66,7 +66,7 @@ const taskSummary = (task: Task, application: Application): Array<SummaryListIte
         text: 'Name',
       },
       value: {
-        text: displayName(application.person),
+        text: displayName(application.person, { laoAsSuffix: true }),
       },
     },
     {

--- a/server/utils/tasks/listTable.test.ts
+++ b/server/utils/tasks/listTable.test.ts
@@ -214,12 +214,12 @@ describe('table', () => {
       })
       expect(nameAnchorCell(task)).toEqual({
         html: linkTo(paths.tasks.show({ id: task.id, taskType: kebabCase(task.taskType) }), {
-          text: `LAO CRN: ${personSummary.crn}`,
+          text: `LAO: ${personSummary.crn}`,
           attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
         }),
       })
     })
-    it('returns the not found CRN when the person summary is UnknownPersonSummary  in the task', () => {
+    it('returns the unknown person CRN when the person summary is UnknownPersonSummary  in the task', () => {
       const personSummary = fullPersonSummaryFactory.build({ personType: 'UnknownPersonSummary' })
       const task = taskFactory.build({
         taskType: 'Assessment',
@@ -227,7 +227,7 @@ describe('table', () => {
       })
       expect(nameAnchorCell(task)).toEqual({
         html: linkTo(paths.tasks.show({ id: task.id, taskType: kebabCase(task.taskType) }), {
-          text: `Not Found CRN: ${personSummary.crn}`,
+          text: `Unknown: ${personSummary.crn}`,
           attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
         }),
       })

--- a/server/utils/tasks/listTable.ts
+++ b/server/utils/tasks/listTable.ts
@@ -1,8 +1,6 @@
 import { isAssessmentTask, isPlacementApplicationTask } from './assertions'
 import {
   AssessmentDecision,
-  FullPersonSummary,
-  PersonSummary,
   PlacementApplicationDecision,
   SortDirection,
   Task,
@@ -16,6 +14,7 @@ import { daysUntilDueCell } from '../tableUtils'
 import { DateFormats } from '../dateUtils'
 
 import { TaskStatusTag } from './statusTag'
+import { displayName } from '../personUtils'
 
 const statusCell = (task: Task): TableCell => ({
   html: new TaskStatusTag(task.status).html(),
@@ -75,22 +74,9 @@ const allocationCell = (task: Task): TableCell => ({
   text: task.allocatedToStaffMember?.name,
 })
 
-const getPersonName = (personSummary: PersonSummary): string => {
-  switch (personSummary.personType) {
-    case 'FullPersonSummary':
-      return (personSummary as FullPersonSummary).name
-    case 'RestrictedPersonSummary':
-      return `LAO CRN: ${personSummary.crn}`
-    case 'UnknownPersonSummary':
-      return `Not Found CRN: ${personSummary.crn}`
-    default:
-      return ''
-  }
-}
-
 const nameAnchorCell = (task: Task): TableCell => ({
   html: linkTo(paths.tasks.show(taskParams(task)), {
-    text: getPersonName(task.personSummary),
+    text: displayName(task.personSummary, true),
     attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
   }),
 })

--- a/server/utils/tasks/listTable.ts
+++ b/server/utils/tasks/listTable.ts
@@ -76,7 +76,7 @@ const allocationCell = (task: Task): TableCell => ({
 
 const nameAnchorCell = (task: Task): TableCell => ({
   html: linkTo(paths.tasks.show(taskParams(task)), {
-    text: displayName(task.personSummary, true),
+    text: displayName(task.personSummary, { showCrn: true }),
     attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
   }),
 })

--- a/server/views/appeals/show.njk
+++ b/server/views/appeals/show.njk
@@ -6,37 +6,35 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
-  {{ govukBackLink({
-      text: "Back to timeline",
-      href: paths.applications.show({ id: application.id }) + "?tab=timeline"
+    {{ govukBackLink({
+        text: "Back to timeline",
+        href: paths.applications.show({ id: application.id }) + "?tab=timeline"
     }) }}
 {% endblock %}
 
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <div class="moj-page-header-actions">
-        <div class="moj-page-header-actions__title">
-          <span class="govuk-caption-l">Assessment</span>
-          <h1 class="govuk-heading-l">
-            {{ application.person.name }}
-          </h1>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="moj-page-header-actions">
+                <div class="moj-page-header-actions__title">
+                    <span class="govuk-caption-l">Assessment</span>
+                    <h1 class="govuk-heading-l">
+                        {{ displayName(application.person) }}
+                    </h1>
+                </div>
+            </div>
         </div>
-      </div>
     </div>
-  </div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
-      {{
-          govukSummaryList({
-              card: {
-                  title: {
-                    text: "Appeal decision"
-                  }
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters">
+            {{ govukSummaryList({
+                card: {
+                    title: {
+                        text: "Appeal decision"
+                    }
                 },
-              rows: AppealsUtils.appealSummaryListItems(appeal)
-          })
-        }}
+                rows: AppealsUtils.appealSummaryListItems(appeal)
+            }) }}
+        </div>
     </div>
-  </div>
 {% endblock %} 

--- a/server/views/applications/appeals/new.njk
+++ b/server/views/applications/appeals/new.njk
@@ -8,91 +8,89 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <div class="moj-page-header-actions">
-        <div class="moj-page-header-actions__title">
-          <span class="govuk-caption-l">{{ pageHeading }}</span>
-          <h1 class="govuk-heading-l">
-            {{ application.person.name }}
-            {% if application.type == 'Offline' %}
-              {{
-                govukTag({
-                  text: "Offline application",
-                  classes: "govuk-tag--grey govuk-!-margin-5"
-                })
-              }}
-            {% endif %}
-          </h1>
-        </div>
-      </div>
-      <form action="{{ paths.applications.appeals.create({ id: applicationId }) }}" method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="moj-page-header-actions">
+                <div class="moj-page-header-actions__title">
+                    <span class="govuk-caption-l">{{ pageHeading }}</span>
+                    <h1 class="govuk-heading-l">
+                        {{ displayName(application.person) }}
+                        {% if application.type == 'Offline' %}
+                            {{ govukTag({
+                                text: "Offline application",
+                                classes: "govuk-tag--grey govuk-!-margin-5"
+                            }) }}
+                        {% endif %}
+                    </h1>
+                </div>
+            </div>
+            <form action="{{ paths.applications.appeals.create({ id: applicationId }) }}" method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-        {{ showErrorSummary(errorSummary) }}
+                {{ showErrorSummary(errorSummary) }}
 
-        {{ govukDateInput({
+                {{ govukDateInput({
                     id: "appealDate",
                     namePrefix: "appealDate",
                     fieldset: {
-                    legend: {
-                        text: "When did you conduct the appeal?",
-                        classes: "govuk-fieldset__legend--s"
+                        legend: {
+                            text: "When did you conduct the appeal?",
+                            classes: "govuk-fieldset__legend--s"
                         }
                     },
                     hint: {
-                    text: "For example, 27 3 2007"
+                        text: "For example, 27 3 2007"
                     },
                     items: dateFieldValues('appealDate', errors),
                     errorMessage: errors.appealDate
                 }) }}
 
-        {{ govukTextarea({
-            name: "appeal[appealDetail]",
-            id: "appealDetail",
-            value: appeal.appealDetail,
-            label: {
-            text: "What was the reason for the appeal?",
-            classes: "govuk-fieldset__legend--s"
-            },
-            errorMessage: errors.appealDetail
-        }) }}
+                {{ govukTextarea({
+                    name: "appeal[appealDetail]",
+                    id: "appealDetail",
+                    value: appeal.appealDetail,
+                    label: {
+                        text: "What was the reason for the appeal?",
+                        classes: "govuk-fieldset__legend--s"
+                    },
+                    errorMessage: errors.appealDetail
+                }) }}
 
-        {{ govukRadios({
-            name: "appeal[decision]",
-            classes: "govuk-radios",
-            fieldset: {
-                legend: {
-                    text: "What decision did you make on the appeal?",
-                    classes: "govuk-fieldset__legend--s"
-                }
-            },
-            items: ApplyUtils.appealDecisionRadioItems(appeal.decision),
-            errorMessage: errors.decision
-        }) }}
+                {{ govukRadios({
+                    name: "appeal[decision]",
+                    classes: "govuk-radios",
+                    fieldset: {
+                        legend: {
+                            text: "What decision did you make on the appeal?",
+                            classes: "govuk-fieldset__legend--s"
+                        }
+                    },
+                    items: ApplyUtils.appealDecisionRadioItems(appeal.decision),
+                    errorMessage: errors.decision
+                }) }}
 
-        {{ govukTextarea({
-            name: "appeal[decisionDetail]",
-            id: "decisionDetail",
-            value: appeal.decisionDetail,
-            label: {
-            text: "What are the reasons for the appeal decision?",
-            classes: "govuk-fieldset__legend--s"
-            },
-            errorMessage: errors.decisionDetail
-        }) }}
+                {{ govukTextarea({
+                    name: "appeal[decisionDetail]",
+                    id: "decisionDetail",
+                    value: appeal.decisionDetail,
+                    label: {
+                        text: "What are the reasons for the appeal decision?",
+                        classes: "govuk-fieldset__legend--s"
+                    },
+                    errorMessage: errors.decisionDetail
+                }) }}
 
-        {{ govukButton({
+                {{ govukButton({
                     name: 'submit',
                     text: "Save appeal decision",
                     preventDoubleClick: true
                 }) }}
-      </form>
+            </form>
+        </div>
     </div>
-  </div>
 {% endblock %}

--- a/server/views/applications/people/selectOffence.njk
+++ b/server/views/applications/people/selectOffence.njk
@@ -5,66 +5,64 @@
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
-  {{ govukBackLink({
-		text: "Back",
-		href: paths.applications.new({ crn: person.crn })
-	}) }}
+    {{ govukBackLink({
+        text: "Back",
+        href: paths.applications.new({ crn: person.crn })
+    }) }}
 
 {% endblock %}
 
 {% block content %}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      {{ showErrorSummary(errorSummary, errorTitle) }}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            {{ showErrorSummary(errorSummary, errorTitle) }}
 
-      <h1>{{ pageHeading}}</h1>
+            <h1>{{ pageHeading }}</h1>
 
-      <p class="govuk-body">
-        Please select the main offence that will be used to assess {{ person.name }}'s sutability
-        for an Approved Premises (the 'index offence') below:
-      </p>
+            <p class="govuk-body">
+                Please select the main offence that will be used to assess {{ person.name }}'s suitability
+                for an Approved Premises (the 'index offence') below:
+            </p>
 
-      {{ govukWarningText({
-        text: "If the required offence is not visible here, you will not be able to proceed with the application until the offence has been added to NDelius",
-        iconFallbackText: "Warning"
-      }) }}
+            {{ govukWarningText({
+                text: "If the required offence is not visible here, you will not be able to proceed with the application until the offence has been added to NDelius",
+                iconFallbackText: "Warning"
+            }) }}
 
-      <form action="{{ paths.applications.create() }}" method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-        <input type="hidden" name="crn" value="{{ person.crn }}"/>
+            <form action="{{ paths.applications.create() }}" method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+                <input type="hidden" name="crn" value="{{ person.crn }}" />
 
-        {{
-            govukTable({
-              firstCellIsHeader: false,
-              head: [
-                {
-                  html: '<span class="govuk-visually-hidden">Select offence</span>'
-                },
-                {
-                  text: "Offence description"
-                },
-                {
-                  text: "Delius event number"
-                },
-                {
-                  text: "Offence date"
-                }
-              ],
-              rows: OffenceUtils.offenceTableRows(offences)
-            })
-          }}
+                {{ govukTable({
+                    firstCellIsHeader: false,
+                    head: [
+                        {
+                            html: '<span class="govuk-visually-hidden">Select offence</span>'
+                        },
+                        {
+                            text: "Offence description"
+                        },
+                        {
+                            text: "Delius event number"
+                        },
+                        {
+                            text: "Offence date"
+                        }
+                    ],
+                    rows: OffenceUtils.offenceTableRows(offences)
+                }) }}
 
-        {{ govukButton({
-            text: "Save and continue",
-            preventDoubleClick: true
-        }) }}
+                {{ govukButton({
+                    text: "Save and continue",
+                    preventDoubleClick: true
+                }) }}
 
-      </form>
+            </form>
+        </div>
     </div>
-  </div>
 {% endblock %}

--- a/server/views/bookings/dateChanges/new.njk
+++ b/server/views/bookings/dateChanges/new.njk
@@ -41,7 +41,7 @@
                             text: "Name"
                         },
                             value: {
-                            text: displayName(booking.person, { laoAsSuffix: true })
+                            text: displayName(booking.person, { laoSuffix: true })
                         }
                         },
                         {

--- a/server/views/bookings/dateChanges/new.njk
+++ b/server/views/bookings/dateChanges/new.njk
@@ -41,7 +41,7 @@
                             text: "Name"
                         },
                             value: {
-                            text: booking.person.name
+                            text: displayName(booking.person, { laoAsSuffix: true })
                         }
                         },
                         {

--- a/server/views/bookings/extensions/confirm.njk
+++ b/server/views/bookings/extensions/confirm.njk
@@ -19,7 +19,7 @@
                         text: "Name"
                     },
                         value: {
-                        text: displayName(person, { laoAsSuffix: true })
+                        text: displayName(person, { laoSuffix: true })
                     }
                     },
                     {

--- a/server/views/bookings/extensions/confirm.njk
+++ b/server/views/bookings/extensions/confirm.njk
@@ -19,7 +19,7 @@
                         text: "Name"
                     },
                         value: {
-                        text: person.name
+                        text: displayName(person, { laoAsSuffix: true })
                     }
                     },
                     {

--- a/server/views/bookings/extensions/new.njk
+++ b/server/views/bookings/extensions/new.njk
@@ -33,7 +33,7 @@
                             text: "Name"
                         },
                             value: {
-                            text: displayName(booking.person, { laoAsSuffix: true })
+                            text: displayName(booking.person, { laoSuffix: true })
                         }
                         },
                         {

--- a/server/views/bookings/extensions/new.njk
+++ b/server/views/bookings/extensions/new.njk
@@ -33,7 +33,7 @@
                             text: "Name"
                         },
                             value: {
-                            text: booking.person.name
+                            text: displayName(booking.person, { laoAsSuffix: true })
                         }
                         },
                         {

--- a/server/views/cancellations/new.njk
+++ b/server/views/cancellations/new.njk
@@ -36,7 +36,7 @@
                             text: "Name"
                         },
                             value: {
-                            text: displayName(booking.person, { laoAsSuffix: true })
+                            text: displayName(booking.person, { laoSuffix: true })
                         }
                         },
                         {

--- a/server/views/cancellations/new.njk
+++ b/server/views/cancellations/new.njk
@@ -14,95 +14,92 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
-  {{ govukBackLink({
-    text: "Back",
-	  href: backLink
-  }) }}
+    {{ govukBackLink({
+        text: "Back",
+        href: backLink
+    }) }}
 {% endblock %}
 
 {% block content %}
-  {{ showErrorSummary(errorSummary) }}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    {{ showErrorSummary(errorSummary) }}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
 
-      <h1>{{pageHeading}}</h1>
+            <h1>{{ pageHeading }}</h1>
 
-      <form action="{{ formAction }}" method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-        {{ govukSummaryList({
-            rows: [
-                {
-                  key: {
-                    text: "Name"
-                  },
-                  value: {
-                    text: booking.person.name
-                  }
-                },
-                {
-                  key: {
-                    text: "CRN"
-                  },
-                  value: {
-                    text: booking.person.crn
-                  }
-                },
-                {
-                  key: {
-                    text: "Arrival Date"
-                  },
-                  value: {
-                    text: formatDate(booking.arrivalDate)
-                  }
-                },
-                {
-                  key: {
-                    text: "Departure Date"
-                  },
-                  value: {
-                    text: formatDate(booking.departureDate)
-                  }
-                }
-              ]
-          })
-        }}
-
+            <form action="{{ formAction }}" method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+                {{ govukSummaryList({
+                    rows: [
+                        {
+                            key: {
+                            text: "Name"
+                        },
+                            value: {
+                            text: displayName(booking.person, { laoAsSuffix: true })
+                        }
+                        },
+                        {
+                            key: {
+                            text: "CRN"
+                        },
+                            value: {
+                            text: booking.person.crn
+                        }
+                        },
+                        {
+                            key: {
+                            text: "Arrival Date"
+                        },
+                            value: {
+                            text: formatDate(booking.arrivalDate)
+                        }
+                        },
+                        {
+                            key: {
+                            text: "Departure Date"
+                        },
+                            value: {
+                            text: formatDate(booking.departureDate)
+                        }
+                        }
+                    ]
+                }) }}
 
 
-        {% set noteConditional %}
-        {{
-          govukTextarea(
-            {
-            name: "cancellation[otherReason]",
-            id: "otherReason",
-            errorMessage: errors.otherReason,
-            label: {
-              text: "Provide more information"
-            }
-            })
-          }}
 
-        {% endset -%}
+                {% set noteConditional %}
+                    {{ govukTextarea(
+                        {
+                            name: "cancellation[otherReason]",
+                            id: "otherReason",
+                            errorMessage: errors.otherReason,
+                            label: {
+                            text: "Provide more information"
+                        }
+                        }) }}
 
-        {{ govukRadios({
-          name: "cancellation[reason]",
-          id: "reason",
-          fieldset: {
-              legend: {
-              text: "Why is this placement being withdrawn?",
-              classes: "govuk-fieldset__legend--m"
-              }
-          },
-          errorMessage: errors.reason,
-          items: BookingUtils.cancellationReasonsRadioItems(cancellationReasons, noteConditional, fetchContext())
-          }) }}
+                {% endset -%}
 
-        {{ govukButton({
-            text: "Withdraw",
-            preventDoubleClick: true
-        }) }}
-      </form>
+                {{ govukRadios({
+                    name: "cancellation[reason]",
+                    id: "reason",
+                    fieldset: {
+                        legend: {
+                            text: "Why is this placement being withdrawn?",
+                            classes: "govuk-fieldset__legend--m"
+                        }
+                    },
+                    errorMessage: errors.reason,
+                    items: BookingUtils.cancellationReasonsRadioItems(cancellationReasons, noteConditional, fetchContext())
+                }) }}
 
+                {{ govukButton({
+                    text: "Withdraw",
+                    preventDoubleClick: true
+                }) }}
+            </form>
+
+        </div>
     </div>
-  </div>
 {% endblock %}

--- a/server/views/match/placementRequests/show.njk
+++ b/server/views/match/placementRequests/show.njk
@@ -11,96 +11,80 @@
 {% set pageTitle = applicationName + " - " + pageHeading %}
 
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-width-container">
-      <div class="govuk-grid-column-full">
-        <h1 class="govuk-heading-l">{{placementRequest.person.name}}</h1>
-        <div class="search-identity-table govuk-body">
+    <h1 class="govuk-heading-l">{{ displayName(placementRequest.person) }}</h1>
 
-          <dl class="search-identity-table__column">
+    <div class="search-identity-table govuk-body">
+        <dl class="search-identity-table__column">
             <dt>
-              <strong>Tier</strong>
+                <strong>Tier</strong>
             </dt>
             <dd>{{ placementRequest.risks.tier.value.level }}</dd>
 
             <dt>
-              <strong>CRN</strong>
+                <strong>CRN</strong>
             </dt>
             <dd>{{ placementRequest.person.crn }}</dd>
 
             <dt>
-              <strong>Release Type</strong>
+                <strong>Release Type</strong>
             </dt>
             <dd>{{ PlacementRequestUtils.formatReleaseType(placementRequest) }}</dd>
-          </dl>
+        </dl>
 
-          <dl class="search-identity-table__column">
+        <dl class="search-identity-table__column">
             <dt>
-              <strong>Date assessed as suitable</strong>
+                <strong>Date assessed as suitable</strong>
             </dt>
             <dd>{{ formatDate(placementRequest.assessmentDate) }}</dd>
             <dt>
-              <strong>Expected arrival date</strong>
+                <strong>Expected arrival date</strong>
             </dt>
             <dd>{{ formatDate(placementRequest.expectedArrival) }}</dd>
-          </dl>
-
-        </div>
-      </div>
-      <hr/>
+        </dl>
     </div>
+
+    <hr />
+
     <div class="govuk-grid-row">
-      <div class="govuk-width-container">
         <div class="govuk-grid-column-two-thirds">
 
-          <h2 class="govuk-heading-m govuk-!-margin-top-4">Matching information</h2>
+            <h2 class="govuk-heading-m govuk-!-margin-top-4">Matching information</h2>
 
-          <p>The information below has been provided by the assessor. The results will be filtered automatically using the placement requirements and offence and risk information shown below. </p>
+            <p>The information below has been provided by the assessor. The results will be filtered
+                automatically using the placement requirements and offence and risk information shown
+                below. </p>
         </div>
-      </div>
     </div>
+  
     <div class="govuk-grid-row">
-      <div class="govuk-width-container">
         <div class="govuk-grid-column-full">
-          {{
-            govukSummaryList(PlacementRequestUtils.assessmentSummary(placementRequest))
-          }}
+            {{ govukSummaryList(PlacementRequestUtils.assessmentSummary(placementRequest)) }}
 
-          {{
-            govukSummaryList(PlacementRequestUtils.matchingInformationSummary(placementRequest))
-          }}
+            {{ govukSummaryList(PlacementRequestUtils.matchingInformationSummary(placementRequest)) }}
 
-          {{
-            govukSummaryList(PlacementRequestUtils.documentSummary(placementRequest))
-          }}
+            {{ govukSummaryList(PlacementRequestUtils.documentSummary(placementRequest)) }}
 
-          {% if placementRequest.cancellations|length > 0  %}
+            {% if placementRequest.cancellations|length > 0 %}
 
-            <h2 class="govuk-heading-m govuk-!-margin-top-4">Appealed bookings</h2>
+                <h2 class="govuk-heading-m govuk-!-margin-top-4">Appealed bookings</h2>
 
-            {% for cancellation in placementRequest.cancellations %}
-              {{
-                govukSummaryList(PlacementRequestUtils.cancellationSummary(cancellation))
-              }}
-            {% endfor %}
+                {% for cancellation in placementRequest.cancellations %}
+                    {{ govukSummaryList(PlacementRequestUtils.cancellationSummary(cancellation)) }}
+                {% endfor %}
 
-          {% endif %}
+            {% endif %}
 
         </div>
-      </div>
     </div>
     <div class="govuk-grid-row">
-      <div class="govuk-width-container">
         <div class="govuk-grid-column-two-thirds">
-          <h3 class="govuk-heading-m">Search for a bed</h3>
+            <h3 class="govuk-heading-m">Search for a bed</h3>
 
-          <p>Search for a suitable bed in an Approved Premises. Results will be filtered to include essential room attributes.</p>
+            <p>Search for a suitable bed in an Approved Premises. Results will be filtered to include essential
+                room attributes.</p>
 
-          {{
-            PlacementRequestUtils.searchButton(placementRequest) | safe
-          }}
+            {{ PlacementRequestUtils.searchButton(placementRequest) | safe }}
         </div>
-      </div>
     </div>
-  </div>
+    </div>
 {% endblock %}

--- a/server/views/partials/personDetails.njk
+++ b/server/views/partials/personDetails.njk
@@ -1,104 +1,104 @@
 {%- from "govuk/components/summary-list/macro.njk" import govukSummaryList -%}
 
 {% macro personDetails(person, showTitle = true, statusOnSubmission = '') %}
-  {% set rows = ([
-    {
-      key: {
-        text: "Name"
-      },
-      value: {
-        text: person.name
-      }
-    }, {
-      key: {
-        text: "CRN"
-      },
-      value: {
-        text: person.crn
-      }
-    }, {
-      key: {
-        text: "Date of Birth"
-      },
-      value: {
-        text: formatDate(person.dateOfBirth, {format: 'short'})if person.dateOfBirth else 
-          ''
-      }
-    }, {
-      key: {
-        text: "NOMIS Number"
-      },
-      value: {
-        text: person.nomsNumber
-      }
-    }, {
-      key: {
-        text: "Nationality"
-      },
-      value: {
-        text: person.nationality
-      }
-    }, {
-      key: {
-        text: "Religion or belief"
-      },
-      value: {
-        text: person.religionOrBelief
-      }
-    }, {
-      key: {
-        text: "Sex"
-      },
-      value: {
-        text: person.sex
-      }
-    }, {
-      key: {
-        text: "Gender Identity"
-      },
-      value: {
-        text: person.genderIdentity
-      }
-    }, {
-      key: {
-        text: "Status on Submission" if statusOnSubmission else 
-          "Status"
-      },
-      value: {
-        html: personStatusTag(statusOnSubmission, 'person') if statusOnSubmission else 
-          personStatusTag(person.status, 'person')
-      }
-    }, {
-      key: {
-        text: "Prison"
-      },
-      value: {
-        text: person.prisonName
-      }
-    }
-  ] | removeBlankSummaryListItems) %}
-
-  {% if showTitle %}
-    {{ govukSummaryList({
-      card: {
-        title: {
-          text: "Person Details",
-          headingLevel: "2",
-          classes: "govuk-heading-m"
+    {% set rows = ([
+        {
+            key: {
+            text: "Name"
         },
-        attributes: {
-          'data-cy-section': "person-details"
+            value: {
+            text: displayName(person, { laoAsSuffix: true })
         }
-      },
-      rows: rows
-    }) }}
-  {% else %}
-    {{ govukSummaryList({
-      attributes: {
-        'data-cy-person-info': true
-      },
-      rows: rows
-    }) }}
-  {% endif %}
+        }, {
+            key: {
+                text: "CRN"
+            },
+            value: {
+                text: person.crn
+            }
+        }, {
+            key: {
+                text: "Date of Birth"
+            },
+            value: {
+                text: formatDate(person.dateOfBirth, {format: 'short'})if person.dateOfBirth else
+                ''
+            }
+        }, {
+            key: {
+                text: "NOMIS Number"
+            },
+            value: {
+                text: person.nomsNumber
+            }
+        }, {
+            key: {
+                text: "Nationality"
+            },
+            value: {
+                text: person.nationality
+            }
+        }, {
+            key: {
+                text: "Religion or belief"
+            },
+            value: {
+                text: person.religionOrBelief
+            }
+        }, {
+            key: {
+                text: "Sex"
+            },
+            value: {
+                text: person.sex
+            }
+        }, {
+            key: {
+                text: "Gender Identity"
+            },
+            value: {
+                text: person.genderIdentity
+            }
+        }, {
+            key: {
+                text: "Status on Submission" if statusOnSubmission else
+                "Status"
+            },
+            value: {
+                html: personStatusTag(statusOnSubmission, 'person') if statusOnSubmission else
+                personStatusTag(person.status, 'person')
+            }
+        }, {
+            key: {
+                text: "Prison"
+            },
+            value: {
+                text: person.prisonName
+            }
+        }
+    ] | removeBlankSummaryListItems) %}
+
+    {% if showTitle %}
+        {{ govukSummaryList({
+            card: {
+                title: {
+                    text: "Person Details",
+                    headingLevel: "2",
+                    classes: "govuk-heading-m"
+                },
+                attributes: {
+                    'data-cy-section': "person-details"
+                }
+            },
+            rows: rows
+        }) }}
+    {% else %}
+        {{ govukSummaryList({
+            attributes: {
+                'data-cy-person-info': true
+            },
+            rows: rows
+        }) }}
+    {% endif %}
 
 {% endmacro %}

--- a/server/views/partials/personDetails.njk
+++ b/server/views/partials/personDetails.njk
@@ -7,7 +7,7 @@
             text: "Name"
         },
             value: {
-            text: displayName(person, { laoAsSuffix: true })
+            text: displayName(person, { laoSuffix: true })
         }
         }, {
             key: {

--- a/server/views/people/timeline/show.njk
+++ b/server/views/people/timeline/show.njk
@@ -24,7 +24,7 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-l">Application history
-                for {{ displayName(timeline.person, { lasoAsSuffix: true }) }}</h1>
+                for {{ displayName(timeline.person, { laoPrefix: false }) }}</h1>
             {{ personDetails(timeline.person, false) }}
             <h2 class="govuk-heading-m">Total applications: {{ applications | length }}</h2>
             <hr />

--- a/server/views/people/timeline/show.njk
+++ b/server/views/people/timeline/show.njk
@@ -4,50 +4,55 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "../../partials/personDetails.njk" import personDetails %}
 
-{% set pageTitle = applicationName + " - " + pageHeading  %}
+{% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body" %}
 
-{% set query = "?crn=" + crn if crn else 
+{% set query = "?crn=" + crn if crn else
     "" %}
 
 {% set applications = ApplyUtils.mapPersonalTimelineForUi(timeline) %}
 
 {% block beforeContent %}
     {{ govukBackLink({
-		text: "Back",
+        text: "Back",
         href: paths.timeline.find({}) + "?crn=" + crn
-	}) }}
+    }) }}
 {% endblock %}
 
 {% block content %}
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-l">Application history for {{timeline.person.name}}</h1>
-            {{personDetails(timeline.person, false)}}
-            <h2 class="govuk-heading-m">Total applications: {{applications | length}}</h2>
-            <hr/>
+            <h1 class="govuk-heading-l">Application history
+                for {{ displayName(timeline.person, { lasoAsSuffix: true }) }}</h1>
+            {{ personDetails(timeline.person, false) }}
+            <h2 class="govuk-heading-m">Total applications: {{ applications | length }}</h2>
+            <hr />
             {% for application in applications %}
-                <h2 class="govuk-heading-m">Application {{loop.index}} of {{applications.length}}</h2>
-                {% set html%}
-                {% if not application.isOfflineApplication %}
-                    <h2 class="govuk-heading-s">Application made by: <span class="govuk-body">{{application.createdBy.name}}</span></h2>
-                {% endif %}
-                <h2 class="govuk-heading-s">Application made on: <span class="govuk-body">{{formatDate(application.createdAt, {format: 'short'})}}</span></h2>
-                {% if not application.isOfflineApplication %}
-                    <h2 class="govuk-heading-s">Status: {{ applicationStatusTag(application.status, {showOnOneLine: true}) | safe}}</h2>
-                {% endif %}
+                <h2 class="govuk-heading-m">Application {{ loop.index }} of {{ applications.length }}</h2>
+                {% set html %}
+                    {% if not application.isOfflineApplication %}
+                        <h2 class="govuk-heading-s">Application made by: <span
+                                    class="govuk-body">{{ application.createdBy.name }}</span></h2>
+                    {% endif %}
+                    <h2 class="govuk-heading-s">Application made on: <span
+                                class="govuk-body">{{ formatDate(application.createdAt, {format: 'short'}) }}</span>
+                    </h2>
+                    {% if not application.isOfflineApplication %}
+                        <h2 class="govuk-heading-s">
+                            Status: {{ applicationStatusTag(application.status, {showOnOneLine: true}) | safe }}</h2>
+                    {% endif %}
                 {% endset %}
 
                 {{ govukInsetText({
-                        html: html
-                })}}
+                    html: html
+                }) }}
 
-                {{applicationTimeline(application.timelineEvents)}}
+                {{ applicationTimeline(application.timelineEvents) }}
                 {% if not loop.last %}
-                    <hr/>
+                    <hr />
                 {% endif %}
-                {%endfor%}
-            </div>
+            {% endfor %}
         </div>
-    {% endblock %}
+    </div>
+{% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1858

# Changes in this PR

A consolidation of the rendering of a person name throughout the service.

This now uses a unique method, `displayName()`, which handles displaying `FullPerson`, `RestrictedPerson`, `UnknownPerson`, and their `...Summary` versions too. The method takes the `Person` or `PersonSummary` as an argument, and an optional `options` argument:

- `showCrn` (defaults to `false`): shorten the displayed text and appends the CRN when the person name cannot be shown.
- `laoPrefix` (defaults to `true`): prefix the person's name with 'LAO:' when it can be displayed but the person is restricted. This is the default, and useful where space is limited (i.e. table cells).
- `laoSuffix` (defaults to `false`): append '(Limited access offender)' to the person's name when it can be displayed but the person is restricted.

The new method has been applied in most instances a name is displayed, save for a couple of pages which throw an error if the person is restricted anyway.

## Screenshots of UI changes

<details><summary>With permission to view LAOs</summary>

<img width="662" alt="Screenshot 2025-02-24 at 12 58 45" src="https://github.com/user-attachments/assets/39907095-675e-4191-88fa-e7ae7100e313" />

---

<img width="997" alt="Screenshot 2025-02-24 at 12 59 11" src="https://github.com/user-attachments/assets/063eabe9-8234-4b2e-80ba-3cc94bb2b010" />

---


<img width="665" alt="Screenshot 2025-02-24 at 12 59 18" src="https://github.com/user-attachments/assets/4286557b-68bd-4117-9c0c-6827744abf76" />

---

<img width="985" alt="Screenshot 2025-02-24 at 12 58 16" src="https://github.com/user-attachments/assets/9f88b246-cb22-427c-b68d-8480d2f06a81" />

---

<img width="1059" alt="Screenshot 2025-02-24 at 12 56 51" src="https://github.com/user-attachments/assets/f407e8aa-a756-4787-85f4-7a3fd0549553" />

---

<img width="1021" alt="Screenshot 2025-02-24 at 12 57 10" src="https://github.com/user-attachments/assets/f10050ed-f05c-416c-9cd8-5889feca0ae4" />

---

<img width="1017" alt="Screenshot 2025-02-24 at 12 58 01" src="https://github.com/user-attachments/assets/5b78a63f-5987-4601-92fb-38f05f081773" />

---

<img width="1018" alt="Screenshot 2025-02-24 at 12 56 13" src="https://github.com/user-attachments/assets/50844461-74ec-4b95-958e-e0c5e4ed59b7" />


</details>

<details><summary>Without permission to view LAOs</summary>

<img width="999" alt="Screenshot 2025-02-24 at 12 59 53" src="https://github.com/user-attachments/assets/31cb490f-0604-46af-8386-4bb248892a3e" />

---

<img width="992" alt="Screenshot 2025-02-24 at 13 05 04" src="https://github.com/user-attachments/assets/f0333ad7-a4b8-46ad-ba98-3074b86f2e5d" />

---

<img width="1002" alt="Screenshot 2025-02-24 at 13 06 16" src="https://github.com/user-attachments/assets/2c9618fa-02ef-499e-8edc-04e8300dc07d" />


</details>
