### PR TITLE
FM-676-Update-to-use-new-endpoint-Cas1NewBookingNotMade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11179,7 +11179,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/server/data/placementRequestClient.ts
+++ b/server/data/placementRequestClient.ts
@@ -3,7 +3,7 @@ import {
   Cas1CruManagementArea,
   Cas1PlacementRequestDetail,
   Cas1PlacementRequestSummary,
-  NewBookingNotMade,
+  Cas1NewBookingNotMade,
   PlacementRequestRequestType,
   PlacementRequestSortField,
   PlacementRequestStatus,
@@ -66,7 +66,7 @@ export default class PlacementRequestClient {
     })
   }
 
-  async bookingNotMade(placementRequestId: string, data: NewBookingNotMade) {
+  async bookingNotMade(placementRequestId: string, data: Cas1NewBookingNotMade) {
     return this.restClient.post<BookingNotMade>({
       path: paths.placementRequests.bookingNotMade({ placementRequestId }),
       data,

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -46,9 +46,6 @@ const person = people.path(':crn')
 
 const cas1Users = cas1Namespace.path('users')
 
-const placementRequests = path('/placement-requests')
-const placementRequestsSingle = placementRequests.path(':placementRequestId')
-
 const referenceData = path('/reference-data')
 
 export default {
@@ -142,7 +139,7 @@ export default {
     show: cas1PlacementRequestSingle,
     dashboard: cas1PlacementRequests,
     changeRequests: cas1PlacementRequests.path('change-requests'),
-    bookingNotMade: placementRequestsSingle.path('booking-not-made'),
+    bookingNotMade: cas1PlacementRequestSingle.path('booking-not-made'),
     withdrawal: {
       create: cas1PlacementRequestSingle.path('withdrawal'),
     },

--- a/server/services/placementRequestService.ts
+++ b/server/services/placementRequestService.ts
@@ -1,7 +1,7 @@
 import { PaginatedResponse, PlacementRequestDashboardSearchOptions } from '@approved-premises/ui'
 import {
   Cas1PlacementRequestDetail,
-  NewBookingNotMade,
+  Cas1NewBookingNotMade,
   PlacementRequestSortField,
   SortDirection,
   WithdrawPlacementRequestReason,
@@ -44,7 +44,7 @@ export default class PlacementRequestService {
     return placementRequestClient.find(id)
   }
 
-  async bookingNotMade(token: string, id: string, body: NewBookingNotMade) {
+  async bookingNotMade(token: string, id: string, body: Cas1NewBookingNotMade) {
     const placementRequestClient = this.placementRequestClientFactory(token)
 
     return placementRequestClient.bookingNotMade(id, body)


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/FM-676
https://dsdmoj.atlassian.net/browse/FM-806

# Changes in this PR

 Updates UI to call new endpoint POST /cas1/placement-requests/{id}/booking-not-made using Cas1NewBookingNotMade.