### PR TITLE
APS-2220 header link

### DIFF
--- a/server/views/partials/header.njk
+++ b/server/views/partials/header.njk
@@ -4,7 +4,7 @@
 <header class="hmpps-header" role="banner">
     <div class="hmpps-header__container">
         <div class="hmpps-header__title">
-            <a class="hmpps-header__link hmpps-header__title__organisation-name" href="/">
+            <a class="hmpps-header__link hmpps-header__title__organisation-name" href="https://www.gov.uk/government/organisations/hm-prison-and-probation-service">
                 <svg role="presentation" focusable="false" class="hmpps-header__logo" xmlns="http://www.w3.org/2000/svg"
                      viewbox="0 0 40 40" height="40" width="40">
                     <path fill-rule="evenodd"
@@ -12,7 +12,8 @@
 
                     <image src="/assets/images/crest.svg" xlink:href="" width="40" height="40"></image>
                 </svg>
-                HMPPS
+                <span aria-hidden="true" class="icon">HMPPS</span>
+                <span class="govuk-visually-hidden">HMPPS homepage</span>
             </a>
 
             <a class="hmpps-header__link hmpps-header__title__service-name" href="/">{{ applicationName }}</a>


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/APS-2220

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->


# Changes in this PR

Changes the header link on the crest/HMPPS to point to the HMPPS homepage as recommended in accessibility audit.
Screen readers now present the link as "HHPPS homepage".

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

No visible change
