### PR TITLE
APS-2135 Remove criteria filter on day view

### DIFF
--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -476,6 +476,15 @@ describe('OccupancyViewController', () => {
       const pathPrefix = `/match/placement-requests/${placementRequestDetail.id}/space-search/occupancy/${premises.id}`
 
       expect(premisesService.getCapacity).toHaveBeenCalledWith('SOME_TOKEN', premises.id, { startDate: date })
+
+      expect(premisesService.getDaySummary).toHaveBeenCalledWith({
+        bookingsSortBy: 'personName',
+        bookingsSortDirection: 'asc',
+        date,
+        premisesId: premises.id,
+        token,
+      })
+
       expect(response.render).toHaveBeenCalledWith('manage/premises/occupancy/dayView', {
         pageHeading: 'Sun 23 Mar 2025',
         backLink: '/backlink',

--- a/server/controllers/match/placementRequests/occupancyViewController.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.ts
@@ -253,7 +253,6 @@ export default class {
           date,
           bookingsSortBy: sortBy,
           bookingsSortDirection: sortDirection,
-          bookingsCriteriaFilter: filteredCriteria,
         }),
         config.flags.pocEnabled ? filteredCriteria : undefined,
       )


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2135
<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

No longer send a room criteria filter to the API when requesting a `daySummary`.
This didn't fail any tests so I added one.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

<details>
  <summary>Before</summary>
<img src="https://github.com/user-attachments/assets/2dd86d8f-c75d-4feb-9187-c8d3fbbe71aa"/>
</details>

<details>
  <summary>After</summary>
<img src="https://github.com/user-attachments/assets/146254aa-9897-4788-abf0-8d77094d6ef4"/>
</details>
