### PR TITLE
APS-2648 Remove desirable criteria

### DIFF
--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
@@ -26,19 +26,18 @@ import {
 } from '../../../../utils/placementCriteriaUtils'
 import { convertKeyValuePairToRadioItems } from '../../../../utils/formUtils'
 import { womensApTypes } from '../../../apply/reasons-for-placement/type-of-ap/apType'
+import { radioMatrixTable } from '../../../../utils/radioMatrixTable'
 
-const placementRequirementPreferences = ['essential' as const, 'desirable' as const, 'notRelevant' as const]
+const placementRequirementPreferences = ['required' as const, 'notRequired' as const]
 export type PlacementRequirementPreference = (typeof placementRequirementPreferences)[number]
 
 const offenceAndRiskRelevance = ['relevant' as const, 'notRelevant' as const]
 export type OffenceAndRiskRelevance = (typeof offenceAndRiskRelevance)[number]
 
 export type MatchingInformationBody = {
-  [Key in OffenceAndRiskCriteria | PlacementRequirementCriteria]: Key extends OffenceAndRiskCriteria
-    ? OffenceAndRiskRelevance
-    : Key extends PlacementRequirementCriteria
-      ? PlacementRequirementPreference
-      : never
+  [Key in OffenceAndRiskCriteria | PlacementRequirementCriteria]:
+    | OffenceAndRiskRelevance
+    | PlacementRequirementPreference
 } & {
   apType: ApTypeCriteria
   cruInformation: string
@@ -72,21 +71,30 @@ export default class MatchingInformation implements TasklistPage {
     cruInformation: 'Information for Central Referral Unit (CRU) manager (optional)',
   }
 
-  placementRequirementTableHeadings = ['Specify placement requirements', 'Essential', 'Desirable', 'Not required']
+  relevantInformationTable = () =>
+    radioMatrixTable(
+      ['Risks and offences to consider', 'Relevant', 'Not required'],
+      offenceAndRiskCriteria,
+      offenceAndRiskRelevance,
+      this.body,
+    )
 
-  placementRequirementCriteria = placementRequirementCriteria
+  prepopulatedRequirementsTable = () => {
+    return radioMatrixTable(
+      ['Specify placement requirements', 'Required', 'Not required'],
+      prepopulatablePlacementRequirementCriteria,
+      placementRequirementPreferences,
+      this.body,
+    )
+  }
 
-  prepopulatablePlacementRequirementCriteria = prepopulatablePlacementRequirementCriteria
-
-  nonPrepopulatablePlacementRequirementCriteria = nonPrepopulatablePlacementRequirementCriteria
-
-  placementRequirementPreferences = placementRequirementPreferences
-
-  relevantInformationTableHeadings = ['Risks and offences to consider', 'Relevant', 'Not required']
-
-  offenceAndRiskCriteria = offenceAndRiskCriteria
-
-  offenceAndRiskInformationRelevance = offenceAndRiskRelevance
+  nonPrepopulatedRequirementsTable = () =>
+    radioMatrixTable(
+      ['Specify placement requirements', 'Required', 'Not required'],
+      nonPrepopulatablePlacementRequirementCriteria,
+      placementRequirementPreferences,
+      this.body,
+    )
 
   availableApTypes: Record<ApTypeCriteria, string>
 
@@ -124,18 +132,26 @@ export default class MatchingInformation implements TasklistPage {
     return ''
   }
 
+  private criteriaMap: Record<string, string> = {
+    essential: 'Required',
+  }
+
+  private criterionValueText = (value: string) => {
+    return this.criteriaMap[value] || sentenceCase(value)
+  }
+
   response() {
     const response = {
       [this.questions.apType]: apTypeCriteriaLabels[this.body.apType],
     }
 
-    this.placementRequirementCriteria.forEach(placementRequirementCriterion => {
+    placementRequirementCriteria.forEach(placementRequirementCriterion => {
       response[`${placementCriteriaLabels[placementRequirementCriterion]}`] =
-        `${sentenceCase(this.body[placementRequirementCriterion])}`
+        `${this.criterionValueText(this.body[placementRequirementCriterion])}`
     })
 
-    this.offenceAndRiskCriteria.forEach(offenceOrRiskCriterion => {
-      response[`${placementCriteriaLabels[offenceOrRiskCriterion]}`] = `${sentenceCase(
+    offenceAndRiskCriteria.forEach(offenceOrRiskCriterion => {
+      response[`${placementCriteriaLabels[offenceOrRiskCriterion]}`] = `${this.criterionValueText(
         this.body[offenceOrRiskCriterion],
       )}`
     })
@@ -162,7 +178,7 @@ export default class MatchingInformation implements TasklistPage {
     if (!Object.keys(this.availableApTypes).includes(this.body.apType))
       errors.apType = 'You must select the type of AP required'
 
-    this.placementRequirementCriteria.forEach(placementRequirementCriterion => {
+    placementRequirementCriteria.forEach(placementRequirementCriterion => {
       if (!this.body[placementRequirementCriterion]) {
         errors[placementRequirementCriterion] = `You must specify a preference for ${placementCriteriaLabels[
           placementRequirementCriterion
@@ -170,7 +186,7 @@ export default class MatchingInformation implements TasklistPage {
       }
     })
 
-    this.offenceAndRiskCriteria.forEach(offenceOrRiskCriterion => {
+    offenceAndRiskCriteria.forEach(offenceOrRiskCriterion => {
       if (!this.body[offenceOrRiskCriterion]) {
         errors[offenceOrRiskCriterion] = `You must specify if ${lowerCase(
           placementCriteriaLabels[offenceOrRiskCriterion],

--- a/server/form-pages/utils/decorators/page.decorator.ts
+++ b/server/form-pages/utils/decorators/page.decorator.ts
@@ -21,7 +21,6 @@ const Page = (options: {
       constructor(...args: Array<any>) {
         super(...args)
         const [body, document] = args
-
         if (options.mergeBody) {
           this.body = { ...(this.body || {}), ...this.createBody(body, ...options.bodyProperties) }
         } else {

--- a/server/services/assessmentService.ts
+++ b/server/services/assessmentService.ts
@@ -52,7 +52,6 @@ export default class AssessmentService {
     userInput?: Record<string, unknown>,
   ) {
     const body = getBody(Page, assessment, request, userInput)
-
     const page = Page.initialize
       ? await Page.initialize(body, assessment, request.user.token, dataServices)
       : new Page(body, assessment)

--- a/server/utils/assessments/acceptanceData.test.ts
+++ b/server/utils/assessments/acceptanceData.test.ts
@@ -133,8 +133,8 @@ describe('acceptanceData', () => {
         type: 'normal',
         location: 'ABC123',
         radius: '100',
-        essentialCriteria: criteriaFromMatchingInformation(matchingInformation).essentialCriteria,
-        desirableCriteria: criteriaFromMatchingInformation(matchingInformation).desirableCriteria,
+        essentialCriteria: criteriaFromMatchingInformation(matchingInformation),
+        desirableCriteria: [],
       })
     })
 
@@ -170,8 +170,8 @@ describe('acceptanceData', () => {
     it('returns all essential criteria for essential and relevant matching information', () => {
       const matchingInformation = createMock<MatchingInformationBody>({
         apType: 'isESAP',
-        isWheelchairDesignated: 'essential',
-        isStepFreeDesignated: 'essential',
+        isWheelchairDesignated: 'required',
+        isStepFreeDesignated: 'required',
         acceptsSexOffenders: 'relevant',
         acceptsChildSexOffenders: 'relevant',
         acceptsNonSexualChildOffenders: 'relevant',
@@ -180,8 +180,7 @@ describe('acceptanceData', () => {
 
       const result = criteriaFromMatchingInformation(matchingInformation)
 
-      expect(result.desirableCriteria).toEqual([])
-      expect(result.essentialCriteria.sort()).toEqual(
+      expect(result.sort()).toEqual(
         [
           'isESAP',
           'isWheelchairDesignated',
@@ -193,19 +192,6 @@ describe('acceptanceData', () => {
           'isSuitedForSexOffenders',
         ].sort(),
       )
-    })
-
-    it('returns all desirable criteria for desirable matching information', () => {
-      const matchingInformation = createMock<MatchingInformationBody>({
-        apType: 'normal',
-        isWheelchairDesignated: 'desirable',
-        isStepFreeDesignated: 'desirable',
-      })
-
-      const result = criteriaFromMatchingInformation(matchingInformation)
-
-      expect(result.desirableCriteria.sort()).toEqual(['isStepFreeDesignated', 'isWheelchairDesignated'].sort())
-      expect(result.essentialCriteria).toEqual([])
     })
 
     it('returns empty objects for not relevant matching information', () => {
@@ -220,10 +206,7 @@ describe('acceptanceData', () => {
         isSuitableForVulnerable: 'notRelevant',
       })
 
-      expect(criteriaFromMatchingInformation(matchingInformation)).toEqual({
-        desirableCriteria: [],
-        essentialCriteria: [],
-      })
+      expect(criteriaFromMatchingInformation(matchingInformation)).toEqual([])
     })
   })
 })

--- a/server/utils/assessments/acceptanceData.ts
+++ b/server/utils/assessments/acceptanceData.ts
@@ -98,45 +98,39 @@ export const placementRequestData = (assessment: Assessment): PlacementRequireme
     'alternativeRadius',
   )
 
-  const criteria = criteriaFromMatchingInformation(matchingInformation)
-
   return {
     type: apType(matchingInformation.apType),
     location,
     radius: alternativeRadius || 50,
-    ...criteria,
+    essentialCriteria: criteriaFromMatchingInformation(matchingInformation),
+    desirableCriteria: [],
   }
 }
 
 export const criteriaFromMatchingInformation = (
   matchingInformation: MatchingInformationBody,
-): { essentialCriteria: Array<PlacementCriteria>; desirableCriteria: Array<PlacementCriteria> } => {
-  const essentialCriteria = [] as Array<PlacementCriteria>
-  const desirableCriteria = [] as Array<PlacementCriteria>
+): Array<PlacementCriteria> => {
+  const criteria: Array<PlacementCriteria> = []
 
   if (matchingInformation.apType !== 'normal') {
-    essentialCriteria.push(matchingInformation.apType)
+    criteria.push(matchingInformation.apType)
   }
 
   placementRequirementCriteria.forEach((requirement: PlacementRequirementCriteria) => {
-    if (matchingInformation[requirement] === 'essential') {
-      essentialCriteria.push(requirement)
-    }
-
-    if (matchingInformation[requirement] === 'desirable') {
-      desirableCriteria.push(requirement)
+    if (matchingInformation[requirement] === 'required') {
+      criteria.push(requirement)
     }
   })
 
   offenceAndRiskCriteria.forEach((requirement: OffenceAndRiskCriteria) => {
     if (matchingInformation[requirement] === 'relevant') {
-      essentialCriteria.push(requirement)
+      criteria.push(requirement)
     }
   })
 
-  if (essentialCriteria.includes('acceptsSexOffenders') || essentialCriteria.includes('acceptsChildSexOffenders')) {
-    essentialCriteria.push('isSuitedForSexOffenders')
+  if (criteria.includes('acceptsSexOffenders') || criteria.includes('acceptsChildSexOffenders')) {
+    criteria.push('isSuitedForSexOffenders')
   }
 
-  return { essentialCriteria, desirableCriteria }
+  return criteria
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -69,7 +69,6 @@ import adminPaths from '../paths/admin'
 import peoplePaths from '../paths/people'
 import staticPaths from '../paths/static'
 import placementApplicationsPaths from '../paths/placementApplications'
-import { radioMatrixTable } from './radioMatrixTable'
 import * as AppealsUtils from './appealsUtils'
 
 import config from '../config'
@@ -77,7 +76,6 @@ import { withdrawalRadioOptions } from './applications/withdrawalReasons'
 import { PersonStatusTag } from './people/personStatusTag'
 import { TaskStatusTag } from './tasks/statusTag'
 import { displayName } from './personUtils'
-import { UiPlacementCriteria } from './placementCriteriaUtils'
 import logger from '../../logger'
 
 export default function nunjucksSetup(app: express.Express, path: pathModule.PlatformPath): void {
@@ -166,18 +164,6 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
     'convertKeyValuePairToRadioItems',
     function sendConvertKeyValuePairToRadioItems(items: Record<string, string>, checkedItem: string) {
       return convertKeyValuePairToRadioItems(items, checkedItem)
-    },
-  )
-
-  njkEnv.addGlobal(
-    'placementRequirementsTable',
-    function sendPlacementRequirementsTable(
-      headings: Array<string>,
-      requirements: Array<UiPlacementCriteria>,
-      preferences: Array<string>,
-      body: Record<string, string>,
-    ) {
-      return radioMatrixTable(headings, requirements, preferences, body)
     },
   )
 

--- a/server/utils/placementCriteriaUtils.ts
+++ b/server/utils/placementCriteriaUtils.ts
@@ -23,21 +23,24 @@ export const applyApTypeToAssessApType: Record<ApTypeSpecialist, SpecialistApTyp
 }
 
 export const specialistApTypeCriteria = apTypes.map((type: ApTypeSpecialist) => applyApTypeToAssessApType[type])
-export const offenceAndRiskCriteria = [
+export const offenceAndRiskCriteria: Array<UiPlacementCriteria> = [
   'isSuitableForVulnerable',
   'acceptsSexOffenders',
   'acceptsChildSexOffenders',
   'acceptsNonSexualChildOffenders',
   'acceptsHateCrimeOffenders',
 ] as const
-export const prepopulatablePlacementRequirementCriteria = [
+export const prepopulatablePlacementRequirementCriteria: Array<UiPlacementCriteria> = [
   'isWheelchairDesignated',
   'isArsonSuitable',
   'isSingle',
   'isCatered',
   'isSuitedForSexOffenders',
 ] as const
-export const nonPrepopulatablePlacementRequirementCriteria = ['isStepFreeDesignated', 'hasEnSuite'] as const
+export const nonPrepopulatablePlacementRequirementCriteria: Array<UiPlacementCriteria> = [
+  'isStepFreeDesignated',
+  'hasEnSuite',
+] as const
 export const placementRequirementCriteria = [
   ...prepopulatablePlacementRequirementCriteria,
   ...nonPrepopulatablePlacementRequirementCriteria,

--- a/server/utils/placementRequests/matchingInformationSummaryList.test.ts
+++ b/server/utils/placementRequests/matchingInformationSummaryList.test.ts
@@ -18,10 +18,7 @@ describe('matchingInformationSummaryList', () => {
             text: 'Information for Matching',
           },
         },
-        rows: [
-          placementRequirementsRow(placementRequest, 'essential'),
-          placementRequirementsRow(placementRequest, 'desirable'),
-        ],
+        rows: [placementRequirementsRow(placementRequest)],
       })
     })
 
@@ -37,14 +34,13 @@ describe('matchingInformationSummaryList', () => {
           },
         },
         rows: [
-          placementRequirementsRow(placementRequest, 'essential'),
-          placementRequirementsRow(placementRequest, 'desirable'),
+          placementRequirementsRow(placementRequest),
           {
             key: {
               text: 'Observations from assessor',
             },
             value: {
-              text: placementRequest.notes,
+              html: '<span class="govuk-summary-list__textblock">Some notes</span>',
             },
           },
         ],
@@ -61,11 +57,7 @@ describe('matchingInformationSummaryList', () => {
             text: 'Information for Matching',
           },
         },
-        rows: [
-          preferredApsRow(placementRequest),
-          placementRequirementsRow(placementRequest, 'essential'),
-          placementRequirementsRow(placementRequest, 'desirable'),
-        ],
+        rows: [preferredApsRow(placementRequest), placementRequirementsRow(placementRequest)],
       })
     })
   })

--- a/server/utils/placementRequests/matchingInformationSummaryList.ts
+++ b/server/utils/placementRequests/matchingInformationSummaryList.ts
@@ -2,6 +2,7 @@ import { Cas1PlacementRequestDetail } from '@approved-premises/api'
 import { SummaryListItem, SummaryListWithCard } from '@approved-premises/ui'
 import { preferredApsRow } from './preferredApsRow'
 import { placementRequirementsRow } from './placementRequirementsRow'
+import { summaryListItem } from '../formUtils'
 
 export const matchingInformationSummary = (placementRequest: Cas1PlacementRequestDetail): SummaryListWithCard => {
   return {
@@ -25,18 +26,10 @@ export const matchingInformationSummaryRows = (
     rows.push(preferredAps)
   }
 
-  rows.push(placementRequirementsRow(placementRequest, 'essential'))
-  rows.push(placementRequirementsRow(placementRequest, 'desirable'))
+  rows.push(placementRequirementsRow(placementRequest))
 
   if (placementRequest.notes) {
-    rows.push({
-      key: {
-        text: 'Observations from assessor',
-      },
-      value: {
-        text: placementRequest.notes,
-      },
-    })
+    rows.push(summaryListItem('Observations from assessor', placementRequest.notes, 'textBlock'))
   }
   return rows
 }

--- a/server/utils/placementRequests/placementRequestSummaryList.test.ts
+++ b/server/utils/placementRequests/placementRequestSummaryList.test.ts
@@ -175,7 +175,7 @@ describe('placementRequestSummaryList', () => {
       },
       {
         key: {
-          text: 'Essential Criteria',
+          text: 'Criteria',
         },
         value: {
           html: '<ul class="govuk-list govuk-list--bullet"><li>Tactile flooring</li></ul>',
@@ -183,18 +183,10 @@ describe('placementRequestSummaryList', () => {
       },
       {
         key: {
-          text: 'Desirable Criteria',
-        },
-        value: {
-          html: '<span class="text-grey">None</span>',
-        },
-      },
-      {
-        key: {
           text: 'Observations from assessor',
         },
         value: {
-          text: 'Test notes',
+          html: '<span class="govuk-summary-list__textblock">Test notes</span>',
         },
       },
     ]

--- a/server/utils/placementRequests/placementRequirementsRow.test.ts
+++ b/server/utils/placementRequests/placementRequirementsRow.test.ts
@@ -4,29 +4,16 @@ import { placementRequirementsRow } from './placementRequirementsRow'
 import { characteristicsBulletList } from '../characteristicsUtils'
 
 describe('placementRequirementsRow', () => {
-  it('returns a list of desirable placement requirements in sentence case', () => {
+  it('returns a list of placement requirements in sentence case', () => {
     const placementRequest = cas1PlacementRequestDetailFactory.build()
 
-    expect(placementRequirementsRow(placementRequest, 'desirable')).toEqual({
+    expect(placementRequirementsRow(placementRequest)).toEqual({
       key: {
-        text: `Desirable Criteria`,
+        text: `Criteria`,
       },
       value: {
-        html: characteristicsBulletList(placementRequest.desirableCriteria),
+        html: characteristicsBulletList(placementRequest.essentialCriteria),
       },
     })
-  })
-})
-
-it('returns a list of essential placement requirements in sentence case', () => {
-  const placementRequest = cas1PlacementRequestDetailFactory.build()
-
-  expect(placementRequirementsRow(placementRequest, 'essential')).toEqual({
-    key: {
-      text: `Essential Criteria`,
-    },
-    value: {
-      html: characteristicsBulletList(placementRequest.essentialCriteria),
-    },
   })
 })

--- a/server/utils/placementRequests/placementRequirementsRow.ts
+++ b/server/utils/placementRequests/placementRequirementsRow.ts
@@ -1,20 +1,8 @@
 import { Cas1PlacementRequestDetail } from '../../@types/shared'
 import { SummaryListItem } from '../../@types/ui'
-import { sentenceCase } from '../utils'
 
 import { characteristicsBulletList } from '../characteristicsUtils'
+import { summaryListItem } from '../formUtils'
 
-export const placementRequirementsRow = (
-  placementRequest: Cas1PlacementRequestDetail,
-  type: 'desirable' | 'essential',
-): SummaryListItem => {
-  const criteria = type === 'essential' ? placementRequest.essentialCriteria : placementRequest.desirableCriteria
-  return {
-    key: {
-      text: `${sentenceCase(type)} Criteria`,
-    },
-    value: {
-      html: characteristicsBulletList(criteria),
-    },
-  }
-}
+export const placementRequirementsRow = (placementRequest: Cas1PlacementRequestDetail): SummaryListItem =>
+  summaryListItem('Criteria', characteristicsBulletList(placementRequest.essentialCriteria), 'html')

--- a/server/utils/radioMatrixTable.ts
+++ b/server/utils/radioMatrixTable.ts
@@ -16,12 +16,10 @@ export const cell = (requirement: string, preference: string, checked?: boolean)
         </td>`
 }
 
-export const row = (rowName: UiPlacementCriteria, option: Array<string>, value: string) => {
-  return `<tr>
+export const row = (rowName: UiPlacementCriteria, options: Array<string>, value: string) => `<tr>
   <th class="govuk-table__cell govuk-!-font-weight-regular" scope="row">${placementCriteriaLabels[rowName]}</td>
-    ${option.map(preference => cell(rowName, preference, value === preference)).join('')}
+    ${options.map(preference => cell(rowName, preference, value === preference)).join('')}
 </tr>`
-}
 
 export const heading = (headingNames: Array<string>) => {
   return `<thead class="govuk-table__head">

--- a/server/views/assessments/pages/matching-information/matching-information.njk
+++ b/server/views/assessments/pages/matching-information/matching-information.njk
@@ -25,15 +25,15 @@
 
     <h2 class="govuk-heading-m">Placement requirements</h2>
 
-    {{ placementRequirementsTable(page.relevantInformationTableHeadings, page.offenceAndRiskCriteria, page.offenceAndRiskInformationRelevance, page.body) | safe }}
+    {{ page.relevantInformationTable() | safe }}
 
-    {{ placementRequirementsTable(page.placementRequirementTableHeadings, page.prepopulatablePlacementRequirementCriteria, page.placementRequirementPreferences, page.body) | safe }}
+    {{ page.prepopulatedRequirementsTable() | safe }}
 
     {{ govukInsetText({
         text: "You must enter the following requirements manually as these are not explicitly asked in the application."
     }) }}
 
-    {{ placementRequirementsTable(page.placementRequirementTableHeadings, page.nonPrepopulatablePlacementRequirementCriteria, page.placementRequirementPreferences, page.body) | safe }}
+    {{ page.nonPrepopulatedRequirementsTable() | safe }}
 
     {% set lengthOfStayAgreedHint %}
         {{ govukSummaryList(page.suggestedStaySummaryListOptions) }}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2648


<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

This PR removes 'desirable criteria' as they are no longer provide any useful functionality.

In assessments, the characteristics were stored in the JSON blob with values 'essential', 'desirable' or 'notRelevant'. These were pre-populated from the application using a mapping that looks for certain values and sets 'essential' where appropriate. The Placement takes two arrays of criteria (essential and desirable) via another mapping.

Note that the values displayed in 'check your answers' are the actual key values, translated to sentences.

I _could_ have just kept the values the same, and gone for re-mapping the text, but 'essential' really makes little sense. The option in this PR re-maps the saved values in the JSON blob to 'required' and 'notRequired' and leaves the text rendering as-is. Also, to handle assessments that are in-flight when this PR goes live, existing values in the JSON blob are re-mapped to the new values on loading.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before

<details>
  <summary>Assessment -> Matching information page</summary>
<img width="963" height="775" alt="image" src="https://github.com/user-attachments/assets/c527f780-a5ba-414f-ad8d-36e4646e411d" />
</details>

<details>
  <summary>Assessment -> Check-your-answers page</summary>
<img width="1162" height="866" alt="image" src="https://github.com/user-attachments/assets/4a408431-c0f1-4498-aac2-7d2840bd2677" />
</details>

<details>
  <summary>Placement request page</summary>
<img width="793" height="361" alt="image" src="https://github.com/user-attachments/assets/c584a6b0-928f-4345-af1a-ac037db087eb" />
</details>



### After

<details>
  <summary>Assessment -> Matching information page</summary>
<img width="998" height="768" alt="image" src="https://github.com/user-attachments/assets/c6fb28e4-6563-4382-9eb6-2c72d79cc26a" />
</details>

<details>
  <summary>Assessment -> Check-your-answers page</summary>
<img width="1135" height="851" alt="image" src="https://github.com/user-attachments/assets/8bedf157-71d7-49f1-abda-650f6fc77ebe" />
</details>

<details>
  <summary>Placement request page</summary>
<img width="1224" height="760" alt="image" src="https://github.com/user-attachments/assets/8d68a541-b021-4837-950f-30efaba1cb95" />
</details>