### PR TITLE
Update expected report filename

### DIFF
--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -29,7 +29,7 @@ test('download reports', async ({ page, reportViewer }) => {
   // When I download the out of service beds report
   const lostBedsDownload = await reportsPage.downloadOutOfServiceBedsReports({ month, year })
   // Then the file should be downloaded with the correct suggested name
-  expect(lostBedsDownload.suggestedFilename()).toMatch(/out-of-service-beds-2023-01-\d{8}_\d{4}.xlsx/)
+  expect(lostBedsDownload.suggestedFilename()).toMatch(/out-of-service-beds-2023-01-01-to-2023-01-31-\d{8}_\d{4}.xlsx/)
 
   // When I download the daily metrics report
   const applicationsDownload = await reportsPage.downloadDailyMetricsReports({ month, year })


### PR DESCRIPTION
All reports now follow the `{reportName}-{startDate}-to-{endDate}-{timestamp}.(csv|xlsx)` format.

Reports E2E run locally:

<img width="494" alt="Screenshot 2025-06-11 at 11 08 46" src="https://github.com/user-attachments/assets/da719ae6-bca3-4ccb-85bc-82383a74f58f" />

