### PR TITLE
chore: Improve Record departure test

### DIFF
--- a/e2e/pages/basePage.ts
+++ b/e2e/pages/basePage.ts
@@ -1,5 +1,6 @@
 import { Page, expect } from '@playwright/test'
 import { Premises } from '@approved-premises/api'
+import { faker } from '@faker-js/faker'
 
 export class BasePage {
   constructor(public readonly page: Page) {}
@@ -44,6 +45,17 @@ export class BasePage {
       })
       .getByLabel(label, { exact: true })
       .check()
+  }
+
+  async selectAnyRadioOption(fieldName: string, excludeOptions: Array<string> = []) {
+    const options = (await this.page.locator(`[name="${fieldName}"] + label`).allTextContents())
+      .map(label => label.trim())
+      .filter(label => !excludeOptions.includes(label))
+
+    const optionLabel = faker.helpers.arrayElement(options)
+    await this.checkRadio(optionLabel)
+
+    return optionLabel
   }
 
   async checkCheckBoxes(labels: Array<string> | ReadonlyArray<string>) {

--- a/e2e/pages/manage/recordDeparturePage.ts
+++ b/e2e/pages/manage/recordDeparturePage.ts
@@ -2,7 +2,6 @@ import { Page, expect } from '@playwright/test'
 import { addHours } from 'date-fns'
 import { faker } from '@faker-js/faker'
 import { BasePage } from '../basePage'
-import { BREACH_OR_RECALL_REASON_ID, PLANNED_MOVE_ON_REASON_ID } from '../../../server/utils/placements'
 import { DateFormats } from '../../../server/utils/dateUtils'
 
 export class RecordDeparturePage extends BasePage {
@@ -20,18 +19,22 @@ export class RecordDeparturePage extends BasePage {
     await this.fillDateField({ year, month, day })
     await this.fillField('What is the time of departure?', `${hours}:${minutes}`)
 
-    const reasons = (
-      await this.page
-        .locator(
-          `[name="reasonId"]:not([value="${BREACH_OR_RECALL_REASON_ID}"]):not([value="${PLANNED_MOVE_ON_REASON_ID}"]) + label`,
-        )
-        .allTextContents()
-    ).map(label => label.trim())
-    const reason = faker.helpers.arrayElement(reasons)
-
-    await this.checkRadio(reason)
-
+    const reason = await this.selectAnyRadioOption('reasonId')
     await this.clickContinue()
+
+    let breachOrRecallReason: string
+
+    if (await this.page.getByText('Breach or recall').isVisible()) {
+      breachOrRecallReason = await this.selectAnyRadioOption('breachOrRecallReasonId')
+      await this.clickContinue()
+    }
+
+    let moveOnCategory: string
+
+    if (await this.page.getByText('Move on').isVisible()) {
+      moveOnCategory = await this.selectAnyRadioOption('moveOnCategoryId', ['Transferred to different AP'])
+      await this.clickContinue()
+    }
 
     const notes = faker.word.words(10)
 
@@ -39,6 +42,6 @@ export class RecordDeparturePage extends BasePage {
 
     await this.clickSubmit()
 
-    return { departureDateTime, reason, notes }
+    return { departureDateTime, reason, breachOrRecallReason, moveOnCategory, notes }
   }
 }

--- a/e2e/steps/manage.ts
+++ b/e2e/steps/manage.ts
@@ -112,7 +112,8 @@ const recordDeparture = async ({ page }: { page: Page }) => {
   const recordDeparturePage = await RecordDeparturePage.initialize(page, 'Record a departure')
 
   // When I record the person as arrived
-  const { departureDateTime, reason, notes } = await recordDeparturePage.recordDeparture()
+  const { departureDateTime, reason, breachOrRecallReason, moveOnCategory, notes } =
+    await recordDeparturePage.recordDeparture()
 
   // Then I should see the placement page with a success banner
   await recordDeparturePage.shouldShowSuccessBanner('You have recorded this person as departed')
@@ -124,5 +125,9 @@ const recordDeparture = async ({ page }: { page: Page }) => {
   )
   await recordDeparturePage.shouldShowSummaryItem('Departure time', DateFormats.timeFromDate(departureDateTime))
   await recordDeparturePage.shouldShowSummaryItem('Departure reason', reason)
+  await recordDeparturePage.shouldShowSummaryItem('Move on', moveOnCategory || 'Not Applicable')
+  if (breachOrRecallReason) {
+    await recordDeparturePage.shouldShowSummaryItem('Breach or recall', breachOrRecallReason)
+  }
   await recordDeparturePage.shouldShowSummaryItem('More information', notes)
 }


### PR DESCRIPTION
The test in question was actively avoiding checking the 'Breach or recall' radio option, to avoid needing more complicated logic for the rest of the test. This however wasn't avoiding some of the options that show the 'Move on' page, resulting in some flaky tests.

The flakiness has been fixed, and the test has been improved by allowing a random radio button to be selected, and acting in the relevant way with further screens being shown.
