### PR TITLE
APS-2437: Update day availability render

### DIFF
--- a/assets/scss/components/_calendar.scss
+++ b/assets/scss/components/_calendar.scss
@@ -46,7 +46,7 @@
       margin: 0;
 
       &:only-of-type {
-        margin-bottom: govuk-spacing(4);
+        margin-top: govuk-spacing(4);
       }
     }
   }

--- a/integration_tests/pages/shared/occupancyFilterPage.ts
+++ b/integration_tests/pages/shared/occupancyFilterPage.ts
@@ -105,7 +105,7 @@ export default class OccupancyFilterPage extends Page {
       },
       {
         available: undefined,
-        availableForCriteria: undefined,
+        full: undefined,
         overbooked: undefined,
       },
     )

--- a/integration_tests/pages/shared/occupancyFilterPage.ts
+++ b/integration_tests/pages/shared/occupancyFilterPage.ts
@@ -57,10 +57,6 @@ export default class OccupancyFilterPage extends Page {
     }
   }
 
-  shouldShowCalendarCell(copy: string | RegExp) {
-    cy.get('.calendar__availability').contains(copy).should('exist')
-  }
-
   shouldShowOccupancyCalendar(
     premiseCapacity: Cas1PremiseCapacity,
     criteria: Array<Cas1SpaceBookingCharacteristic> = [],
@@ -68,16 +64,20 @@ export default class OccupancyFilterPage extends Page {
     const firstMonth = DateFormats.isoDateToMonthAndYear(premiseCapacity.startDate)
     cy.get('.govuk-heading-m').contains(firstMonth).should('exist')
 
-    const summary = occupancySummary(premiseCapacity.capacity, criteria)
-    if (summary.available) {
-      // This matches cells that have the following text:
-      // - 'Available'; or
-      // - a positive number followed by ' for your criteria'
-      this.shouldShowCalendarCell(/Available|(?<!-)[1-9]\d? for your criteria/)
-    }
-    if (summary.overbooked) {
-      this.shouldShowCalendarCell(/-?\d+ in total/)
-    }
+    premiseCapacity.capacity.forEach(capacity => {
+      const status = dayAvailabilityStatus(capacity, criteria)
+      let tagColour = 'green'
+      if (status !== 'available') tagColour = 'red'
+
+      const capacityText = `${capacity.availableBedCount - capacity.bookingCount}/${capacity.availableBedCount}`
+
+      cy.get('.calendar__day')
+        .contains(DateFormats.isoDateToUIDate(capacity.date, { format: 'longNoYear' }))
+        .closest('.calendar__day')
+        .should('have.class', `govuk-tag--${tagColour}`)
+        .should('contain.text', capacityText)
+        .should(criteria.length ? 'contain.text' : 'not.contain.text', 'your criteria')
+    })
   }
 
   getOccupancyForDate(date: Date, capacity: Cas1PremiseCapacity): Cas1PremiseCapacityForDay {

--- a/integration_tests/tests/manage/occupancyView.cy.ts
+++ b/integration_tests/tests/manage/occupancyView.cy.ts
@@ -182,8 +182,8 @@ context('Premises day occupancy', () => {
   const stubDaySummary = (forDate: string, overBook = false): Cas1PremisesDaySummary => {
     const characteristicAvailability = overBook
       ? [
-          premiseCharacteristicAvailability.strictlyOverbooked().build({ characteristic: 'isSingle' }),
-          premiseCharacteristicAvailability.strictlyOverbooked().build({ characteristic: 'hasEnSuite' }),
+          premiseCharacteristicAvailability.overbooked().build({ characteristic: 'isSingle' }),
+          premiseCharacteristicAvailability.overbooked().build({ characteristic: 'hasEnSuite' }),
         ]
       : [
           premiseCharacteristicAvailability.available().build({ characteristic: 'isSingle' }),

--- a/server/testutils/factories/cas1PremiseCapacity.ts
+++ b/server/testutils/factories/cas1PremiseCapacity.ts
@@ -49,10 +49,10 @@ class CapacityForDayFactory extends Factory<Cas1PremiseCapacityForDay> {
     })
   }
 
-  overbookedOrFull() {
+  overbooked() {
     const totalBedCount = faker.number.int({ min: 6, max: 40 })
     const availableBedCount = faker.number.int({ min: totalBedCount - 5, max: totalBedCount })
-    const bookingCount = faker.number.int({ min: availableBedCount, max: totalBedCount + 5 })
+    const bookingCount = faker.number.int({ min: availableBedCount + 1, max: totalBedCount + 5 })
 
     return this.params({
       totalBedCount,
@@ -61,10 +61,10 @@ class CapacityForDayFactory extends Factory<Cas1PremiseCapacityForDay> {
     })
   }
 
-  strictlyOverbooked() {
+  full() {
     const totalBedCount = faker.number.int({ min: 6, max: 40 })
     const availableBedCount = faker.number.int({ min: totalBedCount - 5, max: totalBedCount })
-    const bookingCount = faker.number.int({ min: availableBedCount + 1, max: totalBedCount + 5 })
+    const bookingCount = availableBedCount
 
     return this.params({
       totalBedCount,
@@ -99,9 +99,9 @@ class PremisesCharacteristicAvailability extends Factory<Cas1PremiseCharacterist
     })
   }
 
-  overbookedOrFull() {
+  full() {
     const availableBedsCount = faker.number.int({ min: 5, max: 20 })
-    const bookingsCount = faker.number.int({ min: availableBedsCount, max: 30 })
+    const bookingsCount = availableBedsCount
 
     return this.params({
       availableBedsCount,
@@ -109,7 +109,7 @@ class PremisesCharacteristicAvailability extends Factory<Cas1PremiseCharacterist
     })
   }
 
-  strictlyOverbooked() {
+  overbooked() {
     const availableBedsCount = faker.number.int({ min: 5, max: 20 })
     const bookingsCount = faker.number.int({ min: availableBedsCount + 1, max: 30 })
 

--- a/server/testutils/factories/cas1PremiseCapacity.ts
+++ b/server/testutils/factories/cas1PremiseCapacity.ts
@@ -75,12 +75,12 @@ class CapacityForDayFactory extends Factory<Cas1PremiseCapacityForDay> {
 }
 
 export const cas1PremiseCapacityForDayFactory = CapacityForDayFactory.define(() => {
-  const totalBedCount = faker.number.int({ min: 0, max: 40 })
+  const totalBedCount = faker.number.int({ min: 10, max: 40 })
 
   return {
     date: DateFormats.dateObjToIsoDate(faker.date.future()),
     totalBedCount,
-    availableBedCount: faker.number.int({ min: 0, max: totalBedCount }),
+    availableBedCount: faker.number.int({ min: totalBedCount - 9, max: totalBedCount }),
     bookingCount: faker.number.int({ min: 0, max: totalBedCount + 10 }),
     characteristicAvailability: Object.keys(roomCharacteristicMap).map(characteristic =>
       premiseCharacteristicAvailability.build({ characteristic: characteristic as Cas1SpaceBookingCharacteristic }),

--- a/server/utils/match/occupancy.ts
+++ b/server/utils/match/occupancy.ts
@@ -14,35 +14,34 @@ export const dayAvailabilityCount = (
     : dayCapacity.availableBedCount - dayCapacity.bookingCount
 }
 
-export type DayAvailabilityStatus = 'available' | 'availableForCriteria' | 'overbooked'
+export type DayAvailabilityStatus = 'available' | 'full' | 'overbooked'
 
 export const dayAvailabilityStatus = (
   dayCapacity: Cas1PremiseCapacityForDay,
   criteria: Array<Cas1SpaceBookingCharacteristic> = [],
 ): DayAvailabilityStatus => {
-  let status: DayAvailabilityStatus =
-    dayCapacity.availableBedCount > dayCapacity.bookingCount ? 'available' : 'overbooked'
+  let status: DayAvailabilityStatus = 'available'
+
+  if (dayCapacity.availableBedCount === dayCapacity.bookingCount) status = 'full'
+  if (dayCapacity.availableBedCount < dayCapacity.bookingCount) status = 'overbooked'
 
   if (criteria.length) {
     const criteriaBookableCount = dayAvailabilityCount(dayCapacity, criteria)
 
-    if (criteriaBookableCount > 0 && status === 'overbooked') {
-      status = 'availableForCriteria'
-    } else if (criteriaBookableCount <= 0) {
+    if (criteriaBookableCount < 0) {
       status = 'overbooked'
+    } else if (criteriaBookableCount === 0 && status !== 'overbooked') {
+      status = 'full'
     }
   }
+
   return status
 }
 
 export const dayAvailabilityStatusMap: Record<DayAvailabilityStatus, { title: string; detail: string }> = {
   available: { title: 'Available', detail: 'The space you require is available.' },
-  availableForCriteria: {
-    title: 'Available for your criteria',
-    detail:
-      'This AP is full or overbooked, but the space you require is available as it is occupied by someone who does not need it.',
-  },
-  overbooked: { title: 'Overbooked', detail: 'This AP is full or overbooked. The space you require is not available.' },
+  full: { title: 'Full', detail: 'This AP is full. The space your require is not available.' },
+  overbooked: { title: 'Overbooked', detail: 'This AP is overbooked. The space you require is not available.' },
 }
 
 const durationOptionsMap: Record<number, string> = {

--- a/server/utils/match/occupancyCalendar.test.ts
+++ b/server/utils/match/occupancyCalendar.test.ts
@@ -8,7 +8,7 @@ describe('occupancyCalendar', () => {
       startDate: '2024-12-30',
       endDate: '2025-01-02',
       capacity: [
-        cas1PremiseCapacityForDayFactory.build({ date: '2024-12-30', availableBedCount: 10, bookingCount: 5 }),
+        cas1PremiseCapacityForDayFactory.build({ date: '2024-12-30', availableBedCount: 9, bookingCount: 5 }),
         cas1PremiseCapacityForDayFactory.build({ date: '2024-12-31', availableBedCount: 10, bookingCount: 5 }),
         cas1PremiseCapacityForDayFactory.build({ date: '2025-01-01', availableBedCount: 10, bookingCount: 12 }),
         cas1PremiseCapacityForDayFactory.build({ date: '2025-01-02', availableBedCount: 10, bookingCount: 10 }),
@@ -22,13 +22,15 @@ describe('occupancyCalendar', () => {
           {
             date: '2024-12-30',
             name: 'Mon 30 Dec',
-            bookableCount: 5,
+            capacity: 9,
+            bookableCount: 4,
             status: 'available',
             link: 'path/2024-12-30',
           },
           {
             date: '2024-12-31',
             name: 'Tue 31 Dec',
+            capacity: 10,
             bookableCount: 5,
             status: 'available',
             link: 'path/2024-12-31',
@@ -41,6 +43,7 @@ describe('occupancyCalendar', () => {
           {
             date: '2025-01-01',
             name: 'Wed 1 Jan',
+            capacity: 10,
             bookableCount: -2,
             status: 'overbooked',
             link: 'path/2025-01-01',
@@ -48,6 +51,7 @@ describe('occupancyCalendar', () => {
           {
             date: '2025-01-02',
             name: 'Thu 2 Jan',
+            capacity: 10,
             bookableCount: 0,
             status: 'full',
             link: 'path/2025-01-02',
@@ -110,6 +114,7 @@ describe('occupancyCalendar', () => {
         expect(occupancyCalendar(capacity, 'foo/:date', [])[0].days[0]).toEqual({
           date: '2025-02-02',
           name: 'Sun 2 Feb',
+          capacity: 18,
           bookableCount: 8,
           status: 'available',
           link: 'foo/2025-02-02',
@@ -138,7 +143,7 @@ describe('occupancyCalendar', () => {
     })
 
     describe('when a filter criteria is provided', () => {
-      describe('if there is overall capacity', () => {
+      describe('if there is overall availability', () => {
         it('returns with bookable count and status based on the selected criteria', () => {
           expect(occupancyCalendar(capacity, 'foo/:date', ['hasEnSuite'])[0].days[0]).toEqual(
             expect.objectContaining({
@@ -190,11 +195,11 @@ describe('occupancyCalendar', () => {
         })
       })
 
-      describe('if there is no overall capacity but availability for the criteria', () => {
+      describe('if there is no overall availability but availability for the criteria', () => {
         it.each([
           ['full', 18],
           ['overbooked', 23],
-        ])('returns with status %s based on overall capacity', (status, bookingCount) => {
+        ])('returns with status %s based on overall availability', (status, bookingCount) => {
           const overallCapacity = [
             cas1PremiseCapacityForDayFactory.build({
               ...capacity[0],

--- a/server/utils/match/occupancyCalendar.test.ts
+++ b/server/utils/match/occupancyCalendar.test.ts
@@ -1,4 +1,3 @@
-import { Cas1PremiseCapacityForDay } from '@approved-premises/api'
 import { occupancyCalendar } from './occupancyCalendar'
 import { cas1PremiseCapacityFactory, cas1PremiseCapacityForDayFactory } from '../../testutils/factories'
 import { premiseCharacteristicAvailability } from '../../testutils/factories/cas1PremiseCapacity'
@@ -12,7 +11,7 @@ describe('occupancyCalendar', () => {
         cas1PremiseCapacityForDayFactory.build({ date: '2024-12-30', availableBedCount: 10, bookingCount: 5 }),
         cas1PremiseCapacityForDayFactory.build({ date: '2024-12-31', availableBedCount: 10, bookingCount: 5 }),
         cas1PremiseCapacityForDayFactory.build({ date: '2025-01-01', availableBedCount: 10, bookingCount: 12 }),
-        cas1PremiseCapacityForDayFactory.build({ date: '2025-01-02', availableBedCount: 10, bookingCount: 5 }),
+        cas1PremiseCapacityForDayFactory.build({ date: '2025-01-02', availableBedCount: 10, bookingCount: 10 }),
       ],
     })
 
@@ -49,38 +48,9 @@ describe('occupancyCalendar', () => {
           {
             date: '2025-01-02',
             name: 'Thu 2 Jan',
-            bookableCount: 5,
-            status: 'available',
+            bookableCount: 0,
+            status: 'full',
             link: 'path/2025-01-02',
-          },
-        ],
-      },
-    ])
-  })
-
-  it('returns the calendar without criteria count if an empty list of criteria is provided', () => {
-    const premisesCapacity = cas1PremiseCapacityFactory.build({
-      startDate: '2024-12-30',
-      endDate: '2024-12-30',
-      capacity: [
-        cas1PremiseCapacityForDayFactory.build({
-          date: '2024-12-30',
-          availableBedCount: 10,
-          bookingCount: 6,
-        }),
-      ],
-    })
-
-    expect(occupancyCalendar(premisesCapacity.capacity, 'foo/:date', [])).toEqual([
-      {
-        name: 'December 2024',
-        days: [
-          {
-            date: '2024-12-30',
-            name: 'Mon 30 Dec',
-            bookableCount: 4,
-            status: 'available',
-            link: 'foo/2024-12-30',
           },
         ],
       },
@@ -98,21 +68,18 @@ describe('occupancyCalendar', () => {
       endDate: '2025-02-12',
     })
 
-    expect(occupancyCalendar(premisesCapacity.capacity, placeholder)).toEqual([
-      {
-        name: 'February 2025',
-        days: [expect.objectContaining({ link: expected })],
-      },
-    ])
+    expect(occupancyCalendar(premisesCapacity.capacity, placeholder)[0].days[0]).toEqual(
+      expect.objectContaining({ link: expected }),
+    )
   })
 
-  describe('when a filter criteria is provided', () => {
-    const capacity: Array<Cas1PremiseCapacityForDay> = [
+  describe('status and count for a given day', () => {
+    const capacity = [
       cas1PremiseCapacityForDayFactory.build({
         date: '2025-02-02',
         totalBedCount: 20,
         availableBedCount: 18,
-        bookingCount: 20,
+        bookingCount: 10,
         characteristicAvailability: [
           premiseCharacteristicAvailability.build({
             characteristic: 'hasEnSuite',
@@ -138,126 +105,112 @@ describe('occupancyCalendar', () => {
       }),
     ]
 
-    it('returns the calendar with bookable count for the selected criteria', () => {
-      expect(occupancyCalendar(capacity, 'foo/:date', ['hasEnSuite'])).toEqual([
-        {
-          name: 'February 2025',
-          days: [
-            {
-              date: '2025-02-02',
-              name: 'Sun 2 Feb',
-              bookableCount: -2,
-              criteriaBookableCount: -1,
-              status: 'overbooked',
-              link: 'foo/2025-02-02',
-            },
-          ],
-        },
-      ])
+    describe('when no filter criteria is provided', () => {
+      it('returns without criteria count if an empty list of criteria is provided', () => {
+        expect(occupancyCalendar(capacity, 'foo/:date', [])[0].days[0]).toEqual({
+          date: '2025-02-02',
+          name: 'Sun 2 Feb',
+          bookableCount: 8,
+          status: 'available',
+          link: 'foo/2025-02-02',
+        })
+      })
 
-      expect(occupancyCalendar(capacity, 'foo/:date', ['isSuitedForSexOffenders'])).toEqual([
-        {
-          name: 'February 2025',
-          days: [
-            {
-              date: '2025-02-02',
-              name: 'Sun 2 Feb',
-              bookableCount: -2,
-              criteriaBookableCount: 3,
-              status: 'availableForCriteria',
-              link: 'foo/2025-02-02',
-            },
-          ],
-        },
-      ])
+      it.each([
+        ['available', 10],
+        ['full', 18],
+        ['overbooked', 23],
+      ])('returns the overall status as %s if there are %s bookings', (status, bookingCount) => {
+        const overallCapacity = [
+          cas1PremiseCapacityForDayFactory.build({
+            ...capacity[0],
+            bookingCount,
+          }),
+        ]
 
-      expect(occupancyCalendar(capacity, 'foo/:date', ['isWheelchairDesignated'])).toEqual([
-        {
-          name: 'February 2025',
-          days: [
-            {
-              date: '2025-02-02',
-              name: 'Sun 2 Feb',
-              bookableCount: -2,
-              criteriaBookableCount: 1,
-              status: 'availableForCriteria',
-              link: 'foo/2025-02-02',
-            },
-          ],
-        },
-      ])
-
-      expect(occupancyCalendar(capacity, 'foo/:date', ['isStepFreeDesignated'])).toEqual([
-        {
-          name: 'February 2025',
-          days: [
-            {
-              date: '2025-02-02',
-              name: 'Sun 2 Feb',
-              bookableCount: -2,
-              criteriaBookableCount: 0,
-              status: 'overbooked',
-              link: 'foo/2025-02-02',
-            },
-          ],
-        },
-      ])
+        expect(occupancyCalendar(overallCapacity, ':date', [])[0].days[0]).toEqual(
+          expect.objectContaining({
+            bookableCount: 18 - bookingCount,
+            status,
+          }),
+        )
+      })
     })
 
-    it('returns the calendar with the lowest bookable count for all criteria', () => {
-      expect(
-        occupancyCalendar(capacity, 'foo/:date', ['hasEnSuite', 'isSuitedForSexOffenders', 'isWheelchairDesignated']),
-      ).toEqual([
-        {
-          name: 'February 2025',
-          days: [
-            {
-              date: '2025-02-02',
-              name: 'Sun 2 Feb',
-              bookableCount: -2,
+    describe('when a filter criteria is provided', () => {
+      describe('if there is overall capacity', () => {
+        it('returns with bookable count and status based on the selected criteria', () => {
+          expect(occupancyCalendar(capacity, 'foo/:date', ['hasEnSuite'])[0].days[0]).toEqual(
+            expect.objectContaining({
+              bookableCount: 8,
               criteriaBookableCount: -1,
               status: 'overbooked',
-              link: 'foo/2025-02-02',
-            },
-          ],
-        },
-      ])
-    })
+            }),
+          )
 
-    it('returns the correct availability status if the day is available with and without criteria applied', () => {
-      const capacityAvailable = [cas1PremiseCapacityForDayFactory.build({ ...capacity[0], bookingCount: 0 })]
-
-      expect(occupancyCalendar(capacityAvailable, 'foo/:date', ['isSuitedForSexOffenders'])).toEqual([
-        {
-          name: 'February 2025',
-          days: [
-            {
-              date: '2025-02-02',
-              name: 'Sun 2 Feb',
-              bookableCount: 18,
+          expect(occupancyCalendar(capacity, 'foo/:date', ['isSuitedForSexOffenders'])[0].days[0]).toEqual(
+            expect.objectContaining({
+              bookableCount: 8,
               criteriaBookableCount: 3,
               status: 'available',
-              link: 'foo/2025-02-02',
-            },
-          ],
-        },
-      ])
+            }),
+          )
 
-      expect(occupancyCalendar(capacityAvailable, 'foo/:date', ['isStepFreeDesignated'])).toEqual([
-        {
-          name: 'February 2025',
-          days: [
-            {
-              date: '2025-02-02',
-              name: 'Sun 2 Feb',
-              bookableCount: 18,
+          expect(occupancyCalendar(capacity, 'foo/:date', ['isWheelchairDesignated'])[0].days[0]).toEqual(
+            expect.objectContaining({
+              bookableCount: 8,
+              criteriaBookableCount: 1,
+              status: 'available',
+            }),
+          )
+
+          expect(occupancyCalendar(capacity, 'foo/:date', ['isStepFreeDesignated'])[0].days[0]).toEqual(
+            expect.objectContaining({
+              bookableCount: 8,
               criteriaBookableCount: 0,
+              status: 'full',
+            }),
+          )
+        })
+
+        it('returns with criteria bookable count and status based on the lowest for all criteria', () => {
+          expect(
+            occupancyCalendar(capacity, 'foo/:date', [
+              'hasEnSuite',
+              'isSuitedForSexOffenders',
+              'isWheelchairDesignated',
+            ])[0].days[0],
+          ).toEqual(
+            expect.objectContaining({
+              bookableCount: 8,
+              criteriaBookableCount: -1,
               status: 'overbooked',
-              link: 'foo/2025-02-02',
-            },
-          ],
-        },
-      ])
+            }),
+          )
+        })
+      })
+
+      describe('if there is no overall capacity but availability for the criteria', () => {
+        it.each([
+          ['full', 18],
+          ['overbooked', 23],
+        ])('returns with status %s based on overall capacity', (status, bookingCount) => {
+          const overallCapacity = [
+            cas1PremiseCapacityForDayFactory.build({
+              ...capacity[0],
+              bookingCount,
+            }),
+          ]
+
+          expect(occupancyCalendar(overallCapacity, 'foo/:date', ['isSuitedForSexOffenders'])[0].days[0]).toEqual(
+            expect.objectContaining({
+              bookableCount: 18 - bookingCount,
+              criteriaBookableCount: 3,
+              status,
+            }),
+          )
+        })
+      })
     })
   })
 })

--- a/server/utils/match/occupancyCalendar.ts
+++ b/server/utils/match/occupancyCalendar.ts
@@ -1,13 +1,11 @@
 import type { Cas1PremiseCapacityForDay, Cas1SpaceBookingCharacteristic } from '@approved-premises/api'
 import { DateFormats } from '../dateUtils'
-import { dayAvailabilityCount, dayAvailabilityStatus } from './occupancy'
-
-type CalendarDayStatus = 'available' | 'availableForCriteria' | 'overbooked'
+import { dayAvailabilityCount, type DayAvailabilityStatus, dayAvailabilityStatus } from './occupancy'
 
 type CalendarDay = {
   date: string
   name: string
-  status: CalendarDayStatus
+  status: DayAvailabilityStatus
   bookableCount: number
   criteriaBookableCount?: number
   link: string

--- a/server/utils/match/occupancyCalendar.ts
+++ b/server/utils/match/occupancyCalendar.ts
@@ -6,6 +6,7 @@ type CalendarDay = {
   date: string
   name: string
   status: DayAvailabilityStatus
+  capacity: number
   bookableCount: number
   criteriaBookableCount?: number
   link: string
@@ -39,6 +40,7 @@ export const occupancyCalendar = (
       date: day.date,
       name: DateFormats.isoDateToUIDate(day.date, { format: 'longNoYear' }),
       status: dayAvailabilityStatus(day, criteria),
+      capacity: day.availableBedCount,
       bookableCount,
       link: placeholderLink.replace(':date', day.date),
     }

--- a/server/utils/match/occupancySummary.test.ts
+++ b/server/utils/match/occupancySummary.test.ts
@@ -6,9 +6,9 @@ describe('occupancySummary', () => {
     const capacity = [
       cas1PremiseCapacityForDayFactory.available().build({ date: '2025-02-12' }),
       cas1PremiseCapacityForDayFactory.available().build({ date: '2025-02-13' }),
-      cas1PremiseCapacityForDayFactory.overbookedOrFull().build({ date: '2025-02-14' }),
-      cas1PremiseCapacityForDayFactory.overbookedOrFull().build({ date: '2025-02-15' }),
-      cas1PremiseCapacityForDayFactory.overbookedOrFull().build({ date: '2025-02-16' }),
+      cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-02-14' }),
+      cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-02-15' }),
+      cas1PremiseCapacityForDayFactory.full().build({ date: '2025-02-16' }),
       cas1PremiseCapacityForDayFactory.available().build({ date: '2025-02-17' }),
     ]
 
@@ -24,7 +24,7 @@ describe('occupancySummary', () => {
   })
 
   it('returns only overbooked if no dates are available', () => {
-    const capacity = [cas1PremiseCapacityForDayFactory.overbookedOrFull().build({ date: '2025-04-14' })]
+    const capacity = [cas1PremiseCapacityForDayFactory.overbooked().build({ date: '2025-04-14' })]
 
     const result = occupancySummary(capacity)
 

--- a/server/utils/premises/occupancy.test.ts
+++ b/server/utils/premises/occupancy.test.ts
@@ -41,7 +41,7 @@ describe('apOccupancy utils', () => {
       const availableCharacteristics = premiseCharacteristicAvailability.available().buildList(3)
       const overbookedCharacteristics = [
         ...availableCharacteristics,
-        premiseCharacteristicAvailability.strictlyOverbooked().build(),
+        premiseCharacteristicAvailability.overbooked().build(),
       ]
       const testData: Record<string, Cas1PremiseCapacityForDay> = {
         available: cas1PremiseCapacityForDayFactory.build({
@@ -128,14 +128,14 @@ describe('apOccupancy utils', () => {
       const characteristicAvailability = Object.keys(roomCharacteristicMap).map(characteristic =>
         overbookedCharacteristics.includes(characteristic as Cas1SpaceBookingCharacteristic)
           ? premiseCharacteristicAvailability
-              .strictlyOverbooked()
+              .overbooked()
               .build({ characteristic: characteristic as Cas1SpaceBookingCharacteristic })
           : premiseCharacteristicAvailability
               .available()
               .build({ characteristic: characteristic as Cas1SpaceBookingCharacteristic }),
       )
       const capacityForDay = overbook
-        ? cas1PremiseCapacityForDayFactory.strictlyOverbooked().build({
+        ? cas1PremiseCapacityForDayFactory.overbooked().build({
             characteristicAvailability,
           })
         : cas1PremiseCapacityForDayFactory.available().build({

--- a/server/views/manage/premises/occupancy/view.njk
+++ b/server/views/manage/premises/occupancy/view.njk
@@ -87,7 +87,7 @@
         </section>
 
         <section id="calendar" aria-describedby="calendar-key">
-            {{ occupancyCalendar(calendar) }}
+            {{ occupancyCalendar(calendar, true) }}
         </section>
     {% endif %}
 

--- a/server/views/manage/premises/placements/changes/new.njk
+++ b/server/views/manage/premises/placements/changes/new.njk
@@ -110,19 +110,10 @@
                     <li class="calendar__day govuk-tag--green">
                         Available
                     </li>
-                    <li class="calendar__day govuk-tag--yellow" aria-describedby="calendar-possibly-available">
-                        Possibly available <span aria-hidden="true">*</span>
-                    </li>
                     <li class="calendar__day govuk-tag--red">
                         Full or overbooked
                     </li>
                 </ul>
-
-                <p id="calendar-possibly-available">
-                    <span aria-hidden="true">* Possibly available.</span>
-                    A room matching your criteria is currently booked for someone that does not require it. Check before
-                    booking.
-                </p>
             </section>
 
             <section aria-describedby="calendar-key">

--- a/server/views/match/placementRequests/occupancyView/partials/_occupancyCalendar.njk
+++ b/server/views/match/placementRequests/occupancyView/partials/_occupancyCalendar.njk
@@ -1,20 +1,15 @@
 {% extends "../../../../partials/_calendar.njk" %}
 
-{% block  dayContent %}
-    {% if day.status === 'available' %}
-        <dd>Available</dd>
-    {% else %}
-        {% if day.criteriaBookableCount is defined %}
-            <dd>
-                <span class="govuk-!-font-weight-bold">{{ day.criteriaBookableCount }}</span>
-                <span class="govuk-visually-hidden">for</span>
-                your criteria
-            </dd>
-        {% endif %}
+{% block dayContent %}
+    {% if day.criteriaBookableCount is defined %}
         <dd>
-            <span class="govuk-!-font-weight-bold">{{ day.bookableCount }}</span>
-            <span class="govuk-visually-hidden">in</span>
-            total
+            <span class="govuk-!-font-weight-bold">{{ day.criteriaBookableCount }}</span>
+            <span class="govuk-visually-hidden">for</span>
+            your criteria
         </dd>
     {% endif %}
+    <dd>
+        <span class="govuk-!-font-weight-bold">{{ day.bookableCount }}/{{ day.capacity }}</span>
+        capacity
+    </dd>
 {% endblock %}

--- a/server/views/match/placementRequests/occupancyView/view.njk
+++ b/server/views/match/placementRequests/occupancyView/view.njk
@@ -102,19 +102,10 @@
                     <li class="calendar__day govuk-tag--green">
                         Available
                     </li>
-                    <li class="calendar__day govuk-tag--yellow" aria-describedby="calendar-possibly-available">
-                        Possibly available <span aria-hidden="true">*</span>
-                    </li>
                     <li class="calendar__day govuk-tag--red">
                         Full or overbooked
                     </li>
                 </ul>
-
-                <p id="calendar-possibly-available">
-                    <span aria-hidden="true">* Possibly available.</span>
-                    A room matching your criteria is currently booked for someone that does not require it. Check before
-                    booking.
-                </p>
             </section>
 
             <section aria-describedby="calendar-key">

--- a/server/views/partials/_calendar.njk
+++ b/server/views/partials/_calendar.njk
@@ -1,4 +1,4 @@
-{% macro occupancyCalendar(calendar) %}
+{% macro occupancyCalendar(calendar, highlightFull = false) %}
     <div class="calendar">
         {% for month in calendar %}
             <section>
@@ -9,7 +9,7 @@
 
                         {% set tagColour = 'govuk-tag--green' %}
                         {% if day.status !== 'available' %}
-                            {% set tagColour = 'govuk-tag--yellow' if day.status in ['availableForCriteria','full'] else 'govuk-tag--red' %}
+                            {% set tagColour = 'govuk-tag--yellow' if (highlightFull and day.status === 'full') else 'govuk-tag--red' %}
                         {% endif %}
 
                         <li class="calendar__day calendar__day--{{ day.name.slice(0,3) | lower }} {{ tagColour }}">


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2437
https://dsdmoj.atlassian.net/browse/APS-2436

# Changes in this PR

The day availability is now considered based on the lowest availability for general capacity or criteria, i.e.:

- If the premises or the criteria is overbooked, then the status is 'overbooked'
- If neither premises nor criteria are overbooked, but either the premises or the criteria is full, then the status is 'full'
- If neither the premises nor the criteria are full or overbooked, then the status is 'available'

In any of the above scenario, criteria is not considered if none has been provided, and the status is then based on general availability.

## Screenshots of UI changes

<details><summary>Search occupancy view -- without criteria</summary>

<img width="748" alt="Screenshot 2025-07-01 at 17 42 33" src="https://github.com/user-attachments/assets/df0d8693-1084-4637-8fe4-410bac5eb4d0" />

</details>


<details><summary>Search occupancy view -- with criteria</summary>

#### Criteria unavailability

<img width="751" alt="Screenshot 2025-07-01 at 17 37 14" src="https://github.com/user-attachments/assets/e864896b-43d8-4695-9c93-0fd325801e42" />

---

#### General unavailability

<img width="750" alt="Screenshot 2025-07-01 at 17 37 36" src="https://github.com/user-attachments/assets/9865725f-392a-45f7-ae80-72011506eb83" />


</details>



<details><summary>AP occupancy view (functionally unchanged)</summary>

<img width="750" alt="Screenshot 2025-07-01 at 17 35 02" src="https://github.com/user-attachments/assets/ceb2f557-bf43-492c-a88b-f2be67321860" />

</details>
