### PR TITLE
CHORE: Use upcoming booking by default for placement request factory

### DIFF
--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -6,8 +6,9 @@ import {
   applicationFactory,
   applicationSummaryFactory,
   bookingFactory,
+  bookingSummaryFactory,
   cas1PremisesBasicSummaryFactory,
-  cas1SpaceBookingSummaryFactory,
+  cas1SpaceBookingFactory,
   cruManagementAreaFactory,
   newCancellationFactory,
   placementRequestDetailFactory,
@@ -26,7 +27,6 @@ import paths from '../../../server/paths/api'
 import BookingCancellationConfirmPage from '../../pages/manage/bookingCancellationConfirmation'
 import { allReleaseTypes } from '../../../server/utils/applications/releaseTypeUtils'
 import withdrawablesFactory from '../../../server/testutils/factories/withdrawablesFactory'
-import bookingSummaryFactory from '../../../server/testutils/factories/placementRequestBookingSummary'
 
 context('Placement Requests', () => {
   const stubArtifacts = (applicationData: Record<string, unknown> = {}) => {
@@ -48,10 +48,8 @@ context('Placement Requests', () => {
       spaceBookings: [],
     })
 
-    const matchedPlacementRequest = placementRequestDetailFactory
-      .withSpaceBooking(cas1SpaceBookingSummaryFactory.upcoming().build())
-      .build(matchedPlacementRequests[1])
-    const spaceBooking = bookingFactory.build({
+    const matchedPlacementRequest = placementRequestDetailFactory.build(matchedPlacementRequests[1])
+    const spaceBooking = cas1SpaceBookingFactory.build({
       applicationId: application.id,
       premises: { id: matchedPlacementRequest.booking.premisesId },
       id: matchedPlacementRequest.booking.id,
@@ -59,10 +57,11 @@ context('Placement Requests', () => {
     const legacyBooking = bookingSummaryFactory.build({
       type: 'legacy',
     })
-    const matchedPlacementRequestWithLegacyBooking = placementRequestDetailFactory.withLegacyBooking().build({
+    const matchedPlacementRequestWithLegacyBooking = placementRequestDetailFactory.build({
       ...matchedPlacementRequests[2],
       booking: legacyBooking,
       legacyBooking,
+      spaceBookings: [],
     })
     const unableToMatchPlacementRequest = placementRequestDetailFactory.build(unableToMatchPlacementRequests[0])
 

--- a/integration_tests/tests/manage/placements/changes.cy.ts
+++ b/integration_tests/tests/manage/placements/changes.cy.ts
@@ -3,16 +3,15 @@ import { addDays } from 'date-fns'
 import { Cas1SpaceBooking, Cas1UpdateSpaceBooking } from '@approved-premises/api'
 import { signIn } from '../../signIn'
 import {
-  bookingSummaryFactory,
   cas1PremiseCapacityFactory,
   cas1PremisesFactory,
   cas1SpaceBookingFactory,
+  cas1SpaceBookingSummaryFactory,
   placementRequestDetailFactory,
 } from '../../../../server/testutils/factories'
 import ShowPage from '../../../pages/admin/placementApplications/showPage'
 import Page from '../../../pages/page'
 import { ChangePlacementPage } from '../../../pages/manage/placements/changes/new'
-import { fullPersonFactory } from '../../../../server/testutils/factories/person'
 import { filterRoomLevelCriteria } from '../../../../server/utils/match/spaceSearch'
 import { DateFormats } from '../../../../server/utils/dateUtils'
 import ChangePlacementConfirmPage from '../../../pages/manage/placements/changes/confirm'
@@ -23,15 +22,12 @@ context('Change Placement', () => {
   const expectedArrivalDate = DateFormats.dateObjToIsoDate(faker.date.soon())
   const expectedDepartureDate = DateFormats.dateObjToIsoDate(addDays(expectedArrivalDate, 84))
 
-  const person = fullPersonFactory.build()
   const premises = cas1PremisesFactory.build()
 
   const setupMocks = (placement: Cas1SpaceBooking, startDate?: string, endDate?: string) => {
-    const placementRequestDetail = placementRequestDetailFactory.build({
-      person,
-      status: 'matched',
-      booking: bookingSummaryFactory.fromSpaceBooking(placement).build(),
-    })
+    const placementRequestDetail = placementRequestDetailFactory
+      .withSpaceBooking(cas1SpaceBookingSummaryFactory.build(placement))
+      .build()
     placement.placementRequestId = placementRequestDetail.id
     const capacity = cas1PremiseCapacityFactory.build()
     cy.task('stubSinglePremises', premises)

--- a/server/testutils/factories/placementRequestDetail.ts
+++ b/server/testutils/factories/placementRequestDetail.ts
@@ -1,5 +1,5 @@
 import { Factory } from 'fishery'
-import { Cas1SpaceBookingSummary, PlacementRequestDetail } from '../../@types/shared'
+import { Cas1SpaceBookingSummary, PlacementRequestDetail, type PlacementRequestStatus } from '../../@types/shared'
 
 import cancellationFactory from './cancellation'
 import placementRequestFactory from './placementRequest'
@@ -28,16 +28,18 @@ class PlacementRequestDetailFactory extends Factory<PlacementRequestDetail> {
   }
 }
 
-export default PlacementRequestDetailFactory.define(() => {
-  const spaceBooking = cas1SpaceBookingSummaryFactory.build()
+export default PlacementRequestDetailFactory.define(({ params }) => {
+  const spaceBooking = cas1SpaceBookingSummaryFactory.upcoming().build()
   const bookingSummary = bookingSummaryFactory.fromSpaceBooking(spaceBooking).build()
 
+  const skipBooking = (['notMatched', 'unableToMatch'] as Array<PlacementRequestStatus>).includes(params.status)
+
   return {
-    ...placementRequestFactory.build(),
+    ...placementRequestFactory.build(params),
     cancellations: cancellationFactory.buildList(2),
-    booking: bookingSummary,
+    booking: skipBooking ? undefined : bookingSummary,
     legacyBooking: undefined,
-    spaceBookings: [spaceBooking],
+    spaceBookings: skipBooking ? [] : [spaceBooking],
     application: applicationFactory.build(),
   }
 })

--- a/server/utils/placementRequests/adminIdentityBar.test.ts
+++ b/server/utils/placementRequests/adminIdentityBar.test.ts
@@ -33,20 +33,26 @@ const setup = ({
     href: matchPaths.v2Match.placementRequests.search.spaces({ id: placementRequestDetail.id }),
     text: 'Search for a space',
   }
-  const actionAmendLegacyBooking = {
-    href: managePaths.bookings.dateChanges.new({
-      premisesId: placementRequestDetail.booking.premisesId,
-      bookingId: placementRequestDetail.booking.id,
-    }),
-    text: 'Amend placement',
-  }
-  const actionChangePlacement = {
-    href: managePaths.premises.placements.changes.new({
-      premisesId: placementRequestDetail.booking.premisesId,
-      placementId: placementRequestDetail.booking.id,
-    }),
-    text: 'Change placement',
-  }
+  const actionAmendLegacyBooking = placementRequestDetail.booking
+    ? {
+        href: managePaths.bookings.dateChanges.new({
+          premisesId: placementRequestDetail.booking.premisesId,
+          bookingId: placementRequestDetail.booking.id,
+        }),
+        text: 'Amend placement',
+      }
+    : undefined
+
+  const actionChangePlacement = placementRequestDetail.booking
+    ? {
+        href: managePaths.premises.placements.changes.new({
+          premisesId: placementRequestDetail.booking.premisesId,
+          placementId: placementRequestDetail.booking.id,
+        }),
+        text: 'Change placement',
+      }
+    : undefined
+
   const actionWithdrawPlacement = {
     href: applyPaths.applications.withdraw.new({ id: placementRequestDetail.applicationId }),
     text: 'Withdraw placement',


### PR DESCRIPTION
This ensures a repeatable default for a property that has a bearing on the rendering of the UI itself. Any test requiring a booking of another status should instantiate it explicitly.

To ensure integrity of mock placement requests details, the booking properties (booking, legacyBooking, spaceBookings) are also now derived from the status provided: if 'notMatched' or 'unableToMatch', no linked booking is created.

