### PR TITLE
FM-635 Use placementRequest AP type in profile, rather than deriving from characteristics.

### DIFF
--- a/server/testutils/factories/cas1SpaceBooking.ts
+++ b/server/testutils/factories/cas1SpaceBooking.ts
@@ -25,6 +25,7 @@ import cas1ChangeRequestSummary from './cas1ChangeRequestSummary'
 import { placementCriteria } from './cas1PlacementRequestDetail'
 import cas1KeyworkerAllocationFactory from './cas1KeyworkerAllocation'
 import { overallStatusTextMap } from '../../utils/placements/status'
+import { apTypes } from '../../utils/placementCriteriaUtils'
 
 class Cas1SpaceBookingFactory extends Factory<Cas1SpaceBooking> {
   upcoming() {
@@ -145,6 +146,7 @@ export default Cas1SpaceBookingFactory.define(({ params }) => {
     cancellation: undefined as Cas1SpaceBookingCancellation,
     allowedActions: [] as Array<Cas1SpaceBookingAction>,
     openChangeRequests: cas1ChangeRequestSummary.buildList(3),
+    placementRequestApType: faker.helpers.arrayElement(apTypes),
     status: faker.helpers.arrayElement(Object.keys(overallStatusTextMap)) as Cas1SpaceBookingStatus,
   }
 })

--- a/server/utils/placements/index.test.ts
+++ b/server/utils/placements/index.test.ts
@@ -524,11 +524,12 @@ describe('placementUtils', () => {
       it('should be returned for a placement in a standard AP', () => {
         const placementStandardAp = cas1SpaceBookingFactory.build({
           characteristics: ['acceptsChildSexOffenders', 'acceptsNonSexualChildOffenders', 'hasEnSuite'],
+          placementRequestApType: 'normal',
         })
 
         expect(requirementsInformation(placementStandardAp)).toEqual({
           rows: [
-            { key: { text: 'AP type' }, value: { text: 'Standard AP' } },
+            { key: { text: 'AP type' }, value: { text: 'Standard (all AP types)' } },
             {
               key: { text: 'AP requirements' },
               value: {
@@ -542,7 +543,8 @@ describe('placementUtils', () => {
 
       it('should be returned for a placement in a specialist AP', () => {
         const placementSpecialistAp = cas1SpaceBookingFactory.build({
-          characteristics: ['isESAP', 'acceptsChildSexOffenders', 'hasEnSuite', 'isWheelchairAccessible'],
+          characteristics: ['acceptsChildSexOffenders', 'hasEnSuite', 'isWheelchairAccessible'],
+          placementRequestApType: 'esap',
         })
 
         expect(requirementsInformation(placementSpecialistAp)).toEqual({
@@ -563,11 +565,12 @@ describe('placementUtils', () => {
       it('should be returned for a placement with no requirements', () => {
         const placementNoRequirements = cas1SpaceBookingFactory.build({
           characteristics: [],
+          placementRequestApType: 'normal',
         })
 
         expect(requirementsInformation(placementNoRequirements)).toEqual({
           rows: [
-            { key: { text: 'AP type' }, value: { text: 'Standard AP' } },
+            { key: { text: 'AP type' }, value: { text: 'Standard (all AP types)' } },
             { key: { text: 'AP requirements' }, value: { html: `<span class="text-grey">None</span>` } },
             { key: { text: 'Room requirements' }, value: { html: `<span class="text-grey">None</span>` } },
           ],

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -4,7 +4,6 @@ import {
   Cas1SpaceBooking,
   Cas1SpaceBookingDates,
   Cas1SpaceBookingSummary,
-  Cas1SpaceCharacteristic,
   Cas1SpaceBookingShortSummary,
 } from '@approved-premises/api'
 import { RadioItem, SummaryList, TabItem, TableCell, TaskData, UserDetails } from '@approved-premises/ui'
@@ -13,18 +12,13 @@ import { personKeyDetails } from '../applications/helpers'
 import paths from '../../paths/manage'
 import { hasPermission } from '../users'
 import { summaryListItem, summaryListItemNoBlankRows } from '../formUtils'
-import {
-  ApTypeCriteria,
-  apTypeCriteriaLabels,
-  SpecialistApTypeCriteria,
-  specialistApTypeCriteria,
-} from '../placementCriteriaUtils'
 import { filterApLevelCriteria, filterRoomLevelCriteria } from '../match/spaceSearch'
 import { characteristicsBulletList, roomCharacteristicMap } from '../characteristicsUtils'
 import { StatusTagOptions } from '../statusTag'
 import { PlacementStatusTag } from './statusTag'
 import { detailedStatus, statusTextMap } from './status'
 import { htmlCell, textCell } from '../tableUtils'
+import { apTypeLongLabels } from '../apTypeLabels'
 
 const changeRequestStatuses: Record<Cas1ChangeRequestType, string> = {
   placementAppeal: 'Appeal requested',
@@ -231,21 +225,14 @@ export const departureInformation = (placement: Cas1SpaceBooking): SummaryList =
   }
 }
 
-export const requirementsInformation = (
-  placement: Cas1SpaceBooking | { characteristics: Array<Cas1SpaceCharacteristic> },
-): SummaryList => {
+export const requirementsInformation = (placement: Cas1SpaceBooking | Cas1SpaceBookingShortSummary): SummaryList => {
   const requirements = placement.characteristics
-  const apType =
-    apTypeCriteriaLabels[
-      (requirements.find(requirement => specialistApTypeCriteria.includes(requirement as SpecialistApTypeCriteria)) ||
-        'normal') as ApTypeCriteria
-    ]
   const apRequirements = filterApLevelCriteria(requirements)
   const roomRequirements = filterRoomLevelCriteria(requirements)
 
   return {
     rows: [
-      summaryListItem('AP type', apType),
+      summaryListItem('AP type', apTypeLongLabels[placement.placementRequestApType]),
       summaryListItem('AP requirements', characteristicsBulletList(apRequirements), 'html'),
       summaryListItem('Room requirements', characteristicsBulletList(roomRequirements), 'html'),
     ],

--- a/server/utils/resident/placement.test.ts
+++ b/server/utils/resident/placement.test.ts
@@ -13,6 +13,7 @@ import { characteristicsBulletList } from '../characteristicsUtils'
 import { placementStatusTag } from '../placements'
 
 import * as placementUtils from './placementUtils'
+import { apTypeLongLabels } from '../apTypeLabels'
 
 const token = 'token'
 const crn = 'X123456'
@@ -75,7 +76,7 @@ describe('tabController', () => {
             rows: expect.arrayContaining([
               {
                 key: { text: 'AP type' },
-                value: { text: 'Standard AP' },
+                value: { text: apTypeLongLabels[placement.placementRequestApType] },
               },
               {
                 key: { text: 'AP requirements' },


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/FM-635
<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Displays the AP type from the placement request on the manage/profile placement tab, rather than derive the ap type from the placement characteristics.  Since AP type characteristics are not populated in the placement, all APs were being shown as 'Standard'.

This impacts two areas:

- The single placement view
- The 'All placements' view

These both use the same code to render the placement details.


<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

<details>
  <summary>Before</summary>
<img width="1305" height="669" alt="image" src="https://github.com/user-attachments/assets/016f4aff-50d8-4b06-aca0-38e87e13199b" />
</details>


<details>
  <summary>After</summary>
<img width="1346" height="717" alt="image" src="https://github.com/user-attachments/assets/b8405a15-6bc6-486e-96ea-8d824cbf14d7" />

<img width="1344" height="689" alt="image" src="https://github.com/user-attachments/assets/68160e58-a609-4856-bb8c-2ccf82a3ded9" />
</details>
