### PR TITLE
Text Updates regarding OASys 6 Month Limit change

### DIFF
--- a/server/utils/resident/risk.test.ts
+++ b/server/utils/resident/risk.test.ts
@@ -132,7 +132,7 @@ describe('risks', () => {
           const result = await riskTabController({ personService, token, crn, caseDetail, placement })
           expect(result.cardList).toHaveLength(6)
           expect(result.cardList[5].html).toMatchStringIgnoringWhitespace(
-            '<h3 class="govuk-heading-s">No recent OASys risk assessment available</h3><p>No OASys assessment has been completed in the last 6 months. Check OASys for all assessments.</p>',
+            '<h3 class="govuk-heading-s">No OASys risk assessment available</h3><p>No completed assessment available in OASys</p>',
           )
           expect(render).not.toHaveBeenCalledWith('components/riskWidgets/rosh-widget/template.njk', {
             params: personRisks.roshRisks.value,

--- a/server/utils/resident/riskUtils.ts
+++ b/server/utils/resident/riskUtils.ts
@@ -267,7 +267,7 @@ export const riskOasysCards = ({
     return [
       headingCard,
       card({
-        html: `${subHeadingH3('No recent OASys risk assessment available')}<p>No OASys assessment has been completed in the last 6 months. Check OASys for all assessments.</p>`,
+        html: `${subHeadingH3('No OASys risk assessment available')}<p>No completed assessment available in OASys</p>`,
       }),
     ]
   return [

--- a/server/views/static/whatsNew.njk
+++ b/server/views/static/whatsNew.njk
@@ -17,6 +17,14 @@
 
     <p>See the latest releases and updates for the Manage Approved Premises residents service.</p>
 
+    <h2 class="govuk-heading-m">June 2026</h2>
+
+    <h3 class="govuk-heading-s">All latest OASys assessments will now show on the profile.</h3>
+
+    <p>Previously OASys assessments older than 6 months would not appear on the profile.</p>
+
+    <p>Now, the most recent OASys assessment will show in the profile regardless of how old it is, alongside the date of that assessment.</p>
+
     <h2 class="govuk-heading-m">February 2026</h2>
 
     <h3 class="govuk-heading-s">We released read-only resident profiles</h3>


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/FM-729 

# Changes in this PR

### MAPR Profile wording has been changed from:

"No recent OASys risk assessment available

No OASys assessment has been completed in the last 6 months. Check OASys for all assessments."

### To:

"No OASys risk assessment available

No completed assessment available in OASys"

### Whats New Page has also been updated to show the new update

# Screenshots of UI changes

<Details> 
<summary>Before</summary>

<img width="1195" height="524" alt="Screenshot 2026-06-15 at 16 18 56" src="https://github.com/user-attachments/assets/e638061f-a38f-412f-9c2b-b9a17b8f17a5" />

<img width="980" height="655" alt="Screenshot 2026-06-15 at 16 18 37" src="https://github.com/user-attachments/assets/7d9fa9cd-e1ea-4cca-abb2-77528a802fc9" />


</Details>

<Details> 
<summary>After</summary>

<img width="914" height="509" alt="Screenshot 2026-06-15 at 16 05 59" src="https://github.com/user-attachments/assets/17fd227d-4205-476e-b546-f799977ecaf1" />

<img width="1031" height="808" alt="Screenshot 2026-06-15 at 16 06 15" src="https://github.com/user-attachments/assets/b267c517-4d16-427b-9b64-0c350d7895a2" />

</Details>