### PR TITLE
APS-2087: Use role to permissions mapping from API

### DIFF
--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -118,15 +118,7 @@ context('Placement Requests', () => {
     cy.task('reset')
 
     // Given I am signed in as a CRU member
-    signIn({
-      permissions: [
-        'cas1_view_cru_dashboard',
-        'cas1_booking_create',
-        'cas1_booking_withdraw',
-        'cas1_booking_change_dates',
-        'cas1_space_booking_create',
-      ],
-    })
+    signIn('cru_member')
   })
 
   it('allows me to view all placement requests', () => {

--- a/integration_tests/tests/admin/reports.cy.ts
+++ b/integration_tests/tests/admin/reports.cy.ts
@@ -6,8 +6,8 @@ context('Reports', () => {
   beforeEach(() => {
     cy.task('reset')
 
-    // Given I am logged in as a report viewer
-    signIn({ permissions: ['cas1_reports_view', 'cas1_reports_view_with_pii'] })
+    // Given I am signed in as a report viewer
+    signIn('report_viewer_with_pii')
   })
 
   it('allows me to download reports', () => {

--- a/integration_tests/tests/admin/searchPlacementRequests.cy.ts
+++ b/integration_tests/tests/admin/searchPlacementRequests.cy.ts
@@ -20,8 +20,8 @@ context('Search placement Requests', () => {
   beforeEach(() => {
     cy.task('reset')
 
-    // Given I am logged in as a CRU member
-    signIn({ permissions: ['cas1_view_cru_dashboard'] })
+    // Given I am signed in as a CRU member
+    signIn('cru_member')
 
     cy.task('stubPlacementRequestsSearch', { placementRequests })
     cy.task('stubPlacementRequestsSearch', {

--- a/integration_tests/tests/admin/userManagement.cy.ts
+++ b/integration_tests/tests/admin/userManagement.cy.ts
@@ -14,7 +14,7 @@ context('User management', () => {
     cy.task('reset')
 
     // Given I am signed in as a User manager
-    signIn({ permissions: ['cas1_user_management'] })
+    signIn('user_manager')
   })
 
   it('allows the user to view and update users', () => {

--- a/integration_tests/tests/apply/appeals.cy.ts
+++ b/integration_tests/tests/apply/appeals.cy.ts
@@ -11,7 +11,7 @@ context('Appeals', () => {
     cy.task('reset')
 
     // Given I am signed in as an appeals manager
-    signIn({ permissions: ['cas1_process_an_appeal'] })
+    signIn('appeals_manager')
   })
 
   it('should create an appeal', () => {

--- a/integration_tests/tests/apply/dashboard.cy.ts
+++ b/integration_tests/tests/apply/dashboard.cy.ts
@@ -16,7 +16,7 @@ context('All applications', () => {
     cy.task('reset')
 
     // Given I am signed in as an applicant
-    signIn()
+    signIn('applicant')
   })
 
   it('lists all applications with pagination', () => {

--- a/integration_tests/tests/apply/list.cy.ts
+++ b/integration_tests/tests/apply/list.cy.ts
@@ -14,7 +14,7 @@ context('Applications dashboard', () => {
     cy.task('reset')
 
     // Given I am signed in as an applicant
-    signIn()
+    signIn('applicant')
   })
 
   it('shows the dashboard ', () => {

--- a/integration_tests/tests/apply/setup.ts
+++ b/integration_tests/tests/apply/setup.ts
@@ -13,8 +13,8 @@ import { signIn } from '../signIn'
 export const setup = () => {
   cy.task('reset')
 
-  // Given I am logged in as an applicant
-  signIn({ id: defaultUserId })
+  // Given I am signed in as an applicant
+  signIn('applicant', { id: defaultUserId })
 
   cy.fixture('applicationData.json').then(applicationData => {
     const person = personFactory.build()

--- a/integration_tests/tests/assess/assess.cy.ts
+++ b/integration_tests/tests/assess/assess.cy.ts
@@ -33,7 +33,7 @@ context('Assess', () => {
     cy.task('reset')
 
     // Given I am signed in as an assessor
-    signIn({ permissions: ['cas1_view_assigned_assessments', 'cas1_assess_application'] })
+    signIn('assessor')
 
     // And there is an application awaiting assessment
     cy.fixture('applicationData.json').then(applicationData => {

--- a/integration_tests/tests/assess/list.cy.ts
+++ b/integration_tests/tests/assess/list.cy.ts
@@ -8,8 +8,8 @@ context('List assessments', () => {
   beforeEach(() => {
     cy.task('reset')
 
-    // Given I am logged in as an assessor
-    signIn({ id: defaultUserId, permissions: ['cas1_view_assigned_assessments', 'cas1_assess_placement_application'] })
+    // Given I am signed in as an assessor
+    signIn('assessor', { id: defaultUserId })
   })
 
   it('should list assessments', () => {

--- a/integration_tests/tests/assess/shortNoticeAssessments.cy.ts
+++ b/integration_tests/tests/assess/shortNoticeAssessments.cy.ts
@@ -22,7 +22,7 @@ describe('Short notice assessments', () => {
     cy.task('reset')
 
     // Given I am signed in as an assessor
-    signIn({ permissions: ['cas1_view_assigned_assessments', 'cas1_assess_application'] })
+    signIn('assessor')
 
     // And there is a short notice application awaiting assessment
     cy.fixture('applicationData.json').then(applicationData => {

--- a/integration_tests/tests/dashboard.cy.ts
+++ b/integration_tests/tests/dashboard.cy.ts
@@ -7,17 +7,7 @@ context('Dashboard', () => {
   })
 
   it('displays all services when a user has all permissions required', () => {
-    signIn({
-      permissions: [
-        'cas1_view_assigned_assessments',
-        'cas1_view_manage_tasks',
-        'cas1_view_cru_dashboard',
-        'cas1_view_out_of_service_beds',
-        'cas1_premises_view',
-        'cas1_reports_view',
-        'cas1_user_management',
-      ],
-    })
+    signIn('janitor')
 
     const dashboardPage = DashboardPage.visit()
 
@@ -33,7 +23,7 @@ context('Dashboard', () => {
   })
 
   it('only displays the apply and timeline services when someone has no permissions', () => {
-    signIn()
+    signIn('applicant')
 
     const dashboardPage = DashboardPage.visit()
 

--- a/integration_tests/tests/login.cy.ts
+++ b/integration_tests/tests/login.cy.ts
@@ -26,14 +26,14 @@ context('SignIn', () => {
   })
 
   it('User name visible in header', () => {
-    signIn({ name: 'J. Smith' })
+    signIn('applicant', { name: 'J. Smith' })
 
     const indexPage = Page.verifyOnPage(DashboardPage)
     indexPage.headerUserName().should('contain.text', 'J. Smith')
   })
 
   it('User can log out', () => {
-    signIn()
+    signIn('applicant')
 
     const indexPage = Page.verifyOnPage(DashboardPage)
     indexPage.signOut().click()
@@ -41,7 +41,7 @@ context('SignIn', () => {
   })
 
   it('User can manage their details', () => {
-    signIn()
+    signIn('applicant')
 
     const indexPage = Page.verifyOnPage(DashboardPage)
 
@@ -51,7 +51,7 @@ context('SignIn', () => {
   })
 
   it('Token verification failure takes user to sign in page', () => {
-    signIn()
+    signIn('applicant')
 
     Page.verifyOnPage(DashboardPage)
     cy.task('stubVerifyToken', false)
@@ -61,7 +61,7 @@ context('SignIn', () => {
   })
 
   it('Token verification failure clears user session', () => {
-    signIn()
+    signIn('applicant')
 
     const indexPage = Page.verifyOnPage(DashboardPage)
     cy.task('stubVerifyToken', false)
@@ -70,7 +70,7 @@ context('SignIn', () => {
     cy.request('/').its('body').should('contain', 'Sign in')
 
     cy.task('stubVerifyToken', true)
-    signIn({ name: 'B. BROWN' })
+    signIn('applicant', { name: 'B. BROWN' })
 
     indexPage.headerUserName().contains('B. Brown')
   })

--- a/integration_tests/tests/manage/booking.cy.ts
+++ b/integration_tests/tests/manage/booking.cy.ts
@@ -34,7 +34,7 @@ context('Booking', () => {
 
   it('should allow me to see a booking', () => {
     // Given I am signed in as an applicant
-    signIn()
+    signIn('applicant')
 
     cy.task('stubBookingGet', { premisesId: premises.id, booking })
 

--- a/integration_tests/tests/manage/cancellation.cy.ts
+++ b/integration_tests/tests/manage/cancellation.cy.ts
@@ -21,7 +21,7 @@ context('Cancellation', () => {
     cy.task('stubCancellationReferenceData')
 
     // Given I am signed in as a CRU member
-    signIn({ permissions: ['cas1_booking_withdraw', 'cas1_space_booking_withdraw'] })
+    signIn('cru_member')
   })
 
   it('should allow me to create a cancellation with a reason of "other" ', () => {

--- a/integration_tests/tests/manage/cru_member/viewsAllOutOfServiceBeds.cy.ts
+++ b/integration_tests/tests/manage/cru_member/viewsAllOutOfServiceBeds.cy.ts
@@ -36,7 +36,7 @@ describe('CRU Member with permission to view out of service bed tile lists all O
   beforeEach(() => {
     cy.task('reset')
     // Given I am signed in as a CRU Member with the permission to view the out of service beds tile
-    signIn({ permissions: ['cas1_view_out_of_service_beds'] })
+    signIn('cru_member_enable_out_of_service_beds')
     cy.task('stubApAreaReferenceData', { apArea: apArea1, additionalAreas: [apArea2] })
     cy.task('stubCas1AllPremises', allPremises)
   })

--- a/integration_tests/tests/manage/dateChanges.cy.ts
+++ b/integration_tests/tests/manage/dateChanges.cy.ts
@@ -11,7 +11,7 @@ context('Date Changes', () => {
     cy.task('reset')
 
     // Given I am signed in as a CRU member
-    signIn({ permissions: ['cas1_booking_change_dates'] })
+    signIn('cru_member')
 
     // And I have a booking for a premises
     cy.task('stubBookingGet', { premisesId: premises.id, booking })

--- a/integration_tests/tests/manage/future_manager/beds.cy.ts
+++ b/integration_tests/tests/manage/future_manager/beds.cy.ts
@@ -25,7 +25,7 @@ context('Beds', () => {
 
   it('should allow me to visit a bed from the bed list page', () => {
     // Given I am signed in as a future manager
-    signIn({ permissions: ['cas1_premises_view', 'cas1_out_of_service_bed_create'] })
+    signIn('future_manager')
 
     // When I visit the beds page
     const bedsPage = BedsListPage.visit(premisesId)

--- a/integration_tests/tests/manage/future_manager/cancelsOutOfServiceBed.cy.ts
+++ b/integration_tests/tests/manage/future_manager/cancelsOutOfServiceBed.cy.ts
@@ -14,8 +14,8 @@ describe('Cancelling an out of service bed', () => {
   beforeEach(() => {
     cy.task('reset')
 
-    // Given I am signed in as a future manager
-    signIn({ permissions: ['cas1_view_out_of_service_beds', 'cas1_out_of_service_bed_cancel'] })
+    // Given I am signed in as a CRU member with access to the Beta
+    signIn('cru_member_find_and_book_beta')
   })
 
   it('should allow me to cancel an out of service bed', () => {

--- a/integration_tests/tests/manage/future_manager/createsOutOfServiceBed.cy.ts
+++ b/integration_tests/tests/manage/future_manager/createsOutOfServiceBed.cy.ts
@@ -33,7 +33,7 @@ context('OutOfServiceBeds', () => {
     cy.task('stubBed', { premisesId: premises.id, bedDetail })
 
     // Given I am signed in as a future manager
-    signIn({ permissions: ['cas1_premises_view', 'cas1_out_of_service_bed_create', 'cas1_view_out_of_service_beds'] })
+    signIn('future_manager')
 
     // When I navigate to the out of service bed form
     const page = OutOfServiceBedCreatePage.visit(premises.id, outOfServiceBed.bed.id)
@@ -62,7 +62,7 @@ context('OutOfServiceBeds', () => {
 
   it('should show errors', () => {
     // Given I am signed in as a future manager
-    signIn({ permissions: ['cas1_out_of_service_bed_create'] })
+    signIn('future_manager')
 
     // And a out of service bed is available
     const premises = cas1PremisesFactory.build()
@@ -84,7 +84,7 @@ context('OutOfServiceBeds', () => {
 
   it('should show an error when there are out of service bed conflicts', () => {
     // Given I am signed in as a future manager
-    signIn({ permissions: ['cas1_out_of_service_bed_create', 'cas1_view_out_of_service_beds'] })
+    signIn('future_manager')
 
     const bed = { name: 'abc', id: '123' }
     const premises = cas1PremisesBasicSummaryFactory.build()

--- a/integration_tests/tests/manage/future_manager/updatesOutOfServiceBed.cy.ts
+++ b/integration_tests/tests/manage/future_manager/updatesOutOfServiceBed.cy.ts
@@ -16,7 +16,7 @@ describe('Updating an out of service bed', () => {
     cy.task('stubOutOfServiceBedReasons')
 
     // Given I am signed in as a future manager
-    signIn({ permissions: ['cas1_view_out_of_service_beds', 'cas1_out_of_service_bed_create'] })
+    signIn('future_manager')
   })
 
   it('should allow me to update an out of service bed', () => {

--- a/integration_tests/tests/manage/future_manager/viewsAllOutOfServiceBedsForPremises.cy.ts
+++ b/integration_tests/tests/manage/future_manager/viewsAllOutOfServiceBedsForPremises.cy.ts
@@ -8,7 +8,7 @@ describe('Future Manager lists all OOS beds for a particular premises', () => {
     cy.task('reset')
 
     // Given I am signed in as a CRU member with OOSB permissions
-    signIn({ permissions: ['cas1_view_out_of_service_beds'] })
+    signIn('cru_member_enable_out_of_service_beds')
   })
 
   const outOfServiceBeds = outOfServiceBedFactory.buildList(10)

--- a/integration_tests/tests/manage/future_manager/viewsOutOfServiceBed.cy.ts
+++ b/integration_tests/tests/manage/future_manager/viewsOutOfServiceBed.cy.ts
@@ -17,7 +17,7 @@ context('OutOfServiceBeds', () => {
   describe('for a new out of service bed with all nullable fields present in the initial OoS bed revision', () => {
     it('should show a out of service bed', () => {
       // Given I am signed in as a future manager
-      signIn({ permissions: ['cas1_view_out_of_service_beds'] })
+      signIn('future_manager')
 
       // And I have created a out of service bed
       const bed = { name: 'abc', id: '123' }
@@ -52,7 +52,7 @@ context('OutOfServiceBeds', () => {
   describe('for a legacy "lost bed" records migrated with all nullable fields not present in the initial OoS bed revision', () => {
     it('should show a out of service bed', () => {
       // Given I am signed in as a future manager
-      signIn({ permissions: ['cas1_view_out_of_service_beds'] })
+      signIn('future_manager')
 
       // And I have created a out of service bed
       const bed = { name: 'abc', id: '123' }

--- a/integration_tests/tests/manage/occupancyView.cy.ts
+++ b/integration_tests/tests/manage/occupancyView.cy.ts
@@ -37,6 +37,13 @@ context('Premises occupancy', () => {
 
     // And it has a list of upcoming placements
     cy.task('stubSpaceBookingSummaryList', { premisesId: premises.id, placements, residency: 'upcoming' })
+    cy.task('stubSpaceBookingSummaryList', {
+      premisesId: premises.id,
+      placements,
+      residency: 'current',
+      sortBy: 'personName',
+      perPage: 2000,
+    })
     cy.task('stubPremiseCapacity', {
       premisesId: premises.id,
       startDate,
@@ -47,8 +54,8 @@ context('Premises occupancy', () => {
 
   describe('with premises view permission', () => {
     beforeEach(() => {
-      // Given I am logged in as a future manager
-      signIn({ permissions: ['cas1_premises_view'] })
+      // Given I am signed in as a future manager
+      signIn('future_manager')
     })
 
     it('should show the next 12 weeks if navigated from premises page', () => {
@@ -157,8 +164,8 @@ context('Premises occupancy', () => {
   })
   describe('Without premises view permission', () => {
     it('should not be available if the user lacks premises_view permission', () => {
-      // Given I am logged in as an applicant
-      signIn()
+      // Given I am signed in as an applicant
+      signIn('applicant')
       // When I navigate to the view premises occupancy page
       // Then I should see an error
       OccupancyViewPage.visitUnauthorised(premises)
@@ -199,8 +206,8 @@ context('Premises day occupancy', () => {
 
   describe('with premises view permission', () => {
     beforeEach(() => {
-      // Given I am logged in as a future manager
-      signIn({ permissions: ['cas1_premises_view'] })
+      // Given I am signed in as a future manager
+      signIn('future_manager')
     })
 
     it('should show the day summary if spaces available', () => {
@@ -288,8 +295,8 @@ context('Premises day occupancy', () => {
 
   describe('Without premises view permission', () => {
     it('should not be available if the user lacks premises_view permission', () => {
-      // Given I am logged in as an applicant
-      signIn()
+      // Given I am signed in as an applicant
+      signIn('applicant')
       // When I navigate to the view premises occupancy page
       // Then I should see an error
       OccupancyDayViewPage.visitUnauthorised(premises, date)

--- a/integration_tests/tests/manage/placements/arrivals.cy.ts
+++ b/integration_tests/tests/manage/placements/arrivals.cy.ts
@@ -15,8 +15,8 @@ context('Arrivals', () => {
     cy.task('stubSpaceBookingShow', placement)
     cy.task('stubSpaceBookingArrivalCreate', { premisesId: premises.id, placementId: placement.id })
 
-    // Given I am logged in as a future manager
-    signIn({ permissions: ['cas1_space_booking_view', 'cas1_space_booking_record_arrival'] })
+    // Given I am signed in as a future manager
+    signIn('future_manager')
 
     // When I view a new placement
     let placementPage = PlacementShowPage.visit(placement)

--- a/integration_tests/tests/manage/placements/changes.cy.ts
+++ b/integration_tests/tests/manage/placements/changes.cy.ts
@@ -46,8 +46,8 @@ context('Change Placement', () => {
   beforeEach(() => {
     cy.task('reset')
 
-    // Given I am signed in as a CRU member
-    signIn({ permissions: ['cas1_space_booking_create'] })
+    // Given I am signed in as a CRU member with Beta access
+    signIn('cru_member_find_and_book_beta')
   })
 
   it('allows me to change the dates and criteria of a space booking', () => {

--- a/integration_tests/tests/manage/placements/departures.cy.ts
+++ b/integration_tests/tests/manage/placements/departures.cy.ts
@@ -44,8 +44,8 @@ context('Departures', () => {
       moveOnCategoryId: undefined,
     })
 
-    // Given I am logged in as a future manager
-    signIn({ permissions: ['cas1_space_booking_view', 'cas1_space_booking_record_departure'] })
+    // Given I am signed in as a future manager
+    signIn('future_manager')
 
     // When I view a new placement
     const placementPage = PlacementShowPage.visit(placement)
@@ -168,8 +168,8 @@ context('Departures', () => {
   })
 
   it('Requires the correct permission to record a departure', () => {
-    // Given I am logged in as a future manager
-    signIn({ permissions: ['cas1_space_booking_view'] })
+    // Given I am signed in a CRU member
+    signIn('cru_member')
 
     // And I am on the placement page
     const placementPage = PlacementShowPage.visit(placement)

--- a/integration_tests/tests/manage/placements/keyworker.cy.ts
+++ b/integration_tests/tests/manage/placements/keyworker.cy.ts
@@ -20,8 +20,8 @@ context('Keyworker', () => {
   })
 
   it('Assigns a keyworker to a placement', () => {
-    // Given I am logged in as a future manager
-    signIn({ permissions: ['cas1_space_booking_view', 'cas1_space_booking_record_keyworker'] })
+    // Given I am signed in as a future manager
+    signIn('future_manager')
 
     // And I am on the placement page
     let placementPage = PlacementShowPage.visit(placement)
@@ -52,8 +52,8 @@ context('Keyworker', () => {
   })
 
   it('Requires the correct permission to edit a keyworker', () => {
-    // Given I am logged in and have permission to view the placement, but not edit keyworker
-    signIn({ permissions: ['cas1_space_booking_view'] })
+    // Given I am signed in as a CRU member
+    signIn('cru_member')
 
     // And I am on the placement page
     const placementPage = PlacementShowPage.visit(placement)

--- a/integration_tests/tests/manage/placements/non-arrivals.cy.ts
+++ b/integration_tests/tests/manage/placements/non-arrivals.cy.ts
@@ -28,8 +28,8 @@ context('Non-arrivals', () => {
   }
 
   it('Records a non-arrival against a placement', () => {
-    // Given I am logged in as a future manager
-    signIn({ permissions: ['cas1_space_booking_view', 'cas1_space_booking_record_non_arrival'] })
+    // Given I am signed in as a future manager
+    signIn('future_manager')
 
     // And I am on the placement page
     let placementPage = PlacementShowPage.visit(placement)
@@ -82,8 +82,8 @@ context('Non-arrivals', () => {
   })
 
   it('Requires the correct permission to record a non-arrival against a placement', () => {
-    // Given I am logged in and have permission to view the placement, but not record non-arrival
-    signIn({ permissions: ['cas1_space_booking_view'] })
+    // Given I am signed in as a CRU member
+    signIn('cru_member')
 
     // And I am on the placement page
     const placementPage = PlacementShowPage.visit(placement)

--- a/integration_tests/tests/manage/placements/viewPlacement.cy.ts
+++ b/integration_tests/tests/manage/placements/viewPlacement.cy.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesUserPermission, Cas1SpaceBookingDates, FullPerson } from '@approved-premises/api'
+import { Cas1SpaceBookingDates, FullPerson } from '@approved-premises/api'
 import {
   applicationFactory,
   assessmentFactory,
@@ -17,16 +17,11 @@ import { signIn } from '../../signIn'
 type Mode = 'normal' | 'lao' | 'offline'
 context('Placements', () => {
   describe('show', () => {
-    const setup = (
-      permissions: Array<ApprovedPremisesUserPermission>,
-      placementParameters = {},
-      mode: Mode = 'normal',
-    ) => {
+    beforeEach(() => {
       cy.task('reset')
+    })
 
-      // Given I am signed in
-      signIn({ permissions })
-
+    const setup = (placementParameters = {}, mode: Mode = 'normal') => {
       const premises = premisesSummaryFactory.build()
       const person = mode === 'lao' ? restrictedPersonFactory.build() : personFactory.build()
       const application = applicationFactory.build({ person, personStatusOnSubmission: (person as FullPerson).status })
@@ -57,8 +52,10 @@ context('Placements', () => {
     }
 
     it('should show a placement', () => {
-      // Given that I am logged in with permission to view a placement and a mocked placement
-      const { placement } = setup(['cas1_space_booking_view'])
+      // Given that I am signed in as a future manager
+      signIn('future_manager')
+      // And there is an existing placement
+      const { placement } = setup()
       // When I visit the placement page
       const placementShowPage = PlacementShowPage.visit(placement)
       // Then I should see the person information in the header
@@ -70,8 +67,10 @@ context('Placements', () => {
     })
 
     it('should show placement details tabs', () => {
-      // Given that I am logged in with permission to view a placement and a mocked placement
-      const { placement, application, assessment, timeline, placementRequest } = setup(['cas1_space_booking_view'])
+      // Given that I am signed in as a future manager
+      signIn('future_manager')
+      // And there is an existing placement
+      const { placement, application, assessment, timeline, placementRequest } = setup()
       // When I visit the placement page
       const placementShowPage = PlacementShowPage.visit(placement)
       // And I select the application tab
@@ -110,8 +109,10 @@ context('Placements', () => {
     })
 
     it('should disable tabs if person is LAO', () => {
-      // Given that I am logged in with permission to view a placement and a mocked placement for a Limited Access person
-      const { placement } = setup(['cas1_space_booking_view'], {}, 'lao')
+      // Given that I am signed in as a future manager
+      signIn('future_manager')
+      // And there is an existing placement for a Limited Access person
+      const { placement } = setup({}, 'lao')
       // When I visit the placement page
       const placementShowPage = PlacementShowPage.visit(placement)
       // And I click on the application tab
@@ -129,8 +130,10 @@ context('Placements', () => {
     })
 
     it('should disable tabs if offline application', () => {
-      // Given that I am logged in with permission to view a placement and a mocked placement for an offline application
-      const { placement } = setup(['cas1_space_booking_view'], {}, 'offline')
+      // Given that I am signed in as a future manager
+      signIn('future_manager')
+      // And there is an existing placement for an offline application
+      const { placement } = setup({}, 'offline')
       // When I visit the placement page
       const placementShowPage = PlacementShowPage.visit(placement)
       // Then I should see the offline application warning banner
@@ -159,8 +162,10 @@ context('Placements', () => {
     })
 
     it('should select a tab from the path', () => {
-      // Given that I am logged in with permission to view a placement and a mocked placement
-      const { placement, application } = setup(['cas1_space_booking_view'])
+      // Given that I am signed in as a future manager
+      signIn('future_manager')
+      // And there is an existing placement
+      const { placement, application } = setup()
       // When I visit the placement page with the timeline tab selected
       const placementShowPage = PlacementShowPage.visit(placement, 'application')
       // Then I should see the application for this placement
@@ -170,9 +175,10 @@ context('Placements', () => {
     })
 
     it('should show a placement with missing fields', () => {
-      // Given I am logged in with permission to view a placement
-      // And the mocked placement has missing data
-      const { placement } = setup(['cas1_space_booking_view'], {
+      // Given that I am signed in as a future manager
+      signIn('future_manager')
+      // And there is an existing placement with missing data
+      const { placement } = setup({
         actualArrivalDate: undefined,
         actualDepartureDate: undefined,
       })
@@ -184,11 +190,14 @@ context('Placements', () => {
     })
 
     it('should show a list of linked placements', () => {
+      // Given that I am signed in as a future manager
+      signIn('future_manager')
+      // And there is an existing placement
       const placementList = [
         { id: '1234', canonicalArrivalDate: '2024-06-10', canonicalDepartureDate: '2024-09-10' },
         { id: '1235', canonicalArrivalDate: '2026-01-02', canonicalDepartureDate: '2027-03-04' },
       ] as Array<Cas1SpaceBookingDates>
-      const { placement } = setup(['cas1_space_booking_view'], {
+      const { placement } = setup({
         otherBookingsInPremisesForCrn: placementList,
       })
 
@@ -202,8 +211,10 @@ context('Placements', () => {
     })
 
     it('should require the correct permission to view a placement', () => {
-      // Given I am logged in with permission to view a placement and a mocked placement
-      const { placement } = setup([])
+      // Given that I am signed in as an applicant
+      signIn('applicant')
+      // And there is an existing placement
+      const { placement } = setup()
       // When I visit the placement page
       // I should get an authorsation error
       PlacementShowPage.visitUnauthorised(placement)

--- a/integration_tests/tests/manage/premises.cy.ts
+++ b/integration_tests/tests/manage/premises.cy.ts
@@ -16,8 +16,8 @@ context('Premises', () => {
     it('should list all premises', () => {
       cy.task('reset')
 
-      // Given I am logged in as a future manager
-      signIn({ permissions: ['cas1_premises_view'] })
+      // Given I am signed in as a future manager
+      signIn('future_manager')
 
       const premises = premisesSummaryFactory.buildList(5)
       cy.task('stubAllPremises', premises)
@@ -72,8 +72,8 @@ context('Premises', () => {
 
     describe('with placement list permission', () => {
       beforeEach(() => {
-        // Given I am logged in as a future manager
-        signIn({ permissions: ['cas1_premises_view', 'cas1_space_booking_list'] })
+        // Given I am signed in as a future manager
+        signIn('future_manager')
       })
 
       it('should show a single premises details page', () => {
@@ -266,8 +266,8 @@ context('Premises', () => {
 
     describe('without placement list view permission', () => {
       beforeEach(() => {
-        // Given I am logged in as a user without placement list view permission
-        signIn({ permissions: ['cas1_premises_view'] })
+        // Given I am signed in as a workflow manager
+        signIn('workflow_manager')
       })
 
       it('should not show the placements section', () => {

--- a/integration_tests/tests/manage/updateDepartureDate.cy.ts
+++ b/integration_tests/tests/manage/updateDepartureDate.cy.ts
@@ -8,7 +8,7 @@ context('Departure date', () => {
     cy.task('reset')
 
     // Given I am signed in as a CRU member
-    signIn({ permissions: ['cas1_booking_change_dates'] })
+    signIn('cru_member')
   })
 
   it('should show a form to change a bookings departure date', () => {

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -49,8 +49,8 @@ context('Placement Requests', () => {
   const defaultLicenceExpiryDate = '2030-06-05'
 
   it('allows me to search for an available space', () => {
-    // Given I am signed in as a CRU member
-    signIn({ permissions: ['cas1_view_cru_dashboard', 'cas1_space_booking_create'] })
+    // Given I am signed in as a CRU member with Beta access
+    signIn('cru_member_find_and_book_beta')
 
     // And there is a placement request waiting for me to match
     const person = personFactory.build()
@@ -166,8 +166,8 @@ context('Placement Requests', () => {
     const endDate = '2024-08-06'
     const totalCapacity = 10
 
-    // Given I am signed in as a CRU member
-    signIn({ permissions: ['cas1_view_cru_dashboard', 'cas1_space_booking_create'] })
+    // Given I am signed in as a CRU member with Beta access
+    signIn('cru_member_find_and_book_beta')
 
     // And there is a placement request waiting for me to match
     const person = personFactory.build()
@@ -380,8 +380,8 @@ context('Placement Requests', () => {
   })
 
   it('allows me to mark a placement request as unable to match', () => {
-    // Given I am signed in as a CRU member
-    signIn({ permissions: ['cas1_view_cru_dashboard', 'cas1_space_booking_create'] })
+    // Given I am signed in as a CRU member with Beta access
+    signIn('cru_member_find_and_book_beta')
 
     // Given there is a placement request waiting for me to match
     const placementRequest = placementRequestDetailFactory.build({

--- a/integration_tests/tests/match/placementApplications.cy.ts
+++ b/integration_tests/tests/match/placementApplications.cy.ts
@@ -34,9 +34,8 @@ context('Placement Applications', () => {
     cy.task('reset')
 
     // Given I am signed in as an assessor
-    signIn({
+    signIn('assessor', {
       id: defaultUserId,
-      permissions: ['cas1_view_assigned_assessments', 'cas1_assess_placement_application'],
     })
   })
 

--- a/integration_tests/tests/people/timeline.cy.ts
+++ b/integration_tests/tests/people/timeline.cy.ts
@@ -10,7 +10,7 @@ context('Application timeline', () => {
     cy.task('reset')
 
     // Given I am signed in as an applicant
-    signIn()
+    signIn('applicant')
   })
   ;([true, false] as const).forEach(isOfflineApplication => {
     it(`shows the timeline for a CRN if isOfflineApplication is: ${isOfflineApplication}`, () => {

--- a/integration_tests/tests/redirects.cy.ts
+++ b/integration_tests/tests/redirects.cy.ts
@@ -5,7 +5,7 @@ context('Redirects', () => {
     cy.task('reset')
 
     // Given I am signed in as an applicant
-    signIn()
+    signIn('applicant')
   })
 
   const redirects = [

--- a/integration_tests/tests/signIn.ts
+++ b/integration_tests/tests/signIn.ts
@@ -1,7 +1,8 @@
-import { ApprovedPremisesUser } from '@approved-premises/api'
+import { ApprovedPremisesUser, ApprovedPremisesUserRole } from '@approved-premises/api'
+import { roleToPermissions } from '../../server/utils/users/roles'
 
-export const signIn = (user?: Partial<ApprovedPremisesUser>) => {
+export const signIn = (role: ApprovedPremisesUserRole, user?: Partial<ApprovedPremisesUser>) => {
   cy.task('stubSignIn')
-  cy.task('stubAuthUser', user)
+  cy.task('stubAuthUser', { role, permissions: roleToPermissions(role), ...user })
   cy.signIn()
 }

--- a/integration_tests/tests/tasks/allocations.cy.ts
+++ b/integration_tests/tests/tasks/allocations.cy.ts
@@ -77,8 +77,8 @@ context('Task Allocation', () => {
     cy.task('stubUserSummaryList', { users, roles: ['assessor', 'appeals_manager'] })
     cy.task('stubUserList', { users, roles: ['assessor', 'appeals_manager'] })
 
-    // And I am signed in as a CRU member
-    signIn({ permissions: ['cas1_view_manage_tasks'], cruManagementArea })
+    // And I am signed in as a CRU member with the correct CRU management area
+    signIn('cru_member', { cruManagementArea })
 
     // When I visit the task list page
     const taskListPage = TaskListPage.visit(tasks, [])

--- a/integration_tests/tests/tasks/list.cy.ts
+++ b/integration_tests/tests/tasks/list.cy.ts
@@ -21,7 +21,6 @@ context('Task Allocation', () => {
   const user: Partial<ApprovedPremisesUser> = {
     apArea,
     cruManagementArea: cruManagementAreas[0],
-    permissions: ['cas1_view_manage_tasks'],
   }
 
   beforeEach(() => {
@@ -32,8 +31,8 @@ context('Task Allocation', () => {
   })
 
   it('returns unauthorised if user does not have the cas1 view manage task permission', () => {
-    // Given I am logged in without the required permissions
-    signIn({ apArea, permissions: [] })
+    // Given I am signed in as an applicant with the correct AP area
+    signIn('applicant', { apArea })
 
     const path = paths.tasks.index({})
     cy.request({ url: path, failOnStatusCode: false }).should(response => {
@@ -42,8 +41,8 @@ context('Task Allocation', () => {
   })
 
   it('shows a list of tasks for LAO', () => {
-    // Given I am signed in as a user with tasks allocation permission
-    signIn(user)
+    // Given I am signed in as a CRU member with the correct AP area and CRU management area
+    signIn('cru_member', user)
 
     const allocatedTasks = restrictedPersonSummaryTaskFactory.buildList(5)
     const unallocatedTasks = restrictedPersonSummaryTaskFactory.buildList(5, { allocatedToStaffMember: undefined })
@@ -96,8 +95,8 @@ context('Task Allocation', () => {
   })
 
   it('shows a list of tasks', () => {
-    // Given I am signed in as a user with tasks allocation permission
-    signIn(user)
+    // Given I am signed in as a CRU member with the correct AP area and CRU management area
+    signIn('cru_member', user)
 
     const allocatedTasks = taskFactory.buildList(1, { personSummary: fullPersonSummaryFactory.build() })
     const unallocatedTasks = taskFactory.buildList(1, {
@@ -139,8 +138,8 @@ context('Task Allocation', () => {
   })
 
   it('supports pagination', () => {
-    // Given I am signed in as a user with tasks allocation permission
-    signIn(user)
+    // Given I am signed in as a CRU member with the correct AP area and CRU management area
+    signIn('cru_member', user)
 
     const allocatedTasksPage1 = restrictedPersonSummaryTaskFactory.buildList(10)
     const allocatedTasksPage2 = restrictedPersonSummaryTaskFactory.buildList(10)
@@ -197,8 +196,8 @@ context('Task Allocation', () => {
   })
 
   it('supports sorting', () => {
-    // Given I am signed in as a user with tasks allocation permission
-    signIn(user)
+    // Given I am signed in as a CRU member with the correct AP area and CRU management area
+    signIn('cru_member', user)
 
     const sortFields = ['dueAt', 'person', 'allocatedTo']
     const tasks = restrictedPersonSummaryTaskFactory.buildList(10)
@@ -284,8 +283,8 @@ context('Task Allocation', () => {
 
   Object.keys(filterOptions).forEach(key => {
     it(`allows filter by ${key}`, () => {
-      // Given I am signed in as a user with tasks allocation permission
-      signIn(user)
+      // Given I am signed in as a CRU member with the correct AP area and CRU management area
+      signIn('cru_member', user)
 
       const allocatedTasks = restrictedPersonSummaryTaskFactory.buildList(10)
       const allocatedTasksFiltered = restrictedPersonSummaryTaskFactory.buildList(1)
@@ -328,8 +327,8 @@ context('Task Allocation', () => {
   })
 
   it('maintains filter on tab change', () => {
-    // Given I am signed in as a user with tasks allocation permission
-    signIn(user)
+    // Given I am signed in as a CRU member with the correct AP area and CRU management area
+    signIn('cru_member', user)
 
     const allocatedTasks = restrictedPersonSummaryTaskFactory.buildList(10)
     const allocatedTasksFiltered = restrictedPersonSummaryTaskFactory.buildList(1)
@@ -379,8 +378,8 @@ context('Task Allocation', () => {
   })
 
   it('retains the unallocated filter when applying other filters', () => {
-    // Given I am signed in as a user with tasks allocation permission
-    signIn(user)
+    // Given I am signed in as a CRU member with the correct AP area and CRU management area
+    signIn('cru_member', user)
 
     const allocatedTasks = restrictedPersonSummaryTaskFactory.buildList(10)
     const unallocatedTasks = restrictedPersonSummaryTaskFactory.buildList(10, { allocatedToStaffMember: undefined })
@@ -424,8 +423,8 @@ context('Task Allocation', () => {
   })
 
   it('defaults to user area but allows filter by all areas', () => {
-    // Given I am signed in as a user with tasks allocation permission
-    signIn(user)
+    // Given I am signed in as a CRU member with the correct AP area and CRU management area
+    signIn('cru_member', user)
 
     const allocatedTasks = restrictedPersonSummaryTaskFactory.buildList(1)
     const allocatedTasksFiltered = restrictedPersonSummaryTaskFactory.buildList(10)
@@ -496,8 +495,8 @@ context('Task Allocation', () => {
   })
   ;(['taskType', 'decision', 'completedAt'] as const).forEach(sortField => {
     it(`supports pending placement requests sorting by ${sortField}`, () => {
-      // Given I am signed in as a user with tasks allocation permission
-      signIn(user)
+      // Given I am signed in as a CRU member with the correct AP area and CRU management area
+      signIn('cru_member', user)
 
       cy.task('stubGetAllTasks', {
         tasks: [],

--- a/integration_tests/tests/withdrawals/withdrawals.cy.ts
+++ b/integration_tests/tests/withdrawals/withdrawals.cy.ts
@@ -19,6 +19,7 @@ import Page from '../../pages/page'
 import { signIn } from '../signIn'
 import paths from '../../../server/paths/apply'
 import withdrawablesFactory from '../../../server/testutils/factories/withdrawablesFactory'
+import { roleToPermissions } from '../../../server/utils/users/roles'
 
 context('Withdrawals', () => {
   beforeEach(() => {
@@ -27,15 +28,13 @@ context('Withdrawals', () => {
   })
 
   describe('as a CRU user', () => {
-    const userPermissions: Array<ApprovedPremisesUserPermission> = ['cas1_view_cru_dashboard', 'cas1_booking_withdraw']
-
     beforeEach(() => {
-      // Given I am logged in
-      signIn({ permissions: userPermissions })
+      // Given I am signed in as a CRU member
+      signIn('cru_member')
     })
 
     it('withdraws a placement request, showing all options for withdrawal reason', () =>
-      withdrawsAPlacementRequest(userPermissions))
+      withdrawsAPlacementRequest(roleToPermissions('cru_member')))
 
     it('withdraws a placement application', () => {
       const application = applicationFactory.build({ status: 'submitted' })
@@ -174,15 +173,13 @@ context('Withdrawals', () => {
   })
 
   describe('as a non-CRU user', () => {
-    const userPermissions: Array<ApprovedPremisesUserPermission> = []
-
     beforeEach(() => {
-      // Given I am logged in as an applicant
-      signIn({ permissions: userPermissions })
+      // Given I am signed in as an applicant
+      signIn('applicant')
     })
 
     it('withdraws a placement request, showing all options for withdrawal reason excluding those relating to lack of capacity', () =>
-      withdrawsAPlacementRequest(userPermissions))
+      withdrawsAPlacementRequest(roleToPermissions('applicant')))
 
     it('shows a warning message if there are no withdrawables', () => {
       const application = applicationSummaryFactory.build({

--- a/script/generate-types
+++ b/script/generate-types
@@ -21,4 +21,10 @@ echo "==> Renaming the declaration file..."
 
 mv ./server/@types/shared/index.ts ./server/@types/shared/index.d.ts
 
+echo "==> Copying roles to permissions mapping..."
 
+curl -o ./server/utils/users/data/rolesToPermissions.json -s "https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/$branch/src/main/resources/static/codegen/built-cas1-roles.json"
+
+echo "==> Tidying up roles to permissions formatting..."
+
+npx prettier --write ./server/utils/users/data/rolesToPermissions.json

--- a/server/utils/users/data/rolesToPermissions.json
+++ b/server/utils/users/data/rolesToPermissions.json
@@ -1,0 +1,186 @@
+[
+  {
+    "name": "assessor",
+    "permissions": [
+      "cas1_assess_appealed_application",
+      "cas1_assess_application",
+      "cas1_assess_placement_application",
+      "cas1_view_assigned_assessments"
+    ]
+  },
+  {
+    "name": "matcher",
+    "permissions": [
+      "cas1_assess_placement_application"
+    ]
+  },
+  {
+    "name": "future_manager",
+    "permissions": [
+      "cas1_out_of_service_bed_create",
+      "cas1_premises_view",
+      "cas1_premises_manage",
+      "cas1_space_booking_list",
+      "cas1_space_booking_record_arrival",
+      "cas1_space_booking_record_departure",
+      "cas1_space_booking_record_non_arrival",
+      "cas1_space_booking_record_keyworker",
+      "cas1_space_booking_view",
+      "cas1_view_out_of_service_beds"
+    ]
+  },
+  {
+    "name": "workflow_manager",
+    "permissions": [
+      "cas1_adhoc_booking_create",
+      "cas1_application_withdraw_others",
+      "cas1_booking_change_dates",
+      "cas1_booking_withdraw",
+      "cas1_premises_view",
+      "cas1_request_for_placement_withdraw_others",
+      "cas1_user_list",
+      "cas1_view_cru_dashboard",
+      "cas1_view_manage_tasks"
+    ]
+  },
+  {
+    "name": "cru_member",
+    "permissions": [
+      "cas1_adhoc_booking_create",
+      "cas1_application_withdraw_others",
+      "cas1_booking_change_dates",
+      "cas1_booking_withdraw",
+      "cas1_placement_request_record_unable_to_match",
+      "cas1_premises_view",
+      "cas1_request_for_placement_withdraw_others",
+      "cas1_space_booking_list",
+      "cas1_space_booking_view",
+      "cas1_space_booking_withdraw",
+      "cas1_user_list",
+      "cas1_view_cru_dashboard",
+      "cas1_view_manage_tasks",
+      "cas1_booking_create"
+    ]
+  },
+  {
+    "name": "cru_member_find_and_book_beta",
+    "permissions": [
+      "cas1_adhoc_booking_create",
+      "cas1_application_withdraw_others",
+      "cas1_booking_change_dates",
+      "cas1_booking_withdraw",
+      "cas1_placement_request_record_unable_to_match",
+      "cas1_premises_view",
+      "cas1_request_for_placement_withdraw_others",
+      "cas1_space_booking_list",
+      "cas1_space_booking_view",
+      "cas1_space_booking_withdraw",
+      "cas1_user_list",
+      "cas1_view_cru_dashboard",
+      "cas1_view_manage_tasks",
+      "cas1_space_booking_create",
+      "cas1_out_of_service_bed_create_bed_on_hold",
+      "cas1_out_of_service_bed_cancel",
+      "cas1_out_of_service_bed_create",
+      "cas1_view_out_of_service_beds"
+    ]
+  },
+  {
+    "name": "cru_member_enable_out_of_service_beds",
+    "permissions": [
+      "cas1_out_of_service_bed_create",
+      "cas1_view_out_of_service_beds"
+    ]
+  },
+  {
+    "name": "change_request_dev",
+    "permissions": [
+      "cas1_appeal_create",
+      "cas1_planned_transfer_create"
+    ]
+  },
+  {
+    "name": "applicant",
+    "permissions": []
+  },
+  {
+    "name": "report_viewer",
+    "permissions": [
+      "cas1_reports_view"
+    ]
+  },
+  {
+    "name": "report_viewer_with_pii",
+    "permissions": [
+      "cas1_reports_view",
+      "cas1_reports_view_with_pii"
+    ]
+  },
+  {
+    "name": "excluded_from_assess_allocation",
+    "permissions": []
+  },
+  {
+    "name": "excluded_from_match_allocation",
+    "permissions": []
+  },
+  {
+    "name": "excluded_from_placement_application_allocation",
+    "permissions": []
+  },
+  {
+    "name": "appeals_manager",
+    "permissions": [
+      "cas1_assess_appealed_application",
+      "cas1_assess_application",
+      "cas1_process_an_appeal",
+      "cas1_view_assigned_assessments"
+    ]
+  },
+  {
+    "name": "janitor",
+    "permissions": [
+      "cas1_adhoc_booking_create",
+      "cas1_assess_appealed_application",
+      "cas1_assess_application",
+      "cas1_assess_placement_application",
+      "cas1_booking_create",
+      "cas1_booking_withdraw",
+      "cas1_booking_change_dates",
+      "cas1_out_of_service_bed_create",
+      "cas1_out_of_service_bed_create_bed_on_hold",
+      "cas1_out_of_service_bed_cancel",
+      "cas1_placement_request_record_unable_to_match",
+      "cas1_process_an_appeal",
+      "cas1_user_list",
+      "cas1_user_management",
+      "cas1_view_assigned_assessments",
+      "cas1_view_cru_dashboard",
+      "cas1_view_manage_tasks",
+      "cas1_view_out_of_service_beds",
+      "cas1_space_booking_create",
+      "cas1_space_booking_list",
+      "cas1_space_booking_record_arrival",
+      "cas1_space_booking_record_departure",
+      "cas1_space_booking_record_non_arrival",
+      "cas1_space_booking_record_keyworker",
+      "cas1_space_booking_view",
+      "cas1_space_booking_withdraw",
+      "cas1_premises_view",
+      "cas1_premises_manage",
+      "cas1_application_withdraw_others",
+      "cas1_reports_view",
+      "cas1_reports_view_with_pii",
+      "cas1_request_for_placement_withdraw_others",
+      "cas1_appeal_create",
+      "cas1_planned_transfer_create"
+    ]
+  },
+  {
+    "name": "user_manager",
+    "permissions": [
+      "cas1_user_list",
+      "cas1_user_management"
+    ]
+  }
+]

--- a/server/utils/users/roles.test.ts
+++ b/server/utils/users/roles.test.ts
@@ -1,7 +1,24 @@
-import { filterAllocationRoles, hasPermission, hasRole } from './roles'
+import { ApprovedPremisesUserRole } from '@approved-premises/api'
+import { filterAllocationRoles, hasPermission, hasRole, roleToPermissions } from './roles'
 import { userDetailsFactory } from '../../testutils/factories'
 
 describe('roles utilities', () => {
+  describe('roleToPermissions', () => {
+    it('returns an array of permissions for the given role', () => {
+      expect(roleToPermissions('user_manager')).toEqual(['cas1_user_list', 'cas1_user_management'])
+      expect(roleToPermissions('assessor')).toEqual([
+        'cas1_assess_appealed_application',
+        'cas1_assess_application',
+        'cas1_assess_placement_application',
+        'cas1_view_assigned_assessments',
+      ])
+    })
+
+    it('returns an empty array for a role that does not have a mapping', () => {
+      expect(roleToPermissions('not_a_role' as ApprovedPremisesUserRole)).toEqual([])
+    })
+  })
+
   describe('hasRole', () => {
     it('returns true when the user has the role', () => {
       const user = userDetailsFactory.build({ roles: ['applicant'] })

--- a/server/utils/users/roles.ts
+++ b/server/utils/users/roles.ts
@@ -1,9 +1,11 @@
 import {
   ApprovedPremisesUserPermission,
+  ApprovedPremisesUserRole,
   UserQualification,
   ApprovedPremisesUserRole as UserRole,
 } from '@approved-premises/api'
 import { UserDetails } from '../../@types/ui'
+import rolesToPermissions from './data/rolesToPermissions.json'
 
 export const roles: ReadonlyArray<RoleInUse> = [
   'assessor',
@@ -120,6 +122,16 @@ export const qualificationDictionary: QualificationLabelDictionary = {
   recovery_focused: 'Recovery-focused APs',
   mental_health_specialist: 'Specialist Mental Health APs',
 }
+
+type RoleToPermissionMapping = {
+  name: ApprovedPremisesUserRole
+  permissions: Array<ApprovedPremisesUserPermission>
+}
+
+export const permissionsMap = rolesToPermissions as Array<RoleToPermissionMapping>
+
+export const roleToPermissions = (role: ApprovedPremisesUserRole) =>
+  permissionsMap.find(mapping => mapping.name === role)?.permissions || []
 
 export const hasRole = (user: UserDetails, role: UserRole): boolean => {
   return (user.roles || []).includes(role)


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2087

# Changes in this PR

This PR adds a step to copy the generated roles to permissions mapping from the API during the types generation, and updates all uses of the `signIn()` method in integration tests to revet to using role instead of granular permissions, for a closer to real-world usage.

## Screenshots of UI changes

n/a
