### PR TITLE
CHORE: Cancel previous workflow for the same branch/ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ env:
   API_CLIENT_ID: approved-premises
   API_CLIENT_SECRET: clientsecret
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: "Build 🛠️"


### PR DESCRIPTION
At the moment, a push to a branch that is currently running the CI workflow does not cancel it; instead, the workflow continues running in the background, and results in failure notifications being sent out. This ensures any previously running workflow for a given branch or ref is cancelled by newer ones, therefore saving compute and preventing out-of-date failure notifications being sent out.
