### PR TITLE
Use specific premises in E2E tests

### DIFF
--- a/e2e/pages/match/searchPage.ts
+++ b/e2e/pages/match/searchPage.ts
@@ -15,8 +15,11 @@ export class SearchPage extends MatchBasePage {
     await this.page.getByRole('button', { name: 'Update' }).click()
   }
 
-  async selectFirstAP() {
-    await this.page.getByRole('link', { name: 'View spaces' }).first().click()
+  async selectAp(premisesName: string) {
+    await this.page
+      .locator('.govuk-summary-card', { has: this.page.getByRole('heading', { name: premisesName }) })
+      .getByRole('link', { name: 'View spaces' })
+      .click()
   }
 
   async shouldShowApplicationDetails({
@@ -52,9 +55,5 @@ export class SearchPage extends MatchBasePage {
 
   async shouldShowPreferredPostcode(postcode: string) {
     await expect(this.page.locator('.govuk-details').getByText(postcode)).toBeVisible()
-  }
-
-  async retrieveFirstAPName(): Promise<Premises['name']> {
-    return this.page.locator('.govuk-summary-card__title').first().innerText()
   }
 }

--- a/e2e/steps/match.ts
+++ b/e2e/steps/match.ts
@@ -79,8 +79,8 @@ export const matchAndBookApplication = async ({
   })
 
   // And I select an AP
-  const premisesName = await searchScreen.retrieveFirstAPName()
-  await searchScreen.selectFirstAP()
+  const premisesName = 'SWSC Men Premise 1'
+  await searchScreen.selectAp(premisesName)
 
   // Then I should see the occupancy view screen for that AP
   const occupancyViewPage = await OccupancyViewPage.initialize(page, premisesName)


### PR DESCRIPTION
As part of the removal of legacy bookings, we want to convert all premises in the dev/test environments to support space bookings. The end-to-end tests currently pick the first available premises on the space search screen. Previously this was ‘SWSC Men Premises 1’, but is now ‘NE Men Premises 1’, which doesn’t have any associated key workers assigned, leading to test failures further on in the tests.

This commit changes the E2E logic to always use ‘SWSC Men Premises 1’ for bookings

<img width="500" height="542" alt="Screenshot 2025-07-29 at 12 27 46" src="https://github.com/user-attachments/assets/68b25940-136b-444d-b615-a628a4eea2d5" />