### PR TITLE
Print API endpoints

### DIFF
--- a/server/paths/print-api-endpoints.ts
+++ b/server/paths/print-api-endpoints.ts
@@ -1,0 +1,15 @@
+import routes from './api';
+
+function recurse(paths: { [p: string]: unknown } | ArrayLike<unknown>) {
+  for (const value of Object.values(paths)) {
+    if (value.pattern === undefined) {
+      recurse(value)
+    } else {
+      console.log(value.pattern)
+    }
+  }
+}
+
+recurse({ routes })
+
+


### PR DESCRIPTION
currently prints:
```
/cas1/premises/:premisesId/out-of-service-beds
/cas1/premises/:premisesId/out-of-service-beds
/cas1/premises/:premisesId/out-of-service-beds/:id
/cas1/premises/:premisesId/out-of-service-beds/:id
/cas1/premises/:premisesId/out-of-service-beds/:id/cancellations
/cas1/out-of-service-beds
/cas1/premises/:premisesId
/cas1/premises/summary
/cas1/premises/:premisesId/capacity
/cas1/premises/:premisesId/day-summary/:date
/premises/:premisesId/summary
/cas1/premises/:premisesId/lost-beds
/cas1/premises/:premisesId/lost-beds
/cas1/premises/:premisesId/lost-beds/:id
/cas1/premises/:premisesId/lost-beds/:id
/cas1/premises/:premisesId/lost-beds/:id/cancellations
/cas1/premises/:premisesId/staff
/cas1/premises/:premisesId/beds
/cas1/premises/:premisesId/beds/:bedId
/premises/:premisesId/rooms
/premises/:premisesId/rooms/:roomId
/premises/:premisesId/bookings/:bookingId/moves
/premises/:premisesId/bookings/:bookingId/date-changes
/cas1/premises/:premisesId/space-bookings/:placementId
/cas1/premises/:premisesId/space-bookings
/cas1/premises/:premisesId/space-bookings/:placementId/arrival
/cas1/premises/:premisesId/space-bookings/:placementId/non-arrival
/cas1/premises/:premisesId/space-bookings/:placementId/keyworker
/cas1/premises/:premisesId/space-bookings/:placementId/departure
/cas1/premises/:premisesId/space-bookings/:placementId/cancellations
/cas1/premises/:premisesId/space-bookings/:placementId/timeline
/cas1/premises/:premisesId/space-bookings/:placementId/emergency-transfer
/cas1/premises/:premisesId/space-bookings/:placementId/appeal
/premises/:premisesId/calendar
/cas1/premises/occupancy-report
/bookings/:bookingId
/cas1/space-bookings/:placementId
/applications/:id
/cas1/applications/me
/cas1/applications/all
/applications/:id
/applications
/applications/:id/submission
/applications/:id/documents
/applications/:id/assessment
/applications/:id/withdrawal
/cas1/applications/:id/timeline
/applications/:id/placement-applications
/applications/:id/requests-for-placement
/applications/:id/notes
/applications/:id/withdrawables
/applications/:id/withdrawablesWithNotes
/applications/:id/appeals/:appealId
/applications/:id/appeals
/assessments
/assessments/:id
/assessments/:id
/assessments/:id/acceptance
/assessments/:id/rejection
/assessments/:id/notes
/assessments/:id/notes/:clarificationNoteId
/cas1/spaces/search
/cas1/tasks
/cas1/tasks/:taskType
/cas1/tasks/:taskType/:id
/cas1/tasks/:taskType/:id/allocations
/cas1/placement-requests/:placementRequestId
/placement-requests/dashboard
/cas1/placement-requests/change-requests
/placement-requests/:placementRequestId/booking
/placement-requests/:placementRequestId/booking-not-made
/cas1/placement-requests/:placementRequestId/withdrawal
/cas1/placement-requests/:placementRequestId/space-bookings
/cas1/placement-requests/:placementRequestId/appeal
/cas1/placement-requests/:placementRequestId/planned-transfer
/cas1/placement-requests/:placementRequestId/extension
/cas1/placement-requests/:placementRequestId/change-requests/:changeRequestId
/cas1/placement-applications/:id
/cas1/placement-applications
/cas1/placement-applications/:id
/cas1/placement-applications/:id/submission
/cas1/placement-applications/:id/decision
/cas1/placement-applications/:id/withdraw
/people/search
/people/:crn/prison-case-notes
/people/:crn/adjudications
/people/:crn/acct-alerts
/people/:crn/offences
/documents/:crn/:documentId
/cas1/people/:crn/oasys/metadata
/cas1/people/:crn/oasys/answers
/cas1/people/:crn/timeline
/users
/users/summary
/users/search
/users/delius
/cas1/users/:id
/cas1/users/:id
/cas1/users/:id
/profile/v2
/cas1/reports/:reportName
```

# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before

### After
