### PR TITLE
Update ingress link

### DIFF
--- a/helm_deploy/hmpps-approved-premises-ui/values.yaml
+++ b/helm_deploy/hmpps-approved-premises-ui/values.yaml
@@ -20,7 +20,7 @@ generic-service:
       nginx.ingress.kubernetes.io/proxy-connect-timeout: '120'
       nginx.ingress.kubernetes.io/proxy-send-timeout: '120'
       nginx.ingress.kubernetes.io/proxy-read-timeout: '120'
-      nginx.ingress.kubernetes.io/configuration-snippet: |
+      nginx.ingress.kubernetes.io/server-snippet: |
         server_tokens off;
         location /render-application {
           deny all;


### PR DESCRIPTION
# Context

# Changes in this PR
Fix ingress config to use `server-snippet` rather than `configuration_snippet`
https://github.com/ministryofjustice/hmpps-helm-charts/releases/tag/generic-service-3.0.0

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes
None
