### PR TITLE
APS-2391 Support oasys 'hasApplicableAssessment'

### DIFF
--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -239,7 +239,7 @@ export default class ApplyHelper {
     cy.task('stubPrisonCaseNotes404', { person: this.person })
   }
 
-  stubOasysEndpoints(excludeSection = false) {
+  stubOasysEndpoints(excludeSection = false, hasApplicableAssessment = true) {
     // And there are OASys sections in the db
 
     this.otherOasysSections = [
@@ -255,18 +255,22 @@ export default class ApplyHelper {
     if (excludeSection) {
       this.otherOasysSections[0] = undefined
     }
-    const oasysMetadata = cas1OASysMetadataFactory.build({
-      supportingInformation: [...this.oasysSectionsLinkedToReoffending, ...this.otherOasysSections],
-    })
+
+    const supportingInformation = [...this.oasysSectionsLinkedToReoffending, ...this.otherOasysSections]
+    const oasysMetadata = hasApplicableAssessment
+      ? cas1OASysMetadataFactory.build({ supportingInformation })
+      : cas1OASysMetadataFactory.oasysNotPresent().build({ supportingInformation })
 
     cy.task('stubOasysMetadata', { person: this.person, oasysMetadata })
 
+    const metadata = { assessmentMetadata: { hasApplicableAssessment } }
+
     const oasysSections = {
-      roshSummary: cas1OasysGroupFactory.roshSummary().build(),
-      offenceDetails: cas1OasysGroupFactory.offenceDetails().build(),
-      riskToSelf: cas1OasysGroupFactory.riskToSelf().build(),
-      supportingInformation: cas1OasysGroupFactory.supportingInformation().build(),
-      riskManagementPlan: cas1OasysGroupFactory.riskManagementPlan().build(),
+      roshSummary: cas1OasysGroupFactory.roshSummary().build(metadata),
+      offenceDetails: cas1OasysGroupFactory.offenceDetails().build(metadata),
+      riskToSelf: cas1OasysGroupFactory.riskToSelf().build(metadata),
+      supportingInformation: cas1OasysGroupFactory.supportingInformation().build(metadata),
+      riskManagementPlan: cas1OasysGroupFactory.riskManagementPlan().build(metadata),
     }
 
     this.roshSummaries = oasysSections.roshSummary.answers

--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -22,6 +22,7 @@ import {
   acctAlertFactory,
   adjudicationFactory,
   cas1OasysGroupFactory,
+  cas1OASysMetadataFactory,
   cas1OASysSupportingInformationMetaDataFactory,
   cas1PremisesBasicSummaryFactory,
   contingencyPlanPartnerFactory,
@@ -254,9 +255,11 @@ export default class ApplyHelper {
     if (excludeSection) {
       this.otherOasysSections[0] = undefined
     }
-    const oasysSelection = [...this.oasysSectionsLinkedToReoffending, ...this.otherOasysSections]
+    const oasysMetadata = cas1OASysMetadataFactory.build({
+      supportingInformation: [...this.oasysSectionsLinkedToReoffending, ...this.otherOasysSections],
+    })
 
-    cy.task('stubOasysMetadata', { person: this.person, oasysMetadata: { supportingInformation: oasysSelection } })
+    cy.task('stubOasysMetadata', { person: this.person, oasysMetadata })
 
     const oasysSections = {
       roshSummary: cas1OasysGroupFactory.roshSummary().build(),

--- a/integration_tests/tests/apply/missingInformation.cy.ts
+++ b/integration_tests/tests/apply/missingInformation.cy.ts
@@ -6,12 +6,26 @@ import { setup } from './setup'
 context('Apply - Missing information', () => {
   beforeEach(setup)
 
-  it('handles missing Oasys information', function test() {
+  it('handles missing Oasys information - legacy mechanism - API returns 404', function test() {
     const uiRisks = mapApiPersonRisksForUi(this.application.risks)
     const apply = new ApplyHelper(this.application, this.person, this.offences)
     const oasysMissing = true
 
     apply.setupApplicationStubs(uiRisks, oasysMissing)
+    apply.startApplication()
+    apply.completeBasicInformation({ isEmergencyApplication: false })
+    apply.completeTypeOfApSection()
+    apply.completeOasysSection(oasysMissing)
+  })
+
+  it('handles missing Oasys information - API returns flag', function test() {
+    const uiRisks = mapApiPersonRisksForUi(this.application.risks)
+    const apply = new ApplyHelper(this.application, this.person, this.offences)
+    const hasApplicableAssessment = false
+    const oasysMissing = true
+
+    apply.setupApplicationStubs(uiRisks)
+    apply.stubOasysEndpoints(false, hasApplicableAssessment)
     apply.startApplication()
     apply.completeBasicInformation({ isEmergencyApplication: false })
     apply.completeTypeOfApSection()

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -12,8 +12,10 @@ import type {
   AssessmentTask,
   Cas1ApplicationSummary,
   Cas1CruManagementArea,
+  Cas1OASysAssessmentMetadata,
   Cas1OASysGroup,
   Cas1OASysGroupName,
+  Cas1OASysSupportingInformationQuestionMetaData,
   Cas1PremisesBasicSummary,
   Cas1SpaceBooking,
   Document,
@@ -288,7 +290,7 @@ export type DataServices = Partial<{
     getPrisonCaseNotes: (token: string, crn: string) => Promise<Array<PrisonCaseNote>>
     getAdjudications: (token: string, crn: string) => Promise<Array<Adjudication>>
     getAcctAlerts: (token: string, crn: string) => Promise<Array<PersonAcctAlert>>
-    getOasysMetadata: (token: string, crn: string) => Promise<Array<Cas1OASysSupportingInformationMetaData>>
+    getOasysMetadata: (token: string, crn: string) => Promise<Cas1OASysMetadataUI>
     getOasysAnswers: (
       token: string,
       crn: string,
@@ -537,4 +539,11 @@ export type DateRange = {
   from: string
   to?: string
   duration: number
+}
+
+// This is temporary type to cope with the fact that the Cas1OASysMetadata type doesn't export correctly
+// TODO: Replace with imported type Cas1OASysMetadata
+export type Cas1OASysMetadataUI = {
+  assessmentMetadata: Cas1OASysAssessmentMetadata
+  supportingInformation: Array<Cas1OASysSupportingInformationQuestionMetaData>
 }

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -10,7 +10,7 @@ import {
   activeOffenceFactory,
   adjudicationFactory,
   cas1OasysGroupFactory,
-  cas1OASysSupportingInformationMetaDataFactory,
+  cas1OASysMetadataFactory,
   personFactory,
   prisonCaseNotesFactory,
 } from '../testutils/factories'
@@ -234,7 +234,7 @@ describeCas1NamespaceClient('cas1PersonClient', provider => {
   describe('oasysMetadata', () => {
     it('should return the importable sections of OASys', async () => {
       const crn = 'crn'
-      const oasysMetadata = { supportingInformation: cas1OASysSupportingInformationMetaDataFactory.buildList(5) }
+      const oasysMetadata = cas1OASysMetadataFactory.build()
 
       provider.addInteraction({
         state: 'Server is healthy',
@@ -254,7 +254,7 @@ describeCas1NamespaceClient('cas1PersonClient', provider => {
 
       const result = await personClient.oasysMetadata(crn)
 
-      expect(result).toEqual(oasysMetadata.supportingInformation)
+      expect(result).toEqual(oasysMetadata)
     })
   })
 

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -5,13 +5,13 @@ import type {
   Adjudication,
   Cas1OASysGroup,
   Cas1OASysGroupName,
-  Cas1OASysSupportingInformationQuestionMetaData,
   Cas1PersonalTimeline,
   Person,
   PersonAcctAlert,
   PrisonCaseNote,
 } from '@approved-premises/api'
 
+import { Cas1OASysMetadataUI } from '@approved-premises/ui'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -66,12 +66,8 @@ export default class PersonClient {
     return response as Array<ActiveOffence>
   }
 
-  async oasysMetadata(crn: string): Promise<Array<Cas1OASysSupportingInformationQuestionMetaData>> {
-    const response = (await this.restClient.get({ path: paths.people.oasys.metadata({ crn }) })) as {
-      supportingInformation: Array<Cas1OASysSupportingInformationQuestionMetaData>
-    }
-
-    return response.supportingInformation as Array<Cas1OASysSupportingInformationQuestionMetaData>
+  async oasysMetadata(crn: string): Promise<Cas1OASysMetadataUI> {
+    return (await this.restClient.get({ path: paths.people.oasys.metadata({ crn }) })) as Cas1OASysMetadataUI
   }
 
   async oasysAnswers(

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.ts
@@ -3,7 +3,7 @@ import type { DataServices, OasysPage, PersonRisksUI } from '@approved-premises/
 import type { ApprovedPremisesApplication, OASysQuestion } from '@approved-premises/api'
 
 import { Page } from '../../../utils/decorators'
-import { getOasysSections, oasysImportReponse } from '../../../../utils/oasysImportUtils'
+import { getOasysSection, oasysImportReponse } from '../../../../utils/oasysImportUtils'
 
 type OffenceDetailsBody = {
   offenceDetailsAnswers: Record<string, string>
@@ -37,7 +37,7 @@ export default class OffenceDetails implements OasysPage {
     token: string,
     dataServices: DataServices,
   ) {
-    return getOasysSections(body, application, token, dataServices, OffenceDetails, {
+    return getOasysSection(body, application, token, dataServices, OffenceDetails, {
       groupName: 'offenceDetails',
       summaryKey: 'offenceDetailsSummaries',
       answerKey: 'offenceDetailsAnswers',

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.ts
@@ -3,7 +3,7 @@ import type { DataServices, OasysPage, PersonRisksUI } from '@approved-premises/
 import type { ApprovedPremisesApplication, OASysQuestion } from '@approved-premises/api'
 
 import { Page } from '../../../utils/decorators'
-import { getOasysSections, oasysImportReponse } from '../../../../utils/oasysImportUtils'
+import { getOasysSection, oasysImportReponse } from '../../../../utils/oasysImportUtils'
 
 type RiskManagementBody = {
   riskManagementAnswers: Record<string, string>
@@ -39,7 +39,7 @@ export default class RiskManagementPlan implements OasysPage {
     token: string,
     dataServices: DataServices,
   ) {
-    return getOasysSections(body, application, token, dataServices, RiskManagementPlan, {
+    return getOasysSection(body, application, token, dataServices, RiskManagementPlan, {
       groupName: 'riskManagementPlan',
       summaryKey: 'riskManagementSummaries',
       answerKey: 'riskManagementAnswers',

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.ts
@@ -3,7 +3,7 @@ import type { DataServices, OasysPage, PersonRisksUI } from '@approved-premises/
 import type { ApprovedPremisesApplication, OASysQuestion } from '@approved-premises/api'
 
 import { Page } from '../../../utils/decorators'
-import { getOasysSections, oasysImportReponse } from '../../../../utils/oasysImportUtils'
+import { getOasysSection, oasysImportReponse } from '../../../../utils/oasysImportUtils'
 
 type RiskToSelfBody = {
   riskToSelfAnswers: Record<string, string>
@@ -37,7 +37,7 @@ export default class RiskToSelf implements OasysPage {
     token: string,
     dataServices: DataServices,
   ) {
-    return getOasysSections(body, application, token, dataServices, RiskToSelf, {
+    return getOasysSection(body, application, token, dataServices, RiskToSelf, {
       groupName: 'riskToSelf',
       summaryKey: 'riskToSelfSummaries',
       answerKey: 'riskToSelfAnswers',

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.ts
@@ -3,7 +3,7 @@ import type { DataServices, OasysPage, PersonRisksUI } from '@approved-premises/
 import type { ApprovedPremisesApplication, OASysQuestion } from '@approved-premises/api'
 
 import { Page } from '../../../utils/decorators'
-import { getOasysSections, oasysImportReponse } from '../../../../utils/oasysImportUtils'
+import { getOasysSection, oasysImportReponse } from '../../../../utils/oasysImportUtils'
 
 type RoshSummaryBody = {
   roshAnswers: Record<string, string>
@@ -37,7 +37,7 @@ export default class RoshSummary implements OasysPage {
     token: string,
     dataServices: DataServices,
   ) {
-    return getOasysSections(body, application, token, dataServices, RoshSummary, {
+    return getOasysSection(body, application, token, dataServices, RoshSummary, {
       groupName: 'roshSummary',
       summaryKey: 'roshSummaries',
       answerKey: 'roshAnswers',

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.ts
@@ -3,7 +3,7 @@ import type { DataServices, OasysPage, PersonRisksUI } from '@approved-premises/
 import { ApprovedPremisesApplication, OASysSupportingInformationQuestion } from '@approved-premises/api'
 
 import { Page } from '../../../utils/decorators'
-import { fetchOptionalOasysSections, getOasysSections, oasysImportReponse } from '../../../../utils/oasysImportUtils'
+import { fetchOptionalOasysSections, getOasysSection, oasysImportReponse } from '../../../../utils/oasysImportUtils'
 
 type SupportingInformationBody = {
   supportingInformationAnswers: Record<string, string>
@@ -37,7 +37,7 @@ export default class SupportingInformation implements OasysPage {
     token: string,
     dataServices: DataServices,
   ) {
-    return getOasysSections(body, application, token, dataServices, SupportingInformation, {
+    return getOasysSection(body, application, token, dataServices, SupportingInformation, {
       groupName: 'supportingInformation',
       summaryKey: 'supportingInformationSummaries',
       answerKey: 'supportingInformationAnswers',

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -13,8 +13,8 @@ import {
   personFactory,
   personalTimelineFactory,
   prisonCaseNotesFactory,
-  cas1OASysSupportingInformationMetaDataFactory,
   cas1OasysGroupFactory,
+  cas1OASysMetadataFactory,
 } from '../testutils/factories'
 
 jest.mock('../data/personClient.ts')
@@ -119,7 +119,7 @@ describe('PersonService', () => {
 
   describe('getOasysMetadata', () => {
     it("on success returns the person's OASys metadata given their CRN", async () => {
-      const refOasysMetadata = cas1OASysSupportingInformationMetaDataFactory.buildList(3)
+      const refOasysMetadata = cas1OASysMetadataFactory.build()
 
       personClient.oasysMetadata.mockResolvedValue(refOasysMetadata)
 

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -4,13 +4,13 @@ import type {
   Adjudication,
   Cas1OASysGroup,
   Cas1OASysGroupName,
-  Cas1OASysSupportingInformationQuestionMetaData,
   Cas1PersonalTimeline,
   Person,
   PersonAcctAlert,
   PrisonCaseNote,
 } from '@approved-premises/api'
 import { HttpError } from 'http-errors'
+import { Cas1OASysMetadataUI } from '@approved-premises/ui'
 import type { PersonClient, RestClientBuilder } from '../data'
 
 export class OasysNotFoundError extends Error {}
@@ -55,12 +55,11 @@ export default class PersonService {
     return acctAlerts
   }
 
-  async getOasysMetadata(token: string, crn: string): Promise<Array<Cas1OASysSupportingInformationQuestionMetaData>> {
+  async getOasysMetadata(token: string, crn: string): Promise<Cas1OASysMetadataUI> {
     const personClient = this.personClientFactory(token)
 
     try {
-      const oasysMetaData = await personClient.oasysMetadata(crn)
-      return oasysMetaData
+      return await personClient.oasysMetadata(crn)
     } catch (error) {
       const knownError = error as HttpError
       if (knownError?.data?.status === 404) {

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -60,7 +60,6 @@ export default class PersonService {
 
     try {
       const oasysMetaData = await personClient.oasysMetadata(crn)
-
       return oasysMetaData
     } catch (error) {
       const knownError = error as HttpError

--- a/server/testutils/factories/cas1OASysGroup.ts
+++ b/server/testutils/factories/cas1OASysGroup.ts
@@ -55,6 +55,7 @@ export default Cas1OASysGroupFactory.define(() => {
     assessmentMetadata: {
       dateCompleted,
       dateStarted,
+      hasApplicableAssessment: true,
     },
   } as Cas1OASysGroup
 })

--- a/server/testutils/factories/cas1OASysMetadata.ts
+++ b/server/testutils/factories/cas1OASysMetadata.ts
@@ -1,0 +1,30 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker'
+import { Cas1OASysMetadataUI } from '@approved-premises/ui'
+import { DateFormats } from '../../utils/dateUtils'
+import cas1OASysSupportingInformationMetaDataFactory from './cas1OASysSupportingInformationQuestionMetaData'
+
+class Cas1OASysMetadataFactory extends Factory<Cas1OASysMetadataUI> {
+  oasysNotPresent() {
+    return this.params({
+      assessmentMetadata: {
+        dateCompleted: undefined,
+        dateStarted: undefined,
+        hasApplicableAssessment: false,
+      },
+    })
+  }
+}
+
+export default Cas1OASysMetadataFactory.define(() => {
+  const dateCompleted = DateFormats.dateObjToIsoDateTime(faker.date.recent({ days: 5 }))
+  const dateStarted = DateFormats.dateObjToIsoDateTime(faker.date.recent({ days: 5, refDate: dateCompleted }))
+  return {
+    supportingInformation: cas1OASysSupportingInformationMetaDataFactory.buildList(5),
+    assessmentMetadata: {
+      dateCompleted,
+      dateStarted,
+      hasApplicableAssessment: true,
+    },
+  } as Cas1OASysMetadataUI
+})

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -30,6 +30,7 @@ import {
 import newAppealFactory from './newAppealFactory'
 import noteFactory from './noteFactory'
 import cas1OASysSupportingInformationMetaDataFactory from './cas1OASysSupportingInformationQuestionMetaData'
+import cas1OASysMetadataFactory from './cas1OASysMetadata'
 import {
   newOutOfServiceBedFactory,
   outOfServiceBedCancellationFactory,
@@ -166,6 +167,7 @@ export {
   noteFactory,
   cas1OASysSupportingInformationMetaDataFactory,
   cas1OasysGroupFactory,
+  cas1OASysMetadataFactory,
   oasysQuestionFactory,
   outOfServiceBedFactory,
   outOfServiceBedCancellationFactory,

--- a/server/utils/oasysImportUtils.ts
+++ b/server/utils/oasysImportUtils.ts
@@ -18,7 +18,7 @@ import { logToSentry } from '../../logger'
 
 export type Constructor<T> = new (body: unknown) => T
 
-export const getOasysSections = async <T extends OasysPage>(
+export const getOasysSection = async <T extends OasysPage>(
   body: Record<string, unknown>,
   application: ApprovedPremisesApplication,
   token: string,
@@ -46,7 +46,8 @@ export const getOasysSections = async <T extends OasysPage>(
       groupName,
       selectedSections,
     )
-    oasysSuccess = true
+    const { hasApplicableAssessment } = oasysGroup.assessmentMetadata
+    oasysSuccess = hasApplicableAssessment === undefined ? true : hasApplicableAssessment
   } catch (error) {
     if (error instanceof OasysNotFoundError) {
       oasysGroup = {


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2391

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
If the api response to `.../oasys/answers` and .../oasys/metadata` has the flag `hasApplicableAssessment` set to `false`, the UI:

- Sets `oasysSuccess` to false on the page - thus rendering the page the same as if a 404 had been received for the call.
- Loads the questions/answers from the response, rather than the `oasysStubs.json` file

If hasApplicableAssessment is true or not defined, the behviour is as before.
If the endpoint returns a 404, the `oasysSuccess` is set to false on the page and the questions/answers are loaded from `oasysStubs.json`

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

No change to UI - apart from the API flag causing the UI to render as it did for an API 404.
