### PR TITLE
APS-2702: Update rejection reasons

### DIFF
--- a/integration_tests/tests/assess/assess.cy.ts
+++ b/integration_tests/tests/assess/assess.cy.ts
@@ -225,7 +225,7 @@ context('Assess', () => {
       task: 'make-a-decision',
       page: 'make-a-decision',
       keyValuePairs: {
-        decision: 'otherReasons',
+        decision: 'notNecessaryOrProportionate',
         decisionRationale: 'reject reason',
       },
     })

--- a/server/form-pages/assess/makeADecision/makeADecisionTask/makeADecision.ts
+++ b/server/form-pages/assess/makeADecision/makeADecisionTask/makeADecision.ts
@@ -22,8 +22,8 @@ export default class MakeADecision implements TasklistPage {
       accommodationNeedOnly: 'Accommodation need only',
       needsCannotBeMet: 'Health / social care / disability needs cannot be met',
       supervisionPeriodTooShort: 'Remaining supervision period too short',
-      riskTooLow: 'Risk too low',
-      otherReasons: 'Not suitable for other reasons',
+      notNecessaryOrProportionate: 'AP not necessary or proportionate to manage the identified risk',
+      riskCanBeManagedOtherWay: 'Risk can be appropriately managed with other control measures',
     },
     'Reject, insufficient information': {
       insufficientMoveOnPlan: 'Insufficient move on plan',
@@ -36,6 +36,7 @@ export default class MakeADecision implements TasklistPage {
       riskToCommunity: 'Risk to community',
       riskToOthersInAP: 'Risk to other people in AP',
       riskToStaff: 'Risk to staff',
+      riskToSelf: 'Risk to self',
     },
     'Application withdrawn': {
       withdrawnByPp: 'Application withdrawn by the probation practitioner',

--- a/server/views/assessments/pages/make-a-decision/make-a-decision.njk
+++ b/server/views/assessments/pages/make-a-decision/make-a-decision.njk
@@ -3,56 +3,54 @@
 
 {% block questions %}
 
-  <div class="govuk-form-group">
+    <div class="govuk-form-group">
 
-    {% call govukFieldset({
-      legend: {
-        text: "Make a decision",
-        classes: "govuk-fieldset__legend--l",
-        isPageHeading: true
-      }
-    }) %}
-    <p>This decision is conditional on a place being available in a suitable AP and any other requirements you have stipulated in the assessment.</p>
-    <p>Select one option from the list below. Options have been grouped by the reason for the decision.</p>
-
-    <div class="govuk-radios" data-module="govuk-radios">
-
-      {% for sectionName, subsection in page.responses %}
-        <h2>{{sectionName}}</h2>
-
-        {% for questionId, fullQuestion in subsection %}
-          {% set checked = page.decision == questionId %}
-
-          <div class="govuk-radios__item">
-            {% if checked %}
-              <input class="govuk-radios__input" id="{{ questionId }}" name="decision" type="radio" value="{{ questionId }}" checked>
-            {% else %}
-              <input class="govuk-radios__input" id="{{ questionId }}" name="decision" type="radio" value="{{ questionId }}" >
-              {%endif%}
-
-              <label class="govuk-label govuk-radios__label" for="{{ questionId }}">
-                {{ fullQuestion }}
-              </label>
-            </div>
-
-          {% endfor %}
-
-          {%endfor%}
-        </div>
-
-        {%endcall%}
-      </div>
-      {{
-        formPageTextarea(
-          {
-            fieldName: "decisionRationale",
-            type: "textarea",
-            label: {
-              text: "Rationale for your decision",
-              classes: "govuk-label--m"
+        {% call govukFieldset({
+            legend: {
+                text: "Make a decision",
+                classes: "govuk-fieldset__legend--l",
+                isPageHeading: true
             }
-          },
-          fetchContext()
-        )
-      }}
-    {% endblock %}
+        }) %}
+            <p>This decision is conditional on a place being available in a suitable AP and any other requirements you
+                have stipulated in the assessment.</p>
+            <p>Select one option from the list below. Options have been grouped by the reason for the decision.</p>
+            <p>If you are making a rejection, select the primary reason for the rejection and identify any additional
+                reasons when providing the rationale for your decision.</p>
+
+            <div class="govuk-radios" data-module="govuk-radios">
+
+                {% for sectionName, subsection in page.responses %}
+                    <h2>{{ sectionName }}</h2>
+
+                    {% for questionId, fullQuestion in subsection %}
+                        {% set checked = page.decision == questionId %}
+
+                        <div class="govuk-radios__item">
+                            {% if checked %}
+                                <input class="govuk-radios__input" id="{{ questionId }}" name="decision" type="radio"
+                                       value="{{ questionId }}" checked>
+                            {% else %}
+                                <input class="govuk-radios__input" id="{{ questionId }}" name="decision" type="radio"
+                                       value="{{ questionId }}">
+                            {% endif %}
+
+                            <label class="govuk-label govuk-radios__label" for="{{ questionId }}">
+                                {{ fullQuestion }}
+                            </label>
+                        </div>
+                    {% endfor %}
+                {% endfor %}
+            </div>
+        {% endcall %}
+    </div>
+
+    {{ formPageTextarea({
+        fieldName: "decisionRationale",
+        type: "textarea",
+        label: {
+            text: "Rationale for your decision",
+            classes: "govuk-label--m"
+        }
+    }, fetchContext()) }}
+{% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2702

# Changes in this PR

This PR updates the available radio options for rejecting an application, and update the guidance on that page:

- Replaces "Reject, not suitable for AP – Risk too low" and "Reject, not suitable for AP – Not suitable for other reasons" with "Reject, not suitable for AP - AP not necessary or proportionate to manage the identified risk" and "Reject, not suitable for AP - Risk can be appropriately managed with other control measures"
- Adds the option "Reject, risk too high (must be approved by an AP Area Manager (APAM) – Risk to self"
- Adds a paragraph to the guidance about providing additional rejection reasons to the rationale.

## Screenshots of UI changes

<details><summary>Assessment 'Make a decision' page</summary>

<img width="2152" height="5026" alt="localhost_3000_assessments_6cc6126c-3cc6-4836-9c08-03a29e89c23d_tasks_make-a-decision_pages_make-a-decision" src="https://github.com/user-attachments/assets/1b9b4710-9cf9-451e-801e-bbe33a816c63" />


</details>
