### PR TITLE
APS-2564: Capture CRN in OOSB flow

### DIFF
--- a/e2e/pages/manage/markBedAsOutOfServicePage.ts
+++ b/e2e/pages/manage/markBedAsOutOfServicePage.ts
@@ -45,11 +45,9 @@ export class MarkBedAsOutOfServicePage extends BasePage {
     await this.enterOutOfServiceFromDate()
     await this.enterOutOfServiceToDate()
     await this.checkRadio('Planned Refurbishment (FM)')
-    await this.page.getByLabel('Work order reference number').fill('123456789')
+    await this.page.getByLabel('Work order reference number or CRN').fill('123456789')
     await this.page
-      .getByLabel(
-        'Provide  detail about why the bed is out of service. If FM works are required you should update this record with any progress on that work.',
-      )
+      .getByLabel('Details about why the bed is out of service')
       .fill('Reasons for bed being out of service')
   }
 

--- a/e2e/pages/manage/updateOutOfServiceBedPage.ts
+++ b/e2e/pages/manage/updateOutOfServiceBedPage.ts
@@ -8,7 +8,8 @@ export class UpdateOutOfServiceBedPage extends BasePage {
   }
 
   async updateBed(update: Record<string, string>) {
-    await this.page.getByLabel('Work order reference number').fill(update.referenceNumber)
+    await this.checkRadio('Planned FM works required')
+    await this.page.getByLabel('Work order reference number or CRN').fill(update.referenceNumber)
     await this.page.getByLabel('Provide additional information').fill(update.additionalInformation)
   }
 }

--- a/e2e/tests/manage/out-of-service-beds.spec.ts
+++ b/e2e/tests/manage/out-of-service-beds.spec.ts
@@ -48,7 +48,7 @@ const markABedAsOutOfService = async (page: Page, futureManager: UserLoginDetail
   // When I fill in and submit the manage out-of-service-bed form
   const markBedAsOutOfServicePage = await MarkBedAsOutOfServicePage.initialize(page, 'Mark a bed as out of service')
   await markBedAsOutOfServicePage.completeForm()
-  await markBedAsOutOfServicePage.clickSave()
+  await markBedAsOutOfServicePage.clickSubmit('Save')
 
   // If there is a booking conflict then add 3 days to the start date and try again
   await markBedAsOutOfServicePage.ensureNoBookingConflict()
@@ -122,7 +122,7 @@ test('Future manager updates an out of service bed', async ({ page, futureManage
     additionalInformation: `Additional information about update ${uniqueReferenceNumber}`,
   }
   await updateOOSBedPage.updateBed(update)
-  await updateOOSBedPage.clickSave()
+  await updateOOSBedPage.clickSubmit('Save')
 
   // Then I should see the out of service bed timeline page with the updated details
   const outOfServiceBedPage2 = await OutOfServiceBedPage.initialize(page)

--- a/integration_tests/mockApis/referenceData.ts
+++ b/integration_tests/mockApis/referenceData.ts
@@ -9,6 +9,7 @@ import {
   nonArrivalReasonsFactory,
   referenceDataFactory,
 } from '../../server/testutils/factories'
+import paths from '../../server/paths/api'
 
 export const stubApAreaReferenceData = (
   {
@@ -28,7 +29,7 @@ export const stubApAreaReferenceData = (
   return stubFor({
     request: {
       method: 'GET',
-      url: '/reference-data/ap-areas',
+      url: paths.referenceData({ type: 'ap-areas' }),
     },
     response: {
       status: 200,
@@ -48,7 +49,7 @@ export const stubCruManagementAreaReferenceData = (
   return stubFor({
     request: {
       method: 'GET',
-      url: '/cas1/reference-data/cru-management-areas',
+      url: paths.cas1ReferenceData({ type: 'cru-management-areas' }),
     },
     response: {
       status: 200,
@@ -64,7 +65,7 @@ export const stubNonArrivalReasonsReferenceData = (nonArrivalReasons: Array<NonA
   return stubFor({
     request: {
       method: 'GET',
-      url: '/cas1/reference-data/non-arrival-reasons',
+      url: paths.cas1ReferenceData({ type: 'non-arrival-reasons' }),
     },
     response: {
       status: 200,
@@ -80,7 +81,7 @@ const stubDepartureReasonsReferenceData = (departureReasons?: Array<ReferenceDat
   stubFor({
     request: {
       method: 'GET',
-      url: '/cas1/reference-data/departure-reasons',
+      url: paths.cas1ReferenceData({ type: 'departure-reasons' }),
     },
     response: {
       status: 200,
@@ -95,7 +96,7 @@ const stubMoveOnCategoriesReferenceData = (moveOnCategories?: Array<ReferenceDat
   stubFor({
     request: {
       method: 'GET',
-      url: '/cas1/reference-data/move-on-categories',
+      url: paths.cas1ReferenceData({ type: 'move-on-categories' }),
     },
     response: {
       status: 200,
@@ -116,7 +117,7 @@ const stubChangeRequestReasonsReferenceData = ({
   stubFor({
     request: {
       method: 'GET',
-      url: `/cas1/reference-data/change-request-reasons/${changeRequestType}`,
+      url: paths.cas1ReferenceData({ type: `change-request-reasons/${changeRequestType}` }),
     },
     response: {
       status: 200,
@@ -137,7 +138,7 @@ const stubChangeRequestRejectionReasonsReferenceData = ({
   stubFor({
     request: {
       method: 'GET',
-      url: `/cas1/reference-data/change-request-rejection-reasons/${changeRequestType}`,
+      url: paths.cas1ReferenceData({ type: `change-request-rejection-reasons/${changeRequestType}` }),
     },
     response: {
       status: 200,

--- a/integration_tests/pages/manage/outOfServiceBeds/outOfServiceBedCreate.ts
+++ b/integration_tests/pages/manage/outOfServiceBeds/outOfServiceBedCreate.ts
@@ -31,16 +31,13 @@ export class OutOfServiceBedCreatePage extends Page {
     cy.get('input[name="endDate-month"]').type(String(endDate.getMonth() + 1))
     cy.get('input[name="endDate-year"]').type(String(endDate.getFullYear()))
 
+    cy.get(`input[name="reason"][value="${outOfServiceBed.reason.id}"]`).check()
+
     if (outOfServiceBed.referenceNumber) {
-      cy.get('input[name="outOfServiceBed[referenceNumber]"]').type(outOfServiceBed.referenceNumber)
+      cy.get('input[name="referenceNumber"]').type(outOfServiceBed.referenceNumber)
     }
 
-    cy.get(`input[name="outOfServiceBed[reason]"][value="${outOfServiceBed.reason.id}"]`).check()
-    cy.get('[name="outOfServiceBed[notes]"]').type(outOfServiceBed.notes)
-  }
-
-  public clickSubmit(): void {
-    cy.get('[name="outOfServiceBed[submit]"]').click()
+    cy.get('[name="notes"]').type(outOfServiceBed.notes)
   }
 
   shouldShowDateConflictErrorMessages(

--- a/integration_tests/pages/manage/outOfServiceBeds/outOfServiceBedShow.ts
+++ b/integration_tests/pages/manage/outOfServiceBeds/outOfServiceBedShow.ts
@@ -35,7 +35,7 @@ export class OutOfServiceBedShowPage extends Page {
     }
     if (this.outOfServiceBed.reason) this.assertDefinition('Reason', this.outOfServiceBed.reason.name)
     if (this.outOfServiceBed.referenceNumber)
-      this.assertDefinition('Reference number', this.outOfServiceBed.referenceNumber)
+      this.assertDefinition('Reference/CRN', this.outOfServiceBed.referenceNumber)
     if (this.outOfServiceBed.notes) this.assertDefinition('Additional information', this.outOfServiceBed.notes)
   }
 

--- a/integration_tests/pages/manage/outOfServiceBeds/outOfServiceBedUpdate.ts
+++ b/integration_tests/pages/manage/outOfServiceBeds/outOfServiceBedUpdate.ts
@@ -23,9 +23,9 @@ export class OutOfServiceBedUpdatePage extends Page {
   completeForm(outOfServiceBedUpdate: OutOfServiceBed): void {
     this.clearAndCompleteDateInputs('startDate', outOfServiceBedUpdate.startDate)
     this.clearAndCompleteDateInputs('endDate', outOfServiceBedUpdate.endDate)
-    this.checkRadioByNameAndValue('outOfServiceBed[reason]', outOfServiceBedUpdate.reason.id)
+    this.checkRadioByNameAndValue('reason', outOfServiceBedUpdate.reason.id)
     if (outOfServiceBedUpdate.referenceNumber)
       this.clearAndCompleteTextInputById('referenceNumber', outOfServiceBedUpdate.referenceNumber)
-    this.completeTextArea('outOfServiceBed[notes]', outOfServiceBedUpdate.notes)
+    this.completeTextArea('notes', outOfServiceBedUpdate.notes)
   }
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -750,7 +750,7 @@ export default abstract class Page {
     }
 
     if (bedDetails.referenceNumber) {
-      cy.get('.govuk-summary-list__key').should('contain', 'Reference number')
+      cy.get('.govuk-summary-list__key').should('contain', 'Reference/CRN')
       cy.get('.govuk-summary-list__value').should('contain', bedDetails.referenceNumber)
     }
 

--- a/integration_tests/tests/manage/outOfServiceBeds.cy.ts
+++ b/integration_tests/tests/manage/outOfServiceBeds.cy.ts
@@ -19,13 +19,14 @@ import { signIn } from '../signIn'
 import { sortOutOfServiceBedRevisionsByUpdatedAt } from '../../../server/utils/outOfServiceBedUtils'
 import paths from '../../../server/paths/api'
 import BedShowPage from '../../pages/manage/bed/bedShow'
+import { AND, GIVEN, THEN, WHEN } from '../../helpers'
 
 describe('Out of service beds', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubOutOfServiceBedReasons')
 
-    // Given I am signed in as a Future manager
+    GIVEN('I am signed in as a Future manager')
     signIn('future_manager')
   })
 
@@ -35,20 +36,20 @@ describe('Out of service beds', () => {
     cy.task('stubOutOfServiceBedsList', { outOfServiceBeds, page: 1, perPage: 50, premisesId: premises.id })
     cy.task('stubSinglePremises', premises)
 
-    // Given I am on the out-of-service bed list for the premises
+    GIVEN('I am on the out-of-service bed list for the premises')
     OutOfServiceBedPremisesIndexPage.visit(premises)
 
-    // Then I should see the list of out-of-service beds for the premises
+    THEN('I should see the list of out-of-service beds for the premises')
     const page = Page.verifyOnPage(OutOfServiceBedPremisesIndexPage, premises)
 
-    // And I should see the count of total results (not limited to page)
+    AND('I should see the count of total results (not limited to page)')
     page.hasCountOfAllResultsMatchingFilter()
   })
 
   describe('viewing an out of service bed record', () => {
     describe('for a new out of service bed with all nullable fields present in the initial OoS bed revision', () => {
       it('should show a out of service bed', () => {
-        // And I have created a out of service bed
+        AND('I have created a out of service bed')
         const bed = { name: 'abc', id: '123' }
         const premises = premisesFactory.build()
         const outOfServiceBed = outOfServiceBedFactory.build({ bed })
@@ -58,29 +59,29 @@ describe('Out of service beds', () => {
         cy.task('stubOutOfServiceBed', { premisesId: premises.id, outOfServiceBed })
         cy.task('stubBed', { premisesId: premises.id, bedDetail })
 
-        // And I visit that out of service bed's show page
+        AND("I visit that out of service bed's show page")
         const page = OutOfServiceBedShowPage.visit(premises.id, outOfServiceBed)
 
-        // Then I should see the latest details of that out of service bed
+        THEN('I should see the latest details of that out of service bed')
         page.shouldShowOutOfServiceBedDetail()
 
-        // And I should see the bed characteristics
+        AND('I should see the bed characteristics')
         page.shouldShowCharacteristics(bedDetail)
 
-        // And I should see links to the premises and bed in the page heading
+        AND('I should see links to the premises and bed in the page heading')
         page.shouldLinkToPremisesAndBed(outOfServiceBed)
 
-        // When I click the 'Timeline' tab
+        WHEN("I click the 'Timeline' tab")
         page.clickTab('Timeline')
 
-        // Then I should see the timeline of that out of service bed's revision
+        THEN("I should see the timeline of that out of service bed's revision")
         page.shouldShowTimeline()
       })
     })
 
     describe('for a legacy "lost bed" records migrated with all nullable fields not present in the initial OoS bed revision', () => {
       it('should show a out of service bed', () => {
-        // And I have created a out of service bed
+        AND('I have created a out of service bed')
         const bed = { name: 'abc', id: '123' }
         const premises = premisesFactory.build()
         const outOfServiceBedRevision = outOfServiceBedRevisionFactory.build({
@@ -100,13 +101,13 @@ describe('Out of service beds', () => {
         cy.task('stubOutOfServiceBed', { premisesId: premises.id, outOfServiceBed })
         cy.task('stubBed', { premisesId: premises.id, bedDetail })
 
-        // And I visit that out of service bed's show page
+        AND("I visit that out of service bed's show page")
         const page = OutOfServiceBedShowPage.visit(premises.id, outOfServiceBed)
 
-        // When I click the 'Timeline' tab
+        WHEN("I click the 'Timeline' tab")
         page.clickTab('Timeline')
 
-        // Then I should see the timeline of that out of service bed's revision
+        THEN("I should see the timeline of that out of service bed's revision")
         page.shouldShowTimeline()
       })
     })
@@ -128,14 +129,14 @@ describe('Out of service beds', () => {
       const bedDetail = cas1BedDetailFactory.build({ id: outOfServiceBed.bed.id, name: bedName })
       cy.task('stubBed', { premisesId: premises.id, bedDetail })
 
-      // When I navigate to the out of service bed form
+      WHEN('I navigate to the out of service bed form')
       const page = OutOfServiceBedCreatePage.visit(premises.id, outOfServiceBed.bed.id)
 
-      // And I fill out the form
+      AND('I fill out the form')
       page.completeForm(outOfServiceBed)
       page.clickSubmit()
 
-      // Then a POST to the API should be made to create the OOSB record
+      THEN('a POST to the API should be made to create the OOSB record')
       cy.task('verifyApiPost', paths.manage.premises.outOfServiceBeds.create({ premisesId: premises.id })).then(
         (requestBody: Cas1NewOutOfServiceBed) => {
           expect(requestBody.startDate).equal(outOfServiceBed.startDate)
@@ -146,21 +147,21 @@ describe('Out of service beds', () => {
         },
       )
 
-      // And I should be redirected to the bed page
+      AND('I should be redirected to the bed page')
       const bedPage = Page.verifyOnPage(BedShowPage, bedName)
 
-      // And I should see the confirmation message
+      AND('I should see the confirmation message')
       bedPage.shouldShowBanner('The out of service bed has been recorded')
     })
 
     it('should show errors', () => {
-      // And a out of service bed is available
+      AND('a out of service bed is available')
       const premises = cas1PremisesFactory.build()
 
-      // When I navigate to the out of service bed form
+      WHEN('I navigate to the out of service bed form')
       const page = OutOfServiceBedCreatePage.visit(premises.id, 'bedId')
 
-      // And I have errors on validated fields
+      AND('I have errors on validated fields')
       cy.task('stubOutOfServiceBedErrors', {
         premisesId: premises.id,
         params: ['startDate', 'endDate', 'reason', 'notes'],
@@ -168,7 +169,7 @@ describe('Out of service beds', () => {
 
       page.clickSubmit()
 
-      // Then I should see error messages relating to that field
+      THEN('I should see error messages relating to that field')
       page.shouldShowErrorMessagesForFields(['startDate', 'endDate', 'reason', 'notes'])
     })
 
@@ -185,7 +186,7 @@ describe('Out of service beds', () => {
       const bedDetail = cas1BedDetailFactory.build({ id: bed.id })
       cy.task('stubBed', { premisesId: premises.id, bedDetail })
 
-      // When I navigate to the out of service bed form
+      WHEN('I navigate to the out of service bed form')
       const outOfServiceBed = outOfServiceBedFactory.build({
         bed,
         startDate: '2022-02-11',
@@ -199,11 +200,11 @@ describe('Out of service beds', () => {
 
       const page = OutOfServiceBedCreatePage.visit(premises.id, outOfServiceBed.bed.id)
 
-      // And I fill out the form
+      AND('I fill out the form')
       page.completeForm(outOfServiceBed)
       page.clickSubmit()
 
-      // Then I should see an error message
+      THEN('I should see an error message')
       page.shouldShowDateConflictErrorMessages(conflictingOutOfServiceBed, 'lost-bed')
     })
   })
@@ -217,30 +218,30 @@ describe('Out of service beds', () => {
       })
       const bedDetail = cas1BedDetailFactory.build({ id: bed.id })
 
-      // Given I am viewing an out of service bed
+      GIVEN('I am viewing an out of service bed')
       cy.task('stubOutOfServiceBed', { premisesId: premises.id, outOfServiceBed })
       cy.task('stubBed', { premisesId: premises.id, bedDetail })
       const showPage = OutOfServiceBedShowPage.visit(premises.id, outOfServiceBed)
 
-      // When I click 'Update record'
+      WHEN("I click 'Update record'")
       showPage.clickAction('Update out of service bed')
 
-      // Then I should be taken to the OoS bed update page
+      THEN('I should be taken to the OoS bed update page')
       const updatePage = Page.verifyOnPage(OutOfServiceBedUpdatePage, outOfServiceBed)
 
-      // And it should show the details of the bed from the OoS bed record
+      AND('it should show the details of the bed from the OoS bed record')
       updatePage.shouldShowOutOfServiceBedDetails(outOfServiceBed)
       updatePage.formShouldBePrepopulated()
 
-      // Given I want to update some details of the OoS bed
+      GIVEN('I want to update some details of the OoS bed')
       cy.task('stubOutOfServiceBedUpdate', { premisesId: premises.id, outOfServiceBed })
       const updatedOutOfServiceBed = outOfServiceBedFactory.build({ id: outOfServiceBed.id, bed })
 
-      // When I submit the form
+      WHEN('I submit the form')
       updatePage.completeForm(updatedOutOfServiceBed)
       updatePage.clickSubmit()
 
-      // Then the update is sent to the API
+      THEN('the update is sent to the API')
       cy.task(
         'verifyApiPut',
         paths.manage.premises.outOfServiceBeds.update({ premisesId: premises.id, id: outOfServiceBed.id }),
@@ -259,10 +260,10 @@ describe('Out of service beds', () => {
         expect(body).to.contain(expectedBody)
       })
 
-      // And I should be taken back to the OoS bed timeline page
+      AND('I should be taken back to the OoS bed timeline page')
       Page.verifyOnPage(OutOfServiceBedShowPage, premises.id, outOfServiceBed)
 
-      // And I should see a flash message informing me that the OoS bed has been updated
+      AND('I should see a flash message informing me that the OoS bed has been updated')
       showPage.shouldShowUpdateConfirmationMessage()
     })
 
@@ -275,17 +276,17 @@ describe('Out of service beds', () => {
           bed,
         })
 
-        // Given I am updating an out of service bed
+        GIVEN('I am updating an out of service bed')
         cy.task('stubOutOfServiceBed', { premisesId: premises.id, outOfServiceBed })
         cy.task('stubUpdateOutOfServiceBedErrors', { premisesId: premises.id, outOfServiceBed, params: [dateField] })
 
         const updatePage = OutOfServiceBedUpdatePage.visit(premises.id, outOfServiceBed)
 
-        // When I submit the form with no date
+        WHEN('I submit the form with no date')
         updatePage.clearDateInputs(dateField)
         updatePage.clickSubmit()
 
-        // Then I see an error
+        THEN('I see an error')
         updatePage.shouldShowErrorMessagesForFields([dateField])
       })
     })
@@ -296,7 +297,7 @@ describe('Cancelling an out of service bed', () => {
   beforeEach(() => {
     cy.task('reset')
 
-    // Given I am signed in as a CRU member
+    GIVEN('I am signed in as a CRU member')
     signIn('cru_member')
   })
 
@@ -312,7 +313,7 @@ describe('Cancelling an out of service bed', () => {
     const outOfServiceBed = outOfServiceBeds[0]
     const bedDetail = cas1BedDetailFactory.build({ id: bed.id })
 
-    // Given I am viewing an out of service bed
+    GIVEN('I am viewing an out of service bed')
     cy.task('stubOutOfServiceBed', { premisesId, outOfServiceBed })
     cy.task('stubBed', { premisesId, bedDetail })
     cy.task('stubCancelOutOfServiceBed', { premisesId, outOfServiceBedId: outOfServiceBed.id })
@@ -320,35 +321,35 @@ describe('Cancelling an out of service bed', () => {
     cy.task('stubSinglePremises', premises)
     const showPage = OutOfServiceBedShowPage.visit(premisesId, outOfServiceBed)
 
-    // When I click the action 'Cancel out of service bed'
+    WHEN("I click the action 'Cancel out of service bed'")
     showPage.clickAction('Cancel out of service bed')
 
-    // Then I should be taken to the OOSB cancellation confirmation page
+    THEN('I should be taken to the OOSB cancellation confirmation page')
     const cancelPage = Page.verifyOnPage(OutOfServiceBedCancelPage, outOfServiceBed)
     cancelPage.checkOnPage()
 
-    // And I should see the details of the OOSB I'm about to cancel
+    AND("I should see the details of the OOSB I'm about to cancel")
     cancelPage.warningMessageShouldBeShown()
 
-    // When I click 'Go back'
+    WHEN("I click 'Go back'")
     cancelPage.clickLink('Go back')
 
     // I should be back on the OOB detail page
     Page.verifyOnPage(OutOfServiceBedShowPage, premisesId, outOfServiceBed)
 
-    // When I click the action 'Cancel out of service bed' again
+    WHEN("I click the action 'Cancel out of service bed' again")
     showPage.clickAction('Cancel out of service bed')
 
-    // Then I should be back on the confirmation page
+    THEN('I should be back on the confirmation page')
     Page.verifyOnPage(OutOfServiceBedCancelPage, outOfServiceBed)
 
-    // When I click Cancel out of service bed
+    WHEN('I click Cancel out of service bed')
     cancelPage.clickDoCancel()
 
-    // Then the cancellation is sent to the API
+    THEN('the cancellation is sent to the API')
     cy.task('verifyApiPost', paths.manage.premises.outOfServiceBeds.cancel({ premisesId, id: outOfServiceBed.id }))
 
-    // And I should be taken to the OOSB list page
+    AND('I should be taken to the OOSB list page')
     const listPage = Page.verifyOnPage(OutOfServiceBedPremisesIndexPage, premises)
     listPage.shouldShowBanner(
       `Cancelled out of service bed for ${outOfServiceBed.room.name} ${outOfServiceBed.bed.name}`,

--- a/server/@types/shared/index.d.ts
+++ b/server/@types/shared/index.d.ts
@@ -102,6 +102,7 @@ export type { Cas1OASysSupportingInformationQuestionMetaData } from './models/Ca
 export type { Cas1OutOfServiceBed } from './models/Cas1OutOfServiceBed';
 export type { Cas1OutOfServiceBedCancellation } from './models/Cas1OutOfServiceBedCancellation';
 export type { Cas1OutOfServiceBedReason } from './models/Cas1OutOfServiceBedReason';
+export type { Cas1OutOfServiceBedReasonReferenceType } from './models/Cas1OutOfServiceBedReasonReferenceType';
 export type { Cas1OutOfServiceBedRevision } from './models/Cas1OutOfServiceBedRevision';
 export type { Cas1OutOfServiceBedRevisionType } from './models/Cas1OutOfServiceBedRevisionType';
 export type { Cas1OutOfServiceBedSortField } from './models/Cas1OutOfServiceBedSortField';

--- a/server/@types/shared/models/Cas1OutOfServiceBedReason.ts
+++ b/server/@types/shared/models/Cas1OutOfServiceBedReason.ts
@@ -2,9 +2,11 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { Cas1OutOfServiceBedReasonReferenceType } from './Cas1OutOfServiceBedReasonReferenceType';
 export type Cas1OutOfServiceBedReason = {
     id: string;
     isActive: boolean;
     name: string;
+    referenceType: Cas1OutOfServiceBedReasonReferenceType;
 };
 

--- a/server/@types/shared/models/Cas1OutOfServiceBedReasonReferenceType.ts
+++ b/server/@types/shared/models/Cas1OutOfServiceBedReasonReferenceType.ts
@@ -1,0 +1,5 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type Cas1OutOfServiceBedReasonReferenceType = 'crn' | 'workOrder';

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -261,7 +261,7 @@ export interface ReferenceData {
   serviceScope: string
 }
 
-export interface Cas1ReferenceData {
+export type Cas1ReferenceData = {
   id: string
   name: string
   isActive: boolean

--- a/server/controllers/manage/outOfServiceBeds/outOfServiceBedsController.test.ts
+++ b/server/controllers/manage/outOfServiceBeds/outOfServiceBedsController.test.ts
@@ -86,6 +86,7 @@ describe('OutOfServiceBedsController', () => {
 
       expect(outOfServiceBedService.getOutOfServiceBedReasons).toHaveBeenCalledWith(token)
       expect(response.render).toHaveBeenCalledWith('manage/outOfServiceBeds/new', {
+        backlink: paths.premises.beds.show({ premisesId: request.params.premisesId, bedId: request.params.bedId }),
         premisesId,
         bedId: request.params.bedId,
         outOfServiceBedReasons: outOfServiceBedReasonsJson,

--- a/server/controllers/manage/outOfServiceBeds/outOfServiceBedsController.test.ts
+++ b/server/controllers/manage/outOfServiceBeds/outOfServiceBedsController.test.ts
@@ -89,6 +89,7 @@ describe('OutOfServiceBedsController', () => {
       expect(outOfServiceBedService.getOutOfServiceBedReasons).toHaveBeenCalledWith(token)
       expect(response.render).toHaveBeenCalledWith('manage/outOfServiceBeds/new', {
         backlink: paths.premises.beds.show({ premisesId: request.params.premisesId, bedId: request.params.bedId }),
+        pageHeading: 'Mark a bed as out of service',
         premisesId,
         bedId: request.params.bedId,
         outOfServiceBedReasons: outOfServiceBedReasonsJson,

--- a/server/controllers/manage/outOfServiceBeds/outOfServiceBedsController.ts
+++ b/server/controllers/manage/outOfServiceBeds/outOfServiceBedsController.ts
@@ -69,6 +69,7 @@ export default class OutOfServiceBedsController {
       const outOfServiceBedReasons = await this.outOfServiceBedService.getOutOfServiceBedReasons(req.user.token)
 
       return res.render('manage/outOfServiceBeds/new', {
+        backlink: paths.premises.beds.show({ premisesId, bedId }),
         premisesId,
         bedId,
         outOfServiceBedReasons,

--- a/server/controllers/manage/outOfServiceBeds/outOfServiceBedsController.ts
+++ b/server/controllers/manage/outOfServiceBeds/outOfServiceBedsController.ts
@@ -59,6 +59,7 @@ export default class OutOfServiceBedsController {
 
       return res.render('manage/outOfServiceBeds/new', {
         backlink: paths.premises.beds.show({ premisesId, bedId }),
+        pageHeading: 'Mark a bed as out of service',
         premisesId,
         bedId,
         outOfServiceBedReasons,

--- a/server/controllers/manage/outOfServiceBeds/updateOutOfServiceBedsController.test.ts
+++ b/server/controllers/manage/outOfServiceBeds/updateOutOfServiceBedsController.test.ts
@@ -58,7 +58,7 @@ describe('updateOutOfServiceBedController', () => {
 
       expect(outOfServiceBedService.getOutOfServiceBed).toHaveBeenCalledWith(token, premisesId, outOfServiceBed.id)
       expect(response.render).toHaveBeenCalledWith('manage/outOfServiceBeds/update', {
-        pageHeading: 'updateOutOfServiceBedsController',
+        pageHeading: 'Update out of service bed record',
         backlink: paths.outOfServiceBeds.show({
           premisesId: request.params.premisesId,
           bedId: request.params.bedId,

--- a/server/controllers/manage/outOfServiceBeds/updateOutOfServiceBedsController.test.ts
+++ b/server/controllers/manage/outOfServiceBeds/updateOutOfServiceBedsController.test.ts
@@ -1,6 +1,5 @@
 import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
-import { when } from 'jest-when'
 
 import { ErrorsAndUserInput } from '@approved-premises/ui'
 import { Cas1OutOfServiceBedReason } from '@approved-premises/api'
@@ -44,9 +43,7 @@ describe('updateOutOfServiceBedController', () => {
       },
     })
 
-    when(outOfServiceBedService.getOutOfServiceBed)
-      .calledWith(request.user.token, premisesId, outOfServiceBed.id)
-      .mockResolvedValue(outOfServiceBed)
+    outOfServiceBedService.getOutOfServiceBed.mockResolvedValue(outOfServiceBed)
     outOfServiceBedService.getOutOfServiceBedReasons.mockResolvedValue(
       outOfServiceBedReasonsJson as Array<Cas1OutOfServiceBedReason>,
     )

--- a/server/controllers/manage/outOfServiceBeds/updateOutOfServiceBedsController.ts
+++ b/server/controllers/manage/outOfServiceBeds/updateOutOfServiceBedsController.ts
@@ -44,7 +44,7 @@ export default class UpdateOutOfServiceBedsController {
       } = outOfServiceBed
 
       res.render('manage/outOfServiceBeds/update', {
-        pageHeading: 'updateOutOfServiceBedsController',
+        pageHeading: 'Update out of service bed record',
         backlink: paths.outOfServiceBeds.show({ premisesId, bedId, id, tab: 'details' }),
         outOfServiceBedSummary: outOfServiceBedSummaryList(outOfServiceBed),
         outOfServiceBedReasons,

--- a/server/controllers/manage/outOfServiceBeds/updateOutOfServiceBedsController.ts
+++ b/server/controllers/manage/outOfServiceBeds/updateOutOfServiceBedsController.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../utils/validation'
 import paths from '../../../paths/manage'
 import { SanitisedError } from '../../../sanitisedError'
-import { overwriteOoSBedWithUserInput } from '../../../utils/outOfServiceBedUtils'
+import { outOfServiceBedSummaryList } from '../../../utils/outOfServiceBedUtils'
 
 export default class UpdateOutOfServiceBedsController {
   constructor(private readonly outOfServiceBedService: OutOfServiceBedService) {}
@@ -22,21 +22,25 @@ export default class UpdateOutOfServiceBedsController {
       const outOfServiceBedReasons = await this.outOfServiceBedService.getOutOfServiceBedReasons(req.user.token)
       const outOfServiceBed = await this.outOfServiceBedService.getOutOfServiceBed(req.user.token, premisesId, id)
 
-      const outOfServiceBedWithUserInput = overwriteOoSBedWithUserInput(userInput, outOfServiceBed)
+      const {
+        reason: { id: reason },
+        referenceNumber,
+      } = outOfServiceBed
 
       res.render('manage/outOfServiceBeds/update', {
         pageHeading: 'updateOutOfServiceBedsController',
-        premisesId,
-        bedId,
-        id,
+        backlink: paths.outOfServiceBeds.show({ premisesId, bedId, id, tab: 'details' }),
+        outOfServiceBedSummary: outOfServiceBedSummaryList(outOfServiceBed),
         outOfServiceBedReasons,
         ...DateFormats.isoDateToDateInputs(outOfServiceBed.startDate, 'startDate'),
         ...DateFormats.isoDateToDateInputs(outOfServiceBed.endDate, 'endDate'),
+        reason,
+        referenceNumber,
+        notes: '',
         errors,
         errorSummary,
         errorTitle,
         ...userInput,
-        outOfServiceBed: outOfServiceBedWithUserInput,
       })
     }
   }
@@ -45,18 +49,19 @@ export default class UpdateOutOfServiceBedsController {
     return async (req: Request, res: Response) => {
       const { premisesId, bedId, id } = req.params
 
-      const { startDate } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'startDate')
-      const { endDate } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'endDate')
-
-      const outOfServiceBed = {
-        reason: req.body.outOfServiceBed.reason,
-        notes: req.body.outOfServiceBed.notes,
-        referenceNumber: req.body.outOfServiceBed.referenceNumber,
-        startDate,
-        endDate,
-      }
-
       try {
+        const { startDate } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'startDate')
+        const { endDate } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'endDate')
+        const { reason, referenceNumber, notes } = req.body
+
+        const outOfServiceBed = {
+          startDate,
+          endDate,
+          reason,
+          referenceNumber,
+          notes,
+        }
+
         await this.outOfServiceBedService.updateOutOfServiceBed(req.user.token, id, premisesId, outOfServiceBed)
 
         req.flash('success', 'The out of service bed record has been updated')

--- a/server/data/cas1ReferenceDataClient.test.ts
+++ b/server/data/cas1ReferenceDataClient.test.ts
@@ -6,6 +6,7 @@ import {
   cruManagementAreaFactory,
 } from '../testutils/factories'
 import { describeCas1NamespaceClient } from '../testutils/describeClient'
+import paths from '../paths/api'
 
 describeCas1NamespaceClient('Cas1ReferenceDataClient', provider => {
   let cas1ReferenceDataClient: Cas1ReferenceDataClient
@@ -30,7 +31,7 @@ describeCas1NamespaceClient('Cas1ReferenceDataClient', provider => {
           uponReceiving: `A request to get ${key}`,
           withRequest: {
             method: 'GET',
-            path: `/cas1/reference-data/${key}`,
+            path: paths.cas1ReferenceData({ type: key }),
             headers: {
               authorization: `Bearer ${token}`,
             },
@@ -56,7 +57,7 @@ describeCas1NamespaceClient('Cas1ReferenceDataClient', provider => {
         uponReceiving: `A request to get OOSB reasons`,
         withRequest: {
           method: 'GET',
-          path: `/cas1/reference-data/out-of-service-bed-reasons`,
+          path: paths.cas1ReferenceData({ type: 'out-of-service-bed-reasons' }),
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -81,7 +82,7 @@ describeCas1NamespaceClient('Cas1ReferenceDataClient', provider => {
         uponReceiving: `A request to get CRU management areas`,
         withRequest: {
           method: 'GET',
-          path: `/cas1/reference-data/cru-management-areas`,
+          path: paths.cas1ReferenceData({ type: 'cru-management-areas' }),
           headers: {
             authorization: `Bearer ${token}`,
           },

--- a/server/data/cas1ReferenceDataClient.ts
+++ b/server/data/cas1ReferenceDataClient.ts
@@ -1,5 +1,5 @@
 import type { Cas1ReferenceData } from '@approved-premises/ui'
-import { Cas1CruManagementArea } from '@approved-premises/api'
+import { Cas1CruManagementArea, Cas1OutOfServiceBedReason } from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 
@@ -18,5 +18,11 @@ export default class Cas1ReferenceDataClient {
     return (await this.restClient.get({
       path: `/cas1/reference-data/cru-management-areas`,
     })) as Array<Cas1CruManagementArea>
+  }
+
+  async getOutOfServiceBedReasons(): Promise<Array<Cas1OutOfServiceBedReason>> {
+    return (await this.restClient.get({
+      path: '/cas1/reference-data/out-of-service-bed-reasons',
+    })) as Array<Cas1OutOfServiceBedReason>
   }
 }

--- a/server/data/cas1ReferenceDataClient.ts
+++ b/server/data/cas1ReferenceDataClient.ts
@@ -2,6 +2,7 @@ import type { Cas1ReferenceData } from '@approved-premises/ui'
 import { Cas1CruManagementArea, Cas1OutOfServiceBedReason } from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
+import paths from '../paths/api'
 
 export default class Cas1ReferenceDataClient {
   restClient: RestClient
@@ -10,19 +11,19 @@ export default class Cas1ReferenceDataClient {
     this.restClient = new RestClient('cas1ReferenceDataClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
-  async getReferenceData(objectType: string): Promise<Array<Cas1ReferenceData>> {
-    return (await this.restClient.get({ path: `/cas1/reference-data/${objectType}` })) as Array<Cas1ReferenceData>
+  async getReferenceData(type: string): Promise<Array<Cas1ReferenceData>> {
+    return (await this.restClient.get({ path: paths.cas1ReferenceData({ type }) })) as Array<Cas1ReferenceData>
   }
 
   async getCruManagementAreas(): Promise<Array<Cas1CruManagementArea>> {
     return (await this.restClient.get({
-      path: `/cas1/reference-data/cru-management-areas`,
+      path: paths.cas1ReferenceData({ type: 'cru-management-areas' }),
     })) as Array<Cas1CruManagementArea>
   }
 
   async getOutOfServiceBedReasons(): Promise<Array<Cas1OutOfServiceBedReason>> {
     return (await this.restClient.get({
-      path: '/cas1/reference-data/out-of-service-bed-reasons',
+      path: paths.cas1ReferenceData({ type: 'out-of-service-bed-reasons' }),
     })) as Array<Cas1OutOfServiceBedReason>
   }
 }

--- a/server/data/referenceDataClient.test.ts
+++ b/server/data/referenceDataClient.test.ts
@@ -15,6 +15,7 @@ import {
   referenceDataFactory,
 } from '../testutils/factories'
 import describeClient from '../testutils/describeClient'
+import paths from '../paths/api'
 
 describeClient('ReferenceDataClient', provider => {
   let referenceDataClient: ReferenceDataClient
@@ -42,7 +43,7 @@ describeClient('ReferenceDataClient', provider => {
           uponReceiving: `A request to get ${key}`,
           withRequest: {
             method: 'GET',
-            path: `/reference-data/${key}`,
+            path: paths.referenceData({ type: key }),
             headers: {
               authorization: `Bearer ${token}`,
             },
@@ -68,7 +69,7 @@ describeClient('ReferenceDataClient', provider => {
         uponReceiving: `A request to get probation regions`,
         withRequest: {
           method: 'GET',
-          path: `/reference-data/probation-regions`,
+          path: paths.referenceData({ type: 'probation-regions' }),
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -93,7 +94,7 @@ describeClient('ReferenceDataClient', provider => {
         uponReceiving: `A request to get AP areas`,
         withRequest: {
           method: 'GET',
-          path: `/reference-data/ap-areas`,
+          path: paths.referenceData({ type: 'ap-areas' }),
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -118,7 +119,7 @@ describeClient('ReferenceDataClient', provider => {
         uponReceiving: `A request to get Non-arrival reasons`,
         withRequest: {
           method: 'GET',
-          path: `/reference-data/non-arrival-reasons`,
+          path: paths.referenceData({ type: 'non-arrival-reasons' }),
           headers: {
             authorization: `Bearer ${token}`,
           },

--- a/server/data/referenceDataClient.ts
+++ b/server/data/referenceDataClient.ts
@@ -2,6 +2,7 @@ import type { ReferenceData } from '@approved-premises/ui'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import { ApArea, NonArrivalReason, ProbationRegion } from '../@types/shared'
+import paths from '../paths/api'
 
 export default class ReferenceDataClient {
   restClient: RestClient
@@ -10,19 +11,23 @@ export default class ReferenceDataClient {
     this.restClient = new RestClient('referenceDataClient', config.apis.approvedPremises as ApiConfig, token)
   }
 
-  async getReferenceData(objectType: string): Promise<Array<ReferenceData>> {
-    return (await this.restClient.get({ path: `/reference-data/${objectType}` })) as Array<ReferenceData>
+  async getReferenceData(type: string): Promise<Array<ReferenceData>> {
+    return (await this.restClient.get({ path: paths.referenceData({ type }) })) as Array<ReferenceData>
   }
 
   async getProbationRegions(): Promise<Array<ProbationRegion>> {
-    return (await this.restClient.get({ path: `/reference-data/probation-regions` })) as Array<ProbationRegion>
+    return (await this.restClient.get({
+      path: paths.referenceData({ type: 'probation-regions' }),
+    })) as Array<ProbationRegion>
   }
 
   async getApAreas(): Promise<Array<ApArea>> {
-    return (await this.restClient.get({ path: `/reference-data/ap-areas` })) as Array<ApArea>
+    return (await this.restClient.get({ path: paths.referenceData({ type: 'ap-areas' }) })) as Array<ApArea>
   }
 
   async getNonArrivalReasons(): Promise<Array<NonArrivalReason>> {
-    return (await this.restClient.get({ path: `/reference-data/non-arrival-reasons` })) as Array<NonArrivalReason>
+    return (await this.restClient.get({
+      path: paths.referenceData({ type: 'non-arrival-reasons' }),
+    })) as Array<NonArrivalReason>
   }
 }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -103,7 +103,7 @@
   "endDate": {
     "empty": "You must enter an end date",
     "invalid": "The end date is an invalid date",
-    "beforeStartDate": "The end date must be after the start date",
+    "beforeStartDate": "The end date must be on or after the start date",
     "conflict": "This bedspace is not available for these dates"
   },
   "referenceNumber": {

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -44,7 +44,7 @@
     "doesNotExist": "This reason does not exist"
   },
   "reason": {
-    "empty": "You must choose a valid reason"
+    "empty": "You must select a reason"
   },
   "notes": {
     "empty": "You must provide detail on why the bed is out of service"
@@ -81,7 +81,9 @@
     "doesNotExist": "The destination provider does not exist",
     "empty": "You must enter a destination provider"
   },
-  "moveOnCategoryId": { "empty": "You must enter a move on category" },
+  "moveOnCategoryId": {
+    "empty": "You must enter a move on category"
+  },
   "newDepartureDate": {
     "empty": "You must enter a new departure date",
     "invalid": "The departure date is an invalid date",
@@ -99,24 +101,36 @@
     "conflict": "This bedspace is not available for these dates"
   },
   "endDate": {
-    "empty": "You must enter a end date",
+    "empty": "You must enter an end date",
     "invalid": "The end date is an invalid date",
     "beforeStartDate": "The end date must be after the start date",
     "conflict": "This bedspace is not available for these dates"
   },
-  "referenceNumber": { "empty": "You must enter a reference number" },
-  "query": { "empty": "You must enter a query" },
+  "referenceNumber": {
+    "empty": "You must enter a reference number"
+  },
+  "query": {
+    "empty": "You must enter a query"
+  },
   "userId": {
     "empty": "You must choose a user to allocate the application to",
     "lackingQualifications": "This user lacks the necessary qualifications"
   },
-  "moveBed": { "empty": "You must select a bed to move the person to" },
+  "moveBed": {
+    "empty": "You must select a bed to move the person to"
+  },
   "appealDate": {
     "empty": "You must enter an appeal date",
     "invalid": "You must enter a valid appeal date",
     "mustNotBeFuture": "The appeal date must not be in the future"
   },
-  "appealDetail": { "empty": "You must enter the reason for the appeal" },
-  "decision": { "empty": "You must provide the decision" },
-  "decisionDetail": { "empty": "You must enter the reasons for the appeal decision" }
+  "appealDetail": {
+    "empty": "You must enter the reason for the appeal"
+  },
+  "decision": {
+    "empty": "You must provide the decision"
+  },
+  "decisionDetail": {
+    "empty": "You must enter the reasons for the appeal decision"
+  }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -33,6 +33,12 @@ const cas1Oasys = cas1Person.path('oasys')
 const cas1Applications = cas1Namespace.path('applications')
 const cas1ApplicationsSingle = cas1Applications.path(':id')
 
+const cas1Assessments = cas1Namespace.path('assessments')
+const cas1AssessmentsSingle = cas1Assessments.path(':id')
+const cas1AssessmentsNotes = cas1AssessmentsSingle.path('notes')
+
+const cas1ReferenceData = cas1Namespace.path('reference-data')
+
 // Non-namespaced
 const premises = path('/premises')
 const premisesSingle = premises.path(':premisesId')
@@ -53,9 +59,7 @@ const cas1Users = cas1Namespace.path('users')
 const placementRequests = path('/placement-requests')
 const placementRequestsSingle = placementRequests.path(':placementRequestId')
 
-const cas1Assessments = cas1Namespace.path('assessments')
-const cas1AssessmentsSingle = cas1Assessments.path(':id')
-const cas1AssessmentsNotes = cas1AssessmentsSingle.path('notes')
+const referenceData = path('/reference-data')
 
 export default {
   manage: {
@@ -214,4 +218,6 @@ export default {
     profile: profile.path('v2'),
   },
   reports: cas1Reports.path(':reportName'),
+  cas1ReferenceData: cas1ReferenceData.path(':type'),
+  referenceData: referenceData.path(':type'),
 }

--- a/server/paths/manage.ts
+++ b/server/paths/manage.ts
@@ -116,7 +116,6 @@ const paths = {
   },
   outOfServiceBeds: {
     new: outOfServiceBedsPath.path('new'),
-    create: outOfServiceBedsPath,
     premisesIndex: singlePremisesPath.path('out-of-service-beds').path(':temporality'),
     index: outOfServiceBedsIndexPath.path(':temporality'),
     show: outOfServiceBedPath.path(':tab'),

--- a/server/routes/manage.test.ts
+++ b/server/routes/manage.test.ts
@@ -101,7 +101,7 @@ describe('manage routes', () => {
   it('should allow a user with permission cas1 out of service bed create to create an out of service bed', () => {
     manageRoutes(controllers, router, services)
 
-    expect(postSpy).toHaveBeenCalledWith(paths.outOfServiceBeds.create.pattern, outOfServiceBedsController.create(), {
+    expect(postSpy).toHaveBeenCalledWith(paths.outOfServiceBeds.new.pattern, outOfServiceBedsController.create(), {
       auditEvent: 'CREATE_OUT_OF_SERVICE_BED_SUCCESS',
       redirectAuditEventSpecs: [
         {

--- a/server/routes/manage.ts
+++ b/server/routes/manage.ts
@@ -57,7 +57,7 @@ export default function routes(controllers: Controllers, router: Router, service
   get(paths.deprecated.lostBeds.new.pattern, redirectController.redirect(paths.outOfServiceBeds.new), {
     auditEvent: 'NEW_LOST_BED_REDIRECT',
   })
-  post(paths.deprecated.lostBeds.create.pattern, redirectController.redirect(paths.outOfServiceBeds.create), {
+  post(paths.deprecated.lostBeds.create.pattern, redirectController.redirect(paths.outOfServiceBeds.new), {
     auditEvent: 'CREATE_LOST_BED_REDIRECT',
   })
   get(
@@ -333,7 +333,7 @@ export default function routes(controllers: Controllers, router: Router, service
     auditEvent: 'NEW_OUT_OF_SERVICE_BED',
     allowedPermissions: ['cas1_out_of_service_bed_create'],
   })
-  post(paths.outOfServiceBeds.create.pattern, outOfServiceBedsController.create(), {
+  post(paths.outOfServiceBeds.new.pattern, outOfServiceBedsController.create(), {
     auditEvent: 'CREATE_OUT_OF_SERVICE_BED_SUCCESS',
     redirectAuditEventSpecs: [
       {

--- a/server/services/outOfServiceBedService.test.ts
+++ b/server/services/outOfServiceBedService.test.ts
@@ -1,11 +1,11 @@
-import { LostBedReason, Cas1OutOfServiceBed as OutOfServiceBed } from '@approved-premises/api'
+import { Cas1OutOfServiceBed as OutOfServiceBed } from '@approved-premises/api'
 import { PaginatedResponse } from '@approved-premises/ui'
 import OutOfServiceBedService from './outOfServiceBedService'
 import OutOfServiceBedClient from '../data/outOfServiceBedClient'
 import Cas1ReferenceDataClient from '../data/cas1ReferenceDataClient'
 
 import {
-  cas1ReferenceDataFactory,
+  cas1OutOfServiceBedReasonFactory,
   newOutOfServiceBedFactory,
   outOfServiceBedCancellationFactory,
   outOfServiceBedFactory,
@@ -51,15 +51,15 @@ describe('OutOfServiceBedService', () => {
   describe('getOutOfServiceBedReasons', () => {
     it('returns the list of reasons retrieved from the CAS1 reference data endpoint', async () => {
       const token = 'SOME_TOKEN'
-      const stubbedReferenceData = cas1ReferenceDataFactory.outOfServiceBedReason().buildList(5) as Array<LostBedReason>
+      const outOfServiceBedReasons = cas1OutOfServiceBedReasonFactory.buildList(5)
 
-      cas1ReferenceDataClient.getReferenceData.mockResolvedValue(stubbedReferenceData)
+      cas1ReferenceDataClient.getOutOfServiceBedReasons.mockResolvedValue(outOfServiceBedReasons)
 
       const retrievedReasons = await service.getOutOfServiceBedReasons(token)
 
-      expect(retrievedReasons).toEqual(stubbedReferenceData)
+      expect(retrievedReasons).toEqual(outOfServiceBedReasons)
       expect(Cas1ReferenceDataClientFactory).toHaveBeenCalledWith(token)
-      expect(cas1ReferenceDataClient.getReferenceData).toHaveBeenLastCalledWith('out-of-service-bed-reasons')
+      expect(cas1ReferenceDataClient.getOutOfServiceBedReasons).toHaveBeenCalled()
     })
   })
 

--- a/server/services/outOfServiceBedService.ts
+++ b/server/services/outOfServiceBedService.ts
@@ -1,9 +1,10 @@
-import type { Cas1ReferenceData, PaginatedResponse } from '@approved-premises/ui'
+import type { PaginatedResponse } from '@approved-premises/ui'
 import type {
   Cas1NewOutOfServiceBed as NewOutOfServiceBed,
   Cas1NewOutOfServiceBedCancellation as NewOutOfServiceBedCancellation,
   Cas1OutOfServiceBed as OutOfServiceBed,
   Cas1OutOfServiceBedCancellation as OutOfServiceBedCancellation,
+  Cas1OutOfServiceBedReason,
   Cas1OutOfServiceBedSortField as OutOfServiceBedSortField,
   Premises,
   SortDirection,
@@ -11,8 +12,6 @@ import type {
   UpdateCas1OutOfServiceBed as UpdateOutOfServiceBed,
 } from '@approved-premises/api'
 import type { Cas1ReferenceDataClient, OutOfServiceBedClient, RestClientBuilder } from '../data'
-
-export type OutOfServiceBedReasons = Array<Cas1ReferenceData>
 
 export default class OutOfServiceBedService {
   constructor(
@@ -51,10 +50,10 @@ export default class OutOfServiceBedService {
     return outOfServiceBedClient.update(id, updateOutOfServiceBed, premisesId)
   }
 
-  async getOutOfServiceBedReasons(token: string): Promise<OutOfServiceBedReasons> {
+  async getOutOfServiceBedReasons(token: string): Promise<Array<Cas1OutOfServiceBedReason>> {
     const cas1ReferenceDataClient = this.cas1ReferenceDataClientFactory(token)
 
-    return cas1ReferenceDataClient.getReferenceData('out-of-service-bed-reasons')
+    return cas1ReferenceDataClient.getOutOfServiceBedReasons()
   }
 
   async getOutOfServiceBedsForAPremises(token: string, premisesId: Premises['id']): Promise<Array<OutOfServiceBed>> {

--- a/server/testutils/factories/cas1OutOfServiceBedSummary.ts
+++ b/server/testutils/factories/cas1OutOfServiceBedSummary.ts
@@ -1,19 +1,11 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker'
-import {
-  Cas1OutOfServiceBedReason,
-  Cas1OutOfServiceBedSummary,
-  Cas1SpaceBookingCharacteristic,
-} from '@approved-premises/api'
+import { Cas1OutOfServiceBedSummary, Cas1SpaceBookingCharacteristic } from '@approved-premises/api'
 import { DateFormats } from '../../utils/dateUtils'
 import { roomCharacteristicMap } from '../../utils/characteristicsUtils'
+import { cas1OutOfServiceBedReasonFactory } from './cas1ReferenceData'
 
 export default Factory.define<Cas1OutOfServiceBedSummary>(({ sequence }) => {
-  const reason: Cas1OutOfServiceBedReason = {
-    id: faker.string.uuid(),
-    name: `${faker.word.verb()} ${faker.word.preposition()} ${faker.word.noun()}`,
-    isActive: true,
-  }
   const characteristics = faker.helpers.arrayElements(Object.keys(roomCharacteristicMap), {
     min: 0,
     max: 3,
@@ -27,7 +19,7 @@ export default Factory.define<Cas1OutOfServiceBedSummary>(({ sequence }) => {
     })}-${sequence}`,
     startDate: DateFormats.dateObjToIsoDate(faker.date.recent({ days: 10 })),
     endDate: DateFormats.dateObjToIsoDate(faker.date.soon({ days: 10 })),
-    reason,
+    reason: cas1OutOfServiceBedReasonFactory.build(),
     characteristics,
   }
 })

--- a/server/testutils/factories/cas1ReferenceData.ts
+++ b/server/testutils/factories/cas1ReferenceData.ts
@@ -3,20 +3,25 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 
 import type { Cas1ReferenceData } from '@approved-premises/ui'
 
-import { Cas1CruManagementArea } from '@approved-premises/api'
-import outOfServiceBedReasonsJson from '../referenceData/stubs/cas1/out-of-service-bed-reasons.json'
+import { Cas1CruManagementArea, Cas1OutOfServiceBedReason, DepartureReason } from '@approved-premises/api'
 
-class Cas1ReferenceDataFactory extends Factory<Cas1ReferenceData> {
-  outOfServiceBedReason() {
-    const data = faker.helpers.arrayElement(outOfServiceBedReasonsJson)
-    return this.params(data)
-  }
-}
-
-export default Cas1ReferenceDataFactory.define(() => ({
+const cas1ReferenceDataFactory = Factory.define<Cas1ReferenceData>(() => ({
   id: faker.string.uuid(),
-  name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
+  name: faker.word.words({ count: { min: 1, max: 4 } }),
   isActive: true,
+}))
+
+export default cas1ReferenceDataFactory
+
+export const cas1DepartureReasonsFactory = Factory.define<DepartureReason>(() => ({
+  ...cas1ReferenceDataFactory.build(),
+  serviceScope: 'approved-premises',
+  parentReasonId: faker.helpers.maybe(() => faker.string.uuid(), { probability: 0.2 }),
+}))
+
+export const cas1OutOfServiceBedReasonFactory = Factory.define<Cas1OutOfServiceBedReason>(() => ({
+  ...cas1ReferenceDataFactory.build(),
+  referenceType: faker.helpers.arrayElement(['crn', 'workOrder']),
 }))
 
 export const cruManagementAreaFactory = Factory.define<Cas1CruManagementArea>(({ sequence }) => ({

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -46,7 +46,11 @@ import referenceDataFactory, {
   nonArrivalReasonsFactory,
   probationRegionFactory,
 } from './referenceData'
-import cas1ReferenceDataFactory, { cruManagementAreaFactory } from './cas1ReferenceData'
+import cas1ReferenceDataFactory, {
+  cruManagementAreaFactory,
+  cas1OutOfServiceBedReasonFactory,
+  cas1DepartureReasonsFactory,
+} from './cas1ReferenceData'
 import requestForPlacementFactory from './requestForPlacement'
 import risksFactory, { tierEnvelopeFactory } from './risks'
 import staffMemberFactory from './staffMember'
@@ -115,6 +119,7 @@ export {
   cas1ApprovedPlacementAppealfactory,
   cas1BedDetailFactory,
   cas1ChangeRequestSummaryFactory,
+  cas1DepartureReasonsFactory,
   cas1PremisesBedSummaryFactory,
   cas1OutOfServiceBedSummaryFactory,
   cas1PremisesBasicSummaryFactory,
@@ -139,6 +144,7 @@ export {
   cas1NewSpaceBookingCancellationFactory,
   cas1NonArrivalFactory,
   cas1OverbookingRangeFactory,
+  cas1OutOfServiceBedReasonFactory,
   cas1PlacementRequestDetailFactory,
   cas1KeyworkerAllocationFactory,
   cas1UpdateSpaceBookingFactory,

--- a/server/testutils/factories/outOfServiceBed.ts
+++ b/server/testutils/factories/outOfServiceBed.ts
@@ -4,13 +4,15 @@ import type {
   Cas1NewOutOfServiceBed,
   Cas1OutOfServiceBed,
   Cas1OutOfServiceBedCancellation,
+  Cas1OutOfServiceBedReason,
   Cas1OutOfServiceBedRevision,
 } from '@approved-premises/api'
 
-import cas1ReferenceDataFactory from './cas1ReferenceData'
 import { DateFormats } from '../../utils/dateUtils'
 import userFactory from './user'
 import namedIdFactory from './namedId'
+import { cas1OutOfServiceBedReasonFactory } from './cas1ReferenceData'
+import outOfServiceBedReasonsJson from '../referenceData/stubs/cas1/out-of-service-bed-reasons.json'
 
 export const outOfServiceBedFactory = Factory.define<Cas1OutOfServiceBed>(() => ({
   id: faker.string.uuid(),
@@ -21,7 +23,9 @@ export const outOfServiceBedFactory = Factory.define<Cas1OutOfServiceBed>(() => 
   room: namedIdFactory.build(),
   premises: namedIdFactory.build(),
   apArea: namedIdFactory.build(),
-  reason: cas1ReferenceDataFactory.outOfServiceBedReason().build(),
+  reason: cas1OutOfServiceBedReasonFactory.build(
+    faker.helpers.arrayElement(outOfServiceBedReasonsJson) as Cas1OutOfServiceBedReason,
+  ),
   referenceNumber: faker.helpers.arrayElement([faker.string.uuid(), undefined]),
   notes: faker.lorem.sentence(),
   daysLostCount: faker.number.int({ min: 1, max: 100 }),
@@ -47,7 +51,7 @@ export const newOutOfServiceBedFactory = Factory.define<Cas1NewOutOfServiceBed>(
     'endDate-month': endDate.getMonth().toString(),
     'endDate-year': endDate.getFullYear().toString(),
     referenceNumber: faker.string.uuid(),
-    reason: cas1ReferenceDataFactory.outOfServiceBedReason().build().id,
+    reason: cas1OutOfServiceBedReasonFactory.build().id,
     serviceName: 'approved-premises',
   }
 })
@@ -75,7 +79,7 @@ export const outOfServiceBedRevisionFactory = Factory.define<Cas1OutOfServiceBed
     ] as const),
     startDate: DateFormats.dateObjToIsoDate(faker.date.past()),
     endDate: DateFormats.dateObjToIsoDate(faker.date.future()),
-    reason: cas1ReferenceDataFactory.outOfServiceBedReason().build(),
+    reason: cas1OutOfServiceBedReasonFactory.build(),
     referenceNumber: faker.number.int({ min: 1000, max: 99999 }).toString(),
     notes: faker.lorem.sentences(2),
   }

--- a/server/testutils/factories/outOfServiceBed.ts
+++ b/server/testutils/factories/outOfServiceBed.ts
@@ -13,27 +13,42 @@ import userFactory from './user'
 import namedIdFactory from './namedId'
 import { cas1OutOfServiceBedReasonFactory } from './cas1ReferenceData'
 import outOfServiceBedReasonsJson from '../referenceData/stubs/cas1/out-of-service-bed-reasons.json'
+import { getCrn } from './person'
 
-export const outOfServiceBedFactory = Factory.define<Cas1OutOfServiceBed>(() => ({
-  id: faker.string.uuid(),
-  createdAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
-  startDate: DateFormats.dateObjToIsoDate(faker.date.future()),
-  endDate: DateFormats.dateObjToIsoDate(faker.date.future()),
-  bed: namedIdFactory.build(),
-  room: namedIdFactory.build(),
-  premises: namedIdFactory.build(),
-  apArea: namedIdFactory.build(),
-  reason: cas1OutOfServiceBedReasonFactory.build(
+export const outOfServiceBedFactory = Factory.define<Cas1OutOfServiceBed>(() => {
+  const reason = cas1OutOfServiceBedReasonFactory.build(
     faker.helpers.arrayElement(outOfServiceBedReasonsJson) as Cas1OutOfServiceBedReason,
-  ),
-  referenceNumber: faker.helpers.arrayElement([faker.string.uuid(), undefined]),
-  notes: faker.lorem.sentence(),
-  daysLostCount: faker.number.int({ min: 1, max: 100 }),
-  temporality: faker.helpers.arrayElement(['past', 'current', 'future'] as const),
-  status: faker.helpers.arrayElement(['active', 'cancelled'] as const),
-  cancellation: undefined,
-  revisionHistory: outOfServiceBedRevisionFactory.buildList(3),
-}))
+  )
+  return {
+    id: faker.string.uuid(),
+    createdAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
+    startDate: DateFormats.dateObjToIsoDate(faker.date.future()),
+    endDate: DateFormats.dateObjToIsoDate(faker.date.future()),
+    bed: namedIdFactory.build(),
+    room: namedIdFactory.build(),
+    premises: namedIdFactory.build(),
+    apArea: namedIdFactory.build(),
+    reason,
+    referenceNumber:
+      reason.referenceType === 'crn'
+        ? getCrn()
+        : faker.helpers.arrayElement([
+            faker.string.alphanumeric({
+              length: {
+                min: 5,
+                max: 10,
+              },
+            }),
+            undefined,
+          ]),
+    notes: faker.lorem.sentence(),
+    daysLostCount: faker.number.int({ min: 1, max: 100 }),
+    temporality: faker.helpers.arrayElement(['past', 'current', 'future'] as const),
+    status: faker.helpers.arrayElement(['active', 'cancelled'] as const),
+    cancellation: undefined,
+    revisionHistory: outOfServiceBedRevisionFactory.buildList(3),
+  }
+})
 
 export const newOutOfServiceBedFactory = Factory.define<Cas1NewOutOfServiceBed>(() => {
   const startDate = faker.date.soon()

--- a/server/testutils/factories/outOfServiceBed.ts
+++ b/server/testutils/factories/outOfServiceBed.ts
@@ -16,14 +16,16 @@ import outOfServiceBedReasonsJson from '../referenceData/stubs/cas1/out-of-servi
 import { getCrn } from './person'
 
 export const outOfServiceBedFactory = Factory.define<Cas1OutOfServiceBed>(() => {
+  const startDate = faker.date.future()
+  const endDate = faker.date.future({ refDate: startDate })
   const reason = cas1OutOfServiceBedReasonFactory.build(
     faker.helpers.arrayElement(outOfServiceBedReasonsJson) as Cas1OutOfServiceBedReason,
   )
   return {
     id: faker.string.uuid(),
     createdAt: DateFormats.dateObjToIsoDateTime(faker.date.past()),
-    startDate: DateFormats.dateObjToIsoDate(faker.date.future()),
-    endDate: DateFormats.dateObjToIsoDate(faker.date.future()),
+    startDate: DateFormats.dateObjToIsoDate(startDate),
+    endDate: DateFormats.dateObjToIsoDate(endDate),
     bed: namedIdFactory.build(),
     room: namedIdFactory.build(),
     premises: namedIdFactory.build(),

--- a/server/testutils/factories/outOfServiceBed.ts
+++ b/server/testutils/factories/outOfServiceBed.ts
@@ -34,15 +34,14 @@ export const outOfServiceBedFactory = Factory.define<Cas1OutOfServiceBed>(() => 
     referenceNumber:
       reason.referenceType === 'crn'
         ? getCrn()
-        : faker.helpers.arrayElement([
+        : faker.helpers.maybe(() =>
             faker.string.alphanumeric({
               length: {
                 min: 5,
                 max: 10,
               },
             }),
-            undefined,
-          ]),
+          ),
     notes: faker.lorem.sentence(),
     daysLostCount: faker.number.int({ min: 1, max: 100 }),
     temporality: faker.helpers.arrayElement(['past', 'current', 'future'] as const),

--- a/server/testutils/referenceData/stubs/cas1/out-of-service-bed-reasons.json
+++ b/server/testutils/referenceData/stubs/cas1/out-of-service-bed-reasons.json
@@ -1,27 +1,68 @@
 [
   {
-    "id": "78b9c1a4-1d60-11ed-861d-0242ac120002",
-    "name": "Fire",
-    "isActive": true
-  },
-  {
-    "id": "51b44b8c-f7f3-415d-90c3-61bb7fb96286",
-    "name": "Damaged",
-    "isActive": true
-  },
-  {
-    "id": "9ddc9bfc-72fa-4a25-88c0-cc0ff8c6c00e",
-    "name": "Refurbishment",
-    "isActive": true
-  },
-  {
-    "id": "7f3eb6cd-b3fc-4a8d-b9ce-5959918ffbe8",
-    "name": "Staff shortage",
-    "isActive": true
-  },
-  {
-    "id": "1f2eb6cd-b3fc-4a8d-b9ce-5959918ffbe8",
+    "id": "6943e9e7-ffae-44ba-b2f4-bc299af8773c",
     "name": "Planned FM works required",
-    "isActive": true
+    "isActive": true,
+    "referenceType": "workOrder"
+  },
+  {
+    "id": "55594aa8-1ae1-4a3c-b6f3-7bb55ff14807",
+    "name": "Double room with single occupancy – other (Non-FM)",
+    "isActive": true,
+    "referenceType": "crn"
+  },
+  {
+    "id": "ce0c151c-dda5-450c-8a7f-ca8895fecd04",
+    "name": "Double room with single occupancy – risk (Non-FM)",
+    "isActive": true,
+    "referenceType": "crn"
+  },
+  {
+    "id": "abd5af8d-8f8c-469a-8e22-85635f99ec0d",
+    "name": "Staff shortage / Illness (Non-FM)",
+    "isActive": true,
+    "referenceType": "workOrder"
+  },
+  {
+    "id": "34467c03-b919-4423-b4e2-e0dc92520a56",
+    "name": "Damage by resident requiring FM Repair",
+    "isActive": true,
+    "referenceType": "workOrder"
+  },
+  {
+    "id": "2f46e769-17a5-4b5c-b04a-a5a9a5b3f773",
+    "name": "Planned Refurbishment (FM)",
+    "isActive": true,
+    "referenceType": "workOrder"
+  },
+  {
+    "id": "2f076b35-72d2-410e-9a92-6d00781a559c",
+    "name": "Other unplanned FM works required",
+    "isActive": true,
+    "referenceType": "workOrder"
+  },
+  {
+    "id": "56da56bd-f20f-4830-9e44-ed3b7795cf5e",
+    "name": "Flood / Fire requiring FM repair",
+    "isActive": true,
+    "referenceType": "workOrder"
+  },
+  {
+    "id": "051e7f55-a5a5-47a9-9bbf-a7b11a6ebf97",
+    "name": "Incident not requiring FM repair",
+    "isActive": true,
+    "referenceType": "workOrder"
+  },
+  {
+    "id": "0e2c5f8b-bee7-4947-a3aa-a09d09af611e",
+    "name": "AP Closure / Operational Reduction in Capacity (Non-FM)",
+    "isActive": true,
+    "referenceType": "workOrder"
+  },
+  {
+    "id": "199bef2d-0839-40c0-85e2-00b84fde7fde",
+    "name": "Bed on hold",
+    "isActive": true,
+    "referenceType": "crn"
   }
 ]

--- a/server/testutils/referenceData/stubs/referenceDataStubs.ts
+++ b/server/testutils/referenceData/stubs/referenceDataStubs.ts
@@ -8,11 +8,12 @@ import lostBedReasonsJson from './lost-bed-reasons.json'
 import outOfServiceBedReasonsJson from './cas1/out-of-service-bed-reasons.json'
 import keyWorkersJson from './keyworkers.json'
 import probationRegionsJson from './probation-regions.json'
+import paths from '../../../paths/api'
 
 const departureReasons = {
   request: {
     method: 'GET',
-    url: '/cas1/reference-data/departure-reasons',
+    url: paths.cas1ReferenceData({ type: 'departure-reasons' }),
   },
   response: {
     status: 200,
@@ -26,7 +27,7 @@ const departureReasons = {
 const moveOnCategories = {
   request: {
     method: 'GET',
-    url: '/cas1/reference-data/move-on-categories',
+    url: paths.cas1ReferenceData({ type: 'move-on-categories' }),
   },
   response: {
     status: 200,
@@ -40,7 +41,7 @@ const moveOnCategories = {
 const destinationProviders = {
   request: {
     method: 'GET',
-    url: '/reference-data/destination-providers',
+    url: paths.referenceData({ type: 'destination-providers' }),
   },
   response: {
     status: 200,
@@ -54,7 +55,7 @@ const destinationProviders = {
 const cancellationReasons = {
   request: {
     method: 'GET',
-    url: '/reference-data/cancellation-reasons',
+    url: paths.referenceData({ type: 'cancellation-reasons' }),
   },
   response: {
     status: 200,
@@ -68,7 +69,7 @@ const cancellationReasons = {
 const lostBedReasons = {
   request: {
     method: 'GET',
-    url: '/reference-data/lost-bed-reasons',
+    url: paths.referenceData({ type: 'lost-bed-reasons' }),
   },
   response: {
     status: 200,
@@ -82,7 +83,7 @@ const lostBedReasons = {
 const outOfServiceBedReasons = {
   request: {
     method: 'GET',
-    url: '/cas1/reference-data/out-of-service-bed-reasons',
+    url: paths.cas1ReferenceData({ type: 'out-of-service-bed-reasons' }),
   },
   response: {
     status: 200,
@@ -96,7 +97,7 @@ const outOfServiceBedReasons = {
 const keyWorkers = {
   request: {
     method: 'GET',
-    url: '/reference-data/key-workers',
+    url: paths.referenceData({ type: 'key-workers' }),
   },
   response: {
     status: 200,
@@ -110,7 +111,7 @@ const keyWorkers = {
 const probationRegions = {
   request: {
     method: 'GET',
-    url: '/reference-data/probation-regions',
+    url: paths.referenceData({ type: 'probation-regions' }),
   },
   response: {
     status: 200,

--- a/server/utils/outOfServiceBedUtils.test.ts
+++ b/server/utils/outOfServiceBedUtils.test.ts
@@ -331,6 +331,18 @@ describe('outOfServiceBedUtils', () => {
       notes: 'Some notes',
     }
     const oosbReasons = outOfServiceBedReasonsJson as Array<Cas1OutOfServiceBedReason>
+    const expectErrors = (userInput: CreateOutOfServiceBedBody, expectedErrors: Record<string, string>) => {
+      let error
+
+      try {
+        validateOutOfServiceBedInput(userInput, oosbReasons)
+      } catch (e) {
+        error = e
+      }
+
+      expect(error).toBeInstanceOf(ValidationError)
+      expect(error.data).toEqual(expectedErrors)
+    }
 
     it('throws if the dates are empty', () => {
       const bodyEmptyDates = {
@@ -340,15 +352,7 @@ describe('outOfServiceBedUtils', () => {
         'endDate-month': '',
         'endDate-day': '',
       }
-      let error
-      try {
-        validateOutOfServiceBedInput(bodyEmptyDates, oosbReasons)
-      } catch (e) {
-        error = e
-      }
-
-      expect(error).toBeInstanceOf(ValidationError)
-      expect(error.data).toEqual({
+      expectErrors(bodyEmptyDates, {
         startDate: 'You must enter a start date',
         endDate: 'You must enter an end date',
       })
@@ -360,15 +364,7 @@ describe('outOfServiceBedUtils', () => {
         'startDate-day': '45',
         'endDate-year': 'nope',
       }
-      let error
-      try {
-        validateOutOfServiceBedInput(bodyInvalidDates, oosbReasons)
-      } catch (e) {
-        error = e
-      }
-
-      expect(error).toBeInstanceOf(ValidationError)
-      expect(error.data).toEqual({
+      expectErrors(bodyInvalidDates, {
         startDate: 'You must enter a valid start date',
         endDate: 'You must enter a valid end date',
       })
@@ -384,15 +380,7 @@ describe('outOfServiceBedUtils', () => {
         'endDate-month': '10',
         'endDate-day': '14',
       }
-      let error
-      try {
-        validateOutOfServiceBedInput(bodyEndBeforeStart, oosbReasons)
-      } catch (e) {
-        error = e
-      }
-
-      expect(error).toBeInstanceOf(ValidationError)
-      expect(error.data).toEqual({
+      expectErrors(bodyEndBeforeStart, {
         endDate: 'The end date must be on or after the start date',
       })
     })
@@ -406,15 +394,7 @@ describe('outOfServiceBedUtils', () => {
       it('returns an error if the Work order reference number/CRN field is empty', async () => {
         const bodyNoCrn = { ...bodyCrn, referenceNumber: '' }
 
-        let error
-        try {
-          validateOutOfServiceBedInput(bodyNoCrn, oosbReasons)
-        } catch (e) {
-          error = e
-        }
-
-        expect(error).toBeInstanceOf(ValidationError)
-        expect(error.data).toEqual({
+        expectErrors(bodyNoCrn, {
           referenceNumber: 'You must enter a CRN',
         })
       })
@@ -422,15 +402,7 @@ describe('outOfServiceBedUtils', () => {
       it('returns an error if the Work order reference number/CRN field is an invalid CRN', async () => {
         const bodyInvalidCrn = { ...bodyCrn, referenceNumber: 'not a crn' }
 
-        let error
-        try {
-          validateOutOfServiceBedInput(bodyInvalidCrn, oosbReasons)
-        } catch (e) {
-          error = e
-        }
-
-        expect(error).toBeInstanceOf(ValidationError)
-        expect(error.data).toEqual({
+        expectErrors(bodyInvalidCrn, {
           referenceNumber: 'You must enter a valid CRN',
         })
       })

--- a/server/utils/outOfServiceBedUtils.test.ts
+++ b/server/utils/outOfServiceBedUtils.test.ts
@@ -7,9 +7,9 @@ import {
   bedRevisionDetails,
   generateConflictBespokeError,
   outOfServiceBedActions,
+  outOfServiceBedSummaryList,
   outOfServiceBedTableHeaders,
   outOfServiceBedTableRows,
-  overwriteOoSBedWithUserInput,
   referenceNumberCell,
   sortOutOfServiceBedRevisionsByUpdatedAt,
 } from './outOfServiceBedUtils'
@@ -153,6 +153,30 @@ describe('outOfServiceBedUtils', () => {
     })
   })
 
+  describe('outOfServiceBedSummaryList', () => {
+    it('renders a summary list with the OOSB details', () => {
+      const outOfServiceBed = outOfServiceBedFactory.build({
+        startDate: '2026-02-01',
+        endDate: '2026-03-12',
+        referenceNumber: '123',
+        notes: `some notes\ntwo lines`,
+      })
+
+      expect(outOfServiceBedSummaryList(outOfServiceBed)).toEqual({
+        rows: [
+          { key: { text: 'Start date' }, value: { text: 'Sun 1 Feb 2026' } },
+          { key: { text: 'End date' }, value: { text: 'Thu 12 Mar 2026' } },
+          { key: { text: 'Reason' }, value: { text: outOfServiceBed.reason.name } },
+          { key: { text: 'Reference number/CRN' }, value: { text: '123' } },
+          {
+            key: { text: 'Notes' },
+            value: { html: `<span class="govuk-summary-list__textblock">some notes\ntwo lines</span>` },
+          },
+        ],
+      })
+    })
+  })
+
   describe('bedRevisionDetails', () => {
     it('adds a formatted start date the summary list', () => {
       const startDate = new Date(2024, 2, 1)
@@ -218,28 +242,6 @@ describe('outOfServiceBedUtils', () => {
       const sortedRevisions = sortOutOfServiceBedRevisionsByUpdatedAt(unsortedRevisions)
 
       expect(sortedRevisions).toEqual([latestDate, middleDate, earliestDate])
-    })
-  })
-
-  describe('overwriteOoSBedWithUserInput', () => {
-    it('overwrites the reason ID if there is a reason in the userInput', () => {
-      const userInput = { outOfServiceBed: { reason: 'new reason' } }
-      const outOfServiceBed = outOfServiceBedFactory.build()
-
-      expect(overwriteOoSBedWithUserInput(userInput, outOfServiceBed)).toEqual(
-        expect.objectContaining({
-          reason: expect.objectContaining({ id: 'new reason' }),
-        }),
-      )
-    })
-
-    it('overwrites the reference number if there is a reason in the userInput', () => {
-      const userInput = { outOfServiceBed: { referenceNumber: 'new reason' } }
-      const outOfServiceBed = outOfServiceBedFactory.build()
-
-      expect(overwriteOoSBedWithUserInput(userInput, outOfServiceBed)).toEqual(
-        expect.objectContaining({ referenceNumber: 'new reason' }),
-      )
     })
   })
 

--- a/server/utils/outOfServiceBedUtils.test.ts
+++ b/server/utils/outOfServiceBedUtils.test.ts
@@ -340,15 +340,18 @@ describe('outOfServiceBedUtils', () => {
         'endDate-month': '',
         'endDate-day': '',
       }
+      let error
       try {
         validateOutOfServiceBedInput(bodyEmptyDates, oosbReasons)
       } catch (e) {
-        expect(e).toBeInstanceOf(ValidationError)
-        expect(e.data).toEqual({
-          startDate: 'You must enter a start date',
-          endDate: 'You must enter an end date',
-        })
+        error = e
       }
+
+      expect(error).toBeInstanceOf(ValidationError)
+      expect(error.data).toEqual({
+        startDate: 'You must enter a start date',
+        endDate: 'You must enter an end date',
+      })
     })
 
     it('returns errors if the dates are invalid', async () => {
@@ -357,15 +360,41 @@ describe('outOfServiceBedUtils', () => {
         'startDate-day': '45',
         'endDate-year': 'nope',
       }
+      let error
       try {
         validateOutOfServiceBedInput(bodyInvalidDates, oosbReasons)
       } catch (e) {
-        expect(e).toBeInstanceOf(ValidationError)
-        expect(e.data).toEqual({
-          startDate: 'You must enter a valid start date',
-          endDate: 'You must enter a valid end date',
-        })
+        error = e
       }
+
+      expect(error).toBeInstanceOf(ValidationError)
+      expect(error.data).toEqual({
+        startDate: 'You must enter a valid start date',
+        endDate: 'You must enter a valid end date',
+      })
+    })
+
+    it('returns an error if the end date is before the start date', async () => {
+      const bodyEndBeforeStart = {
+        ...validBody,
+        'startDate-year': '2026',
+        'startDate-month': '10',
+        'startDate-day': '15',
+        'endDate-year': '2026',
+        'endDate-month': '10',
+        'endDate-day': '14',
+      }
+      let error
+      try {
+        validateOutOfServiceBedInput(bodyEndBeforeStart, oosbReasons)
+      } catch (e) {
+        error = e
+      }
+
+      expect(error).toBeInstanceOf(ValidationError)
+      expect(error.data).toEqual({
+        endDate: 'The end date must be on or after the start date',
+      })
     })
 
     describe('when the reason selected is linked to a person and needs a CRN to be entered', () => {
@@ -377,27 +406,33 @@ describe('outOfServiceBedUtils', () => {
       it('returns an error if the Work order reference number/CRN field is empty', async () => {
         const bodyNoCrn = { ...bodyCrn, referenceNumber: '' }
 
+        let error
         try {
           validateOutOfServiceBedInput(bodyNoCrn, oosbReasons)
         } catch (e) {
-          expect(e).toBeInstanceOf(ValidationError)
-          expect(e.data).toEqual({
-            referenceNumber: 'You must enter a CRN',
-          })
+          error = e
         }
+
+        expect(error).toBeInstanceOf(ValidationError)
+        expect(error.data).toEqual({
+          referenceNumber: 'You must enter a CRN',
+        })
       })
 
       it('returns an error if the Work order reference number/CRN field is an invalid CRN', async () => {
         const bodyInvalidCrn = { ...bodyCrn, referenceNumber: 'not a crn' }
 
+        let error
         try {
           validateOutOfServiceBedInput(bodyInvalidCrn, oosbReasons)
         } catch (e) {
-          expect(e).toBeInstanceOf(ValidationError)
-          expect(e.data).toEqual({
-            referenceNumber: 'You must enter a valid CRN',
-          })
+          error = e
         }
+
+        expect(error).toBeInstanceOf(ValidationError)
+        expect(error.data).toEqual({
+          referenceNumber: 'You must enter a valid CRN',
+        })
       })
     })
   })

--- a/server/utils/outOfServiceBedUtils.test.ts
+++ b/server/utils/outOfServiceBedUtils.test.ts
@@ -37,7 +37,7 @@ describe('outOfServiceBedUtils', () => {
         sortHeader<OutOfServiceBedSortField>('End date', 'endDate', sortBy, sortDirection, hrefPrefix),
         sortHeader<OutOfServiceBedSortField>('Reason', 'reason', sortBy, sortDirection, hrefPrefix),
         {
-          text: 'Ref number',
+          text: 'Reference/CRN',
         },
         sortHeader<OutOfServiceBedSortField>('Days lost', 'daysLost', sortBy, sortDirection, hrefPrefix),
         {
@@ -87,7 +87,7 @@ describe('outOfServiceBedUtils', () => {
         { text: 'Start date' },
         { text: 'End date' },
         { text: 'Reason' },
-        { text: 'Ref number' },
+        { text: 'Reference/CRN' },
         { text: 'Details' },
       ])
     })
@@ -171,7 +171,7 @@ describe('outOfServiceBedUtils', () => {
           { key: { text: 'Start date' }, value: { text: 'Sun 1 Feb 2026' } },
           { key: { text: 'End date' }, value: { text: 'Thu 12 Mar 2026' } },
           { key: { text: 'Reason' }, value: { text: outOfServiceBed.reason.name } },
-          { key: { text: 'Reference number/CRN' }, value: { text: '123' } },
+          { key: { text: 'Reference/CRN' }, value: { text: '123' } },
           {
             key: { text: 'Notes' },
             value: { html: `<span class="govuk-summary-list__textblock">some notes\ntwo lines</span>` },
@@ -222,7 +222,7 @@ describe('outOfServiceBedUtils', () => {
       })
 
       expect(bedRevisionDetails(revision)).toEqual(
-        expect.arrayContaining([{ key: { text: 'Reference number' }, value: { text: revision.referenceNumber } }]),
+        expect.arrayContaining([{ key: { text: 'Reference/CRN' }, value: { text: revision.referenceNumber } }]),
       )
     })
 

--- a/server/utils/outOfServiceBedUtils.ts
+++ b/server/utils/outOfServiceBedUtils.ts
@@ -62,7 +62,7 @@ export const allOutOfServiceBedsTableHeaders = (
     sortHeader<OutOfServiceBedSortField>('End date', 'endDate', sortBy, sortDirection, hrefPrefix),
     sortHeader<OutOfServiceBedSortField>('Reason', 'reason', sortBy, sortDirection, hrefPrefix),
     {
-      text: 'Ref number',
+      text: 'Reference/CRN',
     },
     sortHeader<OutOfServiceBedSortField>('Days lost', 'daysLost', sortBy, sortDirection, hrefPrefix),
     {
@@ -90,7 +90,7 @@ export const outOfServiceBedTableHeaders = () => [
   { text: 'Start date' },
   { text: 'End date' },
   { text: 'Reason' },
-  { text: 'Ref number' },
+  { text: 'Reference/CRN' },
   { text: 'Details' },
 ]
 
@@ -165,7 +165,7 @@ export const outOfServiceBedSummaryList = (outOfServiceBed: Cas1OutOfServiceBed)
     summaryListItem('Start date', DateFormats.isoDateToUIDate(outOfServiceBed.startDate, { format: 'long' })),
     summaryListItem('End date', DateFormats.isoDateToUIDate(outOfServiceBed.endDate, { format: 'long' })),
     summaryListItem('Reason', outOfServiceBed.reason.name),
-    summaryListItem('Reference number/CRN', outOfServiceBed.referenceNumber),
+    summaryListItem('Reference/CRN', outOfServiceBed.referenceNumber),
     summaryListItem('Notes', outOfServiceBed.notes, 'textBlock'),
   ],
 })
@@ -196,7 +196,7 @@ export const bedRevisionDetails = (revision: Cas1OutOfServiceBedRevision): Summa
 
   if (revision.referenceNumber) {
     summaryListItems.push({
-      key: textValue('Reference number'),
+      key: textValue('Reference/CRN'),
       value: textValue(revision.referenceNumber),
     })
   }

--- a/server/utils/outOfServiceBedUtils.ts
+++ b/server/utils/outOfServiceBedUtils.ts
@@ -20,6 +20,7 @@ import {
   UserDetails,
 } from '@approved-premises/ui'
 
+import { isBefore } from 'date-fns'
 import paths from '../paths/manage'
 import { linkTo } from './utils'
 import { DateFormats, isoDateIsValid } from './dateUtils'
@@ -295,6 +296,10 @@ export const validateOutOfServiceBedInput = (
     errors.endDate = 'You must enter an end date'
   } else if (!isoDateIsValid(endDate)) {
     errors.endDate = 'You must enter a valid end date'
+  }
+
+  if (!errors.startDate && !errors.endDate && isBefore(endDate, startDate)) {
+    errors.endDate = 'The end date must be on or after the start date'
   }
 
   if (!reason) {

--- a/server/utils/outOfServiceBedUtils.ts
+++ b/server/utils/outOfServiceBedUtils.ts
@@ -1,4 +1,5 @@
 import {
+  Cas1OutOfServiceBed,
   Cas1OutOfServiceBed as OutOfServiceBed,
   Cas1OutOfServiceBedRevision,
   Cas1OutOfServiceBedSortField as OutOfServiceBedSortField,
@@ -23,6 +24,7 @@ import { textValue } from './applications/helpers'
 import { sortHeader } from './sortHeader'
 import { hasPermission } from './users'
 import { SanitisedError } from '../sanitisedError'
+import { summaryListItem } from './formUtils'
 
 export const premisesIndexTabs = (premisesId: string, temporality: 'current' | 'future' | 'past') => [
   {
@@ -152,6 +154,16 @@ export const outOfServiceBedTabs = (
   },
 ]
 
+export const outOfServiceBedSummaryList = (outOfServiceBed: Cas1OutOfServiceBed): SummaryList => ({
+  rows: [
+    summaryListItem('Start date', DateFormats.isoDateToUIDate(outOfServiceBed.startDate, { format: 'long' })),
+    summaryListItem('End date', DateFormats.isoDateToUIDate(outOfServiceBed.endDate, { format: 'long' })),
+    summaryListItem('Reason', outOfServiceBed.reason.name),
+    summaryListItem('Reference number/CRN', outOfServiceBed.referenceNumber),
+    summaryListItem('Notes', outOfServiceBed.notes, 'textBlock'),
+  ],
+})
+
 export const bedRevisionDetails = (revision: Cas1OutOfServiceBedRevision): SummaryList['rows'] => {
   const summaryListItems: Array<SummaryListItem> = []
 
@@ -197,21 +209,6 @@ export const sortOutOfServiceBedRevisionsByUpdatedAt = (revisions: Array<Cas1Out
   return revisions.sort((a, b) => {
     return a.updatedAt > b.updatedAt ? -1 : 1
   })
-}
-
-export const overwriteOoSBedWithUserInput = (userInput: Record<string, unknown>, outOfServiceBed: OutOfServiceBed) => {
-  if (userInput.outOfServiceBed && (userInput.outOfServiceBed as Record<string, string>)?.referenceNumber) {
-    outOfServiceBed.referenceNumber = (userInput.outOfServiceBed as Record<string, string>)?.referenceNumber
-  }
-
-  if (
-    (userInput?.outOfServiceBed as Record<string, string>)?.reason &&
-    typeof (userInput.outOfServiceBed as Record<string, string>)?.reason === 'string'
-  ) {
-    outOfServiceBed.reason.id = (userInput.outOfServiceBed as Record<string, string>).reason
-  }
-
-  return outOfServiceBed
 }
 
 type ConflictingEntityType = EntityType

--- a/server/views/manage/outOfServiceBeds/new.njk
+++ b/server/views/manage/outOfServiceBeds/new.njk
@@ -28,7 +28,7 @@
                 {{ showErrorSummary(errorSummary, errorTitle) }}
 
                 <h1 class="govuk-!-margin-bottom-0">Mark a bed as out of service</h1>
-                <p> Provide details of beds that are out of service within your AP estate</p>
+                <p>Provide details of beds that are out of service within your AP estate</p>
 
                 {{ govukDateInput({
                     id: "startDate",
@@ -58,14 +58,14 @@
 
                 {{ govukRadios({
                     idPrefix: "reason",
-                    name: "outOfServiceBed[reason]",
+                    name: "reason",
                     fieldset: {
                         legend: {
                             text: "What is the reason for marking this bed as out of service?",
                             classes: "govuk-fieldset__legend--s"
                         }
                     },
-                    items: convertObjectsToRadioItems(outOfServiceBedReasons, 'name', 'id', 'outOfServiceBed[reason]'),
+                    items: convertObjectsToRadioItems(outOfServiceBedReasons, 'name', 'id', 'reason'),
                     errorMessage: errors.reason
                 }) }}
 
@@ -75,15 +75,15 @@
                     },
                     classes: "govuk-input--width-6",
                     id: "referenceNumber",
-                    name: "outOfServiceBed[referenceNumber]",
-                    value: outOfServiceBed.referenceNumber,
+                    name: "referenceNumber",
+                    value: referenceNumber,
                     errorMessage: errors.referenceNumber
                 }) }}
 
                 {{ govukTextarea({
                     id: "notes",
-                    name: "outOfServiceBed[notes]",
-                    value: outOfServiceBed.notes,
+                    name: "notes",
+                    value: notes,
                     label: {
                         text: "Provide  detail about why the bed is out of service. If FM works are required you should update this record with any progress on that work.",
                         classes: "govuk-fieldset__legend--s"
@@ -92,8 +92,8 @@
                 }) }}
 
                 {{ govukButton({
+                    type: 'submit',
                     text: "Save and continue",
-                    name: "outOfServiceBed[submit]",
                     preventDoubleClick: true
                 }) }}
             </form>

--- a/server/views/manage/outOfServiceBeds/new.njk
+++ b/server/views/manage/outOfServiceBeds/new.njk
@@ -21,14 +21,13 @@
 {% block content %}
 
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
             <form action="{{ paths.outOfServiceBeds.create({ premisesId: premisesId, bedId: bedId }) }}" method="post">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
                 {{ showErrorSummary(errorSummary, errorTitle) }}
 
-                <h1 class="govuk-!-margin-bottom-0">Mark a bed as out of service</h1>
-                <p>Provide details of beds that are out of service within your AP estate</p>
+                <h1 class="govuk-heading-l">Mark a bed as out of service</h1>
 
                 {{ govukDateInput({
                     id: "startDate",
@@ -71,9 +70,12 @@
 
                 {{ govukInput({
                     label: {
-                        text: "Work order reference number"
+                        text: "Work order reference number or CRN",
+                        classes: 'govuk-label--s'
                     },
-                    classes: "govuk-input--width-6",
+                    hint: {
+                        text: "If the bed is on hold for a person, or if a double room is in use by a single person, enter the person's CRN. Otherwise, enter the work order reference number, if known."
+                    },
                     id: "referenceNumber",
                     name: "referenceNumber",
                     value: referenceNumber,
@@ -85,15 +87,18 @@
                     name: "notes",
                     value: notes,
                     label: {
-                        text: "Provide  detail about why the bed is out of service. If FM works are required you should update this record with any progress on that work.",
-                        classes: "govuk-fieldset__legend--s"
+                        text: "Details about why the bed is out of service",
+                        classes: "govuk-label--s"
+                    },
+                    hint: {
+                        text: 'If FM works are required you should update this record with any progress on that work.'
                     },
                     errorMessage: errors.notes
                 }) }}
 
                 {{ govukButton({
                     type: 'submit',
-                    text: "Save and continue",
+                    text: "Save",
                     preventDoubleClick: true
                 }) }}
             </form>

--- a/server/views/manage/outOfServiceBeds/new.njk
+++ b/server/views/manage/outOfServiceBeds/new.njk
@@ -14,7 +14,7 @@
 {% block beforeContent %}
     {{ govukBackLink({
         text: "Back",
-        href: paths.premises.beds.show({ premisesId: premisesId, bedId: bedId })
+        href: backlink
     }) }}
 {% endblock %}
 
@@ -22,79 +22,14 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
-            <form action="{{ paths.outOfServiceBeds.create({ premisesId: premisesId, bedId: bedId }) }}" method="post">
+            <form method="post">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
                 {{ showErrorSummary(errorSummary, errorTitle) }}
 
                 <h1 class="govuk-heading-l">Mark a bed as out of service</h1>
 
-                {{ govukDateInput({
-                    id: "startDate",
-                    namePrefix: "startDate",
-                    items: dateFieldValues('startDate', errors),
-                    errorMessage: errors.startDate,
-                    fieldset: {
-                        legend: {
-                            text: "Start date",
-                            classes: "govuk-fieldset__legend--s"
-                        }
-                    }
-                }) }}
-
-                {{ govukDateInput({
-                    id: "endDate",
-                    namePrefix: "endDate",
-                    items: dateFieldValues('endDate', errors),
-                    errorMessage: errors.endDate,
-                    fieldset: {
-                        legend: {
-                            text: "End date",
-                            classes: "govuk-fieldset__legend--s"
-                        }
-                    }
-                }) }}
-
-                {{ govukRadios({
-                    idPrefix: "reason",
-                    name: "reason",
-                    fieldset: {
-                        legend: {
-                            text: "What is the reason for marking this bed as out of service?",
-                            classes: "govuk-fieldset__legend--s"
-                        }
-                    },
-                    items: convertObjectsToRadioItems(outOfServiceBedReasons, 'name', 'id', 'reason'),
-                    errorMessage: errors.reason
-                }) }}
-
-                {{ govukInput({
-                    label: {
-                        text: "Work order reference number or CRN",
-                        classes: 'govuk-label--s'
-                    },
-                    hint: {
-                        text: "If the bed is on hold for a person, or if a double room is in use by a single person, enter the person's CRN. Otherwise, enter the work order reference number, if known."
-                    },
-                    id: "referenceNumber",
-                    name: "referenceNumber",
-                    value: referenceNumber,
-                    errorMessage: errors.referenceNumber
-                }) }}
-
-                {{ govukTextarea({
-                    id: "notes",
-                    name: "notes",
-                    value: notes,
-                    label: {
-                        text: "Details about why the bed is out of service",
-                        classes: "govuk-label--s"
-                    },
-                    hint: {
-                        text: 'If FM works are required you should update this record with any progress on that work.'
-                    },
-                    errorMessage: errors.notes
-                }) }}
+                {% include './partials/_formFields.njk' %}
 
                 {{ govukButton({
                     type: 'submit',

--- a/server/views/manage/outOfServiceBeds/partials/_bedDetails.njk
+++ b/server/views/manage/outOfServiceBeds/partials/_bedDetails.njk
@@ -1,61 +1,59 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% macro outOfServiceBedDetails(outOfServiceBed, characteristicsHtml)%}
+{% macro outOfServiceBedDetails(outOfServiceBed, characteristicsHtml) %}
 
 
-  {{
-        govukSummaryList({
-          rows: [
+    {{ govukSummaryList({
+        rows: [
             {
-              key: {
+                key: {
                 text: "Start date"
-              },
-              value: {
+            },
+                value: {
                 text: formatDate(outOfServiceBed.startDate, {format: 'long'}) if outOfServiceBed.startDate else "None supplied"
-              }
-            },
-            {
-              key: {
-                text: "End date"
-              },
-              value: {
-                text: formatDate(outOfServiceBed.endDate, {format: 'long'}) if outOfServiceBed.startDate else "None supplied"
-              }
-            },
-            {
-              key: {
-                text: "Reason"
-              },
-              value: {
-                text: outOfServiceBed.reason.name if outOfServiceBed.reason.name else "None supplied"
-              }
-            },
-            {
-              key: {
-                text: "Reference number"
-              },
-              value: {
-                text: outOfServiceBed.referenceNumber if outOfServiceBed.referenceNumber else "None supplied"
-              }
-            },
-            {
-              key: {
-                text: "Additional information"
-              },
-              value: {
-                text: outOfServiceBed.notes if outOfServiceBed.notes else "None supplied"
-              }
-            },
-            {
-              key: {
-                text: "Characteristics"
-              },
-              value: {
-                html: characteristicsHtml
-              }
             }
-          ]
-        })
-      }}
+            },
+            {
+                key: {
+                text: "End date"
+            },
+                value: {
+                text: formatDate(outOfServiceBed.endDate, {format: 'long'}) if outOfServiceBed.startDate else "None supplied"
+            }
+            },
+            {
+                key: {
+                text: "Reason"
+            },
+                value: {
+                text: outOfServiceBed.reason.name if outOfServiceBed.reason.name else "None supplied"
+            }
+            },
+            {
+                key: {
+                text: "Reference/CRN"
+            },
+                value: {
+                text: outOfServiceBed.referenceNumber if outOfServiceBed.referenceNumber else "None supplied"
+            }
+            },
+            {
+                key: {
+                text: "Additional information"
+            },
+                value: {
+                text: outOfServiceBed.notes if outOfServiceBed.notes else "None supplied"
+            }
+            },
+            {
+                key: {
+                text: "Characteristics"
+            },
+                value: {
+                html: characteristicsHtml
+            }
+            }
+        ]
+    }) }}
 
 {% endmacro %}

--- a/server/views/manage/outOfServiceBeds/partials/_formFields.njk
+++ b/server/views/manage/outOfServiceBeds/partials/_formFields.njk
@@ -1,0 +1,71 @@
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{{ govukDateInput({
+    id: "startDate",
+    namePrefix: "startDate",
+    items: dateFieldValues('startDate', errors),
+    errorMessage: errors.startDate,
+    fieldset: {
+        legend: {
+            text: "Start date",
+            classes: "govuk-fieldset__legend--s"
+        }
+    }
+}) }}
+
+{{ govukDateInput({
+    id: "endDate",
+    namePrefix: "endDate",
+    items: dateFieldValues('endDate', errors),
+    errorMessage: errors.endDate,
+    fieldset: {
+        legend: {
+            text: "End date",
+            classes: "govuk-fieldset__legend--s"
+        }
+    }
+}) }}
+
+{{ govukRadios({
+    idPrefix: "reason",
+    name: "reason",
+    fieldset: {
+        legend: {
+            text: "What is the reason for marking this bed as out of service?",
+            classes: "govuk-fieldset__legend--s"
+        }
+    },
+    items: convertObjectsToRadioItems(outOfServiceBedReasons, 'name', 'id', 'reason'),
+    errorMessage: errors.reason
+}) }}
+
+{{ govukInput({
+    label: {
+        text: "Work order reference number or CRN",
+        classes: 'govuk-label--s'
+    },
+    hint: {
+        text: "If the bed is on hold for a person, or if a double room is in use by a single person, enter the person's CRN. Otherwise, enter the work order reference number, if known."
+    },
+    id: "referenceNumber",
+    name: "referenceNumber",
+    value: referenceNumber,
+    errorMessage: errors.referenceNumber
+}) }}
+
+{{ govukTextarea({
+    id: "notes",
+    name: "notes",
+    value: notes,
+    label: {
+        text: "Details about why the bed is out of service",
+        classes: "govuk-label--s"
+    },
+    hint: {
+        text: 'If FM works are required you should update this record with any progress on that work.'
+    },
+    errorMessage: errors.notes
+}) }}

--- a/server/views/manage/outOfServiceBeds/partials/_formFields.njk
+++ b/server/views/manage/outOfServiceBeds/partials/_formFields.njk
@@ -56,16 +56,24 @@
     errorMessage: errors.referenceNumber
 }) }}
 
+{% set notesLabel = "Details about why the bed is out of service" %}
+{% set notesHint = "If FM works are required you should update this record with any progress on that work." %}
+
+{% if "Update" in pageHeading %}
+    {% set notesLabel = "Provide additional information" %}
+    {% set notesHint = "Add further detail on the reason behind this update" %}
+{% endif %}
+
 {{ govukTextarea({
     id: "notes",
     name: "notes",
     value: notes,
     label: {
-        text: "Details about why the bed is out of service",
+        text: notesLabel,
         classes: "govuk-label--s"
     },
     hint: {
-        text: 'If FM works are required you should update this record with any progress on that work.'
+        text: notesHint
     },
     errorMessage: errors.notes
 }) }}

--- a/server/views/manage/outOfServiceBeds/update.njk
+++ b/server/views/manage/outOfServiceBeds/update.njk
@@ -8,7 +8,6 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageHeading = "Update out of service bed record" %}
 {% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body" %}
 
@@ -38,8 +37,6 @@
                         Please provide additional information on the reason for the change before submitting.
                     "
                 }) }}
-
-
 
                 {% include './partials/_formFields.njk' %}
 

--- a/server/views/manage/outOfServiceBeds/update.njk
+++ b/server/views/manage/outOfServiceBeds/update.njk
@@ -1,13 +1,9 @@
-{% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
-{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
+{% from "partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "./partials/_pageHeading.njk" import outOfServiceBedPageHeading %}
 
 {% extends "../../partials/layout.njk" %}
@@ -15,110 +11,51 @@
 {% set pageHeading = "Update out of service bed record" %}
 {% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "app-container govuk-body" %}
-{% set backLink = paths.outOfServiceBeds.show({ premisesId: premisesId, bedId: bedId, id: id, tab: 'details' }) %}
 
 {% block beforeContent %}
     {{ govukBackLink({
         text: "Back",
-        href: backLink
+        href: backlink
     }) }}
 {% endblock %}
 
 {% block content %}
 
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+            <form method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-        <h1>{{ pageHeading }}</h1>
+                {{ showErrorSummary(errorSummary, errorTitle) }}
 
-        {{ govukSummaryList({
-            rows:OutOfServiceBedUtils.bedRevisionDetails(outOfServiceBed)
-        }) }}
+                <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
-        {{ govukInsetText({
-            text: "You can update any of the details if progress has been made since creating the out of service bed record.
-          Please provide additional information on the reason for the change before submitting."
-        }) }}
-        <form action="{{ paths.outOfServiceBeds.update({ premisesId: premisesId, bedId: bedId, id: id }) }}"
-              method="post">
-            <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+                {{ govukSummaryList(outOfServiceBedSummary) }}
 
-            {{ showErrorSummary(errorSummary, errorTitle) }}
+                {{ govukInsetText({
+                    text: "
+                        You can update any of the details if progress has been made since creating the out of service bed record.
+                        Please provide additional information on the reason for the change before submitting.
+                    "
+                }) }}
 
-            {{ govukDateInput({
-                id: "startDate",
-                namePrefix: "startDate",
-                items: dateFieldValues('startDate', outOfServiceBed.startDate),
-                errorMessage: errors.startDate,
-                fieldset: {
-                    legend: {
-                        text: "Start date",
-                        classes: "govuk-fieldset__legend--s"
-                    }
-                }
-            }) }}
 
-            {{ govukDateInput({
-                id: "endDate",
-                namePrefix: "endDate",
-                items: dateFieldValues('endDate', outOfServiceBed.endDate),
-                errorMessage: errors.endDate,
-                fieldset: {
-                    legend: {
-                        text: "End date",
-                        classes: "govuk-fieldset__legend--s"
-                    }
-                }
-            }) }}
 
-            {{ govukRadios({
-                idPrefix: "reason",
-                name: "outOfServiceBed[reason]",
-                fieldset: {
-                    legend: {
-                        text: "What is the reason for marking this bed as out of service?",
-                        classes: "govuk-fieldset__legend--s"
-                    }
-                },
-                items: convertObjectsToRadioItems(outOfServiceBedReasons, 'name', 'id', 'outOfServiceBed[reason][id]')
-            }) }}
+                {% include './partials/_formFields.njk' %}
 
-            {{ govukInput({
-                label: {
-                    text: "Work order reference number",
-                    classes: "govuk-fieldset__legend--s"
-                },
-                classes: "govuk-input--width-6",
-                id: "referenceNumber",
-                name: "outOfServiceBed[referenceNumber]",
-                value: outOfServiceBed.referenceNumber
-            }) }}
+                {{ govukButton({
+                    type: 'submit',
+                    text: "Save",
+                    preventDoubleClick: true
+                }) }}
 
-            {{ govukTextarea({
-                id: "notes",
-                name: "outOfServiceBed[notes]",
-                label: {
-                    text: "Provide additional information",
-                    classes: "govuk-fieldset__legend--s"
-                },
-                hint: {
-                    text: "Add further detail on the reason behind this update"
-                },
-                errorMessage: errors.notes
-            }) }}
-
-            {{ govukButton({
-                text: "Save and continue",
-                name: "outOfServiceBed[submit]",
-                preventDoubleClick: true
-            }) }}
-
-            {{ govukButton({
-                text: "Go back",
-                href: paths.outOfServiceBeds.show({ premisesId: premisesId, bedId: bedId, id: id, tab: 'details' }),
-                classes: "govuk-button--secondary govuk-!-margin-left-3"
-            }) }}
-        </form>
+                {{ govukButton({
+                    text: "Go back",
+                    href: backlink,
+                    classes: "govuk-button--secondary govuk-!-margin-left-3"
+                }) }}
+            </form>
+        </div>
     </div>
 
-    {% endblock %}
+{% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2564

# Changes in this PR

This PR updates the form to create and update Out of Service Bed records. The main change now requires a CRN is provided when the reason selected is linked to a Person, for instance, when a resident is the single user of a double room, or if the bed is being put on hold for a booking. The 'Work order reference number' field is used for this scenario, but has been relabelled and a hint has been added. Any summary list key or column header has been updated to show 'Reference/CRN' instead of 'Ref number' or 'Reference number' as it was before.

The codebase around the create and update OOSB controllers has been refactored quite a bit, to move a lot of the renderers to the controllers from the template. The tests have also been streamlined quite a bit.

This PR does introduce validation for both create and update screens, which could quite feasibly be done by the API; open for discussion!

## Screenshots of UI changes

<details><summary>Create Out of Service Bed record screen showing updated fields</summary>

<img width="499" height="900" alt="Screenshot 2025-08-01 at 15 32 05" src="https://github.com/user-attachments/assets/f343c581-8e00-4f56-9435-6f01d39bdbfb" />

</details>

<details><summary>Create Out of Service Bed record with CRN required error</summary>

<img width="499" height="823" alt="Screenshot 2025-08-01 at 15 32 45" src="https://github.com/user-attachments/assets/eb0d44d1-e1ba-41ab-946b-ca19294089c5" />

</details>

<details><summary>List of OOSB for premises showing updated column header</summary>

<img width="499" height="473" alt="Screenshot 2025-08-01 at 15 33 28" src="https://github.com/user-attachments/assets/75571591-8b74-4bd8-9027-98e3281a40c8" />

</details>

<details><summary>OOSB details page with updated reference label</summary>

<img width="499" height="460" alt="Screenshot 2025-08-01 at 15 33 39" src="https://github.com/user-attachments/assets/d7fedcb5-659d-4b8f-aa2c-f8021487a454" />

</details>

<details><summary>Update Out of Service Bed record page</summary>

<img width="499" height="921" alt="Screenshot 2025-08-01 at 15 34 00" src="https://github.com/user-attachments/assets/57e80177-62d8-4ab0-a9f8-1d25c555870e" />

</details>

<details><summary>OOSB timeline showing updated reference label</summary>

<img width="499" height="621" alt="Screenshot 2025-08-01 at 15 34 25" src="https://github.com/user-attachments/assets/91ae5b96-41bb-48d4-9013-4a1de319ee05" />

</details>

<details><summary>National OOSB list with updated column header</summary>

<img width="499" height="621" alt="Screenshot 2025-08-01 at 15 34 44" src="https://github.com/user-attachments/assets/1bdafeca-f6d7-4c11-a699-4212460bfa33" />

</details>
