### PR TITLE
APS-2784 Change release type options

### DIFF
--- a/server/form-pages/apply/reasons-for-placement/basic-information/releaseType.test.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/releaseType.test.ts
@@ -1,6 +1,4 @@
-import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared'
 import { applicationFactory } from '../../../../testutils/factories'
-import { retrieveQuestionResponseFromFormArtifact } from '../../../../utils/retrieveQuestionResponseFromFormArtifact'
 
 import ReleaseType from './releaseType'
 
@@ -13,68 +11,7 @@ describe('ReleaseType', () => {
     data: { 'basic-information': { 'sentence-type': { sentenceType: 'standardDeterminate' } } },
   })
 
-  describe('body', () => {
-    it('should set the body', () => {
-      const page = new ReleaseType({ releaseType: 'rotl' }, application)
-
-      expect(page.body).toEqual({ releaseType: 'rotl' })
-    })
-  })
-
-  itShouldHavePreviousValue(new ReleaseType({}, application), 'sentence-type')
-  itShouldHaveNextValue(new ReleaseType({}, application), 'release-date')
-
-  describe('errors', () => {
-    it('should return an empty object if the release type is populated', () => {
-      const page = new ReleaseType({ releaseType: 'rotl' }, application)
-      expect(page.errors()).toEqual({})
-    })
-
-    it('should return an errors if the release type is not populated', () => {
-      const page = new ReleaseType({}, application)
-      expect(page.errors()).toEqual({ releaseType: 'You must choose a release type' })
-    })
-  })
-
   describe('items', () => {
-    describe('releaseType', () => {
-      it('if the sentence type is "standardDeterminate" then all the items should be shown', () => {
-        ;(retrieveQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue('standardDeterminate')
-
-        const items = new ReleaseType({}, application).items()
-
-        expect(new Set(items.map(item => item.value))).toEqual(
-          new Set(['licence', 'rotl', 'hdc', 'pss', 'paroleDirectedLicence', 'reReleasedPostRecall']),
-        )
-      })
-
-      it('if the sentence type is "extendedDeterminate" then the reduced list of items should be shown', () => {
-        ;(retrieveQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue('extendedDeterminate')
-
-        const items = new ReleaseType({}, application).items()
-
-        expect(new Set(items.map(item => item.value))).toEqual(
-          new Set(['rotl', 'extendedDeterminateLicence', 'paroleDirectedLicence']),
-        )
-      })
-
-      it('if the sentence type is "ipp" then the reduced list of items should be shown', () => {
-        ;(retrieveQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue('ipp')
-
-        const items = new ReleaseType({}, application).items()
-
-        expect(new Set(items.map(item => item.value))).toEqual(new Set(['rotl', 'licence']))
-      })
-
-      it('if the sentence type is "life" then the reduced list of items should be shown', () => {
-        ;(retrieveQuestionResponseFromFormArtifact as jest.Mock).mockReturnValue('life')
-
-        const items = new ReleaseType({}, application).items()
-
-        expect(new Set(items.map(item => item.value))).toEqual(new Set(['rotl', 'licence']))
-      })
-    })
-
     it('marks an option as selected when the releaseType is set', () => {
       const page = new ReleaseType({ releaseType: 'rotl' }, application)
 
@@ -90,16 +27,6 @@ describe('ReleaseType', () => {
       const selectedOptions = page.items().filter(item => item.checked)
 
       expect(selectedOptions.length).toEqual(0)
-    })
-  })
-
-  describe('response', () => {
-    it('should return a translated version of the response', () => {
-      const page = new ReleaseType({ releaseType: 'rotl' }, application)
-
-      expect(page.response()).toEqual({
-        [page.title]: 'Release on Temporary Licence (ROTL)',
-      })
     })
   })
 })

--- a/server/form-pages/placement-application/request-a-placement/releaseType.test.ts
+++ b/server/form-pages/placement-application/request-a-placement/releaseType.test.ts
@@ -1,4 +1,4 @@
-import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../shared'
+import { itShouldHaveNextValue } from '../../shared'
 import { placementApplicationFactory } from '../../../testutils/factories'
 
 import ReleaseType from './releaseType'
@@ -10,28 +10,7 @@ jest.mock('../../../utils/retrieveQuestionResponseFromFormArtifact', () => {
 describe('ReleaseType', () => {
   const application = placementApplicationFactory.build()
 
-  describe('body', () => {
-    it('should set the body', () => {
-      const page = new ReleaseType({ releaseType: 'rotl' }, application)
-
-      expect(page.body).toEqual({ releaseType: 'rotl' })
-    })
-  })
-
-  itShouldHavePreviousValue(new ReleaseType({}, application), 'sentence-type')
   itShouldHaveNextValue(new ReleaseType({}, application), 'additional-placement-details')
-
-  describe('errors', () => {
-    it('should return an empty object if the release type is populated', () => {
-      const page = new ReleaseType({ releaseType: 'rotl' }, application)
-      expect(page.errors()).toEqual({})
-    })
-
-    it('should return an errors if the release type is not populated', () => {
-      const page = new ReleaseType({}, application)
-      expect(page.errors()).toEqual({ releaseType: 'You must choose a release type' })
-    })
-  })
 
   describe('items', () => {
     it('marks an option as selected when the releaseType is set', () => {
@@ -49,16 +28,6 @@ describe('ReleaseType', () => {
       const selectedOptions = page.items().filter(item => item.checked)
 
       expect(selectedOptions.length).toEqual(0)
-    })
-  })
-
-  describe('response', () => {
-    it('should return a translated version of the response', () => {
-      const page = new ReleaseType({ releaseType: 'rotl' }, application)
-
-      expect(page.response()).toEqual({
-        [page.title]: 'Release on Temporary Licence (ROTL)',
-      })
     })
   })
 })

--- a/server/form-pages/shared/releaseType.test.ts
+++ b/server/form-pages/shared/releaseType.test.ts
@@ -1,7 +1,8 @@
 import { ReleaseTypeOption } from '@approved-premises/api'
-import { placementApplicationFactory } from '../../testutils/factories'
+import { applicationFactory, placementApplicationFactory } from '../../testutils/factories'
 import ReleaseType from './releaseType'
 import { allReleaseTypes } from '../../utils/applications/releaseTypeUtils'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from './index'
 
 const getExpected = (set: Array<ReleaseTypeOption>): Record<ReleaseTypeOption, string> => {
   return set.reduce(
@@ -13,32 +14,75 @@ const getExpected = (set: Array<ReleaseTypeOption>): Record<ReleaseTypeOption, s
   )
 }
 
-describe('ReleaseType.getReleaseTypes', () => {
-  const releaseType = new ReleaseType({}, placementApplicationFactory.build())
+jest.mock('../../utils/retrieveQuestionResponseFromFormArtifact', () => {
+  return { retrieveQuestionResponseFromFormArtifact: jest.fn(() => 'standardDeterminate') }
+})
 
-  describe('releaseType', () => {
-    it('if the sentence type is "standardDeterminate" then all the items should be shown', () => {
-      releaseType.sentenceType = 'standardDeterminate'
-      expect(releaseType.getReleaseTypes()).toEqual(
-        getExpected(['licence', 'rotl', 'hdc', 'pss', 'paroleDirectedLicence', 'reReleasedPostRecall']),
-      )
+describe('ReleaseType', () => {
+  const application = applicationFactory.build({
+    data: { 'basic-information': { 'sentence-type': { sentenceType: 'standardDeterminate' } } },
+  })
+
+  describe('body', () => {
+    it('should set the body', () => {
+      const page = new ReleaseType({ releaseType: 'rotl' }, application)
+
+      expect(page.body).toEqual({ releaseType: 'rotl' })
+    })
+  })
+
+  itShouldHavePreviousValue(new ReleaseType({}, application), 'sentence-type')
+  itShouldHaveNextValue(new ReleaseType({}, application), 'release-date')
+
+  describe('errors', () => {
+    it('should return an empty object if the release type is populated', () => {
+      const page = new ReleaseType({ releaseType: 'rotl' }, application)
+      expect(page.errors()).toEqual({})
     })
 
-    it('if the sentence type is "extendedDeterminate" then the reduced list of items should be shown', () => {
-      releaseType.sentenceType = 'extendedDeterminate'
-      expect(releaseType.getReleaseTypes()).toEqual(
-        getExpected(['rotl', 'extendedDeterminateLicence', 'paroleDirectedLicence']),
-      )
+    it('should return an errors if the release type is not populated', () => {
+      const page = new ReleaseType({}, application)
+      expect(page.errors()).toEqual({ releaseType: 'You must choose a release type' })
     })
+  })
 
-    it('if the sentence type is "ipp" then the reduced list of items should be shown', () => {
-      releaseType.sentenceType = 'ipp'
-      expect(releaseType.getReleaseTypes()).toEqual(getExpected(['rotl', 'licence']))
+  describe('ReleaseType.getReleaseTypes', () => {
+    const releaseType = new ReleaseType({}, placementApplicationFactory.build())
+
+    describe('releaseType', () => {
+      it('if the sentence type is "standardDeterminate" then all the items should be shown', () => {
+        releaseType.sentenceType = 'standardDeterminate'
+        expect(releaseType.getReleaseTypes()).toEqual(
+          getExpected(['licence', 'rotl', 'hdc', 'pss', 'paroleDirectedLicence', 'reReleasedPostRecall']),
+        )
+      })
+
+      it('if the sentence type is "extendedDeterminate" then the reduced list of items should be shown', () => {
+        releaseType.sentenceType = 'extendedDeterminate'
+        expect(releaseType.getReleaseTypes()).toEqual(
+          getExpected(['rotl', 'extendedDeterminateLicence', 'paroleDirectedLicence']),
+        )
+      })
+
+      it('if the sentence type is "ipp" then the reduced list of items should be shown', () => {
+        releaseType.sentenceType = 'ipp'
+        expect(releaseType.getReleaseTypes()).toEqual(getExpected(['rotl', 'paroleDirectedLicence']))
+      })
+
+      it('if the sentence type is "life" then the reduced list of items should be shown', () => {
+        releaseType.sentenceType = 'life'
+        expect(releaseType.getReleaseTypes()).toEqual(getExpected(['rotl', 'paroleDirectedLicence']))
+      })
     })
+  })
 
-    it('if the sentence type is "life" then the reduced list of items should be shown', () => {
-      releaseType.sentenceType = 'life'
-      expect(releaseType.getReleaseTypes()).toEqual(getExpected(['rotl', 'licence']))
+  describe('response', () => {
+    it('should return a translated version of the response', () => {
+      const page = new ReleaseType({ releaseType: 'rotl' }, application)
+
+      expect(page.response()).toEqual({
+        [page.title]: 'Release on Temporary Licence (ROTL)',
+      })
     })
   })
 })

--- a/server/form-pages/shared/releaseType.ts
+++ b/server/form-pages/shared/releaseType.ts
@@ -73,7 +73,7 @@ export default class ReleaseType implements TasklistPage {
       ])
     }
     if (this.sentenceType === 'life' || this.sentenceType === 'ipp') {
-      return pick(selectableReleaseTypes, ['rotl', 'licence'])
+      return pick(selectableReleaseTypes, ['rotl', 'paroleDirectedLicence'])
     }
     if (this.sentenceType === 'extendedDeterminate') {
       return pick(selectableReleaseTypes, ['rotl', 'extendedDeterminateLicence', 'paroleDirectedLicence'])

--- a/server/utils/applications/releaseTypeUtils.ts
+++ b/server/utils/applications/releaseTypeUtils.ts
@@ -25,7 +25,7 @@ type StandardDeterminateReleaseTypeOptions = Pick<
   ReleaseTypeOptions,
   'licence' | 'paroleDirectedLicence' | 'rotl' | 'hdc' | 'pss'
 >
-type LifeIppReleaseTypeOptions = Pick<ReleaseTypeOptions, 'rotl' | 'licence'>
+type LifeIppReleaseTypeOptions = Pick<ReleaseTypeOptions, 'rotl' | 'paroleDirectedLicence'>
 export type PossibleReleaseTypeOptions =
   | ExtendedDetermindateReleaseTypeOptions
   | StandardDeterminateReleaseTypeOptions


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/APS-2784

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Actually a trivial change; the mapping of sentence-types to selectable release types has changed.

I used the opportunity to remove some duplicated unit tests - left over from the release type work. Duplicate unit tests have been moved from the apply/basic-information and request-a-placement flows into the test for the shared releaseType page that the others inherit from.

[x] I have run the E2E tests locally and they passed
```
Running 15 tests using 2 workers
  15 passed (4.1m)
```

## Screenshots of UI changes

<details>
  <summary>Sentence type selector</summary>
<img width="1398" height="1040" alt="image" src="https://github.com/user-attachments/assets/c5db4768-8fdc-4abc-a19c-23a91f327e28" />
</details>

### Before
<details>
  <summary>Release type selection - for ipp or life</summary>
<img width="727" height="343" alt="image" src="https://github.com/user-attachments/assets/4728da14-6058-400a-911e-9e1a9c0d7c63" />
</details>

### After
<details>
  <summary>Release type selection - for ipp or life</summary>
<img width="1302" height="642" alt="image" src="https://github.com/user-attachments/assets/01222d71-07d8-4314-b852-1295f94e0209" />
</details>
