### PR TITLE
Fix reports e2e test filename assertion

### DIFF
--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -29,12 +29,12 @@ test('download reports', async ({ page, reportViewer }) => {
   // When I download the out of service beds report
   const lostBedsDownload = await reportsPage.downloadOutOfServiceBedsReports({ month, year })
   // Then the file should be downloaded with the correct suggested name
-  expect(lostBedsDownload.suggestedFilename()).toMatch(/out-of-service-beds-2023-01-[0-9_]*.xlsx/)
+  expect(lostBedsDownload.suggestedFilename()).toMatch(/out-of-service-beds-2023-01-\d{8}_\d{4}.xlsx/)
 
   // When I download the daily metrics report
   const applicationsDownload = await reportsPage.downloadDailyMetricsReports({ month, year })
   // Then the file should be downloaded with the correct suggested name
-  expect(applicationsDownload.suggestedFilename()).toMatch(/daily-metrics-2023-01-[0-9_]*.xlsx/)
+  expect(applicationsDownload.suggestedFilename()).toMatch(/daily-metrics-2023-01-01-to-2023-01-31-\d{8}_\d{4}.csv/)
 })
 
 test('manage users', async ({ page, userToAddAndDelete, administrator }) => {


### PR DESCRIPTION
The filename for the daily metrics report now follows the format `daily-metrics-{startDate}-to-{endDate}-{timestamp}.csv`.
