### PR TITLE
FM-844 Use new createApplication endpoint

### DIFF
--- a/integration_tests/mockApis/journeyUtils.ts
+++ b/integration_tests/mockApis/journeyUtils.ts
@@ -1,5 +1,10 @@
 import { SuperAgentRequest } from 'superagent'
-import { Cas1Application as Application, Cas1Assessment as Assessment } from '@approved-premises/api'
+import {
+  Cas1Application,
+  Cas1Application as Application,
+  Cas1Assessment as Assessment,
+  FullPerson,
+} from '@approved-premises/api'
 
 import { UiTask } from '@approved-premises/ui'
 import { bulkStub, getMatchingRequests } from './setup'
@@ -191,46 +196,58 @@ export const stubJourney = (form: Application | Assessment): SuperAgentRequest =
   const journeyType = isAssessment(form) ? 'assessment' : 'application'
   const scenarioName = journeyType === 'assessment' ? 'assess' : 'apply'
 
-  const startRequest =
-    journeyType === 'application'
-      ? {
-          method: 'POST',
-          url: paths.applications.new({}),
-        }
-      : {
-          method: 'GET',
-          url: paths.assessments.show({ id: form.id }),
-        }
-  const getEndpoint =
-    journeyType === 'application' ? paths.applications.show({ id: form.id }) : paths.assessments.show({ id: form.id })
-
-  const stubs = [
-    {
+  const stubs = []
+  // Creation
+  if (journeyType === 'application') {
+    const application = form as Cas1Application
+    stubs.push({
       scenarioName,
       requiredScenarioState: `Started`,
       newScenarioState: `${journeyType}Created`,
-      request: startRequest,
+      request: {
+        method: 'POST',
+        url: paths.applications.new({}),
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: { applicationId: application.id, tier: (application.person as FullPerson).tier },
+      },
+    })
+  } else {
+    stubs.push({
+      scenarioName,
+      requiredScenarioState: `Started`,
+      newScenarioState: `${journeyType}Created`,
+      request: {
+        method: 'GET',
+        url: paths.assessments.show({ id: form.id }),
+      },
       response: {
         status: 201,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: { ...form, data: null },
       },
+    })
+  }
+
+  const getEndpoint =
+    journeyType === 'application' ? paths.applications.show({ id: form.id }) : paths.assessments.show({ id: form.id })
+
+  stubs.push({
+    scenarioName,
+    requiredScenarioState: `${journeyType}Created`,
+    newScenarioState: `${journeyType}Started`,
+    request: {
+      method: 'GET',
+      url: getEndpoint,
     },
-    {
-      scenarioName,
-      requiredScenarioState: `${journeyType}Created`,
-      newScenarioState: `${journeyType}Started`,
-      request: {
-        method: 'GET',
-        url: getEndpoint,
-      },
-      response: {
-        status: 200,
-        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: { ...form, data: {} },
-      },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: { ...form, data: {} },
     },
-  ] as Array<Record<string, unknown>>
+  })
 
   const tasks = isAssessment(form)
     ? getSections(form as Assessment)

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -6,6 +6,7 @@ import {
   personFactory,
   restrictedPersonFactory,
   risksFactory,
+  tierDtoFactory,
   tierEnvelopeFactory,
   userFactory,
 } from '../../../server/testutils/factories'
@@ -116,19 +117,22 @@ context('Apply', () => {
       crn: this.person.crn,
       tier: tierEnvelopeFactory.build({ value: { level: 'D1' } }),
     })
-    cy.task('stubApplicationGet', { application: this.application })
-    cy.task('stubApplications', [this.application])
+    const tier = tierDtoFactory.v2Ineligible().build()
+    this.person.tier = tier
+    const application = { ...this.application, person: { ...this.person, tier } }
+    cy.task('stubApplicationGet', { application })
+    cy.task('stubApplications', [application])
 
     AND('I start the application and left')
-    const apply = new ApplyHelper(this.application, this.person, this.offences)
+    const apply = new ApplyHelper(application, application.person, this.offences)
     apply.setupApplicationStubs()
     apply.startApplication()
 
     AND('I visit the list page')
-    const listPage = ListPage.visit([this.application], [], [])
+    const listPage = ListPage.visit([application], [], [])
 
     WHEN('I click the application from list')
-    listPage.clickApplication(this.application)
+    listPage.clickApplication(application)
 
     AND('I click the basic information')
     apply.clickBasicInformation()
@@ -202,12 +206,11 @@ context('Apply', () => {
 
   it(`allows the user to specify if the case is exceptional if the offender's tier is not eligible`, function test() {
     GIVEN('the person does not have an eligible risk tier')
-    this.application.risks = risksFactory.build({
-      crn: this.person.crn,
-      tier: tierEnvelopeFactory.build({ value: { level: 'D1' } }),
-    })
+    const tier = tierDtoFactory.v2Ineligible().build()
+    this.person.tier = tier
+    const application = { ...this.application, person: { ...this.person, tier } }
 
-    const apply = new ApplyHelper(this.application, this.person, this.offences)
+    const apply = new ApplyHelper(application, application.person, this.offences)
     apply.setupApplicationStubs()
     apply.startApplication()
 
@@ -215,17 +218,17 @@ context('Apply', () => {
     apply.completeExceptionalCase()
 
     AND('I should be on the Confirm Your Details page')
-    Page.verifyOnPage(ConfirmYourDetailsPage, this.application)
+    Page.verifyOnPage(ConfirmYourDetailsPage, application)
   })
 
   it('tells the user that their application is not applicable if the tier is not eligible and it is not an exceptional case', function test() {
     GIVEN('the person does not have an eligible risk tier')
-    this.application.risks = risksFactory.build({
-      crn: this.person.crn,
-      tier: tierEnvelopeFactory.build({ value: { level: 'D1' } }),
-    })
+    const tier = tierDtoFactory.v2Ineligible().build()
+    this.person.tier = tier
+    const application = { ...this.application, person: { ...this.person, tier } }
 
-    const apply = new ApplyHelper(this.application, this.person, this.offences)
+    cy.task('stubApplicationGet', { application })
+    const apply = new ApplyHelper(application, application.person, this.offences)
     apply.setupApplicationStubs()
     apply.startApplication()
 

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -21,6 +21,7 @@ import SubmissionConfirmation from '../../pages/apply/submissionConfirmation'
 import { mapApiPersonRisksForUi } from '../../../server/utils/utils'
 import { setup } from './setup'
 import { AND, GIVEN, THEN, WHEN } from '../../helpers'
+import { fullPersonFactory } from '../../../server/testutils/factories/person'
 
 context('Apply', () => {
   beforeEach(setup)
@@ -188,12 +189,10 @@ context('Apply', () => {
 
   it(`allows the user to specify if the risk level if the person does not have a tier`, function test() {
     AND('that person does not have an eligible risk tier')
+    const person = fullPersonFactory.build({ tier: undefined })
+    this.application.person = person
 
-    this.application.risks = risksFactory.build({
-      tier: undefined,
-    })
-
-    const apply = new ApplyHelper(this.application, this.person, this.offences)
+    const apply = new ApplyHelper(this.application, person, this.offences)
     apply.setupApplicationStubs()
     apply.startApplication()
 

--- a/integration_tests/tests/apply/setup.ts
+++ b/integration_tests/tests/apply/setup.ts
@@ -3,22 +3,21 @@ import {
   activeOffenceFactory,
   applicationFactory,
   assessmentFactory,
-  personFactory,
   risksFactory,
   tierEnvelopeFactory,
 } from '../../../server/testutils/factories'
 import { DateFormats } from '../../../server/utils/dateUtils'
 import { defaultUserId } from '../../mockApis/auth'
 import { signIn } from '../signIn'
+import { fullPersonFactory } from '../../../server/testutils/factories/person'
 
 export const setup = () => {
   cy.task('reset')
 
   GIVEN('I am signed in as an applicant')
   signIn('applicant', { id: defaultUserId })
-
   cy.fixture('applicationData.json').then(applicationData => {
-    const person = personFactory.build()
+    const person = fullPersonFactory.build()
     const assessment = assessmentFactory.build()
     const application = applicationFactory.build({
       person,
@@ -35,7 +34,6 @@ export const setup = () => {
 
     application.data = updateApplicationReleaseDate(applicationData)
     application.risks = risks
-
     cy.task('stubApplicationGet', { application })
     cy.task('stubApplications', [application])
     cy.task('stubAllApplications', { applications: [], anyQuery: true })

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -20,6 +20,7 @@ import {
   applicationFactory,
   assessmentFactory,
   cas1ApplicationSummaryFactory,
+  cas1CreateApplicationOutcomeFactory,
   cas1TimelineEventFactory,
   paginatedResponseFactory,
   personFactory,
@@ -656,9 +657,10 @@ describe('applicationsController', () => {
   })
 
   describe('create', () => {
-    const application = applicationFactory.build()
+    const outcome = cas1CreateApplicationOutcomeFactory.build()
     const firstPage = '/foo/bar'
     const offences = activeOffenceFactory.buildList(2)
+    const person = personFactory.build()
 
     beforeEach(() => {
       request = createMock<Request>({
@@ -668,7 +670,8 @@ describe('applicationsController', () => {
       request.body.offenceId = offences[0].offenceId
 
       personService.getOffences.mockResolvedValue(offences)
-      applicationService.createApplication.mockResolvedValue(application)
+      personService.findByCrn.mockResolvedValue(person)
+      applicationService.createApplication.mockResolvedValue(outcome)
 
       jest.spyOn(applicationUtils, 'firstPageOfApplicationJourney').mockReturnValue(firstPage)
     })
@@ -679,16 +682,8 @@ describe('applicationsController', () => {
       await requestHandler(request, response, next)
 
       expect(applicationService.createApplication).toHaveBeenCalledWith('SOME_TOKEN', 'some-crn', offences[0])
-      expect(applicationUtils.firstPageOfApplicationJourney).toHaveBeenCalledWith(application)
+      expect(applicationUtils.firstPageOfApplicationJourney).toHaveBeenCalledWith(outcome.applicationId, person)
       expect(response.redirect).toHaveBeenCalledWith(firstPage)
-    })
-
-    it('saves the application to the session', async () => {
-      const requestHandler = applicationsController.create()
-
-      await requestHandler(request, response, next)
-
-      expect(request.session.application).toEqual(application)
     })
 
     it('sets errors and redirects if the offence not selected', async () => {
@@ -697,7 +692,7 @@ describe('applicationsController', () => {
       await requestHandler(request, response, next)
 
       expect(applicationService.createApplication).toHaveBeenCalledWith('SOME_TOKEN', 'some-crn', offences[0])
-      expect(applicationUtils.firstPageOfApplicationJourney).toHaveBeenCalledWith(application)
+      expect(applicationUtils.firstPageOfApplicationJourney).toHaveBeenCalledWith(outcome.applicationId, person)
       expect(response.redirect).toHaveBeenCalledWith(firstPage)
     })
 

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -251,13 +251,16 @@ export default class ApplicationsController {
 
       const person = await this.personService.findByCrn(req.user.token, crn)
       if (!isFullPerson(person)) throw new RestrictedPersonError(crn)
+
       const offences = await this.personService.getOffences(req.user.token, crn)
       const indexOffence = offences.find(o => o.offenceId === offenceId)
-      const application = await this.applicationService.createApplication(req.user.token, crn, indexOffence)
+      const outcome = await this.applicationService.createApplication(req.user.token, crn, indexOffence)
 
-      req.session.application = application
+      // If this is a new CRN, it's possible that the tier is in the person requested earlier is not populated - however it should be populated in the create-application response
+      // So we substitue the later and more-reliable version
+      person.tier = outcome.tier
 
-      return res.redirect(firstPageOfApplicationJourney(application))
+      return res.redirect(firstPageOfApplicationJourney(outcome.applicationId, person))
     }
   }
 

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -10,6 +10,7 @@ import {
   activeOffenceFactory,
   applicationFactory,
   cas1ApplicationSummaryFactory,
+  cas1CreateApplicationOutcomeFactory,
   cas1TimelineEventFactory,
   documentFactory,
   noteFactory,
@@ -25,6 +26,7 @@ describeClient('ApplicationClient', provider => {
   let applicationClient: ApplicationClient
 
   const token = 'token-1'
+  const crn = 'D1234'
 
   beforeEach(() => {
     config.flags.oasysDisabled = false
@@ -33,8 +35,8 @@ describeClient('ApplicationClient', provider => {
 
   describe('create', () => {
     it('should return an application when a crn is posted', async () => {
-      const application = applicationFactory.build()
       const offence = activeOffenceFactory.build()
+      const outcome = cas1CreateApplicationOutcomeFactory.build()
 
       await provider.addInteraction({
         state: 'Server is healthy',
@@ -44,11 +46,10 @@ describeClient('ApplicationClient', provider => {
           path: paths.applications.new.pattern,
           query: {},
           body: {
-            crn: application.person.crn,
+            crn,
             convictionId: offence.convictionId,
             deliusEventNumber: offence.deliusEventNumber,
             offenceId: offence.offenceId,
-            type: 'CAS1',
           },
           headers: {
             authorization: `Bearer ${token}`,
@@ -56,13 +57,13 @@ describeClient('ApplicationClient', provider => {
         },
         willRespondWith: {
           status: 201,
-          body: application,
+          body: outcome,
         },
       })
 
-      const result = await applicationClient.create(application.person.crn, offence)
+      const result = await applicationClient.create(crn, offence)
 
-      expect(result).toEqual(application)
+      expect(result).toEqual(outcome)
     })
 
     describe('when oasys integration is disabled', () => {
@@ -71,8 +72,8 @@ describeClient('ApplicationClient', provider => {
       })
 
       it('should request that the risks are skipped', async () => {
-        const application = applicationFactory.build()
         const offence = activeOffenceFactory.build()
+        const outcome = cas1CreateApplicationOutcomeFactory.build()
 
         await provider.addInteraction({
           state: 'Server is healthy',
@@ -82,11 +83,10 @@ describeClient('ApplicationClient', provider => {
             path: paths.applications.new.pattern,
             query: {},
             body: {
-              crn: application.person.crn,
+              crn,
               convictionId: offence.convictionId,
               deliusEventNumber: offence.deliusEventNumber,
               offenceId: offence.offenceId,
-              type: 'CAS1',
             },
             headers: {
               authorization: `Bearer ${token}`,
@@ -94,13 +94,13 @@ describeClient('ApplicationClient', provider => {
           },
           willRespondWith: {
             status: 201,
-            body: application,
+            body: outcome,
           },
         })
 
-        const result = await applicationClient.create(application.person.crn, offence)
+        const result = await applicationClient.create(crn, offence)
 
-        expect(result).toEqual(application)
+        expect(result).toEqual(outcome)
       })
     })
   })

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -13,6 +13,8 @@ import type {
   UpdateApprovedPremisesApplication,
   Withdrawables,
   Cas1ExpireApplicationReason,
+  Cas1NewApplication,
+  Cas1CreateApplicationOutcome,
 } from '@approved-premises/api'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
@@ -33,12 +35,17 @@ export default class ApplicationClient {
     })
   }
 
-  async create(crn: string, activeOffence: ActiveOffence): Promise<Application> {
+  async create(crn: string, activeOffence: ActiveOffence): Promise<Cas1CreateApplicationOutcome> {
     const { convictionId, deliusEventNumber, offenceId } = activeOffence
-
-    return this.restClient.post<Application>({
+    const data: Cas1NewApplication = {
+      crn,
+      convictionId,
+      deliusEventNumber,
+      offenceId,
+    }
+    return this.restClient.post<Cas1CreateApplicationOutcome>({
       path: paths.applications.new.pattern,
-      data: { crn, convictionId, deliusEventNumber, offenceId, type: 'CAS1' },
+      data,
     })
   }
 

--- a/server/form-pages/apply/reasons-for-placement/basic-information/isExceptionalCase.ts
+++ b/server/form-pages/apply/reasons-for-placement/basic-information/isExceptionalCase.ts
@@ -1,5 +1,5 @@
 import type { TaskListErrors, YesOrNo } from '@approved-premises/ui'
-import { Cas1Application as Application } from '@approved-premises/api'
+import { Cas1Application as Application, FullPerson } from '@approved-premises/api'
 import { sentenceCase } from '../../../../utils/utils'
 import { Page } from '../../../utils/decorators'
 
@@ -15,7 +15,8 @@ export default class IsExceptionalCase implements TasklistPage {
     readonly body: { isExceptionalCase?: YesOrNo },
     readonly application: Application,
   ) {
-    this.tier = this.application?.risks?.tier?.value?.level
+    const person = this.application?.person as FullPerson
+    this.tier = person?.tier?.tierScore
   }
 
   response() {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -100,7 +100,7 @@ export default {
     me: cas1Applications.path('me'),
     all: cas1Applications.path('all'),
     update: cas1ApplicationsSingle,
-    new: cas1Applications,
+    new: cas1Applications.path('create'),
     submission: cas1ApplicationsSingle.path('submission'),
     documents: cas1ApplicationsSingle.path('documents'),
     withdrawal: cas1ApplicationsSingle.path('withdrawal'),

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -23,6 +23,7 @@ import {
   activeOffenceFactory,
   applicationFactory,
   cas1ApplicationSummaryFactory,
+  cas1CreateApplicationOutcomeFactory,
   documentFactory,
   noteFactory,
   paginatedResponseFactory,
@@ -121,13 +122,14 @@ describe('ApplicationService', () => {
   describe('createApplication', () => {
     it('calls the create method and returns an application', async () => {
       const application = applicationFactory.build()
+      const createApplicationOutcome = cas1CreateApplicationOutcomeFactory.build()
       const offence = activeOffenceFactory.build()
 
-      applicationClient.create.mockResolvedValue(application)
+      applicationClient.create.mockResolvedValue(createApplicationOutcome)
 
       const result = await service.createApplication(token, application.person.crn, offence)
 
-      expect(result).toEqual(application)
+      expect(result).toEqual(createApplicationOutcome)
 
       expect(applicationClientFactory).toHaveBeenCalledWith(token)
       expect(applicationClient.create).toHaveBeenCalledWith(application.person.crn, offence)

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -15,6 +15,7 @@ import type {
   SortDirection,
   Cas1ApplicationSummary,
   Cas1ExpireApplicationReason,
+  Cas1CreateApplicationOutcome,
 } from '@approved-premises/api'
 
 import { updateFormArtifactData } from '../form-pages/utils/updateFormArtifactData'
@@ -30,7 +31,11 @@ import { getResponses } from '../utils/applications/getResponses'
 export default class ApplicationService {
   constructor(private readonly applicationClientFactory: RestClientBuilder<ApplicationClient>) {}
 
-  async createApplication(token: string, crn: string, activeOffence: ActiveOffence): Promise<Application> {
+  async createApplication(
+    token: string,
+    crn: string,
+    activeOffence: ActiveOffence,
+  ): Promise<Cas1CreateApplicationOutcome> {
     const applicationClient = this.applicationClientFactory(token)
 
     return applicationClient.create(crn, activeOffence)

--- a/server/testutils/factories/cas1CreateApplicationOutcome.ts
+++ b/server/testutils/factories/cas1CreateApplicationOutcome.ts
@@ -1,0 +1,9 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { Cas1CreateApplicationOutcome } from '@approved-premises/api'
+import tierDtoFactory from './tierDto'
+
+export default Factory.define<Cas1CreateApplicationOutcome>(() => ({
+  applicationId: faker.string.uuid(),
+  tier: tierDtoFactory.build(),
+}))

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -96,6 +96,8 @@ import licenceFactory from './licence'
 import csraSummaryFactory from './csraSummary'
 import offenceFactory from './offence'
 import dietAndAllergyResponseFactory from './dietAndAllergyResponse'
+import tierDtoFactory from './tierDto'
+import cas1CreateApplicationOutcomeFactory from './cas1CreateApplicationOutcome'
 
 export {
   acctAlertFactory,
@@ -200,4 +202,6 @@ export {
   offenceFactory,
   dietAndAllergyResponseFactory,
   registrationFactory,
+  tierDtoFactory,
+  cas1CreateApplicationOutcomeFactory,
 }

--- a/server/testutils/factories/person.ts
+++ b/server/testutils/factories/person.ts
@@ -9,6 +9,7 @@ import type {
   UnknownPerson,
 } from '@approved-premises/api'
 import { DateFormats } from '../../utils/dateUtils'
+import tierDtoFactory from './tierDto'
 
 export const getCrn = () => `C${faker.number.int({ min: 100000, max: 999999 })}`
 export const fullPersonFactory = Factory.define<FullPerson>(() => ({
@@ -26,6 +27,7 @@ export const fullPersonFactory = Factory.define<FullPerson>(() => ({
   isRestricted: false,
   ethnicity: faker.helpers.arrayElement(['White', 'Black', 'Asian', 'Mixed', undefined]),
   genderIdentity: faker.helpers.arrayElement(['Man', 'Woman', undefined]),
+  tier: tierDtoFactory.v2().build(),
 }))
 
 export const restrictedPersonFactory = Factory.define<RestrictedPerson>(() => ({

--- a/server/testutils/factories/person.ts
+++ b/server/testutils/factories/person.ts
@@ -27,7 +27,7 @@ export const fullPersonFactory = Factory.define<FullPerson>(() => ({
   isRestricted: false,
   ethnicity: faker.helpers.arrayElement(['White', 'Black', 'Asian', 'Mixed', undefined]),
   genderIdentity: faker.helpers.arrayElement(['Man', 'Woman', undefined]),
-  tier: tierDtoFactory.v2().build(),
+  tier: tierDtoFactory.v2Eligible().build(),
 }))
 
 export const restrictedPersonFactory = Factory.define<RestrictedPerson>(() => ({

--- a/server/testutils/factories/tierDto.ts
+++ b/server/testutils/factories/tierDto.ts
@@ -1,0 +1,40 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { TierDto } from '@approved-premises/api'
+import { DateFormats } from '../../utils/dateUtils'
+
+const v3EligibleTiers = ['A', 'B', 'C']
+const v3IneligibleTiers = ['D', 'E', 'F', 'G']
+const v2EligibleTiers = ['A1', 'A2', 'A3', 'B1', 'B2', 'B3']
+const v2IneligibleTiers = ['C1', 'C2', 'C3']
+
+class TierDtoFactory extends Factory<TierDto> {
+  v3() {
+    return this.params({
+      tierScore: faker.helpers.arrayElement([...v3EligibleTiers, ...v3IneligibleTiers]),
+      version: 'V3',
+    })
+  }
+
+  v2() {
+    return this.params({
+      tierScore: faker.helpers.arrayElement([...v2EligibleTiers, ...v2IneligibleTiers]),
+      version: 'V2',
+    })
+  }
+
+  v2Eligible() {
+    return this.params({ tierScore: faker.helpers.arrayElement(v2EligibleTiers), version: 'V2' })
+  }
+
+  v2Ineligible() {
+    return this.params({ tierScore: faker.helpers.arrayElement(v2IneligibleTiers), version: 'V2' })
+  }
+}
+
+export default TierDtoFactory.define(() => ({
+  calculationDate: DateFormats.dateObjToIsoDate(faker.date.recent({ days: 365 })),
+  provisional: faker.datatype.boolean(),
+  tierScore: faker.helpers.arrayElement([...v3EligibleTiers, ...v3IneligibleTiers]),
+  version: faker.helpers.arrayElement(['V2', 'V3']) as TierDto['version'],
+}))

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -20,6 +20,7 @@ import {
   personalTimelineFactory,
   restrictedPersonFactory,
   tierEnvelopeFactory,
+  tierDtoFactory,
 } from '../../testutils/factories'
 import paths from '../../paths/apply'
 import managePaths from '../../paths/manage'
@@ -506,42 +507,43 @@ describe('utils', () => {
   })
 
   describe('firstPageOfApplicationJourney', () => {
+    const applicationId = 'application-id'
+
     it('returns the sentence type page for an applicable application', () => {
       jest.spyOn(personUtils, 'isApplicableTier').mockReturnValue(true)
-      const application = applicationFactory.withFullPerson().build()
+      const tier = tierDtoFactory.v2Eligible().build()
+      const person = personFactory.build({ tier })
 
-      expect(firstPageOfApplicationJourney(application)).toEqual(
-        paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'confirm-your-details' }),
+      expect(firstPageOfApplicationJourney(applicationId, person)).toEqual(
+        paths.applications.pages.show({ id: applicationId, task: 'basic-information', page: 'confirm-your-details' }),
       )
     })
 
     it('returns the "enter risk level" page for an application for a person without a tier', () => {
-      const application = applicationFactory.withFullPerson().build({
-        risks: undefined,
-      })
+      const person = personFactory.build({ tier: undefined })
 
-      expect(firstPageOfApplicationJourney(application)).toEqual(
-        paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'enter-risk-level' }),
+      expect(firstPageOfApplicationJourney(applicationId, person)).toEqual(
+        paths.applications.pages.show({ id: applicationId, task: 'basic-information', page: 'enter-risk-level' }),
       )
     })
 
     it('returns the is exceptional case page for an application with an unsuitable tier', () => {
       jest.spyOn(personUtils, 'isApplicableTier').mockReturnValue(false)
-      const application = applicationFactory.withFullPerson().build()
+      const tier = tierDtoFactory.v2Ineligible().build()
+      const person = personFactory.build({ tier })
 
-      expect(firstPageOfApplicationJourney(application)).toEqual(
-        paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'is-exceptional-case' }),
+      expect(firstPageOfApplicationJourney(applicationId, person)).toEqual(
+        paths.applications.pages.show({ id: applicationId, task: 'basic-information', page: 'is-exceptional-case' }),
       )
     })
 
     it('throws an error if the person is not a Full Person', () => {
-      const restrictedPerson = restrictedPersonFactory.build()
-      const application = applicationFactory.build({ person: restrictedPerson })
+      const restrictedPerson = restrictedPersonFactory.build() as FullPerson
 
-      expect(() => firstPageOfApplicationJourney(application)).toThrowError(
+      expect(() => firstPageOfApplicationJourney(applicationId, restrictedPerson)).toThrowError(
         `CRN: ${restrictedPerson.crn} is restricted`,
       )
-      expect(() => firstPageOfApplicationJourney(application)).toThrowError(RestrictedPersonError)
+      expect(() => firstPageOfApplicationJourney(applicationId, restrictedPerson)).toThrowError(RestrictedPersonError)
     })
   })
 
@@ -977,15 +979,16 @@ describe('utils', () => {
   describe('tierQualificationPage', () => {
     it('returns undefined for valid tier', () => {
       jest.spyOn(personUtils, 'isApplicableTier').mockReturnValue(true)
-      const application = applicationFactory.withFullPerson().build()
+      const tier = tierDtoFactory.v2Eligible().build()
+      const person = fullPersonFactory.build({ tier })
+      const application = applicationFactory.withFullPerson().build({ person })
 
       expect(tierQualificationPage(application)).toBe(undefined)
     })
 
     it('returns the "enter risk level" page for an application for a person without a tier', () => {
-      const application = applicationFactory.withFullPerson().build({
-        risks: undefined,
-      })
+      const person = fullPersonFactory.build({ tier: undefined })
+      const application = applicationFactory.withFullPerson().build({ person })
 
       expect(tierQualificationPage(application)).toEqual(
         paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'enter-risk-level' }),
@@ -993,8 +996,8 @@ describe('utils', () => {
     })
 
     it('returns the is exceptional case page for an application with an unsuitable tier', () => {
-      jest.spyOn(personUtils, 'isApplicableTier').mockReturnValue(false)
-      const application = applicationFactory.withFullPerson().build()
+      const person = fullPersonFactory.build({ tier: tierDtoFactory.v2Ineligible().build() })
+      const application = applicationFactory.build({ person })
 
       expect(tierQualificationPage(application)).toEqual(
         paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'is-exceptional-case' }),

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -21,17 +21,18 @@ import type {
   SortDirection,
   Cas1ApplicationSummary,
   Cas1Application,
+  FullPerson,
+  RestrictedPerson,
 } from '@approved-premises/api'
 import IsExceptionalCase from '../../form-pages/apply/reasons-for-placement/basic-information/isExceptionalCase'
 import paths from '../../paths/apply'
 
 import placementApplicationPaths from '../../paths/placementApplications'
-import { displayName, isApplicableTier, isFullPerson, PersonAny } from '../personUtils'
+import { displayName, isApplicableTierDto, isFullPerson, PersonAny } from '../personUtils'
 import { DateFormats } from '../dateUtils'
 import { arrivalDateFromApplication } from './arrivalDateFromApplication'
 import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQuestionResponseFromFormArtifact'
 import ExceptionDetails from '../../form-pages/apply/reasons-for-placement/basic-information/exceptionDetails'
-import { RestrictedPersonError } from '../errors'
 import { sortHeader } from '../sortHeader'
 import { linkTo } from '../utils'
 import { createNameAnchorElement, getTierOrBlank } from './helpers'
@@ -40,6 +41,7 @@ import { renderTimelineEventContent } from '../timeline'
 import { summaryListItem } from '../formUtils'
 import { htmlCell, textCell } from '../tableUtils'
 import { getPlacementLink } from '../resident'
+import { RestrictedPersonError } from '../errors'
 
 export { withdrawableTypeRadioOptions, withdrawableRadioOptions } from './withdrawables'
 export { placementApplicationWithdrawalReasons } from './withdrawables/withdrawalReasons'
@@ -186,28 +188,34 @@ const isInapplicable = (application: Application): boolean => {
   return isExceptionalCase === 'no' || (isExceptionalCase === 'yes' && agreedCaseWithManager === 'no')
 }
 
-const tierQualificationPage = (application: Application) => {
-  if (!isFullPerson(application.person)) throw new RestrictedPersonError(application.person.crn)
+const tierQualificationPage = (application: Cas1Application) => {
+  const person: FullPerson = application?.person as FullPerson
 
-  if (!application?.risks?.tier?.value) {
-    return paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'enter-risk-level' })
+  return tierQualificationPageTierDto(application?.id, person)
+}
+
+const tierQualificationPageTierDto = (applicationId: string, person: FullPerson) => {
+  if (!isFullPerson(person)) throw new RestrictedPersonError((person as RestrictedPerson).crn)
+
+  if (!person?.tier) {
+    return paths.applications.pages.show({ id: applicationId, task: 'basic-information', page: 'enter-risk-level' })
   }
 
-  if (!isApplicableTier(application.person.sex, application.risks?.tier?.value?.level)) {
-    return paths.applications.pages.show({ id: application.id, task: 'basic-information', page: 'is-exceptional-case' })
+  if (!isApplicableTierDto(person)) {
+    return paths.applications.pages.show({ id: applicationId, task: 'basic-information', page: 'is-exceptional-case' })
   }
   return undefined
 }
 
-const firstPageOfApplicationJourney = (application: Application) => {
-  const firstPage = tierQualificationPage(application)
+const firstPageOfApplicationJourney = (applicationId: string, person: FullPerson) => {
+  const firstPage = tierQualificationPageTierDto(applicationId, person)
 
   if (firstPage) {
     return firstPage
   }
 
   return paths.applications.pages.show({
-    id: application.id,
+    id: applicationId,
     task: 'basic-information',
     page: 'confirm-your-details',
   })

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -17,6 +17,15 @@ const tierBadge = (tier: string): string => {
   return `<span class="moj-badge ${colour}">${tier}</span>`
 }
 
+const isApplicableTierDto = (person: FullPerson) => {
+  const { version, tierScore } = person.tier || {}
+
+  if (version === 'V2') {
+    return isApplicableTier(person.sex, tierScore)
+  }
+  return ['A', 'B', 'C'].includes(tierScore)
+}
+
 const isApplicableTier = (sex: string, tier: string): boolean => {
   const applicableTiersAll = ['A1', 'A2', 'A3', 'B1', 'B2', 'B3']
   const applicableTiersWomen = ['C3']
@@ -90,4 +99,4 @@ const displayName = (
   }
 }
 
-export { tierBadge, isApplicableTier, isFullPerson, displayName, isUnknownPerson }
+export { tierBadge, isApplicableTier, isApplicableTierDto, isFullPerson, displayName, isUnknownPerson }

--- a/server/utils/taskListUtils.test.ts
+++ b/server/utils/taskListUtils.test.ts
@@ -5,6 +5,7 @@ import assessPaths from '../paths/assess'
 import { applicationFactory, assessmentFactory } from '../testutils/factories'
 import { TaskListStatusTag, taskLinkHtml } from './taskListUtils'
 import { isApplicableTier, isFullPerson } from './personUtils'
+import { fullPersonFactory } from '../testutils/factories/person'
 
 jest.mock('./personUtils')
 
@@ -29,7 +30,8 @@ describe('taskListUtils', () => {
 
   describe('taskLink', () => {
     describe('with an application', () => {
-      const application = applicationFactory.build({ id: 'some-uuid' })
+      const person = fullPersonFactory.build()
+      const application = applicationFactory.build({ id: 'some-uuid', person })
 
       it('should return a link to a task the task can be started', () => {
         task.status = 'in_progress'


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/FM-844
<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Switch application create to use new endpoint `/cas1/applications/create`

The new endpoint returns a rather stripped-down response from the old creation endpoint.  Rather than the full application, we only receive the tier and new applicationId.

Decisions are to be made regarding the next page the user is directed to. These are currently based on the person's `sex` and `tier`. Without the new `application` in the response, the controller now uses the `person` as retrieved immediately prior to the application creation, but substituting the `tier` as returned from application creation since it's possible that this is a new CRN and the tier may not have been available prior to application creation.
Methods that used to be passed the `Cas1Application`, have changed to take `person` instead.

Note that if the user immediately navigates away after application creation and returns later, they will be taken to the correct page as the correct (live) `tier` will now be returned in the person as part of the `Cas1Application` 

[x] I have run the E2E tests locally and they passed
```
Running 15 tests using 1 worker
  15 passed (7.0m)
```

## Screenshots of UI changes
No UI change
