### PR TITLE
Fix E2E tests - side effects on manage/departure

### DIFF
--- a/e2e/pages/assess/assessPage.ts
+++ b/e2e/pages/assess/assessPage.ts
@@ -9,15 +9,14 @@ export class AssessPage extends BasePage {
     return new AssessPage(page)
   }
 
-  checkListOfRequirements(
+  async checkListOfRequirements(
     requirements: Array<string>,
     relevancy: 'essential' | 'desirable' | 'notRelevant' | 'relevant',
   ) {
-    return Promise.all(
-      requirements.map(async requirement => {
-        await this.checkRequirement(requirement, relevancy)
-      }),
-    )
+    for (const requirement of requirements) {
+      // eslint-disable-next-line no-await-in-loop
+      await this.checkRequirement(requirement, relevancy)
+    }
   }
 
   async checkRequirement(requirement: string, status: string) {

--- a/server/controllers/manage/premises/placements/departuresController.ts
+++ b/server/controllers/manage/premises/placements/departuresController.ts
@@ -99,11 +99,7 @@ export default class DeparturesController {
   private newErrors(body: DepartureFormData, placement: Cas1SpaceBooking): DepartureFormErrors | null {
     const errors: DepartureFormErrors = {}
 
-    const { departureTime, reasonId } = body
-    const { departureDate } = DateFormats.dateAndTimeInputsToIsoString(
-      body as ObjectWithDateParts<'departureDate'>,
-      'departureDate',
-    )
+    const { departureTime, departureDate, reasonId } = body
 
     if (!departureDate) {
       errors.departureDate = 'You must enter a date of departure'
@@ -151,6 +147,10 @@ export default class DeparturesController {
       const placement = await this.premisesService.getPlacement({ token, premisesId, placementId })
 
       try {
+        body.departureDate = DateFormats.dateAndTimeInputsToIsoString(
+          body as ObjectWithDateParts<'departureDate'>,
+          'departureDate',
+        ).departureDate
         const errors = this.newErrors(body, placement)
 
         if (errors) {


### PR DESCRIPTION
# Context

- Fixes E2E test failures resulting from removal of side-effect update in `DateFormats.dateAndTimeInputsToIsoString()`.
- Also, should (hopefully) remove the test flakiness where e2e tests fail because the 'step free access' radio button was not clicked in assess. I think this was caused by improper structuring of promises, allowing the submit page transition to sometimes occur before the button click had completed.

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

[x] I have run the E2E tests locally and they passed

No functional change
