### PR TITLE
BUGFIX/APS-2172: dateutils BST issue

### DIFF
--- a/integration_tests/pages/manage/placements/departures/new.ts
+++ b/integration_tests/pages/manage/placements/departures/new.ts
@@ -4,22 +4,12 @@ import { DateFormats } from '../../../../../server/utils/dateUtils'
 import paths from '../../../../../server/paths/manage'
 
 export class DepartureNewPage extends Page {
-  departureDate: string
-
-  departureTime: string
-
   constructor(
     private readonly placement: Cas1SpaceBooking,
     private readonly newDeparture?: Cas1NewDeparture,
     title: string = 'Record a departure',
   ) {
     super(title)
-
-    if (this.newDeparture) {
-      const [isoDate, hours, minutes] = this.newDeparture.departureDateTime.split(/T|:/)
-      this.departureDate = isoDate
-      this.departureTime = `${hours}:${minutes}`
-    }
   }
 
   shouldShowFormAndExpectedDepartureDate(): void {
@@ -35,14 +25,14 @@ export class DepartureNewPage extends Page {
   }
 
   completeForm(reasonId?: string) {
-    this.clearAndCompleteDateInputs('departureDate', this.departureDate)
-    this.clearAndCompleteTextInputById('departureTime', this.departureTime)
+    this.clearAndCompleteDateInputs('departureDate', this.newDeparture.departureDate)
+    this.clearAndCompleteTextInputById('departureTime', this.newDeparture.departureTime)
     this.checkRadioByNameAndValue('reasonId', reasonId || this.newDeparture.reasonId)
   }
 
   shouldShowPopulatedForm(reasonId?: string) {
-    this.dateInputsShouldContainDate('departureDate', this.departureDate)
-    this.verifyTextInputContentsById('departureTime', this.departureTime)
+    this.dateInputsShouldContainDate('departureDate', this.newDeparture.departureDate)
+    this.verifyTextInputContentsById('departureTime', this.newDeparture.departureTime)
     this.verifyRadioInputByName('reasonId', reasonId || this.newDeparture.reasonId)
   }
 

--- a/server/controllers/manage/premises/placements/arrivalsController.ts
+++ b/server/controllers/manage/premises/placements/arrivalsController.ts
@@ -77,7 +77,7 @@ export default class ArrivalsController {
         }
 
         const placementArrival: Cas1NewArrival = {
-          arrivalTime: DateFormats.isoDateTimeToTime(arrivalDateTime),
+          arrivalTime,
           arrivalDate: DateFormats.isoDateTimeToIsoDate(arrivalDateTime),
         }
 

--- a/server/controllers/manage/premises/placements/departuresController.ts
+++ b/server/controllers/manage/premises/placements/departuresController.ts
@@ -361,13 +361,8 @@ export default class DeparturesController {
         }
 
         const placementDeparture: Cas1NewDeparture = {
-          departureDateTime: DateFormats.dateAndTimeInputsToIsoString(
-            {
-              ...departureData,
-              'departureDate-time': departureData.departureTime,
-            } as ObjectWithDateParts<'departureDate'>,
-            'departureDate',
-          ).departureDate,
+          departureDate: departureData.departureDate,
+          departureTime: departureData.departureTime,
           reasonId,
           moveOnCategoryId,
           notes,

--- a/server/testutils/factories/cas1NewDeparture.ts
+++ b/server/testutils/factories/cas1NewDeparture.ts
@@ -1,14 +1,14 @@
 import { Factory } from 'fishery'
 import { Cas1NewDeparture } from '@approved-premises/api'
 import { faker } from '@faker-js/faker'
+import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<Cas1NewDeparture>(() => {
-  const departureDateTime = faker.date.recent({ days: 1 })
-  departureDateTime.setSeconds(0)
-  departureDateTime.setMilliseconds(0)
+  const departureDateTime = faker.date.recent({ days: 1 }).toISOString()
 
   return {
-    departureDateTime: departureDateTime.toISOString(),
+    departureDate: DateFormats.isoDateTimeToIsoDate(departureDateTime),
+    departureTime: DateFormats.isoDateTimeToTime(departureDateTime),
     reasonId: faker.string.uuid(),
     moveOnCategoryId: faker.string.uuid(),
     notes: faker.word.words(),

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -586,16 +586,25 @@ describe('timeIsValid24hrFormat', () => {
 })
 
 describe('dateObjToIsoTime', () => {
-  it.each([
-    ['00:00', 0, 0, 0],
-    ['12:01', 12, 1, 1],
-    ['23:59', 23, 59, 59],
-  ])('returns the iso time part of the date with time like %s', (expected, h, m, s) => {
-    const date = new Date()
-    date.setUTCHours(h)
-    date.setUTCMinutes(m)
-    date.setUTCSeconds(s)
-    expect(DateFormats.dateObjTo24hrTime(date)).toBe(expected)
+  describe.each([
+    ['British Summer Time', '2025-04-01'],
+    ['Greenwich Mean Time (UTC)', '2025-01-01'],
+  ])('during %s', (_, timezoneDate) => {
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date(timezoneDate))
+    })
+
+    it.each([
+      ['00:00', 0, 0, 0],
+      ['12:01', 12, 1, 1],
+      ['23:59', 23, 59, 59],
+    ])('returns the local 24-hour time part of the date with time like %s', (expected, h, m, s) => {
+      const date = new Date()
+      date.setHours(h)
+      date.setMinutes(m)
+      date.setSeconds(s)
+      expect(DateFormats.dateObjTo24hrTime(date)).toBe(expected)
+    })
   })
 })
 


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2172

# Changes in this PR

The switch over to BST has uncovered a couple of bugs with the unit tests, and with the recording of arrivals and departure times. For arrivals, the time was derived from a date reconstructed from both date and time input by the user; this was resulting in the wrong time being set. For departures, the date and time were still sent as one ISO string -- the API is now able to receive separate date and time, similarly to the arrivals, so this has now been switched over tot he same mechanism.

A test for a date utility wasn't explicit with the timezone it was running in: this has also been fixed to ensure clarity and cover both timezones that happen in the UK.

## Screenshots of UI changes

n/a
