### PR TITLE
Chore: Enable TS sourcemap support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "qs": "^6.14.0",
         "redis": "^4.3.1",
         "reflect-metadata": "^0.2.0",
+        "source-map-support": "^0.5.21",
         "static-path": "^0.0.4",
         "superagent": "^9.0.0",
         "underscore": "^1.13.7",
@@ -6684,7 +6685,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bunyan": {
@@ -12659,6 +12659,17 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/jest-runtime": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
@@ -17007,7 +17018,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -17024,10 +17034,9 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "qs": "^6.14.0",
     "redis": "^4.3.1",
     "reflect-metadata": "^0.2.0",
+    "source-map-support": "^0.5.21",
     "static-path": "^0.0.4",
     "superagent": "^9.0.0",
     "underscore": "^1.13.7",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,5 @@
 /* istanbul ignore file */
-
+import 'source-map-support/register'
 import promClient from 'prom-client'
 import { createMetricsApp } from './monitoring/metricsApp'
 import createApp from './app'


### PR DESCRIPTION
This enables TypeScript sourcemap support, which renders traces relative to the TS source instead of compiled JS:

```
Error: Testing errors
    at /Users/fred.marecesche/Repos/hmpps-approved-premises-ui/server/controllers/admin/placementRequests/placementRequestsController.ts:20:15
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at /Users/fred.marecesche/Repos/hmpps-approved-premises-ui/server/middleware/auditMiddleware.ts:54:5
```
