### PR TITLE
Fix emergency transfer factory

### DIFF
--- a/server/testutils/factories/cas1NewEmergencyTransfer.ts
+++ b/server/testutils/factories/cas1NewEmergencyTransfer.ts
@@ -1,11 +1,10 @@
 import { Factory } from 'fishery'
 import type { Cas1NewEmergencyTransfer } from '@approved-premises/api'
 import { faker } from '@faker-js/faker'
-import { addDays } from 'date-fns'
 import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<Cas1NewEmergencyTransfer>(() => ({
   destinationPremisesId: faker.string.uuid(),
-  arrivalDate: DateFormats.dateObjToIsoDate(addDays(faker.date.recent({ days: 8 }), 1)),
+  arrivalDate: DateFormats.dateObjToIsoDate(faker.date.recent({ days: 7 })),
   departureDate: DateFormats.dateObjToIsoDate(faker.date.future()),
 }))


### PR DESCRIPTION
The `faker.date.recent` function may return a datetime on the current day, so there is no need to add a day to create a valid arrival date -- doing so may result in tomorrow being returned instead, which would fail the integration test!
