### PR TITLE
APS-2192 Change optional OASys question in E2Es

### DIFF
--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -53,6 +53,6 @@ export const test = base.extend<TestOptions>({
     },
     { option: true },
   ],
-  oasysSections: [['3. Accommodation'], { option: true }],
+  oasysSections: [['6. Relationships'], { option: true }],
   emergencyApplicationUser: [process.env.CAS1_E2E_EMERGENCY_ASSESSOR_NAME_TO_ALLOCATE_TO, { option: true }],
 })


### PR DESCRIPTION
Previously the tests selected the optional ‘Accommodation’ section. This is no longer optional, so the tests now select ‘Relationships’ instead
