### PR TITLE
APS-2686: Validate duration weeks and days fields

### DIFF
--- a/server/form-pages/apply/move-on/placementDuration.test.ts
+++ b/server/form-pages/apply/move-on/placementDuration.test.ts
@@ -7,6 +7,7 @@ import { applicationFactory } from '../../../testutils/factories'
 import { addResponsesToFormArtifact } from '../../../testutils/addToApplication'
 import { arrivalDateFromApplication } from '../../../utils/applications/arrivalDateFromApplication'
 import { DateFormats } from '../../../utils/dateUtils'
+import * as formUtils from '../../../utils/formUtils'
 
 jest.mock('../../../utils/applications/getDefaultPlacementDurationInDays')
 jest.mock('../../../utils/applications/arrivalDateFromApplication')
@@ -106,21 +107,23 @@ describe('PlacementDuration', () => {
       })
     })
 
-    it('returns an error if the different duration response is yes but both durations are not set', () => {
-      let page = new PlacementDuration(
-        { differentDuration: 'yes', durationWeeks: '1', reason: 'Some reason' },
+    it('validates the duration fields', () => {
+      jest.spyOn(formUtils, 'validWeeksAndDaysDuration')
+
+      const page = new PlacementDuration(
+        {
+          differentDuration: 'yes',
+          durationWeeks: 'a',
+          durationDays: 'b',
+          reason: 'Some reason',
+        },
         application,
       )
 
       expect(page.errors()).toEqual({
         duration: 'You must specify the duration of the placement',
       })
-
-      page = new PlacementDuration({ differentDuration: 'yes', durationDays: '1', reason: 'Some reason' }, application)
-
-      expect(page.errors()).toEqual({
-        duration: 'You must specify the duration of the placement',
-      })
+      expect(formUtils.validWeeksAndDaysDuration).toHaveBeenCalledWith('a', 'b')
     })
   })
 

--- a/server/form-pages/apply/move-on/placementDuration.ts
+++ b/server/form-pages/apply/move-on/placementDuration.ts
@@ -8,6 +8,7 @@ import TasklistPage from '../../tasklistPage'
 import { sentenceCase } from '../../../utils/utils'
 import { getDefaultPlacementDurationInDays } from '../../../utils/applications/getDefaultPlacementDurationInDays'
 import { arrivalDateFromApplication } from '../../../utils/applications/arrivalDateFromApplication'
+import { validWeeksAndDaysDuration } from '../../../utils/formUtils'
 
 type PlacementDurationBody = {
   differentDuration: YesOrNo
@@ -73,11 +74,7 @@ export default class PlacementDuration implements TasklistPage {
     }
 
     if (this.body.differentDuration === 'yes') {
-      if (!this.body.durationDays) {
-        errors.duration = 'You must specify the duration of the placement'
-      }
-
-      if (!this.body.durationWeeks) {
+      if (!validWeeksAndDaysDuration(this.body.durationWeeks, this.body.durationDays)) {
         errors.duration = 'You must specify the duration of the placement'
       }
 

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -3,6 +3,7 @@ import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../share
 
 import MatchingInformation, { MatchingInformationBody } from './matchingInformation'
 import * as matchingInformtionUtils from '../../../utils/matchingInformationUtils'
+import * as formUtils from '../../../../utils/formUtils'
 
 jest.mock('../../../../utils/applications/placementDurationFromApplication')
 jest.mock('../../../../utils/retrieveQuestionResponseFromFormArtifact')
@@ -49,7 +50,7 @@ const defaultMatchingInformationValuesReturnValue: Partial<MatchingInformationBo
 
 describe('MatchingInformation', () => {
   afterEach(() => {
-    jest.resetAllMocks()
+    jest.restoreAllMocks()
   })
 
   describe('title', () => {
@@ -87,28 +88,19 @@ describe('MatchingInformation', () => {
       })
     })
 
-    it.each([
-      ['1', undefined, false],
-      ['1', '', false],
-      ['-1', '5', true],
-      ['7', '0', false],
-    ])(
-      'if lengthOfStayAgreed is "no", weeks is "%s" and days is "%s" it should error %s',
-      (weeks: string, days: string, shouldError: boolean) => {
-        const page = new MatchingInformation(
-          { ...defaultArguments, lengthOfStayAgreed: 'no', lengthOfStayWeeks: weeks, lengthOfStayDays: days },
-          assessment,
-        )
+    it('validates the duration fields', () => {
+      jest.spyOn(formUtils, 'validWeeksAndDaysDuration')
 
-        expect(page.errors()).toEqual(
-          shouldError
-            ? {
-                lengthOfStay: 'You must provide a recommended length of stay',
-              }
-            : {},
-        )
-      },
-    )
+      const page = new MatchingInformation(
+        { ...defaultArguments, lengthOfStayAgreed: 'no', lengthOfStayWeeks: 'a', lengthOfStayDays: 'b' },
+        assessment,
+      )
+
+      expect(page.errors()).toEqual({
+        lengthOfStay: 'You must provide a recommended length of stay',
+      })
+      expect(formUtils.validWeeksAndDaysDuration).toHaveBeenCalledWith('a', 'b')
+    })
 
     it("should return an error if the type is not available for a women's application", () => {
       const page = new MatchingInformation({ ...defaultArguments, apType: 'isMHAPElliottHouse' }, weAssessment)

--- a/server/form-pages/utils/matchingInformationUtils.ts
+++ b/server/form-pages/utils/matchingInformationUtils.ts
@@ -25,7 +25,7 @@ import { OffenceAndRiskCriteria, PlacementRequirementCriteria } from '../../util
 import SelectApType from '../apply/reasons-for-placement/type-of-ap/apType'
 import PlacementDate from '../apply/reasons-for-placement/basic-information/placementDate'
 import ReleaseDate from '../apply/reasons-for-placement/basic-information/releaseDate'
-import { isCardinal } from '../../utils/utils'
+import { validWeeksAndDaysDuration } from '../../utils/formUtils'
 
 export interface TaskListPageField {
   name: string
@@ -65,8 +65,7 @@ export const lengthOfStay = ({
   lengthOfStayAgreed,
 }: MatchingInformationBody): string | undefined => {
   if (lengthOfStayAgreed === 'no') {
-    if ((lengthOfStayWeeks && !isCardinal(lengthOfStayWeeks)) || (lengthOfStayDays && !isCardinal(lengthOfStayDays)))
-      return undefined
+    if (!validWeeksAndDaysDuration(lengthOfStayWeeks, lengthOfStayDays)) return undefined
 
     const lengthOfStayWeeksInDays = weeksToDays(Number(lengthOfStayWeeks || 0))
     const totalLengthInDays = lengthOfStayWeeksInDays + Number(lengthOfStayDays || 0)

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -17,6 +17,7 @@ import {
   summaryListItem,
   tierSelectOptions,
   validPostcodeArea,
+  validWeeksAndDaysDuration,
 } from './formUtils'
 
 describe('formUtils', () => {
@@ -519,6 +520,29 @@ describe('formUtils', () => {
 
     it('when passed a non-postcode string returns false', () => {
       expect(validPostcodeArea('foo')).toBe(false)
+    })
+  })
+
+  describe('validWeeksAndDaysDuration', () => {
+    it.each([
+      ['1', '1'],
+      ['12', ''],
+      ['', '8'],
+      ['0', '12'],
+      ['3', '0'],
+    ])('returns true if weeks is "%s" and days is "%s"', (durationWeeks: string, durationDays: string) => {
+      expect(validWeeksAndDaysDuration(durationWeeks, durationDays)).toBe(true)
+    })
+
+    it.each([
+      ['', ''],
+      [undefined, undefined],
+      ['1', 'a'],
+      ['a', 'a'],
+      ['1', '-1'],
+      ['a', ''],
+    ])('returns false if weeks is "%s" and days is "%s"', (durationWeeks: string, durationDays: string) => {
+      expect(validWeeksAndDaysDuration(durationWeeks, durationDays)).toBe(false)
     })
   })
 

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -11,7 +11,7 @@ import type {
 } from '@approved-premises/ui'
 import type { RiskTierLevel } from '@approved-premises/api'
 import { PlacementRequestStatus } from '@approved-premises/api'
-import { resolvePath, sentenceCase } from './utils'
+import { isCardinal, resolvePath, sentenceCase } from './utils'
 import postcodeAreas from '../etc/postcodeAreas.json'
 
 export const dateFieldValues = (
@@ -195,6 +195,16 @@ export const summaryListItem = (
  */
 export function validPostcodeArea(potentialPostcode: string) {
   return postcodeAreas.includes(potentialPostcode.trim().toUpperCase())
+}
+
+/**
+ * Performs validation on a set of 'weeks' and 'days' fields
+ * @returns true if both fields are cardinal numbers or if one is a cardinal number and the other is empty
+ * @param weeks
+ * @param days
+ */
+export function validWeeksAndDaysDuration(weeks: string, days: string) {
+  return (isCardinal(weeks) && isCardinal(days)) || (isCardinal(weeks) && !days) || (!weeks && isCardinal(days))
 }
 
 /**


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2686

# Changes in this PR

This introduces validation for the duration fields of the Placement duration and move-on page, which is shown when the assessor does not agree with the requested placement duration. The validation matches that already used on another such weeks/days set of inputs: both fields are cardinal numbers, or one is with the other empty.

## Screenshots of UI changes

Error when any field contains something else than a cardinal number:

<img width="453" height="170" alt="Screenshot 2025-08-19 at 16 00 35" src="https://github.com/user-attachments/assets/8f381f04-3e68-4c09-a1f0-8fe929e9ed95" />

