### PR TITLE
APS-2204: new inactive tab - tweaks

### DIFF
--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -9,6 +9,7 @@ import { DateFormats } from '../../utils/dateUtils'
 import {
   applicationShowPageTabs,
   applicationsTabs,
+  applicationStatusSelectOptions,
   firstPageOfApplicationJourney,
 } from '../../utils/applications/utils'
 import { getResponses } from '../../utils/applications/getResponses'
@@ -65,13 +66,14 @@ export default class ApplicationsController {
 
       res.render('applications/dashboard', {
         pageHeading: 'Approved Premises applications',
+        statuses: applicationStatusSelectOptions(searchOptions.status),
+        crnOrName: searchOptions.crnOrName,
         applications: result.data,
         pageNumber: Number(result.pageNumber),
         totalPages: Number(result.totalPages),
         hrefPrefix,
         sortBy,
         sortDirection,
-        ...searchOptions,
       })
     }
   }

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -954,6 +954,7 @@ describe('utils', () => {
           value: applicationSuitableStatuses,
         },
         { selected: false, text: 'Application withdrawn', value: 'withdrawn' },
+        { selected: false, text: 'Expired application', value: 'expired' },
       ])
     })
 
@@ -973,6 +974,7 @@ describe('utils', () => {
           value: applicationSuitableStatuses,
         },
         { selected: false, text: 'Application withdrawn', value: 'withdrawn' },
+        { selected: false, text: 'Expired application', value: 'expired' },
       ])
     })
   })

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -402,9 +402,7 @@ export const applicationShowPageTab = (id: Application['id'], tab: ApplicationSh
 
 export type ApplicationStatusForFilter = ApplicationStatus | typeof applicationSuitableStatuses
 
-const applicationStatusSelectOptions = (
-  selectedOption: ApplicationStatusForFilter | undefined | null,
-): Array<SelectOption> => {
+const applicationStatusSelectOptions = (selectedOption?: ApplicationStatusForFilter): Array<SelectOption> => {
   const statusFilters: ReadonlyArray<ApplicationStatus> = [
     'inapplicable',
     'started',

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -412,6 +412,7 @@ const applicationStatusSelectOptions = (selectedOption?: ApplicationStatusForFil
     'requestedFurtherInformation',
     'rejected',
     'withdrawn',
+    'expired',
   ]
 
   const options: Array<SelectOption> = statusFilters.map(status => ({

--- a/server/views/applications/_table.njk
+++ b/server/views/applications/_table.njk
@@ -17,7 +17,8 @@
                     attributes: { "aria-sort": "none" }
                 },
                 {
-                    text: "Tier"
+                    text: "Tier",
+                    attributes: { "aria-sort": "none" }
                 },
                 {
                     text: "Arrival date",

--- a/server/views/applications/dashboard.njk
+++ b/server/views/applications/dashboard.njk
@@ -48,7 +48,7 @@
                         },
                         id: "status",
                         name: "status",
-                        items: ApplyUtils.applicationStatusSelectOptions(status)
+                        items: statuses
                     }) }}
 
                     {{ govukButton({


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2204

# Changes in this PR

This PR:

- Re-adds sorting by tier (while current sort isn't accurate, it matches the sort order done by the API on other pages -- tickets exist to fix sorting algorithm in both API and UI)
- Adds the 'Expired application' status to the filter under 'All applications'

## Screenshots of UI changes

<details><summary>'Expired application' filter option</summary>

<img width="999" alt="Screenshot 2025-06-23 at 18 08 26" src="https://github.com/user-attachments/assets/2bc6f79c-3ffc-431c-969b-5486e4667822" />

</details>
