### PR TITLE
APS-2086: assess consistent validation

### DIFF
--- a/e2e/pages/manage/outOfServiceBedPage.ts
+++ b/e2e/pages/manage/outOfServiceBedPage.ts
@@ -9,7 +9,7 @@ export class OutOfServiceBedPage extends BasePage {
 
   async selectUpdateRecord() {
     await this.page.getByRole('button', { name: 'Actions' }).click()
-    await this.page.getByRole('button', { name: 'Update record' }).click()
+    await this.page.getByRole('button', { name: 'Update out of service bed' }).click()
   }
 
   async shouldShowUpdatedDetails(update: Record<string, string>) {

--- a/server/form-pages/assess/assessApplication/requiredActions/requiredActions.test.ts
+++ b/server/form-pages/assess/assessApplication/requiredActions/requiredActions.test.ts
@@ -112,7 +112,7 @@ describe('RequiredActions', () => {
         concernsOfUnmanagableRisk: 'no',
       })
       expect(page.errors()).toEqual({
-        additionalRecommendationsComments: 'You must add more detail about the additional recommendations',
+        additionalRecommendationsComments: 'Add detail about the additional recommendations',
         curfewsOrSignInsComments: 'You must detail the additional curfews or sign ins recommended',
       })
     })

--- a/server/form-pages/assess/assessApplication/requiredActions/requiredActions.test.ts
+++ b/server/form-pages/assess/assessApplication/requiredActions/requiredActions.test.ts
@@ -104,12 +104,25 @@ describe('RequiredActions', () => {
       })
     })
 
+    it('must show an error if the answer to "curfewsAndSigns" or "additionalRecommendationsComments",  is yes and there are no corresponding additional comments', () => {
+      const page = new RequiredActions({
+        additionalActions: 'no',
+        curfewsOrSignIns: 'yes',
+        additionalRecommendations: 'yes',
+        concernsOfUnmanagableRisk: 'no',
+      })
+      expect(page.errors()).toEqual({
+        additionalRecommendationsComments: 'You must add more detail about the additional recommendations',
+        curfewsOrSignInsComments: 'You must detail the additional curfews or sign ins recommended',
+      })
+    })
+
     it('if the answer to "concernsOfUnmanagableRisk" is "yes" then there must be comments in the "additionalRecommendations" box', () => {
       const page = new RequiredActions({
         additionalActions: 'yes',
-        curfewsOrSignIns: 'yes',
+        curfewsOrSignIns: 'no',
         concernsOfUnmanagableRisk: 'yes',
-        additionalRecommendations: 'yes',
+        additionalRecommendations: 'no',
       })
 
       expect(page.errors()).toEqual({

--- a/server/form-pages/assess/assessApplication/requiredActions/requiredActions.ts
+++ b/server/form-pages/assess/assessApplication/requiredActions/requiredActions.ts
@@ -102,6 +102,9 @@ export default class RequiredActions implements TasklistPage {
     if (!this.body.curfewsOrSignIns)
       errors.curfewsOrSignIns = 'You must state if there are any additional curfews or sign ins recommended'
 
+    if (this.body.curfewsOrSignIns === 'yes' && !this.body.curfewsOrSignInsComments)
+      errors.curfewsOrSignInsComments = 'You must detail the additional curfews or sign ins recommended'
+
     if (!this.body.concernsOfUnmanagableRisk)
       errors.concernsOfUnmanagableRisk =
         'You must state if there are any concerns that the person poses an potentially unmanageable risk to staff or others'
@@ -123,6 +126,9 @@ export default class RequiredActions implements TasklistPage {
 
     if (!this.body.additionalRecommendations)
       errors.additionalRecommendations = 'You must state if there are any additional recommendations'
+
+    if (this.body.additionalRecommendations === 'yes' && !this.body.additionalRecommendationsComments)
+      errors.additionalRecommendationsComments = 'You must add more detail about the additional recommendations'
 
     return errors
   }

--- a/server/form-pages/assess/assessApplication/requiredActions/requiredActions.ts
+++ b/server/form-pages/assess/assessApplication/requiredActions/requiredActions.ts
@@ -128,7 +128,7 @@ export default class RequiredActions implements TasklistPage {
       errors.additionalRecommendations = 'You must state if there are any additional recommendations'
 
     if (this.body.additionalRecommendations === 'yes' && !this.body.additionalRecommendationsComments)
-      errors.additionalRecommendationsComments = 'You must add more detail about the additional recommendations'
+      errors.additionalRecommendationsComments = 'Add detail about the additional recommendations'
 
     return errors
   }

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/contingencyPlanSuitability.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/contingencyPlanSuitability.test.ts
@@ -44,10 +44,29 @@ describe('ContingencyPlanSuitability', () => {
       const page = new ContingencyPlanSuitability({} as ContingencyPlanSuitabilityBody, assessment)
 
       expect(page.errors()).toEqual({
-        additionalComments: 'You must provide additional comments',
         contingencyPlanSufficient:
           'You must confirm if the contingency plan is sufficient to manage behaviour or a failure to return out of hours',
       })
+    })
+
+    it('should show an error if the answer is yes and there are no comments', () => {
+      const page = new ContingencyPlanSuitability(
+        { contingencyPlanSufficient: 'no' } as ContingencyPlanSuitabilityBody,
+        assessment,
+      )
+
+      expect(page.errors()).toEqual({
+        additionalComments: 'You must provide additional comments',
+      })
+    })
+
+    it('should not show an error if the answer is no and there are no additional comments', () => {
+      const page = new ContingencyPlanSuitability(
+        { contingencyPlanSufficient: 'yes' } as ContingencyPlanSuitabilityBody,
+        assessment,
+      )
+
+      expect(page.errors()).toEqual({})
     })
   })
 

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/contingencyPlanSuitability.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/contingencyPlanSuitability.ts
@@ -56,7 +56,8 @@ export default class ContingencyPlanSuitability implements TasklistPage {
       errors.contingencyPlanSufficient =
         'You must confirm if the contingency plan is sufficient to manage behaviour or a failure to return out of hours'
 
-    if (!this.body.additionalComments) errors.additionalComments = 'You must provide additional comments'
+    if (this.body.contingencyPlanSufficient === 'no' && !this.body.additionalComments)
+      errors.additionalComments = 'You must provide additional comments'
 
     return errors
   }

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/esapSuitability.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/esapSuitability.test.ts
@@ -52,6 +52,32 @@ describe('EsapSuitability', () => {
           'You must confirm if a Enhanced Security Approved Premises (ESAP) has been identified as a suitable placement',
       })
     })
+
+    it('should show an error if the ESAP is identified as suitable but the corresponding comments box is not populated', () => {
+      const page = new EsapSuitability(
+        {
+          esapPlacementNeccessary: 'yes',
+        } as EsapSuitabilityBody,
+        assessment,
+      )
+
+      expect(page.errors()).toEqual({
+        yesDetail: 'You must provide details to support the decision',
+      })
+    })
+    it('should show an error if the ESAP is identified as not suitable but the corresponding comments box and the rationale box are not populated', () => {
+      const page = new EsapSuitability(
+        {
+          esapPlacementNeccessary: 'no',
+        } as EsapSuitabilityBody,
+        assessment,
+      )
+
+      expect(page.errors()).toEqual({
+        noDetail: 'You must provide details to support the decision',
+        unsuitabilityForEsapRationale: 'You must provide a summary of the rationale',
+      })
+    })
   })
 
   describe('response', () => {

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/esapSuitability.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/esapSuitability.test.ts
@@ -65,7 +65,8 @@ describe('EsapSuitability', () => {
         yesDetail: 'You must provide details to support the decision',
       })
     })
-    it('should show an error if the ESAP is identified as not suitable but the corresponding comments box and the rationale box are not populated', () => {
+
+    it('should show two errors if the ESAP is identified as not suitable but the corresponding comments box and the rationale box are not populated', () => {
       const page = new EsapSuitability(
         {
           esapPlacementNeccessary: 'no',
@@ -75,13 +76,27 @@ describe('EsapSuitability', () => {
 
       expect(page.errors()).toEqual({
         noDetail: 'You must provide details to support the decision',
-        unsuitabilityForEsapRationale: 'You must provide a summary of the rationale',
+        unsuitabilityForEsapRationale: 'Provide a summary of the rationale',
+      })
+    })
+
+    it('should show an error if the ESAP is identified as not suitable but the rationale box is not populated', () => {
+      const page = new EsapSuitability(
+        {
+          esapPlacementNeccessary: 'no',
+          noDetail: 'some detail',
+        } as EsapSuitabilityBody,
+        assessment,
+      )
+
+      expect(page.errors()).toEqual({
+        unsuitabilityForEsapRationale: 'Provide a summary of the rationale',
       })
     })
   })
 
   describe('response', () => {
-    it('returns the response when the asnwer is yes', () => {
+    it('returns the response when the answer is yes', () => {
       const page = new EsapSuitability(body, assessment)
 
       expect(page.response()).toEqual({
@@ -92,7 +107,7 @@ describe('EsapSuitability', () => {
       })
     })
 
-    it('returns the response when the asnwer is no', () => {
+    it('returns the response when the answer is no', () => {
       const page = new EsapSuitability(
         { ...body, esapPlacementNeccessary: 'no', noDetail: 'Some no detail' },
         assessment,

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/esapSuitability.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/esapSuitability.ts
@@ -72,7 +72,7 @@ export default class EsapSuitability implements TasklistPage {
         'You must confirm if a Enhanced Security Approved Premises (ESAP) has been identified as a suitable placement'
 
     if (this.body.esapPlacementNeccessary === 'no' && !this.body.unsuitabilityForEsapRationale)
-      errors.unsuitabilityForEsapRationale = 'You must provide a summary of the rationale'
+      errors.unsuitabilityForEsapRationale = 'Provide a summary of the rationale'
     return errors
   }
 }

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/esapSuitability.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/esapSuitability.ts
@@ -71,6 +71,8 @@ export default class EsapSuitability implements TasklistPage {
       errors.esapPlacementNeccessary =
         'You must confirm if a Enhanced Security Approved Premises (ESAP) has been identified as a suitable placement'
 
+    if (this.body.esapPlacementNeccessary === 'no' && !this.body.unsuitabilityForEsapRationale)
+      errors.unsuitabilityForEsapRationale = 'You must provide a summary of the rationale'
     return errors
   }
 }

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.test.ts
@@ -75,13 +75,27 @@ describe('RfapSuitability', () => {
 
       expect(page.errors()).toEqual({
         noDetail: 'You must provide details to support the decision',
-        unsuitabilityForRfapRationale: 'You must provide a summary of the rationale',
+        unsuitabilityForRfapRationale: 'Provide a summary of the rationale',
+      })
+    })
+
+    it('should show an error if the ESAP is identified as not suitable but the rationale box is not populated', () => {
+      const page = new RfapSuitability(
+        {
+          rfapIdentifiedAsSuitable: 'no',
+          noDetail: 'Some detail',
+        } as RfapSuitabilityBody,
+        assessment,
+      )
+
+      expect(page.errors()).toEqual({
+        unsuitabilityForRfapRationale: 'Provide a summary of the rationale',
       })
     })
   })
 
   describe('response', () => {
-    it('returns the response when the asnwer is yes', () => {
+    it('returns the response when the answer is yes', () => {
       const page = new RfapSuitability(body, assessment)
 
       expect(page.response()).toEqual({
@@ -92,7 +106,7 @@ describe('RfapSuitability', () => {
       })
     })
 
-    it('returns the response when the asnwer is no', () => {
+    it('returns the response when the answer is no', () => {
       const page = new RfapSuitability(
         { ...body, rfapIdentifiedAsSuitable: 'no', noDetail: 'Some no detail' },
         assessment,

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.test.ts
@@ -51,6 +51,33 @@ describe('RfapSuitability', () => {
           'You must confirm if a Recovery Focused Approved Premises (RFAP) been identified as a suitable placement',
       })
     })
+
+    it('should show an error if the RFAP is identified as suitable but the corresponding comments box is not populated', () => {
+      const page = new RfapSuitability(
+        {
+          rfapIdentifiedAsSuitable: 'yes',
+        } as RfapSuitabilityBody,
+        assessment,
+      )
+
+      expect(page.errors()).toEqual({
+        yesDetail: 'You must provide details to support the decision',
+      })
+    })
+
+    it('should show an error if the ESAP is identified as not suitable but the corresponding comments box and the rationale box are not populated', () => {
+      const page = new RfapSuitability(
+        {
+          rfapIdentifiedAsSuitable: 'no',
+        } as RfapSuitabilityBody,
+        assessment,
+      )
+
+      expect(page.errors()).toEqual({
+        noDetail: 'You must provide details to support the decision',
+        unsuitabilityForRfapRationale: 'You must provide a summary of the rationale',
+      })
+    })
   })
 
   describe('response', () => {

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.ts
@@ -71,6 +71,9 @@ export default class RfapSuitability implements TasklistPage {
       errors.rfapIdentifiedAsSuitable =
         'You must confirm if a Recovery Focused Approved Premises (RFAP) been identified as a suitable placement'
 
+    if (this.body.rfapIdentifiedAsSuitable === 'no' && !this.body.unsuitabilityForRfapRationale)
+      errors.unsuitabilityForRfapRationale = 'You must provide a summary of the rationale'
+
     return errors
   }
 }

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/rfapSuitability.ts
@@ -72,7 +72,7 @@ export default class RfapSuitability implements TasklistPage {
         'You must confirm if a Recovery Focused Approved Premises (RFAP) been identified as a suitable placement'
 
     if (this.body.rfapIdentifiedAsSuitable === 'no' && !this.body.unsuitabilityForRfapRationale)
-      errors.unsuitabilityForRfapRationale = 'You must provide a summary of the rationale'
+      errors.unsuitabilityForRfapRationale = 'Provide a summary of the rationale'
 
     return errors
   }

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
@@ -204,6 +204,26 @@ describe('SuitabilityAssessment', () => {
           'You must confirm if the application explains how an AP placement would be beneficial for risk management',
       })
     })
+
+    it('should show errors if the answers are no and no comments are provided', () => {
+      const page = new SuitabilityAssessment(
+        {
+          riskFactors: 'no',
+          riskManagement: 'no',
+          locationOfPlacement: 'no',
+          moveOnPlan: 'no',
+        },
+        assessment,
+      )
+
+      expect(page.errors()).toEqual({
+        moveOnPlanComments: 'You must explain why the move on plan is insufficient',
+        riskFactorsComments:
+          'You must explain how the application fails to identify the risk factors that an AP placement can support',
+        riskManagementComments:
+          'You must explain how the application fails to identify how an AP placement would be beneficial for risk management',
+      })
+    })
   })
 
   describe('response', () => {

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
@@ -185,7 +185,7 @@ describe('SuitabilityAssessment', () => {
   )
 
   describe('errors', () => {
-    it('should have an error if there is no answers', () => {
+    it('should have an error if there are no answers', () => {
       const page = new SuitabilityAssessment(
         {
           riskFactors: '' as YesOrNo,
@@ -197,7 +197,7 @@ describe('SuitabilityAssessment', () => {
       )
 
       expect(page.errors()).toEqual({
-        locationOfPlacement: 'You must confirm if there factors to consider regarding the location of placement',
+        locationOfPlacement: 'You must confirm if there are factors to consider regarding the location of placement',
         moveOnPlan: 'You must confirm if the move on plan is sufficient',
         riskFactors: 'You must confirm if the application identifies the risk factors that an AP placement can support',
         riskManagement:
@@ -220,6 +220,7 @@ describe('SuitabilityAssessment', () => {
         moveOnPlanComments: 'You must explain why the move on plan is insufficient',
         riskFactorsComments:
           'You must explain how the application fails to identify the risk factors that an AP placement can support',
+        locationOfPlacementComments: 'You must comment on how location factors have not been considered',
         riskManagementComments:
           'You must explain how the application fails to identify how an AP placement would be beneficial for risk management',
       })

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.test.ts
@@ -210,19 +210,17 @@ describe('SuitabilityAssessment', () => {
         {
           riskFactors: 'no',
           riskManagement: 'no',
-          locationOfPlacement: 'no',
+          locationOfPlacement: 'yes',
           moveOnPlan: 'no',
         },
         assessment,
       )
 
       expect(page.errors()).toEqual({
-        moveOnPlanComments: 'You must explain why the move on plan is insufficient',
-        riskFactorsComments:
-          'You must explain how the application fails to identify the risk factors that an AP placement can support',
-        locationOfPlacementComments: 'You must comment on how location factors have not been considered',
-        riskManagementComments:
-          'You must explain how the application fails to identify how an AP placement would be beneficial for risk management',
+        moveOnPlanComments: 'Explain how the move on plan is insufficient',
+        riskFactorsComments: 'Identify the risk factors',
+        locationOfPlacementComments: 'State the risk factors regarding location',
+        riskManagementComments: 'Explain why the AP cannot manage the risk factors identified',
       })
     })
   })

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.ts
@@ -73,28 +73,26 @@ export default class SuitabilityAssessment implements TasklistPage {
         'You must confirm if the application identifies the risk factors that an AP placement can support'
 
     if (this.body.riskFactors === 'no' && !this.body.riskFactorsComments)
-      errors.riskFactorsComments =
-        'You must explain how the application fails to identify the risk factors that an AP placement can support'
+      errors.riskFactorsComments = 'Identify the risk factors'
 
     if (!this.body.riskManagement)
       errors.riskManagement =
         'You must confirm if the application explains how an AP placement would be beneficial for risk management'
 
     if (this.body.riskManagement === 'no' && !this.body.riskManagementComments)
-      errors.riskManagementComments =
-        'You must explain how the application fails to identify how an AP placement would be beneficial for risk management'
+      errors.riskManagementComments = 'Explain why the AP cannot manage the risk factors identified'
 
     if (!this.body.locationOfPlacement)
       errors.locationOfPlacement =
         'You must confirm if there are factors to consider regarding the location of placement'
 
-    if (this.body.locationOfPlacement === 'no' && !this.body.locationOfPlacementComments)
-      errors.locationOfPlacementComments = 'You must comment on how location factors have not been considered'
+    if (this.body.locationOfPlacement === 'yes' && !this.body.locationOfPlacementComments)
+      errors.locationOfPlacementComments = 'State the risk factors regarding location'
 
     if (!this.body.moveOnPlan) errors.moveOnPlan = 'You must confirm if the move on plan is sufficient'
 
     if (this.body.moveOnPlan === 'no' && !this.body.moveOnPlanComments)
-      errors.moveOnPlanComments = 'You must explain why the move on plan is insufficient'
+      errors.moveOnPlanComments = 'Explain how the move on plan is insufficient'
 
     return errors
   }

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.ts
@@ -71,6 +71,7 @@ export default class SuitabilityAssessment implements TasklistPage {
     if (!this.body.riskFactors)
       errors.riskFactors =
         'You must confirm if the application identifies the risk factors that an AP placement can support'
+
     if (this.body.riskFactors === 'no' && !this.body.riskFactorsComments)
       errors.riskFactorsComments =
         'You must explain how the application fails to identify the risk factors that an AP placement can support'
@@ -78,14 +79,20 @@ export default class SuitabilityAssessment implements TasklistPage {
     if (!this.body.riskManagement)
       errors.riskManagement =
         'You must confirm if the application explains how an AP placement would be beneficial for risk management'
+
     if (this.body.riskManagement === 'no' && !this.body.riskManagementComments)
       errors.riskManagementComments =
         'You must explain how the application fails to identify how an AP placement would be beneficial for risk management'
 
     if (!this.body.locationOfPlacement)
-      errors.locationOfPlacement = 'You must confirm if there factors to consider regarding the location of placement'
+      errors.locationOfPlacement =
+        'You must confirm if there are factors to consider regarding the location of placement'
+
+    if (this.body.locationOfPlacement === 'no' && !this.body.locationOfPlacementComments)
+      errors.locationOfPlacementComments = 'You must comment on how location factors have not been considered'
 
     if (!this.body.moveOnPlan) errors.moveOnPlan = 'You must confirm if the move on plan is sufficient'
+
     if (this.body.moveOnPlan === 'no' && !this.body.moveOnPlanComments)
       errors.moveOnPlanComments = 'You must explain why the move on plan is insufficient'
 

--- a/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.ts
+++ b/server/form-pages/assess/assessApplication/suitablityAssessment/suitabilityAssessment.ts
@@ -71,15 +71,23 @@ export default class SuitabilityAssessment implements TasklistPage {
     if (!this.body.riskFactors)
       errors.riskFactors =
         'You must confirm if the application identifies the risk factors that an AP placement can support'
+    if (this.body.riskFactors === 'no' && !this.body.riskFactorsComments)
+      errors.riskFactorsComments =
+        'You must explain how the application fails to identify the risk factors that an AP placement can support'
 
     if (!this.body.riskManagement)
       errors.riskManagement =
         'You must confirm if the application explains how an AP placement would be beneficial for risk management'
+    if (this.body.riskManagement === 'no' && !this.body.riskManagementComments)
+      errors.riskManagementComments =
+        'You must explain how the application fails to identify how an AP placement would be beneficial for risk management'
 
     if (!this.body.locationOfPlacement)
       errors.locationOfPlacement = 'You must confirm if there factors to consider regarding the location of placement'
 
     if (!this.body.moveOnPlan) errors.moveOnPlan = 'You must confirm if the move on plan is sufficient'
+    if (this.body.moveOnPlan === 'no' && !this.body.moveOnPlanComments)
+      errors.moveOnPlanComments = 'You must explain why the move on plan is insufficient'
 
     return errors
   }


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2086

# Changes in this PR

Added validation as described in the ticket. 
Originally, I intended to make the additional info boxes conditional (as in apply) but the questions seem so complex that I am not sufficiently confident that the textareas would be shown in the right circumstances, so left as-is.


## Screenshots of UI changes

<details>
  <summary>Suitability assessment</summary>
  <img src="https://github.com/user-attachments/assets/302d2ccb-c444-477b-9510-765e73fe8742"/>
</details>

<details>
  <summary>Required actionst</summary>
  <img src="https://github.com/user-attachments/assets/ede1687c-5b67-4df2-9a4c-b76b30e1490c"/>
</details>

<details>
  <summary>Esap</summary>
  <img src="https://github.com/user-attachments/assets/207f61b5-9998-4fdc-9e2e-1a8037bbd415"/>
</details>

