### PR TITLE
APS-2688 Task allocation improvement

### DIFF
--- a/integration_tests/pages/tasks/allocationPage.ts
+++ b/integration_tests/pages/tasks/allocationPage.ts
@@ -18,7 +18,7 @@ export default class AllocationsPage extends Page {
     private readonly task: Task,
     title?: string,
   ) {
-    super(title || `Reallocate`)
+    super(title || `Allocate`)
   }
 
   static visit(application: Application, task: Task): AllocationsPage {
@@ -69,5 +69,9 @@ export default class AllocationsPage extends Page {
 
   shouldShowTimelineTab() {
     cy.get('label').should('contain', 'Add a note to the application')
+  }
+
+  shouldNotShowAllocationSection() {
+    cy.contains('Allocate task to').should('not.exist')
   }
 }

--- a/integration_tests/pages/tasks/listPage.ts
+++ b/integration_tests/pages/tasks/listPage.ts
@@ -18,36 +18,22 @@ export default class ListPage extends Page {
   }
 
   shouldShowAllocatedTasks(tasks): void {
-    shouldShowTableRows(allocatedTableRows(tasks, true))
+    shouldShowTableRows(allocatedTableRows(tasks))
   }
 
   shouldShowUnallocatedTasks(tasks): void {
-    shouldShowTableRows(unallocatedTableRows(tasks, true))
+    shouldShowTableRows(unallocatedTableRows(tasks))
   }
 
   shouldShowCompletedTasks(tasks): void {
     shouldShowTableRows(completedTableRows(tasks))
   }
 
-  private testContainsHeaderLinks(tasks: Array<Task>, shouldContain: boolean): void {
-    const headerTexts = tableRowsToArrays(allocatedTableRows(tasks, true)).map(row => row[0])
-    headerTexts.forEach(text => {
-      cy.contains('th', text).within(() => {
-        if (shouldContain) {
-          cy.get('a').should('have.text', text)
-        } else {
-          cy.get('a').should('not.exist')
-        }
-      })
-    })
-  }
-
   shouldContainHeaderLinks(tasks: Array<Task>): void {
-    this.testContainsHeaderLinks(tasks, true)
-  }
-
-  shouldNotContainHeaderLinks(tasks: Array<Task>): void {
-    this.testContainsHeaderLinks(tasks, false)
+    const headerTexts = tableRowsToArrays(allocatedTableRows(tasks)).map(row => row[0])
+    headerTexts.forEach(text => {
+      cy.contains('th a', text)
+    })
   }
 
   shouldShowAllocatedToUserFilter() {

--- a/integration_tests/tests/tasks/list.cy.ts
+++ b/integration_tests/tests/tasks/list.cy.ts
@@ -95,7 +95,7 @@ context('Task Allocation', () => {
     AND('the tasks that are completed')
     listPage.clickTab('Completed')
     listPage.shouldShowCompletedTasks(completedTasks)
-    listPage.shouldNotContainHeaderLinks(completedTasks)
+    listPage.shouldContainHeaderLinks(completedTasks)
   })
 
   it('shows a list of tasks', () => {
@@ -139,28 +139,6 @@ context('Task Allocation', () => {
 
     AND('I should not see the allocated to user select option')
     listPage.shouldNotShowAllocatedToUserFilter()
-  })
-
-  it(`Doesn't show allocation links if user lacks permission`, () => {
-    GIVEN('I am signed in as a AP area manager (without the cas1_tasks_allocate permission)')
-    signIn('ap_area_manager', user)
-
-    const allocatedTasks = taskFactory.buildList(1, { personSummary: fullPersonSummaryFactory.build() })
-
-    cy.task('stubGetAllTasks', {
-      tasks: allocatedTasks,
-      allocatedFilter: 'allocated',
-      page: '1',
-      sortDirection: 'asc',
-      cruManagementAreaId: cruManagementAreas[0].id,
-    })
-
-    WHEN('I visit the tasks dashboard')
-    const listPage = ListPage.visit()
-
-    THEN('I should see the tasks that are allocated')
-    listPage.shouldShowAllocatedTasks(allocatedTasks)
-    listPage.shouldNotContainHeaderLinks(allocatedTasks)
   })
 
   it('supports pagination', () => {

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -19,7 +19,7 @@ export default function routes(controllers: Controllers, router: Router, service
   })
   get(paths.tasks.show.pattern, tasksController.show(), {
     auditEvent: 'SHOW_TASK',
-    allowedPermissions: ['cas1_tasks_allocate'],
+    allowedPermissions: ['cas1_view_manage_tasks'],
   })
   post(paths.tasks.allocations.create.pattern, allocationsController.create(), {
     auditEvent: 'REALLOCATE_TASK_SUCCESS',

--- a/server/utils/tasks/listTable.test.ts
+++ b/server/utils/tasks/listTable.test.ts
@@ -37,9 +37,9 @@ describe('table', () => {
       it('returns an array of table rows', () => {
         const task = taskFactory.build()
 
-        expect(allocatedTableRows([task], true)).toEqual([
+        expect(allocatedTableRows([task])).toEqual([
           [
-            nameAnchorCell(task, true),
+            nameAnchorCell(task),
             daysUntilDueCell(task, 'task--index__warning'),
             {
               text: task.expectedArrivalDate
@@ -68,9 +68,9 @@ describe('table', () => {
       it('returns an array of allocated table rows', () => {
         const task = taskFactory.build()
 
-        expect(tasksTableRows([task], 'allocated', true)).toEqual([
+        expect(tasksTableRows([task], 'allocated')).toEqual([
           [
-            nameAnchorCell(task, true),
+            nameAnchorCell(task),
             daysUntilDueCell(task, 'task--index__warning'),
             {
               text: task.expectedArrivalDate
@@ -103,9 +103,9 @@ describe('table', () => {
       it('returns an array of table rows', () => {
         const task = taskFactory.build()
 
-        expect(unallocatedTableRows([task], true)).toEqual([
+        expect(unallocatedTableRows([task])).toEqual([
           [
-            nameAnchorCell(task, true),
+            nameAnchorCell(task),
             daysUntilDueCell(task, 'task--index__warning'),
             {
               text: task.expectedArrivalDate
@@ -129,9 +129,9 @@ describe('table', () => {
       it('returns an array of unallocated table rows', () => {
         const task = taskFactory.build()
 
-        expect(tasksTableRows([task], 'unallocated', true)).toEqual([
+        expect(tasksTableRows([task], 'unallocated')).toEqual([
           [
-            nameAnchorCell(task, true),
+            nameAnchorCell(task),
             daysUntilDueCell(task, 'task--index__warning'),
             {
               text: task.expectedArrivalDate
@@ -236,7 +236,7 @@ describe('table', () => {
     })
     it('returns the name when the person summary is FullPersonSummary  in the task', () => {
       const personSummary = fullPersonSummaryFactory.build()
-      expect(nameAnchorCell({ ...task, personSummary }, true)).toEqual({
+      expect(nameAnchorCell({ ...task, personSummary })).toEqual({
         html: linkTo(paths.tasks.show({ id: task.id, taskType: kebabCase(task.taskType) }), {
           text: personSummary.name,
           attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
@@ -245,7 +245,7 @@ describe('table', () => {
     })
     it('returns the Limited Access Offender (LAO) CRN when the person summary is RestrictedPersonSummary in the task', () => {
       const personSummary = fullPersonSummaryFactory.build({ personType: 'RestrictedPersonSummary' })
-      expect(nameAnchorCell({ ...task, personSummary }, true)).toEqual({
+      expect(nameAnchorCell({ ...task, personSummary })).toEqual({
         html: linkTo(paths.tasks.show({ id: task.id, taskType: kebabCase(task.taskType) }), {
           text: `LAO: ${personSummary.crn}`,
           attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
@@ -254,17 +254,11 @@ describe('table', () => {
     })
     it('returns the unknown person CRN when the person summary is UnknownPersonSummary  in the task', () => {
       const personSummary = fullPersonSummaryFactory.build({ personType: 'UnknownPersonSummary' })
-      expect(nameAnchorCell({ ...task, personSummary }, true)).toEqual({
+      expect(nameAnchorCell({ ...task, personSummary })).toEqual({
         html: linkTo(paths.tasks.show({ id: task.id, taskType: kebabCase(task.taskType) }), {
           text: `Unknown: ${personSummary.crn}`,
           attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
         }),
-      })
-    })
-    it('returns the person without a link if the canAllocate parameter is false', () => {
-      const personSummary = fullPersonSummaryFactory.build({ personType: 'UnknownPersonSummary' })
-      expect(nameAnchorCell({ ...task, personSummary }, false)).toEqual({
-        text: `Unknown: ${personSummary.crn}`,
       })
     })
   })
@@ -435,7 +429,7 @@ describe('table', () => {
 
       expect(completedTableRows([task])).toEqual([
         [
-          nameAnchorCell(task, false),
+          nameAnchorCell(task),
           completedAtDateCell(task),
           completedByCell(task),
           taskTypeCell(task),
@@ -447,9 +441,9 @@ describe('table', () => {
     it('returns an array of completed task table rows', () => {
       const task = taskFactory.build()
 
-      expect(tasksTableRows([task], 'completed', true)).toEqual([
+      expect(tasksTableRows([task], 'completed')).toEqual([
         [
-          nameAnchorCell(task, false),
+          nameAnchorCell(task),
           completedAtDateCell(task),
           completedByCell(task),
           taskTypeCell(task),

--- a/server/utils/tasks/listTable.ts
+++ b/server/utils/tasks/listTable.ts
@@ -81,17 +81,12 @@ const allocationCell = (task: Task): TableCell => ({
   text: task.allocatedToStaffMember?.name,
 })
 
-const nameAnchorCell = (task: Task, canAllocate: boolean): TableCell =>
-  canAllocate
-    ? {
-        html: linkTo(paths.tasks.show(taskParams(task)), {
-          text: displayName(task.personSummary, { showCrn: true }),
-          attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
-        }),
-      }
-    : {
-        text: displayName(task.personSummary, { showCrn: true }),
-      }
+const nameAnchorCell = (task: Task): TableCell => ({
+  html: linkTo(paths.tasks.show(taskParams(task)), {
+    text: displayName(task.personSummary, { showCrn: true }),
+    attributes: { 'data-cy-taskId': task.id, 'data-cy-applicationId': task.applicationId },
+  }),
+})
 
 const apTypeCell = (task: Task): TableCell => ({
   text: apTypeShortLabels[task.apType] || '',
@@ -101,11 +96,11 @@ const apAreaCell = (task: Task): TableCell => ({
   text: task.apArea?.name || 'No area supplied',
 })
 
-const allocatedTableRows = (tasks: Array<Task>, canAllocate: boolean): Array<TableRow> => {
+const allocatedTableRows = (tasks: Array<Task>): Array<TableRow> => {
   const rows: Array<TableRow> = []
   tasks.forEach(task => {
     rows.push([
-      nameAnchorCell(task, canAllocate),
+      nameAnchorCell(task),
       daysUntilDueCell(task, 'task--index__warning'),
       arrivalDateCell(task),
       allocationCell(task),
@@ -119,12 +114,12 @@ const allocatedTableRows = (tasks: Array<Task>, canAllocate: boolean): Array<Tab
   return rows
 }
 
-const unallocatedTableRows = (tasks: Array<Task>, canAllocate: boolean): Array<TableRow> => {
+const unallocatedTableRows = (tasks: Array<Task>): Array<TableRow> => {
   const rows = [] as Array<TableRow>
 
   tasks.forEach(task => {
     rows.push([
-      nameAnchorCell(task, canAllocate),
+      nameAnchorCell(task),
       daysUntilDueCell(task, 'task--index__warning'),
       arrivalDateCell(task),
       statusCell(task),
@@ -154,7 +149,7 @@ const completedTableRows = (tasks: Array<Task>): Array<TableRow> => {
 
   tasks.forEach(task => {
     rows.push([
-      nameAnchorCell(task, false),
+      nameAnchorCell(task),
       completedAtDateCell(task),
       completedByCell(task),
       taskTypeCell(task),
@@ -165,12 +160,12 @@ const completedTableRows = (tasks: Array<Task>): Array<TableRow> => {
   return rows
 }
 
-const tasksTableRows = (tasks: Array<Task>, allocatedFilter: TaskTab, canAllocate: boolean): Array<TableRow> => {
+const tasksTableRows = (tasks: Array<Task>, allocatedFilter: TaskTab): Array<TableRow> => {
   if (allocatedFilter === 'allocated') {
-    return allocatedTableRows(tasks, canAllocate)
+    return allocatedTableRows(tasks)
   }
   if (allocatedFilter === 'unallocated') {
-    return unallocatedTableRows(tasks, canAllocate)
+    return unallocatedTableRows(tasks)
   }
   return completedTableRows(tasks)
 }

--- a/server/views/tasks/show.njk
+++ b/server/views/tasks/show.njk
@@ -4,9 +4,10 @@
 
 {% from "components/sortableTable/macro.njk" import sortableTable %}
 
-{% from "../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "partials/filters.njk" import filterWrapper, filterSelect %}
 
-{% extends "../partials/layout.njk" %}
+{% extends "partials/layout.njk" %}
 
 {% block content %}
     <div class="govuk-grid-row">
@@ -22,54 +23,27 @@
             {{ showErrorSummary(errorSummary) }}
         </div>
     </div>
-
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <h2 class="govuk-heading-m">Allocate task to</h2>
+    {% if canAllocate %}
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <h2 class="govuk-heading-m">Allocate task to</h2>
+            </div>
         </div>
-    </div>
 
-    <form action="{{ paths.tasks.show(TaskUtils.taskParams(task)) }}" method="get" class="search-and-filter">
+        {% call filterWrapper('Filters') %}
+            <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+            {{ filterSelect('cruManagementAreaId', 'AP area', convertObjectsToSelectOptions(cruManagementAreas, 'All areas', 'name', 'id', 'cruManagementAreaId')) }}
+            {{ filterSelect('qualification', 'Qualifications', UserUtils.userQualificationsSelectOptions(qualification)) }}
+        {% endcall %}
 
-        <h2 class="govuk-heading-m">Filters</h2>
+        {{ sortableTable({
+            attributes: { 'data-module': 'moj-sortable-table' },
+            firstCellIsHeader: true,
+            head: TaskUtils.userTableHeader(),
+            rows: TaskUtils.userTableRows(users, task, csrfToken)
+        }) }}
 
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-
-        <div class="search-and-filter__row">
-            {{ govukSelect({
-                label: {
-                    text: "AP area",
-                    classes: "govuk-label--s"
-                },
-                id: "cruManagementAreaId",
-                name: "cruManagementAreaId",
-                items: convertObjectsToSelectOptions(cruManagementAreas, 'All areas', 'name', 'id', 'cruManagementAreaId')
-            }) }}
-
-            {{ govukSelect({
-                label: {
-                    text: "Qualifications",
-                    classes: "govuk-label--s"
-                },
-                id: "qualification",
-                name: "qualification",
-                items: UserUtils.userQualificationsSelectOptions(qualification)
-            }) }}
-
-            {{ govukButton({
-                "name": "submit",
-                "text": "Apply filters",
-                "preventDoubleClick": true
-            }) }}
-        </div>
-    </form>
-
-    {{ sortableTable({
-        attributes: { 'data-module': 'moj-sortable-table' },
-        firstCellIsHeader: true,
-        head: TaskUtils.userTableHeader(),
-        rows: TaskUtils.userTableRows(users, task, csrfToken)
-    }) }}
+    {% endif %}
 
 {% endblock %}
 


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2688

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR


After discussions with Rob, I agree that I didn't implement this ticket the best way. 
It would be better to allow users who don't have permissions to a task, to view to the 'Allocate' page but not get the user list and allocation button. Similarly for completed tasks.
This means that they can review the details of the task, some of which are not shown on the task list page.

I've had to change the title on the task allocation page as it's not appropriate for a 'view' mode. 'Reallocate' was bad in that the title showed for both allocated and unallocated tasks. It now shows 'View XXXX' or 'Allocate XXXX' depending on whether allocation is enabled.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

<details>
  <summary>Allocation allowed</summary>
<img src="https://github.com/user-attachments/assets/71912a0f-b4d9-4176-be2d-196fa1613874"/>
</details>

<details>
  <summary>Allocation not allowed</summary>
<img src="https://github.com/user-attachments/assets/3d6443ad-3e5b-40b8-aafb-3eec88167f3e"/>
</details>


