### PR TITLE
Fix e2e Tests - isArsonSuitable label

### DIFF
--- a/e2e/steps/assess.ts
+++ b/e2e/steps/assess.ts
@@ -149,7 +149,7 @@ export const addMatchingInformation = async (page: Page) => {
     'Accepts sex offenders',
     'Is suitable for vulnerable',
     'Accepts child sex offenders',
-    'Is arson designated',
+    'Is arson suitable',
   ]
 
   const essentialCharacteristics = ['Is catered', 'Has en suite']


### PR DESCRIPTION
# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

Fix e2e tests to looks for the new label 'Is arson suitable'

# Changes in this PR

Update label for isArsonSuitable

<!-- [] I have run the E2E tests locally and they passed -->

