### PR TITLE
APS-468 Restore navigation in assess

### DIFF
--- a/integration_tests/pages/assess/assessPage.ts
+++ b/integration_tests/pages/assess/assessPage.ts
@@ -21,5 +21,6 @@ export default class AssessPage extends FormPage {
 
     this.tasklistPage = new Class(assessment.data?.[taskName]?.[pageName], assessment)
     this.shouldShowKeyDetails(keyDetails(assessment))
+    this.shouldShowMenuItem('Assess')
   }
 }

--- a/server/views/assessments/layouts/with-details.njk
+++ b/server/views/assessments/layouts/with-details.njk
@@ -1,9 +1,6 @@
 {% from "../../components/keyDetails/macro.njk" import keyDetails %}
 {% extends "../../partials/layout.njk" %}
 
-{% set hideNav = true %}
-{% set hidePhaseBanner = true %}
-
 {% block header %}
   {{ super() }}
   {{ keyDetails(AssessmentUtils.keyDetails(assessment)) }}

--- a/server/views/partials/header.njk
+++ b/server/views/partials/header.njk
@@ -45,7 +45,6 @@
 {% endif %}
 
 {% block phaseBanner %}
-  {% if not hidePhaseBanner %}
     {{ govukPhaseBanner({
     attributes: { "data-cy-phase-banner": "phase-banner" },
     classes: "hmpps-header__container",
@@ -54,5 +53,4 @@
     },
     html: 'This is a new service. <a class="govuk-link" href="https://forms.office.com/e/jSiRQFF82r">Give us your feedback</a> or <a class="govuk-link" href="mailto:APServiceSupport@digital.justice.gov.uk">email us</a> to report a bug'
   }) }}
-  {% endif %}
 {% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-468

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

The navigation and beta banner were deliberately hidden on assessment pages. This PR removes the hiding.
<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/588cf746-9905-4919-bb76-74c51b93bd03)


### After
![image](https://github.com/user-attachments/assets/56150cd3-4f44-48a4-843c-c022f204e061)

