### PR TITLE
Move oasys risk flags under details block

### DIFF
--- a/server/utils/resident/riskUtils.test.ts
+++ b/server/utils/resident/riskUtils.test.ts
@@ -85,6 +85,20 @@ describe('risk utils', () => {
       expect((rows[0][0] as { html: string }).html).toContain(registrations[0].riskFlagGroupDescription)
     })
 
+    it('should render OASys imported notes in a details block', () => {
+      const registration = registrationFactory.build({
+        description: 'Risk to Staff',
+      })
+
+      const rows = registrationRows([registration])
+
+      expect((rows[0][1] as { html: string }).html).toContain('Nunjucks template partials/detailsBlock.njk')
+      expect(render).toHaveBeenCalledWith('partials/detailsBlock.njk', {
+        summaryText: `View full OASys notes for ${registration.description.toLowerCase()}`,
+        text: registration.riskNotesDetail[0].note,
+      })
+    })
+
     it('Should render an error card when caseDetail request fails', () => {
       const result = ndeliusRiskCards(crn, undefined, 'failure')
 

--- a/server/utils/resident/riskUtils.ts
+++ b/server/utils/resident/riskUtils.ts
@@ -151,10 +151,22 @@ export const registrationRows = (registrations: Array<Registration>): Array<Tabl
       : ''
     const flagHtml = `<strong>${registration.description}</strong><br>${riskFlagGroup}<br>${dateAdded}`
 
-    const notesHtml =
-      registration.riskNotesDetail.length > 0
-        ? `<p class="govuk-body govuk-body__text-block">${registration.riskNotesDetail[0].note}</p>` // As agreed we need only the first (latest) note to render
-        : '<p class="govuk-body">No information in NDelius</p>'
+    const isOasysImportedFlag = [
+      'risk to staff',
+      'risk to children',
+      'risk to known adult',
+      'risk to prisoner',
+      'risk to public',
+    ].includes(registration.description.toLowerCase())
+
+    let notesHtml = '<p class="govuk-body">No information in NDelius</p>'
+
+    if (registration.riskNotesDetail.length > 0) {
+      const [{ note }] = registration.riskNotesDetail // As agreed we need only the first (latest) note to render
+      notesHtml = isOasysImportedFlag
+        ? detailsBody(`View full OASys notes for ${registration.description.toLowerCase()}`, note)
+        : `<p class="govuk-body govuk-body__text-block">${note}</p>`
+    }
 
     return [{ html: flagHtml, classes: 'govuk-!-width-one-third' }, htmlCell(notesHtml)]
   })


### PR DESCRIPTION
# Context

Jira comment: https://dsdmoj.atlassian.net/browse/FM-372?focusedCommentId=758316

# Changes in this PR

Hide oasys risk flags under details component

## Screenshots of UI changes

<details>
  <summary>Before</summary>
<img width="595" height="847" alt="Screenshot 2026-04-16 at 13 47 10" src="https://github.com/user-attachments/assets/31a60122-bb00-4d0c-a1ad-18853e1d2944" />
</details>

<details>
  <summary>After</summary>
<img width="602" height="186" alt="Screenshot 2026-04-16 at 17 21 10" src="https://github.com/user-attachments/assets/99865d56-d3c3-4dd5-a993-7f52c347f6ba" />
</details>