### PR TITLE
bugfix/APS-2756: Retain filters for placement request back link

### DIFF
--- a/integration_tests/tests/admin/placementRequests.cy.ts
+++ b/integration_tests/tests/admin/placementRequests.cy.ts
@@ -195,6 +195,9 @@ context('Placement Requests', () => {
       WHEN('I go back to the dashboard')
       showPage.clickBack()
 
+      AND('I click the Ready to book tab')
+      showPage.clickTab('Ready to book')
+
       AND('I click the parole placement request')
       listPage.clickPlacementRequest(parolePlacementRequest)
 
@@ -446,23 +449,7 @@ context('Placement Requests', () => {
       })
 
       it(`supports filtering`, () => {
-        const {
-          unmatchedPlacementRequests,
-          matchedPlacementRequests,
-          unableToMatchPlacementRequests,
-          cruManagementAreas,
-        } = stubArtifacts()
-        cy.task('stubPlacementRequestsDashboard', {
-          placementRequests: [
-            ...unmatchedPlacementRequests,
-            ...matchedPlacementRequests,
-            ...unableToMatchPlacementRequests,
-          ],
-          status: 'notMatched',
-          sortBy: 'created_at',
-          sortDirection: 'asc',
-        })
-        cy.task('stubPlacementRequestsDashboard', { placementRequests: matchedPlacementRequests, status: 'matched' })
+        const { matchedPlacementRequests, cruManagementAreas, matchedPlacementRequest } = stubArtifacts()
 
         GIVEN('I am on the placement request dashboard')
         const listPage = ListPage.visit()
@@ -487,6 +474,20 @@ context('Placement Requests', () => {
         listPage.clickTab('Booked')
 
         THEN('the page should retain the area and request type filter')
+        listPage.shouldHaveSelectText('cruManagementArea', cruManagementAreas[1].name)
+        listPage.shouldHaveSelectText('requestType', 'Parole')
+
+        WHEN('I click on a placement request')
+        listPage.clickPlacementRequest(matchedPlacementRequest)
+
+        THEN("I should see the placement request's details")
+        const placementRequestPage = Page.verifyOnPage(ShowPage, matchedPlacementRequest)
+
+        WHEN('I click the back link')
+        placementRequestPage.clickBack()
+
+        THEN('I should be taken back to the placement request dashboard with the correct status and filters applied')
+        listPage.shouldShowPlacementRequests(matchedPlacementRequests, 'matched')
         listPage.shouldHaveSelectText('cruManagementArea', cruManagementAreas[1].name)
         listPage.shouldHaveSelectText('requestType', 'Parole')
       })

--- a/server/controllers/admin/index.ts
+++ b/server/controllers/admin/index.ts
@@ -12,8 +12,8 @@ import NationalOccupancyController from './nationalOccupancyController'
 import type { Services } from '../../services'
 
 export const controllers = (services: Services) => {
-  const { placementRequestService, premisesService, reportService, cruManagementAreaService } = services
-  const adminPlacementRequestsController = new AdminPlacementRequestsController(placementRequestService)
+  const { placementRequestService, premisesService, reportService, cruManagementAreaService, sessionService } = services
+  const adminPlacementRequestsController = new AdminPlacementRequestsController(placementRequestService, sessionService)
   const cruDashboardController = new CruDashboardController(
     placementRequestService,
     cruManagementAreaService,

--- a/server/controllers/admin/placementRequests/placementRequestsController.test.ts
+++ b/server/controllers/admin/placementRequests/placementRequestsController.test.ts
@@ -3,7 +3,7 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 
 import PlacementRequestsController from './placementRequestsController'
 
-import { PlacementRequestService } from '../../../services'
+import { PlacementRequestService, SessionService } from '../../../services'
 import {
   userDetailsFactory,
   cas1PlacementRequestDetailFactory,
@@ -28,16 +28,18 @@ describe('PlacementRequestsController', () => {
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
   const placementRequestService = createMock<PlacementRequestService>({})
+  const sessionService = createMock<SessionService>({})
 
   let placementRequestsController: PlacementRequestsController
 
   beforeEach(() => {
     jest.resetAllMocks()
-    placementRequestsController = new PlacementRequestsController(placementRequestService)
+    placementRequestsController = new PlacementRequestsController(placementRequestService, sessionService)
   })
 
   describe('show', () => {
     it('should render the placement request template with a space booking', async () => {
+      jest.spyOn(sessionService, 'getPageBackLink').mockReturnValue('/admin/cru-dashboard?status=unableToMatch&page=2')
       const placementRequest = cas1PlacementRequestDetailFactory.build({
         openChangeRequests: cas1ChangeRequestSummaryFactory.buildList(2),
       })
@@ -49,7 +51,13 @@ describe('PlacementRequestsController', () => {
 
       await requestHandler(request, response, next)
 
+      expect(sessionService.getPageBackLink).toHaveBeenCalledWith(
+        '/admin/placement-requests/:placementRequestId',
+        request,
+        ['/admin/cru-dashboard', '/admin/cru-dashboard/change-requests', '/admin/cru-dashboard/search'],
+      )
       expect(response.render).toHaveBeenCalledWith('admin/placementRequests/show', {
+        backlink: '/admin/cru-dashboard?status=unableToMatch&page=2',
         adminIdentityBar: adminIdentityBar(placementRequest, response.locals.user),
         contextKeyDetails: placementRequestKeyDetails(placementRequest),
         placementRequest,

--- a/server/controllers/admin/placementRequests/placementRequestsController.ts
+++ b/server/controllers/admin/placementRequests/placementRequestsController.ts
@@ -1,13 +1,17 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 import { changeRequestBanners } from '../../../utils/placementRequests/changeRequestsUtils'
-import { PlacementRequestService } from '../../../services'
+import { PlacementRequestService, SessionService } from '../../../services'
 import { placementRequestSummaryList } from '../../../utils/placementRequests/placementRequestSummaryList'
 import { placementSummaryList } from '../../../utils/placementRequests/placementSummaryList'
 import { adminIdentityBar } from '../../../utils/placementRequests'
 import { placementRequestKeyDetails } from '../../../utils/placementRequests/utils'
+import paths from '../../../paths/admin'
 
 export default class PlacementRequestsController {
-  constructor(private readonly placementRequestService: PlacementRequestService) {}
+  constructor(
+    private readonly placementRequestService: PlacementRequestService,
+    private readonly sessionService: SessionService,
+  ) {}
 
   show(): TypedRequestHandler<Request> {
     return async (req: Request, res: Response) => {
@@ -18,6 +22,11 @@ export default class PlacementRequestsController {
       )
 
       res.render('admin/placementRequests/show', {
+        backlink: this.sessionService.getPageBackLink(paths.admin.placementRequests.show.pattern, req, [
+          paths.admin.cruDashboard.index.pattern,
+          paths.admin.cruDashboard.changeRequests.pattern,
+          paths.admin.cruDashboard.search.pattern,
+        ]),
         adminIdentityBar: adminIdentityBar(placementRequest, res.locals.user),
         contextKeyDetails: placementRequestKeyDetails(placementRequest),
         placementRequest,

--- a/server/views/admin/placementRequests/show.njk
+++ b/server/views/admin/placementRequests/show.njk
@@ -10,7 +10,7 @@
 {% block beforeContent %}
     {{ govukBackLink({
         text: "Back",
-        href: paths.admin.cruDashboard.index({})
+        href: backlink
     }) }}
 {% endblock %}
 


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2756

# Changes in this PR

Ensures CRU dashboard tab selection and filtering is retained when clicking the back link on a placement request.

## Screenshots of UI changes

No UI changes.
