### PR TITLE
chore: Use official Redis image for integration tests

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,7 +1,7 @@
 services:
 
   redis:
-    image: 'bitnami/redis:7.0.11'
+    image: redis
     networks:
       - hmpps_int
     environment:


### PR DESCRIPTION
This removes reliance on deprecated bitnami images.

https://mojdt.slack.com/archives/CH6D099DF/p1755184628615669