### PR TITLE
APS-2136 App date in booking notification

### DIFF
--- a/integration_tests/pages/admin/placementApplications/listPage.ts
+++ b/integration_tests/pages/admin/placementApplications/listPage.ts
@@ -1,7 +1,9 @@
 import {
   ApplicationSortField,
   ApprovedPremisesApplicationSummary,
+  Cas1SpaceBooking,
   PlacementRequest,
+  PlacementRequestDetail,
   PlacementRequestSortField,
   PlacementRequestStatus,
   SortOrder,
@@ -12,6 +14,7 @@ import paths from '../../../../server/paths/admin'
 import { shouldShowTableRows, tableRowsToArrays } from '../../../helpers'
 import { dashboardTableRows } from '../../../../server/utils/placementRequests/table'
 import { pendingPlacementRequestTableRows } from '../../../../server/utils/applications/pendingPlacementRequestTable'
+import { creationNotificationBody } from '../../../../server/utils/match'
 
 export default class ListPage extends Page {
   constructor() {
@@ -24,11 +27,9 @@ export default class ListPage extends Page {
     return new ListPage()
   }
 
-  shouldShowSpaceBookingConfirmation(crn: string, premisesName: string) {
-    this.shouldShowBanner(
-      `Place booked for ${crn} at ${premisesName} 
-      A confirmation email will be sent to the AP and probation practitioner.`,
-    )
+  shouldShowSpaceBookingConfirmation(spaceBooking: Cas1SpaceBooking, placementRequest: PlacementRequestDetail) {
+    const body = creationNotificationBody(spaceBooking, placementRequest)
+    this.shouldShowBanner(`Place booked for ${spaceBooking.person.crn} ${body}`)
   }
 
   shouldShowPlacementRequests(placementRequests: Array<PlacementRequest>, status?: PlacementRequestStatus): void {

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -354,16 +354,17 @@ context('Placement Requests', () => {
     page.shouldShowBookingDetails(placementRequest, premises, arrivalDate, departureDate, searchState.roomCriteria)
 
     // And when I complete the form
-    const spaceBooking = cas1SpaceBookingFactory.upcoming().build()
+    const spaceBooking = cas1SpaceBookingFactory.upcoming().build({ placementRequestId: placementRequest.id })
     cy.task('stubSpaceBookingCreate', { placementRequestId: placementRequest.id, spaceBooking })
     cy.task('stubPlacementRequestsDashboard', { placementRequests: [placementRequest], status: 'matched' })
+    cy.task('stubPlacementRequest', placementRequest)
     page.clickSubmit()
 
     // Then I should be redirected to the 'Matched' tab
     const cruDashboard = Page.verifyOnPage(ListPage)
 
     // And I should see a success message
-    cruDashboard.shouldShowSpaceBookingConfirmation(spaceBooking.person.crn, spaceBooking.premises.name)
+    cruDashboard.shouldShowSpaceBookingConfirmation(spaceBooking, placementRequest)
 
     // And the booking details should have been sent to the API
     cy.task('verifyApiPost', apiPaths.placementRequests.spaceBookings.create({ id: placementRequest.id })).then(

--- a/server/controllers/match/placementRequests/spaceBookingsController.test.ts
+++ b/server/controllers/match/placementRequests/spaceBookingsController.test.ts
@@ -15,6 +15,7 @@ import paths from '../../../paths/admin'
 import matchPaths from '../../../paths/match'
 import * as validationUtils from '../../../utils/validation'
 import { spaceBookingConfirmationSummaryListRows } from '../../../utils/match'
+import { DateFormats } from '../../../utils/dateUtils'
 
 describe('SpaceBookingsController', () => {
   const token = 'SOME_TOKEN'
@@ -116,6 +117,7 @@ describe('SpaceBookingsController', () => {
       const spaceBooking = cas1SpaceBookingFactory.build()
 
       spaceSearchService.createSpaceBooking.mockResolvedValue(spaceBooking)
+
       const flash = jest.fn()
 
       const requestHandler = spaceBookingsController.create()
@@ -127,8 +129,10 @@ describe('SpaceBookingsController', () => {
         newSpaceBooking,
       )
       expect(flash).toHaveBeenCalledWith('success', {
-        heading: `Place booked for ${spaceBooking.person.crn} at ${spaceBooking.premises.name}`,
-        body: `<p>A confirmation email will be sent to the AP and probation practitioner.</p>`,
+        heading: `Place booked for ${spaceBooking.person.crn}`,
+        body: `<ul><li><strong>Approved Premises:</strong> ${spaceBooking.premises.name}</li>
+<li><strong>Date of application:</strong> ${DateFormats.isoDateToUIDate(placementRequestDetail.applicationDate, { format: 'short' })}</li></ul>
+<p>A confirmation email will be sent to the AP and probation practitioner.</p>`,
       })
       expect(mockSessionSave).toHaveBeenCalled()
       expect(response.redirect).toHaveBeenCalledWith(`${paths.admin.cruDashboard.index({})}?status=matched`)

--- a/server/controllers/match/placementRequests/spaceBookingsController.ts
+++ b/server/controllers/match/placementRequests/spaceBookingsController.ts
@@ -4,7 +4,7 @@ import { PlacementRequestService, PremisesService, SpaceSearchService } from '..
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import paths from '../../../paths/admin'
 import matchPaths from '../../../paths/match'
-import { spaceBookingConfirmationSummaryListRows } from '../../../utils/match'
+import { creationNotificationBody, spaceBookingConfirmationSummaryListRows } from '../../../utils/match'
 
 interface NewRequest extends Request {
   params: {
@@ -80,9 +80,13 @@ export default class {
 
       try {
         const placement = await this.spaceSearchService.createSpaceBooking(token, id, newSpaceBooking)
+        const placementRequest = await this.placementRequestService.getPlacementRequest(
+          token,
+          placement.placementRequestId,
+        )
         req.flash('success', {
-          heading: `Place booked for ${placement.person.crn} at ${placement.premises.name}`,
-          body: '<p>A confirmation email will be sent to the AP and probation practitioner.</p>',
+          heading: `Place booked for ${placement.person.crn}`,
+          body: creationNotificationBody(placement, placementRequest),
         })
         this.spaceSearchService.removeSpaceSearchState(id, req.session)
 

--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -3,6 +3,7 @@ import applyPaths from '../../paths/apply'
 import {
   cas1PremisesFactory,
   cas1PremisesSearchResultSummaryFactory,
+  cas1SpaceBookingFactory,
   personFactory,
   placementRequestDetailFactory,
   restrictedPersonFactory,
@@ -14,6 +15,7 @@ import {
   apTypeRow,
   apTypeWithViewTimelineActionRow,
   characteristicsRow,
+  creationNotificationBody,
   distanceRow,
   filterOutAPTypes,
   keyDetails,
@@ -350,6 +352,17 @@ describe('matchUtils', () => {
       placementRequest.person = restrictedPerson
 
       expect(() => keyDetails(placementRequest)).toThrow('Restricted person')
+    })
+  })
+
+  describe('creationNotificationBody', () => {
+    it('Should build the notification body', () => {
+      const placementRequest = placementRequestDetailFactory.build()
+      const placement = cas1SpaceBookingFactory.build()
+      expect(creationNotificationBody(placement, placementRequest))
+        .toEqual(`<ul><li><strong>Approved Premises:</strong> ${placement.premises.name}</li>
+<li><strong>Date of application:</strong> ${DateFormats.isoDateToUIDate(placementRequest.applicationDate, { format: 'short' })}</li></ul>
+<p>A confirmation email will be sent to the AP and probation practitioner.</p>`)
     })
   })
 })

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -3,6 +3,7 @@ import {
   ApprovedPremisesApplication,
   Cas1Premises,
   Cas1PremisesSearchResultSummary,
+  type Cas1SpaceBooking,
   Cas1SpaceBookingCharacteristic,
   PlacementCriteria,
   PlacementRequest,
@@ -239,3 +240,10 @@ export const keyDetails = (placementRequest: PlacementRequestDetail): KeyDetails
     ],
   }
 }
+
+export const creationNotificationBody = (
+  placement: Cas1SpaceBooking,
+  placementRequest: PlacementRequest,
+) => `<ul><li><strong>Approved Premises:</strong> ${placement.premises.name}</li>
+<li><strong>Date of application:</strong> ${DateFormats.isoDateToUIDate(placementRequest.applicationDate, { format: 'short' })}</li></ul>
+<p>A confirmation email will be sent to the AP and probation practitioner.</p>`


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2136

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Adds the application date to the booking creation banner, displayed on the CRU dashboard page. To acquire the application date, the UI makes an extra API request to get the PlacementRequestDetail.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/ab8dc6ce-db33-4b09-aefa-4c5f96a17d38)

