### PR TITLE
FM-863 Tier filter population

### DIFF
--- a/integration_tests/mockApis/placementRequests.ts
+++ b/integration_tests/mockApis/placementRequests.ts
@@ -4,7 +4,6 @@ import type {
   Cas1PlacementRequestDetail,
   Cas1PlacementRequestSummary,
   PlacementRequestStatus,
-  RiskTierLevel,
 } from '@approved-premises/api'
 import { readFileSync } from 'fs'
 import path from 'path'
@@ -146,9 +145,10 @@ export default {
         },
       })
     ).body.requests,
+
   verifyPlacementRequestsSearch: async ({
     crnOrName,
-    tier,
+    tierOnApplicationCreation,
     arrivalDateStart,
     arrivalDateEnd,
     status,
@@ -157,7 +157,7 @@ export default {
     sortDirection = 'asc',
   }: {
     crnOrName: string
-    tier: RiskTierLevel
+    tierOnApplicationCreation: string
     arrivalDateStart: string
     arrivalDateEnd: string
     status: string
@@ -173,8 +173,8 @@ export default {
           crnOrName: {
             equalTo: crnOrName,
           },
-          tier: {
-            equalTo: tier,
+          tierOnApplicationCreation: {
+            equalTo: tierOnApplicationCreation,
           },
           status: {
             equalTo: status,

--- a/integration_tests/mockApis/referenceData.ts
+++ b/integration_tests/mockApis/referenceData.ts
@@ -1,5 +1,12 @@
 import { Response } from 'superagent'
-import { ApArea, Cas1ChangeRequestType, Cas1CruManagementArea, NamedId, NonArrivalReason } from '@approved-premises/api'
+import {
+  ApArea,
+  AvailableTierDto,
+  Cas1ChangeRequestType,
+  Cas1CruManagementArea,
+  NamedId,
+  NonArrivalReason,
+} from '@approved-premises/api'
 import { ReferenceData } from '@approved-premises/ui'
 import { stubFor } from './setup'
 import {
@@ -149,6 +156,21 @@ const stubChangeRequestRejectionReasonsReferenceData = ({
     },
   })
 
+const stubTierReferenceData = ({ tiers }: { tiers: Array<AvailableTierDto> }) =>
+  stubFor({
+    request: {
+      method: 'GET',
+      url: paths.referenceData({ type: 'tiers' }),
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: tiers,
+    },
+  })
+
 export default {
   stubApAreaReferenceData,
   stubCruManagementAreaReferenceData,
@@ -157,4 +179,5 @@ export default {
   stubMoveOnCategoriesReferenceData,
   stubChangeRequestReasonsReferenceData,
   stubChangeRequestRejectionReasonsReferenceData,
+  stubTierReferenceData,
 }

--- a/integration_tests/pages/admin/placementApplications/searchPage.ts
+++ b/integration_tests/pages/admin/placementApplications/searchPage.ts
@@ -11,7 +11,7 @@ export default class SearchPage extends ListPage {
 
   enterSearchQuery(searchOptions: PlacementRequestDashboardSearchOptions): void {
     this.getTextInputByIdAndEnterDetails('crnOrName', searchOptions.crnOrName)
-    this.getSelectInputByIdAndSelectAnEntry('tier', searchOptions.tier)
+    this.getSelectInputByIdAndSelectAnEntry('tier', searchOptions.tierOnApplicationCreation)
     this.getSelectInputByIdAndSelectAnEntry('status', searchOptions.status)
     this.getTextInputByIdAndEnterDetails('arrivalDateStart', searchOptions.arrivalDateStart)
     this.getTextInputByIdAndEnterDetails('arrivalDateEnd', searchOptions.arrivalDateEnd)

--- a/integration_tests/tests/admin/searchPlacementRequests.cy.ts
+++ b/integration_tests/tests/admin/searchPlacementRequests.cy.ts
@@ -1,9 +1,11 @@
 import { PlacementRequestDashboardSearchOptions } from '@approved-premises/ui'
+import { AvailableTierDto } from '@approved-premises/api'
 import SearchPage from '../../pages/admin/placementApplications/searchPage'
 
 import { cas1PlacementRequestSummaryFactory } from '../../../server/testutils/factories'
 import { normaliseCrn } from '../../../server/utils/normaliseCrn'
 import { signIn } from '../signIn'
+import { AND, GIVEN, THEN, WHEN } from '../../helpers'
 
 context('Search placement Requests', () => {
   const placementRequests = cas1PlacementRequestSummaryFactory.buildList(3)
@@ -11,16 +13,20 @@ context('Search placement Requests', () => {
 
   const searchQuery = {
     crnOrName: 'CRN123',
-    tier: 'D2',
+    tierOnApplicationCreation: 'A3',
     arrivalDateStart: '2022-01-01',
     arrivalDateEnd: '2022-01-03',
     status: 'notMatched',
   } as PlacementRequestDashboardSearchOptions
 
+  const tiers = ['A3', 'A2', 'A1', 'B3', 'B2', 'B1', 'D3', 'D2', 'D1'].map(tier => ({
+    tier,
+  })) as Array<AvailableTierDto>
+
   beforeEach(() => {
     cy.task('reset')
 
-    // Given I am signed in as a CRU member
+    GIVEN('I am signed in as a CRU member')
     signIn('cru_member')
 
     cy.task('stubPlacementRequestsSearch', { placementRequests })
@@ -29,22 +35,23 @@ context('Search placement Requests', () => {
       ...searchQuery,
       crnOrName: normaliseCrn(searchQuery.crnOrName),
     })
+    cy.task('stubTierReferenceData', { tiers })
   })
 
   it('allows me to search for placement requests', () => {
-    // When I visit the search page
+    WHEN('I visit the search page')
     const searchPage = SearchPage.visit()
 
-    // Then I should see a list of placement requests
+    THEN('I should see a list of placement requests')
     searchPage.shouldShowPlacementRequests(placementRequests)
 
-    // When I search for a CRN
+    WHEN('I search for a CRN')
     searchPage.enterSearchQuery(searchQuery)
 
-    // Then I should see the search results
+    THEN('I should see the search results')
     searchPage.shouldShowPlacementRequests(searchResults)
 
-    // And the API should have received a request for the CRN
+    AND('the API should have received a request for the CRN')
     cy.task('verifyPlacementRequestsSearch', searchQuery).then(requests => {
       expect(requests).to.have.length(1)
     })
@@ -62,27 +69,27 @@ context('Search placement Requests', () => {
       page: '9',
     })
 
-    // When I visit the search page
+    WHEN('I visit the search page')
     const searchPage = SearchPage.visit()
 
-    // Then I should see a list of placement requests
+    THEN('I should see a list of placement requests')
     searchPage.shouldShowPlacementRequests(placementRequests)
 
-    // And I search for a CRN
+    AND('I search for a CRN')
     searchPage.enterSearchQuery(searchQuery)
 
-    // When I click next
+    WHEN('I click next')
     searchPage.clickNext()
 
-    // Then the API should have received a request for the next page
+    THEN('the API should have received a request for the next page')
     cy.task('verifyPlacementRequestsSearch', { page: '2', ...searchQuery }).then(requests => {
       expect(requests).to.have.length(1)
     })
 
-    // When I click on a page number
+    WHEN('I click on a page number')
     searchPage.clickPageNumber('9')
 
-    // Then the API should have received a request for the that page number
+    THEN('the API should have received a request for the that page number')
     cy.task('verifyPlacementRequestsSearch', { page: '9', ...searchQuery }).then(requests => {
       expect(requests).to.have.length(1)
     })
@@ -102,22 +109,22 @@ context('Search placement Requests', () => {
       sortDirection: 'desc',
     })
 
-    // When I visit the search page
+    WHEN('I visit the search paget')
     const searchPage = SearchPage.visit()
 
-    // Then I should see a list of placement requests
+    THEN('I should see a list of placement requests')
     searchPage.shouldShowPlacementRequests(placementRequests)
 
-    // And I search for a CRN
+    AND('I search for a CRN')
     searchPage.enterSearchQuery(searchQuery)
 
-    // When I sort by expected arrival in ascending order
+    WHEN('I sort by expected arrival in ascending order')
     searchPage.clickSortBy('expected_arrival')
 
-    // Then the dashboard should be sorted by expected arrival
+    THEN('the dashboard should be sorted by expected arrival')
     searchPage.shouldBeSortedByField('expected_arrival', 'ascending')
 
-    // And the API should have received a request for the correct sort order
+    AND('the API should have received a request for the correct sort order')
     cy.task('verifyPlacementRequestsSearch', {
       ...searchQuery,
       sortBy: 'expected_arrival',
@@ -126,13 +133,13 @@ context('Search placement Requests', () => {
       expect(requests).to.have.length(1)
     })
 
-    // When I sort by expected arrival in descending order
+    WHEN('I sort by expected arrival in descending order')
     searchPage.clickSortBy('expected_arrival')
 
-    // Then the dashboard should be sorted by expected arrival in descending order
+    THEN('the dashboard should be sorted by expected arrival in descending order')
     searchPage.shouldBeSortedByField('expected_arrival', 'descending')
 
-    // And the API should have received a request for the correct sort order
+    AND('the API should have received a request for the correct sort order')
     cy.task('verifyPlacementRequestsSearch', {
       ...searchQuery,
       sortBy: 'expected_arrival',

--- a/integration_tests/tests/admin/searchPlacementRequests.cy.ts
+++ b/integration_tests/tests/admin/searchPlacementRequests.cy.ts
@@ -109,7 +109,7 @@ context('Search placement Requests', () => {
       sortDirection: 'desc',
     })
 
-    WHEN('I visit the search paget')
+    WHEN('I visit the search page')
     const searchPage = SearchPage.visit()
 
     THEN('I should see a list of placement requests')

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -467,7 +467,7 @@ export type MiddlewareSpec = {
 
 export type PlacementRequestDashboardSearchOptions = {
   crnOrName?: string
-  tier?: RiskTierLevel
+  tier?: string
   personTier?: string
   tierOnApplicationCreation?: string
   arrivalDateStart?: string

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -468,6 +468,8 @@ export type MiddlewareSpec = {
 export type PlacementRequestDashboardSearchOptions = {
   crnOrName?: string
   tier?: RiskTierLevel
+  personTier?: string
+  tierOnApplicationCreation?: string
   arrivalDateStart?: string
   arrivalDateEnd?: string
   status?: PlacementRequestStatus

--- a/server/controllers/admin/cruDashboardController.test.ts
+++ b/server/controllers/admin/cruDashboardController.test.ts
@@ -20,6 +20,8 @@ import { dashboardTableHeader, dashboardTableRows } from '../../utils/placementR
 import { pagination } from '../../utils/pagination'
 import { placementRequestStatusSelectOptions, tierSelectOptions } from '../../utils/formUtils'
 import { createQueryString } from '../../utils/utils'
+import ReferenceDataService from '../../services/referenceDataService'
+import config from '../../config'
 
 describe('CruDashboardController', () => {
   const token = 'SOME_TOKEN'
@@ -32,20 +34,25 @@ describe('CruDashboardController', () => {
   const placementRequestService = createMock<PlacementRequestService>({})
   const cruManagementAreaService = createMock<CruManagementAreaService>({})
   const premisesService = createMock<PremisesService>({})
+  const referenceDataService = createMock<ReferenceDataService>({})
 
   const cruManagementAreas = cruManagementAreaFactory.buildList(5)
   let cruDashboardController: CruDashboardController
+
+  const tiers = ['T1', 'T2', 'T3']
 
   beforeEach(() => {
     jest.clearAllMocks()
 
     jest.spyOn(getPaginationDetails, 'getPaginationDetails')
     cruManagementAreaService.getCruManagementAreas.mockResolvedValue(cruManagementAreas)
+    referenceDataService.getTiers.mockResolvedValue(tiers)
 
     cruDashboardController = new CruDashboardController(
       placementRequestService,
       cruManagementAreaService,
       premisesService,
+      referenceDataService,
     )
   })
 
@@ -202,9 +209,15 @@ describe('CruDashboardController', () => {
     const searchPath = paths.admin.cruDashboard.search({})
 
     let searchRequest: Request
+    let originalUseLiveTiers: boolean
 
     beforeEach(() => {
+      originalUseLiveTiers = config.flags.useLiveTiers
       placementRequestService.search.mockResolvedValue(paginatedResponse)
+    })
+
+    afterEach(() => {
+      config.flags.useLiveTiers = originalUseLiveTiers
     })
 
     it('should render the search template', async () => {
@@ -220,7 +233,7 @@ describe('CruDashboardController', () => {
         tabs: cruDashboardTabItems(user, 'search'),
         activeTab: 'search',
         crnOrName: undefined,
-        tierOptions: tierSelectOptions(undefined),
+        tierOptions: tierSelectOptions(tiers, undefined),
         statusOptions: placementRequestStatusSelectOptions(undefined),
         tableHead: dashboardTableHeader(undefined, 'name' as PlacementRequestSortField, 'asc', expectedHrefPrefix),
         tableRows: dashboardTableRows(paginatedResponse.data),
@@ -255,29 +268,64 @@ describe('CruDashboardController', () => {
       })
     })
 
-    it('should search for placement requests by tier and dates', async () => {
-      const requestHandler = cruDashboardController.search()
-      searchRequest = {
-        ...request,
-        query: { tier: 'A1', arrivalDateStart: '2022-01-01', arrivalDateEnd: '2022-01-03' },
-      }
+    it('should search for placement requests by application tier and dates', async () => {
+      config.flags.useLiveTiers = false
 
-      await requestHandler(searchRequest, response, next)
+      const query = { tier: 'A1', arrivalDateStart: '2022-01-01', arrivalDateEnd: '2022-01-03' }
+
+      searchRequest = { ...request, query }
+
+      await cruDashboardController.search()(searchRequest, response, next)
 
       expect(response.render).toHaveBeenCalledWith(
         'admin/cruDashboard/search',
         expect.objectContaining({
-          tier: 'A1',
-          arrivalDateStart: '2022-01-01',
-          arrivalDateEnd: '2022-01-03',
+          tierOptions: tierSelectOptions(tiers, 'A1'),
+          ...query,
         }),
       )
 
-      expect(getPaginationDetails.getPaginationDetails).toHaveBeenCalledWith(searchRequest, searchPath, {
-        tier: 'A1',
-        arrivalDateStart: '2022-01-01',
-        arrivalDateEnd: '2022-01-03',
-      })
+      expect(getPaginationDetails.getPaginationDetails).toHaveBeenCalledWith(searchRequest, searchPath, query)
+
+      expect(placementRequestService.search).toHaveBeenCalledWith(
+        token,
+        {
+          arrivalDateEnd: '2022-01-03',
+          arrivalDateStart: '2022-01-01',
+          tierOnApplicationCreation: 'A1',
+        },
+        undefined,
+        undefined,
+        undefined,
+      )
+    })
+
+    it('should search for placement requests by live tier', async () => {
+      config.flags.useLiveTiers = true
+
+      const query = { tier: 'B2' }
+
+      searchRequest = { ...request, query }
+
+      await cruDashboardController.search()(searchRequest, response, next)
+
+      expect(response.render).toHaveBeenCalledWith(
+        'admin/cruDashboard/search',
+        expect.objectContaining({
+          tierOptions: tierSelectOptions(tiers, 'B2'),
+          ...query,
+        }),
+      )
+
+      expect(getPaginationDetails.getPaginationDetails).toHaveBeenCalledWith(searchRequest, searchPath, query)
+
+      expect(placementRequestService.search).toHaveBeenCalledWith(
+        token,
+        { personTier: 'B2' },
+        undefined,
+        undefined,
+        undefined,
+      )
     })
 
     it('should remove empty queries from the search request', async () => {

--- a/server/controllers/admin/cruDashboardController.ts
+++ b/server/controllers/admin/cruDashboardController.ts
@@ -8,14 +8,18 @@ import {
 } from '@approved-premises/api'
 import { PlacementRequestDashboardSearchOptions } from '@approved-premises/ui'
 import createError from 'http-errors'
+
+import config from '../../config'
 import { CruManagementAreaService, PlacementRequestService, PremisesService } from '../../services'
 import adminPaths from '../../paths/admin'
+import { objectClean } from '../../utils/utils'
 import { getPaginationDetails } from '../../utils/getPaginationDetails'
 import { getSearchOptions } from '../../utils/getSearchOptions'
 import { cruDashboardActions, cruDashboardTabItems } from '../../utils/admin/cruDashboardUtils'
 import { pagination } from '../../utils/pagination'
 import { dashboardTableHeader, dashboardTableRows } from '../../utils/placementRequests/table'
 import { placementRequestStatusSelectOptions, tierSelectOptions } from '../../utils/formUtils'
+import ReferenceDataService from '../../services/referenceDataService'
 
 interface IndexRequest extends Request {
   query: {
@@ -33,6 +37,7 @@ export default class CruDashboardController {
     private readonly placementRequestService: PlacementRequestService,
     private readonly cruManagementAreaService: CruManagementAreaService,
     private readonly premisesService: PremisesService,
+    private readonly referenceDataService: ReferenceDataService,
   ) {}
 
   index(): TypedRequestHandler<Request, Response> {
@@ -97,26 +102,35 @@ export default class CruDashboardController {
         'arrivalDateEnd',
         'status',
       ])
+
       const { pageNumber, sortBy, sortDirection, hrefPrefix } = getPaginationDetails<PlacementRequestSortField>(
         req,
         adminPaths.admin.cruDashboard.search({}),
         searchOptions,
       )
 
+      const tierFieldName = config.flags.useLiveTiers ? 'personTier' : 'tierOnApplicationCreation'
+
       const dashboard = await this.placementRequestService.search(
         req.user.token,
-        searchOptions,
+        objectClean({
+          ...searchOptions,
+          [tierFieldName]: searchOptions.tier,
+          tier: undefined,
+        }),
         pageNumber,
         sortBy,
         sortDirection,
       )
+
+      const tiers = await this.referenceDataService.getTiers(req.user.token)
 
       res.render('admin/cruDashboard/search', {
         pageHeading: 'CRU Dashboard',
         tabs: cruDashboardTabItems(res.locals.user, 'search'),
         activeTab: 'search',
         ...searchOptions,
-        tierOptions: tierSelectOptions(searchOptions.tier),
+        tierOptions: tierSelectOptions(tiers, searchOptions.tier),
         statusOptions: placementRequestStatusSelectOptions(searchOptions.status),
         tableHead: dashboardTableHeader(undefined, sortBy, sortDirection, hrefPrefix),
         tableRows: dashboardTableRows(dashboard.data),

--- a/server/controllers/admin/index.ts
+++ b/server/controllers/admin/index.ts
@@ -11,12 +11,14 @@ import NationalOccupancyController from './nationalOccupancyController'
 import type { Services } from '../../services'
 
 export const controllers = (services: Services) => {
-  const { placementRequestService, premisesService, reportService, cruManagementAreaService } = services
+  const { placementRequestService, premisesService, reportService, cruManagementAreaService, referenceDataService } =
+    services
   const adminPlacementRequestsController = new AdminPlacementRequestsController(placementRequestService)
   const cruDashboardController = new CruDashboardController(
     placementRequestService,
     cruManagementAreaService,
     premisesService,
+    referenceDataService,
   )
   const placementRequestWithdrawalsController = new PlacementRequestsWithdrawalsController(placementRequestService)
   const reportsController = new ReportsController(reportService)

--- a/server/data/referenceDataClient.test.ts
+++ b/server/data/referenceDataClient.test.ts
@@ -1,4 +1,5 @@
 import {
+  AvailableTierDto,
   CancellationReason,
   DepartureReason,
   DestinationProvider,
@@ -132,6 +133,30 @@ describeClient('ReferenceDataClient', provider => {
 
       const output = await referenceDataClient.getNonArrivalReasons()
       expect(output).toEqual(nonArrivalReasons)
+    })
+  })
+
+  describe('getTiers', () => {
+    it('should return an array of AvailableTierDto objects', async () => {
+      const tiers: Array<AvailableTierDto> = [{ tier: 'T1' }, { tier: 'T2' }, { tier: 'T3' }]
+
+      await provider.addInteraction({
+        state: 'Server is healthy',
+        uponReceiving: `A request to get available Tiers`,
+        withRequest: {
+          method: 'GET',
+          path: paths.referenceData({ type: 'tiers' }),
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+        },
+        willRespondWith: {
+          status: 200,
+          body: tiers,
+        },
+      })
+
+      expect(await referenceDataClient.getTiers()).toEqual(tiers)
     })
   })
 })

--- a/server/data/referenceDataClient.ts
+++ b/server/data/referenceDataClient.ts
@@ -1,7 +1,7 @@
 import type { ReferenceData } from '@approved-premises/ui'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
-import { ApArea, NonArrivalReason, ProbationRegion } from '../@types/shared'
+import { ApArea, AvailableTierDto, NonArrivalReason, ProbationRegion } from '../@types/shared'
 import paths from '../paths/api'
 
 export default class ReferenceDataClient {
@@ -28,6 +28,12 @@ export default class ReferenceDataClient {
   async getNonArrivalReasons(): Promise<Array<NonArrivalReason>> {
     return this.restClient.get<Array<NonArrivalReason>>({
       path: paths.referenceData({ type: 'non-arrival-reasons' }),
+    })
+  }
+
+  async getTiers(): Promise<Array<AvailableTierDto>> {
+    return this.restClient.get<Array<AvailableTierDto>>({
+      path: paths.referenceData({ type: 'tiers' }),
     })
   }
 }

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -19,6 +19,7 @@ import ApAreaService from './apAreaService'
 import CruManagementAreaService from './cruManagementAreaService'
 import AppealService from './appealService'
 import FormDataService from './formDataService'
+import ReferenceDataService from './referenceDataService'
 
 export const services = () => {
   const {
@@ -60,6 +61,7 @@ export const services = () => {
   const apAreaService = new ApAreaService(referenceDataClientBuilder)
   const cruManagementAreaService = new CruManagementAreaService(cas1ReferenceDataClientBuilder)
   const formDataService = new FormDataService(formClientBuilder)
+  const referenceDataService = new ReferenceDataService(referenceDataClientBuilder)
 
   return {
     appealService,
@@ -79,6 +81,7 @@ export const services = () => {
     apAreaService,
     cruManagementAreaService,
     formDataService,
+    referenceDataService,
   }
 }
 

--- a/server/services/referenceDataService.test.ts
+++ b/server/services/referenceDataService.test.ts
@@ -1,0 +1,32 @@
+import { ReferenceDataClient } from '../data'
+import ReferenceDataService from './referenceDataService'
+
+jest.mock('../data/referenceDataClient.ts')
+
+describe('ApAreaService', () => {
+  const referenceDataClient = new ReferenceDataClient(null) as jest.Mocked<ReferenceDataClient>
+  const referenceDataClientFactory = jest.fn()
+
+  const service = new ReferenceDataService(referenceDataClientFactory)
+
+  const token = 'SOME_TOKEN'
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    referenceDataClientFactory.mockReturnValue(referenceDataClient)
+  })
+
+  describe('getTiers', () => {
+    it('calls the getTiers client method and maps the result to an array of plain strings', async () => {
+      const tiersFromApi = [{ tier: 'T1' }, { tier: 'T2' }, { tier: 'T3' }]
+
+      referenceDataClient.getTiers.mockResolvedValue(tiersFromApi)
+
+      const result = await service.getTiers(token)
+
+      expect(referenceDataClientFactory).toHaveBeenCalledWith(token)
+      expect(referenceDataClient.getTiers).toHaveBeenCalled()
+      expect(result).toEqual(['T1', 'T2', 'T3'])
+    })
+  })
+})

--- a/server/services/referenceDataService.ts
+++ b/server/services/referenceDataService.ts
@@ -1,0 +1,11 @@
+import type { ReferenceDataClient, RestClientBuilder } from '../data'
+
+export default class ReferenceDataService {
+  constructor(private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>) {}
+
+  async getTiers(token: string): Promise<Array<string>> {
+    const client = this.referenceDataClientFactory(token)
+
+    return (await client.getTiers()).map(({ tier }) => tier)
+  }
+}

--- a/server/testutils/factories/tierDto.ts
+++ b/server/testutils/factories/tierDto.ts
@@ -6,7 +6,8 @@ import { DateFormats } from '../../utils/dateUtils'
 const v3EligibleTiers = ['A', 'B', 'C']
 const v3IneligibleTiers = ['D', 'E', 'F', 'G']
 const v2EligibleTiers = ['A1', 'A2', 'A3', 'B1', 'B2', 'B3']
-const v2IneligibleTiers = ['C1', 'C2', 'C3']
+const v2IneligibleTiers = ['C1', 'C2']
+const v2WomenEligibleTiers = ['C3']
 
 class TierDtoFactory extends Factory<TierDto> {
   v3() {
@@ -18,7 +19,7 @@ class TierDtoFactory extends Factory<TierDto> {
 
   v2() {
     return this.params({
-      tierScore: faker.helpers.arrayElement([...v2EligibleTiers, ...v2IneligibleTiers]),
+      tierScore: faker.helpers.arrayElement([...v2EligibleTiers, ...v2IneligibleTiers, ...v2WomenEligibleTiers]),
       version: 'V2',
     })
   }

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -520,7 +520,7 @@ describe('utils', () => {
 
     it('returns the is exceptional case page for an application with an unsuitable tier', () => {
       const tier = tierDtoFactory.v2Ineligible().build()
-      const person = personFactory.build({ sex: 'Male', tier })
+      const person = fullPersonFactory.build({ tier })
 
       expect(firstPageOfApplicationJourney(applicationId, person)).toEqual(
         paths.applications.pages.show({ id: applicationId, task: 'basic-information', page: 'is-exceptional-case' }),

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -520,7 +520,7 @@ describe('utils', () => {
 
     it('returns the is exceptional case page for an application with an unsuitable tier', () => {
       const tier = tierDtoFactory.v2Ineligible().build()
-      const person = fullPersonFactory.build({ tier })
+      const person = fullPersonFactory.build({ sex: 'Male', tier })
 
       expect(firstPageOfApplicationJourney(applicationId, person)).toEqual(
         paths.applications.pages.show({ id: applicationId, task: 'basic-information', page: 'is-exceptional-case' }),

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -662,47 +662,22 @@ describe('formUtils', () => {
   })
 
   describe('tierSelectOptions', () => {
+    const tiers = ['T1', 'T2', 'T3']
     it('returns a list of tiers as select options', () => {
-      expect(tierSelectOptions(undefined)).toEqual([
+      expect(tierSelectOptions(tiers, undefined)).toEqual([
         { text: 'Please select', value: '', selected: true },
-        { text: 'D0', value: 'D0', selected: false },
-        { text: 'D1', value: 'D1', selected: false },
-        { text: 'D2', value: 'D2', selected: false },
-        { text: 'D3', value: 'D3', selected: false },
-        { text: 'C0', value: 'C0', selected: false },
-        { text: 'C1', value: 'C1', selected: false },
-        { text: 'C2', value: 'C2', selected: false },
-        { text: 'C3', value: 'C3', selected: false },
-        { text: 'B0', value: 'B0', selected: false },
-        { text: 'B1', value: 'B1', selected: false },
-        { text: 'B2', value: 'B2', selected: false },
-        { text: 'B3', value: 'B3', selected: false },
-        { text: 'A0', value: 'A0', selected: false },
-        { text: 'A1', value: 'A1', selected: false },
-        { text: 'A2', value: 'A2', selected: false },
-        { text: 'A3', value: 'A3', selected: false },
+        { text: 'T1', value: 'T1', selected: false },
+        { text: 'T2', value: 'T2', selected: false },
+        { text: 'T3', value: 'T3', selected: false },
       ])
     })
 
     it('return the selected tier if specified', () => {
-      expect(tierSelectOptions('C1')).toEqual([
+      expect(tierSelectOptions(tiers, 'T2')).toEqual([
         { text: 'Please select', value: '', selected: false },
-        { text: 'D0', value: 'D0', selected: false },
-        { text: 'D1', value: 'D1', selected: false },
-        { text: 'D2', value: 'D2', selected: false },
-        { text: 'D3', value: 'D3', selected: false },
-        { text: 'C0', value: 'C0', selected: false },
-        { text: 'C1', value: 'C1', selected: true },
-        { text: 'C2', value: 'C2', selected: false },
-        { text: 'C3', value: 'C3', selected: false },
-        { text: 'B0', value: 'B0', selected: false },
-        { text: 'B1', value: 'B1', selected: false },
-        { text: 'B2', value: 'B2', selected: false },
-        { text: 'B3', value: 'B3', selected: false },
-        { text: 'A0', value: 'A0', selected: false },
-        { text: 'A1', value: 'A1', selected: false },
-        { text: 'A2', value: 'A2', selected: false },
-        { text: 'A3', value: 'A3', selected: false },
+        { text: 'T1', value: 'T1', selected: false },
+        { text: 'T2', value: 'T2', selected: true },
+        { text: 'T3', value: 'T3', selected: false },
       ])
     })
   })

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -11,7 +11,6 @@ import type {
   SummaryListItem,
   TextItem,
 } from '@approved-premises/ui'
-import type { RiskTierLevel } from '@approved-premises/api'
 import { PlacementRequestStatus } from '@approved-premises/api'
 import { isCardinal, resolvePath, sentenceCase } from './utils'
 import { DateFormats } from './dateUtils'
@@ -257,10 +256,7 @@ export const escape = (text: string): string => {
   const escapeFilter = new nunjucks.Environment().getFilter('escape')
   return escapeFilter(text).val
 }
-
-export const tierSelectOptions = (selectedOption: RiskTierLevel | undefined): Array<SelectOption> => {
-  const tiers = ['D0', 'D1', 'D2', 'D3', 'C0', 'C1', 'C2', 'C3', 'B0', 'B1', 'B2', 'B3', 'A0', 'A1', 'A2', 'A3']
-
+export const tierSelectOptions = (tiers: Array<string>, selectedOption: string | undefined): Array<SelectOption> => {
   const options = tiers.map(tier => ({
     text: tier,
     value: tier,


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/FM-863
<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- Pulls the list of tiers used on the CRU dashboard/search tab, from an API reference data endpoint, rather than using a hardcoded list.
- The selector list is presented in the order received, i.e. the UI does no sorting.
- The tier filter field presented to the API `placement_request` endpoint is now switched depending on the state of the `USE_LIVE_TIER` feature flag. If enabled, the selected tier is passed in the `personTier` field, otherwise in the `tierOnApplicationCreation` field. I chose to keep the page search URL search parameter as `tier` rather than reflect the actual field names since those are not very 'user-friendly'.

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

No UI changes - the selector should be the same.

<details>
  <summary>Tier filter selector populated from API</summary>
<img width="597" height="775" alt="image" src="https://github.com/user-attachments/assets/d1cad211-820c-44a1-be12-4134028194fe" />
</details>


