### PR TITLE
Split CodeQL job from main test workflow

### DIFF
--- a/.github/workflows/codeQL.yml
+++ b/.github/workflows/codeQL.yml
@@ -1,0 +1,34 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  codeQL:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: 'javascript'
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,30 +11,6 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  codeQL:
-    name: CodeQL
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.1.7
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: 'javascript'
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
-        with:
-          category: '/language:javascript'
-
   helm_lint:
     name: "Helm config linting 🔎"
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/test_helm_lint.yml@v2


### PR DESCRIPTION
Code scanning reports errors in the Github interface if any part of the workflow running the CodeQL job fails, even if the CodeQL job itself was run successfully. This could cause worry and is generally distracting when trying to assess whether the given codebase is sane. 

To prevent this, we run CodeQL as a completely separate job, which should suppress the issue. 

<details><summary>Screenshots of various false warnings in Github</summary>

## Security overview page

<img width="956" alt="Screenshot 2025-06-03 at 16 52 08" src="https://github.com/user-attachments/assets/d34a69fb-65dd-44f7-bde2-ef5008757184" />

---

## Code scanning page

<img width="958" alt="Screenshot 2025-06-03 at 16 48 23" src="https://github.com/user-attachments/assets/1f4f2188-e80d-4f7a-92e3-a4d89dfc7852" />

---

## CodeQL configuration page

<img width="959" alt="Screenshot 2025-06-03 at 16 48 36" src="https://github.com/user-attachments/assets/79150863-d762-4b1f-8be0-6c81944ad00d" />



</details>
