### PR TITLE
APS-2221: Remove `aria-describedby` attribute when no error

### DIFF
--- a/server/utils/attachDocumentsUtils.test.ts
+++ b/server/utils/attachDocumentsUtils.test.ts
@@ -138,13 +138,13 @@ describe('attachDocumentsUtils', () => {
 
       expect(descriptionTextArea(document, {})).toMatchStringIgnoringWhitespace(
         `<label class="govuk-visually-hidden" for="document_123_description">Description of file.pdf</label>
-        <textarea class="govuk-textarea" id="document_123_description" name="documentDescriptions[123]" rows="3" aria-describedby="selectedDocuments_123_error">
+        <textarea class="govuk-textarea" id="document_123_description" name="documentDescriptions[123]" rows="3">
           Description goes here
         </textarea>`,
       )
     })
 
-    it('appends errors if they are present', () => {
+    it('appends errors and aria-describedby attribute if there are errors', () => {
       const document = documentFactory.build({ id: '123', fileName: 'file.pdf', description: 'Description goes here' })
       const errors = {
         selectedDocuments_123: {

--- a/server/utils/attachDocumentsUtils.ts
+++ b/server/utils/attachDocumentsUtils.ts
@@ -57,17 +57,17 @@ const documentCheckbox = (document: Document, selectedDocumentIds: Array<string>
 }
 
 const descriptionTextArea = (document: Document, errors: ErrorMessages): string => {
+  const hasError = errors[`selectedDocuments_${document.id}`]
+
   let input = `<label class="govuk-visually-hidden" for="document_${document.id}_description">Description of ${
     document.fileName
-  }</label><textarea class="govuk-textarea ${
-    errors[`selectedDocuments_${document.id}`] ? 'govuk-input--error' : ''
-  }" id="document_${document.id}_description" name="documentDescriptions[${
+  }</label><textarea class="govuk-textarea ${hasError ? 'govuk-input--error' : ''}" id="document_${document.id}_description" name="documentDescriptions[${
     document.id
-  }]" rows="3" aria-describedby="selectedDocuments_${document.id}_error">${
+  }]" rows="3" ${hasError ? `aria-describedby="selectedDocuments_${document.id}_error"` : ''}>${
     document.description ? document.description : ''
   }</textarea>`
 
-  if (errors[`selectedDocuments_${document.id}`]) {
+  if (hasError) {
     input = `
       ${input}
       <p id="selectedDocuments_${document.id}_error" class="govuk-error-message govuk-!-font-size-16">


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2221

# Changes in this PR

This ensures the document description textarea only has an `aria-describedby` attribute pointing to the error when there is an error for the field.

## Screenshots of UI changes

n/a
