### PR TITLE
CHORE: Suppress Sass compile warnings

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -1,31 +1,29 @@
-$govuk-global-styles: true;
-$path: "/assets/images/";
+@use "govuk-frontend/dist/govuk/index" with (
+  $govuk-global-styles: true
+);
+@use "@ministryofjustice/frontend/moj/all";
 
-@import "govuk-frontend/dist/govuk/index";
-@import "@ministryofjustice/frontend/moj/all";
+@use './components/header-bar';
+@use './components/identity-bar';
+@use './components/task-list';
+@use './components/risk-widgets';
+@use './components/summary-list';
+@use './components/sub-navigation';
+@use './components/space-search-identity';
+@use './components/space-search-inputs';
+@use './components/filter';
+@use './components/calendar';
+@use './components/withdrawal-reasons';
+@use './components/sortable-table';
+@use './components/search-and-filter';
+@use './components/key-details-bar';
+@use './components/moj-identity-bar';
+@use './components/status-tag';
+@use './components/notification-banner';
+@use './components/autocomplete';
 
-@import './components/header-bar';
-@import './components/identity-bar';
-@import './components/task-list';
-@import './components/risk-widgets';
-@import './components/summary-list';
-@import './components/sub-navigation';
-@import './components/space-search-identity';
-@import './components/space-search-inputs';
-@import './components/filter';
-@import './components/calendar';
-@import './components/withdrawal-reasons';
-@import './components/sortable-table';
-@import './components/search-and-filter';
-@import './components/key-details-bar';
-@import './components/moj-identity-bar';
-@import './components/status-tag';
-@import './components/notification-banner';
-@import './components/autocomplete';
+@use './pages/assessments-index';
+@use './pages/applications-pages-attach-document';
+@use './pages/dashboard-index';
 
-@import './pages/assessments-index';
-@import './pages/applications-pages-attach-document';
-@import './pages/dashboard-index';
-
-@import 'local';
-
+@use 'local';

--- a/assets/scss/components/_autocomplete.scss
+++ b/assets/scss/components/_autocomplete.scss
@@ -1,3 +1,4 @@
+@use "govuk-frontend/dist/govuk" as *;
 @import 'accessible-autocomplete/src/autocomplete.css';
 
 .autocomplete__wrapper,

--- a/assets/scss/components/_calendar.scss
+++ b/assets/scss/components/_calendar.scss
@@ -1,3 +1,5 @@
+@use "govuk-frontend/dist/govuk" as *;
+
 .calendar__month {
   border-top: 1px solid $govuk-border-colour;
 

--- a/assets/scss/components/_filter.scss
+++ b/assets/scss/components/_filter.scss
@@ -1,3 +1,5 @@
+@use "govuk-frontend/dist/govuk" as *;
+
 .moj-filter {
   margin-bottom: govuk-spacing(6);
   border: 1px solid $govuk-border-colour;
@@ -12,7 +14,7 @@
 
         &:hover {
           background-color: govuk-colour('white');
-          color:govuk-colour('black');
+          color: govuk-colour('black');
         }
       }
     }

--- a/assets/scss/components/_header-bar.scss
+++ b/assets/scss/components/_header-bar.scss
@@ -1,13 +1,15 @@
+@use "govuk-frontend/dist/govuk" as *;
+
 .hmpps-header {
   @include govuk-responsive-padding(3, 'top');
   @include govuk-responsive-padding(3, 'bottom');
   background-color: govuk-colour('black');
 
   &__container {
-    @include govuk-width-container;
     display: flex;
     justify-content: space-between;
     align-items: center;
+    @include govuk-width-container;
   }
 
   &__logo {
@@ -24,9 +26,9 @@
 
     &__organisation-name {
       @include govuk-responsive-margin(2, 'right');
-      @include govuk-font($size: 24, $weight: 'bold');
       display: flex;
       align-items: center;
+      @include govuk-font($size: 24, $weight: 'bold');
     }
 
     &__service-name {
@@ -63,8 +65,9 @@
     }
 
     &__sub-text {
-      @include govuk-font(16);
       display: none;
+
+      @include govuk-font(16);
 
       @include govuk-media-query($from: tablet) {
         display: block;
@@ -86,9 +89,10 @@
     }
 
     &__item {
-      @include govuk-font(19);
       margin-bottom: govuk-spacing(1);
       text-align: right;
+
+      @include govuk-font(19);
 
       @include govuk-media-query($from: tablet) {
         @include govuk-responsive-margin(4, 'right');
@@ -115,14 +119,15 @@
 }
 
 .location-bar {
-  @include govuk-width-container;
-  @include govuk-responsive-margin(3, 'bottom');
-  @include govuk-responsive-padding(3, 'top');
-  @include govuk-responsive-padding(3, 'bottom');
   width: 100%;
   display: flex;
   flex-wrap: wrap;
   border-bottom: 1px solid $govuk-border-colour;
+
+  @include govuk-width-container;
+  @include govuk-responsive-margin(3, 'bottom');
+  @include govuk-responsive-padding(3, 'top');
+  @include govuk-responsive-padding(3, 'bottom');
 
   &__location {
     @include govuk-font($size: 19, $weight: 'bold');

--- a/assets/scss/components/_key-details-bar.scss
+++ b/assets/scss/components/_key-details-bar.scss
@@ -1,3 +1,5 @@
+@use "govuk-frontend/dist/govuk" as *;
+
 .key-details-bar {
   background-color: govuk-colour('blue');
 
@@ -31,6 +33,7 @@
   margin-top: 6px;
   padding-top: 10px;
 }
+
 @media (min-width: 40.0625em) {
   .key-details-bar .key-details-bar__key-details .key-details-bar__name {
     font-size: 1.675rem;

--- a/assets/scss/components/_risk-widgets.scss
+++ b/assets/scss/components/_risk-widgets.scss
@@ -1,3 +1,5 @@
+@use "govuk-frontend/dist/govuk" as *;
+
 $low-score-colour: #485b10;
 $low-score-border-colour: #85994b;
 $medium-score-colour: #a34e00;
@@ -21,6 +23,7 @@ $mappa-colour: #4c2c92;
   & :nth-child(2) {
     margin-bottom: govuk-spacing(2);
   }
+
   & :nth-child(3) {
     margin-bottom: govuk-spacing(1);
   }
@@ -103,6 +106,7 @@ $mappa-colour: #4c2c92;
   & p {
     margin-bottom: govuk-spacing(1);
   }
+
   & :last-child {
     margin-bottom: 0;
   }
@@ -126,6 +130,7 @@ $mappa-colour: #4c2c92;
     margin-bottom: 0;
     font-weight: 400;
   }
+
   & :last-child {
     margin-bottom: 0;
   }

--- a/assets/scss/components/_search-and-filter.scss
+++ b/assets/scss/components/_search-and-filter.scss
@@ -1,8 +1,10 @@
+@use "govuk-frontend/dist/govuk" as *;
+
 .search-and-filter {
+  background-color: govuk-colour('light-grey');
+
   @include govuk-responsive-padding(6);
   @include govuk-responsive-margin(6, 'bottom');
-
-  background-color: govuk-colour('light-grey');
 
   &__crn-label {
     &--small {

--- a/assets/scss/components/_sortable-table.scss
+++ b/assets/scss/components/_sortable-table.scss
@@ -1,3 +1,5 @@
+@use "govuk-frontend/dist/govuk" as *;
+
 [aria-sort] {
   a,
   button {
@@ -20,8 +22,8 @@
 
     &:hover {
       text-decoration: underline;
-      @include govuk-link-common;
       padding: 0 16px 0 0;
+      @include govuk-link-common;
     }
 
     &:focus {

--- a/assets/scss/components/_space-search-identity.scss
+++ b/assets/scss/components/_space-search-identity.scss
@@ -1,3 +1,5 @@
+@use "govuk-frontend/dist/govuk" as *;
+
 .search-identity-table {
   display: flex;
 
@@ -7,6 +9,7 @@
     display: inline-block;
     width: 40%;
   }
+
   dd {
     @include govuk-responsive-padding(2, 'bottom');
     display: inline-block;

--- a/assets/scss/components/_space-search-inputs.scss
+++ b/assets/scss/components/_space-search-inputs.scss
@@ -1,3 +1,5 @@
+@use "govuk-frontend/dist/govuk" as *;
+
 .space-search-inputs {
   display: flex;
   flex-direction: column;
@@ -6,6 +8,7 @@
   .govuk-form-group {
     margin-top: auto;
   }
+
   .button {
     margin-top: auto;
   }

--- a/assets/scss/components/_sub-navigation.scss
+++ b/assets/scss/components/_sub-navigation.scss
@@ -1,3 +1,5 @@
+@use "govuk-frontend/dist/govuk" as *;
+
 .moj-sub-navigation__link[aria-selected] {
   color: $govuk-link-active-colour;
   position: relative;
@@ -8,7 +10,9 @@
     content: "";
     display: block;
     height: 100%;
-    position: absolute; bottom: 0; left: 0;
+    position: absolute;
+    bottom: 0;
+    left: 0;
     width: 5px;
 
     @include govuk-media-query($from: tablet) {
@@ -25,7 +29,8 @@
 
   }
 }
+
 .moj-sub-navigation__item.disabled .moj-sub-navigation__link {
-  color:  $govuk-secondary-text-colour;
+  color: $govuk-secondary-text-colour;
   cursor: default;
 }

--- a/assets/scss/components/_summary-list.scss
+++ b/assets/scss/components/_summary-list.scss
@@ -1,3 +1,5 @@
+@use "govuk-frontend/dist/govuk" as *;
+
 .govuk-summary-list--embedded {
   font-size: 0.9em;
   padding-bottom: govuk-spacing(6);
@@ -34,6 +36,7 @@
     font-weight: 700;
   }
 }
+
 .govuk-summary-list__textblock {
   white-space: pre-line;
 }
@@ -41,6 +44,7 @@
 .govuk-summary-list__row {
   min-height: 1.5rem;
 }
+
 .govuk-tag--float-right {
   float: right;
 }

--- a/assets/scss/components/_task-list.scss
+++ b/assets/scss/components/_task-list.scss
@@ -1,3 +1,5 @@
+@use "govuk-frontend/dist/govuk" as *;
+
 // Task list pattern
 
 .app-task-list {
@@ -12,7 +14,7 @@
 
 .app-task-list__section {
   display: table;
-  @include govuk-font($size:24, $weight: bold);
+  @include govuk-font($size: 24, $weight: bold);
 }
 
 .app-task-list__section-number {
@@ -25,10 +27,10 @@
 }
 
 .app-task-list__items {
-  @include govuk-font($size: 19);
-  @include govuk-responsive-margin(9, "bottom");
   list-style: none;
   padding-left: 0;
+  @include govuk-font($size: 19);
+  @include govuk-responsive-margin(9, "bottom");
   @include govuk-media-query($from: tablet) {
     padding-left: govuk-spacing(6);
   }

--- a/assets/scss/components/_withdrawal-reasons.scss
+++ b/assets/scss/components/_withdrawal-reasons.scss
@@ -1,3 +1,5 @@
+@use "govuk-frontend/dist/govuk" as *;
+
 .govuk-radios {
   &--withdrawal-reasons {
     .govuk-radios__divider {

--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -1,3 +1,5 @@
+@use "govuk-frontend/dist/govuk" as *;
+
 .govuk-main-wrapper {
   min-height: 600px;
 }

--- a/assets/scss/pages/_dashboard-index.scss
+++ b/assets/scss/pages/_dashboard-index.scss
@@ -1,3 +1,5 @@
+@use "govuk-frontend/dist/govuk" as *;
+
 .dashboard--index {
   .card-container {
     display: flex;


### PR DESCRIPTION
This PR replaces local uses of `@import` with `@use` to suppress compile-time warnings about `@import` deprecation (more info: https://sass-lang.com/documentation/at-rules/import/).

A few `@include` rules have been moved to prevent a [warning about mixed declarations]([1] https://sass-lang.com/documentation/breaking-changes/mixed-decls/).

The resulting compiled CSS is largely identical to the previous version, with the exception of the rules resulting from the above mentioned `@include` statements appearing further below, but in the same declaration block. Attached is a full diff of changes, ignoring whitespace.

<details><summary>Full diff of changes</summary>

```diff
11724,11726d11723
<     max-width: 960px;
<     margin-right: 15px;
<     margin-left: 15px;
11729a11727,11729
>   max-width: 960px;
>   margin-right: 15px;
>   margin-left: 15px;
11773a11774,11775
>   display: flex;
>   align-items: center;
11783,11784d11784
<     display: flex;
<     align-items: center;
11903a11904
>   display: none;
11913d11913
<     display: none;
11951a11952,11953
>   margin-bottom: 5px;
>   text-align: right;
11961,11962d11962
<     margin-bottom: 5px;
<     text-align: right;
12012a12013,12016
>   width: 100%;
>   display: flex;
>   flex-wrap: wrap;
>   border-bottom: 1px solid #b1b4b6;
12019,12022d12022
<     width: 100%;
<     display: flex;
<     flex-wrap: wrap;
<     border-bottom: 1px solid #b1b4b6;
12228a12229,12230
>   list-style: none;
>   padding-left: 0;
12239,12240d12240
<     list-style: none;
<     padding-left: 0;
12639a12640
>   padding: 0 16px 0 0;
12649d12649
<     padding: 0 16px 0 0;
12725a12726
>   background-color: #f3f2f1;
12728d12728
<     background-color: #f3f2f1;
12958c12958
< /*# sourceMappingURL=app.WM76EIOF.css.map */
---
> /*# sourceMappingURL=app.F23PPRCF.css.map */

```

</details>


