### PR TITLE
APS-2403 Support link to service now

### DIFF
--- a/e2e/tests/feedback-banner.spec.ts
+++ b/e2e/tests/feedback-banner.spec.ts
@@ -6,13 +6,18 @@ test('feedback banner', async ({ page, userWithoutRoles }) => {
   await signIn(page, userWithoutRoles)
 
   await page.goto('/')
+  const link = page.getByRole('link', { name: 'report a bug' })
 
-  await expect(page.getByRole('link', { name: 'email us' })).toHaveAttribute(
+  await expect(link).toHaveAttribute(
     'href',
-    'mailto:APServiceSupport@digital.justice.gov.uk',
+    'https://mojprod.service-now.com/moj_sp?id=sc_cat_item&table=sc_cat_item&sys_id=1ba4a5691b9f9a10a1e2ddf0b24bcbb1&recordUrl=com.glideapp.servicecatalog_cat_item_view.do%3Fv%3D1&sysparm_id=1ba4a5691b9f9a10a1e2ddf0b24bcbb1',
   )
+  await expect(link).toHaveAttribute('target', '_blank')
+  await expect(link).toHaveAttribute('rel', 'noreferrer noopener')
 
-  await page.getByRole('link', { name: 'Give us your feedback' }).click()
+  const feedbackLink = page.getByRole('link', { name: 'Give us your feedback' })
 
-  await expect(page).toHaveTitle('Satisfaction survey - Approved Premises (AP) also known as CAS1')
+  await expect(feedbackLink).toHaveAttribute('href', 'https://forms.office.com/e/jSiRQFF82r')
+  await expect(feedbackLink).toHaveAttribute('target', '_blank')
+  await expect(feedbackLink).toHaveAttribute('rel', 'noreferrer noopener')
 })

--- a/integration_tests/pages/dashboard.ts
+++ b/integration_tests/pages/dashboard.ts
@@ -3,7 +3,7 @@ import Page from './page'
 export default class DashboardPage extends Page {
   constructor() {
     super('Approved Premises')
-    this.checkPhaseBanner('email us')
+    this.checkPhaseBanner()
   }
 
   static visit(): DashboardPage {

--- a/integration_tests/pages/formPage.ts
+++ b/integration_tests/pages/formPage.ts
@@ -17,7 +17,7 @@ export default class FormPage extends Page {
     }
 
     if (checkPhaseBanner) {
-      this.checkPhaseBanner('Give us your feedback')
+      this.checkPhaseBanner()
     }
   }
 

--- a/integration_tests/pages/manage/placements/placementShow.ts
+++ b/integration_tests/pages/manage/placements/placementShow.ts
@@ -20,7 +20,7 @@ export default class PlacementShowPage extends Page {
       title = `${DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' })} to ${DateFormats.isoDateToUIDate(departureDate, { format: 'short' })}`
     }
     super(title)
-    this.checkPhaseBanner('Give us your feedback')
+    this.checkPhaseBanner()
   }
 
   static visit(placement: Cas1SpaceBooking, tab: PlacementTab = null): PlacementShowPage {

--- a/integration_tests/pages/manage/premisesList.ts
+++ b/integration_tests/pages/manage/premisesList.ts
@@ -6,7 +6,7 @@ import paths from '../../../server/paths/manage'
 export default class PremisesListPage extends Page {
   constructor() {
     super('Premises')
-    this.checkPhaseBanner('Give us your feedback')
+    this.checkPhaseBanner()
   }
 
   static visit(): PremisesListPage {

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -515,8 +515,16 @@ export default abstract class Page {
     })
   }
 
-  checkPhaseBanner(copy: string): void {
-    cy.get('[data-cy-phase-banner="phase-banner"]').contains(copy)
+  checkPhaseBanner(): void {
+    cy.get('[data-cy-phase-banner="phase-banner"]').contains('Give us your feedback')
+  }
+
+  textOrHtmlFromTableCell(tableCell: TableCell): string {
+    if ('text' in tableCell) {
+      return tableCell.text
+    }
+
+    return tableCell.html
   }
 
   checkForBackButton(path: string) {

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -274,5 +274,8 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addFilter('assetMap', (url: string) => assetManifest[url] || url)
 
   njkEnv.addGlobal('feedbackSurveyUrl', 'https://forms.office.com/e/jSiRQFF82r')
-  njkEnv.addGlobal('supportEmail', 'APServiceSupport@digital.justice.gov.uk')
+  njkEnv.addGlobal(
+    'serviceNowUrl',
+    'https://mojprod.service-now.com/moj_sp?id=sc_cat_item&table=sc_cat_item&sys_id=1ba4a5691b9f9a10a1e2ddf0b24bcbb1&recordUrl=com.glideapp.servicecatalog_cat_item_view.do%3Fv%3D1&sysparm_id=1ba4a5691b9f9a10a1e2ddf0b24bcbb1',
+  )
 }

--- a/server/views/partials/header.njk
+++ b/server/views/partials/header.njk
@@ -53,6 +53,6 @@
         tag: {
             text: "Beta"
         },
-        html: 'This is a new service. <a class="govuk-link" href="' + feedbackSurveyUrl + '">Give us your feedback</a> or <a class="govuk-link" href="mailto:' + supportEmail + '">email us</a> to report a bug'
+        html: 'This is a new service. <a class="govuk-link" href="' + feedbackSurveyUrl + '" target="_blank" rel="noreferrer noopener">Give us your feedback</a> or <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="' + serviceNowUrl + '">report a bug</a> in a new tab.'
     }) }}
 {% endblock %}

--- a/server/views/roleError.njk
+++ b/server/views/roleError.njk
@@ -9,6 +9,6 @@
   </p>
 
   <p>
-    If you think this is a mistake, please <a class="govuk-link" href="mailto:{{ PhaseBannerUtils.supportEmail }}">contact support</a>
+    If you think this is a mistake, please <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="{{ serviceNowUrl }}">report it here</a> in a new tab.
   </p>
 {% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2403

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Changes the support link in the header and on the authorisation error page, to the provided service-now link.

Both of these, and the feedback link now open in a new tab with appropriate content changes. (The rationale being that leaving feedback or reporting a problem should not interfere with the task the user is currently engaged in and they might want to include a screen-grab in the report)

THIS BRANCH IS NOT TO BE MERGED until go-live as service-now is still being updated.

[x] I have run the E2E tests locally and they passed

## Screenshots of UI changes

<details>
  <summary>Before</summary>
<img src="https://github.com/user-attachments/assets/aad2a885-daba-478f-9c06-12b29a8bbf77"/>
</details>

<details>
  <summary>After</summary>
<img src="https://github.com/user-attachments/assets/4378488c-9a9d-4ab1-a088-bbdc614c49e1"/>
</details>

