### PR TITLE
APS-2453: Use cas1 tasks end point

### DIFF
--- a/server/controllers/tasksController.test.ts
+++ b/server/controllers/tasksController.test.ts
@@ -3,6 +3,7 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
 import { Task } from '@approved-premises/api'
 import { when } from 'jest-when'
+import { ErrorsAndUserInput, PaginatedResponse } from '@approved-premises/ui'
 import TasksController from './tasksController'
 import {
   applicationFactory,
@@ -15,8 +16,7 @@ import {
 } from '../testutils/factories'
 import { ApplicationService, CruManagementAreaService, TaskService, UserService } from '../services'
 import { fetchErrorsAndUserInput } from '../utils/validation'
-import { ErrorsAndUserInput, PaginatedResponse } from '../@types/ui'
-import paths from '../paths/api'
+import paths from '../paths/tasks'
 
 import { getPaginationDetails } from '../utils/getPaginationDetails'
 import { tasksTableHeader, tasksTableRows, userQualificationsSelectOptions } from '../utils/tasks'

--- a/server/controllers/tasksController.ts
+++ b/server/controllers/tasksController.ts
@@ -1,12 +1,12 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
+import { AllocatedFilter, TaskSortField, UserQualification } from '@approved-premises/api'
+import { TaskSearchQualification } from '@approved-premises/ui'
 import { TaskTab, tasksTableHeader, tasksTableRows } from '../utils/tasks/listTable'
 import { convertToTitleCase, sentenceCase } from '../utils/utils'
 import { ApplicationService, CruManagementAreaService, TaskService, UserService } from '../services'
 import { fetchErrorsAndUserInput } from '../utils/validation'
 import { getPaginationDetails } from '../utils/getPaginationDetails'
-import paths from '../paths/api'
-import { AllocatedFilter, TaskSortField, UserQualification } from '../@types/shared'
-import { TaskSearchQualification } from '../@types/ui'
+import paths from '../paths/tasks'
 import { userQualificationsSelectOptions } from '../utils/tasks'
 
 export default class TasksController {

--- a/server/data/taskClient.test.ts
+++ b/server/data/taskClient.test.ts
@@ -7,10 +7,10 @@ import {
   taskFactory,
   taskWrapperFactory,
 } from '../testutils/factories'
-import describeClient from '../testutils/describeClient'
+import { describeCas1NamespaceClient } from '../testutils/describeClient'
 import { TaskType } from '../@types/shared'
 
-describeClient('taskClient', provider => {
+describeCas1NamespaceClient('taskClient', provider => {
   let taskClient: TaskClient
 
   const token = 'token-1'

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -19,6 +19,8 @@ const cas1PlacementApplicationsSingle = cas1PlacementApplications.path(':id')
 const cas1PlacementRequests = cas1Namespace.path('placement-requests')
 const cas1PlacementRequestSingle = cas1PlacementRequests.path(':placementRequestId')
 const cas1SpaceBookings = cas1PlacementRequestSingle.path('space-bookings')
+const cas1Tasks = cas1Namespace.path('tasks')
+const cas1TasksSingle = cas1Tasks.path(':taskType/:id')
 
 const cas1Reports = cas1Namespace.path('reports')
 
@@ -46,9 +48,6 @@ const person = people.path(':crn')
 
 const users = path('/users')
 const cas1Users = cas1Namespace.path('users')
-
-const tasks = path('/tasks')
-const taskSingle = tasks.path(':taskType/:id')
 
 const placementRequests = path('/placement-requests')
 const placementRequestsSingle = placementRequests.path(':placementRequestId')
@@ -155,13 +154,13 @@ export default {
     findSpaces: cas1Namespace.path('spaces/search'),
   },
   tasks: {
-    index: tasks,
+    index: cas1Tasks,
     type: {
-      index: tasks.path(':taskType'),
+      index: cas1Tasks.path(':taskType'),
     },
-    show: taskSingle,
+    show: cas1TasksSingle,
     allocations: {
-      create: taskSingle.path('allocations'),
+      create: cas1TasksSingle.path('allocations'),
     },
   },
   placementRequests: {


### PR DESCRIPTION
This updates the Tasks API endpoints to the new namespaced versions, as created in https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/3783

https://dsdmoj.atlassian.net/browse/APS-2453