### PR TITLE
APS-2267 - Booking changed timeline fixes

### DIFF
--- a/server/utils/timeline.test.ts
+++ b/server/utils/timeline.test.ts
@@ -43,24 +43,27 @@ describe('timeline utilities', () => {
       describe('if there is no schema version', () => {
         it('renders a basic description of changes', () => {
           const timelineEvent = cas1TimelineEventFactory.build({
-            type: 'booking_changed',
             payload: cas1TimelineEventContentPayloadFactory.build({
               type: 'booking_changed',
               premises: {
                 name: premises.name,
                 id: premises.id,
               },
+              expectedArrival: '2025-09-18',
+              expectedDeparture: '2025-12-18',
               schemaVersion: undefined,
-              arrivalOn: '2025-04-17',
-              departureOn: '2025-06-21',
+              previousExpectedArrival: null,
+              previousExpectedDeparture: null,
+              characteristics: null,
+              previousCharacteristics: null,
             } as Cas1TimelineEventContentPayload),
           })
 
           const result = renderTimelineEventContent(timelineEvent)
 
-          expect(result).toEqual(
-            `The placement at ${premises.name} had its arrival and/or departure date changed to Thu 17 Apr 2025 to Sat 21 Jun 2025.`,
-          )
+          expect(result).toMatchStringIgnoringWhitespace(`
+            <p class="govuk-body">The placement at ${premises.name} had its arrival and/or departure dates changed to Thu 18 Sep 2025 to Thu 18 Dec 2025.</p>
+          `)
         })
       })
 

--- a/server/views/partials/timelineEvents/booking_changed.njk
+++ b/server/views/partials/timelineEvents/booking_changed.njk
@@ -1,15 +1,1 @@
-<p class="govuk-body">The placement at {{ premises.name }} has been changed:</p>
-<ul class="govuk-list govuk-list--bullet">
-    {% if previousExpectedArrival %}
-        <li>Arrival date changed from {{ previousExpectedArrival }} to {{ expectedArrival }}</li>
-    {% endif %}
-    {% if previousExpectedDeparture %}
-        <li>Departure date changed from {{ previousExpectedDeparture }} to {{ expectedDeparture }}</li>
-    {% endif %}
-    {% if previousCharacteristics %}
-        <li>Room criteria changed from {{ previousCharacteristics }} to {{ characteristics }}</li>
-    {% endif %}
-    {% if not previousExpectedArrival and not previousExpectedDeparture and not previousCharacteristics %}
-        <li>No change</li>
-    {% endif %}
-</ul>
+<p class="govuk-body">The placement at {{ premises.name }} had its arrival and/or departure dates changed to {{ expectedArrival }} to {{ expectedDeparture }}.</p>

--- a/server/views/partials/timelineEvents/booking_changed_v2.njk
+++ b/server/views/partials/timelineEvents/booking_changed_v2.njk
@@ -1,0 +1,15 @@
+<p class="govuk-body">The placement at {{ premises.name }} has been changed:</p>
+<ul class="govuk-list govuk-list--bullet">
+    {% if previousExpectedArrival %}
+        <li>Arrival date changed from {{ previousExpectedArrival }} to {{ expectedArrival }}</li>
+    {% endif %}
+    {% if previousExpectedDeparture %}
+        <li>Departure date changed from {{ previousExpectedDeparture }} to {{ expectedDeparture }}</li>
+    {% endif %}
+    {% if previousCharacteristics %}
+        <li>Room criteria changed from {{ previousCharacteristics }} to {{ characteristics }}</li>
+    {% endif %}
+    {% if not previousExpectedArrival and not previousExpectedDeparture and not previousCharacteristics %}
+        <li>No change</li>
+    {% endif %}
+</ul>


### PR DESCRIPTION
Whilst there was logic before this commit to render the booking changed timeline using structured data when the payload schemaVersion is null, the API was not populating the payload so the code was unused.

The API will start populating the payload in the near future using the same schema expected for V2 schema versions, allowing us to simplify the UI code

This PR is safe to go live immediately as the API doesn't currently return a payload for null schema version

Screenshots from when the API _is_ populating the payload for null schema version

# schema version null

![Screenshot 2025-05-02 at 09 35 37](https://github.com/user-attachments/assets/b3e08234-ab48-49b7-b320-6eba4df5faad)

# schema version 2

![Screenshot 2025-05-02 at 09 35 55](https://github.com/user-attachments/assets/5e3a1ee3-2646-491e-8c35-e84d145d9960)