### PR TITLE
chore: Remove roles JSON cleanup command

### DIFF
--- a/script/generate-types
+++ b/script/generate-types
@@ -24,7 +24,3 @@ mv ./server/@types/shared/index.ts ./server/@types/shared/index.d.ts
 echo "==> Copying roles to permissions mapping..."
 
 curl -o ./server/utils/users/data/rolesToPermissions.json -s "https://raw.githubusercontent.com/ministryofjustice/hmpps-approved-premises-api/$branch/src/main/resources/static/codegen/built-cas1-roles.json"
-
-echo "==> Tidying up roles to permissions formatting..."
-
-npx prettier --write ./server/utils/users/data/rolesToPermissions.json


### PR DESCRIPTION
The roles to permissions JSON mapping from the API is now formatted in a more useful way for comparing diffs (https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/3281), so there is no need to run this step during the import as well.
