### PR TITLE
APS-2385: Show AP area on booking confirmation screen

### DIFF
--- a/server/controllers/match/placementRequests/spaceBookingsController.test.ts
+++ b/server/controllers/match/placementRequests/spaceBookingsController.test.ts
@@ -14,7 +14,7 @@ import {
 import paths from '../../../paths/admin'
 import matchPaths from '../../../paths/match'
 import * as validationUtils from '../../../utils/validation'
-import { spaceBookingConfirmationSummaryListRows } from '../../../utils/match'
+import * as matchUtils from '../../../utils/match'
 import { DateFormats } from '../../../utils/dateUtils'
 
 describe('SpaceBookingsController', () => {
@@ -68,7 +68,7 @@ describe('SpaceBookingsController', () => {
         submitLink: matchPaths.v2Match.placementRequests.spaceBookings.create(params),
         placementRequest: placementRequestDetail,
         premises,
-        summaryListRows: spaceBookingConfirmationSummaryListRows({
+        summaryListRows: matchUtils.spaceBookingConfirmationSummaryListRows({
           premises,
           expectedArrivalDate: searchState.arrivalDate,
           expectedDepartureDate: searchState.departureDate,
@@ -80,6 +80,25 @@ describe('SpaceBookingsController', () => {
       })
       expect(placementRequestService.getPlacementRequest).toHaveBeenCalledWith(token, placementRequestDetail.id)
       expect(premisesService.find).toHaveBeenCalledWith(token, premises.id)
+    })
+
+    it("should render the summary list without AP area for a women's AP application", async () => {
+      jest.spyOn(matchUtils, 'spaceBookingConfirmationSummaryListRows')
+
+      const womensPlacementRequestDetail = cas1PlacementRequestDetailFactory.build({
+        application: { isWomensApplication: true },
+      })
+
+      placementRequestService.getPlacementRequest.mockResolvedValue(womensPlacementRequestDetail)
+
+      const requestHandler = spaceBookingsController.new()
+      await requestHandler(request, response, next)
+
+      expect(matchUtils.spaceBookingConfirmationSummaryListRows).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isWomensApplication: true,
+        }),
+      )
     })
 
     it('redirects to the suitability search if no search state is present', async () => {

--- a/server/controllers/match/placementRequests/spaceBookingsController.ts
+++ b/server/controllers/match/placementRequests/spaceBookingsController.ts
@@ -53,6 +53,7 @@ export default class {
         expectedDepartureDate: searchState.departureDate,
         criteria: searchState.roomCriteria,
         releaseType: placementRequest.releaseType,
+        isWomensApplication: placementRequest.application.isWomensApplication,
       })
 
       return res.render('match/placementRequests/spaceBookings/new', {

--- a/server/utils/match/index.test.ts
+++ b/server/utils/match/index.test.ts
@@ -247,6 +247,7 @@ describe('matchUtils', () => {
       ).toEqual([
         { key: { text: 'Approved Premises' }, value: { text: premises.name } },
         { key: { text: 'Address' }, value: { text: `${premises.fullAddress}, ${premises.postcode}` } },
+        { key: { text: 'AP area' }, value: { text: premises.apArea.name } },
         {
           key: { text: 'Room criteria' },
           value: {
@@ -268,7 +269,6 @@ describe('matchUtils', () => {
         criteria,
       })
 
-      expect(rows).toHaveLength(6)
       expect(rows).toEqual(expect.not.arrayContaining([expect.objectContaining({ key: { text: 'Release type' } })]))
     })
 
@@ -282,7 +282,6 @@ describe('matchUtils', () => {
         actualArrivalDate: '2025-04-25',
       })
 
-      expect(rows).toHaveLength(7)
       expect(rows).toEqual(
         expect.arrayContaining([
           { key: { text: 'Actual arrival date' }, value: { text: 'Fri 25 Apr 2025' } },
@@ -292,6 +291,19 @@ describe('matchUtils', () => {
       expect(rows).toEqual(
         expect.not.arrayContaining([{ key: { text: 'Arrival date' }, value: { text: 'Fri 23 May 2025' } }]),
       )
+    })
+
+    it("returns summary list items without the AP area if the booking is for a women's AP", () => {
+      const rows = spaceBookingConfirmationSummaryListRows({
+        premises,
+        expectedArrivalDate,
+        expectedDepartureDate,
+        criteria,
+        releaseType: placementRequest.releaseType,
+        isWomensApplication: true,
+      })
+
+      expect(rows).toEqual(expect.not.arrayContaining([expect.objectContaining({ key: { text: 'AP area' } })]))
     })
   })
 

--- a/server/utils/match/index.ts
+++ b/server/utils/match/index.ts
@@ -39,21 +39,31 @@ type SpaceBookingConfirmationData = {
   expectedDepartureDate: string
   criteria: Array<Cas1SpaceBookingCharacteristic>
   releaseType?: ReleaseTypeOption
+  isWomensApplication?: boolean
 }
 
 export const spaceBookingConfirmationSummaryListRows = (data: SpaceBookingConfirmationData): Array<SummaryListItem> => {
-  const { premises, expectedArrivalDate, actualArrivalDate, expectedDepartureDate, criteria, releaseType } = data
+  const {
+    premises,
+    expectedArrivalDate,
+    actualArrivalDate,
+    expectedDepartureDate,
+    criteria,
+    releaseType,
+    isWomensApplication,
+  } = data
 
   return [
     summaryListItem('Approved Premises', premises.name),
     summaryListItem('Address', premisesAddress(premises)),
+    !isWomensApplication && summaryListItem('AP area', premises.apArea.name),
     summaryListItem('Room criteria', characteristicsBulletList(criteria, { noneText: 'No room criteria' }), 'html'),
     actualArrivalDate
       ? summaryListItem('Actual arrival date', DateFormats.isoDateToUIDate(actualArrivalDate))
       : summaryListItem('Expected arrival date', DateFormats.isoDateToUIDate(expectedArrivalDate)),
     summaryListItem('Expected departure date', DateFormats.isoDateToUIDate(expectedDepartureDate)),
     summaryListItem('Length of stay', DateFormats.durationBetweenDates(expectedDepartureDate, expectedArrivalDate).ui),
-    releaseType ? summaryListItem('Release type', allReleaseTypes[releaseType]) : undefined,
+    releaseType && summaryListItem('Release type', allReleaseTypes[releaseType]),
   ].filter(Boolean)
 }
 


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2385

# Changes in this PR

Adds a row indicating the AP area of the chosen premises on the booking confirmation page. This row is not shown for applications to the women's estate.

## Screenshots of UI changes

<details><summary>Booking confirmation page</summary>

<img width="738" alt="Screenshot 2025-06-26 at 16 19 07" src="https://github.com/user-attachments/assets/e93adc62-29df-409e-968c-a637a5abee0d" />

</details>
