### PR TITLE
APS-2152 isArsonDesignated in legacy assessment

### DIFF
--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -146,6 +146,31 @@ describe('MatchingInformation', () => {
       expect(response['Do you agree with the suggested length of stay?']).toEqual('No')
       expect(response['Recommended length of stay']).toEqual('5 weeks, 5 days')
     })
+
+    describe('a legacy assessment with isArsonDesignated defined', () => {
+      it('returns a value for isArson designated if it is defined', () => {
+        const page = new MatchingInformation({ isArsonDesignated: 'essential' }, assessment)
+        const response = page.response()
+        expect(response).toEqual(expect.objectContaining({ 'Designated arson room': 'Essential' }))
+      })
+
+      it('does not return a value for isArsonDesignated if isArsonSuitable is defined', () => {
+        const page = new MatchingInformation(
+          { isArsonSuitable: 'desirable', isArsonDesignated: 'essential' },
+          assessment,
+        )
+        const response = page.response()
+        expect(response).toEqual(expect.not.objectContaining({ 'Designated arson room': 'Essential' }))
+        expect(response).toEqual(expect.objectContaining({ 'Suitable for active arson risk': 'Desirable' }))
+      })
+
+      it('returns a default value for isArsonSuitable is nothing is defined', () => {
+        const page = new MatchingInformation({}, assessment)
+        const response = page.response()
+        expect(response['Designated arson room']).toBeUndefined()
+        expect(response['Suitable for active arson risk']).toEqual('')
+      })
+    })
   })
 
   describe('suggestedStaySummaryListOptions', () => {

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
@@ -90,6 +90,8 @@ export default class MatchingInformation implements TasklistPage {
 
   availableApTypes: Record<ApTypeCriteria, string>
 
+  rawBody: MatchingInformationBody
+
   constructor(
     private _body: Partial<MatchingInformationBody>,
     public assessment: Assessment,
@@ -109,6 +111,7 @@ export default class MatchingInformation implements TasklistPage {
   }
 
   set body(value: MatchingInformationBody) {
+    this.rawBody = { ...this.body }
     this._body = { ...value, ...defaultMatchingInformationValues(this.body, this.assessment.application) }
   }
 
@@ -128,10 +131,16 @@ export default class MatchingInformation implements TasklistPage {
     const response = {
       [this.questions.apType]: apTypeCriteriaLabels[this.body.apType],
     }
+    let placementCriteria: Array<PlacementRequirementCriteria> = [...this.placementRequirementCriteria]
 
-    this.placementRequirementCriteria.forEach(placementRequirementCriterion => {
+    if (this.rawBody.isArsonDesignated && !this.rawBody.isArsonSuitable)
+      placementCriteria = [...placementRequirementCriteria, 'isArsonDesignated'].filter(
+        placementCriterion => placementCriterion !== 'isArsonSuitable',
+      ) as Array<PlacementRequirementCriteria>
+
+    placementCriteria.forEach(placementRequirementCriterion => {
       response[`${placementCriteriaLabels[placementRequirementCriterion]}`] =
-        `${sentenceCase(this.body[placementRequirementCriterion])}`
+        `${sentenceCase(this.rawBody[placementRequirementCriterion])}`
     })
 
     this.offenceAndRiskCriteria.forEach(offenceOrRiskCriterion => {

--- a/server/form-pages/utils/matchingInformationUtils.test.ts
+++ b/server/form-pages/utils/matchingInformationUtils.test.ts
@@ -426,6 +426,18 @@ describe('matchingInformationUtils', () => {
             )
           })
         })
+
+        describe('isArsonDesignated (legacy)', () => {
+          it('is set if isArsonDesignated is defined in the stored data', () => {
+            const matchingInformationBody: MatchingInformationBody = {
+              ...bodyWithUndefinedValues,
+              isArsonDesignated: 'essential',
+            }
+            expect(defaultMatchingInformationValues(matchingInformationBody, application)).toEqual(
+              expect.objectContaining({ isArsonDesignated: 'essential' }),
+            )
+          })
+        })
       })
     })
 

--- a/server/form-pages/utils/matchingInformationUtils.ts
+++ b/server/form-pages/utils/matchingInformationUtils.ts
@@ -109,7 +109,7 @@ const defaultMatchingInformationValues = (
   body: MatchingInformationBody,
   application: ApprovedPremisesApplication,
 ): Partial<MatchingInformationBody> => {
-  return {
+  const defaults = {
     acceptsChildSexOffenders: getValue<GetValueOffenceAndRisk>(
       body,
       'acceptsChildSexOffenders',
@@ -153,6 +153,15 @@ const defaultMatchingInformationValues = (
       'notRelevant',
     ),
     apType: apType(body, application),
+    isArsonDesignated: getValue<GetValuePlacementRequirement>(
+      body,
+      'isArsonDesignated',
+      application,
+      [],
+      [],
+      undefined,
+      undefined,
+    ),
     isArsonSuitable: getValue<GetValuePlacementRequirement>(
       body,
       'isArsonSuitable',
@@ -219,8 +228,11 @@ const defaultMatchingInformationValues = (
       'essential',
       'notRelevant',
     ),
-    lengthOfStay: lengthOfStay(body),
   }
+  const filteredDefaults = Object.entries(defaults).reduce((out, [key, value]) => {
+    return value ? { ...out, [key]: value } : out
+  }, {})
+  return { ...filteredDefaults, lengthOfStay: lengthOfStay(body) }
 }
 
 // TODO: remove once arson remapping (APS-1876) is completed


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2152

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

CAS1 uses a document mechanism to show the questions and answers as they were at the moment of submission of an application. There is no such feature for assessments.
As we have removed isArsonDesignated as a field, legacy assessments that have isArsonDesignated set in their data block, do not show a value for 'Designated arson room' but do show isArsonSuitable which gets defaulted to 'Not relevant'.

The response method on the MatchingInformationPage applies defaulting logic to its stored body on load.  This defaulting logic is useful to apply to the form, but shouldn't really be applied to the read-only view as that should show the content that was actually saved, rather than any update on it.  Hence I added a rawBody property to the page object to allow the construction of a non-defaulted response.



<!-- [x] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before

<details>
  <summary>Read-only view on a legacy assessment (where user selected isArsonDesignated as essential)</summary>
<img src="https://github.com/user-attachments/assets/290fd97c-1589-41eb-9a03-9662641e4a72"/>
</details>

### After

<details>
  <summary>Read-only view on same legacy assessment as above</summary>
<img src="https://github.com/user-attachments/assets/732300ee-f390-480f-8a28-00b35fe3b954"/>
</details>

<details>
  <summary>New assessment - Matching information form</summary>
<img src="https://github.com/user-attachments/assets/819e93cd-87bd-440a-9ec1-fbfefeebeadb"/>
</details>

<details>
  <summary>Check-your-answers page on new assessment</summary>
<img src="https://github.com/user-attachments/assets/81812dc8-d394-44d2-8725-98cbbfe259e1"/>
</details>

<details>
  <summary>Read-only view on completed new assessment</summary>
<img src="https://github.com/user-attachments/assets/720d85ed-0619-4b4b-9219-bde8c2a7956f"/>
</details>



