### PR TITLE
APS-2475: Use datepicker for Manage AP occupancy view

### DIFF
--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -218,7 +218,7 @@ export default abstract class Page {
   }
 
   completeDatePicker(name: string, date: string): void {
-    const formattedDate = date.split('-').reverse().join('/')
+    const formattedDate = date.split('-').reverse().map(this.stripLeadingZeros).join('/')
     this.completeTextInput(name, formattedDate)
   }
 
@@ -232,6 +232,12 @@ export default abstract class Page {
     cy.get(`#${prefix}-day`).invoke('val').then(this.stripLeadingZeros).should('equal', day)
     cy.get(`#${prefix}-month`).invoke('val').then(this.stripLeadingZeros).should('equal', month)
     cy.get(`#${prefix}-year`).invoke('val').then(this.stripLeadingZeros).should('equal', year)
+  }
+
+  datePickerShouldContainDate(name: string, date: string): void {
+    cy.get(`[name="${name}"]`)
+      .invoke('val')
+      .should('equal', date.split('-').map(this.stripLeadingZeros).reverse().join('/'))
   }
 
   clickButton(text: string): void {
@@ -427,6 +433,10 @@ export default abstract class Page {
     cy.get('textarea').clear()
   }
 
+  clearInput(name: string): void {
+    cy.get(`[name="${name}"]`).clear()
+  }
+
   clearDateInputs(prefix: string): void {
     cy.get(`#${prefix}-day`).clear()
     cy.get(`#${prefix}-month`).clear()
@@ -442,6 +452,11 @@ export default abstract class Page {
   clearAndCompleteDateInputs(prefix: string, date: string): void {
     this.clearDateInputs(prefix)
     this.completeDateInputs(prefix, date)
+  }
+
+  clearAndCompleteDatePicker(name: string, date: string): void {
+    this.clearInput(name)
+    this.completeDatePicker(name, date)
   }
 
   getTextInputByIdAndClear(id: string): void {

--- a/server/controllers/manage/premises/apOccupancyViewController.test.ts
+++ b/server/controllers/manage/premises/apOccupancyViewController.test.ts
@@ -90,7 +90,7 @@ describe('AP occupancyViewController', () => {
         user: { token },
         params: { premisesId },
         flash: jest.fn(),
-        query: { 'startDate-year': '2024', 'startDate-month': '06', 'startDate-day': '20', durationDays: '7' },
+        query: { startDate: '20/06/2024', durationDays: '7' },
       })
       const { premisesSummary, premisesCapacity } = await mockPremises('2024-06-20')
 
@@ -116,7 +116,7 @@ describe('AP occupancyViewController', () => {
         user: { token },
         params: { premisesId },
         flash: jest.fn(),
-        query: { 'startDate-year': '2023', 'startDate-month': '02', 'startDate-day': '29', durationDays: '7' },
+        query: { startDate: 'not really a date', durationDays: '7' },
       })
       const { premisesSummary } = await mockPremises('2024-06-20')
 

--- a/server/controllers/manage/premises/apOccupancyViewController.ts
+++ b/server/controllers/manage/premises/apOccupancyViewController.ts
@@ -1,6 +1,5 @@
 import type { Request, RequestHandler, Response } from 'express'
 
-import { ObjectWithDateParts } from '@approved-premises/ui'
 import {
   Cas1PremiseCapacity,
   Cas1Premises,
@@ -27,9 +26,9 @@ import {
   tableCaptions,
   tableHeader,
 } from '../../../utils/premises/occupancy'
-import { DateFormats, dateAndTimeInputsAreValidDates, daysToWeeksAndDays } from '../../../utils/dateUtils'
+import { DateFormats, daysToWeeksAndDays, isoDateIsValid } from '../../../utils/dateUtils'
 import { placementDates } from '../../../utils/match'
-import { fetchErrorsAndUserInput, generateErrorMessages, generateErrorSummary } from '../../../utils/validation'
+import { generateErrorMessages, generateErrorSummary } from '../../../utils/validation'
 import { getPaginationDetails } from '../../../utils/getPaginationDetails'
 import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
 import { createQueryString, makeArrayOfType } from '../../../utils/utils'
@@ -46,46 +45,41 @@ export default class ApOccupancyViewController {
     return async (req: Request, res: Response) => {
       const { token } = req.user
       const { premisesId } = req.params
-      const { errors, errorSummary } = fetchErrorsAndUserInput(req)
-      let startDate
-      if (req.query.durationDays) {
-        if (dateAndTimeInputsAreValidDates(req.query as ObjectWithDateParts<'startDate'>, 'startDate')) {
-          startDate = DateFormats.dateAndTimeInputsToIsoString(
-            req.query as ObjectWithDateParts<'startDate'>,
-            'startDate',
-          ).startDate
-        } else {
-          const dateError = { startDate: 'Enter a valid date' }
-          Object.assign(errors, generateErrorMessages(dateError))
-          errorSummary.push(generateErrorSummary(dateError)[0])
-          startDate = DateFormats.dateObjToIsoDate(new Date())
-        }
+      const errors: Record<string, string> = {}
+
+      const { durationDays = '84', startDate = DateFormats.dateObjtoUIDate(new Date(), { format: 'datePicker' }) } =
+        req.query
+
+      const startDateIso = DateFormats.datepickerInputToIsoString(String(startDate))
+
+      if (!startDate || !isoDateIsValid(startDateIso)) {
+        errors.startDate = 'Enter a valid date'
       }
-      startDate = startDate || DateFormats.dateObjToIsoDate(new Date())
-      const { durationDays = '84', ...startDateParts } = req.query
+
       const premises = await this.premisesService.find(req.user.token, premisesId)
       let calendar: Calendar = []
-      if (!errorSummary.length) {
-        const capacityDates = placementDates(String(startDate), parseInt(String(durationDays), 10) - 1)
+      let calendarHeading: string
+
+      if (!Object.keys(errors).length) {
+        const capacityDates = placementDates(startDateIso, parseInt(String(durationDays), 10) - 1)
         const capacity = await this.premisesService.getCapacity(token, premisesId, {
           startDate: capacityDates.startDate,
           endDate: capacityDates.endDate,
         })
         calendar = occupancyCalendar(capacity.capacity, premisesId)
+        calendarHeading = `Showing ${DateFormats.formatDuration(daysToWeeksAndDays(String(durationDays)))} from ${DateFormats.isoDateToUIDate(startDateIso, { format: 'short' })}`
       }
-      const calendarHeading = `Showing ${DateFormats.formatDuration(daysToWeeksAndDays(String(durationDays)))} from ${DateFormats.isoDateToUIDate(startDate, { format: 'short' })}`
+
       return res.render('manage/premises/occupancy/view', {
         pageHeading: `View spaces in ${premises.name}`,
         premises,
         calendar,
         backLink: paths.premises.show({ premisesId }),
         calendarHeading,
-        ...DateFormats.isoDateToDateInputs(startDate, 'startDate'),
-        ...startDateParts,
-        selfPath: paths.premises.occupancy.view({ premisesId }),
+        startDate,
         durationOptions: durationSelectOptions(String(durationDays)),
-        errors,
-        errorSummary,
+        errors: generateErrorMessages(errors),
+        errorSummary: generateErrorSummary(errors),
       })
     }
   }

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -34,6 +34,7 @@ const uiDateFormats = {
   long: 'ccc d MMM y',
   longNoYear: 'ccc d MMM',
   dateFieldHint: 'd M y',
+  datePicker: 'd/M/y',
 }
 type UiDateFormat = keyof typeof uiDateFormats
 

--- a/server/views/manage/premises/occupancy/view.njk
+++ b/server/views/manage/premises/occupancy/view.njk
@@ -3,13 +3,13 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
-{% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "partials/filters.njk" import filterWrapper, filterSelect, filterDatepicker %}
 {% from "./_calendar.njk" import occupancyCalendar %}
 
 {%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
 
-{% extends "../../../partials/layout.njk" %}
+{% extends "partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body" %}
@@ -30,43 +30,11 @@
     <span class="govuk-caption-l">{{ premises.name }}</span>
     <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
-    <div class="search-and-filter">
-        <form action="{{ selfPath }}"
-              method="get">
-            <h2 class="govuk-heading-m">Filter</h2>
+    {% call filterWrapper('Filter') %}
+        {{ filterDatepicker('startDate', 'Start date', fetchContext()) }}
 
-            <div class="search-and-filter__row">
-                {{ govukDateInput({
-                    id: "startDate",
-                    namePrefix: "startDate",
-                    fieldset: {
-                        legend: {
-                            text: "Start date",
-                            classes: "govuk-fieldset__legend--s"
-                        }
-                    },
-                    items: dateFieldValues('startDate', errors),
-                    errorMessage: errors.startDate
-                }) }}
-
-                {{ govukSelect({
-                    id: 'durationDays',
-                    name: 'durationDays',
-                    label: {
-                        text: 'Duration',
-                        classes: 'govuk-label--s'
-                    },
-                    items: durationOptions
-                }) }}
-            </div>
-            <div class="search-and-filter__row">
-                {{ govukButton({
-                    text: 'Apply filters',
-                    preventDoubleClick: true
-                }) }}
-            </div>
-        </form>
-    </div>
+        {{ filterSelect('durationDays', 'Duration', durationOptions) }}
+    {% endcall %}
 
     {% if errorSummary.length === 0 %}
         <h2 class="govuk-heading-l">{{ calendarHeading }}</h2>

--- a/server/views/partials/filters.njk
+++ b/server/views/partials/filters.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "moj/components/date-picker/macro.njk" import mojDatePicker %}
 
 {% macro filterWrapper(title) %}
     <div class="search-and-filter">
@@ -31,7 +32,7 @@
     }) }}
 {% endmacro %}
 
-{% macro filterSelect(name,label, options) %}
+{% macro filterSelect(name, label, options) %}
     {{ govukSelect({
         id: name,
         name: name,
@@ -40,5 +41,18 @@
             classes: 'govuk-label--s'
         },
         items: options
+    }) }}
+{% endmacro %}
+
+{% macro filterDatepicker(name, label, context) %}
+    {{ mojDatePicker({
+        id: name,
+        name: name,
+        label: {
+            text: label,
+            classes: "govuk-label--s"
+        },
+        value: context[name],
+        errorMessage: context.errors[name]
     }) }}
 {% endmacro %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2475

# Changes in this PR

This PR replaces the 3-part date input in the Manage AP Occupancy view filters with the [datepicker component](https://design-patterns.service.justice.gov.uk/components/date-picker/).

## Screenshots of UI changes

<details><summary>Filter with datepicker</summary>

<img width="983" height="303" alt="Screenshot 2025-07-14 at 14 30 24" src="https://github.com/user-attachments/assets/62813a12-6bf0-452a-b98b-c6be3fd3e15f" />

</details>

<details><summary>Filter with date error</summary>

<img width="997" height="541" alt="Screenshot 2025-07-14 at 14 31 15" src="https://github.com/user-attachments/assets/20c1c568-920a-454b-92ed-3689a691f320" />

</details>
