### PR TITLE
FM-535 No valid OASys assessment handling

### DIFF
--- a/server/testutils/factories/cas1OASysGroup.ts
+++ b/server/testutils/factories/cas1OASysGroup.ts
@@ -7,8 +7,15 @@ import { oasysGroupMapping, oasysQuestionMappping } from '../../utils/resident/r
 
 class Cas1OASysGroupFactory extends Factory<Cas1OASysGroup> {
   group(group: Cas1OASysGroupName) {
+    const dateCompleted = DateFormats.dateObjToIsoDateTime(faker.date.recent({ days: 5 }))
+    const dateStarted = DateFormats.dateObjToIsoDateTime(faker.date.recent({ days: 5, refDate: dateCompleted }))
     return this.params({
       group,
+      assessmentMetadata: {
+        dateCompleted,
+        dateStarted,
+        hasApplicableAssessment: true,
+      },
       answers: oasysQuestionMappping[group].map(params => ({ ...params, answer: faker.lorem.paragraph() })),
     })
   }

--- a/server/utils/resident/risk.test.ts
+++ b/server/utils/resident/risk.test.ts
@@ -60,6 +60,7 @@ describe('risk tab controller', () => {
             return null
         }
       })
+
       personService.riskProfile.mockResolvedValue(personRisks)
       const result = await riskTabController({ personService, token, crn, caseDetail })
 
@@ -126,11 +127,11 @@ describe('risk tab controller', () => {
         personService.riskProfile.mockResolvedValue(personRisks)
 
         const result = await riskTabController({ personService, token, crn, caseDetail, placement })
-        expect(result.cardList).toHaveLength(8)
+        expect(result.cardList).toHaveLength(6)
         expect(result.cardList[5].html).toMatchStringIgnoringWhitespace(
-          'Nunjucks template components/riskWidgets/rosh-widget/template.njk',
+          '<h3 class="govuk-heading-s">No recent OASys risk assessment available</h3><p>No OASys assessment has been completed in the last 6 months. Check OASys for all assessments.</p>',
         )
-        expect(render).toHaveBeenCalledWith('components/riskWidgets/rosh-widget/template.njk', {
+        expect(render).not.toHaveBeenCalledWith('components/riskWidgets/rosh-widget/template.njk', {
           params: personRisks.roshRisks.value,
         })
       })

--- a/server/utils/resident/risk.ts
+++ b/server/utils/resident/risk.ts
@@ -1,10 +1,8 @@
 import { Cas1OASysGroup, PersonRisks } from '@approved-premises/api'
-import { card, insetText, subHeadingH2, subHeadingH3, TabData } from './index'
-import { DateFormats } from '../dateUtils'
+import { card, insetText, TabData } from './index'
 import { TabControllerParameters } from './TabControllerParameters'
-import { ndeliusRiskCards, riskOasysCards, roshWidget } from './riskUtils'
-import { linkTo, settlePromisesWithOutcomes } from '../utils'
-import paths from '../../paths/manage'
+import { ndeliusRiskCards, riskOasysCards } from './riskUtils'
+import { settlePromisesWithOutcomes } from '../utils'
 
 export const riskTabController = async ({
   personService,
@@ -23,23 +21,23 @@ export const riskTabController = async ({
     personService.getOasysAnswers(token, crn, 'offenceDetails'),
     personService.riskProfile(token, crn),
   ])
-
+  // roshSummary.assessmentMetadata.hasApplicableAssessment = false
   return {
     subHeading: 'Risk information',
     cardList: [
       card({ html: insetText('Imported from NDelius and OASys.') }),
       ...ndeliusRiskCards(crn, caseDetail?.registrations, caseDetailOutcome),
-      card({ html: subHeadingH2('OASys risk assessments') }),
-      roshWidget(personRisks.roshRisks?.status?.toLowerCase() === 'retrieved' && personRisks.roshRisks.value),
-      card({ html: subHeadingH3('Risk assessment') }),
-      card({
-        html: insetText(
-          roshSummary?.assessmentMetadata?.hasApplicableAssessment
-            ? `Assessment completed on ${DateFormats.isoDateToUIDate(roshSummary?.assessmentMetadata?.dateCompleted)}`
-            : `<p class="govuk-!-margin-bottom-2">No OASys risk assessment for person added</p><p>Go to the ${linkTo(paths.resident.tabPlacement.application({ placementId: placement.id, crn }), { text: 'application' })} to view risk information for this person.</p>`,
-        ),
+      ...riskOasysCards({
+        crn,
+        placement,
+        personRisks,
+        roshSummary,
+        roshResult,
+        riskManagementPlan,
+        rmResult,
+        offenceDetails,
+        offenceResult,
       }),
-      ...riskOasysCards({ roshSummary, roshResult, riskManagementPlan, rmResult, offenceDetails, offenceResult }),
     ],
   }
 }

--- a/server/utils/resident/risk.ts
+++ b/server/utils/resident/risk.ts
@@ -21,7 +21,6 @@ export const riskTabController = async ({
     personService.getOasysAnswers(token, crn, 'offenceDetails'),
     personService.riskProfile(token, crn),
   ])
-  // roshSummary.assessmentMetadata.hasApplicableAssessment = false
   return {
     subHeading: 'Risk information',
     cardList: [

--- a/server/utils/resident/riskUtils.ts
+++ b/server/utils/resident/riskUtils.ts
@@ -1,4 +1,12 @@
-import { Cas1OASysGroup, Cas1OASysGroupName, OASysQuestion, Registration, RoshRisks } from '@approved-premises/api'
+import {
+  Cas1OASysGroup,
+  Cas1OASysGroupName,
+  Cas1SpaceBooking,
+  OASysQuestion,
+  PersonRisks,
+  Registration,
+  RoshRisks,
+} from '@approved-premises/api'
 import { SummaryListWithCard, TableRow } from '@approved-premises/ui'
 import nunjucks from 'nunjucks'
 import {
@@ -10,10 +18,11 @@ import {
   ndeliusDeeplink,
   ResidentProfileSubTab,
   subHeadingH2,
+  subHeadingH3,
 } from './index'
 import paths from '../../paths/manage'
 import { DateFormats } from '../dateUtils'
-import { ApiOutcome } from '../utils'
+import { ApiOutcome, linkTo } from '../utils'
 import { htmlCell, textCell } from '../tableUtils'
 import config from '../../config'
 
@@ -163,7 +172,7 @@ export const registrationRows = (registrations: Array<Registration>): Array<Tabl
     let notesHtml = '<p class="govuk-body">No information in NDelius</p>'
 
     if (registration.riskNotesDetail.length > 0) {
-      const [{ note }] = registration.riskNotesDetail // As agreed we need only the first (latest) note to render
+      const [{ note }] = registration.riskNotesDetail // As agreed, we need only the first (latest) note to render
       notesHtml = isOasysImportedFlag
         ? detailsBodyWithPreview(`View full OASys notes for ${registration.description.toLowerCase()}`, note)
         : `<p class="govuk-body govuk-body__text-block">${note}</p>`
@@ -221,6 +230,9 @@ export const ndeliusRiskCards = (
 }
 
 export const riskOasysCards = ({
+  crn,
+  placement,
+  personRisks,
   roshSummary,
   roshResult,
   riskManagementPlan,
@@ -228,6 +240,9 @@ export const riskOasysCards = ({
   offenceDetails,
   offenceResult,
 }: {
+  crn: string
+  placement: Cas1SpaceBooking
+  personRisks: PersonRisks
   roshSummary: Cas1OASysGroup
   roshResult: ApiOutcome
   riskManagementPlan: Cas1OASysGroup
@@ -235,7 +250,25 @@ export const riskOasysCards = ({
   offenceDetails: Cas1OASysGroup
   offenceResult: ApiOutcome
 }): Array<SummaryListWithCard> => {
+  const headingCard = card({ html: subHeadingH2('OASys risk assessments') })
+  if (roshSummary?.assessmentMetadata?.hasApplicableAssessment === false)
+    return [
+      headingCard,
+      card({
+        html: `${subHeadingH3('No recent OASys risk assessment available')}<p>No OASys assessment has been completed in the last 6 months. Check OASys for all assessments.</p>`,
+      }),
+    ]
   return [
+    headingCard,
+    roshWidget(personRisks.roshRisks?.status?.toLowerCase() === 'retrieved' && personRisks.roshRisks.value),
+    card({ html: subHeadingH3('Risk assessment') }),
+    card({
+      html: insetText(
+        roshSummary?.assessmentMetadata?.hasApplicableAssessment
+          ? `Assessment completed on ${DateFormats.isoDateToUIDate(roshSummary?.assessmentMetadata?.dateCompleted)}`
+          : `<p class="govuk-!-margin-bottom-2">No OASys risk assessment for person added</p><p>Go to the ${linkTo(paths.resident.tabPlacement.application({ placementId: placement.id, crn }), { text: 'application' })} to view risk information for this person.</p>`,
+      ),
+    }),
     ...summaryCards(['R10.1', 'R10.2'], roshSummary, roshResult),
     ...summaryCards(['RM30', 'RM31', 'RM32', 'RM34'], riskManagementPlan, rmResult),
     ...summaryCards(['2.4.1', '2.4.2'], offenceDetails, offenceResult),


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/FM-535
<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
This feature is to improve the handling and reporting of missing or outdated OASys assessments on the risk page by removing all the OASys cards and replacing them with some content.

After investigation, it seems that in the case of a missing, or old assessment, the API returns valid structures to all requests and does not 404.
This PR therefore implements a check on the `/cas1/people/{crn}/oasys/answers` endpoint request for the `roshSummary` and checks the value of `assessmentMetadata.hasApplicableAssessment`. If false, the OASys sections are removed and replaced by the new content, otherwise normal handling is carried out.

This treatment is tentative as it's a best guess at what's returned in these circumstances. It needs to be checked in pre-prod for users that lack an up-to-date assessment.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

<details>
  <summary>Error display</summary>
<img width="2560" height="786" alt="image" src="https://github.com/user-attachments/assets/a16e78b9-cb88-4de3-b166-aa944b6b187c" />
</details>

