### PR TITLE
CHORE: Fix flaky placement request integration test

### DIFF
--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -7,6 +7,7 @@ import {
   applicationSummaryFactory,
   bookingFactory,
   cas1PremisesBasicSummaryFactory,
+  cas1SpaceBookingSummaryFactory,
   cruManagementAreaFactory,
   newCancellationFactory,
   placementRequestDetailFactory,
@@ -47,7 +48,9 @@ context('Placement Requests', () => {
       spaceBookings: [],
     })
 
-    const matchedPlacementRequest = placementRequestDetailFactory.build(matchedPlacementRequests[1])
+    const matchedPlacementRequest = placementRequestDetailFactory
+      .withSpaceBooking(cas1SpaceBookingSummaryFactory.upcoming().build())
+      .build(matchedPlacementRequests[1])
     const spaceBooking = bookingFactory.build({
       applicationId: application.id,
       premises: { id: matchedPlacementRequest.booking.premisesId },


### PR DESCRIPTION
The test in question relies on a Placement Request created from a factory, and checks for the presence of a 'Change placement' action on the page. This action only shows if the placement status is not 'departed' or 'notArrived'. However, the factory would set the status randomly, with one of those 2 occurring approximately 18% of the time (2/11 possible statuses).

This ensures the placement request being tested has an upcoming booking, rather than one of any status.


