### PR TITLE
Dateutils - use spread to silence vulnerability alert

### DIFF
--- a/server/form-pages/apply/add-documents/attachDocuments.ts
+++ b/server/form-pages/apply/add-documents/attachDocuments.ts
@@ -3,6 +3,7 @@ import { DataServices, type PageResponse, TaskListErrors } from '@approved-premi
 import { Page } from '../../utils/decorators'
 
 import TasklistPage from '../../tasklistPage'
+import { objectFilter } from '../../../utils/utils'
 
 const maxDocumentsToUpload = 5
 
@@ -17,8 +18,8 @@ type AttachDocumentsResponse = {
   documentDescriptions?: Record<string, string>
   otherDocumentDetails?: string
 }
-
-@Page({ name: 'attach-documents', bodyProperties: ['selectedDocuments', 'otherDocumentDetails'] })
+const bodyProperties = ['selectedDocuments', 'otherDocumentDetails']
+@Page({ name: 'attach-documents', bodyProperties })
 export default class AttachDocuments implements TasklistPage {
   title = 'Select any relevant documents to support your application'
 
@@ -50,7 +51,7 @@ export default class AttachDocuments implements TasklistPage {
             }
           })
 
-    const page = new AttachDocuments({ ...body, selectedDocuments }, application)
+    const page = new AttachDocuments({ ...objectFilter(body, bodyProperties), selectedDocuments }, application)
     page.documents = documents
 
     return page

--- a/server/form-pages/apply/reasons-for-placement/basic-information/exceptionDetails.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/exceptionDetails.ts
@@ -4,7 +4,7 @@ import { Page } from '../../../utils/decorators'
 import { DateFormats, dateAndTimeInputsAreValidDates } from '../../../../utils/dateUtils'
 
 import TasklistPage from '../../../tasklistPage'
-import { dateBodyInputProperties } from '../../../utils/dateBodyProperties'
+import { dateBodyProperties } from '../../../utils/dateBodyProperties'
 
 export type ExceptionDetailsBody = ObjectWithDateParts<'agreementDate'> & {
   agreedCaseWithManager: YesOrNo
@@ -14,12 +14,7 @@ export type ExceptionDetailsBody = ObjectWithDateParts<'agreementDate'> & {
 
 @Page({
   name: 'exception-details',
-  bodyProperties: [
-    'agreedCaseWithManager',
-    'managerName',
-    ...dateBodyInputProperties('agreementDate'),
-    'agreementSummary',
-  ],
+  bodyProperties: ['agreedCaseWithManager', 'managerName', ...dateBodyProperties('agreementDate'), 'agreementSummary'],
   mergeBody: true,
 })
 export default class ExceptionDetails implements TasklistPage {

--- a/server/form-pages/apply/reasons-for-placement/basic-information/exceptionDetails.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/exceptionDetails.ts
@@ -4,6 +4,7 @@ import { Page } from '../../../utils/decorators'
 import { DateFormats, dateAndTimeInputsAreValidDates } from '../../../../utils/dateUtils'
 
 import TasklistPage from '../../../tasklistPage'
+import { dateBodyInputProperties } from '../../../utils/dateBodyProperties'
 
 export type ExceptionDetailsBody = ObjectWithDateParts<'agreementDate'> & {
   agreedCaseWithManager: YesOrNo
@@ -16,12 +17,10 @@ export type ExceptionDetailsBody = ObjectWithDateParts<'agreementDate'> & {
   bodyProperties: [
     'agreedCaseWithManager',
     'managerName',
-    'agreementDate',
-    'agreementDate-year',
-    'agreementDate-month',
-    'agreementDate-day',
+    ...dateBodyInputProperties('agreementDate'),
     'agreementSummary',
   ],
+  mergeBody: true,
 })
 export default class ExceptionDetails implements TasklistPage {
   title = 'Provide details for exemption application'

--- a/server/form-pages/apply/reasons-for-placement/basic-information/relevantDates.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/relevantDates.ts
@@ -25,10 +25,9 @@ export type RelevantDateLabels = RelevantDatesT[RelevantDateKeys]
 export type RelevantDatesBody = {
   selectedDates: ReadonlyArray<RelevantDateKeys>
 } & ObjectWithDateParts<RelevantDateKeys>
-
 @Page({
   name: 'relevant-dates',
-  bodyProperties: [...relevantDateKeys.map(key => dateBodyProperties(key)).flat(), 'selectedDates'],
+  bodyProperties: [...relevantDateKeys.map(key => [...dateBodyProperties(key), key]).flat(), 'selectedDates'],
 })
 export default class RelevantDates implements TasklistPage {
   title = 'Which of the following dates are relevant?'
@@ -50,7 +49,7 @@ export default class RelevantDates implements TasklistPage {
     this._body = {} as RelevantDatesBody
     this._body.selectedDates = value.selectedDates || []
     this._body.selectedDates.forEach((selectedDate: RelevantDateKeys) => {
-      dateBodyProperties(selectedDate).forEach(element => {
+      ;[...dateBodyProperties(selectedDate), selectedDate].forEach(element => {
         this._body[element] = value[element]
       })
     })

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapExceptionalCase.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapExceptionalCase.ts
@@ -4,7 +4,7 @@ import { Page } from '../../../utils/decorators'
 import { DateFormats, dateAndTimeInputsAreValidDates } from '../../../../utils/dateUtils'
 
 import TasklistPage from '../../../tasklistPage'
-import { dateBodyInputProperties } from '../../../utils/dateBodyProperties'
+import { dateBodyProperties } from '../../../utils/dateBodyProperties'
 
 export type EsapExceptionalCaseBody = ObjectWithDateParts<'agreementDate'> & {
   agreedCaseWithCommunityHopp: YesOrNo
@@ -17,7 +17,7 @@ export type EsapExceptionalCaseBody = ObjectWithDateParts<'agreementDate'> & {
   bodyProperties: [
     'agreedCaseWithCommunityHopp',
     'communityHoppName',
-    ...dateBodyInputProperties('agreementDate'),
+    ...dateBodyProperties('agreementDate'),
     'agreementSummary',
   ],
   mergeBody: true,

--- a/server/form-pages/apply/reasons-for-placement/type-of-ap/esapExceptionalCase.ts
+++ b/server/form-pages/apply/reasons-for-placement/type-of-ap/esapExceptionalCase.ts
@@ -4,6 +4,7 @@ import { Page } from '../../../utils/decorators'
 import { DateFormats, dateAndTimeInputsAreValidDates } from '../../../../utils/dateUtils'
 
 import TasklistPage from '../../../tasklistPage'
+import { dateBodyInputProperties } from '../../../utils/dateBodyProperties'
 
 export type EsapExceptionalCaseBody = ObjectWithDateParts<'agreementDate'> & {
   agreedCaseWithCommunityHopp: YesOrNo
@@ -16,12 +17,10 @@ export type EsapExceptionalCaseBody = ObjectWithDateParts<'agreementDate'> & {
   bodyProperties: [
     'agreedCaseWithCommunityHopp',
     'communityHoppName',
-    'agreementDate',
-    'agreementDate-year',
-    'agreementDate-month',
-    'agreementDate-day',
+    ...dateBodyInputProperties('agreementDate'),
     'agreementSummary',
   ],
+  mergeBody: true,
 })
 export default class EsapExceptionalCase implements TasklistPage {
   title =

--- a/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/pregnancy.ts
+++ b/server/form-pages/apply/risk-and-need-factors/access-and-healthcare/pregnancy.ts
@@ -11,6 +11,7 @@ import { Page } from '../../../utils/decorators'
 import { DateFormats } from '../../../../utils/dateUtils'
 import { sentenceCase } from '../../../../utils/utils'
 import { yesNoOrDontKnowResponseWithDetail, yesOrNoResponseWithDetailForYes } from '../../../utils'
+import { dateBodyProperties } from '../../../utils/dateBodyProperties'
 
 export type PregnancyBody = {
   childRemoved?: YesOrNo | 'decisionPending'
@@ -21,10 +22,7 @@ export type PregnancyBody = {
 @Page({
   name: 'pregnancy',
   bodyProperties: [
-    'expectedDeliveryDate',
-    'expectedDeliveryDate-year',
-    'expectedDeliveryDate-month',
-    'expectedDeliveryDate-day',
+    ...dateBodyProperties('expectedDeliveryDate'),
     'socialCareInvolvement',
     'socialCareInvolvementDetail',
     'childRemoved',
@@ -49,13 +47,10 @@ export default class Pregnancy implements TasklistPage {
   public set body(value: Partial<PregnancyBody>) {
     this._body = {
       ...value,
-      'expectedDeliveryDate-year': value['expectedDeliveryDate-year'] as string,
-      'expectedDeliveryDate-month': value['expectedDeliveryDate-month'] as string,
-      'expectedDeliveryDate-day': value['expectedDeliveryDate-day'] as string,
-      expectedDeliveryDate: DateFormats.dateAndTimeInputsToIsoString(
+      ...DateFormats.dateAndTimeInputsToIsoString(
         value as ObjectWithDateParts<'expectedDeliveryDate'>,
         'expectedDeliveryDate',
-      ).expectedDeliveryDate,
+      ),
     }
   }
 

--- a/server/form-pages/assess/assessApplication/requiredActions/requiredActions.test.ts
+++ b/server/form-pages/assess/assessApplication/requiredActions/requiredActions.test.ts
@@ -32,7 +32,7 @@ describe('RequiredActions', () => {
         additionalRecommendations: 'yes',
         additionalRecommendationsComments: '',
         nameOfAreaManager: 'frank',
-        dateOfDiscussion: '2023-2-1',
+        dateOfDiscussion: '2023-01-02',
         'dateOfDiscussion-year': '2023',
         'dateOfDiscussion-month': '1',
         'dateOfDiscussion-day': '2',

--- a/server/form-pages/assess/assessApplication/requiredActions/requiredActions.ts
+++ b/server/form-pages/assess/assessApplication/requiredActions/requiredActions.ts
@@ -5,7 +5,7 @@ import { Page } from '../../../utils/decorators'
 import TasklistPage from '../../../tasklistPage'
 import { responsesForYesNoAndCommentsSections } from '../../../utils/index'
 import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../../utils/dateUtils'
-import { dateBodyInputProperties } from '../../../utils/dateBodyProperties'
+import { dateBodyProperties } from '../../../utils/dateBodyProperties'
 
 export type RequiredActionsSections = {
   additionalActions: string
@@ -26,7 +26,7 @@ export type RequiredActionsSections = {
     'additionalRecommendations',
     'additionalRecommendationsComments',
     'nameOfAreaManager',
-    ...dateBodyInputProperties('dateOfDiscussion'),
+    ...dateBodyProperties('dateOfDiscussion'),
     'outlineOfDiscussion',
   ],
   mergeBody: true,

--- a/server/form-pages/assess/assessApplication/requiredActions/requiredActions.ts
+++ b/server/form-pages/assess/assessApplication/requiredActions/requiredActions.ts
@@ -5,7 +5,7 @@ import { Page } from '../../../utils/decorators'
 import TasklistPage from '../../../tasklistPage'
 import { responsesForYesNoAndCommentsSections } from '../../../utils/index'
 import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../../utils/dateUtils'
-import { dateBodyProperties } from '../../../utils/dateBodyProperties'
+import { dateBodyInputProperties } from '../../../utils/dateBodyProperties'
 
 export type RequiredActionsSections = {
   additionalActions: string
@@ -26,9 +26,10 @@ export type RequiredActionsSections = {
     'additionalRecommendations',
     'additionalRecommendationsComments',
     'nameOfAreaManager',
-    ...dateBodyProperties('dateOfDiscussion'),
+    ...dateBodyInputProperties('dateOfDiscussion'),
     'outlineOfDiscussion',
   ],
+  mergeBody: true,
 })
 export default class RequiredActions implements TasklistPage {
   name = 'required-actions'
@@ -65,10 +66,7 @@ export default class RequiredActions implements TasklistPage {
     } & Partial<ObjectWithDateParts<'dateOfDiscussion'>>,
   ) {
     this.body = {
-      dateOfDiscussion: DateFormats.dateAndTimeInputsToIsoString(
-        body as ObjectWithDateParts<'dateOfDiscussion'>,
-        'dateOfDiscussion',
-      ).dateOfDiscussion,
+      ...DateFormats.dateAndTimeInputsToIsoString(body as ObjectWithDateParts<'dateOfDiscussion'>, 'dateOfDiscussion'),
       ...this.body,
     }
   }

--- a/server/form-pages/placement-application/request-a-placement/additionalDocuments.ts
+++ b/server/form-pages/placement-application/request-a-placement/additionalDocuments.ts
@@ -3,6 +3,7 @@ import { DataServices, TaskListErrors } from '@approved-premises/ui'
 import { Page } from '../../utils/decorators'
 
 import TasklistPage from '../../tasklistPage'
+import { objectFilter } from '../../../utils/utils'
 
 const maxDocumentsToUpload = 5
 
@@ -18,7 +19,8 @@ type AdditionalDocumentsResponse = {
   otherDocumentDetails?: string
 }
 
-@Page({ name: 'additional-documents', bodyProperties: ['selectedDocuments', 'otherDocumentDetails'] })
+const bodyProperties: Array<string> = ['selectedDocuments', 'otherDocumentDetails']
+@Page({ name: 'additional-documents', bodyProperties })
 export default class AdditionalDocuments implements TasklistPage {
   title = 'Select any additional documents that are required to support your application'
 
@@ -53,7 +55,10 @@ export default class AdditionalDocuments implements TasklistPage {
             }
           })
 
-    const page = new AdditionalDocuments({ ...body, selectedDocuments }, placementApplication)
+    const page = new AdditionalDocuments(
+      { ...objectFilter(body, bodyProperties), selectedDocuments },
+      placementApplication,
+    )
     page.documents = documents
     page.application = application
 

--- a/server/form-pages/placement-application/request-a-placement/additionalPlacementDetails.ts
+++ b/server/form-pages/placement-application/request-a-placement/additionalPlacementDetails.ts
@@ -4,6 +4,7 @@ import type { ObjectWithDateParts, TaskListErrors } from '@approved-premises/ui'
 import TasklistPage from '../../tasklistPage'
 import { Page } from '../../utils/decorators'
 import { DateFormats, dateAndTimeInputsAreValidDates } from '../../../utils/dateUtils'
+import { dateBodyProperties } from '../../utils/dateBodyProperties'
 
 export type Body = {
   duration: string
@@ -14,16 +15,7 @@ export type Body = {
 
 @Page({
   name: 'additional-placement-details',
-  bodyProperties: [
-    'arrivalDate',
-    'arrivalDate-day',
-    'arrivalDate-month',
-    'arrivalDate-year',
-    'duration',
-    'durationDays',
-    'durationWeeks',
-    'reason',
-  ],
+  bodyProperties: [...dateBodyProperties('arrivalDate'), 'duration', 'durationDays', 'durationWeeks', 'reason'],
 })
 export default class AdditionalPlacementDetails implements TasklistPage {
   title = 'Placement details'
@@ -38,13 +30,7 @@ export default class AdditionalPlacementDetails implements TasklistPage {
 
   get body() {
     return {
-      'arrivalDate-year': this._body['arrivalDate-year'],
-      'arrivalDate-month': this._body['arrivalDate-month'],
-      'arrivalDate-day': this._body['arrivalDate-day'],
-      arrivalDate: DateFormats.dateAndTimeInputsToIsoString(
-        this._body as ObjectWithDateParts<'arrivalDate'>,
-        'arrivalDate',
-      ).arrivalDate,
+      ...DateFormats.dateAndTimeInputsToIsoString(this._body as ObjectWithDateParts<'arrivalDate'>, 'arrivalDate'),
       durationDays: this._body.durationDays,
       durationWeeks: this._body.durationWeeks,
       duration: this.lengthInDays(),

--- a/server/form-pages/placement-application/request-a-placement/decisionToRelease.test.ts
+++ b/server/form-pages/placement-application/request-a-placement/decisionToRelease.test.ts
@@ -6,7 +6,6 @@ import { DateFormats } from '../../../utils/dateUtils'
 
 describe('DecisionToRelease', () => {
   const body = {
-    duration: '12',
     informationFromDirectionToRelease: 'Some information',
     'decisionToReleaseDate-year': '2023',
     'decisionToReleaseDate-month': '12',

--- a/server/form-pages/placement-application/request-a-placement/decisionToRelease.ts
+++ b/server/form-pages/placement-application/request-a-placement/decisionToRelease.ts
@@ -11,12 +11,13 @@ export type Body = {
 @Page({
   name: 'decision-to-release',
   bodyProperties: [
-    'decisionToReleaseDate',
+    // 'decisionToReleaseDate',
     'decisionToReleaseDate-day',
     'decisionToReleaseDate-month',
     'decisionToReleaseDate-year',
     'informationFromDirectionToRelease',
   ],
+  mergeBody: true,
 })
 export default class DecisionToRelease implements TasklistPage {
   title = 'Release details'

--- a/server/form-pages/placement-application/request-a-placement/decisionToRelease.ts
+++ b/server/form-pages/placement-application/request-a-placement/decisionToRelease.ts
@@ -3,6 +3,7 @@ import type { ObjectWithDateParts, TaskListErrors } from '@approved-premises/ui'
 import TasklistPage from '../../tasklistPage'
 import { Page } from '../../utils/decorators'
 import { DateFormats, dateAndTimeInputsAreValidDates } from '../../../utils/dateUtils'
+import { dateBodyProperties } from '../../utils/dateBodyProperties'
 
 export type Body = {
   informationFromDirectionToRelease: string
@@ -10,13 +11,7 @@ export type Body = {
 
 @Page({
   name: 'decision-to-release',
-  bodyProperties: [
-    // 'decisionToReleaseDate',
-    'decisionToReleaseDate-day',
-    'decisionToReleaseDate-month',
-    'decisionToReleaseDate-year',
-    'informationFromDirectionToRelease',
-  ],
+  bodyProperties: [...dateBodyProperties('decisionToReleaseDate'), 'informationFromDirectionToRelease'],
   mergeBody: true,
 })
 export default class DecisionToRelease implements TasklistPage {
@@ -32,14 +27,10 @@ export default class DecisionToRelease implements TasklistPage {
 
   constructor(_body: Body) {
     this.body = {
-      'decisionToReleaseDate-year': _body['decisionToReleaseDate-year'],
-      'decisionToReleaseDate-month': _body['decisionToReleaseDate-month'],
-      'decisionToReleaseDate-day': _body['decisionToReleaseDate-day'],
-      decisionToReleaseDate: DateFormats.dateAndTimeInputsToIsoString(
+      ...DateFormats.dateAndTimeInputsToIsoString(
         _body as ObjectWithDateParts<'decisionToReleaseDate'>,
         'decisionToReleaseDate',
-      ).decisionToReleaseDate,
-
+      ),
       informationFromDirectionToRelease: _body.informationFromDirectionToRelease,
     }
   }

--- a/server/form-pages/placement-application/request-a-placement/previousRotlPlacement.ts
+++ b/server/form-pages/placement-application/request-a-placement/previousRotlPlacement.ts
@@ -15,13 +15,13 @@ export type Body = ObjectWithDateParts<'lastPlacementDate'> & {
   name: 'previous-rotl-placement',
   bodyProperties: [
     'previousRotlPlacement',
-    'lastPlacementDate',
     'lastPlacementDate-year',
     'lastPlacementDate-month',
     'lastPlacementDate-day',
     'lastAp',
     'details',
   ],
+  mergeBody: true,
 })
 export default class PreviousRotlPlacement implements TasklistPage {
   title = 'Previous ROTL placements'

--- a/server/form-pages/placement-application/request-a-placement/previousRotlPlacement.ts
+++ b/server/form-pages/placement-application/request-a-placement/previousRotlPlacement.ts
@@ -4,6 +4,7 @@ import TasklistPage from '../../tasklistPage'
 import { Page } from '../../utils/decorators'
 import { DateFormats, dateAndTimeInputsAreValidDates } from '../../../utils/dateUtils'
 import { sentenceCase } from '../../../utils/utils'
+import { dateBodyProperties } from '../../utils/dateBodyProperties'
 
 export type Body = ObjectWithDateParts<'lastPlacementDate'> & {
   previousRotlPlacement: YesOrNo
@@ -13,14 +14,7 @@ export type Body = ObjectWithDateParts<'lastPlacementDate'> & {
 
 @Page({
   name: 'previous-rotl-placement',
-  bodyProperties: [
-    'previousRotlPlacement',
-    'lastPlacementDate-year',
-    'lastPlacementDate-month',
-    'lastPlacementDate-day',
-    'lastAp',
-    'details',
-  ],
+  bodyProperties: ['previousRotlPlacement', ...dateBodyProperties('lastPlacementDate'), 'lastAp', 'details'],
   mergeBody: true,
 })
 export default class PreviousRotlPlacement implements TasklistPage {
@@ -39,13 +33,10 @@ export default class PreviousRotlPlacement implements TasklistPage {
     this.body = {
       previousRotlPlacement: _body.previousRotlPlacement,
       lastAp: _body.lastAp,
-      'lastPlacementDate-year': _body['lastPlacementDate-year'],
-      'lastPlacementDate-month': _body['lastPlacementDate-month'],
-      'lastPlacementDate-day': _body['lastPlacementDate-day'],
-      lastPlacementDate: DateFormats.dateAndTimeInputsToIsoString(
+      ...DateFormats.dateAndTimeInputsToIsoString(
         _body as ObjectWithDateParts<'lastPlacementDate'>,
         'lastPlacementDate',
-      ).lastPlacementDate,
+      ),
       details: _body.details,
     }
   }

--- a/server/form-pages/utils/dateBodyProperties.test.ts
+++ b/server/form-pages/utils/dateBodyProperties.test.ts
@@ -2,6 +2,6 @@ import { dateBodyProperties } from './dateBodyProperties'
 
 describe('dateBodyProperties', () => {
   it('returns date field names for use in page body properties', () => {
-    expect(dateBodyProperties('someDate')).toEqual(['someDate', 'someDate-year', 'someDate-month', 'someDate-day'])
+    expect(dateBodyProperties('someDate')).toEqual(['someDate-year', 'someDate-month', 'someDate-day'])
   })
 })

--- a/server/form-pages/utils/dateBodyProperties.ts
+++ b/server/form-pages/utils/dateBodyProperties.ts
@@ -1,9 +1,5 @@
 import { ObjectWithDateParts } from '@approved-premises/ui'
 
 export const dateBodyProperties = <K extends string>(root: K): Array<keyof ObjectWithDateParts<K>> => {
-  return [root, `${root}-year`, `${root}-month`, `${root}-day`]
-}
-
-export const dateBodyInputProperties = <K extends string>(root: K): Array<keyof ObjectWithDateParts<K>> => {
   return [`${root}-year`, `${root}-month`, `${root}-day`]
 }

--- a/server/form-pages/utils/dateBodyProperties.ts
+++ b/server/form-pages/utils/dateBodyProperties.ts
@@ -3,3 +3,7 @@ import { ObjectWithDateParts } from '@approved-premises/ui'
 export const dateBodyProperties = <K extends string>(root: K): Array<keyof ObjectWithDateParts<K>> => {
   return [root, `${root}-year`, `${root}-month`, `${root}-day`]
 }
+
+export const dateBodyInputProperties = <K extends string>(root: K): Array<keyof ObjectWithDateParts<K>> => {
+  return [`${root}-year`, `${root}-month`, `${root}-day`]
+}

--- a/server/form-pages/utils/decorators/page.decorator.test.ts
+++ b/server/form-pages/utils/decorators/page.decorator.test.ts
@@ -55,4 +55,31 @@ describe('tasklistPageDecorator', () => {
 
     expect(classWithApplication.application).toEqual(application)
   })
+
+  it(`overwrites body with child constructor's body if mergeBody not set`, () => {
+    @Page({
+      bodyProperties: ['named'],
+      name: 'Some Name',
+    })
+    class TestClass {
+      constructor(readonly body: Record<string, unknown>) {}
+    }
+
+    const testClass = new TestClass({ named: 1, inherited: 2 })
+    expect(testClass.body).toEqual({ named: 1 })
+  })
+
+  it(`merges body with child constructor's body if mergeBody set`, () => {
+    @Page({
+      bodyProperties: ['named'],
+      name: 'Some Name',
+      mergeBody: true,
+    })
+    class TestClass {
+      constructor(readonly body: Record<string, unknown>) {}
+    }
+
+    const testClass = new TestClass({ named: 1, inherited: 2 })
+    expect(testClass.body).toEqual({ named: 1, inherited: 2 })
+  })
 })

--- a/server/form-pages/utils/decorators/page.decorator.ts
+++ b/server/form-pages/utils/decorators/page.decorator.ts
@@ -4,7 +4,12 @@ import 'reflect-metadata'
 
 type Constructor = new (...args: Array<any>) => object
 
-const Page = (options: { bodyProperties: Array<string>; name: string; controllerActions?: { update: string } }) => {
+const Page = (options: {
+  bodyProperties: Array<string>
+  name: string
+  controllerActions?: { update: string }
+  mergeBody?: boolean
+}) => {
   return <T extends Constructor>(constructor: T) => {
     const TaskListPage = class extends constructor {
       name = options.name
@@ -17,7 +22,11 @@ const Page = (options: { bodyProperties: Array<string>; name: string; controller
         super(...args)
         const [body, document] = args
 
-        this.body = this.createBody(body, ...options.bodyProperties)
+        if (options.mergeBody) {
+          this.body = { ...(this.body || {}), ...this.createBody(body, ...options.bodyProperties) }
+        } else {
+          this.body = this.createBody(body, ...options.bodyProperties)
+        }
         this.document = document
       }
 

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -123,28 +123,24 @@ export class DateFormats {
     dateInputObj: ObjectWithDateParts<K>,
     key: K,
   ): ObjectWithDateParts<K> {
-    // Validate the key to prevent prototype pollution
-    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
-      throw new Error(`Invalid key: ${key}`)
-    }
-
     const day = dateInputObj[`${key}-day`] && `0${dateInputObj[`${key}-day`]}`.slice(-2)
     const month = dateInputObj[`${key}-month`] && `0${dateInputObj[`${key}-month`]}`.slice(-2)
     const year = dateInputObj[`${key}-year`]
     const time = dateInputObj[`${key}-time`] && `0${dateInputObj[`${key}-time`]}`.slice(-5)
 
-    const o: { [P in K]?: string } = dateInputObj
+    let isoDate: string
     if (day && month && year) {
       if (time) {
-        o[key] = `${year}-${month}-${day}T${time}`
+        isoDate = `${year}-${month}-${day}T${time}`
       } else {
-        o[key] = `${year}-${month}-${day}`
+        isoDate = `${year}-${month}-${day}`
       }
-    } else {
-      o[key] = undefined
     }
 
-    return dateInputObj
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      throw new Error(`Invalid property ${key}`)
+    }
+    return { ...dateInputObj, [key]: isoDate }
   }
 
   /**

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -223,3 +223,12 @@ export const joinWithCommas = (arr: Array<string>): string => {
 export const isCardinal = (str: string): boolean => {
   return /^\s*\d+\s*$/.test(str)
 }
+
+export const objectFilter = (obj: Record<string, unknown>, fields: Array<string>) => {
+  return Object.entries(obj).reduce((out, [key, value]) => {
+    if (fields.includes(key)) {
+      return { ...out, [key]: value }
+    }
+    return out
+  }, {})
+}


### PR DESCRIPTION
# Context

Change dateutils to use a spread operator to avoid prototype pollution vulnerability alerts. 


No functional change
