### PR TITLE
FM-829 Post application document at every update

### DIFF
--- a/integration_tests/fixtures/applicationDocument.json
+++ b/integration_tests/fixtures/applicationDocument.json
@@ -3,27 +3,27 @@
     {
       "If you need to update your details, select the relevant box below": "Phone number, Email address, Name, Area",
       "Applicant name": "Bob Smith",
-      "Applicant email address": "bob@test.com",
+      "Applicant email address": "bob@test.gov.uk",
       "Applicant phone number": "01234567890",
       "Applicant AP area": "Greater Manchester",
       "Do you have case management responsibility?": "No"
     },
     {
       "Case manager name": "Bob Smith",
-      "Case manager email": "bob@test.com",
+      "Case manager email": "bob@test.gov.uk",
       "Case manager phone number": "01234567890"
     },
     {
       "Is the person transgender or do they have a transgender history?": "Yes"
     },
     {
-      "Does the person's gender identity require a complex case board to review their application?": "Yes"
+      "What type of AP does the person need?": "Men's AP"
+    },
+    {
+      "Does this person require a complex case board?": "Yes"
     },
     {
       "Has the Complex Case Board taken place?": "Yes"
-    },
-    {
-      "What type of AP has the complex case board agreed to?": "Men's AP"
     },
     {
       "Parole eligibility date": "Thu 14 Nov 2024",
@@ -53,13 +53,21 @@
   ],
   "type-of-ap": [
     {
-      "Which type of AP does the person require?": "Recovery Focused AP (RFAP)"
+      "Which type of AP does the person require?": "Psychologically Informed Planned Environment (PIPE)"
+    },
+    {
+      "Has the person been screened into the Offender Personality Disorder Pathway (OPD)?": "Yes",
+      "When was the person's last consultation or formulation?": "Mon 9 Sep 2024"
+    },
+    {
+      "Has an application for PIPE placement been recommended in the OPD pathway plan?": "Yes",
+      "Provide any additional detail about why the person needs a PIPE placement.": "Details"
     }
   ],
   "oasys-import": [
     {
-      "Needs linked to reoffending": "1. Accommodation, 2. Relationships",
-      "Needs not linked to risk of serious harm or reoffending": "3. Emotional, 4. Thinking"
+      "Needs linked to reoffending": "1. , 2. ",
+      "Needs not linked to risk of serious harm or reoffending": "3. , 4. "
     },
     {
       "Q1: The first RoSH question": "Some answer for the first RoSH question. With an extra comment Q1",
@@ -93,10 +101,9 @@
       "Provide details of any additional measures that will be necessary for the management of risk": "deleniti enim necessitatibus"
     },
     {
-      "Has the person ever been convicted of any arson offences, sexual offences, hate crimes or non-sexual offences against children?": "Yes"
+      "Has the person ever been convicted of any sexual offences, hate crimes or non-sexual offences against children?": "Yes"
     },
     {
-      "Is the arson offence current or previous?": "Current",
       "Is the hate crime current or previous?": "Previous",
       "Is the non sexual offences against children current or previous?": "Current and previous",
       "Is the contact sexual offences against adults current or previous?": "Current and previous",
@@ -176,7 +183,7 @@
       "What is the preferred postcode area for the Approved Premises (AP) placement?": "SW11",
       "Give details of why this postcode area would benefit the person": "Some positive factors",
       "Are there any restrictions linked to placement location?": "Yes",
-      "Provide details of any restraining orders, exclusion zones or other location based licence conditions. You must also provide an exclusion zone map in the ‘attach required documents’ screen.": "Restrictions go here",
+      "Upload any exclusion zone maps to NDelius. You cannot upload these to the service.": "Restrictions go here",
       "If an AP Placement is not available in the persons preferred area, would a placement further away be considered?": "Yes",
       "Choose the maximum radius (in miles)": "70 miles"
     },
@@ -201,11 +208,15 @@
       "Does the person require the use of a wheelchair?": "Yes",
       "Does the person have any known health conditions?": "Yes - Some detail",
       "Does the person have any prescribed medication?": "Yes - Some detail",
-      "Is the person pregnant?": "Yes",
+      "Is the person pregnant?": "Yes"
+    },
+    {
       "What is their expected date of delivery?": "Sun 31 Dec 2023",
-      "Will the child be removed from the person's care at birth?": "Decision pending",
       "Is there social care involvement?": "Yes - Some detail",
-      "Are there any pregnancy related issues relevant to placement?": "Yes - some considerations",
+      "Will the child be removed from the person's care at birth?": "Decision pending",
+      "Are there any pregnancy related issues relevant to placement?": "Yes - some considerations"
+    },
+    {
       "Specify any additional details and adjustments required for the person's mobility, learning disability, neurodivergent conditions or pregnancy needs": "Some detail"
     },
     {
@@ -227,14 +238,6 @@
     },
     {
       "Has the person stayed or been offered a placement in an AP before?": "Yes - Some details here"
-    },
-    {
-      "Does this person need a RFAP?": "Yes"
-    },
-    {
-      "How has the person demonstrated their motivation to address their substance misuse?": "Some motivation",
-      "Is this person receiving clinical, medical and/or psychosocial treatment for their substance misuse?": "Yes - Some details here",
-      "How is the person planning to continue their recovery work whilst in the AP?": "Some work"
     },
     {
       "Can the person be placed in a self-catered Approved Premises (AP)?": "No - Some details here"

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -41,6 +41,7 @@ context('Apply', () => {
 
       expect(body).to.have.keys(
         'data',
+        'document',
         'arrivalDate',
         'duration',
         'apType',
@@ -330,6 +331,7 @@ context('Apply', () => {
         'arrivalDate',
         'duration',
         'data',
+        'document',
         'apType',
         'isWomensApplication',
         'targetLocation',

--- a/integration_tests/tests/apply/invalidations.cy.ts
+++ b/integration_tests/tests/apply/invalidations.cy.ts
@@ -38,6 +38,7 @@ context('Apply', () => {
       const body = JSON.parse(requests[0].body)
       expect(body).to.have.keys(
         'data',
+        'document',
         'arrivalDate',
         'duration',
         'apType',
@@ -82,6 +83,7 @@ context('Apply', () => {
 
       expect(body).to.have.keys(
         'data',
+        'document',
         'arrivalDate',
         'duration',
         'apType',

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,5 +1,5 @@
 import type { ErrorMessages } from '@approved-premises/ui'
-import type { ApprovedPremisesApplication, PlacementApplicationDecisionEnvelope } from '@approved-premises/api'
+import type { Cas1Application, PlacementApplicationDecisionEnvelope } from '@approved-premises/api'
 
 export default {}
 
@@ -8,7 +8,7 @@ declare module 'express-session' {
   interface SessionData {
     returnTo: string
     nowInMinutes: number
-    application: ApprovedPremisesApplication
+    application: Cas1Application
     user: UserDetails
     placementApplicationDecisions: Record<string, Partial<PlacementApplicationDecisionEnvelope>>
     messages: Array<string>

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -35,6 +35,7 @@ import {
   UserQualification,
   LocalAuthorityArea,
   type Cas1OASysAssessmentSuitabilityStrategyDto,
+  Cas1Application,
 } from '@approved-premises/api'
 import type { Request } from 'express'
 import { Session } from 'express-session'
@@ -338,7 +339,7 @@ export type DataServices = Partial<{
   }
   applicationService: {
     getDocuments: (token: string, application: Cas1Application) => Promise<Array<Document>>
-    findApplication: (token: string, id: string) => Promise<ApprovedPremisesApplication>
+    findApplication: (token: string, id: string) => Promise<Cas1Application>
   }
   userService: {
     getUserById: (token: string, id: string) => Promise<User>

--- a/server/controllers/manage/placementController.ts
+++ b/server/controllers/manage/placementController.ts
@@ -1,5 +1,5 @@
 import type { Request, RequestHandler, Response } from 'express'
-import { ApprovedPremisesApplication, Cas1Assessment, Cas1TimelineEvent } from '@approved-premises/api'
+import { Cas1Application, Cas1Assessment, Cas1TimelineEvent } from '@approved-premises/api'
 import { SummaryListItem } from '@approved-premises/ui'
 import {
   ApplicationService,
@@ -47,7 +47,7 @@ export default class PlacementController {
       const { arrivalDate, departureDate } = canonicalDates(placement)
       const pageHeading = `${DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' })} to ${DateFormats.isoDateToUIDate(departureDate, { format: 'short' })}`
       let timelineEvents: Array<Cas1TimelineEvent> = []
-      let application: ApprovedPremisesApplication = null
+      let application: Cas1Application = null
       let assessment: Cas1Assessment = null
       let placementRequestSummaryRows: Array<SummaryListItem> = null
 

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -1,6 +1,6 @@
 import type {
   ActiveOffence,
-  ApprovedPremisesApplication as Application,
+  Cas1Application as Application,
   ApplicationSortField,
   ApplicationTimelineNote,
   Cas1ApplicationSummary,

--- a/server/form-pages/apply/move-on/placementDuration.test.ts
+++ b/server/form-pages/apply/move-on/placementDuration.test.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesApplication } from '@approved-premises/api'
+import { Cas1Application } from '@approved-premises/api'
 import { addDays } from 'date-fns'
 import { getDefaultPlacementDurationInDays } from '../../../utils/applications/getDefaultPlacementDurationInDays'
 
@@ -13,7 +13,7 @@ jest.mock('../../../utils/applications/getDefaultPlacementDurationInDays')
 jest.mock('../../../utils/applications/arrivalDateFromApplication')
 
 describe('PlacementDuration', () => {
-  let application: ApprovedPremisesApplication
+  let application: Cas1Application
 
   beforeEach(() => {
     application = applicationFactory
@@ -78,7 +78,7 @@ describe('PlacementDuration', () => {
         task: 'basic-information',
         page: 'placement-date',
         keyValuePairs: { startDateSameAsReleaseDate: 'no', startDate: '2022-11-11' },
-      }) as ApprovedPremisesApplication
+      })
     })
 
     it('next', () => {

--- a/server/form-pages/apply/move-on/placementDuration.ts
+++ b/server/form-pages/apply/move-on/placementDuration.ts
@@ -1,6 +1,6 @@
 import { addDays, weeksToDays } from 'date-fns'
 import type { PageResponse, TaskListErrors, YesOrNo } from '@approved-premises/ui'
-import { ApprovedPremisesApplication } from '@approved-premises/api'
+import { Cas1Application } from '@approved-premises/api'
 import { DateFormats, weeksAndDaysToDays } from '../../../utils/dateUtils'
 import { Page } from '../../utils/decorators'
 
@@ -37,7 +37,7 @@ export default class PlacementDuration implements TasklistPage {
 
   constructor(
     public body: Partial<PlacementDurationBody>,
-    private readonly application: ApprovedPremisesApplication,
+    private readonly application: Cas1Application,
   ) {
     this.body.duration = this.lengthInDays()
     this.initializeDates()

--- a/server/form-pages/placement-application/request-a-placement/additionalDocuments.ts
+++ b/server/form-pages/placement-application/request-a-placement/additionalDocuments.ts
@@ -1,8 +1,4 @@
-import type {
-  Cas1Application,
-  Document,
-  PlacementApplication,
-} from '@approved-premises/api'
+import type { Cas1Application, Document, PlacementApplication } from '@approved-premises/api'
 import { DataServices, TaskListErrors } from '@approved-premises/ui'
 import { Page } from '../../utils/decorators'
 

--- a/server/form-pages/placement-application/request-a-placement/additionalDocuments.ts
+++ b/server/form-pages/placement-application/request-a-placement/additionalDocuments.ts
@@ -1,4 +1,8 @@
-import type { ApprovedPremisesApplication, Document, PlacementApplication } from '@approved-premises/api'
+import type {
+  Cas1Application,
+  Document,
+  PlacementApplication,
+} from '@approved-premises/api'
 import { DataServices, TaskListErrors } from '@approved-premises/ui'
 import { Page } from '../../utils/decorators'
 
@@ -26,7 +30,7 @@ export default class AdditionalDocuments implements TasklistPage {
 
   documents: Array<Document> | undefined
 
-  application: ApprovedPremisesApplication
+  application: Cas1Application
 
   constructor(
     public body: AdditionalDocumentsBody,

--- a/server/form-pages/placement-application/request-a-placement/checkYourAnswers.ts
+++ b/server/form-pages/placement-application/request-a-placement/checkYourAnswers.ts
@@ -2,7 +2,7 @@ import type { DataServices, TaskListErrors } from '@approved-premises/ui'
 import { Page } from '../../utils/decorators'
 
 import TasklistPage from '../../tasklistPage'
-import { ApprovedPremisesApplication as Application, PlacementApplication } from '../../../@types/shared'
+import { Cas1Application as Application, PlacementApplication } from '../../../@types/shared'
 
 type Body = { reviewed?: string }
 

--- a/server/form-pages/placement-application/request-a-placement/sentenceTypeCheck.ts
+++ b/server/form-pages/placement-application/request-a-placement/sentenceTypeCheck.ts
@@ -1,5 +1,10 @@
 import { DataServices, SummaryListItem, TaskListErrors, YesOrNo } from '@approved-premises/ui'
-import type { PlacementApplication, ReleaseTypeOption, SentenceTypeOption } from '@approved-premises/api'
+import type {
+  ApprovedPremisesApplication,
+  PlacementApplication,
+  ReleaseTypeOption,
+  SentenceTypeOption,
+} from '@approved-premises/api'
 
 import TasklistPage from '../../tasklistPage'
 import { Page } from '../../utils/decorators'
@@ -50,8 +55,8 @@ export default class SentenceTypeCheck implements TasklistPage {
         token,
         placementApplication.applicationId,
       )
-      page.applicationReleaseType = application.releaseType
-      page.applicationSentenceType = application.sentenceType
+      page.applicationReleaseType = (application as ApprovedPremisesApplication).releaseType
+      page.applicationSentenceType = (application as ApprovedPremisesApplication).sentenceType
     }
 
     page.summaryRows = [

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -9,6 +9,7 @@ import type {
   WithdrawalReason,
 } from '@approved-premises/api'
 
+import { getResponses } from '../utils/applications/getResponses'
 import { updateFormArtifactData } from '../form-pages/utils/updateFormArtifactData'
 import type TasklistPage from '../form-pages/tasklistPage'
 import { TasklistPageInterface } from '../form-pages/tasklistPage'
@@ -45,12 +46,15 @@ Apply.pages['basic-information'] = {
   second: SecondPage,
 }
 
+Apply.sections = []
+
 jest.mock('../data/applicationClient.ts')
 jest.mock('../data/personClient.ts')
 jest.mock('../utils/applications/utils')
 jest.mock('../form-pages/utils/updateFormArtifactData')
 jest.mock('../form-pages/utils')
 jest.mock('../utils/applications/getApplicationData')
+jest.mock('../utils/applications/getResponses')
 
 describe('ApplicationService', () => {
   const token = 'some-token'
@@ -295,6 +299,7 @@ describe('ApplicationService', () => {
       beforeEach(() => {
         ;(updateFormArtifactData as jest.Mock).mockReturnValue(application)
         ;(getApplicationUpdateData as jest.Mock).mockReturnValue(applicationData)
+        ;(getResponses as jest.Mock).mockReturnValue([])
 
         page = createMock<TasklistPage>({
           errors: () => {
@@ -317,6 +322,7 @@ describe('ApplicationService', () => {
 
         expect(applicationClientFactory).toHaveBeenCalledWith(token)
         expect(applicationClient.update).toHaveBeenCalledWith(application.id, applicationData)
+        expect(getResponses).toHaveBeenCalledWith(application)
       })
     })
 

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -122,7 +122,7 @@ export default class ApplicationService {
     } else {
       const application = await this.findApplication(request.user.token, request.params.id)
       const updatedApplication = updateFormArtifactData(page, application, Review)
-      console.log('*** application',application)
+
       application.document = getResponses(application)
 
       const client = this.applicationClientFactory(request.user.token)

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -7,7 +7,7 @@ import type {
 } from '@approved-premises/ui'
 import type {
   ActiveOffence,
-  ApprovedPremisesApplication as Application,
+  Cas1Application as Application,
   ApplicationSortField,
   ApplicationTimelineNote,
   Document,
@@ -25,6 +25,7 @@ import { ValidationError } from '../utils/errors'
 
 import { getBody } from '../form-pages/utils'
 import Review from '../form-pages/apply/check-your-answers/review'
+import { getResponses } from '../utils/applications/getResponses'
 
 export default class ApplicationService {
   constructor(private readonly applicationClientFactory: RestClientBuilder<ApplicationClient>) {}
@@ -121,6 +122,8 @@ export default class ApplicationService {
     } else {
       const application = await this.findApplication(request.user.token, request.params.id)
       const updatedApplication = updateFormArtifactData(page, application, Review)
+      console.log('*** application',application)
+      application.document = getResponses(application)
 
       const client = this.applicationClientFactory(request.user.token)
 

--- a/server/services/placementApplicationService.ts
+++ b/server/services/placementApplicationService.ts
@@ -1,7 +1,7 @@
 import type { Request } from 'express'
 import { DataServices } from '@approved-premises/ui'
 import {
-  ApprovedPremisesApplication as Application,
+  Cas1Application as Application,
   PlacementApplication,
   PlacementApplicationDecisionEnvelope,
 } from '@approved-premises/api'

--- a/server/utils/applications/applicantAndCaseManagerDetails.ts
+++ b/server/utils/applications/applicantAndCaseManagerDetails.ts
@@ -1,7 +1,4 @@
-import {
-  ApprovedPremisesApplication as Application,
-  Cas1ApplicationUserDetails as UserDetails,
-} from '../../@types/shared'
+import { Cas1Application as Application, Cas1ApplicationUserDetails as UserDetails } from '../../@types/shared'
 import ConfirmYourDetails from '../../form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails'
 import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
 import { userDetailsFromCaseManagerPage, userDetailsFromConfirmYourDetailsPage } from './userDetailsFromApplication'

--- a/server/utils/applications/forPagesInTask.test.ts
+++ b/server/utils/applications/forPagesInTask.test.ts
@@ -209,7 +209,7 @@ describe('forPagesInTask', () => {
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
-  it('throws if the saved data creates an infinite loop', () => {
+  it('stops iterating if the saved data creates an infinite loop', () => {
     ;(journeyTypeFromArtifact as jest.MockedFunction<typeof journeyTypeFromArtifact>).mockReturnValue('applications')
 
     const firstApplyPageInstance = {
@@ -228,10 +228,9 @@ describe('forPagesInTask', () => {
         [firstApplySectionTask1Id]: { first: { foo: 'bar' }, second: { bar: 'foo' } },
       },
     })
-
-    expect(() => forPagesInTask(application, applySection1Task1, spy)).toThrow(
-      new Error('Page already visited while building task list: first. Visited pages: first, second'),
-    )
+    forPagesInTask(application, applySection1Task1, spy)
+    expect(spy).toHaveBeenCalledWith(firstApplyPageInstance, 'first')
+    expect(spy).toHaveBeenCalledWith(secondApplyPageInstance, 'second')
   })
 
   it('prevents a page being visited again through lack of previous page data', () => {

--- a/server/utils/applications/forPagesInTask.ts
+++ b/server/utils/applications/forPagesInTask.ts
@@ -9,29 +9,29 @@ export const forPagesInTask = (
   callback: (page: TasklistPage, pageName: string) => void,
 ): void => {
   const pageNames = Object.keys(task.pages)
-  let pageName = pageNames?.[0]
+
+  // find the first page that has been populated
+  let pageName = pageNames.find(name => !!formArtifact?.data?.[task.id]?.[name])
 
   const visited: Array<string> = []
 
   while (pageName && pageName !== 'check-your-answers') {
-    if (visited.includes(pageName)) {
-      throw new Error(
-        `Page already visited while building task list: ${pageName}. Visited pages: ${visited.join(', ')}`,
-      )
-    }
-
-    visited.push(pageName)
-    pageNames.splice(pageNames.indexOf(pageName), 1)
-
-    const Page = getPage(task.id, pageName, journeyTypeFromArtifact(formArtifact))
-    const body = formArtifact?.data?.[task.id]?.[pageName]
-    if (body) {
-      const page = new Page(body, formArtifact)
-      callback(page, pageName)
-      pageName = page.next()
-    } else if (pageNames.indexOf(pageName) + 1 < pageNames.length) {
-      pageName = pageNames[pageNames.indexOf(pageName) + 1]
+    // If the page has not been visited yet, process and add to visited list
+    if (!visited.includes(pageName)) {
+      visited.push(pageName)
+      pageNames.splice(pageNames.indexOf(pageName), 1)
+      const body = formArtifact?.data?.[task.id]?.[pageName]
+      if (body) {
+        const Page = getPage(task.id, pageName, journeyTypeFromArtifact(formArtifact))
+        const page = new Page(body, formArtifact)
+        callback(page, pageName)
+        pageName = page.next()
+      } else {
+        // Once we start on populated pages, if we hit an unpopulated one, that is where the user is up to, so stop rendering
+        pageName = pageNames[pageNames.indexOf(pageName) + 1]
+      }
     } else {
+      // If we hit a visited page, we have looped back, so we've rendered all the pages possible
       pageName = ''
     }
   }

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -178,6 +178,7 @@ describe('getApplicationData', () => {
 
       expect(getApplicationUpdateData(application)).toEqual({
         data: application.data,
+        document: application.document,
         isInapplicable: false,
         apType: undefined,
         isWomensApplication: false,
@@ -214,6 +215,7 @@ describe('getApplicationData', () => {
 
       expect(getApplicationUpdateData(application)).toEqual({
         data: application.data,
+        document: application.document,
         apType: 'normal',
         isInapplicable: false,
         isWomensApplication: false,

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -1,5 +1,5 @@
 import {
-  ApprovedPremisesApplication as Application,
+  Cas1Application as Application,
   ReleaseTypeOption,
   SentenceTypeOption,
   SubmitApprovedPremisesApplication,

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -39,6 +39,7 @@ type QuestionResponseFunction = (formArtifact: FormArtifact, Page: unknown, ques
 export const getApplicationUpdateData = (application: Application): UpdateApprovedPremisesApplication => {
   return {
     data: application.data,
+    document: application.document,
     isInapplicable: isInapplicable(application),
     ...getUpdateFirstClassFields(application),
   }

--- a/server/utils/applications/getResponseFixture.test.ts
+++ b/server/utils/applications/getResponseFixture.test.ts
@@ -1,0 +1,12 @@
+import { applicationFactory } from '../../testutils/factories'
+import applicationData from '../../../integration_tests/fixtures/applicationData.json'
+import { getResponses } from './getResponses'
+import applicationDocument from '../../../integration_tests/fixtures/applicationDocument.json'
+
+describe('getResponses - fixture', () => {
+  it('returns the correct document for the application fixture', async () => {
+    const application = applicationFactory.build({ data: applicationData })
+    const document = getResponses(application)
+    expect(document).toEqual(applicationDocument)
+  })
+})

--- a/server/utils/applications/isWomensApplication.ts
+++ b/server/utils/applications/isWomensApplication.ts
@@ -1,4 +1,4 @@
-import type { ApprovedPremisesApplication as Application, FullPerson } from '@approved-premises/api'
+import type { Cas1Application as Application, FullPerson } from '@approved-premises/api'
 import complexCaseBoard from '../../form-pages/apply/reasons-for-placement/basic-information/complexCaseBoard'
 import boardTakenPlace from '../../form-pages/apply/reasons-for-placement/basic-information/boardTakenPlace'
 import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'

--- a/server/utils/applications/licenceExpiryDateFromApplication.ts
+++ b/server/utils/applications/licenceExpiryDateFromApplication.ts
@@ -1,4 +1,4 @@
-import type { ApprovedPremisesApplication as Application } from '@approved-premises/api'
+import type { Cas1Application as Application } from '@approved-premises/api'
 
 export const licenceExpiryDateFromApplication = (application: Application): string | null => {
   const basicInformation = application.data?.['basic-information']

--- a/server/utils/applications/reasonForShortNoticeDetails.ts
+++ b/server/utils/applications/reasonForShortNoticeDetails.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesApplication as Application } from '../../@types/shared'
+import { Cas1Application as Application } from '../../@types/shared'
 import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
 import { startDateOutsideOfNationalStandardsTimescales } from './startDateOutsideOfNationalStandardsTimescales'
 import ReasonForShortNotice from '../../form-pages/apply/reasons-for-placement/basic-information/reasonForShortNotice'

--- a/server/utils/applications/summaryListUtils.ts
+++ b/server/utils/applications/summaryListUtils.ts
@@ -1,8 +1,4 @@
-import {
-  ApprovedPremisesApplication as Application,
-  Cas1Assessment as Assessment,
-  Document,
-} from '@approved-premises/api'
+import { Cas1Application as Application, Cas1Assessment as Assessment, Document } from '@approved-premises/api'
 import { FormArtifact, HtmlItem, SummaryListItem, TextItem, UiTask } from '@approved-premises/ui'
 
 import applyPaths from '../../paths/apply'

--- a/server/utils/applications/userDetailsFromApplication.ts
+++ b/server/utils/applications/userDetailsFromApplication.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesApplication as Application, Cas1ApplicationUserDetails } from '@approved-premises/api'
+import { Cas1Application as Application, Cas1ApplicationUserDetails } from '@approved-premises/api'
 import CaseManagerInformation, {
   caseManagerKeys,
 } from '../../form-pages/apply/reasons-for-placement/basic-information/caseManagerInformation'

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -20,7 +20,7 @@ import type {
   Cas1TimelineEventUrlType,
   SortDirection,
   Cas1ApplicationSummary,
-  ApprovedPremisesApplication,
+  Cas1Application,
 } from '@approved-premises/api'
 import IsExceptionalCase from '../../form-pages/apply/reasons-for-placement/basic-information/isExceptionalCase'
 import paths from '../../paths/apply'
@@ -139,7 +139,7 @@ const dashboardTableRows = (
 const getArrivalDateorNA = (arrivalDate: string | null | undefined) =>
   arrivalDate ? DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' }) : 'N/A'
 
-export const getApplicationSummary = (application: ApprovedPremisesApplication) => [
+export const getApplicationSummary = (application: Cas1Application) => [
   summaryListItem('Created on', application.createdAt, 'date'),
   summaryListItem('Created by', application.createdByUserName),
   summaryListItem('Requested arrival date', application.arrivalDate, 'date'),

--- a/server/utils/forms/submittedDocumentRenderer.ts
+++ b/server/utils/forms/submittedDocumentRenderer.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesApplication as Application, Cas1Assessment as Assessment } from '@approved-premises/api'
+import { Cas1Application as Application, Cas1Assessment as Assessment } from '@approved-premises/api'
 import { FormSections, SummaryListItem, UiTask } from '@approved-premises/ui'
 import Apply from '../../form-pages/apply'
 import { documentsFromApplication } from '../assessments/documentUtils'

--- a/server/utils/placementRequests/placementApplicationSubmissionData.ts
+++ b/server/utils/placementRequests/placementApplicationSubmissionData.ts
@@ -1,6 +1,6 @@
 import { addWeeks } from 'date-fns'
 import {
-  ApprovedPremisesApplication as Application,
+  Cas1Application as Application,
   Cas1RequestedPlacementPeriod,
   PlacementApplication,
   ReleaseTypeOption,

--- a/server/utils/resident/index.ts
+++ b/server/utils/resident/index.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesApplication, Cas1SpaceBooking, CaseDetail } from '@approved-premises/api'
+import { Cas1Application, Cas1SpaceBooking, CaseDetail } from '@approved-premises/api'
 import {
   HtmlItem,
   RequestWithSession,
@@ -201,7 +201,7 @@ export const renderCardList = (cardListData: Array<SummaryListWithCard>) => {
   return nunjucks.render(`manage/resident/partials/cardList.njk`, { cardList: cardListData })
 }
 
-export const renderPersonDetails = (application: ApprovedPremisesApplication): string => {
+export const renderPersonDetails = (application: Cas1Application): string => {
   return nunjucks.render(`manage/resident/partials/personDetails.njk`, { application })
 }
 

--- a/server/utils/resident/placement.ts
+++ b/server/utils/resident/placement.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesApplication, Cas1Assessment, Cas1SpaceBooking } from '@approved-premises/api'
+import { Cas1Application, Cas1Assessment, Cas1SpaceBooking } from '@approved-premises/api'
 import { SummaryListWithCard } from '@approved-premises/ui'
 import { TabData } from './index'
 import {
@@ -27,7 +27,7 @@ export const placementApplicationTabController = async ({
   token,
   placement,
 }: TabControllerParameters): Promise<TabData & { bottomCardList?: Array<SummaryListWithCard> }> => {
-  const [application, assessment] = await settlePromises<[ApprovedPremisesApplication, Cas1Assessment]>([
+  const [application, assessment] = await settlePromises<[Cas1Application, Cas1Assessment]>([
     applicationService.findApplication(token, placement.applicationId),
     placement.assessmentId && assessmentService.findAssessment(token, placement.assessmentId),
   ])

--- a/server/utils/resident/placementUtils.ts
+++ b/server/utils/resident/placementUtils.ts
@@ -1,9 +1,4 @@
-import {
-  ApprovedPremisesApplication,
-  Cas1Assessment,
-  Cas1SpaceBooking,
-  Cas1SpaceBookingShortSummary,
-} from '@approved-premises/api'
+import { Cas1Application, Cas1Assessment, Cas1SpaceBooking, Cas1SpaceBookingShortSummary } from '@approved-premises/api'
 import { SummaryListWithCard } from '@approved-premises/ui'
 import {
   Accordion,
@@ -22,7 +17,7 @@ import paths from '../../paths/manage'
 import assessPaths from '../../paths/assess'
 import { linkTo } from '../utils'
 
-export const applicationDocumentAccordion = (application: ApprovedPremisesApplication): Accordion => {
+export const applicationDocumentAccordion = (application: Cas1Application): Accordion => {
   const sections = new SubmittedDocumentRenderer(application).response
 
   const personDetails = { heading: { text: 'Person details' }, content: { html: renderPersonDetails(application) } }
@@ -43,7 +38,7 @@ export const applicationDocumentAccordion = (application: ApprovedPremisesApplic
   }
 }
 
-export const applicationCardList = (application: ApprovedPremisesApplication): Array<SummaryListWithCard> => {
+export const applicationCardList = (application: Cas1Application): Array<SummaryListWithCard> => {
   return [
     card({
       html: alertBanner({

--- a/server/utils/reviewUtils.ts
+++ b/server/utils/reviewUtils.ts
@@ -1,4 +1,4 @@
-import { ApprovedPremisesApplication as Application, Cas1Assessment as Assessment } from '../@types/shared'
+import { Cas1Application as Application, Cas1Assessment as Assessment } from '../@types/shared'
 import { SummaryListActions, SummaryListItem, UiTask } from '../@types/ui'
 import Apply from '../form-pages/apply'
 import getSections from './assessments/getSections'


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/FM-829

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

The document is now built and posted with every put to `/cas1/applications/{applicationId}`.
This should have been fairly simple, but I found a problem with rendering the document when the pages are not all properly completed that was highlighted by a failing integration test.
The page traversal mechanism worked as follows:

- Start with the first page (index 0 in the page index)
- If that page has data in the JSON blob, call the `next()` method on that page to find the next page.
- If that page does not have data, go to the next page in the index, or, if the last page in the index is reached, stop.

There is also a 'visited' mechanism that detects if the same page is visited twice(which would lead to an infinite loop) and throws an error.  This mechanism was being tripped during the integration test.

So, the problem is that if a populated page is reached by travelling forwards through the page list, skipping non-populated pages, then reaches a populated page that jumps backwards, the 'visited' mechanism would trip.

Since we are now rendering the document on all possible states of completion of that form, we cannot tolerate throwing on a loop, since there are certain user paths that actually include a loop.  Because of this, the task page sequencer has been alterered to:

1. skip initial non-populated pages until it finds the first populated page
2. terminate on hitting a visited page, rather than throw an error

Since this change _could_ affect the existing document output, I built a temporary test that used the old and new page sequencers and compared the list of pages calculated by the old algorithm with the new for the `applicationData.json` fixture.  From this, I updated the `applicationDocument.json` to match included a test that checks that the document renderer matches the document fixture, given the data fixture.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

No UI change
