### PR TITLE
BUGFIX/APS-2407: Prevent render error on `null` OASys section

### DIFF
--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.test.ts
@@ -234,6 +234,18 @@ describe('OptionalOasysSections', () => {
           [pageWithOnlyOtherNeeds.otherNeedsHeading]: '2. Some other section',
         })
       })
+
+      it('ignores sections that are set as `null`', () => {
+        const page = new OptionalOasysSections({
+          needsLinkedToReoffending: [needLinkedToReoffendingA, null, needLinkedToReoffendingB],
+          otherNeeds: [otherNeedA, otherNeedB, null, null],
+        })
+
+        expect(page.response()).toEqual({
+          [page.needsLinkedToReoffendingHeading]: '1. Some section, 2. Some other section',
+          [page.otherNeedsHeading]: '3. Foo section, 4. Bar section',
+        })
+      })
     })
   })
 })

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
@@ -128,9 +128,13 @@ export default class OptionalOasysSections implements TasklistPage {
   }
 
   getResponseForTypeOfNeed(typeOfNeed: Array<Cas1OASysSupportingInformationQuestionMetaData>) {
-    if (Array.isArray(typeOfNeed) && typeOfNeed.length) {
-      return typeOfNeed.map(need => `${need.section}. ${sentenceCase(need.sectionLabel)}`).join(', ')
+    if (Array.isArray(typeOfNeed)) {
+      return typeOfNeed
+        .filter(Boolean)
+        .map(need => `${need.section}. ${sentenceCase(need.sectionLabel)}`)
+        .join(', ')
     }
+
     return ''
   }
 


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2407

# Changes in this PR

After removal of certain OASys sections, some application may end up with OASys section equal to `null`. This PR filters out such sections before rendering to prevent an error being thrown.

## Screenshots of UI changes

n/a
