### PR TITLE
FM-83 Personal contacts - enable in production

### DIFF
--- a/server/utils/resident/contactUtils.test.ts
+++ b/server/utils/resident/contactUtils.test.ts
@@ -27,29 +27,64 @@ describe('contactUtils', () => {
   })
 
   describe('contactCard', () => {
-    it('should render a contact card', () => {
-      const contacts = personalContactFactory.build({
-        mobileNumber: '010101',
-        telephoneNumber: '101010',
-        relationship: 'Relationship',
-        name: { forename: 'Forename', surname: 'Surname' },
-        relationshipType: { code: 'CD', description: 'Type' },
-      })
-      expect(contactCard('title', [contacts])).toEqual({
-        card: {
-          title: textCell('title'),
-        },
-        table: {
-          head: ['Type', 'Description', 'Name', 'Phone number'].map(textCell),
-          rows: [
-            [
-              { text: 'Type', attributes: { 'data-code': 'CD' } },
-              ...['Relationship', 'Forename Surname'].map(textCell),
-              htmlCell('101010<br/>mob: 010101'),
-            ],
+    const getExpected = () => ({
+      card: {
+        title: textCell('title'),
+      },
+      table: {
+        head: ['Type', 'Description', 'Name', 'Phone number'].map(textCell),
+        rows: [
+          [
+            { text: 'Type', attributes: { 'data-code': 'CD' } },
+            ...['Relationship', 'Forename Surname'].map(textCell),
+            htmlCell('101010<br/>010101 (mobile)'),
           ],
-        },
+        ],
+      },
+    })
+
+    const testContact = {
+      mobileNumber: '010101',
+      telephoneNumber: '101010',
+      relationship: 'Relationship',
+      name: { forename: 'Forename', surname: 'Surname' },
+      relationshipType: { code: 'CD', description: 'Type' },
+    }
+
+    it('should render a contact card', () => {
+      const contacts = personalContactFactory.build(testContact)
+      expect(contactCard('title', [contacts])).toEqual(getExpected())
+    })
+
+    it('should only indicate mobile number if there is a landline too', () => {
+      const contacts = personalContactFactory.build({
+        ...testContact,
+        telephoneNumber: undefined,
       })
+      const expected = getExpected()
+      expected.table.rows[0][3] = htmlCell('010101')
+
+      expect(contactCard('title', [contacts])).toEqual(expected)
+    })
+
+    it('should render text in place of missing information', () => {
+      const contacts = personalContactFactory.build({
+        ...testContact,
+        mobileNumber: undefined,
+        telephoneNumber: undefined,
+        relationship: undefined,
+        name: { forename: undefined, surname: undefined },
+      })
+      const emptyText = 'Not entered in NDelius'
+
+      const expected = getExpected()
+      expected.table.rows[0] = [
+        { text: 'Type', attributes: { 'data-code': 'CD' } },
+        ...[emptyText, emptyText].map(textCell),
+        htmlCell(emptyText),
+      ]
+
+      expect(contactCard('title', [contacts])).toEqual(expected)
     })
 
     it('should render an empty card', () => {

--- a/server/utils/resident/contactUtils.ts
+++ b/server/utils/resident/contactUtils.ts
@@ -38,19 +38,20 @@ export const groupContacts = (contacts: Array<PersonalContact>): Record<ContactG
   )
 
 export const contactCard = (title: string, contacts: Array<PersonalContact>): SummaryListWithCard => {
+  const notEnteredText = 'Not entered in NDelius'
   const contactRow = (contact: PersonalContact): TableRow => {
     const {
       name: { forename, surname },
       mobileNumber,
       telephoneNumber,
     } = contact
+    const telephoneHtml = `${telephoneNumber || ''}${mobileNumber ? `${telephoneNumber ? '<br/>' : ''}${mobileNumber}${telephoneNumber ? ' (mobile)' : ''}` : ''}`
+    const nameText = `${forename || ''} ${surname || ''}`.trim()
     return [
       { text: `${contact.relationshipType?.description}`, attributes: { 'data-code': contact.relationshipType?.code } },
-      textCell(contact.relationship),
-      textCell(`${forename} ${surname}`),
-      htmlCell(
-        `${telephoneNumber || ''}${mobileNumber ? `${telephoneNumber ? '<br/>' : ''}mob: ${mobileNumber}` : ''}`,
-      ),
+      textCell(contact.relationship || notEnteredText),
+      textCell(nameText || notEnteredText),
+      htmlCell(telephoneHtml || notEnteredText),
     ]
   }
   return card({

--- a/server/utils/resident/personalUtils.test.ts
+++ b/server/utils/resident/personalUtils.test.ts
@@ -109,7 +109,7 @@ describe('personalUtils', () => {
     })
 
     const caseDetail = caseDetailFactory.build()
-    const nDeliusLink = 'PersonalContacts:View more contact information in NDelius (opens in a new tab).'
+    const nDeliusLink = 'PersonalContacts:View contact information in NDelius (opens in a new tab).'
 
     it('should render the personal contacts cards', () => {
       const result = contactsCardList(caseDetail, 'success', 'crn')

--- a/server/utils/resident/personalUtils.test.ts
+++ b/server/utils/resident/personalUtils.test.ts
@@ -10,7 +10,6 @@ import { getTierOrBlank } from '../applications/helpers'
 import * as utils from './index'
 import * as contactUtils from './contactUtils'
 import { htmlCell } from '../tableUtils'
-import config from '../../config'
 
 describe('personalUtils', () => {
   const placement = cas1SpaceBookingFactory.build()
@@ -135,18 +134,6 @@ describe('personalUtils', () => {
           `inset("<p>We cannot load contacts information right now because NDelius is not available.<br>Try again later</p>${nDeliusLink}")`,
         ),
       ])
-    })
-
-    it('should render original message and link in production', () => {
-      config.isProduction = true
-
-      expect(contactsCardList(caseDetail, 'success', 'crn')).toEqual([
-        {
-          html: `inset("<p>We cannot display personal contacts from NDelius yet. For example, probation practitioner contact details.</p>PersonalContacts:View personal contacts in NDelius (opens in a new tab).")`,
-        },
-      ])
-
-      config.isProduction = false
     })
   })
 })

--- a/server/utils/resident/personalUtils.ts
+++ b/server/utils/resident/personalUtils.ts
@@ -5,7 +5,6 @@ import { PersonStatusTag } from '../people/personStatusTag'
 import { getTierOrBlank } from '../applications/helpers'
 import { ApiOutcome } from '../utils'
 import { contactCard, ContactGroup, groupContacts } from './contactUtils'
-import config from '../../config'
 
 export const personalSideNavigation = (subTab: ResidentProfileSubTab, crn: string, placementId: string) => {
   const basePath = paths.resident.tabPersonal
@@ -64,30 +63,20 @@ export const contactsCardList = (caseDetail: CaseDetail, caseDetailOutcome: ApiO
   }
 
   const groupedContacts = groupContacts(caseDetail?.personalContacts || [])
-  return config.isProduction // TODO: remove once live
-    ? [
-        card({
-          html: insetText(
-            `<p>We cannot display personal contacts from NDelius yet. For example, probation practitioner contact details.</p>${ndeliusDeeplink(
-              { crn, text: 'View personal contacts in NDelius (opens in a new tab).', component: 'PersonalContacts' },
-            )}`,
-          ),
-        }),
-      ]
-    : [
-        card({
-          html: insetText(
-            `<p>${errorMessage || 'Imported from NDelius'}</p>${ndeliusDeeplink({
-              crn,
-              text: 'View more contact information in NDelius (opens in a new tab).',
-              component: 'PersonalContacts',
-            })}`,
-          ),
-        }),
-        ...(!errorMessage
-          ? Object.entries(groupedContacts).map(([group, contacts]) =>
-              contactCard(groupNames[group as ContactGroup], contacts),
-            )
-          : []),
-      ]
+  return [
+    card({
+      html: insetText(
+        `<p>${errorMessage || 'Imported from NDelius'}</p>${ndeliusDeeplink({
+          crn,
+          text: 'View more contact information in NDelius (opens in a new tab).',
+          component: 'PersonalContacts',
+        })}`,
+      ),
+    }),
+    ...(!errorMessage
+      ? Object.entries(groupedContacts).map(([group, contacts]) =>
+          contactCard(groupNames[group as ContactGroup], contacts),
+        )
+      : []),
+  ]
 }

--- a/server/utils/resident/personalUtils.ts
+++ b/server/utils/resident/personalUtils.ts
@@ -68,7 +68,7 @@ export const contactsCardList = (caseDetail: CaseDetail, caseDetailOutcome: ApiO
       html: insetText(
         `<p>${errorMessage || 'Imported from NDelius'}</p>${ndeliusDeeplink({
           crn,
-          text: 'View more contact information in NDelius (opens in a new tab).',
+          text: 'View contact information in NDelius (opens in a new tab).',
           component: 'PersonalContacts',
         })}`,
       ),


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/FM-83
https://dsdmoj.atlassian.net/browse/FM-467
<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Enables personal contacts in production
Also makes a few minor tweaks from FM-467 :

- Show _<number> (mobile)_ rather than `mob: <number>` for mobiles - only if both numbers are given.
- Show 'Not entered in NDelius' where data are missing
- Inset text change remove 'more':  'View more contact...' to 'View contact information on NDelius'.

<!-- [] I have run the E2E tests locally and they passed -->

