### PR TITLE
APS-2102: 'Expected arrival date' column in Assess

### DIFF
--- a/server/utils/assessments/tableUtils.test.ts
+++ b/server/utils/assessments/tableUtils.test.ts
@@ -82,7 +82,7 @@ describe('tableUtils', () => {
           {
             text: 'Tier',
           },
-          sortHeader<AssessmentSortField>('Arrival date', 'arrivalDate', sortBy, sortDirection, hrefPrefix),
+          sortHeader<AssessmentSortField>('Expected arrival date', 'arrivalDate', sortBy, sortDirection, hrefPrefix),
           {
             text: 'Current location',
           },
@@ -105,7 +105,7 @@ describe('tableUtils', () => {
           {
             text: 'Current location',
           },
-          sortHeader<AssessmentSortField>('Arrival date', 'arrivalDate', sortBy, sortDirection, hrefPrefix),
+          sortHeader<AssessmentSortField>('Expected arrival date', 'arrivalDate', sortBy, sortDirection, hrefPrefix),
           {
             text: 'Days since received',
           },
@@ -125,7 +125,7 @@ describe('tableUtils', () => {
           {
             text: 'Tier',
           },
-          sortHeader<AssessmentSortField>('Arrival date', 'arrivalDate', sortBy, sortDirection, hrefPrefix),
+          sortHeader<AssessmentSortField>('Expected arrival date', 'arrivalDate', sortBy, sortDirection, hrefPrefix),
           sortHeader<AssessmentSortField>('Status', 'status', sortBy, sortDirection, hrefPrefix),
         ],
         rows: completedTableRows(assessments),

--- a/server/utils/assessments/tableUtils.ts
+++ b/server/utils/assessments/tableUtils.ts
@@ -86,7 +86,7 @@ const assessmentTable = (
           {
             text: 'Current location',
           },
-          sortHeader<AssessmentSortField>('Arrival date', 'arrivalDate', sortBy, sortDirection, hrefPrefix),
+          sortHeader<AssessmentSortField>('Expected arrival date', 'arrivalDate', sortBy, sortDirection, hrefPrefix),
           {
             text: 'Days since received',
           },
@@ -104,7 +104,7 @@ const assessmentTable = (
           {
             text: 'Tier',
           },
-          sortHeader<AssessmentSortField>('Arrival date', 'arrivalDate', sortBy, sortDirection, hrefPrefix),
+          sortHeader<AssessmentSortField>('Expected arrival date', 'arrivalDate', sortBy, sortDirection, hrefPrefix),
           sortHeader<AssessmentSortField>('Status', 'status', sortBy, sortDirection, hrefPrefix),
         ],
         rows: completedTableRows(assessments),
@@ -118,7 +118,7 @@ const assessmentTable = (
           {
             text: 'Tier',
           },
-          sortHeader<AssessmentSortField>('Arrival date', 'arrivalDate', sortBy, sortDirection, hrefPrefix),
+          sortHeader<AssessmentSortField>('Expected arrival date', 'arrivalDate', sortBy, sortDirection, hrefPrefix),
           {
             text: 'Current location',
           },


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2102

# Changes in this PR

- [ ] Changed from 'Arrival date' to 'Expected arrival date' for consistency with other uses.
- [ ] Added the 'Expected arrival date' column to the 'Requests for placement' tab

## Screenshots of UI changes

### Before

### After
