### PR TITLE
APS-2003: Update arrival/departure date labels

### DIFF
--- a/integration_tests/pages/manage/placements/changes/confirm.ts
+++ b/integration_tests/pages/manage/placements/changes/confirm.ts
@@ -15,14 +15,15 @@ export default class ChangePlacementConfirmPage extends Page {
     super('Confirm booking changes')
   }
 
-  shouldShowProposedChanges() {
+  shouldShowProposedChanges(actualArrivalDate?: string) {
     this.shouldContainSummaryListItems(
-      spaceBookingConfirmationSummaryListRows(
-        this.premises,
-        this.query.arrivalDate,
-        this.query.departureDate,
-        makeArrayOfType<Cas1SpaceBookingCharacteristic>(this.query.criteria),
-      ),
+      spaceBookingConfirmationSummaryListRows({
+        premises: this.premises,
+        expectedArrivalDate: this.query.arrivalDate,
+        actualArrivalDate,
+        expectedDepartureDate: this.query.departureDate,
+        criteria: makeArrayOfType<Cas1SpaceBookingCharacteristic>(this.query.criteria),
+      }),
     )
   }
 }

--- a/integration_tests/pages/match/bookASpacePage.ts
+++ b/integration_tests/pages/match/bookASpacePage.ts
@@ -21,8 +21,8 @@ export default class BookASpacePage extends Page {
       { key: { text: 'Approved Premises' }, value: { text: premises.name } },
       { key: { text: 'Address' }, value: { text: `${premises.fullAddress}, ${premises.postcode}` } },
       { key: { text: 'Room criteria' }, value: { html: requirementsHtmlString(criteria) } },
-      { key: { text: 'Arrival date' }, value: { text: DateFormats.isoDateToUIDate(arrivalDate) } },
-      { key: { text: 'Departure date' }, value: { text: DateFormats.isoDateToUIDate(departureDate) } },
+      { key: { text: 'Expected arrival date' }, value: { text: DateFormats.isoDateToUIDate(arrivalDate) } },
+      { key: { text: 'Expected departure date' }, value: { text: DateFormats.isoDateToUIDate(departureDate) } },
       {
         key: { text: 'Length of stay' },
         value: { text: DateFormats.formatDuration(daysToWeeksAndDays(differenceInDays(departureDate, arrivalDate))) },

--- a/integration_tests/tests/manage/placements/changes.cy.ts
+++ b/integration_tests/tests/manage/placements/changes.cy.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker'
 import { addDays } from 'date-fns'
+import { Cas1SpaceBooking, Cas1UpdateSpaceBooking } from '@approved-premises/api'
 import { signIn } from '../../signIn'
 import {
   bookingSummaryFactory,
@@ -17,8 +18,6 @@ import { DateFormats } from '../../../../server/utils/dateUtils'
 import ChangePlacementConfirmPage from '../../../pages/manage/placements/changes/confirm'
 import apiPaths from '../../../../server/paths/api'
 import { roomCharacteristicMap } from '../../../../server/utils/characteristicsUtils'
-import { Cas1SpaceBooking } from '../../../../server/@types/shared/models/Cas1SpaceBooking'
-import { Cas1UpdateSpaceBooking } from '../../../../server/@types/shared/models/Cas1UpdateSpaceBooking'
 
 context('Change Placement', () => {
   const expectedArrivalDate = DateFormats.dateObjToIsoDate(faker.date.soon())
@@ -209,7 +208,7 @@ context('Change Placement', () => {
       departureDate: DateFormats.dateObjToIsoDate(addDays(arrivedPlacement.expectedDepartureDate, 5)),
       criteria: arrivedPlacement.characteristics.filter(characteristic => roomCharacteristicMap[characteristic]),
     })
-    confirmPage.shouldShowProposedChanges()
+    confirmPage.shouldShowProposedChanges(arrivedPlacement.actualArrivalDateOnly)
 
     // When I submit the confirmation page
     confirmPage.clickSubmit()

--- a/server/controllers/manage/premises/placements/changesController.test.ts
+++ b/server/controllers/manage/premises/placements/changesController.test.ts
@@ -344,12 +344,12 @@ describe('changesController', () => {
         pageHeading: 'Confirm booking changes',
         backlink: expectedBackLink,
         placement,
-        summaryListRows: spaceBookingConfirmationSummaryListRows(
+        summaryListRows: spaceBookingConfirmationSummaryListRows({
           premises,
-          query.arrivalDate,
-          query.departureDate,
-          query.criteria ? makeArrayOfType<Cas1SpaceBookingCharacteristic>(query.criteria) : [],
-        ),
+          expectedArrivalDate: query.arrivalDate,
+          expectedDepartureDate: query.departureDate,
+          criteria: query.criteria ? makeArrayOfType<Cas1SpaceBookingCharacteristic>(query.criteria) : [],
+        }),
         arrivalDate: query.arrivalDate,
         departureDate: query.departureDate,
         criteria: query.criteria,

--- a/server/controllers/manage/premises/placements/changesController.ts
+++ b/server/controllers/manage/premises/placements/changesController.ts
@@ -216,12 +216,13 @@ export default class ChangesController {
         pageHeading: 'Confirm booking changes',
         backlink,
         placement,
-        summaryListRows: spaceBookingConfirmationSummaryListRows(
+        summaryListRows: spaceBookingConfirmationSummaryListRows({
           premises,
-          arrivalDate || placement.expectedArrivalDate,
-          departureDate,
-          makeArrayOfType<Cas1SpaceBookingCharacteristic>(criteria) || [],
-        ),
+          actualArrivalDate: placement.actualArrivalDateOnly,
+          expectedArrivalDate: arrivalDate || placement.expectedArrivalDate,
+          expectedDepartureDate: departureDate,
+          criteria: makeArrayOfType<Cas1SpaceBookingCharacteristic>(criteria) || [],
+        }),
         arrivalDate,
         departureDate,
         criteria,

--- a/server/controllers/match/placementRequests/spaceBookingsController.test.ts
+++ b/server/controllers/match/placementRequests/spaceBookingsController.test.ts
@@ -66,13 +66,13 @@ describe('SpaceBookingsController', () => {
         submitLink: matchPaths.v2Match.placementRequests.spaceBookings.create(params),
         placementRequest: placementRequestDetail,
         premises,
-        summaryListRows: spaceBookingConfirmationSummaryListRows(
+        summaryListRows: spaceBookingConfirmationSummaryListRows({
           premises,
-          searchState.arrivalDate,
-          searchState.departureDate,
-          searchState.roomCriteria,
-          placementRequestDetail.releaseType,
-        ),
+          expectedArrivalDate: searchState.arrivalDate,
+          expectedDepartureDate: searchState.departureDate,
+          criteria: searchState.roomCriteria,
+          releaseType: placementRequestDetail.releaseType,
+        }),
         errorSummary: [],
         errors: {},
       })

--- a/server/controllers/match/placementRequests/spaceBookingsController.ts
+++ b/server/controllers/match/placementRequests/spaceBookingsController.ts
@@ -42,13 +42,13 @@ export default class {
       const submitLink = matchPaths.v2Match.placementRequests.spaceBookings.create({ id, premisesId })
       const backLink = matchPaths.v2Match.placementRequests.search.occupancy({ id, premisesId })
 
-      const summaryListRows = spaceBookingConfirmationSummaryListRows(
+      const summaryListRows = spaceBookingConfirmationSummaryListRows({
         premises,
-        searchState.arrivalDate,
-        searchState.departureDate,
-        searchState.roomCriteria,
-        placementRequest.releaseType,
-      )
+        expectedArrivalDate: searchState.arrivalDate,
+        expectedDepartureDate: searchState.departureDate,
+        criteria: searchState.roomCriteria,
+        releaseType: placementRequest.releaseType,
+      })
 
       return res.render('match/placementRequests/spaceBookings/new', {
         backLink,

--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -234,19 +234,19 @@ describe('matchUtils', () => {
   describe('spaceBookingConfirmationSummaryListRows', () => {
     const placementRequest = placementRequestDetailFactory.build()
     const premises = cas1PremisesFactory.build()
-    const arrivalDate = '2025-05-23'
-    const departureDate = '2025-07-18'
+    const expectedArrivalDate = '2025-05-23'
+    const expectedDepartureDate = '2025-07-18'
     const criteria: Array<Cas1SpaceBookingCharacteristic> = ['hasEnSuite', 'isArsonSuitable']
 
     it('returns summary list items for the space booking confirmation screen', () => {
       expect(
-        spaceBookingConfirmationSummaryListRows(
+        spaceBookingConfirmationSummaryListRows({
           premises,
-          arrivalDate,
-          departureDate,
+          expectedArrivalDate,
+          expectedDepartureDate,
           criteria,
-          placementRequest.releaseType,
-        ),
+          releaseType: placementRequest.releaseType,
+        }),
       ).toEqual([
         { key: { text: 'Approved Premises' }, value: { text: premises.name } },
         { key: { text: 'Address' }, value: { text: `${premises.fullAddress}, ${premises.postcode}` } },
@@ -256,17 +256,45 @@ describe('matchUtils', () => {
             html: '<ul class="govuk-list govuk-list--bullet"><li>En-suite bathroom</li><li>Arson offences</li></ul>',
           },
         },
-        { key: { text: 'Arrival date' }, value: { text: 'Fri 23 May 2025' } },
-        { key: { text: 'Departure date' }, value: { text: 'Fri 18 Jul 2025' } },
+        { key: { text: 'Expected arrival date' }, value: { text: 'Fri 23 May 2025' } },
+        { key: { text: 'Expected departure date' }, value: { text: 'Fri 18 Jul 2025' } },
         { key: { text: 'Length of stay' }, value: { text: '8 weeks' } },
         { key: { text: 'Release type' }, value: { text: allReleaseTypes[placementRequest.releaseType] } },
       ])
     })
 
     it('returns summary list items with no release type for the space booking confirmation screen', () => {
-      const rows = spaceBookingConfirmationSummaryListRows(premises, arrivalDate, departureDate, criteria)
+      const rows = spaceBookingConfirmationSummaryListRows({
+        premises,
+        expectedArrivalDate,
+        expectedDepartureDate,
+        criteria,
+      })
 
       expect(rows).toHaveLength(6)
+      expect(rows).toEqual(expect.not.arrayContaining([expect.objectContaining({ key: { text: 'Release type' } })]))
+    })
+
+    it('returns summary list items with the actual arrival date instead if one is provided and adjusts the length of stay accordingly', () => {
+      const rows = spaceBookingConfirmationSummaryListRows({
+        premises,
+        expectedArrivalDate,
+        expectedDepartureDate,
+        criteria,
+        releaseType: placementRequest.releaseType,
+        actualArrivalDate: '2025-04-25',
+      })
+
+      expect(rows).toHaveLength(7)
+      expect(rows).toEqual(
+        expect.arrayContaining([
+          { key: { text: 'Actual arrival date' }, value: { text: 'Fri 25 Apr 2025' } },
+          { key: { text: 'Length of stay' }, value: { text: '12 weeks' } },
+        ]),
+      )
+      expect(rows).toEqual(
+        expect.not.arrayContaining([{ key: { text: 'Arrival date' }, value: { text: 'Fri 23 May 2025' } }]),
+      )
     })
   })
 

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -33,22 +33,31 @@ export const placementLength = (lengthInDays: number): string => {
   return DateFormats.formatDuration(daysToWeeksAndDays(lengthInDays), ['weeks', 'days'])
 }
 
-export const spaceBookingConfirmationSummaryListRows = (
-  premises: Cas1Premises,
-  arrivalDate: string,
-  departureDate: string,
-  criteria: Array<Cas1SpaceBookingCharacteristic>,
-  releaseType?: ReleaseTypeOption,
-): Array<SummaryListItem> => {
+type SpaceBookingConfirmationData = {
+  premises: Cas1Premises
+  expectedArrivalDate: string
+  actualArrivalDate?: string
+  expectedDepartureDate: string
+  criteria: Array<Cas1SpaceBookingCharacteristic>
+  releaseType?: ReleaseTypeOption
+}
+
+export const spaceBookingConfirmationSummaryListRows = (data: SpaceBookingConfirmationData): Array<SummaryListItem> => {
+  const { premises, expectedArrivalDate, actualArrivalDate, expectedDepartureDate, criteria, releaseType } = data
+
   return [
     summaryListItem('Approved Premises', premises.name),
     summaryListItem('Address', premisesAddress(premises)),
     summaryListItem('Room criteria', requirementsHtmlString(criteria), 'html'),
-    summaryListItem('Arrival date', DateFormats.isoDateToUIDate(arrivalDate)),
-    summaryListItem('Departure date', DateFormats.isoDateToUIDate(departureDate)),
+    actualArrivalDate
+      ? summaryListItem('Actual arrival date', DateFormats.isoDateToUIDate(actualArrivalDate))
+      : summaryListItem('Expected arrival date', DateFormats.isoDateToUIDate(expectedArrivalDate)),
+    summaryListItem('Expected departure date', DateFormats.isoDateToUIDate(expectedDepartureDate)),
     summaryListItem(
       'Length of stay',
-      DateFormats.formatDuration(daysToWeeksAndDays(differenceInDays(departureDate, arrivalDate))),
+      DateFormats.formatDuration(
+        daysToWeeksAndDays(differenceInDays(expectedDepartureDate, actualArrivalDate || expectedArrivalDate)),
+      ),
     ),
     releaseType ? summaryListItem('Release type', allReleaseTypes[releaseType]) : undefined,
   ].filter(Boolean)


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2003

# Changes in this PR

This now renders the arrival and departure dates as 'Expected ...' in the space booking confirmation screen, as well as the change/extend booking screens. For booking extensions, the 'Expected arrival date' instead shows as 'Actual arrival date'. The length of stay is corrected accordingly.

## Screenshots of UI changes

<details><summary>Booking confirmation</summary>

<img width="1000" alt="Screenshot 2025-02-24 at 18 12 32" src="https://github.com/user-attachments/assets/83f190ca-fa63-4ae8-bc8a-ec3c8a94fe38" />

</details>

<details><summary>Extension confirmation</summary>

This shows the 'Actual arrival date' instead of the 'Expected arrival date':

<img width="1004" alt="Screenshot 2025-02-24 at 18 09 12" src="https://github.com/user-attachments/assets/1499c595-7e63-45d3-a81f-64bbccdaeb3a" />




</details>
