### PR TITLE
Fix integration tests - fixed release date

### DIFF
--- a/integration_tests/tests/assess/assess.cy.ts
+++ b/integration_tests/tests/assess/assess.cy.ts
@@ -27,6 +27,7 @@ import applicationDocument from '../../fixtures/applicationDocument.json'
 import paths from '../../../server/paths/assess'
 import { signIn } from '../signIn'
 import { getResponses } from '../../../server/utils/applications/getResponses'
+import { updateApplicationReleaseDate } from '../../helpers'
 
 context('Assess', () => {
   beforeEach(() => {
@@ -39,9 +40,11 @@ context('Assess', () => {
     cy.fixture('applicationData.json').then(applicationData => {
       cy.fixture('assessmentData.json').then(assessmentData => {
         const clarificationNote = clarificationNoteFactory.build({ response: undefined })
+        const adjustedApplicationData = updateApplicationReleaseDate(applicationData)
+
         const assessment = assessmentFactory.build({
           decision: undefined,
-          application: { data: applicationData, person: personFactory.build(), document: applicationDocument },
+          application: { data: adjustedApplicationData, person: personFactory.build(), document: applicationDocument },
           clarificationNotes: [clarificationNote],
         })
 


### PR DESCRIPTION
# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Fixes failing integration tests.

Some integration tests use a JSON fixture to build an application for the tests. 
This fixture has a hardcoded release date of 14 November 2026 which means that when tests were run after 14 May 2026, the application would fall inside the proper timeframe. As such, the assessment journey is altered and hence, the tests fail.

This PR updates the date loaded from the fixture to 7 months from the current date - as is done elsewhere.
The release date in the fixture has been left unchanged to prove that the mechanism works correctly.

[] I have run the E2E tests locally and they passed
```
Running 15 tests using 2 workers
  15 passed (4.8m)
```

## Screenshots of UI changes
None
