### PR TITLE
APS-2139 Fix assessment duration override

### DIFF
--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -87,16 +87,28 @@ describe('MatchingInformation', () => {
       })
     })
 
-    it('should add an error if lengthOfStayAgreed is no and the details are not provided', () => {
-      const page = new MatchingInformation(
-        { ...defaultArguments, lengthOfStayAgreed: 'no', lengthOfStayWeeks: null, lengthOfStayDays: null },
-        assessment,
-      )
+    it.each([
+      ['1', undefined, true],
+      ['1', '', true],
+      ['-1', '5', true],
+      ['7', '0', false],
+    ])(
+      'if lengthOfStayAgreed is "no", weeks is "%s" and days is "%s" it should error %s',
+      (weeks: string, days: string, shouldError: boolean) => {
+        const page = new MatchingInformation(
+          { ...defaultArguments, lengthOfStayAgreed: 'no', lengthOfStayWeeks: weeks, lengthOfStayDays: days },
+          assessment,
+        )
 
-      expect(page.errors()).toEqual({
-        lengthOfStay: 'You must provide a recommended length of stay',
-      })
-    })
+        expect(page.errors()).toEqual(
+          shouldError
+            ? {
+                lengthOfStay: 'You must provide a recommended length of stay in whole weeks and days',
+              }
+            : {},
+        )
+      },
+    )
 
     it("should return an error if the type is not available for a women's application", () => {
       const page = new MatchingInformation({ ...defaultArguments, apType: 'isMHAPElliottHouse' }, weAssessment)
@@ -135,8 +147,7 @@ describe('MatchingInformation', () => {
         {
           ...defaultArguments,
           lengthOfStayAgreed: 'no',
-          lengthOfStayDays: '5',
-          lengthOfStayWeeks: '5',
+          lengthOfStay: '40',
         },
         assessment,
       )

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -2,14 +2,10 @@ import { applicationFactory, assessmentFactory } from '../../../../testutils/fac
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 
 import MatchingInformation, { MatchingInformationBody } from './matchingInformation'
-import {
-  defaultMatchingInformationValues,
-  suggestedStaySummaryListOptions,
-} from '../../../utils/matchingInformationUtils'
+import * as matchingInformtionUtils from '../../../utils/matchingInformationUtils'
 
 jest.mock('../../../../utils/assessments/placementDurationFromApplication')
 jest.mock('../../../../utils/retrieveQuestionResponseFromFormArtifact')
-jest.mock('../../../utils/matchingInformationUtils')
 
 const assessment = assessmentFactory.build({
   application: applicationFactory.build({ isWomensApplication: false }),
@@ -62,7 +58,9 @@ describe('MatchingInformation', () => {
 
   describe('body', () => {
     it('should set the body', () => {
-      ;(defaultMatchingInformationValues as jest.Mock).mockReturnValue(defaultMatchingInformationValuesReturnValue)
+      jest
+        .spyOn(matchingInformtionUtils, 'defaultMatchingInformationValues')
+        .mockReturnValue(defaultMatchingInformationValuesReturnValue)
 
       const page = new MatchingInformation(defaultArguments, assessment)
 
@@ -75,8 +73,10 @@ describe('MatchingInformation', () => {
   itShouldHavePreviousValue(new MatchingInformation(defaultArguments, assessment), 'dashboard')
 
   describe('errors', () => {
-    it('should have an error if there is no answers', () => {
-      ;(defaultMatchingInformationValues as jest.Mock).mockReturnValue(defaultMatchingInformationValuesReturnValue)
+    it('should have an error if there are no answers', () => {
+      jest
+        .spyOn(matchingInformtionUtils, 'defaultMatchingInformationValues')
+        .mockReturnValue(defaultMatchingInformationValuesReturnValue)
 
       const page = new MatchingInformation({}, assessment)
 
@@ -88,8 +88,8 @@ describe('MatchingInformation', () => {
     })
 
     it.each([
-      ['1', undefined, true],
-      ['1', '', true],
+      ['1', undefined, false],
+      ['1', '', false],
       ['-1', '5', true],
       ['7', '0', false],
     ])(
@@ -103,7 +103,7 @@ describe('MatchingInformation', () => {
         expect(page.errors()).toEqual(
           shouldError
             ? {
-                lengthOfStay: 'You must provide a recommended length of stay in whole weeks and days',
+                lengthOfStay: 'You must provide a recommended length of stay',
               }
             : {},
         )
@@ -147,7 +147,8 @@ describe('MatchingInformation', () => {
         {
           ...defaultArguments,
           lengthOfStayAgreed: 'no',
-          lengthOfStay: '40',
+          lengthOfStayWeeks: '5',
+          lengthOfStayDays: '4',
         },
         assessment,
       )
@@ -155,7 +156,7 @@ describe('MatchingInformation', () => {
       const response = page.response()
 
       expect(response['Do you agree with the suggested length of stay?']).toEqual('No')
-      expect(response['Recommended length of stay']).toEqual('5 weeks, 5 days')
+      expect(response['Recommended length of stay']).toEqual('5 weeks, 4 days')
     })
   })
 
@@ -169,10 +170,11 @@ describe('MatchingInformation', () => {
           { key: { text: 'Dates of placement' }, value: { text: 'formatted dates of placement' } },
         ],
       }
-      ;(suggestedStaySummaryListOptions as jest.Mock).mockReturnValue(utilsReturnValue)
+      const mockSuggestedStaySummaryListOptions = jest.spyOn(matchingInformtionUtils, 'suggestedStaySummaryListOptions')
+      mockSuggestedStaySummaryListOptions.mockReturnValue(utilsReturnValue)
 
       expect(page.suggestedStaySummaryListOptions).toEqual(utilsReturnValue)
-      expect(suggestedStaySummaryListOptions).toHaveBeenLastCalledWith(assessment.application)
+      expect(mockSuggestedStaySummaryListOptions).toHaveBeenLastCalledWith(assessment.application)
     })
   })
 

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
@@ -3,13 +3,14 @@ import type { SummaryList, TaskListErrors, YesOrNo } from '@approved-premises/ui
 import { ApprovedPremisesAssessment as Assessment } from '@approved-premises/api'
 import {
   defaultMatchingInformationValues,
+  lengthOfStay,
   suggestedStaySummaryListOptions,
 } from '../../../utils/matchingInformationUtils'
 import { DateFormats, daysToWeeksAndDays } from '../../../../utils/dateUtils'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
-import { isCardinal, lowerCase, sentenceCase } from '../../../../utils/utils'
+import { lowerCase, sentenceCase } from '../../../../utils/utils'
 import {
   type ApTypeCriteria,
   type ApTypeSpecialist,
@@ -54,7 +55,6 @@ export type MatchingInformationBody = {
     'lengthOfStayAgreed',
     'lengthOfStayWeeks',
     'lengthOfStayDays',
-    'lengthOfStay',
     'cruInformation',
     ...placementRequirementCriteria,
     ...offenceAndRiskCriteria,
@@ -143,7 +143,7 @@ export default class MatchingInformation implements TasklistPage {
     response['Do you agree with the suggested length of stay?'] = sentenceCase(this.body.lengthOfStayAgreed)
 
     if (this.body.lengthOfStayAgreed === 'no') {
-      response['Recommended length of stay'] = DateFormats.formatDuration(daysToWeeksAndDays(this.body.lengthOfStay), [
+      response['Recommended length of stay'] = DateFormats.formatDuration(daysToWeeksAndDays(lengthOfStay(this.body)), [
         'weeks',
         'days',
       ])
@@ -183,8 +183,8 @@ export default class MatchingInformation implements TasklistPage {
     }
 
     if (this.body.lengthOfStayAgreed === 'no') {
-      if (!isCardinal(this.body.lengthOfStayWeeks) || !isCardinal(this.body.lengthOfStayDays)) {
-        errors.lengthOfStay = 'You must provide a recommended length of stay in whole weeks and days'
+      if (!(Number(lengthOfStay(this.body)) > 0)) {
+        errors.lengthOfStay = 'You must provide a recommended length of stay'
       }
     }
 

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
@@ -5,11 +5,11 @@ import {
   defaultMatchingInformationValues,
   suggestedStaySummaryListOptions,
 } from '../../../utils/matchingInformationUtils'
-import { DateFormats } from '../../../../utils/dateUtils'
+import { DateFormats, daysToWeeksAndDays } from '../../../../utils/dateUtils'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
-import { lowerCase, sentenceCase } from '../../../../utils/utils'
+import { isCardinal, lowerCase, sentenceCase } from '../../../../utils/utils'
 import {
   type ApTypeCriteria,
   type ApTypeSpecialist,
@@ -143,10 +143,10 @@ export default class MatchingInformation implements TasklistPage {
     response['Do you agree with the suggested length of stay?'] = sentenceCase(this.body.lengthOfStayAgreed)
 
     if (this.body.lengthOfStayAgreed === 'no') {
-      response['Recommended length of stay'] = DateFormats.formatDuration({
-        weeks: this.body.lengthOfStayWeeks,
-        days: this.body.lengthOfStayDays,
-      })
+      response['Recommended length of stay'] = DateFormats.formatDuration(daysToWeeksAndDays(this.body.lengthOfStay), [
+        'weeks',
+        'days',
+      ])
     }
 
     if (this.body.cruInformation) {
@@ -182,8 +182,10 @@ export default class MatchingInformation implements TasklistPage {
       errors.lengthOfStayAgreed = 'You must state if you agree with the length of the stay'
     }
 
-    if (this.body.lengthOfStayAgreed === 'no' && !this.body.lengthOfStayWeeks && !this.body.lengthOfStayDays) {
-      errors.lengthOfStay = 'You must provide a recommended length of stay'
+    if (this.body.lengthOfStayAgreed === 'no') {
+      if (!isCardinal(this.body.lengthOfStayWeeks) || !isCardinal(this.body.lengthOfStayDays)) {
+        errors.lengthOfStay = 'You must provide a recommended length of stay in whole weeks and days'
+      }
     }
 
     return errors

--- a/server/form-pages/utils/matchingInformationUtils.test.ts
+++ b/server/form-pages/utils/matchingInformationUtils.test.ts
@@ -100,14 +100,7 @@ describe('matchingInformationUtils', () => {
         .calledWith(application, SelectApType, 'type')
         .mockReturnValue('pipe')
 
-      const body: MatchingInformationBody = {
-        ...bodyWithUndefinedValues,
-        lengthOfStayAgreed: 'no',
-        lengthOfStayDays: '3',
-        lengthOfStayWeeks: '3',
-      }
-
-      expect(defaultMatchingInformationValues(body, application)).toEqual({
+      expect(defaultMatchingInformationValues(bodyWithUndefinedValues, application)).toEqual({
         acceptsChildSexOffenders: 'relevant',
         acceptsHateCrimeOffenders: 'relevant',
         acceptsNonSexualChildOffenders: 'relevant',
@@ -119,7 +112,6 @@ describe('matchingInformationUtils', () => {
         isSuitableForVulnerable: 'relevant',
         isSuitedForSexOffenders: 'essential',
         isWheelchairDesignated: 'essential',
-        lengthOfStay: '24',
       })
     })
 
@@ -462,47 +454,6 @@ describe('matchingInformationUtils', () => {
           },
         }
         expect(remapArsonAssessmentData(assessmentData)).toEqual(assessmentData)
-      })
-    })
-
-    describe('lengthOfStay', () => {
-      it('is set to `undefined` when `lengthOfStayAgreed` is undefined', () => {
-        expect(defaultMatchingInformationValues({ ...bodyWithUndefinedValues }, application)).toEqual(
-          expect.objectContaining({ lengthOfStay: undefined }),
-        )
-      })
-
-      it("is set to `undefined` when `lengthOfStayAgreed` === 'yes'", () => {
-        expect(
-          defaultMatchingInformationValues({ ...bodyWithUndefinedValues, lengthOfStayAgreed: 'yes' }, application),
-        ).toEqual(expect.objectContaining({ lengthOfStay: undefined }))
-      })
-
-      it("is set to `undefined` when `lengthOfStayAgreed` === 'no' but `lengthOfStayDays` is undefined", () => {
-        expect(
-          defaultMatchingInformationValues(
-            { ...bodyWithUndefinedValues, lengthOfStayAgreed: 'no', lengthOfStayDays: undefined },
-            application,
-          ),
-        ).toEqual(expect.objectContaining({ lengthOfStay: undefined }))
-      })
-
-      it("is set to `undefined` when `lengthOfStayAgreed` === 'no' and `lengthOfStayDays` is defined but `lengthOfStayWeeks` is not", () => {
-        expect(
-          defaultMatchingInformationValues(
-            { ...bodyWithUndefinedValues, lengthOfStayAgreed: 'no', lengthOfStayWeeks: undefined },
-            application,
-          ),
-        ).toEqual(expect.objectContaining({ lengthOfStay: undefined }))
-      })
-
-      it("is set to the total length of stay in days when `lengthOfStayAgreed` === 'no' and both `lengthOfStayDays` and `lengthOfStayWeeks` are defined", () => {
-        expect(
-          defaultMatchingInformationValues(
-            { ...bodyWithUndefinedValues, lengthOfStayAgreed: 'no', lengthOfStayDays: '3', lengthOfStayWeeks: '3' },
-            application,
-          ),
-        ).toEqual(expect.objectContaining({ lengthOfStay: '24' }))
       })
     })
   })

--- a/server/form-pages/utils/matchingInformationUtils.ts
+++ b/server/form-pages/utils/matchingInformationUtils.ts
@@ -25,6 +25,7 @@ import { OffenceAndRiskCriteria, PlacementRequirementCriteria } from '../../util
 import SelectApType from '../apply/reasons-for-placement/type-of-ap/apType'
 import PlacementDate from '../apply/reasons-for-placement/basic-information/placementDate'
 import ReleaseDate from '../apply/reasons-for-placement/basic-information/releaseDate'
+import { isCardinal } from '../../utils/utils'
 
 export interface TaskListPageField {
   name: string
@@ -58,11 +59,17 @@ const apType = (
   return applyAssessMap[applyValue]
 }
 
-const lengthOfStay = (body: MatchingInformationBody): string | undefined => {
-  if (body.lengthOfStayAgreed === 'no' && body.lengthOfStayDays && body.lengthOfStayWeeks) {
-    const lengthOfStayWeeksInDays = weeksToDays(Number(body.lengthOfStayWeeks))
-    const totalLengthInDays = lengthOfStayWeeksInDays + Number(body.lengthOfStayDays)
+export const lengthOfStay = ({
+  lengthOfStayWeeks,
+  lengthOfStayDays,
+  lengthOfStayAgreed,
+}: MatchingInformationBody): string | undefined => {
+  if (lengthOfStayAgreed === 'no') {
+    if ((lengthOfStayWeeks && !isCardinal(lengthOfStayWeeks)) || (lengthOfStayDays && !isCardinal(lengthOfStayDays)))
+      return undefined
 
+    const lengthOfStayWeeksInDays = weeksToDays(Number(lengthOfStayWeeks || 0))
+    const totalLengthInDays = lengthOfStayWeeksInDays + Number(lengthOfStayDays || 0)
     return String(totalLengthInDays)
   }
 
@@ -219,7 +226,6 @@ const defaultMatchingInformationValues = (
       'essential',
       'notRelevant',
     ),
-    lengthOfStay: lengthOfStay(body),
   }
 }
 

--- a/server/testutils/mockQuestionResponse.ts
+++ b/server/testutils/mockQuestionResponse.ts
@@ -92,7 +92,6 @@ export const mockOptionalQuestionResponse = ({
   isExceptionalCase,
   shouldPersonBePlacedInMaleAp,
   agreedCaseWithManager,
-  lengthOfStay,
   cruInformation,
   pssDate,
   situation,
@@ -116,7 +115,6 @@ export const mockOptionalQuestionResponse = ({
   reviewRequired?: string
   hasBoardTakenPlace?: string
   agreedCaseWithManager?: string
-  lengthOfStay?: string
   cruInformation?: string
   pssDate?: string
   situation?: string
@@ -174,10 +172,6 @@ export const mockOptionalQuestionResponse = ({
 
       if (question === 'agreedCaseWithManager') {
         return agreedCaseWithManager
-      }
-
-      if (question === 'lengthOfStay') {
-        return lengthOfStay
       }
 
       if (question === 'cruInformation') {

--- a/server/utils/assessments/acceptanceData.test.ts
+++ b/server/utils/assessments/acceptanceData.test.ts
@@ -87,8 +87,11 @@ describe('acceptanceData', () => {
 
     it('should return the placement dates if an arrival date is provided', () => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(expectedArrival)
-
-      mockOptionalQuestionResponse({ lengthOfStay: '12' })
+      ;(pageDataFromApplicationOrAssessment as jest.Mock).mockReturnValue({
+        lengthOfStayWeeks: '1',
+        lengthOfStayDays: '5',
+        lengthOfStayAgreed: 'no',
+      })
 
       const result = placementDates(assessment)
 
@@ -96,11 +99,10 @@ describe('acceptanceData', () => {
       expect(result.duration).toEqual(12)
     })
 
-    it('should return the default duration if a duration is not provided', () => {
+    it('should return the duration from the application if a duration is not provided', () => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(expectedArrival)
       ;(placementDurationFromApplication as jest.Mock).mockReturnValueOnce('52')
-
-      mockOptionalQuestionResponse({ lengthOfStay: undefined })
+      ;(pageDataFromApplicationOrAssessment as jest.Mock).mockReturnValue({ lengthOfStayAgreed: 'yes' })
 
       const result = placementDates(assessment)
 
@@ -124,7 +126,6 @@ describe('acceptanceData', () => {
 
       mockQuestionResponse({ postcodeArea: 'ABC123', type: 'normal', duration: '12' })
       mockOptionalQuestionResponse({
-        lengthOfStay: '12',
         alternativeRadius: '100',
       })
 

--- a/server/utils/assessments/acceptanceData.ts
+++ b/server/utils/assessments/acceptanceData.ts
@@ -29,6 +29,7 @@ import { placementDurationFromApplication } from './placementDurationFromApplica
 import { getResponses } from '../applications/getResponses'
 import ApplicationTimeliness from '../../form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness'
 import type { ApplicationTimelinessBody } from '../../form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness'
+import { lengthOfStay } from '../../form-pages/utils/matchingInformationUtils'
 
 export const acceptanceData = (assessment: Assessment): AssessmentAcceptance => {
   const notes = retrieveOptionalQuestionResponseFromFormArtifact(assessment, MatchingInformation, 'cruInformation')
@@ -51,7 +52,7 @@ export const placementDates = (assessment: Assessment): PlacementDates | null =>
   }
 
   const placementDuration =
-    retrieveOptionalQuestionResponseFromFormArtifact(assessment, MatchingInformation, 'lengthOfStay') ||
+    lengthOfStay(pageDataFromApplicationOrAssessment(MatchingInformation, assessment)) ||
     placementDurationFromApplication(assessment.application)
 
   return {

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -357,6 +357,7 @@ describe('joinWithCommas', () => {
 describe('isCardinal', () => {
   it.each([
     ['1', true],
+    [' 2 ', true],
     ['0', true],
     ['1234567890', true],
     ['-1', false],

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -5,6 +5,7 @@ import {
   camelCase,
   convertToTitleCase,
   initialiseName,
+  isCardinal,
   joinWithCommas,
   linebreaksToParagraphs,
   linkTo,
@@ -350,5 +351,20 @@ describe('joinWithCommas', () => {
     [[], ''],
   ])('joins %s giving %s', (list: Array<string>, expected: string) => {
     expect(joinWithCommas(list)).toEqual(expected)
+  })
+})
+
+describe('isCardinal', () => {
+  it.each([
+    ['1', true],
+    ['0', true],
+    ['1234567890', true],
+    ['-1', false],
+    ['1.1', false],
+    ['', false],
+    [' ', false],
+    ['1a', false],
+  ])('tests "%s" giving %s', (str, expected) => {
+    expect(isCardinal(str)).toBe(expected)
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -221,5 +221,5 @@ export const joinWithCommas = (arr: Array<string>): string => {
  * @return true iff string is cardinal
  */
 export const isCardinal = (str: string): boolean => {
-  return /^\d+$/.test(str)
+  return /^\s*\d+\s*$/.test(str)
 }

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -214,3 +214,12 @@ export const joinWithCommas = (arr: Array<string>): string => {
   if (arr.length <= 1) return arr[0] || ''
   return `${arr.slice(0, arr.length - 1).join(', ')} and ${arr[arr.length - 1]}`
 }
+
+/**
+ * Return true if a string contains a cardinal number (including 0)
+ * @param str string to test
+ * @return true iff string is cardinal
+ */
+export const isCardinal = (str: string): boolean => {
+  return /^\d+$/.test(str)
+}

--- a/server/views/components/formFields/form-page-day-weeks-input/macro.njk
+++ b/server/views/components/formFields/form-page-day-weeks-input/macro.njk
@@ -24,7 +24,7 @@
     {% if context.errors[fieldName] %}
       <p id="{{ fieldname }}-error" class="govuk-error-message" data-cy-error-{{ fieldname }}="true">
         <span class="govuk-visually-hidden">Error:</span>
-        {{ context.errors[fieldname].text }}
+        {{ context.errors[fieldName].text }}
       </p>
     {% endif %}
 

--- a/server/views/components/formFields/form-page-day-weeks-input/macro.njk
+++ b/server/views/components/formFields/form-page-day-weeks-input/macro.njk
@@ -22,7 +22,7 @@
  %}
 
     {% if context.errors[fieldName] %}
-      <p id="{{ fieldname }}-error" class="govuk-error-message" data-cy-error-{{ fieldname }}="true">
+      <p id="{{ fieldName }}-error" class="govuk-error-message" data-cy-error-{{ fieldName }}="true">
         <span class="govuk-visually-hidden">Error:</span>
         {{ context.errors[fieldName].text }}
       </p>


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2139

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- Fixes the bug in the linked ticket. 
- In the assessment form, users are forced to enter a valid non-zero duration comprised of weeks or days. One of the input boxes can be left empty. Populated fields however must contain valid cardinal numbers. The 'day' box is not limited in magnitude so it's still possible to enter say '0' weeks and '54' days since it's possible that some users may prefer this and so the functionality should not be removed.
- Submission of the matchingDetails form no longer saves a `lengthOfStay` as a calculated day duration.
- The 'check your answers' page now displays the duration formatted from the as-entered `lengthOfStayWeeks` and `lengthOfStayDays`. 
- On submission, the day duration is calculated and written to a first-class field `duration`. This field drives the booking process.
- The error message on failing to enter valid numbers was updated. Also, there was a typo in the week/day input macro that prevented the error message from displaying so that was fixed also.
- Several tests failed because the test files mocked whole modules and, as a side effect, broke the functionality being tested. These have been refactored to leave non-mocked functions alone.


<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

<details>
  <summary>Validation errors</summary>
<img src="https://github.com/user-attachments/assets/800a922c-dd0d-425c-9068-0b932133dcba"/>
<img src="https://github.com/user-attachments/assets/cae96651-f4e6-43f1-a43a-8f7e43ada115"/>
<img src="https://github.com/user-attachments/assets/c520f945-3992-4f02-bd43-c1d4198ebf43"/>
</details>

