### PR TITLE
APS-2008 Sort order on current tab

### DIFF
--- a/integration_tests/tests/manage/premises.cy.ts
+++ b/integration_tests/tests/manage/premises.cy.ts
@@ -15,6 +15,7 @@ context('Premises', () => {
   describe('list', () => {
     it('should list all premises', () => {
       cy.task('reset')
+
       // Given I am logged in as a future manager
       signIn(['future_manager'])
       const premises = premisesSummaryFactory.buildList(5)
@@ -47,7 +48,7 @@ context('Premises', () => {
         premisesId: premises.id,
         placements,
         residency: 'current',
-        sortBy: 'canonicalDepartureDate',
+        sortBy: 'personName',
         sortDirection: 'asc',
         perPage: 2000,
       })

--- a/server/controllers/manage/premises/premisesController.test.ts
+++ b/server/controllers/manage/premises/premisesController.test.ts
@@ -106,7 +106,7 @@ describe('V2PremisesController', () => {
         expect.objectContaining({
           premises: premisesSummary,
           showPlacements: true,
-          sortBy: 'canonicalDepartureDate',
+          sortBy: 'personName',
           sortDirection: 'asc',
           activeTab: 'current',
           pageNumber: 1,
@@ -124,7 +124,7 @@ describe('V2PremisesController', () => {
         status: 'current',
         page: 1,
         perPage: 2000,
-        sortBy: 'canonicalDepartureDate',
+        sortBy: 'personName',
         sortDirection: 'asc',
       })
     })
@@ -278,7 +278,7 @@ describe('V2PremisesController', () => {
         expect.objectContaining({
           premises: premisesSummary,
           showPlacements: false,
-          sortBy: 'canonicalDepartureDate',
+          sortBy: 'personName',
           sortDirection: 'asc',
           activeTab: 'current',
           pageNumber: undefined,

--- a/server/controllers/manage/premises/premisesController.ts
+++ b/server/controllers/manage/premises/premisesController.ts
@@ -23,7 +23,7 @@ export default class PremisesController {
     return async (req: Request, res: Response) => {
       const tabSettings: Record<PremisesTab, TabSettings> = {
         upcoming: { pageSize: 20, sortBy: 'canonicalArrivalDate', sortDirection: 'asc' },
-        current: { pageSize: 2000, sortBy: 'canonicalDepartureDate', sortDirection: 'asc' },
+        current: { pageSize: 2000, sortBy: 'personName', sortDirection: 'asc' },
         historic: { pageSize: 20, sortBy: 'canonicalDepartureDate', sortDirection: 'desc' },
         search: { pageSize: 20, sortBy: 'canonicalArrivalDate', sortDirection: 'desc' },
       }


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2008
<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Changes the default sort order on the 'Current' tab on the premises view page, to `personName` ascending, rather than `canonicalDepartureDate`
<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/f4d0d9fe-b6af-400c-ba4b-2400f02f37be)

