### PR TITLE
Add 2 rejection reasons

### DIFF
--- a/server/form-pages/assess/makeADecision/makeADecisionTask/makeADecision.ts
+++ b/server/form-pages/assess/makeADecision/makeADecisionTask/makeADecision.ts
@@ -29,6 +29,8 @@ export default class MakeADecision implements TasklistPage {
       insufficientMoveOnPlan: 'Insufficient move on plan',
       insufficientContingencyPlan: 'Insufficient contingency plan',
       informationNotProvided: 'Requested information not provided by probation practitioner',
+      insufficientQuality: 'Application of insufficient quality',
+      inaccurateOrOutdatedInformation: 'Inaccurate or outdated information in application',
     },
     'Reject, risk too high (must be approved by an AP Area Manager (APAM)': {
       riskToCommunity: 'Risk to community',


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2085

# Changes in this PR

Adds the following rejection reasons under the 'Reject, insufficient information' section:

- Application of insufficient quality (`insufficientQuality`)
- Inaccurate or outdated information in application (`inaccurateOrOutdatedInformation`)

The reasons are posted as a string to the API so no further type checking or testing coverage should be necessary.

## Screenshots of UI changes

<details><summary>New reasons on Make a decision page</summary>

<img width="465" alt="Screenshot 2025-03-13 at 11 27 51" src="https://github.com/user-attachments/assets/afb1033c-3944-4d4d-975a-c313ac78f034" />

</details>