### PR TITLE
APS-2160 Prevent manage actions on cancelled placement

### DIFF
--- a/server/testutils/factories/cas1SpaceBooking.ts
+++ b/server/testutils/factories/cas1SpaceBooking.ts
@@ -3,6 +3,7 @@ import { faker } from '@faker-js/faker'
 import type {
   Cas1KeyWorkerAllocation,
   Cas1SpaceBooking,
+  Cas1SpaceBookingCancellation,
   Cas1SpaceBookingNonArrival,
   Person,
 } from '@approved-premises/api'
@@ -14,6 +15,7 @@ import staffMemberFactory from './staffMember'
 import { DateFormats } from '../../utils/dateUtils'
 import cas1SpaceBookingNonArrivalFactory from './cas1SpaceBookingNonArrival'
 import cas1SpaceBookingDepartureFactory from './cas1SpaceBookingDeparture'
+import cas1NewSpaceBookingCancellationFactory from './cas1NewSpaceBookingCancellation'
 import { departureReasonFactory } from './referenceData'
 import { BREACH_OR_RECALL_REASON_ID, PLANNED_MOVE_ON_REASON_ID } from '../../utils/placements'
 import { filterOutAPTypes } from '../../utils/match'
@@ -83,6 +85,12 @@ class Cas1SpaceBookingFactory extends Factory<Cas1SpaceBooking> {
       }),
     })
   }
+
+  cancelled() {
+    return this.params({
+      cancellation: cas1NewSpaceBookingCancellationFactory.build(),
+    })
+  }
 }
 
 export default Cas1SpaceBookingFactory.define(() => {
@@ -122,5 +130,6 @@ export default Cas1SpaceBookingFactory.define(() => {
     otherBookingsInPremisesForCrn: cas1SpaceBookingDatesFactory.buildList(4),
     deliusEventNumber: String(faker.number.int()),
     nonArrival: undefined as Cas1SpaceBookingNonArrival,
+    cancellation: undefined as Cas1SpaceBookingCancellation,
   }
 })

--- a/server/testutils/factories/cas1SpaceBookingSummary.ts
+++ b/server/testutils/factories/cas1SpaceBookingSummary.ts
@@ -50,6 +50,15 @@ class Cas1SpaceBookingSummaryFactory extends Factory<Cas1SpaceBookingSummary> {
       isNonArrival: true,
     })
   }
+
+  cancelled() {
+    return this.params({
+      actualArrivalDate: undefined,
+      actualDepartureDate: undefined,
+      isNonArrival: false,
+      isCancelled: true,
+    })
+  }
 }
 
 export default Cas1SpaceBookingSummaryFactory.define(() => {
@@ -71,7 +80,7 @@ export default Cas1SpaceBookingSummaryFactory.define(() => {
     actualArrivalDate: arrivedStatuses.includes(status) ? canonicalArrivalDate : undefined,
     actualDepartureDate: status === 'departed' ? canonicalDepartureDate : undefined,
     isNonArrival: status === 'notArrived',
-    isCancelled: status === 'cancelled',
+    isCancelled: false,
     tier: faker.helpers.arrayElement(['A', 'B', 'C']),
     keyWorkerAllocation: cas1KeyworkerAllocationFactory.build(),
     characteristics: faker.helpers.arrayElements(Object.keys(roomCharacteristicMap)) as Array<Cas1SpaceCharacteristic>,

--- a/server/utils/placements/index.test.ts
+++ b/server/utils/placements/index.test.ts
@@ -39,7 +39,7 @@ describe('placementUtils', () => {
       const current = typeFactory.current()
       const departed = typeFactory.departed()
       const nonArrival = typeFactory.nonArrival()
-      const cancelled = cas1SpaceBookingFactory.cancelled()
+      const cancelled = typeFactory.cancelled()
 
       beforeEach(() => {
         jest.useFakeTimers().setSystemTime(new Date('2025-03-01'))

--- a/server/utils/placements/index.test.ts
+++ b/server/utils/placements/index.test.ts
@@ -39,6 +39,7 @@ describe('placementUtils', () => {
       const current = typeFactory.current()
       const departed = typeFactory.departed()
       const nonArrival = typeFactory.nonArrival()
+      const cancelled = cas1SpaceBookingFactory.cancelled()
 
       beforeEach(() => {
         jest.useFakeTimers().setSystemTime(new Date('2025-03-01'))
@@ -110,6 +111,12 @@ describe('placementUtils', () => {
           factory: nonArrival,
           params: {},
           expected: { overall: 'notArrived', detailed: 'notArrived' },
+        },
+        {
+          label: 'a cancelled placement',
+          factory: cancelled,
+          params: { expectedArrivalDate: '2025-05-01' },
+          expected: { overall: 'cancelled', detailed: 'cancelled' },
         },
       ]
 
@@ -252,6 +259,13 @@ describe('placementUtils', () => {
       const placementAfterDeparture = cas1SpaceBookingFactory.departed().build({ id: placementId, premises })
       it('should allow nothing', () => {
         expect(actions(placementAfterDeparture, userDetails)).toEqual(null)
+      })
+    })
+
+    describe('when the placement has been cancelled', () => {
+      const placementCancelled = cas1SpaceBookingFactory.cancelled().build({ id: placementId, premises })
+      it('should allow nothing', () => {
+        expect(actions(placementCancelled, userDetails)).toEqual(null)
       })
     })
   })

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -54,13 +54,11 @@ type SpaceBookingStatus = keyof typeof statusTextMap
 const isSpaceBooking = (placement: Cas1SpaceBooking | Cas1SpaceBookingSummary): placement is Cas1SpaceBooking =>
   Boolean((placement as Cas1SpaceBooking).otherBookingsInPremisesForCrn)
 
-const isCancelled = (placement: Cas1SpaceBooking | Cas1SpaceBookingSummary): boolean =>
-  'isCancelled' in placement ? placement.isCancelled : Boolean(placement.cancellation)
-
 export const overallStatus = (placement: Cas1SpaceBookingSummary | Cas1SpaceBooking): SpaceBookingOverallStatus => {
   const isNonArrival = isSpaceBooking(placement) ? placement.nonArrival : placement.isNonArrival
+  const isCancelled = isSpaceBooking(placement) ? placement.cancellation : placement.isCancelled
 
-  if (isCancelled(placement)) return 'cancelled'
+  if (isCancelled) return 'cancelled'
   if (isNonArrival) return 'notArrived'
   if (placement.actualDepartureDate) return 'departed'
   if (placement.actualArrivalDate) return 'arrived'

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -54,8 +54,8 @@ type SpaceBookingStatus = keyof typeof statusTextMap
 const isSpaceBooking = (placement: Cas1SpaceBooking | Cas1SpaceBookingSummary): placement is Cas1SpaceBooking =>
   Boolean((placement as Cas1SpaceBooking).otherBookingsInPremisesForCrn)
 
-const isCancelled = (placement: Cas1SpaceBooking | Cas1SpaceBookingSummary): placement is Cas1SpaceBooking =>
-  Boolean((placement as Cas1SpaceBooking).cancellation)
+const isCancelled = (placement: Cas1SpaceBooking | Cas1SpaceBookingSummary): boolean =>
+  'isCancelled' in placement ? placement.isCancelled : Boolean(placement.cancellation)
 
 export const overallStatus = (placement: Cas1SpaceBookingSummary | Cas1SpaceBooking): SpaceBookingOverallStatus => {
   const isNonArrival = isSpaceBooking(placement) ? placement.nonArrival : placement.isNonArrival

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -34,6 +34,7 @@ export const overallStatusTextMap = {
   arrived: 'Arrived',
   notArrived: 'Not arrived',
   departed: 'Departed',
+  cancelled: 'Cancelled',
 } as const
 
 export const statusTextMap = {
@@ -53,9 +54,13 @@ type SpaceBookingStatus = keyof typeof statusTextMap
 const isSpaceBooking = (placement: Cas1SpaceBooking | Cas1SpaceBookingSummary): placement is Cas1SpaceBooking =>
   Boolean((placement as Cas1SpaceBooking).otherBookingsInPremisesForCrn)
 
+const isCancelled = (placement: Cas1SpaceBooking | Cas1SpaceBookingSummary): placement is Cas1SpaceBooking =>
+  Boolean((placement as Cas1SpaceBooking).cancellation)
+
 export const overallStatus = (placement: Cas1SpaceBookingSummary | Cas1SpaceBooking): SpaceBookingOverallStatus => {
   const isNonArrival = isSpaceBooking(placement) ? placement.nonArrival : placement.isNonArrival
 
+  if (isCancelled(placement)) return 'cancelled'
   if (isNonArrival) return 'notArrived'
   if (placement.actualDepartureDate) return 'departed'
   if (placement.actualArrivalDate) return 'arrived'
@@ -65,7 +70,7 @@ export const overallStatus = (placement: Cas1SpaceBookingSummary | Cas1SpaceBook
 export const detailedStatus = (placement: Cas1SpaceBookingSummary | Cas1SpaceBooking): SpaceBookingStatus => {
   const status = overallStatus(placement)
 
-  if (['notArrived', 'departed'].includes(status)) return status
+  if (['notArrived', 'departed', 'cancelled'].includes(status)) return status
 
   if (status === 'arrived') {
     const daysFromDeparture = differenceInCalendarDays(placement.expectedDepartureDate, new Date())


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2160

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Adds a 'cancelled' logical status to placements. This means that the action menu on the placement details page is blank as all actions are dependent on specific statuses.

It's impossible to tell if a placement is cancelled from the `Cas1SpaceBookingSummary` hence there is a bit of a bodge in the status tests that test all statuses for both a `Cas1SpaceBooking` and `Cas1SpaceBookingSummary` but I thought it better to stick with the structure.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes
Both screenshots are of the same cancelled placement - as accessed through `timeline` from the CRU dashboard.

<details>
  <summary>Before</summary>
<img src="https://github.com/user-attachments/assets/b58fa3ad-b76b-4af0-95a1-471ac43e2629"/>
</details>

<details>
  <summary>After</summary>
<img src="https://github.com/user-attachments/assets/49570b60-d619-4ea9-99f4-55ac1bec5f74"/>
</details>

