### PR TITLE
Document render endpoint - token protection

### DIFF
--- a/helm_deploy/hmpps-approved-premises-ui/values.yaml
+++ b/helm_deploy/hmpps-approved-premises-ui/values.yaml
@@ -20,12 +20,6 @@ generic-service:
       nginx.ingress.kubernetes.io/proxy-connect-timeout: '120'
       nginx.ingress.kubernetes.io/proxy-send-timeout: '120'
       nginx.ingress.kubernetes.io/proxy-read-timeout: '120'
-      nginx.ingress.kubernetes.io/server-snippet: |
-        server_tokens off;
-        location /render-application {
-          deny all;
-          return 401;
-        }
 
   livenessProbe:
     httpGet:

--- a/server/middleware/setUpDocumentRender.ts
+++ b/server/middleware/setUpDocumentRender.ts
@@ -1,34 +1,9 @@
 import express, { Router } from 'express'
-import { jwtDecode } from 'jwt-decode'
 import { documentRender } from '../services/documentRender'
-import logger from '../../logger'
-
-const requiredRole = 'ROLE_PROBATION'
 
 export default function setUpDocumentRender(): Router {
   const router = express.Router()
-
-  router.post('/render-application', (req, res) => {
-    const authHeader = req.headers.authorization
-    const token = authHeader && authHeader.split(' ')[1] // Bearer <token>
-    if (token) {
-      try {
-        const { authorities: roles = [] } = jwtDecode(token) as { authorities?: Array<string> }
-        if (roles.includes(requiredRole)) return res.json(documentRender(req.body))
-        const error: string = `User lacks required role ${requiredRole} (${roles.join(', ')})`
-        logger.error(error)
-        return res.status(403).json({ success: false, error })
-      } catch {
-        /* allow to fall through */
-      }
-    }
-
-    logger.error('User is not authorised to access this')
-    return res.status(401).json({
-      success: false,
-      error: 'Authentication token missing or invalid',
-    })
-  })
+  router.post('/render-application', (req, res) => documentRender(req, res))
 
   return router
 }

--- a/server/middleware/setUpDocumentRender.ts
+++ b/server/middleware/setUpDocumentRender.ts
@@ -1,11 +1,33 @@
 import express, { Router } from 'express'
+import { jwtDecode } from 'jwt-decode'
 import { documentRender } from '../services/documentRender'
+import logger from '../../logger'
+
+const requiredRole = 'ROLE_PROBATION'
 
 export default function setUpDocumentRender(): Router {
   const router = express.Router()
 
-  router.post('/render-application', (req, res, next) => {
-    res.json(documentRender(req.body))
+  router.post('/render-application', (req, res) => {
+    const authHeader = req.headers.authorization
+    const token = authHeader && authHeader.split(' ')[1] // Bearer <token>
+    if (token) {
+      try {
+        const { authorities: roles = [] } = jwtDecode(token) as { authorities?: Array<string> }
+        if (roles.includes(requiredRole)) return res.json(documentRender(req.body))
+        const error: string = `User lacks required role ${requiredRole} (${roles.join(', ')})`
+        logger.error(error)
+        return res.status(403).json({ success: false, error })
+      } catch {
+        /* allow to fall through */
+      }
+    }
+
+    logger.error('User is not authorised to access this')
+    return res.status(401).json({
+      success: false,
+      error: 'Authentication token missing or invalid',
+    })
   })
 
   return router

--- a/server/services/documentRender.ts
+++ b/server/services/documentRender.ts
@@ -1,6 +1,30 @@
-import { Cas1Application } from '@approved-premises/api'
+import { jwtDecode } from 'jwt-decode'
+import { Request, Response } from 'express'
 import { getResponses } from '../utils/applications/getResponses'
+import logger from '../../logger'
 
-export const documentRender = (application: Cas1Application): unknown => {
-  return getResponses(application)
+export const caseDetailRole = 'ROLE_PROBATION_API__APPROVED_PREMISES__CASE_DETAIL'
+
+export const documentRender = (req: Request, res: Response): unknown => {
+  const authHeader = req.headers.authorization
+  const token = authHeader && authHeader.split(' ')[1] // Bearer <token>
+  if (token) {
+    try {
+      const { authorities: roles = [] } = jwtDecode(token) as { authorities?: Array<string> }
+      if (roles.includes(caseDetailRole)) {
+        return res.json(getResponses(req.body))
+      }
+      const error: string = `User lacks required role ${caseDetailRole} (${roles.join(', ')})`
+      logger.error(error)
+      return res.status(403).json({ success: false, error })
+    } catch {
+      /* allow to fall through */
+    }
+  }
+
+  logger.error('User is not authorised to access this')
+  return res.status(401).json({
+    success: false,
+    error: 'Authentication token missing or invalid',
+  })
 }

--- a/server/services/documentRenderer.test.ts
+++ b/server/services/documentRenderer.test.ts
@@ -1,12 +1,58 @@
-import { documentRender } from './documentRender'
+import { createMock } from '@golevelup/ts-jest'
+import { Request, Response } from 'express'
+import jwt from 'jsonwebtoken'
+import { caseDetailRole, documentRender } from './documentRender'
 import { applicationFactory } from '../testutils/factories'
 import applicationData from '../../integration_tests/fixtures/applicationData.json'
 import applicationDocument from '../../integration_tests/fixtures/applicationDocument.json'
+import logger from '../../logger'
+
+jest.mock('../../logger')
+
+function createToken(authorities: Array<string>) {
+  const payload = {
+    user_name: 'USER1',
+    scope: ['read', 'write'],
+    auth_source: 'delius',
+    authorities,
+    jti: 'a610a10-cca6-41db-985f-e87efb303aaf',
+    client_id: 'clientid',
+  }
+
+  return jwt.sign(payload, 'secret', { expiresIn: '1h' })
+}
 
 describe('DocumentRenderer', () => {
+  const application = applicationFactory.build({ data: applicationData })
+
+  const response = createMock<Response>()
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
   it('returns a rendered document from an application', async () => {
-    const application = applicationFactory.build({ data: applicationData })
-    const document = await documentRender(application)
-    expect(document).toEqual(applicationDocument)
+    const token = createToken([caseDetailRole])
+    const request = createMock<Request>({ headers: { authorization: `Bearer ${token}` }, body: application })
+    await documentRender(request, response)
+    expect(response.json).toHaveBeenCalledWith(applicationDocument)
+  })
+
+  it('fails if no token provided', async () => {
+    const request = createMock<Request>({ body: application })
+    await documentRender(request, response)
+    expect(response.json).not.toBeCalled()
+    expect(response.status).toBeCalledWith(401)
+    expect(logger.error).toHaveBeenCalledWith('User is not authorised to access this')
+  })
+
+  it('fails if token does not have the right role', async () => {
+    const token = createToken(['ROLE_INCORRECT'])
+    const request = createMock<Request>({ headers: { authorization: `Bearer ${token}` }, body: application })
+    await documentRender(request, response)
+    expect(response.json).not.toBeCalled()
+    expect(response.status).toBeCalledWith(403)
+    expect(logger.error).toHaveBeenCalledWith(
+      'User lacks required role ROLE_PROBATION_API__APPROVED_PREMISES__CASE_DETAIL (ROLE_INCORRECT)',
+    )
   })
 })


### PR DESCRIPTION
# Context

Following on from https://dsdmoj.atlassian.net/browse/FM-830
The ingress rule appears to block all access to the `/application-render` endpoint, so this ticket removes the rule and replaces it by using awt authentication.

The endpoint now expects to see a `Bearer` awt in the `authorization` header. This should have the role `ROLE_PROBATION_API__APPROVED_PREMISES__CASE_DETAIL`

- If no valid token is provided, a 401 response is returned.
- If the token does not have the required role, a 403 response is returned.

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->


