### PR TITLE
Add live risk widgets to assessments

### DIFF
--- a/server/controllers/assess/assessmentsController.test.ts
+++ b/server/controllers/assess/assessmentsController.test.ts
@@ -283,6 +283,7 @@ describe('assessmentsController', () => {
 
       afterEach(() => {
         config.flags.useLiveTiers = false
+        personService.riskProfile.mockClear()
       })
 
       it('sources the risk widgets from the risk profile endpoint', async () => {

--- a/server/controllers/assess/assessmentsController.test.ts
+++ b/server/controllers/assess/assessmentsController.test.ts
@@ -6,12 +6,14 @@ import { Cas1AssessmentSummary as AssessmentSummary, Task } from '@approved-prem
 import { addErrorMessageToFlash, fetchErrorsAndUserInput } from '../../utils/validation'
 import TasklistService from '../../services/tasklistService'
 import AssessmentsController from './assessmentsController'
-import { AssessmentService, TaskService } from '../../services'
+import { AssessmentService, PersonService, TaskService } from '../../services'
+import config from '../../config'
 
 import {
   assessmentFactory,
   assessmentSummaryFactory,
   paginatedResponseFactory,
+  risksFactory,
   taskFactory,
 } from '../../testutils/factories'
 
@@ -36,11 +38,12 @@ describe('assessmentsController', () => {
 
   const assessmentService = createMock<AssessmentService>({})
   const taskService = createMock<TaskService>({})
+  const personService = createMock<PersonService>({})
 
   let assessmentsController: AssessmentsController
 
   beforeEach(() => {
-    assessmentsController = new AssessmentsController(assessmentService, taskService)
+    assessmentsController = new AssessmentsController(assessmentService, taskService, personService)
     response = createMock<Response>({ locals: { user: { id: userId } } })
     request = createMock<Request>({ user: { token }, query: {} })
   })
@@ -185,6 +188,7 @@ describe('assessmentsController', () => {
         contextKeyDetails: assessmentKeyDetails(assessment),
         pageHeading: 'Assess an Approved Premises (AP) application',
         taskList: stubTaskList,
+        risks: assessment.application.risks,
         errorSummary: [],
         errors: {},
       })
@@ -235,6 +239,7 @@ describe('assessmentsController', () => {
         contextKeyDetails: assessmentKeyDetails(assessment),
         pageHeading: 'Assess an Approved Premises (AP) application',
         taskList: stubTaskList,
+        risks: assessment.application.risks,
         errorSummary: [],
         errors: {},
       })
@@ -259,11 +264,47 @@ describe('assessmentsController', () => {
           contextKeyDetails: assessmentKeyDetails(assessment),
           pageHeading: 'Assess an Approved Premises (AP) application',
           taskList: stubTaskList,
+          risks: assessment.application.risks,
           errorSummary: errorsAndUserInput.errorSummary,
           errors: errorsAndUserInput.errors,
         })
 
         expect(assessmentService.findAssessment).toHaveBeenCalledWith(token, assessment.id)
+      })
+    })
+
+    describe('when the live tiers feature flag is enabled', () => {
+      const liveRisks = risksFactory.build()
+
+      beforeEach(() => {
+        config.flags.useLiveTiers = true
+        personService.riskProfile.mockResolvedValue(liveRisks)
+      })
+
+      afterEach(() => {
+        config.flags.useLiveTiers = false
+      })
+
+      it('sources the risk widgets from the risk profile endpoint', async () => {
+        await assessmentsController.show()(request, response, next)
+
+        expect(personService.riskProfile).toHaveBeenCalledWith(token, assessment.application.person.crn)
+        expect(response.render).toHaveBeenCalledWith(
+          'assessments/tasklist',
+          expect.objectContaining({ risks: liveRisks }),
+        )
+      })
+    })
+
+    describe('when the live tiers feature flag is disabled', () => {
+      it('sources the risk widgets from the application risks and does not call the risk profile endpoint', async () => {
+        await assessmentsController.show()(request, response, next)
+
+        expect(personService.riskProfile).not.toHaveBeenCalled()
+        expect(response.render).toHaveBeenCalledWith(
+          'assessments/tasklist',
+          expect.objectContaining({ risks: assessment.application.risks }),
+        )
       })
     })
   })

--- a/server/controllers/assess/assessmentsController.test.ts
+++ b/server/controllers/assess/assessmentsController.test.ts
@@ -286,7 +286,7 @@ describe('assessmentsController', () => {
         personService.riskProfile.mockClear()
       })
 
-      it('sources the risk widgets from the risk profile endpoint', async () => {
+      it('renders the task list with risks from the risk profile endpoint', async () => {
         await assessmentsController.show()(request, response, next)
 
         expect(personService.riskProfile).toHaveBeenCalledWith(token, assessment.application.person.crn)
@@ -298,7 +298,7 @@ describe('assessmentsController', () => {
     })
 
     describe('when the live tiers feature flag is disabled', () => {
-      it('sources the risk widgets from the application risks and does not call the risk profile endpoint', async () => {
+      it('renders the task list with risks from the application when live tiers are disabled', async () => {
         await assessmentsController.show()(request, response, next)
 
         expect(personService.riskProfile).not.toHaveBeenCalled()

--- a/server/controllers/assess/assessmentsController.ts
+++ b/server/controllers/assess/assessmentsController.ts
@@ -2,8 +2,9 @@ import type { Request, RequestHandler, Response } from 'express'
 
 import { addErrorMessageToFlash, fetchErrorsAndUserInput } from '../../utils/validation'
 import TasklistService from '../../services/tasklistService'
-import { AssessmentService, TaskService } from '../../services'
+import { AssessmentService, PersonService, TaskService } from '../../services'
 import informationSetAsNotReceived from '../../utils/assessments/informationSetAsNotReceived'
+import config from '../../config'
 
 import paths from '../../paths/assess'
 import { Cas1Assessment, AssessmentSortField, Cas1AssessmentStatus, TaskSortField } from '../../@types/shared'
@@ -17,6 +18,7 @@ export default class AssessmentsController {
   constructor(
     private readonly assessmentService: AssessmentService,
     private readonly taskService: TaskService,
+    private readonly personService: PersonService,
   ) {}
 
   index(): RequestHandler {
@@ -101,11 +103,16 @@ export default class AssessmentsController {
       } else {
         const taskList = new TasklistService(assessment)
 
+        const risks = config.flags.useLiveTiers
+          ? await this.personService.riskProfile(req.user.token, assessment.application.person.crn)
+          : assessment.application.risks
+
         res.render('assessments/tasklist', {
           assessment,
           pageHeading: tasklistPageHeading,
           contextKeyDetails: assessmentKeyDetails(assessment),
           taskList,
+          risks,
           errorSummary,
           errors,
         })

--- a/server/controllers/assess/index.ts
+++ b/server/controllers/assess/index.ts
@@ -16,7 +16,7 @@ export const controllers = (services: Services) => {
     userService,
     assessmentService,
   } as unknown as DataServices)
-  const supportingInformationController = new SupportingInformationController(assessmentService)
+  const supportingInformationController = new SupportingInformationController(assessmentService, personService)
 
   return {
     assessmentsController,

--- a/server/controllers/assess/index.ts
+++ b/server/controllers/assess/index.ts
@@ -8,9 +8,9 @@ import { type Services } from '../../services'
 import { DataServices } from '../../@types/ui'
 
 export const controllers = (services: Services) => {
-  const { assessmentService, applicationService, userService, taskService } = services
+  const { assessmentService, applicationService, userService, taskService, personService } = services
 
-  const assessmentsController = new AssessmentsController(assessmentService, taskService)
+  const assessmentsController = new AssessmentsController(assessmentService, taskService, personService)
   const assessmentPagesController = new AssessmentPagesController(assessmentService, {
     applicationService,
     userService,

--- a/server/controllers/assess/supportingInformationController.test.ts
+++ b/server/controllers/assess/supportingInformationController.test.ts
@@ -10,11 +10,13 @@ import {
   assessmentFactory,
   cas1OasysGroupFactory,
   prisonCaseNotesFactory,
+  risksFactory,
 } from '../../testutils/factories'
 
 import SupportingInformationController from './supportingInformationController'
-import { AssessmentService } from '../../services'
+import { AssessmentService, PersonService } from '../../services'
 import { DateFormats } from '../../utils/dateUtils'
+import config from '../../config'
 
 describe('supportingInformationController', () => {
   const token = 'SOME_TOKEN'
@@ -25,13 +27,14 @@ describe('supportingInformationController', () => {
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
   const assessmentService = createMock<AssessmentService>({})
+  const personService = createMock<PersonService>({})
 
   let supportingInformationController: SupportingInformationController
   let request: DeepMocked<Request>
 
   beforeEach(() => {
     jest.resetAllMocks()
-    supportingInformationController = new SupportingInformationController(assessmentService)
+    supportingInformationController = new SupportingInformationController(assessmentService, personService)
     request = createMock<Request>({
       user: { token },
       flash: flashSpy,
@@ -51,7 +54,7 @@ describe('supportingInformationController', () => {
     describe('for "risk-information"', () => {
       let oasysImport: Record<string, OasysSummariesSection>
 
-      it('renders the view', async () => {
+      beforeEach(() => {
         request.params.category = 'risk-information'
 
         oasysImport = {
@@ -68,6 +71,9 @@ describe('supportingInformationController', () => {
         }
 
         assessmentService.findAssessment.mockResolvedValue(assessment)
+      })
+
+      it('renders the view', async () => {
         const requestHandler = supportingInformationController.show()
 
         await requestHandler(request, response, next)
@@ -86,6 +92,45 @@ describe('supportingInformationController', () => {
           pageHeading: 'Review risk information',
         })
         expect(assessmentService.findAssessment).toBeCalledWith(token, request.params.id)
+      })
+
+      describe('when the live tiers feature flag is enabled', () => {
+        const liveRisks = risksFactory.build()
+
+        beforeEach(() => {
+          config.flags.useLiveTiers = true
+          personService.riskProfile.mockResolvedValue(liveRisks)
+        })
+
+        afterEach(() => {
+          config.flags.useLiveTiers = false
+        })
+
+        it('sources the risk widgets from the risk profile endpoint', async () => {
+          const requestHandler = supportingInformationController.show()
+
+          await requestHandler(request, response, next)
+
+          expect(personService.riskProfile).toHaveBeenCalledWith(token, assessment.application.person.crn)
+          expect(response.render).toHaveBeenCalledWith(
+            'assessments/pages/risk-information/oasys-information',
+            expect.objectContaining({ risks: liveRisks }),
+          )
+        })
+      })
+
+      describe('when the live tiers feature flag is disabled', () => {
+        it('sources the risk widgets from the application risks and does not call the risk profile endpoint', async () => {
+          const requestHandler = supportingInformationController.show()
+
+          await requestHandler(request, response, next)
+
+          expect(personService.riskProfile).not.toHaveBeenCalled()
+          expect(response.render).toHaveBeenCalledWith(
+            'assessments/pages/risk-information/oasys-information',
+            expect.objectContaining({ risks: assessment.application.risks }),
+          )
+        })
       })
     })
 

--- a/server/controllers/assess/supportingInformationController.test.ts
+++ b/server/controllers/assess/supportingInformationController.test.ts
@@ -106,7 +106,7 @@ describe('supportingInformationController', () => {
           config.flags.useLiveTiers = false
         })
 
-        it('sources the risk widgets from the risk profile endpoint', async () => {
+        it('renders the view with risks from the risk profile endpoint', async () => {
           const requestHandler = supportingInformationController.show()
 
           await requestHandler(request, response, next)
@@ -120,7 +120,7 @@ describe('supportingInformationController', () => {
       })
 
       describe('when the live tiers feature flag is disabled', () => {
-        it('sources the risk widgets from the application risks and does not call the risk profile endpoint', async () => {
+        it('renders the view with risks from the application when live tiers are disabled', async () => {
           const requestHandler = supportingInformationController.show()
 
           await requestHandler(request, response, next)

--- a/server/controllers/assess/supportingInformationController.ts
+++ b/server/controllers/assess/supportingInformationController.ts
@@ -1,7 +1,8 @@
 import { Request, RequestHandler, Response } from 'express'
 
-import { AssessmentService } from '../../services'
+import { AssessmentService, PersonService } from '../../services'
 import { DateFormats } from '../../utils/dateUtils'
+import config from '../../config'
 
 import {
   acctAlertsFromAssessment,
@@ -11,7 +12,10 @@ import {
 import { oasysInformationFromAssessment } from '../../utils/assessments/oasysUtils'
 
 export default class SupportingInformationController {
-  constructor(private readonly assessmentService: AssessmentService) {}
+  constructor(
+    private readonly assessmentService: AssessmentService,
+    private readonly personService: PersonService,
+  ) {}
 
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
@@ -26,6 +30,10 @@ export default class SupportingInformationController {
           'risk-to-self': { riskToSelfSummaries: unknown }
         }
 
+        const risks = config.flags.useLiveTiers
+          ? await this.personService.riskProfile(req.user.token, assessment.application.person.crn)
+          : assessment.application.risks
+
         res.render('assessments/pages/risk-information/oasys-information', {
           pageHeading: 'Review risk information',
           oasysSections: {
@@ -37,7 +45,7 @@ export default class SupportingInformationController {
           },
           dateOfImport: DateFormats.isoDateToUIDate(assessment.application.submittedAt),
           assessmentId: assessment.id,
-          risks: assessment.application.risks,
+          risks,
         })
       } else {
         res.render('assessments/pages/risk-information/prison-information', {

--- a/server/views/assessments/tasklist.njk
+++ b/server/views/assessments/tasklist.njk
@@ -85,7 +85,7 @@
 
     {% if not oasysDisabled %}
         <div class="govuk-grid-column-one-third">
-            {{ widgets(assessment.application.risks | mapApiPersonRisksForUi) }}
+            {{ widgets(risks | mapApiPersonRisksForUi) }}
         </div>
     {% endif %}
 


### PR DESCRIPTION
# Context

[This](https://dsdmoj.atlassian.net/jira/software/c/projects/FM/boards/8980?assignee=712020%3Af8a1d1e0-d9b6-4c6b-a607-b0cd523fe827&selectedIssue=FM-973) allows the assessment tasklist to use live risk widgets when `USE_LIVE_TIER` is turned on

~Wasn't sure the best way to test this one on/off locally~

# Changes in this PR

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

### Before
Tasklist
<img width="1003" height="819" alt="image" src="https://github.com/user-attachments/assets/8231255b-27d4-48e3-aaf8-6f09692c6ee8" />

Supporting information page
<img width="991" height="779" alt="image" src="https://github.com/user-attachments/assets/fabc4c63-ac41-4f04-9098-932b48897a3e" />

### After
Tasklist
<img width="989" height="714" alt="image" src="https://github.com/user-attachments/assets/fc3e16f1-6b79-4f2a-8385-25e20bbf98b6" />

Supporting information page
<img width="1002" height="796" alt="image" src="https://github.com/user-attachments/assets/4e6ee5a1-1fc1-4c93-b9ff-8cff25f31b02" />
