### PR TITLE
Bugfix/APS-2769: user search error

### DIFF
--- a/integration_tests/mockApis/users.ts
+++ b/integration_tests/mockApis/users.ts
@@ -116,6 +116,7 @@ const stubUserSummaryList = (args: { users: Array<UserSummary>; roles: Array<Use
 
 const stubUsers = (args: {
   users: Array<User>
+  nameOrEmail?: string
   roles?: Array<UserRole>
   qualifications?: Array<UserQualification>
   apAreaId: string
@@ -134,6 +135,12 @@ const stubUsers = (args: {
       equalTo: args.sortDirection || 'asc',
     },
   } as Record<string, unknown>
+
+  if (args.nameOrEmail) {
+    queryParameters.nameOrEmail = {
+      equalTo: args.nameOrEmail,
+    }
+  }
 
   if (args.roles) {
     queryParameters.roles = {

--- a/integration_tests/tests/admin/userManagement.cy.ts
+++ b/integration_tests/tests/admin/userManagement.cy.ts
@@ -94,27 +94,6 @@ context('User management', () => {
     showPage.shouldHaveCriteriaSelected(updatedRoles.roles as unknown as Array<string>)
   })
 
-  it('allows searching for users', () => {
-    const usersForResults = userFactory.buildList(10)
-    const initialUsers = userFactory.buildList(10)
-    cy.task('stubUsers', { users: initialUsers })
-    cy.task('stubCruManagementAreaReferenceData')
-
-    // When I visit the list page
-    const page = ListPage.visit()
-
-    // Then I should see the users and their details
-    page.shouldShowUsers(initialUsers)
-
-    // When I search for a user
-    const searchTerm = 'search term'
-    cy.task('stubUserSearch', { results: usersForResults, searchTerm })
-    page.search(searchTerm)
-
-    // Then the page should show the results
-    page.shouldShowUsers(usersForResults)
-  })
-
   it('enables adding a user from Delius', () => {
     const users = userFactory.buildList(10)
     cy.task('stubCruManagementAreaReferenceData')
@@ -287,7 +266,7 @@ context('User management', () => {
     })
   })
 
-  it('allows filter for users', () => {
+  it('allows filtering users', () => {
     const usersForResultsPage1 = userFactory.buildList(1)
     const usersForResultsPage2 = userFactory.buildList(1)
     const cruManagementAreas = cruManagementAreaFactory.buildList(5)
@@ -305,17 +284,20 @@ context('User management', () => {
     // When I search for a user
     cy.task('stubUsers', {
       users: usersForResultsPage1,
+      nameOrEmail: 'Foo',
       roles: ['assessor'] as Array<ApprovedPremisesUserRole>,
       qualifications: ['lao'] as Array<UserQualification>,
       cruManagementAreaId: cruManagementAreas[2].id,
     })
     cy.task('stubUsers', {
       users: usersForResultsPage2,
+      nameOrEmail: 'Foo',
       roles: ['assessor'] as Array<ApprovedPremisesUserRole>,
       qualifications: ['lao'] as Array<UserQualification>,
       cruManagementAreaId: cruManagementAreas[2].id,
       page: '2',
     })
+    page.completeTextInput('nameOrEmail', 'Foo')
     page.searchBy('role', 'assessor')
     page.searchBy('area', cruManagementAreas[2].id)
     page.searchBy('qualification', 'lao')

--- a/integration_tests/tests/admin/userManagement.cy.ts
+++ b/integration_tests/tests/admin/userManagement.cy.ts
@@ -8,17 +8,18 @@ import SearchDeliusPage from '../../pages/admin/userManagement/searchDeliusPage'
 import ShowPage from '../../pages/admin/userManagement/showPage'
 import Page from '../../pages/page'
 import { signIn } from '../signIn'
+import { AND, GIVEN, THEN, WHEN } from '../../helpers'
 
 context('User management', () => {
   beforeEach(() => {
     cy.task('reset')
 
-    // Given I am signed in as a User manager
+    GIVEN('I am signed in as a User manager')
     signIn('user_manager')
   })
 
   it('allows the user to view and update users', () => {
-    // Given there are users in the DB
+    GIVEN('there are users in the DB')
     const users = userFactory.buildList(10, { roles: ['assessor'], cruManagementAreaOverride: undefined })
     const user = users[0]
     const cruManagementAreas = cruManagementAreaFactory.buildList(5)
@@ -26,23 +27,23 @@ context('User management', () => {
     cy.task('stubUsers', { users })
     cy.task('stubCruManagementAreaReferenceData', { cruManagementAreas })
 
-    // When I visit the list page
+    WHEN('I visit the list page')
     const listPage = ListPage.visit()
 
-    // Then I should see the users and their details
+    THEN('I should see the users and their details')
     listPage.shouldShowUsers(users)
 
-    // Given I want to manage a user's permissions
-    // When I click on a user's name
+    GIVEN("I want to manage a user's permissions")
+    WHEN("I click on a user's name")
     listPage.clickUser(user.name)
 
-    // Then I am taken to the user's permissions page
+    THEN("I am taken to the user's permissions page")
     const showPage = Page.verifyOnPage(ShowPage)
 
     showPage.checkForBackButton(paths.admin.userManagement.index({}))
     showPage.shouldShowUserDetails(user)
 
-    // When I update the user's CRU management area, roles and qualifications
+    WHEN("I update the user's CRU management area, roles and qualifications")
     const updatedCruManagementArea = cruManagementAreas[1]
     const updatedRoles = {
       roles: ['cru_member', 'report_viewer'] as const,
@@ -71,7 +72,7 @@ context('User management', () => {
     cy.task('stubFindUser', { user: updatedUser, id: user.id })
     showPage.clickSubmit()
 
-    // Then the user is updated in the DB
+    THEN('the user is updated in the DB')
     cy.task('verifyUserUpdate', user.id).then(requests => {
       expect(requests).to.have.length(1)
 
@@ -84,10 +85,10 @@ context('User management', () => {
       })
     })
 
-    // And I should see a message confirming the details have been updated
+    AND('I should see a message confirming the details have been updated')
     showPage.shouldShowBanner('User updated')
 
-    // And I should see updated user roles
+    AND('I should see updated user roles')
     const revisitedListPage = ListPage.visit()
     revisitedListPage.shouldShowUsers(users)
     revisitedListPage.clickUser(user.name)
@@ -98,41 +99,41 @@ context('User management', () => {
     const users = userFactory.buildList(10)
     cy.task('stubCruManagementAreaReferenceData')
     cy.task('stubUsers', { users })
-    // Given I am on the list page
+    GIVEN('I am on the list page')
     const listPage = ListPage.visit()
 
-    // When I click the add user button
+    WHEN('I click the add user button')
     listPage.clickAddUser()
 
-    // Then I am taken to the add user page
+    THEN('I am taken to the add user page')
     const searchDeliusPage = Page.verifyOnPage(SearchDeliusPage)
     searchDeliusPage.checkForBackButton(paths.admin.userManagement.index({}))
 
-    // When I search for a username that doesn't exist
+    WHEN("I search for a username that doesn't exist")
     const notFoundSearchTerm = 'user not in delius'
     cy.task('stubNotFoundDeliusUserSearch', { searchTerm: notFoundSearchTerm })
     searchDeliusPage.searchForUser(notFoundSearchTerm)
 
-    // Then I should see an error
+    THEN('I should see an error')
     searchDeliusPage.shouldShowErrorMessagesForFields(['username'], {
       username: 'User not found. Enter the NDelius username as appears on NDelius',
     })
 
-    // When I search for a user
+    WHEN('I search for a user')
     const newUser = userFactory.build()
     cy.task('stubDeliusUserSearch', { result: newUser, searchTerm: newUser.deliusUsername })
     searchDeliusPage.searchForUser(newUser.deliusUsername)
 
-    // Then I should be taken to the confirm details of the new user page
+    THEN('I should be taken to the confirm details of the new user page')
     const confirmationPage = Page.verifyOnPage(ConfirmUserDetailsPage)
     confirmationPage.checkForBackButton(paths.admin.userManagement.new({}))
     confirmationPage.shouldShowUserDetails(newUser)
 
-    // When I click 'continue'
+    WHEN(" click 'continue'")
     cy.task('stubFindUser', { user: newUser, id: newUser.id })
     confirmationPage.clickContinue()
 
-    // Then I should be taken to the user management dashboard
+    THEN('I should be taken to the user management dashboard')
     Page.verifyOnPage(ShowPage)
   })
 
@@ -143,24 +144,24 @@ context('User management', () => {
     cy.task('stubFindUser', { user: userToDelete, id: userToDelete.id })
     cy.task('stubCruManagementAreaReferenceData')
 
-    // Given I am on a user's permissions page
+    GIVEN("I am on a user's permissions page")
     const permissionsPage = ShowPage.visit(userToDelete.id)
 
-    // When I click the delete user button
+    WHEN('I click the delete user button')
     permissionsPage.clickRemoveAccess()
 
-    // Then I should be taken to the confirmation screen
+    THEN('I should be taken to the confirmation screen')
     const confirmationPage = Page.verifyOnPage(ConfirmDeletionPage)
     confirmationPage.checkForBackButton(paths.admin.userManagement.edit({ id: userToDelete.id }))
 
-    // When I click 'Remove access'
+    WHEN(" click 'Remove access'")
     cy.task('stubUserDelete', { id: userToDelete.id })
     confirmationPage.clickSubmit()
 
-    // Then I should be redirected to the user management dashboard
+    THEN('I should be redirected to the user management dashboard')
     const listPage = Page.verifyOnPage(ListPage)
 
-    // And I should see a message confirming the user has been deleted
+    AND('I should see a message confirming the user has been deleted')
     listPage.shouldShowBanner('User deleted')
   })
 
@@ -183,32 +184,32 @@ context('User management', () => {
       page: '9',
     })
 
-    // When I visit the tasks dashboard
+    WHEN('I visit the tasks dashboard')
     const listPage = ListPage.visit()
 
-    // Then I should see a list of placement requests
+    THEN('I should see a list of placement requests')
     listPage.shouldShowUsers(usersPage1)
 
-    // When I click next
+    WHEN('I click next')
     listPage.clickNext()
 
-    // Then the API should have received a request for the next page
+    THEN('the API should have received a request for the next page')
     cy.task('verifyUsersRequest', { page: '2' }).then(requests => {
       expect(requests).to.have.length(1)
     })
 
-    // And the second page of users should be shown
+    AND('the second page of users should be shown')
     listPage.shouldShowUsers(usersPage2)
 
-    // When I click on a page number
+    WHEN('I click on a page number')
     listPage.clickPageNumber('9')
 
-    // Then the API should have received a request for the next page
+    THEN('the API should have received a request for the next page')
     cy.task('verifyUsersRequest', { page: '9' }).then(requests => {
       expect(requests).to.have.length(1)
     })
 
-    // And the users for that page number should be shown
+    AND('the users for that page number should be shown')
     listPage.shouldShowUsers(usersPage9)
   })
 
@@ -231,19 +232,19 @@ context('User management', () => {
     })
     cy.task('stubCruManagementAreaReferenceData')
 
-    // When I visit the tasks dashboard
+    WHEN('I visit the tasks dashboard')
     const listPage = ListPage.visit()
 
-    // Then I should see a list of placement requests
+    THEN('I should see a list of placement requests')
     listPage.shouldShowUsers(users)
 
-    // When I sort by expected arrival in ascending order
+    WHEN('I sort by expected arrival in ascending order')
     listPage.clickSortBy('name')
 
-    // Then the dashboard should be sorted by expected arrival
+    THEN('the dashboard should be sorted by expected arrival')
     listPage.shouldBeSortedByField('name', 'ascending')
 
-    // And the API should have received a request for the correct sort order
+    AND('the API should have received a request for the correct sort order')
     cy.task('verifyUsersRequest', {
       sortBy: 'name',
       sortDirection: 'asc',
@@ -251,13 +252,13 @@ context('User management', () => {
       expect(requests).to.have.length.greaterThan(0)
     })
 
-    // When I sort by expected arrival in descending order
+    WHEN('I sort by expected arrival in descending order')
     listPage.clickSortBy('name')
 
-    // Then the dashboard should be sorted by expected arrival in descending order
+    THEN('the dashboard should be sorted by expected arrival in descending order')
     listPage.shouldBeSortedByField('name', 'descending')
 
-    // And the API should have received a request for the correct sort order
+    AND('the API should have received a request for the correct sort order')
     cy.task('verifyUsersRequest', {
       sortBy: 'name',
       sortDirection: 'desc',
@@ -275,13 +276,13 @@ context('User management', () => {
     cy.task('stubUsers', { users: initialUsers })
     cy.task('stubCruManagementAreaReferenceData', { cruManagementAreas })
 
-    // When I visit the list page
+    WHEN('I visit the list page')
     const page = ListPage.visit()
 
-    // Then I should see the users and their details
+    THEN('I should see the users and their details')
     page.shouldShowUsers(initialUsers)
 
-    // When I search for a user
+    WHEN('I search for a user')
     cy.task('stubUsers', {
       users: usersForResultsPage1,
       nameOrEmail: 'Foo',
@@ -303,13 +304,13 @@ context('User management', () => {
     page.searchBy('qualification', 'lao')
     page.clickApplyFilter()
 
-    // Then the page should show the results
+    THEN('the page should show the results')
     page.shouldShowUsers(usersForResultsPage1)
 
-    // When I click on a page number
+    WHEN('I click on a page number')
     page.clickPageNumber('2')
 
-    // Then the page should show the results for the second page
+    THEN('the page should show the results for the second page')
     page.shouldShowUsers(usersForResultsPage2)
   })
 })

--- a/server/controllers/admin/userManagementController.test.ts
+++ b/server/controllers/admin/userManagementController.test.ts
@@ -58,10 +58,7 @@ describe('UserManagementController', () => {
 
       expect(userService.getUsers).toHaveBeenCalledWith(
         token,
-        undefined,
-        [],
-        [],
-        undefined,
+        {},
         paginationDetails.pageNumber,
         paginationDetails.sortBy,
         paginationDetails.sortDirection,
@@ -112,10 +109,7 @@ describe('UserManagementController', () => {
 
       expect(userService.getUsers).toHaveBeenCalledWith(
         token,
-        '1234',
-        [],
-        [],
-        undefined,
+        { cruManagementAreaId: '1234' },
         paginationDetails.pageNumber,
         paginationDetails.sortBy,
         paginationDetails.sortDirection,
@@ -146,10 +140,7 @@ describe('UserManagementController', () => {
 
       expect(userService.getUsers).toHaveBeenCalledWith(
         token,
-        undefined,
-        ['assessor'],
-        [],
-        undefined,
+        { roles: ['assessor'] },
         paginationDetails.pageNumber,
         paginationDetails.sortBy,
         paginationDetails.sortDirection,
@@ -167,8 +158,6 @@ describe('UserManagementController', () => {
       })
       expect(getPaginationDetails).toHaveBeenCalledWith(requestWithQuery, paths.admin.userManagement.index({}), {
         role: 'assessor',
-        qualification: undefined,
-        area: undefined,
       })
     })
 
@@ -180,10 +169,7 @@ describe('UserManagementController', () => {
 
       expect(userService.getUsers).toHaveBeenCalledWith(
         token,
-        undefined,
-        [],
-        ['esap'],
-        undefined,
+        { qualifications: ['esap'] },
         paginationDetails.pageNumber,
         paginationDetails.sortBy,
         paginationDetails.sortDirection,
@@ -200,10 +186,7 @@ describe('UserManagementController', () => {
         selectedQualification: 'esap',
       })
       expect(getPaginationDetails).toHaveBeenCalledWith(requestWithQuery, paths.admin.userManagement.index({}), {
-        role: undefined,
         qualification: 'esap',
-        nameOrEmail: undefined,
-        area: undefined,
       })
     })
 
@@ -215,10 +198,7 @@ describe('UserManagementController', () => {
 
       expect(userService.getUsers).toHaveBeenCalledWith(
         token,
-        undefined,
-        [],
-        [],
-        'Harry',
+        { nameOrEmail: 'Harry' },
         paginationDetails.pageNumber,
         paginationDetails.sortBy,
         paginationDetails.sortDirection,
@@ -235,10 +215,7 @@ describe('UserManagementController', () => {
         nameOrEmail: 'Harry',
       })
       expect(getPaginationDetails).toHaveBeenCalledWith(requestWithQuery, paths.admin.userManagement.index({}), {
-        role: undefined,
-        qualification: undefined,
         nameOrEmail: 'Harry',
-        area: undefined,
       })
     })
 
@@ -250,10 +227,7 @@ describe('UserManagementController', () => {
 
       expect(userService.getUsers).toHaveBeenCalledWith(
         token,
-        undefined,
-        ['assessor'],
-        ['esap'],
-        'David',
+        { roles: ['assessor'], qualifications: ['esap'], nameOrEmail: 'David' },
         paginationDetails.pageNumber,
         paginationDetails.sortBy,
         paginationDetails.sortDirection,
@@ -275,7 +249,6 @@ describe('UserManagementController', () => {
         role: 'assessor',
         qualification: 'esap',
         nameOrEmail: 'David',
-        area: undefined,
       })
     })
   })

--- a/server/controllers/admin/userManagementController.test.ts
+++ b/server/controllers/admin/userManagementController.test.ts
@@ -61,6 +61,7 @@ describe('UserManagementController', () => {
         undefined,
         [],
         [],
+        undefined,
         paginationDetails.pageNumber,
         paginationDetails.sortBy,
         paginationDetails.sortDirection,
@@ -114,6 +115,7 @@ describe('UserManagementController', () => {
         '1234',
         [],
         [],
+        undefined,
         paginationDetails.pageNumber,
         paginationDetails.sortBy,
         paginationDetails.sortDirection,
@@ -147,6 +149,7 @@ describe('UserManagementController', () => {
         undefined,
         ['assessor'],
         [],
+        undefined,
         paginationDetails.pageNumber,
         paginationDetails.sortBy,
         paginationDetails.sortDirection,
@@ -180,6 +183,7 @@ describe('UserManagementController', () => {
         undefined,
         [],
         ['esap'],
+        undefined,
         paginationDetails.pageNumber,
         paginationDetails.sortBy,
         paginationDetails.sortDirection,
@@ -198,12 +202,48 @@ describe('UserManagementController', () => {
       expect(getPaginationDetails).toHaveBeenCalledWith(requestWithQuery, paths.admin.userManagement.index({}), {
         role: undefined,
         qualification: 'esap',
+        nameOrEmail: undefined,
+        area: undefined,
+      })
+    })
+
+    it('filters users by name or email', async () => {
+      const requestWithQuery = { ...request, query: { nameOrEmail: 'Harry' } }
+      const requestHandler = userManagementController.index()
+
+      await requestHandler(requestWithQuery, response, next)
+
+      expect(userService.getUsers).toHaveBeenCalledWith(
+        token,
+        undefined,
+        [],
+        [],
+        'Harry',
+        paginationDetails.pageNumber,
+        paginationDetails.sortBy,
+        paginationDetails.sortDirection,
+      )
+
+      expect(response.render).toHaveBeenCalledWith('admin/users/index', {
+        pageHeading: 'User management dashboard',
+        users,
+        pageNumber: Number(paginatedResponse.pageNumber),
+        totalPages: Number(paginatedResponse.totalPages),
+        hrefPrefix: paginationDetails.hrefPrefix,
+        sortBy: paginationDetails.sortBy,
+        sortDirection: paginationDetails.sortDirection,
+        nameOrEmail: 'Harry',
+      })
+      expect(getPaginationDetails).toHaveBeenCalledWith(requestWithQuery, paths.admin.userManagement.index({}), {
+        role: undefined,
+        qualification: undefined,
+        nameOrEmail: 'Harry',
         area: undefined,
       })
     })
 
     it('applies more than one filter', async () => {
-      const requestWithQuery = { ...request, query: { qualification: 'esap', role: 'assessor' } }
+      const requestWithQuery = { ...request, query: { qualification: 'esap', role: 'assessor', nameOrEmail: 'David' } }
       const requestHandler = userManagementController.index()
 
       await requestHandler(requestWithQuery, response, next)
@@ -213,6 +253,7 @@ describe('UserManagementController', () => {
         undefined,
         ['assessor'],
         ['esap'],
+        'David',
         paginationDetails.pageNumber,
         paginationDetails.sortBy,
         paginationDetails.sortDirection,
@@ -228,29 +269,13 @@ describe('UserManagementController', () => {
         sortDirection: paginationDetails.sortDirection,
         selectedQualification: 'esap',
         selectedRole: 'assessor',
+        nameOrEmail: 'David',
       })
       expect(getPaginationDetails).toHaveBeenCalledWith(requestWithQuery, paths.admin.userManagement.index({}), {
         role: 'assessor',
         qualification: 'esap',
+        nameOrEmail: 'David',
         area: undefined,
-      })
-    })
-  })
-
-  describe('search', () => {
-    it('calls the service method with the query and renders the index template with the result', async () => {
-      const users = userFactory.buildList(1)
-      userService.search.mockResolvedValue(users)
-      const name = 'name'
-
-      const requestHandler = userManagementController.search()
-      await requestHandler({ ...request, body: { name } }, response, next)
-
-      expect(userService.search).toHaveBeenCalledWith(token, name)
-      expect(response.render).toHaveBeenCalledWith('admin/users/index', {
-        pageHeading: 'User management dashboard',
-        users,
-        name,
       })
     })
   })

--- a/server/controllers/admin/userManagementController.ts
+++ b/server/controllers/admin/userManagementController.ts
@@ -18,11 +18,12 @@ export default class UserController {
       const role = req.query.role as UserRole
       const qualification = req.query.qualification as UserQualification
       const selectedArea = req.query.area as string
+      const nameOrEmail = req.query.nameOrEmail as string
 
       const { pageNumber, sortBy, sortDirection, hrefPrefix } = getPaginationDetails<UserSortField>(
         req,
         paths.admin.userManagement.index({}),
-        { role, qualification, area: selectedArea },
+        { role, qualification, nameOrEmail, area: selectedArea },
       )
 
       const usersResponse = await this.userService.getUsers(
@@ -30,6 +31,7 @@ export default class UserController {
         selectedArea,
         [role],
         [qualification],
+        nameOrEmail,
         pageNumber,
         sortBy,
         sortDirection,
@@ -46,6 +48,7 @@ export default class UserController {
         hrefPrefix,
         sortBy,
         sortDirection,
+        nameOrEmail,
         selectedArea,
         selectedQualification: qualification,
         selectedRole: role,
@@ -81,20 +84,6 @@ export default class UserController {
 
       req.flash('success', 'User updated')
       res.redirect(paths.admin.userManagement.edit({ id: req.params.id }))
-    }
-  }
-
-  search(): TypedRequestHandler<Request, Response> {
-    return async (req: Request, res: Response) => {
-      const users = await this.userService.search(req.user.token, req.body.name as string)
-      const cruManagementAreas = await this.cruManagementAreaService.getCruManagementAreas(req.user.token)
-
-      res.render('admin/users/index', {
-        pageHeading: 'User management dashboard',
-        users,
-        cruManagementAreas,
-        name: req.body.name,
-      })
     }
   }
 

--- a/server/controllers/admin/userManagementController.ts
+++ b/server/controllers/admin/userManagementController.ts
@@ -28,10 +28,12 @@ export default class UserController {
 
       const usersResponse = await this.userService.getUsers(
         req.user.token,
-        selectedArea,
-        [role],
-        [qualification],
-        nameOrEmail,
+        {
+          cruManagementAreaId: selectedArea,
+          roles: role ? [role] : undefined,
+          qualifications: qualification ? [qualification] : undefined,
+          nameOrEmail,
+        },
         pageNumber,
         sortBy,
         sortDirection,

--- a/server/data/userClient.test.ts
+++ b/server/data/userClient.test.ts
@@ -243,7 +243,7 @@ describeCas1NamespaceClient('UserClient', provider => {
         },
       })
 
-      const output = await userClient.getUsers('', [], [], 2)
+      const output = await userClient.getUsers('', [], [], '', 2)
 
       expect(output).toEqual({
         data: users,
@@ -281,7 +281,7 @@ describeCas1NamespaceClient('UserClient', provider => {
         },
       })
 
-      const output = await userClient.getUsers('', [], [], 1, 'name', 'asc')
+      const output = await userClient.getUsers('', [], [], '', 1, 'name', 'asc')
 
       expect(output).toEqual({
         data: users,
@@ -400,6 +400,47 @@ describeCas1NamespaceClient('UserClient', provider => {
       })
 
       const output = await userClient.getUsers('', ['assessor', 'appeals_manager'], ['pipe', 'emergency'])
+
+      expect(output).toEqual({
+        data: users,
+        pageNumber: '1',
+        totalPages: '10',
+        totalResults: '100',
+        pageSize: '10',
+      })
+    })
+
+    it('should query by qualifications, roles and name or email', async () => {
+      await provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request to get a list of users with roles, qualifications and name',
+        withRequest: {
+          method: 'GET',
+          path: paths.users.index({}),
+          query: {
+            roles: 'assessor',
+            qualifications: 'pipe',
+            nameOrEmail: 'John',
+            page: '1',
+            sortBy: 'name',
+            sortDirection: 'asc',
+          },
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: users,
+          headers: {
+            'X-Pagination-TotalPages': '10',
+            'X-Pagination-TotalResults': '100',
+            'X-Pagination-PageSize': '10',
+          },
+        },
+      })
+
+      const output = await userClient.getUsers('', ['assessor'], ['pipe'], 'John')
 
       expect(output).toEqual({
         data: users,

--- a/server/data/userClient.test.ts
+++ b/server/data/userClient.test.ts
@@ -243,7 +243,7 @@ describeCas1NamespaceClient('UserClient', provider => {
         },
       })
 
-      const output = await userClient.getUsers('', [], [], '', 2)
+      const output = await userClient.getUsers({}, 2)
 
       expect(output).toEqual({
         data: users,
@@ -281,7 +281,7 @@ describeCas1NamespaceClient('UserClient', provider => {
         },
       })
 
-      const output = await userClient.getUsers('', [], [], '', 1, 'name', 'asc')
+      const output = await userClient.getUsers({}, 1, 'name', 'asc')
 
       expect(output).toEqual({
         data: users,
@@ -320,7 +320,7 @@ describeCas1NamespaceClient('UserClient', provider => {
         },
       })
 
-      const output = await userClient.getUsers('', ['assessor', 'appeals_manager'])
+      const output = await userClient.getUsers({ roles: ['assessor', 'appeals_manager'] })
 
       expect(output).toEqual({
         data: users,
@@ -359,7 +359,7 @@ describeCas1NamespaceClient('UserClient', provider => {
         },
       })
 
-      const output = await userClient.getUsers('', [], ['pipe', 'emergency'])
+      const output = await userClient.getUsers({ qualifications: ['pipe', 'emergency'] })
 
       expect(output).toEqual({
         data: users,
@@ -399,7 +399,10 @@ describeCas1NamespaceClient('UserClient', provider => {
         },
       })
 
-      const output = await userClient.getUsers('', ['assessor', 'appeals_manager'], ['pipe', 'emergency'])
+      const output = await userClient.getUsers({
+        roles: ['assessor', 'appeals_manager'],
+        qualifications: ['pipe', 'emergency'],
+      })
 
       expect(output).toEqual({
         data: users,
@@ -410,7 +413,7 @@ describeCas1NamespaceClient('UserClient', provider => {
       })
     })
 
-    it('should query by qualifications, roles and name or email', async () => {
+    it('should query by cru management area, qualifications, roles and name or email', async () => {
       await provider.addInteraction({
         state: 'Server is healthy',
         uponReceiving: 'A request to get a list of users with roles, qualifications and name',
@@ -418,6 +421,7 @@ describeCas1NamespaceClient('UserClient', provider => {
           method: 'GET',
           path: paths.users.index({}),
           query: {
+            cruManagementAreaId: 'area-id',
             roles: 'assessor',
             qualifications: 'pipe',
             nameOrEmail: 'John',
@@ -440,7 +444,12 @@ describeCas1NamespaceClient('UserClient', provider => {
         },
       })
 
-      const output = await userClient.getUsers('', ['assessor'], ['pipe'], 'John')
+      const output = await userClient.getUsers({
+        cruManagementAreaId: 'area-id',
+        roles: ['assessor'],
+        qualifications: ['pipe'],
+        nameOrEmail: 'John',
+      })
 
       expect(output).toEqual({
         data: users,

--- a/server/data/userClient.ts
+++ b/server/data/userClient.ts
@@ -62,6 +62,7 @@ export default class UserClient {
     cruManagementAreaId: string = '',
     roles: Array<UserRole> = [],
     qualifications: Array<UserQualification> = [],
+    nameOrEmail = '',
     page = 1,
     sortBy: UserSortField = 'name',
     sortDirection: SortDirection = 'asc',
@@ -78,6 +79,10 @@ export default class UserClient {
 
     if (cruManagementAreaId) {
       filters.cruManagementAreaId = cruManagementAreaId
+    }
+
+    if (nameOrEmail) {
+      filters.nameOrEmail = nameOrEmail
     }
 
     return this.restClient.getPaginatedResponse({

--- a/server/data/userClient.ts
+++ b/server/data/userClient.ts
@@ -22,6 +22,13 @@ export type UsersSearchParams = {
   page: number
 }
 
+export type UsersSearchFilters = {
+  cruManagementAreaId?: string
+  roles?: Array<UserRole>
+  qualifications?: Array<UserQualification>
+  nameOrEmail?: string
+}
+
 export default class UserClient {
   restClient: RestClient
 
@@ -59,36 +66,19 @@ export default class UserClient {
   }
 
   async getUsers(
-    cruManagementAreaId: string = '',
-    roles: Array<UserRole> = [],
-    qualifications: Array<UserQualification> = [],
-    nameOrEmail = '',
+    filters: UsersSearchFilters = {},
     page = 1,
     sortBy: UserSortField = 'name',
     sortDirection: SortDirection = 'asc',
   ): Promise<PaginatedResponse<User>> {
-    const filters = {} as Record<string, string>
-
-    if (roles.length) {
-      filters.roles = roles.join(',')
-    }
-
-    if (qualifications.length) {
-      filters.qualifications = qualifications.join(',')
-    }
-
-    if (cruManagementAreaId) {
-      filters.cruManagementAreaId = cruManagementAreaId
-    }
-
-    if (nameOrEmail) {
-      filters.nameOrEmail = nameOrEmail
-    }
+    const { nameOrEmail, cruManagementAreaId } = filters
+    const roles = filters.roles ? filters.roles.join(',') : undefined
+    const qualifications = filters.qualifications ? filters.qualifications.join(',') : undefined
 
     return this.restClient.getPaginatedResponse({
       path: paths.users.index({}),
       page: page.toString(),
-      query: { ...filters, sortBy, sortDirection },
+      query: { nameOrEmail, cruManagementAreaId, roles, qualifications, sortBy, sortDirection },
     })
   }
 

--- a/server/paths/admin.ts
+++ b/server/paths/admin.ts
@@ -47,7 +47,6 @@ export default {
     userManagement: {
       index: userManagementPath,
       edit: userManagementPath.path(':id'),
-      update: userManagementPath.path(':id'),
       searchDelius: userManagementPath.path('search/delius'),
       confirmDelete: userManagementPath.path(':id/confirm-delete'),
       delete: userManagementPath.path(':id/delete'),

--- a/server/paths/admin.ts
+++ b/server/paths/admin.ts
@@ -48,7 +48,6 @@ export default {
       index: userManagementPath,
       edit: userManagementPath.path(':id'),
       update: userManagementPath.path(':id'),
-      search: userManagementPath.path('search'),
       searchDelius: userManagementPath.path('search/delius'),
       confirmDelete: userManagementPath.path(':id/confirm-delete'),
       delete: userManagementPath.path(':id/delete'),

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -143,7 +143,7 @@ export default function routes(controllers: Controllers, router: Router, service
     auditEvent: 'ADMIN_USER_PERMISSIONS_PAGE',
     allowedPermissions: ['cas1_user_management'],
   })
-  put(paths.admin.userManagement.update.pattern, userManagementController.update(), {
+  put(paths.admin.userManagement.edit.pattern, userManagementController.update(), {
     auditEvent: 'ADMIN_UPDATE_USER_PERMISSIONS_SUCCESS',
     allowedPermissions: ['cas1_user_management'],
   })

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -147,10 +147,6 @@ export default function routes(controllers: Controllers, router: Router, service
     auditEvent: 'ADMIN_UPDATE_USER_PERMISSIONS_SUCCESS',
     allowedPermissions: ['cas1_user_management'],
   })
-  post(paths.admin.userManagement.search.pattern, userManagementController.search(), {
-    auditEvent: 'ADMIN_SEARCH_USERS',
-    allowedPermissions: ['cas1_user_management'],
-  })
 
   return router
 }

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -153,18 +153,35 @@ describe('User service', () => {
   })
 
   describe('getUsers', () => {
-    it('returns users by role and qualification', async () => {
+    it('returns users by role, qualification and name or email', async () => {
       const response = paginatedResponseFactory.build({
         data: userFactory.buildList(4),
       }) as PaginatedResponse<ApprovedPremisesUser>
 
       userClient.getUsers.mockResolvedValue(response)
 
-      const result = await userService.getUsers(token, 'test', ['applicant', 'assessor'], ['pipe'], 1, 'name', 'asc')
+      const result = await userService.getUsers(
+        token,
+        'test',
+        ['applicant', 'assessor'],
+        ['pipe'],
+        'Foo Smith',
+        1,
+        'name',
+        'asc',
+      )
 
       expect(result).toEqual(response)
 
-      expect(userClient.getUsers).toHaveBeenCalledWith('test', ['applicant', 'assessor'], ['pipe'], 1, 'name', 'asc')
+      expect(userClient.getUsers).toHaveBeenCalledWith(
+        'test',
+        ['applicant', 'assessor'],
+        ['pipe'],
+        'Foo Smith',
+        1,
+        'name',
+        'asc',
+      )
     })
   })
 

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -7,7 +7,7 @@ import { ApprovedPremisesUser } from '../@types/shared'
 import ReferenceDataClient from '../data/referenceDataClient'
 import { convertToTitleCase } from '../utils/utils'
 import { userProfileFactory } from '../testutils/factories/user'
-import { UsersSearchParams } from '../data/userClient'
+import { UsersSearchFilters, UsersSearchParams } from '../data/userClient'
 
 jest.mock('../data/userClient')
 jest.mock('../data/referenceDataClient.ts')
@@ -160,28 +160,18 @@ describe('User service', () => {
 
       userClient.getUsers.mockResolvedValue(response)
 
-      const result = await userService.getUsers(
-        token,
-        'test',
-        ['applicant', 'assessor'],
-        ['pipe'],
-        'Foo Smith',
-        1,
-        'name',
-        'asc',
-      )
+      const filters: UsersSearchFilters = {
+        cruManagementAreaId: 'test',
+        roles: ['applicant', 'assessor'],
+        qualifications: ['pipe'],
+        nameOrEmail: 'Foo Smith',
+      }
+
+      const result = await userService.getUsers(token, filters, 1, 'name', 'asc')
 
       expect(result).toEqual(response)
 
-      expect(userClient.getUsers).toHaveBeenCalledWith(
-        'test',
-        ['applicant', 'assessor'],
-        ['pipe'],
-        'Foo Smith',
-        1,
-        'name',
-        'asc',
-      )
+      expect(userClient.getUsers).toHaveBeenCalledWith(filters, 1, 'name', 'asc')
     })
   })
 

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -3,7 +3,6 @@ import {
   ProbationRegion,
   SortDirection,
   ApprovedPremisesUser as User,
-  UserQualification,
   ApprovedPremisesUserRole as UserRole,
   UserSortField,
   type UserSummary,
@@ -11,7 +10,7 @@ import {
 import { PaginatedResponse, UserDetails } from '@approved-premises/ui'
 import { ReferenceDataClient, RestClientBuilder, UserClient } from '../data'
 import { convertToTitleCase } from '../utils/utils'
-import { UsersSearchParams } from '../data/userClient'
+import { UsersSearchFilters, UsersSearchParams } from '../data/userClient'
 
 export class DeliusAccountMissingStaffDetailsError extends Error {}
 export class UnsupportedProbationRegionError extends Error {}
@@ -66,16 +65,13 @@ export default class UserService {
 
   async getUsers(
     token: string,
-    areaId: string = '',
-    roles: Array<UserRole> = [],
-    qualifications: Array<UserQualification> = [],
-    nameOrEmail = '',
+    filters: UsersSearchFilters = {},
     page: number = 1,
     sortBy: UserSortField = 'name',
     sortDirection: SortDirection = 'asc',
   ): Promise<PaginatedResponse<User>> {
     const client = this.userClientFactory(token)
-    return client.getUsers(areaId, roles, qualifications, nameOrEmail, page, sortBy, sortDirection)
+    return client.getUsers(filters, page, sortBy, sortDirection)
   }
 
   async updateUser(token: string, userId: string, updateUserData: Cas1UpdateUser): Promise<User> {

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -69,12 +69,13 @@ export default class UserService {
     areaId: string = '',
     roles: Array<UserRole> = [],
     qualifications: Array<UserQualification> = [],
+    nameOrEmail = '',
     page: number = 1,
     sortBy: UserSortField = 'name',
     sortDirection: SortDirection = 'asc',
   ): Promise<PaginatedResponse<User>> {
     const client = this.userClientFactory(token)
-    return client.getUsers(areaId, roles, qualifications, page, sortBy, sortDirection)
+    return client.getUsers(areaId, roles, qualifications, nameOrEmail, page, sortBy, sortDirection)
   }
 
   async updateUser(token: string, userId: string, updateUserData: Cas1UpdateUser): Promise<User> {

--- a/server/views/admin/users/edit.njk
+++ b/server/views/admin/users/edit.njk
@@ -32,7 +32,7 @@
 
             <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
 
-            <form action="{{ paths.admin.userManagement.update({id: updateUser.id}) }}?_method=PUT" method="post">
+            <form action="{{ paths.admin.userManagement.edit({id: updateUser.id}) }}?_method=PUT" method="post">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
                 {{ govukSummaryList({

--- a/server/views/admin/users/index.njk
+++ b/server/views/admin/users/index.njk
@@ -24,42 +24,24 @@
         </div>
 
         <div class="search-and-filter">
-            <form action="{{ paths.admin.userManagement.search({}) }}" method="post">
-                <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+            <form action="{{ currentUrl }}" method="get">
+                <h2 class="govuk-heading-m">Filters</h2>
 
                 <div class="search-and-filter__row">
                     {{ govukInput({
-                        classes: "moj-search__input",
                         label: {
-                            text: "Find a user",
-                            classes: "govuk-label--m"
+                            text: "Name or email",
+                            classes: "govuk-label--s"
                         },
-                        id: 'search-by-name',
+                        id: 'nameOrEmail',
                         hint: {
-                            text: "You can search for a person by name e.g. 'John' or 'smith' or 'john Smith'",
-                            classes: "moj-crn__hint"
+                            text: "e.g. 'John' or 'smith' or 'john Smith'"
                         },
-                        name: "name",
-                        value: name,
-                        errorMessage: errors.name
+                        name: "nameOrEmail",
+                        value: nameOrEmail,
+                        errorMessage: errors.nameOrEmail
                     }) }}
 
-
-                    {{ govukButton({
-                        "text": "Search",
-                        "type": "submit",
-                        "classes": "govuk-grid-column-one-quarter govuk-!-margin-top-9",
-                        "preventDoubleClick": true
-                    }) }}
-                </div>
-            </form>
-
-            <form action="{{ paths.admin.userManagement.index({}) }}" method="get">
-                <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-
-                <h2 class="govuk-heading-m govuk-!-margin-top-4">Filters</h2>
-
-                <div class="search-and-filter__row">
                     {{ govukSelect({
                         label: {
                             text: "Role",
@@ -92,9 +74,9 @@
                     }) }}
 
                     {{ govukButton({
-                        "name": "submit",
-                        "text": "Apply filters",
-                        "preventDoubleClick": true
+                        type: "submit",
+                        text: "Apply filters",
+                        preventDoubleClick: true
                     }) }}
                 </div>
             </form>


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2769

# Changes in this PR

This PR reworks the filters on the User Management page: the 'name' field is now sitting alongside other filters so they can be queried at the same time, and there is no longer a separate handler for 'Search'. The name field can also now accept an email, as the API already provides this functionality. The CSRF hidden input has been removed from the filters form, as it is of no use for `GET` form submissions.

Ultimately, this work intended to fix a bug where a user may perform a search for a user of a given name, then reload the search results page: given there was no `GET` handler for this path, the app considered this a request for a specific user with an id of `search`, which was causing an API error, and as a result a UI error. The separate URL for Search no longer exists, and searches are now using the main user management index path, so there is no longer any reason a user may end up on `/admin/user-management/search`, so the bug should be considered fixed as a result.

## Screenshots of UI changes

<details><summary>Updated Filters</summary>

<img width="988" height="328" alt="Screenshot 2025-09-24 at 15 43 31" src="https://github.com/user-attachments/assets/3f1a6025-1695-4a5d-ad96-f0d4384eeb11" />

</details>
