### PR TITLE
Ensure test waits for page load after click

### DIFF
--- a/e2e/pages/manage/recordDeparturePage.ts
+++ b/e2e/pages/manage/recordDeparturePage.ts
@@ -21,12 +21,14 @@ export class RecordDeparturePage extends BasePage {
 
     const reason = await this.selectAnyRadioOption('reasonId')
     await this.clickContinue()
+    await this.page.waitForLoadState()
 
     let breachOrRecallReason: string
 
     if (await this.page.getByText('Breach or recall').isVisible()) {
       breachOrRecallReason = await this.selectAnyRadioOption('breachOrRecallReasonId')
       await this.clickContinue()
+      await this.page.waitForLoadState()
     }
 
     let moveOnCategory: string


### PR DESCRIPTION
The stack is fast enough locally that the steps to check whether 'Breach or recall' or 'Move on' are present on the page always return true when those elements exist on the next page.

However, when running against the dev environment, the latency means that the timeout for checking those elements exist is often reached before the page has time to load, making the runner assume the elements simply do not exist.

This commit enforces a wait for the page load event before attempting to find those elements.

