### PR TITLE
CHORE: Allow E2E tests to be triggered manually

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -2,6 +2,7 @@ name: CAS1 UI E2E tests
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   e2e_test:


### PR DESCRIPTION
Small Github Actions config change to enable triggering a manual run of the E2E test.