### PR TITLE
BUGFIX/APS-2293: Add leading zero to time input where required

### DIFF
--- a/e2e/pages/manage/recordArrivalPage.ts
+++ b/e2e/pages/manage/recordArrivalPage.ts
@@ -13,7 +13,10 @@ export class RecordArrivalPage extends BasePage {
 
   async recordArrival() {
     const arrivalDateTime = addDays(new Date(), -1) // Yesterday same time
-    const [year, month, day, hours, minutes] = DateFormats.dateObjToIsoDateTime(arrivalDateTime).split(/\D/)
+    const [year, month, day, hours, minutes] = DateFormats.dateObjToIsoDateTime(arrivalDateTime)
+      .split(/\D/)
+      .map(part => part.replace(/^0+/, '')) // remove leading zeros for realistic input
+
     await this.fillDateField({ year, month, day })
     await this.fillField('What is the time of arrival?', `${hours}:${minutes}`)
 

--- a/e2e/pages/manage/recordDeparturePage.ts
+++ b/e2e/pages/manage/recordDeparturePage.ts
@@ -14,7 +14,9 @@ export class RecordDeparturePage extends BasePage {
 
   async recordDeparture() {
     const departureDateTime = addHours(new Date(), -1) // One hour ago
-    const [year, month, day, hours, minutes] = DateFormats.dateObjToIsoDateTime(departureDateTime).split(/\D/)
+    const [year, month, day, hours, minutes] = DateFormats.dateObjToIsoDateTime(departureDateTime)
+      .split(/\D/)
+      .map(part => part.replace(/^0+/, '')) // remove leading zeros for realistic input
 
     await this.fillDateField({ year, month, day })
     await this.fillField('What is the time of departure?', `${hours}:${minutes}`)

--- a/server/controllers/manage/premises/placements/arrivalsController.test.ts
+++ b/server/controllers/manage/premises/placements/arrivalsController.test.ts
@@ -10,6 +10,7 @@ import * as validationUtils from '../../../../utils/validation'
 import paths from '../../../../paths/manage'
 import PlacementService from '../../../../services/placementService'
 import { ValidationError } from '../../../../utils/errors'
+import { timeAddLeadingZero } from '../../../../utils/dateUtils'
 
 describe('ArrivalsController', () => {
   const token = 'SOME_TOKEN'
@@ -85,7 +86,7 @@ describe('ArrivalsController', () => {
     }
 
     it.each([
-      ['2024-11-05', '09:45'],
+      ['2024-11-05', '9:45'],
       ['2025-03-31', '12:13'],
     ])('creates the arrival for %s at %s and redirects to the placement page', async (date, time) => {
       const [year, month, day] = date.split('-').map(part => part.replace(/^0+/g, ''))
@@ -102,7 +103,7 @@ describe('ArrivalsController', () => {
 
       expect(placementService.createArrival).toHaveBeenCalledWith(token, premisesId, placement.id, {
         arrivalDate: date,
-        arrivalTime: time,
+        arrivalTime: timeAddLeadingZero(time),
       })
       expect(request.flash).toHaveBeenCalledWith('success', 'You have recorded this person as arrived')
       expect(response.redirect).toHaveBeenCalledWith(

--- a/server/controllers/manage/premises/placements/arrivalsController.ts
+++ b/server/controllers/manage/premises/placements/arrivalsController.ts
@@ -5,7 +5,12 @@ import { PremisesService } from '../../../../services'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../../utils/validation'
 import PlacementService from '../../../../services/placementService'
 import paths from '../../../../paths/manage'
-import { DateFormats, dateAndTimeInputsAreValidDates, timeIsValid24hrFormat } from '../../../../utils/dateUtils'
+import {
+  DateFormats,
+  dateAndTimeInputsAreValidDates,
+  timeIsValid24hrFormat,
+  timeAddLeadingZero,
+} from '../../../../utils/dateUtils'
 import { ValidationError } from '../../../../utils/errors'
 
 export default class ArrivalsController {
@@ -72,7 +77,7 @@ export default class ArrivalsController {
         }
 
         const placementArrival: Cas1NewArrival = {
-          arrivalTime,
+          arrivalTime: timeAddLeadingZero(arrivalTime),
           arrivalDate: DateFormats.isoDateTimeToIsoDate(arrivalDateTime),
         }
 

--- a/server/controllers/manage/premises/placements/departuresController.test.ts
+++ b/server/controllers/manage/premises/placements/departuresController.test.ts
@@ -21,6 +21,7 @@ import {
   MOVE_TO_AP_REASON_ID,
   PLANNED_MOVE_ON_REASON_ID,
 } from '../../../../utils/placements'
+import { timeAddLeadingZero } from '../../../../utils/dateUtils'
 
 describe('DeparturesController', () => {
   const token = 'SOME_TOKEN'
@@ -654,7 +655,7 @@ describe('DeparturesController', () => {
 
   describe('create', () => {
     it.each([
-      ['2024-10-08', '09:35'],
+      ['2024-10-08', '9:35'],
       ['2025-03-31', '11:15'],
     ])(
       'creates the departure on %s at %s, clears the session and redirects to the placement page',
@@ -680,7 +681,7 @@ describe('DeparturesController', () => {
 
         expect(placementService.createDeparture).toHaveBeenCalledWith(token, premisesId, placement.id, {
           departureDate: date,
-          departureTime: time,
+          departureTime: timeAddLeadingZero(time),
           reasonId: rootDepartureReason1.id,
           notes: 'Some notes',
         })

--- a/server/controllers/manage/premises/placements/departuresController.ts
+++ b/server/controllers/manage/premises/placements/departuresController.ts
@@ -10,6 +10,7 @@ import {
   isoDateAndTimeToDateObj,
   timeIsValid24hrFormat,
   dateIsPast,
+  timeAddLeadingZero,
 } from '../../../../utils/dateUtils'
 import { ValidationError } from '../../../../utils/errors'
 import paths from '../../../../paths/manage'
@@ -355,7 +356,7 @@ export default class DeparturesController {
 
         const placementDeparture: Cas1NewDeparture = {
           departureDate: departureData.departureDate,
-          departureTime: departureData.departureTime,
+          departureTime: timeAddLeadingZero(departureData.departureTime),
           reasonId,
           moveOnCategoryId,
           notes,

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -16,6 +16,7 @@ import {
   timeIsValid24hrFormat,
   uiDateOrDateEmptyMessage,
   yearOptions,
+  timeAddLeadingZero,
 } from './dateUtils'
 
 jest.mock('../data/bankHolidays/bank-holidays.json', () => {
@@ -559,6 +560,15 @@ describe('timeIsValid24hrFormat', () => {
       expect(timeIsValid24hrFormat(time)).toEqual(false)
     },
   )
+})
+
+describe('addLeadingZero', () => {
+  it.each(['9:35', '0:10', '5:00'])('adds a leading zero to %s', time => {
+    expect(timeAddLeadingZero(time)).toEqual(`0${time}`)
+  })
+  it.each(['19:35', '10:10', '23:00'])('does not add a leading zero to %s', time => {
+    expect(timeAddLeadingZero(time)).toEqual(time)
+  })
 })
 
 describe('dateObjTo24hrTime', () => {

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -359,6 +359,8 @@ export const timeIsValid24hrFormat = (time: string): Boolean => {
   return /^(2[0-3]|[01]?[0-9]):[0-5][0-9]$/.test(time)
 }
 
+export const timeAddLeadingZero = (time: string): string => time.padStart(5, '0')
+
 export const isoDateAndTimeToDateObj = (isoDate: string, time: string): Date => {
   const date = DateFormats.isoToDateObj(isoDate)
   if (timeIsValid24hrFormat(time)) {


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2293

# Changes in this PR

This avoids the API returning an error when the user hasn't entered the leading zero. We do this instead of enforcing a leading zero on validation, to avoid adding friction to user input.

The E2E tests now remove the leading zero from date and time entry for a more realistic user input.

