### PR TITLE
CHORE: Prevent concurrent CodeQL workflow for same branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
This applies the same concurrency policy for the CodeQL workflow [as the one added to the CI workflow](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/2388), so that a newer workflow on the same branch cancels the currently running one.

