### PR TITLE
FM-960 - Show live tiers on ‘my applications’

### DIFF
--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -23,6 +23,7 @@ generic-service:
     IN_MAINTENANCE_MODE: false
     PLANNED_MAINTENANCE_BANNER: false
     NDELIUS_RISK_FLAGS_ENABLED: 'true'
+    USE_LIVE_TIER: 'true'
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -21,6 +21,7 @@ generic-service:
     IN_MAINTENANCE_MODE: false
     PLANNED_MAINTENANCE_BANNER: false
     NDELIUS_RISK_FLAGS_ENABLED: 'true'
+    USE_LIVE_TIER: 'false'
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -21,6 +21,7 @@ generic-service:
     IN_MAINTENANCE_MODE: false
     PLANNED_MAINTENANCE_BANNER: false
     NDELIUS_RISK_FLAGS_ENABLED: 'true'
+    USE_LIVE_TIER: 'false'
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -26,6 +26,7 @@ generic-service:
     AUDIT_SQS_QUEUE_URL: ""
     AUDIT_SQS_QUEUE_NAME: ""
     NDELIUS_RISK_FLAGS_ENABLED: 'true'
+    USE_LIVE_TIER: 'true'
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-approved-premises-nonprod

--- a/server/config.ts
+++ b/server/config.ts
@@ -52,6 +52,7 @@ export default {
     plannedMaintenance: getFlag('PLANNED_MAINTENANCE_BANNER'),
     oasysDisabled: getFlag('OASYS_DISABLED'),
     ndeliusRiskFlagsEnabled: getFlag('NDELIUS_RISK_FLAGS_ENABLED'),
+    useLiveTiers: getFlag('USE_LIVE_TIER'),
   },
   paths: {
     ndeliusDeeplink: get('NDELIUS_DEEPLINK', ''),

--- a/server/testutils/factories/person.ts
+++ b/server/testutils/factories/person.ts
@@ -7,6 +7,7 @@ import type {
   FullPersonSummary,
   RestrictedPerson,
   UnknownPerson,
+  RestrictedPersonSummary,
 } from '@approved-premises/api'
 import { DateFormats } from '../../utils/dateUtils'
 import tierDtoFactory from './tierDto'
@@ -45,7 +46,7 @@ export const personSummaryFactory = Factory.define<PersonSummary>(() => ({
   personType: faker.helpers.arrayElement(['FullPersonSummary', 'RestrictedPersonSummary', 'UnknownPersonSummary']),
 }))
 
-export const restrictedPersonSummaryFactory = Factory.define<PersonSummary>(() => ({
+export const restrictedPersonSummaryFactory = Factory.define<RestrictedPersonSummary>(() => ({
   crn: getCrn(),
   personType: 'RestrictedPersonSummary',
 }))

--- a/server/utils/applications/helpers.test.ts
+++ b/server/utils/applications/helpers.test.ts
@@ -1,16 +1,19 @@
+import { RiskTier } from '@approved-premises/api'
 import {
   cas1ApplicationSummaryFactory,
   personFactory,
   restrictedPersonFactory,
   tierEnvelopeFactory,
 } from '../../testutils/factories'
-import { createNameAnchorElement, getTierOrBlank, personKeyDetails } from './helpers'
+import { createNameAnchorElement, getTierOrBlank, getVersionedTierOrBlank, personKeyDetails } from './helpers'
 import paths from '../../paths/apply'
 import * as personUtils from '../personUtils'
 import { fullPersonFactory, unknownPersonFactory } from '../../testutils/factories/person'
 import { displayName } from '../personUtils'
 import { DateFormats } from '../dateUtils'
 import { htmlCell, textCell } from '../tableUtils'
+import config from '../../config'
+import tierDtoFactory from '../../testutils/factories/tierDto'
 
 describe('helpers', () => {
   beforeEach(() => {
@@ -102,6 +105,10 @@ describe('helpers', () => {
       jest.spyOn(personUtils, 'tierBadge')
     })
 
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
     it('should return the tier when present', () => {
       expect(getTierOrBlank('foo')).toEqual(personUtils.tierBadge('foo'))
       expect(personUtils.tierBadge).toHaveBeenCalledWith('foo')
@@ -117,6 +124,85 @@ describe('helpers', () => {
       expect(personUtils.tierBadge).not.toHaveBeenCalled()
     })
   })
+
+  describe('getVersionedTierOrBlank', () => {
+    beforeEach(() => {
+      jest.spyOn(personUtils, 'tierBadge')
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    describe('use live tiers disabled, use tier on application creation', () => {
+      beforeEach(() => {
+        config.flags.useLiveTiers = false
+      })
+
+      it('should return the application tier when present', () => {
+        const tierOnApplicationCreation = tierEnvelopeFactory.build({ value: { level: 'static', version: 'V2' } }).value
+        const personWithLiveTier = personFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'live' }) })
+
+        expect(getVersionedTierOrBlank(personWithLiveTier, tierOnApplicationCreation)).toEqual(
+          personUtils.tierBadge('static'),
+        )
+        expect(personUtils.tierBadge).toHaveBeenCalledWith('static')
+      })
+
+      it('should return an empty string when undefined', () => {
+        const tierOnApplicationCreation: RiskTier = undefined
+        const personWithLiveTier = personFactory.build({
+          tier: tierDtoFactory.v2().build({ tierScore: 'live', version: 'V2' }),
+        })
+
+        expect(getVersionedTierOrBlank(personWithLiveTier, tierOnApplicationCreation)).toEqual('')
+        expect(personUtils.tierBadge).not.toHaveBeenCalled()
+      })
+
+      it('should return an empty string when null', () => {
+        const tierOnApplicationCreation: RiskTier = null
+        const personWithLiveTier = personFactory.build({
+          tier: tierDtoFactory.v2().build({ tierScore: 'live', version: 'V2' }),
+        })
+
+        expect(getVersionedTierOrBlank(personWithLiveTier, tierOnApplicationCreation)).toEqual('')
+        expect(personUtils.tierBadge).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('use live tiers enabled, use person tier', () => {
+      beforeEach(() => {
+        config.flags.useLiveTiers = true
+      })
+
+      it('should return the person tier when present', () => {
+        const tierOnApplicationCreation = tierEnvelopeFactory.build({ value: { level: 'static', version: 'V2' } }).value
+        const personWithLiveTier = personFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'live' }) })
+
+        expect(getVersionedTierOrBlank(personWithLiveTier, tierOnApplicationCreation)).toEqual(
+          personUtils.tierBadge('live'),
+        )
+        expect(personUtils.tierBadge).toHaveBeenCalledWith('live')
+      })
+
+      it('should return an empty string when undefined', () => {
+        const tierOnApplicationCreation = tierEnvelopeFactory.build({ value: { level: 'static', version: 'V2' } }).value
+        const personWithLiveTier = personFactory.build({ tier: undefined })
+
+        expect(getVersionedTierOrBlank(personWithLiveTier, tierOnApplicationCreation)).toEqual('')
+        expect(personUtils.tierBadge).not.toHaveBeenCalled()
+      })
+
+      it('should return an empty string when null', () => {
+        const tierOnApplicationCreation = tierEnvelopeFactory.build({ value: { level: 'static', version: 'V2' } }).value
+        const personWithLiveTier = personFactory.build({ tier: null })
+
+        expect(getVersionedTierOrBlank(personWithLiveTier, tierOnApplicationCreation)).toEqual('')
+        expect(personUtils.tierBadge).not.toHaveBeenCalled()
+      })
+    })
+  })
+
   describe('personKeyDetails', () => {
     const tier = tierEnvelopeFactory.build().value.level
 

--- a/server/utils/applications/helpers.ts
+++ b/server/utils/applications/helpers.ts
@@ -1,9 +1,10 @@
 import { KeyDetailsArgs } from '@approved-premises/ui'
-import { Cas1Application, Cas1ApplicationSummary, Person } from '../../@types/shared'
-import { displayName, isFullPerson, tierBadge } from '../personUtils'
+import { Cas1Application, Cas1ApplicationSummary, Person, PersonSummary, RiskTier } from '../../@types/shared'
+import { displayName, isFullPerson, personTier, tierBadge, versionedTierBadge } from '../personUtils'
 import paths from '../../paths/apply'
 import { DateFormats } from '../dateUtils'
 import { htmlCell, textCell } from '../tableUtils'
+import config from '../../config'
 
 export const createNameAnchorElement = (
   person: Person,
@@ -31,7 +32,18 @@ export const createNameAnchorElement = (
     : textCell(name)
 }
 
+/**
+ * @deprecated Use getVersionedTierOrBlank instead
+ */
 export const getTierOrBlank = (tier: string | null | undefined) => (tier ? tierBadge(tier) : '')
+
+export const getVersionedTierOrBlank = (person: Person | PersonSummary, tierOnApplicationCreation: RiskTier) => {
+  if (!config.flags.useLiveTiers) {
+    return getTierOrBlank(tierOnApplicationCreation?.level)
+  }
+  const tier = personTier(person)
+  return tier ? versionedTierBadge(tier) : ''
+}
 
 export const personKeyDetails = (person: Person, tier?: string): KeyDetailsArgs => ({
   header: { value: displayName(person), key: '', showKey: false },

--- a/server/utils/applications/utils.ts
+++ b/server/utils/applications/utils.ts
@@ -35,7 +35,7 @@ import { retrieveOptionalQuestionResponseFromFormArtifact } from '../retrieveQue
 import ExceptionDetails from '../../form-pages/apply/reasons-for-placement/basic-information/exceptionDetails'
 import { sortHeader } from '../sortHeader'
 import { linkTo } from '../utils'
-import { createNameAnchorElement, getTierOrBlank } from './helpers'
+import { createNameAnchorElement, getTierOrBlank, getVersionedTierOrBlank } from './helpers'
 import { APPLICATION_SUITABLE, ApplicationStatusTag, applicationSuitableStatuses } from './statusTag'
 import { renderTimelineEventContent } from '../timeline'
 import { summaryListItem } from '../formUtils'
@@ -60,7 +60,7 @@ const applicationTableRows = (applications: Array<Cas1ApplicationSummary>): Arra
       attributes: { 'data-sort-value': displayName(application.person) },
     },
     textCell(application.person.crn),
-    htmlCell(getTierOrBlank(application.risks?.tier?.value?.level)),
+    htmlCell(getVersionedTierOrBlank(application.person, application.risks?.tier?.value)),
     {
       ...textCell(getArrivalDateorNA(application.arrivalDate)),
       attributes: { 'data-sort-value': application.arrivalDate || '' },

--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -1,3 +1,4 @@
+import { TierDto } from '@approved-premises/api'
 import {
   fullPersonFactory,
   fullPersonSummaryFactory,
@@ -12,8 +13,11 @@ import {
   isFullPerson,
   isNotRestrictedPerson,
   isUnknownPerson,
+  personTier,
   tierBadge,
+  versionedTierBadge,
 } from './personUtils'
+import tierDtoFactory from '../testutils/factories/tierDto'
 
 describe('personUtils', () => {
   describe('tierBadge', () => {
@@ -24,6 +28,39 @@ describe('personUtils', () => {
     it('returns the correct tier badge for B', () => {
       expect(tierBadge('B')).toEqual('<span class="moj-badge moj-badge--purple">B</span>')
     })
+
+    it('returns the correct tier badge for C', () => {
+      expect(tierBadge('C')).toEqual('<span class="moj-badge undefined">C</span>')
+    })
+  })
+
+  describe('versionedTierBadge', () => {
+    it('returns the correct tier badge for version 2, A', () => {
+      expect(versionedTierBadge(tierDtoFactory.v2().build({ tierScore: 'A' }))).toEqual(
+        '<span class="moj-badge moj-badge--red">A</span>',
+      )
+    })
+
+    it('returns the correct tier badge for version 2, B', () => {
+      expect(versionedTierBadge(tierDtoFactory.v2().build({ tierScore: 'B' }))).toEqual(
+        '<span class="moj-badge moj-badge--purple">B</span>',
+      )
+    })
+
+    it('returns the correct tier badge for version 2, C', () => {
+      expect(versionedTierBadge(tierDtoFactory.v2().build({ tierScore: 'C' }))).toEqual(
+        '<span class="moj-badge undefined">C</span>',
+      )
+    })
+
+    it.each(['A', 'B', 'C'])(
+      'returns the correct, consistently coloured tiers badges for version 3 tiers "%s"',
+      tier => {
+        expect(versionedTierBadge(tierDtoFactory.v3().build({ tierScore: tier }))).toEqual(
+          `<span class="moj-badge">${tier}</span>`,
+        )
+      },
+    )
   })
 
   describe('isApplicableTier', () => {
@@ -178,6 +215,38 @@ describe('personUtils', () => {
 
     it('returns false if the person is not Unknown person', () => {
       expect(isUnknownPerson(restrictedPersonFactory.build())).toEqual(false)
+    })
+  })
+
+  describe('personTier', () => {
+    let tier: TierDto
+
+    beforeEach(() => {
+      tier = tierDtoFactory.build()
+    })
+
+    it('returns tier if full person', () => {
+      expect(personTier(fullPersonFactory.build({ tier }))).toEqual(tier)
+    })
+
+    it('returns tier if full person summary', () => {
+      expect(personTier(fullPersonSummaryFactory.build({ tier }))).toEqual(tier)
+    })
+
+    it('returns tier if restricted person', () => {
+      expect(personTier(restrictedPersonFactory.build({ tier }))).toEqual(tier)
+    })
+
+    it('returns tier if restricted person summary', () => {
+      expect(personTier(restrictedPersonSummaryFactory.build({ tier }))).toEqual(tier)
+    })
+
+    it('returns undefined if unknown person', () => {
+      expect(personTier(unknownPersonFactory.build())).toEqual(undefined)
+    })
+
+    it('returns undefined if unknown person summary', () => {
+      expect(personTier(unknownPersonSummaryFactory.build())).toEqual(undefined)
     })
   })
 })

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -5,6 +5,7 @@ import {
   PersonSummary,
   RestrictedPerson,
   RestrictedPersonSummary,
+  TierDto,
   UnknownPerson,
   UnknownPersonSummary,
 } from '../@types/shared'
@@ -15,6 +16,19 @@ const tierBadge = (tier: string): string => {
   const colour = { A: 'moj-badge--red', B: 'moj-badge--purple' }[tier[0]]
 
   return `<span class="moj-badge ${colour}">${tier}</span>`
+}
+
+const tierBadgeV3 = (tier: string): string => {
+  if (!tier) return ''
+
+  return `<span class="moj-badge">${tier}</span>`
+}
+
+const versionedTierBadge = (tier: TierDto): string => {
+  if (tier.version === 'V2') {
+    return tierBadge(tier.tierScore)
+  }
+  return tierBadgeV3(tier.tierScore)
 }
 
 const isApplicableTierDto = (person: FullPerson) => {
@@ -99,4 +113,28 @@ const displayName = (
   }
 }
 
-export { tierBadge, isApplicableTier, isApplicableTierDto, isFullPerson, displayName, isUnknownPerson }
+const personTier = (person: Person | PersonSummary): TierDto => {
+  const personType: string = (person as Person).type || (person as PersonSummary).personType
+
+  switch (personType) {
+    case 'FullPerson':
+    case 'FullPersonSummary':
+      return (person as FullPerson).tier
+    case 'RestrictedPerson':
+    case 'RestrictedPersonSummary':
+      return (person as RestrictedPerson).tier
+    default:
+      return undefined
+  }
+}
+
+export {
+  tierBadge,
+  versionedTierBadge,
+  isApplicableTier,
+  isApplicableTierDto,
+  isFullPerson,
+  displayName,
+  isUnknownPerson,
+  personTier,
+}

--- a/server/utils/tableUtils.test.ts
+++ b/server/utils/tableUtils.test.ts
@@ -1,18 +1,21 @@
 import { when } from 'jest-when'
 import { assessmentSummaryFactory, taskFactory } from '../testutils/factories'
-import { displayName, tierBadge } from './personUtils'
+import { displayName, tierBadge, versionedTierBadge } from './personUtils'
 import {
   crnCell,
   dateCell,
   dateCellNoWrap,
+  dateCellSortable,
   daysUntilDueCell,
   emailCell,
   nameCellLink,
   textCellNoWrap,
   tierCell,
+  versionedTierCell,
 } from './tableUtils'
 import { DateFormats } from './dateUtils'
 import { fullPersonFactory } from '../testutils/factories/person'
+import tierDtoFactory from '../testutils/factories/tierDto'
 
 describe('tableUtils', () => {
   describe('dateCell', () => {
@@ -43,6 +46,25 @@ describe('tableUtils', () => {
     })
   })
 
+  describe('dateCellSortable', () => {
+    it('returns a cell with a date in the short format from an ISO date wrapped in a non-break span with sort info', () => {
+      expect(dateCellSortable('2022-01-01')).toEqual({
+        attributes: {
+          'data-sort-value': '2022-01-01',
+        },
+        text: '1 Jan 2022',
+      })
+    })
+    it('handles an empty date', () => {
+      expect(dateCellSortable(undefined)).toEqual({
+        attributes: {
+          'data-sort-value': undefined,
+        },
+        text: '',
+      })
+    })
+  })
+
   describe('crnCell', () => {
     it('returns the crn of the person the task is assigned to as a TableCell object', () => {
       const task = taskFactory.build()
@@ -60,6 +82,23 @@ describe('tableUtils', () => {
       [undefined, ''],
     ])('returns the tier badge and sort key for the tier %s', (tier, sortKey) => {
       expect(tierCell(tier)).toEqual({ html: tierBadge(tier), attributes: { 'data-sort-value': sortKey } })
+    })
+  })
+
+  describe('versionedTierCell', () => {
+    it.each([
+      ['A1', 'A8'],
+      ['B3S', 'B6S'],
+      ['BzS', 'BzS'],
+      ['Q', 'Q'],
+      ['', ''],
+      [undefined, ''],
+    ])('returns the tier badge and sort key for the tier %s', (tierScore, sortKey) => {
+      const tier = tierDtoFactory.build({ tierScore })
+      expect(versionedTierCell(tier)).toEqual({
+        html: versionedTierBadge(tier),
+        attributes: { 'data-sort-value': sortKey },
+      })
     })
   })
 

--- a/server/utils/tableUtils.ts
+++ b/server/utils/tableUtils.ts
@@ -1,7 +1,7 @@
-import { Person } from '../@types/shared'
+import { Person, TierDto } from '../@types/shared'
 import { TableCell } from '../@types/ui'
 import { DateFormats } from './dateUtils'
-import { displayName, tierBadge } from './personUtils'
+import { displayName, tierBadge, versionedTierBadge } from './personUtils'
 import { pluralize } from './utils'
 
 const DUE_DATE_APPROACHING_DAYS_WINDOW = 3
@@ -32,6 +32,11 @@ const tierSortKey = (tier: string) =>
 export const tierCell = (value: string) => ({
   html: tierBadge(value),
   attributes: { 'data-sort-value': tierSortKey(value) },
+})
+
+export const versionedTierCell = (tier: TierDto) => ({
+  html: versionedTierBadge(tier),
+  attributes: { 'data-sort-value': tierSortKey(tier.tierScore) },
 })
 
 export const nameCellLink = (person: Person, link?: string) =>


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/FM-960

# Changes in this PR

If feature flag ‘USE_LIVE_TIER’ is ‘true’, the person’s live tier value will be shown when listing applications across all tabs on the ‘my application screen’.

This commit also adds support for v3 tiers, using a different badge function, allowing us to use different style rules for v3 tiers

Also add missing coverage to dateCellSortable

## Screenshots of UI changes

### Before

<img width="607" height="454" alt="Screenshot 2026-07-28 at 09 39 54" src="https://github.com/user-attachments/assets/07063308-fcf9-4b1d-9d95-88e269cb2df4" />

### After

when using v2 tiers (tier was manually changed in the `cases` table to differentiate from 'static' tier)

<img width="545" height="377" alt="Screenshot 2026-07-28 at 09 24 00" src="https://github.com/user-attachments/assets/d413e939-01d7-4573-854f-0e77946d2ba6" />

when using v3 tiers

<img width="647" height="464" alt="Screenshot 2026-07-28 at 09 30 25" src="https://github.com/user-attachments/assets/d5f40c21-dd05-477e-8139-47d296828cd5" />
