### PR TITLE
APS-2191 Line-feeds in assess risk details

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -32,6 +32,10 @@
   }
 }
 
+.govuk-body__text-block {
+  white-space: pre-wrap;
+}
+
 a.link-disabled {
   cursor: default;
   background: govuk-colour("light-grey");

--- a/server/utils/assessments/oasysUtils.test.ts
+++ b/server/utils/assessments/oasysUtils.test.ts
@@ -23,7 +23,7 @@ describe('OasysQuestions', () => {
     const sections = roshSummaryFactory.buildList(2)
 
     expect(oasysQuestions(sections)).toBe(
-      `<h2 class="govuk-heading-m">${sections[0].questionNumber}. ${sections[0].label}</h2><p class="govuk-body">${sections[0].answer}</p><hr class="govuk-!-margin-bottom-2"/><h2 class="govuk-heading-m">${sections[1].questionNumber}. ${sections[1].label}</h2><p class="govuk-body">${sections[1].answer}</p><hr class="govuk-!-margin-bottom-2"/>`,
+      `<h2 class="govuk-heading-m">${sections[0].questionNumber}. ${sections[0].label}</h2><p class="govuk-body govuk-body__text-block">${sections[0].answer}</p><hr class="govuk-!-margin-bottom-2"/><h2 class="govuk-heading-m">${sections[1].questionNumber}. ${sections[1].label}</h2><p class="govuk-body govuk-body__text-block">${sections[1].answer}</p><hr class="govuk-!-margin-bottom-2"/>`,
     )
   })
 })

--- a/server/utils/assessments/oasysUtils.ts
+++ b/server/utils/assessments/oasysUtils.ts
@@ -8,7 +8,7 @@ const oasysQuestions = (section: Array<OASysQuestion>) =>
   section
     .map(
       question =>
-        `<h2 class="govuk-heading-m">${question.questionNumber}. ${question.label}</h2><p class="govuk-body">${question.answer}</p><hr class="govuk-!-margin-bottom-2"/>`,
+        `<h2 class="govuk-heading-m">${question.questionNumber}. ${question.label}</h2><p class="govuk-body govuk-body__text-block">${question.answer}</p><hr class="govuk-!-margin-bottom-2"/>`,
     )
     .join('')
 


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2191

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Expand linefeeds in the risk details section in Assess.
This uses a helper class added to the `govuk-body` paragraphs. 

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before

### After
