### PR TITLE
APS-2363 Add Overdue Placements Report

### DIFF
--- a/server/utils/reportUtils.test.ts
+++ b/server/utils/reportUtils.test.ts
@@ -48,6 +48,13 @@ describe('reportUtils', () => {
             text: 'Placements where the following fall within the requested date range - expected arrival/departure, actual arrival/departure, non arrival, withdrawal. This only includes placements for regions taking part in the Find and Booking Private Beta.',
           },
         },
+        {
+          value: 'overduePlacements',
+          text: 'Overdue Placements',
+          hint: {
+            text: 'Placements where the expected arrival or departure date falls within the requested date range, and there is an overdue arrival or departure. This only includes placements for regions taking part in the Find and Booking Private Beta.',
+          },
+        },
       ])
     })
 
@@ -131,6 +138,13 @@ describe('reportUtils', () => {
           text: 'Raw Placement Report (PII)',
           hint: {
             text: 'Includes additional columns of PII data.',
+          },
+        },
+        {
+          value: 'overduePlacements',
+          text: 'Overdue Placements',
+          hint: {
+            text: 'Placements where the expected arrival or departure date falls within the requested date range, and there is an overdue arrival or departure. This only includes placements for regions taking part in the Find and Booking Private Beta.',
           },
         },
       ])

--- a/server/utils/reportUtils.test.ts
+++ b/server/utils/reportUtils.test.ts
@@ -10,7 +10,7 @@ describe('reportUtils', () => {
           value: 'outOfServiceBeds',
           text: 'Out of service beds',
           hint: {
-            text: 'A report of all out of service beds within the month and how long they were unavailable for.',
+            text: 'A report of all out of service beds within the requested date range and how long they were unavailable for.',
           },
         },
         {
@@ -24,28 +24,28 @@ describe('reportUtils', () => {
           value: 'applicationsV2',
           text: 'Raw Applications for Performance Hub',
           hint: {
-            text: 'Applications submitted or withdrawn within the requested month.',
+            text: 'Applications submitted or withdrawn within the requested date range.',
           },
         },
         {
           value: 'requestsForPlacement',
           text: 'Raw Requests for Placement for Performance Hub',
           hint: {
-            text: 'Requests for placements submitted or withdrawn within the requested month.',
+            text: 'Requests for placements submitted or withdrawn within the requested date range.',
           },
         },
         {
           value: 'placementMatchingOutcomesV2',
           text: 'Raw Placement Matching Outcomes Report V2',
           hint: {
-            text: 'Placement matching outcomes for placement requests with a requested arrival within the month. This includes withdrawn requests.',
+            text: 'Placement matching outcomes for placement requests with a requested arrival date within the requested date range. This includes withdrawn requests.',
           },
         },
         {
           value: 'placements',
           text: 'Raw Placement Report',
           hint: {
-            text: 'Placements where the following fall within the requested month - expected arrival/departure, actual arrival/departure, non arrival, withdrawal. This only includes placements for regions taking part in the Find and Booking Private Beta.',
+            text: 'Placements where the following fall within the requested date range - expected arrival/departure, actual arrival/departure, non arrival, withdrawal. This only includes placements for regions taking part in the Find and Booking Private Beta.',
           },
         },
       ])
@@ -60,7 +60,7 @@ describe('reportUtils', () => {
           value: 'outOfServiceBeds',
           text: 'Out of service beds',
           hint: {
-            text: 'A report of all out of service beds within the month and how long they were unavailable for.',
+            text: 'A report of all out of service beds within the requested date range and how long they were unavailable for.',
           },
         },
         {
@@ -81,7 +81,7 @@ describe('reportUtils', () => {
           value: 'applicationsV2',
           text: 'Raw Applications for Performance Hub',
           hint: {
-            text: 'Applications submitted or withdrawn within the requested month.',
+            text: 'Applications submitted or withdrawn within the requested date range.',
           },
         },
         {
@@ -95,7 +95,7 @@ describe('reportUtils', () => {
           value: 'requestsForPlacement',
           text: 'Raw Requests for Placement for Performance Hub',
           hint: {
-            text: 'Requests for placements submitted or withdrawn within the requested month.',
+            text: 'Requests for placements submitted or withdrawn within the requested date range.',
           },
         },
         {
@@ -109,7 +109,7 @@ describe('reportUtils', () => {
           value: 'placementMatchingOutcomesV2',
           text: 'Raw Placement Matching Outcomes Report V2',
           hint: {
-            text: 'Placement matching outcomes for placement requests with a requested arrival within the month. This includes withdrawn requests.',
+            text: 'Placement matching outcomes for placement requests with a requested arrival date within the requested date range. This includes withdrawn requests.',
           },
         },
         {
@@ -123,7 +123,7 @@ describe('reportUtils', () => {
           value: 'placements',
           text: 'Raw Placement Report',
           hint: {
-            text: 'Placements where the following fall within the requested month - expected arrival/departure, actual arrival/departure, non arrival, withdrawal. This only includes placements for regions taking part in the Find and Booking Private Beta.',
+            text: 'Placements where the following fall within the requested date range - expected arrival/departure, actual arrival/departure, non arrival, withdrawal. This only includes placements for regions taking part in the Find and Booking Private Beta.',
           },
         },
         {

--- a/server/utils/reportUtils.ts
+++ b/server/utils/reportUtils.ts
@@ -4,7 +4,7 @@ import { hasPermission } from './users'
 export const reportInputLabels = {
   outOfServiceBeds: {
     text: 'Out of service beds',
-    hint: 'A report of all out of service beds within the month and how long they were unavailable for.',
+    hint: 'A report of all out of service beds within the requested date range and how long they were unavailable for.',
   },
   outOfServiceBedsWithPii: {
     text: 'Out of service beds (PII)',
@@ -16,7 +16,7 @@ export const reportInputLabels = {
   },
   applicationsV2: {
     text: 'Raw Applications for Performance Hub',
-    hint: 'Applications submitted or withdrawn within the requested month.',
+    hint: 'Applications submitted or withdrawn within the requested date range.',
   },
   applicationsV2WithPii: {
     text: 'Raw Applications for Performance Hub (PII)',
@@ -24,7 +24,7 @@ export const reportInputLabels = {
   },
   requestsForPlacement: {
     text: 'Raw Requests for Placement for Performance Hub',
-    hint: 'Requests for placements submitted or withdrawn within the requested month.',
+    hint: 'Requests for placements submitted or withdrawn within the requested date range.',
   },
   requestsForPlacementWithPii: {
     text: 'Raw Requests for Placement for Performance Hub (PII)',
@@ -32,7 +32,7 @@ export const reportInputLabels = {
   },
   placementMatchingOutcomesV2: {
     text: 'Raw Placement Matching Outcomes Report V2',
-    hint: 'Placement matching outcomes for placement requests with a requested arrival within the month. This includes withdrawn requests.',
+    hint: 'Placement matching outcomes for placement requests with a requested arrival date within the requested date range. This includes withdrawn requests.',
   },
   placementMatchingOutcomesV2WithPii: {
     text: 'Raw Placement Matching Outcomes Report V2 (PII)',
@@ -40,7 +40,7 @@ export const reportInputLabels = {
   },
   placements: {
     text: 'Raw Placement Report',
-    hint: 'Placements where the following fall within the requested month - expected arrival/departure, actual arrival/departure, non arrival, withdrawal. This only includes placements for regions taking part in the Find and Booking Private Beta.',
+    hint: 'Placements where the following fall within the requested date range - expected arrival/departure, actual arrival/departure, non arrival, withdrawal. This only includes placements for regions taking part in the Find and Booking Private Beta.',
   },
   placementsWithPii: {
     text: 'Raw Placement Report (PII)',

--- a/server/utils/reportUtils.ts
+++ b/server/utils/reportUtils.ts
@@ -2,22 +2,6 @@ import { UserDetails } from '@approved-premises/ui'
 import { hasPermission } from './users'
 
 export const reportInputLabels = {
-  applications: {
-    text: 'Raw Applications',
-    hint: 'A raw data extract for applications submitted within the month. Includes data up to the point of assessment completion.',
-  },
-  placementApplications: {
-    text: 'Raw requests for placement',
-    hint: 'A raw data extract for request for placements created within the month. Includes application data, but does not include matching or booking data.',
-  },
-  placementMatchingOutcomes: {
-    text: 'Raw data for Placement matching outcomes',
-    hint: 'A raw data extract to help identify placement matching outcomes. This downloads Match requests based on the Expected Arrival Date.',
-  },
-  lostBeds: {
-    text: 'Lost beds (no longer in use)',
-    hint: 'This report provides information on lost beds recorded before out of service beds functionality was enabled. This will be removed in the near future.',
-  },
   outOfServiceBeds: {
     text: 'Out of service beds',
     hint: 'A report of all out of service beds within the month and how long they were unavailable for.',
@@ -66,12 +50,7 @@ export const reportInputLabels = {
 
 export type ReportType = (keyof typeof reportInputLabels)[number]
 
-export const unusedReports = [
-  'applications',
-  'placementApplications',
-  'placementMatchingOutcomes',
-  'lostBeds',
-] as Array<string>
+export const unusedReports = [] as Array<string>
 
 export const piiReports = [
   'applicationsV2WithPii',

--- a/server/utils/reportUtils.ts
+++ b/server/utils/reportUtils.ts
@@ -46,6 +46,10 @@ export const reportInputLabels = {
     text: 'Raw Placement Report (PII)',
     hint: 'Includes additional columns of PII data.',
   },
+  overduePlacements: {
+    text: 'Overdue Placements',
+    hint: 'Placements where the expected arrival or departure date falls within the requested date range, and there is an overdue arrival or departure. This only includes placements for regions taking part in the Find and Booking Private Beta.',
+  },
 } as const
 
 export type ReportType = (keyof typeof reportInputLabels)[number]


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2363

![Screenshot 2025-06-18 at 10 08 44](https://github.com/user-attachments/assets/3731a5db-28e8-4319-beaa-443c94a4e774)

# Changes in this PR

Add overdue placements report

This PR also tidies up some report code:

* The list of unused reports have now been removed from the API, so they will not be returning in the future. This commit empties the `unusedReports` array and removes the corresponding report definitions
* Reports can now be generated for a given date range, instead of a for a specific month. This PR updates the report descriptions to reflect this change.

## Screenshots of UI changes

### Before

![Screenshot 2025-06-18 at 09 33 16](https://github.com/user-attachments/assets/8ebbc2e2-6a4c-4a54-9ccf-4a477737a438)

### After

![Screenshot 2025-06-18 at 09 58 49](https://github.com/user-attachments/assets/b6a3dc83-d083-430a-a956-a491acbb65fc)
