### PR TITLE
Fix e2e tests - appeals

### DIFF
--- a/e2e/pages/workflow/listPage.ts
+++ b/e2e/pages/workflow/listPage.ts
@@ -45,7 +45,7 @@ export class ListPage extends PaginatedPage {
     expect(actualDeadlineInDays).toBeLessThanOrEqual(expectedDeadlineInDays + 4)
 
     if (user) {
-      await expect(row.locator('td').nth(1)).toContainText(user)
+      await expect(row.locator('td').nth(2)).toContainText(user)
     }
   }
 


### PR DESCRIPTION
# Context

# Changes in this PR

Changes column index to get correct user column on appeals table after insertion of arrival date.

<!-- [x] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

No change
