### PR TITLE
APS-2484 Restrict task allocation

### DIFF
--- a/integration_tests/pages/tasks/allocationPage.ts
+++ b/integration_tests/pages/tasks/allocationPage.ts
@@ -16,13 +16,21 @@ export default class AllocationsPage extends Page {
   constructor(
     private readonly application: Application,
     private readonly task: Task,
+    title?: string,
   ) {
-    super(`Reallocate`)
+    super(title || `Reallocate`)
   }
 
   static visit(application: Application, task: Task): AllocationsPage {
     cy.visit(paths.tasks.show({ id: task.id, taskType: kebabCase(task.taskType) }))
     return new AllocationsPage(application, task)
+  }
+
+  static visitUnauthorised(task: Task): AllocationsPage {
+    cy.visit(paths.tasks.show({ id: task.id, taskType: kebabCase(task.taskType) }), {
+      failOnStatusCode: false,
+    })
+    return new AllocationsPage(null, null, `Authorisation Error`)
   }
 
   shouldShowInformationAboutTask() {

--- a/integration_tests/tests/tasks/allocations.cy.ts
+++ b/integration_tests/tests/tasks/allocations.cy.ts
@@ -22,11 +22,7 @@ context('Task Allocation', () => {
 
   const cruManagementAreas = [...cruManagementAreaFactory.buildList(4), cruManagementArea]
   const qualifications = qualificationFactory.buildList(2)
-  // Given there are some users in the database
-  const users = [...userWithWorkloadFactory.buildList(3), userWithWorkloadFactory.build({ qualifications })]
-  const selectedUser = users[0]
 
-  // And there is an allocated task
   const applicantUserDetails = applicationUserDetailsFactory.build()
   const caseManagerUserDetails = applicationUserDetailsFactory.build()
   const application = applicationFactory.build({
@@ -63,6 +59,10 @@ context('Task Allocation', () => {
   describe('when logged in as CRU member', () => {
     beforeEach(() => {
       cy.task('reset')
+      GIVEN('there are some users in the database')
+      const users = [...userWithWorkloadFactory.buildList(3), userWithWorkloadFactory.build({ qualifications })]
+
+      AND('there is an allocated task')
       cy.task('stubGetAllTasks', {
         tasks,
         allocatedFilter: 'allocated',
@@ -87,7 +87,7 @@ context('Task Allocation', () => {
       cy.wrap(taskWithRestrictedPerson).as('taskWithRestrictedPerson')
       cy.wrap(tasks).as('tasks')
       cy.wrap(users).as('users')
-      cy.wrap(selectedUser).as('selectedUser')
+      cy.wrap(users[0]).as('selectedUser')
       cy.wrap(application).as('application')
       cy.wrap(applicationForRestrictedPerson).as('applicationForRestrictedPerson')
       cy.wrap(cruManagementArea).as('cruManagementArea')

--- a/integration_tests/tests/tasks/allocations.cy.ts
+++ b/integration_tests/tests/tasks/allocations.cy.ts
@@ -18,210 +18,220 @@ import { fullPersonFactory } from '../../../server/testutils/factories/person'
 import { signIn } from '../signIn'
 
 context('Task Allocation', () => {
-  beforeEach(() => {
-    cy.task('reset')
-    cy.task('stubSignIn')
+  const cruManagementArea = cruManagementAreaFactory.build()
 
-    const cruManagementArea = cruManagementAreaFactory.build()
-    const cruManagementAreas = [...cruManagementAreaFactory.buildList(4), cruManagementArea]
-    const qualifications = qualificationFactory.buildList(2)
-    // Given there are some users in the database
-    const users = [...userWithWorkloadFactory.buildList(3), userWithWorkloadFactory.build({ qualifications })]
-    const selectedUser = users[0]
+  const cruManagementAreas = [...cruManagementAreaFactory.buildList(4), cruManagementArea]
+  const qualifications = qualificationFactory.buildList(2)
+  // Given there are some users in the database
+  const users = [...userWithWorkloadFactory.buildList(3), userWithWorkloadFactory.build({ qualifications })]
+  const selectedUser = users[0]
 
-    // And there is an allocated task
-    const applicantUserDetails = applicationUserDetailsFactory.build()
-    const caseManagerUserDetails = applicationUserDetailsFactory.build()
-    const application = applicationFactory.build({
-      person: fullPersonFactory.build(),
-      applicantUserDetails,
-      caseManagerUserDetails,
-      caseManagerIsNotApplicant: true,
-      apType: 'pipe',
-      isWomensApplication: false,
-    })
-
-    const task = taskFactory.build({
-      allocatedToStaffMember: userFactory.build(),
-      applicationId: application.id,
-      taskType: 'Assessment',
-      probationDeliveryUnit: { id: '2', name: 'East Sussex (includes Brighton and Hove)' },
-    })
-
-    const restrictedPerson = personFactory.build({ isRestricted: true })
-    const applicationForRestrictedPerson = applicationFactory.withReleaseDate().build({
-      apType: 'pipe',
-      person: restrictedPerson,
-      isWomensApplication: false,
-    })
-
-    const taskWithRestrictedPerson = taskFactory.build({
-      allocatedToStaffMember: userFactory.build(),
-      applicationId: applicationForRestrictedPerson.id,
-      taskType: 'Assessment',
-      probationDeliveryUnit: { id: '1', name: 'East Sussex (includes Brighton and Hove)' },
-    })
-
-    const tasks = [task, taskWithRestrictedPerson]
-
-    cy.task('stubGetAllTasks', {
-      tasks,
-      allocatedFilter: 'allocated',
-      page: '1',
-      sortDirection: 'asc',
-      cruManagementAreaId: cruManagementArea.id,
-    })
-    cy.task('stubTaskGet', { application, task, users })
-    cy.task('stubApplicationGet', { application })
-    cy.task('stubCruManagementAreaReferenceData', { cruManagementAreas })
-    cy.task('stubUserSummaryList', { users, roles: ['assessor', 'appeals_manager'] })
-    cy.task('stubUserList', { users, roles: ['assessor', 'appeals_manager'] })
-
-    // And I am signed in as a CRU member with the correct CRU management area
-    signIn('cru_member', { cruManagementArea })
-
-    // When I visit the task list page
-    const taskListPage = TaskListPage.visit(tasks, [])
-
-    cy.wrap(task).as('task')
-    cy.wrap(taskListPage).as('taskListPage')
-    cy.wrap(taskWithRestrictedPerson).as('taskWithRestrictedPerson')
-    cy.wrap(tasks).as('tasks')
-    cy.wrap(users).as('users')
-    cy.wrap(selectedUser).as('selectedUser')
-    cy.wrap(application).as('application')
-    cy.wrap(applicationForRestrictedPerson).as('applicationForRestrictedPerson')
-    cy.wrap(cruManagementArea).as('cruManagementArea')
-    cy.wrap(qualifications).as('qualification')
+  // And there is an allocated task
+  const applicantUserDetails = applicationUserDetailsFactory.build()
+  const caseManagerUserDetails = applicationUserDetailsFactory.build()
+  const application = applicationFactory.build({
+    person: fullPersonFactory.build(),
+    applicantUserDetails,
+    caseManagerUserDetails,
+    caseManagerIsNotApplicant: true,
+    apType: 'pipe',
+    isWomensApplication: false,
   })
 
-  it('allows me to allocate a task', function test() {
-    cy.task('stubTaskAllocationCreate', {
-      task: { ...this.task, applicationId: this.application.id, allocatedToStaffMember: this.selectedUser },
-      reallocation: reallocationFactory.build({ taskType: this.task.taskType, user: this.selectedUser }),
+  const task = taskFactory.build({
+    allocatedToStaffMember: userFactory.build(),
+    applicationId: application.id,
+    taskType: 'Assessment',
+    probationDeliveryUnit: { id: '2', name: 'East Sussex (includes Brighton and Hove)' },
+  })
+
+  const restrictedPerson = personFactory.build({ isRestricted: true })
+  const applicationForRestrictedPerson = applicationFactory.withReleaseDate().build({
+    apType: 'pipe',
+    person: restrictedPerson,
+    isWomensApplication: false,
+  })
+
+  const taskWithRestrictedPerson = taskFactory.build({
+    allocatedToStaffMember: userFactory.build(),
+    applicationId: applicationForRestrictedPerson.id,
+    taskType: 'Assessment',
+    probationDeliveryUnit: { id: '1', name: 'East Sussex (includes Brighton and Hove)' },
+  })
+
+  const tasks = [task, taskWithRestrictedPerson]
+  describe('when logged in as CRU member', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      // cy.task('stubSignIn')
+      cy.task('stubGetAllTasks', {
+        tasks,
+        allocatedFilter: 'allocated',
+        page: '1',
+        sortDirection: 'asc',
+        cruManagementAreaId: cruManagementArea.id,
+      })
+      cy.task('stubTaskGet', { application, task, users })
+      cy.task('stubApplicationGet', { application })
+      cy.task('stubCruManagementAreaReferenceData', { cruManagementAreas })
+      cy.task('stubUserSummaryList', { users, roles: ['assessor', 'appeals_manager'] })
+      cy.task('stubUserList', { users, roles: ['assessor', 'appeals_manager'] })
+
+      // And I am signed in as a CRU member with the correct CRU management area
+      signIn('cru_member', { cruManagementArea })
+
+      // When I visit the task list page
+      const taskListPage = TaskListPage.visit()
+
+      cy.wrap(task).as('task')
+      cy.wrap(taskListPage).as('taskListPage')
+      cy.wrap(taskWithRestrictedPerson).as('taskWithRestrictedPerson')
+      cy.wrap(tasks).as('tasks')
+      cy.wrap(users).as('users')
+      cy.wrap(selectedUser).as('selectedUser')
+      cy.wrap(application).as('application')
+      cy.wrap(applicationForRestrictedPerson).as('applicationForRestrictedPerson')
+      cy.wrap(cruManagementArea).as('cruManagementArea')
+      cy.wrap(qualifications).as('qualification')
     })
 
-    // And I click to allocate the task
-    this.taskListPage.clickTask(this.task)
+    it('allows me to allocate a task', function test() {
+      cy.task('stubTaskAllocationCreate', {
+        task: { ...this.task, applicationId: this.application.id, allocatedToStaffMember: this.selectedUser },
+        reallocation: reallocationFactory.build({ taskType: this.task.taskType, user: this.selectedUser }),
+      })
 
-    // Then I should be on the Allocations page for that task
-    const allocationsPage = Page.verifyOnPage(AllocationsPage, this.application, this.task)
+      // And I click to allocate the task
+      this.taskListPage.clickTask(this.task)
 
-    // And I should see some information about that task
-    allocationsPage.shouldShowInformationAboutTask()
+      // Then I should be on the Allocations page for that task
+      const allocationsPage = Page.verifyOnPage(AllocationsPage, this.application, this.task)
 
-    // And I should see a list of staff members who can be allocated to that task
-    allocationsPage.shouldShowUserTable(this.users, this.task)
+      // And I should see some information about that task
+      allocationsPage.shouldShowInformationAboutTask()
 
-    // When I select a new user to allocate the application to
-    allocationsPage.clickAllocateToUser(this.users[0])
+      // And I should see a list of staff members who can be allocated to that task
+      allocationsPage.shouldShowUserTable(this.users, this.task)
 
-    // Then I should be redirected to the index page
-    Page.verifyOnPage(TaskListPage, [], [])
+      // When I select a new user to allocate the application to
+      allocationsPage.clickAllocateToUser(this.users[0])
 
-    // And I should see a confirmation message
-    this.taskListPage.shouldShowBanner(`Assessment has been allocated to ${this.selectedUser.name}`)
+      // Then I should be redirected to the index page
+      Page.verifyOnPage(TaskListPage, [], [])
 
-    // And the API should have received the correct data
-    cy.task('verifyAllocationCreate', this.task).then(requests => {
-      // Then the API should have had a clarification note added
-      expect(requests).to.have.length(1)
-      const body = JSON.parse(requests[0].body)
+      // And I should see a confirmation message
+      this.taskListPage.shouldShowBanner(`Assessment has been allocated to ${this.selectedUser.name}`)
 
-      expect(body.userId).equal(this.selectedUser.id)
+      // And the API should have received the correct data
+      cy.task('verifyAllocationCreate', this.task).then(requests => {
+        // Then the API should have had a clarification note added
+        expect(requests).to.have.length(1)
+        const body = JSON.parse(requests[0].body)
+
+        expect(body.userId).equal(this.selectedUser.id)
+      })
+    })
+
+    it('highlights if a person is limited access offender', function test() {
+      cy.task('stubTaskGet', {
+        application: this.applicationForRestrictedPerson,
+        task: this.taskWithRestrictedPerson,
+        users: this.users,
+      })
+      cy.task('stubApplicationGet', { application: this.applicationForRestrictedPerson })
+
+      // When I click on a task for a restricted person
+      this.taskListPage.clickTask(this.taskWithRestrictedPerson)
+
+      // Then I should be on the Allocations page for that task
+      const allocationsPage = Page.verifyOnPage(
+        AllocationsPage,
+        this.applicationForRestrictedPerson,
+        this.taskWithRestrictedPerson,
+      )
+
+      allocationsPage.shouldShowPersonIsLimitedAccessOffender()
+    })
+
+    it('allows filters on users dashboard', function test() {
+      // And I click to view the task
+      this.taskListPage.clickTask(this.task)
+
+      // Then I should be on the Allocations page for that task
+      const allocationsPage = Page.verifyOnPage(AllocationsPage, this.application, this.task)
+
+      // And I should see a list of staff members who can be allocated to that task
+      allocationsPage.shouldShowUserTable(this.users, this.task)
+
+      // And the table should be sortable
+      allocationsPage.shouldBeSortableBy('Tasks pending')
+      allocationsPage.shouldBeSortableBy('Name')
+      allocationsPage.shouldBeSortableBy('Tasks completed in previous 7 days')
+      allocationsPage.shouldBeSortableBy('Tasks completed in previous 30 days')
+
+      // When I filter by CRU Management Area
+      allocationsPage.searchBy('cruManagementAreaId', this.cruManagementArea.id)
+      allocationsPage.clickApplyFilter()
+
+      // Then I should be shown a list of users with that CRU Management Area
+      let expectedUsers = this.users.filter(user => user.cruManagementArea.id === this.cruManagementArea.id)
+      allocationsPage.shouldShowUserTable(expectedUsers, this.task)
+
+      // When I filter by all areas it should clear the filter
+      allocationsPage.searchBy('cruManagementAreaId', '')
+      allocationsPage.clickApplyFilter()
+
+      // Then I should be shown a list of users for all areas
+      allocationsPage.shouldShowUserTable(this.users, this.task)
+
+      // When I filter by qualifications
+      allocationsPage.searchBy('qualification', this.qualification[0])
+      allocationsPage.clickApplyFilter()
+
+      // Then I should be shown a list of users with that qualification
+      expectedUsers = this.users.filter(user => user.qualifications?.includes(this.qualification[0]))
+      allocationsPage.shouldShowUserTable(expectedUsers, this.task)
+
+      // When I filter by both filters
+      allocationsPage.searchBy('cruManagementAreaId', this.cruManagementArea.id)
+      allocationsPage.clickApplyFilter()
+
+      // Then I should be shown a list of users with that qualification and CRU Management Area
+      expectedUsers = expectedUsers.filter(user => user.cruManagementArea.id === this.cruManagementArea.id)
+      allocationsPage.shouldShowUserTable(expectedUsers, this.task)
+    })
+
+    it('allows me to view timeline for task', function test() {
+      const timeline = cas1TimelineEventFactory.buildList(10)
+      cy.task('stubTaskAllocationCreate', {
+        task: { ...this.task, applicationId: this.application.id, allocatedToStaffMember: this.selectedUser },
+        reallocation: reallocationFactory.build({ taskType: this.task.taskType, user: this.selectedUser }),
+      })
+      const updatedApplication = { ...this.application, status: 'awaitingAssesment' }
+      cy.task('stubApplicationGet', { application: updatedApplication })
+      cy.task('stubApplicationTimeline', { applicationId: updatedApplication.id, timeline })
+
+      // And I click to allocate the task
+      this.taskListPage.clickTask(this.task)
+
+      // Then I should be on the Allocations page for that task
+      const allocationsPage = Page.verifyOnPage(AllocationsPage, this.application, this.task)
+
+      // And I should see some information about that task
+      allocationsPage.shouldShowInformationAboutTask()
+
+      // Then I should see timeline page
+      allocationsPage.clickViewTimeline()
+      allocationsPage.shouldShowTimelineTab()
     })
   })
 
-  it('highlights if a person is limited access offender', function test() {
-    cy.task('stubTaskGet', {
-      application: this.applicationForRestrictedPerson,
-      task: this.taskWithRestrictedPerson,
-      users: this.users,
+  describe('when logged in as an AP area manager', () => {
+    it('should prevent access to the allocate page', () => {
+      // And I am signed in as an ap area manager
+      signIn('ap_area_manager')
+      // Then I should see an error if I attempt to access the allocation page
+      AllocationsPage.visitUnauthorised(task)
     })
-    cy.task('stubApplicationGet', { application: this.applicationForRestrictedPerson })
-
-    // When I click on a task for a restricted person
-    this.taskListPage.clickTask(this.taskWithRestrictedPerson)
-
-    // Then I should be on the Allocations page for that task
-    const allocationsPage = Page.verifyOnPage(
-      AllocationsPage,
-      this.applicationForRestrictedPerson,
-      this.taskWithRestrictedPerson,
-    )
-
-    allocationsPage.shouldShowPersonIsLimitedAccessOffender()
-  })
-
-  it('allows filters on users dashboard', function test() {
-    // And I click to view the task
-    this.taskListPage.clickTask(this.task)
-
-    // Then I should be on the Allocations page for that task
-    const allocationsPage = Page.verifyOnPage(AllocationsPage, this.application, this.task)
-
-    // And I should see a list of staff members who can be allocated to that task
-    allocationsPage.shouldShowUserTable(this.users, this.task)
-
-    // And the table should be sortable
-    allocationsPage.shouldBeSortableBy('Tasks pending')
-    allocationsPage.shouldBeSortableBy('Name')
-    allocationsPage.shouldBeSortableBy('Tasks completed in previous 7 days')
-    allocationsPage.shouldBeSortableBy('Tasks completed in previous 30 days')
-
-    // When I filter by CRU Management Area
-    allocationsPage.searchBy('cruManagementAreaId', this.cruManagementArea.id)
-    allocationsPage.clickApplyFilter()
-
-    // Then I should be shown a list of users with that CRU Management Area
-    let expectedUsers = this.users.filter(user => user.cruManagementArea.id === this.cruManagementArea.id)
-    allocationsPage.shouldShowUserTable(expectedUsers, this.task)
-
-    // When I filter by all areas it should clear the filter
-    allocationsPage.searchBy('cruManagementAreaId', '')
-    allocationsPage.clickApplyFilter()
-
-    // Then I should be shown a list of users for all areas
-    allocationsPage.shouldShowUserTable(this.users, this.task)
-
-    // When I filter by qualifications
-    allocationsPage.searchBy('qualification', this.qualification[0])
-    allocationsPage.clickApplyFilter()
-
-    // Then I should be shown a list of users with that qualification
-    expectedUsers = this.users.filter(user => user.qualifications?.includes(this.qualification[0]))
-    allocationsPage.shouldShowUserTable(expectedUsers, this.task)
-
-    // When I filter by both filters
-    allocationsPage.searchBy('cruManagementAreaId', this.cruManagementArea.id)
-    allocationsPage.clickApplyFilter()
-
-    // Then I should be shown a list of users with that qualification and CRU Management Area
-    expectedUsers = expectedUsers.filter(user => user.cruManagementArea.id === this.cruManagementArea.id)
-    allocationsPage.shouldShowUserTable(expectedUsers, this.task)
-  })
-
-  it('allows me to view timeline for task', function test() {
-    const timeline = cas1TimelineEventFactory.buildList(10)
-    cy.task('stubTaskAllocationCreate', {
-      task: { ...this.task, applicationId: this.application.id, allocatedToStaffMember: this.selectedUser },
-      reallocation: reallocationFactory.build({ taskType: this.task.taskType, user: this.selectedUser }),
-    })
-    const updatedApplication = { ...this.application, status: 'awaitingAssesment' }
-    cy.task('stubApplicationGet', { application: updatedApplication })
-    cy.task('stubApplicationTimeline', { applicationId: updatedApplication.id, timeline })
-
-    // And I click to allocate the task
-    this.taskListPage.clickTask(this.task)
-
-    // Then I should be on the Allocations page for that task
-    const allocationsPage = Page.verifyOnPage(AllocationsPage, this.application, this.task)
-
-    // And I should see some information about that task
-    allocationsPage.shouldShowInformationAboutTask()
-
-    // Then I should see timeline page
-    allocationsPage.clickViewTimeline()
-    allocationsPage.shouldShowTimelineTab()
   })
 })

--- a/integration_tests/tests/tasks/allocations.cy.ts
+++ b/integration_tests/tests/tasks/allocations.cy.ts
@@ -1,7 +1,7 @@
+import { AND, GIVEN, THEN, WHEN } from '../../helpers'
 import TaskListPage from '../../pages/tasks/listPage'
 import AllocationsPage from '../../pages/tasks/allocationPage'
 import Page from '../../pages/page'
-
 import {
   applicationFactory,
   cas1TimelineEventFactory,
@@ -63,7 +63,6 @@ context('Task Allocation', () => {
   describe('when logged in as CRU member', () => {
     beforeEach(() => {
       cy.task('reset')
-      // cy.task('stubSignIn')
       cy.task('stubGetAllTasks', {
         tasks,
         allocatedFilter: 'allocated',
@@ -77,10 +76,10 @@ context('Task Allocation', () => {
       cy.task('stubUserSummaryList', { users, roles: ['assessor', 'appeals_manager'] })
       cy.task('stubUserList', { users, roles: ['assessor', 'appeals_manager'] })
 
-      // And I am signed in as a CRU member with the correct CRU management area
+      GIVEN('I am signed in as a CRU member with the correct CRU management area')
       signIn('cru_member', { cruManagementArea })
 
-      // When I visit the task list page
+      WHEN('I visit the task list page')
       const taskListPage = TaskListPage.visit()
 
       cy.wrap(task).as('task')
@@ -101,30 +100,30 @@ context('Task Allocation', () => {
         reallocation: reallocationFactory.build({ taskType: this.task.taskType, user: this.selectedUser }),
       })
 
-      // And I click to allocate the task
+      AND('I click to allocate the task')
       this.taskListPage.clickTask(this.task)
 
-      // Then I should be on the Allocations page for that task
+      THEN('I should be on the Allocations page for that task')
       const allocationsPage = Page.verifyOnPage(AllocationsPage, this.application, this.task)
 
-      // And I should see some information about that task
+      AND('I should see some information about that task')
       allocationsPage.shouldShowInformationAboutTask()
 
-      // And I should see a list of staff members who can be allocated to that task
+      AND('I should see a list of staff members who can be allocated to that task')
       allocationsPage.shouldShowUserTable(this.users, this.task)
 
-      // When I select a new user to allocate the application to
+      WHEN('I select a new user to allocate the application to')
       allocationsPage.clickAllocateToUser(this.users[0])
 
-      // Then I should be redirected to the index page
+      THEN('I should be redirected to the index page')
       Page.verifyOnPage(TaskListPage, [], [])
 
-      // And I should see a confirmation message
+      AND('I should see a confirmation message')
       this.taskListPage.shouldShowBanner(`Assessment has been allocated to ${this.selectedUser.name}`)
 
-      // And the API should have received the correct data
+      AND('the API should have received the correct data')
       cy.task('verifyAllocationCreate', this.task).then(requests => {
-        // Then the API should have had a clarification note added
+        THEN('the API should have had a clarification note added')
         expect(requests).to.have.length(1)
         const body = JSON.parse(requests[0].body)
 
@@ -140,10 +139,10 @@ context('Task Allocation', () => {
       })
       cy.task('stubApplicationGet', { application: this.applicationForRestrictedPerson })
 
-      // When I click on a task for a restricted person
+      WHEN('I click on a task for a restricted person')
       this.taskListPage.clickTask(this.taskWithRestrictedPerson)
 
-      // Then I should be on the Allocations page for that task
+      THEN('I should be on the Allocations page for that task')
       const allocationsPage = Page.verifyOnPage(
         AllocationsPage,
         this.applicationForRestrictedPerson,
@@ -154,49 +153,49 @@ context('Task Allocation', () => {
     })
 
     it('allows filters on users dashboard', function test() {
-      // And I click to view the task
+      AND('I click to view the task')
       this.taskListPage.clickTask(this.task)
 
-      // Then I should be on the Allocations page for that task
+      THEN('I should be on the Allocations page for that task')
       const allocationsPage = Page.verifyOnPage(AllocationsPage, this.application, this.task)
 
-      // And I should see a list of staff members who can be allocated to that task
+      AND('I should see a list of staff members who can be allocated to that task')
       allocationsPage.shouldShowUserTable(this.users, this.task)
 
-      // And the table should be sortable
+      AND('the table should be sortable')
       allocationsPage.shouldBeSortableBy('Tasks pending')
       allocationsPage.shouldBeSortableBy('Name')
       allocationsPage.shouldBeSortableBy('Tasks completed in previous 7 days')
       allocationsPage.shouldBeSortableBy('Tasks completed in previous 30 days')
 
-      // When I filter by CRU Management Area
+      WHEN('I filter by CRU Management Area')
       allocationsPage.searchBy('cruManagementAreaId', this.cruManagementArea.id)
       allocationsPage.clickApplyFilter()
 
-      // Then I should be shown a list of users with that CRU Management Area
+      THEN('I should be shown a list of users with that CRU Management Area')
       let expectedUsers = this.users.filter(user => user.cruManagementArea.id === this.cruManagementArea.id)
       allocationsPage.shouldShowUserTable(expectedUsers, this.task)
 
-      // When I filter by all areas it should clear the filter
+      WHEN('I filter by all areas it should clear the filter')
       allocationsPage.searchBy('cruManagementAreaId', '')
       allocationsPage.clickApplyFilter()
 
-      // Then I should be shown a list of users for all areas
+      THEN('I should be shown a list of users for all areas')
       allocationsPage.shouldShowUserTable(this.users, this.task)
 
-      // When I filter by qualifications
+      WHEN('I filter by qualifications')
       allocationsPage.searchBy('qualification', this.qualification[0])
       allocationsPage.clickApplyFilter()
 
-      // Then I should be shown a list of users with that qualification
+      THEN('I should be shown a list of users with that qualification')
       expectedUsers = this.users.filter(user => user.qualifications?.includes(this.qualification[0]))
       allocationsPage.shouldShowUserTable(expectedUsers, this.task)
 
-      // When I filter by both filters
+      WHEN('I filter by both filters')
       allocationsPage.searchBy('cruManagementAreaId', this.cruManagementArea.id)
       allocationsPage.clickApplyFilter()
 
-      // Then I should be shown a list of users with that qualification and CRU Management Area
+      THEN('I should be shown a list of users with that qualification and CRU Management Area')
       expectedUsers = expectedUsers.filter(user => user.cruManagementArea.id === this.cruManagementArea.id)
       allocationsPage.shouldShowUserTable(expectedUsers, this.task)
     })
@@ -211,16 +210,16 @@ context('Task Allocation', () => {
       cy.task('stubApplicationGet', { application: updatedApplication })
       cy.task('stubApplicationTimeline', { applicationId: updatedApplication.id, timeline })
 
-      // And I click to allocate the task
+      AND('I click to allocate the task')
       this.taskListPage.clickTask(this.task)
 
-      // Then I should be on the Allocations page for that task
+      THEN('I should be on the Allocations page for that task')
       const allocationsPage = Page.verifyOnPage(AllocationsPage, this.application, this.task)
 
-      // And I should see some information about that task
+      AND('I should see some information about that task')
       allocationsPage.shouldShowInformationAboutTask()
 
-      // Then I should see timeline page
+      THEN('I should see timeline page')
       allocationsPage.clickViewTimeline()
       allocationsPage.shouldShowTimelineTab()
     })
@@ -228,9 +227,9 @@ context('Task Allocation', () => {
 
   describe('when logged in as an AP area manager', () => {
     it('should prevent access to the allocate page', () => {
-      // And I am signed in as an ap area manager
+      AND('I am signed in as an ap area manager')
       signIn('ap_area_manager')
-      // Then I should see an error if I attempt to access the allocation page
+      THEN('I should see an error if I attempt to access the allocation page')
       AllocationsPage.visitUnauthorised(task)
     })
   })

--- a/server/controllers/tasksController.test.ts
+++ b/server/controllers/tasksController.test.ts
@@ -1,9 +1,9 @@
 import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
-import { Task } from '@approved-premises/api'
-import { when } from 'jest-when'
-import { ErrorsAndUserInput, PaginatedResponse } from '@approved-premises/ui'
+import { SortDirection, Task, TaskSortField } from '@approved-premises/api'
+import { ErrorsAndUserInput, ErrorSummary, PaginatedResponse, TaskSearchQualification } from '@approved-premises/ui'
+import { faker } from '@faker-js/faker'
 import TasksController from './tasksController'
 import {
   applicationFactory,
@@ -52,172 +52,123 @@ describe('TasksController', () => {
       data: tasks,
     }) as PaginatedResponse<Task>
     const cruManagementAreas = cruManagementAreaFactory.buildList(3)
-    const paginationDetails = {
+
+    const paginationDetails: {
+      hrefPrefix: string
+      pageNumber: number
+      sortBy: TaskSortField
+      sortDirection: SortDirection
+    } = {
       hrefPrefix: paths.tasks.index({}),
       pageNumber: 1,
+      sortBy: faker.helpers.arrayElement(['person', 'dueAt', 'expectedArrivalDate', 'allocatedTo', 'apType']),
+      sortDirection: faker.helpers.arrayElement(['asc', 'desc']),
+    }
+    const template = 'tasks/index'
+    const renderParameters = {
+      pageHeading: 'Task Allocation',
+      taskHeader: tasksTableHeader(
+        'allocated',
+        paginationDetails.sortBy,
+        paginationDetails.sortDirection,
+        paginationDetails.hrefPrefix,
+      ),
+      taskRows: tasksTableRows(tasks, 'allocated', true),
+      allocatedFilter: 'allocated',
+      cruManagementAreas,
+      pageNumber: Number(paginatedResponse.pageNumber),
+      totalPages: Number(paginatedResponse.totalPages),
+      hrefPrefix: paginationDetails.hrefPrefix,
+      cruManagementArea: cruManagementArea.id,
+      userQualificationSelectOptions: userQualificationsSelectOptions(null),
+      users,
+      activeTab: 'allocated',
+    }
+
+    const apiGetAllParameters = {
+      allocatedFilter: 'allocated',
+      token,
+      sortBy: paginationDetails.sortBy,
+      sortDirection: paginationDetails.sortDirection,
+      page: paginationDetails.pageNumber,
+      cruManagementAreaId: cruManagementArea.id,
+      taskTypes: ['PlacementApplication', 'Assessment'],
+      requiredQualification: null as TaskSearchQualification,
+      isCompleted: false,
     }
 
     beforeEach(() => {
-      when(cruManagementAreaService.getCruManagementAreas).calledWith(token).mockResolvedValue(cruManagementAreas)
-      when(taskService.getAll).calledWith(expect.anything()).mockResolvedValue(paginatedResponse)
-      when(userService.getUserList).calledWith(token, ['assessor', 'appeals_manager']).mockResolvedValue(users)
-      when(getPaginationDetails as jest.Mock)
-        .calledWith(request, paths.tasks.index({}), expect.anything())
-        .mockReturnValue(paginationDetails)
+      cruManagementAreaService.getCruManagementAreas.mockResolvedValue(cruManagementAreas)
+      taskService.getAll.mockResolvedValue(paginatedResponse)
+      userService.getUserList.mockResolvedValue(users)
+      ;(getPaginationDetails as jest.Mock).mockReturnValue(paginationDetails)
 
       response.locals.user = user
     })
 
     it('should render the tasks template with the users CRU management area filtered by default', async () => {
-      const requestHandler = tasksController.index()
-      await requestHandler(request, response, next)
+      await tasksController.index()(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('tasks/index', {
-        pageHeading: 'Task Allocation',
-        taskHeader: tasksTableHeader('allocated', 'createdAt', 'asc', paginationDetails.hrefPrefix),
-        taskRows: tasksTableRows(tasks, 'allocated', true),
-        allocatedFilter: 'allocated',
-        cruManagementAreas,
-        pageNumber: Number(paginatedResponse.pageNumber),
-        totalPages: Number(paginatedResponse.totalPages),
-        hrefPrefix: paginationDetails.hrefPrefix,
-        cruManagementArea: cruManagementArea.id,
-        userQualificationSelectOptions: userQualificationsSelectOptions(null),
-        users,
-        activeTab: 'allocated',
-      })
+      expect(response.render).toHaveBeenCalledWith(template, renderParameters)
 
-      expect(taskService.getAll).toHaveBeenCalledWith({
-        allocatedFilter: 'allocated',
-        token,
-        sortBy: 'createdAt',
-        sortDirection: 'asc',
-        page: 1,
-        cruManagementAreaId: cruManagementArea.id,
-        taskTypes: ['PlacementApplication', 'Assessment'],
-        requiredQualification: null,
-        isCompleted: false,
-      })
+      expect(taskService.getAll).toHaveBeenCalledWith(apiGetAllParameters)
     })
 
     it('should handle request parameters correctly', async () => {
-      const paramPaginationDetails = {
-        hrefPrefix: paths.tasks.index({}),
-        pageNumber: 1,
-        sortBy: 'name',
-        sortDirection: 'desc',
+      const query = {
+        activeTab: 'unallocated',
+        crnOrName: 'ABC123',
+        allocatedFilter: 'unallocated',
+        area: '1234',
+        allocatedToUserId: '123',
+        requiredQualification: 'emergency' as TaskSearchQualification,
       }
-      const cruManagementAreaId = '1234'
-      const allocatedFilter = 'unallocated'
-      const allocatedToUserId = '123'
-      const requiredQualification = 'emergency'
-      const crnOrName = 'ABC123'
-      const activeTab = 'unallocated'
 
-      const requestHandler = tasksController.index()
       const unallocatedRequest = {
         ...request,
-        query: {
-          activeTab,
-          allocatedFilter,
-          area: cruManagementAreaId,
-          allocatedToUserId,
-          requiredQualification,
-          crnOrName,
-        },
+        query,
       }
 
-      when(getPaginationDetails as jest.Mock)
-        .calledWith(unallocatedRequest, paths.tasks.index({}), {
-          activeTab,
-          allocatedFilter,
-          area: cruManagementAreaId,
-          allocatedToUserId,
-          requiredQualification,
-          crnOrName,
-        })
-        .mockReturnValue(paramPaginationDetails)
-
-      await requestHandler(unallocatedRequest, response, next)
+      await tasksController.index()(unallocatedRequest, response, next)
 
       expect(response.render).toHaveBeenCalledWith('tasks/index', {
-        pageHeading: 'Task Allocation',
-        taskHeader: tasksTableHeader('unallocated', 'createdAt', 'asc', paginationDetails.hrefPrefix),
+        ...renderParameters,
+        taskHeader: tasksTableHeader(
+          'unallocated',
+          paginationDetails.sortBy,
+          paginationDetails.sortDirection,
+          paginationDetails.hrefPrefix,
+        ),
         taskRows: tasksTableRows(tasks, 'unallocated', true),
-        allocatedFilter,
-        cruManagementAreas,
-        pageNumber: Number(paginatedResponse.pageNumber),
-        totalPages: Number(paginatedResponse.totalPages),
-        hrefPrefix: paginationDetails.hrefPrefix,
-        cruManagementArea: cruManagementAreaId,
-        users,
-        allocatedToUserId,
-        userQualificationSelectOptions: userQualificationsSelectOptions(requiredQualification),
-        crnOrName,
-        activeTab,
+
+        cruManagementArea: query.area,
+        allocatedFilter: query.allocatedFilter,
+        allocatedToUserId: query.allocatedToUserId,
+        userQualificationSelectOptions: userQualificationsSelectOptions(query.requiredQualification),
+        crnOrName: query.crnOrName,
+        activeTab: query.activeTab,
       })
 
-      expect(getPaginationDetails).toHaveBeenCalledWith(unallocatedRequest, paths.tasks.index({}), {
-        activeTab,
-        allocatedFilter,
-        area: cruManagementAreaId,
-        allocatedToUserId,
-        requiredQualification,
-        crnOrName,
-      })
+      expect(getPaginationDetails).toHaveBeenCalledWith(unallocatedRequest, paths.tasks.index({}), query)
 
       expect(taskService.getAll).toHaveBeenCalledWith({
-        allocatedFilter,
-        token,
-        sortBy: paramPaginationDetails.sortBy,
-        sortDirection: paramPaginationDetails.sortDirection,
-        page: paramPaginationDetails.pageNumber,
-        cruManagementAreaId,
+        ...apiGetAllParameters,
         taskTypes: ['PlacementApplication', 'Assessment'],
-        allocatedToUserId,
-        requiredQualification,
-        crnOrName,
+        allocatedFilter: query.allocatedFilter,
+        requiredQualification: query.requiredQualification,
+        cruManagementAreaId: query.area,
+        allocatedToUserId: query.allocatedToUserId,
+        crnOrName: query.crnOrName,
         isCompleted: false,
       })
     })
 
     it('should not send an area query if the  if the query is "all"', async () => {
-      const paramPaginationDetails = {
-        hrefPrefix: paths.tasks.index({}),
-        pageNumber: 1,
-        sortBy: 'createdAt',
-        sortDirection: 'asc',
-        allocatedFilter: 'allocated',
-      }
-
-      const requestHandler = tasksController.index()
       const requestWithQuery = { ...request, query: { area: 'all' } }
 
-      when(getPaginationDetails as jest.Mock)
-        .calledWith(requestWithQuery, paths.tasks.index({}), {
-          activeTab: 'allocated',
-          allocatedFilter: 'allocated',
-          area: 'all',
-          requiredQualification: null,
-        })
-        .mockReturnValue(paramPaginationDetails)
+      await tasksController.index()(requestWithQuery, response, next)
 
-      await requestHandler(requestWithQuery, response, next)
-
-      expect(response.render).toHaveBeenCalledWith('tasks/index', {
-        pageHeading: 'Task Allocation',
-        taskHeader: tasksTableHeader('allocated', 'createdAt', 'asc', paginationDetails.hrefPrefix),
-        taskRows: tasksTableRows(tasks, 'allocated', true),
-        allocatedFilter: paramPaginationDetails.allocatedFilter,
-        cruManagementAreas,
-        pageNumber: Number(paginatedResponse.pageNumber),
-        totalPages: Number(paginatedResponse.totalPages),
-        hrefPrefix: paginationDetails.hrefPrefix,
-        cruManagementArea: 'all',
-        users,
-        userQualificationSelectOptions: userQualificationsSelectOptions(null),
-        activeTab: 'allocated',
-      })
+      expect(response.render).toHaveBeenCalledWith(template, { ...renderParameters, cruManagementArea: 'all' })
       expect(getPaginationDetails).toHaveBeenCalledWith(requestWithQuery, paths.tasks.index({}), {
         activeTab: 'allocated',
         allocatedFilter: 'allocated',
@@ -226,11 +177,7 @@ describe('TasksController', () => {
       })
 
       expect(taskService.getAll).toHaveBeenCalledWith({
-        allocatedFilter: paramPaginationDetails.allocatedFilter,
-        token,
-        sortBy: paramPaginationDetails.sortBy,
-        sortDirection: paramPaginationDetails.sortDirection,
-        page: paramPaginationDetails.pageNumber,
+        ...apiGetAllParameters,
         cruManagementAreaId: '',
         taskTypes: ['PlacementApplication', 'Assessment'],
         requiredQualification: null,
@@ -239,83 +186,31 @@ describe('TasksController', () => {
     })
 
     it('should send isCompleted true for completed tab', async () => {
-      const paramPaginationDetails = {
-        hrefPrefix: paths.tasks.index({}),
-        pageNumber: 1,
-        sortBy: 'name',
-        sortDirection: 'desc',
-        activeTab: 'completed',
-      }
-      const cruManagementAreaId = '1234'
-      const allocatedFilter = 'unallocated'
-      const allocatedToUserId = '123'
-      const requiredQualification = 'emergency'
-      const crnOrName = 'ABC123'
       const activeTab = 'completed'
 
-      const requestHandler = tasksController.index()
-      const unallocatedRequest = {
+      const completedRequest = {
         ...request,
         query: {
           activeTab,
-          allocatedFilter,
-          area: cruManagementAreaId,
-          allocatedToUserId,
-          requiredQualification,
-          crnOrName,
         },
       }
 
-      when(getPaginationDetails as jest.Mock)
-        .calledWith(unallocatedRequest, paths.tasks.index({}), {
+      await tasksController.index()(completedRequest, response, next)
+
+      expect(response.render).toHaveBeenCalledWith(template, {
+        ...renderParameters,
+        activeTab,
+        taskHeader: tasksTableHeader(
           activeTab,
-          allocatedFilter,
-          area: cruManagementAreaId,
-          allocatedToUserId,
-          requiredQualification,
-          crnOrName,
-        })
-        .mockReturnValue(paramPaginationDetails)
-
-      await requestHandler(unallocatedRequest, response, next)
-
-      expect(response.render).toHaveBeenCalledWith('tasks/index', {
-        pageHeading: 'Task Allocation',
-        taskHeader: tasksTableHeader(activeTab, 'createdAt', 'asc', paginationDetails.hrefPrefix),
+          paginationDetails.sortBy,
+          paginationDetails.sortDirection,
+          paginationDetails.hrefPrefix,
+        ),
         taskRows: tasksTableRows(tasks, activeTab, true),
-        allocatedFilter,
-        cruManagementAreas,
-        pageNumber: Number(paginatedResponse.pageNumber),
-        totalPages: Number(paginatedResponse.totalPages),
-        hrefPrefix: paginationDetails.hrefPrefix,
-        cruManagementArea: cruManagementAreaId,
-        users,
-        allocatedToUserId,
-        userQualificationSelectOptions: userQualificationsSelectOptions(requiredQualification),
-        crnOrName,
-        activeTab,
-      })
-
-      expect(getPaginationDetails).toHaveBeenCalledWith(unallocatedRequest, paths.tasks.index({}), {
-        activeTab,
-        allocatedFilter,
-        area: cruManagementAreaId,
-        allocatedToUserId,
-        requiredQualification,
-        crnOrName,
       })
 
       expect(taskService.getAll).toHaveBeenCalledWith({
-        allocatedFilter,
-        token,
-        sortBy: paramPaginationDetails.sortBy,
-        sortDirection: paramPaginationDetails.sortDirection,
-        page: paramPaginationDetails.pageNumber,
-        cruManagementAreaId,
-        taskTypes: ['PlacementApplication', 'Assessment'],
-        allocatedToUserId,
-        requiredQualification,
-        crnOrName,
+        ...apiGetAllParameters,
         isCompleted: true,
       })
     })
@@ -339,6 +234,18 @@ describe('TasksController', () => {
     const taskWrapper = taskWrapperFactory.build({ task })
     const application = applicationFactory.build()
     const cruManagementAreas = cruManagementAreaFactory.buildList(3)
+    const template = 'tasks/show'
+    const expectedRenderParameters = {
+      pageHeading: `Reallocate Request for Placement`,
+      application,
+      task: taskWrapper.task,
+      users: taskWrapper.users,
+      errors: {},
+      errorSummary: [] as Array<ErrorSummary>,
+      cruManagementAreas,
+      cruManagementAreaId: '',
+      qualification: '',
+    }
 
     beforeEach(() => {
       cruManagementAreaService.getCruManagementAreas.mockResolvedValue(cruManagementAreas)
@@ -348,22 +255,11 @@ describe('TasksController', () => {
     })
 
     it('fetches the application and a list of qualified users', async () => {
-      const requestHandler = tasksController.show()
       request.params.taskType = 'placement-request'
 
-      await requestHandler(request, response, next)
+      await tasksController.show()(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('tasks/show', {
-        pageHeading: `Reallocate Request for Placement`,
-        application,
-        task: taskWrapper.task,
-        users: taskWrapper.users,
-        errors: {},
-        errorSummary: [],
-        cruManagementAreas,
-        cruManagementAreaId: '',
-        qualification: '',
-      })
+      expect(response.render).toHaveBeenCalledWith(template, expectedRenderParameters)
 
       expect(taskService.find).toHaveBeenCalledWith(request.user.token, request.params.id, request.params.taskType, {
         cruManagementAreaId: '',
@@ -375,21 +271,14 @@ describe('TasksController', () => {
       const placementApplication = taskFactory.build({ taskType: 'PlacementApplication' })
       const placementApplicationTaskWrapper = taskWrapperFactory.build({ task: placementApplication })
       taskService.find.mockResolvedValue(placementApplicationTaskWrapper)
-      const requestHandler = tasksController.show()
       request.params.taskType = 'placement-request'
 
-      await requestHandler(request, response, next)
+      await tasksController.show()(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('tasks/show', {
-        pageHeading: `Reallocate Request for Placement`,
-        application,
+      expect(response.render).toHaveBeenCalledWith(template, {
+        ...expectedRenderParameters,
         task: placementApplicationTaskWrapper.task,
         users: placementApplicationTaskWrapper.users,
-        errors: {},
-        errorSummary: [],
-        cruManagementAreas,
-        cruManagementAreaId: '',
-        qualification: '',
       })
 
       expect(taskService.find).toHaveBeenCalledWith(request.user.token, request.params.id, request.params.taskType, {
@@ -401,19 +290,12 @@ describe('TasksController', () => {
       const errorsAndUserInput = createMock<ErrorsAndUserInput>()
       ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
 
-      const requestHandler = tasksController.show()
-      await requestHandler(request, response, next)
+      await tasksController.show()(request, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('tasks/show', {
-        pageHeading: `Reallocate Request for Placement`,
-        application,
-        task: taskWrapper.task,
-        users: taskWrapper.users,
+      expect(response.render).toHaveBeenCalledWith(template, {
+        ...expectedRenderParameters,
         errors: errorsAndUserInput.errors,
         errorSummary: errorsAndUserInput.errorSummary,
-        cruManagementAreas,
-        cruManagementAreaId: '',
-        qualification: '',
         ...errorsAndUserInput.userInput,
       })
     })
@@ -422,17 +304,11 @@ describe('TasksController', () => {
       const params = { id: 'task-id', taskType: 'placement-request' }
       const userFilters = { cruManagementAreaId: 'some-id', qualification: 'esap' }
       const requestWithQuery = { ...request, params, query: userFilters }
-      const requestHandler = tasksController.show()
-      await requestHandler(requestWithQuery, response, next)
 
-      expect(response.render).toHaveBeenCalledWith('tasks/show', {
-        pageHeading: `Reallocate Request for Placement`,
-        application,
-        errors: {},
-        errorSummary: [],
-        task: taskWrapper.task,
-        users: taskWrapper.users,
-        cruManagementAreas,
+      await tasksController.show()(requestWithQuery, response, next)
+
+      expect(response.render).toHaveBeenCalledWith(template, {
+        ...expectedRenderParameters,
         cruManagementAreaId: userFilters.cruManagementAreaId,
         qualification: userFilters.qualification,
       })

--- a/server/controllers/tasksController.ts
+++ b/server/controllers/tasksController.ts
@@ -8,6 +8,7 @@ import { fetchErrorsAndUserInput } from '../utils/validation'
 import { getPaginationDetails } from '../utils/getPaginationDetails'
 import paths from '../paths/tasks'
 import { userQualificationsSelectOptions } from '../utils/tasks'
+import { hasPermission } from '../utils/users'
 
 export default class TasksController {
   constructor(
@@ -25,6 +26,7 @@ export default class TasksController {
       const activeTab = (req.query.activeTab || 'allocated') as TaskTab
       const isCompleted = activeTab === 'completed'
 
+      const canAllocate = !isCompleted && hasPermission(res.locals.user, ['cas1_tasks_allocate'])
       const cruManagementAreaId = req.query.area || res.locals.user.cruManagementArea?.id
       const allocatedToUserId = req.query.allocatedToUserId as string
       const requiredQualification = req.query.requiredQualification
@@ -64,7 +66,7 @@ export default class TasksController {
 
       res.render('tasks/index', {
         pageHeading: 'Task Allocation',
-        taskRows: tasksTableRows(tasks.data, activeTab),
+        taskRows: tasksTableRows(tasks.data, activeTab, canAllocate),
         taskHeader: tasksTableHeader(activeTab, sortBy, sortDirection, hrefPrefix),
         allocatedFilter,
         pageNumber: Number(tasks.pageNumber),

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -19,12 +19,12 @@ export default function routes(controllers: Controllers, router: Router, service
   })
   get(paths.tasks.show.pattern, tasksController.show(), {
     auditEvent: 'SHOW_TASK',
-    allowedPermissions: ['cas1_view_manage_tasks'],
+    allowedPermissions: ['cas1_tasks_allocate'],
   })
   post(paths.tasks.allocations.create.pattern, allocationsController.create(), {
     auditEvent: 'REALLOCATE_TASK_SUCCESS',
     redirectAuditEventSpecs: [{ path: paths.tasks.show.pattern, auditEvent: 'REALLOCATE_TASK_FAILURE' }],
-    allowedPermissions: ['cas1_view_manage_tasks'],
+    allowedPermissions: ['cas1_tasks_allocate'],
   })
 
   return router

--- a/server/utils/tasks/listTable.test.ts
+++ b/server/utils/tasks/listTable.test.ts
@@ -37,9 +37,9 @@ describe('table', () => {
       it('returns an array of table rows', () => {
         const task = taskFactory.build()
 
-        expect(allocatedTableRows([task])).toEqual([
+        expect(allocatedTableRows([task], true)).toEqual([
           [
-            nameAnchorCell(task),
+            nameAnchorCell(task, true),
             daysUntilDueCell(task, 'task--index__warning'),
             {
               text: task.expectedArrivalDate
@@ -68,9 +68,9 @@ describe('table', () => {
       it('returns an array of allocated table rows', () => {
         const task = taskFactory.build()
 
-        expect(tasksTableRows([task], 'allocated')).toEqual([
+        expect(tasksTableRows([task], 'allocated', true)).toEqual([
           [
-            nameAnchorCell(task),
+            nameAnchorCell(task, true),
             daysUntilDueCell(task, 'task--index__warning'),
             {
               text: task.expectedArrivalDate
@@ -103,9 +103,9 @@ describe('table', () => {
       it('returns an array of table rows', () => {
         const task = taskFactory.build()
 
-        expect(unallocatedTableRows([task])).toEqual([
+        expect(unallocatedTableRows([task], true)).toEqual([
           [
-            nameAnchorCell(task),
+            nameAnchorCell(task, true),
             daysUntilDueCell(task, 'task--index__warning'),
             {
               text: task.expectedArrivalDate
@@ -129,9 +129,9 @@ describe('table', () => {
       it('returns an array of unallocated table rows', () => {
         const task = taskFactory.build()
 
-        expect(tasksTableRows([task], 'unallocated')).toEqual([
+        expect(tasksTableRows([task], 'unallocated', true)).toEqual([
           [
-            nameAnchorCell(task),
+            nameAnchorCell(task, true),
             daysUntilDueCell(task, 'task--index__warning'),
             {
               text: task.expectedArrivalDate
@@ -231,13 +231,12 @@ describe('table', () => {
   })
 
   describe('nameAnchorCell', () => {
+    const task = taskFactory.build({
+      taskType: 'Assessment',
+    })
     it('returns the name when the person summary is FullPersonSummary  in the task', () => {
       const personSummary = fullPersonSummaryFactory.build()
-      const task = taskFactory.build({
-        taskType: 'Assessment',
-        personSummary,
-      })
-      expect(nameAnchorCell(task)).toEqual({
+      expect(nameAnchorCell({ ...task, personSummary }, true)).toEqual({
         html: linkTo(paths.tasks.show({ id: task.id, taskType: kebabCase(task.taskType) }), {
           text: personSummary.name,
           attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
@@ -246,11 +245,7 @@ describe('table', () => {
     })
     it('returns the Limited Access Offender (LAO) CRN when the person summary is RestrictedPersonSummary in the task', () => {
       const personSummary = fullPersonSummaryFactory.build({ personType: 'RestrictedPersonSummary' })
-      const task = taskFactory.build({
-        taskType: 'Assessment',
-        personSummary,
-      })
-      expect(nameAnchorCell(task)).toEqual({
+      expect(nameAnchorCell({ ...task, personSummary }, true)).toEqual({
         html: linkTo(paths.tasks.show({ id: task.id, taskType: kebabCase(task.taskType) }), {
           text: `LAO: ${personSummary.crn}`,
           attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
@@ -259,15 +254,17 @@ describe('table', () => {
     })
     it('returns the unknown person CRN when the person summary is UnknownPersonSummary  in the task', () => {
       const personSummary = fullPersonSummaryFactory.build({ personType: 'UnknownPersonSummary' })
-      const task = taskFactory.build({
-        taskType: 'Assessment',
-        personSummary,
-      })
-      expect(nameAnchorCell(task)).toEqual({
+      expect(nameAnchorCell({ ...task, personSummary }, true)).toEqual({
         html: linkTo(paths.tasks.show({ id: task.id, taskType: kebabCase(task.taskType) }), {
           text: `Unknown: ${personSummary.crn}`,
           attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
         }),
+      })
+    })
+    it('returns the person without a link if the canAllocate parameter is false', () => {
+      const personSummary = fullPersonSummaryFactory.build({ personType: 'UnknownPersonSummary' })
+      expect(nameAnchorCell({ ...task, personSummary }, false)).toEqual({
+        text: `Unknown: ${personSummary.crn}`,
       })
     })
   })
@@ -438,7 +435,7 @@ describe('table', () => {
 
       expect(completedTableRows([task])).toEqual([
         [
-          nameAnchorCell(task),
+          nameAnchorCell(task, false),
           completedAtDateCell(task),
           completedByCell(task),
           taskTypeCell(task),
@@ -450,9 +447,9 @@ describe('table', () => {
     it('returns an array of completed task table rows', () => {
       const task = taskFactory.build()
 
-      expect(tasksTableRows([task], 'completed')).toEqual([
+      expect(tasksTableRows([task], 'completed', true)).toEqual([
         [
-          nameAnchorCell(task),
+          nameAnchorCell(task, false),
           completedAtDateCell(task),
           completedByCell(task),
           taskTypeCell(task),

--- a/server/utils/tasks/listTable.ts
+++ b/server/utils/tasks/listTable.ts
@@ -81,12 +81,17 @@ const allocationCell = (task: Task): TableCell => ({
   text: task.allocatedToStaffMember?.name,
 })
 
-const nameAnchorCell = (task: Task): TableCell => ({
-  html: linkTo(paths.tasks.show(taskParams(task)), {
-    text: displayName(task.personSummary, { showCrn: true }),
-    attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
-  }),
-})
+const nameAnchorCell = (task: Task, canAllocate: boolean): TableCell =>
+  canAllocate
+    ? {
+        html: linkTo(paths.tasks.show(taskParams(task)), {
+          text: displayName(task.personSummary, { showCrn: true }),
+          attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
+        }),
+      }
+    : {
+        text: displayName(task.personSummary, { showCrn: true }),
+      }
 
 const apTypeCell = (task: Task): TableCell => ({
   text: apTypeShortLabels[task.apType] || '',
@@ -96,11 +101,11 @@ const apAreaCell = (task: Task): TableCell => ({
   text: task.apArea?.name || 'No area supplied',
 })
 
-const allocatedTableRows = (tasks: Array<Task>): Array<TableRow> => {
+const allocatedTableRows = (tasks: Array<Task>, canAllocate: boolean): Array<TableRow> => {
   const rows: Array<TableRow> = []
   tasks.forEach(task => {
     rows.push([
-      nameAnchorCell(task),
+      nameAnchorCell(task, canAllocate),
       daysUntilDueCell(task, 'task--index__warning'),
       arrivalDateCell(task),
       allocationCell(task),
@@ -114,12 +119,12 @@ const allocatedTableRows = (tasks: Array<Task>): Array<TableRow> => {
   return rows
 }
 
-const unallocatedTableRows = (tasks: Array<Task>): Array<TableRow> => {
+const unallocatedTableRows = (tasks: Array<Task>, canAllocate: boolean): Array<TableRow> => {
   const rows = [] as Array<TableRow>
 
   tasks.forEach(task => {
     rows.push([
-      nameAnchorCell(task),
+      nameAnchorCell(task, canAllocate),
       daysUntilDueCell(task, 'task--index__warning'),
       arrivalDateCell(task),
       statusCell(task),
@@ -149,7 +154,7 @@ const completedTableRows = (tasks: Array<Task>): Array<TableRow> => {
 
   tasks.forEach(task => {
     rows.push([
-      nameAnchorCell(task),
+      nameAnchorCell(task, false),
       completedAtDateCell(task),
       completedByCell(task),
       taskTypeCell(task),
@@ -160,12 +165,12 @@ const completedTableRows = (tasks: Array<Task>): Array<TableRow> => {
   return rows
 }
 
-const tasksTableRows = (tasks: Array<Task>, allocatedFilter: TaskTab): Array<TableRow> => {
+const tasksTableRows = (tasks: Array<Task>, allocatedFilter: TaskTab, canAllocate: boolean): Array<TableRow> => {
   if (allocatedFilter === 'allocated') {
-    return allocatedTableRows(tasks)
+    return allocatedTableRows(tasks, canAllocate)
   }
   if (allocatedFilter === 'unallocated') {
-    return unallocatedTableRows(tasks)
+    return unallocatedTableRows(tasks, canAllocate)
   }
   return completedTableRows(tasks)
 }

--- a/server/utils/users/roles.ts
+++ b/server/utils/users/roles.ts
@@ -16,6 +16,7 @@ export const roles: ReadonlyArray<RoleInUse> = [
   'report_viewer',
   'report_viewer_with_pii',
   'future_manager',
+  'ap_area_manager',
   'user_manager',
   'change_request_dev',
   'janitor',
@@ -30,7 +31,6 @@ export const unusedRoles = [
   'workflow_manager',
   'cru_member_find_and_book_beta',
   'cru_member_enable_out_of_service_beds',
-  'ap_area_manager',
 ] as const
 
 type UnusedRole = (typeof unusedRoles)[number]
@@ -81,6 +81,10 @@ export const roleLabelDictionary: RoleLabelDictionary = {
   future_manager: {
     label: 'Future manager',
     hint: 'Provides access to manage and creating out of service beds',
+  },
+  ap_area_manager: {
+    label: 'AP area manager',
+    hint: 'Can access task allocation information, but cannot allocate tasks',
   },
   user_manager: {
     label: 'User manager',

--- a/server/utils/users/userManagement.test.ts
+++ b/server/utils/users/userManagement.test.ts
@@ -127,6 +127,11 @@ describe('userRolesSelectOptions', () => {
         text: 'Future manager',
         value: 'future_manager',
       },
+      {
+        selected: false,
+        text: 'AP area manager',
+        value: 'ap_area_manager',
+      },
       { selected: false, text: 'User manager', value: 'user_manager' },
       { selected: false, text: 'Change request development', value: 'change_request_dev' },
       {
@@ -151,23 +156,12 @@ describe('userRolesSelectOptions', () => {
         text: 'Excluded from placement application allocation',
         value: 'excluded_from_placement_application_allocation',
       },
-      {
-        selected: false,
-        text: 'Appeals manager',
-        value: 'appeals_manager',
-      },
-      {
-        selected: false,
-        text: 'Future manager',
-        value: 'future_manager',
-      },
+      { selected: false, text: 'Appeals manager', value: 'appeals_manager' },
+      { selected: false, text: 'Future manager', value: 'future_manager' },
+      { selected: false, text: 'AP area manager', value: 'ap_area_manager' },
       { selected: false, text: 'User manager', value: 'user_manager' },
       { selected: false, text: 'Change request development', value: 'change_request_dev' },
-      {
-        selected: false,
-        text: 'Janitor',
-        value: 'janitor',
-      },
+      { selected: false, text: 'Janitor', value: 'janitor' },
     ])
   })
 })

--- a/server/utils/users/userManagement.ts
+++ b/server/utils/users/userManagement.ts
@@ -60,6 +60,7 @@ const userRoles: Record<RoleInUse, string> = {
   excluded_from_placement_application_allocation: 'Excluded from placement application allocation',
   appeals_manager: 'Appeals manager',
   future_manager: 'Future manager',
+  ap_area_manager: 'AP area manager',
   user_manager: 'User manager',
   change_request_dev: 'Change request development',
   janitor: 'Janitor',


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2484
https://dsdmoj.atlassian.net/browse/APS-2482

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
This PR tackles two tickets as the required functionality for each is so closely related.

- Remove links to the task allocation page if:
  - the user doesn't have `cas1_tasks_allocate` permission 
  - or the task is completed (i.e on the completed tab)
- Restrict access to the task allocation page if the user doesn't have `cas1_tasks_allocate` permission.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

<details>
  <summary>After</summary>
<img src="https://github.com/user-attachments/assets/a3875bea-367b-4782-a24e-137340e72f47"/>
</details>
