### PR TITLE
FM-371 Enable diet and allergy

### DIFF
--- a/server/utils/resident/healthUtils.test.ts
+++ b/server/utils/resident/healthUtils.test.ts
@@ -143,7 +143,7 @@ describe('healthUtils', () => {
       it('should format item lists', () => {
         const item1 = dietaryItemDtoFactory.build({ comment: undefined, value: { description: 'description 1' } })
         const item2 = dietaryItemDtoFactory.build({ comment: 'Comment 2', value: { description: 'description 2' } })
-        const expected2 = 'description 2 <span class="govuk-body govuk-hint">(Comment 2)</span>'
+        const expected2 = 'description 2<span>: Comment 2</span>'
 
         expect(healthUtils.listDietItems([item1])).toEqual('description 1')
         expect(healthUtils.listDietItems([item2])).toEqual(expected2)
@@ -160,15 +160,6 @@ describe('healthUtils', () => {
         expect(result.topHtml).toEqual(
           `<p class="govuk-body-m govuk-hint govuk-!-margin-bottom-2">Imported from Digital Prison Service (DPS)</p><p class="govuk-body-m govuk-hint">Last updated: ${DateFormats.isoDateToUIDate(soon)}</p>`,
         )
-      })
-
-      it('should not show diet and allery in production', () => {
-        config.isProduction = true
-        const result = healthDetailsCards(defaultArguments)
-
-        expect(result).toHaveLength(3)
-        expect(result.map(card => card.card?.title)).not.toContainEqual({ text: 'Diet and food allergies' })
-        config.isProduction = false
       })
     })
 

--- a/server/utils/resident/healthUtils.test.ts
+++ b/server/utils/resident/healthUtils.test.ts
@@ -23,7 +23,6 @@ import { ApiOutcome } from '../utils'
 import * as healthUtils from './healthUtils'
 import { bulletList, summaryListItem } from '../formUtils'
 import { dietaryItemDtoFactory } from '../../testutils/factories/dietAndAllergyResponse'
-import config from '../../config'
 
 jest.mock('nunjucks')
 

--- a/server/utils/resident/healthUtils.ts
+++ b/server/utils/resident/healthUtils.ts
@@ -8,21 +8,12 @@ import {
   ValueWithMetadataString,
 } from '@approved-premises/api'
 import { SummaryListWithCard } from '@approved-premises/ui'
-import {
-  card,
-  cellMetaData,
-  combineResultAndContent,
-  insetText,
-  loadingErrorMessage,
-  ResidentProfileSubTab,
-  summaryItemNd,
-} from '.'
+import { card, cellMetaData, combineResultAndContent, insetText, loadingErrorMessage, ResidentProfileSubTab } from '.'
 import paths from '../../paths/manage'
 import { dateCellNoWrap, textCell } from '../tableUtils'
 import { oasysQuestionDetailsByNumber, summaryCards, tableRow } from './riskUtils'
 import { ApiOutcome, linkTo } from '../utils'
 import { bulletList, summaryListItem } from '../formUtils'
-import config from '../../config'
 
 export const smokingStatusMapping: Record<string, string> = {
   Yes: 'Smoker',
@@ -53,8 +44,7 @@ export const healthSideNavigation = (subTab: ResidentProfileSubTab, crn: string,
 
 export const listDietItems = (items: Array<DietaryItemDto> = []): string => {
   const itemsHtml = items.map(
-    ({ value, comment }) =>
-      `${value?.description}${comment?.length ? ` <span class="govuk-body govuk-hint">(${comment})</span>` : ''}`,
+    ({ value, comment }) => `${value?.description}${comment?.length ? `<span>: ${comment}</span>` : ''}`,
   )
   if (items?.length > 1) return bulletList(itemsHtml)
   if (items?.length === 1) return itemsHtml[0]
@@ -92,10 +82,10 @@ export const dietCard = (dietResponse: DietAndAllergyResponse, result: ApiOutcom
     topHtml: error || cellMetaData('dps', lastModified),
     rows: !error
       ? [
-          summaryItemNd('Catering instructions', cateringInstructions, 'textBlock'),
           summaryListItem('Medical diet', listDietItems(medicalRequirementList), 'html'),
           summaryListItem('Food allergies', listDietItems(foodAllergyList), 'html'),
           summaryListItem('Personalised dietary requirements', listDietItems(personalisedDietaryList), 'html'),
+          summaryListItem('Catering instructions', cateringInstructions || 'None', 'textBlock'),
         ]
       : undefined,
   })
@@ -148,12 +138,10 @@ export const healthDetailsCards = ({
     cards = cards.concat(summaryCards(['13.1'], supportingInformation, supportingInformationOutcome))
   }
 
-  cards = cards
-    .concat([
-      !config.isProduction && dietCard(dietAndAllergy, dietAndAllergyOutcome),
-      smokerCard(bookingDetails, bookingDetailsOutcome),
-    ])
-    .filter(Boolean)
+  cards = cards.concat([
+    dietCard(dietAndAllergy, dietAndAllergyOutcome),
+    smokerCard(bookingDetails, bookingDetailsOutcome),
+  ])
   return cards
 }
 

--- a/server/utils/resident/index.ts
+++ b/server/utils/resident/index.ts
@@ -255,6 +255,7 @@ export const cellMetaData = (service: Service, lastUpdated?: string) => {
     : ''
   return `<p class="govuk-body-m govuk-hint govuk-!-margin-bottom-2">Imported from ${serviceNames[service]}</p>${lastUpdatedStr}`
 }
+
 /**
  * Alters the outcome of a request where there are no data, but the API request was successful.
  * If the outcome is 'success', it will be returned as 'notFound' if the content is falsy


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/FM-371

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Some very small tweaks to the health and allergy widget, and enable in production.

- Swaps the comments field from being in brackets and with a hint styling to having it separated with a colon - space ': ' and normal styling. 
- Moves the Catering instructions to the bottom of the card and display as 'None' if empty,

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes
<details>
  <summary>Before</summary>
<img width="757" height="753" alt="image" src="https://github.com/user-attachments/assets/38a6fa3f-9c75-4305-9cb4-ac12b4e81820" />

</details>

<details>
  <summary>After</summary>
<img width="845" height="730" alt="image" src="https://github.com/user-attachments/assets/e9b42b90-5918-462c-9f42-0e36c63648b8" />
</details>

