### PR TITLE
FM-830 Document render endpoint

### DIFF
--- a/helm_deploy/hmpps-approved-premises-ui/values.yaml
+++ b/helm_deploy/hmpps-approved-premises-ui/values.yaml
@@ -20,6 +20,12 @@ generic-service:
       nginx.ingress.kubernetes.io/proxy-connect-timeout: '120'
       nginx.ingress.kubernetes.io/proxy-send-timeout: '120'
       nginx.ingress.kubernetes.io/proxy-read-timeout: '120'
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        server_tokens off;
+        location /render-application {
+          deny all;
+          return 401;
+        }
 
   livenessProbe:
     httpGet:

--- a/integration_tests/fixtures/applicationData.json
+++ b/integration_tests/fixtures/applicationData.json
@@ -11,12 +11,7 @@
           "name": "Greater Manchester"
         }
       ],
-      "detailsToUpdate": [
-        "phoneNumber",
-        "emailAddress",
-        "name",
-        "area"
-      ],
+      "detailsToUpdate": ["phoneNumber", "emailAddress", "name", "area"],
       "caseManagementResponsibility": "no",
       "userDetailsFromDelius": {
         "name": "Frank",
@@ -96,10 +91,7 @@
       "startDateSameAsReleaseDate": "yes"
     },
     "placement-purpose": {
-      "placementPurposes": [
-        "drugAlcoholMonitoring",
-        "otherReason"
-      ],
+      "placementPurposes": ["drugAlcoholMonitoring", "otherReason"],
       "otherReason": "Reason"
     }
   },
@@ -280,33 +272,13 @@
       "response": "yes"
     },
     "date-of-offence": {
-      "hateCrime": [
-        "previous"
-      ],
-      "nonSexualOffencesAgainstChildren": [
-        "current",
-        "previous"
-      ],
-      "contactSexualOffencesAgainstAdults": [
-        "current",
-        "previous"
-      ],
-      "nonContactSexualOffencesAgainstAdults": [
-        "current",
-        "previous"
-      ],
-      "contactSexualOffencesAgainstChildren": [
-        "current",
-        "previous"
-      ],
-      "nonContactSexualOffencesAgainstChildren": [
-        "current",
-        "previous"
-      ],
-      "otherSexualOffences": [
-        "current",
-        "previous"
-      ]
+      "hateCrime": ["previous"],
+      "nonSexualOffencesAgainstChildren": ["current", "previous"],
+      "contactSexualOffencesAgainstAdults": ["current", "previous"],
+      "nonContactSexualOffencesAgainstAdults": ["current", "previous"],
+      "contactSexualOffencesAgainstChildren": ["current", "previous"],
+      "nonContactSexualOffencesAgainstChildren": ["current", "previous"],
+      "otherSexualOffences": ["current", "previous"]
     },
     "rehabilitative-interventions": {
       "rehabilitativeInterventions": [
@@ -327,10 +299,7 @@
   },
   "prison-information": {
     "case-notes": {
-      "caseNoteIds": [
-        "a30173ca-061f-42c9-a1a2-28c70b282d3f",
-        "4a477187-b77f-4fcc-a919-43a6633ee868"
-      ],
+      "caseNoteIds": ["a30173ca-061f-42c9-a1a2-28c70b282d3f", "4a477187-b77f-4fcc-a919-43a6633ee868"],
       "selectedCaseNotes": [
         {
           "authorName": "Denise Collins",
@@ -438,12 +407,7 @@
   },
   "access-and-healthcare": {
     "access-needs": {
-      "additionalNeeds": [
-        "mobility",
-        "learningDisability",
-        "neurodivergentConditions",
-        "pregnancy"
-      ],
+      "additionalNeeds": ["mobility", "learningDisability", "neurodivergentConditions", "pregnancy"],
       "religiousOrCulturalNeeds": "yes",
       "religiousOrCulturalNeedsDetail": "sunt at minus",
       "needsInterpreter": "yes",

--- a/server/app.ts
+++ b/server/app.ts
@@ -21,6 +21,7 @@ import setUpWebRequestParsing from './middleware/setupRequestParsing'
 import setUpWebSecurity from './middleware/setUpWebSecurity'
 import setUpWebSession from './middleware/setUpWebSession'
 import setUpMaintenancePageRedirect from './middleware/setUpMaintenancePageRedirect'
+import setUpDocumentRender from './middleware/setUpDocumentRender'
 import { appInsightsMiddleware } from './utils/azureAppInsights'
 
 import routes from './routes'
@@ -44,6 +45,7 @@ export default function createApp(controllers: Controllers, services: Services):
   app.use(setUpWebSecurity())
   app.use(setUpWebSession())
   app.use(setUpWebRequestParsing())
+  app.use(setUpDocumentRender())
   app.use(setUpStaticResources())
 
   app.use(flash())

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -106,7 +106,6 @@ export default class ApplicationsController {
   show(): RequestHandler {
     return async (req: ShowRequest, res: Response) => {
       const application = await this.applicationService.findApplication(req.user.token, req.params.id)
-
       const backLink = getPageBackLink(paths.applications.show.pattern, req, [
         paths.applications.index.pattern,
         paths.applications.dashboard.pattern,

--- a/server/middleware/setUpDocumentRender.ts
+++ b/server/middleware/setUpDocumentRender.ts
@@ -1,0 +1,12 @@
+import express, { Router } from 'express'
+import { documentRender } from '../services/documentRender'
+
+export default function setUpDocumentRender(): Router {
+  const router = express.Router()
+
+  router.post('/render-application', (req, res, next) => {
+    res.json(documentRender(req.body))
+  })
+
+  return router
+}

--- a/server/middleware/setupRequestParsing.ts
+++ b/server/middleware/setupRequestParsing.ts
@@ -3,7 +3,7 @@ import trimInput from './trimInput'
 
 export default function setUpWebRequestParsing(): Router {
   const router = express.Router()
-  router.use(express.json())
+  router.use(express.json({ limit: '1mb' }))
   router.use(express.urlencoded({ extended: true, limit: '1mb', parameterLimit: 2500 }))
   router.use(trimInput())
   return router

--- a/server/services/documentRender.ts
+++ b/server/services/documentRender.ts
@@ -1,0 +1,6 @@
+import { Cas1Application } from '@approved-premises/api'
+import { getResponses } from '../utils/applications/getResponses'
+
+export const documentRender = (application: Cas1Application): unknown => {
+  return getResponses(application)
+}

--- a/server/services/documentRenderer.test.ts
+++ b/server/services/documentRenderer.test.ts
@@ -1,0 +1,12 @@
+import { documentRender } from './documentRender'
+import { applicationFactory } from '../testutils/factories'
+import applicationData from '../../integration_tests/fixtures/applicationData.json'
+import applicationDocument from '../../integration_tests/fixtures/applicationDocument.json'
+
+describe('DocumentRenderer', () => {
+  it('returns a rendered document from an application', async () => {
+    const application = applicationFactory.build({ data: applicationData })
+    const document = await documentRender(application)
+    expect(document).toEqual(applicationDocument)
+  })
+})

--- a/server/utils/applications/forPagesInTask.ts
+++ b/server/utils/applications/forPagesInTask.ts
@@ -20,6 +20,7 @@ export const forPagesInTask = (
     if (!visited.includes(pageName)) {
       visited.push(pageName)
       pageNames.splice(pageNames.indexOf(pageName), 1)
+
       const body = formArtifact?.data?.[task.id]?.[pageName]
       if (body) {
         const Page = getPage(task.id, pageName, journeyTypeFromArtifact(formArtifact))


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/FM-830

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Adds an endpoint that allows the generation of document objects from non-submitted applications to allow document backfill.

- The endpoint is available on `/render-application`
- it is not secured and does not require any token.
- The endpoint supports only POST requests and expects the body to contain a complete `Cas1Application` object. 
- In particular, the `data` field of the application should be populated with an application in a partly or fully completed state. 
- If the data field is not populated, the resulting document will simply be a list of section headings with empty contents for each. 
- If the document field is populated, it will be ignored.
- The response is a JSON document object.
- The JSON body parser limit has been increased to 1Mb from its default of 100Kb to allow applications to be posted.

To test a local instance, save a complete application in a file as JSON, then use the following curl command:
```
curl -H "Content-Type: application/json" --request POST --data '@application.json' http://localhost:3000/render-application
```


<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

No UI changes
