### PR TITLE
Fix reference to build step to get app_version

### DIFF
--- a/.github/workflows/deploy_to_test.yml
+++ b/.github/workflows/deploy_to_test.yml
@@ -21,4 +21,4 @@ jobs:
     secrets: inherit
     with:
       environment: 'test'
-      app_version: '${{ needs.build.outputs.app_version }}'
+      app_version: '${{ needs.docker_build.outputs.app_version }}'


### PR DESCRIPTION
For the 'Deploy to test' workflow, this was incorrectly set to `build` -- in this workflow, the build step is called `docker_build`.
