### PR TITLE
Live Tier Switch POC

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -52,6 +52,7 @@ export default {
     plannedMaintenance: getFlag('PLANNED_MAINTENANCE_BANNER'),
     oasysDisabled: getFlag('OASYS_DISABLED'),
     ndeliusRiskFlagsEnabled: getFlag('NDELIUS_RISK_FLAGS_ENABLED'),
+    useLiveTiers: getFlag('USE_LIVE_TIER'),
   },
   paths: {
     ndeliusDeeplink: get('NDELIUS_DEEPLINK', ''),

--- a/server/testutils/factories/person.ts
+++ b/server/testutils/factories/person.ts
@@ -9,6 +9,7 @@ import type {
   UnknownPerson,
 } from '@approved-premises/api'
 import { DateFormats } from '../../utils/dateUtils'
+import { tierDtoFactory } from './tierDto'
 
 export const getCrn = () => `C${faker.number.int({ min: 100000, max: 999999 })}`
 export const fullPersonFactory = Factory.define<FullPerson>(() => ({
@@ -26,6 +27,7 @@ export const fullPersonFactory = Factory.define<FullPerson>(() => ({
   isRestricted: false,
   ethnicity: faker.helpers.arrayElement(['White', 'Black', 'Asian', 'Mixed', undefined]),
   genderIdentity: faker.helpers.arrayElement(['Man', 'Woman', undefined]),
+  tier: tierDtoFactory.build(),
 }))
 
 export const restrictedPersonFactory = Factory.define<RestrictedPerson>(() => ({

--- a/server/testutils/factories/tierDto.ts
+++ b/server/testutils/factories/tierDto.ts
@@ -1,0 +1,11 @@
+import { Factory } from 'fishery'
+import type { TierDto } from '@approved-premises/api'
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { DateFormats } from '../../utils/dateUtils'
+
+export const tierDtoFactory = Factory.define<TierDto>(() => ({
+  calculationDate: DateFormats.dateObjToIsoDate(faker.date.past()),
+  provisional: false,
+  tierScore: faker.string.alpha({ length: 1 }),
+  version: 'V2',
+}))

--- a/server/utils/applications/helpers.test.ts
+++ b/server/utils/applications/helpers.test.ts
@@ -1,16 +1,19 @@
+import { RiskTier } from '@approved-premises/api'
 import {
   cas1ApplicationSummaryFactory,
   personFactory,
   restrictedPersonFactory,
   tierEnvelopeFactory,
 } from '../../testutils/factories'
-import { createNameAnchorElement, getTierOrBlank, personKeyDetails } from './helpers'
+import { createNameAnchorElement, getTierOrBlank, getVersionedTierOrBlank, personKeyDetails } from './helpers'
 import paths from '../../paths/apply'
 import * as personUtils from '../personUtils'
 import { fullPersonFactory, unknownPersonFactory } from '../../testutils/factories/person'
 import { displayName } from '../personUtils'
 import { DateFormats } from '../dateUtils'
 import { htmlCell, textCell } from '../tableUtils'
+import config from '../../config'
+import { tierDtoFactory } from '../../testutils/factories/tierDto'
 
 describe('helpers', () => {
   beforeEach(() => {
@@ -102,6 +105,10 @@ describe('helpers', () => {
       jest.spyOn(personUtils, 'tierBadge')
     })
 
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
     it('should return the tier when present', () => {
       expect(getTierOrBlank('foo')).toEqual(personUtils.tierBadge('foo'))
       expect(personUtils.tierBadge).toHaveBeenCalledWith('foo')
@@ -117,6 +124,81 @@ describe('helpers', () => {
       expect(personUtils.tierBadge).not.toHaveBeenCalled()
     })
   })
+
+  describe('getVersionedTierOrBlank', () => {
+    beforeEach(() => {
+      jest.spyOn(personUtils, 'tierBadge')
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    describe('use live tiers disabled, use tier on application creation', () => {
+      beforeEach(() => {
+        config.flags.useLiveTiers = false
+      })
+
+      it('should return the application tier when present', () => {
+        const tierOnApplicationCreation = tierEnvelopeFactory.build({ value: { level: 'static' } }).value
+        const personWithLiveTier = personFactory.build({ tier: tierDtoFactory.build({ tierScore: 'live' }) })
+
+        expect(getVersionedTierOrBlank(personWithLiveTier, tierOnApplicationCreation)).toEqual(
+          personUtils.tierBadge('static'),
+        )
+        expect(personUtils.tierBadge).toHaveBeenCalledWith('static')
+      })
+
+      it('should return an empty string when undefined', () => {
+        const tierOnApplicationCreation: RiskTier = undefined
+        const personWithLiveTier = personFactory.build({ tier: tierDtoFactory.build({ tierScore: 'live' }) })
+
+        expect(getVersionedTierOrBlank(personWithLiveTier, tierOnApplicationCreation)).toEqual('')
+        expect(personUtils.tierBadge).not.toHaveBeenCalled()
+      })
+
+      it('should return an empty string when null', () => {
+        const tierOnApplicationCreation: RiskTier = null
+        const personWithLiveTier = personFactory.build({ tier: tierDtoFactory.build({ tierScore: 'live' }) })
+
+        expect(getVersionedTierOrBlank(personWithLiveTier, tierOnApplicationCreation)).toEqual('')
+        expect(personUtils.tierBadge).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('use live tiers enabled, use person tier', () => {
+      beforeEach(() => {
+        config.flags.useLiveTiers = true
+      })
+
+      it('should return the person tier when present', () => {
+        const tierOnApplicationCreation = tierEnvelopeFactory.build({ value: { level: 'static' } }).value
+        const personWithLiveTier = personFactory.build({ tier: tierDtoFactory.build({ tierScore: 'live' }) })
+
+        expect(getVersionedTierOrBlank(personWithLiveTier, tierOnApplicationCreation)).toEqual(
+          personUtils.tierBadge('live'),
+        )
+        expect(personUtils.tierBadge).toHaveBeenCalledWith('live')
+      })
+
+      it('should return an empty string when undefined', () => {
+        const tierOnApplicationCreation = tierEnvelopeFactory.build({ value: { level: 'static' } }).value
+        const personWithLiveTier = personFactory.build({ tier: undefined })
+
+        expect(getVersionedTierOrBlank(personWithLiveTier, tierOnApplicationCreation)).toEqual('')
+        expect(personUtils.tierBadge).not.toHaveBeenCalled()
+      })
+
+      it('should return an empty string when null', () => {
+        const tierOnApplicationCreation = tierEnvelopeFactory.build({ value: { level: 'static' } }).value
+        const personWithLiveTier = personFactory.build({ tier: null })
+
+        expect(getVersionedTierOrBlank(personWithLiveTier, tierOnApplicationCreation)).toEqual('')
+        expect(personUtils.tierBadge).not.toHaveBeenCalled()
+      })
+    })
+  })
+
   describe('personKeyDetails', () => {
     const tier = tierEnvelopeFactory.build().value.level
 

--- a/server/utils/applications/helpers.ts
+++ b/server/utils/applications/helpers.ts
@@ -1,9 +1,10 @@
 import { KeyDetailsArgs } from '@approved-premises/ui'
-import { Cas1Application, Cas1ApplicationSummary, Person } from '../../@types/shared'
-import { displayName, isFullPerson, tierBadge } from '../personUtils'
+import { Cas1Application, Cas1ApplicationSummary, Person, PersonSummary, RiskTier } from '../../@types/shared'
+import { displayName, isFullPerson, personTier, tierBadge, versionedTierBadge } from '../personUtils'
 import paths from '../../paths/apply'
 import { DateFormats } from '../dateUtils'
 import { htmlCell, textCell } from '../tableUtils'
+import config from '../../config'
 
 export const createNameAnchorElement = (
   person: Person,
@@ -31,7 +32,18 @@ export const createNameAnchorElement = (
     : textCell(name)
 }
 
+/**
+ * @deprecated Use getVersionedTierOrBlank instead
+ */
 export const getTierOrBlank = (tier: string | null | undefined) => (tier ? tierBadge(tier) : '')
+
+export const getVersionedTierOrBlank = (person: Person | PersonSummary, tierOnApplicationCreation: RiskTier) => {
+  if (!config.flags.useLiveTiers) {
+    return getTierOrBlank(tierOnApplicationCreation?.level)
+  }
+  const tier = personTier(person)
+  return tier ? versionedTierBadge(tier) : ''
+}
 
 export const personKeyDetails = (person: Person, tier?: string): KeyDetailsArgs => ({
   header: { value: displayName(person), key: '', showKey: false },

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -34,7 +34,7 @@ import ExceptionDetails from '../../form-pages/apply/reasons-for-placement/basic
 import { RestrictedPersonError } from '../errors'
 import { sortHeader } from '../sortHeader'
 import { linkTo } from '../utils'
-import { createNameAnchorElement, getTierOrBlank } from './helpers'
+import { createNameAnchorElement, getTierOrBlank, getVersionedTierOrBlank } from './helpers'
 import { APPLICATION_SUITABLE, ApplicationStatusTag, applicationSuitableStatuses } from './statusTag'
 import { renderTimelineEventContent } from '../timeline'
 import { summaryListItem } from '../formUtils'
@@ -58,7 +58,7 @@ const applicationTableRows = (applications: Array<Cas1ApplicationSummary>): Arra
       attributes: { 'data-sort-value': displayName(application.person) },
     },
     textCell(application.person.crn),
-    htmlCell(getTierOrBlank(application.risks?.tier?.value?.level)),
+    htmlCell(getVersionedTierOrBlank(application.person, application.risks?.tier?.value)),
     {
       ...textCell(getArrivalDateorNA(application.arrivalDate)),
       attributes: { 'data-sort-value': application.arrivalDate || '' },

--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -180,4 +180,30 @@ describe('personUtils', () => {
       expect(isUnknownPerson(restrictedPersonFactory.build())).toEqual(false)
     })
   })
+
+  describe('personTier', () => {
+    it('returns tier if full person', () => {
+      // TODO: implement all tests once we have a tier factory
+    })
+
+    it('returns tier if full person summary', () => {
+      // TODO: implement all tests once we have a tier factory
+    })
+
+    it('returns tier if restricted person', () => {
+      // TODO: implement all tests once we have a tier factory
+    })
+
+    it('returns tier if restricted person summary', () => {
+      // TODO: implement all tests once we have a tier factory
+    })
+
+    it('returns undefined if unknown person', () => {
+      // TODO: implement all tests once we have a tier factory
+    })
+
+    it('returns undefined if unknown person summary', () => {
+      // TODO: implement all tests once we have a tier factory
+    })
+  })
 })

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -5,6 +5,7 @@ import {
   PersonSummary,
   RestrictedPerson,
   RestrictedPersonSummary,
+  TierDto,
   UnknownPerson,
   UnknownPersonSummary,
 } from '../@types/shared'
@@ -15,6 +16,19 @@ const tierBadge = (tier: string): string => {
   const colour = { A: 'moj-badge--red', B: 'moj-badge--purple' }[tier[0]]
 
   return `<span class="moj-badge ${colour}">${tier}</span>`
+}
+
+const tierBadgeV3 = (tier: string): string => {
+  if (!tier) return ''
+
+  return `<span class="moj-badge">${tier}</span>`
+}
+
+const versionedTierBadge = (tier: TierDto): string => {
+  if (tier.version === 'V2') {
+    return tierBadge(tier.tierScore)
+  }
+  return tierBadgeV3(tier.tierScore)
 }
 
 const isApplicableTier = (sex: string, tier: string): boolean => {
@@ -90,4 +104,19 @@ const displayName = (
   }
 }
 
-export { tierBadge, isApplicableTier, isFullPerson, displayName, isUnknownPerson }
+const personTier = (person: Person | PersonSummary): TierDto => {
+  const personType: string = (person as Person).type || (person as PersonSummary).personType
+
+  switch (personType) {
+    case 'FullPerson':
+    case 'FullPersonSummary':
+      return (person as FullPerson).tier
+    case 'RestrictedPerson':
+    case 'RestrictedPersonSummary':
+      return (person as RestrictedPerson).tier
+    default:
+      return undefined
+  }
+}
+
+export { tierBadge, versionedTierBadge, isApplicableTier, isFullPerson, displayName, isUnknownPerson, personTier }

--- a/server/utils/tableUtils.test.ts
+++ b/server/utils/tableUtils.test.ts
@@ -63,6 +63,10 @@ describe('tableUtils', () => {
     })
   })
 
+  describe('versionedTierCell', () => {
+    // TODO: implement once have tier factory
+  })
+
   describe('nameCellLink', () => {
     const person = fullPersonFactory.build()
 

--- a/server/utils/tableUtils.ts
+++ b/server/utils/tableUtils.ts
@@ -1,7 +1,7 @@
-import { Person } from '../@types/shared'
+import { Person, TierDto } from '../@types/shared'
 import { TableCell } from '../@types/ui'
 import { DateFormats } from './dateUtils'
-import { displayName, tierBadge } from './personUtils'
+import { displayName, tierBadge, versionedTierBadge } from './personUtils'
 import { pluralize } from './utils'
 
 const DUE_DATE_APPROACHING_DAYS_WINDOW = 3
@@ -32,6 +32,11 @@ const tierSortKey = (tier: string) =>
 export const tierCell = (value: string) => ({
   html: tierBadge(value),
   attributes: { 'data-sort-value': tierSortKey(value) },
+})
+
+export const versionedTierCell = (tier: TierDto) => ({
+  html: versionedTierBadge(tier),
+  attributes: { 'data-sort-value': tierSortKey(tier.tierScore) },
 })
 
 export const nameCellLink = (person: Person, link?: string) =>


### PR DESCRIPTION
Working example of optionally using live tiers for all applications tables in ‘apply’.

Tests need completing, waiting on other work using TierDto to be completed to avoid merge headaches
