### PR TITLE
APS-2622: Send requested placement duration as first-class

### DIFF
--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -20,12 +20,13 @@ import Page from '../../pages/page'
 import SubmissionConfirmation from '../../pages/apply/submissionConfirmation'
 import { mapApiPersonRisksForUi } from '../../../server/utils/utils'
 import { setup } from './setup'
+import { AND, GIVEN, THEN, WHEN } from '../../helpers'
 
 context('Apply', () => {
   beforeEach(setup)
 
   it('allows completion of the form', function test() {
-    // And I complete the application
+    AND('I complete the application')
     const uiRisks = mapApiPersonRisksForUi(this.application.risks)
     const apply = new ApplyHelper(this.application, this.person, this.offences)
 
@@ -33,7 +34,7 @@ context('Apply', () => {
     apply.startApplication()
     apply.completeApplication()
 
-    // Then the application should be submitted to the API
+    THEN('the application should be submitted to the API')
     cy.task('verifyApplicationUpdate', this.application.id).then((requests: Array<{ body: string }>) => {
       expect(requests).to.have.length(apply.numberOfPages())
       const body = JSON.parse(requests[requests.length - 1].body)
@@ -41,6 +42,7 @@ context('Apply', () => {
       expect(body).to.have.keys(
         'data',
         'arrivalDate',
+        'duration',
         'apType',
         'isWomensApplication',
         'targetLocation',
@@ -68,6 +70,7 @@ context('Apply', () => {
       const body = JSON.parse(requests[0].body)
       expect(body).to.have.keys(
         'arrivalDate',
+        'duration',
         'translatedDocument',
         'apType',
         'isEmergencyApplication',
@@ -86,28 +89,28 @@ context('Apply', () => {
       )
     })
 
-    // And I should be taken to the confirmation page
+    AND('I should be taken to the confirmation page')
     const confirmationPage = new SubmissionConfirmation()
 
-    // Given there are applications in the database
+    GIVEN('there are applications in the database')
     const applications = applicationFactory.withReleaseDate().buildList(5)
     cy.task('stubApplications', applications)
 
-    // And there are risks in the database
+    AND('there are risks in the database')
     const risks = risksFactory.buildList(5)
     applications.forEach((stubbedApplication, i) => {
       cy.task('stubPersonRisks', { person: stubbedApplication.person, risks: risks[i] })
     })
 
-    // When I click 'Back to dashboard'
+    WHEN("I click 'Back to dashboard'")
     confirmationPage.clickBackToDashboard()
 
-    // Then I am taken back to the dashboard
+    THEN('I am taken back to the dashboard')
     Page.verifyOnPage(ListPage)
   })
 
   it('If users navigates away from application when told tier not eligible, return to is exceptional case page', function test() {
-    // Given the person does not have an eligible risk tier
+    GIVEN('the person does not have an eligible risk tier')
     this.application.risks = risksFactory.build({
       crn: this.person.crn,
       tier: tierEnvelopeFactory.build({ value: { level: 'D1' } }),
@@ -115,21 +118,21 @@ context('Apply', () => {
     cy.task('stubApplicationGet', { application: this.application })
     cy.task('stubApplications', [this.application])
 
-    // And I start the application and left
+    AND('I start the application and left')
     const apply = new ApplyHelper(this.application, this.person, this.offences)
     apply.setupApplicationStubs()
     apply.startApplication()
 
-    // And I visit the list page
+    AND('I visit the list page')
     const listPage = ListPage.visit([this.application], [], [])
 
-    // When I click the application from list
+    WHEN('I click the application from list')
     listPage.clickApplication(this.application)
 
-    // And I click the basic information
+    AND('I click the basic information')
     apply.clickBasicInformation()
 
-    // Then I should see the is exceptional case page
+    THEN('I should see the is exceptional case page')
     Page.verifyOnPage(ApplyPages.IsExceptionalCasePage, this.application)
   })
 
@@ -137,16 +140,16 @@ context('Apply', () => {
     const lao = restrictedPersonFactory.build()
     cy.task('stubFindPerson', { person: lao })
 
-    // Given I visit the start page
+    GIVEN('I visit the start page')
     const startPage = StartPage.visit()
     startPage.startApplication()
 
-    // And I enter a CRN that is restricted
+    AND('I enter a CRN that is restricted')
     const crnPage = new EnterCRNPage()
     crnPage.enterCrn(lao.crn)
     crnPage.clickSubmit()
 
-    // Then I should see an error message telling me the CRN is restricted
+    THEN('I should see an error message telling me the CRN is restricted')
     crnPage.shouldShowRestrictedCrnMessage(lao)
   })
 
@@ -155,36 +158,36 @@ context('Apply', () => {
     cy.task('stubFindPerson', { person: restrictedPerson })
     cy.task('stubPersonOffences', { person: restrictedPerson, offences: activeOffenceFactory.buildList(1) })
 
-    // Given I visit the start page
+    GIVEN('I visit the start page')
     const startPage = StartPage.visit()
     startPage.startApplication()
 
-    // And I enter a CRN that is restricted
+    AND('I enter a CRN that is restricted')
     const crnPage = new EnterCRNPage()
     crnPage.enterCrn(restrictedPerson.crn)
     crnPage.clickSubmit()
 
-    // Then I should see LAO messaging on the confirmation page
+    THEN('I should see LAO messaging on the confirmation page')
     const confirmDetailsPage = new ConfirmDetailsPage(restrictedPerson)
     confirmDetailsPage.verifyRestrictedPersonMessaging()
   })
 
   it('creates an application with the correct index offence when there are multiple offences present', function test() {
-    // Given the person has more than one offence listed under their CRN
+    GIVEN('the person has more than one offence listed under their CRN')
     const offences = activeOffenceFactory.buildList(4)
 
     const apply = new ApplyHelper(this.application, this.person, offences)
     apply.setupApplicationStubs()
 
-    // Then I should be able to select an offence
+    THEN('I should be able to select an offence')
     apply.startApplication(offences[2])
 
-    // Then I should be on the Confirm Your Details page
+    THEN('I should be on the Confirm Your Details page')
     Page.verifyOnPage(ConfirmYourDetailsPage, this.application)
   })
 
   it(`allows the user to specify if the risk level if the person does not have a tier`, function test() {
-    // And that person does not have an eligible risk tier
+    AND('that person does not have an eligible risk tier')
     const risks = risksFactory.build({
       tier: undefined,
     })
@@ -195,12 +198,12 @@ context('Apply', () => {
     apply.setupApplicationStubs()
     apply.startApplication()
 
-    // Then I should be able to confirm that the case is exceptional
+    THEN('I should be able to confirm that the case is exceptional')
     apply.completeMissingTierSection()
   })
 
   it(`allows the user to specify if the case is exceptional if the offender's tier is not eligible`, function test() {
-    // Given the person does not have an eligible risk tier
+    GIVEN('the person does not have an eligible risk tier')
     const risks = risksFactory.build({
       crn: this.person.crn,
       tier: tierEnvelopeFactory.build({ value: { level: 'D1' } }),
@@ -211,15 +214,15 @@ context('Apply', () => {
     apply.setupApplicationStubs()
     apply.startApplication()
 
-    // Then I should be able to confirm that the case is exceptional
+    THEN('I should be able to confirm that the case is exceptional')
     apply.completeExceptionalCase()
 
-    // And I should be on the Confirm Your Details page
+    AND('I should be on the Confirm Your Details page')
     Page.verifyOnPage(ConfirmYourDetailsPage, this.application)
   })
 
   it('tells the user that their application is not applicable if the tier is not eligible and it is not an exceptional case', function test() {
-    // Given the person does not have an eligible risk tier
+    GIVEN('the person does not have an eligible risk tier')
     const risks = risksFactory.build({
       crn: this.person.crn,
       tier: tierEnvelopeFactory.build({ value: { level: 'D1' } }),
@@ -230,19 +233,19 @@ context('Apply', () => {
     apply.setupApplicationStubs()
     apply.startApplication()
 
-    // Then I should be prompted to confirm that the case is exceptional
+    THEN('I should be prompted to confirm that the case is exceptional')
     const isExceptionalCasePage = Page.verifyOnPage(IsExceptionalCasePage)
 
-    // And I select no
+    AND('I select no')
     isExceptionalCasePage.completeForm('no')
     isExceptionalCasePage.clickSubmit()
 
-    // Then I should be told the application is not eligible
+    THEN('I should be told the application is not eligible')
     Page.verifyOnPage(NotEligiblePage)
   })
 
   it('allows completion of application emergency flow', function test() {
-    // Given I need to complete I need a placement
+    GIVEN('I need to complete I need a placement')
     const user = userFactory.build()
     this.application.createdByUserId = user.id
     this.application.submittedAt = undefined
@@ -276,11 +279,11 @@ context('Apply', () => {
         additionalConditionsDetail: 'some details',
       },
     })
-    // When I start the application
+    WHEN('I start the application')
     apply.setupApplicationStubs(uiRisks)
     apply.startApplication()
 
-    // Then I am able to complete the Emergency application flow
+    THEN('I am able to complete the Emergency application flow')
     apply.completeEmergencyApplication()
   })
 
@@ -313,7 +316,7 @@ context('Apply', () => {
 
     this.application.person = person
 
-    // And I complete the application
+    AND('I complete the application')
     const uiRisks = mapApiPersonRisksForUi(this.application.risks)
     const apply = new ApplyHelper(this.application, person, this.offences)
 
@@ -321,13 +324,14 @@ context('Apply', () => {
     apply.startApplication()
     apply.completeApplication({ isExceptionalCase: false, isInComunity: true })
 
-    // Then the application should be submitted to the API
+    THEN('the application should be submitted to the API')
     cy.task('verifyApplicationUpdate', this.application.id).then((requests: Array<{ body: string }>) => {
       expect(requests).to.have.length(apply.numberOfPages())
       const body = JSON.parse(requests[requests.length - 1].body)
 
       expect(body).to.have.keys(
         'arrivalDate',
+        'duration',
         'data',
         'apType',
         'isWomensApplication',
@@ -357,6 +361,7 @@ context('Apply', () => {
       const body = JSON.parse(requests[0].body)
       expect(body).to.have.keys(
         'arrivalDate',
+        'duration',
         'translatedDocument',
         'apType',
         'isEmergencyApplication',
@@ -377,33 +382,33 @@ context('Apply', () => {
   })
 
   it('redirects to no offence page if there are no offence', function test() {
-    // Given a person has no offences
+    GIVEN('a person has no offences')
     const offences = activeOffenceFactory.buildList(0)
 
-    // When I enter their CRN
+    WHEN('I enter their CRN')
     const apply = new ApplyHelper(this.application, this.person, offences)
     apply.setupApplicationStubs()
     apply.enterCrnDetails()
 
-    // Then I should see a screen telling me they have no offences
+    THEN('I should see a screen telling me they have no offences')
     const noOffencePage = Page.verifyOnPage(NoOffencePage)
     noOffencePage.shouldShowParagraphText('an Approved Premises application')
     noOffencePage.confirmLinkText('dashboard')
   })
 
   it('shows the user a message if there are no documents imported from Delius', function test() {
-    // Given I complete the documents selection of application
+    GIVEN('I complete the documents selection of application')
     const uiRisks = mapApiPersonRisksForUi(this.application.risks)
     const apply = new ApplyHelper(this.application, this.person, this.offences)
 
     apply.setupApplicationStubs(uiRisks)
 
-    // And no documents uploaded to the application
+    AND('no documents uploaded to the application')
     apply.stubDocumentEndpoints([])
     apply.startApplication()
     apply.completeApplication({ isNoDocuments: true })
 
-    // Then should display No documents have been imported from Delius message will be displayed
+    THEN('should display No documents have been imported from Delius message will be displayed')
     apply.verifyNoDocumentsDisplayed()
   })
 })

--- a/integration_tests/tests/apply/invalidations.cy.ts
+++ b/integration_tests/tests/apply/invalidations.cy.ts
@@ -1,22 +1,23 @@
 import { addResponsesToFormArtifact } from '../../../server/testutils/addToApplication'
 import * as ApplyPages from '../../pages/apply'
 import { setup } from './setup'
+import { AND, GIVEN, THEN } from '../../helpers'
 
 context('Apply', () => {
   beforeEach(setup)
 
   it('invalidates the check your answers step if an answer is changed', function test() {
-    // Given there is a complete application in the database
+    GIVEN('there is a complete application in the database')
     const application = { ...this.application, status: 'started' }
     cy.task('stubApplicationGet', { application })
 
-    // And I visit the tasklist
+    AND('I visit the tasklist')
     ApplyPages.TaskListPage.visit(application)
 
-    // And I click on a task
+    AND('I click on a task')
     cy.get('[data-cy-task-name="location-factors"]').click()
 
-    // And I change my response
+    AND('I change my response')
     this.application = addResponsesToFormArtifact(this.application, {
       task: 'location-factors',
       page: 'describe-location-factors',
@@ -31,13 +32,14 @@ context('Apply', () => {
     describeLocationFactorsPage.completeForm()
     describeLocationFactorsPage.clickSubmit()
 
-    // Then the application should be updated with the Check Your Answers section removed
+    THEN('the application should be updated with the Check Your Answers section removed')
     cy.task('verifyApplicationUpdate', this.application.id).then((requests: Array<{ body: string }>) => {
       expect(requests).to.have.length(1)
       const body = JSON.parse(requests[0].body)
       expect(body).to.have.keys(
         'data',
         'arrivalDate',
+        'duration',
         'apType',
         'isWomensApplication',
         'targetLocation',
@@ -59,21 +61,21 @@ context('Apply', () => {
   })
 
   it('does not invalidate the check your answers step if an answer is reviewed and not changed', function test() {
-    // Given there is a complete application in the database
+    GIVEN('there is a complete application in the database')
     const application = { ...this.application, status: 'started' }
     cy.task('stubApplicationGet', { application })
 
-    // And I visit the tasklist
+    AND('I visit the tasklist')
     ApplyPages.TaskListPage.visit(application)
 
-    // And I click on a task
+    AND('I click on a task')
     cy.get('[data-cy-task-name="location-factors"]').click()
 
-    // And I review a section
+    AND('I review a section')
     const describeLocationFactorsPage = new ApplyPages.DescribeLocationFactors(this.application)
     describeLocationFactorsPage.clickSubmit()
 
-    // Then the application should be updated with the Check Your Answers section removed
+    THEN('the application should be updated with the Check Your Answers section removed')
     cy.task('verifyApplicationUpdate', this.application.id).then((requests: Array<{ body: string }>) => {
       expect(requests).to.have.length(1)
       const body = JSON.parse(requests[0].body)
@@ -81,6 +83,7 @@ context('Apply', () => {
       expect(body).to.have.keys(
         'data',
         'arrivalDate',
+        'duration',
         'apType',
         'isWomensApplication',
         'targetLocation',

--- a/integration_tests/tests/apply/setup.ts
+++ b/integration_tests/tests/apply/setup.ts
@@ -1,4 +1,4 @@
-import { updateApplicationReleaseDate } from '../../helpers'
+import { GIVEN, updateApplicationReleaseDate } from '../../helpers'
 import {
   activeOffenceFactory,
   applicationFactory,
@@ -13,7 +13,7 @@ import { signIn } from '../signIn'
 export const setup = () => {
   cy.task('reset')
 
-  // Given I am signed in as an applicant
+  GIVEN('I am signed in as an applicant')
   signIn('applicant', { id: defaultUserId })
 
   cy.fixture('applicationData.json').then(applicationData => {

--- a/server/@types/shared/models/SubmitApprovedPremisesApplication.ts
+++ b/server/@types/shared/models/SubmitApprovedPremisesApplication.ts
@@ -16,9 +16,16 @@ export type SubmitApprovedPremisesApplication = (SubmitApplication & {
     apAreaId?: string;
     apType?: ApType;
     applicantUserDetails?: Cas1ApplicationUserDetails;
+    /**
+     * If the applicant has requested a placement, this is the requested arrival date
+     */
     arrivalDate?: string;
     caseManagerIsNotApplicant?: boolean;
     caseManagerUserDetails?: Cas1ApplicationUserDetails;
+    /**
+     * If the applicant has requested a placement, this is the requested duration in days
+     */
+    duration?: number;
     /**
      * noticeType should be used to indicate if this an emergency application
      */

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -4,7 +4,7 @@ import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../share
 import MatchingInformation, { MatchingInformationBody } from './matchingInformation'
 import * as matchingInformtionUtils from '../../../utils/matchingInformationUtils'
 
-jest.mock('../../../../utils/assessments/placementDurationFromApplication')
+jest.mock('../../../../utils/applications/placementDurationFromApplication')
 jest.mock('../../../../utils/retrieveQuestionResponseFromFormArtifact')
 
 const assessment = assessmentFactory.build({

--- a/server/form-pages/utils/matchingInformationUtils.test.ts
+++ b/server/form-pages/utils/matchingInformationUtils.test.ts
@@ -1,6 +1,6 @@
 import { when } from 'jest-when'
 import { BackwardsCompatibleApplyApType } from '@approved-premises/ui'
-import { placementDurationFromApplication } from '../../utils/assessments/placementDurationFromApplication'
+import { placementDurationFromApplication } from '../../utils/applications/placementDurationFromApplication'
 import {
   retrieveOptionalQuestionResponseFromFormArtifact,
   retrieveQuestionResponseFromFormArtifact,
@@ -24,7 +24,7 @@ import SelectApType from '../apply/reasons-for-placement/type-of-ap/apType'
 import PlacementDate from '../apply/reasons-for-placement/basic-information/placementDate'
 import ReleaseDate from '../apply/reasons-for-placement/basic-information/releaseDate'
 
-jest.mock('../../utils/assessments/placementDurationFromApplication')
+jest.mock('../../utils/applications/placementDurationFromApplication')
 jest.mock('../../utils/retrieveQuestionResponseFromFormArtifact')
 
 describe('matchingInformationUtils', () => {

--- a/server/form-pages/utils/matchingInformationUtils.ts
+++ b/server/form-pages/utils/matchingInformationUtils.ts
@@ -3,7 +3,7 @@ import { weeksToDays } from 'date-fns'
 import { BackwardsCompatibleApplyApType, SummaryList } from '@approved-premises/ui'
 import { placementDates } from '../../utils/match'
 import { DateFormats, daysToWeeksAndDays } from '../../utils/dateUtils'
-import { placementDurationFromApplication } from '../../utils/assessments/placementDurationFromApplication'
+import { placementDurationFromApplication } from '../../utils/applications/placementDurationFromApplication'
 import {
   retrieveOptionalQuestionResponseFromFormArtifact,
   retrieveQuestionResponseFromFormArtifact,

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -9,6 +9,7 @@ import {
   mockQuestionResponse,
 } from '../../testutils/mockQuestionResponse'
 import { arrivalDateFromApplication } from './arrivalDateFromApplication'
+import { placementDurationFromApplication } from './placementDurationFromApplication'
 import { isInapplicable } from './utils'
 import { isWomensApplication } from './isWomensApplication'
 import { reasonForShortNoticeDetails } from './reasonForShortNoticeDetails'
@@ -19,6 +20,7 @@ import { licenceExpiryDateFromApplication } from './licenceExpiryDateFromApplica
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
 jest.mock('../applications/applicantAndCaseManagerDetails')
 jest.mock('./arrivalDateFromApplication')
+jest.mock('./placementDurationFromApplication')
 jest.mock('./utils')
 jest.mock('./isWomensApplication')
 jest.mock('./reasonForShortNoticeDetails')
@@ -57,10 +59,12 @@ describe('getApplicationData', () => {
     const releaseType: ReleaseTypeOption = 'licence'
     const sentenceType: SentenceTypeOption = 'standardDeterminate'
     const arrivalDate = '2023-01-01'
+    const duration = 84
     const licenceExpiryDate = DateFormats.dateObjToIsoDate(faker.date.soon())
 
     beforeEach(() => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(arrivalDate)
+      ;(placementDurationFromApplication as jest.Mock).mockReturnValue(duration)
       ;(isWomensApplication as jest.Mock).mockReturnValue(false)
       ;(licenceExpiryDateFromApplication as jest.Mock).mockReturnValue(licenceExpiryDate)
       mockOptionalQuestionResponse({
@@ -85,6 +89,7 @@ describe('getApplicationData', () => {
         situation: null,
         targetLocation,
         arrivalDate,
+        duration,
         isEmergencyApplication: true,
         apAreaId,
         applicantUserDetails,
@@ -166,6 +171,7 @@ describe('getApplicationData', () => {
   describe('getApplicationUpdateData', () => {
     it('returns empty attributes for a new application', () => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(undefined)
+      ;(placementDurationFromApplication as jest.Mock).mockReturnValue(undefined)
       ;(isInapplicable as jest.Mock).mockReturnValue(false)
       ;(isWomensApplication as jest.Mock).mockReturnValue(false)
       mockOptionalQuestionResponse({})
@@ -180,6 +186,7 @@ describe('getApplicationData', () => {
         sentenceType: undefined,
         targetLocation: undefined,
         arrivalDate: undefined,
+        duration: undefined,
         isEmergencyApplication: false,
         apAreaId: undefined,
         caseManagerIsNotApplicant: undefined,
@@ -191,6 +198,7 @@ describe('getApplicationData', () => {
 
     it('returns all the defined attributes', () => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2023-01-01')
+      ;(placementDurationFromApplication as jest.Mock).mockReturnValue(56)
       ;(isInapplicable as jest.Mock).mockReturnValue(false)
       ;(isWomensApplication as jest.Mock).mockReturnValue(false)
       mockOptionalQuestionResponse({
@@ -214,6 +222,7 @@ describe('getApplicationData', () => {
         situation: null,
         targetLocation,
         arrivalDate: '2023-01-01',
+        duration: 56,
         isEmergencyApplication: true,
         apAreaId,
         caseManagerIsNotApplicant: true,

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -25,6 +25,7 @@ import { applicantAndCaseManagerDetails } from './applicantAndCaseManagerDetails
 import { reasonForShortNoticeDetails } from './reasonForShortNoticeDetails'
 import { isWomensApplication } from './isWomensApplication'
 import { licenceExpiryDateFromApplication } from './licenceExpiryDateFromApplication'
+import { placementDurationFromApplication } from './placementDurationFromApplication'
 
 type FirstClassFields<T> = T extends UpdateApprovedPremisesApplication
   ? Omit<UpdateApprovedPremisesApplication, 'data'>
@@ -62,6 +63,7 @@ const firstClassFields = <T>(
   const situation =
     releaseType === 'in_community' ? retrieveQuestionResponse(application, Situation, 'situation') : null
   const arrivalDate = arrivalDateFromApplication(application)
+  const duration = placementDurationFromApplication(application)
   const isEmergencyApplication = noticeType === 'emergency'
   const apAreaId = retrieveQuestionResponse(application, ConfirmYourDetails, 'area')
   const { applicantUserDetails, caseManagerUserDetails, caseManagerIsNotApplicant } =
@@ -77,6 +79,7 @@ const firstClassFields = <T>(
     sentenceType,
     situation,
     arrivalDate,
+    duration,
     isEmergencyApplication,
     apAreaId,
     applicantUserDetails,

--- a/server/utils/applications/getDefaultPlacementDurationInDays.test.ts
+++ b/server/utils/applications/getDefaultPlacementDurationInDays.test.ts
@@ -1,8 +1,8 @@
 import { applicationFactory } from '../../testutils/factories'
-import { retrieveQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
+import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
 import { getDefaultPlacementDurationInDays } from './getDefaultPlacementDurationInDays'
 
-jest.mock('../retrieveQuestionResponseFromFormArtifact.ts')
+jest.mock('../retrieveQuestionResponseFromFormArtifact')
 
 describe('getDefaultPlacementDurationInDays', () => {
   const application = applicationFactory.build()
@@ -16,12 +16,12 @@ describe('getDefaultPlacementDurationInDays', () => {
     [26, 'pipe'],
     [52, 'esap'],
   ])('returns %s weeks when the AP type is "%s"', (weeks, apType) => {
-    ;(retrieveQuestionResponseFromFormArtifact as jest.Mock).mockReturnValueOnce(apType)
+    ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValueOnce(apType)
     expect(getDefaultPlacementDurationInDays(application)).toEqual(weeks * 7)
   })
 
   it('returns null when the AP type is anything else', () => {
-    ;(retrieveQuestionResponseFromFormArtifact as jest.Mock).mockReturnValueOnce('something else')
+    ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValueOnce('something else')
     expect(getDefaultPlacementDurationInDays(application)).toEqual(null)
   })
 })

--- a/server/utils/applications/getDefaultPlacementDurationInDays.ts
+++ b/server/utils/applications/getDefaultPlacementDurationInDays.ts
@@ -1,10 +1,10 @@
 import { ApprovedPremisesApplication as Application } from '@approved-premises/api'
 import { BackwardsCompatibleApplyApType } from '@approved-premises/ui'
 import SelectApType from '../../form-pages/apply/reasons-for-placement/type-of-ap/apType'
-import { retrieveQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
+import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
 
 export const getDefaultPlacementDurationInDays = (application: Application) => {
-  const apType = retrieveQuestionResponseFromFormArtifact(
+  const apType = retrieveOptionalQuestionResponseFromFormArtifact(
     application,
     SelectApType,
     'type',

--- a/server/utils/applications/placementDurationFromApplication.test.ts
+++ b/server/utils/applications/placementDurationFromApplication.test.ts
@@ -1,11 +1,11 @@
 import { applicationFactory } from '../../testutils/factories'
 import PlacementDuration from '../../form-pages/apply/move-on/placementDuration'
-import { getDefaultPlacementDurationInDays } from '../applications/getDefaultPlacementDurationInDays'
+import { getDefaultPlacementDurationInDays } from './getDefaultPlacementDurationInDays'
 import { placementDurationFromApplication } from './placementDurationFromApplication'
 import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
 
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
-jest.mock('../applications/getDefaultPlacementDurationInDays')
+jest.mock('./getDefaultPlacementDurationInDays')
 
 describe('placementDurationFromApplication', () => {
   const application = applicationFactory.build()

--- a/server/utils/applications/placementDurationFromApplication.ts
+++ b/server/utils/applications/placementDurationFromApplication.ts
@@ -1,6 +1,6 @@
 import { ApprovedPremisesApplication as Application } from '@approved-premises/api'
 import PlacementDuration from '../../form-pages/apply/move-on/placementDuration'
-import { getDefaultPlacementDurationInDays } from '../applications/getDefaultPlacementDurationInDays'
+import { getDefaultPlacementDurationInDays } from './getDefaultPlacementDurationInDays'
 import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
 
 export const placementDurationFromApplication = (application: Application) => {

--- a/server/utils/assessments/acceptanceData.test.ts
+++ b/server/utils/assessments/acceptanceData.test.ts
@@ -14,7 +14,7 @@ import {
 import { assessmentFactory } from '../../testutils/factories'
 import { pageDataFromApplicationOrAssessment } from '../../form-pages/utils'
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
-import { placementDurationFromApplication } from './placementDurationFromApplication'
+import { placementDurationFromApplication } from '../applications/placementDurationFromApplication'
 import { getResponses } from '../applications/getResponses'
 import { ApTypeCriteria } from '../placementCriteriaUtils'
 import ApplicationTimeliness, {
@@ -26,7 +26,7 @@ jest.mock('../../form-pages/utils')
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
 jest.mock('../applications/arrivalDateFromApplication')
 jest.mock('../applications/applicantAndCaseManagerDetails')
-jest.mock('./placementDurationFromApplication')
+jest.mock('../applications/placementDurationFromApplication')
 jest.mock('../applications/getResponses')
 
 describe('acceptanceData', () => {

--- a/server/utils/assessments/acceptanceData.ts
+++ b/server/utils/assessments/acceptanceData.ts
@@ -25,7 +25,7 @@ import {
   offenceAndRiskCriteria,
   placementRequirementCriteria,
 } from '../placementCriteriaUtils'
-import { placementDurationFromApplication } from './placementDurationFromApplication'
+import { placementDurationFromApplication } from '../applications/placementDurationFromApplication'
 import { getResponses } from '../applications/getResponses'
 import ApplicationTimeliness from '../../form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness'
 import type { ApplicationTimelinessBody } from '../../form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness'

--- a/server/utils/placementRequests/placementApplicationSubmissionData.test.ts
+++ b/server/utils/placementRequests/placementApplicationSubmissionData.test.ts
@@ -3,7 +3,7 @@ import DatesOfPlacement from '../../form-pages/placement-application/request-a-p
 import DecisionToRelease from '../../form-pages/placement-application/request-a-placement/decisionToRelease'
 import { getPageName, pageDataFromApplicationOrAssessment } from '../../form-pages/utils'
 import { applicationFactory, placementApplicationFactory } from '../../testutils/factories'
-import { placementDurationFromApplication } from '../assessments/placementDurationFromApplication'
+import { placementDurationFromApplication } from '../applications/placementDurationFromApplication'
 import { DateFormats } from '../dateUtils'
 import {
   durationAndArrivalDateFromPlacementApplication,
@@ -12,7 +12,7 @@ import {
 } from './placementApplicationSubmissionData'
 
 jest.mock('../../form-pages/utils')
-jest.mock('../../utils/assessments/placementDurationFromApplication')
+jest.mock('../applications/placementDurationFromApplication')
 
 const datesOfPlacement = [
   {

--- a/server/utils/placementRequests/placementApplicationSubmissionData.ts
+++ b/server/utils/placementRequests/placementApplicationSubmissionData.ts
@@ -14,7 +14,7 @@ import DatesOfPlacement, {
   DateOfPlacement,
 } from '../../form-pages/placement-application/request-a-placement/datesOfPlacement'
 import AdditionalPlacementDetails from '../../form-pages/placement-application/request-a-placement/additionalPlacementDetails'
-import { placementDurationFromApplication } from '../assessments/placementDurationFromApplication'
+import { placementDurationFromApplication } from '../applications/placementDurationFromApplication'
 import DecisionToRelease from '../../form-pages/placement-application/request-a-placement/decisionToRelease'
 import { DateFormats } from '../dateUtils'
 


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2622

# Changes in this PR

This PR adds the requested placement duration as a first-class field on submission of the application. The utility to determine the default duration for a given application has been moved to the `applications` directory, as it is no longer explicitly used during the assessment process. This has resulted in the updated to a fair few import paths! The utility also now considers the `apType` for an application as optional: its requirement is only useful with regards to submission, where the value for `apType` is checked in a throwable manner anyway.

## Screenshots of UI changes

No UI changes.
