### PR TITLE
APS-2335: Add static page for accessibility statement

### DIFF
--- a/integration_tests/pages/accessibilityStatement.ts
+++ b/integration_tests/pages/accessibilityStatement.ts
@@ -1,0 +1,7 @@
+import Page from './page'
+
+export default class AccessibilityStatementPage extends Page {
+  constructor() {
+    super('Accessibility statement')
+  }
+}

--- a/integration_tests/tests/staticPages.cy.ts
+++ b/integration_tests/tests/staticPages.cy.ts
@@ -1,0 +1,16 @@
+import Page from '../pages/page'
+import AccessibilityStatementPage from '../pages/accessibilityStatement'
+import DashboardPage from '../pages/dashboard'
+import { signIn } from './signIn'
+
+context('static pages', () => {
+  it('renders the accessibility statement', () => {
+    signIn('applicant')
+
+    const indexPage = Page.verifyOnPage(DashboardPage)
+
+    indexPage.clickLink('Accessibility')
+
+    Page.verifyOnPage(AccessibilityStatementPage)
+  })
+})

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -16,6 +16,7 @@ import TimelineController from './people/timelineController'
 import ReviewController from './placementApplications/reviewController'
 import WithdrawalsController from './placementApplications/withdrawalsController'
 import RedirectController from './redirectController'
+import StaticController from './staticController'
 
 export const controllers = (services: Services) => {
   const redirectController = new RedirectController()
@@ -35,6 +36,7 @@ export const controllers = (services: Services) => {
   const placementApplicationWithdrawalsController = new WithdrawalsController(services.placementApplicationService)
   const peopleController = new PeopleController(services.personService)
   const timelineController = new TimelineController(services.personService)
+  const staticController = new StaticController()
 
   return {
     redirectController,
@@ -46,6 +48,7 @@ export const controllers = (services: Services) => {
     placementApplicationWithdrawalsController,
     peopleController,
     timelineController,
+    staticController,
     ...applyControllers(services),
     ...assessControllers(services),
     ...matchControllers(services),

--- a/server/controllers/staticController.test.ts
+++ b/server/controllers/staticController.test.ts
@@ -1,0 +1,22 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+import StaticController from './staticController'
+
+describe('StaticController', () => {
+  const request: DeepMocked<Request> = createMock<Request>({})
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+  let staticController: StaticController
+
+  beforeEach(() => {
+    staticController = new StaticController()
+  })
+
+  it('renders the given template', () => {
+    const requestHandler = staticController.render('template-name')
+
+    requestHandler(request, response, next)
+
+    expect(response.render).toHaveBeenCalledWith('static/template-name.njk')
+  })
+})

--- a/server/controllers/staticController.ts
+++ b/server/controllers/staticController.ts
@@ -1,0 +1,9 @@
+import { Request, RequestHandler, Response } from 'express'
+
+export default class StaticController {
+  render(template: string): RequestHandler {
+    return async (_req: Request, res: Response) => {
+      return res.render(`static/${template}.njk`)
+    }
+  }
+}

--- a/server/paths/static.ts
+++ b/server/paths/static.ts
@@ -1,0 +1,9 @@
+import { path } from 'static-path'
+
+const paths = {
+  pages: {
+    accessibilityStatement: path('/accessibility'),
+  },
+}
+
+export default paths

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -14,6 +14,7 @@ import tasksRoutes from './tasks'
 import placementApplicationRoutes from './placementApplications'
 import adminRoutes from './admin'
 import peopleRoutes from './people'
+import staticRoutes from './static'
 
 export default function routes(controllers: Controllers, services: Partial<Services>): Router {
   const router = Router()
@@ -32,6 +33,7 @@ export default function routes(controllers: Controllers, services: Partial<Servi
   placementApplicationRoutes(controllers, router, services)
   adminRoutes(controllers, router, services)
   peopleRoutes(controllers, router, services)
+  staticRoutes(controllers, router, services)
 
   return router
 }

--- a/server/routes/static.ts
+++ b/server/routes/static.ts
@@ -1,0 +1,19 @@
+/* istanbul ignore file */
+
+import type { Router } from 'express'
+import type { Controllers } from '../controllers'
+import type { Services } from '../services'
+import actions from './utils'
+import staticPaths from '../paths/static'
+
+export default function routes(controllers: Controllers, router: Router, services: Partial<Services>): Router {
+  const { get } = actions(router, services.auditService)
+
+  const { staticController } = controllers
+
+  get(staticPaths.pages.accessibilityStatement.pattern, staticController.render('accessibility'), {
+    auditEvent: 'VIEW_ACCESSIBILITY_STATEMENT',
+  })
+
+  return router
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -68,6 +68,7 @@ import tasksPaths from '../paths/tasks'
 import matchPaths from '../paths/match'
 import adminPaths from '../paths/admin'
 import peoplePaths from '../paths/people'
+import staticPaths from '../paths/static'
 import placementApplicationsPaths from '../paths/placementApplications'
 import { radioMatrixTable } from './radioMatrixTable'
 import * as AppealsUtils from './appealsUtils'
@@ -190,6 +191,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
     ...placementApplicationsPaths,
     ...adminPaths,
     ...peoplePaths,
+    ...staticPaths,
   })
 
   njkEnv.addGlobal('linkTo', linkTo)

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -20,3 +20,16 @@
     <script type="module" src="{{ '/assets/js/app.js' | assetMap }}"></script>
     {% block extraScripts %}{% endblock %}
 {% endblock %}
+
+{% block footer %}
+    {{ govukFooter({
+        meta: {
+            items: [
+                {
+                    href: paths.pages.accessibilityStatement({}),
+                    text: "Accessibility"
+                }
+            ]
+        }
+    }) }}
+{% endblock %}

--- a/server/views/static/accessibility.njk
+++ b/server/views/static/accessibility.njk
@@ -1,0 +1,57 @@
+{% extends "partials/layout.njk" %}
+
+{% block content %}
+    <h1 class="govuk-heading-l">
+        Accessibility statement
+    </h1>
+
+    <p>Ministry of Justice is committed to making its website accessible, in accordance with the Public Sector Bodies
+        (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
+    <p>This accessibility statement applies to the Approved Premises service.</p>
+
+    <h2 class="govuk-heading-m">Compliance status</h2>
+
+    <p>This website is partially compliant with the Web Content Accessibility Guidelines version 2.2 AA standard, due to
+        the non-compliances listed below.</p>
+
+    <h2 class="govuk-heading-m">Non-accessible content</h2>
+
+    <p>The content listed below is non-accessible for the following reasons:</p>
+
+    <ol class="govuk-list govuk-list--number">
+        <li>non-compliance with the accessibility regulations
+            <ul class="govuk-list govuk-list--bullet">
+                <li>Announcement of sort icons in tables could be confusing</li>
+                <li>Distinction between optional or mandatory questions is not announced</li>
+                <li>Some unclear progression instructions</li>
+                <li>Different links go to same target in the header</li>
+                <li>Some broken ARIA references</li>
+            </ul>
+        </li>
+    </ol>
+
+    <h2 class="govuk-heading-m">Preparation of this accessibility statement</h2>
+
+    <p>This statement was prepared on 21 May 2025, following an evaluation by an external company called User
+        Vision.</p>
+
+    <p>The statement was reviewed on 21 May 2025. A further audit is due to take place 26 May 2025. This statement will
+        then be updated by 15 July 2025.</p>
+
+    <h2 class="govuk-heading-m">Feedback and contact information</h2>
+
+    <p>If you find any problems not listed on this page or think we’re not meeting accessibility requirements or if you
+        need information on this website in a different format like accessible PDF, large print, easy read, audio
+        recording or braille, contact
+        <a href="mailto:APServiceSupport@digital.justice.gov.uk">APServiceSupport@digital.justice.gov.uk</a> and we will
+        respond within 5 working days.</p>
+
+    <h2 class="govuk-heading-m">Enforcement procedure</h2>
+
+    <p>The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites
+        and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).</p>
+
+    <p>If you’re not happy with how we respond to your complaint, contact the <a
+                href="https://www.equalityadvisoryservice.com">Equality Advisory and Support Service
+            (EASS)</a>.</p>
+{% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2335

# Changes in this PR

This PR adds all the plumbing required to render static pages. A static page is a page with no dynamic content, that can be rendered by simply rendering the template itself. 

The Accessibility statement has been added as a link to the footer.

## Screenshots of UI changes

<details><summary>Accessibility statement</summary>

<img width="794" alt="Screenshot 2025-06-04 at 17 11 06" src="https://github.com/user-attachments/assets/606d467a-b163-47a6-bd85-23331efcc084" />

</details>

<details><summary>Link to accessibility statement in footer</summary>

<img width="801" alt="Screenshot 2025-06-04 at 17 10 07" src="https://github.com/user-attachments/assets/e7cac69d-e4b6-4c43-bfc5-090484843415" />

</details>