### PR TITLE
CHORE: Remove skipped deleted user search test

### DIFF
--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -104,35 +104,3 @@ test('manage users', async ({ page, userToAddAndDelete, administrator }) => {
   // Then I should see the 'User deleted' banner
   await userListPage.shouldShowUserDeletedBanner()
 })
-
-test.fixme('Search shows deleted user', async ({ page }) => {
-  // The following behaviour only exists in CI
-  // Locally users are hard deleted. Once they are deleted they cannot be found via search as they are removed from the DB and only reseeded when the local API is restarted
-  // In deployed envs the user is soft deleted and can be found via search
-
-  // Given I visit the dashboard
-  const dashboard = await visitDashboard(page)
-
-  // And I click the manage users link
-  await dashboard.clickUserMangement()
-
-  // Then I should be taken to user list page
-  const userListPage = await UserList.initialize(page)
-
-  // Given a user is not visisble in the list
-  const userToSearchFor = 'AutomatedTestUser'
-  await userListPage.shouldNotShowUser(userToSearchFor)
-
-  // When I search for them
-  await userListPage.search(userToSearchFor)
-
-  // Then I should be able to see their name
-  await userListPage.shouldShowUser(userToSearchFor)
-
-  // When I click on their name
-  await userListPage.clickEditUser(userToSearchFor)
-
-  // Then I should be taken to the Edit User page
-  const editUserPage = await EditUser.initialize(page)
-  await editUserPage.shouldShowUserName(userToSearchFor)
-})


### PR DESCRIPTION
This test claims that users are soft deleted and findable using the search form on deployed env, but not locally. It does not seem to be the case that deleted users are findable on deployed envs, so this test does not cover existing behaviour, locally or elsewhere, and it can therefore be removed.

