### PR TITLE
FM-724 Add error handling for submit placement application

### DIFF
--- a/server/controllers/match/placementRequestsController.test.ts
+++ b/server/controllers/match/placementRequestsController.test.ts
@@ -14,6 +14,7 @@ import paths from '../../paths/placementApplications'
 
 import { getResponses } from '../../utils/applications/getResponses'
 import { placementRequestKeyDetails } from '../../utils/placementRequests/utils'
+import * as validationUtils from '../../utils/validation'
 
 jest.mock('../../utils/applications/utils')
 jest.mock('../../utils/applications/getResponses')
@@ -132,6 +133,37 @@ describe('PlacementRequestsController', () => {
             text: 'You must confirm that the information you have provided is correct',
           },
         })
+      })
+    })
+
+    describe('when confirmation is "1" and API errors', () => {
+      beforeEach(() => {
+        jest.spyOn(validationUtils, 'catchValidationErrorOrPropogate').mockReturnValue()
+      })
+
+      it('redirects to the show answers screen', async () => {
+        const placementApplication = placementApplicationFactory.build()
+
+        const apiError = new Error()
+        placementApplicationService.submit.mockRejectedValue(apiError)
+
+        const indexRequest = { ...request, body: { confirmation: '1' }, params: { id: placementApplication.id } }
+
+        await placementRequestsController.submit()(indexRequest, response, next)
+
+        const { id } = placementApplication
+        const expectedRedirect = paths.placementApplications.pages.show({
+          id,
+          task: 'request-a-placement',
+          page: 'check-your-answers',
+        })
+
+        expect(validationUtils.catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+          indexRequest,
+          response,
+          apiError,
+          expectedRedirect,
+        )
       })
     })
   })

--- a/server/controllers/match/placementRequestsController.ts
+++ b/server/controllers/match/placementRequestsController.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, TypedRequestHandler } from 'express'
 import { ApplicationService, PlacementApplicationService, PlacementRequestService } from '../../services'
 import paths from '../../paths/placementApplications'
-import { addErrorMessageToFlash } from '../../utils/validation'
+import { addErrorMessageToFlash, catchValidationErrorOrPropogate } from '../../utils/validation'
 import { getResponses } from '../../utils/applications/getResponses'
 import { placementRequestKeyDetails } from '../../utils/placementRequests/utils'
 
@@ -64,11 +64,20 @@ export default class PlacementRequestsController {
         req.user.token,
         placementApplication.applicationId,
       )
-      await this.placementApplicationService.submit(req.user.token, placementApplication, application)
+      try {
+        await this.placementApplicationService.submit(req.user.token, placementApplication, application)
 
-      return res.render('placement-applications/confirm', {
-        pageHeading: 'Request for placement confirmed',
-      })
+        return res.render('placement-applications/confirm', {
+          pageHeading: 'Request for placement confirmed',
+        })
+      } catch (error) {
+        return catchValidationErrorOrPropogate(
+          req,
+          res,
+          error,
+          paths.placementApplications.pages.show({ id, task: 'request-a-placement', page: 'check-your-answers' }),
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
The API is currently returning some specific ‘generic’ errors, although typically the UI stops these from ever happening (e.g. creating a placement application against an expired application, creating a placement application with no placement dates). If these occur the user will see a generic error page.

We have a requirement to add some validation in the API to catch a specific edge case (0 day placements) to minimise change required in the UI. This commit adds an error handler so we can present errors returned by the API to the user, instead of showing a generic error page.

The screenshot below shows a test message being rendered

<img width="1175" height="918" alt="Screenshot 2026-06-10 at 10 37 13" src="https://github.com/user-attachments/assets/4e42b5bc-9ae7-44b4-b651-e2a5620f9340" />
