### PR TITLE
APS-2400: Use CRU management areas instead of AP areas

### DIFF
--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -202,7 +202,7 @@ export default class ApplyHelper {
     const premises1 = cas1PremisesBasicSummaryFactory.build({ id: '1', apArea: { id: '1', name: 'area1' } })
     const premises2 = cas1PremisesBasicSummaryFactory.build({ id: '2', apArea: { id: '2', name: 'area2' } })
     const premises3 = cas1PremisesBasicSummaryFactory.build({ id: '3', apArea: { id: '3', name: 'area3' } })
-    cy.task('stubCas1AllPremises', [premises1, premises2, premises3])
+    cy.task('stubCas1AllPremises', { premises: [premises1, premises2, premises3] })
   }
 
   private stubPersonEndpoints() {

--- a/integration_tests/mockApis/premises.ts
+++ b/integration_tests/mockApis/premises.ts
@@ -9,18 +9,21 @@ import type {
 import { getMatchingRequests, stubFor } from './setup'
 import paths from '../../server/paths/api'
 
-const stubCas1AllPremises = (premises: Array<Cas1PremisesBasicSummary>) => {
+const stubCas1AllPremises = (args: { premises: Array<Cas1PremisesBasicSummary>; cruManagementAreaId?: string }) => {
   return stubFor({
     request: {
       method: 'GET',
-      urlPattern: '/cas1/premises/summary.*',
+      urlPath: paths.premises.index({}),
+      queryParameters: {
+        cruManagementAreaId: args.cruManagementAreaId ? { equalTo: args.cruManagementAreaId } : { absent: true },
+      },
     },
     response: {
       status: 200,
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
       },
-      jsonBody: premises,
+      jsonBody: args.premises,
     },
   })
 }

--- a/integration_tests/pages/manage/premisesList.ts
+++ b/integration_tests/pages/manage/premisesList.ts
@@ -17,14 +17,13 @@ export default class PremisesListPage extends Page {
   shouldShowPremises(premises: Array<Cas1PremisesBasicSummary>): void {
     premises.forEach((item: Cas1PremisesBasicSummary) => {
       cy.contains(item.name)
-        .parent()
+        .closest('tr')
         .within(() => {
+          cy.get('th')
+            .contains(item.name)
+            .should('have.attr', 'href', paths.premises.show({ premisesId: item.id }))
           cy.get('td').eq(0).contains(item.apCode)
           cy.get('td').eq(1).contains(item.bedCount)
-          cy.get('td')
-            .eq(2)
-            .contains('View')
-            .should('have.attr', 'href', paths.premises.show({ premisesId: item.id }))
         })
     })
   }

--- a/integration_tests/pages/manage/premisesList.ts
+++ b/integration_tests/pages/manage/premisesList.ts
@@ -1,4 +1,4 @@
-import type { Cas1PremisesBasicSummary } from '@approved-premises/api'
+import type { Cas1CruManagementArea, Cas1PremisesBasicSummary } from '@approved-premises/api'
 
 import Page from '../page'
 import paths from '../../../server/paths/manage'
@@ -29,22 +29,8 @@ export default class PremisesListPage extends Page {
     })
   }
 
-  shouldNotShowPremises(premises: Array<Cas1PremisesBasicSummary>): void {
-    premises.forEach((item: Cas1PremisesBasicSummary) => {
-      cy.get('td').should('not.contain', item.name)
-    })
-  }
-
-  filterPremisesByRegion(region: ProbationRegion['name']): void {
-    cy.get('#region').select(region)
-    this.clickSubmit()
-  }
-
-  followLinkToPremisesNamed(premisesName: string): void {
-    cy.contains(premisesName)
-      .parent()
-      .within(() => {
-        cy.get('a').contains('View').click()
-      })
+  filterPremisesByArea(area: Cas1CruManagementArea['name']): void {
+    cy.get('#selectedArea').select(area)
+    this.clickButton('Apply filter')
   }
 }

--- a/integration_tests/pages/manage/premisesList.ts
+++ b/integration_tests/pages/manage/premisesList.ts
@@ -1,4 +1,4 @@
-import type { Cas1PremisesBasicSummary, ProbationRegion } from '@approved-premises/api'
+import type { Cas1PremisesBasicSummary } from '@approved-premises/api'
 
 import Page from '../page'
 import paths from '../../../server/paths/manage'

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -94,7 +94,7 @@ context('Placement Requests', () => {
 
     const cas1premises = cas1PremisesBasicSummaryFactory.buildList(3, { supportsSpaceBookings: false })
     const cas1SpaceBookingPremises = cas1PremisesBasicSummaryFactory.buildList(2, { supportsSpaceBookings: true })
-    cy.task('stubCas1AllPremises', [...cas1premises, ...cas1SpaceBookingPremises])
+    cy.task('stubCas1AllPremises', { premises: [...cas1premises, ...cas1SpaceBookingPremises] })
     cy.task('stubBookingFromPlacementRequest', unmatchedPlacementRequest)
 
     return {

--- a/integration_tests/tests/manage/cru_member/viewsAllOutOfServiceBeds.cy.ts
+++ b/integration_tests/tests/manage/cru_member/viewsAllOutOfServiceBeds.cy.ts
@@ -38,7 +38,7 @@ describe('CRU Member with permission to view out of service bed tile lists all O
     // Given I am signed in as a CRU Member with the permission to view the out of service beds tile
     signIn('cru_member_enable_out_of_service_beds')
     cy.task('stubApAreaReferenceData', { apArea: apArea1, additionalAreas: [apArea2] })
-    cy.task('stubCas1AllPremises', allPremises)
+    cy.task('stubCas1AllPremises', { premises: allPremises })
   })
 
   const outOfServiceBeds = outOfServiceBedFactory.buildList(10, {

--- a/integration_tests/tests/manage/placements/change_requests.cy.ts
+++ b/integration_tests/tests/manage/placements/change_requests.cy.ts
@@ -131,7 +131,7 @@ context('Change requests', () => {
 
     cy.task('stubSpaceBookingShow', placement)
     cy.task('stubSpaceBookingGetWithoutPremises', placement)
-    cy.task('stubCas1AllPremises', allApprovedPremises)
+    cy.task('stubCas1AllPremises', { premises: allApprovedPremises })
     cy.task('stubSinglePremises', destinationAp)
     cy.task('stubSpaceBookingEmergencyTransferCreate', placement)
 

--- a/integration_tests/tests/manage/placements/departures.cy.ts
+++ b/integration_tests/tests/manage/placements/departures.cy.ts
@@ -35,7 +35,7 @@ context('Departures', () => {
     cy.task('stubDepartureReasonsReferenceData', departureReasonsJson)
     cy.task('stubMoveOnCategoriesReferenceData', moveOnCategoriesJson)
     cy.task('stubSpaceBookingDepartureCreate', placement)
-    cy.task('stubCas1AllPremises', premisesList)
+    cy.task('stubCas1AllPremises', { premises: premisesList })
   })
 
   it('lets a user with the correct permissions mark a person as departed', () => {

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -112,9 +112,13 @@ export interface HtmlItem {
   html: string
 }
 
-export type TableCell =
-  | { text: string; attributes?: HtmlAttributes; classes?: string }
-  | { html: string; attributes?: HtmlAttributes }
+export type TableCell = (TextItem | HtmlItem) & {
+  attributes?: HtmlAttributes
+  classes?: string
+  format?: 'numeric'
+  colspan?: number
+  rowspan?: number
+}
 
 export type TableRow = Array<TableCell>
 
@@ -125,7 +129,7 @@ export type RadioItem = {
   conditional?: {
     html?: string
   }
-  hint?: { text: string } | { html: string }
+  hint?: TextItem | HtmlItem
 }
 
 export type CheckBoxItem =
@@ -133,9 +137,7 @@ export type CheckBoxItem =
       text: string
       value: string
       checked?: boolean
-      hint?: {
-        text: string
-      }
+      hint?: TextItem | HtmlItem
       behaviour?: 'exclusive'
     }
   | Divider
@@ -185,9 +187,7 @@ export interface SummaryListItem {
 }
 
 export interface IdentityBar {
-  title: {
-    html: string
-  }
+  title: HtmlItem
   classes?: string
   menus?: Array<IdentityBarMenu>
 }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -282,7 +282,7 @@ type ManWoman = 'man' | 'woman'
 
 export interface PremisesFilters {
   gender?: ManWoman
-  apAreaId?: string
+  cruManagementAreaId?: string
 }
 
 export type DataServices = Partial<{

--- a/server/controllers/manage/index.ts
+++ b/server/controllers/manage/index.ts
@@ -23,7 +23,11 @@ import PlannedTransferController from './premises/changeRequests/plannedTransfer
 import PlacementAppealController from './premises/changeRequests/placementAppealController'
 
 export const controllers = (services: Services) => {
-  const premisesController = new PremisesController(services.premisesService, services.cruManagementAreaService)
+  const premisesController = new PremisesController(
+    services.premisesService,
+    services.cruManagementAreaService,
+    services.sessionService,
+  )
   const bedsController = new BedsController(services.premisesService)
   const outOfServiceBedsController = new OutOfServiceBedsController(
     services.outOfServiceBedService,

--- a/server/controllers/manage/index.ts
+++ b/server/controllers/manage/index.ts
@@ -23,7 +23,7 @@ import PlannedTransferController from './premises/changeRequests/plannedTransfer
 import PlacementAppealController from './premises/changeRequests/placementAppealController'
 
 export const controllers = (services: Services) => {
-  const premisesController = new PremisesController(services.premisesService, services.apAreaService)
+  const premisesController = new PremisesController(services.premisesService, services.cruManagementAreaService)
   const bedsController = new BedsController(services.premisesService)
   const outOfServiceBedsController = new OutOfServiceBedsController(
     services.outOfServiceBedService,

--- a/server/controllers/manage/premises/premisesController.test.ts
+++ b/server/controllers/manage/premises/premisesController.test.ts
@@ -15,7 +15,12 @@ import {
   staffMemberFactory,
   userDetailsFactory,
 } from '../../../testutils/factories'
-import { premisesOverbookingSummary, summaryListForPremises } from '../../../utils/premises'
+import {
+  premisesOverbookingSummary,
+  premisesTableHead,
+  premisesTableRows,
+  summaryListForPremises,
+} from '../../../utils/premises'
 
 describe('V2PremisesController', () => {
   const token = 'SOME_TOKEN'
@@ -310,12 +315,13 @@ describe('V2PremisesController', () => {
       cruManagementAreaService.getCruManagementAreas.mockResolvedValue(cruManagementAreas)
     })
 
-    it("should render the template with the premises and CRU management areas set to the current user's", async () => {
+    it("should render the template with the premises and CRU management area set to the current user's", async () => {
       const requestHandler = premisesController.index()
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('manage/premises/index', {
-        premisesSummaries,
+        tableHead: premisesTableHead,
+        tableRows: premisesTableRows(premisesSummaries),
         areas: cruManagementAreas,
         selectedArea: user.cruManagementArea.id,
       })
@@ -331,11 +337,13 @@ describe('V2PremisesController', () => {
       const requestHandler = premisesController.index()
       await requestHandler({ ...request, query: { selectedArea: areaId } }, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('manage/premises/index', {
-        premisesSummaries,
-        areas: cruManagementAreas,
-        selectedArea: areaId,
-      })
+      expect(response.render).toHaveBeenCalledWith(
+        'manage/premises/index',
+        expect.objectContaining({
+          areas: cruManagementAreas,
+          selectedArea: areaId,
+        }),
+      )
       expect(premisesService.getCas1All).toHaveBeenCalledWith(token, { cruManagementAreaId: areaId })
     })
 
@@ -345,11 +353,13 @@ describe('V2PremisesController', () => {
       const requestHandler = premisesController.index()
       await requestHandler({ ...request, query: { selectedArea: areaId } }, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('manage/premises/index', {
-        premisesSummaries,
-        areas: cruManagementAreas,
-        selectedArea: 'all',
-      })
+      expect(response.render).toHaveBeenCalledWith(
+        'manage/premises/index',
+        expect.objectContaining({
+          areas: cruManagementAreas,
+          selectedArea: 'all',
+        }),
+      )
       expect(premisesService.getCas1All).toHaveBeenCalledWith(token, {})
     })
   })

--- a/server/controllers/manage/premises/premisesController.test.ts
+++ b/server/controllers/manage/premises/premisesController.test.ts
@@ -309,7 +309,7 @@ describe('V2PremisesController', () => {
         selectedArea: '',
       })
 
-      expect(premisesService.getCas1All).toHaveBeenCalledWith(token, undefined)
+      expect(premisesService.getCas1All).toHaveBeenCalledWith(token, {})
       expect(cruManagementAreaService.getCruManagementAreas).toHaveBeenCalledWith(token)
     })
 
@@ -322,7 +322,7 @@ describe('V2PremisesController', () => {
       premisesService.getCas1All.mockResolvedValue(premisesSummaries)
 
       const requestHandler = premisesController.index()
-      await requestHandler({ ...request, body: { selectedArea: areaId } }, response, next)
+      await requestHandler({ ...request, query: { selectedArea: areaId } }, response, next)
 
       expect(response.render).toHaveBeenCalledWith('manage/premises/index', {
         premisesSummaries,

--- a/server/controllers/manage/premises/premisesController.test.ts
+++ b/server/controllers/manage/premises/premisesController.test.ts
@@ -3,14 +3,14 @@ import type { Cas1Premises, Cas1SpaceBookingSummary } from '@approved-premises/a
 import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
-import { ApAreaService, PremisesService } from '../../../services'
+import { CruManagementAreaService, PremisesService } from '../../../services'
 import PremisesController from './premisesController'
 
 import {
-  apAreaFactory,
   cas1PremisesBasicSummaryFactory,
   cas1PremisesFactory,
   cas1SpaceBookingSummaryFactory,
+  cruManagementAreaFactory,
   paginatedResponseFactory,
   staffMemberFactory,
 } from '../../../testutils/factories'
@@ -25,8 +25,8 @@ describe('V2PremisesController', () => {
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
   const premisesService = createMock<PremisesService>({})
-  const apAreaService = createMock<ApAreaService>({})
-  const premisesController = new PremisesController(premisesService, apAreaService)
+  const cruManagementAreaService = createMock<CruManagementAreaService>({})
+  const premisesController = new PremisesController(premisesService, cruManagementAreaService)
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -293,12 +293,11 @@ describe('V2PremisesController', () => {
   })
 
   describe('index', () => {
-    it('should render the template with the premises and areas', async () => {
+    it('should render the template with the premises and CRU management areas', async () => {
       const premisesSummaries = cas1PremisesBasicSummaryFactory.buildList(1)
+      const cruManagementAreas = cruManagementAreaFactory.buildList(1)
 
-      const apAreas = apAreaFactory.buildList(1)
-
-      apAreaService.getApAreas.mockResolvedValue(apAreas)
+      cruManagementAreaService.getCruManagementAreas.mockResolvedValue(cruManagementAreas)
       premisesService.getCas1All.mockResolvedValue(premisesSummaries)
 
       const requestHandler = premisesController.index()
@@ -306,20 +305,20 @@ describe('V2PremisesController', () => {
 
       expect(response.render).toHaveBeenCalledWith('manage/premises/index', {
         premisesSummaries,
-        areas: apAreas,
+        areas: cruManagementAreas,
         selectedArea: '',
       })
 
       expect(premisesService.getCas1All).toHaveBeenCalledWith(token, undefined)
-      expect(apAreaService.getApAreas).toHaveBeenCalledWith(token)
+      expect(cruManagementAreaService.getCruManagementAreas).toHaveBeenCalledWith(token)
     })
 
-    it('should call the premises service with the AP area ID if supplied', async () => {
-      const areaId = 'ap-area-id'
+    it('should call the premises service with the CRU management area ID if supplied', async () => {
+      const areaId = 'cru-management-area-id'
       const premisesSummaries = cas1PremisesBasicSummaryFactory.buildList(1)
-      const areas = apAreaFactory.buildList(1)
+      const cruManagementAreas = cruManagementAreaFactory.buildList(1)
 
-      apAreaService.getApAreas.mockResolvedValue(areas)
+      cruManagementAreaService.getCruManagementAreas.mockResolvedValue(cruManagementAreas)
       premisesService.getCas1All.mockResolvedValue(premisesSummaries)
 
       const requestHandler = premisesController.index()
@@ -327,12 +326,12 @@ describe('V2PremisesController', () => {
 
       expect(response.render).toHaveBeenCalledWith('manage/premises/index', {
         premisesSummaries,
-        areas,
+        areas: cruManagementAreas,
         selectedArea: areaId,
       })
 
-      expect(premisesService.getCas1All).toHaveBeenCalledWith(token, { apAreaId: areaId })
-      expect(apAreaService.getApAreas).toHaveBeenCalledWith(token)
+      expect(premisesService.getCas1All).toHaveBeenCalledWith(token, { cruManagementAreaId: areaId })
+      expect(cruManagementAreaService.getCruManagementAreas).toHaveBeenCalledWith(token)
     })
   })
 })

--- a/server/controllers/manage/premises/premisesController.test.ts
+++ b/server/controllers/manage/premises/premisesController.test.ts
@@ -3,7 +3,7 @@ import type { Cas1Premises, Cas1SpaceBookingSummary } from '@approved-premises/a
 import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
-import { CruManagementAreaService, PremisesService } from '../../../services'
+import { CruManagementAreaService, PremisesService, SessionService } from '../../../services'
 import PremisesController from './premisesController'
 
 import {
@@ -19,6 +19,7 @@ import { premisesOverbookingSummary, summaryListForPremises } from '../../../uti
 describe('V2PremisesController', () => {
   const token = 'SOME_TOKEN'
   const premisesId = 'some-uuid'
+  const referrer = 'referrer/path'
 
   let request: DeepMocked<Request>
   let response: DeepMocked<Response> = createMock<Response>({})
@@ -26,13 +27,15 @@ describe('V2PremisesController', () => {
 
   const premisesService = createMock<PremisesService>({})
   const cruManagementAreaService = createMock<CruManagementAreaService>({})
-  const premisesController = new PremisesController(premisesService, cruManagementAreaService)
+  const sessionService = createMock<SessionService>({})
+  const premisesController = new PremisesController(premisesService, cruManagementAreaService, sessionService)
 
   beforeEach(() => {
     jest.resetAllMocks()
     request = createMock<Request>({ user: { token }, params: { premisesId } })
     response = createMock<Response>({ locals: { user: { permissions: ['cas1_space_booking_list'] } } })
     jest.useFakeTimers()
+    sessionService.getPageBackLink.mockReturnValue(referrer)
   })
 
   describe('show', () => {
@@ -71,6 +74,7 @@ describe('V2PremisesController', () => {
       })
 
       expect(response.render).toHaveBeenCalledWith('manage/premises/show', {
+        backlink: referrer,
         premises: premisesSummary,
         summaryList: summaryListForPremises(premisesSummary),
         showPlacements: true,

--- a/server/controllers/manage/premises/premisesController.ts
+++ b/server/controllers/manage/premises/premisesController.ts
@@ -87,11 +87,10 @@ export default class PremisesController {
 
   index(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const selectedArea = req.body.selectedArea as ApArea['id']
-      const premisesSummaries = await this.premisesService.getCas1All(
-        req.user.token,
-        selectedArea && { cruManagementAreaId: selectedArea },
-      )
+      const selectedArea = req.query.selectedArea as ApArea['id']
+      const premisesSummaries = await this.premisesService.getCas1All(req.user.token, {
+        cruManagementAreaId: selectedArea,
+      })
       const areas = await this.cruManagementAreaService.getCruManagementAreas(req.user.token)
 
       return res.render('manage/premises/index', {

--- a/server/controllers/manage/premises/premisesController.ts
+++ b/server/controllers/manage/premises/premisesController.ts
@@ -1,7 +1,7 @@
 import type { Request, RequestHandler, Response } from 'express'
 
 import { ApArea, Cas1SpaceBookingSummarySortField, SortDirection } from '@approved-premises/api'
-import { ApAreaService, PremisesService } from '../../../services'
+import { CruManagementAreaService, PremisesService } from '../../../services'
 import managePaths from '../../../paths/manage'
 import { getPaginationDetails } from '../../../utils/getPaginationDetails'
 import { hasPermission } from '../../../utils/users'
@@ -24,7 +24,7 @@ interface ShowRequest extends Request {
 export default class PremisesController {
   constructor(
     private readonly premisesService: PremisesService,
-    private readonly apAreaService: ApAreaService,
+    private readonly cruManagementAreaService: CruManagementAreaService,
   ) {}
 
   show(): RequestHandler {
@@ -90,9 +90,9 @@ export default class PremisesController {
       const selectedArea = req.body.selectedArea as ApArea['id']
       const premisesSummaries = await this.premisesService.getCas1All(
         req.user.token,
-        selectedArea && { apAreaId: selectedArea },
+        selectedArea && { cruManagementAreaId: selectedArea },
       )
-      const areas = await this.apAreaService.getApAreas(req.user.token)
+      const areas = await this.cruManagementAreaService.getCruManagementAreas(req.user.token)
 
       return res.render('manage/premises/index', {
         premisesSummaries,

--- a/server/controllers/manage/premises/premisesController.ts
+++ b/server/controllers/manage/premises/premisesController.ts
@@ -1,6 +1,6 @@
 import type { Request, RequestHandler, Response } from 'express'
 
-import { ApArea, Cas1SpaceBookingSummarySortField, SortDirection } from '@approved-premises/api'
+import { Cas1CruManagementArea, Cas1SpaceBookingSummarySortField, SortDirection } from '@approved-premises/api'
 import { CruManagementAreaService, PremisesService, SessionService } from '../../../services'
 import managePaths from '../../../paths/manage'
 import { getPaginationDetails } from '../../../utils/getPaginationDetails'
@@ -18,6 +18,12 @@ interface ShowRequest extends Request {
     crnOrName: string
     keyworker: string
     activeTab: PremisesTab
+  }
+}
+
+interface IndexRequest extends Request {
+  query: {
+    selectedArea: Cas1CruManagementArea['id'] | 'all'
   }
 }
 
@@ -90,18 +96,18 @@ export default class PremisesController {
   }
 
   index(): RequestHandler {
-    return async (req: Request, res: Response) => {
+    return async (req: IndexRequest, res: Response) => {
       const { user } = res.locals
       const selectedArea = req.query.selectedArea || user.cruManagementArea?.id
       const premisesSummaries = await this.premisesService.getCas1All(req.user.token, {
-        cruManagementAreaId: selectedArea,
+        cruManagementAreaId: selectedArea === 'all' ? undefined : selectedArea,
       })
       const areas = await this.cruManagementAreaService.getCruManagementAreas(req.user.token)
 
       return res.render('manage/premises/index', {
         premisesSummaries,
         areas,
-        selectedArea: selectedArea || '',
+        selectedArea,
       })
     }
   }

--- a/server/controllers/manage/premises/premisesController.ts
+++ b/server/controllers/manage/premises/premisesController.ts
@@ -91,7 +91,8 @@ export default class PremisesController {
 
   index(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const selectedArea = req.query.selectedArea as ApArea['id']
+      const { user } = res.locals
+      const selectedArea = req.query.selectedArea || user.cruManagementArea?.id
       const premisesSummaries = await this.premisesService.getCas1All(req.user.token, {
         cruManagementAreaId: selectedArea,
       })

--- a/server/controllers/manage/premises/premisesController.ts
+++ b/server/controllers/manage/premises/premisesController.ts
@@ -1,7 +1,7 @@
 import type { Request, RequestHandler, Response } from 'express'
 
 import { ApArea, Cas1SpaceBookingSummarySortField, SortDirection } from '@approved-premises/api'
-import { CruManagementAreaService, PremisesService } from '../../../services'
+import { CruManagementAreaService, PremisesService, SessionService } from '../../../services'
 import managePaths from '../../../paths/manage'
 import { getPaginationDetails } from '../../../utils/getPaginationDetails'
 import { hasPermission } from '../../../utils/users'
@@ -25,6 +25,7 @@ export default class PremisesController {
   constructor(
     private readonly premisesService: PremisesService,
     private readonly cruManagementAreaService: CruManagementAreaService,
+    private readonly sessionService: SessionService,
   ) {}
 
   show(): RequestHandler {
@@ -66,6 +67,9 @@ export default class PremisesController {
         }))
 
       return res.render('manage/premises/show', {
+        backlink: this.sessionService.getPageBackLink(managePaths.premises.show.pattern, req, [
+          managePaths.premises.index.pattern,
+        ]),
         premises,
         summaryList: summaryListForPremises(premises),
         showPlacements,

--- a/server/controllers/manage/premises/premisesController.ts
+++ b/server/controllers/manage/premises/premisesController.ts
@@ -5,7 +5,13 @@ import { CruManagementAreaService, PremisesService, SessionService } from '../..
 import managePaths from '../../../paths/manage'
 import { getPaginationDetails } from '../../../utils/getPaginationDetails'
 import { hasPermission } from '../../../utils/users'
-import { PremisesTab, premisesOverbookingSummary, summaryListForPremises } from '../../../utils/premises'
+import {
+  PremisesTab,
+  premisesOverbookingSummary,
+  summaryListForPremises,
+  premisesTableRows,
+  premisesTableHead,
+} from '../../../utils/premises'
 
 type TabSettings = {
   pageSize: number
@@ -105,7 +111,8 @@ export default class PremisesController {
       const areas = await this.cruManagementAreaService.getCruManagementAreas(req.user.token)
 
       return res.render('manage/premises/index', {
-        premisesSummaries,
+        tableHead: premisesTableHead,
+        tableRows: premisesTableRows(premisesSummaries),
         areas,
         selectedArea,
       })

--- a/server/routes/manage.ts
+++ b/server/routes/manage.ts
@@ -109,10 +109,6 @@ export default function routes(controllers: Controllers, router: Router, service
     auditEvent: 'LIST_PREMISES',
     allowedPermissions: ['cas1_premises_view'],
   })
-  post(paths.premises.index.pattern, premisesController.index(), {
-    auditEvent: 'FILTER_PREMISES',
-    allowedPermissions: ['cas1_premises_view'],
-  })
   get(paths.premises.show.pattern, premisesController.show(), {
     auditEvent: 'SHOW_PREMISES',
     allowedPermissions: ['cas1_premises_view'],

--- a/server/utils/premises/index.test.ts
+++ b/server/utils/premises/index.test.ts
@@ -152,53 +152,44 @@ describe('premisesUtils', () => {
       expect(premisesTableRows(premises)).toEqual([
         [
           {
-            text: premises2.name,
+            html: linkTo(paths.premises.show({ premisesId: premises2.id }), {
+              text: premises2.name,
+            }),
           },
           {
             text: premises2.apCode,
           },
           {
             text: premises2.bedCount.toString(),
-          },
-          {
-            html: linkTo(paths.premises.show({ premisesId: premises2.id }), {
-              text: 'View',
-              hiddenText: `about ${premises2.name}`,
-            }),
+            format: 'numeric',
           },
         ],
         [
           {
-            text: premises3.name,
+            html: linkTo(paths.premises.show({ premisesId: premises3.id }), {
+              text: premises3.name,
+            }),
           },
           {
             text: premises3.apCode,
           },
           {
             text: premises3.bedCount.toString(),
-          },
-          {
-            html: linkTo(paths.premises.show({ premisesId: premises3.id }), {
-              text: 'View',
-              hiddenText: `about ${premises3.name}`,
-            }),
+            format: 'numeric',
           },
         ],
         [
           {
-            text: premises1.name,
+            html: linkTo(paths.premises.show({ premisesId: premises1.id }), {
+              text: premises1.name,
+            }),
           },
           {
             text: premises1.apCode,
           },
           {
             text: premises1.bedCount.toString(),
-          },
-          {
-            html: linkTo(paths.premises.show({ premisesId: premises1.id }), {
-              text: 'View',
-              hiddenText: `about ${premises1.name}`,
-            }),
+            format: 'numeric',
           },
         ],
       ])

--- a/server/utils/premises/index.ts
+++ b/server/utils/premises/index.ts
@@ -95,9 +95,7 @@ export const premisesTableHead: TableRow = [
   },
   {
     text: 'Number of beds',
-  },
-  {
-    html: '<span class="govuk-visually-hidden">Actions</span>',
+    format: 'numeric',
   },
 ]
 
@@ -106,12 +104,9 @@ export const premisesTableRows = (premisesSummaries: Array<Cas1PremisesBasicSumm
     .sort((a, b) => a.name.localeCompare(b.name))
     .map((p: Cas1PremisesBasicSummary) => {
       return [
-        textValue(p.name),
+        htmlValue(linkTo(managePaths.premises.show({ premisesId: p.id }), { text: p.name })),
         textValue(p.apCode),
-        textValue(p.bedCount.toString()),
-        htmlValue(
-          linkTo(managePaths.premises.show({ premisesId: p.id }), { text: 'View', hiddenText: `about ${p.name}` }),
-        ),
+        { ...textValue(p.bedCount.toString()), format: 'numeric' },
       ]
     })
 

--- a/server/utils/premises/index.ts
+++ b/server/utils/premises/index.ts
@@ -19,6 +19,7 @@ import { displayName } from '../personUtils'
 import { canonicalDates, placementStatusHtml } from '../placements'
 
 export { premisesActions } from './premisesActions'
+
 export const summaryListForPremises = (premises: Cas1Premises): SummaryList => {
   return {
     rows: [
@@ -85,8 +86,23 @@ export const cas1PremisesSummaryRadioOptions = (
     }
   })
 
-export const premisesTableRows = (premisesSummaries: Array<Cas1PremisesBasicSummary>) => {
-  return premisesSummaries
+export const premisesTableHead: TableRow = [
+  {
+    text: 'Name',
+  },
+  {
+    text: 'Code',
+  },
+  {
+    text: 'Number of beds',
+  },
+  {
+    html: '<span class="govuk-visually-hidden">Actions</span>',
+  },
+]
+
+export const premisesTableRows = (premisesSummaries: Array<Cas1PremisesBasicSummary>): Array<TableRow> =>
+  premisesSummaries
     .sort((a, b) => a.name.localeCompare(b.name))
     .map((p: Cas1PremisesBasicSummary) => {
       return [
@@ -98,7 +114,6 @@ export const premisesTableRows = (premisesSummaries: Array<Cas1PremisesBasicSumm
         ),
       ]
     })
-}
 
 export type PremisesTab = Cas1SpaceBookingResidency | 'search'
 

--- a/server/views/manage/premises/index.njk
+++ b/server/views/manage/premises/index.njk
@@ -26,12 +26,10 @@
 
             <div class="govuk-grid-column-one-quarter">
                 {{ govukButton({
-                    "text": "Apply filter",
-                    "type": "submit",
-                    classes: "govuk-!-margin-top-6",
+                    text: "Apply filter",
+                    type: "submit",
                     preventDoubleClick: true
-                }) }}
-            </div>
+            }) }}</div>
         </div>
     </form>
 

--- a/server/views/manage/premises/index.njk
+++ b/server/views/manage/premises/index.njk
@@ -9,27 +9,28 @@
 
     <h1 class="govuk-heading-l">List of Approved Premises</h1>
 
-    <form action="{{ paths.premises.index({}) }}" method="get">
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-one-quarter">
-                {{ govukSelect({
-                    label: {
-                        text: "Areas",
-                        classes: "govuk-label--s"
-                    },
-                    classes: "govuk-input--width-20",
-                    id: "selectedArea",
-                    name: "selectedArea",
-                    items: convertObjectsToSelectOptions(areas, 'All areas', 'name', 'id', 'selectedArea', 'all', context)
-                }) }}
-            </div>
+    <form action="{{ currentUrl }}" method="get" class="search-and-filter">
 
-            <div class="govuk-grid-column-one-quarter">
-                {{ govukButton({
-                    text: "Apply filter",
-                    type: "submit",
-                    preventDoubleClick: true
-            }) }}</div>
+        <h2 class="govuk-heading-m">Filter</h2>
+
+        <div class="search-and-filter__row">
+            {{ govukSelect({
+                label: {
+                    text: "AP area",
+                    classes: "govuk-label--s"
+                },
+                classes: "govuk-input--width-20",
+                id: "selectedArea",
+                name: "selectedArea",
+                items: convertObjectsToSelectOptions(areas, 'All areas', 'name', 'id', 'selectedArea', 'all', context)
+            }) }}
+
+            {{ govukButton({
+                text: "Apply filter",
+                type: "submit",
+
+                preventDoubleClick: true
+            }) }}
         </div>
     </form>
 

--- a/server/views/manage/premises/index.njk
+++ b/server/views/manage/premises/index.njk
@@ -20,7 +20,7 @@
                     classes: "govuk-input--width-20",
                     id: "selectedArea",
                     name: "selectedArea",
-                    items: convertObjectsToSelectOptions(areas, 'All areas', 'name', 'id', 'selectedArea', '', context)
+                    items: convertObjectsToSelectOptions(areas, 'All areas', 'name', 'id', 'selectedArea', 'all', context)
                 }) }}
             </div>
 

--- a/server/views/manage/premises/index.njk
+++ b/server/views/manage/premises/index.njk
@@ -8,12 +8,10 @@
 {% block content %}
 
     <h1 class="govuk-heading-l">List of Approved Premises</h1>
-    
-    <form action="{{ paths.premises.index({}) }}" method="post">
+
+    <form action="{{ paths.premises.index({}) }}" method="get">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-quarter">
-                <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-
                 {{ govukSelect({
                     label: {
                         text: "Areas",

--- a/server/views/manage/premises/index.njk
+++ b/server/views/manage/premises/index.njk
@@ -38,20 +38,7 @@
     {{ govukTable({
         captionClasses: "govuk-table__caption--m",
         firstCellIsHeader: true,
-        head: [
-            {
-                text: "Name"
-            },
-            {
-                text: "Code"
-            },
-            {
-                text: "Number of beds"
-            },
-            {
-                html: '<span class="govuk-visually-hidden">Actions</span>'
-            }
-        ],
-        rows: PremisesUtils.premisesTableRows(premisesSummaries)
+        head: tableHead,
+        rows: tableRows
     }) }}
 {% endblock %}

--- a/server/views/manage/premises/show.njk
+++ b/server/views/manage/premises/show.njk
@@ -23,7 +23,7 @@
 {% block beforeContent %}
     {{ govukBackLink({
         text: "Back",
-        href: paths.premises.index()
+        href: backlink
     }) }}
 {% endblock %}
 


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2400 & https://dsdmoj.atlassian.net/browse/APS-2371

# Changes in this PR

This PR sets the options in the AP area filter of the list of Premises to use CRU managements areas instead of AP areas, to match other such filters in the service (e.g. on the CRU dashboard). The filter is set to the user's CRU management area by default.

Changing the filter submits the form as a `GET` request, instead of `POST`: this ensures the user can navigate back to the same view from the Premises details page back link, and without the 'Confirm form resubmission' prompt if they use the browser back button.

The filter has been wrapped in a filter component to make it consistent with all other filters around the service.

The table has been updated a bit:
- The link to the Premises has been moved from the 'View' link in the last column to the name of the Premises in the first one, again, to ensure consistency with other tables around the service. This last 'Action' column has been removed.
- The 'Number of beds' column has been set as a `numeric` format: this ensures it is aligned right for better displaying the numbers.

_NOTE: this PR involved a change of signature for `stubCas1AllPremises`, which touched a fair few integration tests._

## Screenshots of UI changes

<details><summary>Before</summary>

<img width="987" alt="Screenshot 2025-06-24 at 17 51 10" src="https://github.com/user-attachments/assets/88379bf3-387e-48f2-bba7-c915652968d8" />

</details>

<details><summary>After</summary>

<img width="996" alt="Screenshot 2025-06-24 at 17 50 59" src="https://github.com/user-attachments/assets/8e3dec93-881d-4579-be04-1307fe0e28d2" />



</details>
