### PR TITLE
Fix slack bot token source

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -83,4 +83,4 @@ jobs:
           title: "CAS1 E2E Tests"
           job: "e2e_test"
           channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID }}
-          slack_bot_token: ${{ vars.HMPPS_SRE_SLACK_BOT_TOKEN }}
+          slack_bot_token: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}


### PR DESCRIPTION
The token is saved as a repository secret, not variable.
