### PR TITLE
Prevent cancelling of concurrent pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   packages: write


### PR DESCRIPTION
Now that the pipeline.yml workflow is only used when merging, we do not want to cancel any run, even if a newer commit is pushed to main, as we want to retain the ability to deploy each merge commit separately.

Only the 'Test' workflow requires this, as it is useful to cancel a previous run of automated tests on the same Pull Request.