### PR TITLE
Chore: Fix Manage Premises E2E test selector

### DIFF
--- a/e2e/pages/manage/premisesListPage.ts
+++ b/e2e/pages/manage/premisesListPage.ts
@@ -10,10 +10,11 @@ export class PremisesListPage extends BasePage {
   }
 
   async choosePremises(premisesName: string) {
-    await this.page.getByRole('link', { name: `View about ${premisesName}`, exact: true }).click()
-  }
+    if (!(await this.page.getByRole('link', { name: premisesName }).isVisible())) {
+      await this.page.getByRole('combobox', { name: 'AP area' }).selectOption('All areas')
+      await this.page.getByRole('button', { name: 'Apply filter' }).click()
+    }
 
-  async filterPremises(apArea: string) {
-    await this.page.getByLabel('Areas').selectOption({ label: apArea })
+    await this.page.getByRole('link', { name: premisesName, exact: true }).click()
   }
 }


### PR DESCRIPTION
Follow-up to #2554

As the link to Premises page has changed, the selector used in the E2E test also needed updating. This also adds a step to view premises from 'All areas' if the relevant premises is not shown at first.

<img width="492" alt="Screenshot 2025-06-25 at 15 07 12" src="https://github.com/user-attachments/assets/1b05dffa-5e10-491e-be06-a23125e0731f" />

