### PR TITLE
APS-2426 Cookie policy

### DIFF
--- a/integration_tests/pages/accessibilityStatement.ts
+++ b/integration_tests/pages/accessibilityStatement.ts
@@ -1,7 +1,0 @@
-import Page from './page'
-
-export default class AccessibilityStatementPage extends Page {
-  constructor() {
-    super('Accessibility statement')
-  }
-}

--- a/integration_tests/tests/staticPages.cy.ts
+++ b/integration_tests/tests/staticPages.cy.ts
@@ -1,16 +1,25 @@
 import Page from '../pages/page'
-import AccessibilityStatementPage from '../pages/accessibilityStatement'
 import DashboardPage from '../pages/dashboard'
 import { signIn } from './signIn'
 
 context('static pages', () => {
-  it('renders the accessibility statement', () => {
+  it('renders the static accesibility statement', () => {
     signIn('applicant')
 
     const indexPage = Page.verifyOnPage(DashboardPage)
 
     indexPage.clickLink('Accessibility statement')
 
-    Page.verifyOnPage(AccessibilityStatementPage)
+    Page.verifyOnPage(Page, 'Accessibility statement')
+  })
+
+  it('renders the cookies policy', () => {
+    signIn('applicant')
+
+    const indexPage = Page.verifyOnPage(DashboardPage)
+
+    indexPage.clickLink('Cookies policy')
+
+    Page.verifyOnPage(Page, 'Cookies policy')
   })
 })

--- a/server/paths/static.ts
+++ b/server/paths/static.ts
@@ -4,6 +4,7 @@ const paths = {
   pages: {
     accessibilityStatement: path('/accessibility'),
     maintenance: path('/maintenance'),
+    cookiesPolicy: path('/cookies'),
   },
 }
 

--- a/server/routes/static.ts
+++ b/server/routes/static.ts
@@ -19,5 +19,9 @@ export default function routes(controllers: Controllers, router: Router, service
     auditEvent: 'VIEW_MAINTENANCE',
   })
 
+  get(staticPaths.pages.cookiesPolicy.pattern, staticController.render('cookiePolicy'), {
+    auditEvent: 'COOKIE_POLICY',
+  })
+
   return router
 }

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -27,6 +27,10 @@
                 {
                     href: paths.pages.accessibilityStatement({}),
                     text: "Accessibility statement"
+                },
+                {
+                    href: paths.pages.cookiesPolicy({}),
+                    text: "Cookies policy"
                 }
             ]
         }

--- a/server/views/static/cookiePolicy.njk
+++ b/server/views/static/cookiePolicy.njk
@@ -1,0 +1,49 @@
+{% extends "partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - Cookies policy" %}
+{% set hideNav = true %}
+
+{% block content %}
+    <h1 class="govuk-heading-l">
+        Cookies policy
+    </h1>
+
+    <p>Digital Prison Services stores small pieces of data (known as ‘cookies’) on your computer in order to operate and
+        to collect information about how you browse the site.</p>
+    <p>Cookies are used to: </p>
+    <ol class="govuk-list govuk-list--bullet">
+        <li>keep you logged into the website</li>
+        <li>measure how you use the website so it can be
+            updated and improved based on your needs
+        </li>
+    </ol>
+    <p>Third party cookies on Digital Prison Services aren’t
+        used to identify you personally.</p>
+
+    <h2 class="govuk-heading-m">Sessions</h2>
+
+
+    <p>Digital Prison Services will store a cookie when you log into the site to open a session. The cookies used on DPS
+        are classed as essential cookies. This means they are necessary to provide the online DPS service where they are
+        used to transmit, carry out or facilitate the transmission of communications over a network.</p>
+
+
+    <h2 class="govuk-heading-m">Measuring website usage (Google Analytics)</h2>
+
+    <p>We use Google Analytics software to collect
+        information about how you use Digital Prison
+        Services. We do this to help make sure the site is
+        meeting the needs of its users and to <a href="https://insidegovuk.blog.gov.uk/2014/10/29/info-pages
+        publishing-data-about-user-needs-and-metrics/">help us make improvements</a>.</p>
+
+    <p>Google Analytics stores information about:</p>
+    <ol class="govuk-list govuk-list--bullet">
+        <li>the pages you visit on Digital Prison Services</li>
+        <li>how long you spend on each Digital Prison Service page</li>
+        <li>what you click on while you’re visiting the site</li>
+    </ol>
+    <p>We don’t allow Google to collect or store your personal information (eg your name or address) so this information
+        can’t be used to identify who you are.</p>
+
+    <p>We don’t allow Google to use or share our analytics data.</p>
+{% endblock %}


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/APS-2426

# Changes in this PR
Adds the cookies policy as a static page, with link on footer

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

<details>
  <summary>Cookies policy page</summary>
<img width="1409" height="1284" alt="image" src="https://github.com/user-attachments/assets/4881c799-caeb-4969-8f49-f3584b3bced5" />
</details>
