### PR TITLE
APS-2401 Manage beds list view update

### DIFF
--- a/integration_tests/pages/manage/bed/bedList.ts
+++ b/integration_tests/pages/manage/bed/bedList.ts
@@ -18,6 +18,12 @@ export default class BedsListPage extends Page {
   shouldShowBeds(beds: Array<Cas1PremisesBedSummary>, premisesId: Premises['id']): void {
     const rows = bedsTableRows(beds, premisesId)
     this.shouldContainTableRows(rows)
+    cy.contains(`Showing ${beds.length} beds`)
+  }
+
+  filterBeds(): void {
+    cy.contains('Step-free').click()
+    this.clickButton('Apply filters')
   }
 
   clickBed(bed: Cas1BedDetail): void {

--- a/integration_tests/pages/manage/bed/bedShow.ts
+++ b/integration_tests/pages/manage/bed/bedShow.ts
@@ -3,7 +3,7 @@ import { Cas1BedDetail, Cas1Premises, Premises } from '@approved-premises/api'
 import Page from '../../page'
 import paths from '../../../../server/paths/manage'
 
-import { bedDetails } from '../../../../server/utils/bedUtils'
+import { characteristicsSummary } from '../../../../server/utils/bedUtils'
 
 export default class BedShowPage extends Page {
   constructor(readonly bedName: string) {
@@ -19,7 +19,7 @@ export default class BedShowPage extends Page {
     cy.get('.govuk-caption-l').contains(bed.roomName)
     cy.get('h1').contains(bed.name)
 
-    this.shouldContainSummaryListItems(bedDetails(bed).rows)
+    this.shouldContainSummaryListItems(characteristicsSummary(bed.characteristics).rows)
   }
 
   shouldLinkToPremises(premises: Cas1Premises): void {

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -472,16 +472,23 @@ export default abstract class Page {
   shouldContainTableRows(rows: Array<Array<TableCell>>): void {
     cy.get('tbody tr').should('have.length', rows.length)
 
+    const textFromTableCell = (tableCell: TableCell): string => {
+      if ('text' in tableCell) {
+        return tableCell.text
+      }
+      return ''
+    }
+
     rows.forEach(row => {
-      cy.contains(this.textOrHtmlFromTableCell(row[0]))
+      const firstTextContent = textFromTableCell(row.find(column => 'text' in column))
+      cy.contains(firstTextContent)
         .parent()
         .within(() => {
-          const cols = row.slice(1)
-          cols.forEach((column, i) => {
+          row.forEach((column, i) => {
             if ('text' in column) {
-              cy.get('td').eq(i).contains(column.text)
+              cy.get('td,th').eq(i).contains(column.text)
             } else if ('html' in column) {
-              cy.get('td')
+              cy.get('td,th')
                 .eq(i)
                 .then($td => {
                   const { actual, expected } = parseHtml($td, column.html)
@@ -491,14 +498,6 @@ export default abstract class Page {
           })
         })
     })
-  }
-
-  textOrHtmlFromTableCell(tableCell: TableCell): string {
-    if ('text' in tableCell) {
-      return tableCell.text
-    }
-
-    return tableCell.html
   }
 
   checkPhaseBanner(copy: string): void {

--- a/integration_tests/tests/manage/future_manager/beds.cy.ts
+++ b/integration_tests/tests/manage/future_manager/beds.cy.ts
@@ -10,7 +10,10 @@ import {
 
 context('Beds', () => {
   const premisesId = 'premisesId'
-  const bedSummaries = cas1PremisesBedSummaryFactory.buildList(5)
+  const bedSummaries = [
+    ...cas1PremisesBedSummaryFactory.buildList(4),
+    cas1PremisesBedSummaryFactory.build({ characteristics: [] }),
+  ]
   const bedDetail = cas1BedDetailFactory.build({ ...bedSummaries[0], name: bedSummaries[1].bedName })
   const premises = cas1PremisesFactory.build({ id: premisesId })
 
@@ -35,6 +38,15 @@ context('Beds', () => {
 
     // And I should have a link to view all of this premises' out-of-service beds
     bedsPage.shouldIncludeLinkToAllPremisesOutOfServiceBeds(premisesId)
+
+    // When I filter the beds
+    bedsPage.filterBeds()
+
+    // Then I should see a reduced list of beds
+    bedsPage.shouldShowBeds(
+      bedSummaries.filter(({ characteristics }) => characteristics.includes('isStepFreeDesignated')),
+      premisesId,
+    )
 
     // When I click on a bed
     bedsPage.clickBed(bedDetail)

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -673,7 +673,7 @@ describe('utils', () => {
         })
 
         expect(actionsLink(applicationSummary)).toBe(
-          '<a href="/applications/an-application-id/withdrawals/new"  >Withdraw</a>',
+          '<a href="/applications/an-application-id/withdrawals/new">Withdraw</a>',
         )
       },
     )
@@ -688,7 +688,7 @@ describe('utils', () => {
         })
 
         expect(actionsLink(applicationSummary)).toEqual(
-          '<a href="/placement-applications?id=an-application-id"  >Create request for placement</a>',
+          '<a href="/placement-applications?id=an-application-id">Create request for placement</a>',
         )
       },
     )

--- a/server/utils/characteristicsUtils.test.ts
+++ b/server/utils/characteristicsUtils.test.ts
@@ -50,6 +50,19 @@ describe('characteristicsUtils', () => {
         '<span class="text-grey">Nothing here</span>',
       )
     })
+
+    it('should add a class if provided', () => {
+      const result = characteristicsBulletList(placementRequest.essentialCriteria, {
+        labels: roomCharacteristicMap,
+        classes: 'test-class',
+      })
+
+      expect(result).toMatchStringIgnoringWhitespace(`
+        <ul class="govuk-list govuk-list--bullet test-class">
+          <li>${roomCharacteristicMap.isStepFreeDesignated}</li>
+        </ul>
+      `)
+    })
   })
 
   describe('roomCharacteristicsInlineList', () => {

--- a/server/utils/characteristicsUtils.ts
+++ b/server/utils/characteristicsUtils.ts
@@ -17,14 +17,14 @@ export const getRoomCharacteristicLabel = (characteristic: Cas1SpaceCharacterist
 
 export const characteristicsBulletList = (
   requirements: Array<Cas1SpaceCharacteristic | PlacementCriteria>,
-  options: { labels?: Record<string, string>; noneText?: string } = {},
+  options: { labels?: Record<string, string>; noneText?: string; classes?: string } = {},
 ): string => {
   const { labels = placementCriteriaLabels, noneText = 'None' } = options
 
   const listItems = Object.keys(labels).filter(key => ((requirements || []) as Array<string>).includes(key))
 
   return listItems.length
-    ? `<ul class="govuk-list govuk-list--bullet">${listItems.map((key: UiPlacementCriteria) => `<li>${labels[key]}</li>`).join('')}</ul>`
+    ? `<ul class="govuk-list govuk-list--bullet${options.classes ? ` ${options.classes}` : ''}">${listItems.map((key: UiPlacementCriteria) => `<li>${labels[key]}</li>`).join('')}</ul>`
     : `<span class="text-grey">${noneText}</span>`
 }
 

--- a/server/utils/placementRequests/changeRequestsUtils.test.ts
+++ b/server/utils/placementRequests/changeRequestsUtils.test.ts
@@ -61,7 +61,7 @@ describe('changeRequestsUtils', () => {
       expect(changeRequestsTableRows(changeRequests)).toEqual([
         [
           {
-            html: `<a href="${adminPaths.admin.placementRequests.show({ id: changeRequests[0].placementRequestId })}"  >John Smith, C123456</a>`,
+            html: `<a href="${adminPaths.admin.placementRequests.show({ id: changeRequests[0].placementRequestId })}">John Smith, C123456</a>`,
           },
           { html: tierBadge('B3') },
           { text: '6 May 2025' },
@@ -70,7 +70,7 @@ describe('changeRequestsUtils', () => {
         ],
         [
           {
-            html: `<a href="${adminPaths.admin.placementRequests.show({ id: changeRequests[1].placementRequestId })}"  >Limited Access Offender, X987654</a>`,
+            html: `<a href="${adminPaths.admin.placementRequests.show({ id: changeRequests[1].placementRequestId })}">Limited Access Offender, X987654</a>`,
           },
           { html: tierBadge('A1') },
           { text: '12 Jul 2025' },
@@ -79,7 +79,7 @@ describe('changeRequestsUtils', () => {
         ],
         [
           {
-            html: `<a href="${adminPaths.admin.placementRequests.show({ id: changeRequests[2].placementRequestId })}"  >Unknown person, A333444</a>`,
+            html: `<a href="${adminPaths.admin.placementRequests.show({ id: changeRequests[2].placementRequestId })}">Unknown person, A333444</a>`,
           },
           { html: tierBadge('C1') },
           { text: '6 Jun 2025' },

--- a/server/utils/premises/occupancy.test.ts
+++ b/server/utils/premises/occupancy.test.ts
@@ -18,6 +18,7 @@ import {
   daySummaryRows,
   durationSelectOptions,
   filterOutOfServiceBeds,
+  generateCharacteristicsSummary,
   generateDaySummaryText,
   occupancyCalendar,
   outOfServiceBedTableRows,
@@ -381,6 +382,14 @@ describe('apOccupancy utils', () => {
         placementTableCaption: '1 person booked in on Wed 12 Feb 2025',
       })
     })
+  })
+})
+
+describe('generateCharacteristicsSummary', () => {
+  it('should render a prefixed list of characteristics', () => {
+    expect(generateCharacteristicsSummary(['isSingle', 'isArsonSuitable'], ' prefix ')).toEqual(
+      ' prefix single room and suitable for active arson risk',
+    )
   })
 })
 

--- a/server/utils/premises/occupancy.ts
+++ b/server/utils/premises/occupancy.ts
@@ -190,8 +190,8 @@ export const tableCaptions = (
   const formattedDate = DateFormats.isoDateToUIDate(daySummary.forDate)
   return detailedFormat
     ? {
-        placementTableCaption: `${pluralize('person', daySummary.spaceBookingSummaries?.length, 'people')} booked in on ${formattedDate}${generateCharacteristicsSummary(characteristicsArray)}`,
-        outOfServiceBedCaption: `${pluralize('out of service bed', daySummary.outOfServiceBeds?.length)} on ${formattedDate}${generateCharacteristicsSummary(characteristicsArray, 'with')}`,
+        placementTableCaption: `${pluralize('person', daySummary.spaceBookingSummaries?.length, 'people')} booked in on ${formattedDate}${generateCharacteristicsSummary(characteristicsArray, ' requiring: ')}`,
+        outOfServiceBedCaption: `${pluralize('out of service bed', daySummary.outOfServiceBeds?.length)} on ${formattedDate}${generateCharacteristicsSummary(characteristicsArray, ' with: ')}`,
       }
     : {
         placementTableCaption: `People booked in on ${formattedDate}`,
@@ -292,10 +292,10 @@ export const outOfServiceBedTableRows = (
 
 export const generateCharacteristicsSummary = (
   characteristicsArray: Array<Cas1SpaceBookingCharacteristic>,
-  verb = 'requiring',
+  prefix = ' requiring: ',
 ) => {
   return characteristicsArray?.length
-    ? ` ${verb}: ${joinWithCommas(
+    ? `${prefix}${joinWithCommas(
         characteristicsArray.map(characteristic => roomCharacteristicMap[characteristic].toLowerCase()),
       )}`
     : ''

--- a/server/utils/tableUtils.ts
+++ b/server/utils/tableUtils.ts
@@ -6,6 +6,10 @@ import { pluralize } from './utils'
 
 const DUE_DATE_APPROACHING_DAYS_WINDOW = 3
 
+export const textCell = (text: string): TableCell => ({ text })
+
+export const htmlCell = (html: string): TableCell => ({ html })
+
 export const nameCell = (item: { personName?: string }): TableCell => ({ text: item.personName })
 
 export const crnCell = (item: { crn?: string }): TableCell => ({ text: item.crn })

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -239,7 +239,13 @@ describe('linkTo', () => {
   it('allows hidden text to be specified', () => {
     expect(
       linkTo(path('/foo/:id')({ id: '123' }), { text: 'Hello', hiddenText: 'Hidden' }),
-    ).toMatchStringIgnoringWhitespace('<a href="/foo/123">Hello <span class="govuk-visually-hidden">Hidden</span></a>')
+    ).toMatchStringIgnoringWhitespace('<a href="/foo/123">Hello<span class="govuk-visually-hidden">Hidden</span></a>')
+  })
+
+  it('allows hidden prefix text to be specified', () => {
+    expect(
+      linkTo(path('/foo/:id')({ id: '123' }), { text: 'Hello', hiddenPrefix: 'Hidden' }),
+    ).toMatchStringIgnoringWhitespace('<a href="/foo/123"><span class="govuk-visually-hidden">Hidden</span>Hello</a>')
   })
 
   it('allows attributes to be specified', () => {

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -112,26 +112,25 @@ export const linkTo = (
     query = {},
     attributes = {},
     hiddenText = '',
+    hiddenPrefix = '',
     openInNewTab = false,
   }: {
     text: string
     query?: Record<string, string>
     attributes?: Record<string, string>
     hiddenText?: string
+    hiddenPrefix?: string
     openInNewTab?: boolean
   },
 ): string => {
-  let linkBody = text
-
-  if (hiddenText) {
-    linkBody = `${linkBody} <span class="govuk-visually-hidden">${hiddenText}</span>`
-  }
+  const hiddenSpan = (hidden: string) => (hidden ? `<span class="govuk-visually-hidden">${hidden}</span>` : '')
+  const linkBody = `${hiddenSpan(hiddenPrefix)}${text}${hiddenSpan(hiddenText)}`
 
   const attrBody = Object.keys(attributes)
-    .map(a => `${a}="${attributes[a]}"`)
-    .join(' ')
+    .map(a => ` ${a}="${attributes[a]}"`)
+    .join('')
 
-  return `<a href="${path}${createQueryString(query, { addQueryPrefix: true })}" ${attrBody} ${openInNewTab ? 'target="_blank"' : ''}>${linkBody}</a>`
+  return `<a href="${path}${createQueryString(query, { addQueryPrefix: true })}"${attrBody}${openInNewTab ? ' target="_blank"' : ''}>${linkBody}</a>`
 }
 
 /**

--- a/server/views/manage/premises/beds/index.njk
+++ b/server/views/manage/premises/beds/index.njk
@@ -1,7 +1,9 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "components/sortableTable/macro.njk" import sortableTable %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+{% from "../../../partials/filters.njk" import filterWrapper, filterCheckboxes %}
 
 {% extends "../../../partials/layout.njk" %}
 
@@ -17,7 +19,7 @@
 {% block content %}
     {% set headingHtml %}
         <span class="govuk-caption-l">
-            <a href="{{ backLink }}">{{ premises.name }}</a>
+            {{ premises.name }}
         </span>
         <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
     {% endset %}
@@ -29,15 +31,21 @@
         menus: actions
     }) }}
 
-    {{ govukTable({
-        captionClasses: "govuk-table__caption--m",
-        firstCellIsHeader: true,
-        head: [
-            { text: "Room Name" },
-            { text: "Bed Name" },
-            { text: "Action" }
-        ],
-        rows: tableRows
-    }) }}
+    {% call filterWrapper('Filter') %}
+        {{ filterCheckboxes('characteristics','Room characteristics',characteristicOptions) }}
+    {%- endcall %}
+
+    <section>
+        <h2 class="govuk-heading-m">{{ tableCaption }}</h2>
+
+        {{ sortableTable({
+            attributes: { 'data-module': 'moj-sortable-table' },
+            captionClasses: "govuk-table__caption--m",
+            firstCellIsHeader: true,
+            head: tableHeader,
+            rows: tableRows
+        }) }}
+
+    </section>>
 {% endblock %}
 

--- a/server/views/manage/premises/index.njk
+++ b/server/views/manage/premises/index.njk
@@ -1,6 +1,8 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../../partials/filters.njk" import filterWrapper, filterSelect %}
+
 {% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - Home" %}
@@ -9,30 +11,10 @@
 
     <h1 class="govuk-heading-l">List of Approved Premises</h1>
 
-    <form action="{{ currentUrl }}" method="get" class="search-and-filter">
-
-        <h2 class="govuk-heading-m">Filter</h2>
-
-        <div class="search-and-filter__row">
-            {{ govukSelect({
-                label: {
-                    text: "AP area",
-                    classes: "govuk-label--s"
-                },
-                classes: "govuk-input--width-20",
-                id: "selectedArea",
-                name: "selectedArea",
-                items: convertObjectsToSelectOptions(areas, 'All areas', 'name', 'id', 'selectedArea', 'all', context)
-            }) }}
-
-            {{ govukButton({
-                text: "Apply filter",
-                type: "submit",
-
-                preventDoubleClick: true
-            }) }}
-        </div>
-    </form>
+    {% call filterWrapper('Filter') %}
+        <input type="hidden" name="activeTab" value="{{ activeTab }}" />
+        {{ filterSelect('selectedArea','AP area',convertObjectsToSelectOptions(areas, 'All areas', 'name', 'id', 'selectedArea', 'all', context)) }}
+    {%- endcall %}
 
     {{ govukTable({
         captionClasses: "govuk-table__caption--m",

--- a/server/views/manage/premises/show.njk
+++ b/server/views/manage/premises/show.njk
@@ -2,8 +2,6 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
-{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
-{% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
@@ -14,6 +12,7 @@
 {% from "components/sortableTable/macro.njk" import sortableTable %}
 
 {%- from "./partials/_overbookingSummary.njk" import overbookingSummary -%}
+{% from "../../partials/filters.njk" import filterWrapper, filterSelect %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -59,28 +58,10 @@
             }) }}
 
             {% if activeTab === 'upcoming' or activeTab === 'current' %}
-                <form action="{{ hrefPrefix }}" method="get" class="search-and-filter">
+                {% call filterWrapper('Filter') %}
                     <input type="hidden" name="activeTab" value="{{ activeTab }}" />
-
-                    <h3 class="govuk-heading-m">Filters</h3>
-
-                    <div class="search-and-filter__row">
-                        {{ govukSelect({
-                            id: 'keyworker',
-                            name: 'keyworker',
-                            label: {
-                                text: 'Keyworker',
-                                classes: 'govuk-label--s'
-                            },
-                            items: convertObjectsToSelectOptions(keyworkersList, 'All keyworkers', 'name', 'code', 'keyworker')
-                        }) }}
-
-                        {{ govukButton({
-                            text: 'Apply filters',
-                            preventDoubleClick: true
-                        }) }}
-                    </div>
-                </form>
+                    {{ filterSelect('keyworker','Keyworker',convertObjectsToSelectOptions(keyworkersList, 'All keyworkers', 'name', 'code', 'keyworker')) }}
+                {%- endcall %}
             {% endif %}
 
             {% if activeTab === 'search' %}

--- a/server/views/partials/filters.njk
+++ b/server/views/partials/filters.njk
@@ -1,0 +1,44 @@
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+
+{% macro filterWrapper(title) %}
+    <div class="search-and-filter">
+        <form method="get">
+            <h2 class="govuk-heading-m">{{ title }}</h2>
+            <div class="search-and-filter__row">
+                {{ caller() }}
+                {{ govukButton({
+                    text: 'Apply filters',
+                    preventDoubleClick: true
+                }) }}
+            </div>
+        </form>
+    </div>
+{% endmacro %}
+
+{% macro filterCheckboxes(name, legend, filterOptions) %}
+    {{ govukCheckboxes({
+        name: name,
+        classes: 'govuk-checkboxes--small govuk-checkboxes--inline',
+        fieldset: {
+            legend: {
+                text: legend,
+                classes: 'govuk-fieldset__legend govuk-fieldset__legend--s'
+            }
+        },
+        items: filterOptions
+    }) }}
+{% endmacro %}
+
+{% macro filterSelect(name,label, options) %}
+    {{ govukSelect({
+        id: name,
+        name: name,
+        label: {
+            text: label,
+            classes: 'govuk-label--s'
+        },
+        items: options
+    }) }}
+{% endmacro %}


### PR DESCRIPTION
# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->
https://dsdmoj.atlassian.net/browse/APS-2401

# Changes in this PR
A revamp of the manage beds view page.

- Removed the 'View' link column and put the details link on the bed name (first) column for consistency.
- Added sorting by bed name (AFAICS, the bed name is prefixed by the room name, so there's no point in )
- Added a list of bed characteristics on the table (I would like feedback as to whether this is needed/wanted given the filter. I think it's OK even for the worst premises but it could be made into a details expander list perhaps?)
- Added a filter for the bed characteristics
- Slight restructure of template around the filters and restructured a couple of other filters using these - we should probably switch all the filters over to get better consistency,
- Uncovered a bug in a test helper that tests column rows. This is only used in one place and couldn't handle the column restructure - so needed fixing
- While fixing the above, I found a few tiny issues with html rendering that inserts extra unnecessary spaces into mark-up. I left the fixes in place so had up update a few tests to get rid of the spare spaces.

Note, I added the class `govuk-list--compact` to the bed characteristics block in the table. This is not supported in this PR, but in https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/2547. It will remove the extra padding from that list.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before
<details>
   <summary>Before</summary>
<img src="https://github.com/user-attachments/assets/4bffd73d-d2a9-4cff-889c-10ee12a5d891"/>
</details>

### After
<details>
   <summary>After</summary>
<img src="https://github.com/user-attachments/assets/8e881235-549e-46b4-8c80-abf607db34cf"/>
</details>


