### PR TITLE
APS-2280: Use createdBySummary instead of deprecated createdBy

### DIFF
--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -599,10 +599,10 @@ export default abstract class Page {
           cy.wrap($el).within(() => {
             cy.get('.moj-timeline__header').should('contain', eventTypeTranslations[sortedTimelineEvents[i].type])
             cy.get('time').should('have.attr', { time: sortedTimelineEvents[i].occurredAt })
-            if (timelineEvents[i].createdBy?.name) {
+            if (timelineEvents[i].createdBySummary?.name) {
               cy.get('.moj-timeline__header > .moj-timeline__byline').should(
                 'contain',
-                timelineEvents[i].triggerSource === 'system' ? 'System' : timelineEvents[i].createdBy.name,
+                timelineEvents[i].triggerSource === 'system' ? 'System' : timelineEvents[i].createdBySummary.name,
               )
             }
             if (timelineEvents[i].associatedUrls?.length) {

--- a/server/testutils/factories/cas1Timeline.ts
+++ b/server/testutils/factories/cas1Timeline.ts
@@ -11,7 +11,7 @@ import {
 } from '@approved-premises/api'
 import { faker } from '@faker-js/faker'
 import { DateFormats } from '../../utils/dateUtils'
-import userFactory from './user'
+import userFactory, { userSummaryFactory } from './user'
 import namedIdFactory from './namedId'
 import { fullPersonFactory } from './person'
 
@@ -46,7 +46,7 @@ export const cas1TimelineEventFactory = Factory.define<Cas1TimelineEvent>(() => 
   type: faker.helpers.arrayElement(cas1TimelineEventTypes),
   occurredAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
   content: faker.datatype.boolean() ? faker.lorem.sentences() : undefined,
-  createdBy: userFactory.build(),
+  createdBySummary: userSummaryFactory.build(),
   payload: cas1TimelineEventContentPayloadFactory.build(),
   associatedUrls: cas1TimelineEventAssociatedUrlFactory.buildList(1, { type: 'application' }),
   triggerSource: faker.helpers.arrayElement(cas1TriggerSourceTypes),

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -699,7 +699,7 @@ describe('utils', () => {
             text: eventTypeTranslations[timelineEvents[0].type],
           },
           content: renderTimelineEventContent(timelineEvents[0]),
-          createdBy: timelineEvents[0].createdBy.name,
+          createdBy: timelineEvents[0].createdBySummary.name,
           associatedUrls: expect.arrayContaining(
             mapTimelineUrlsForUi([
               {
@@ -725,7 +725,7 @@ describe('utils', () => {
             text: eventTypeTranslations[timelineEvents[0].type],
           },
           content: renderTimelineEventContent(timelineEvents[0]),
-          createdBy: timelineEvents[0].createdBy.name,
+          createdBy: timelineEvents[0].createdBySummary.name,
           associatedUrls: [],
         },
       ])

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -297,7 +297,7 @@ const mapApplicationTimelineEventsForUi = (
         event.associatedUrls = timelineEvent.associatedUrls ? mapTimelineUrlsForUi(timelineEvent.associatedUrls) : []
       }
 
-      const createdBy = timelineEvent.triggerSource === 'system' ? 'System' : timelineEvent.createdBy?.name
+      const createdBy = timelineEvent.triggerSource === 'system' ? 'System' : timelineEvent.createdBySummary?.name
       if (createdBy) {
         return {
           ...event,


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2280

# Changes in this PR

Switch uses of the deprecated `Cas1TimelineEvent.createdBy` to `Cas1TimelineEvent.createdBySummary`.


