### PR TITLE
Update ‘whats new’ version to ensure it’s shown

### DIFF
--- a/server/controllers/staticController.ts
+++ b/server/controllers/staticController.ts
@@ -1,6 +1,6 @@
 import { Request, RequestHandler, Response } from 'express'
 
-export const TECHNICAL_BANNER_VERSION = '12-2-2026'
+export const TECHNICAL_BANNER_VERSION = '16-6-2026'
 export const TECHNICAL_BANNER_COOKIE_NAME = 'technical-updates-banner'
 
 export default class StaticController {

--- a/server/views/static/whatsNew.njk
+++ b/server/views/static/whatsNew.njk
@@ -12,6 +12,13 @@
     }) }}
 {% endblock %}
 
+{#
+
+When updating this page, you should also update the TECHNICAL_BANNER_VERSION version in staticController.ts
+This will ensure that the 'whats new' banner will appear to users who have viewed previous versions of this page
+
+#}
+
 {% block content %}
     <h1 class="govuk-heading-l">What's new</h1>
 


### PR DESCRIPTION
A previous commit updating the ‘wahtsNew’ page content but we did not update the `TECHNICAL_BANNER_VERSION`. This commit makes that change.
