### PR TITLE
Replace instances of `submitted' status

### DIFF
--- a/integration_tests/pages/apply/list.ts
+++ b/integration_tests/pages/apply/list.ts
@@ -39,7 +39,7 @@ export default class ListPage extends Page {
   }
 
   shouldShowSubmittedApplications(): void {
-    this.shouldShowApplications(this.submittedApplications, 'Application submitted')
+    this.shouldShowApplications(this.submittedApplications, 'Awaiting assessment')
   }
 
   shouldShowInactiveApplications(): void {

--- a/integration_tests/tests/apply/appeals.cy.ts
+++ b/integration_tests/tests/apply/appeals.cy.ts
@@ -61,7 +61,7 @@ context('Appeals', () => {
   it('should show error messages for missed fields', () => {
     // Given there is an application
     const person = personFactory.build()
-    const application = applicationFactory.build({ person, status: 'submitted' })
+    const application = applicationFactory.build({ person, status: 'rejected' })
 
     cy.task('stubApplicationGet', { application })
     cy.task('stubAppealErrors', {

--- a/integration_tests/tests/apply/list.cy.ts
+++ b/integration_tests/tests/apply/list.cy.ts
@@ -20,7 +20,7 @@ context('Applications dashboard', () => {
   it('shows the dashboard ', () => {
     // Given there are applications in the database
     const inProgressApplications = cas1ApplicationSummaryFactory.buildList(5, { status: 'started' })
-    const submittedApplications = cas1ApplicationSummaryFactory.buildList(5, { status: 'submitted' })
+    const submittedApplications = cas1ApplicationSummaryFactory.buildList(5, { status: 'awaitingAssesment' })
     const requestedFurtherInformationApplications = cas1ApplicationSummaryFactory.buildList(5, {
       status: 'requestedFurtherInformation',
     })
@@ -82,7 +82,7 @@ context('Applications dashboard', () => {
       status: 'started',
       person: personFactory.build({ isRestricted: true }),
     })
-    const submittedApplications = cas1ApplicationSummaryFactory.buildList(5, { status: 'submitted' })
+    const submittedApplications = cas1ApplicationSummaryFactory.buildList(5, { status: 'awaitingAssesment' })
     const requestedFurtherInformationApplications = cas1ApplicationSummaryFactory.buildList(5, {
       status: 'requestedFurtherInformation',
     })

--- a/integration_tests/tests/apply/viewApplication.cy.ts
+++ b/integration_tests/tests/apply/viewApplication.cy.ts
@@ -25,7 +25,7 @@ context('show applications', () => {
     // Given I have completed an application
     const timeline = cas1TimelineEventFactory.buildList(10)
 
-    const updatedApplication = { ...this.application, status: 'submitted', document: applicationDocument }
+    const updatedApplication = { ...this.application, status: 'awaitingAssesment', document: applicationDocument }
     cy.task('stubApplicationGet', { application: updatedApplication })
     cy.task('stubApplicationTimeline', { applicationId: updatedApplication.id, timeline })
     cy.task('stubApplications', [updatedApplication])
@@ -134,7 +134,7 @@ context('show applications', () => {
     // Given I have completed an application
     const application = {
       ...this.application,
-      status: 'submitted',
+      status: 'awaitingAssesment',
       assessmentDecision: 'accepted',
       assessmentDecisionDate: '2023-01-01',
       assessmentId: faker.string.uuid(),
@@ -187,7 +187,7 @@ context('show applications', () => {
   it('should show requests for placement and allow their withdrawal', function test() {
     const application = applicationFactory.build({
       ...this.application,
-      status: 'submitted',
+      status: 'awaitingAssesment',
       createdByUserId: defaultUserId,
     })
     const requestsForPlacement = requestForPlacementFactory.buildList(4)
@@ -253,7 +253,7 @@ context('show applications', () => {
   it('should allow me to add a note to an application', function test() {
     const application = {
       ...this.application,
-      status: 'submitted',
+      status: 'awaitingAssesment',
     }
 
     const timeline = cas1TimelineEventFactory.buildList(10)

--- a/integration_tests/tests/manage/booking.cy.ts
+++ b/integration_tests/tests/manage/booking.cy.ts
@@ -16,7 +16,7 @@ context('Booking', () => {
   const person = personFactory.build()
   const premises = bookingPremisesSummaryFactory.build()
   const application = applicationFactory.build({
-    status: 'submitted',
+    status: 'awaitingPlacement',
   })
   const assessment = assessmentFactory.build({
     status: 'completed',

--- a/integration_tests/tests/match/placementApplications.cy.ts
+++ b/integration_tests/tests/match/placementApplications.cy.ts
@@ -444,7 +444,7 @@ context('Placement Applications', () => {
   it('does not allow me to create a placement application if the assessment is not yet assessed', () => {
     // Given there is an unassesed application that I created
     const application = applicationFactory.build({
-      status: 'submitted',
+      status: 'awaitingAssesment',
       id: '123',
       createdByUserId: defaultUserId,
       assessmentDecision: undefined,

--- a/integration_tests/tests/tasks/allocations.cy.ts
+++ b/integration_tests/tests/tasks/allocations.cy.ts
@@ -207,7 +207,7 @@ context('Task Allocation', () => {
       task: { ...this.task, applicationId: this.application.id, allocatedToStaffMember: this.selectedUser },
       reallocation: reallocationFactory.build({ taskType: this.task.taskType, user: this.selectedUser }),
     })
-    const updatedApplication = { ...this.application, status: 'submitted' }
+    const updatedApplication = { ...this.application, status: 'awaitingAssesment' }
     cy.task('stubApplicationGet', { application: updatedApplication })
     cy.task('stubApplicationTimeline', { applicationId: updatedApplication.id, timeline })
 

--- a/integration_tests/tests/withdrawals/withdrawals.cy.ts
+++ b/integration_tests/tests/withdrawals/withdrawals.cy.ts
@@ -37,7 +37,7 @@ context('Withdrawals', () => {
       withdrawsAPlacementRequest(roleToPermissions('cru_member')))
 
     it('withdraws a placement application', () => {
-      const application = applicationFactory.build({ status: 'submitted' })
+      const application = applicationFactory.build({ status: 'awaitingAssesment' })
       const placementApplication = placementApplicationFactory.build({ applicationId: application.id })
       const placementApplicationWithdrawable = withdrawableFactory.build({
         type: 'placement_application',

--- a/server/@types/shared/models/ApprovedPremisesApplicationStatus.ts
+++ b/server/@types/shared/models/ApprovedPremisesApplicationStatus.ts
@@ -2,4 +2,4 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type ApprovedPremisesApplicationStatus = 'started' | 'submitted' | 'rejected' | 'awaitingAssesment' | 'unallocatedAssesment' | 'assesmentInProgress' | 'awaitingPlacement' | 'placementAllocated' | 'inapplicable' | 'withdrawn' | 'requestedFurtherInformation' | 'pendingPlacementRequest' | 'expired';
+export type ApprovedPremisesApplicationStatus = 'started' | 'rejected' | 'awaitingAssesment' | 'unallocatedAssesment' | 'assesmentInProgress' | 'awaitingPlacement' | 'placementAllocated' | 'inapplicable' | 'withdrawn' | 'requestedFurtherInformation' | 'pendingPlacementRequest' | 'expired';

--- a/server/@types/shared/models/Cas1ApplicationStatus.ts
+++ b/server/@types/shared/models/Cas1ApplicationStatus.ts
@@ -2,4 +2,4 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type Cas1ApplicationStatus = 'started' | 'submitted' | 'rejected' | 'awaitingAssesment' | 'unallocatedAssesment' | 'assesmentInProgress' | 'awaitingPlacement' | 'placementAllocated' | 'inapplicable' | 'withdrawn' | 'requestedFurtherInformation' | 'pendingPlacementRequest' | 'expired';
+export type Cas1ApplicationStatus = 'started' | 'rejected' | 'awaitingAssesment' | 'unallocatedAssesment' | 'assesmentInProgress' | 'awaitingPlacement' | 'placementAllocated' | 'inapplicable' | 'withdrawn' | 'requestedFurtherInformation' | 'pendingPlacementRequest' | 'expired';

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -228,7 +228,7 @@ describe('applicationsController', () => {
     })
 
     it('renders the readonly view if the application has been submitted', async () => {
-      application.status = 'submitted'
+      application.status = 'awaitingAssesment'
 
       const requestHandler = applicationsController.show()
 
@@ -270,7 +270,7 @@ describe('applicationsController', () => {
     describe('when the tab=timeline query param is present', () => {
       it('calls the timeline method on the application service and passes the tab: "timeline" property', async () => {
         const timelineEvents = cas1TimelineEventFactory.buildList(1)
-        application.status = 'submitted'
+        application.status = 'awaitingAssesment'
 
         const requestHandler = applicationsController.show()
 
@@ -302,7 +302,7 @@ describe('applicationsController', () => {
     describe('when the tab=placementRequests query param is present', () => {
       it('calls the getPlacementApplications method on the application service and passes the tab: "placementRequests" property', async () => {
         const requestsForPlacement = requestForPlacementFactory.buildList(1)
-        application.status = 'submitted'
+        application.status = 'awaitingAssesment'
 
         const requestHandler = applicationsController.show()
 

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -66,8 +66,7 @@ describe('ApplicationService', () => {
   })
 
   describe('getAllForLoggedInUser', () => {
-    // TODO: Remove type exclusion when 'submitted' status has been removed from API
-    const applications: Record<Exclude<Cas1ApplicationStatus, 'submitted'>, Array<Cas1ApplicationSummary>> = {
+    const applications: Record<Cas1ApplicationStatus, Array<Cas1ApplicationSummary>> = {
       started: cas1ApplicationSummaryFactory.buildList(1, { status: 'started' }),
       requestedFurtherInformation: cas1ApplicationSummaryFactory.buildList(1, {
         status: 'requestedFurtherInformation',

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -66,12 +66,12 @@ describe('ApplicationService', () => {
   })
 
   describe('getAllForLoggedInUser', () => {
-    const applications: Record<Cas1ApplicationStatus, Array<Cas1ApplicationSummary>> = {
+    // TODO: Remove type exclusion when 'submitted' status has been removed from API
+    const applications: Record<Exclude<Cas1ApplicationStatus, 'submitted'>, Array<Cas1ApplicationSummary>> = {
       started: cas1ApplicationSummaryFactory.buildList(1, { status: 'started' }),
       requestedFurtherInformation: cas1ApplicationSummaryFactory.buildList(1, {
         status: 'requestedFurtherInformation',
       }),
-      submitted: cas1ApplicationSummaryFactory.buildList(1, { status: 'submitted' }),
       awaitingAssesment: cas1ApplicationSummaryFactory.buildList(1, { status: 'awaitingAssesment' }),
       unallocatedAssesment: cas1ApplicationSummaryFactory.buildList(1, { status: 'unallocatedAssesment' }),
       assesmentInProgress: cas1ApplicationSummaryFactory.buildList(1, { status: 'assesmentInProgress' }),
@@ -85,7 +85,6 @@ describe('ApplicationService', () => {
     }
 
     const submittedApplications = [
-      ...applications.submitted,
       ...applications.awaitingAssesment,
       ...applications.unallocatedAssesment,
       ...applications.assesmentInProgress,

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -118,7 +118,7 @@ class ApplicationFactory extends Factory<ApprovedPremisesApplication> {
 
   completed(assessmentDecision: AssessmentDecision) {
     return this.params({
-      status: 'submitted',
+      status: 'awaitingPlacement',
       assessmentDecision,
       assessmentDecisionDate: DateFormats.dateObjToIsoDateTime(faker.date.past()),
       assessmentId: faker.string.uuid(),

--- a/server/testutils/factories/cas1Timeline.ts
+++ b/server/testutils/factories/cas1Timeline.ts
@@ -75,7 +75,6 @@ export const applicationTimelineFactory = Factory.define<Cas1ApplicationTimeline
   id: faker.string.uuid(),
   status: faker.helpers.arrayElement([
     'started',
-    'submitted',
     'rejected',
     'awaitingAssesment',
     'unallocatedAssesment',

--- a/server/utils/applications/statusTag.ts
+++ b/server/utils/applications/statusTag.ts
@@ -6,7 +6,6 @@ export const APPLICATION_SUITABLE = 'Application suitable' as const
 export class ApplicationStatusTag extends StatusTag<ApplicationStatus> {
   static readonly statuses: Record<ApplicationStatus, string> = {
     started: 'Not submitted',
-    submitted: 'Application submitted',
     rejected: 'Application rejected',
     awaitingAssesment: 'Awaiting assessment',
     unallocatedAssesment: 'Unallocated assessment',
@@ -22,7 +21,6 @@ export class ApplicationStatusTag extends StatusTag<ApplicationStatus> {
 
   static readonly colours: Record<ApplicationStatus, string> = {
     started: 'blue',
-    submitted: '',
     rejected: 'red',
     awaitingAssesment: 'blue',
     unallocatedAssesment: 'blue',

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -299,7 +299,7 @@ describe('utils', () => {
       requestedFurtherInformation: cas1ApplicationSummaryFactory.buildList(2, {
         status: 'requestedFurtherInformation',
       }),
-      submitted: cas1ApplicationSummaryFactory.buildList(6, { status: 'submitted' }),
+      submitted: cas1ApplicationSummaryFactory.buildList(6, { status: 'awaitingAssesment' }),
       inactive: cas1ApplicationSummaryFactory.buildList(4, { status: 'expired' }),
     }
 
@@ -663,9 +663,9 @@ describe('utils', () => {
   })
 
   describe('actionsCell', () => {
-    it.each(['started', 'requestedFurtherInformation'] as const)(
+    it.each(['started', 'requestedFurtherInformation'] as Array<ApplicationStatus>)(
       'returns a link to withdraw the application when the status is %s',
-      (status: ApplicationStatus) => {
+      status => {
         const applicationSummary = cas1ApplicationSummaryFactory.build({
           id: 'an-application-id',
           status,
@@ -678,7 +678,7 @@ describe('utils', () => {
       },
     )
 
-    it.each(['awaitingPlacement', 'pendingPlacementRequest'] as const)(
+    it.each(['awaitingPlacement', 'pendingPlacementRequest'] as Array<ApplicationStatus>)(
       'returns a link to request for placement of the application when the status is %s and hasRequestsForPlacement is false',
       status => {
         const applicationSummary = cas1ApplicationSummaryFactory.build({
@@ -693,9 +693,9 @@ describe('utils', () => {
       },
     )
 
-    it.each(['rejected', 'withdrawn', 'submitted'])(
+    it.each(['rejected', 'withdrawn', 'awaitingAssesment'] as Array<ApplicationStatus>)(
       'does not return a link to withdraw the application if the status is %s',
-      (status: ApplicationStatus) => {
+      status => {
         const applicationSummary = cas1ApplicationSummaryFactory.build({
           id: 'an-application-id',
           status,


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-866

# Changes in this PR

This PR replaces uses of the now-removed `submitted` status for applications. When an application is submitted, it now automatically gets the `awaitingAssesment` status (typo included), so most uses have been changed to that.