### PR TITLE
APS-2076 Remove releaseType from occupancy day views

### DIFF
--- a/integration_tests/pages/manage/occupancyDayView.ts
+++ b/integration_tests/pages/manage/occupancyDayView.ts
@@ -39,12 +39,11 @@ export default class OccupancyDayViewPage extends Page {
 
   shouldShowListOfPlacements(placementSummaryList: Array<Cas1SpaceBookingDaySummary>) {
     placementSummaryList.forEach(
-      ({ person, canonicalArrivalDate, canonicalDepartureDate, releaseType, essentialCharacteristics }) => {
+      ({ person, canonicalArrivalDate, canonicalDepartureDate, essentialCharacteristics }) => {
         cy.get('.govuk-table__body').contains(person.crn).closest('.govuk-table__row').as('row')
         cy.get('@row').contains(displayName(person))
         cy.get('@row').contains(DateFormats.isoDateToUIDate(canonicalArrivalDate, { format: 'short' }))
         cy.get('@row').contains(DateFormats.isoDateToUIDate(canonicalDepartureDate, { format: 'short' }))
-        cy.get('@row').contains(releaseType)
         essentialCharacteristics.forEach(characteristic => {
           if (spaceSearchCriteriaApLevelLabels[characteristic])
             cy.get('@row').contains(spaceSearchCriteriaApLevelLabels[characteristic])

--- a/server/controllers/manage/premises/apOccupancyViewController.ts
+++ b/server/controllers/manage/premises/apOccupancyViewController.ts
@@ -1,7 +1,7 @@
 import type { Request, RequestHandler, Response } from 'express'
 
 import { ObjectWithDateParts } from '@approved-premises/ui'
-import { Cas1SpaceBookingCharacteristic, Cas1SpaceBookingDaySummarySortField } from '@approved-premises/api'
+import { Cas1SpaceBookingCharacteristic } from '@approved-premises/api'
 import { PremisesService, SessionService } from '../../../services'
 
 import paths from '../../../paths/manage'
@@ -9,6 +9,7 @@ import {
   Calendar,
   type OutOfServiceBedColumnField,
   type PlacementColumnField,
+  type SortablePlacementColumnField,
   daySummaryRows,
   durationSelectOptions,
   filterOutOfServiceBeds,
@@ -96,11 +97,9 @@ export default class ApOccupancyViewController {
         sortBy = 'personName',
         sortDirection = 'asc',
         hrefPrefix,
-      } = getPaginationDetails<Cas1SpaceBookingDaySummarySortField>(
-        req,
-        paths.premises.occupancy.day({ premisesId, date }),
-        { characteristics: characteristicsArray },
-      )
+      } = getPaginationDetails<SortablePlacementColumnField>(req, paths.premises.occupancy.day({ premisesId, date }), {
+        characteristics: characteristicsArray,
+      })
 
       const getDayLink = (targetDate: string) =>
         `${paths.premises.occupancy.day({

--- a/server/controllers/match/placementRequests/occupancyViewController.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.ts
@@ -1,6 +1,6 @@
 import { Request, Response, TypedRequestHandler } from 'express'
 import type { ObjectWithDateParts } from '@approved-premises/ui'
-import type { Cas1SpaceBookingCharacteristic, Cas1SpaceBookingDaySummarySortField } from '@approved-premises/api'
+import type { Cas1SpaceBookingCharacteristic } from '@approved-premises/api'
 import { PlacementRequestService, PremisesService, SessionService, SpaceSearchService } from '../../../services'
 import { occupancySummary, placementDates, validateSpaceBooking } from '../../../utils/match'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
@@ -18,6 +18,7 @@ import { filterRoomLevelCriteria } from '../../../utils/match/spaceSearch'
 import {
   type OutOfServiceBedColumnField,
   type PlacementColumnField,
+  SortablePlacementColumnField,
   daySummaryRows,
   filterOutOfServiceBeds,
   outOfServiceBedColumnMap,
@@ -232,7 +233,7 @@ export default class {
         sortBy = 'personName',
         sortDirection = 'asc',
         hrefPrefix,
-      } = getPaginationDetails<Cas1SpaceBookingDaySummarySortField>(
+      } = getPaginationDetails<SortablePlacementColumnField>(
         req,
         paths.v2Match.placementRequests.search.dayOccupancy({ id, premisesId, date }),
       )

--- a/server/utils/premises/occupancy.test.ts
+++ b/server/utils/premises/occupancy.test.ts
@@ -299,8 +299,7 @@ describe('apOccupancy utils', () => {
       expect(row[1].html).toEqual(getTierOrBlank(placement.tier))
       expect(row[2].text).toEqual(DateFormats.isoDateToUIDate(placement.canonicalArrivalDate, { format: 'short' }))
       expect(row[3].text).toEqual(DateFormats.isoDateToUIDate(placement.canonicalDepartureDate, { format: 'short' }))
-      expect(row[4].text).toEqual(placement.releaseType)
-      expect(row[5].html).toMatchStringIgnoringWhitespace(
+      expect(row[4].html).toMatchStringIgnoringWhitespace(
         `<ul class="govuk-list govuk-list"><li>Suitable for active arson risk</li></ul>`,
       )
     }

--- a/server/utils/premises/occupancy.ts
+++ b/server/utils/premises/occupancy.ts
@@ -207,7 +207,8 @@ const itemListHtml = (items: Array<string>): { html: string } =>
   </ul>
 `)
 
-export type PlacementColumnField = Cas1SpaceBookingDaySummarySortField | 'spaceType'
+export type SortablePlacementColumnField = Exclude<Cas1SpaceBookingDaySummarySortField, 'releaseType'>
+export type PlacementColumnField = SortablePlacementColumnField | 'spaceType'
 export type OutOfServiceBedColumnField = keyof Cas1OutOfServiceBedSummary
 
 export type ColumnDefinition<T> = {
@@ -221,7 +222,6 @@ export const placementColumnMap: Array<ColumnDefinition<PlacementColumnField>> =
   { title: 'Tier', fieldName: 'tier', sortable: true },
   { title: 'Arrival date', fieldName: 'canonicalArrivalDate', sortable: true },
   { title: 'Departure date', fieldName: 'canonicalDepartureDate', sortable: true },
-  { title: 'Release type', fieldName: 'releaseType', sortable: true },
   { title: 'Room criteria', fieldName: 'spaceType', sortable: false },
 ]
 
@@ -248,26 +248,23 @@ export const placementTableRows = (
   premisesId: string,
   placements: Array<Cas1SpaceBookingDaySummary>,
 ): Array<TableRow> =>
-  placements.map(
-    ({ id, person, tier, canonicalArrivalDate, canonicalDepartureDate, releaseType, essentialCharacteristics }) => {
-      const fieldValues: Record<PlacementColumnField, TableCell> = {
-        personName: htmlValue(
-          `<a href="${managePaths.premises.placements.show({
-            premisesId,
-            placementId: id,
-          })}" data-cy-id="${id}">${displayName(person)}, ${person.crn}</a>`,
-        ),
-        tier: htmlValue(getTierOrBlank(tier)),
-        canonicalArrivalDate: textValue(DateFormats.isoDateToUIDate(canonicalArrivalDate, { format: 'short' })),
-        canonicalDepartureDate: textValue(DateFormats.isoDateToUIDate(canonicalDepartureDate, { format: 'short' })),
-        releaseType: textValue(releaseType),
-        spaceType: itemListHtml(
-          essentialCharacteristics.map(characteristic => getRoomCharacteristicLabel(characteristic)).filter(Boolean),
-        ),
-      }
-      return placementColumnMap.map(({ fieldName }: ColumnDefinition<PlacementColumnField>) => fieldValues[fieldName])
-    },
-  )
+  placements.map(({ id, person, tier, canonicalArrivalDate, canonicalDepartureDate, essentialCharacteristics }) => {
+    const fieldValues: Record<PlacementColumnField, TableCell> = {
+      personName: htmlValue(
+        `<a href="${managePaths.premises.placements.show({
+          premisesId,
+          placementId: id,
+        })}" data-cy-id="${id}">${displayName(person)}, ${person.crn}</a>`,
+      ),
+      tier: htmlValue(getTierOrBlank(tier)),
+      canonicalArrivalDate: textValue(DateFormats.isoDateToUIDate(canonicalArrivalDate, { format: 'short' })),
+      canonicalDepartureDate: textValue(DateFormats.isoDateToUIDate(canonicalDepartureDate, { format: 'short' })),
+      spaceType: itemListHtml(
+        essentialCharacteristics.map(characteristic => getRoomCharacteristicLabel(characteristic)).filter(Boolean),
+      ),
+    }
+    return placementColumnMap.map(({ fieldName }: ColumnDefinition<PlacementColumnField>) => fieldValues[fieldName])
+  })
 
 export const outOfServiceBedTableRows = (
   premisesId: string,


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2076

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Removes the `releaseType` from the AP occupancy view pages in both match and manage. the API currently returns 'TBD' for both of these and is not going to be providing this information in the near future.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

<details>
  <summary>Before</summary>
<img src="https://github.com/user-attachments/assets/908d9aa3-9fad-4a93-9075-1a3a2f5162b6"/>
</details>

<details>
  <summary>After</summary>
<img src="https://github.com/user-attachments/assets/6464d480-e618-4b92-ba2f-60e848f02779"/>
</details>


