### PR TITLE
APS-2376: add AP area to search results

### DIFF
--- a/server/controllers/match/search/spaceSearchController.test.ts
+++ b/server/controllers/match/search/spaceSearchController.test.ts
@@ -18,6 +18,7 @@ import { ValidationError } from '../../../utils/errors'
 import paths from '../../../paths/admin'
 import { roomCharacteristicMap } from '../../../utils/characteristicsUtils'
 import { spaceSearchCriteriaApLevelLabels } from '../../../utils/match/spaceSearchLabels'
+import { spaceSearchResultsCards } from '../../../utils/match'
 
 describe('spaceSearchController', () => {
   const token = 'SOME_TOKEN'
@@ -68,7 +69,11 @@ describe('spaceSearchController', () => {
 
       expect(response.render).toHaveBeenCalledWith('match/search', {
         pageHeading: 'Find a space in an Approved Premises',
-        spaceSearchResults,
+        spaceSearchResults: spaceSearchResultsCards(
+          placementRequestDetail.id,
+          searchState.postcode,
+          spaceSearchResults.results,
+        ),
         placementRequest: placementRequestDetail,
         placementRequestInfoSummaryList: placementRequestSummaryList(placementRequestDetail, { showActions: false }),
         formPath: searchPath,

--- a/server/controllers/match/search/spaceSearchController.test.ts
+++ b/server/controllers/match/search/spaceSearchController.test.ts
@@ -70,7 +70,7 @@ describe('spaceSearchController', () => {
       expect(response.render).toHaveBeenCalledWith('match/search', {
         pageHeading: 'Find a space in an Approved Premises',
         spaceSearchResults: spaceSearchResultsCards(
-          placementRequestDetail.id,
+          placementRequestDetail,
           searchState.postcode,
           spaceSearchResults.results,
         ),

--- a/server/controllers/match/search/spaceSearchController.ts
+++ b/server/controllers/match/search/spaceSearchController.ts
@@ -12,6 +12,7 @@ import { ValidationError } from '../../../utils/errors'
 import { roomCharacteristicMap } from '../../../utils/characteristicsUtils'
 import MultiPageFormManager from '../../../utils/multiPageFormManager'
 import { spaceSearchCriteriaApLevelLabels } from '../../../utils/match/spaceSearchLabels'
+import { spaceSearchResultsCards } from '../../../utils/match'
 
 export default class SpaceSearchController {
   formData: MultiPageFormManager<'spaceSearch'>
@@ -32,7 +33,7 @@ export default class SpaceSearchController {
       const placementRequest = await this.placementRequestService.getPlacementRequest(token, id)
 
       if (req.headers?.referer?.includes(paths.admin.placementRequests.show({ id }))) {
-        this.formData.remove(id, req.session)
+        await this.formData.remove(id, req.session)
       }
 
       const searchState =
@@ -48,7 +49,11 @@ export default class SpaceSearchController {
 
       res.render('match/search', {
         pageHeading: 'Find a space in an Approved Premises',
-        spaceSearchResults,
+        spaceSearchResults: spaceSearchResultsCards(
+          placementRequest.id,
+          searchState.postcode,
+          spaceSearchResults.results || [],
+        ),
         placementRequest,
         placementRequestInfoSummaryList: placementRequestSummaryList(placementRequest, { showActions: false }),
         formPath: matchPaths.v2Match.placementRequests.search.spaces({ id: placementRequest.id }),

--- a/server/controllers/match/search/spaceSearchController.ts
+++ b/server/controllers/match/search/spaceSearchController.ts
@@ -50,7 +50,7 @@ export default class SpaceSearchController {
       res.render('match/search', {
         pageHeading: 'Find a space in an Approved Premises',
         spaceSearchResults: spaceSearchResultsCards(
-          placementRequest.id,
+          placementRequest,
           searchState.postcode,
           spaceSearchResults.results || [],
         ),

--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -1,5 +1,6 @@
 import type { ApType, Cas1SpaceBookingCharacteristic, FullPerson, PlacementCriteria } from '@approved-premises/api'
 import applyPaths from '../../paths/apply'
+import matchPaths from '../../paths/match'
 import {
   cas1PremisesFactory,
   cas1PremisesSearchResultSummaryFactory,
@@ -24,6 +25,7 @@ import {
   premisesAddress,
   requestedOrEstimatedArrivalDateRow,
   spaceBookingConfirmationSummaryListRows,
+  spaceSearchResultsCards,
   startDateObjFromParams,
   summaryCardRows,
 } from '.'
@@ -78,6 +80,37 @@ describe('matchUtils', () => {
         addressRow(spaceSearchResult),
         distanceRow(spaceSearchResult, postcodeArea),
         characteristicsRow(spaceSearchResult),
+      ])
+    })
+  })
+
+  describe('spaceSearchResultsCards', () => {
+    it('renders a list of space search results as summary lists with cards', () => {
+      const placementRequestId = 'placement-request-id'
+      const postcodeArea = 'HR1 2AF'
+      const spaceSearchResults = spaceSearchResultFactory.buildList(1)
+
+      const resultCards = spaceSearchResultsCards(placementRequestId, postcodeArea, spaceSearchResults)
+
+      expect(resultCards).toEqual([
+        {
+          card: {
+            actions: {
+              items: [
+                {
+                  href: matchPaths.v2Match.placementRequests.search.occupancy({
+                    id: placementRequestId,
+                    premisesId: spaceSearchResults[0].premises.id,
+                  }),
+                  text: 'View spaces',
+                  visuallyHiddenText: `View spaces at ${spaceSearchResults[0].premises.name}`,
+                },
+              ],
+            },
+            title: { headingLevel: '3', text: spaceSearchResults[0].premises.name },
+          },
+          rows: summaryCardRows(spaceSearchResults[0], postcodeArea),
+        },
       ])
     })
   })

--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -72,10 +72,10 @@ describe('matchUtils', () => {
   })
 
   describe('summaryCardsRow', () => {
-    it('calls the correct row functions', () => {
-      const postcodeArea = 'HR1 2AF'
-      const spaceSearchResult = spaceSearchResultFactory.build()
+    const postcodeArea = 'HR1 2AF'
+    const spaceSearchResult = spaceSearchResultFactory.build()
 
+    it('calls the correct row functions', () => {
       expect(summaryCardRows(spaceSearchResult, postcodeArea)).toEqual([
         apTypeRow(spaceSearchResult.premises.apType),
         summaryListItem('AP area', spaceSearchResult.premises.apArea.name),
@@ -84,15 +84,24 @@ describe('matchUtils', () => {
         characteristicsRow(spaceSearchResult),
       ])
     })
+
+    it('does not return the ap area row if the placement request is for a womens AP', () => {
+      expect(summaryCardRows(spaceSearchResult, postcodeArea, true)).toEqual([
+        apTypeRow(spaceSearchResult.premises.apType),
+        addressRow(spaceSearchResult),
+        distanceRow(spaceSearchResult, postcodeArea),
+        characteristicsRow(spaceSearchResult),
+      ])
+    })
   })
 
   describe('spaceSearchResultsCards', () => {
-    it('renders a list of space search results as summary lists with cards', () => {
-      const placementRequestId = 'placement-request-id'
-      const postcodeArea = 'HR1 2AF'
-      const spaceSearchResults = spaceSearchResultFactory.buildList(1)
+    const placementRequest = cas1PlacementRequestDetailFactory.build()
+    const postcodeArea = 'HR1 2AF'
+    const spaceSearchResults = spaceSearchResultFactory.buildList(1)
 
-      const resultCards = spaceSearchResultsCards(placementRequestId, postcodeArea, spaceSearchResults)
+    it('renders a list of space search results as summary lists with cards', () => {
+      const resultCards = spaceSearchResultsCards(placementRequest, postcodeArea, spaceSearchResults)
 
       expect(resultCards).toEqual([
         {
@@ -101,7 +110,7 @@ describe('matchUtils', () => {
               items: [
                 {
                   href: matchPaths.v2Match.placementRequests.search.occupancy({
-                    id: placementRequestId,
+                    id: placementRequest.id,
                     premisesId: spaceSearchResults[0].premises.id,
                   }),
                   text: 'View spaces',
@@ -114,6 +123,13 @@ describe('matchUtils', () => {
           rows: summaryCardRows(spaceSearchResults[0], postcodeArea),
         },
       ])
+    })
+
+    it('does not contain the AP area row if the placement request is for a womens AP', () => {
+      placementRequest.application.isWomensApplication = true
+      const resultCards = spaceSearchResultsCards(placementRequest, postcodeArea, spaceSearchResults)
+
+      expect(resultCards[0].rows).toEqual(summaryCardRows(spaceSearchResults[0], postcodeArea, true))
     })
   })
 

--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -33,6 +33,7 @@ import { apTypeLongLabels } from '../apTypeLabels'
 import { textValue } from '../applications/helpers'
 import { allReleaseTypes } from '../applications/releaseTypeUtils'
 import { displayName } from '../personUtils'
+import { summaryListItem } from '../formUtils'
 
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
 
@@ -77,6 +78,7 @@ describe('matchUtils', () => {
 
       expect(summaryCardRows(spaceSearchResult, postcodeArea)).toEqual([
         apTypeRow(spaceSearchResult.premises.apType),
+        summaryListItem('AP area', spaceSearchResult.premises.apArea.name),
         addressRow(spaceSearchResult),
         distanceRow(spaceSearchResult, postcodeArea),
         characteristicsRow(spaceSearchResult),

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -91,18 +91,21 @@ export const departureDateRow = (departureDate: string) => ({
   },
 })
 
-export const summaryCardRows = (spaceSearchResult: SpaceSearchResult, postcodeArea: string): Array<SummaryListItem> => {
-  return [
+export const summaryCardRows = (
+  spaceSearchResult: SpaceSearchResult,
+  postcodeArea: string,
+  isWomensApplication = false,
+): Array<SummaryListItem> =>
+  [
     apTypeRow(spaceSearchResult.premises.apType),
-    summaryListItem('AP area', spaceSearchResult.premises.apArea.name),
+    !isWomensApplication && summaryListItem('AP area', spaceSearchResult.premises.apArea.name),
     addressRow(spaceSearchResult),
     distanceRow(spaceSearchResult, postcodeArea),
     characteristicsRow(spaceSearchResult),
-  ]
-}
+  ].filter(Boolean)
 
 export const spaceSearchResultsCards = (
-  placementRequestId: string,
+  placementRequest: Cas1PlacementRequestDetail,
   postcode: string,
   spaceSearchResults: Array<Cas1SpaceSearchResult>,
 ): Array<SummaryListWithCard> =>
@@ -116,7 +119,7 @@ export const spaceSearchResultsCards = (
         items: [
           {
             href: matchPaths.v2Match.placementRequests.search.occupancy({
-              id: placementRequestId,
+              id: placementRequest.id,
               premisesId: result.premises.id,
             }),
             text: 'View spaces',
@@ -125,7 +128,7 @@ export const spaceSearchResultsCards = (
         ],
       },
     },
-    rows: summaryCardRows(result, postcode),
+    rows: summaryCardRows(result, postcode, placementRequest.application.isWomensApplication),
   }))
 
 export const apTypeRow = (apType: ApType) => ({

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -12,8 +12,9 @@ import {
   ReleaseTypeOption,
   Cas1SpaceCharacteristic as SpaceCharacteristic,
   Cas1SpaceSearchResult as SpaceSearchResult,
+  Cas1SpaceSearchResult,
 } from '@approved-premises/api'
-import { KeyDetailsArgs, ObjectWithDateParts, SummaryListItem } from '@approved-premises/ui'
+import { KeyDetailsArgs, ObjectWithDateParts, SummaryListItem, SummaryListWithCard } from '@approved-premises/ui'
 import { DateFormats, daysToWeeksAndDays } from '../dateUtils'
 import { apTypeLongLabels } from '../apTypeLabels'
 import { summaryListItem } from '../formUtils'
@@ -21,6 +22,7 @@ import { textValue } from '../applications/helpers'
 import { displayName, isFullPerson } from '../personUtils'
 import { allReleaseTypes } from '../applications/releaseTypeUtils'
 import paths from '../../paths/apply'
+import matchPaths from '../../paths/match'
 import { characteristicsBulletList } from '../characteristicsUtils'
 import { spaceSearchResultsCharacteristicsLabels } from './spaceSearchLabels'
 
@@ -97,6 +99,33 @@ export const summaryCardRows = (spaceSearchResult: SpaceSearchResult, postcodeAr
     characteristicsRow(spaceSearchResult),
   ]
 }
+
+export const spaceSearchResultsCards = (
+  placementRequestId: string,
+  postcode: string,
+  spaceSearchResults: Array<Cas1SpaceSearchResult>,
+): Array<SummaryListWithCard> =>
+  spaceSearchResults.map(result => ({
+    card: {
+      title: {
+        text: result.premises.name,
+        headingLevel: '3',
+      },
+      actions: {
+        items: [
+          {
+            href: matchPaths.v2Match.placementRequests.search.occupancy({
+              id: placementRequestId,
+              premisesId: result.premises.id,
+            }),
+            text: 'View spaces',
+            visuallyHiddenText: `View spaces at ${result.premises.name}`,
+          },
+        ],
+      },
+    },
+    rows: summaryCardRows(result, postcode),
+  }))
 
 export const apTypeRow = (apType: ApType) => ({
   key: {

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -94,6 +94,7 @@ export const departureDateRow = (departureDate: string) => ({
 export const summaryCardRows = (spaceSearchResult: SpaceSearchResult, postcodeArea: string): Array<SummaryListItem> => {
   return [
     apTypeRow(spaceSearchResult.premises.apType),
+    summaryListItem('AP area', spaceSearchResult.premises.apArea.name),
     addressRow(spaceSearchResult),
     distanceRow(spaceSearchResult, postcodeArea),
     characteristicsRow(spaceSearchResult),

--- a/server/views/match/search.njk
+++ b/server/views/match/search.njk
@@ -41,7 +41,7 @@
         {{ govukSummaryList(placementRequestInfoSummaryList) }}
     {% endcall %}
 
-    <h2 class="govuk-heading-m">{{ spaceSearchResults.resultsCount }} Approved Premises found</h2>
+    <h2 class="govuk-heading-m">{{ spaceSearchResults | length }} Approved Premises found</h2>
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
@@ -55,25 +55,25 @@
                     <div class="space-search-inputs">
 
                         {% call govukFieldset( {
-                                legend: {
-                                    html: locationTitle
-                                    },
-                                hint: {
-                            text: "For example, M5"
+                            legend: {
+                                html: locationTitle
+                            },
+                            hint: {
+                                text: "For example, M5"
                             }
                         }) %}
 
-                        {{ govukInput({
-                            id: "postcode",
-                            name: "postcode",
-                            value: postcode,
-                            label: {
-                                text: "Postcode"
+                            {{ govukInput({
+                                id: "postcode",
+                                name: "postcode",
+                                value: postcode,
+                                label: {
+                                    text: "Postcode"
 
-                            },
-                            classes: "govuk-input--width-3",
-                            errorMessage: errors.postcode
-                        }) }}
+                                },
+                                classes: "govuk-input--width-3",
+                                errorMessage: errors.postcode
+                            }) }}
 
                         {% endcall %}
 
@@ -119,23 +119,8 @@
         </div>
 
         <div class="govuk-grid-column-two-thirds">
-            {% for spaceSearchResult in spaceSearchResults.results %}
-                {{ govukSummaryList({
-                    card: {
-                        title: {
-                            text: spaceSearchResult.premises.name,
-                            headingLevel: 3
-                        },
-                        actions: {
-                            items: [{
-                                href: paths.v2Match.placementRequests.search.occupancy({ id: placementRequest.id, premisesId: spaceSearchResult.premises.id }),
-                                text: "View spaces",
-                                visuallyHiddenText: "View spaces at " + spaceSearchResult.premises.name
-                            }]
-                        }
-                    },
-                    rows: MatchUtils.summaryCardRows(spaceSearchResult, postcode)
-                }) }}
+            {% for spaceSearchResultCard in spaceSearchResults %}
+                {{ govukSummaryList(spaceSearchResultCard) }}
             {% endfor %}
 
             <h3 class="govuk-heading-m">Mark this case as unable to match</h3>


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2376

# Changes in this PR

Adds the premises AP area as a summary list item to search results cards. This is not shown for searches for a women AP.

## Screenshots of UI changes

<img width="657" alt="Screenshot 2025-06-19 at 14 02 23" src="https://github.com/user-attachments/assets/d1893724-0b95-4d2f-be0f-5a0a28d6c1d4" />

