### PR TITLE
APS-2513 Update report descriptions for find and book

### DIFF
--- a/server/utils/reportUtils.test.ts
+++ b/server/utils/reportUtils.test.ts
@@ -45,14 +45,14 @@ describe('reportUtils', () => {
           value: 'placements',
           text: 'Raw Placement Report',
           hint: {
-            text: 'Placements where the following fall within the requested date range - expected arrival/departure, actual arrival/departure, non arrival, withdrawal. This only includes placements for regions taking part in the Find and Booking Private Beta.',
+            text: 'Placements where the following fall within the requested date range - expected arrival/departure, actual arrival/departure, non arrival, withdrawal.',
           },
         },
         {
           value: 'overduePlacements',
           text: 'Overdue Placements',
           hint: {
-            text: 'Placements where the expected arrival or departure date falls within the requested date range, and there is an overdue arrival or departure. This only includes placements for regions taking part in the Find and Booking Private Beta.',
+            text: 'Placements where the expected arrival or departure date falls within the requested date range, and there is an overdue arrival or departure.',
           },
         },
       ])
@@ -130,7 +130,7 @@ describe('reportUtils', () => {
           value: 'placements',
           text: 'Raw Placement Report',
           hint: {
-            text: 'Placements where the following fall within the requested date range - expected arrival/departure, actual arrival/departure, non arrival, withdrawal. This only includes placements for regions taking part in the Find and Booking Private Beta.',
+            text: 'Placements where the following fall within the requested date range - expected arrival/departure, actual arrival/departure, non arrival, withdrawal.',
           },
         },
         {
@@ -144,7 +144,7 @@ describe('reportUtils', () => {
           value: 'overduePlacements',
           text: 'Overdue Placements',
           hint: {
-            text: 'Placements where the expected arrival or departure date falls within the requested date range, and there is an overdue arrival or departure. This only includes placements for regions taking part in the Find and Booking Private Beta.',
+            text: 'Placements where the expected arrival or departure date falls within the requested date range, and there is an overdue arrival or departure.',
           },
         },
       ])

--- a/server/utils/reportUtils.ts
+++ b/server/utils/reportUtils.ts
@@ -40,7 +40,7 @@ export const reportInputLabels = {
   },
   placements: {
     text: 'Raw Placement Report',
-    hint: 'Placements where the following fall within the requested date range - expected arrival/departure, actual arrival/departure, non arrival, withdrawal. This only includes placements for regions taking part in the Find and Booking Private Beta.',
+    hint: 'Placements where the following fall within the requested date range - expected arrival/departure, actual arrival/departure, non arrival, withdrawal.',
   },
   placementsWithPii: {
     text: 'Raw Placement Report (PII)',
@@ -48,7 +48,7 @@ export const reportInputLabels = {
   },
   overduePlacements: {
     text: 'Overdue Placements',
-    hint: 'Placements where the expected arrival or departure date falls within the requested date range, and there is an overdue arrival or departure. This only includes placements for regions taking part in the Find and Booking Private Beta.',
+    hint: 'Placements where the expected arrival or departure date falls within the requested date range, and there is an overdue arrival or departure.',
   },
 } as const
 


### PR DESCRIPTION
# Context

Find and book is now used by all regions, so all regions will appear in placement reports.

## Screenshots of UI changes

### Before

<img width="813" height="444" alt="Screenshot 2025-07-14 at 16 42 38" src="https://github.com/user-attachments/assets/e4e964f6-af17-4a42-a728-e7d872c12bc4" />

### After

<img width="844" height="416" alt="Screenshot 2025-07-14 at 16 42 25" src="https://github.com/user-attachments/assets/2e67b59d-18fb-4b50-8a11-3107b315ee32" />
