### PR TITLE
APS-2428: Add legend to non-arrival reason radio buttons

### DIFF
--- a/server/views/manage/premises/placements/arrival.njk
+++ b/server/views/manage/premises/placements/arrival.njk
@@ -22,56 +22,64 @@
 {% endblock %}
 
 {% block content %}
-    <form action="{{ paths.premises.placements.arrival({ premisesId: placement.premises.id, placementId: placement.id }) }}"
-          method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+            {{ showErrorSummary(errorSummary, errorTitle) }}
 
-        {{ showErrorSummary(errorSummary, errorTitle) }}
+            <h1 class="govuk-heading-l">Record someone as arrived</h1>
+        </div>
+    </div>
 
-        <h1 class="govuk-heading-l">Record someone as arrived</h1>
-
-        {{ govukSummaryList({
-            rows: [{
-                key: {
-                    text: "Expected arrival date"
-                },
-                value: {
-                    text: formatDate(placement.expectedArrivalDate)
-                }
-            }]
-        }) }}
-
-        {{ govukDateInput({
-            id: "arrivalDateTime",
-            namePrefix: "arrivalDateTime",
-            items: dateFieldValues('arrivalDateTime', errors),
-            errorMessage: errors.arrivalDateTime,
-            fieldset: {
-                legend: {
-                    text: "What is the arrival date?",
-                    classes: "govuk-fieldset__legend--m"
-                }
+    {{ govukSummaryList({
+        rows: [{
+            key: {
+                text: "Expected arrival date"
+            },
+            value: {
+                text: formatDate(placement.expectedArrivalDate)
             }
-        }) }}
+        }]
+    }) }}
 
-        {{ govukInput({
-            label: {
-                text: 'What is the time of arrival?',
-                classes: 'govuk-fieldset__legend--m'
-            },
-            hint: {
-                text: 'For example, 09:30 or 14:55.'
-            },
-            classes: 'govuk-input--width-5',
-            id: 'arrivalTime',
-            name: 'arrivalTime',
-            value: arrivalTime,
-            errorMessage: errors.arrivalTime
-        }) }}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+            <form action="{{ paths.premises.placements.arrival({ premisesId: placement.premises.id, placementId: placement.id }) }}"
+                  method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-        {{ govukButton({
-            text: "Submit",
-            preventDoubleClick: true
-        }) }}
-    </form>
+                {{ govukDateInput({
+                    id: "arrivalDateTime",
+                    namePrefix: "arrivalDateTime",
+                    items: dateFieldValues('arrivalDateTime', errors),
+                    errorMessage: errors.arrivalDateTime,
+                    fieldset: {
+                        legend: {
+                            text: "What is the arrival date?",
+                            classes: "govuk-fieldset__legend--m"
+                        }
+                    }
+                }) }}
+
+                {{ govukInput({
+                    label: {
+                        text: 'What is the time of arrival?',
+                        classes: 'govuk-label--m'
+                    },
+                    hint: {
+                        text: 'For example, 09:30 or 14:55.'
+                    },
+                    classes: 'govuk-input--width-5',
+                    id: 'arrivalTime',
+                    name: 'arrivalTime',
+                    value: arrivalTime,
+                    errorMessage: errors.arrivalTime
+                }) }}
+
+                {{ govukButton({
+                    text: "Submit",
+                    preventDoubleClick: true
+                }) }}
+            </form>
+        </div>
+    </div>
 {% endblock %}

--- a/server/views/manage/premises/placements/departure/partials/layout.njk
+++ b/server/views/manage/premises/placements/departure/partials/layout.njk
@@ -20,7 +20,7 @@
 
 {% block content %}
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
             {{ showErrorSummary(errorSummary, errorTitle) }}
 
             <h1 class="govuk-heading-l">Record a departure</h1>
@@ -39,7 +39,7 @@
     }) }}
 
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
             <form action="{{ currentUrl }}" method="post">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 

--- a/server/views/manage/premises/placements/keyworker.njk
+++ b/server/views/manage/premises/placements/keyworker.njk
@@ -23,44 +23,50 @@
 {% endblock %}
 
 {% block content %}
+    {% include "../../../_messages.njk" %}
 
-    <form action="{{ paths.premises.placements.keyworker({ premisesId: placement.premises.id, placementId: placement.id }) }}"
-          method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+            {{ showErrorSummary(errorSummary, errorTitle) }}
 
-        {{ showErrorSummary(errorSummary, errorTitle) }}
+            <h1 class="govuk-heading-l">Edit keyworker details</h1>
+        </div>
+    </div>
 
-        {% include "../../../_messages.njk" %}
-
-        <h1 class="govuk-heading-l">Edit keyworker details</h1>
-
-
-        {{ govukSummaryList({
-            rows: [{
-                key: {
-                    text: "Keyworker"
-                },
-                value: {
-                    text: currentKeyworkerName
-                }
-            }]
-        }) }}
-
-        {{ govukSelect({
-            label: {
-                text: "Select keyworker",
-                classes: "govuk-label--s"
+    {{ govukSummaryList({
+        rows: [{
+            key: {
+                text: "Keyworker"
             },
-            id: "staffCode",
-            name: "staffCode",
-            items: keyworkersOptions
-        }) }}
+            value: {
+                text: currentKeyworkerName
+            }
+        }]
+    }) }}
 
-        {{ govukButton({
-            text: "Submit",
-            preventDoubleClick: true
-        }) }}
-    </form>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+            <form action="{{ paths.premises.placements.keyworker({ premisesId: placement.premises.id, placementId: placement.id }) }}"
+                  method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+                {{ govukSelect({
+                    label: {
+                        text: "Select keyworker",
+                        classes: "govuk-label--m"
+                    },
+                    id: "staffCode",
+                    name: "staffCode",
+                    items: keyworkersOptions
+                }) }}
+
+                {{ govukButton({
+                    text: "Submit",
+                    preventDoubleClick: true
+                }) }}
+            </form>
+        </div>
+    </div>
 
 {% endblock %}
 

--- a/server/views/manage/premises/placements/non-arrival.njk
+++ b/server/views/manage/premises/placements/non-arrival.njk
@@ -23,57 +23,63 @@
 {% endblock %}
 
 {% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+            {{ showErrorSummary(errorSummary, errorTitle) }}
 
-    <form action="{{ paths.premises.placements.nonArrival({ premisesId: placement.premises.id, placementId: placement.id }) }}"
-          method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+            <h1 class="govuk-heading-l">Record someone as not arrived</h1>
+        </div>
+    </div>
 
-        {{ showErrorSummary(errorSummary, errorTitle) }}
-
-        <h1 class="govuk-heading-l">Record someone as not arrived</h1>
-
-
-        {{ govukSummaryList({
-            rows: [{
-                key: {
-                    text: "Expected arrival date"
-                },
-                value: {
-                    text: formatDate(placement.expectedArrivalDate)
-                }
-            }]
-        }) }}
-
-        {{ govukRadios({
-            idPrefix: "reason",
-            fieldset: {
-                legend: {
-                    text: "Reason",
-                    classes: "govuk-fieldset__legend--m"
-                }
+    {{ govukSummaryList({
+        rows: [{
+            key: {
+                text: "Expected arrival date"
             },
-            errorMessage: errors.reason,
-            name: "reason",
-            items: convertObjectsToRadioItems(nonArrivalReasons, 'name', 'id', 'reason',{reason:reason})
-        }) }}
+            value: {
+                text: formatDate(placement.expectedArrivalDate)
+            }
+        }]
+    }) }}
 
-        {{ govukCharacterCount({
-            id: "notes",
-            name: "notes",
-            maxlength: 200,
-            value: notes,
-            label: {
-                text: "Any other information",
-                classes: "govuk-label--m"
-            },
-            errorMessage: errors.notes
-        }) }}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+            <form action="{{ paths.premises.placements.nonArrival({ premisesId: placement.premises.id, placementId: placement.id }) }}"
+                  method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-        {{ govukButton({
-            text: "Submit",
-            preventDoubleClick: true
-        }) }}
-    </form>
 
+                {{ govukRadios({
+                    idPrefix: "reason",
+                    fieldset: {
+                        legend: {
+                            text: "Reason",
+                            classes: "govuk-fieldset__legend--m"
+                        }
+                    },
+                    errorMessage: errors.reason,
+                    name: "reason",
+                    items: convertObjectsToRadioItems(nonArrivalReasons, 'name', 'id', 'reason',{reason:reason})
+                }) }}
+
+                {{ govukCharacterCount({
+                    id: "notes",
+                    name: "notes",
+                    maxlength: 200,
+                    value: notes,
+                    label: {
+                        text: "Any other information",
+                        classes: "govuk-label--m"
+                    },
+                    errorMessage: errors.notes
+                }) }}
+
+                {{ govukButton({
+                    text: "Submit",
+                    preventDoubleClick: true
+                }) }}
+            </form>
+        </div>
+    </div>
 {% endblock %}
 

--- a/server/views/manage/premises/placements/transfers/confirm.njk
+++ b/server/views/manage/premises/placements/transfers/confirm.njk
@@ -22,12 +22,12 @@
 {% endblock %}
 
 {% block content %}
-    {{ showErrorSummary(errorSummary) }}
-
-    <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
+            {{ showErrorSummary(errorSummary) }}
+
+            <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
             <form action="{{ currentUrl }}" method="post">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 

--- a/server/views/manage/premises/placements/transfers/emergency-details.njk
+++ b/server/views/manage/premises/placements/transfers/emergency-details.njk
@@ -23,12 +23,12 @@
 {% endblock %}
 
 {% block content %}
-    {{ showErrorSummary(errorSummary) }}
-
-    <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
+            {{ showErrorSummary(errorSummary) }}
+
+            <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
             <form action="{{ currentUrl }}" method="post">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
@@ -37,7 +37,7 @@
                     name: "destinationPremisesId",
                     label: {
                         text: "Where is the person being transferred to?",
-                        classes: "govuk-fieldset__legend--m"
+                        classes: "govuk-label--m"
                     },
                     attributes: {
                         'data-autocomplete': { value: true, optional: true },

--- a/server/views/manage/premises/placements/transfers/new.njk
+++ b/server/views/manage/premises/placements/transfers/new.njk
@@ -22,34 +22,37 @@
 {% endblock %}
 
 {% block content %}
-    {{ showErrorSummary(errorSummary) }}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+            {{ showErrorSummary(errorSummary) }}
 
-    <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+            <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
-    <form action="{{ currentUrl }}" method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+            <form action="{{ currentUrl }}" method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-        {{ govukDateInput({
-            id: "transferDate",
-            namePrefix: "transferDate",
-            fieldset: {
-                legend: {
-                    text: "When does the person need to be transferred?",
-                    classes: "govuk-fieldset__legend--m"
-                }
-            },
-            hint: {
-                text: "Enter the date that the transfer happened or will happen."
-            },
-            items: dateFieldValues('transferDate', errors),
-            errorMessage: errors.transferDate
-        }) }}
+                {{ govukDateInput({
+                    id: "transferDate",
+                    namePrefix: "transferDate",
+                    fieldset: {
+                        legend: {
+                            text: "When does the person need to be transferred?",
+                            classes: "govuk-fieldset__legend--m"
+                        }
+                    },
+                    hint: {
+                        text: "Enter the date that the transfer happened or will happen."
+                    },
+                    items: dateFieldValues('transferDate', errors),
+                    errorMessage: errors.transferDate
+                }) }}
 
-        {{ govukButton({
-            text: "Continue",
-            preventDoubleClick: true
-        }) }}
-    </form>
-
+                {{ govukButton({
+                    text: "Continue",
+                    preventDoubleClick: true
+                }) }}
+            </form>
+        </div>
+    </div>
 
 {% endblock %}

--- a/server/views/manage/premises/placements/transfers/planned-details.njk
+++ b/server/views/manage/premises/placements/transfers/planned-details.njk
@@ -40,14 +40,15 @@
 {% endblock %}
 
 {% block content %}
-    {{ showErrorSummary(errorSummary) }}
-
-    <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
+            {{ showErrorSummary(errorSummary) }}
+
+            <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
             <form action="{{ currentUrl }}" method="post">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
                 {{ govukRadios({
                     fieldset: {
                         legend: {


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2428

# Changes in this PR

This PR fixes an accessibility audit issue, which found no legend on the radio buttons used to record the reason for a non-arrival. Label wording has been taken from original designs.

The PR also ensures that any page showing a booking action form is consistent with original designs:

- error summary, heading and main form span 2/2 of the full width on desktop;
- any summary list between the heading and the form itself spans the full width.

Label classes have been updated to be consistent and use the class relevant to the element used.

## Screenshots of UI changes

<details><summary>Record non-arrival</summary>

<img width="738" alt="Screenshot 2025-06-26 at 14 55 52" src="https://github.com/user-attachments/assets/94914975-fced-4d1b-8e32-5579185d952d" />


</details>

<details><summary>Record arrival</summary>

<img width="738" alt="Screenshot 2025-06-26 at 14 55 34" src="https://github.com/user-attachments/assets/e3d18be4-f3ff-4250-9026-30cad8db1885" />


</details>

<details><summary>Record departure</summary>

<img width="738" alt="Screenshot 2025-06-26 at 15 06 16" src="https://github.com/user-attachments/assets/9835d2b9-30c5-471a-b258-e6bbb44fdd2d" />


</details>


<details><summary>Assign keyworker</summary>

<img width="738" alt="Screenshot 2025-06-26 at 15 05 24" src="https://github.com/user-attachments/assets/63b4b1d5-2883-4746-8729-6598cbc78b07" />

</details>
