### PR TITLE
CHORE: remove unnecessary date utils

### DIFF
--- a/server/controllers/manage/premises/placements/arrivalsController.ts
+++ b/server/controllers/manage/premises/placements/arrivalsController.ts
@@ -1,16 +1,11 @@
 import { type Request, RequestHandler, type Response } from 'express'
 import { Cas1NewArrival } from '@approved-premises/api'
+import { isPast, isToday } from 'date-fns'
 import { PremisesService } from '../../../../services'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../../utils/validation'
 import PlacementService from '../../../../services/placementService'
 import paths from '../../../../paths/manage'
-import {
-  DateFormats,
-  dateAndTimeInputsAreValidDates,
-  dateIsToday,
-  datetimeIsInThePast,
-  timeIsValid24hrFormat,
-} from '../../../../utils/dateUtils'
+import { DateFormats, dateAndTimeInputsAreValidDates, timeIsValid24hrFormat } from '../../../../utils/dateUtils'
 import { ValidationError } from '../../../../utils/errors'
 
 export default class ArrivalsController {
@@ -65,8 +60,8 @@ export default class ArrivalsController {
         }
 
         if (!Object.keys(errors).length) {
-          if (!datetimeIsInThePast(arrivalDateTime)) {
-            if (dateIsToday(arrivalDateTime)) {
+          if (!isPast(arrivalDateTime)) {
+            if (isToday(arrivalDateTime)) {
               errors.arrivalTime = 'The time of arrival must be in the past'
             } else errors.arrivalDateTime = 'The date of arrival must be today or in the past'
           }

--- a/server/controllers/manage/premises/placements/transfersController.ts
+++ b/server/controllers/manage/premises/placements/transfersController.ts
@@ -1,5 +1,5 @@
 import type { Request, RequestHandler, Response } from 'express'
-import { addDays } from 'date-fns'
+import { addDays, isBefore } from 'date-fns'
 import { TransferFormData } from '@approved-premises/ui'
 import { Cas1NewEmergencyTransfer } from '@approved-premises/api'
 import { Params } from 'static-path'
@@ -7,12 +7,7 @@ import { PlacementService, PremisesService } from '../../../../services'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../../utils/validation'
 import managePaths from '../../../../paths/manage'
 import { ValidationError } from '../../../../utils/errors'
-import {
-  dateAndTimeInputsAreValidDates,
-  DateFormats,
-  dateIsToday,
-  datetimeIsInThePast,
-} from '../../../../utils/dateUtils'
+import { dateAndTimeInputsAreValidDates, DateFormats } from '../../../../utils/dateUtils'
 import MultiPageFormManager from '../../../../utils/multiPageFormManager'
 import { allApprovedPremisesOptions, transferSummaryList } from '../../../../utils/placements/transfers'
 
@@ -60,7 +55,7 @@ export default class TransfersController {
       const oneWeekAgo = DateFormats.dateObjToIsoDate(addDays(new Date(), -7))
       const tomorrow = DateFormats.dateObjToIsoDate(addDays(new Date(), 1))
 
-      if (datetimeIsInThePast(transferDate, oneWeekAgo) || !datetimeIsInThePast(transferDate, tomorrow)) {
+      if (isBefore(transferDate, oneWeekAgo) || !isBefore(transferDate, tomorrow)) {
         errors.transferDate = 'The date of transfer must be today or in the last 7 days'
       }
     }
@@ -142,7 +137,7 @@ export default class TransfersController {
     } else {
       const { transferDate } = this.formData.get(req.params.placementId, req.session)
 
-      if (datetimeIsInThePast(placementEndDate, transferDate) || dateIsToday(placementEndDate, transferDate)) {
+      if (isBefore(placementEndDate, transferDate) || placementEndDate === transferDate) {
         errors.placementEndDate = `The placement end date must be after the transfer date, ${DateFormats.isoDateToUIDate(transferDate, { format: 'short' })}`
       }
     }

--- a/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/placementDate.ts
@@ -5,13 +5,7 @@ import { isAfter, isSameDay } from 'date-fns'
 import { retrieveOptionalQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 import TasklistPage from '../../../tasklistPage'
 import { convertToTitleCase } from '../../../../utils/utils'
-import {
-  DateFormats,
-  dateAndTimeInputsAreValidDates,
-  dateIsBlank,
-  dateIsToday,
-  datetimeIsInThePast,
-} from '../../../../utils/dateUtils'
+import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank, dateIsPast } from '../../../../utils/dateUtils'
 import { Page } from '../../../utils/decorators'
 import ReleaseDate from './releaseDate'
 import { dateBodyProperties } from '../../../utils/dateBodyProperties'
@@ -126,7 +120,7 @@ export default class PlacementDate implements TasklistPage {
         errors.startDate = 'You must enter a start date'
       } else if (!dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'startDate'>, 'startDate')) {
         errors.startDate = 'The start date is an invalid date'
-      } else if (!dateIsToday(this.body.startDate) && datetimeIsInThePast(this.body.startDate)) {
+      } else if (dateIsPast(this.body.startDate)) {
         errors.startDate = 'The start date must not be in the past'
       }
     }

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -10,8 +10,6 @@ import {
   bankHolidays,
   dateAndTimeInputsAreValidDates,
   dateIsBlank,
-  dateIsToday,
-  datetimeIsInThePast,
   daysToWeeksAndDays,
   isoDateAndTimeToDateObj,
   monthOptions,
@@ -481,82 +479,6 @@ describe('dateIsBlank', () => {
     }
 
     expect(dateIsBlank(date, 'field')).toEqual(false)
-  })
-})
-
-describe('datetimeIsInThePast', () => {
-  beforeEach(() => {
-    jest.useFakeTimers().setSystemTime(new Date('2022-01-01'))
-  })
-
-  afterEach(() => {
-    jest.useRealTimers()
-  })
-
-  it('returns true if the date is in the past', () => {
-    expect(datetimeIsInThePast('2020-01-01')).toEqual(true)
-  })
-
-  it('returns false if the date is not in the past', () => {
-    expect(datetimeIsInThePast('2024-01-01')).toEqual(false)
-  })
-
-  it('returns false if the date is today', () => {
-    expect(datetimeIsInThePast('2022-01-01')).toEqual(false)
-  })
-
-  it('returns true if the date is before the provided reference date', () => {
-    expect(datetimeIsInThePast('2024-01-01', '2024-03-14')).toEqual(true)
-  })
-
-  it('returns false if the date is after the provided reference date', () => {
-    expect(datetimeIsInThePast('2024-01-01', '2023-01-12')).toEqual(false)
-  })
-
-  it('returns false if the date is the same as the reference date', () => {
-    expect(datetimeIsInThePast('2023-01-12', '2023-01-12')).toEqual(false)
-  })
-
-  it('handles UTC to BST conversion', () => {
-    expect(datetimeIsInThePast('2023-04-01T12:00', '2023-04-01T11:01:00.000Z')).toEqual(true)
-  })
-})
-
-describe('dateIsToday', () => {
-  beforeEach(() => {
-    jest.useFakeTimers().setSystemTime(new Date('2022-04-01'))
-  })
-
-  afterEach(() => {
-    jest.useRealTimers()
-  })
-
-  it('returns true if the date is today', () => {
-    expect(dateIsToday('2022-04-01')).toEqual(true)
-  })
-
-  it('returns false if the date is not today', () => {
-    expect(dateIsToday('2022-04-02')).toEqual(false)
-  })
-
-  it('returns true if the date is the same as the reference date', () => {
-    expect(dateIsToday('2022-04-28', '2022-04-28')).toEqual(true)
-  })
-
-  it('returns true if the date is the same as the reference date with different time', () => {
-    expect(dateIsToday('2022-04-28T09:30', '2022-04-28T13:45')).toEqual(true)
-  })
-
-  it('returns false if the date is not the same as the reference date', () => {
-    expect(dateIsToday('2022-01-01', '2022-05-21')).toEqual(false)
-  })
-
-  it('returns true if the local date is the same as the UTC reference date', () => {
-    expect(dateIsToday('2022-04-02', '2022-04-01T23:30:00.000Z')).toEqual(true)
-  })
-
-  it('returns true if the dates compared are both UTC but different times', () => {
-    expect(dateIsToday('2022-04-01T12:00:00.000Z', '2022-04-01T22:00:00.000Z')).toEqual(true)
   })
 })
 

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -8,7 +8,6 @@ import {
   formatDuration,
   formatISO,
   isBefore,
-  isPast,
   isValid,
   isWeekend,
   isWithinInterval,
@@ -299,23 +298,8 @@ export const dateIsBlank = <K extends string | number>(
   return !['year' as const, 'month' as const, 'day' as const].every(part => !!dateInputObj[`${key}-${part}`])
 }
 
-export const datetimeIsInThePast = (dateString: string, refDateString?: string): boolean => {
-  const date = DateFormats.isoToDateObj(dateString)
-
-  if (refDateString) {
-    const refDate = DateFormats.isoToDateObj(refDateString)
-    return isBefore(date, refDate)
-  }
-
-  return isPast(date)
-}
-
-export const dateIsToday = (date: string, refDate?: string): boolean => {
-  const dateIso = DateFormats.dateObjToIsoDate(DateFormats.isoToDateObj(date))
-  const refDateIso = DateFormats.dateObjToIsoDate(refDate ? DateFormats.isoToDateObj(refDate) : new Date())
-
-  return dateIso === refDateIso
-}
+export const dateIsPast = (date: string | number | Date): boolean =>
+  isBefore(date, DateFormats.dateObjToIsoDate(new Date()))
 
 export const monthOptions = [
   { name: 'January', value: '1' },

--- a/server/utils/match/validateSpaceBooking.ts
+++ b/server/utils/match/validateSpaceBooking.ts
@@ -1,5 +1,6 @@
 import type { ObjectWithDateParts } from '@approved-premises/ui'
-import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank, datetimeIsInThePast } from '../dateUtils'
+import { isBefore } from 'date-fns'
+import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank } from '../dateUtils'
 
 export const validateSpaceBooking = (body: ObjectWithDateParts<string>): Record<string, string> => {
   const errors: Record<string, string> = {}
@@ -27,7 +28,7 @@ export const validateSpaceBooking = (body: ObjectWithDateParts<string>): Record<
       'departureDate',
     )
     const textArrivalDate = actualArrivalDate || arrivalDate
-    if (datetimeIsInThePast(departureDate, textArrivalDate) || departureDate === textArrivalDate) {
+    if (isBefore(departureDate, textArrivalDate) || departureDate === textArrivalDate) {
       errors.departureDate = 'The departure date must be after the arrival date'
     }
   }


### PR DESCRIPTION
The date-fns utilities `isBefore`, `isPast` and `isToday` are sufficient
for most date comparisons, so `datetimeIsInThePast` and `dateIsToday`
can be removed.

A single new utility is added, `dateIsPast`, as date-fns does not
provide for assessing whether a single date is in the past -- passing an
ISO date (with no time) to `isPast` returns true on teh same day, as the
comparison is made between now and the turn of the day.

## TODO
- [x] rebase on main once #2478 has been merged