### PR TITLE
Use isArsonSuitable for arson risk on assessment

### DIFF
--- a/server/controllers/assess/assessments/pagesController.test.ts
+++ b/server/controllers/assess/assessments/pagesController.test.ts
@@ -3,6 +3,7 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import createError from 'http-errors'
 
 import type { DataServices, FormPages, TaskNames } from '@approved-premises/ui'
+import { Unit } from '@approved-premises/api'
 import PagesController from './pagesController'
 import { AssessmentService } from '../../../services'
 import TasklistPage from '../../../form-pages/tasklistPage'
@@ -18,6 +19,7 @@ import paths from '../../../paths/assess'
 import { viewPath } from '../../../form-pages/utils'
 
 import { assessmentFactory, clarificationNoteFactory } from '../../../testutils/factories'
+import * as matchingInformationUtils from '../../../form-pages/utils/matchingInformationUtils'
 
 const PageConstructor = jest.fn()
 
@@ -57,6 +59,9 @@ describe('pagesController', () => {
   describe('show', () => {
     const request: DeepMocked<Request> = createMock<Request>({ url: 'assessments' })
     const errorsAndUserInput = { errors: {}, errorSummary: [] as Array<never>, userInput: {} }
+    const mockedRemapArsonAssessmentData = jest
+      .spyOn(matchingInformationUtils, 'remapArsonAssessmentData')
+      .mockImplementation((assessmentData: Unit) => assessmentData)
 
     beforeEach(() => {
       ;(viewPath as jest.Mock).mockReturnValue('assessments/pages/some/view')
@@ -67,7 +72,7 @@ describe('pagesController', () => {
     it('renders a page', async () => {
       const requestHandler = pagesController.show(someTask, 'some-page')
       await requestHandler(request, response, next)
-
+      expect(mockedRemapArsonAssessmentData).toHaveBeenCalledWith(assessment.data)
       expect(assessmentService.initializePage).toHaveBeenCalledWith(PageConstructor, assessment, request, {}, {})
       expect(response.render).toHaveBeenCalledWith('assessments/pages/some/view', {
         assessmentId: request.params.id,

--- a/server/controllers/assess/assessments/pagesController.test.ts
+++ b/server/controllers/assess/assessments/pagesController.test.ts
@@ -3,7 +3,6 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import createError from 'http-errors'
 
 import type { DataServices, FormPages, TaskNames } from '@approved-premises/ui'
-import { Unit } from '@approved-premises/api'
 import PagesController from './pagesController'
 import { AssessmentService } from '../../../services'
 import TasklistPage from '../../../form-pages/tasklistPage'
@@ -59,9 +58,7 @@ describe('pagesController', () => {
   describe('show', () => {
     const request: DeepMocked<Request> = createMock<Request>({ url: 'assessments' })
     const errorsAndUserInput = { errors: {}, errorSummary: [] as Array<never>, userInput: {} }
-    const mockedRemapArsonAssessmentData = jest
-      .spyOn(matchingInformationUtils, 'remapArsonAssessmentData')
-      .mockImplementation((assessmentData: Unit) => assessmentData)
+    const spyRemapArsonAssessmentData = jest.spyOn(matchingInformationUtils, 'remapArsonAssessmentData')
 
     beforeEach(() => {
       ;(viewPath as jest.Mock).mockReturnValue('assessments/pages/some/view')
@@ -72,7 +69,7 @@ describe('pagesController', () => {
     it('renders a page', async () => {
       const requestHandler = pagesController.show(someTask, 'some-page')
       await requestHandler(request, response, next)
-      expect(mockedRemapArsonAssessmentData).toHaveBeenCalledWith(assessment.data)
+      expect(spyRemapArsonAssessmentData).toHaveBeenCalledWith(assessment.data)
       expect(assessmentService.initializePage).toHaveBeenCalledWith(PageConstructor, assessment, request, {}, {})
       expect(response.render).toHaveBeenCalledWith('assessments/pages/some/view', {
         assessmentId: request.params.id,

--- a/server/controllers/assess/assessments/pagesController.ts
+++ b/server/controllers/assess/assessments/pagesController.ts
@@ -15,6 +15,7 @@ import { UnknownPageError } from '../../../utils/errors'
 import { viewPath } from '../../../form-pages/utils'
 import TasklistPage, { TasklistPageInterface } from '../../../form-pages/tasklistPage'
 import { DataServices, TaskNames } from '../../../@types/ui'
+import { remapArsonAssessmentData } from '../../../form-pages/utils/matchingInformationUtils'
 
 export default class PagesController {
   constructor(
@@ -26,7 +27,13 @@ export default class PagesController {
     return async (req: Request, res: Response, next: NextFunction) => {
       try {
         const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
-        const assessment = await this.assessmentService.findAssessment(req.user.token, req.params.id)
+        const rawAssessment = await this.assessmentService.findAssessment(req.user.token, req.params.id)
+
+        // TODO: remove once arson remapping (APS-1876) is completed
+        const assessment: Assessment = {
+          ...rawAssessment,
+          data: remapArsonAssessmentData(rawAssessment.data),
+        }
 
         const Page: TasklistPageInterface = getPage(taskName, pageName)
         const page: TasklistPage = await this.assessmentService.initializePage(

--- a/server/controllers/assess/assessmentsController.ts
+++ b/server/controllers/assess/assessmentsController.ts
@@ -6,9 +6,10 @@ import { AssessmentService, TaskService } from '../../services'
 import informationSetAsNotReceived from '../../utils/assessments/informationSetAsNotReceived'
 
 import paths from '../../paths/assess'
-import { AssessmentSortField, AssessmentStatus, TaskSortField } from '../../@types/shared'
+import { ApprovedPremisesAssessment, AssessmentSortField, AssessmentStatus, TaskSortField } from '../../@types/shared'
 import { awaitingAssessmentStatuses } from '../../utils/assessments/utils'
 import { getPaginationDetails } from '../../utils/getPaginationDetails'
+import { remapArsonAssessmentData } from '../../form-pages/utils/matchingInformationUtils'
 
 export const tasklistPageHeading = 'Assess an Approved Premises (AP) application'
 
@@ -112,7 +113,13 @@ export default class AssessmentsController {
 
   submit(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const assessment = await this.assessmentService.findAssessment(req.user.token, req.params.id)
+      const rawAssessment = await this.assessmentService.findAssessment(req.user.token, req.params.id)
+
+      // TODO: remove once arson remapping (APS-1876) is completed
+      const assessment: ApprovedPremisesAssessment = {
+        ...rawAssessment,
+        data: remapArsonAssessmentData(rawAssessment.data),
+      }
 
       if (req.body?.confirmation !== 'confirmed') {
         addErrorMessageToFlash(

--- a/server/controllers/manage/premises/placements/changesController.test.ts
+++ b/server/controllers/manage/premises/placements/changesController.test.ts
@@ -176,7 +176,7 @@ describe('changesController', () => {
       'departureDate-day': '13',
       'departureDate-month': '8',
       'departureDate-year': '2025',
-      criteria: 'hasEnSuite,isArsonDesignated',
+      criteria: 'hasEnSuite,isArsonSuitable',
     }
 
     it('should redirect to the confirmation screen with criteria when the submitted dates are valid', async () => {
@@ -184,7 +184,7 @@ describe('changesController', () => {
         {
           arrivalDate: '2025-06-23',
           departureDate: '2025-08-13',
-          criteria: ['hasEnSuite', 'isArsonDesignated'],
+          criteria: ['hasEnSuite', 'isArsonSuitable'],
         },
         {
           arrayFormat: 'repeat',
@@ -203,7 +203,7 @@ describe('changesController', () => {
         'startDate-month': '5',
         'startDate-year': '2025',
         durationDays: '7',
-        criteria: ['hasEnSuite', 'isArsonDesignated'],
+        criteria: ['hasEnSuite', 'isArsonSuitable'],
       }
 
       const expectedRedirectUrl = `${managePaths.premises.placements.changes.confirm(params)}?${createQueryString(
@@ -211,7 +211,7 @@ describe('changesController', () => {
           ...query,
           arrivalDate: '2025-06-23',
           departureDate: '2025-08-13',
-          criteria: ['hasEnSuite', 'isArsonDesignated'],
+          criteria: ['hasEnSuite', 'isArsonSuitable'],
         },
         {
           arrayFormat: 'repeat',
@@ -232,7 +232,7 @@ describe('changesController', () => {
       it(`should redirect to the view when dates are empty`, async () => {
         const body = {}
         const query = {
-          criteria: ['hasEnSuite', 'isArsonDesignated'],
+          criteria: ['hasEnSuite', 'isArsonSuitable'],
         }
 
         const requestHandler = changesController.saveNew()
@@ -247,7 +247,7 @@ describe('changesController', () => {
           request,
           response,
           new ValidationError({}),
-          `${viewUrl}?criteria=hasEnSuite&criteria=isArsonDesignated`,
+          `${viewUrl}?criteria=hasEnSuite&criteria=isArsonSuitable`,
         )
 
         const errorData = (validationUtils.catchValidationErrorOrPropogate as jest.Mock).mock.lastCall[2].data

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -20,7 +20,7 @@ const weAssessment = assessmentFactory.build({
 
 const defaultArguments = {
   apType: 'isESAP' as const,
-  isArsonDesignated: 'essential',
+  isArsonSuitable: 'essential',
   isWheelchairDesignated: 'essential',
   isSingle: 'desirable',
   isStepFreeDesignated: 'desirable',
@@ -42,7 +42,7 @@ const defaultMatchingInformationValuesReturnValue: Partial<MatchingInformationBo
   acceptsHateCrimeOffenders: 'relevant',
   acceptsSexOffenders: 'relevant',
   apType: 'isPIPE',
-  isArsonDesignated: 'essential',
+  isArsonSuitable: 'essential',
   isCatered: 'essential',
   isSingle: 'desirable',
   isSuitableForVulnerable: 'relevant',
@@ -113,7 +113,7 @@ describe('MatchingInformation', () => {
 
       expect(page.response()).toEqual({
         'What type of AP is required?': 'Enhanced Security AP (ESAP)',
-        'Designated arson room': 'Essential',
+        'Suitable for active arson risk': 'Essential',
         'Room suitable for a person with sexual offences': 'Not relevant',
         'Wheelchair accessible': 'Essential',
         'Single room': 'Desirable',

--- a/server/form-pages/utils/matchingInformationUtils.ts
+++ b/server/form-pages/utils/matchingInformationUtils.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesApplication } from '@approved-premises/api'
+import { ApprovedPremisesApplication, Unit } from '@approved-premises/api'
 import { weeksToDays } from 'date-fns'
 import { BackwardsCompatibleApplyApType, SummaryList } from '@approved-premises/ui'
 import { placementDates } from '../../utils/match/placementDates'
@@ -153,9 +153,9 @@ const defaultMatchingInformationValues = (
       'notRelevant',
     ),
     apType: apType(body, application),
-    isArsonDesignated: getValue<GetValuePlacementRequirement>(
+    isArsonSuitable: getValue<GetValuePlacementRequirement>(
       body,
-      'isArsonDesignated',
+      'isArsonSuitable',
       application,
       [{ name: 'arson', page: Arson }],
       ['yes'],
@@ -221,6 +221,25 @@ const defaultMatchingInformationValues = (
     ),
     lengthOfStay: lengthOfStay(body),
   }
+}
+
+// TODO: remove once arson remapping (APS-1876) is completed
+export const remapArsonAssessmentData = (assessmentData: Unit): Unit => {
+  if (assessmentData?.['matching-information']?.['matching-information']) {
+    const matchingInformationBody: MatchingInformationBody = {
+      ...assessmentData['matching-information']['matching-information'],
+    }
+    matchingInformationBody.isArsonSuitable =
+      matchingInformationBody.isArsonSuitable || matchingInformationBody.isArsonDesignated
+    return {
+      ...assessmentData,
+      'matching-information': {
+        ...assessmentData['matching-information'],
+        'matching-information': matchingInformationBody,
+      },
+    }
+  }
+  return assessmentData
 }
 
 const suggestedStaySummaryListOptions = (application: ApprovedPremisesApplication): SummaryList => {

--- a/server/testutils/factories/cas1PremisesSearchResultSummary.ts
+++ b/server/testutils/factories/cas1PremisesSearchResultSummary.ts
@@ -28,7 +28,6 @@ const characteristics: ReadonlyArray<Cas1SpaceCharacteristic> = [
   'hasWideAccessToCommunalAreas',
   'hasWideDoor',
   'hasWideStepFreeAccess',
-  'isArsonDesignated',
   'isArsonSuitable',
   'isCatered',
   'isFullyFm',

--- a/server/utils/characteristicsUtils.test.ts
+++ b/server/utils/characteristicsUtils.test.ts
@@ -25,7 +25,7 @@ describe('characteristicsUtils', () => {
   describe('characteristicsBulletList', () => {
     const placementRequest = placementRequestDetailFactory.build({
       essentialCriteria: ['hasBrailleSignage', 'hasHearingLoop', 'isStepFreeDesignated'],
-      desirableCriteria: ['isArsonDesignated'],
+      desirableCriteria: ['isArsonSuitable'],
     })
 
     it('should return HTML lists of the given requirements', () => {
@@ -38,7 +38,7 @@ describe('characteristicsUtils', () => {
       `)
       expect(characteristicsBulletList(placementRequest.desirableCriteria)).toMatchStringIgnoringWhitespace(`
         <ul class="govuk-list govuk-list--bullet">
-          <li>${placementCriteriaLabels.isArsonDesignated}</li>
+          <li>${placementCriteriaLabels.isArsonSuitable}</li>
         </ul>
       `)
     })

--- a/server/utils/placementCriteriaUtils.ts
+++ b/server/utils/placementCriteriaUtils.ts
@@ -32,7 +32,7 @@ export const offenceAndRiskCriteria = [
 ] as const
 export const prepopulatablePlacementRequirementCriteria = [
   'isWheelchairDesignated',
-  'isArsonDesignated',
+  'isArsonSuitable',
   'isSingle',
   'isCatered',
   'isSuitedForSexOffenders',
@@ -45,7 +45,7 @@ export const placementRequirementCriteria = [
 
 export type ApTypeCriteria = SpecialistApTypeCriteria | 'normal'
 export type OffenceAndRiskCriteria = (typeof offenceAndRiskCriteria)[number]
-export type PlacementRequirementCriteria = (typeof placementRequirementCriteria)[number]
+export type PlacementRequirementCriteria = (typeof placementRequirementCriteria)[number] | 'isArsonDesignated'
 
 export const placementCriteriaLabels: Record<UiPlacementCriteria, string> = {
   isPIPE: 'Psychologically Informed Planned Environment (PIPE)',


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-1902

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

This commit effectively removes the ‘Is Designated Arson Room’ question (mapping to `isArsonDesignated`) and replaces it with an `Suitable for active arson risk` question (mapping to `isArsonSuitable`).

The new question continues to be prepopulated from the ‘Does the person pose an arson risk?’ response in the application

Any assessments that have been started before release of this code may have a value for isArsonDesignated and we should avoid losing this setting. 
As a temporary measure, when an assessment is loaded, if `isArsonSuitable` is not populated, it is copied from `isArsonDesignated`. This means that if the user uses the 'Matching information' or 'Check your answers' pages, the correct setting will be shown and if the assessment was complete apart from submission at the time of the update, isArsonSuitable would be populated at submission and hence carry the setting through to find and book.
  

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

No UI changes