### PR TITLE
APS-2447 National occupancy view

### DIFF
--- a/integration_tests/pages/admin/nationaOccupancy/nationalViewPage.ts
+++ b/integration_tests/pages/admin/nationaOccupancy/nationalViewPage.ts
@@ -1,0 +1,77 @@
+import Page from '../../page'
+import paths from '../../../../server/paths/admin'
+import { DateFormats } from '../../../../server/utils/dateUtils'
+import { roomCharacteristicMap, spaceSearchCriteriaApLevelLabels } from '../../../../server/utils/characteristicsUtils'
+import { makeArrayOfType } from '../../../../server/utils/utils'
+
+export default class NationalViewPage extends Page {
+  constructor(title = 'View all Approved Premises spaces') {
+    super(title)
+  }
+
+  static visit(query?: string): NationalViewPage {
+    const path = paths.admin.nationalOccupancy.weekView({})
+    cy.visit(query ? `${path}?${query}` : path)
+    return new NationalViewPage()
+  }
+
+  static visitUnauthorised() {
+    cy.visit(paths.admin.nationalOccupancy.weekView({}), { failOnStatusCode: false })
+    return new NationalViewPage(`Authorisation Error`)
+  }
+
+  verifyDefaultSettings() {
+    this.verifyTextInputContentsById(
+      'arrivalDate',
+      DateFormats.isoDateToUIDate(DateFormats.dateObjToIsoDate(new Date()), { format: 'datePicker' }),
+    )
+    this.verifyTextInputContentsById('postcodeArea', '')
+    this.shouldHaveSelectText('apArea', "All areas - Men's")
+    this.shouldHaveSelectText('apType', 'Standard (all AP types)')
+    Object.values(roomCharacteristicMap).forEach(label => this.verifyCheckboxByLabel(label, false))
+    Object.values(spaceSearchCriteriaApLevelLabels).forEach(label => this.verifyCheckboxByLabel(label, false))
+  }
+
+  setInvalidFilters() {
+    this.completeTextInput('postcodeArea', 'SW5LX')
+    this.completeDatePicker('arrivalDate', '2025-6-45')
+  }
+
+  setValidFilters(settings: Record<string, string | Array<string>>) {
+    this.completeTextInput('postcodeArea', settings.postcodeArea as string)
+    this.completeTextInput('arrivalDate', settings.arrivalDate as string)
+    this.getSelectInputByIdAndSelectAnEntry('apArea', settings.apArea as string)
+    this.getSelectInputByIdAndSelectAnEntry('apType', settings.apType as string)
+    makeArrayOfType(settings.apCharacteristics).forEach(characteristic => {
+      this.checkCheckboxByNameAndValue('apCharacteristics', characteristic as string)
+    })
+    makeArrayOfType(settings.roomCharacteristics).forEach(characteristic => {
+      this.checkCheckboxByNameAndValue('roomCharacteristics', characteristic as string)
+    })
+  }
+
+  applyFilters() {
+    this.clickButton('Apply filters')
+  }
+
+  shouldSeeValidationErrors() {
+    this.shouldShowErrorMessagesForFields(['postcodeArea'], {
+      postcodeArea: 'Invalid postcode area',
+      arrivalDate: 'Invalid arrival date',
+    })
+  }
+
+  submitCheckQueryParameters(expected) {
+    cy.intercept(`${paths.admin.nationalOccupancy.weekView({})}*`, req => {
+      req.continue()
+    }).as('filter')
+
+    this.applyFilters()
+    cy.wait('@filter').then(({ request }) => {
+      const query = request.query as Record<string, unknown>
+      query.apCharacteristics = makeArrayOfType(query.apCharacteristics)
+      query.roomCharacteristics = makeArrayOfType(query.roomCharacteristics)
+      expect(query).to.eql(expected)
+    })
+  }
+}

--- a/integration_tests/pages/admin/nationaOccupancy/nationalViewPage.ts
+++ b/integration_tests/pages/admin/nationaOccupancy/nationalViewPage.ts
@@ -25,7 +25,7 @@ export default class NationalViewPage extends Page {
       'arrivalDate',
       DateFormats.isoDateToUIDate(DateFormats.dateObjToIsoDate(new Date()), { format: 'datePicker' }),
     )
-    this.verifyTextInputContentsById('postcodeArea', '')
+    this.verifyTextInputContentsById('postcode', '')
     this.shouldHaveSelectText('apArea', "All areas - Men's")
     this.shouldHaveSelectText('apType', 'Standard (all AP types)')
     Object.values(roomCharacteristicMap).forEach(label => this.verifyCheckboxByLabel(label, false))
@@ -33,31 +33,30 @@ export default class NationalViewPage extends Page {
   }
 
   setInvalidFilters() {
-    this.completeTextInput('postcodeArea', 'SW5LX')
+    this.clearInput('postcode')
+    this.completeTextInput('postcode', 'SW5LX')
     this.completeDatePicker('arrivalDate', '2025-6-45')
   }
 
   setValidFilters(settings: Record<string, string | Array<string>>) {
-    this.completeTextInput('postcodeArea', settings.postcodeArea as string)
+    this.clearInput('postcode')
+    this.completeTextInput('postcode', settings.postcode as string)
+    this.clearInput('arrivalDate')
     this.completeTextInput('arrivalDate', settings.arrivalDate as string)
     this.getSelectInputByIdAndSelectAnEntry('apArea', settings.apArea as string)
     this.getSelectInputByIdAndSelectAnEntry('apType', settings.apType as string)
-    makeArrayOfType(settings.apCharacteristics).forEach(characteristic => {
-      this.checkCheckboxByNameAndValue('apCharacteristics', characteristic as string)
+    makeArrayOfType(settings.apCriteria).forEach(characteristic => {
+      this.checkCheckboxByNameAndValue('apCriteria', characteristic as string)
     })
-    makeArrayOfType(settings.roomCharacteristics).forEach(characteristic => {
-      this.checkCheckboxByNameAndValue('roomCharacteristics', characteristic as string)
+    makeArrayOfType(settings.roomCriteria).forEach(characteristic => {
+      this.checkCheckboxByNameAndValue('roomCriteria', characteristic as string)
     })
-  }
-
-  applyFilters() {
-    this.clickButton('Apply filters')
   }
 
   shouldSeeValidationErrors() {
-    this.shouldShowErrorMessagesForFields(['postcodeArea'], {
-      postcodeArea: 'Invalid postcode area',
-      arrivalDate: 'Invalid arrival date',
+    this.shouldShowErrorMessagesForFields(['postcode', 'arrivalDate'], {
+      postcode: 'Enter a valid postcode area',
+      arrivalDate: 'Enter a valid arrival date',
     })
   }
 
@@ -66,12 +65,21 @@ export default class NationalViewPage extends Page {
       req.continue()
     }).as('filter')
 
-    this.applyFilters()
+    this.clickButton('Apply filters')
     cy.wait('@filter').then(({ request }) => {
       const query = request.query as Record<string, unknown>
-      query.apCharacteristics = makeArrayOfType(query.apCharacteristics)
-      query.roomCharacteristics = makeArrayOfType(query.roomCharacteristics)
+      query.apCriteria = makeArrayOfType(query.apCriteria)
+      query.roomCriteria = makeArrayOfType(query.roomCriteria)
       expect(query).to.eql(expected)
     })
+  }
+
+  verifyFiltersPopulated(expected) {
+    this.verifyTextInputContentsById('postcode', expected.postcode)
+    this.verifyTextInputContentsById('arrivalDate', expected.arrivalDate)
+    this.shouldBeSelected(expected.apArea)
+    this.shouldBeSelected(expected.apType)
+    expected.apCriteria.forEach(characteristic => this.verifyCheckboxByNameAndValue('apCriteria', characteristic))
+    expected.roomCriteria.forEach(characteristic => this.verifyCheckboxByNameAndValue('roomCriteria', characteristic))
   }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -198,7 +198,6 @@ export default abstract class Page {
   }
 
   completeTextInput(name: string, value: string): void {
-    cy.get(`input[name="${name}"]`).clear()
     cy.get(`input[name="${name}"]`).type(value)
   }
 
@@ -490,6 +489,10 @@ export default abstract class Page {
       .parent()
       .find('input')
       .should(checked ? 'be.checked' : 'not.be.checked')
+  }
+
+  verifyCheckboxByNameAndValue(name: string, value: string, checked = true) {
+    cy.get(`input[name="${name}"][value="${value}"]`).should(checked ? 'be.checked' : 'not.be.checked')
   }
 
   clearAndCompleteTextInputById(id: string, text: string): void {

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -198,6 +198,7 @@ export default abstract class Page {
   }
 
   completeTextInput(name: string, value: string): void {
+    cy.get(`input[name="${name}"]`).clear()
     cy.get(`input[name="${name}"]`).type(value)
   }
 

--- a/integration_tests/tests/admin/nationalOccupancy.cy.ts
+++ b/integration_tests/tests/admin/nationalOccupancy.cy.ts
@@ -1,0 +1,70 @@
+import { cruManagementAreaFactory } from '../../../server/testutils/factories'
+import { signIn } from '../signIn'
+import { CRU_AREA_WOMENS } from '../../../server/utils/admin/nationalOccupancyUtils'
+import NationalViewPage from '../../pages/admin/nationaOccupancy/nationalViewPage'
+import ListPage from '../../pages/admin/placementApplications/listPage'
+
+context('National occupancy view', () => {
+  const cruManagementAreas = [
+    ...cruManagementAreaFactory.buildList(5),
+    cruManagementAreaFactory.build({ id: CRU_AREA_WOMENS }),
+  ]
+
+  const filterSettings = {
+    postcodeArea: 'SW13A',
+    arrivalDate: '12/9/2024',
+    apArea: cruManagementAreas[3].id,
+    apType: 'pipe',
+    apCharacteristics: ['isCatered'],
+    roomCharacteristics: ['isWheelchairDesignated'],
+  }
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubCruManagementAreaReferenceData', { cruManagementAreas })
+    cy.task('stubPlacementRequestsDashboard', { placementRequests: [], status: 'notMatched' })
+  })
+
+  it('allows me to set up filters for the national view', () => {
+    cy.log('Given that I sign in as a cru member with national occupancy view permissions')
+    signIn('cru_member', { permissions: ['cas1_view_cru_dashboard', 'cas1_national_occupancy_view'] }) // TODO: Remove explicit permissions
+
+    cy.log('Given that I am on the CRU dashboard page')
+    const cruDashboard = ListPage.visit()
+
+    cy.log('When I select the action to view national availability')
+    cruDashboard.clickAction('View all approved premises spaces')
+
+    cy.log('Then I should be on the national availabiliy view page')
+    const viewPage = new NationalViewPage()
+    viewPage.checkOnPage()
+
+    cy.log('And the filter should be at the default settings')
+    viewPage.verifyDefaultSettings()
+
+    cy.log('When I set invalid filters and submit')
+    viewPage.setInvalidFilters()
+    viewPage.applyFilters()
+
+    cy.log('Then I should see validation errors')
+    viewPage.shouldSeeValidationErrors()
+
+    cy.log('When I set valid filters')
+    viewPage.setValidFilters(filterSettings)
+    viewPage.submitCheckQueryParameters(filterSettings)
+  })
+
+  it('denys access to the view if user lacks permission', () => {
+    cy.log('Given I am signed in as a CRU member without occupancy view permission')
+    signIn('applicant', { permissions: ['cas1_view_cru_dashboard'] })
+
+    cy.log('When I navigate to the CRU dashboard')
+    const cruDashboard = ListPage.visit()
+
+    cy.log('Then the action menu should not be shown')
+    cruDashboard.actionMenuShouldNotExist()
+
+    cy.log('When I try to navigate to the view directly - Then I should not have access')
+    NationalViewPage.visitUnauthorised()
+  })
+})

--- a/integration_tests/tests/admin/nationalOccupancy.cy.ts
+++ b/integration_tests/tests/admin/nationalOccupancy.cy.ts
@@ -11,12 +11,12 @@ context('National occupancy view', () => {
   ]
 
   const filterSettings = {
-    postcodeArea: 'SW13A',
+    postcode: 'SW1A',
     arrivalDate: '12/9/2024',
     apArea: cruManagementAreas[3].id,
     apType: 'pipe',
-    apCharacteristics: ['isCatered'],
-    roomCharacteristics: ['isWheelchairDesignated'],
+    apCriteria: ['isCatered'],
+    roomCriteria: ['isWheelchairDesignated'],
   }
 
   beforeEach(() => {
@@ -44,19 +44,29 @@ context('National occupancy view', () => {
 
     cy.log('When I set invalid filters and submit')
     viewPage.setInvalidFilters()
-    viewPage.applyFilters()
+    viewPage.clickButton('Apply filters')
 
     cy.log('Then I should see validation errors')
     viewPage.shouldSeeValidationErrors()
 
     cy.log('When I set valid filters')
     viewPage.setValidFilters(filterSettings)
+    viewPage.clickButton('Apply filters')
+
+    cy.log('Then the form should be populated with the correct data')
     viewPage.submitCheckQueryParameters(filterSettings)
+    viewPage.verifyFiltersPopulated(filterSettings)
+
+    cy.log('When I revisit the page with no query parameters')
+    const noQueryPage = NationalViewPage.visit()
+
+    cy.log('Then the filter should still be populated (from the session)')
+    noQueryPage.verifyFiltersPopulated(filterSettings)
   })
 
-  it('denys access to the view if user lacks permission', () => {
-    cy.log('Given I am signed in as a CRU member without occupancy view permission')
-    signIn('applicant', { permissions: ['cas1_view_cru_dashboard'] })
+  it('denies access to the view if user lacks permission', () => {
+    cy.log('Given I am signed in as a user with CRU dashboard permissions but without occupancy view permission')
+    signIn('cru_member', { permissions: ['cas1_view_cru_dashboard'] })
 
     cy.log('When I navigate to the CRU dashboard')
     const cruDashboard = ListPage.visit()

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -465,15 +465,22 @@ export type SpaceSearchApCriteria = keyof typeof spaceSearchCriteriaApLevelLabel
 
 export type SpaceSearchRoomCriteria = keyof typeof roomCharacteristicMap
 
-export type SpaceSearchFormData = {
-  applicationId?: string
+type SpaceSearchCommonFields = {
   postcode?: string
   apType?: ApTypeCriteria
   apCriteria?: Array<SpaceSearchApCriteria>
   roomCriteria?: Array<SpaceSearchRoomCriteria>
   startDate?: string
-  durationDays?: number
   arrivalDate?: string
+}
+
+export type NationalSpaceSearchFormData = SpaceSearchCommonFields & {
+  apArea?: string
+}
+
+export type SpaceSearchFormData = SpaceSearchCommonFields & {
+  applicationId?: string
+  durationDays?: number
   departureDate?: string
 }
 
@@ -501,6 +508,7 @@ export type MultiPageFormData = {
   spaceSearch?: Record<PlacementRequestDetail['id'], SpaceSearchFormData>
   transfers?: Record<Cas1SpaceBooking['id'], TransferFormData>
   appeals?: Record<Cas1SpaceBooking[id], AppealFormData>
+  nationalSpaceSearch?: Record<string, NationalSpaceSearchFormData>
 }
 
 export type ChangeRequestReason =

--- a/server/controllers/admin/index.ts
+++ b/server/controllers/admin/index.ts
@@ -8,6 +8,7 @@ import DeliusUserController from './deliusUserController'
 import ReportsController from './reportsController'
 import CruDashboardController from './cruDashboardController'
 import ChangeRequestsController from './placementRequests/changeRequestsController'
+import NationalOccupancyController from './nationalOccupancyController'
 
 import type { Services } from '../../services'
 
@@ -33,6 +34,7 @@ export const controllers = (services: Services) => {
     services.placementRequestService,
     services.placementService,
   )
+  const nationalOccupancyController = new NationalOccupancyController(cruManagementAreaService)
 
   return {
     adminPlacementRequestsController,
@@ -43,6 +45,7 @@ export const controllers = (services: Services) => {
     userManagementController,
     deliusUserController,
     changeRequestsController,
+    nationalOccupancyController,
   }
 }
 
@@ -53,4 +56,5 @@ export {
   ReportsController,
   DeliusUserController,
   ChangeRequestsController,
+  NationalOccupancyController,
 }

--- a/server/controllers/admin/nationalOccupancyController.test.ts
+++ b/server/controllers/admin/nationalOccupancyController.test.ts
@@ -1,0 +1,147 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+import type { ErrorsAndUserInput } from '@approved-premises/ui'
+import { when } from 'jest-when'
+import { faker } from '@faker-js/faker'
+import { cruManagementAreaFactory, userDetailsFactory } from '../../testutils/factories'
+import { CruManagementAreaService } from '../../services'
+import NationalOccupancyController from './nationalOccupancyController'
+import { convertKeyValuePairToCheckBoxItems } from '../../utils/formUtils'
+import { spaceSearchCriteriaApLevelLabels } from '../../utils/match/spaceSearchLabels'
+import { apTypeLongLabels } from '../../utils/apTypeLabels'
+import { DateFormats } from '../../utils/dateUtils'
+import { CRU_AREA_WOMENS, getManagementAreaSelectGroups } from '../../utils/admin/nationalOccupancyUtils'
+import { roomCharacteristicMap } from '../../utils/characteristicsUtils'
+import * as validationUtils from '../../utils/validation'
+
+describe('NationalOccupancyController', () => {
+  const token = 'TEST_TOKEN'
+  const user = userDetailsFactory.build()
+
+  let request: DeepMocked<Request>
+  let response: DeepMocked<Response>
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const cruManagementAreaService = createMock<CruManagementAreaService>({})
+
+  const cruManagementAreas = [
+    ...cruManagementAreaFactory.buildList(5),
+    cruManagementAreaFactory.build({ id: CRU_AREA_WOMENS }),
+  ]
+  const errorsAndUserInput = createMock<ErrorsAndUserInput>({ errors: {}, errorSummary: [] })
+
+  let nationalOccupancyController: NationalOccupancyController
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    request = createMock<Request>({ user: { token }, query: {} })
+    response = createMock<Response>({ locals: { user } })
+
+    cruManagementAreaService.getCruManagementAreas.mockResolvedValue(cruManagementAreas)
+
+    nationalOccupancyController = new NationalOccupancyController(cruManagementAreaService)
+    jest.spyOn(validationUtils, 'fetchErrorsAndUserInput')
+
+    when(validationUtils.fetchErrorsAndUserInput).calledWith(request).mockReturnValue(errorsAndUserInput)
+  })
+
+  describe('index', () => {
+    it('should render the form with default values', async () => {
+      await nationalOccupancyController.index()(request, response, next)
+
+      expect(response.render).toBeCalledWith('admin/nationalOccupancy/index', {
+        pageHeading: 'View all Approved Premises spaces',
+        backLink: '/admin/cru-dashboard',
+        apCharacteristics: convertKeyValuePairToCheckBoxItems(spaceSearchCriteriaApLevelLabels, []),
+        roomCharacteristics: convertKeyValuePairToCheckBoxItems(roomCharacteristicMap, []),
+        apType: undefined,
+        apTypes: Object.entries(apTypeLongLabels).map(([id, name]) => ({ id, name })),
+        arrivalDate: DateFormats.isoDateToUIDate(DateFormats.dateObjToIsoDate(new Date()), { format: 'datePicker' }),
+        cruManagementAreaOptions: getManagementAreaSelectGroups(
+          cruManagementAreas,
+          undefined,
+          cruManagementAreas[0].id,
+        ),
+        postcodeArea: '',
+        errorSummary: errorsAndUserInput.errorSummary,
+        errors: errorsAndUserInput.errors,
+      })
+
+      expect(cruManagementAreaService.getCruManagementAreas).toBeCalled()
+    })
+
+    it('should render the populated form', async () => {
+      const arrivalDate = '16/12/2025'
+      const apType = faker.helpers.arrayElement(Object.keys(apTypeLongLabels))
+      const postcodeArea = 'SW14A'
+      const roomCharacteristics = faker.helpers.arrayElements(Object.keys(roomCharacteristicMap), { min: 1, max: 3 })
+      const apCharacteristics = faker.helpers.arrayElements(Object.keys(spaceSearchCriteriaApLevelLabels), {
+        min: 1,
+        max: 3,
+      })
+      const apArea = cruManagementAreas[1].id
+
+      const parameterRequest = createMock<Request>({
+        user: { token },
+        query: { arrivalDate, apType, apArea, postcodeArea, roomCharacteristics, apCharacteristics },
+      })
+
+      await nationalOccupancyController.index()(parameterRequest, response, next)
+
+      expect(response.render).toBeCalledWith(
+        'admin/nationalOccupancy/index',
+        expect.objectContaining({
+          apCharacteristics: convertKeyValuePairToCheckBoxItems(spaceSearchCriteriaApLevelLabels, apCharacteristics),
+          roomCharacteristics: convertKeyValuePairToCheckBoxItems(roomCharacteristicMap, roomCharacteristics),
+          apType,
+          arrivalDate,
+          cruManagementAreaOptions: getManagementAreaSelectGroups(cruManagementAreas, apArea, cruManagementAreas[0].id),
+          postcodeArea,
+        }),
+      )
+    })
+
+    it('should render errors on invalid input', async () => {
+      const arrivalDate = '16/14/2025'
+      const postcodeArea = 'SW14AX'
+
+      const errorRequest = createMock<Request>({
+        user: { token },
+        query: { arrivalDate, postcodeArea },
+      })
+
+      await nationalOccupancyController.index()(errorRequest, response, next)
+
+      expect(response.render).toBeCalledWith(
+        'admin/nationalOccupancy/index',
+        expect.objectContaining({
+          postcodeArea,
+          arrivalDate,
+          errors: {
+            arrivalDate: { attributes: { 'data-cy-error-arrivalDate': true }, text: 'Invalid arrival date' },
+            postcodeArea: { attributes: { 'data-cy-error-postcodeArea': true }, text: 'Invalid postcode area' },
+          },
+          errorSummary: [
+            { href: '#arrivalDate', text: 'Invalid arrival date' },
+            { href: '#postcodeArea', text: 'Invalid postcode area' },
+          ],
+        }),
+      )
+    })
+
+    it(`should default ap area to women's estate if user is in women's cru area`, async () => {
+      const responseWomensUser: DeepMocked<Response> = createMock<Response>({
+        locals: { user: { cruManagementArea: { id: CRU_AREA_WOMENS } } },
+      })
+
+      await nationalOccupancyController.index()(request, responseWomensUser, next)
+
+      expect(responseWomensUser.render).toBeCalledWith(
+        'admin/nationalOccupancy/index',
+        expect.objectContaining({
+          cruManagementAreaOptions: getManagementAreaSelectGroups(cruManagementAreas, undefined, CRU_AREA_WOMENS),
+        }),
+      )
+    })
+  })
+})

--- a/server/controllers/admin/nationalOccupancyController.ts
+++ b/server/controllers/admin/nationalOccupancyController.ts
@@ -1,18 +1,25 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 import { Cas1SpaceBookingCharacteristic, Cas1SpaceCharacteristic } from '@approved-premises/api'
+import { NationalSpaceSearchFormData } from '@approved-premises/ui'
 import { CruManagementAreaService } from '../../services'
 import { DateFormats, isoDateIsValid } from '../../utils/dateUtils'
-import { getManagementAreaSelectGroups } from '../../utils/admin/nationalOccupancyUtils'
-import { apTypeLongLabels } from '../../utils/apTypeLabels'
-import { convertKeyValuePairToCheckBoxItems } from '../../utils/formUtils'
+import { getApTypeOptions, getManagementAreaSelectGroups } from '../../utils/admin/nationalOccupancyUtils'
+import { convertKeyValuePairToCheckBoxItems, validPostcodeArea } from '../../utils/formUtils'
 import { roomCharacteristicMap } from '../../utils/characteristicsUtils'
 import { spaceSearchCriteriaApLevelLabels } from '../../utils/match/spaceSearchLabels'
 import { makeArrayOfType } from '../../utils/utils'
 import { generateErrorMessages, generateErrorSummary } from '../../utils/validation'
 import paths from '../../paths/admin'
+import MultiPageFormManager from '../../utils/multiPageFormManager'
+
+export const defaultSessionKey = 'default'
 
 export default class NationalOccupancyController {
-  constructor(private readonly cruManagementAreaService: CruManagementAreaService) {}
+  formData: MultiPageFormManager<'nationalSpaceSearch'>
+
+  constructor(private readonly cruManagementAreaService: CruManagementAreaService) {
+    this.formData = new MultiPageFormManager('nationalSpaceSearch')
+  }
 
   index(): TypedRequestHandler<Request, Response> {
     return async (req: Request, res: Response) => {
@@ -23,8 +30,21 @@ export default class NationalOccupancyController {
       } = res
       const {
         user: { token },
-        query: { postcodeArea, arrivalDate: rawArrivalDate, apArea, apType, roomCharacteristics, apCharacteristics },
+        query,
       } = req
+
+      const sessionData = this.formData.get(defaultSessionKey, req.session) || {}
+      const combinedQuery = { ...sessionData, ...query }
+
+      const {
+        postcode,
+        arrivalDate: rawArrivalDate,
+        apArea,
+        apType,
+        roomCriteria,
+        apCriteria,
+      } = combinedQuery as NationalSpaceSearchFormData
+
       const errors: Record<string, string> = {}
 
       const slashToday = DateFormats.isoDateToUIDate(DateFormats.dateObjToIsoDate(new Date()), { format: 'datePicker' })
@@ -33,32 +53,35 @@ export default class NationalOccupancyController {
       const arrivalDate = rawArrivalDate || slashToday
 
       if (!isoDateIsValid(DateFormats.datepickerInputToIsoString(arrivalDate as string))) {
-        errors.arrivalDate = 'Invalid arrival date'
+        errors.arrivalDate = 'Enter a valid arrival date'
       }
-      if (postcodeArea && !/^[A-Z]{1,2}[0-9]{1,2}[A-Z]?$/i.test(postcodeArea as string)) {
-        errors.postcodeArea = 'Invalid postcode area'
+      if (postcode && !validPostcodeArea(postcode)) {
+        errors.postcode = 'Enter a valid postcode area'
+      }
+
+      if (!errors.length) {
+        await this.formData.update(defaultSessionKey, req.session, combinedQuery)
       }
 
       res.render('admin/nationalOccupancy/index', {
         pageHeading: 'View all Approved Premises spaces',
         backLink: paths.admin.cruDashboard.index({}),
         arrivalDate,
-        postcodeArea: postcodeArea || '',
+        postcode: postcode || '',
         cruManagementAreaOptions: getManagementAreaSelectGroups(
           cruManagementAreas,
           apArea as string,
           cruManagementArea?.id,
         ),
-        apTypes: Object.entries(apTypeLongLabels).map(([id, name]) => ({ id, name })),
-        apType,
-        roomCharacteristics: convertKeyValuePairToCheckBoxItems(
+        roomCriteria: convertKeyValuePairToCheckBoxItems(
           roomCharacteristicMap,
-          makeArrayOfType<Cas1SpaceBookingCharacteristic>(roomCharacteristics),
+          makeArrayOfType<Cas1SpaceBookingCharacteristic>(roomCriteria),
         ),
-        apCharacteristics: convertKeyValuePairToCheckBoxItems(
+        apCriteria: convertKeyValuePairToCheckBoxItems(
           spaceSearchCriteriaApLevelLabels,
-          makeArrayOfType<Cas1SpaceCharacteristic>(apCharacteristics),
+          makeArrayOfType<Cas1SpaceCharacteristic>(apCriteria),
         ),
+        apTypeOptions: getApTypeOptions(apType),
         errors: generateErrorMessages(errors),
         errorSummary: generateErrorSummary(errors),
       })

--- a/server/controllers/admin/nationalOccupancyController.ts
+++ b/server/controllers/admin/nationalOccupancyController.ts
@@ -1,0 +1,67 @@
+import type { Request, Response, TypedRequestHandler } from 'express'
+import { Cas1SpaceBookingCharacteristic, Cas1SpaceCharacteristic } from '@approved-premises/api'
+import { CruManagementAreaService } from '../../services'
+import { DateFormats, isoDateIsValid } from '../../utils/dateUtils'
+import { getManagementAreaSelectGroups } from '../../utils/admin/nationalOccupancyUtils'
+import { apTypeLongLabels } from '../../utils/apTypeLabels'
+import { convertKeyValuePairToCheckBoxItems } from '../../utils/formUtils'
+import { roomCharacteristicMap } from '../../utils/characteristicsUtils'
+import { spaceSearchCriteriaApLevelLabels } from '../../utils/match/spaceSearchLabels'
+import { makeArrayOfType } from '../../utils/utils'
+import { generateErrorMessages, generateErrorSummary } from '../../utils/validation'
+import paths from '../../paths/admin'
+
+export default class NationalOccupancyController {
+  constructor(private readonly cruManagementAreaService: CruManagementAreaService) {}
+
+  index(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      const {
+        locals: {
+          user: { cruManagementArea },
+        },
+      } = res
+      const {
+        user: { token },
+        query: { postcodeArea, arrivalDate: rawArrivalDate, apArea, apType, roomCharacteristics, apCharacteristics },
+      } = req
+      const errors: Record<string, string> = {}
+
+      const slashToday = DateFormats.isoDateToUIDate(DateFormats.dateObjToIsoDate(new Date()), { format: 'datePicker' })
+
+      const cruManagementAreas = await this.cruManagementAreaService.getCruManagementAreas(token)
+      const arrivalDate = rawArrivalDate || slashToday
+
+      if (!isoDateIsValid(DateFormats.datepickerInputToIsoString(arrivalDate as string))) {
+        errors.arrivalDate = 'Invalid arrival date'
+      }
+      if (postcodeArea && !/^[A-Z]{1,2}[0-9]{1,2}[A-Z]?$/i.test(postcodeArea as string)) {
+        errors.postcodeArea = 'Invalid postcode area'
+      }
+
+      res.render('admin/nationalOccupancy/index', {
+        pageHeading: 'View all Approved Premises spaces',
+        backLink: paths.admin.cruDashboard.index({}),
+        arrivalDate,
+        postcodeArea: postcodeArea || '',
+        cruManagementAreaOptions: getManagementAreaSelectGroups(
+          cruManagementAreas,
+          apArea as string,
+          cruManagementArea?.id,
+        ),
+        apTypes: Object.entries(apTypeLongLabels).map(([id, name]) => ({ id, name })),
+        apType,
+        roomCharacteristics: convertKeyValuePairToCheckBoxItems(
+          roomCharacteristicMap,
+          makeArrayOfType<Cas1SpaceBookingCharacteristic>(roomCharacteristics),
+        ),
+        apCharacteristics: convertKeyValuePairToCheckBoxItems(
+          spaceSearchCriteriaApLevelLabels,
+          makeArrayOfType<Cas1SpaceCharacteristic>(apCharacteristics),
+        ),
+        errors: generateErrorMessages(errors),
+        errorSummary: generateErrorSummary(errors),
+      })
+    }
+  }
+}

--- a/server/paths/admin.ts
+++ b/server/paths/admin.ts
@@ -13,6 +13,8 @@ const withdrawalPath = placementRequestPath.path('withdrawal')
 
 const cruDashboardPath = adminPath.path('cru-dashboard')
 
+const nationalOccupancyPath = adminPath.path('national-occupancy')
+
 export default {
   admin: {
     cruDashboard: {
@@ -20,6 +22,9 @@ export default {
       changeRequests: cruDashboardPath.path('change-requests'),
       search: cruDashboardPath.path('search'),
       downloadOccupancyReport: cruDashboardPath.path('occupancy-report'),
+    },
+    nationalOccupancy: {
+      weekView: nationalOccupancyPath,
     },
     placementRequests: {
       index: placementRequestsPath,

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -20,6 +20,7 @@ export default function routes(controllers: Controllers, router: Router, service
     userManagementController,
     deliusUserController,
     changeRequestsController,
+    nationalOccupancyController,
   } = controllers
 
   get(paths.admin.cruDashboard.index.pattern, cruDashboardController.index(), {
@@ -37,6 +38,12 @@ export default function routes(controllers: Controllers, router: Router, service
   get(paths.admin.cruDashboard.downloadOccupancyReport.pattern, cruDashboardController.downloadReport(), {
     auditEvent: 'ADMIN_DOWNLOAD_OCCUPANCY_REPORT',
     allowedPermissions: ['cas1_premises_capacity_report_view'],
+  })
+
+  // National occupancy view
+  get(paths.admin.nationalOccupancy.weekView.pattern, nationalOccupancyController.index(), {
+    auditEvent: 'NATIONAL_OCCUPANCY_VIEW',
+    allowedPermissions: ['cas1_national_occupancy_view'],
   })
 
   // Change requests

--- a/server/utils/admin/cruDashboardUtils.ts
+++ b/server/utils/admin/cruDashboardUtils.ts
@@ -5,23 +5,26 @@ import paths from '../../paths/admin'
 import { TabItem } from '../tasks/listTable'
 import { createQueryString } from '../utils'
 
-export const cruDashboardActions = (user: UserDetails): Array<IdentityBarMenu> =>
-  hasPermission(user, ['cas1_premises_capacity_report_view'])
-    ? [
-        {
-          items: [
-            {
-              text: 'Download CRU occupancy report',
-              classes: 'govuk-button--secondary',
-              href: paths.admin.cruDashboard.downloadOccupancyReport({}),
-              attributes: {
-                download: '',
-              },
-            },
-          ],
-        },
-      ]
-    : null
+export const cruDashboardActions = (user: UserDetails): Array<IdentityBarMenu> => {
+  const reportView = {
+    text: 'Download CRU occupancy report',
+    classes: 'govuk-button--secondary',
+    href: paths.admin.cruDashboard.downloadOccupancyReport({}),
+    attributes: {
+      download: '',
+    },
+  }
+  const nationalOccupancy = {
+    text: 'View all approved premises spaces',
+    classes: 'govuk-button--secondary',
+    href: paths.admin.nationalOccupancy.weekView({}),
+  }
+  const items = [
+    hasPermission(user, ['cas1_premises_capacity_report_view']) && reportView,
+    hasPermission(user, ['cas1_national_occupancy_view']) && nationalOccupancy,
+  ].filter(Boolean)
+  return items.length ? [{ items }] : null
+}
 
 const cruDashboardTabLink = (query: ParsedQs) =>
   `${paths.admin.cruDashboard.index({})}${createQueryString(query, { addQueryPrefix: true })}`

--- a/server/utils/admin/nationalOccupancyUtils.test.ts
+++ b/server/utils/admin/nationalOccupancyUtils.test.ts
@@ -1,0 +1,53 @@
+import { cruManagementAreaFactory } from '../../testutils/factories'
+import { CRU_AREA_WOMENS, getManagementAreaSelectGroups } from './nationalOccupancyUtils'
+
+describe('nationalOccupancyUtils', () => {
+  describe('getManagementAreaSelectGroups', () => {
+    const mensAreas = cruManagementAreaFactory.buildList(6)
+    const womensArea = cruManagementAreaFactory.build({ id: CRU_AREA_WOMENS })
+    const cruManagementAreas = [...mensAreas, womensArea]
+    const resultNoSelect = () => [
+      {
+        label: "Men's AP",
+        items: [
+          { text: "All areas - Men's", value: 'allMens', selected: false },
+          ...mensAreas.map(({ id, name }) => ({ value: id, text: name, selected: false })),
+        ],
+      },
+      {
+        label: "Women's AP",
+        items: [{ value: 'allWomens', text: "All areas - Women's", selected: false }],
+      },
+    ]
+
+    it('should generate a nested list of cru management areas with allMens selected by default', () => {
+      const expected = resultNoSelect()
+      expected[0].items[0].selected = true
+      expect(getManagementAreaSelectGroups(cruManagementAreas, undefined, undefined)).toEqual(expected)
+    })
+
+    it(`should select allMens if user has a men's area id`, () => {
+      const expected = resultNoSelect()
+      expected[0].items[0].selected = true
+      expect(getManagementAreaSelectGroups(cruManagementAreas, undefined, mensAreas[1].id)).toEqual(expected)
+    })
+
+    it(`should select allWomens if the user has the women's area id`, () => {
+      const expected = resultNoSelect()
+      expected[1].items[0].selected = true
+      expect(getManagementAreaSelectGroups(cruManagementAreas, undefined, CRU_AREA_WOMENS)).toEqual(expected)
+    })
+
+    it(`should select the currently selected area if an area id is selected`, () => {
+      const expected = resultNoSelect()
+      expected[0].items[2].selected = true
+      expect(getManagementAreaSelectGroups(cruManagementAreas, mensAreas[1].id, CRU_AREA_WOMENS)).toEqual(expected)
+    })
+
+    it(`should select allMens if that was selected`, () => {
+      const expected = resultNoSelect()
+      expected[0].items[0].selected = true
+      expect(getManagementAreaSelectGroups(cruManagementAreas, 'allMens', CRU_AREA_WOMENS)).toEqual(expected)
+    })
+  })
+})

--- a/server/utils/admin/nationalOccupancyUtils.test.ts
+++ b/server/utils/admin/nationalOccupancyUtils.test.ts
@@ -1,5 +1,6 @@
 import { cruManagementAreaFactory } from '../../testutils/factories'
-import { CRU_AREA_WOMENS, getManagementAreaSelectGroups } from './nationalOccupancyUtils'
+import { CRU_AREA_WOMENS, getApTypeOptions, getManagementAreaSelectGroups } from './nationalOccupancyUtils'
+import { apTypeLongLabels } from '../apTypeLabels'
 
 describe('nationalOccupancyUtils', () => {
   describe('getManagementAreaSelectGroups', () => {
@@ -48,6 +49,19 @@ describe('nationalOccupancyUtils', () => {
       const expected = resultNoSelect()
       expected[0].items[0].selected = true
       expect(getManagementAreaSelectGroups(cruManagementAreas, 'allMens', CRU_AREA_WOMENS)).toEqual(expected)
+    })
+  })
+
+  describe('getApTypeOptions', () => {
+    it('should render a set of ap type options with nothing selected', () => {
+      const optionList = getApTypeOptions()
+      expect(optionList).toHaveLength(Object.keys(apTypeLongLabels).length)
+      expect(optionList.findIndex(({ selected }) => selected)).toEqual(-1)
+    })
+
+    it('should render a set of ap type options with one selected', () => {
+      const optionList = getApTypeOptions(Object.keys(apTypeLongLabels)[3])
+      expect(optionList.findIndex(({ selected }) => selected)).toEqual(3)
     })
   })
 })

--- a/server/utils/admin/nationalOccupancyUtils.ts
+++ b/server/utils/admin/nationalOccupancyUtils.ts
@@ -1,0 +1,24 @@
+import { Cas1CruManagementArea } from '@approved-premises/api'
+import { SelectGroup } from '@approved-premises/ui'
+
+export const CRU_AREA_WOMENS = 'bfb04c2a-1954-4512-803d-164f7fcf252c'
+
+export const getManagementAreaSelectGroups = (
+  cruManagementAreas: Array<Cas1CruManagementArea>,
+  value: string,
+  cruManagementArea: string,
+) => {
+  const selectedValue = value || (cruManagementArea === CRU_AREA_WOMENS ? 'allWomens' : 'allMens')
+  const groupWrap = (group: Array<Cas1CruManagementArea>, label: string): SelectGroup => ({
+    label,
+    items: group.map(({ id, name }) => ({ text: name, value: id, selected: selectedValue === id })),
+  })
+
+  return [
+    groupWrap(
+      [{ id: 'allMens', name: `All areas - Men's` }, ...cruManagementAreas.filter(({ id }) => id !== CRU_AREA_WOMENS)],
+      `Men's AP`,
+    ),
+    groupWrap([{ id: 'allWomens', name: `All areas - Women's` }], `Women's AP`),
+  ]
+}

--- a/server/utils/admin/nationalOccupancyUtils.ts
+++ b/server/utils/admin/nationalOccupancyUtils.ts
@@ -1,5 +1,7 @@
 import { Cas1CruManagementArea } from '@approved-premises/api'
 import { SelectGroup } from '@approved-premises/ui'
+import { apTypeLongLabels } from '../apTypeLabels'
+import { convertObjectsToSelectOptions } from '../formUtils'
 
 export const CRU_AREA_WOMENS = 'bfb04c2a-1954-4512-803d-164f7fcf252c'
 
@@ -21,4 +23,9 @@ export const getManagementAreaSelectGroups = (
     ),
     groupWrap([{ id: 'allWomens', name: `All areas - Women's` }], `Women's AP`),
   ]
+}
+
+export const getApTypeOptions = (apType?: string) => {
+  const apTypes = Object.entries(apTypeLongLabels).map(([id, name]) => ({ id, name }))
+  return convertObjectsToSelectOptions(apTypes, null, 'name', 'id', 'apType', null, { apType })
 }

--- a/server/utils/characteristicsUtils.ts
+++ b/server/utils/characteristicsUtils.ts
@@ -11,6 +11,13 @@ export const roomCharacteristicMap: Record<Cas1SpaceBookingCharacteristic, strin
   isSuitedForSexOffenders: 'Suitable for sexual offence risk',
 }
 
+export const spaceSearchCriteriaApLevelLabels: Partial<Record<Cas1SpaceCharacteristic, string>> = {
+  acceptsSexOffenders: 'Sexual offences against adults',
+  acceptsChildSexOffenders: 'Sexual offences against children',
+  acceptsNonSexualChildOffenders: 'Non-sexual offences against children',
+  isCatered: 'Catered',
+}
+
 export const getRoomCharacteristicLabel = (characteristic: Cas1SpaceCharacteristic): string => {
   return roomCharacteristicMap[characteristic as Cas1SpaceBookingCharacteristic]
 }

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -104,6 +104,15 @@ describe('DateFormats', () => {
       expect(DateFormats.isoDateToUIDate(date, { format: 'dateFieldHint' })).toEqual(expectedUiDate)
     })
 
+    it.each([
+      ['2022-11-09T00:00', '9/11/2022'],
+      ['2022-04-11T00:00', '11/4/2022'],
+      ['2025-04-02T00:00', '2/4/2025'],
+      ['2025-04-02T23:30:00.000Z', '3/4/2025'],
+    ])('converts local ISO8601 date %s to a slash separated date picker date', (date, expectedUiDate) => {
+      expect(DateFormats.isoDateToUIDate(date, { format: 'datePicker' })).toEqual(expectedUiDate)
+    })
+
     it('raises an error if the date is not a valid ISO8601 date string', () => {
       const date = '23/11/2022'
 

--- a/server/views/admin/nationalOccupancy/index.njk
+++ b/server/views/admin/nationalOccupancy/index.njk
@@ -1,8 +1,8 @@
-{% extends "../../partials/layout.njk" %}
+{% extends "partials/layout.njk" %}
 
-{% from "../../partials/filters.njk" import filterWrapper, filterSelect, filterDatepicker, filterText, filterCheckboxes with context  %}
-{% from "../../components/formFields/selectWithOptgroup.njk" import govukSelectWithOptgroup %}
-{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "partials/filters.njk" import filterWrapper, filterSelect, filterDatepicker, filterText, filterCheckboxes %}
+{% from "components/formFields/selectWithOptgroup.njk" import govukSelectWithOptgroup %}
+{% from "partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - " + pageHeading %}
@@ -17,11 +17,11 @@
 {% block content %}
 
     {{ showErrorSummary(errorSummary) }}
-<h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+    <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
     {% call filterWrapper('Filter') %}
-        {{ filterDatepicker('arrivalDate', 'Arrival date') }}
-        {{ filterText('postcodeArea','Postcode area') }}
+        {{ filterDatepicker('arrivalDate', 'Arrival date', fetchContext()) }}
+        {{ filterText('postcode','Postcode area', fetchContext()) }}
         {{ govukSelectWithOptgroup({
             label: {
                 classes: "govuk-fieldset__legend--s",
@@ -32,9 +32,9 @@
             items: cruManagementAreaOptions
         }) }}
 
-        {{ filterSelect('apType','Type of AP',convertObjectsToSelectOptions(apTypes, null, 'name', 'id', 'apType', null, context)) }}
-        {{ filterCheckboxes('apCharacteristics','AP criteria',apCharacteristics) }}
-        {{ filterCheckboxes('roomCharacteristics','Room criteria',roomCharacteristics) }}
+        {{ filterSelect('apType','Type of AP',apTypeOptions ) }}
+        {{ filterCheckboxes('apCriteria','AP criteria',apCriteria) }}
+        {{ filterCheckboxes('roomCriteria','Room criteria',roomCriteria) }}
     {%- endcall %}
 
 {% endblock %}

--- a/server/views/admin/nationalOccupancy/index.njk
+++ b/server/views/admin/nationalOccupancy/index.njk
@@ -1,0 +1,40 @@
+{% extends "../../partials/layout.njk" %}
+
+{% from "../../partials/filters.njk" import filterWrapper, filterSelect, filterDatepicker, filterText, filterCheckboxes with context  %}
+{% from "../../components/formFields/selectWithOptgroup.njk" import govukSelectWithOptgroup %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% set pageTitle = applicationName + " - " + pageHeading %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        text: "Back",
+        href: backLink
+    }) }}
+{% endblock %}
+
+{% block content %}
+
+    {{ showErrorSummary(errorSummary) }}
+<h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+    {% call filterWrapper('Filter') %}
+        {{ filterDatepicker('arrivalDate', 'Arrival date') }}
+        {{ filterText('postcodeArea','Postcode area') }}
+        {{ govukSelectWithOptgroup({
+            label: {
+                classes: "govuk-fieldset__legend--s",
+                text: "AP area"
+            },
+            id: "apArea",
+            name: "apArea",
+            items: cruManagementAreaOptions
+        }) }}
+
+        {{ filterSelect('apType','Type of AP',convertObjectsToSelectOptions(apTypes, null, 'name', 'id', 'apType', null, context)) }}
+        {{ filterCheckboxes('apCharacteristics','AP criteria',apCharacteristics) }}
+        {{ filterCheckboxes('roomCharacteristics','Room criteria',roomCharacteristics) }}
+    {%- endcall %}
+
+{% endblock %}

--- a/server/views/components/formFields/selectWithOptgroup.njk
+++ b/server/views/components/formFields/selectWithOptgroup.njk
@@ -8,8 +8,6 @@
   {% set describedBy = params.describedBy if params.describedBy else 
     "" %}
 
-  {% set prompt = params.prompt if params.prompt else 
-    "Please select" %}
   <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}" {%- for attribute, value in params.formGroup.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
     {{ govukLabel({
     html: params.label.html,
@@ -49,7 +47,9 @@
     {%- if params.disabled %} disabled{% endif %}
     {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
-      <option value="" selected>{{ prompt }}</option>
+    {% if params.prompt %}
+      <option value="" selected>{{ params.prompt }}</option>
+      {% endif %}
       {% for optgroup in params.items %}
         {% if optgroup %}
           <optgroup label="{{ optgroup.label }}">

--- a/server/views/partials/filters.njk
+++ b/server/views/partials/filters.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "moj/components/date-picker/macro.njk" import mojDatePicker %}
 
 {% macro filterWrapper(title) %}
@@ -44,7 +45,22 @@
     }) }}
 {% endmacro %}
 
-{% macro filterDatepicker(name, label, context) %}
+{% macro filterText(name, label) %}
+    {% set context=fetchContext() %}
+    {{ govukInput({
+        label: {
+            text: label,
+            classes: "govuk-label--s"
+        },
+        id: name,
+        name: name,
+        value: context[name],
+        errorMessage: context.errors[name]
+    }) }}
+{% endmacro %}
+
+{% macro filterDatepicker(name, label) %}
+    {% set context=fetchContext() %}
     {{ mojDatePicker({
         id: name,
         name: name,
@@ -56,3 +72,4 @@
         errorMessage: context.errors[name]
     }) }}
 {% endmacro %}
+

--- a/server/views/partials/filters.njk
+++ b/server/views/partials/filters.njk
@@ -45,8 +45,7 @@
     }) }}
 {% endmacro %}
 
-{% macro filterText(name, label) %}
-    {% set context=fetchContext() %}
+{% macro filterText(name, label, context) %}
     {{ govukInput({
         label: {
             text: label,
@@ -59,8 +58,7 @@
     }) }}
 {% endmacro %}
 
-{% macro filterDatepicker(name, label) %}
-    {% set context=fetchContext() %}
+{% macro filterDatepicker(name, label, context) %}
     {{ mojDatePicker({
         id: name,
         name: name,
@@ -72,4 +70,3 @@
         errorMessage: context.errors[name]
     }) }}
 {% endmacro %}
-


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2447

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Adds a National occupancy view page with filters, but without running any query on the API yet.

The feature is controlled by a new permission `cas1_national_occupancy_view` which is only given to `janitor`, so this incomplete feature is safe to deploy to production.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes
<details>
  <summary>Filter</summary>
<img src="https://github.com/user-attachments/assets/be617891-c151-4ba3-916a-dcefa413f916"/>
</details>

<details>
  <summary>Validation errors</summary>
<img src="https://github.com/user-attachments/assets/f866c44a-9b6e-41f4-a972-bad21df39033"/>
</details>
