### PR TITLE
APS-1963: Use updated response for Person Acct Alerts

### DIFF
--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -382,17 +382,19 @@
       "acctAlerts": [
         {
           "alertId": 47419,
+          "alertTypeDescription": "AcctAlert type one",
           "dateCreated": "2022-12-05",
           "dateExpires": "2023-05-29",
-          "comment": "Soluta harum harum hic maxime reprehenderit quis harum necessitatibus.",
+          "description": "Soluta harum harum hic maxime reprehenderit quis harum necessitatibus.",
           "expired": false,
           "active": true
         },
         {
           "alertId": 429,
+          "alertTypeDescription": "AcctAlert type two",
           "dateCreated": "2022-05-21",
           "dateExpires": "2023-12-16",
-          "comment": "Quia ex nisi deserunt voluptatibus sit ipsa.",
+          "description": "Quia ex nisi deserunt voluptatibus sit ipsa.",
           "expired": false,
           "active": true
         }

--- a/integration_tests/fixtures/applicationDocument.json
+++ b/integration_tests/fixtures/applicationDocument.json
@@ -157,13 +157,13 @@
       ],
       "ACCT Alerts": [
         {
-          "Alert type": 47419,
+          "Alert type": "AcctAlert type one",
           "ACCT description": "Soluta harum harum hic maxime reprehenderit quis harum necessitatibus.",
           "Date created": "Mon 5 Dec 2022",
           "Expiry date": "Mon 29 May 2023"
         },
         {
-          "Alert type": 429,
+          "Alert type": "AcctAlert type two",
           "ACCT description": "Quia ex nisi deserunt voluptatibus sit ipsa.",
           "Date created": "Sat 21 May 2022",
           "Expiry date": "Sat 16 Dec 2023"

--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -387,16 +387,16 @@ export default class ApplyHelper {
 
   private stubAcctAlertsEndpoint() {
     const acctAlert1 = acctAlertFactory.build({
-      alertId: 47419,
+      alertTypeDescription: 'AcctAlert type one',
       dateCreated: '2022-12-05',
       dateExpires: '2023-05-29',
-      comment: 'Soluta harum harum hic maxime reprehenderit quis harum necessitatibus.',
+      description: 'Soluta harum harum hic maxime reprehenderit quis harum necessitatibus.',
     })
     const acctAlert2 = acctAlertFactory.build({
-      alertId: 429,
+      alertTypeDescription: 'AcctAlert type two',
       dateCreated: '2022-05-21',
       dateExpires: '2023-12-16',
-      comment: 'Quia ex nisi deserunt voluptatibus sit ipsa.',
+      description: 'Quia ex nisi deserunt voluptatibus sit ipsa.',
     })
 
     this.acctAlerts = [acctAlert1, acctAlert2]

--- a/integration_tests/pages/apply/checkYourAnswersPage.ts
+++ b/integration_tests/pages/apply/checkYourAnswersPage.ts
@@ -148,8 +148,8 @@ export default class CheckYourAnswersPage extends ApplyPage {
             cy.wrap($items).should('have.length', acctAlerts.length)
             acctAlerts.forEach((acctAlert, i) => {
               cy.wrap($items[i]).within(() => {
-                this.assertDefinition('Alert type', String(acctAlert.alertId))
-                this.assertDefinition('ACCT description', acctAlert.comment)
+                this.assertDefinition('Alert type', String(acctAlert.alertTypeDescription))
+                this.assertDefinition('ACCT description', acctAlert.description)
                 this.assertDefinition('Date created', DateFormats.isoDateToUIDate(acctAlert.dateCreated))
                 this.assertDefinition('Expiry date', DateFormats.isoDateToUIDate(acctAlert.dateExpires))
               })

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -359,10 +359,10 @@ export default abstract class Page {
     cy.get('a').contains('ACCT').click()
     acctAlerts.forEach(acctAlert => {
       cy.get('tr')
-        .contains(`${acctAlert.alertId}`)
+        .contains(`${acctAlert.alertTypeDescription}`)
         .parent()
         .within(() => {
-          cy.get('td').eq(1).contains(acctAlert.comment)
+          cy.get('td').eq(1).contains(acctAlert.description)
           cy.get('td').eq(2).contains(DateFormats.isoDateToUIDate(acctAlert.dateCreated))
           cy.get('td')
             .eq(3)

--- a/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.test.ts
@@ -66,30 +66,30 @@ describe('adjudicationResponse', () => {
 describe('acctAlertResponse', () => {
   it('returns a response for an ACCT Alert', () => {
     const acctAlert = acctAlertFactory.build({
-      alertId: 123,
-      comment: 'Some description',
+      alertTypeDescription: 'Some alert type',
+      description: 'Some description',
       dateCreated: '2022-01-01T10:00:00Z',
       dateExpires: '2022-01-09T10:00:00Z',
     })
 
     expect(acctAlertResponse(acctAlert)).toEqual({
-      'Alert type': 123,
+      'Alert type': 'Some alert type',
       'ACCT description': 'Some description',
       'Date created': DateFormats.isoDateToUIDate(acctAlert.dateCreated),
       'Expiry date': DateFormats.isoDateToUIDate(acctAlert.dateExpires),
     })
   })
 
-  it('returns an empty string for the comment if it is undefined', () => {
+  it('returns an empty string for the description if it is undefined', () => {
     const acctAlert = acctAlertFactory.build({
-      alertId: 123,
-      comment: undefined,
+      alertTypeDescription: 'Some alert',
+      description: undefined,
       dateCreated: '2022-01-01T10:00:00Z',
       dateExpires: '2022-01-09T10:00:00Z',
     })
 
     expect(acctAlertResponse(acctAlert)).toEqual({
-      'Alert type': 123,
+      'Alert type': 'Some alert',
       'Date created': DateFormats.isoDateToUIDate(acctAlert.dateCreated),
       'Expiry date': DateFormats.isoDateToUIDate(acctAlert.dateExpires),
       'ACCT description': '',

--- a/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
+++ b/server/form-pages/apply/risk-and-need-factors/prison-information/caseNotes.ts
@@ -45,8 +45,8 @@ export const adjudicationResponse = (adjudication: Adjudication) => {
 
 export const acctAlertResponse = (acctAlert: PersonAcctAlert) => {
   return {
-    'Alert type': acctAlert.alertId,
-    'ACCT description': acctAlert.comment ?? '',
+    'Alert type': acctAlert.alertTypeDescription,
+    'ACCT description': acctAlert.description || '',
     'Date created': uiDateOrDateEmptyMessage(acctAlert, 'dateCreated', DateFormats.isoDateToUIDate),
     'Expiry date': uiDateOrDateEmptyMessage(acctAlert, 'dateExpires', DateFormats.isoDateToUIDate),
   }

--- a/server/views/partials/prisonInformationTable.njk
+++ b/server/views/partials/prisonInformationTable.njk
@@ -3,93 +3,97 @@
 {% macro prisonInformationTable(caseNotes, adjudications, acctAlerts) %}
 
     {{ mojSubNavigation({
-                label: 'Sub navigation',
-                items: [{
-                    text: 'Prison case notes',
-                    href: '#caseNotes',
-                    attributes: {
-                        'aria-controls': 'caseNotes',
-                        'id': 'caseNotesTab',
-                        'aria-selected': true
-                    }
-                },
-                {
-                    text: 'Adjudications',
-                    href: '#adjudications',
-                    attributes: {
-                        'aria-controls': 'adjudications',
-                        'id': 'adjudicationsTab'
-                    }
-                },
-                {
-                    text: 'ACCT',
-                    href: '#acct',
-                    attributes: {
-                        'aria-controls': 'acct',
-                        'id': 'acctTab'
-                    }
-                }]
-            }) }}
+        label: 'Sub navigation',
+        items: [{
+            text: 'Prison case notes',
+            href: '#caseNotes',
+            attributes: {
+                'aria-controls': 'caseNotes',
+                'id': 'caseNotesTab',
+                'aria-selected': true
+            }
+        },
+            {
+                text: 'Adjudications',
+                href: '#adjudications',
+                attributes: {
+                'aria-controls': 'adjudications',
+                'id': 'adjudicationsTab'
+            }
+            },
+            {
+                text: 'ACCT',
+                href: '#acct',
+                attributes: {
+                'aria-controls': 'acct',
+                'id': 'acctTab'
+            }
+            }]
+    }) }}
 
-    <div class="govuk-column-full-width" id="caseNotes" role="tabpanel" aria-labelledby="caseNotesTab" class="govuk-visually-hidden">
-        {{caseNotes | safe}}
+    <div class="govuk-column-full-width" id="caseNotes" role="tabpanel" aria-labelledby="caseNotesTab"
+         class="govuk-visually-hidden">
+        {{ caseNotes | safe }}
     </div>
 
-    <div class="govuk-column-full-width" id="adjudications" role="tabpanel" aria-labelledby="adjudicationsTab" class="govuk-visually-hidden">
+    <div class="govuk-column-full-width" id="adjudications" role="tabpanel" aria-labelledby="adjudicationsTab"
+         class="govuk-visually-hidden">
         <table class="govuk-table">
             <caption class="govuk-table__caption govuk-table__caption--m">Adjudications</caption>
 
             <thead class="govuk-table__head">
-                <tr class="govuk-table__row">
-                    <th scope="col" class="govuk-table__header">Adjudication number</th>
-                    <th scope="col" class="govuk-table__header">Report date and time</th>
-                    <th scope="col" class="govuk-table__header">Establishment</th>
-                    <th scope="col" class="govuk-table__header govuk-!-width-one-third">Offence description	</th>
-                    <th scope="col" class="govuk-table__header">Finding</th>
-                </tr>
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Adjudication number</th>
+                <th scope="col" class="govuk-table__header">Report date and time</th>
+                <th scope="col" class="govuk-table__header">Establishment</th>
+                <th scope="col" class="govuk-table__header govuk-!-width-one-third">Offence description</th>
+                <th scope="col" class="govuk-table__header">Finding</th>
+            </tr>
             </thead>
 
             <tbody class="govuk-table__body">
-                {% for adjudication in adjudications %}
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">{{ adjudication.id }}</td>
-                        <td class="govuk-table__cell">{{ uiDateOrDateEmptyMessage(adjudication, 'reportedAt', formatDateTime) }}</td>
-                        <td class="govuk-table__cell">{{ adjudication.establishment }}</td>
-                        <td class="govuk-table__cell">{{ adjudication.offenceDescription }}</td>
-                        <td class="govuk-table__cell">{{ adjudication.finding | sentenceCase }}</td>
-                    </tr>
-                {% endfor %}
+            {% for adjudication in adjudications %}
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">{{ adjudication.id }}</td>
+                    <td class="govuk-table__cell">{{ uiDateOrDateEmptyMessage(adjudication, 'reportedAt', formatDateTime) }}</td>
+                    <td class="govuk-table__cell">{{ adjudication.establishment }}</td>
+                    <td class="govuk-table__cell">{{ adjudication.offenceDescription }}</td>
+                    <td class="govuk-table__cell">{{ adjudication.finding | sentenceCase }}</td>
+                </tr>
+            {% endfor %}
             </tbody>
         </table>
     </div>
 
-    <div class="govuk-column-full-width" id="acct" role="tabpanel" aria-labelledby="acctTab" class="govuk-visually-hidden">
+    <div class="govuk-column-full-width" id="acct" role="tabpanel" aria-labelledby="acctTab"
+         class="govuk-visually-hidden">
         <table class="govuk-table">
             <caption class="govuk-table__caption govuk-table__caption--m">ACCT</caption>
             <thead class="govuk-table__head">
-                <tr class="govuk-table__row">
-                    <th scope="col" class="govuk-table__header" style="width:100px;">Alert type</th>
-                    <th scope="col" class="govuk-table__header">ACCT description</th>
-                    <th scope="col" class="govuk-table__header">Date created</th>
-                    <th scope="col" class="govuk-table__header">Expiry date</th>
-                </tr>
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header" style="width:100px;">Alert type</th>
+                <th scope="col" class="govuk-table__header">ACCT description</th>
+                <th scope="col" class="govuk-table__header">Date created</th>
+                <th scope="col" class="govuk-table__header">Expiry date</th>
+            </tr>
             </thead>
 
             <tbody class="govuk-table__body">
-                {% for alert in acctAlerts %}
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">{{ alert.alertId }}</td>
-                        <td class="govuk-table__cell">{{ alert.comment }}</td>
-                        <td class="govuk-table__cell">{{ uiDateOrDateEmptyMessage(alert, 'dateCreated', formatDate) }}</td>
-                        <td class="govuk-table__cell">{{ uiDateOrDateEmptyMessage(alert, 'dateExpires', formatDate) }}</td>
-                    </tr>
-                {% endfor %}
+            {% for alert in acctAlerts %}
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">{{ alert.alertTypeDescription }}</td>
+                    <td class="govuk-table__cell">{{ alert.description }}</td>
+                    <td class="govuk-table__cell">{{ uiDateOrDateEmptyMessage(alert, 'dateCreated', formatDate) }}</td>
+                    <td class="govuk-table__cell">{{ uiDateOrDateEmptyMessage(alert, 'dateExpires', formatDate) }}</td>
+                </tr>
+            {% endfor %}
             </tbody>
         </table>
     </div>
 
     {% block extraScripts %}
-        <script type="text/javascript" nonce="{{ cspNonce }}" src="../../../../../assets/tabPanelTableScript.js"></script>
+        <script type="text/javascript" nonce="{{ cspNonce }}"
+                src="../../../../../assets/tabPanelTableScript.js"></script>
     {% endblock %}
 
-    {% endmacro%}
+{% endmacro %}


### PR DESCRIPTION
This swaps the deprecated `comment` for the new `description`, and renders 'Alert type' as the value of `alertTypeDescription` instead of `alertId`.

# Context

https://dsdmoj.atlassian.net/browse/APS-1963

# Changes in this PR

This swaps the deprecated `comment` for the new `description`, and renders 'Alert type' as the value of `alertTypeDescription` instead of `alertId`.

