### PR TITLE
APS-2641 National occupancy view - filter on room criteria

### DIFF
--- a/server/controllers/admin/nationalOccupancyController.test.ts
+++ b/server/controllers/admin/nationalOccupancyController.test.ts
@@ -123,7 +123,7 @@ describe('NationalOccupancyController', () => {
       }) as Array<Cas1SpaceCharacteristic>
       const apArea = cruManagementAreas[1].id
 
-      const allApCharacteristics = apCriteria.concat(apTypeToSpaceCharacteristicMap[apType] || [])
+      const allApCharacteristics = apCriteria.concat(apTypeToSpaceCharacteristicMap[apType] || [], roomCriteria)
 
       const request = mockRequest({ arrivalDate, apType, apArea, postcode, roomCriteria, apCriteria })
 

--- a/server/controllers/admin/nationalOccupancyController.ts
+++ b/server/controllers/admin/nationalOccupancyController.ts
@@ -114,7 +114,10 @@ export default class NationalOccupancyController {
           cruManagementAreaIds: expandManagementArea(cruManagementAreas, apArea),
           fromDate,
           postcodeArea: postcode,
-          premisesCharacteristics: (premisesCharacteristics || []).concat(apTypeToSpaceCharacteristicMap[apType] || []),
+          premisesCharacteristics: (premisesCharacteristics || []).concat(
+            apTypeToSpaceCharacteristicMap[apType] || [],
+            roomCharacteristics || [],
+          ),
           roomCharacteristics,
         })
       }


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2641
<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

So that the national occupancy calendar (one week national view) filters the list of displayed APS based on the filtering room criteria, as well as AP criteria, the controller concatenates the list of room criteria passed to the `premisesCharacteristics` as well as passing it as `roomCharacteristics`. This means that the AP will remove any APs that have no rooms meeting any of the characteristics passed, as well as returning the number of available rooms metting those criteria. 

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

<details>
  <summary>Before</summary>
<img src="https://github.com/user-attachments/assets/b9e3a387-a549-4c45-8398-ff483beb5f18"/>
</details>

<details>
  <summary>After</summary>
<img src="https://github.com/user-attachments/assets/de9eae73-8ec4-4817-9d11-4ae997e51792"/>
</details>
