### PR TITLE
Feature/fm 962 apply add live tier to person banner

### DIFF
--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -188,7 +188,7 @@ export default class ApplicationsController {
         applicationList.length > 0 ? applicationList[0].person : await this.personService.findByCrn(req.user.token, crn)
 
       return res.render('applications/manageApplications', {
-        contextKeyDetails: personKeyDetails(person, applicationList[0] && applicationList[0].risks?.tier?.value?.level),
+        contextKeyDetails: personKeyDetails(person, applicationList[0] && applicationList[0].risks?.tier?.value),
         continuePath: applicationList.length > 0 ? undefined : paths.applications.people.selectOffence({ crn }),
         pageHeading: getApplicationsHeading(applicationList),
         applicationsHeader: getApplicationTableHeader(),

--- a/server/controllers/match/newPlacement/newPlacementController.test.ts
+++ b/server/controllers/match/newPlacement/newPlacementController.test.ts
@@ -27,10 +27,7 @@ import { convertKeyValuePairToRadioItems } from '../../../utils/formUtils'
 describe('newPlacementController', () => {
   const token = 'TEST_TOKEN'
   const placementRequestDetail = cas1PlacementRequestDetailFactory.build()
-  const contextKeyDetails = personKeyDetails(
-    placementRequestDetail.person,
-    placementRequestDetail.risks.tier.value.level,
-  )
+  const contextKeyDetails = personKeyDetails(placementRequestDetail.person, placementRequestDetail.risks.tier.value)
   const params = { placementRequestId: placementRequestDetail.id }
 
   let request: DeepMocked<Request>

--- a/server/controllers/match/newPlacement/newPlacementController.ts
+++ b/server/controllers/match/newPlacement/newPlacementController.ts
@@ -28,7 +28,7 @@ export default class NewPlacementController {
     const { placementRequestId } = req.params
     const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
     const placementRequest = await this.placementRequestService.getPlacementRequest(req.user.token, placementRequestId)
-    const contextKeyDetails = personKeyDetails(placementRequest.person, placementRequest.risks.tier.value.level)
+    const contextKeyDetails = personKeyDetails(placementRequest.person, placementRequest.risks.tier.value)
 
     return { placementRequestId, placementRequest, contextKeyDetails, errors, errorSummary, userInput }
   }

--- a/server/utils/applications/helpers.test.ts
+++ b/server/utils/applications/helpers.test.ts
@@ -97,7 +97,7 @@ describe('helpers', () => {
   })
 
   describe('personKeyDetails', () => {
-    const tier = tierEnvelopeFactory.build().value.level
+    const tier = tierEnvelopeFactory.build().value
 
     it('should return the key information for a placement', () => {
       const person = personFactory.build()
@@ -106,7 +106,7 @@ describe('helpers', () => {
         header: { key: '', showKey: false, value: person.name },
         items: [
           { key: { text: 'CRN' }, value: { text: person.crn } },
-          { key: { text: 'Tier' }, value: { text: tier } },
+          { key: { text: 'Tier' }, value: { text: tier.level } },
           {
             key: { text: 'Date of birth' },
             value: {
@@ -142,7 +142,7 @@ describe('helpers', () => {
         header: { key: '', showKey: false, value: 'Limited Access Offender' },
         items: [
           { key: { text: 'CRN' }, value: { text: person.crn } },
-          { key: { text: 'Tier' }, value: { text: tier } },
+          { key: { text: 'Tier' }, value: { text: tier.level } },
         ],
       })
     })
@@ -154,7 +154,7 @@ describe('helpers', () => {
         header: { key: '', showKey: false, value: 'Unknown person' },
         items: [
           { key: { text: 'CRN' }, value: { text: person.crn } },
-          { key: { text: 'Tier' }, value: { text: tier } },
+          { key: { text: 'Tier' }, value: { text: tier.level } },
         ],
       })
     })

--- a/server/utils/applications/helpers.ts
+++ b/server/utils/applications/helpers.ts
@@ -1,6 +1,6 @@
 import { KeyDetailsArgs } from '@approved-premises/ui'
-import { Cas1Application, Cas1ApplicationSummary, Person } from '../../@types/shared'
-import { displayName, isFullPerson } from '../personUtils'
+import { Cas1Application, Cas1ApplicationSummary, Person, RiskTier } from '../../@types/shared'
+import { displayName, getVersionedTierValue, isFullPerson } from '../personUtils'
 import paths from '../../paths/apply'
 import { DateFormats } from '../dateUtils'
 import { htmlCell, textCell } from '../tableUtils'
@@ -31,11 +31,14 @@ export const createNameAnchorElement = (
     : textCell(name)
 }
 
-export const personKeyDetails = (person: Person, tier?: string): KeyDetailsArgs => ({
+export const personKeyDetails = (person: Person, tierOnApplicationCreation?: RiskTier): KeyDetailsArgs => ({
   header: { value: displayName(person), key: '', showKey: false },
   items: [
     { key: textCell('CRN'), value: textCell(person.crn) },
-    { key: { text: 'Tier' }, value: { text: tier || 'Not available' } },
+    {
+      key: { text: 'Tier' },
+      value: { text: getVersionedTierValue(person, tierOnApplicationCreation) || 'Not available' },
+    },
     isFullPerson(person)
       ? {
           key: { text: 'Date of birth' },
@@ -48,4 +51,4 @@ export const personKeyDetails = (person: Person, tier?: string): KeyDetailsArgs 
 })
 
 export const applicationKeyDetails = (application: Cas1Application): KeyDetailsArgs =>
-  personKeyDetails(application.person, application.risks?.tier?.value?.level)
+  personKeyDetails(application.person, application.risks?.tier?.value)

--- a/server/utils/applications/helpers.ts
+++ b/server/utils/applications/helpers.ts
@@ -4,6 +4,7 @@ import { displayName, getVersionedTierValue, isFullPerson } from '../personUtils
 import paths from '../../paths/apply'
 import { DateFormats } from '../dateUtils'
 import { htmlCell, textCell } from '../tableUtils'
+import { summaryListItem } from '../formUtils'
 
 export const createNameAnchorElement = (
   person: Person,
@@ -34,18 +35,10 @@ export const createNameAnchorElement = (
 export const personKeyDetails = (person: Person, tierOnApplicationCreation?: RiskTier): KeyDetailsArgs => ({
   header: { value: displayName(person), key: '', showKey: false },
   items: [
-    { key: textCell('CRN'), value: textCell(person.crn) },
-    {
-      key: { text: 'Tier' },
-      value: { text: getVersionedTierValue(person, tierOnApplicationCreation) || 'Not available' },
-    },
+    summaryListItem('CRN', person.crn),
+    summaryListItem('Tier', getVersionedTierValue(person, tierOnApplicationCreation) || 'Not available'),
     isFullPerson(person)
-      ? {
-          key: { text: 'Date of birth' },
-          value: {
-            text: DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }),
-          },
-        }
+      ? summaryListItem('Date of birth', DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }))
       : undefined,
   ],
 })

--- a/server/utils/placementRequests/utils.test.ts
+++ b/server/utils/placementRequests/utils.test.ts
@@ -70,7 +70,7 @@ describe('utils', () => {
 
       expect(applicationHelpers.personKeyDetails).toHaveBeenCalledWith(
         placementRequest.person,
-        placementRequest.risks.tier.value.level,
+        placementRequest.risks.tier.value,
       )
     })
   })

--- a/server/utils/placementRequests/utils.ts
+++ b/server/utils/placementRequests/utils.ts
@@ -31,7 +31,7 @@ export const withdrawalMessage = (duration: number, expectedArrivalDate: string)
   `Request for placement for ${DateFormats.formatDuration(duration)} starting on ${DateFormats.isoDateToUIDate(expectedArrivalDate, { format: 'short' })} withdrawn successfully`
 
 export const placementRequestKeyDetails = (placementRequest: Cas1PlacementRequestDetail) =>
-  personKeyDetails(placementRequest.person, placementRequest.risks?.tier?.value?.level)
+  personKeyDetails(placementRequest.person, placementRequest.risks?.tier?.value)
 
 export const placementRadioItems = (
   placements: Array<Cas1SpaceBookingSummary>,

--- a/server/utils/placements/index.test.ts
+++ b/server/utils/placements/index.test.ts
@@ -269,7 +269,7 @@ describe('placementUtils', () => {
 
       placementKeyDetails(placement)
 
-      expect(applicationHelpers.personKeyDetails).toHaveBeenCalledWith(placement.person, placement.tier)
+      expect(applicationHelpers.personKeyDetails).toHaveBeenCalledWith(placement.person, { level: placement.tier })
     })
   })
 

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -7,6 +7,7 @@ import {
   Cas1SpaceBookingShortSummary,
 } from '@approved-premises/api'
 import { RadioItem, SummaryList, TabItem, TableCell, TaskData, UserDetails } from '@approved-premises/ui'
+import { RiskTier } from '../../@types/shared'
 import { DateFormats } from '../dateUtils'
 import { personKeyDetails } from '../applications/helpers'
 import paths from '../../paths/manage'
@@ -125,7 +126,8 @@ export const actions = (placement: Cas1SpaceBooking, user: UserDetails, profileD
   return actionList.length ? [{ items: actionList }] : null
 }
 
-export const placementKeyDetails = (placement: Cas1SpaceBooking) => personKeyDetails(placement.person, placement.tier)
+export const placementKeyDetails = (placement: Cas1SpaceBooking) =>
+  personKeyDetails(placement.person, placement.tier ? ({ level: placement.tier } as RiskTier) : undefined)
 
 export const placementName = (placement: Cas1SpaceBookingSummary): string =>
   `${placement.premises.name} from ${DateFormats.isoDateToUIDate(placement.expectedArrivalDate)}`

--- a/server/utils/placements/index.ts
+++ b/server/utils/placements/index.ts
@@ -5,9 +5,9 @@ import {
   Cas1SpaceBookingDates,
   Cas1SpaceBookingSummary,
   Cas1SpaceBookingShortSummary,
+  RiskTier,
 } from '@approved-premises/api'
 import { RadioItem, SummaryList, TabItem, TableCell, TaskData, UserDetails } from '@approved-premises/ui'
-import { RiskTier } from '../../@types/shared'
 import { DateFormats } from '../dateUtils'
 import { personKeyDetails } from '../applications/helpers'
 import paths from '../../paths/manage'


### PR DESCRIPTION
# Context

This updates the banner in [apply](https://dsdmoj.atlassian.net/browse/FM-962)/[manage](https://dsdmoj.atlassian.net/browse/FM-980)/[cru](https://dsdmoj.atlassian.net/browse/FM-976) to use live tier.
Because of the shared functionality between the 3s banners this addresses multiple tickets.



# Changes in this PR

## Screenshots of UI changes

### Before
<img width="977" height="491" alt="image" src="https://github.com/user-attachments/assets/b45f8608-9bfb-4083-81bf-2f29b9138650" />

### After
V2
<img width="982" height="414" alt="image" src="https://github.com/user-attachments/assets/0ab2926a-86fb-43e1-a576-9099a4627481" />

V3
<img width="976" height="498" alt="image" src="https://github.com/user-attachments/assets/09902ad6-2a05-42be-84c5-a0be0e5b8f17" />

