### PR TITLE
Fix e2e tests (remove 'health' check)

### DIFF
--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -53,6 +53,6 @@ export const test = base.extend<TestOptions>({
     },
     { option: true },
   ],
-  oasysSections: [['3. Accommodation', '13. Health'], { option: true }],
+  oasysSections: [['3. Accommodation'], { option: true }],
   emergencyApplicationUser: [process.env.CAS1_E2E_EMERGENCY_ASSESSOR_NAME_TO_ALLOCATE_TO, { option: true }],
 })


### PR DESCRIPTION
# Context

Fix e2e tests
Remove checking 'Health' on OAsys selection page as API no longer supplying it.

