### PR TITLE
Remove unused dependency body-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "accessible-autocomplete": "^3.0.1",
         "agentkeepalive": "^4.6.0",
         "applicationinsights": "^2.9.6",
-        "body-parser": "^1.20.0",
         "bunyan": "^1.8.15",
         "bunyan-format": "^0.2.1",
         "case": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "accessible-autocomplete": "^3.0.1",
     "agentkeepalive": "^4.6.0",
     "applicationinsights": "^2.9.6",
-    "body-parser": "^1.20.0",
     "bunyan": "^1.8.15",
     "bunyan-format": "^0.2.1",
     "case": "^1.6.3",


### PR DESCRIPTION
`body-parser` is included in Express and not a direct dependency. The app uses the parser provided by Express directly: https://github.com/ministryofjustice/hmpps-approved-premises-ui/blob/f42032b07281e69250faa3bcbae72760e1225e2c/server/middleware/setupRequestParsing.ts#L6-L7

This will close #2517 