### PR TITLE
FM-815 Placement duration calculation from API

### DIFF
--- a/integration_tests/helpers/assess.ts
+++ b/integration_tests/helpers/assess.ts
@@ -24,7 +24,11 @@ import {
 } from '../pages/assess'
 import Page from '../pages/page'
 import AssessPage from '../pages/assess/assessPage'
-import { assessmentSummaryFactory, personFactory } from '../../server/testutils/factories'
+import {
+  assessmentSummaryFactory,
+  cas1RequestsForPlacementDurationsCalculationResponseDtoFactory,
+  personFactory,
+} from '../../server/testutils/factories'
 import PipeSuitabilityPage from '../pages/assess/pipeSuitability'
 import ContingencyPlanSuitabilityPage from '../pages/assess/contingencyPlanSuitability'
 
@@ -77,6 +81,10 @@ export default class AseessHelper {
     })
     cy.task('stubAssessmentRejection', this.assessment)
     cy.task('stubAssessmentAcceptance', this.assessment)
+    cy.task('stubGetPlacementDuration', {
+      applicationId: this.assessment.application.id,
+      durationObj: cas1RequestsForPlacementDurationsCalculationResponseDtoFactory.build(),
+    })
   }
 
   updateAssessmentStatus(status: AssessmentStatus) {

--- a/integration_tests/mockApis/applications.ts
+++ b/integration_tests/mockApis/applications.ts
@@ -1,16 +1,17 @@
 import { SuperAgentRequest } from 'superagent'
 
-import type {
+import {
   Appeal,
   ApplicationSortField,
   ApplicationTimelineNote,
   ApprovedPremisesApplication,
   Cas1ApplicationSummary,
+  Cas1RequestsForPlacementDurationsCalculationResponseDto,
   Cas1TimelineEvent,
   RequestForPlacement,
   SortDirection,
+  Withdrawables,
 } from '@approved-premises/api'
-import { Withdrawables } from '@approved-premises/api'
 import { ApplicationDashboardSearchOptions } from '@approved-premises/ui'
 import { getMatchingRequests, stubFor } from './setup'
 import paths from '../../server/paths/api'
@@ -288,6 +289,26 @@ export default {
 
   stubAppealErrors: ({ applicationId, params }: { applicationId: string; params: Array<string> }) =>
     stubFor(errorStub(params, paths.applications.appeals.create({ id: applicationId }))),
+
+  stubGetPlacementDuration: ({
+    applicationId,
+    durationObj,
+  }: {
+    applicationId: string
+    durationObj: Cas1RequestsForPlacementDurationsCalculationResponseDto
+  }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPath: paths.applications.calc.durations({ id: applicationId }),
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: durationObj,
+      },
+    }),
+
   verifyApplicationWithdrawn: async (args: { applicationId: string }) =>
     (
       await getMatchingRequests({

--- a/integration_tests/tests/apply/setup.ts
+++ b/integration_tests/tests/apply/setup.ts
@@ -3,6 +3,7 @@ import {
   activeOffenceFactory,
   applicationFactory,
   assessmentFactory,
+  cas1RequestsForPlacementDurationsCalculationResponseDtoFactory,
   personFactory,
   risksFactory,
   tierEnvelopeFactory,
@@ -39,6 +40,10 @@ export const setup = () => {
     cy.task('stubApplicationGet', { application })
     cy.task('stubApplications', [application])
     cy.task('stubAllApplications', { applications: [], anyQuery: true })
+    cy.task('stubGetPlacementDuration', {
+      applicationId: application.id,
+      durationObj: cas1RequestsForPlacementDurationsCalculationResponseDtoFactory.build(),
+    })
 
     cy.wrap(person).as('person')
     cy.wrap(offences).as('offences')

--- a/integration_tests/tests/assess/assess.cy.ts
+++ b/integration_tests/tests/assess/assess.cy.ts
@@ -1,3 +1,4 @@
+import { DataServices } from '@approved-premises/ui'
 import { Cas1Assessment as Assessment } from '../../../server/@types/shared'
 import {
   assessmentFactory,
@@ -86,11 +87,12 @@ context('Assess', () => {
     assessHelper.completeAssessment()
 
     // Then the API should have received the correct data
-    cy.task('verifyAssessmentAcceptance', this.assessment).then(requests => {
+    cy.task('verifyAssessmentAcceptance', this.assessment).then(async requests => {
       expect(requests).to.have.length(1)
 
       const body = JSON.parse(requests[0].body)
-      expect(body).to.deep.equal(acceptanceData(this.assessment))
+      const expected = await acceptanceData(this.assessment, {} as DataServices, '')
+      expect(body).to.deep.equal(expected)
     })
   })
 
@@ -340,9 +342,9 @@ context('Assess', () => {
   it('does not invalidate the check your answers step if an answer is reviewed and not changed', function test() {
     // Given there is a complete application in the database
 
-    let assessment = assessmentFactory.build({ data: this.assessment.data, status: 'in_progress' })
+    // let assessment = assessmentFactory.build({ data: this.assessment.data, status: 'in_progress' })
 
-    assessment = addResponsesToFormArtifact<Assessment>(this.assessment, {
+    const assessment = addResponsesToFormArtifact<Assessment>(this.assessment, {
       page: 'application-timeliness',
       task: 'suitability-assessment',
       keyValuePairs: {

--- a/integration_tests/tests/assess/shortNoticeAssessments.cy.ts
+++ b/integration_tests/tests/assess/shortNoticeAssessments.cy.ts
@@ -1,5 +1,6 @@
 import { addDays } from 'date-fns'
 import { Cas1Application as Application } from '@approved-premises/api'
+import { DataServices } from '@approved-premises/ui'
 import {
   applicationFactory,
   assessmentFactory,
@@ -104,11 +105,12 @@ describe('Short notice assessments', () => {
     this.assessHelper.completeAssessment({ isShortNoticeApplication: true })
 
     THEN('the API should have received the correct data')
-    cy.task('verifyAssessmentAcceptance', this.assessment).then(requests => {
+    cy.task('verifyAssessmentAcceptance', this.assessment).then(async requests => {
       expect(requests).to.have.length(1)
 
       const body = JSON.parse(requests[0].body)
-      expect(body).to.deep.equal(acceptanceData(this.assessHelper.assessment))
+      const expected = await acceptanceData(this.assessHelper.assessment, {} as DataServices, '')
+      expect(body).to.deep.equal(expected)
     })
   })
 })

--- a/integration_tests/tests/match/placementApplications.cy.ts
+++ b/integration_tests/tests/match/placementApplications.cy.ts
@@ -2,6 +2,7 @@ import { ReleaseTypeOption } from '@approved-premises/api'
 import { faker } from '@faker-js/faker'
 import {
   applicationFactory,
+  cas1RequestsForPlacementDurationsCalculationResponseDtoFactory,
   documentFactory,
   personFactory,
   placementApplicationFactory,
@@ -72,6 +73,10 @@ context('Placement Applications', () => {
       cy.task('stubApplicationRequestsForPlacement', {
         applicationId: completedApplication.id,
         requestsForPlacement: [requestForPlacement],
+      })
+      cy.task('stubGetPlacementDuration', {
+        applicationId: completedApplication.id,
+        durationObj: cas1RequestsForPlacementDurationsCalculationResponseDtoFactory.build(),
       })
     })
 

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -35,7 +35,9 @@ import {
   UserQualification,
   LocalAuthorityArea,
   type Cas1OASysAssessmentSuitabilityStrategyDto,
-  Cas1Application,
+  type Cas1Application as Application,
+  type SentenceTypeOption,
+  Cas1RequestsForPlacementDurationsCalculationResponseDto,
 } from '@approved-premises/api'
 import type { Request } from 'express'
 import { Session } from 'express-session'
@@ -338,8 +340,14 @@ export type DataServices = Partial<{
     ) => Promise<Cas1OASysGroup>
   }
   applicationService: {
-    getDocuments: (token: string, application: Cas1Application) => Promise<Array<Document>>
-    findApplication: (token: string, id: string) => Promise<Cas1Application>
+    getDocuments: (token: string, application: Application) => Promise<Array<Document>>
+    findApplication: (token: string, id: string) => Promise<Application>
+    getPlacementDuration: (
+      token: string,
+      applicationId: string,
+      apType: ApType,
+      sentenceType: SentenceTypeOption,
+    ) => Promise<Cas1RequestsForPlacementDurationsCalculationResponseDto>
   }
   userService: {
     getUserById: (token: string, id: string) => Promise<User>

--- a/server/controllers/assess/assessmentsController.test.ts
+++ b/server/controllers/assess/assessmentsController.test.ts
@@ -6,7 +6,7 @@ import { Cas1AssessmentSummary as AssessmentSummary, Task } from '@approved-prem
 import { addErrorMessageToFlash, fetchErrorsAndUserInput } from '../../utils/validation'
 import TasklistService from '../../services/tasklistService'
 import AssessmentsController from './assessmentsController'
-import { AssessmentService, TaskService } from '../../services'
+import { ApplicationService, AssessmentService, TaskService } from '../../services'
 
 import {
   assessmentFactory,
@@ -36,11 +36,12 @@ describe('assessmentsController', () => {
 
   const assessmentService = createMock<AssessmentService>({})
   const taskService = createMock<TaskService>({})
+  const applicationService = createMock<ApplicationService>({})
 
   let assessmentsController: AssessmentsController
 
   beforeEach(() => {
-    assessmentsController = new AssessmentsController(assessmentService, taskService)
+    assessmentsController = new AssessmentsController(assessmentService, taskService, applicationService)
     response = createMock<Response>({ locals: { user: { id: userId } } })
     request = createMock<Request>({ user: { token }, query: {} })
   })
@@ -300,7 +301,7 @@ describe('assessmentsController', () => {
         await assessmentsController.submit()(indexRequest, response, next)
 
         expect(assessmentService.findAssessment).toHaveBeenCalledWith(token, 'some-id')
-        expect(assessmentService.submit).toHaveBeenCalledWith(token, assessment)
+        expect(assessmentService.submit).toHaveBeenCalledWith(token, assessment, { applicationService })
         expect(response.render).toHaveBeenCalledWith('assessments/confirm', {
           pageHeading: 'Assessment submission confirmed',
           assessment,
@@ -324,7 +325,7 @@ describe('assessmentsController', () => {
         await assessmentsController.submit()(indexRequest, response, next)
 
         expect(assessmentService.findAssessment).toHaveBeenCalledWith(token, 'some-id')
-        expect(assessmentService.submit).toHaveBeenCalledWith(token, expectedAssessment)
+        expect(assessmentService.submit).toHaveBeenCalledWith(token, expectedAssessment, { applicationService })
         expect(response.render).toHaveBeenCalledWith('assessments/confirm', {
           pageHeading: 'Assessment submission confirmed',
           assessment: expectedAssessment,

--- a/server/controllers/assess/assessmentsController.ts
+++ b/server/controllers/assess/assessmentsController.ts
@@ -1,8 +1,9 @@
 import type { Request, RequestHandler, Response } from 'express'
 
+import { DataServices } from '@approved-premises/ui'
 import { addErrorMessageToFlash, fetchErrorsAndUserInput } from '../../utils/validation'
 import TasklistService from '../../services/tasklistService'
-import { AssessmentService, TaskService } from '../../services'
+import { ApplicationService, AssessmentService, TaskService } from '../../services'
 import informationSetAsNotReceived from '../../utils/assessments/informationSetAsNotReceived'
 
 import paths from '../../paths/assess'
@@ -17,6 +18,7 @@ export default class AssessmentsController {
   constructor(
     private readonly assessmentService: AssessmentService,
     private readonly taskService: TaskService,
+    private readonly applicationService: ApplicationService,
   ) {}
 
   index(): RequestHandler {
@@ -132,8 +134,8 @@ export default class AssessmentsController {
 
         return res.redirect(paths.assessments.show({ id: assessment.id }))
       }
-
-      await this.assessmentService.submit(req.user.token, assessment)
+      const dataServices: Partial<DataServices> = { applicationService: this.applicationService }
+      await this.assessmentService.submit(req.user.token, assessment, dataServices)
 
       return res.render('assessments/confirm', {
         pageHeading: 'Assessment submission confirmed',

--- a/server/controllers/assess/index.ts
+++ b/server/controllers/assess/index.ts
@@ -10,7 +10,7 @@ import { DataServices } from '../../@types/ui'
 export const controllers = (services: Services) => {
   const { assessmentService, applicationService, userService, taskService } = services
 
-  const assessmentsController = new AssessmentsController(assessmentService, taskService)
+  const assessmentsController = new AssessmentsController(assessmentService, taskService, applicationService)
   const assessmentPagesController = new AssessmentPagesController(assessmentService, {
     applicationService,
     userService,

--- a/server/controllers/match/placementRequestsController.test.ts
+++ b/server/controllers/match/placementRequestsController.test.ts
@@ -107,7 +107,9 @@ describe('PlacementRequestsController', () => {
         expect(response.render).toHaveBeenCalledWith('placement-applications/confirm', {
           pageHeading: 'Request for placement confirmed',
         })
-        expect(placementApplicationService.submit).toHaveBeenCalledWith(token, placementApplication, application)
+        expect(placementApplicationService.submit).toHaveBeenCalledWith(token, placementApplication, application, {
+          applicationService,
+        })
       })
     })
 

--- a/server/controllers/match/placementRequestsController.ts
+++ b/server/controllers/match/placementRequestsController.ts
@@ -65,7 +65,9 @@ export default class PlacementRequestsController {
         placementApplication.applicationId,
       )
       try {
-        await this.placementApplicationService.submit(req.user.token, placementApplication, application)
+        await this.placementApplicationService.submit(req.user.token, placementApplication, application, {
+          applicationService: this.applicationService,
+        })
 
         return res.render('placement-applications/confirm', {
           pageHeading: 'Request for placement confirmed',

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -1,15 +1,18 @@
 import {
   ApType,
   Cas1ExpireApplicationReason,
+  SentenceTypeOption,
   SubmitApprovedPremisesApplication,
   WithdrawalReason,
 } from '@approved-premises/api'
+import { faker } from '@faker-js/faker'
 import ApplicationClient from './applicationClient'
 import config from '../config'
 import {
   activeOffenceFactory,
   applicationFactory,
   cas1ApplicationSummaryFactory,
+  cas1RequestsForPlacementDurationsCalculationResponseDtoFactory,
   cas1TimelineEventFactory,
   documentFactory,
   noteFactory,
@@ -535,6 +538,35 @@ describeCas1NamespaceClient('Cas1ApplicationClient', provider => {
       })
 
       await applicationClient.timeline(applicationId)
+    })
+  })
+
+  describe('getPlacementDuration', () => {
+    it('gets the placement duration with the application id, ap type and sentence type', async () => {
+      const applicationId = faker.string.uuid()
+      const sentenceType: SentenceTypeOption = 'standardDeterminate'
+      const apType: ApType = 'esap'
+
+      const durations = cas1RequestsForPlacementDurationsCalculationResponseDtoFactory.build()
+
+      await provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: 'A request for a calculated placement duration',
+        withRequest: {
+          method: 'GET',
+          path: paths.applications.calc.durations({ id: applicationId }),
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+          query: { sentenceType, apType },
+        },
+        willRespondWith: {
+          status: 200,
+          body: durations,
+        },
+      })
+
+      await applicationClient.getPlacementDuration(applicationId, apType, sentenceType)
     })
   })
 })

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -1,4 +1,4 @@
-import type {
+import {
   ActiveOffence,
   Cas1Application as Application,
   ApplicationSortField,
@@ -13,6 +13,9 @@ import type {
   UpdateApprovedPremisesApplication,
   Withdrawables,
   Cas1ExpireApplicationReason,
+  ApType,
+  SentenceTypeOption,
+  Cas1RequestsForPlacementDurationsCalculationResponseDto,
 } from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
@@ -119,6 +122,17 @@ export default class ApplicationClient {
   async withdrawablesWithNotes(applicationId: string): Promise<Withdrawables> {
     return this.restClient.get<Withdrawables>({
       path: paths.applications.withdrawablesWithNotes({ id: applicationId }),
+    })
+  }
+
+  async getPlacementDuration(
+    applicationId: string,
+    apType: ApType,
+    sentenceType: SentenceTypeOption,
+  ): Promise<Cas1RequestsForPlacementDurationsCalculationResponseDto> {
+    return this.restClient.get<Cas1RequestsForPlacementDurationsCalculationResponseDto>({
+      path: paths.applications.calc.durations({ id: applicationId }),
+      query: { apType, sentenceType },
     })
   }
 }

--- a/server/form-pages/apply/move-on/placementDuration.test.ts
+++ b/server/form-pages/apply/move-on/placementDuration.test.ts
@@ -1,5 +1,6 @@
 import { Cas1Application } from '@approved-premises/api'
 import { addDays } from 'date-fns'
+import { createMock } from '@golevelup/ts-jest'
 import { getDefaultPlacementDurationInDays } from '../../../utils/applications/getDefaultPlacementDurationInDays'
 
 import PlacementDuration from './placementDuration'
@@ -8,9 +9,13 @@ import { addResponsesToFormArtifact } from '../../../testutils/addToApplication'
 import { arrivalDateFromApplication } from '../../../utils/applications/arrivalDateFromApplication'
 import { DateFormats } from '../../../utils/dateUtils'
 import * as formUtils from '../../../utils/formUtils'
+import { ApplicationService } from '../../../services'
 
 jest.mock('../../../utils/applications/getDefaultPlacementDurationInDays')
 jest.mock('../../../utils/applications/arrivalDateFromApplication')
+
+const applicationService = createMock<ApplicationService>({})
+const token = 'test_token'
 
 describe('PlacementDuration', () => {
   let application: Cas1Application
@@ -50,12 +55,12 @@ describe('PlacementDuration', () => {
   })
 
   describe('initializeDates', () => {
-    it('sets the dates based on arrivalDateFromApplication', () => {
+    it('sets the dates based on arrivalDateFromApplication', async () => {
       const arrivalDate = '2022-11-11'
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(arrivalDate)
       ;(getDefaultPlacementDurationInDays as jest.Mock).mockReturnValue(30)
 
-      const page = new PlacementDuration({}, application)
+      const page = await PlacementDuration.initialize({}, application, token, { applicationService })
 
       expect(page.arrivalDate).toEqual(DateFormats.isoDateToUIDate(arrivalDate))
       const arrivalDatePlus30Days = addDays(new Date(arrivalDate), 30)

--- a/server/form-pages/apply/move-on/placementDuration.ts
+++ b/server/form-pages/apply/move-on/placementDuration.ts
@@ -1,6 +1,6 @@
 import { addDays, weeksToDays } from 'date-fns'
-import type { PageResponse, TaskListErrors, YesOrNo } from '@approved-premises/ui'
-import { Cas1Application } from '@approved-premises/api'
+import type { DataServices, PageResponse, TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import { Cas1Application as Application, Cas1Application } from '@approved-premises/api'
 import { DateFormats, weeksAndDaysToDays } from '../../../utils/dateUtils'
 import { Page } from '../../utils/decorators'
 
@@ -35,12 +35,25 @@ export default class PlacementDuration implements TasklistPage {
     reason: 'Why does this person require a different placement duration?',
   }
 
+  dataServices: DataServices
+
   constructor(
     public body: Partial<PlacementDurationBody>,
     private readonly application: Cas1Application,
   ) {
     this.body.duration = this.lengthInDays()
-    this.initializeDates()
+  }
+
+  static async initialize(
+    body: Partial<PlacementDurationBody>,
+    application: Application,
+    token: string,
+    dataServices: DataServices,
+  ): Promise<PlacementDuration> {
+    const page = new PlacementDuration(body, application)
+    await page.initializeDates(dataServices, token)
+
+    return page
   }
 
   previous() {
@@ -94,11 +107,11 @@ export default class PlacementDuration implements TasklistPage {
     return undefined
   }
 
-  private initializeDates(): void {
+  private async initializeDates(dataServices: DataServices, token: string): Promise<void> {
     const arrivalDateIso = arrivalDateFromApplication(this.application)
 
     if (arrivalDateIso) {
-      const standardPlacementDuration = getDefaultPlacementDurationInDays(this.application)
+      const standardPlacementDuration = await getDefaultPlacementDurationInDays(this.application, dataServices, token)
 
       const arrivalDate = DateFormats.isoToDateObj(arrivalDateIso)
       const departureDate = addDays(arrivalDate, standardPlacementDuration)

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.test.ts
@@ -1,3 +1,4 @@
+import { createMock } from '@golevelup/ts-jest'
 import { applicationFactory, assessmentFactory } from '../../../../testutils/factories'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared'
 
@@ -10,9 +11,13 @@ import {
   prepopulatablePlacementRequirementCriteria,
 } from '../../../../utils/placementCriteriaUtils'
 import { radioMatrixTable } from '../../../../utils/radioMatrixTable'
+import { ApplicationService } from '../../../../services'
 
 jest.mock('../../../../utils/applications/placementDurationFromApplication')
 jest.mock('../../../../utils/retrieveQuestionResponseFromFormArtifact')
+
+const applicationService = createMock<ApplicationService>({})
+const token = 'test_token'
 
 const assessment = assessmentFactory.build({
   application: applicationFactory.build({ isWomensApplication: false }),
@@ -159,9 +164,7 @@ describe('MatchingInformation', () => {
   })
 
   describe('suggestedStaySummaryListOptions', () => {
-    it('wraps around the namesake utils method, returning its return value', () => {
-      const page = new MatchingInformation(defaultArguments, assessment)
-
+    it('wraps around the namesake utils method, returning its return value', async () => {
       const utilsReturnValue = {
         rows: [
           { key: { text: 'Placement duration' }, value: { text: 'a formatted duration' } },
@@ -169,10 +172,16 @@ describe('MatchingInformation', () => {
         ],
       }
       const mockSuggestedStaySummaryListOptions = jest.spyOn(matchingInformtionUtils, 'suggestedStaySummaryListOptions')
-      mockSuggestedStaySummaryListOptions.mockReturnValue(utilsReturnValue)
+      mockSuggestedStaySummaryListOptions.mockResolvedValue(utilsReturnValue)
+
+      const page = await MatchingInformation.initialize(defaultArguments, assessment, token, { applicationService })
 
       expect(page.suggestedStaySummaryListOptions).toEqual(utilsReturnValue)
-      expect(mockSuggestedStaySummaryListOptions).toHaveBeenLastCalledWith(assessment.application)
+      expect(mockSuggestedStaySummaryListOptions).toHaveBeenLastCalledWith(
+        assessment.application,
+        { applicationService },
+        token,
+      )
     })
   })
 

--- a/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
+++ b/server/form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation.ts
@@ -1,4 +1,4 @@
-import type { SummaryList, TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import type { DataServices, SummaryList, TaskListErrors, YesOrNo } from '@approved-premises/ui'
 
 import { Cas1Assessment as Assessment } from '@approved-premises/api'
 import {
@@ -69,6 +69,23 @@ export default class MatchingInformation implements TasklistPage {
     lengthOfStayAgreed: 'Do you agree with the suggested length of stay?',
     lengthOfStay: 'Provide recommended length of stay',
     cruInformation: 'Information for Central Referral Unit (CRU) manager (optional)',
+  }
+
+  suggestedStaySummaryListOptions: SummaryList
+
+  static async initialize(
+    body: Partial<MatchingInformationBody>,
+    assessment: Assessment,
+    token: string,
+    dataServices: DataServices,
+  ): Promise<MatchingInformation> {
+    const page = new MatchingInformation(body, assessment)
+    page.suggestedStaySummaryListOptions = await suggestedStaySummaryListOptions(
+      assessment.application,
+      dataServices,
+      token,
+    )
+    return page
   }
 
   relevantInformationTable = () =>
@@ -202,10 +219,6 @@ export default class MatchingInformation implements TasklistPage {
     }
 
     return errors
-  }
-
-  get suggestedStaySummaryListOptions(): SummaryList {
-    return suggestedStaySummaryListOptions(this.assessment.application)
   }
 
   get apTypeItems() {

--- a/server/form-pages/utils/matchingInformationUtils.test.ts
+++ b/server/form-pages/utils/matchingInformationUtils.test.ts
@@ -1,5 +1,6 @@
 import { when } from 'jest-when'
-import { BackwardsCompatibleApplyApType } from '@approved-premises/ui'
+import { BackwardsCompatibleApplyApType, DataServices } from '@approved-premises/ui'
+import { createMock } from '@golevelup/ts-jest'
 import { placementDurationFromApplication } from '../../utils/applications/placementDurationFromApplication'
 import {
   retrieveOptionalQuestionResponseFromFormArtifact,
@@ -26,9 +27,15 @@ import Vulnerability from '../apply/risk-and-need-factors/further-considerations
 import SelectApType from '../apply/reasons-for-placement/type-of-ap/apType'
 import PlacementDate from '../apply/reasons-for-placement/basic-information/placementDate'
 import ReleaseDate from '../apply/reasons-for-placement/basic-information/releaseDate'
+import { ApplicationService } from '../../services'
 
 jest.mock('../../utils/applications/placementDurationFromApplication')
 jest.mock('../../utils/retrieveQuestionResponseFromFormArtifact')
+
+const applicationService = createMock<ApplicationService>({})
+const dataServices = { applicationService } as DataServices
+
+const token = 'test_token'
 
 describe('matchingInformationUtils', () => {
   const application = applicationFactory.build()
@@ -482,7 +489,7 @@ describe('matchingInformationUtils', () => {
 
     describe('if the release date is known', () => {
       describe('when the start date is the same as the release date', () => {
-        it('returns the suggested stay from the application as summary list options, using the release date as the start date', () => {
+        it('returns the suggested stay from the application as summary list options, using the release date as the start date', async () => {
           when(retrieveQuestionResponseFromFormArtifact)
             .calledWith(application, ReleaseDate, 'knowReleaseDate')
             .mockReturnValue('yes')
@@ -493,7 +500,7 @@ describe('matchingInformationUtils', () => {
             .calledWith(application, ReleaseDate)
             .mockReturnValue('2024-03-07T00:00:00Z')
 
-          expect(suggestedStaySummaryListOptions(application)).toEqual({
+          expect(await suggestedStaySummaryListOptions(application, dataServices, token)).toEqual({
             rows: [
               { key: { text: 'Placement duration' }, value: { text: '1 week, 5 days', classes: 'placement-duration' } },
               {
@@ -503,7 +510,7 @@ describe('matchingInformationUtils', () => {
             ],
           })
 
-          expect(placementDurationFromApplication).toHaveBeenCalledWith(application)
+          expect(placementDurationFromApplication).toHaveBeenCalledWith(application, dataServices, token)
           expect(retrieveQuestionResponseFromFormArtifact).toHaveBeenCalledWith(
             application,
             PlacementDate,
@@ -514,7 +521,7 @@ describe('matchingInformationUtils', () => {
       })
 
       describe('when the start date is not the same as the release date', () => {
-        it('returns the suggested stay from the application as summary list options, using the start date from the placement date screen', () => {
+        it('returns the suggested stay from the application as summary list options, using the start date from the placement date screen', async () => {
           when(retrieveQuestionResponseFromFormArtifact)
             .calledWith(application, ReleaseDate, 'knowReleaseDate')
             .mockReturnValue('yes')
@@ -525,7 +532,7 @@ describe('matchingInformationUtils', () => {
             .calledWith(application, PlacementDate, 'startDate')
             .mockReturnValue('2024-05-07T00:00:00Z')
 
-          expect(suggestedStaySummaryListOptions(application)).toEqual({
+          expect(await suggestedStaySummaryListOptions(application, dataServices, token)).toEqual({
             rows: [
               { key: { text: 'Placement duration' }, value: { text: '1 week, 5 days', classes: 'placement-duration' } },
               {
@@ -535,7 +542,7 @@ describe('matchingInformationUtils', () => {
             ],
           })
 
-          expect(placementDurationFromApplication).toHaveBeenCalledWith(application)
+          expect(placementDurationFromApplication).toHaveBeenCalledWith(application, dataServices, token)
           expect(retrieveQuestionResponseFromFormArtifact).toHaveBeenCalledWith(
             application,
             PlacementDate,
@@ -551,18 +558,18 @@ describe('matchingInformationUtils', () => {
     })
 
     describe('if the release date is not  known', () => {
-      it('returns only the placement duration row', () => {
+      it('returns only the placement duration row', async () => {
         when(retrieveQuestionResponseFromFormArtifact)
           .calledWith(application, ReleaseDate, 'knowReleaseDate')
           .mockReturnValue('no')
 
-        expect(suggestedStaySummaryListOptions(application)).toEqual({
+        expect(await suggestedStaySummaryListOptions(application, dataServices, token)).toEqual({
           rows: [
             { key: { text: 'Placement duration' }, value: { text: '1 week, 5 days', classes: 'placement-duration' } },
           ],
         })
 
-        expect(placementDurationFromApplication).toHaveBeenCalledWith(application)
+        expect(placementDurationFromApplication).toHaveBeenCalledWith(application, dataServices, token)
         expect(retrieveQuestionResponseFromFormArtifact).toHaveBeenCalledWith(
           application,
           ReleaseDate,

--- a/server/form-pages/utils/matchingInformationUtils.ts
+++ b/server/form-pages/utils/matchingInformationUtils.ts
@@ -1,6 +1,6 @@
 import { Cas1Application as Application, Cas1Assessment as Assessment, Cas1Application } from '@approved-premises/api'
 import { weeksToDays } from 'date-fns'
-import { BackwardsCompatibleApplyApType, SummaryList } from '@approved-premises/ui'
+import { BackwardsCompatibleApplyApType, DataServices, SummaryList } from '@approved-premises/ui'
 import { placementDates } from '../../utils/match'
 import { DateFormats } from '../../utils/dateUtils'
 import { placementDurationFromApplication } from '../../utils/applications/placementDurationFromApplication'
@@ -262,8 +262,12 @@ export const remapArsonAssessmentData = (assessmentData: Assessment['data']): As
   return assessmentData
 }
 
-const suggestedStaySummaryListOptions = (application: Application): SummaryList => {
-  const duration = placementDurationFromApplication(application)
+const suggestedStaySummaryListOptions = async (
+  application: Application,
+  dataServices: DataServices,
+  token: string,
+): Promise<SummaryList> => {
+  const duration = await placementDurationFromApplication(application, dataServices, token)
   const formattedDuration = DateFormats.formatDuration(duration)
   const rows: SummaryList['rows'] = [
     { key: { text: 'Placement duration' }, value: { text: formattedDuration, classes: 'placement-duration' } },

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -113,6 +113,9 @@ export default {
       show: cas1Appeals.path(':appealId'),
       create: cas1Appeals,
     },
+    calc: {
+      durations: cas1ApplicationsSingle.path('requests-for-placement/calc/durations'),
+    },
   },
   assessments: {
     index: cas1Assessments,

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -1,7 +1,7 @@
 import type { Request } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import type { DataServices, PaginatedResponse, TaskListErrors } from '@approved-premises/ui'
-import type {
+import {
   Cas1ApplicationStatus,
   Cas1ApplicationSummary,
   SubmitApprovedPremisesApplication,
@@ -23,6 +23,7 @@ import {
   activeOffenceFactory,
   applicationFactory,
   cas1ApplicationSummaryFactory,
+  cas1RequestsForPlacementDurationsCalculationResponseDtoFactory,
   documentFactory,
   noteFactory,
   paginatedResponseFactory,
@@ -357,7 +358,7 @@ describe('ApplicationService', () => {
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
       expect(applicationClient.submit).toHaveBeenCalledWith(application.id, applicationData)
 
-      expect(getApplicationSubmissionData).toHaveBeenCalledWith(application)
+      expect(getApplicationSubmissionData).toHaveBeenCalledWith(application, { applicationService: service }, token)
     })
   })
 
@@ -485,6 +486,23 @@ describe('ApplicationService', () => {
       expect(result).toEqual(withdrawables)
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
       expect(applicationClient.withdrawablesWithNotes).toHaveBeenCalledWith(applicationId)
+    })
+  })
+
+  describe('getPlacementDuration', () => {
+    it('calls the client with the ID and the token and returns the result', async () => {
+      const application = applicationFactory.build()
+      const durations = cas1RequestsForPlacementDurationsCalculationResponseDtoFactory.build()
+      applicationClient.getPlacementDuration.mockResolvedValue(durations)
+
+      const result = await service.getPlacementDuration(
+        token,
+        application.id,
+        application.apType,
+        application.sentenceType,
+      )
+
+      expect(result).toEqual(durations)
     })
   })
 })

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -15,6 +15,8 @@ import type {
   SortDirection,
   Cas1ApplicationSummary,
   Cas1ExpireApplicationReason,
+  ApType,
+  SentenceTypeOption,
 } from '@approved-premises/api'
 
 import { updateFormArtifactData } from '../form-pages/utils/updateFormArtifactData'
@@ -93,9 +95,7 @@ export default class ApplicationService {
   async getDocuments(token: string, application: Application): Promise<Array<Document>> {
     const applicationClient = this.applicationClientFactory(token)
 
-    const documents = await applicationClient.documents(application)
-
-    return documents
+    return applicationClient.documents(application)
   }
 
   async initializePage(
@@ -107,11 +107,9 @@ export default class ApplicationService {
     const application = await this.findApplication(request.user.token, request.params.id)
     const body = getBody(Page, application, request, userInput)
 
-    const page = Page.initialize
-      ? await Page.initialize(body, application, request.user.token, dataServices)
+    return Page.initialize
+      ? Page.initialize(body, application, request.user.token, dataServices)
       : new Page(body, application)
-
-    return page
   }
 
   async save(page: TasklistPage, request: Request) {
@@ -127,14 +125,20 @@ export default class ApplicationService {
 
       const client = this.applicationClientFactory(request.user.token)
 
-      await client.update(application.id, getApplicationUpdateData(updatedApplication))
+      await client.update(
+        application.id,
+        await getApplicationUpdateData(updatedApplication, { applicationService: this }, request.user.token),
+      )
     }
   }
 
   async submit(token: string, application: Application) {
     const client = this.applicationClientFactory(token)
 
-    await client.submit(application.id, getApplicationSubmissionData(application))
+    await client.submit(
+      application.id,
+      await getApplicationSubmissionData(application, { applicationService: this }, token),
+    )
   }
 
   async getApplicationFromSessionOrAPI(request: Request): Promise<Application> {
@@ -147,46 +151,39 @@ export default class ApplicationService {
   }
 
   async withdraw(token: string, applicationId: string, body: NewWithdrawal) {
-    const client = this.applicationClientFactory(token)
-
-    await client.withdrawal(applicationId, body)
+    await this.applicationClientFactory(token).withdrawal(applicationId, body)
   }
 
   async expire(token: string, applicationId: string, body: Cas1ExpireApplicationReason) {
-    const client = this.applicationClientFactory(token)
-
-    await client.expire(applicationId, body)
+    await this.applicationClientFactory(token).expire(applicationId, body)
   }
 
   async timeline(token: string, applicationId: string) {
-    const client = this.applicationClientFactory(token)
-
-    const timeline = await client.timeline(applicationId)
-
-    return timeline
+    return this.applicationClientFactory(token).timeline(applicationId)
   }
 
   async getRequestsForPlacement(token: string, applicationId: string) {
-    const client = this.applicationClientFactory(token)
-
-    const requestsForPlacement = await client.requestsForPlacement(applicationId)
-
-    return requestsForPlacement
+    return this.applicationClientFactory(token).requestsForPlacement(applicationId)
   }
 
   async addNote(token: Request['user']['token'], applicationId: Application['id'], note: ApplicationTimelineNote) {
     const client = this.applicationClientFactory(token)
 
-    const addedNote = await client.addNote(applicationId, note)
-
-    return addedNote
+    return client.addNote(applicationId, note)
   }
 
   async getWithdrawablesWithNotes(token: Request['user']['token'], applicationId: Application['id']) {
+    return this.applicationClientFactory(token).withdrawablesWithNotes(applicationId)
+  }
+
+  async getPlacementDuration(
+    token: Request['user']['token'],
+    applicationId: Application['id'],
+    apType: ApType,
+    sentenceType: SentenceTypeOption,
+  ) {
     const client = this.applicationClientFactory(token)
 
-    const withdrawables = await client.withdrawablesWithNotes(applicationId)
-
-    return withdrawables
+    return client.getPlacementDuration(applicationId, apType, sentenceType)
   }
 }

--- a/server/services/assessmentService.test.ts
+++ b/server/services/assessmentService.test.ts
@@ -22,6 +22,7 @@ import { ApplicationOrAssessmentResponse } from '../utils/applications/utils'
 import { applicationAccepted } from '../utils/assessments/decisionUtils'
 import { getResponses } from '../utils/applications/getResponses'
 import { getResponseForPage } from '../utils/applications/getResponseForPage'
+import { ApplicationService } from './index'
 
 jest.mock('../data/assessmentClient.ts')
 jest.mock('../data/personClient.ts')
@@ -32,6 +33,9 @@ jest.mock('../utils/applications/getResponses')
 jest.mock('../utils/applications/getResponseForPage')
 jest.mock('../utils/assessments/acceptanceData')
 jest.mock('../utils/assessments/decisionUtils')
+
+const applicationService = createMock<ApplicationService>({})
+const dataServices = { applicationService } as DataServices
 
 describe('AssessmentService', () => {
   const assessmentClient = new AssessmentClient(null) as jest.Mocked<AssessmentClient>
@@ -102,7 +106,6 @@ describe('AssessmentService', () => {
     })
 
     it("should call a page's initialize method if it exists", async () => {
-      const dataServices = createMock<DataServices>({}) as DataServices
       ;(getBody as jest.Mock).mockReturnValue(request.body)
 
       const TestPage = { initialize: jest.fn() } as unknown as TasklistPageInterface
@@ -184,7 +187,7 @@ describe('AssessmentService', () => {
       ;(applicationAccepted as jest.Mock).mockReturnValue(true)
       ;(acceptanceData as jest.Mock).mockReturnValue(assessmentAcceptance)
 
-      await service.submit(token, assessment)
+      await service.submit(token, assessment, dataServices)
 
       expect(assessmentClientFactory).toHaveBeenCalledWith(token)
       expect(assessmentClient.acceptance).toHaveBeenCalledWith(assessment.id, assessmentAcceptance)
@@ -202,7 +205,7 @@ describe('AssessmentService', () => {
       ;(getResponses as jest.Mock).mockReturnValue(document)
       ;(getResponseForPage as jest.Mock).mockReturnValue(response)
 
-      await service.submit(token, assessment)
+      await service.submit(token, assessment, dataServices)
 
       expect(assessmentClientFactory).toHaveBeenCalledWith(token)
       expect(assessmentClient.rejection).toHaveBeenCalledWith(assessment.id, document, response.Decision)

--- a/server/services/assessmentService.ts
+++ b/server/services/assessmentService.ts
@@ -51,11 +51,9 @@ export default class AssessmentService {
   ) {
     const body = getBody(Page, assessment, request, userInput)
 
-    const page = Page.initialize
-      ? await Page.initialize(body, assessment, request.user.token, dataServices)
+    return Page.initialize
+      ? Page.initialize(body, assessment, request.user.token, dataServices)
       : new Page(body, assessment)
-
-    return page
   }
 
   async save(page: TasklistPage, request: Request) {
@@ -73,7 +71,7 @@ export default class AssessmentService {
     }
   }
 
-  async submit(token: string, assessment: Assessment) {
+  async submit(token: string, assessment: Assessment, dataServices: DataServices) {
     const client = this.assessmentClientFactory(token)
 
     if (!applicationAccepted(assessment)) {
@@ -81,7 +79,7 @@ export default class AssessmentService {
       return client.rejection(assessment.id, document, rejectionRationaleFromAssessmentResponses(assessment))
     }
 
-    return client.acceptance(assessment.id, acceptanceData(assessment))
+    return client.acceptance(assessment.id, await acceptanceData(assessment, dataServices, token))
   }
 
   async createClarificationNote(token: string, assessmentId: string, clarificationNote: Cas1NewClarificationNote) {

--- a/server/services/placementApplicationService.test.ts
+++ b/server/services/placementApplicationService.test.ts
@@ -14,10 +14,14 @@ import TasklistPage, { TasklistPageInterface } from '../form-pages/tasklistPage'
 import { ValidationError } from '../utils/errors'
 
 import { placementApplicationSubmissionData } from '../utils/placementRequests/placementApplicationSubmissionData'
+import { ApplicationService } from './index'
 
 jest.mock('../data/placementApplicationClient.ts')
 jest.mock('../form-pages/utils')
 jest.mock('../utils/placementRequests/placementApplicationSubmissionData')
+
+const applicationService = createMock<ApplicationService>({})
+const dataServices = { applicationService } as DataServices
 
 describe('placementApplicationService', () => {
   const placementApplicationClient = new PlacementApplicationClient(null) as jest.Mocked<PlacementApplicationClient>
@@ -46,8 +50,6 @@ describe('placementApplicationService', () => {
 
   describe('initializePage', () => {
     let request: DeepMocked<Request>
-
-    const dataServices = createMock<DataServices>({}) as DataServices
     const placementApplication = placementApplicationFactory.build({
       data: { 'request-a-placement': { 'sentence-type-check': { sentenceTypeCheck: 'no' } } },
     })
@@ -205,7 +207,7 @@ describe('placementApplicationService', () => {
 
       placementApplicationClient.submission.mockResolvedValue(placementApplication)
 
-      const result = service.submit(token, placementApplication, application)
+      const result = service.submit(token, placementApplication, application, dataServices)
 
       expect(result).resolves.toEqual(placementApplication)
     })

--- a/server/services/placementApplicationService.ts
+++ b/server/services/placementApplicationService.ts
@@ -73,12 +73,17 @@ export default class PlacementApplicationService {
     }
   }
 
-  async submit(token: string, placementApplication: PlacementApplication, application: Application) {
+  async submit(
+    token: string,
+    placementApplication: PlacementApplication,
+    application: Application,
+    dataServices: DataServices,
+  ) {
     const placementApplicationClient = this.placementApplicationClientFactory(token)
 
     return placementApplicationClient.submission(
       placementApplication.id,
-      placementApplicationSubmissionData(placementApplication, application),
+      placementApplicationSubmissionData(placementApplication, application, dataServices, token),
     )
   }
 

--- a/server/testutils/factories/cas1RequestsForPlacementDurationsCalculationResponseDto.ts
+++ b/server/testutils/factories/cas1RequestsForPlacementDurationsCalculationResponseDto.ts
@@ -1,0 +1,13 @@
+import { Factory } from 'fishery'
+import { Cas1RequestsForPlacementDurationsCalculationResponseDto } from '@approved-premises/api'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+class Cas1RequestsForPlacementDurationsCalculationResponseDtoFactory extends Factory<Cas1RequestsForPlacementDurationsCalculationResponseDto> {}
+
+export default Cas1RequestsForPlacementDurationsCalculationResponseDtoFactory.define(() => {
+  const defaultDurationDays = faker.number.int({ min: 1, max: 365 })
+  return {
+    defaultDurationDays,
+    maxDurationDays: faker.number.int({ min: defaultDurationDays, max: 365 }),
+  }
+})

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -96,6 +96,7 @@ import licenceFactory from './licence'
 import csraSummaryFactory from './csraSummary'
 import offenceFactory from './offence'
 import dietAndAllergyResponseFactory from './dietAndAllergyResponse'
+import cas1RequestsForPlacementDurationsCalculationResponseDtoFactory from './cas1RequestsForPlacementDurationsCalculationResponseDto'
 
 export {
   acctAlertFactory,
@@ -200,4 +201,5 @@ export {
   offenceFactory,
   dietAndAllergyResponseFactory,
   registrationFactory,
+  cas1RequestsForPlacementDurationsCalculationResponseDtoFactory,
 }

--- a/server/utils/applications/arrivalDateFromApplication.ts
+++ b/server/utils/applications/arrivalDateFromApplication.ts
@@ -2,7 +2,6 @@ import type { Cas1Application as Application } from '@approved-premises/api'
 
 export const arrivalDateFromApplication = (application: Application): string | null => {
   const basicInformation = application.data?.['basic-information']
-
   if (!basicInformation) return null
 
   const {

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -1,6 +1,8 @@
 import { Cas1RequestedPlacementPeriod, ReleaseTypeOption, SentenceTypeOption } from '@approved-premises/api'
 import { when } from 'jest-when'
 import { faker } from '@faker-js/faker/locale/en_GB'
+import { createMock } from '@golevelup/ts-jest'
+import { DataServices } from '@approved-premises/ui'
 import { applicationFactory } from '../../testutils/factories'
 import { getApplicationSubmissionData, getApplicationUpdateData } from './getApplicationData'
 import {
@@ -16,6 +18,7 @@ import { reasonForShortNoticeDetails } from './reasonForShortNoticeDetails'
 import { applicationUserDetailsFactory } from '../../testutils/factories/application'
 import { DateFormats } from '../dateUtils'
 import { licenceExpiryDateFromApplication } from './licenceExpiryDateFromApplication'
+import { ApplicationService } from '../../services'
 
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
 jest.mock('../applications/applicantAndCaseManagerDetails')
@@ -25,6 +28,10 @@ jest.mock('./utils')
 jest.mock('./isWomensApplication')
 jest.mock('./reasonForShortNoticeDetails')
 jest.mock('./licenceExpiryDateFromApplication')
+
+const applicationService = createMock<ApplicationService>({})
+const dataServices: DataServices = { applicationService }
+const token = 'test_token'
 
 const apAreaId = 'test-id'
 const applicantUserDetails = applicationUserDetailsFactory.build()
@@ -78,10 +85,10 @@ describe('getApplicationData', () => {
       })
     })
 
-    it('returns the correct data', () => {
+    it('returns the correct data', async () => {
       mockRequiredQuestionResponses({ type: 'normal' })
 
-      expect(getApplicationSubmissionData(application)).toEqual({
+      expect(await getApplicationSubmissionData(application, dataServices, token)).toEqual({
         translatedDocument: application.document,
         apType: 'normal',
         isWomensApplication: false,
@@ -100,17 +107,17 @@ describe('getApplicationData', () => {
       })
     })
 
-    it('handles when a release type is missing', () => {
+    it('handles when a release type is missing', async () => {
       mockOptionalQuestionResponse({ releaseType: undefined })
       mockRequiredQuestionResponses({})
 
-      expect(getApplicationSubmissionData(application).releaseType).toEqual(undefined)
+      expect((await getApplicationSubmissionData(application, dataServices, token)).releaseType).toEqual(undefined)
     })
 
-    it('returns the correct data for a community order application', () => {
+    it('returns the correct data for a community order application', async () => {
       mockRequiredQuestionResponses({ sentenceType: 'communityOrder', situation: 'riskManagement' })
 
-      expect(getApplicationSubmissionData(application)).toEqual(
+      expect(await getApplicationSubmissionData(application, dataServices, token)).toEqual(
         expect.objectContaining({
           releaseType: 'in_community',
           sentenceType: 'communityOrder',
@@ -119,10 +126,10 @@ describe('getApplicationData', () => {
       )
     })
 
-    it('returns the correct data for a bail placement application', () => {
+    it('returns the correct data for a bail placement application', async () => {
       mockRequiredQuestionResponses({ sentenceType: 'bailPlacement', situation: 'riskManagement' })
 
-      expect(getApplicationSubmissionData(application)).toEqual(
+      expect(await getApplicationSubmissionData(application, dataServices, token)).toEqual(
         expect.objectContaining({
           releaseType: 'in_community',
           sentenceType: 'bailPlacement',
@@ -131,10 +138,10 @@ describe('getApplicationData', () => {
       )
     })
 
-    it('returns the correct data for a non-statutory application', () => {
+    it('returns the correct data for a non-statutory application', async () => {
       mockRequiredQuestionResponses({ sentenceType: 'nonStatutory' })
 
-      expect(getApplicationSubmissionData(application)).toEqual(
+      expect(await getApplicationSubmissionData(application, dataServices, token)).toEqual(
         expect.objectContaining({
           releaseType: 'not_applicable',
           sentenceType: 'nonStatutory',
@@ -142,12 +149,12 @@ describe('getApplicationData', () => {
       )
     })
 
-    it('returns the correct data for a reason for short notice application', () => {
+    it('returns the correct data for a reason for short notice application', async () => {
       when(reasonForShortNoticeDetails).calledWith(application).mockReturnValue({
         reasonForShortNotice: 'other',
         reasonForShortNoticeOther: 'test',
       })
-      expect(getApplicationSubmissionData(application)).toEqual(
+      expect(await getApplicationSubmissionData(application, dataServices, token)).toEqual(
         expect.objectContaining({
           reasonForShortNotice: 'other',
           reasonForShortNoticeOther: 'test',
@@ -155,13 +162,15 @@ describe('getApplicationData', () => {
       )
     })
 
-    it('returns correct data for a womens application', () => {
+    it('returns correct data for a womens application', async () => {
       ;(isWomensApplication as jest.Mock).mockReturnValue(true)
-      expect(getApplicationSubmissionData(application)).toEqual(expect.objectContaining({ isWomensApplication: true }))
+      expect(await getApplicationSubmissionData(application, dataServices, token)).toEqual(
+        expect.objectContaining({ isWomensApplication: true }),
+      )
     })
 
-    it('returns the licence expiry date', () => {
-      expect(getApplicationSubmissionData(application)).toEqual(
+    it('returns the licence expiry date', async () => {
+      expect(await getApplicationSubmissionData(application, dataServices, token)).toEqual(
         expect.objectContaining({
           licenseExpiryDate: licenceExpiryDate,
         }),
@@ -170,14 +179,14 @@ describe('getApplicationData', () => {
   })
 
   describe('getApplicationUpdateData', () => {
-    it('returns empty attributes for a new application', () => {
+    it('returns empty attributes for a new application', async () => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(undefined)
       ;(placementDurationFromApplication as jest.Mock).mockReturnValue(undefined)
       ;(isInapplicable as jest.Mock).mockReturnValue(false)
       ;(isWomensApplication as jest.Mock).mockReturnValue(false)
       mockOptionalQuestionResponse({})
 
-      expect(getApplicationUpdateData(application)).toEqual({
+      expect(await getApplicationUpdateData(application, dataServices, token)).toEqual({
         data: application.data,
         document: application.document,
         isInapplicable: false,
@@ -198,7 +207,7 @@ describe('getApplicationData', () => {
       })
     })
 
-    it('returns all the defined attributes', () => {
+    it('returns all the defined attributes', async () => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue('2023-01-01')
       ;(placementDurationFromApplication as jest.Mock).mockReturnValue(56)
       ;(isInapplicable as jest.Mock).mockReturnValue(false)
@@ -214,7 +223,7 @@ describe('getApplicationData', () => {
         caseManagerUserDetails,
       })
 
-      expect(getApplicationUpdateData(application)).toEqual({
+      expect(await getApplicationUpdateData(application, dataServices, token)).toEqual({
         data: application.data,
         document: application.document,
         apType: 'normal',
@@ -234,33 +243,33 @@ describe('getApplicationData', () => {
       })
     })
 
-    it('returns the correct data for a community order application', () => {
+    it('returns the correct data for a community order application', async () => {
       mockOptionalQuestionResponse({ sentenceType: 'communityOrder' })
 
-      expect(getApplicationUpdateData(application).releaseType).toEqual('in_community')
+      expect((await getApplicationUpdateData(application, dataServices, token)).releaseType).toEqual('in_community')
     })
 
-    it('returns the correct data for a bail placement application', () => {
+    it('returns the correct data for a bail placement application', async () => {
       mockOptionalQuestionResponse({ sentenceType: 'bailPlacement' })
 
-      expect(getApplicationUpdateData(application).releaseType).toEqual('in_community')
+      expect((await getApplicationUpdateData(application, dataServices, token)).releaseType).toEqual('in_community')
     })
 
-    it('returns the return value of `isInapplicable`', () => {
+    it('returns the return value of `isInapplicable`', async () => {
       ;(isInapplicable as jest.Mock).mockReturnValue(true)
       mockOptionalQuestionResponse({})
 
-      expect(getApplicationUpdateData(application).isInapplicable).toEqual(true)
+      expect((await getApplicationUpdateData(application, dataServices, token)).isInapplicable).toEqual(true)
       expect(isInapplicable).toHaveBeenCalledWith(application)
     })
 
-    it('returns the correct data for a reason for short notice application', () => {
+    it('returns the correct data for a reason for short notice application', async () => {
       mockOptionalQuestionResponse({})
       when(reasonForShortNoticeDetails).calledWith(application).mockReturnValue({
         reasonForShortNotice: 'other',
         reasonForShortNoticeOther: 'test',
       })
-      expect(getApplicationUpdateData(application)).toEqual(
+      expect(await getApplicationUpdateData(application, dataServices, token)).toEqual(
         expect.objectContaining({
           reasonForShortNotice: 'other',
           reasonForShortNoticeOther: 'test',

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -18,7 +18,7 @@ import {
 import DescribeLocationFactors from '../../form-pages/apply/risk-and-need-factors/location-factors/describeLocationFactors'
 import { arrivalDateFromApplication } from './arrivalDateFromApplication'
 import { isInapplicable } from './utils'
-import { BackwardsCompatibleApplyApType, FormArtifact } from '../../@types/ui'
+import { BackwardsCompatibleApplyApType, DataServices, FormArtifact } from '../../@types/ui'
 import { noticeTypeFromApplication } from './noticeTypeFromApplication'
 import Situation from '../../form-pages/apply/reasons-for-placement/basic-information/situation'
 import ConfirmYourDetails from '../../form-pages/apply/reasons-for-placement/basic-information/confirmYourDetails'
@@ -37,26 +37,36 @@ type FirstClassFields<T> = T extends UpdateApprovedPremisesApplication
 
 type QuestionResponseFunction = (formArtifact: FormArtifact, Page: unknown, question?: string) => unknown
 
-export const getApplicationUpdateData = (application: Application): UpdateApprovedPremisesApplication => {
+export const getApplicationUpdateData = async (
+  application: Application,
+  dataServices: DataServices,
+  token: string,
+): Promise<UpdateApprovedPremisesApplication> => {
   return {
     data: application.data,
     document: application.document,
     isInapplicable: isInapplicable(application),
-    ...getUpdateFirstClassFields(application),
+    ...(await getUpdateFirstClassFields(application, dataServices, token)),
   }
 }
 
-export const getApplicationSubmissionData = (application: Application): SubmitApprovedPremisesApplication => {
+export const getApplicationSubmissionData = async (
+  application: Application,
+  dataServices: DataServices,
+  token: string,
+): Promise<SubmitApprovedPremisesApplication> => {
   return {
     translatedDocument: application.document,
-    ...getSubmitFirstClassFields(application),
+    ...(await getSubmitFirstClassFields(application, dataServices, token)),
   }
 }
 
-const firstClassFields = <T>(
+const firstClassFields = async <T>(
   application: Application,
   retrieveQuestionResponse: QuestionResponseFunction,
-): FirstClassFields<T> => {
+  dataServices: DataServices,
+  token: string,
+): Promise<FirstClassFields<T>> => {
   const noticeType = noticeTypeFromApplication(application)
   const apTypeResponse = retrieveQuestionResponse(application, SelectApType, 'type') as BackwardsCompatibleApplyApType
   const apType = apTypeResponse === 'standard' ? 'normal' : apTypeResponse
@@ -67,7 +77,7 @@ const firstClassFields = <T>(
     releaseType === 'in_community' ? retrieveQuestionResponse(application, Situation, 'situation') : null
   const arrival = arrivalDateFromApplication(application)
   const requestedPlacementPeriod: Cas1RequestedPlacementPeriod = arrival
-    ? { arrival, duration: placementDurationFromApplication(application) }
+    ? { arrival, duration: await placementDurationFromApplication(application, dataServices, token) }
     : undefined
   const isEmergencyApplication = noticeType === 'emergency'
   const apAreaId = retrieveQuestionResponse(application, ConfirmYourDetails, 'area')
@@ -96,12 +106,20 @@ const firstClassFields = <T>(
   } as FirstClassFields<T>
 }
 
-const getUpdateFirstClassFields = (application: Application): FirstClassFields<UpdateApprovedPremisesApplication> => {
-  return firstClassFields(application, retrieveOptionalQuestionResponseFromFormArtifact)
+const getUpdateFirstClassFields = async (
+  application: Application,
+  dataServices: DataServices,
+  token: string,
+): Promise<FirstClassFields<UpdateApprovedPremisesApplication>> => {
+  return firstClassFields(application, retrieveOptionalQuestionResponseFromFormArtifact, dataServices, token)
 }
 
-const getSubmitFirstClassFields = (application: Application): FirstClassFields<SubmitApprovedPremisesApplication> => {
-  return firstClassFields(application, retrieveQuestionResponseFromFormArtifact)
+const getSubmitFirstClassFields = async (
+  application: Application,
+  dataServices: DataServices,
+  token: string,
+): Promise<FirstClassFields<SubmitApprovedPremisesApplication>> => {
+  return firstClassFields(application, retrieveQuestionResponseFromFormArtifact, dataServices, token)
 }
 
 const getReleaseType = (application: FormArtifact, sentenceType: SentenceTypeOption): ReleaseTypeOption =>

--- a/server/utils/applications/getDefaultPlacementDurationInDays.test.ts
+++ b/server/utils/applications/getDefaultPlacementDurationInDays.test.ts
@@ -1,27 +1,34 @@
-import { applicationFactory } from '../../testutils/factories'
-import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
+import { createMock } from '@golevelup/ts-jest'
+import { DataServices } from '@approved-premises/ui'
+import {
+  applicationFactory,
+  cas1RequestsForPlacementDurationsCalculationResponseDtoFactory,
+} from '../../testutils/factories'
 import { getDefaultPlacementDurationInDays } from './getDefaultPlacementDurationInDays'
+import { ApplicationService } from '../../services'
 
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
+const applicationService = createMock<ApplicationService>({})
+const dataServices = { applicationService } as DataServices
+
+const token = 'test_token'
 
 describe('getDefaultPlacementDurationInDays', () => {
-  const application = applicationFactory.build()
-
-  it.each([
-    [12, 'normal'],
-    [12, 'standard'],
-    [12, 'mhapElliottHouse'],
-    [12, 'mhapStJosephs'],
-    [12, 'rfap'],
-    [26, 'pipe'],
-    [52, 'esap'],
-  ])('returns %s weeks when the AP type is "%s"', (weeks, apType) => {
-    ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValueOnce(apType)
-    expect(getDefaultPlacementDurationInDays(application)).toEqual(weeks * 7)
+  const application = applicationFactory.build({
+    data: { 'basic-information': { 'sentence-type': { sentenceType: 'sentence-type' } } },
   })
+  const durations = cas1RequestsForPlacementDurationsCalculationResponseDtoFactory.build()
+  applicationService.getPlacementDuration.mockResolvedValue(durations)
 
-  it('returns null when the AP type is anything else', () => {
-    ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValueOnce('something else')
-    expect(getDefaultPlacementDurationInDays(application)).toEqual(null)
+  it('calls the api to calculate the default placement duration', async () => {
+    expect(await getDefaultPlacementDurationInDays(application, dataServices, token)).toEqual(
+      durations.defaultDurationDays,
+    )
+    expect(applicationService.getPlacementDuration).toHaveBeenCalledWith(
+      token,
+      application.id,
+      application.apType,
+      'sentence-type',
+    )
   })
 })

--- a/server/utils/applications/getDefaultPlacementDurationInDays.ts
+++ b/server/utils/applications/getDefaultPlacementDurationInDays.ts
@@ -1,19 +1,26 @@
-import { Cas1Application as Application } from '@approved-premises/api'
-import { BackwardsCompatibleApplyApType } from '@approved-premises/ui'
-import SelectApType from '../../form-pages/apply/reasons-for-placement/type-of-ap/apType'
-import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
+import { Cas1Application as Application, SentenceTypeOption } from '@approved-premises/api'
+import { DataServices } from '@approved-premises/ui'
 
-export const getDefaultPlacementDurationInDays = (application: Application) => {
-  const apType = retrieveOptionalQuestionResponseFromFormArtifact(
-    application,
-    SelectApType,
-    'type',
-  ) as BackwardsCompatibleApplyApType
+const sentenceTypeFromApplication = (application: Application): SentenceTypeOption => {
+  const basicInformation = application.data?.['basic-information']
+  if (!basicInformation) return null
 
-  if (['standard', 'normal', 'mhapElliottHouse', 'mhapStJosephs', 'rfap'].includes(apType)) {
-    return 12 * 7
+  const { sentenceType = '' } = {
+    ...basicInformation['sentence-type'],
   }
-  if (apType === 'pipe') return 26 * 7
-  if (apType === 'esap') return 52 * 7
-  return null
+  return sentenceType as SentenceTypeOption
 }
+
+export const getDefaultPlacementDurationInDays = async (
+  application: Application,
+  dataServices: DataServices,
+  token: string,
+) =>
+  (
+    await dataServices.applicationService.getPlacementDuration(
+      token,
+      application.id,
+      application.apType,
+      sentenceTypeFromApplication(application),
+    )
+  )?.defaultDurationDays

--- a/server/utils/applications/placementDurationFromApplication.test.ts
+++ b/server/utils/applications/placementDurationFromApplication.test.ts
@@ -1,11 +1,18 @@
+import { createMock } from '@golevelup/ts-jest'
+import { DataServices } from '@approved-premises/ui'
 import { applicationFactory } from '../../testutils/factories'
 import PlacementDuration from '../../form-pages/apply/move-on/placementDuration'
 import { getDefaultPlacementDurationInDays } from './getDefaultPlacementDurationInDays'
 import { placementDurationFromApplication } from './placementDurationFromApplication'
 import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
+import { ApplicationService } from '../../services'
 
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
 jest.mock('./getDefaultPlacementDurationInDays')
+
+const applicationService = createMock<ApplicationService>({})
+const dataServices = { applicationService } as DataServices
+const token = 'test_token'
 
 describe('placementDurationFromApplication', () => {
   const application = applicationFactory.build()
@@ -14,10 +21,10 @@ describe('placementDurationFromApplication', () => {
     jest.clearAllMocks()
   })
 
-  it('should return the duration if provided', () => {
+  it('should return the duration if provided', async () => {
     ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValueOnce(52)
 
-    expect(placementDurationFromApplication(application)).toEqual(52)
+    expect(await placementDurationFromApplication(application, dataServices, token)).toEqual(52)
 
     expect(retrieveOptionalQuestionResponseFromFormArtifact).toHaveBeenCalledWith(
       application,
@@ -27,17 +34,17 @@ describe('placementDurationFromApplication', () => {
     expect(getDefaultPlacementDurationInDays).not.toHaveBeenCalled()
   })
 
-  it('should return the default duration an alternative duration is not provided', () => {
+  it('should return the default duration an alternative duration is not provided', async () => {
     ;(retrieveOptionalQuestionResponseFromFormArtifact as jest.Mock).mockReturnValueOnce(undefined)
     ;(getDefaultPlacementDurationInDays as jest.Mock).mockReturnValueOnce(12)
 
-    expect(placementDurationFromApplication(application)).toEqual(12)
+    expect(await placementDurationFromApplication(application, dataServices, token)).toEqual(12)
 
     expect(retrieveOptionalQuestionResponseFromFormArtifact).toHaveBeenCalledWith(
       application,
       PlacementDuration,
       'duration',
     )
-    expect(getDefaultPlacementDurationInDays).toHaveBeenCalledWith(application)
+    expect(getDefaultPlacementDurationInDays).toHaveBeenCalledWith(application, dataServices, token)
   })
 })

--- a/server/utils/applications/placementDurationFromApplication.ts
+++ b/server/utils/applications/placementDurationFromApplication.ts
@@ -1,11 +1,16 @@
 import { Cas1Application as Application } from '@approved-premises/api'
+import { DataServices } from '@approved-premises/ui'
 import PlacementDuration from '../../form-pages/apply/move-on/placementDuration'
 import { getDefaultPlacementDurationInDays } from './getDefaultPlacementDurationInDays'
 import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
 
-export const placementDurationFromApplication = (application: Application) => {
+export const placementDurationFromApplication = async (
+  application: Application,
+  dataservices: DataServices,
+  token: string,
+) => {
   return (
     Number(retrieveOptionalQuestionResponseFromFormArtifact(application, PlacementDuration, 'duration')) ||
-    getDefaultPlacementDurationInDays(application)
+    getDefaultPlacementDurationInDays(application, dataservices, token)
   )
 }

--- a/server/utils/assessments/acceptanceData.test.ts
+++ b/server/utils/assessments/acceptanceData.test.ts
@@ -1,10 +1,11 @@
 import { createMock } from '@golevelup/ts-jest'
-import { ApType } from '@approved-premises/api'
+import { ApType, PlacementDates, PlacementRequirements } from '@approved-premises/api'
+import { DataServices } from '@approved-premises/ui'
 import { mockOptionalQuestionResponse, mockQuestionResponse } from '../../testutils/mockQuestionResponse'
 import MatchingInformation, {
   MatchingInformationBody,
 } from '../../form-pages/assess/matchingInformation/matchingInformationTask/matchingInformation'
-import { acceptanceData, criteriaFromMatchingInformation, placementDates, placementRequestData } from './acceptanceData'
+import * as acceptanceData from './acceptanceData'
 import { assessmentFactory } from '../../testutils/factories'
 import { pageDataFromApplicationOrAssessment } from '../../form-pages/utils'
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
@@ -15,6 +16,7 @@ import ApplicationTimeliness, {
   ApplicationTimelinessBody,
 } from '../../form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness'
 import { TasklistPageInterface } from '../../form-pages/tasklistPage'
+import { ApplicationService } from '../../services'
 
 jest.mock('../../form-pages/utils')
 jest.mock('../retrieveQuestionResponseFromFormArtifact')
@@ -23,8 +25,16 @@ jest.mock('../applications/applicantAndCaseManagerDetails')
 jest.mock('../applications/placementDurationFromApplication')
 jest.mock('../applications/getResponses')
 
+const applicationService = createMock<ApplicationService>({})
+const dataServices = { applicationService } as DataServices
+const token = 'test-token'
+
 describe('acceptanceData', () => {
   const assessment = assessmentFactory.build()
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+  })
 
   describe('acceptanceData', () => {
     const matchingInformation = createMock<MatchingInformationBody>({ apType: 'normal' })
@@ -44,40 +54,46 @@ describe('acceptanceData', () => {
       })
       mockOptionalQuestionResponse({ cruInformation: 'Some notes' })
       ;(getResponses as jest.Mock).mockReturnValue(responses)
+      jest.spyOn(acceptanceData, 'placementRequestData').mockReturnValue({} as PlacementRequirements)
+      jest.spyOn(acceptanceData, 'placementDates').mockResolvedValue({} as PlacementDates)
     })
 
-    it('should return the acceptance data for the assessment', () => {
-      expect(acceptanceData(assessment)).toEqual({
+    it('should return the acceptance data for the assessment', async () => {
+      expect(await acceptanceData.acceptanceData(assessment, { applicationService }, token)).toEqual({
         document: responses,
-        requirements: placementRequestData(assessment),
-        placementDates: placementDates(assessment),
+        requirements: {},
+        placementDates: {},
         notes: 'Some notes',
       })
       expect(getResponses).toHaveBeenCalledWith(assessment)
+      expect(acceptanceData.placementDates).toHaveBeenCalledWith(assessment, dataServices, token)
+      expect(acceptanceData.placementRequestData).toHaveBeenCalledWith(assessment)
     })
 
-    it('should return the acceptance data for the assessment with optional timeliness information', () => {
+    it('should return the acceptance data for the assessment with optional timeliness information', async () => {
       timelinessInformation = createMock<ApplicationTimelinessBody>({
         agreeWithShortNoticeReason: 'no',
         agreeWithShortNoticeReasonComments: 'comments',
         reasonForLateApplication: 'furtherOffence',
       })
-      expect(acceptanceData(assessment)).toEqual({
+      expect(await acceptanceData.acceptanceData(assessment, dataServices, token)).toEqual({
         document: responses,
-        requirements: placementRequestData(assessment),
-        placementDates: placementDates(assessment),
+        requirements: {},
+        placementDates: {},
         notes: 'Some notes',
         ...timelinessInformation,
         agreeWithShortNoticeReason: false,
       })
       expect(getResponses).toHaveBeenCalledWith(assessment)
+      expect(acceptanceData.placementDates).toHaveBeenCalledWith(assessment, dataServices, token)
+      expect(acceptanceData.placementRequestData).toHaveBeenCalledWith(assessment)
     })
   })
 
   describe('placementDates', () => {
     const expectedArrival = '2020-01-01'
 
-    it('should return the placement dates if an arrival date is provided', () => {
+    it('should return the placement dates if an arrival date is provided', async () => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(expectedArrival)
       ;(pageDataFromApplicationOrAssessment as jest.Mock).mockReturnValue({
         lengthOfStayWeeks: '1',
@@ -85,27 +101,27 @@ describe('acceptanceData', () => {
         lengthOfStayAgreed: 'no',
       })
 
-      const result = placementDates(assessment)
+      const result = await acceptanceData.placementDates(assessment, dataServices, token)
 
       expect(result.expectedArrival).toEqual(expectedArrival)
       expect(result.duration).toEqual(12)
     })
 
-    it('should return the duration from the application if a duration is not provided', () => {
+    it('should return the duration from the application if a duration is not provided', async () => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(expectedArrival)
       ;(placementDurationFromApplication as jest.Mock).mockReturnValueOnce('52')
       ;(pageDataFromApplicationOrAssessment as jest.Mock).mockReturnValue({ lengthOfStayAgreed: 'yes' })
 
-      const result = placementDates(assessment)
+      const result = await acceptanceData.placementDates(assessment, dataServices, token)
 
       expect(result.expectedArrival).toEqual(expectedArrival)
       expect(result.duration).toEqual(52)
     })
 
-    it('should return null if the arrival date is not provided', () => {
+    it('should return null if the arrival date is not provided', async () => {
       ;(arrivalDateFromApplication as jest.Mock).mockReturnValue(undefined)
 
-      const result = placementDates(assessment)
+      const result = await acceptanceData.placementDates(assessment, dataServices, token)
 
       expect(result).toBeNull()
     })
@@ -121,12 +137,12 @@ describe('acceptanceData', () => {
         alternativeRadius: '100',
       })
 
-      expect(placementRequestData(assessment)).toEqual({
+      expect(acceptanceData.placementRequestData(assessment)).toEqual({
         type: 'normal',
         location: 'ABC123',
         radius: '100',
         desirableCriteria: [],
-        essentialCriteria: criteriaFromMatchingInformation(matchingInformation),
+        essentialCriteria: acceptanceData.criteriaFromMatchingInformation(matchingInformation),
       })
     })
 
@@ -142,7 +158,7 @@ describe('acceptanceData', () => {
         const matchingInformation = createMock<MatchingInformationBody>({ apType: apTypeCriteria })
         ;(pageDataFromApplicationOrAssessment as jest.Mock).mockReturnValue(matchingInformation)
 
-        expect(placementRequestData(assessment).type).toEqual(apType)
+        expect(acceptanceData.placementRequestData(assessment).type).toEqual(apType)
       })
     })
 
@@ -153,7 +169,7 @@ describe('acceptanceData', () => {
 
         mockOptionalQuestionResponse({ alternativeRadius: undefined })
 
-        expect(placementRequestData(assessment).radius).toEqual(50)
+        expect(acceptanceData.placementRequestData(assessment).radius).toEqual(50)
       })
     })
   })
@@ -170,7 +186,7 @@ describe('acceptanceData', () => {
         isSuitableForVulnerable: 'relevant',
       })
 
-      const result = criteriaFromMatchingInformation(matchingInformation)
+      const result = acceptanceData.criteriaFromMatchingInformation(matchingInformation)
 
       expect(result.sort()).toEqual(
         [
@@ -198,7 +214,7 @@ describe('acceptanceData', () => {
         isSuitableForVulnerable: 'notRelevant',
       })
 
-      expect(criteriaFromMatchingInformation(matchingInformation)).toEqual([])
+      expect(acceptanceData.criteriaFromMatchingInformation(matchingInformation)).toEqual([])
     })
   })
 })

--- a/server/utils/assessments/acceptanceData.ts
+++ b/server/utils/assessments/acceptanceData.ts
@@ -5,6 +5,7 @@ import {
   PlacementDates,
   PlacementRequirements,
 } from '@approved-premises/api'
+import { DataServices } from '@approved-premises/ui'
 import { ShortNoticeReasons } from '../../form-pages/apply/reasons-for-placement/basic-information/reasonForShortNotice'
 import { pageDataFromApplicationOrAssessment } from '../../form-pages/utils'
 import {
@@ -30,19 +31,26 @@ import ApplicationTimeliness from '../../form-pages/assess/assessApplication/sui
 import type { ApplicationTimelinessBody } from '../../form-pages/assess/assessApplication/suitablityAssessment/applicationTimeliness'
 import { lengthOfStay } from '../../form-pages/utils/matchingInformationUtils'
 
-export const acceptanceData = (assessment: Assessment): Cas1AssessmentAcceptance => {
+export const acceptanceData = async (
+  assessment: Assessment,
+  dataServices: DataServices,
+  token: string,
+): Promise<Cas1AssessmentAcceptance> => {
   const notes = retrieveOptionalQuestionResponseFromFormArtifact(assessment, MatchingInformation, 'cruInformation')
-
   return {
     document: getResponses(assessment),
     requirements: placementRequestData(assessment),
-    placementDates: placementDates(assessment),
+    placementDates: await placementDates(assessment, dataServices, token),
     notes,
     ...timelinessDataFromAssessment(assessment),
   }
 }
 
-export const placementDates = (assessment: Assessment): PlacementDates | null => {
+export const placementDates = async (
+  assessment: Assessment,
+  dataServices: DataServices,
+  token: string,
+): Promise<PlacementDates | null> => {
   const arrivalDate = arrivalDateFromApplication(assessment.application)
 
   if (!arrivalDate) {
@@ -51,7 +59,7 @@ export const placementDates = (assessment: Assessment): PlacementDates | null =>
 
   const placementDuration =
     lengthOfStay(pageDataFromApplicationOrAssessment(MatchingInformation, assessment)) ||
-    placementDurationFromApplication(assessment.application)
+    (await placementDurationFromApplication(assessment.application, dataServices, token))
 
   return {
     expectedArrival: arrivalDate,

--- a/server/utils/placementRequests/placementApplicationSubmissionData.test.ts
+++ b/server/utils/placementRequests/placementApplicationSubmissionData.test.ts
@@ -1,4 +1,6 @@
 import { Cas1RequestedPlacementPeriod } from '@approved-premises/api'
+import { createMock } from '@golevelup/ts-jest'
+import { DataServices } from '@approved-premises/ui'
 import AdditionalPlacementDetails from '../../form-pages/placement-application/request-a-placement/additionalPlacementDetails'
 import DatesOfPlacement from '../../form-pages/placement-application/request-a-placement/datesOfPlacement'
 import DecisionToRelease from '../../form-pages/placement-application/request-a-placement/decisionToRelease'
@@ -10,9 +12,14 @@ import {
   durationAndArrivalDateFromPlacementApplication,
   placementApplicationSubmissionData,
 } from './placementApplicationSubmissionData'
+import { ApplicationService } from '../../services'
 
 jest.mock('../../form-pages/utils')
 jest.mock('../applications/placementDurationFromApplication')
+
+const applicationService = createMock<ApplicationService>({})
+const dataServices = { applicationService } as DataServices
+const token = 'test_token'
 
 describe('placementApplicationSubmissionData', () => {
   const datesOfPlacement = [
@@ -71,7 +78,9 @@ describe('placementApplicationSubmissionData', () => {
       ;(getPageName as jest.MockedFn<typeof getPageName>).mockReturnValueOnce('reason')
       ;(getPageName as jest.MockedFn<typeof getPageName>).mockReturnValueOnce('dates-of-placement')
 
-      expect(placementApplicationSubmissionData(placementApplication, applicationFactory.build())).toEqual({
+      expect(
+        placementApplicationSubmissionData(placementApplication, applicationFactory.build(), dataServices, token),
+      ).toEqual({
         sentenceType: 'licence',
         releaseType: 'rotl',
         translatedDocument: {},
@@ -94,7 +103,13 @@ describe('placementApplicationSubmissionData', () => {
       })
 
       expect(
-        durationAndArrivalDateFromPlacementApplication(placementApplication, 'rotl', applicationFactory.build()),
+        durationAndArrivalDateFromPlacementApplication(
+          placementApplication,
+          'rotl',
+          applicationFactory.build(),
+          dataServices,
+          token,
+        ),
       ).toEqual(datesOfPlacementForApi)
       expect(pageDataFromApplicationOrAssessment).toHaveBeenCalledWith(DatesOfPlacement, placementApplication)
     })
@@ -110,7 +125,13 @@ describe('placementApplicationSubmissionData', () => {
       })
 
       expect(
-        durationAndArrivalDateFromPlacementApplication(placementApplication, 'rotl', applicationFactory.build()),
+        durationAndArrivalDateFromPlacementApplication(
+          placementApplication,
+          'rotl',
+          applicationFactory.build(),
+          dataServices,
+          token,
+        ),
       ).toEqual([{ ...datesOfPlacementForApi[0], arrivalFlexible: undefined }])
       expect(pageDataFromApplicationOrAssessment).toHaveBeenCalledWith(DatesOfPlacement, placementApplication)
     })
@@ -130,6 +151,8 @@ describe('placementApplicationSubmissionData', () => {
           placementApplication,
           'not_applicable',
           applicationFactory.build(),
+          dataServices,
+          token,
         ),
       ).toEqual([
         {
@@ -154,6 +177,8 @@ describe('placementApplicationSubmissionData', () => {
           placementApplication,
           'paroleDirectedLicence',
           applicationFactory.build(),
+          dataServices,
+          token,
         ),
       ).toEqual([
         {

--- a/server/utils/placementRequests/placementApplicationSubmissionData.ts
+++ b/server/utils/placementRequests/placementApplicationSubmissionData.ts
@@ -7,6 +7,7 @@ import {
   SubmitPlacementApplication,
 } from '@approved-premises/api'
 
+import { DataServices } from '@approved-premises/ui'
 import {
   retrieveOptionalQuestionResponseFromFormArtifact,
   retrieveQuestionResponseFromFormArtifact,
@@ -24,12 +25,16 @@ import { getSentenceType } from '../placementApplications'
 export const placementApplicationSubmissionData = (
   placementApplication: PlacementApplication,
   application: Application,
+  dataServices: DataServices,
+  token: string,
 ): SubmitPlacementApplication => {
   const { releaseType, sentenceType, situation } = getSentenceType(placementApplication)
   const requestedPlacementPeriods = durationAndArrivalDateFromPlacementApplication(
     placementApplication,
     releaseType,
     application,
+    dataServices,
+    token,
   )
   return {
     translatedDocument: placementApplication.document,
@@ -70,6 +75,8 @@ export const durationAndArrivalDateFromPlacementApplication = (
   placementApplication: PlacementApplication,
   reasonForPlacement: ReleaseTypeOption,
   application: Application,
+  dataServices: DataServices,
+  token: string,
 ): Array<Cas1RequestedPlacementPeriod> => {
   switch (reasonForPlacement) {
     case 'rotl': {
@@ -84,7 +91,7 @@ export const durationAndArrivalDateFromPlacementApplication = (
       return [
         {
           arrival: DateFormats.dateObjToIsoDate(addWeeks(DateFormats.isoToDateObj(decisionToReleaseDate), 6)),
-          duration: Number(placementDurationFromApplication(application)),
+          duration: Number(placementDurationFromApplication(application, dataServices, token)),
         },
       ]
     }


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/FM-815
<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Removes the internal UI calculation for default duration and replaces it with a call to the API.
The required placement duration is not stored in the Application unless overridden and hence, the default duration was being calculated whenever it was required. The calculation was a pure function, so this was quite straightforward.

For the calculation to be carried out in the API instead, all the pure function callls need to be async and hence, all the chain of calling functions need to be async too. Also, the application service ad token have to be passed down the function chain. These changes also flow through to quite an impact to the unit and end-to-end tests.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

No UI change
