### PR TITLE
Chore: Specify repository for token generation

### DIFF
--- a/.github/workflows/generate-types.yml
+++ b/.github/workflows/generate-types.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            hmpps-approved-premises-ui
 
       - name: Generate Types
         run: ./script/generate-types  ${{ vars.CAS1_API_SPEC_URL }}


### PR DESCRIPTION
This ensures the token generated has permissions for the correct repository, even when generated from an external workflow (i.e. API).