### PR TITLE
APS-2710 Sorting suitability search results with preferred AP's at top

### DIFF
--- a/integration_tests/pages/match/searchPage.ts
+++ b/integration_tests/pages/match/searchPage.ts
@@ -38,6 +38,7 @@ export default class SearchPage extends Page {
 
   shouldDisplaySearchResults(spaceSearchResults: Cas1SpaceSearchResults, targetPostcodeDistrict: string): void {
     cy.get('h2').contains(`${spaceSearchResults.resultsCount} Approved Premises found`)
+    cy.contains('Results are ordered by suitable preferred AP and distance from location.')
 
     spaceSearchResults.results.forEach(result => {
       cy.contains('h3', result.premises.name)

--- a/server/controllers/match/search/spaceSearchController.test.ts
+++ b/server/controllers/match/search/spaceSearchController.test.ts
@@ -76,11 +76,7 @@ describe('spaceSearchController', () => {
       expect(response.render).toHaveBeenCalledWith('match/search', {
         pageHeading: 'Find a space in an Approved Premises',
         contextKeyDetails: placementRequestKeyDetails(placementRequestDetail),
-        summaryCards: summaryCards(
-          spaceSearchResults.results,
-          searchState.postcode,
-          placementRequestDetail.application.isWomensApplication,
-        ),
+        summaryCards: summaryCards(spaceSearchResults.results, searchState.postcode, placementRequestDetail),
         placementRequest: placementRequestDetail,
         placementRequestInfoSummaryList: placementRequestSummaryList(placementRequestDetail, { showActions: false }),
         formPath: searchPath,

--- a/server/controllers/match/search/spaceSearchController.ts
+++ b/server/controllers/match/search/spaceSearchController.ts
@@ -55,11 +55,7 @@ export default class SpaceSearchController {
       res.render('match/search', {
         pageHeading: 'Find a space in an Approved Premises',
         contextKeyDetails: placementRequestKeyDetails(placementRequest),
-        summaryCards: summaryCards(
-          spaceSearchResults,
-          formValues.postcode,
-          placementRequest.application.isWomensApplication,
-        ),
+        summaryCards: summaryCards(spaceSearchResults, formValues.postcode, placementRequest),
         placementRequest,
         placementRequestInfoSummaryList: placementRequestSummaryList(placementRequest, { showActions: false }),
         formPath: matchPaths.v2Match.placementRequests.search.spaces({ placementRequestId }),

--- a/server/utils/match/spaceSearch.test.ts
+++ b/server/utils/match/spaceSearch.test.ts
@@ -1,4 +1,4 @@
-import { PlacementCriteria } from '@approved-premises/api'
+import { Cas1SpaceSearchResult, PlacementCriteria } from '@approved-premises/api'
 import { faker } from '@faker-js/faker'
 import {
   apTypeRadioItems,
@@ -8,6 +8,7 @@ import {
   initialiseSearchState,
   spaceSearchStateToApiPayload,
   summaryCardRows,
+  summaryCards,
 } from './spaceSearch'
 import {
   cas1PlacementRequestDetailFactory,
@@ -19,6 +20,7 @@ import * as formUtils from '../formUtils'
 import { ApTypeCriteria, apTypeCriteriaLabels } from '../placementCriteriaUtils'
 import { addressRow, apTypeRow, distanceRow, restrictionsRow } from './index'
 import { summaryListItem } from '../formUtils'
+import * as artifactUtils from '../retrieveQuestionResponseFromFormArtifact'
 
 describe('Space search utils', () => {
   describe('initialiseSearchState', () => {
@@ -225,6 +227,50 @@ describe('Space search utils', () => {
         distanceRow(spaceSearchResult, postcodeArea),
         restrictionsRow(spaceSearchResult),
       ])
+    })
+  })
+
+  describe('summaryCards', () => {
+    const nonPreferredResultsList = spaceSearchResultFactory.buildList(10)
+    const preferredList = spaceSearchResultFactory.buildList(3)
+    const allResults = [...nonPreferredResultsList, ...preferredList]
+    const placementRequest = cas1PlacementRequestDetailFactory.build()
+
+    beforeEach(() => {
+      jest.resetAllMocks()
+    })
+
+    const getDistances = (results: Array<Cas1SpaceSearchResult>): Array<number> => {
+      return results.map(({ distanceInMiles }) => distanceInMiles)
+    }
+
+    const getResultsFromCards = (cards: Array<{ spaceSearchResult: Cas1SpaceSearchResult }>) => {
+      return cards.map(({ spaceSearchResult }) => spaceSearchResult)
+    }
+
+    it('should render the results by distance if there are no preferred APs', () => {
+      const expectedDistances = getDistances(allResults).sort((a, b) => a - b)
+      const sortedResults = getResultsFromCards(summaryCards(allResults, '123456', placementRequest))
+
+      expect(getDistances(sortedResults)).toEqual(expectedDistances)
+    })
+
+    it('should not mutate the original results array', () => {
+      summaryCards(allResults, '123456', placementRequest)
+      expect(allResults).toEqual([...nonPreferredResultsList, ...preferredList])
+    })
+
+    it('should move preferred APs to the top, if provided', () => {
+      jest
+        .spyOn(artifactUtils, 'retrieveOptionalQuestionResponseFromFormArtifact')
+        .mockReturnValue(preferredList.map(result => result.premises))
+
+      const expectedDistances = getDistances(nonPreferredResultsList).sort((a, b) => a - b)
+      const sortedResults = getResultsFromCards(summaryCards(allResults, '123456', placementRequest))
+
+      expect(sortedResults.slice(0, 3)).toEqual(preferredList)
+
+      expect(getDistances(sortedResults.slice(3))).toEqual(expectedDistances)
     })
   })
 })

--- a/server/views/match/search.njk
+++ b/server/views/match/search.njk
@@ -44,6 +44,8 @@
 
     <h2 class="govuk-heading-m">{{ summaryCards | length }} Approved Premises found</h2>
 
+    <p>Results are ordered by suitable preferred AP and distance from location.</p>
+
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
             <form action="{{ formPath }}" method="post">


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2710

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Sorting of space search results in the UI, putting preferred AP's (if any) at the top in order of preference, followed by all the others ordered by distance from postcode.


<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before
<details>
  <summary>Before</summary>
<img width="1231" height="2570" alt="image" src="https://github.com/user-attachments/assets/6766f507-0ce4-4391-8a50-fe95b0052c5f" />
</details>

<details>
  <summary>After</summary>
<img width="1305" height="2647" alt="image" src="https://github.com/user-attachments/assets/1d53e063-1ff2-49bb-aa78-f4bacd1e0d35" />
</details>

