### PR TITLE
Updated "Back to top" jump links to behave like GDS site

### DIFF
--- a/assets/js/backToTop.js
+++ b/assets/js/backToTop.js
@@ -1,0 +1,29 @@
+function backToTop(jumpLink) {
+  // browser doesn't support InteractionObserver, just use default behaviour
+  if (!('IntersectionObserver' in window)) {
+    return
+  }
+
+  jumpLink.classList.add('back-to-top--hidden', 'back-to-top--fixed')
+
+  // show jump link as fixed when side navigation is no longer visible
+  // change jump link to relative when footer is visible
+  const navObserver = new IntersectionObserver(([entry]) => {
+    jumpLink.classList.toggle('back-to-top--hidden', entry.isIntersecting)
+  })
+  const footerObserver = new IntersectionObserver(([entry]) => {
+    jumpLink.classList.toggle('back-to-top--fixed', !entry.isIntersecting)
+  })
+
+  const sideNav = document.querySelector('nav.moj-side-navigation')
+  if (sideNav) {
+    navObserver.observe(sideNav)
+  }
+
+  const footer = document.querySelector('footer')
+  if (footer) {
+    footerObserver.observe(footer)
+  }
+}
+
+export default backToTop

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -5,6 +5,7 @@ import linkDebounce from './linkDebounce'
 import SubNavAsTabs from './tabPanelTableScript'
 import makeAutocomplete from './accessibleAutocomplete'
 import clearErrorsOnSubmit from './clearErrors'
+import backToTop from './backToTop'
 
 GOVUKFrontend.initAll()
 
@@ -29,3 +30,4 @@ document.querySelectorAll('[data-module="moj-date-picker"]').forEach(el => {
   new DatePicker(el)
 })
 document.querySelectorAll('form[data-clear-errors-on-submit]').forEach(clearErrorsOnSubmit)
+document.querySelectorAll('#backToTopJumpLink').forEach(backToTop)

--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -29,6 +29,7 @@
 @use './components/profile-banner';
 @use './components/width_override';
 @use './components/technical-updates-banner';
+@use './components/back-top-top-jump-link';
 
 @use './pages/assessments-index';
 @use './pages/applications-pages-attach-document';

--- a/assets/scss/components/_back-top-top-jump-link.scss
+++ b/assets/scss/components/_back-top-top-jump-link.scss
@@ -1,0 +1,18 @@
+@use "govuk-frontend/dist/govuk" as *;
+
+.back-to-top {
+  position: relative;
+  margin-left: govuk-spacing(3);
+  bottom: govuk-spacing(3);
+  height: 0;
+  overflow: visible;
+}
+
+.back-to-top--hidden {
+  display: none;
+}
+
+.back-to-top--fixed {
+  position: fixed;
+  margin-bottom: govuk-spacing(9);
+}

--- a/integration_tests/tests/manage/placements/residentProfile.cy.ts
+++ b/integration_tests/tests/manage/placements/residentProfile.cy.ts
@@ -253,7 +253,10 @@ context('ResidentProfile', () => {
       AND('the Offence details information should be shown')
       page.shouldShowOffencesInformation(caseDetail, oasysOffenceDetails)
 
-      AND('the "back to top" jump link should be shown')
+      WHEN('I scroll to the bottom of the page')
+      cy.scrollTo('bottom')
+
+      THEN('the "back to top" jump link should be shown')
       page.clickLink('Back to top')
 
       WHEN('I select the licence side-nav')

--- a/server/controllers/manage/residentProfileController.test.ts
+++ b/server/controllers/manage/residentProfileController.test.ts
@@ -84,7 +84,6 @@ describe('residentProfileController', () => {
     user,
     actions: [] as Array<never>,
     resident: getResidentHeader(placement, caseDetail),
-    showBackToTopJumpLink: false,
   })
 
   describe('show', () => {
@@ -134,7 +133,6 @@ describe('residentProfileController', () => {
           tabItems: residentTabItems(placement, 'sentence'),
           sideNavigation: sentenceSideNavigation('offence', crn, placement.id),
           ...tabData,
-          showBackToTopJumpLink: true, // sentence -> offence tab should show the "back to top" jump link
         },
       ])
 
@@ -158,7 +156,6 @@ describe('residentProfileController', () => {
           sideNavigation: riskSideNavigation('riskDetails', crn, placement.id),
           ...renderParameters(placement, caseDetail, 'risk'),
           ...tabData,
-          showBackToTopJumpLink: true, // risk -> risk details tab should show the "back to top" jump link
         },
       ])
 

--- a/server/controllers/manage/residentProfileController.ts
+++ b/server/controllers/manage/residentProfileController.ts
@@ -13,7 +13,6 @@ import {
   getResidentHeader,
   tabLabels,
   TabData,
-  shouldEnableBackToTopJumpLink,
 } from '../../utils/resident'
 
 import {
@@ -126,8 +125,6 @@ export default class ResidentProfileController {
         paths.premises.show({ premisesId: placement.premises.id }),
       )
 
-      const showBackToTopJumpLink = shouldEnableBackToTopJumpLink(activeTab, subTab)
-
       return res.render(`manage/resident/residentProfile`, {
         crn,
         placement,
@@ -139,7 +136,6 @@ export default class ResidentProfileController {
         actions: placementActions ? placementActions[0].items : [],
         activeTab,
         sideNavigation,
-        showBackToTopJumpLink,
         ...tabData,
       })
     }

--- a/server/utils/resident/index.test.ts
+++ b/server/utils/resident/index.test.ts
@@ -11,11 +11,8 @@ import {
   getPlacementLink,
   getResidentHeader,
   loadingErrorMessage,
-  ResidentProfileSubTab,
-  ResidentProfileTab,
   residentTabItems,
   returnPath,
-  shouldEnableBackToTopJumpLink,
 } from './index'
 import { cas1SpaceBookingFactory, caseDetailFactory, userFactory } from '../../testutils/factories'
 import { canonicalDates, placementStatusTag } from '../placements'
@@ -246,36 +243,6 @@ describe('residentsUtils', () => {
         expect(combineResultAndContent('success', undefined)).toEqual('notFound')
         expect(combineResultAndContent('failure', undefined)).toEqual('failure')
       })
-    })
-
-    describe('shouldEnableBackToTopJumpLink', () => {
-      it.each([
-        ['health', 'mentalHealth'],
-        ['placement', 'application'],
-        ['risk', 'riskDetails'],
-        ['sentence', 'offence'],
-        ['sentence', 'licence'],
-        ['sentence', 'prison'],
-      ])(
-        '%s -> %s should enable the "Back to top" jump link',
-        (activeTab: ResidentProfileTab, subTab: ResidentProfileSubTab) => {
-          expect(shouldEnableBackToTopJumpLink(activeTab, subTab)).toBe(true)
-        },
-      )
-
-      it.each([
-        ['personal', 'personalDetails'],
-        ['personal', 'contacts'],
-        ['health', 'healthDetails'],
-        ['placement', 'placementDetails'],
-        ['placement', 'allApPlacements'],
-        ['drugAndAlcohol', undefined],
-      ])(
-        '%s -> %s should not enable the "Back to top" jump link',
-        (activeTab: ResidentProfileTab, subTab?: ResidentProfileSubTab) => {
-          expect(shouldEnableBackToTopJumpLink(activeTab, subTab)).toBe(false)
-        },
-      )
     })
   })
 })

--- a/server/utils/resident/index.ts
+++ b/server/utils/resident/index.ts
@@ -295,19 +295,3 @@ export const getPlacementLink = ({
         placementId,
       })
 }
-
-const enabledBackToTopJumpLinkTabs: Record<ResidentProfileTab, Array<ResidentProfileSubTab>> = {
-  health: ['mentalHealth'],
-  placement: ['application'],
-  risk: ['riskDetails'],
-  sentence: ['offence', 'licence', 'prison'],
-  personal: [],
-  drugAndAlcohol: [],
-}
-
-export const shouldEnableBackToTopJumpLink = (
-  activeTab: ResidentProfileTab,
-  subTab: ResidentProfileSubTab,
-): boolean => {
-  return enabledBackToTopJumpLinkTabs[activeTab]?.includes(subTab)
-}

--- a/server/views/components/backToTop/macro.njk
+++ b/server/views/components/backToTop/macro.njk
@@ -1,0 +1,10 @@
+{% macro backToTop() %}
+    <div id="backToTopJumpLink" class="back-to-top">
+        <a class="govuk-link govuk-link--no-visited-state" href="#top">
+            <svg role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
+                <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
+            </svg>
+            Back to top
+        </a>
+    </div>
+{% endmacro %}

--- a/server/views/manage/resident/residentProfile.njk
+++ b/server/views/manage/resident/residentProfile.njk
@@ -5,6 +5,7 @@
 {% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
 {% from "moj/components/side-navigation/macro.njk" import mojSideNavigation %}
 {% from "govuk/components/accordion/macro.njk" import govukAccordion %}
+{% from "components/backToTop/macro.njk" import backToTop %}
 
 {% set pageTitle = applicationName + " - " + pageHeading %}
 {% set mainClasses = "govuk-body govuk-!-padding-top-0" %}
@@ -66,16 +67,9 @@
                 {% set cardList = bottomCardList %}
                 {% include "./partials/cardList.njk" %}
             {% endif %}
-
-            {% if showBackToTopJumpLink %}
-                <a class="govuk-link govuk-link--no-visited-state" href="#resident-name">
-                    <svg role="presentation" focusable="false" class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
-                        <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
-                    </svg>
-                    Back to top
-                </a>
-            {% endif %}
         </div>
+
+        {{ backToTop() }}
     </div>
 
 {% endblock %}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -13,7 +13,9 @@
     {% include "./header.njk" %}
 {% endblock %}
 
-{% block bodyStart %}{% endblock %}
+{% block bodyStart %}
+    <a id="top"></a>
+{% endblock %}
 
 {% block bodyEnd %}
     <script type="module" src="{{ '/assets/js/app.js' | assetMap }}"></script>


### PR DESCRIPTION
# Context

Based on additional feedback of the back of [FM-391](https://dsdmoj.atlassian.net/browse/FM-391)

Made the "Back to top" link behave the same way as on the GDS website: scroll down on [this page](https://design-system.service.gov.uk/components/footer/) and see the behaviour

Jump link appears when the side navigation is no longer on screen, and sticks to the bottom left until the footer appears when it sticks above the footer. The link takes the user to the very top of the page

After discussing with Beth, I've enabled it on all Manage a Resident pages, but it only appears if the content is long enough to be able to scroll until the side navigation no longer visible

I've made `backToTop` into a nunjucks macro so we can use it across other pages too

# Changes in this PR

https://github.com/user-attachments/assets/1defc422-f895-4a13-885e-ae7dbf81a35a
