### PR TITLE
FM-83 Personal contacts

### DIFF
--- a/integration_tests/pages/manage/placements/residentProfile.ts
+++ b/integration_tests/pages/manage/placements/residentProfile.ts
@@ -26,7 +26,7 @@ import { DateFormats } from '../../../../server/utils/dateUtils'
 
 import { licenseCards, offencesTabCards, prisonCards } from '../../../../server/utils/resident/sentenceUtils'
 import { placementDetailsCards, allApPlacementsTabData } from '../../../../server/utils/resident/placementUtils'
-import { personDetailsCardList } from '../../../../server/utils/resident/personalUtils'
+import { contactsCardList, personDetailsCardList } from '../../../../server/utils/resident/personalUtils'
 import { AND, THEN, WHEN } from '../../../helpers'
 import { SubmittedDocumentRenderer } from '../../../../server/utils/forms/submittedDocumentRenderer'
 import { detailedStatus } from '../../../../server/utils/placements/status'
@@ -81,27 +81,29 @@ export default class ResidentProfilePage extends Page {
         ? cardTitle.text
         : new DOMParser().parseFromString(cardTitle.html, 'text/html').body.textContent)
     cy.log('*****  Checking card:', title)
-    if (title?.length) cy.get('.govuk-summary-card__title').contains(title).should('exist')
-    cy.get('.govuk-summary-card__title')
-      .contains(title)
-      .parents('.govuk-summary-card')
-      .within(() => {
-        if (card.rows) {
-          this.shouldContainSummaryListItems(card.rows)
-        }
-        if (card.table) {
-          cy.get('table:not(.text-table)').within(() => {
-            this.shouldContainTableColumns(card.table.head.map(cell => (cell as TextItem).text))
-            this.shouldContainOrderedTableRows(card.table.rows)
-          })
-        }
-        if (card.html) {
-          cy.get('.govuk-summary-card__content').then($el => {
-            const { actual, expected } = parseHtml($el, card.html)
-            expect(actual).to.contain(expected)
-          })
-        }
-      })
+    if (title?.length) {
+      cy.get('.govuk-summary-card__title').contains(title).should('exist')
+      cy.get('.govuk-summary-card__title')
+        .contains(title)
+        .parents('.govuk-summary-card')
+        .within(() => {
+          if (card.rows) {
+            this.shouldContainSummaryListItems(card.rows)
+          }
+          if (card.table) {
+            cy.get('table:not(.text-table)').within(() => {
+              this.shouldContainTableColumns(card.table.head.map(cell => (cell as TextItem).text))
+              this.shouldContainOrderedTableRows(card.table.rows)
+            })
+          }
+          if (card.html) {
+            cy.get('.govuk-summary-card__content').then($el => {
+              const { actual, expected } = parseHtml($el, card.html)
+              expect(actual).to.contain(expected)
+            })
+          }
+        })
+    }
   }
 
   checkHeader() {
@@ -218,10 +220,10 @@ export default class ResidentProfilePage extends Page {
     cards.forEach(card => this.shouldShowCard(card))
   }
 
-  shouldShowContacts() {
-    cy.contains(
-      'We cannot display personal contacts from NDelius yet. For example, probation practitioner contact details.',
-    )
+  shouldShowContacts(caseDetail: CaseDetail) {
+    cy.contains('Imported from NDelius')
+    const cards = contactsCardList(caseDetail, 'success', 'crn')
+    cards.forEach(card => this.shouldShowCard(card))
   }
 
   shouldShowOasysCards(numbers: Array<string>, group: Cas1OASysGroup, groupName: string) {

--- a/integration_tests/tests/manage/placements/residentProfile.cy.ts
+++ b/integration_tests/tests/manage/placements/residentProfile.cy.ts
@@ -79,7 +79,7 @@ context('ResidentProfile', () => {
       page.clickSideNav('Contacts')
 
       THEN('I should see the contacts section')
-      page.shouldShowContacts()
+      page.shouldShowContacts(caseDetail)
     })
 
     it('should show the health tab', () => {

--- a/server/testutils/factories/caseDetail.ts
+++ b/server/testutils/factories/caseDetail.ts
@@ -1,9 +1,31 @@
 import { Factory } from 'fishery'
-import { CaseDetail, MappaDetail, NoteDetail, PersonalContact, Registration } from '@approved-premises/api'
+import {
+  CaseDetail,
+  MappaDetail,
+  NoteDetail,
+  PersonalContact,
+  Registration,
+  RelationshipType,
+} from '@approved-premises/api'
 import { faker } from '@faker-js/faker'
 import caseSummaryFactory from './caseSummary'
 import offenceFactory from './offence'
 import { DateFormats } from '../../utils/dateUtils'
+import { contactGroupMapping } from '../../utils/resident/contactUtils'
+
+const relationships = ['Friend', 'Brother', 'Mother', 'Father', 'Partner', 'Solicitor', 'OS']
+const relationshipDescriptions = [
+  'Family member',
+  'Next of kin',
+  'Other personal contact',
+  'Emergency contact',
+  'Solicitor/Lawyer',
+  'Other contact',
+]
+const relationshipTypes: Array<RelationshipType> = Object.keys(contactGroupMapping).map(key => ({
+  code: key,
+  description: faker.helpers.arrayElement(relationshipDescriptions),
+}))
 
 const noteDetail = Factory.define<NoteDetail>(() => ({
   note: faker.lorem.sentence(2),
@@ -28,12 +50,13 @@ export const registrationFactory = Factory.define<Registration>(({ sequence }) =
   riskFlagGroupDescription: faker.helpers.arrayElement(['Cohort', 'Public protection', 'Safeguarding Risks', 'RoSH']),
 }))
 
-export const personalContact = Factory.define<PersonalContact>(() => ({
+export const personalContactFactory = Factory.define<PersonalContact>(() => ({
   address: { addressNumber: `${faker.number.int({ min: 1, max: 30 })}` },
   name: { forename: faker.person.firstName(), middleNames: [], surname: faker.person.lastName() },
-  relationship: faker.string.alphanumeric(),
-  relationshipType: { code: faker.helpers.arrayElement(['R1', 'R2', 'R3']), description: faker.word.words(4) },
-  telephoneNumber: faker.string.numeric({ length: 10 }),
+  relationship: faker.helpers.arrayElement(relationships),
+  relationshipType: faker.helpers.arrayElement(relationshipTypes),
+  telephoneNumber: faker.datatype.boolean() ? faker.string.numeric({ length: 10 }) : undefined,
+  mobileNumber: faker.datatype.boolean() ? faker.string.numeric({ length: 10 }) : undefined,
 }))
 
 export default Factory.define<CaseDetail>(() => {
@@ -53,7 +76,7 @@ export default Factory.define<CaseDetail>(() => {
         startDate: DateFormats.dateObjToIsoDate(faker.date.past({ refDate: endDate, years: 5 })),
       },
     ],
-    personalContacts: personalContact.buildList(3),
+    personalContacts: personalContactFactory.buildList(3),
     mappaDetail: mappaDetailFactory.build(),
   }
 })

--- a/server/utils/resident/contactUtils.test.ts
+++ b/server/utils/resident/contactUtils.test.ts
@@ -1,0 +1,64 @@
+import { personalContactFactory } from '../../testutils/factories/caseDetail'
+import { contactCard, contactGroupMapping, groupContacts } from './contactUtils'
+import { htmlCell, textCell } from '../tableUtils'
+
+describe('contactUtils', () => {
+  describe('groupContacts', () => {
+    it('should group contacts by type', () => {
+      const contacts = Object.keys(contactGroupMapping).map(code => {
+        return personalContactFactory.build({ relationshipType: { code } })
+      })
+
+      const groups = groupContacts(contacts)
+      expect(groups.PROF).toHaveLength(12)
+      expect(groups.PERS).toHaveLength(5)
+      expect(groups.OTH).toHaveLength(2)
+    })
+
+    it('should allocate an unknown code to the "other" list', () => {
+      const contact = personalContactFactory.build({ relationshipType: { code: 'INVALID' } })
+      expect(groupContacts([contact])).toEqual({ PROF: [], PERS: [], OTH: [contact] })
+    })
+
+    it('should group an empty contact list', () => {
+      const groups = groupContacts([])
+      expect(groups).toEqual({ PROF: [], PERS: [], OTH: [] })
+    })
+  })
+
+  describe('contactCard', () => {
+    it('should render a contact card', () => {
+      const contacts = personalContactFactory.build({
+        mobileNumber: '010101',
+        telephoneNumber: '101010',
+        relationship: 'Relationship',
+        name: { forename: 'Forename', surname: 'Surname' },
+        relationshipType: { code: 'CD', description: 'Type' },
+      })
+      expect(contactCard('title', [contacts])).toEqual({
+        card: {
+          title: textCell('title'),
+        },
+        table: {
+          head: ['Type', 'Description', 'Name', 'Phone number'].map(textCell),
+          rows: [
+            [
+              { text: 'Type', attributes: { 'data-code': 'CD' } },
+              ...['Relationship', 'Forename Surname'].map(textCell),
+              htmlCell('101010<br/>mob: 010101'),
+            ],
+          ],
+        },
+      })
+    })
+
+    it('should render an empty card', () => {
+      expect(contactCard('title', [])).toEqual({
+        card: {
+          title: textCell('title'),
+        },
+        html: 'title not provided',
+      })
+    })
+  })
+})

--- a/server/utils/resident/contactUtils.ts
+++ b/server/utils/resident/contactUtils.ts
@@ -1,0 +1,63 @@
+import { PersonalContact } from '@approved-premises/api'
+import { SummaryListWithCard, TableRow } from '@approved-premises/ui'
+import { htmlCell, textCell } from '../tableUtils'
+import { card } from './index'
+
+export type ContactGroup = 'PROF' | 'PERS' | 'OTH'
+
+export const contactGroupMapping: Record<string, ContactGroup> = {
+  CA: 'PROF',
+  MW: 'PROF',
+  CH: 'PERS',
+  RT04: 'OTH',
+  MC: 'PROF',
+  CE: 'OTH',
+  RT01: 'PROF',
+  ME: 'PERS',
+  OF: 'PERS',
+  RT02: 'PROF',
+  CR: 'PROF',
+  NK: 'PERS',
+  MO: 'PERS',
+  DR: 'PROF',
+  PA: 'PROF',
+  MP: 'PROF',
+  RT03: 'PROF',
+  SL: 'PROF',
+  MS: 'PROF',
+}
+
+export const groupContacts = (contacts: Array<PersonalContact>): Record<ContactGroup, Array<PersonalContact>> =>
+  contacts.reduce(
+    (out, contact) => {
+      const contactCode = contact.relationshipType?.code
+      out[contactGroupMapping[contactCode] || 'OTH'].push(contact)
+      return out
+    },
+    { PROF: [], PERS: [], OTH: [] },
+  )
+
+export const contactCard = (title: string, contacts: Array<PersonalContact>): SummaryListWithCard => {
+  const contactRow = (contact: PersonalContact): TableRow => {
+    const {
+      name: { forename, surname },
+      mobileNumber,
+      telephoneNumber,
+    } = contact
+    return [
+      { text: `${contact.relationshipType?.description}`, attributes: { 'data-code': contact.relationshipType?.code } },
+      textCell(contact.relationship),
+      textCell(`${forename} ${surname}`),
+      htmlCell(
+        `${telephoneNumber || ''}${mobileNumber ? `${telephoneNumber ? '<br/>' : ''}mob: ${mobileNumber}` : ''}`,
+      ),
+    ]
+  }
+  return card({
+    title,
+    table: contacts.length
+      ? { head: ['Type', 'Description', 'Name', 'Phone number'].map(textCell), rows: contacts.map(contactRow) }
+      : undefined,
+    html: !contacts.length ? `${title} not provided` : undefined,
+  })
+}

--- a/server/utils/resident/personal.test.ts
+++ b/server/utils/resident/personal.test.ts
@@ -41,16 +41,14 @@ describe('Personal tab', () => {
     it('should render the contacts tab content', async () => {
       jest.spyOn(utils, 'ndeliusDeeplink').mockReturnValue('NDelius deeplink')
       jest.spyOn(utils, 'insetText').mockImplementation(text => `inset("${text}")`)
+      jest.spyOn(personalUtils, 'contactsCardList').mockReturnValue([])
 
-      const {
-        subHeading,
-        cardList: [{ html }],
-      } = await contactsTabController({})
+      const { subHeading, cardList } = await contactsTabController({ crn, caseDetail, caseDetailOutcome: 'success' })
 
       expect(subHeading).toMatch('Contact')
-      expect(html).toMatchStringIgnoringWhitespace(`
-inset("<p>We cannot display personal contacts from NDelius yet. For example, probation practitioner contact details.</p>
-NDelius deeplink")`)
+      expect(cardList).toEqual([])
+
+      expect(personalUtils.contactsCardList).toHaveBeenCalledWith(caseDetail, 'success', crn)
     })
   })
 })

--- a/server/utils/resident/personal.ts
+++ b/server/utils/resident/personal.ts
@@ -19,9 +19,11 @@ export const personalDetailsTabController = async ({
   }
 }
 
-export const contactsTabController = async ({ crn }: TabControllerParameters): Promise<TabData> => {
-  return {
-    subHeading: 'Contacts',
-    cardList: contactsCardList(crn),
-  }
-}
+export const contactsTabController = async ({
+  crn,
+  caseDetail,
+  caseDetailOutcome,
+}: TabControllerParameters): Promise<TabData> => ({
+  subHeading: 'Contacts',
+  cardList: contactsCardList(caseDetail, caseDetailOutcome, crn),
+})

--- a/server/utils/resident/personalUtils.test.ts
+++ b/server/utils/resident/personalUtils.test.ts
@@ -1,17 +1,24 @@
 import { SummaryListWithCard } from '@approved-premises/ui'
 import { FullPerson } from '@approved-premises/api'
 import { faker } from '@faker-js/faker/locale/en_GB'
-import { personalSideNavigation, personDetailsCardList } from './personalUtils'
-import { cas1SpaceBookingFactory, risksFactory } from '../../testutils/factories'
+import { contactsCardList, personalSideNavigation, personDetailsCardList } from './personalUtils'
+import { cas1SpaceBookingFactory, caseDetailFactory, risksFactory } from '../../testutils/factories'
 import { fullPersonFactory } from '../../testutils/factories/person'
 import { DateFormats } from '../dateUtils'
 import { PersonStatusTag } from '../people/personStatusTag'
 import { getTierOrBlank } from '../applications/helpers'
 import * as utils from './index'
+import * as contactUtils from './contactUtils'
+import { htmlCell } from '../tableUtils'
+import config from '../../config'
 
 describe('personalUtils', () => {
   const placement = cas1SpaceBookingFactory.build()
   const { crn } = placement.person
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
 
   describe('personalSideNavigation', () => {
     it('should return the side navigation for the personal tab', () => {
@@ -91,6 +98,55 @@ describe('personalUtils', () => {
       validatePersonalCard(result[1], person)
       validateNumbersCard(result[2], person)
       validateEqualityCard(result[3], person)
+    })
+  })
+
+  describe('contactsCardList', () => {
+    beforeEach(() => {
+      jest.spyOn(utils, 'insetText').mockImplementation(text => `inset("${text}")`)
+      jest.spyOn(utils, 'ndeliusDeeplink').mockImplementation(({ text, component }) => `${component}:${text}`)
+      jest.spyOn(contactUtils, 'contactCard')
+      jest.spyOn(contactUtils, 'groupContacts').mockReturnValue({ PROF: [], PERS: [], OTH: [] })
+    })
+
+    const caseDetail = caseDetailFactory.build()
+    const nDeliusLink = 'PersonalContacts:View more contact information in NDelius (opens in a new tab).'
+
+    it('should render the personal contacts cards', () => {
+      const result = contactsCardList(caseDetail, 'success', 'crn')
+
+      expect(result).toEqual([
+        {
+          html: `inset("<p>Imported from NDelius</p>${nDeliusLink}")`,
+        },
+        expect.objectContaining(utils.card({ title: 'Professional contacts' })),
+        expect.objectContaining(utils.card({ title: 'Personal contacts' })),
+        expect.objectContaining(utils.card({ title: 'Other contacts' })),
+      ])
+      expect(contactUtils.contactCard).toHaveBeenCalledWith('Professional contacts', [])
+      expect(contactUtils.contactCard).toHaveBeenCalledWith('Personal contacts', [])
+      expect(contactUtils.contactCard).toHaveBeenCalledWith('Other contacts', [])
+      expect(contactUtils.groupContacts).toHaveBeenCalledWith(caseDetail.personalContacts)
+    })
+
+    it('should render on a caseDetails failure', () => {
+      expect(contactsCardList(caseDetail, 'failure', 'crn')).toEqual([
+        htmlCell(
+          `inset("<p>We cannot load contacts information right now because NDelius is not available.<br>Try again later</p>${nDeliusLink}")`,
+        ),
+      ])
+    })
+
+    it('should render original message and link in production', () => {
+      config.isProduction = true
+
+      expect(contactsCardList(caseDetail, 'success', 'crn')).toEqual([
+        {
+          html: `inset("<p>We cannot display personal contacts from NDelius yet. For example, probation practitioner contact details.</p>PersonalContacts:View personal contacts in NDelius (opens in a new tab).")`,
+        },
+      ])
+
+      config.isProduction = false
     })
   })
 })

--- a/server/utils/resident/personalUtils.ts
+++ b/server/utils/resident/personalUtils.ts
@@ -1,8 +1,11 @@
-import { FullPerson, PersonRisks } from '@approved-premises/api'
-import { card, insetText, ndeliusDeeplink, ResidentProfileSubTab, summaryItemNd } from './index'
+import { CaseDetail, FullPerson, PersonRisks } from '@approved-premises/api'
+import { card, insetText, loadingErrorMessage, ndeliusDeeplink, ResidentProfileSubTab, summaryItemNd } from './index'
 import paths from '../../paths/manage'
 import { PersonStatusTag } from '../people/personStatusTag'
 import { getTierOrBlank } from '../applications/helpers'
+import { ApiOutcome } from '../utils'
+import { contactCard, ContactGroup, groupContacts } from './contactUtils'
+import config from '../../config'
 
 export const personalSideNavigation = (subTab: ResidentProfileSubTab, crn: string, placementId: string) => {
   const basePath = paths.resident.tabPersonal
@@ -52,10 +55,39 @@ export const personDetailsCardList = (person: FullPerson, personRisks: PersonRis
   ]
 }
 
-export const contactsCardList = (crn: string) => [
-  card({
-    html: insetText(`<p>We cannot display personal contacts from NDelius yet. For example, probation practitioner contact details.</p>
-${ndeliusDeeplink({ crn, text: 'View personal contacts in NDelius (opens in a new tab).', component: 'PersonalContacts' })}
-`),
-  }),
-]
+export const contactsCardList = (caseDetail: CaseDetail, caseDetailOutcome: ApiOutcome, crn: string) => {
+  const errorMessage = loadingErrorMessage(caseDetailOutcome, 'contacts', 'nDelius')
+  const groupNames: Record<ContactGroup, string> = {
+    PROF: 'Professional contacts',
+    PERS: 'Personal contacts',
+    OTH: 'Other contacts',
+  }
+
+  const groupedContacts = groupContacts(caseDetail?.personalContacts || [])
+  return config.isProduction // TODO: remove once live
+    ? [
+        card({
+          html: insetText(
+            `<p>We cannot display personal contacts from NDelius yet. For example, probation practitioner contact details.</p>${ndeliusDeeplink(
+              { crn, text: 'View personal contacts in NDelius (opens in a new tab).', component: 'PersonalContacts' },
+            )}`,
+          ),
+        }),
+      ]
+    : [
+        card({
+          html: insetText(
+            `<p>${errorMessage || 'Imported from NDelius'}</p>${ndeliusDeeplink({
+              crn,
+              text: 'View more contact information in NDelius (opens in a new tab).',
+              component: 'PersonalContacts',
+            })}`,
+          ),
+        }),
+        ...(!errorMessage
+          ? Object.entries(groupedContacts).map(([group, contacts]) =>
+              contactCard(groupNames[group as ContactGroup], contacts),
+            )
+          : []),
+      ]
+}


### PR DESCRIPTION
# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->
https://dsdmoj.atlassian.net/browse/FM-83

# Changes in this PR

Adds personal contacts.

- These are contained in the existing `caseDetail` object so no new API calls were needed.
- The contacts are split between Professional, Personal and other, using a hardcoded mapping in the UI. At some stage, we may want to pull this mapping from an API, but no such API exists in probation integration at the moment. 
- No email address is provided by the API. There appear to be very few email addresses populated in NDelius.
- Both mobile and landline phone numbers are shown if present. This deviates from NDelius which only shows landline numbers. Many mobile numbers are populated in NDelius, rather more than landlines in fact.
- Any unrecognised contact types are added to the 'Other' group.
- The original content of the page is shown in production until we can verify the behaviour of the page using real data in pre-prod.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

<details>
  <summary>Personal contacts page</summary>
<img width="2527" height="2475" alt="image" src="https://github.com/user-attachments/assets/aa494bb2-427a-4b4b-945c-b25c4da26acf" />
</details>
