### PR TITLE
CHORE: notify slack on e2e failure

### DIFF
--- a/.github/actions/slack_failure_notification/action.yml
+++ b/.github/actions/slack_failure_notification/action.yml
@@ -1,0 +1,62 @@
+name: 'Slack failure notification'
+description: 'Sends a Slack message to notify of a Github Action failure'
+
+inputs:
+  title:
+    description: "Name of the job that failed."
+    required: true
+  job:
+    description: "Text for the job that failed. Optional. Defaults to the id of the job calling this action."
+    required: false
+  channel_id:
+    description: "Slack channel id to send the notification to."
+    required: true
+  slack_bot_token:
+    description: "Slack bot token"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+      with:
+        channel-id: ${{ inputs.channel_id }}
+        payload: |
+          {
+            "text": "Failed: ${{ inputs.title }} (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})",
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":red_circle: Failed: ${{ inputs.title }}",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Job:*\n${{ inputs.job || github.job }}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Repository:*\n<${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Workflow triggered by:*\n${{ github.actor }}"
+                  }
+                ]
+              }
+            ],
+            "unfurl_links": false,
+            "unfurl_media": false
+          }
+      env:
+        SLACK_BOT_TOKEN: ${{ inputs.slack_bot_token }}

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -70,3 +70,17 @@ jobs:
           path: test-results
           retention-days: 30
           if-no-files-found: ignore
+
+  e2e_test_notify_slack:
+    name: "E2E test failure notification"
+    needs: e2e_test
+    if: ${{ always() && needs.e2e_test.result == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        uses: ministryofjustice/hmpps-approved-premises-ui/.github/actions/slack_failure_notification@main
+        with:
+          title: "CAS1 E2E Tests"
+          job: "e2e_test"
+          channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID }}
+          slack_bot_token: ${{ vars.HMPPS_SRE_SLACK_BOT_TOKEN }}


### PR DESCRIPTION
This PR adds an action to send a notification to Slack for any Github Action failure. This action takes a `title` as input and shows:

- a title of 'Failed: {inputs.title}'
- a link to the failed workflow
- the id of  the failing job (e.g. `build`)
- a link to the project's repository
- the username of the user who triggered the workflow

The E2E tests workflow now has a new job that calls this action. This new job only runs if one or more of the parallel E2E test runs has failed.
