### PR TITLE
BUGFIX/APS-2408: Redact OASys answer for Sentry alert

### DIFF
--- a/server/utils/oasysImportUtils.test.ts
+++ b/server/utils/oasysImportUtils.test.ts
@@ -239,9 +239,21 @@ describe('OASysImportUtils', () => {
     })
 
     it('calls logToSentry and returns an empty string if a summary is not find', () => {
-      expect(findSummaryLabel('1', [{ questionNumber: '20', label: 'some label' }])).toBe('')
+      expect(
+        findSummaryLabel('1', [
+          {
+            questionNumber: '20',
+            label: 'some label',
+            answer: 'Some answer here',
+          },
+          {
+            questionNumber: '12.4',
+            label: 'foo',
+          },
+        ]),
+      ).toBe('')
       expect(logToSentry).toHaveBeenCalledWith(
-        'OASys summary not found for question number: 1. Summaries [{"questionNumber":"20","label":"some label"}]',
+        'OASys summary not found for question number: 1. Summaries [{"questionNumber":"20","label":"some label","answer":"***redacted***"},{"questionNumber":"12.4","label":"foo"}]',
       )
     })
   })

--- a/server/utils/oasysImportUtils.ts
+++ b/server/utils/oasysImportUtils.ts
@@ -117,8 +117,12 @@ export const findSummaryLabel = (questionNumber: string, summaries: Array<OASysQ
   let summary: OASysQuestion | undefined = summaries.find(i => i.questionNumber === questionNumber)
 
   if (!summary) {
+    const redactedSummaries = summaries.map(question => ({
+      ...question,
+      answer: question.answer ? '***redacted***' : undefined,
+    }))
     logToSentry(
-      `OASys summary not found for question number: ${questionNumber}. Summaries ${JSON.stringify(summaries)}`,
+      `OASys summary not found for question number: ${questionNumber}. Summaries ${JSON.stringify(redactedSummaries)}`,
     )
     summary = { label: '', questionNumber }
   }


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2408

# Changes in this PR

If an OASys summary is not defined, an alert containing all summaries for the OASys section is sent to Sentry. This PR ensures any user input (in the `answer` property of a summary) is redacted before the alert is created.

## Screenshots of UI changes

n/a
