### PR TITLE
APS-2717 - Use ‘submitted at’ for RfP made on date

### DIFF
--- a/server/utils/placementRequests/requestForPlacementSummaryCards.test.ts
+++ b/server/utils/placementRequests/requestForPlacementSummaryCards.test.ts
@@ -61,7 +61,7 @@ describe('RequestForPlacementSummaryCards', () => {
       expect(summaryCard).toEqual({
         card: expect.objectContaining({
           title: {
-            text: `Request made on ${DateFormats.isoDateToUIDate(requestForPlacement.createdAt, { format: 'short' })}`,
+            text: `Request made on ${DateFormats.isoDateToUIDate(requestForPlacement.submittedAt, { format: 'short' })}`,
             headingLevel: '3',
           },
           attributes: {
@@ -194,7 +194,7 @@ describe('RequestForPlacementSummaryCards', () => {
       expect(summaryCard).toEqual({
         card: expect.objectContaining({
           title: {
-            text: `Request made on ${DateFormats.isoDateToUIDate(requestForPlacement.createdAt, { format: 'short' })}`,
+            text: `Request made on ${DateFormats.isoDateToUIDate(requestForPlacement.submittedAt, { format: 'short' })}`,
             headingLevel: '3',
           },
           attributes: {

--- a/server/utils/placementRequests/requestForPlacementSummaryCards.ts
+++ b/server/utils/placementRequests/requestForPlacementSummaryCards.ts
@@ -64,7 +64,7 @@ export class RequestForPlacementSummaryCards {
     return {
       card: {
         title: {
-          text: `Request made on ${DateFormats.isoDateToUIDate(this.requestForPlacement.createdAt, { format: 'short' })}`,
+          text: `Request made on ${DateFormats.isoDateToUIDate(this.requestForPlacement.submittedAt, { format: 'short' })}`,
           headingLevel: '3',
         },
         attributes: {


### PR DESCRIPTION
Up until recently the request for placement ‘created at’ and ‘submitted at’ values were typically the same because the request for placement had to be created and submitted in the same session (they were lost if the user didn’t complete them)

Now we’ve started capturing initial request for placement details in the database as placement applications these dates can be very different e.g.

created at. - when the original application as created submitted at - when the original application was submitted

this could be days/weeks apart.

given this, when showing ‘request made on’ on the ‘requests for placements’ tab, we should submitted at instead