### PR TITLE
PSS release type removal tidy-up

### DIFF
--- a/integration_tests/tests/match/placementApplications.cy.ts
+++ b/integration_tests/tests/match/placementApplications.cy.ts
@@ -80,7 +80,6 @@ context('Placement Applications', () => {
       const releaseType: ReleaseTypeOption = faker.helpers.arrayElement([
         'licence',
         'hdc',
-        'pss',
         'reReleasedPostRecall',
         'reReleasedFollowingFixedTermRecall',
       ])

--- a/server/form-pages/shared/releaseType.test.ts
+++ b/server/form-pages/shared/releaseType.test.ts
@@ -52,24 +52,7 @@ describe('ReleaseType', () => {
       jest.useRealTimers()
     })
     describe('releaseType', () => {
-      it('if the sentence type is "standardDeterminate" and it is before before 01/05/2026 then all the items should be shown including PSS', () => {
-        jest.useFakeTimers()
-        jest.setSystemTime(new Date('2026-04-30'))
-        releaseType.sentenceType = 'standardDeterminate'
-        expect(releaseType.getReleaseTypes()).toEqual(
-          getExpected([
-            'licence',
-            'rotl',
-            'hdc',
-            'pss',
-            'paroleDirectedLicence',
-            'reReleasedPostRecall',
-            'reReleasedFollowingFixedTermRecall',
-          ]),
-        )
-      })
-
-      it('if the sentence type is "standardDeterminate" and it is after 01/05/2026 then PSS should not be shown', () => {
+      it('if the sentence type is "standardDeterminate" then the full list of release types should be shown', () => {
         jest.useFakeTimers()
         jest.setSystemTime(new Date('2026-05-01'))
         releaseType.sentenceType = 'standardDeterminate'

--- a/server/form-pages/shared/releaseType.ts
+++ b/server/form-pages/shared/releaseType.ts
@@ -10,10 +10,8 @@ import {
   SelectableReleaseTypes,
   SentenceTypeResponse,
   PossibleReleaseTypeOptions,
-  standardDeterminateReleaseTypesWithPss,
 } from '../../utils/applications/releaseTypeUtils'
 import { SessionDataError } from '../../utils/errors'
-import { DateFormats } from '../../utils/dateUtils'
 
 @Page({ name: 'release-type', bodyProperties: ['releaseType'] })
 export default class ReleaseType implements TasklistPage {
@@ -73,8 +71,6 @@ export default class ReleaseType implements TasklistPage {
 
   getReleaseTypes(): PossibleReleaseTypeOptions {
     if (this.sentenceType === 'standardDeterminate') {
-      // TODO: Remove this after 01/05/2026
-      if (DateFormats.dateObjToIsoDate(new Date()) < '2026-05') return standardDeterminateReleaseTypesWithPss
       return standardDeterminateReleaseTypes
     }
     if (this.sentenceType === 'life' || this.sentenceType === 'ipp') {

--- a/server/utils/applications/releaseTypeUtils.ts
+++ b/server/utils/applications/releaseTypeUtils.ts
@@ -26,17 +26,6 @@ export const standardDeterminateReleaseTypes = pick(allReleaseTypes, [
   'reReleasedFollowingFixedTermRecall',
 ])
 
-// TODO: Remove this after 01/05/2026
-export const standardDeterminateReleaseTypesWithPss = pick(allReleaseTypes, [
-  'licence',
-  'hdc',
-  'pss',
-  'rotl',
-  'paroleDirectedLicence',
-  'reReleasedPostRecall',
-  'reReleasedFollowingFixedTermRecall',
-])
-
 export const extendedDeterminateReleaseTypes = pick(allReleaseTypes, [
   'rotl',
   'extendedDeterminateLicence',


### PR DESCRIPTION
# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Clean up of code now that the PSS release type is no longer available for applications or placement applications.
This will also sort out some integration test flakiness.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes
none
