### PR TITLE
APS-2249 National occupancy AP view

### DIFF
--- a/integration_tests/pages/admin/nationaOccupancy/nationalViewPage.ts
+++ b/integration_tests/pages/admin/nationaOccupancy/nationalViewPage.ts
@@ -119,4 +119,13 @@ export default class NationalViewPage extends Page {
         })
     })
   }
+
+  clickOnDayCell(premisesName: string, dayIndex: number) {
+    cy.get('a')
+      .contains(premisesName)
+      .closest('tr')
+      .within(() => {
+        cy.get(`td`).eq(dayIndex).click()
+      })
+  }
 }

--- a/integration_tests/pages/admin/nationaOccupancy/premisesOccupancyViewPage.ts
+++ b/integration_tests/pages/admin/nationaOccupancy/premisesOccupancyViewPage.ts
@@ -1,0 +1,66 @@
+import type { Cas1PremiseCapacity, Cas1Premises, Cas1SpaceBookingCharacteristic } from '@approved-premises/api'
+import Page from '../../page'
+import { DateFormats } from '../../../../server/utils/dateUtils'
+import paths from '../../../../server/paths/manage'
+import { dayAvailabilityCount, dayAvailabilityStatus } from '../../../../server/utils/match/occupancy'
+
+export default class PremisesOccupancyViewPage extends Page {
+  constructor(title: string) {
+    super(title)
+  }
+
+  static visit(premises: Cas1Premises): PremisesOccupancyViewPage {
+    cy.visit(paths.premises.occupancy.view({ premisesId: premises.id }))
+    return new PremisesOccupancyViewPage(`View spaces in ${premises.name}`)
+  }
+
+  static visitUnauthorised(premises: Cas1Premises): PremisesOccupancyViewPage {
+    cy.visit(paths.premises.occupancy.view({ premisesId: premises.id }), {
+      failOnStatusCode: false,
+    })
+    return new PremisesOccupancyViewPage(`Authorisation Error`)
+  }
+
+  shouldSeeValidationErrors() {
+    this.shouldShowErrorMessagesForFields(['arrivalDate'], {
+      arrivalDate: 'Enter a valid arrival date',
+    })
+  }
+
+  shouldShowCalendarKey(): void {
+    cy.get('#calendar-key').within(() => {
+      cy.contains('Available')
+      cy.contains('Full or overbooked')
+    })
+  }
+
+  shouldShowCalendar(
+    premisesCapacity: Cas1PremiseCapacity,
+    criteria: Array<Cas1SpaceBookingCharacteristic> = [],
+  ): void {
+    cy.get('#calendar').find('li').should('have.length', premisesCapacity.capacity.length)
+    cy.get('#calendar')
+      .find('li')
+      .each((day, index) => {
+        const capacity = premisesCapacity.capacity[index]
+        const { availableBedCount, date } = capacity
+        const bookableCount = dayAvailabilityCount(capacity, criteria)
+        const dayStatus = dayAvailabilityStatus(capacity, criteria)
+        const expectedClass = { overbooked: 'govuk-tag--red', full: 'govuk-tag--red', available: 'govuk-tag--green' }[
+          dayStatus
+        ]
+        cy.wrap(day).within(() => {
+          cy.contains(criteria.length ? `${bookableCount}` : `${bookableCount}/${availableBedCount}`)
+          cy.contains(DateFormats.isoDateToUIDate(date, { format: 'longNoYear' }))
+        })
+        cy.wrap(day).should('have.class', expectedClass)
+      })
+  }
+
+  shouldBePopululatedWith({ durationText, arrivalDate }: { durationText: string; arrivalDate: string }) {
+    cy.get('.search-and-filter').within(() => {
+      this.verifyTextInputContentsById('arrivalDate', arrivalDate)
+      this.shouldHaveSelectText('durationDays', durationText)
+    })
+  }
+}

--- a/integration_tests/pages/admin/nationaOccupancy/premisesOccupancyViewPage.ts
+++ b/integration_tests/pages/admin/nationaOccupancy/premisesOccupancyViewPage.ts
@@ -1,8 +1,6 @@
-import type { Cas1PremiseCapacity, Cas1Premises, Cas1SpaceBookingCharacteristic } from '@approved-premises/api'
+import type { Cas1Premises } from '@approved-premises/api'
 import Page from '../../page'
-import { DateFormats } from '../../../../server/utils/dateUtils'
 import paths from '../../../../server/paths/manage'
-import { dayAvailabilityCount, dayAvailabilityStatus } from '../../../../server/utils/match/occupancy'
 
 export default class PremisesOccupancyViewPage extends Page {
   constructor(title: string) {
@@ -21,43 +19,7 @@ export default class PremisesOccupancyViewPage extends Page {
     return new PremisesOccupancyViewPage(`Authorisation Error`)
   }
 
-  shouldSeeValidationErrors() {
-    this.shouldShowErrorMessagesForFields(['arrivalDate'], {
-      arrivalDate: 'Enter a valid arrival date',
-    })
-  }
-
-  shouldShowCalendarKey(): void {
-    cy.get('#calendar-key').within(() => {
-      cy.contains('Available')
-      cy.contains('Full or overbooked')
-    })
-  }
-
-  shouldShowCalendar(
-    premisesCapacity: Cas1PremiseCapacity,
-    criteria: Array<Cas1SpaceBookingCharacteristic> = [],
-  ): void {
-    cy.get('#calendar').find('li').should('have.length', premisesCapacity.capacity.length)
-    cy.get('#calendar')
-      .find('li')
-      .each((day, index) => {
-        const capacity = premisesCapacity.capacity[index]
-        const { availableBedCount, date } = capacity
-        const bookableCount = dayAvailabilityCount(capacity, criteria)
-        const dayStatus = dayAvailabilityStatus(capacity, criteria)
-        const expectedClass = { overbooked: 'govuk-tag--red', full: 'govuk-tag--red', available: 'govuk-tag--green' }[
-          dayStatus
-        ]
-        cy.wrap(day).within(() => {
-          cy.contains(criteria.length ? `${bookableCount}` : `${bookableCount}/${availableBedCount}`)
-          cy.contains(DateFormats.isoDateToUIDate(date, { format: 'longNoYear' }))
-        })
-        cy.wrap(day).should('have.class', expectedClass)
-      })
-  }
-
-  shouldBePopululatedWith({ durationText, arrivalDate }: { durationText: string; arrivalDate: string }) {
+  shouldBePopulatedWith({ durationText, arrivalDate }: { durationText: string; arrivalDate: string }) {
     cy.get('.search-and-filter').within(() => {
       this.verifyTextInputContentsById('arrivalDate', arrivalDate)
       this.shouldHaveSelectText('durationDays', durationText)

--- a/integration_tests/pages/manage/occupancyView.ts
+++ b/integration_tests/pages/manage/occupancyView.ts
@@ -1,8 +1,7 @@
-import type { Cas1PremiseCapacity, Cas1Premises } from '@approved-premises/api'
+import type { Cas1Premises } from '@approved-premises/api'
 import Page from '../page'
 import { DateFormats, daysToWeeksAndDays } from '../../../server/utils/dateUtils'
 import paths from '../../../server/paths/manage'
-import { dayStatusFromDayCapacity } from '../../../server/utils/premises/occupancy'
 
 export default class OccupancyViewPage extends Page {
   constructor(private pageTitle: string) {
@@ -24,27 +23,5 @@ export default class OccupancyViewPage extends Page {
   shouldShowCalendarHeading(startDate: string, durationDays: number): void {
     const calendarTitle = `Showing ${DateFormats.formatDuration(daysToWeeksAndDays(String(durationDays)))} from ${DateFormats.isoDateToUIDate(startDate, { format: 'short' })}`
     cy.contains(calendarTitle)
-  }
-
-  shouldShowCalendar(premisesCapacity: Cas1PremiseCapacity): void {
-    cy.get('#calendar-key').within(() => {
-      cy.contains('Available')
-      cy.contains('Full')
-      cy.contains('Overbooked')
-    })
-    cy.get('#calendar').find('li').should('have.length', premisesCapacity.capacity.length)
-    cy.get('#calendar')
-      .find('li')
-      .each((day, index) => {
-        const { bookingCount, availableBedCount, date } = premisesCapacity.capacity[index]
-        const dayStatus = dayStatusFromDayCapacity(premisesCapacity.capacity[index])
-        const expectedClass = { overbooked: 'govuk-tag--red', full: 'govuk-tag--yellow', available: '' }[dayStatus]
-        cy.wrap(day).within(() => {
-          cy.contains(`${bookingCount} booked`)
-          cy.contains(`${availableBedCount - bookingCount} available`)
-          cy.contains(DateFormats.isoDateToUIDate(date, { format: 'longNoYear' }))
-        })
-        if (expectedClass) cy.wrap(day).should('have.class', expectedClass)
-      })
   }
 }

--- a/integration_tests/pages/match/dayAvailabilityPage.ts
+++ b/integration_tests/pages/match/dayAvailabilityPage.ts
@@ -6,7 +6,7 @@ import {
 import Page from '../page'
 import {
   DayAvailabilityStatus,
-  dayAvailabilityStatus,
+  dayAvailabilityStatusForCriteria,
   dayAvailabilityStatusMap,
 } from '../../../server/utils/match/occupancy'
 import { DateFormats } from '../../../server/utils/dateUtils'
@@ -23,7 +23,7 @@ export default class DayAvailabilityPage extends Page {
   ) {
     super(DateFormats.isoDateToUIDate(daySummary.forDate, { format: 'long' }))
 
-    this.availability = dayAvailabilityStatus(dayCapacity, criteria)
+    this.availability = dayAvailabilityStatusForCriteria(dayCapacity, criteria)
   }
 
   shouldShowDayAvailability() {

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -841,7 +841,7 @@ export default abstract class Page {
     verbose?: boolean
   }): void {
     const statusClasses = verbose
-      ? { overbooked: 'govuk-tag--red', full: 'govuk-tag--yellow', available: '' }
+      ? { overbooked: 'govuk-tag--red', full: 'govuk-tag--yellow', available: 'govuk-tag--green' }
       : { overbooked: 'govuk-tag--red', full: 'govuk-tag--red', available: 'govuk-tag--green' }
     cy.get('#calendar').find('li').should('have.length', premisesCapacity.capacity.length)
     cy.get('#calendar')

--- a/integration_tests/pages/shared/occupancyFilterPage.ts
+++ b/integration_tests/pages/shared/occupancyFilterPage.ts
@@ -6,7 +6,7 @@ import type {
 import Page from '../page'
 import { DateFormats } from '../../../server/utils/dateUtils'
 import { occupancySummary } from '../../../server/utils/match'
-import { DayAvailabilityStatus, dayAvailabilityStatus } from '../../../server/utils/match/occupancy'
+import { DayAvailabilityStatus, dayAvailabilityStatusForCriteria } from '../../../server/utils/match/occupancy'
 
 export default class OccupancyFilterPage extends Page {
   shouldShowFilters(startDate: string, selectedDuration: string, newCriteria: Array<string>) {
@@ -57,29 +57,6 @@ export default class OccupancyFilterPage extends Page {
     }
   }
 
-  shouldShowOccupancyCalendar(
-    premiseCapacity: Cas1PremiseCapacity,
-    criteria: Array<Cas1SpaceBookingCharacteristic> = [],
-  ) {
-    const firstMonth = DateFormats.isoDateToMonthAndYear(premiseCapacity.startDate)
-    cy.get('.govuk-heading-m').contains(firstMonth).should('exist')
-
-    premiseCapacity.capacity.forEach(capacity => {
-      const status = dayAvailabilityStatus(capacity, criteria)
-      let tagColour = 'green'
-      if (status !== 'available') tagColour = 'red'
-
-      const capacityText = `${capacity.availableBedCount - capacity.bookingCount}/${capacity.availableBedCount}`
-
-      cy.get('.calendar__day')
-        .contains(DateFormats.isoDateToUIDate(capacity.date, { format: 'longNoYear' }))
-        .closest('.calendar__day')
-        .should('have.class', `govuk-tag--${tagColour}`)
-        .should('contain.text', capacityText)
-        .should(criteria.length ? 'contain.text' : 'not.contain.text', 'your criteria')
-    })
-  }
-
   getOccupancyForDate(date: Date, capacity: Cas1PremiseCapacity): Cas1PremiseCapacityForDay {
     return capacity.capacity.find(day => day.date === DateFormats.dateObjToIsoDate(date))
   }
@@ -96,7 +73,7 @@ export default class OccupancyFilterPage extends Page {
   ): Array<Date> {
     const dates: Record<DayAvailabilityStatus, Date> = premiseCapacity.capacity.reduce(
       (statuses, day) => {
-        const status = dayAvailabilityStatus(day, criteria)
+        const status = dayAvailabilityStatusForCriteria(day, criteria)
 
         return {
           ...statuses,

--- a/integration_tests/tests/admin/nationalOccupancy.cy.ts
+++ b/integration_tests/tests/admin/nationalOccupancy.cy.ts
@@ -1,4 +1,5 @@
 import { ApType, Cas1SpaceBookingCharacteristic, Cas1SpaceCharacteristic } from '@approved-premises/api'
+import Page from '../../pages/page'
 import {
   cas1NationalOccupancyFactory,
   cas1PremiseCapacityFactory,
@@ -135,7 +136,7 @@ context('National occupancy view', () => {
     weekPage.clickLink(nationalOccupancy.premises[1].summary.name)
 
     THEN('I should be on the single premises view page')
-    const page = new PremisesOccupancyViewPage(`View spaces in ${premises.name}`)
+    const page = Page.verifyOnPage(PremisesOccupancyViewPage, `View spaces in ${premises.name}`)
 
     AND('the default duration should be set')
     page.shouldHaveSelectText('durationDays', 'Up to 12 weeks')
@@ -147,7 +148,9 @@ context('National occupancy view', () => {
     page.clickButton('Apply filters')
 
     THEN('I should see an error')
-    page.shouldSeeValidationErrors()
+    page.shouldShowErrorMessagesForFields(['arrivalDate'], {
+      arrivalDate: 'Enter a valid arrival date',
+    })
 
     WHEN('I correct the invalid date')
     page.clearInput('arrivalDate')
@@ -155,22 +158,27 @@ context('National occupancy view', () => {
     page.clickButton('Apply filters')
 
     AND('I should see the calendar')
-    page.shouldShowCalendarKey()
-    page.shouldShowCalendar(capacities[1].premiseCapacity, filterSettings.roomCriteria)
+    page.shouldShowCalendarKey('twoColour')
+    page.shouldShowCalendar({ premisesCapacity: capacities[1].premiseCapacity, criteria: filterSettings.roomCriteria })
 
     WHEN(`I change the 'filter' to no room criteria`)
     page.uncheckCheckboxbyNameAndValue('roomCriteria', 'isWheelchairDesignated')
     page.clickButton('Apply filters')
 
     THEN('I should see the calendar in no criteria format')
-    page.shouldShowCalendarKey()
-    page.shouldShowCalendar(capacities[1].premiseCapacity, [])
+    page.shouldShowCalendarKey('twoColour')
+    page.shouldShowCalendar({ premisesCapacity: capacities[1].premiseCapacity })
 
     WHEN('I click on a day')
     page.clickLink(DateFormats.isoDateToUIDate(daySummaryDate, { format: 'longNoYear' }))
 
     THEN('I should see the day details view for that day')
-    const dayPage = new DayAvailabilityPage(premisesDaySummary, capacities[2].premiseCapacity.capacity[0], [])
+    const dayPage = Page.verifyOnPage(
+      DayAvailabilityPage,
+      premisesDaySummary,
+      capacities[2].premiseCapacity.capacity[0],
+      [],
+    )
 
     AND('I should see availability details')
     dayPage.shouldShowDayAvailability()
@@ -180,7 +188,7 @@ context('National occupancy view', () => {
 
     THEN('I am on the AP view page again with all my settings unchanged')
     page.checkOnPage()
-    page.shouldBePopululatedWith({ durationText: 'Up to 1 week', arrivalDate: filterSettings.arrivalDate })
+    page.shouldBePopulatedWith({ durationText: 'Up to 1 week', arrivalDate: filterSettings.arrivalDate })
 
     WHEN('I click back')
     page.clickBack()

--- a/integration_tests/tests/manage/occupancyView.cy.ts
+++ b/integration_tests/tests/manage/occupancyView.cy.ts
@@ -75,7 +75,8 @@ context('Premises occupancy', () => {
 
       // and the calendar should be shown
       occPage.shouldShowCalendarHeading(startDate, DateFormats.durationBetweenDates(endDate, startDate).number)
-      occPage.shouldShowCalendar(premisesCapacity)
+      occPage.shouldShowCalendarKey('threeColour')
+      occPage.shouldShowCalendar({ premisesCapacity, verbose: true })
     })
 
     it('should allow the user to change the start date and the calendar duration', () => {

--- a/integration_tests/tests/match/match.cy.ts
+++ b/integration_tests/tests/match/match.cy.ts
@@ -131,7 +131,8 @@ context('Placement Requests', () => {
     occupancyViewPage.shouldShowOccupancySummary(premiseCapacity, searchState.roomCriteria)
 
     // And I should see an occupancy calendar
-    occupancyViewPage.shouldShowOccupancyCalendar(premiseCapacity, searchState.roomCriteria)
+    occupancyViewPage.shouldShowCalendarKey('twoColour')
+    occupancyViewPage.shouldShowCalendar({ premisesCapacity: premiseCapacity, criteria: searchState.roomCriteria })
   })
 
   it('allows me to view spaces and occupancy capacity with blank licence expiry date', () => {
@@ -142,7 +143,8 @@ context('Placement Requests', () => {
     occupancyViewPage.shouldShowOccupancySummary(premiseCapacity, searchState.roomCriteria)
 
     // And I should see an occupancy calendar
-    occupancyViewPage.shouldShowOccupancyCalendar(premiseCapacity, searchState.roomCriteria)
+    occupancyViewPage.shouldShowCalendarKey('twoColour')
+    occupancyViewPage.shouldShowCalendar({ premisesCapacity: premiseCapacity, criteria: searchState.roomCriteria })
   })
 
   it('allows me to submit invalid dates in the book your placement form on occupancy view page and displays appropriate validation messages', () => {
@@ -267,7 +269,8 @@ context('Placement Requests', () => {
     occupancyViewPage.shouldShowOccupancySummary(premiseCapacity, searchState.roomCriteria)
 
     // And I should see an occupancy calendar
-    occupancyViewPage.shouldShowOccupancyCalendar(premiseCapacity, searchState.roomCriteria)
+    occupancyViewPage.shouldShowCalendarKey('twoColour')
+    occupancyViewPage.shouldShowCalendar({ premisesCapacity: premiseCapacity, criteria: searchState.roomCriteria })
 
     // And I should be able to see any day's availability details
     const datesByStatus = occupancyViewPage.getDatesForEachAvailabilityStatus(premiseCapacity, searchState.roomCriteria)
@@ -276,7 +279,8 @@ context('Placement Requests', () => {
     })
 
     // Then I should see the calendar again
-    occupancyViewPage.shouldShowOccupancyCalendar(premiseCapacity, searchState.roomCriteria)
+    occupancyViewPage.shouldShowCalendarKey('twoColour')
+    occupancyViewPage.shouldShowCalendar({ premisesCapacity: premiseCapacity, criteria: searchState.roomCriteria })
 
     // When I filter with an invalid date
     occupancyViewPage.filterAvailability({ newStartDate: '2025-02-35' })

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -472,6 +472,7 @@ type SpaceSearchCommonFields = {
   roomCriteria?: Array<SpaceSearchRoomCriteria>
   startDate?: string
   arrivalDate?: string
+  durationDays?: number
 }
 
 export type NationalSpaceSearchFormData = SpaceSearchCommonFields & {
@@ -481,7 +482,6 @@ export type NationalSpaceSearchFormData = SpaceSearchCommonFields & {
 
 export type SpaceSearchFormData = SpaceSearchCommonFields & {
   applicationId?: string
-  durationDays?: number
   departureDate?: string
 }
 

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -467,7 +467,6 @@ export type SpaceSearchRoomCriteria = keyof typeof roomCharacteristicMap
 
 type SpaceSearchCommonFields = {
   postcode?: string
-  apType?: ApTypeCriteria
   apCriteria?: Array<SpaceSearchApCriteria>
   roomCriteria?: Array<SpaceSearchRoomCriteria>
   startDate?: string
@@ -483,6 +482,7 @@ export type NationalSpaceSearchFormData = SpaceSearchCommonFields & {
 export type SpaceSearchFormData = SpaceSearchCommonFields & {
   applicationId?: string
   departureDate?: string
+  apType?: ApTypeCriteria
 }
 
 export type DepartureFormData = ObjectWithDateParts<'departureDate'> & {

--- a/server/controllers/admin/index.ts
+++ b/server/controllers/admin/index.ts
@@ -29,6 +29,7 @@ export const controllers = (services: Services) => {
     services.placementRequestService,
     services.placementService,
   )
+
   const nationalOccupancyController = new NationalOccupancyController(premisesService, cruManagementAreaService)
 
   return {

--- a/server/controllers/admin/nationalOccupancyController.ts
+++ b/server/controllers/admin/nationalOccupancyController.ts
@@ -159,13 +159,13 @@ export default class NationalOccupancyController {
         })
       }
 
-      const { arrivalDate: arrivalDateSlash, roomCriteria, durationDays } = { durationDays: 84, ...sessionData }
+      const { arrivalDate: arrivalDateSlash, roomCriteria, durationDays = 84 } = sessionData
       const roomCharacteristics = makeArrayOfType<Cas1SpaceBookingCharacteristic>(roomCriteria || [])
 
       let calendar: Calendar
       let premises: Cas1Premises
 
-      const arrivalDate = DateFormats.datepickerInputToIsoString(arrivalDateSlash as string)
+      const arrivalDate = DateFormats.datepickerInputToIsoString(arrivalDateSlash)
 
       const errors: Record<string, string> = {}
 

--- a/server/controllers/admin/nationalOccupancyController.ts
+++ b/server/controllers/admin/nationalOccupancyController.ts
@@ -1,5 +1,10 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
-import { Cas1NationalOccupancy, Cas1SpaceCharacteristic } from '@approved-premises/api'
+import {
+  Cas1NationalOccupancy,
+  Cas1Premises,
+  Cas1SpaceBookingCharacteristic,
+  Cas1SpaceCharacteristic,
+} from '@approved-premises/api'
 import { CruManagementAreaService, PremisesService } from '../../services'
 import { DateFormats, isoDateIsValid } from '../../utils/dateUtils'
 import {
@@ -14,11 +19,14 @@ import {
 import { convertKeyValuePairToCheckBoxItems, validPostcodeArea } from '../../utils/formUtils'
 import { roomCharacteristicMap } from '../../utils/characteristicsUtils'
 import { spaceSearchCriteriaApLevelLabels } from '../../utils/match/spaceSearchLabels'
-import { makeArrayOfType } from '../../utils/utils'
+import { createQueryString, makeArrayOfType } from '../../utils/utils'
 import { generateErrorMessages, generateErrorSummary } from '../../utils/validation'
 import paths from '../../paths/admin'
 import MultiPageFormManager from '../../utils/multiPageFormManager'
 import { apTypeToSpaceCharacteristicMap } from '../../utils/apTypeLabels'
+import { durationSelectOptions } from '../../utils/match/occupancy'
+import { type Calendar, occupancyCalendar } from '../../utils/match/occupancyCalendar'
+import { placementDates } from '../../utils/match'
 
 export const defaultSessionKey = 'default'
 
@@ -116,7 +124,7 @@ export default class NationalOccupancyController {
         backLink: paths.admin.cruDashboard.index({}),
         pagination: capacity && getPagination(fromDate),
         arrivalDate: rawArrivalDate || slashToday,
-        processedCapacity: capacity && processCapacity(capacity, postcode),
+        processedCapacity: capacity && processCapacity(capacity, postcode, roomCriteria),
         dateHeader: capacity && getDateHeader(capacity),
         postcode: postcode || '',
         cruManagementAreaOptions: getManagementAreaSelectGroups(
@@ -129,6 +137,72 @@ export default class NationalOccupancyController {
         apTypeOptions: getApTypeOptions(apType),
         fromDate,
         criteriaBlock: getCriteriaBlock(premisesCharacteristics, roomCharacteristics),
+        errors: generateErrorMessages(errors),
+        errorSummary: generateErrorSummary(errors),
+      })
+    }
+  }
+
+  premisesView(): TypedRequestHandler<Request, Response> {
+    return async (req: Request, res: Response) => {
+      const {
+        user: { token },
+        params: { premisesId },
+        query,
+      } = req
+
+      const sessionData = this.formData.get(defaultSessionKey, req.session) || {}
+
+      if (query.arrivalDate !== undefined) {
+        Object.assign(sessionData, query, {
+          roomCriteria: query.roomCriteria,
+        })
+      }
+
+      const { arrivalDate: arrivalDateSlash, roomCriteria, durationDays } = { durationDays: 84, ...sessionData }
+      const roomCharacteristics = makeArrayOfType<Cas1SpaceBookingCharacteristic>(roomCriteria || [])
+
+      let calendar: Calendar
+      let premises: Cas1Premises
+
+      const arrivalDate = DateFormats.datepickerInputToIsoString(arrivalDateSlash as string)
+
+      const errors: Record<string, string> = {}
+
+      if (!isoDateIsValid(arrivalDate)) {
+        errors.arrivalDate = 'Enter a valid arrival date'
+      }
+
+      if (!Object.keys(errors).length) {
+        if (query.arrivalDate) {
+          await this.formData.update(defaultSessionKey, req.session, sessionData)
+        }
+        premises = await this.premisesService.find(token, premisesId)
+        const capacityDates = placementDates(arrivalDate, durationDays)
+        const capacity = await this.premisesService.getCapacity(token, premisesId, {
+          startDate: capacityDates.startDate,
+          endDate: capacityDates.endDate,
+        })
+
+        const placeholderDetailsUrl = `${paths.admin.nationalOccupancy.premisesDayView({ premisesId, date: ':date' })}${createQueryString(
+          { criteria: roomCharacteristics },
+          {
+            arrayFormat: 'repeat',
+            addQueryPrefix: true,
+          },
+        )}`
+        calendar = occupancyCalendar(capacity.capacity, placeholderDetailsUrl, roomCharacteristics)
+      }
+
+      return res.render('admin/nationalOccupancy/premises', {
+        pageHeading: premises && `View spaces in ${premises.name}`,
+        backLink: `${paths.admin.nationalOccupancy.weekView({})}?fromDate=${arrivalDate}`,
+        premises,
+        arrivalDate: arrivalDateSlash,
+        durationOptions: durationSelectOptions(durationDays),
+        criteriaOptions: convertKeyValuePairToCheckBoxItems(roomCharacteristicMap, roomCharacteristics),
+        criteriaBlock: getCriteriaBlock(undefined, roomCharacteristics),
+        calendar,
         errors: generateErrorMessages(errors),
         errorSummary: generateErrorSummary(errors),
       })

--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -19,7 +19,11 @@ import matchPaths from '../../../paths/match'
 import { occupancyCalendar } from '../../../utils/match/occupancyCalendar'
 import * as validationUtils from '../../../utils/validation'
 import { DateFormats } from '../../../utils/dateUtils'
-import { dayAvailabilityStatus, dayAvailabilityStatusMap, durationSelectOptions } from '../../../utils/match/occupancy'
+import {
+  dayAvailabilityStatusForCriteria,
+  dayAvailabilityStatusMap,
+  durationSelectOptions,
+} from '../../../utils/match/occupancy'
 import { placementRequestSummaryList } from '../../../utils/placementRequests/placementRequestSummaryList'
 import { ValidationError } from '../../../utils/errors'
 import { filterRoomLevelCriteria, initialiseSearchState } from '../../../utils/match/spaceSearch'
@@ -466,7 +470,10 @@ describe('OccupancyViewController', () => {
     const query = {
       criteria: ['isWheelchairDesignated', 'isArsonSuitable'],
     }
-    const expectedStatus = dayAvailabilityStatus(dayCapacity, filterRoomLevelCriteria(makeArrayOfType(query.criteria)))
+    const expectedStatus = dayAvailabilityStatusForCriteria(
+      dayCapacity,
+      filterRoomLevelCriteria(makeArrayOfType(query.criteria)),
+    )
 
     beforeEach(() => {
       premisesService.getDaySummary.mockResolvedValue(premisesDaySummary)

--- a/server/controllers/match/placementRequests/occupancyViewController.test.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.test.ts
@@ -3,7 +3,7 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
 import { when } from 'jest-when'
 import { addDays } from 'date-fns'
-import { Cas1SpaceBookingCharacteristic, PlacementCriteria } from '@approved-premises/api'
+import { Cas1SpaceBookingCharacteristic } from '@approved-premises/api'
 import { PlacementRequestService, PremisesService, SessionService, SpaceSearchService } from '../../../services'
 import {
   cas1PlacementRequestDetailFactory,
@@ -453,33 +453,36 @@ describe('OccupancyViewController', () => {
   describe('viewDay', () => {
     const date = '2025-03-23'
     const premisesDaySummary = cas1PremisesDaySummaryFactory.build({ forDate: date })
-    beforeEach(() => {
-      premisesService.getDaySummary.mockResolvedValue(premisesDaySummary)
+    const excludeSpaceBookingId = 'excluded-id'
+
+    const dayCapacity = cas1PremiseCapacityForDayFactory.build()
+    const premisesCapacityForDay = cas1PremiseCapacityFactory.build({
+      startDate: date,
+      endDate: date,
+      capacity: [dayCapacity],
     })
 
-    it('should render the day occupancy view template with given approved premises, date and room requirement criteria', async () => {
-      const criteria: Array<Cas1SpaceBookingCharacteristic> = ['isWheelchairDesignated', 'isArsonSuitable']
+    const criteria: Array<Cas1SpaceBookingCharacteristic> = ['isWheelchairDesignated', 'isArsonSuitable']
+    const query = {
+      criteria: ['isWheelchairDesignated', 'isArsonSuitable'],
+    }
+    const expectedStatus = dayAvailabilityStatus(dayCapacity, filterRoomLevelCriteria(makeArrayOfType(query.criteria)))
 
-      const dayCapacity = cas1PremiseCapacityForDayFactory.build()
-      const premisesCapacityForDay = cas1PremiseCapacityFactory.build({
-        startDate: date,
-        endDate: date,
-        capacity: [dayCapacity],
-      })
+    beforeEach(() => {
+      premisesService.getDaySummary.mockResolvedValue(premisesDaySummary)
       when(premisesService.getCapacity)
         .calledWith(request.user.token, premises.id, { startDate: date })
         .mockResolvedValue(premisesCapacityForDay)
 
-      const query = {
-        criteria,
-      }
+      when(premisesService.getCapacity)
+        .calledWith(request.user.token, premises.id, { startDate: date, excludeSpaceBookingId })
+        .mockResolvedValue(premisesCapacityForDay)
+    })
 
-      const requestHandler = occupancyViewController.viewDay()
+    it('should render the day occupancy view template with given approved premises, date and room requirement criteria', async () => {
+      await occupancyViewController.viewDay()({ ...request, params: { ...params, date }, query }, response, next)
 
-      await requestHandler({ ...request, params: { ...params, date }, query }, response, next)
-
-      const expectedStatus = dayAvailabilityStatus(dayCapacity, filterRoomLevelCriteria(makeArrayOfType(criteria)))
-      const pathPrefix = `/match/placement-requests/${placementRequestDetail.id}/space-search/occupancy/${premises.id}`
+      const pathPrefix = `/match/placement-requests/${placementRequestDetail.id}/space-search/occupancy/${premises.id}/date`
 
       expect(premisesService.getCapacity).toHaveBeenCalledWith('SOME_TOKEN', premises.id, { startDate: date })
 
@@ -498,8 +501,8 @@ describe('OccupancyViewController', () => {
         daySummaryRows: daySummaryRows(dayCapacity, criteria, 'singleRow'),
         placementRequest: placementRequestDetail,
         premises,
-        nextDayLink: `${pathPrefix}/date/2025-03-24?criteria=isWheelchairDesignated&criteria=isArsonSuitable`,
-        previousDayLink: `${pathPrefix}/date/2025-03-22?criteria=isWheelchairDesignated&criteria=isArsonSuitable`,
+        nextDayLink: `${pathPrefix}/2025-03-24?criteria=isWheelchairDesignated&criteria=isArsonSuitable`,
+        previousDayLink: `${pathPrefix}/2025-03-22?criteria=isWheelchairDesignated&criteria=isArsonSuitable`,
         ...tableCaptions(premisesDaySummary, [], true),
         outOfServiceBedTableHeader: tableHeader<OutOfServiceBedColumnField>(outOfServiceBedColumnMap),
         outOfServiceBedTableRows: outOfServiceBedTableRows(premises.id, premisesDaySummary.outOfServiceBeds),
@@ -507,38 +510,52 @@ describe('OccupancyViewController', () => {
           placementColumnMap,
           'canonicalArrivalDate',
           undefined,
-          `${pathPrefix}/date/2025-03-23`,
+          `${pathPrefix}/2025-03-23`,
         ),
         placementTableRows: placementTableRows(premises.id, premisesDaySummary.spaceBookingSummaries),
       })
     })
 
     it('should fetch capacity data with a placement id to exclude', async () => {
-      const criteria: Array<PlacementCriteria> = ['isWheelchairDesignated']
-      const excludeSpaceBookingId = 'excluded-id'
-
-      const dayCapacity = cas1PremiseCapacityForDayFactory.build({})
-      const premisesCapacityForDay = cas1PremiseCapacityFactory.build({
-        startDate: date,
-        endDate: date,
-        capacity: [dayCapacity],
-      })
-      when(premisesService.getCapacity)
-        .calledWith(request.user.token, premises.id, { startDate: date, excludeSpaceBookingId })
-        .mockResolvedValue(premisesCapacityForDay)
-
-      const query = {
-        criteria,
-        excludeSpaceBookingId,
-      }
-
-      const requestHandler = occupancyViewController.viewDay()
-
-      await requestHandler({ ...request, params: { ...params, date }, query }, response, next)
+      await occupancyViewController.viewDay()(
+        { ...request, params: { ...params, date }, query: { ...query, excludeSpaceBookingId } },
+        response,
+        next,
+      )
 
       expect(premisesService.getCapacity).toHaveBeenCalledWith('SOME_TOKEN', premises.id, {
         startDate: date,
         excludeSpaceBookingId,
+      })
+    })
+
+    it('should render the occupancy view without a placementRequest id', async () => {
+      await occupancyViewController.viewDay()(
+        { ...request, params: { premisesId: premises.id, date }, query },
+        response,
+        next,
+      )
+
+      const pathPrefix = `/admin/national-occupancy/premises/${premises.id}/date`
+
+      expect(response.render).toHaveBeenCalledWith('manage/premises/occupancy/dayView', {
+        pageHeading: 'Sun 23 Mar 2025',
+        backLink: '/backlink',
+        dayAvailabilityStatus: dayAvailabilityStatusMap[expectedStatus],
+        daySummaryRows: daySummaryRows(dayCapacity, criteria, 'singleRow'),
+        premises,
+        nextDayLink: `${pathPrefix}/2025-03-24?criteria=isWheelchairDesignated&criteria=isArsonSuitable`,
+        previousDayLink: `${pathPrefix}/2025-03-22?criteria=isWheelchairDesignated&criteria=isArsonSuitable`,
+        ...tableCaptions(premisesDaySummary, [], true),
+        outOfServiceBedTableHeader: tableHeader<OutOfServiceBedColumnField>(outOfServiceBedColumnMap),
+        outOfServiceBedTableRows: outOfServiceBedTableRows(premises.id, premisesDaySummary.outOfServiceBeds),
+        placementTableHeader: tableHeader<PlacementColumnField>(
+          placementColumnMap,
+          'canonicalArrivalDate',
+          undefined,
+          `${pathPrefix}/2025-03-23`,
+        ),
+        placementTableRows: placementTableRows(premises.id, premisesDaySummary.spaceBookingSummaries),
       })
     })
   })

--- a/server/controllers/match/placementRequests/occupancyViewController.ts
+++ b/server/controllers/match/placementRequests/occupancyViewController.ts
@@ -6,7 +6,11 @@ import { occupancySummary, placementDates, validateSpaceBooking } from '../../..
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import { type Calendar, occupancyCalendar } from '../../../utils/match/occupancyCalendar'
 import { DateFormats, isoDateIsValid } from '../../../utils/dateUtils'
-import { dayAvailabilityStatus, dayAvailabilityStatusMap, durationSelectOptions } from '../../../utils/match/occupancy'
+import {
+  dayAvailabilityStatusForCriteria,
+  dayAvailabilityStatusMap,
+  durationSelectOptions,
+} from '../../../utils/match/occupancy'
 import { convertKeyValuePairToCheckBoxItems } from '../../../utils/formUtils'
 import { OccupancySummary } from '../../../utils/match/occupancySummary'
 import paths from '../../../paths/match'
@@ -264,7 +268,7 @@ export default class {
         excludeSpaceBookingId,
       })
       const dayCapacity = premisesCapacity.capacity[0]
-      const status = dayAvailabilityStatus(dayCapacity, filteredCriteria)
+      const status = dayAvailabilityStatusForCriteria(dayCapacity, filteredCriteria)
 
       return res.render('manage/premises/occupancy/dayView', {
         backLink,

--- a/server/paths/admin.ts
+++ b/server/paths/admin.ts
@@ -13,6 +13,8 @@ const cruDashboardPath = adminPath.path('cru-dashboard')
 
 const nationalOccupancyPath = adminPath.path('national-occupancy')
 
+const nationalOccupancyPremisesPath = nationalOccupancyPath.path('premises/:premisesId')
+
 export default {
   admin: {
     cruDashboard: {
@@ -23,7 +25,8 @@ export default {
     },
     nationalOccupancy: {
       weekView: nationalOccupancyPath,
-      premisesView: nationalOccupancyPath.path('premises/:premisesId'),
+      premisesView: nationalOccupancyPremisesPath,
+      premisesDayView: nationalOccupancyPremisesPath.path('date/:date'),
     },
     placementRequests: {
       index: placementRequestsPath,

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -20,6 +20,7 @@ export default function routes(controllers: Controllers, router: Router, service
     deliusUserController,
     changeRequestsController,
     nationalOccupancyController,
+    occupancyViewController,
   } = controllers
 
   get(paths.admin.cruDashboard.index.pattern, cruDashboardController.index(), {
@@ -42,6 +43,14 @@ export default function routes(controllers: Controllers, router: Router, service
   // National occupancy view
   get(paths.admin.nationalOccupancy.weekView.pattern, nationalOccupancyController.index(), {
     auditEvent: 'NATIONAL_OCCUPANCY_VIEW',
+    allowedPermissions: ['cas1_national_occupancy_view'],
+  })
+  get(paths.admin.nationalOccupancy.premisesView.pattern, nationalOccupancyController.premisesView(), {
+    auditEvent: 'NATIONAL_OCCUPANCY_PREMISES_VIEW',
+    allowedPermissions: ['cas1_national_occupancy_view'],
+  })
+  get(paths.admin.nationalOccupancy.premisesDayView.pattern, occupancyViewController.viewDay(), {
+    auditEvent: 'NATIONAL_OCCUPANCY_PREMISES__DAY_VIEW',
     allowedPermissions: ['cas1_national_occupancy_view'],
   })
 

--- a/server/testutils/factories/cas1NationalOccupancy.ts
+++ b/server/testutils/factories/cas1NationalOccupancy.ts
@@ -46,12 +46,18 @@ export const cas1NationalOccupancyParametersFactory = Factory.define<Cas1Nationa
   ) as Array<Cas1SpaceCharacteristic>,
 }))
 
-export default Factory.define<Cas1NationalOccupancy>(() => {
-  const startDate = DateFormats.dateObjToIsoDate(new Date())
-  const endDate = DateFormats.dateObjToIsoDate(addDays(startDate, 5))
+export default Factory.define<Cas1NationalOccupancy>(({ params }) => {
+  const startDate = params.startDate || DateFormats.dateObjToIsoDate(new Date())
+  const endDate = params.endDate || DateFormats.dateObjToIsoDate(addDays(startDate, 5))
+  const premises = cas1NationalOccupancyPremisesFactory.buildList(5)
+  premises.forEach(premisesOccupancy => {
+    premisesOccupancy.capacity.forEach((capacity, index) => {
+      capacity.date = DateFormats.dateObjToIsoDate(addDays(startDate, index))
+    })
+  })
   return {
     startDate,
     endDate,
-    premises: cas1NationalOccupancyPremisesFactory.buildList(5),
+    premises,
   }
 })

--- a/server/utils/admin/nationalOccupancyUtils.test.ts
+++ b/server/utils/admin/nationalOccupancyUtils.test.ts
@@ -96,8 +96,8 @@ describe('nationalOccupancyUtils', () => {
     it('should process the received capacity into a structure for the template to consume', () => {
       const postcode = 'RG15'
       const apiCapacity = cas1NationalOccupancyFactory.build()
+      const processed = processCapacity(apiCapacity, postcode, [])
 
-      const processed = processCapacity(apiCapacity, postcode)
       expect(processed).toHaveLength(apiCapacity.premises.length)
       processed.forEach(({ summaryRows, apCapacity }, index) => {
         const ap = apiCapacity.premises[index]
@@ -105,12 +105,12 @@ describe('nationalOccupancyUtils', () => {
         expect(summaryRows[1]).toEqual(apTypeShortLabels[ap.summary.apType])
         expect(summaryRows[2]).toEqual(`${ap.distanceInMiles.toFixed(1)} miles from ${postcode}`)
         apCapacity.forEach(({ capacity, classes, link }, characteristicIndex) => {
-          const { forRoomCharacteristic, inServiceBedCount, vacantBedCount } = ap.capacity[characteristicIndex]
+          const { forRoomCharacteristic, inServiceBedCount, vacantBedCount, date } = ap.capacity[characteristicIndex]
           expect(classes).toEqual(vacantBedCount > 0 ? 'govuk-tag--green' : 'govuk-tag--red')
           expect(capacity).toEqual(
             forRoomCharacteristic ? `${vacantBedCount}` : `${vacantBedCount}/${inServiceBedCount}`,
           )
-          expect(link).toEqual('#')
+          expect(link).toEqual(`/admin/national-occupancy/premises/${ap.summary.id}/date/${date}`)
         })
       })
     })

--- a/server/utils/admin/nationalOccupancyUtils.test.ts
+++ b/server/utils/admin/nationalOccupancyUtils.test.ts
@@ -14,6 +14,7 @@ import {
 } from './nationalOccupancyUtils'
 import { apTypeLongLabels, apTypeShortLabels } from '../apTypeLabels'
 import { DateFormats } from '../dateUtils'
+import { createQueryString } from '../utils'
 
 describe('nationalOccupancyUtils', () => {
   const mensAreas = cruManagementAreaFactory.buildList(6)
@@ -93,27 +94,45 @@ describe('nationalOccupancyUtils', () => {
   })
 
   describe('processCapacity', () => {
-    it('should process the received capacity into a structure for the template to consume', () => {
-      const postcode = 'RG15'
-      const apiCapacity = cas1NationalOccupancyFactory.build()
-      const processed = processCapacity(apiCapacity, postcode, [])
+    it.each([
+      ['with criteria', ['hasEnsuite']],
+      ['without criteria', undefined],
+    ])(
+      'should process the received capacity into a structure for the template to consume %s',
+      (_, roomCriteria: Array<Cas1SpaceBookingCharacteristic>) => {
+        const postcode = 'RG15'
+        const apiCapacity = cas1NationalOccupancyFactory.build()
+        const processed = processCapacity(
+          apiCapacity,
+          postcode,
+          roomCriteria as unknown as Array<Cas1SpaceBookingCharacteristic>,
+        )
 
-      expect(processed).toHaveLength(apiCapacity.premises.length)
-      processed.forEach(({ summaryRows, apCapacity }, index) => {
-        const ap = apiCapacity.premises[index]
-        expect(summaryRows[0]).toMatch(ap.summary.name)
-        expect(summaryRows[1]).toEqual(apTypeShortLabels[ap.summary.apType])
-        expect(summaryRows[2]).toEqual(`${ap.distanceInMiles.toFixed(1)} miles from ${postcode}`)
-        apCapacity.forEach(({ capacity, classes, link }, characteristicIndex) => {
-          const { forRoomCharacteristic, inServiceBedCount, vacantBedCount, date } = ap.capacity[characteristicIndex]
-          expect(classes).toEqual(vacantBedCount > 0 ? 'govuk-tag--green' : 'govuk-tag--red')
-          expect(capacity).toEqual(
-            forRoomCharacteristic ? `${vacantBedCount}` : `${vacantBedCount}/${inServiceBedCount}`,
-          )
-          expect(link).toEqual(`/admin/national-occupancy/premises/${ap.summary.id}/date/${date}`)
+        expect(processed).toHaveLength(apiCapacity.premises.length)
+        processed.forEach(({ summaryRows, apCapacity }, index) => {
+          const ap = apiCapacity.premises[index]
+          expect(summaryRows[0]).toMatch(ap.summary.name)
+          expect(summaryRows[1]).toEqual(apTypeShortLabels[ap.summary.apType])
+          expect(summaryRows[2]).toEqual(`${ap.distanceInMiles.toFixed(1)} miles from ${postcode}`)
+          apCapacity.forEach(({ capacity, classes, link }, characteristicIndex) => {
+            const { inServiceBedCount, vacantBedCount, date } = ap.capacity[characteristicIndex]
+            expect(classes).toEqual(vacantBedCount > 0 ? 'govuk-tag--green' : 'govuk-tag--red')
+            expect(capacity).toEqual(
+              roomCriteria?.length ? `${vacantBedCount}` : `${vacantBedCount}/${inServiceBedCount}`,
+            )
+            expect(link).toEqual(
+              `/admin/national-occupancy/premises/${ap.summary.id}/date/${date}${createQueryString(
+                { criteria: roomCriteria },
+                {
+                  arrayFormat: 'repeat',
+                  addQueryPrefix: true,
+                },
+              )}`,
+            )
+          })
         })
-      })
-    })
+      },
+    )
   })
 
   describe('getPagination', () => {
@@ -123,11 +142,11 @@ describe('nationalOccupancyUtils', () => {
         expect.objectContaining({
           previous: {
             text: 'Previous week',
-            href: `/admin/national-occupancy?fromDate=2025-07-18`,
+            href: `/admin/national-occupancy?fromDate=2025-07-18#calendar-heading`,
           },
           next: {
             text: 'Next week',
-            href: `/admin/national-occupancy?fromDate=2025-08-01`,
+            href: `/admin/national-occupancy?fromDate=2025-08-01#calendar-heading`,
           },
         }),
       )

--- a/server/utils/admin/nationalOccupancyUtils.ts
+++ b/server/utils/admin/nationalOccupancyUtils.ts
@@ -61,9 +61,9 @@ export const processCapacity = (
       postcode && `${premises.distanceInMiles.toFixed(1)} miles from ${postcode}`,
     ].filter(Boolean),
 
-    apCapacity: premises.capacity.map(({ forRoomCharacteristic, vacantBedCount, inServiceBedCount, date }) => {
+    apCapacity: premises.capacity.map(({ vacantBedCount, inServiceBedCount, date }) => {
       return {
-        capacity: `${vacantBedCount}${forRoomCharacteristic ? '' : `/${inServiceBedCount}`}`,
+        capacity: `${vacantBedCount}${roomCriteria?.length ? '' : `/${inServiceBedCount}`}`,
         link: `${paths.admin.nationalOccupancy.premisesDayView({ premisesId: premises.summary.id, date })}${createQueryString(
           { criteria: roomCriteria },
           {
@@ -79,7 +79,7 @@ export const processCapacity = (
 export const getPagination = (fromDate: string) => {
   const links = [-7, 7].map(
     days =>
-      `${paths.admin.nationalOccupancy.weekView({})}${createQueryString({ fromDate: DateFormats.dateObjToIsoDate(addDays(fromDate, days)) }, { addQueryPrefix: true })}`,
+      `${paths.admin.nationalOccupancy.weekView({})}${createQueryString({ fromDate: DateFormats.dateObjToIsoDate(addDays(fromDate, days)) }, { addQueryPrefix: true })}#calendar-heading`,
   )
 
   return {

--- a/server/utils/admin/nationalOccupancyUtils.ts
+++ b/server/utils/admin/nationalOccupancyUtils.ts
@@ -51,6 +51,7 @@ export const expandManagementArea = (cruManagementAreas: Array<Cas1CruManagement
 export const processCapacity = (
   capacity: Cas1NationalOccupancy,
   postcode: string,
+  roomCriteria: Array<Cas1SpaceCharacteristic>,
 ): Array<{ summaryRows: Array<string>; apCapacity: Array<{ capacity: string; link: string; classes: string }> }> =>
   capacity.premises.map(premises => ({
     summaryRows: [
@@ -60,10 +61,16 @@ export const processCapacity = (
       postcode && `${premises.distanceInMiles.toFixed(1)} miles from ${postcode}`,
     ].filter(Boolean),
 
-    apCapacity: premises.capacity.map(({ forRoomCharacteristic, vacantBedCount, inServiceBedCount }) => {
+    apCapacity: premises.capacity.map(({ forRoomCharacteristic, vacantBedCount, inServiceBedCount, date }) => {
       return {
         capacity: `${vacantBedCount}${forRoomCharacteristic ? '' : `/${inServiceBedCount}`}`,
-        link: '#',
+        link: `${paths.admin.nationalOccupancy.premisesDayView({ premisesId: premises.summary.id, date })}${createQueryString(
+          { criteria: roomCriteria },
+          {
+            arrayFormat: 'repeat',
+            addQueryPrefix: true,
+          },
+        )}`,
         classes: vacantBedCount > 0 ? 'govuk-tag--green' : 'govuk-tag--red',
       }
     }),
@@ -100,7 +107,8 @@ export const getCriteriaBlock = (
     (roomCriteria || []).map(characteristic => roomCharacteristicMap[characteristic as Cas1SpaceBookingCharacteristic]),
   )
   const apList = ddList((apCriteria || []).map(characteristic => spaceSearchCriteriaApLevelLabels[characteristic]))
-  return `<dl class="details-list"><dt>AP criteria:</dt>${apList}<dt>Room criteria:</dt>${roomList}</dl>`
+
+  return `<dl class="details-list">${apCriteria !== undefined ? `<dt>AP criteria:</dt>${apList}` : ''}<dt>Room criteria:</dt>${roomList}</dl>`
 }
 
 export const getDateHeader = (capacity: Cas1NationalOccupancy): Array<string> => {

--- a/server/utils/match/occupancy.test.ts
+++ b/server/utils/match/occupancy.test.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker'
 import { Cas1PremiseCapacityForDay } from '@approved-premises/api'
 import { cas1PremiseCapacityForDayFactory } from '../../testutils/factories'
-import { dayAvailabilityCount, dayAvailabilityStatus, durationSelectOptions } from './occupancy'
+import { dayAvailabilityCount, dayAvailabilityStatusForCriteria, durationSelectOptions } from './occupancy'
 import { premiseCharacteristicAvailability } from '../../testutils/factories/cas1PremiseCapacity'
 
 const capacityWithCriteria: Cas1PremiseCapacityForDay = cas1PremiseCapacityForDayFactory.build({
@@ -67,19 +67,19 @@ describe('dayAvailabilityStatus', () => {
     it('returns available if there is availability', () => {
       const capacityForDay = cas1PremiseCapacityForDayFactory.available().build()
 
-      expect(dayAvailabilityStatus(capacityForDay)).toEqual('available')
+      expect(dayAvailabilityStatusForCriteria(capacityForDay)).toEqual('available')
     })
 
     it('returns overbooked if the day is overbooked', () => {
       const capacityForDay = cas1PremiseCapacityForDayFactory.overbooked().build()
 
-      expect(dayAvailabilityStatus(capacityForDay)).toEqual('overbooked')
+      expect(dayAvailabilityStatusForCriteria(capacityForDay)).toEqual('overbooked')
     })
 
     it('returns full if the day is at capacity', () => {
       const capacityForDay = cas1PremiseCapacityForDayFactory.full().build()
 
-      expect(dayAvailabilityStatus(capacityForDay)).toEqual('full')
+      expect(dayAvailabilityStatusForCriteria(capacityForDay)).toEqual('full')
     })
   })
 
@@ -95,17 +95,17 @@ describe('dayAvailabilityStatus', () => {
       })
 
       it('returns available if there is availability for all the criteria', () => {
-        expect(dayAvailabilityStatus(capacityForDay, ['isSuitedForSexOffenders', 'isArsonSuitable'])).toEqual(
-          'available',
-        )
+        expect(
+          dayAvailabilityStatusForCriteria(capacityForDay, ['isSuitedForSexOffenders', 'isArsonSuitable']),
+        ).toEqual('available')
       })
 
       it('returns full if one of the required criteria is full', () => {
-        expect(dayAvailabilityStatus(capacityForDay, ['isSingle', 'isArsonSuitable'])).toEqual('full')
+        expect(dayAvailabilityStatusForCriteria(capacityForDay, ['isSingle', 'isArsonSuitable'])).toEqual('full')
       })
 
       it('returns overbooked if one of the required criteria is overbooked', () => {
-        expect(dayAvailabilityStatus(capacityForDay, ['isSingle', 'hasEnSuite'])).toEqual('overbooked')
+        expect(dayAvailabilityStatusForCriteria(capacityForDay, ['isSingle', 'hasEnSuite'])).toEqual('overbooked')
       })
     })
 
@@ -120,7 +120,7 @@ describe('dayAvailabilityStatus', () => {
           characteristicAvailability,
         })
 
-        expect(dayAvailabilityStatus(capacity, ['isSingle'])).toEqual('full')
+        expect(dayAvailabilityStatusForCriteria(capacity, ['isSingle'])).toEqual('full')
       })
 
       it('returns overbooked if general availability is overbooked', () => {
@@ -128,7 +128,7 @@ describe('dayAvailabilityStatus', () => {
           characteristicAvailability,
         })
 
-        expect(dayAvailabilityStatus(capacity, ['hasEnSuite'])).toEqual('overbooked')
+        expect(dayAvailabilityStatusForCriteria(capacity, ['hasEnSuite'])).toEqual('overbooked')
       })
     })
   })

--- a/server/utils/match/occupancy.ts
+++ b/server/utils/match/occupancy.ts
@@ -16,7 +16,7 @@ export const dayAvailabilityCount = (
 
 export type DayAvailabilityStatus = 'available' | 'full' | 'overbooked'
 
-export const dayAvailabilityStatus = (
+export const dayAvailabilityStatusForCriteria = (
   dayCapacity: Cas1PremiseCapacityForDay,
   criteria: Array<Cas1SpaceBookingCharacteristic> = [],
 ): DayAvailabilityStatus => {

--- a/server/utils/match/occupancyCalendar.ts
+++ b/server/utils/match/occupancyCalendar.ts
@@ -1,6 +1,6 @@
 import type { Cas1PremiseCapacityForDay, Cas1SpaceBookingCharacteristic } from '@approved-premises/api'
 import { DateFormats } from '../dateUtils'
-import { dayAvailabilityCount, type DayAvailabilityStatus, dayAvailabilityStatus } from './occupancy'
+import { dayAvailabilityCount, type DayAvailabilityStatus, dayAvailabilityStatusForCriteria } from './occupancy'
 
 type CalendarDay = {
   date: string
@@ -39,7 +39,7 @@ export const occupancyCalendar = (
     const calendarDay: CalendarDay = {
       date: day.date,
       name: DateFormats.isoDateToUIDate(day.date, { format: 'longNoYear' }),
-      status: dayAvailabilityStatus(day, criteria),
+      status: dayAvailabilityStatusForCriteria(day, criteria),
       capacity: day.availableBedCount,
       bookableCount,
       link: placeholderLink.replace(':date', day.date),

--- a/server/views/admin/nationalOccupancy/index.njk
+++ b/server/views/admin/nationalOccupancy/index.njk
@@ -43,7 +43,7 @@
 
     {% if processedCapacity %}
 
-        <section>
+        <section id="calendar-heading">
             <h2 class="govuk-heading-l">Showing spaces from {{ formatDate(fromDate,{format:'short'}) }}</h2>
             <h3 class="govuk-heading-m">{{ processedCapacity.length }} Approved Premises found</h3>
             {{ criteriaBlock | safe }}

--- a/server/views/admin/nationalOccupancy/partials/_singleApCalendar.njk
+++ b/server/views/admin/nationalOccupancy/partials/_singleApCalendar.njk
@@ -6,8 +6,8 @@
             <span class="govuk-!-font-weight-bold">{{ day.criteriaBookableCount }}</span>
         </dd>
     {% else %}
-    <dd>
-        <span class="govuk-!-font-weight-bold">{{ day.bookableCount }}/{{ day.capacity }}</span>
-    </dd>
-{% endif %}
+        <dd>
+            <span class="govuk-!-font-weight-bold">{{ day.bookableCount }}/{{ day.capacity }}</span>
+        </dd>
+    {% endif %}
 {% endblock %}

--- a/server/views/admin/nationalOccupancy/partials/_singleApCalendar.njk
+++ b/server/views/admin/nationalOccupancy/partials/_singleApCalendar.njk
@@ -1,0 +1,13 @@
+{% extends "partials/_calendar.njk" %}
+
+{% block dayContent %}
+    {% if day.criteriaBookableCount is defined %}
+        <dd>
+            <span class="govuk-!-font-weight-bold">{{ day.criteriaBookableCount }}</span>
+        </dd>
+    {% else %}
+    <dd>
+        <span class="govuk-!-font-weight-bold">{{ day.bookableCount }}/{{ day.capacity }}</span>
+    </dd>
+{% endif %}
+{% endblock %}

--- a/server/views/admin/nationalOccupancy/partials/_weekCalendar.njk
+++ b/server/views/admin/nationalOccupancy/partials/_weekCalendar.njk
@@ -11,7 +11,7 @@
         <tbody>
         {% for ap in capacity %}
             <tr>
-                <th class="govuk-table__header" scope="row" role="rowheader">
+                <th class="govuk-table__header" scope="row">
                     <dl>
                         {% for field in ap.summaryRows %}
                             <dd>{{ field | safe }}</dd>
@@ -19,12 +19,12 @@
                     </dl>
                 </th>
                 {% for day in ap.apCapacity %}
-                    <td class="{{ day.classes }}" role="cell">
-                        <a class="calendar__link" href="#"
-                           {% if day.link %}href="{{ day.link }}"{% endif %}>
+                    <td class="{{ day.classes }}">
+                        <a class="calendar__link"
+                           href="{{ day.link }}">
                             <dl class="calendar__availability">
                                 <dt class="govuk-visually-hidden">Availability:</dt>
-                                <dd>{{ day.capacity }}</dd>
+                                <dd class="govuk-!-font-weight-bold">{{ day.capacity }}</dd>
                             </dl>
                         </a>
                     </td>

--- a/server/views/admin/nationalOccupancy/premises.njk
+++ b/server/views/admin/nationalOccupancy/premises.njk
@@ -1,0 +1,53 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "partials/filters.njk" import filterWrapper, filterSelect, filterDatepicker, filterCheckboxes %}
+{% from "./partials/_singleApCalendar.njk" import occupancyCalendar %}
+{% from "partials/_calendar.njk" import calendarKey %}
+
+{%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+
+{% extends "partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + pageHeading %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        text: "Back to all APs",
+        href: backLink
+    }) }}
+{% endblock %}
+
+{% set titleHtml %}
+
+{% endset %}
+
+{% block content %}
+    {{ showErrorSummary(errorSummary) }}
+    <span class="govuk-caption-l">{{ premises.name }}</span>
+    <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+
+    {% call filterWrapper('Filter') %}
+        {{ filterDatepicker('arrivalDate', 'Arrival date', fetchContext()) }}
+        {{ filterSelect('durationDays', 'Duration', durationOptions) }}
+        {{ filterCheckboxes('roomCriteria', 'Room criteria', criteriaOptions) }}
+    {% endcall %}
+
+    {% if errorSummary.length === 0 %}
+
+        {{ criteriaBlock | safe }}
+
+        {{ calendarKey() }}
+
+        <section id="calendar" aria-describedby="calendar-key">
+            {{ occupancyCalendar(calendar) }}
+        </section>
+    {% endif %}
+
+{% endblock %}
+
+

--- a/server/views/manage/premises/placements/changes/new.njk
+++ b/server/views/manage/premises/placements/changes/new.njk
@@ -60,7 +60,7 @@
 
             {{ calendarKey() }}
 
-            <section aria-describedby="calendar-key">
+            <section id="calendar" aria-describedby="calendar-key">
                 {{ occupancyCalendar(calendar) }}
             </section>
         {% endif %}

--- a/server/views/match/placementRequests/occupancyView/view.njk
+++ b/server/views/match/placementRequests/occupancyView/view.njk
@@ -64,15 +64,13 @@
 
         {% if not errors.startDate %}
 
-
-
             <section class="govuk-visually-hidden">
                 {{ occupancySummary(summary) }}
             </section>
 
             {{ calendarKey() }}
 
-            <section aria-describedby="calendar-key">
+            <section id="calendar" aria-describedby="calendar-key">
                 {{ occupancyCalendar(calendar) }}
             </section>
         {% endif %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2449

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Adds a single AP occupancy view page and a single premises single day view page as part of the national occupancy view.
The premises view has a new controller as there are too many differences between the page operating within match (in the context of a Placement request) and in the national view where there is no placement request. In this case, many of the calendar processing utilities are re-used and the calendar outer template is defined, but inheriting the majority of its functionality from the generic calendar template. The designs have not been followed in that the rendering of calendar days/cells match the national view since there should be consistency on successive pages used in conjunction.

The single day view is almost unchanged from the version in match, save for the lack of placement request context. A new route has been added to the existing controller and some of the controller logic tweaked to handle the case where the placement request id is not provided.

The connection of links is quite complex since the single premises/day view can be reached from either the national view (by clicking on a day) or from the single premises view. The back buttons should return the user to the page they accessed it from.  Also, the parameters of the search (room criteria and start date) are passed from the national view to the premises view in the session so that if the filter is updated in either view, the changes are persisted to the other. The duration selected in the premises view is also persisted in the session. This session object is not cleared so whenever the user returns to the national view within the same session, the last filter choices will be retained - although the results will not load automatically.

Also, a tweak to the rendering of cells in the national week view. The choice of single number or ratio should be dependent on whether the user has chosen any room criteria or not, and be independent of the `forRoomCharacteristic` field returned for each cell. 

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

<details>
  <summary>Single premises calendar view</summary>
   <img src="https://github.com/user-attachments/assets/0e2c4c7c-0f3e-455c-b02a-204312c3ed6e"/>
</details>

<details>
  <summary>Single premises day view</summary>
   <img src="https://github.com/user-attachments/assets/994dfffb-2ba1-4059-ba2f-badd9d96dd90"/>
</details>
