### PR TITLE
chore: Update contract test framework

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
 
   unit_test:
     name: "Unit testing 🧪"
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, hmpps-github-actions-runner ]
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "@jgoz/esbuild-plugin-typecheck": "^4.0.3",
         "@ministryofjustice/eslint-config-hmpps": "^0.0.1-beta.2",
         "@pact-foundation/pact": "^15.0.0",
+        "@pactflow/openapi-pact-comparator": "^1.4.0",
         "@types/bunyan": "^1.8.8",
         "@types/bunyan-format": "^0.2.5",
         "@types/compression": "^1.8.0",
@@ -108,7 +109,6 @@
         "shellcheck": "^3.1.0",
         "start-server-and-test": "^2.0.12",
         "supertest": "^7.1.1",
-        "swagger-mock-validator": "^11.0.0",
         "ts-jest": "^29.3.4",
         "typescript": "^5.8.3"
       },
@@ -147,54 +147,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/philsturgeon"
-      }
-    },
-    "node_modules/@apidevtools/openapi-schemas": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
-      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@apidevtools/swagger-methods": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
-      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@apidevtools/swagger-parser": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
-      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@apidevtools/openapi-schemas": "^2.0.4",
-        "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "z-schema": "^5.0.1"
-      },
-      "peerDependencies": {
-        "openapi-types": ">=7"
-      }
-    },
-    "node_modules/@apidevtools/swagger-parser/node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
-      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -3449,6 +3401,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@pactflow/openapi-pact-comparator": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pactflow/openapi-pact-comparator/-/openapi-pact-comparator-1.4.0.tgz",
+      "integrity": "sha512-OCq1V5YdUO9AdXVbVrx2kB/NUX9nz52v6JLeMd4xTZ8hTwpSRQiknpMMx32f42zb8QTYd+aRlyDMefnOOjgQNA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "openapi-pact-comparator": "dist/cli.cjs"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -6866,13 +6828,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/call-me-maybe": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
-      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -7755,13 +7710,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/decimal.js": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/decompress": {
       "version": "4.2.1",
@@ -13085,16 +13033,6 @@
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==",
       "license": "MIT"
     },
-    "node_modules/jsonpointer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
-      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/jsonstream-next": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jsonstream-next/-/jsonstream-next-3.0.0.tgz",
@@ -13332,14 +13270,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -13350,14 +13280,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
@@ -14703,13 +14625,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/openapi-types": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-7.2.3.tgz",
-      "integrity": "sha512-olbaNxz12R27+mTyJ/ZAFEfUruauHH27AkeQHDHRq5AF0LdNkK1SSV7EourXQDK+4aX7dv2HtyirAGK06WMAsA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/openapi-typescript-codegen": {
       "version": "0.29.0",
@@ -17685,56 +17600,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/swagger-mock-validator": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/swagger-mock-validator/-/swagger-mock-validator-11.0.0.tgz",
-      "integrity": "sha512-nolHh1QvSQytFD8dSZFJfl9tZix/RYWis4Lr+eg4CDVyzX9iezVVODarsj6oSc/qUpQyj7WgiHSQZbX0ocK97A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ajv": "^6.12.6",
-        "axios": "^1.6.8",
-        "commander": "^7.0.0",
-        "decimal.js": "^10.2.0",
-        "js-yaml": "^4.0.0",
-        "jsonpointer": "^5.0.0",
-        "lodash": "^4.17.10",
-        "openapi-types": "^7.0.1",
-        "swagger-parser": "^10.0.2",
-        "uuidjs": "^4.0.3",
-        "validator": "^13.1.17",
-        "verror": "^1.8.1"
-      },
-      "bin": {
-        "swagger-mock-validator": "bin/swagger-mock-validator"
-      },
-      "engines": {
-        "node": ">=6.14.3"
-      }
-    },
-    "node_modules/swagger-mock-validator/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/swagger-parser": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
-      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@apidevtools/swagger-parser": "10.0.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/sync-child-process": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
@@ -18596,16 +18461,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/uuidjs": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/uuidjs/-/uuidjs-4.2.14.tgz",
-      "integrity": "sha512-Z4iL8AWHlTWeAmi6v1TCPKBF5QkTxpdLDS2yrAm9cA9GvEwWFxnRm7uEEcDY5TrZuO2A/cLQyeuXjlohAMcCIQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "uuidjs": "bin/cli.js"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -18619,16 +18474,6 @@
       },
       "engines": {
         "node": ">=10.12.0"
-      }
-    },
-    "node_modules/validator": {
-      "version": "13.15.15",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
-      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/varint": {
@@ -19098,38 +18943,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/z-schema": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
-      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.5.0",
-        "validator": "^13.7.0"
-      },
-      "bin": {
-        "z-schema": "bin/z-schema"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "commander": "^9.4.1"
-      }
-    },
-    "node_modules/z-schema/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "@jgoz/esbuild-plugin-typecheck": "^4.0.3",
     "@ministryofjustice/eslint-config-hmpps": "^0.0.1-beta.2",
     "@pact-foundation/pact": "^15.0.0",
+    "@pactflow/openapi-pact-comparator": "^1.4.0",
     "@types/bunyan": "^1.8.8",
     "@types/bunyan-format": "^0.2.5",
     "@types/compression": "^1.8.0",
@@ -205,7 +206,6 @@
     "shellcheck": "^3.1.0",
     "start-server-and-test": "^2.0.12",
     "supertest": "^7.1.1",
-    "swagger-mock-validator": "^11.0.0",
     "ts-jest": "^29.3.4",
     "typescript": "^5.8.3"
   },

--- a/server/data/appealClient.test.ts
+++ b/server/data/appealClient.test.ts
@@ -17,7 +17,7 @@ describeClient('AppealClient', provider => {
       const newAppeal = newAppealFactory.build()
       const appeal = appealFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request for an appeal',
         withRequest: {
@@ -45,7 +45,7 @@ describeClient('AppealClient', provider => {
       const application = applicationFactory.build()
       const appeal = appealFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request for an appeal',
         withRequest: {

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -31,7 +31,7 @@ describeClient('ApplicationClient', provider => {
       const application = applicationFactory.build()
       const offence = activeOffenceFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to create an Application with risks',
         withRequest: {
@@ -71,7 +71,7 @@ describeClient('ApplicationClient', provider => {
         const application = applicationFactory.build()
         const offence = activeOffenceFactory.build()
 
-        provider.addInteraction({
+        await provider.addInteraction({
           state: 'Server is healthy',
           uponReceiving: 'A request to create an Application without risks',
           withRequest: {
@@ -108,7 +108,7 @@ describeClient('ApplicationClient', provider => {
     it('should return an application', async () => {
       const application = applicationFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request for an application',
         withRequest: {
@@ -142,7 +142,7 @@ describeClient('ApplicationClient', provider => {
         type: 'CAS1' as const,
       }
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'Request to update an application',
         withRequest: {
@@ -180,7 +180,7 @@ describeClient('ApplicationClient', provider => {
         type: 'CAS1',
       }
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to submit an application',
         withRequest: {
@@ -205,7 +205,7 @@ describeClient('ApplicationClient', provider => {
       const application = applicationFactory.build()
       const documents = documentFactory.buildList(5)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request for all documents for an application',
         withRequest: {
@@ -232,7 +232,7 @@ describeClient('ApplicationClient', provider => {
       const applicationId = 'applicationId'
       const newWithdrawal = { reason: 'duplicate_application' as WithdrawalReason, otherReason: 'other reason' }
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to withdraw an application',
         withRequest: {
@@ -257,7 +257,7 @@ describeClient('ApplicationClient', provider => {
       const applicationId = 'applicationId'
       const requestsForPlacement = requestForPlacementFactory.buildList(1)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request for the requests for placements of an application',
         withRequest: {
@@ -283,7 +283,7 @@ describeClient('ApplicationClient', provider => {
       const applicationId = 'applicationId'
       const note = noteFactory.build({ id: undefined })
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request for to add a note to an application',
         withRequest: {
@@ -311,7 +311,7 @@ describeClient('ApplicationClient', provider => {
       const withdrawable = withdrawableFactory.buildList(1)
       const withdrawables = withdrawablesFactory.build({ withdrawables: withdrawable })
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request for to add a note to an application',
         withRequest: {
@@ -346,7 +346,7 @@ describeCas1NamespaceClient('Cas1ApplicationClient', provider => {
     it('should get all applications created by the current user', async () => {
       const applications = cas1ApplicationSummaryFactory.buildList(5)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request for all applications created by the current user',
         withRequest: {
@@ -372,7 +372,7 @@ describeCas1NamespaceClient('Cas1ApplicationClient', provider => {
     it('should get all applications', async () => {
       const allApplications = cas1ApplicationSummaryFactory.buildList(5)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request for all applications',
         withRequest: {
@@ -381,7 +381,6 @@ describeCas1NamespaceClient('Cas1ApplicationClient', provider => {
           query: { page: '1', sortBy: 'arrivalDate', sortDirection: 'asc' },
           headers: {
             authorization: `Bearer ${token}`,
-            'X-Service-Name': 'approved-premises',
           },
         },
         willRespondWith: {
@@ -409,7 +408,7 @@ describeCas1NamespaceClient('Cas1ApplicationClient', provider => {
     it('should pass a page number', async () => {
       const allApplications = cas1ApplicationSummaryFactory.buildList(5)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request for all applications',
         withRequest: {
@@ -418,7 +417,6 @@ describeCas1NamespaceClient('Cas1ApplicationClient', provider => {
           query: { page: '2', sortBy: 'createdAt', sortDirection: 'desc' },
           headers: {
             authorization: `Bearer ${token}`,
-            'X-Service-Name': 'approved-premises',
           },
         },
         willRespondWith: {
@@ -446,7 +444,7 @@ describeCas1NamespaceClient('Cas1ApplicationClient', provider => {
     it('should pass search options', async () => {
       const allApplications = cas1ApplicationSummaryFactory.buildList(5)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request for all applications',
         withRequest: {
@@ -461,7 +459,6 @@ describeCas1NamespaceClient('Cas1ApplicationClient', provider => {
           },
           headers: {
             authorization: `Bearer ${token}`,
-            'X-Service-Name': 'approved-premises',
           },
         },
         willRespondWith: {
@@ -495,7 +492,7 @@ describeCas1NamespaceClient('Cas1ApplicationClient', provider => {
       const applicationId = 'applicationId'
       const timelineEvents = cas1TimelineEventFactory.buildList(1)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request for the timeline of an application',
         withRequest: {

--- a/server/data/assessmentClient.test.ts
+++ b/server/data/assessmentClient.test.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker'
 import AssessmentClient from './assessmentClient'
 import {
   assessmentFactory,
@@ -13,6 +14,8 @@ describeClient('AssessmentClient', provider => {
 
   const token = 'token-1'
 
+  const assessmentId = faker.string.uuid()
+
   beforeEach(() => {
     assessmentClient = new AssessmentClient(token)
   })
@@ -21,7 +24,7 @@ describeClient('AssessmentClient', provider => {
     it('should get all assessments', async () => {
       const assessments = assessmentSummaryFactory.buildList(3)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get all assessments',
         withRequest: {
@@ -65,7 +68,7 @@ describeClient('AssessmentClient', provider => {
     it('should get an assessment', async () => {
       const assessment = assessmentFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get an assessment',
         withRequest: {
@@ -91,7 +94,7 @@ describeClient('AssessmentClient', provider => {
     it('should return an assessment when a PUT request is made', async () => {
       const assessment = assessmentFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to update an assessment',
         withRequest: {
@@ -116,13 +119,12 @@ describeClient('AssessmentClient', provider => {
 
   describe('acceptance', () => {
     it('should call the acceptance endpoint with the assessment', async () => {
-      const assessmentId = 'some-id'
       const data = {
         document: {},
         requirements: placementRequestFactory.build(),
       }
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to accept an assessment',
         withRequest: {
@@ -147,7 +149,7 @@ describeClient('AssessmentClient', provider => {
       const assessment = assessmentFactory.build()
       const response = { section: [{ task: 'response' }] }
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to reject an assessment',
         withRequest: {
@@ -172,13 +174,12 @@ describeClient('AssessmentClient', provider => {
 
   describe('createClarificationNote', () => {
     it('should return a note when a POST request is made', async () => {
-      const assessmentId = 'some-id'
       const note = clarificationNoteFactory.build()
       const newNote = {
         query: note.query,
       }
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to create a clarification note',
         withRequest: {
@@ -203,14 +204,13 @@ describeClient('AssessmentClient', provider => {
 
   describe('updateClarificationNote', () => {
     it('should return a note when a PUT request is made', async () => {
-      const assessmentId = 'some-id'
       const note = clarificationNoteFactory.build()
       const updatedNote = {
         response: note.response,
         responseReceivedOn: note.responseReceivedOn,
       }
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to update a clarification note',
         withRequest: {

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -19,7 +19,7 @@ export default class BookingClient {
   }
 
   async find(premisesId: Premises['id'], bookingId: Booking['id']): Promise<Booking> {
-    return (await this.restClient.get({ path: this.bookingPath(premisesId, bookingId) })) as Booking
+    return (await this.restClient.get({ path: paths.premises.bookings.show({ premisesId, bookingId }) })) as Booking
   }
 
   async findWithoutPremises(bookingId: Booking['id']): Promise<Booking> {
@@ -29,19 +29,19 @@ export default class BookingClient {
   }
 
   async allBookingsForPremisesId(premisesId: string): Promise<Array<Booking>> {
-    return (await this.restClient.get({ path: this.bookingsPath(premisesId) })) as Array<Booking>
+    return (await this.restClient.get({ path: paths.premises.bookings.index({ premisesId }) })) as Array<Booking>
   }
 
   async extendBooking(premisesId: string, bookingId: string, bookingExtension: NewExtension): Promise<Extension> {
     return (await this.restClient.post({
-      path: `/premises/${premisesId}/bookings/${bookingId}/extensions`,
+      path: paths.premises.bookings.extensions({ premisesId, bookingId }),
       data: bookingExtension,
     })) as Extension
   }
 
   async cancel(premisesId: string, bookingId: string, cancellation: NewCancellation): Promise<Cancellation> {
     const response = await this.restClient.post({
-      path: `${this.bookingPath(premisesId, bookingId)}/cancellations`,
+      path: paths.premises.bookings.cancellations({ premisesId, bookingId }),
       data: cancellation,
     })
 
@@ -53,13 +53,5 @@ export default class BookingClient {
       path: paths.premises.bookings.dateChange({ premisesId, bookingId }),
       data: dateChange,
     })
-  }
-
-  private bookingsPath(premisesId: string): string {
-    return `/premises/${premisesId}/bookings`
-  }
-
-  private bookingPath(premisesId: string, bookingId: string): string {
-    return [this.bookingsPath(premisesId), bookingId].join('/')
   }
 }

--- a/server/data/cas1ReferenceDataClient.test.ts
+++ b/server/data/cas1ReferenceDataClient.test.ts
@@ -22,7 +22,7 @@ describeCas1NamespaceClient('Cas1ReferenceDataClient', provider => {
 
     Object.keys(data).forEach((key: keyof typeof data) => {
       it(`should return an array of ${key}`, async () => {
-        provider.addInteraction({
+        await provider.addInteraction({
           state: 'Server is healthy',
           uponReceiving: `A request to get ${key}`,
           withRequest: {

--- a/server/data/cas1UserClient.test.ts
+++ b/server/data/cas1UserClient.test.ts
@@ -15,18 +15,16 @@ describeCas1NamespaceClient('Cas1UserClient', provider => {
 
   describe('getUser', () => {
     const user = userFactory.build()
-    const id = 'SOME_ID'
 
     it('should return a user', async () => {
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get a user',
         withRequest: {
           method: 'GET',
-          path: paths.users.show({ id }),
+          path: paths.users.show({ id: user.id }),
           headers: {
             authorization: `Bearer ${token}`,
-            'X-Service-Name': 'approved-premises',
           },
         },
         willRespondWith: {
@@ -35,7 +33,7 @@ describeCas1NamespaceClient('Cas1UserClient', provider => {
         },
       })
 
-      const output = await userClient.getUser(id)
+      const output = await userClient.getUser(user.id)
       expect(output).toEqual(user)
     })
   })
@@ -47,10 +45,10 @@ describeCas1NamespaceClient('Cas1UserClient', provider => {
       const updateUserData: Cas1UpdateUser = {
         roles: user.roles,
         qualifications: user.qualifications,
-        cruManagementAreaOverrideId: 'foo-id',
+        cruManagementAreaOverrideId: user.cruManagementAreaOverride.id,
       }
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to update a user',
         withRequest: {
@@ -58,7 +56,6 @@ describeCas1NamespaceClient('Cas1UserClient', provider => {
           path: paths.users.update({ id: user.id }),
           headers: {
             authorization: `Bearer ${token}`,
-            'X-Service-Name': 'approved-premises',
           },
           body: updateUserData,
         },
@@ -77,7 +74,7 @@ describeCas1NamespaceClient('Cas1UserClient', provider => {
     it('should delete a user', async () => {
       const user = userFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to delete a user',
         withRequest: {
@@ -85,7 +82,6 @@ describeCas1NamespaceClient('Cas1UserClient', provider => {
           path: paths.users.delete({ id: user.id }),
           headers: {
             authorization: `Bearer ${token}`,
-            'X-Service-Name': 'approved-premises',
           },
         },
         willRespondWith: {

--- a/server/data/outOfServiceBedClient.test.ts
+++ b/server/data/outOfServiceBedClient.test.ts
@@ -2,6 +2,7 @@ import type {
   Cas1NewOutOfServiceBedCancellation as NewOutOfServiceBedCancellation,
   UpdateCas1OutOfServiceBed as UpdateOutOfServiceBed,
 } from '@approved-premises/api'
+import { faker } from '@faker-js/faker'
 import OutOfServiceBedClient from './outOfServiceBedClient'
 import {
   newOutOfServiceBedFactory,
@@ -16,7 +17,7 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
 
   const token = 'token-1'
 
-  const premisesId = 'premisesId'
+  const premisesId = faker.string.uuid()
 
   beforeEach(() => {
     outOfServiceBedClient = new OutOfServiceBedClient(token)
@@ -27,7 +28,7 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
       const outOfServiceBed = outOfServiceBedFactory.build({})
       const newOutOfServiceBed = newOutOfServiceBedFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to create a lost bed',
         withRequest: {
@@ -56,7 +57,7 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
         cancellation: {},
       })
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to find a lost bed',
         withRequest: {
@@ -72,7 +73,7 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
         },
       })
 
-      const result = await outOfServiceBedClient.find('premisesId', outOfServiceBed.id)
+      const result = await outOfServiceBedClient.find(premisesId, outOfServiceBed.id)
 
       expect(result).toEqual(outOfServiceBed)
     })
@@ -82,7 +83,7 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
     it('should get all outOfServiceBeds for a premises', async () => {
       const outOfServiceBeds = outOfServiceBedFactory.buildList(2)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get lost beds',
         withRequest: {
@@ -98,7 +99,7 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
         },
       })
 
-      const result = await outOfServiceBedClient.getAllByPremises('premisesId')
+      const result = await outOfServiceBedClient.getAllByPremises(premisesId)
 
       expect(result).toEqual(outOfServiceBeds)
     })
@@ -115,7 +116,7 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
       const temporality = 'future'
       const apAreaId = '123'
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get out of service beds',
         withRequest: {
@@ -177,7 +178,7 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
         notes,
       }
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to update a lost bed',
         withRequest: {
@@ -194,7 +195,7 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
         },
       })
 
-      const result = await outOfServiceBedClient.update(outOfServiceBed.id, outOfServiceBedUpdateData, 'premisesId')
+      const result = await outOfServiceBedClient.update(outOfServiceBed.id, outOfServiceBedUpdateData, premisesId)
 
       expect(result).toEqual(outOfServiceBed)
     })
@@ -209,7 +210,7 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
         notes,
       }
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to cancel a lost bed',
         withRequest: {
@@ -228,7 +229,7 @@ describeCas1NamespaceClient('OutOfServiceBedClient', provider => {
 
       const result = await outOfServiceBedClient.cancel(
         outOfServiceBedCancellation.id,
-        'premisesId',
+        premisesId,
         outOfServiceBedCancellationData,
       )
 

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -33,7 +33,7 @@ describeClient('PersonClient', provider => {
     it('should return a person', async () => {
       const person = personFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to search for a person',
         withRequest: {
@@ -60,7 +60,7 @@ describeClient('PersonClient', provider => {
     it('should return append checkCaseload if checkCaseload is true', async () => {
       const person = personFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to search for a person and check the caseload',
         withRequest: {
@@ -91,7 +91,7 @@ describeClient('PersonClient', provider => {
       const crn = 'crn'
       const prisonCaseNotes = prisonCaseNotesFactory.buildList(3)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get the case notes for a person',
         withRequest: {
@@ -119,7 +119,7 @@ describeClient('PersonClient', provider => {
       const crn = 'crn'
       const adjudications = adjudicationFactory.buildList(5)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get the adjudications for a person',
         withRequest: {
@@ -147,7 +147,7 @@ describeClient('PersonClient', provider => {
       const crn = 'crn'
       const acctAlerts = acctAlertFactory.buildList(5)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get the acctAlerts for a person',
         withRequest: {
@@ -174,7 +174,7 @@ describeClient('PersonClient', provider => {
       const crn = 'crn'
       const offences = activeOffenceFactory.buildList(5)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get offences for a person',
         withRequest: {
@@ -199,10 +199,10 @@ describeClient('PersonClient', provider => {
   describe('document', () => {
     it('should pipe the document from the API', async () => {
       const crn = 'crn'
-      const documentId = '123'
+      const documentId = faker.string.uuid()
       const response = createMock<Response>({})
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get a document for a person',
         withRequest: {
@@ -236,7 +236,7 @@ describeCas1NamespaceClient('cas1PersonClient', provider => {
       const crn = 'crn'
       const oasysMetadata = cas1OASysMetadataFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get the importable sections of OASys for a person',
         withRequest: {
@@ -265,7 +265,7 @@ describeCas1NamespaceClient('cas1PersonClient', provider => {
       const group: Cas1OASysGroupName = faker.helpers.arrayElement(['riskToSelf', 'supportingInformation'])
       const oasysGroup = cas1OasysGroupFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving:
           'A request to get the questions and answers for a single group from OASys including optionals for supporting information',
@@ -296,7 +296,7 @@ describeCas1NamespaceClient('cas1PersonClient', provider => {
     it('calls the API with CRN', async () => {
       const crn = 'crn'
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get the timeline for a person',
         withRequest: {

--- a/server/data/placementApplicationClient.test.ts
+++ b/server/data/placementApplicationClient.test.ts
@@ -1,10 +1,10 @@
+import { faker } from '@faker-js/faker'
 import PlacementApplicationClient from './placementApplicationClient'
 import paths from '../paths/api'
 
 import { placementApplicationDecisionEnvelopeFactory, placementApplicationFactory } from '../testutils/factories'
 import { describeCas1NamespaceClient } from '../testutils/describeClient'
 import { SubmitPlacementApplication } from '../@types/shared'
-import { WithdrawPlacementRequestReason } from '../@types/shared/models/WithdrawPlacementRequestReason'
 
 describeCas1NamespaceClient('placementApplicationClient', provider => {
   let placementApplicationClient: PlacementApplicationClient
@@ -19,7 +19,7 @@ describeCas1NamespaceClient('placementApplicationClient', provider => {
     it('makes a get request to the placementApplication endpoint', async () => {
       const placementApplication = placementApplicationFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get a placement application',
         withRequest: {
@@ -42,10 +42,10 @@ describeCas1NamespaceClient('placementApplicationClient', provider => {
   })
   describe('create', () => {
     it('should return a placement application when a application ID is posted', async () => {
-      const applicationId = '123'
+      const applicationId = faker.string.uuid()
       const placementApplication = placementApplicationFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to create a placement application',
         withRequest: {
@@ -73,7 +73,7 @@ describeCas1NamespaceClient('placementApplicationClient', provider => {
     it('updates and returns a placement application', async () => {
       const placementApplication = placementApplicationFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to update a placement application',
         withRequest: {
@@ -107,7 +107,7 @@ describeCas1NamespaceClient('placementApplicationClient', provider => {
         translatedDocument: {},
       }
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to submit a placement application',
         withRequest: {
@@ -135,7 +135,7 @@ describeCas1NamespaceClient('placementApplicationClient', provider => {
       const decisionEnvelope = placementApplicationDecisionEnvelopeFactory.build()
       const placementApplication = placementApplicationFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to submit a placement application decision',
         withRequest: {
@@ -161,9 +161,9 @@ describeCas1NamespaceClient('placementApplicationClient', provider => {
   describe('withdraw', () => {
     it('withdraws a placement application and returns the result', async () => {
       const placementApplication = placementApplicationFactory.build()
-      const reason: WithdrawPlacementRequestReason = 'AlternativeProvisionIdentified'
+      const reason = 'DuplicatePlacementRequest'
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to withdraw a placement application',
         withRequest: {

--- a/server/data/placementClient.test.ts
+++ b/server/data/placementClient.test.ts
@@ -29,7 +29,7 @@ describeCas1NamespaceClient('PlacementClient', provider => {
   describe('getPlacement', () => {
     it('gets the details for a placement by id', async () => {
       const placement: Cas1SpaceBooking = cas1SpaceBookingFactory.build()
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request for placement details',
         withRequest: {
@@ -54,7 +54,7 @@ describeCas1NamespaceClient('PlacementClient', provider => {
     it('gets the timeline for a placement', async () => {
       const timeLine: Array<Cas1TimelineEvent> = cas1TimelineEventFactory.buildList(10)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request for placement timeline',
         withRequest: {
@@ -78,7 +78,7 @@ describeCas1NamespaceClient('PlacementClient', provider => {
     it('patches a placement and returns it', async () => {
       const updatePlacement = cas1UpdateSpaceBookingFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to update a placement',
         withRequest: {
@@ -104,7 +104,7 @@ describeCas1NamespaceClient('PlacementClient', provider => {
     it('creates and returns an arrival for a given placement', async () => {
       const newPlacementArrival = cas1NewArrivalFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to record a placement arrival',
         withRequest: {
@@ -130,7 +130,7 @@ describeCas1NamespaceClient('PlacementClient', provider => {
     it('assigns a keyworker to a given placement', async () => {
       const keyworkerAssignment = cas1AssignKeyWorkerFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to assign a keyworker to a placement',
         withRequest: {
@@ -156,7 +156,7 @@ describeCas1NamespaceClient('PlacementClient', provider => {
     it('records a non-arrival against a given placement', async () => {
       const nonArrival = cas1NonArrivalFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to record a non-arrival',
         withRequest: {
@@ -182,7 +182,7 @@ describeCas1NamespaceClient('PlacementClient', provider => {
     it('creates a departure for a given placement', async () => {
       const newPlacementDeparture = cas1NewDepartureFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to record a placement departure',
         withRequest: {
@@ -206,7 +206,7 @@ describeCas1NamespaceClient('PlacementClient', provider => {
     it('cancels the given placement', async () => {
       const cancellation = cas1NewSpaceBookingCancellationFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to cancel a placement',
         withRequest: {
@@ -230,7 +230,7 @@ describeCas1NamespaceClient('PlacementClient', provider => {
     it('creates an emergency transfer', async () => {
       const newEmergencyTransfer = cas1NewEmergencyTransferFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to create an emergency transfer',
         withRequest: {
@@ -254,7 +254,7 @@ describeCas1NamespaceClient('PlacementClient', provider => {
     it('approves a placement appeal', async () => {
       const approvedPlacementAppeal: Cas1ApprovedPlacementAppeal = cas1ApprovedPlacementAppealfactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to approve a placement appeal',
         withRequest: {

--- a/server/data/placementRequestClient.test.ts
+++ b/server/data/placementRequestClient.test.ts
@@ -497,8 +497,9 @@ describeCas1NamespaceClient('Cas1PlacementRequestClient', provider => {
 
   describe('createPlacementAppeal', () => {
     it('creates an appeal change request against a placementRequest', async () => {
-      const placementRequestId = 'placement-request-id'
+      const placementRequestId = faker.string.uuid()
       const newChangeRequest: Cas1NewChangeRequest = cas1NewChangeRequestFactory.build({ type: 'placementAppeal' })
+
       await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to create an appeal changeRequest against a placementRequest',
@@ -521,8 +522,9 @@ describeCas1NamespaceClient('Cas1PlacementRequestClient', provider => {
 
   describe('createPlannedTransfer', () => {
     it('creates a planned transfer change request against a placementRequest', async () => {
-      const placementRequestId = 'placement-request-id'
+      const placementRequestId = faker.string.uuid()
       const newChangeRequest: Cas1NewChangeRequest = cas1NewChangeRequestFactory.build({ type: 'plannedTransfer' })
+
       await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to create a planned transfer changeRequest against a placementRequest',
@@ -545,7 +547,7 @@ describeCas1NamespaceClient('Cas1PlacementRequestClient', provider => {
 
   describe('createExtension', () => {
     it('creates an extension change request against a placementRequest', async () => {
-      const placementRequestId = 'placement-request-id'
+      const placementRequestId = faker.string.uuid()
       const newChangeRequest: Cas1NewChangeRequest = cas1NewChangeRequestFactory.build({ type: 'placementExtension' })
       await provider.addInteraction({
         state: 'Server is healthy',
@@ -569,8 +571,9 @@ describeCas1NamespaceClient('Cas1PlacementRequestClient', provider => {
 
   describe('rejectChangeRequest', () => {
     it('rejects a changeRequest against a placementRequest', async () => {
-      const placementRequestId = 'placement-request-id'
-      const changeRequestId = 'change-request-id'
+      const placementRequestId = faker.string.uuid()
+      const changeRequestId = faker.string.uuid()
+
       // TODO: remove override once API type corrected - APS-2353
       const rejectChangeRequest: Cas1RejectChangeRequest = cas1RejectChangeRequestFactory.build({
         decisionJson: { notes: { innerKey: 'inner' } },

--- a/server/data/premisesClient.test.ts
+++ b/server/data/premisesClient.test.ts
@@ -36,7 +36,7 @@ describeCas1NamespaceClient('PremisesCas1Client', provider => {
 
   describe('find', () => {
     it('should get a single premises', async () => {
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get a single premises',
         withRequest: {
@@ -62,7 +62,7 @@ describeCas1NamespaceClient('PremisesCas1Client', provider => {
       const gender = 'man'
       const premisesSummaries = cas1PremisesBasicSummaryFactory.buildList(5)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get all CAS1 premises summaries',
         withRequest: {
@@ -98,7 +98,7 @@ describeCas1NamespaceClient('PremisesCas1Client', provider => {
         const sortBy = 'personName'
         const sortDirection = 'asc'
 
-        provider.addInteraction({
+        await provider.addInteraction({
           state: 'Server is healthy',
           uponReceiving: `A request to get ${status} placements for a premises`,
           withRequest: {
@@ -151,7 +151,7 @@ describeCas1NamespaceClient('PremisesCas1Client', provider => {
       const sortBy = 'canonicalArrivalDate'
       const sortDirection = 'desc'
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: `A request to get placements matching "${crnOrName}" for a premises`,
         withRequest: {
@@ -197,7 +197,7 @@ describeCas1NamespaceClient('PremisesCas1Client', provider => {
     it('should return details of a single placement', async () => {
       const placement: Cas1SpaceBooking = cas1SpaceBookingFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get a single placement',
         withRequest: {
@@ -226,7 +226,7 @@ describeCas1NamespaceClient('PremisesCas1Client', provider => {
     it('should return a list of beds for a given premises', async () => {
       const beds = cas1PremisesBedSummaryFactory.buildList(5)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get a list of beds for a premises',
         withRequest: {
@@ -251,7 +251,7 @@ describeCas1NamespaceClient('PremisesCas1Client', provider => {
     it('should return a bed for a given premises', async () => {
       const bed = cas1BedDetailFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get a bed for a premises',
         withRequest: {
@@ -279,7 +279,7 @@ describeCas1NamespaceClient('PremisesCas1Client', provider => {
       const excludeSpaceBookingId = 'id-to-exclude'
       const premiseCapacity = cas1PremiseCapacityFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get the capacity of a premise',
         withRequest: {
@@ -348,7 +348,7 @@ describeCas1NamespaceClient('PremisesCas1Client', provider => {
     it('should return a list of staff for a given premises', async () => {
       const staffList = staffMemberFactory.buildList(5)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get a list of staff for a premises',
         withRequest: {
@@ -373,7 +373,7 @@ describeCas1NamespaceClient('PremisesCas1Client', provider => {
     it('should pipe the occupancy report', async () => {
       const response = createMock<Response>({})
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to download the occupancy report',
         withRequest: {
@@ -381,7 +381,6 @@ describeCas1NamespaceClient('PremisesCas1Client', provider => {
           path: paths.premises.occupancyReport({}),
           headers: {
             authorization: `Bearer ${token}`,
-            'X-Service-Name': 'approved-premises',
           },
         },
         willRespondWith: {

--- a/server/data/referenceDataClient.test.ts
+++ b/server/data/referenceDataClient.test.ts
@@ -37,7 +37,7 @@ describeClient('ReferenceDataClient', provider => {
 
     Object.keys(data).forEach((key: keyof typeof data) => {
       it(`should return an array of ${key}`, async () => {
-        provider.addInteraction({
+        await provider.addInteraction({
           state: 'Server is healthy',
           uponReceiving: `A request to get ${key}`,
           withRequest: {
@@ -63,7 +63,7 @@ describeClient('ReferenceDataClient', provider => {
     it('should return an array of probation regions', async () => {
       const probationRegions = probationRegionFactory.buildList(5)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: `A request to get probation regions`,
         withRequest: {
@@ -88,7 +88,7 @@ describeClient('ReferenceDataClient', provider => {
     it('should return an array of AP areas', async () => {
       const apAreas = apAreaFactory.buildList(5)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: `A request to get AP areas`,
         withRequest: {
@@ -113,7 +113,7 @@ describeClient('ReferenceDataClient', provider => {
     it('should return an array of non-arrival reasons', async () => {
       const nonArrivalReasons = nonArrivalReasonsFactory.buildList(5)
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: `A request to get Non-arrival reasons`,
         withRequest: {

--- a/server/data/reportClient.test.ts
+++ b/server/data/reportClient.test.ts
@@ -24,7 +24,7 @@ describeCas1NamespaceClient('ReportClient', provider => {
         const endDate = '2025-04-30'
         const response = createMock<Response>({})
 
-        provider.addInteraction({
+        await provider.addInteraction({
           state: 'Server is healthy',
           uponReceiving: 'A request to get application reports ',
           withRequest: {

--- a/server/data/spaceSearchClient.test.ts
+++ b/server/data/spaceSearchClient.test.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker'
 import SpaceSearchClient from './spaceSearchClient'
 import paths from '../paths/api'
 
@@ -23,7 +24,7 @@ describeCas1NamespaceClient('SpaceSearchClient', provider => {
       const spaceSearchResult = spaceSearchResultsFactory.build()
       const payload = spaceSearchParametersFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get details of available spaces matching the crieteria',
         withRequest: {
@@ -48,11 +49,11 @@ describeCas1NamespaceClient('SpaceSearchClient', provider => {
 
   describe('createSpaceBooking', () => {
     it('makes a POST request to the space booking endpoint', async () => {
-      const placementRequestId = 'placement-request-id'
+      const placementRequestId = faker.string.uuid()
       const newSpaceBooking = newSpaceBookingFactory.build()
       const spaceBooking = cas1SpaceBookingFactory.build()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to create a space booking from a placement request',
         withRequest: {

--- a/server/data/taskClient.test.ts
+++ b/server/data/taskClient.test.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker'
 import TaskClient from './taskClient'
 import paths from '../paths/api'
 
@@ -29,7 +30,7 @@ describeCas1NamespaceClient('taskClient', provider => {
       const requiredQualification = 'emergency'
       const crnOrName = 'CRN123'
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: `A request to get a list of tasks`,
         withRequest: {
@@ -89,7 +90,7 @@ describeCas1NamespaceClient('taskClient', provider => {
     it('makes a get request to the tasks endpoint', async () => {
       const tasks = [placementApplicationTaskFactory.buildList(1), assessmentTaskFactory.buildList(1)].flat()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: `A request to get a list of tasks`,
         withRequest: {
@@ -116,10 +117,10 @@ describeCas1NamespaceClient('taskClient', provider => {
     it('should get a task', async () => {
       const taskWrapper = taskWrapperFactory.build()
 
-      const applicationId = 'some-application-id'
+      const applicationId = faker.string.uuid()
       const taskType = 'placement-request'
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get a task',
         withRequest: {
@@ -146,10 +147,10 @@ describeCas1NamespaceClient('taskClient', provider => {
     it('should allocate a task', async () => {
       const task = taskFactory.build()
 
-      const applicationId = 'some-application-id'
-      const userId = 'some-user-id'
+      const applicationId = faker.string.uuid()
+      const userId = faker.string.uuid()
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to allocate a task',
         withRequest: {

--- a/server/data/userClient.test.ts
+++ b/server/data/userClient.test.ts
@@ -16,7 +16,7 @@ describeClient('UserClient', provider => {
     const user = userFactory.build()
 
     it('should return a user', async () => {
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get a user profile',
         withRequest: {
@@ -42,7 +42,7 @@ describeClient('UserClient', provider => {
     const users = userSummaryFactory.buildList(4)
 
     it('should return all users without pagination', async () => {
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get a list of all users without pagination',
         withRequest: {
@@ -68,7 +68,7 @@ describeClient('UserClient', provider => {
     })
 
     it('should return all users with a given role without pagination', async () => {
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get a list of all users without pagination',
         withRequest: {
@@ -98,7 +98,7 @@ describeClient('UserClient', provider => {
     const users = userFactory.buildList(4)
 
     it('should return all users when no queries are specified', async () => {
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get a list of users',
         withRequest: {
@@ -137,7 +137,7 @@ describeClient('UserClient', provider => {
     })
 
     it('should return all users when a specific page number specified', async () => {
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get a list of users',
         withRequest: {
@@ -176,7 +176,7 @@ describeClient('UserClient', provider => {
     })
 
     it('should return all users when a specific sort direction specified', async () => {
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get a list of users',
         withRequest: {
@@ -215,7 +215,7 @@ describeClient('UserClient', provider => {
     })
 
     it('should query by role', async () => {
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get a list of users with roles',
         withRequest: {
@@ -255,7 +255,7 @@ describeClient('UserClient', provider => {
     })
 
     it('should query by qualifications', async () => {
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get a list of users with qualifications',
         withRequest: {
@@ -295,7 +295,7 @@ describeClient('UserClient', provider => {
     })
 
     it('should query by qualifications and roles', async () => {
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get a list of users with roles and qualifications',
         withRequest: {
@@ -341,7 +341,7 @@ describeClient('UserClient', provider => {
       const users = userFactory.buildList(1)
       const name = 'name'
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to search for a user',
         withRequest: {
@@ -371,7 +371,7 @@ describeClient('UserClient', provider => {
       const user = userFactory.build()
       const name = 'name'
 
-      provider.addInteraction({
+      await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to search for a user in delius',
         withRequest: {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -35,7 +35,8 @@ const cas1ApplicationsSingle = cas1Applications.path(':id')
 const premises = path('/premises')
 const premisesSingle = premises.path(':premisesId')
 const rooms = premisesSingle.path('rooms')
-const booking = premisesSingle.path('bookings/:bookingId')
+const bookings = premisesSingle.path('bookings')
+const booking = bookings.path(':bookingId')
 
 const profile = path('/profile')
 
@@ -94,8 +95,12 @@ export default {
     rooms,
     room: rooms.path(':roomId'),
     bookings: {
+      index: bookings,
+      show: booking,
       move: booking.path('moves'),
       dateChange: booking.path('date-changes'),
+      cancellations: booking.path('cancellations'),
+      extensions: booking.path('extensions'),
     },
     placements: {
       show: cas1SpaceBookingSingle,

--- a/server/testutils/describeClient.ts
+++ b/server/testutils/describeClient.ts
@@ -5,18 +5,12 @@ import { Pact } from '@pact-foundation/pact'
 import config from '../config'
 
 const describeClient = (consumer: string, fn: (provider: Pact) => void) => {
-  verifyClientMeetsContract(consumer, fn, { cas1Namespace: false })
+  verifyClientMeetsContract(consumer, fn)
 }
 
-export const describeCas1NamespaceClient = (consumer: string, fn: (provider: Pact) => void) => {
-  verifyClientMeetsContract(consumer, fn, { cas1Namespace: true })
-}
+export const describeCas1NamespaceClient = describeClient
 
-const verifyClientMeetsContract = (
-  consumer: string,
-  fn: (provider: Pact) => void,
-  { cas1Namespace } = { cas1Namespace: false },
-) => {
+const verifyClientMeetsContract = (consumer: string, fn: (provider: Pact) => void) => {
   const provider = 'API'
   const dir = path.join(__dirname, '..', '..', 'tmp', 'pacts')
 
@@ -29,10 +23,10 @@ const verifyClientMeetsContract = (
       fn(pact)
     })
 
-    it('meets the contract for the service', () => {
+    it('meets the contract for the service', async () => {
       const pactPath = `${dir}/${consumer}-${provider}.json`
-      expect(pactPath).toMatchOpenAPISpec({ cas1Namespace })
-    })
+      await expect(pactPath).toMatchOpenAPISpec()
+    }, 15000)
   })
 }
 

--- a/server/testutils/factories/bookingExtension.ts
+++ b/server/testutils/factories/bookingExtension.ts
@@ -10,5 +10,5 @@ export default Factory.define<Extension>(() => ({
   newDepartureDate: DateFormats.dateObjToIsoDate(faker.date.future()),
   bookingId: faker.string.uuid(),
   notes: faker.lorem.sentence(),
-  createdAt: DateFormats.dateObjToIsoDate(faker.date.past()),
+  createdAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
 }))

--- a/server/testutils/factories/cas1NewChangeRequest.ts
+++ b/server/testutils/factories/cas1NewChangeRequest.ts
@@ -17,7 +17,7 @@ export default Cas1NewChangeRequestFactory.define(() => {
   return {
     spaceBookingId: faker.string.uuid(),
     type: faker.helpers.arrayElement(changeRequestTypes),
-    reasonId: faker.string.alpha({ length: { min: 3, max: 10 } }),
+    reasonId: faker.string.uuid(),
     requestJson: {},
   }
 })

--- a/server/testutils/factories/clarificationNote.ts
+++ b/server/testutils/factories/clarificationNote.ts
@@ -19,7 +19,6 @@ export default ClarificationNoteFactory.define(() => ({
   id: faker.string.uuid(),
   createdAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
   createdByStaffMemberId: faker.string.uuid(),
-  text: faker.lorem.paragraph(),
   query: faker.lorem.sentence(),
   response: faker.lorem.sentence(),
   responseReceivedOn: DateFormats.dateObjToIsoDate(faker.date.past()),

--- a/server/testutils/factories/placementApplication.ts
+++ b/server/testutils/factories/placementApplication.ts
@@ -11,8 +11,6 @@ export default Factory.define<PlacementApplication>(() => ({
   applicationCompletedAt: DateFormats.dateObjToIsoDateTime(faker.date.recent()),
   assessmentCompletedAt: DateFormats.dateObjToIsoDateTime(faker.date.recent()),
   createdByUserId: faker.string.uuid(),
-  schemaVersion: faker.string.uuid(),
-  outdatedSchema: false,
   createdAt: DateFormats.dateObjToIsoDateTime(faker.date.recent()),
   submittedAt: DateFormats.dateObjToIsoDateTime(faker.date.recent()),
   data: {},

--- a/server/testutils/factories/referenceData.ts
+++ b/server/testutils/factories/referenceData.ts
@@ -55,7 +55,6 @@ class ReferenceDataFactory extends Factory<ReferenceData> {
 export default ReferenceDataFactory.define(() => ({
   id: faker.string.uuid(),
   name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
-  serviceScope: 'approved-premises',
   isActive: true,
 }))
 

--- a/server/testutils/factories/staffMember.ts
+++ b/server/testutils/factories/staffMember.ts
@@ -12,7 +12,6 @@ class StaffMemberFactory extends Factory<StaffMember> {
 }
 
 export default StaffMemberFactory.define(() => ({
-  id: faker.number.int(),
   name: faker.person.fullName(),
   code: faker.string.uuid(),
   keyWorker: faker.datatype.boolean(),


### PR DESCRIPTION
This enables the contract testing to handle the new API spec, which is of version 3.1.0, which `swagger-mock-validator` was unfortunately not compatible with. With no indication as to a possible update enabling support anytime soon, the decision was made to switch to a newer, more up-to-date library, `@pactflow/openapi-pact-comparator`.

The newer, tighter OpenAPI spec from the API has also uncovered a fair few inconsistencies with the current factories, which in a few cases seemed to carry extra properties not documented by the API. The spec now also specifies a stricter format for UUID strings, so these now have to conform.

Finally, the new unit tests are now pulling the API spec directly from the API rather than the repository, and therefore needs to be run on a self-hosted runner.

## Todo

- [x] The API no longer specifies pagination headers in the OpenAPI -- this should be fixed, but will be required for the tests to pass on this branch.
