### PR TITLE
BUGFIX/APS-2575: Update link to placement

### DIFF
--- a/integration_tests/pages/admin/placementApplications/showPage.ts
+++ b/integration_tests/pages/admin/placementApplications/showPage.ts
@@ -53,5 +53,18 @@ export default class ShowPage extends Page {
 
   shouldShowParoleNotification() {
     cy.get('.govuk-notification-banner').contains('Parole board directed release').should('exist')
+
+    if (this.placementRequest.booking) {
+      cy.get('a')
+        .contains('change the arrival date')
+        .should(
+          'have.attr',
+          'href',
+          managePaths.premises.placements.changes.new({
+            premisesId: this.placementRequest.booking.premisesId,
+            placementId: this.placementRequest.booking.id,
+          }),
+        )
+    }
   }
 }

--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -36,15 +36,12 @@ context('Placement Requests', () => {
     const matchedPlacementRequests = placementRequestFactory.buildList(3)
     const unableToMatchPlacementRequests = placementRequestFactory.unableToMatch().buildList(2)
 
-    const unmatchedPlacementRequest = cas1PlacementRequestDetailFactory.build({
-      ...unmatchedPlacementRequests[0],
-      spaceBookings: [],
-    })
+    const unmatchedPlacementRequest = cas1PlacementRequestDetailFactory.build(unmatchedPlacementRequests[0])
 
-    const parolePlacementRequest = cas1PlacementRequestDetailFactory.build({
-      ...unmatchedPlacementRequests[1],
-      spaceBookings: [],
-    })
+    const parolePlacementRequest = cas1PlacementRequestDetailFactory
+      .params(unmatchedPlacementRequests[1])
+      .withSpaceBooking()
+      .build()
 
     const matchedPlacementRequest = cas1PlacementRequestDetailFactory.build(matchedPlacementRequests[1])
     const spaceBooking = cas1SpaceBookingFactory.build({

--- a/server/views/admin/placementRequests/show.njk
+++ b/server/views/admin/placementRequests/show.njk
@@ -40,7 +40,7 @@
             {% if placementRequest.booking %}
                 <p class="govuk-body">
                     If needed, you can <a
-                            href="{{ paths.bookings.dateChanges.new({ premisesId: placementRequest.booking.premisesId, bookingId: placementRequest.booking.id }) }}">change
+                            href="{{ paths.premises.placements.changes.new({ premisesId: placementRequest.booking.premisesId, placementId: placementRequest.booking.id }) }}">change
                         the arrival date</a> in the Approved Premises service.
                 </p>
             {% endif %}


### PR DESCRIPTION

# Context

https://dsdmoj.atlassian.net/browse/APS-2575

# Changes in this PR

Parole placement requests show a banner message, which, if the placement request has a linked booking, shows a link to changing the booking date. This link had not been updated to point to the new placement page. This commit adds an integration test to cover that scenario, and fixes the issue.

## Screenshots of UI changes

No UI changes.