### PR TITLE
FM-506 Set suitability strategy for get oasys calls

### DIFF
--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -227,7 +227,7 @@ export default class ApplyHelper {
 
   private stubOasys404() {
     cy.task('stubOasysMetadata404', { person: this.person, suitabilityStrategy: 'completed_in_last_six_months' })
-    cy.task('stubOasysGroup404', { person: this.person, suitabilityStrategy: 'completed_in_last_six_months' })
+    cy.task('stubOasysGroup404', { person: this.person })
 
     this.roshSummaries = oasysStubs.roshSummary
     this.offenceDetailSummaries = oasysStubs.offenceDetails
@@ -286,7 +286,12 @@ export default class ApplyHelper {
 
     Object.values(oasysSections).forEach((group: Cas1OASysGroup) => {
       const includeOptionalSections = group.group === 'supportingInformation' ? [1, 2, 3, 4] : undefined
-      cy.task('stubOasysGroup', { person: this.person, group, includeOptionalSections })
+      cy.task('stubOasysGroup', {
+        person: this.person,
+        group,
+        suitabilityStrategy: 'completed_in_last_six_months',
+        includeOptionalSections,
+      })
     })
   }
 

--- a/integration_tests/helpers/apply.ts
+++ b/integration_tests/helpers/apply.ts
@@ -226,8 +226,8 @@ export default class ApplyHelper {
   }
 
   private stubOasys404() {
-    cy.task('stubOasysMetadata404', { person: this.person })
-    cy.task('stubOasysGroup404', { person: this.person })
+    cy.task('stubOasysMetadata404', { person: this.person, suitabilityStrategy: 'completed_in_last_six_months' })
+    cy.task('stubOasysGroup404', { person: this.person, suitabilityStrategy: 'completed_in_last_six_months' })
 
     this.roshSummaries = oasysStubs.roshSummary
     this.offenceDetailSummaries = oasysStubs.offenceDetails
@@ -262,7 +262,11 @@ export default class ApplyHelper {
       ? cas1OASysMetadataFactory.build({ supportingInformation })
       : cas1OASysMetadataFactory.oasysNotPresent().build({ supportingInformation })
 
-    cy.task('stubOasysMetadata', { person: this.person, oasysMetadata })
+    cy.task('stubOasysMetadata', {
+      person: this.person,
+      suitabilityStrategy: 'completed_in_last_six_months',
+      oasysMetadata,
+    })
 
     const metadata = { assessmentMetadata: { hasApplicableAssessment } }
 

--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -15,6 +15,7 @@ import type {
   DietAndAllergyResponse,
   Document,
   Licence,
+  Cas1OASysAssessmentSuitabilityStrategyDto,
   Person,
   PersonAcctAlert,
   PersonRisks,
@@ -215,12 +216,13 @@ export default {
 
   stubOasysMetadata: (args: {
     person: Person
+    suitabilityStrategy: Cas1OASysAssessmentSuitabilityStrategyDto
     oasysMetadata: { supportingInformation: Array<Cas1OASysSupportingInformationQuestionMetaData> }
   }) =>
     stubFor({
       request: {
         method: 'GET',
-        url: paths.people.oasys.metadata({ crn: args.person.crn }),
+        url: `${paths.people.oasys.metadata({ crn: args.person.crn })}?${createQueryString({ suitabilityStrategy: args.suitabilityStrategy })}`,
       },
 
       response: {
@@ -230,11 +232,11 @@ export default {
       },
     }),
 
-  stubOasysMetadata404: (args: { person: Person }) =>
+  stubOasysMetadata404: (args: { person: Person; suitabilityStrategy: Cas1OASysAssessmentSuitabilityStrategyDto }) =>
     stubFor({
       request: {
         method: 'GET',
-        url: paths.people.oasys.metadata({ crn: args.person.crn }),
+        url: `${paths.people.oasys.metadata({ crn: args.person.crn })}?${createQueryString({ suitabilityStrategy: args.suitabilityStrategy })}`,
       },
       response: {
         status: 404,

--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -245,11 +245,16 @@ export default {
       },
     }),
 
-  stubOasysGroup: (args: { person: Person; group: Cas1OASysGroup; includeOptionalSections: Array<number> }) =>
+  stubOasysGroup: (args: {
+    person: Person
+    group: Cas1OASysGroup
+    suitabilityStrategy: Cas1OASysAssessmentSuitabilityStrategyDto
+    includeOptionalSections: Array<number>
+  }) =>
     stubFor({
       request: {
         method: 'GET',
-        url: `${paths.people.oasys.answers({ crn: args.person.crn })}?${createQueryString({ group: args.group.group, includeOptionalSections: args.includeOptionalSections })}`,
+        url: `${paths.people.oasys.answers({ crn: args.person.crn })}?${createQueryString({ group: args.group.group, suitabilityStrategy: args.suitabilityStrategy, includeOptionalSections: args.includeOptionalSections })}`,
       },
       response: {
         status: 200,

--- a/integration_tests/tests/manage/placements/residentProfile.cy.ts
+++ b/integration_tests/tests/manage/placements/residentProfile.cy.ts
@@ -96,15 +96,21 @@ context('ResidentProfile', () => {
       const dietAndAllergyResponse = dietAndAllergyResponseFactory.build()
 
       cy.task('stubAcctAlerts', { person: placement.person, acctAlerts })
-      cy.task('stubOasysGroup', { person: placement.person, group: riskToSelf })
+      cy.task('stubOasysGroup', {
+        person: placement.person,
+        suitabilityStrategy: 'allow_all',
+        group: riskToSelf,
+      })
       cy.task('stubOasysGroup', {
         person: placement.person,
         group: oasysSupportingInformation,
+        suitabilityStrategy: 'allow_all',
         includeOptionalSections: [13],
       })
       cy.task('stubOasysGroup', {
         person: placement.person,
         group: oasysSupportingInformation,
+        suitabilityStrategy: 'allow_all',
         includeOptionalSections: [10],
       })
       cy.task('stubBookingDetails', { person: placement.person, bookingDetails })
@@ -202,9 +208,17 @@ context('ResidentProfile', () => {
       const caseDetail = caseDetailFactory.build()
       const { placement, personRisks } = setup()
 
-      cy.task('stubOasysGroup', { person: placement.person, group: oasysOffenceDetails })
-      cy.task('stubOasysGroup', { person: placement.person, group: oasysRoshSummary })
-      cy.task('stubOasysGroup', { person: placement.person, group: oasysRiskManagementPlan })
+      cy.task('stubOasysGroup', {
+        person: placement.person,
+        suitabilityStrategy: 'allow_all',
+        group: oasysOffenceDetails,
+      })
+      cy.task('stubOasysGroup', { person: placement.person, suitabilityStrategy: 'allow_all', group: oasysRoshSummary })
+      cy.task('stubOasysGroup', {
+        person: placement.person,
+        suitabilityStrategy: 'allow_all',
+        group: oasysRiskManagementPlan,
+      })
       cy.task('stubCaseDetail', { person: placement.person, caseDetail })
 
       const page = visitPage({ placement, caseDetail }, 'Risk')
@@ -244,9 +258,17 @@ context('ResidentProfile', () => {
       const caseDetail = caseDetailFactory.build()
       const { placement } = setup()
 
-      cy.task('stubOasysGroup', { person: placement.person, group: oasysOffenceDetails })
-      cy.task('stubOasysGroup', { person: placement.person, group: oasysRoshSummary })
-      cy.task('stubOasysGroup', { person: placement.person, group: oasysRiskManagementPlan })
+      cy.task('stubOasysGroup', {
+        person: placement.person,
+        suitabilityStrategy: 'allow_all',
+        group: oasysOffenceDetails,
+      })
+      cy.task('stubOasysGroup', { person: placement.person, suitabilityStrategy: 'allow_all', group: oasysRoshSummary })
+      cy.task('stubOasysGroup', {
+        person: placement.person,
+        suitabilityStrategy: 'allow_all',
+        group: oasysRiskManagementPlan,
+      })
       cy.task('stubCaseDetail', { person: placement.person, caseDetail })
 
       const page = visitPage({ placement, caseDetail }, 'Risk', ['future_manager', 'experimental'])
@@ -267,7 +289,7 @@ context('ResidentProfile', () => {
       const { person } = placement
 
       cy.task('stubCaseDetail', { person, caseDetail })
-      cy.task('stubOasysGroup', { person, group: oasysOffenceDetails })
+      cy.task('stubOasysGroup', { person, group: oasysOffenceDetails, suitabilityStrategy: 'allow_all' })
       cy.task('stubAdjudications', { person, adjudications })
       cy.task('stubLicence', { person, licence })
       cy.task('stubCsra', { person, csraSummaries })
@@ -308,6 +330,7 @@ context('ResidentProfile', () => {
       cy.task('stubOasysGroup', {
         person: placement.person,
         group: oasysSupportingInformation,
+        suitabilityStrategy: 'allow_all',
         includeOptionalSections: [8, 9],
       })
 

--- a/server/@types/shared/index.d.ts
+++ b/server/@types/shared/index.d.ts
@@ -216,6 +216,7 @@ export type { NewWithdrawal } from './models/NewWithdrawal';
 export type { NonArrivalReason } from './models/NonArrivalReason';
 export type { NoteDetail } from './models/NoteDetail';
 export type { OASysAssessmentState } from './models/OASysAssessmentState';
+export type { Cas1OASysAssessmentSuitabilityStrategyDto } from './models/Cas1OASysAssessmentSuitabilityStrategyDto';
 export type { OASysQuestion } from './models/OASysQuestion';
 export type { OASysSections } from './models/OASysSections';
 export type { OASysSupportingInformationQuestion } from './models/OASysSupportingInformationQuestion';

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -34,6 +34,7 @@ import {
   TransferReason,
   UserQualification,
   LocalAuthorityArea,
+  type Cas1OASysAssessmentSuitabilityStrategyDto,
 } from '@approved-premises/api'
 import type { Request } from 'express'
 import { Session } from 'express-session'
@@ -322,7 +323,11 @@ export type DataServices = Partial<{
     getPrisonCaseNotes: (token: string, crn: string) => Promise<Array<PrisonCaseNote>>
     getAdjudications: (token: string, crn: string) => Promise<Array<Adjudication>>
     getAcctAlerts: (token: string, crn: string) => Promise<Array<PersonAcctAlert>>
-    getOasysMetadata: (token: string, crn: string) => Promise<Cas1OASysMetadata>
+    getOasysMetadata: (
+      token: string,
+      crn: string,
+      suitabilityStrategy: Cas1OASysAssessmentSuitabilityStrategyDto,
+    ) => Promise<Cas1OASysMetadata>
     getOasysAnswers: (
       token: string,
       crn: string,

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -332,6 +332,7 @@ export type DataServices = Partial<{
       token: string,
       crn: string,
       group: Cas1OASysGroupName,
+      suitabilityStrategy: Cas1OASysAssessmentSuitabilityStrategyDto,
       selectedSections?: Array<number>,
     ) => Promise<Cas1OASysGroup>
   }

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -251,6 +251,10 @@ describeCas1NamespaceClient('cas1PersonClient', provider => {
       const optionalSections = [1, 2, 3]
       const group: Cas1OASysGroupName = faker.helpers.arrayElement(['riskToSelf', 'supportingInformation'])
       const oasysGroup = cas1OasysGroupFactory.build()
+      const suitabilityStrategy: Cas1OASysAssessmentSuitabilityStrategyDto = faker.helpers.arrayElement([
+        'allow_all',
+        'completed_in_last_six_months',
+      ])
 
       await provider.addInteraction({
         state: 'Server is healthy',
@@ -261,6 +265,7 @@ describeCas1NamespaceClient('cas1PersonClient', provider => {
           path: paths.people.oasys.answers({ crn }),
           query: {
             group,
+            suitabilityStrategy,
             includeOptionalSections: optionalSections.map(num => num.toString()),
           },
           headers: {
@@ -273,7 +278,7 @@ describeCas1NamespaceClient('cas1PersonClient', provider => {
         },
       })
 
-      const result = await personClient.oasysAnswers(crn, group, optionalSections)
+      const result = await personClient.oasysAnswers(crn, group, suitabilityStrategy, optionalSections)
 
       expect(result).toEqual(oasysGroup)
     })

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -1,7 +1,7 @@
 import { Response } from 'express'
 import { createMock } from '@golevelup/ts-jest'
 
-import { Cas1OASysGroupName } from '@approved-premises/api'
+import { Cas1OASysGroupName, type Cas1OASysAssessmentSuitabilityStrategyDto } from '@approved-premises/api'
 import { faker } from '@faker-js/faker'
 import PersonClient from './personClient'
 import config from '../config'
@@ -216,6 +216,10 @@ describeCas1NamespaceClient('cas1PersonClient', provider => {
   describe('oasysMetadata', () => {
     it('should return the importable sections of OASys', async () => {
       const oasysMetadata = cas1OASysMetadataFactory.build()
+      const suitabilityStrategy: Cas1OASysAssessmentSuitabilityStrategyDto = faker.helpers.arrayElement([
+        'allow_all',
+        'completed_in_last_six_months',
+      ])
 
       await provider.addInteraction({
         state: 'Server is healthy',
@@ -223,6 +227,9 @@ describeCas1NamespaceClient('cas1PersonClient', provider => {
         withRequest: {
           method: 'GET',
           path: paths.people.oasys.metadata({ crn }),
+          query: {
+            suitabilityStrategy,
+          },
           headers: {
             authorization: `Bearer ${token}`,
           },
@@ -233,7 +240,7 @@ describeCas1NamespaceClient('cas1PersonClient', provider => {
         },
       })
 
-      const result = await personClient.oasysMetadata(crn)
+      const result = await personClient.oasysMetadata(crn, suitabilityStrategy)
 
       expect(result).toEqual(oasysMetadata)
     })

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -77,6 +77,7 @@ export default class PersonClient {
   async oasysAnswers(
     crn: string,
     groupName: Cas1OASysGroupName,
+    suitabilityStrategy: Cas1OASysAssessmentSuitabilityStrategyDto,
     optionalSections?: Array<number>,
   ): Promise<Cas1OASysGroup> {
     let response: Cas1OASysGroup
@@ -88,7 +89,11 @@ export default class PersonClient {
         assessmentMetadata: oasysStubs.assessmentMetadata,
       }
     } else {
-      const queryString: string = createQueryString({ group: groupName, includeOptionalSections: optionalSections })
+      const queryString: string = createQueryString({
+        group: groupName,
+        suitabilityStrategy,
+        includeOptionalSections: optionalSections,
+      })
 
       const path = `${paths.people.oasys.answers({ crn })}${queryString ? `?${queryString}` : ''}`
 

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -17,6 +17,7 @@ import type {
   PrisonCaseNote,
   CaseDetail,
   DietAndAllergyResponse,
+  Cas1OASysAssessmentSuitabilityStrategyDto,
 } from '@approved-premises/api'
 
 import RestClient from './restClient'
@@ -63,8 +64,14 @@ export default class PersonClient {
     return this.restClient.get<Array<ActiveOffence>>({ path: paths.people.offences({ crn }) })
   }
 
-  async oasysMetadata(crn: string): Promise<Cas1OASysMetadata> {
-    return this.restClient.get<Cas1OASysMetadata>({ path: paths.people.oasys.metadata({ crn }) })
+  async oasysMetadata(
+    crn: string,
+    suitabilityStrategy: Cas1OASysAssessmentSuitabilityStrategyDto,
+  ): Promise<Cas1OASysMetadata> {
+    const queryString: string = createQueryString({ suitabilityStrategy })
+    const path = `${paths.people.oasys.metadata({ crn })}?${queryString}`
+
+    return this.restClient.get<Cas1OASysMetadata>({ path })
   }
 
   async oasysAnswers(

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/offenceDetails.test.ts
@@ -35,7 +35,13 @@ describe('OffenceDetails', () => {
     it('calls the getOasysSections  method on the client with a token and the persons CRN', async () => {
       await OffenceDetails.initialize({}, application, 'some-token', fromPartial({ personService }))
 
-      expect(getOasysAnswersMock).toHaveBeenCalledWith('some-token', application.person.crn, 'offenceDetails', [])
+      expect(getOasysAnswersMock).toHaveBeenCalledWith(
+        'some-token',
+        application.person.crn,
+        'offenceDetails',
+        'completed_in_last_six_months',
+        [],
+      )
     })
 
     it('adds the offenceDetailsSummaries and personRisks to the page object', async () => {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.test.ts
@@ -64,7 +64,11 @@ describe('OptionalOasysSections', () => {
     it('calls the getOasysSelections method on the client with a token and the persons CRN', async () => {
       callInitialize()
 
-      expect(getOasysMetadataMock).toHaveBeenCalledWith('some-token', application.person.crn)
+      expect(getOasysMetadataMock).toHaveBeenCalledWith(
+        'some-token',
+        application.person.crn,
+        'completed_in_last_six_months',
+      )
     })
 
     it('filters the OASys sections into needs linked to reoffending and other needs not linked to reoffending or harm', async () => {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/optionalOasysSections.ts
@@ -52,7 +52,11 @@ export default class OptionalOasysSections implements TasklistPage {
       const {
         supportingInformation,
         assessmentMetadata: { hasApplicableAssessment },
-      }: Cas1OASysMetadata = await dataServices.personService.getOasysMetadata(token, application.person.crn)
+      }: Cas1OASysMetadata = await dataServices.personService.getOasysMetadata(
+        token,
+        application.person.crn,
+        'completed_in_last_six_months',
+      )
 
       const allNeedsLinkedToReoffending = supportingInformation.filter(
         section => section && section.inclusionOptional && section.oasysAnswerLinkedToReOffending,

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskManagementPlan.test.ts
@@ -33,7 +33,13 @@ describe('RiskManagement', () => {
     it('calls the getOasysSections and getPersonRisks method on the client with a token and the persons CRN', async () => {
       await RiskManagementPlan.initialize({}, application, 'some-token', fromPartial({ personService }))
 
-      expect(getOasysGroupMock).toHaveBeenCalledWith('some-token', application.person.crn, 'riskManagementPlan', [])
+      expect(getOasysGroupMock).toHaveBeenCalledWith(
+        'some-token',
+        application.person.crn,
+        'riskManagementPlan',
+        'completed_in_last_six_months',
+        [],
+      )
     })
 
     it('adds the riskManagementSummaries and personRisks to the page object', async () => {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/riskToSelf.test.ts
@@ -30,7 +30,13 @@ describe('RiskToSelf', () => {
     it('calls the getOasysSections  method on the client with a token and the persons CRN', async () => {
       await RiskToSelf.initialize({}, application, 'some-token', fromPartial({ personService }))
 
-      expect(getOasysGroupMock).toHaveBeenCalledWith('some-token', application.person.crn, 'riskToSelf', [])
+      expect(getOasysGroupMock).toHaveBeenCalledWith(
+        'some-token',
+        application.person.crn,
+        'riskToSelf',
+        'completed_in_last_six_months',
+        [],
+      )
     })
 
     it('adds the riskToSelfSummaries and personRisks to the page object', async () => {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/roshSummary.test.ts
@@ -34,7 +34,13 @@ describe('RoshSummary', () => {
     it('calls the getOasysSections method on the client with a token and the persons CRN', async () => {
       await RoshSummary.initialize({}, application, 'some-token', fromPartial({ personService }))
 
-      expect(getOasysGroupMock).toHaveBeenCalledWith('some-token', application.person.crn, 'roshSummary', [])
+      expect(getOasysGroupMock).toHaveBeenCalledWith(
+        'some-token',
+        application.person.crn,
+        'roshSummary',
+        'completed_in_last_six_months',
+        [],
+      )
     })
 
     it('adds the roshSummary and personRisks to the page object', async () => {

--- a/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.test.ts
+++ b/server/form-pages/apply/risk-and-need-factors/oasys-import/supportingInformation.test.ts
@@ -54,6 +54,7 @@ describe('SupportingInformation', () => {
         'some-token',
         application.person.crn,
         'supportingInformation',
+        'completed_in_last_six_months',
         [1, 2],
       )
     })

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -131,12 +131,12 @@ describe('PersonService', () => {
 
       personClient.oasysMetadata.mockResolvedValue(refOasysMetadata)
 
-      const metadata = await service.getOasysMetadata(token, crn)
+      const metadata = await service.getOasysMetadata(token, crn, 'completed_in_last_six_months')
 
       expect(metadata).toEqual(refOasysMetadata)
 
       expect(personClientFactory).toHaveBeenCalledWith(token)
-      expect(personClient.oasysMetadata).toHaveBeenCalledWith(crn)
+      expect(personClient.oasysMetadata).toHaveBeenCalledWith(crn, 'completed_in_last_six_months')
     })
 
     it('on 404 it throws an OasysNotFoundError', async () => {
@@ -145,7 +145,7 @@ describe('PersonService', () => {
         throw err
       })
 
-      const t = () => service.getOasysMetadata(token, crn)
+      const t = () => service.getOasysMetadata(token, crn, 'completed_in_last_six_months')
 
       await expect(t).rejects.toThrowError(OasysNotFoundError)
       await expect(t).rejects.toThrowError(`Oasys record not found for CRN: crn`)
@@ -158,7 +158,7 @@ describe('PersonService', () => {
       })
 
       try {
-        await service.getOasysMetadata(token, crn)
+        await service.getOasysMetadata(token, crn, 'completed_in_last_six_months')
       } catch (error) {
         expect(error).toEqual(err)
       }
@@ -170,7 +170,9 @@ describe('PersonService', () => {
         throw genericError
       })
 
-      await expect(() => service.getOasysMetadata(token, crn)).rejects.toThrowError(Error)
+      await expect(() => service.getOasysMetadata(token, crn, 'completed_in_last_six_months')).rejects.toThrowError(
+        Error,
+      )
     })
   })
 

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -1,8 +1,9 @@
 import { Response } from 'express'
 import { createMock } from '@golevelup/ts-jest'
-import type { Person } from '@approved-premises/api'
+import type { Cas1OASysAssessmentSuitabilityStrategyDto, Person } from '@approved-premises/api'
 
 import { when } from 'jest-when'
+import { faker } from '@faker-js/faker'
 import { SanitisedError } from '../sanitisedError'
 import PersonService, { OasysNotFoundError } from './personService'
 import PersonClient from '../data/personClient'
@@ -178,16 +179,20 @@ describe('PersonService', () => {
 
   describe('getOasysAnswers', () => {
     const oasysGroup = cas1OasysGroupFactory.build()
+    const suitabilityStrategy: Cas1OASysAssessmentSuitabilityStrategyDto = faker.helpers.arrayElement([
+      'allow_all',
+      'completed_in_last_six_months',
+    ])
 
     it("on success returns the person's OASys answers given their CRN and groupName", async () => {
       personClient.oasysAnswers.mockResolvedValue(oasysGroup)
 
-      const serviceOasysSections = await service.getOasysAnswers(token, crn, oasysGroup.group)
+      const serviceOasysSections = await service.getOasysAnswers(token, crn, oasysGroup.group, suitabilityStrategy)
 
       expect(serviceOasysSections).toEqual(oasysGroup)
 
       expect(personClientFactory).toHaveBeenCalledWith(token)
-      expect(personClient.oasysAnswers).toHaveBeenCalledWith(crn, oasysGroup.group, [])
+      expect(personClient.oasysAnswers).toHaveBeenCalledWith(crn, oasysGroup.group, suitabilityStrategy, [])
     })
 
     it('on 404 it throws an OasysNotFoundError', async () => {
@@ -196,7 +201,7 @@ describe('PersonService', () => {
         throw err
       })
 
-      const t = () => service.getOasysAnswers(token, crn, oasysGroup.group)
+      const t = () => service.getOasysAnswers(token, crn, oasysGroup.group, suitabilityStrategy)
 
       await expect(t).rejects.toThrowError(OasysNotFoundError)
       await expect(t).rejects.toThrowError(`Oasys record not found for CRN: crn`)
@@ -209,7 +214,7 @@ describe('PersonService', () => {
       })
 
       try {
-        await service.getOasysAnswers(token, crn, oasysGroup.group)
+        await service.getOasysAnswers(token, crn, oasysGroup.group, suitabilityStrategy)
       } catch (error) {
         expect(error).toEqual(err)
       }
@@ -221,7 +226,9 @@ describe('PersonService', () => {
         throw genericError
       })
 
-      await expect(() => service.getOasysAnswers(token, crn, oasysGroup.group)).rejects.toThrowError(Error)
+      await expect(() =>
+        service.getOasysAnswers(token, crn, oasysGroup.group, suitabilityStrategy),
+      ).rejects.toThrowError(Error)
     })
   })
 

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -73,11 +73,12 @@ export default class PersonService {
     token: string,
     crn: string,
     group: Cas1OASysGroupName,
+    suitabilityStrategy: Cas1OASysAssessmentSuitabilityStrategyDto,
     selectedSections: Array<number> = [],
   ): Promise<Cas1OASysGroup> {
     const personClient = this.personClientFactory(token)
     try {
-      return await personClient.oasysAnswers(crn, group, selectedSections)
+      return await personClient.oasysAnswers(crn, group, suitabilityStrategy, selectedSections)
     } catch (error) {
       if ((error as HttpError)?.data?.status === 404) {
         throw new OasysNotFoundError(`Oasys record not found for CRN: ${crn}`, { status: 404 })

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -15,6 +15,7 @@ import type {
   PersonRisks,
   PrisonCaseNote,
   CaseDetail,
+  Cas1OASysAssessmentSuitabilityStrategyDto,
 } from '@approved-premises/api'
 import { HttpError } from 'http-errors'
 import type { PersonClient, RestClientBuilder } from '../data'
@@ -51,11 +52,15 @@ export default class PersonService {
     return this.personClientFactory(token).acctAlerts(crn)
   }
 
-  async getOasysMetadata(token: string, crn: string): Promise<Cas1OASysMetadata> {
+  async getOasysMetadata(
+    token: string,
+    crn: string,
+    suitabilityStrategy: Cas1OASysAssessmentSuitabilityStrategyDto = 'completed_in_last_six_months',
+  ): Promise<Cas1OASysMetadata> {
     const personClient = this.personClientFactory(token)
 
     try {
-      return await personClient.oasysMetadata(crn)
+      return await personClient.oasysMetadata(crn, suitabilityStrategy)
     } catch (error) {
       if ((error as HttpError)?.data?.status === 404) {
         throw new OasysNotFoundError(`Oasys record not found for CRN: ${crn}`, { status: 404 })

--- a/server/utils/oasysImportUtils.ts
+++ b/server/utils/oasysImportUtils.ts
@@ -43,6 +43,7 @@ export const getOasysSection = async <T extends OasysPage>(
       token,
       application.person.crn,
       groupName,
+      'completed_in_last_six_months',
       selectedSections,
     )
     const { hasApplicableAssessment } = oasysGroup.assessmentMetadata

--- a/server/utils/resident/drugAndAlcohol.test.ts
+++ b/server/utils/resident/drugAndAlcohol.test.ts
@@ -26,7 +26,13 @@ describe('Drug and Alcohol tab', () => {
 
       expect(result).toEqual({ cardList: mockCardList })
 
-      expect(personService.getOasysAnswers).toHaveBeenCalledWith(token, crn, 'supportingInformation', [8, 9])
+      expect(personService.getOasysAnswers).toHaveBeenCalledWith(
+        token,
+        crn,
+        'supportingInformation',
+        'allow_all',
+        [8, 9],
+      )
       expect(drugAndAlcoholUtils.drugAndAlcoholCards).toHaveBeenCalledWith(supportingInformation, 'success')
     })
   })

--- a/server/utils/resident/drugAndAlcohol.ts
+++ b/server/utils/resident/drugAndAlcohol.ts
@@ -13,7 +13,7 @@ export const drugAndAlcoholTabController = async ({
     values: [supportingInformation],
     outcomes: [supportingInformationResult],
   } = await settlePromisesWithOutcomes<[Cas1OASysGroup]>([
-    personService.getOasysAnswers(token, crn, 'supportingInformation', [8, 9]),
+    personService.getOasysAnswers(token, crn, 'supportingInformation', 'allow_all', [8, 9]),
   ])
   return { cardList: drugAndAlcoholCards(supportingInformation, supportingInformationResult) }
 }

--- a/server/utils/resident/health.test.ts
+++ b/server/utils/resident/health.test.ts
@@ -53,7 +53,7 @@ describe('Health tab', () => {
       const result = await healthTabController({ personService, token, crn, placement })
 
       expect(result).toEqual({ cardList: mockCardList, subHeading: 'Health and disability' })
-      expect(personService.getOasysAnswers).toHaveBeenCalledWith(token, crn, 'supportingInformation', [13])
+      expect(personService.getOasysAnswers).toHaveBeenCalledWith(token, crn, 'supportingInformation', 'allow_all', [13])
       expect(personService.getBookingDetails).toHaveBeenCalledWith(token, crn)
       expect(healthDetailsCards).toHaveBeenCalledWith({
         supportingInformation,
@@ -88,8 +88,8 @@ describe('Health tab', () => {
 
       expect(result).toEqual({ cardList: mockCardList, subHeading: 'Mental health' })
       expect(personService.getAcctAlerts).toHaveBeenCalledWith(token, crn)
-      expect(personService.getOasysAnswers).toHaveBeenCalledWith(token, crn, 'riskToSelf')
-      expect(personService.getOasysAnswers).toHaveBeenCalledWith(token, crn, 'supportingInformation', [10])
+      expect(personService.getOasysAnswers).toHaveBeenCalledWith(token, crn, 'riskToSelf', 'allow_all')
+      expect(personService.getOasysAnswers).toHaveBeenCalledWith(token, crn, 'supportingInformation', 'allow_all', [10])
 
       expect(healthUtils.mentalHealthCards).toHaveBeenCalledWith(successParameters)
     })

--- a/server/utils/resident/health.ts
+++ b/server/utils/resident/health.ts
@@ -15,7 +15,7 @@ export const healthTabController = async ({
     outcomes: [supportingInformationOutcome, bookingDetailsOutcome, dietAndAllergyOutcome],
   }: { values: [Cas1OASysGroup, BookingDetails, DietAndAllergyResponse]; outcomes: Array<ApiOutcome> } =
     await settlePromisesWithOutcomes([
-      personService.getOasysAnswers(token, crn, 'supportingInformation', [13]),
+      personService.getOasysAnswers(token, crn, 'supportingInformation', 'allow_all', [13]),
       personService.getBookingDetails(token, crn),
       personService.getDietAndAllergyDetails(token, crn),
     ])
@@ -45,8 +45,8 @@ export const mentalHealthTabController = async ({
   }: { values: [Array<PersonAcctAlert>, Cas1OASysGroup, Cas1OASysGroup]; outcomes: Array<ApiOutcome> } =
     await settlePromisesWithOutcomes([
       personService.getAcctAlerts(token, crn),
-      personService.getOasysAnswers(token, crn, 'riskToSelf'),
-      personService.getOasysAnswers(token, crn, 'supportingInformation', [10]),
+      personService.getOasysAnswers(token, crn, 'riskToSelf', 'allow_all'),
+      personService.getOasysAnswers(token, crn, 'supportingInformation', 'allow_all', [10]),
     ])
   return {
     subHeading: 'Mental health',

--- a/server/utils/resident/risk.ts
+++ b/server/utils/resident/risk.ts
@@ -21,9 +21,9 @@ export const riskTabController = async ({
     values: [roshSummary, riskManagementPlan, offenceDetails, personRisks],
     outcomes: [roshResult, rmResult, offenceResult],
   } = await settlePromisesWithOutcomes<[Cas1OASysGroup, Cas1OASysGroup, Cas1OASysGroup, PersonRisks]>([
-    personService.getOasysAnswers(token, crn, 'roshSummary'),
-    personService.getOasysAnswers(token, crn, 'riskManagementPlan'),
-    personService.getOasysAnswers(token, crn, 'offenceDetails'),
+    personService.getOasysAnswers(token, crn, 'roshSummary', 'allow_all'),
+    personService.getOasysAnswers(token, crn, 'riskManagementPlan', 'allow_all'),
+    personService.getOasysAnswers(token, crn, 'offenceDetails', 'allow_all'),
     personService.riskProfile(token, crn),
   ])
   return {

--- a/server/utils/resident/sentence.test.ts
+++ b/server/utils/resident/sentence.test.ts
@@ -53,7 +53,7 @@ describe('sentenceTabController', () => {
         ],
       })
 
-      expect(personService.getOasysAnswers).toHaveBeenCalledWith(token, crn, 'offenceDetails')
+      expect(personService.getOasysAnswers).toHaveBeenCalledWith(token, crn, 'offenceDetails', 'allow_all')
     })
 
     it('should render the sentenceOffencesTab card list if there is no oasys record and no offences', async () => {
@@ -78,7 +78,7 @@ describe('sentenceTabController', () => {
         ],
       })
 
-      expect(personService.getOasysAnswers).toHaveBeenCalledWith(token, crn, 'offenceDetails')
+      expect(personService.getOasysAnswers).toHaveBeenCalledWith(token, crn, 'offenceDetails', 'allow_all')
     })
   })
 

--- a/server/utils/resident/sentence.ts
+++ b/server/utils/resident/sentence.ts
@@ -14,7 +14,9 @@ export const sentenceOffencesTabController = async ({
   const {
     outcomes: [oasysOutcome],
     values: [oasysAnswers],
-  } = await settlePromisesWithOutcomes<[Cas1OASysGroup]>([personService.getOasysAnswers(token, crn, 'offenceDetails')])
+  } = await settlePromisesWithOutcomes<[Cas1OASysGroup]>([
+    personService.getOasysAnswers(token, crn, 'offenceDetails', 'allow_all'),
+  ])
   return {
     subHeading: 'Offence and sentence',
     cardList: offencesTabCards({ caseDetail, caseDetailOutcome, oasysAnswers, oasysOutcome }),


### PR DESCRIPTION
For calls to oasys metadata & answers in `apply`, use the `completed_in_last_six_months` strategy.

For calls to oasys answers in `residents profile`, use the `allow_all` strategy.