### PR TITLE
APS-1899 - Update isArsonSuitable Placement Criteria Label

### DIFF
--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -250,7 +250,7 @@ describe('matchUtils', () => {
         {
           key: { text: 'Room criteria' },
           value: {
-            html: '<ul class="govuk-list govuk-list--bullet"><li>En-suite bathroom</li><li>Arson offences</li></ul>',
+            html: '<ul class="govuk-list govuk-list--bullet"><li>En-suite bathroom</li><li>Suitable for active arson risk</li></ul>',
           },
         },
         { key: { text: 'Expected arrival date' }, value: { text: 'Tue 23 Sep 2025' } },

--- a/server/utils/placementCriteriaUtils.ts
+++ b/server/utils/placementCriteriaUtils.ts
@@ -65,7 +65,7 @@ export const placementCriteriaLabels: Record<UiPlacementCriteria, string> = {
   isCatered: 'Catering required',
   hasEnSuite: 'En-suite bathroom',
   isSuitedForSexOffenders: 'Room suitable for a person with sexual offences',
-  isArsonSuitable: 'Arson offences',
+  isArsonSuitable: 'Suitable for active arson risk',
   hasBrailleSignage: 'Braille signage',
   hasTactileFlooring: 'Tactile flooring',
   hasHearingLoop: 'Hearing loop',


### PR DESCRIPTION
This commit updates the isArsonSuitable characteristic label from ‘Arson offences’ to ‘Suitable for active arson risk’.

At point of merge there are currently no usages of this characteristic in production, as all usages have been migrated to use the `arsonOffences` characteristic instead.

# Context

This screen shows a placement request with the following criteria (in order shown)

* isArsonSuitable
* isDesignatedArsonRoom
* arsonOffences

![Screenshot 2025-03-06 at 09 23 56](https://github.com/user-attachments/assets/3662ff6e-07b3-4bea-bdee-69a769efc862)

