### PR TITLE
CHORE: Add GITHUB_TOKEN to action env to avoid rate limit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,8 @@ jobs:
 
       - name: Run shell scripts lint checks
         run: npm run shellcheck
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   unit_test:
     name: "Unit testing 🧪"


### PR DESCRIPTION
Adding the `GITHUB_TOKEN` environment variable to the run command for `shellcheck` should prevent hitting the rate limit when downloading the binary: https://github.com/gunar/shellcheck?tab=readme-ov-file#usage
