### PR TITLE
bugfix: prevent 'Cannot set headers after they are sent to the client' error

### DIFF
--- a/server/controllers/admin/cruDashboardController.ts
+++ b/server/controllers/admin/cruDashboardController.ts
@@ -47,6 +47,7 @@ export default class CruDashboardController {
 
       if (!['notMatched', 'unableToMatch', 'matched'].includes(status)) {
         next(createError(404, 'Not found'))
+        return
       }
 
       const cruManagementAreas = await this.cruManagementAreaService.getCruManagementAreas(token)


### PR DESCRIPTION
Ensuring the request handler returns directly after creating the error prevents the controller from setting any further headers -- this could have happened after the error response itself had been sent to the browser, in turns causing a 'Cannot set headers after they are sent to the client' error.

Will suppress the following Sentry alerts: https://ministryofjustice.sentry.io/issues/6878600235