### PR TITLE
APS-2627: Use namespaced versions of applications endpoints

### DIFF
--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -271,7 +271,7 @@ export default {
     (
       await getMatchingRequests({
         method: 'POST',
-        url: `${paths.applications.new({})}?createWithRisks=true`,
+        url: paths.applications.new({}),
       })
     ).body.requests,
   verifyApplicationUpdate: async (applicationId: string) =>

--- a/integration_tests/mockApis/journeyUtils.ts
+++ b/integration_tests/mockApis/journeyUtils.ts
@@ -185,7 +185,7 @@ export const stubJourney = (form: Application | Assessment): SuperAgentRequest =
     journeyType === 'application'
       ? {
           method: 'POST',
-          url: `${paths.applications.new({})}?createWithRisks=true`,
+          url: paths.applications.new({}),
         }
       : {
           method: 'GET',

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -65,7 +65,7 @@ context('Apply', () => {
     cy.task('verifyApplicationSubmit', this.application.id).then(requests => {
       expect(requests).to.have.length(1)
 
-      expect(requests[0].url).to.equal(`/applications/${this.application.id}/submission`)
+      expect(requests[0].url).to.equal(`/cas1/applications/${this.application.id}/submission`)
 
       const body = JSON.parse(requests[0].body)
       expect(body).to.have.keys(
@@ -356,7 +356,7 @@ context('Apply', () => {
     cy.task('verifyApplicationSubmit', this.application.id).then(requests => {
       expect(requests).to.have.length(1)
 
-      expect(requests[0].url).to.equal(`/applications/${this.application.id}/submission`)
+      expect(requests[0].url).to.equal(`/cas1/applications/${this.application.id}/submission`)
 
       const body = JSON.parse(requests[0].body)
       expect(body).to.have.keys(

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -37,9 +37,7 @@ describeClient('ApplicationClient', provider => {
         withRequest: {
           method: 'POST',
           path: paths.applications.new.pattern,
-          query: {
-            createWithRisks: 'true',
-          },
+          query: {},
           body: {
             crn: application.person.crn,
             convictionId: offence.convictionId,
@@ -77,9 +75,7 @@ describeClient('ApplicationClient', provider => {
           withRequest: {
             method: 'POST',
             path: paths.applications.new.pattern,
-            query: {
-              createWithRisks: 'false',
-            },
+            query: {},
             body: {
               crn: application.person.crn,
               convictionId: offence.convictionId,

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -36,7 +36,7 @@ export default class ApplicationClient {
     const { convictionId, deliusEventNumber, offenceId } = activeOffence
 
     return (await this.restClient.post({
-      path: `${paths.applications.new.pattern}?createWithRisks=${!config.flags.oasysDisabled}`,
+      path: paths.applications.new.pattern,
       data: { crn, convictionId, deliusEventNumber, offenceId, type: 'CAS1' },
     })) as Application
   }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -32,6 +32,7 @@ const cas1Oasys = cas1Person.path('oasys')
 
 const cas1Applications = cas1Namespace.path('applications')
 const cas1ApplicationsSingle = cas1Applications.path(':id')
+const cas1Appeals = cas1ApplicationsSingle.path('appeals')
 
 const cas1Assessments = cas1Namespace.path('assessments')
 const cas1AssessmentsSingle = cas1Assessments.path(':id')
@@ -45,10 +46,6 @@ const premisesSingle = premises.path(':premisesId')
 const rooms = premisesSingle.path('rooms')
 
 const profile = path('/profile')
-
-const applications = path('/applications')
-const applicationsSingle = applications.path(':id')
-const appeals = applicationsSingle.path('appeals')
 
 const people = path('/people')
 const person = people.path(':crn')
@@ -125,24 +122,24 @@ export default {
     placementWithoutPremises: cas1Namespace.path('space-bookings/:placementId'),
   },
   applications: {
-    show: applicationsSingle,
+    show: cas1ApplicationsSingle,
     me: cas1Applications.path('me'),
     all: cas1Applications.path('all'),
-    update: applicationsSingle,
-    new: applications,
-    submission: applicationsSingle.path('submission'),
-    documents: applicationsSingle.path('documents'),
-    assessment: applicationsSingle.path('assessment'),
-    withdrawal: applicationsSingle.path('withdrawal'),
+    update: cas1ApplicationsSingle,
+    new: cas1Applications,
+    submission: cas1ApplicationsSingle.path('submission'),
+    documents: cas1ApplicationsSingle.path('documents'),
+    assessment: cas1ApplicationsSingle.path('assessment'),
+    withdrawal: cas1ApplicationsSingle.path('withdrawal'),
     timeline: cas1ApplicationsSingle.path('timeline'),
-    placementApplications: applicationsSingle.path('placement-applications'),
-    requestsForPlacement: applicationsSingle.path('requests-for-placement'),
-    addNote: applicationsSingle.path('notes'),
-    withdrawables: applicationsSingle.path('withdrawables'),
-    withdrawablesWithNotes: applicationsSingle.path('withdrawablesWithNotes'),
+    placementApplications: cas1ApplicationsSingle.path('placement-applications'),
+    requestsForPlacement: cas1ApplicationsSingle.path('requests-for-placement'),
+    addNote: cas1ApplicationsSingle.path('notes'),
+    withdrawables: cas1ApplicationsSingle.path('withdrawables'),
+    withdrawablesWithNotes: cas1ApplicationsSingle.path('withdrawablesWithNotes'),
     appeals: {
-      show: appeals.path(':appealId'),
-      create: appeals,
+      show: cas1Appeals.path(':appealId'),
+      create: cas1Appeals,
     },
   },
   assessments: {


### PR DESCRIPTION
# Context

Task: https://dsdmoj.atlassian.net/browse/APS-2627
Parent: https://dsdmoj.atlassian.net/browse/APS-2621

# Changes in this PR

This PR updates all applications API endpoints to use the new namespaced equivalents. It also removes the `createWithRisks` flag, as it is now assumed `true` by the API.

All E2E tests passing:

<img width="356" height="190" alt="Screenshot 2025-09-11 at 11 32 24" src="https://github.com/user-attachments/assets/bf8b017e-213f-41af-a5fd-a58dfdff1014" />



## Screenshots of UI changes

No UI changes.