### PR TITLE
Feature/fm 964 assess display live tier in banner

### DIFF
--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -118,6 +118,7 @@ context('Apply', () => {
       tier: tierEnvelopeFactory.build({ value: { level: 'D1' } }),
     })
     const tier = tierDtoFactory.v2Ineligible().build()
+    this.person.sex = 'Male'
     this.person.tier = tier
     const application = { ...this.application, person: { ...this.person, tier } }
     cy.task('stubApplicationGet', { application })
@@ -207,6 +208,7 @@ context('Apply', () => {
   it(`allows the user to specify if the case is exceptional if the offender's tier is not eligible`, function test() {
     GIVEN('the person does not have an eligible risk tier')
     const tier = tierDtoFactory.v2Ineligible().build()
+    this.person.sex = 'Male'
     this.person.tier = tier
     const application = { ...this.application, person: { ...this.person, tier } }
 
@@ -224,6 +226,7 @@ context('Apply', () => {
   it('tells the user that their application is not applicable if the tier is not eligible and it is not an exceptional case', function test() {
     GIVEN('the person does not have an eligible risk tier')
     const tier = tierDtoFactory.v2Ineligible().build()
+    this.person.sex = 'Male'
     this.person.tier = tier
     const application = { ...this.application, person: { ...this.person, tier } }
 

--- a/server/utils/applications/utils.test.ts
+++ b/server/utils/applications/utils.test.ts
@@ -519,9 +519,8 @@ describe('utils', () => {
     })
 
     it('returns the is exceptional case page for an application with an unsuitable tier', () => {
-      jest.spyOn(personUtils, 'isApplicableTier').mockReturnValue(false)
       const tier = tierDtoFactory.v2Ineligible().build()
-      const person = personFactory.build({ tier })
+      const person = personFactory.build({ sex: 'Male', tier })
 
       expect(firstPageOfApplicationJourney(applicationId, person)).toEqual(
         paths.applications.pages.show({ id: applicationId, task: 'basic-information', page: 'is-exceptional-case' }),
@@ -987,7 +986,7 @@ describe('utils', () => {
     })
 
     it('returns the is exceptional case page for an application with an unsuitable tier', () => {
-      const person = fullPersonFactory.build({ tier: tierDtoFactory.v2Ineligible().build() })
+      const person = fullPersonFactory.build({ sex: 'Male', tier: tierDtoFactory.v2Ineligible().build() })
       const application = applicationFactory.build({ person })
 
       expect(tierQualificationPage(application)).toEqual(

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -35,7 +35,6 @@ import { arrivalDateFromApplication } from '../applications/arrivalDateFromAppli
 import { applicationAccepted, decisionFromAssessment } from './decisionUtils'
 import { getResponseForPage } from '../applications/getResponseForPage'
 import { displayName } from '../personUtils'
-import config from '../../config'
 import { DateFormats } from '../dateUtils'
 import { linkTo } from '../utils'
 import applyPaths from '../../paths/apply'

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -403,6 +403,15 @@ describe('utils', () => {
         ],
       })
     })
+
+    it('should show the tier as not available if it is not defined', () => {
+      const application = applicationFactory.build({ person, risks: undefined })
+      const assessment = assessmentFactory.build({ application })
+
+      const result = assessmentKeyDetails(assessment)
+
+      expect(result.items[1].value).toEqual({ text: 'Not available' })
+    })
   })
 
   describe('assessmentsTabItems', () => {

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -24,6 +24,9 @@ import {
   assessmentSummaryFactory,
   personFactory,
   prisonCaseNotesFactory,
+  risksFactory,
+  tierDtoFactory,
+  tierEnvelopeFactory,
   userDetailsFactory,
   userFactory,
 } from '../../testutils/factories'
@@ -31,7 +34,8 @@ import {
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
 import { applicationAccepted, decisionFromAssessment } from './decisionUtils'
 import { getResponseForPage } from '../applications/getResponseForPage'
-import { displayName, getVersionedTier } from '../personUtils'
+import { displayName } from '../personUtils'
+import config from '../../config'
 import { DateFormats } from '../dateUtils'
 import { linkTo } from '../utils'
 import applyPaths from '../../paths/apply'
@@ -328,10 +332,13 @@ describe('utils', () => {
   })
 
   describe('assessmentKeyDetails', () => {
-    const person = personFactory.build()
+    const person = personFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'D2Live' }) })
+    const risks = risksFactory.build({
+      tier: tierEnvelopeFactory.build({ value: { level: 'D2' } }),
+    })
 
     it('should return key details for an assessment when an arrival date is provided', () => {
-      const application = applicationFactory.build({ arrivalDate: '2022-01-01', person })
+      const application = applicationFactory.build({ arrivalDate: '2022-01-01', person, risks })
       const assessment = assessmentFactory.build({ application })
 
       expect(assessmentKeyDetails(assessment)).toEqual({
@@ -347,7 +354,7 @@ describe('utils', () => {
           },
           {
             key: { text: 'Tier' },
-            value: { text: getVersionedTier(application.person, application.risks?.tier?.value) },
+            value: { text: 'D2' },
           },
           {
             key: { text: 'Arrival Date' },
@@ -368,7 +375,7 @@ describe('utils', () => {
     })
 
     it('should return key details for an assessment when an arrival date is not provided', () => {
-      const application = applicationFactory.build({ arrivalDate: undefined, person })
+      const application = applicationFactory.build({ arrivalDate: undefined, person, risks })
       const assessment = assessmentFactory.build({ application })
 
       expect(assessmentKeyDetails(assessment)).toEqual({
@@ -384,7 +391,7 @@ describe('utils', () => {
           },
           {
             key: { text: 'Tier' },
-            value: { text: getVersionedTier(application.person, application.risks?.tier?.value) },
+            value: { text: 'D2' },
           },
           {
             key: { text: 'Arrival Date' },

--- a/server/utils/assessments/utils.test.ts
+++ b/server/utils/assessments/utils.test.ts
@@ -31,7 +31,7 @@ import {
 import { arrivalDateFromApplication } from '../applications/arrivalDateFromApplication'
 import { applicationAccepted, decisionFromAssessment } from './decisionUtils'
 import { getResponseForPage } from '../applications/getResponseForPage'
-import { displayName } from '../personUtils'
+import { displayName, getVersionedTier } from '../personUtils'
 import { DateFormats } from '../dateUtils'
 import { linkTo } from '../utils'
 import applyPaths from '../../paths/apply'
@@ -346,6 +346,10 @@ describe('utils', () => {
             value: { text: application.person.crn },
           },
           {
+            key: { text: 'Tier' },
+            value: { text: getVersionedTier(application.person, application.risks?.tier?.value) },
+          },
+          {
             key: { text: 'Arrival Date' },
             value: {
               text: DateFormats.isoDateToUIDate(application.arrivalDate),
@@ -377,6 +381,10 @@ describe('utils', () => {
           {
             key: { text: 'CRN' },
             value: { text: application.person.crn },
+          },
+          {
+            key: { text: 'Tier' },
+            value: { text: getVersionedTier(application.person, application.risks?.tier?.value) },
           },
           {
             key: { text: 'Arrival Date' },

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -12,7 +12,7 @@ import { getApplicationType } from '../applications/utils'
 import { applicationAccepted, decisionFromAssessment } from './decisionUtils'
 import { formattedArrivalDate } from './dateUtils'
 import { getResponseForPage } from '../applications/getResponseForPage'
-import { displayName, getVersionedTier } from '../personUtils'
+import { displayName, getVersionedTierValue } from '../personUtils'
 import { DateFormats } from '../dateUtils'
 import applyPaths from '../../paths/apply'
 import assessPaths from '../../paths/assess'
@@ -144,7 +144,7 @@ const assessmentKeyDetails = (assessment: Assessment): KeyDetailsArgs => {
       },
       {
         key: { text: 'Tier' },
-        value: { text: getVersionedTier(assessment.application.person, assessment.application.risks?.tier?.value) || 'Not available' },
+        value: { text: getVersionedTierValue(assessment.application.person, assessment.application.risks?.tier?.value) || 'Not available' },
       },
       {
         key: { text: 'Arrival Date' },

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -12,7 +12,7 @@ import { getApplicationType } from '../applications/utils'
 import { applicationAccepted, decisionFromAssessment } from './decisionUtils'
 import { formattedArrivalDate } from './dateUtils'
 import { getResponseForPage } from '../applications/getResponseForPage'
-import { displayName } from '../personUtils'
+import { displayName, getVersionedTier } from '../personUtils'
 import { DateFormats } from '../dateUtils'
 import applyPaths from '../../paths/apply'
 import assessPaths from '../../paths/assess'
@@ -141,6 +141,10 @@ const assessmentKeyDetails = (assessment: Assessment): KeyDetailsArgs => {
       {
         key: { text: 'CRN' },
         value: { text: assessment.application.person.crn },
+      },
+      {
+        key: { text: 'Tier' },
+        value: { text: getVersionedTier(assessment.application.person, assessment.application.risks?.tier?.value) },
       },
       {
         key: { text: 'Arrival Date' },

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -144,7 +144,7 @@ const assessmentKeyDetails = (assessment: Assessment): KeyDetailsArgs => {
       },
       {
         key: { text: 'Tier' },
-        value: { text: getVersionedTier(assessment.application.person, assessment.application.risks?.tier?.value) },
+        value: { text: getVersionedTier(assessment.application.person, assessment.application.risks?.tier?.value) || 'Not available' },
       },
       {
         key: { text: 'Arrival Date' },

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -144,7 +144,11 @@ const assessmentKeyDetails = (assessment: Assessment): KeyDetailsArgs => {
       },
       {
         key: { text: 'Tier' },
-        value: { text: getVersionedTierValue(assessment.application.person, assessment.application.risks?.tier?.value) || 'Not available' },
+        value: {
+          text:
+            getVersionedTierValue(assessment.application.person, assessment.application.risks?.tier?.value) ||
+            'Not available',
+        },
       },
       {
         key: { text: 'Arrival Date' },

--- a/server/utils/assessments/utils.ts
+++ b/server/utils/assessments/utils.ts
@@ -17,6 +17,7 @@ import { DateFormats } from '../dateUtils'
 import applyPaths from '../../paths/apply'
 import assessPaths from '../../paths/assess'
 import { hasPermission } from '../users'
+import { summaryListItem } from '../formUtils'
 
 const awaitingAssessmentStatuses = ['in_progress', 'not_started'] as Array<Cas1AssessmentStatus>
 
@@ -138,26 +139,18 @@ const assessmentKeyDetails = (assessment: Assessment): KeyDetailsArgs => {
       showKey: false,
     },
     items: [
-      {
-        key: { text: 'CRN' },
-        value: { text: assessment.application.person.crn },
-      },
-      {
-        key: { text: 'Tier' },
-        value: {
-          text:
-            getVersionedTierValue(assessment.application.person, assessment.application.risks?.tier?.value) ||
-            'Not available',
-        },
-      },
-      {
-        key: { text: 'Arrival Date' },
-        value: {
-          text: assessment.application.arrivalDate
-            ? DateFormats.isoDateToUIDate(assessment.application.arrivalDate)
-            : 'Not provided',
-        },
-      },
+      summaryListItem('CRN', assessment.application.person.crn),
+      summaryListItem(
+        'Tier',
+        getVersionedTierValue(assessment.application.person, assessment.application.risks?.tier?.value) ||
+          'Not available',
+      ),
+      summaryListItem(
+        'Arrival Date',
+        assessment.application.arrivalDate
+          ? DateFormats.isoDateToUIDate(assessment.application.arrivalDate)
+          : 'Not provided',
+      ),
       {
         value: {
           html: linkTo(applyPaths.applications.show({ id: assessment.application.id }), {

--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -277,19 +277,17 @@ describe('personUtils', () => {
     })
 
     describe('when live tiers are disabled', () => {
+      const person = fullPersonFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'live' }) })
+
       beforeEach(() => {
         config.flags.useLiveTiers = false
       })
 
       it('returns the tier badge from application creation when present', () => {
-        const person = fullPersonFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'live' }) })
-
         expect(getVersionedTierOrBlank(person, tierOnApplicationCreation)).toEqual(tierBadge('static'))
       })
 
       it('returns an empty string when the application tier is undefined', () => {
-        const person = fullPersonFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'live' }) })
-
         expect(getVersionedTierOrBlank(person, undefined)).toEqual('')
       })
     })
@@ -315,6 +313,9 @@ describe('personUtils', () => {
   })
 
   describe('getVersionedTierValue', () => {
+    const tierOnApplicationCreation = tierEnvelopeFactory.build({ value: { level: 'static', version: 'V2' } }).value
+    const personWithLiveTier = personFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'live' }) })
+
     afterEach(() => {
       config.flags.useLiveTiers = false
     })
@@ -325,15 +326,10 @@ describe('personUtils', () => {
       })
 
       it('returns the tier from application creation when present', () => {
-        const tierOnApplicationCreation = tierEnvelopeFactory.build({ value: { level: 'static', version: 'V2' } }).value
-        const personWithLiveTier = personFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'live' }) })
-
         expect(getVersionedTierValue(personWithLiveTier, tierOnApplicationCreation)).toEqual('static')
       })
 
       it('returns an empty string when the application tier is undefined', () => {
-        const personWithLiveTier = personFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'live' }) })
-
         expect(getVersionedTierValue(personWithLiveTier, undefined)).toEqual('')
       })
     })
@@ -344,17 +340,13 @@ describe('personUtils', () => {
       })
 
       it('returns the live person tier when present', () => {
-        const tierOnApplicationCreation = tierEnvelopeFactory.build({ value: { level: 'static', version: 'V2' } }).value
-        const personWithLiveTier = personFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'live' }) })
-
         expect(getVersionedTierValue(personWithLiveTier, tierOnApplicationCreation)).toEqual('live')
       })
 
       it('returns an empty string when the person has no tier', () => {
-        const tierOnApplicationCreation = tierEnvelopeFactory.build({ value: { level: 'static', version: 'V2' } }).value
-        const personWithLiveTier = personFactory.build({ tier: undefined })
+        const personWithoutTier = personFactory.build({ tier: undefined })
 
-        expect(getVersionedTierValue(personWithLiveTier, tierOnApplicationCreation)).toEqual('')
+        expect(getVersionedTierValue(personWithoutTier, tierOnApplicationCreation)).toEqual('')
       })
     })
   })

--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -1,5 +1,4 @@
 import { RiskTier, TierDto } from '@approved-premises/api'
-import config from '../config'
 import { personFactory, tierEnvelopeFactory } from '../testutils/factories'
 import {
   fullPersonFactory,
@@ -13,13 +12,14 @@ import {
   displayName,
   getTierOrBlank,
   getVersionedTierOrBlank,
-  getVersionedTier,
+  getVersionedTierValue,
   isApplicableTier,
   isFullPerson,
   isNotRestrictedPerson,
   isUnknownPerson,
   personTier,
   tierBadge,
+  tierBadgeV3,
   versionedTierBadge,
 } from './personUtils'
 import tierDtoFactory from '../testutils/factories/tierDto'
@@ -271,7 +271,7 @@ describe('personUtils', () => {
   })
 
   describe('getVersionedTierOrBlank', () => {
-    const tierOnApplicationCreation = { level: 'static' } as RiskTier
+    const tierOnApplicationCreation = { level: 'static', version: 'V2' } as RiskTier
 
     afterEach(() => {
       config.flags.useLiveTiers = false
@@ -292,6 +292,13 @@ describe('personUtils', () => {
         const person = fullPersonFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'live' }) })
 
         expect(getVersionedTierOrBlank(person, undefined)).toEqual('')
+      })
+
+      it('returns the V3 tier badge when the application tier is V3', () => {
+        const person = fullPersonFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'live' }) })
+        const v3TierOnApplicationCreation = { level: 'static', version: 'V3' } as RiskTier
+
+        expect(getVersionedTierOrBlank(person, v3TierOnApplicationCreation)).toEqual(tierBadgeV3('static'))
       })
     })
 
@@ -315,7 +322,11 @@ describe('personUtils', () => {
     })
   })
 
-  describe('getVersionedTier', () => {
+  describe('getVersionedTierValue', () => {
+    afterEach(() => {
+      config.flags.useLiveTiers = false
+    })
+
     describe('when live tiers are disabled', () => {
       beforeEach(() => {
         config.flags.useLiveTiers = false
@@ -325,13 +336,13 @@ describe('personUtils', () => {
         const tierOnApplicationCreation = tierEnvelopeFactory.build({ value: { level: 'static', version: 'V2' } }).value
         const personWithLiveTier = personFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'live' }) })
 
-        expect(getVersionedTier(personWithLiveTier, tierOnApplicationCreation)).toEqual('static')
+        expect(getVersionedTierValue(personWithLiveTier, tierOnApplicationCreation)).toEqual('static')
       })
 
       it('returns an empty string when the application tier is undefined', () => {
         const personWithLiveTier = personFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'live' }) })
 
-        expect(getVersionedTier(personWithLiveTier, undefined)).toEqual('')
+        expect(getVersionedTierValue(personWithLiveTier, undefined)).toEqual('')
       })
     })
 
@@ -344,14 +355,14 @@ describe('personUtils', () => {
         const tierOnApplicationCreation = tierEnvelopeFactory.build({ value: { level: 'static', version: 'V2' } }).value
         const personWithLiveTier = personFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'live' }) })
 
-        expect(getVersionedTier(personWithLiveTier, tierOnApplicationCreation)).toEqual('live')
+        expect(getVersionedTierValue(personWithLiveTier, tierOnApplicationCreation)).toEqual('live')
       })
 
       it('returns an empty string when the person has no tier', () => {
         const tierOnApplicationCreation = tierEnvelopeFactory.build({ value: { level: 'static', version: 'V2' } }).value
         const personWithLiveTier = personFactory.build({ tier: undefined })
 
-        expect(getVersionedTier(personWithLiveTier, tierOnApplicationCreation)).toEqual('')
+        expect(getVersionedTierValue(personWithLiveTier, tierOnApplicationCreation)).toEqual('')
       })
     })
   })

--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -1,4 +1,6 @@
 import { RiskTier, TierDto } from '@approved-premises/api'
+import config from '../config'
+import { personFactory, tierEnvelopeFactory } from '../testutils/factories'
 import {
   fullPersonFactory,
   fullPersonSummaryFactory,
@@ -11,6 +13,7 @@ import {
   displayName,
   getTierOrBlank,
   getVersionedTierOrBlank,
+  getVersionedTier,
   isApplicableTier,
   isFullPerson,
   isNotRestrictedPerson,
@@ -308,6 +311,47 @@ describe('personUtils', () => {
         const person = fullPersonFactory.build({ tier: undefined })
 
         expect(getVersionedTierOrBlank(person, tierOnApplicationCreation)).toEqual('')
+      })
+    })
+  })
+
+  describe('getVersionedTier', () => {
+    describe('when live tiers are disabled', () => {
+      beforeEach(() => {
+        config.flags.useLiveTiers = false
+      })
+
+      it('returns the tier from application creation when present', () => {
+        const tierOnApplicationCreation = tierEnvelopeFactory.build({ value: { level: 'static', version: 'V2' } }).value
+        const personWithLiveTier = personFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'live' }) })
+
+        expect(getVersionedTier(personWithLiveTier, tierOnApplicationCreation)).toEqual('static')
+      })
+
+      it('returns an empty string when the application tier is undefined', () => {
+        const personWithLiveTier = personFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'live' }) })
+
+        expect(getVersionedTier(personWithLiveTier, undefined)).toEqual('')
+      })
+    })
+
+    describe('when live tiers are enabled', () => {
+      beforeEach(() => {
+        config.flags.useLiveTiers = true
+      })
+
+      it('returns the live person tier when present', () => {
+        const tierOnApplicationCreation = tierEnvelopeFactory.build({ value: { level: 'static', version: 'V2' } }).value
+        const personWithLiveTier = personFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'live' }) })
+
+        expect(getVersionedTier(personWithLiveTier, tierOnApplicationCreation)).toEqual('live')
+      })
+
+      it('returns an empty string when the person has no tier', () => {
+        const tierOnApplicationCreation = tierEnvelopeFactory.build({ value: { level: 'static', version: 'V2' } }).value
+        const personWithLiveTier = personFactory.build({ tier: undefined })
+
+        expect(getVersionedTier(personWithLiveTier, tierOnApplicationCreation)).toEqual('')
       })
     })
   })

--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -19,7 +19,6 @@ import {
   isUnknownPerson,
   personTier,
   tierBadge,
-  tierBadgeV3,
   versionedTierBadge,
 } from './personUtils'
 import tierDtoFactory from '../testutils/factories/tierDto'
@@ -271,7 +270,7 @@ describe('personUtils', () => {
   })
 
   describe('getVersionedTierOrBlank', () => {
-    const tierOnApplicationCreation = { level: 'static', version: 'V2' } as RiskTier
+    const tierOnApplicationCreation = { level: 'static' } as RiskTier
 
     afterEach(() => {
       config.flags.useLiveTiers = false
@@ -292,13 +291,6 @@ describe('personUtils', () => {
         const person = fullPersonFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'live' }) })
 
         expect(getVersionedTierOrBlank(person, undefined)).toEqual('')
-      })
-
-      it('returns the V3 tier badge when the application tier is V3', () => {
-        const person = fullPersonFactory.build({ tier: tierDtoFactory.v2().build({ tierScore: 'live' }) })
-        const v3TierOnApplicationCreation = { level: 'static', version: 'V3' } as RiskTier
-
-        expect(getVersionedTierOrBlank(person, v3TierOnApplicationCreation)).toEqual(tierBadgeV3('static'))
       })
     })
 

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -11,7 +11,6 @@ import {
   UnknownPerson,
   UnknownPersonSummary,
 } from '../@types/shared'
-import config from '../config'
 
 const tierBadge = (tier: string): string => {
   if (!tier) return ''
@@ -32,13 +31,6 @@ const versionedTierBadge = (tier: TierDto): string => {
     return tierBadge(tier.tierScore)
   }
   return tierBadgeV3(tier.tierScore)
-}
-
-const getVersionedTier = (person: Person | PersonSummary, tierOnApplicationCreation?: RiskTier): string => {
-  if (!config.flags.useLiveTiers) {
-    return tierOnApplicationCreation?.level || ''
-  }
-  return personTier(person)?.tierScore || ''
 }
 
 const isApplicableTierDto = (person: FullPerson) => {
@@ -151,6 +143,13 @@ const getVersionedTierOrBlank = (person: Person | PersonSummary, tierOnApplicati
   return tier ? versionedTierBadge(tier) : ''
 }
 
+const getVersionedTierValue = (person: Person | PersonSummary, tierOnApplicationCreation?: RiskTier): string => {
+  if (!config.flags.useLiveTiers) {
+    return tierOnApplicationCreation?.level || ''
+  }
+  return personTier(person)?.tierScore || ''
+}
+
 export {
   tierBadge,
   versionedTierBadge,
@@ -162,5 +161,5 @@ export {
   displayName,
   isUnknownPerson,
   personTier,
-  getVersionedTier,
+  getVersionedTierValue,
 }

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -1,3 +1,4 @@
+import config from '../config'
 import {
   FullPerson,
   FullPersonSummary,
@@ -31,6 +32,13 @@ const versionedTierBadge = (tier: TierDto): string => {
     return tierBadge(tier.tierScore)
   }
   return tierBadgeV3(tier.tierScore)
+}
+
+const getVersionedTier = (person: Person | PersonSummary, tierOnApplicationCreation?: RiskTier): string => {
+  if (!config.flags.useLiveTiers) {
+    return tierOnApplicationCreation?.level || ''
+  }
+  return personTier(person)?.tierScore || ''
 }
 
 const isApplicableTierDto = (person: FullPerson) => {
@@ -154,4 +162,5 @@ export {
   displayName,
   isUnknownPerson,
   personTier,
+  getVersionedTier,
 }


### PR DESCRIPTION
# Context
[This](https://dsdmoj.atlassian.net/browse/FM-964) adds tier into the assess banner.

I've mirrored how another banner handles tier and just use a plain tier rather than a badge. Unless we specifically want the badge styling?

## Screenshots of UI changes

### Before
<img width="784" height="142" alt="image" src="https://github.com/user-attachments/assets/3e440fe9-01e3-4841-a3cb-4ea6b361ba63" />

### After
<img width="1039" height="202" alt="image" src="https://github.com/user-attachments/assets/9fd7f054-d378-45f9-9fd2-27450e55e737" />

**V3**
<img width="903" height="138" alt="image" src="https://github.com/user-attachments/assets/174748a5-ed7c-4362-a2a7-9ceef981aa82" />
