### PR TITLE
APS-2020 Daylight saving duration error

### DIFF
--- a/integration_tests/pages/manage/premisesShow.ts
+++ b/integration_tests/pages/manage/premisesShow.ts
@@ -1,5 +1,4 @@
 import type { Cas1OverbookingRange, Cas1Premises, Cas1SpaceBookingSummary } from '@approved-premises/api'
-import { differenceInDays, formatDuration } from 'date-fns'
 import { DateFormats } from '../../../server/utils/dateUtils'
 
 import Page from '../page'
@@ -112,7 +111,9 @@ export default class PremisesShowPage extends Page {
     PremisesShowPage.overbookingSummary.forEach(({ startInclusive, endInclusive }) => {
       const toText = startInclusive !== endInclusive ? ` to ${DateFormats.isoDateToUIDate(endInclusive)}` : ''
       const dateRangeText = `${DateFormats.isoDateToUIDate(startInclusive)}${toText}`
-      const duration = formatDuration({ days: differenceInDays(endInclusive, startInclusive) + 1 })
+      const duration = DateFormats.formatDuration({
+        days: DateFormats.durationBetweenDates(endInclusive, startInclusive).number + 1,
+      })
       cy.get('.govuk-notification-banner__content').contains(dateRangeText)
       cy.get('.govuk-notification-banner__content').contains(duration)
     })

--- a/integration_tests/pages/match/bookASpacePage.ts
+++ b/integration_tests/pages/match/bookASpacePage.ts
@@ -1,7 +1,6 @@
 import type { Cas1Premises, Cas1SpaceBookingCharacteristic, PlacementRequestDetail } from '@approved-premises/api'
-import { differenceInDays } from 'date-fns'
 import Page from '../page'
-import { DateFormats, daysToWeeksAndDays } from '../../../server/utils/dateUtils'
+import { DateFormats } from '../../../server/utils/dateUtils'
 import { requirementsHtmlString } from '../../../server/utils/match'
 import { allReleaseTypes } from '../../../server/utils/applications/releaseTypeUtils'
 
@@ -25,7 +24,7 @@ export default class BookASpacePage extends Page {
       { key: { text: 'Expected departure date' }, value: { text: DateFormats.isoDateToUIDate(departureDate) } },
       {
         key: { text: 'Length of stay' },
-        value: { text: DateFormats.formatDuration(daysToWeeksAndDays(differenceInDays(departureDate, arrivalDate))) },
+        value: { text: DateFormats.durationBetweenDates(departureDate, arrivalDate).ui },
       },
       { key: { text: 'Release type' }, value: { text: allReleaseTypes[placementRequest.releaseType] } },
     ])

--- a/server/controllers/manage/premises/placements/changesController.test.ts
+++ b/server/controllers/manage/premises/placements/changesController.test.ts
@@ -1,7 +1,6 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
 import { Cas1SpaceBookingCharacteristic, Cas1UpdateSpaceBooking } from '@approved-premises/api'
-import { differenceInDays } from 'date-fns'
 import { PlacementService, PremisesService } from '../../../../services'
 import {
   cas1PremiseCapacityFactory,
@@ -37,7 +36,9 @@ describe('changesController', () => {
   const changesController = new ChangesController(placementService, premisesService)
 
   const premises = cas1PremisesFactory.build()
-  const placement = cas1SpaceBookingFactory.upcoming().build({ premises })
+  const placement = cas1SpaceBookingFactory
+    .upcoming()
+    .build({ premises, expectedArrivalDate: '2025-10-02', expectedDepartureDate: '2025-11-02' })
   const capacity = cas1PremiseCapacityFactory.build()
   const params = { premisesId: premises.id, placementId: placement.id }
   const viewUrl = managePaths.premises.placements.changes.new(params)
@@ -67,7 +68,7 @@ describe('changesController', () => {
         premisesId: premises.id,
         date: ':date',
       })}?${createQueryString({ criteria: expectedCriteria, excludeSpaceBookingId: placement.id })}`
-      const expectedDuration = differenceInDays(placement.expectedDepartureDate, placement.expectedArrivalDate)
+      const expectedDuration = 31
 
       expect(placementService.getPlacement).toHaveBeenCalledWith(token, placement.id)
       expect(premisesService.getCapacity).toHaveBeenCalledWith(token, premises.id, {

--- a/server/controllers/manage/premises/placements/changesController.ts
+++ b/server/controllers/manage/premises/placements/changesController.ts
@@ -1,7 +1,7 @@
 import { type Request, RequestHandler, type Response } from 'express'
 import { Cas1SpaceBookingCharacteristic, Cas1UpdateSpaceBooking } from '@approved-premises/api'
 import { ObjectWithDateParts } from '@approved-premises/ui'
-import { addDays, differenceInDays } from 'date-fns'
+import { addDays } from 'date-fns'
 import { PlacementService, PremisesService } from '../../../../services'
 import {
   catchValidationErrorOrPropogate,
@@ -84,12 +84,12 @@ export default class ChangesController {
       let pageHeading = 'Change placement'
       let startDate = placement.expectedArrivalDate
       let endDate = placement.expectedDepartureDate
-      let durationDays = differenceInDays(endDate, startDate)
+      let durationDays = DateFormats.durationBetweenDates(endDate, startDate).number
 
       if (placement.actualArrivalDateOnly) {
         startDate = placement.actualArrivalDateOnly
         endDate = DateFormats.dateObjToIsoDate(addDays(startDate, getClosestDuration(durationDays)))
-        durationDays = differenceInDays(endDate, startDate)
+        durationDays = DateFormats.durationBetweenDates(endDate, startDate).number
         pageHeading = 'Extend placement'
       }
 

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -225,16 +225,22 @@ describe('DateFormats', () => {
     })
   })
 
-  describe('differenceInDays', () => {
-    const baseDate = new Date(2023, 3, 12)
+  describe('durationBetweenDates', () => {
+    const baseDate = '2023-10-12'
+    const baseDateObj = DateFormats.isoToDateObj(baseDate)
 
     it.each([
-      [new Date(2023, 3, 11), '1 day', 1],
-      [new Date(2023, 3, 15), '3 days', -3],
-      [new Date(2023, 4, 12), '30 days', -30],
-      [new Date(2023, 0, 1), '101 days', 101],
+      ['2023-10-13', '1 day', 1],
+      ['2023-10-15', '3 days', 3],
+      ['2023-11-12', '4 weeks 3 days', 31],
+      ['2024-01-01', '11 weeks 4 days', 81],
     ])('returns the different in days for %s', (compareDate, ui, number) => {
-      expect(DateFormats.differenceInDays(baseDate, compareDate)).toEqual({
+      expect(DateFormats.durationBetweenDates(baseDate, compareDate)).toEqual({
+        ui,
+        number,
+      })
+      const compareDateObj = DateFormats.isoDateToUIDate(compareDate)
+      expect(DateFormats.durationBetweenDates(baseDateObj, compareDateObj)).toEqual({
         ui,
         number,
       })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -3,9 +3,8 @@ import {
   addBusinessDays as addBusinsessDaysWithoutBankHolidays,
   addDays,
   differenceInBusinessDays as differenceInBusinessDaysDateFns,
-  differenceInDays,
+  differenceInHours,
   format,
-  formatDistanceStrict,
   formatDuration,
   formatISO,
   isBefore,
@@ -20,8 +19,6 @@ import {
 import type { ObjectWithDateParts } from '@approved-premises/ui'
 
 import rawBankHolidays from '../data/bankHolidays/bank-holidays.json'
-
-type DifferenceInDays = { ui: string; number: number }
 
 type DurationWithNumberOrString = {
   years?: number | string
@@ -171,10 +168,12 @@ export class DateFormats {
   /**
    * @param date1 first day to compare.
    * @param date2 second day to compare.
-   * @returns {DifferenceInDays} an object with the difference in days as a string for UI purposes (EG '2 Days') and as a number.
+   * @returns an object with the difference in days as a string for UI purposes (EG '2 Days') and as a number.
    */
-  static differenceInDays(date1: Date, date2: Date): DifferenceInDays {
-    return { ui: formatDistanceStrict(date1, date2, { unit: 'day' }), number: differenceInDays(date1, date2) }
+  static durationBetweenDates(date1: string | Date, date2: string | Date): { number: number; ui: string } {
+    const days = Math.abs(Math.trunc(differenceInHours(date1, date2) / 24)) || 0
+    const formatted = formatDuration(daysToWeeksAndDays(days))
+    return { number: days, ui: formatted }
   }
 
   /**

--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -234,8 +234,8 @@ describe('matchUtils', () => {
   describe('spaceBookingConfirmationSummaryListRows', () => {
     const placementRequest = placementRequestDetailFactory.build()
     const premises = cas1PremisesFactory.build()
-    const expectedArrivalDate = '2025-05-23'
-    const expectedDepartureDate = '2025-07-18'
+    const expectedArrivalDate = '2025-09-23'
+    const expectedDepartureDate = '2025-11-18'
     const criteria: Array<Cas1SpaceBookingCharacteristic> = ['hasEnSuite', 'isArsonSuitable']
 
     it('returns summary list items for the space booking confirmation screen', () => {
@@ -256,8 +256,8 @@ describe('matchUtils', () => {
             html: '<ul class="govuk-list govuk-list--bullet"><li>En-suite bathroom</li><li>Arson offences</li></ul>',
           },
         },
-        { key: { text: 'Expected arrival date' }, value: { text: 'Fri 23 May 2025' } },
-        { key: { text: 'Expected departure date' }, value: { text: 'Fri 18 Jul 2025' } },
+        { key: { text: 'Expected arrival date' }, value: { text: 'Tue 23 Sep 2025' } },
+        { key: { text: 'Expected departure date' }, value: { text: 'Tue 18 Nov 2025' } },
         { key: { text: 'Length of stay' }, value: { text: '8 weeks' } },
         { key: { text: 'Release type' }, value: { text: allReleaseTypes[placementRequest.releaseType] } },
       ])
@@ -289,7 +289,7 @@ describe('matchUtils', () => {
       expect(rows).toEqual(
         expect.arrayContaining([
           { key: { text: 'Actual arrival date' }, value: { text: 'Fri 25 Apr 2025' } },
-          { key: { text: 'Length of stay' }, value: { text: '12 weeks' } },
+          { key: { text: 'Length of stay' }, value: { text: '8 weeks' } },
         ]),
       )
       expect(rows).toEqual(

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -1,4 +1,3 @@
-import { differenceInDays } from 'date-fns'
 import {
   ApType,
   ApprovedPremisesApplication,
@@ -53,12 +52,7 @@ export const spaceBookingConfirmationSummaryListRows = (data: SpaceBookingConfir
       ? summaryListItem('Actual arrival date', DateFormats.isoDateToUIDate(actualArrivalDate))
       : summaryListItem('Expected arrival date', DateFormats.isoDateToUIDate(expectedArrivalDate)),
     summaryListItem('Expected departure date', DateFormats.isoDateToUIDate(expectedDepartureDate)),
-    summaryListItem(
-      'Length of stay',
-      DateFormats.formatDuration(
-        daysToWeeksAndDays(differenceInDays(expectedDepartureDate, actualArrivalDate || expectedArrivalDate)),
-      ),
-    ),
+    summaryListItem('Length of stay', DateFormats.durationBetweenDates(expectedDepartureDate, expectedArrivalDate).ui),
     releaseType ? summaryListItem('Release type', allReleaseTypes[releaseType]) : undefined,
   ].filter(Boolean)
 }

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -119,7 +119,7 @@ export const placementSummary = (placement: Cas1SpaceBooking): SummaryList => {
           actualDepartureDateOnly &&
           DateFormats.formatDuration(
             daysToWeeksAndDays(
-              DateFormats.differenceInDays(
+              DateFormats.durationBetweenDates(
                 DateFormats.isoToDateObj(actualDepartureDateOnly),
                 DateFormats.isoToDateObj(actualArrivalDateOnly),
               ).number,

--- a/server/utils/premises/index.test.ts
+++ b/server/utils/premises/index.test.ts
@@ -305,14 +305,16 @@ describe('premisesUtils', () => {
   describe('premisesOverbookingSummary', () => {
     it('Should generate the premisesOverbooking summary', () => {
       const overbookingSummary: Array<Cas1OverbookingRange> = [
-        { startInclusive: '2025-01-10', endInclusive: '2025-01-20' },
-        { startInclusive: '2025-01-25', endInclusive: '2025-01-25' },
+        { startInclusive: '2025-03-01', endInclusive: '2025-04-01' },
+        { startInclusive: '2025-10-20', endInclusive: '2025-10-28' },
+        { startInclusive: '2025-10-30', endInclusive: '2025-10-30' },
       ]
 
       const premises = cas1PremisesFactory.build({ overbookingSummary })
       expect(premisesOverbookingSummary(premises)).toEqual([
-        { duration: 11, from: '2025-01-10', to: '2025-01-20' },
-        { duration: 1, from: '2025-01-25', to: '2025-01-25' },
+        { duration: 32, from: '2025-03-01', to: '2025-04-01' },
+        { duration: 9, from: '2025-10-20', to: '2025-10-28' },
+        { duration: 1, from: '2025-10-30', to: '2025-10-30' },
       ])
     })
     it('Should generate an empty premisesOverbooking summary', () => {

--- a/server/utils/premises/index.ts
+++ b/server/utils/premises/index.ts
@@ -9,7 +9,6 @@ import type {
   SortDirection,
 } from '@approved-premises/api'
 import { DateRange, SelectGroup, SelectOption, SummaryList, TableCell, TableRow } from '@approved-premises/ui'
-import { differenceInDays } from 'date-fns'
 import { DateFormats } from '../dateUtils'
 import { getTierOrBlank, htmlValue, textValue } from '../applications/helpers'
 import managePaths from '../../paths/manage'
@@ -178,6 +177,6 @@ export const premisesOverbookingSummary = (premises: Cas1Premises): Array<DateRa
   return overbookingSummary.map(({ startInclusive, endInclusive }: Cas1OverbookingRange) => ({
     from: startInclusive,
     to: endInclusive,
-    duration: differenceInDays(endInclusive, startInclusive) + 1,
+    duration: DateFormats.durationBetweenDates(endInclusive, startInclusive).number + 1,
   }))
 }


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2020

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

The utility function  `differenceInDays()` of `date_fns` returns the number of whole days between dates, truncating any hour residue. When passed dates that span the autumnal daylight saving transition (BST -> GMT), one hour is removed from the duration and hence, the function returns one day fewer than it should.
The `date_fns` help recommends using the `differenceInHours` and dividing by 24 to correct this.

the bug was spotted on the Match confirmation page, but can occur wherever `differenceInDays` is used. I found other instances where this causes a problem after adjusting the unit tests to span 26 October 2025.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

<details>
  <summary>Before</summary>
<img src="https://github.com/user-attachments/assets/7770083f-5cc4-4f9b-9d7e-6fece1706719"/>
</details>

<details>
  <summary>After</summary>
<img src="https://github.com/user-attachments/assets/b114578c-955b-4ab2-8e59-28868d2756d1"/>
</details>


