### PR TITLE
Namespace E2E tests artefacts

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -57,7 +57,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: E2E-playwright-report-${{ matrix.shard }}-of-${{ strategy.job-total }}
+          name: CAS1-E2E-playwright-report-${{ matrix.shard }}-of-${{ strategy.job-total }}
           path: playwright-report
           retention-days: 30
           if-no-files-found: ignore
@@ -66,7 +66,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: E2E-artefacts-${{ matrix.shard }}-of-${{ strategy.job-total }}
+          name: CAS1-E2E-artefacts-${{ matrix.shard }}-of-${{ strategy.job-total }}
           path: test-results
           retention-days: 30
           if-no-files-found: ignore


### PR DESCRIPTION
This will prevent artefact name collisions when the various UI E2E workflows are run as part of the same API E2E workflow run, therefore allowing the artefacts to be uploaded without error.
