### PR TITLE
FM-974 Live tiers on CRU Dashboard

### DIFF
--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -135,7 +135,7 @@ const personTier = (person: Person | PersonSummary): TierDto => {
  */
 const getTierOrBlank = (tier: string | null | undefined) => (tier ? tierBadge(tier) : '')
 
-const getVersionedTierOrBlank = (person: Person | PersonSummary, tierOnApplicationCreation?: RiskTier) => {
+const getVersionedTierOrBlank = (person: Person | PersonSummary, tierOnApplicationCreation?: Partial<RiskTier>) => {
   if (!config.flags.useLiveTiers) {
     return getTierOrBlank(tierOnApplicationCreation?.level)
   }

--- a/server/utils/placementRequests/table.test.ts
+++ b/server/utils/placementRequests/table.test.ts
@@ -4,11 +4,12 @@ import { dashboardTableHeader, dashboardTableRows, durationCell, nameCell } from
 import { DateFormats } from '../dateUtils'
 import { htmlCell, textCell } from '../tableUtils'
 import { sortHeader } from '../sortHeader'
-import { displayName, tierBadge } from '../personUtils'
+import { displayName, personTier, tierBadge, versionedTierBadge } from '../personUtils'
 import * as utils from '../utils'
 import adminPaths from '../../paths/admin'
 import { fullPersonFactory } from '../../testutils/factories/person'
 import { placementRequestStatus } from '../formUtils'
+import config from '../../config'
 
 describe('tableUtils', () => {
   beforeEach(() => {
@@ -75,6 +76,14 @@ describe('tableUtils', () => {
       matched: cas1PlacementRequestSummaryFactory.matched(),
     }
 
+    beforeEach(() => {
+      config.flags.useLiveTiers = true
+    })
+
+    afterEach(() => {
+      config.flags.useLiveTiers = false
+    })
+
     it.each(['notMatched', 'unableToMatch'])(
       'returns table rows for placement requests with status %s',
       (status: PlacementRequestStatus) => {
@@ -86,7 +95,7 @@ describe('tableUtils', () => {
         expect(dashboardTableRows([placementRequest], status)).toEqual([
           [
             nameCell(placementRequest),
-            htmlCell(tierBadge(placementRequest.personTier)),
+            htmlCell(versionedTierBadge(personTier(placementRequest.person))),
             textCell('Parole'),
             textCell(DateFormats.isoDateToUIDate(placementRequest.applicationSubmittedDate, { format: 'short' })),
             textCell(DateFormats.isoDateToUIDate(placementRequest.requestedPlacementArrivalDate, { format: 'short' })),
@@ -102,7 +111,7 @@ describe('tableUtils', () => {
       expect(dashboardTableRows([placementRequest], 'matched')).toEqual([
         [
           nameCell(placementRequest),
-          htmlCell(tierBadge(placementRequest.personTier)),
+          htmlCell(versionedTierBadge(personTier(placementRequest.person))),
           textCell('Parole'),
           textCell(DateFormats.isoDateToUIDate(placementRequest.firstBookingArrivalDate, { format: 'short' })),
           textCell(placementRequest.firstBookingPremisesName),
@@ -128,11 +137,26 @@ describe('tableUtils', () => {
       expect(dashboardTableRows([placementRequest], undefined)).toEqual([
         [
           nameCell(placementRequest),
-          htmlCell(tierBadge(placementRequest.personTier)),
+          htmlCell(versionedTierBadge(personTier(placementRequest.person))),
           textCell('Parole'),
           textCell(DateFormats.isoDateToUIDate(placementRequest.requestedPlacementArrivalDate, { format: 'short' })),
           durationCell(placementRequest.requestedPlacementDuration),
           textCell(placementRequestStatus[placementRequest.placementRequestStatus]),
+        ],
+      ])
+    })
+
+    it('returns the static tier badge if the useLiveTiers feature flag is not enabled', () => {
+      config.flags.useLiveTiers = false
+
+      const placementRequest = factories.matched.build({ isParole: true })
+      expect(dashboardTableRows([placementRequest], 'matched')).toEqual([
+        [
+          nameCell(placementRequest),
+          htmlCell(tierBadge(placementRequest.personTier)),
+          textCell('Parole'),
+          textCell(DateFormats.isoDateToUIDate(placementRequest.firstBookingArrivalDate, { format: 'short' })),
+          textCell(placementRequest.firstBookingPremisesName),
         ],
       ])
     })
@@ -143,12 +167,20 @@ describe('tableUtils', () => {
     const sortDirection = 'asc'
     const hrefPrefix = 'http://example.com'
 
+    beforeEach(() => {
+      config.flags.useLiveTiers = true
+    })
+
+    afterEach(() => {
+      config.flags.useLiveTiers = false
+    })
+
     it.each(['notMatched', 'unableToMatch'])(
       'returns the table headers for the %s status',
       (status: PlacementRequestStatus) => {
         expect(dashboardTableHeader(status, sortBy, sortDirection, hrefPrefix)).toEqual([
           sortHeader<PlacementRequestSortField>('Name and CRN', 'person_name', sortBy, sortDirection, hrefPrefix),
-          sortHeader<PlacementRequestSortField>('Tier', 'person_risks_tier', sortBy, sortDirection, hrefPrefix),
+          sortHeader<PlacementRequestSortField>('Tier', 'person_tier', sortBy, sortDirection, hrefPrefix),
           sortHeader<PlacementRequestSortField>('Request type', 'request_type', sortBy, sortDirection, hrefPrefix),
           sortHeader<PlacementRequestSortField>(
             'Application date',
@@ -172,7 +204,7 @@ describe('tableUtils', () => {
     it('returns the table headers for the matched status', () => {
       expect(dashboardTableHeader('matched', sortBy, sortDirection, hrefPrefix)).toEqual([
         sortHeader<PlacementRequestSortField>('Name and CRN', 'person_name', sortBy, sortDirection, hrefPrefix),
-        sortHeader<PlacementRequestSortField>('Tier', 'person_risks_tier', sortBy, sortDirection, hrefPrefix),
+        sortHeader<PlacementRequestSortField>('Tier', 'person_tier', sortBy, sortDirection, hrefPrefix),
         sortHeader<PlacementRequestSortField>('Request type', 'request_type', sortBy, sortDirection, hrefPrefix),
         sortHeader<PlacementRequestSortField>(
           'Booked arrival date',
@@ -188,7 +220,7 @@ describe('tableUtils', () => {
     it('returns the table headers when no status is provided (Search tab)', () => {
       expect(dashboardTableHeader(undefined, sortBy, sortDirection, hrefPrefix)).toEqual([
         sortHeader<PlacementRequestSortField>('Name and CRN', 'person_name', sortBy, sortDirection, hrefPrefix),
-        sortHeader<PlacementRequestSortField>('Tier', 'person_risks_tier', sortBy, sortDirection, hrefPrefix),
+        sortHeader<PlacementRequestSortField>('Tier', 'person_tier', sortBy, sortDirection, hrefPrefix),
         sortHeader<PlacementRequestSortField>('Request type', 'request_type', sortBy, sortDirection, hrefPrefix),
         sortHeader<PlacementRequestSortField>(
           'Requested arrival date',
@@ -199,6 +231,24 @@ describe('tableUtils', () => {
         ),
         sortHeader<PlacementRequestSortField>('Length of stay', 'duration', sortBy, sortDirection, hrefPrefix),
         { text: 'Status' },
+      ])
+    })
+
+    it('uses the static tier "person_risks_tier" rather than "person_tier" if the useLiveTiers flag is not enabled', () => {
+      config.flags.useLiveTiers = false
+
+      expect(dashboardTableHeader('matched', sortBy, sortDirection, hrefPrefix)).toEqual([
+        sortHeader<PlacementRequestSortField>('Name and CRN', 'person_name', sortBy, sortDirection, hrefPrefix),
+        sortHeader<PlacementRequestSortField>('Tier', 'person_risks_tier', sortBy, sortDirection, hrefPrefix),
+        sortHeader<PlacementRequestSortField>('Request type', 'request_type', sortBy, sortDirection, hrefPrefix),
+        sortHeader<PlacementRequestSortField>(
+          'Booked arrival date',
+          'canonical_arrival_date',
+          sortBy,
+          sortDirection,
+          hrefPrefix,
+        ),
+        sortHeader<PlacementRequestSortField>('Approved Premises', 'name', sortBy, sortDirection, hrefPrefix),
       ])
     })
   })

--- a/server/utils/placementRequests/table.test.ts
+++ b/server/utils/placementRequests/table.test.ts
@@ -2,9 +2,9 @@ import { PlacementRequestSortField, PlacementRequestStatus } from '@approved-pre
 import { cas1PlacementRequestSummaryFactory, restrictedPersonFactory } from '../../testutils/factories'
 import { dashboardTableHeader, dashboardTableRows, durationCell, nameCell } from './table'
 import { DateFormats } from '../dateUtils'
-import { htmlCell, textCell } from '../tableUtils'
+import { textCell, versionedTierCell } from '../tableUtils'
 import { sortHeader } from '../sortHeader'
-import { displayName, personTier, tierBadge, versionedTierBadge } from '../personUtils'
+import { displayName } from '../personUtils'
 import * as utils from '../utils'
 import adminPaths from '../../paths/admin'
 import { fullPersonFactory } from '../../testutils/factories/person'
@@ -95,7 +95,7 @@ describe('tableUtils', () => {
         expect(dashboardTableRows([placementRequest], status)).toEqual([
           [
             nameCell(placementRequest),
-            htmlCell(versionedTierBadge(personTier(placementRequest.person))),
+            versionedTierCell(placementRequest.person, { level: placementRequest.personTier }),
             textCell('Parole'),
             textCell(DateFormats.isoDateToUIDate(placementRequest.applicationSubmittedDate, { format: 'short' })),
             textCell(DateFormats.isoDateToUIDate(placementRequest.requestedPlacementArrivalDate, { format: 'short' })),
@@ -111,7 +111,7 @@ describe('tableUtils', () => {
       expect(dashboardTableRows([placementRequest], 'matched')).toEqual([
         [
           nameCell(placementRequest),
-          htmlCell(versionedTierBadge(personTier(placementRequest.person))),
+          versionedTierCell(placementRequest.person, { level: placementRequest.personTier }),
           textCell('Parole'),
           textCell(DateFormats.isoDateToUIDate(placementRequest.firstBookingArrivalDate, { format: 'short' })),
           textCell(placementRequest.firstBookingPremisesName),
@@ -137,7 +137,7 @@ describe('tableUtils', () => {
       expect(dashboardTableRows([placementRequest], undefined)).toEqual([
         [
           nameCell(placementRequest),
-          htmlCell(versionedTierBadge(personTier(placementRequest.person))),
+          versionedTierCell(placementRequest.person, { level: placementRequest.personTier }),
           textCell('Parole'),
           textCell(DateFormats.isoDateToUIDate(placementRequest.requestedPlacementArrivalDate, { format: 'short' })),
           durationCell(placementRequest.requestedPlacementDuration),
@@ -153,7 +153,7 @@ describe('tableUtils', () => {
       expect(dashboardTableRows([placementRequest], 'matched')).toEqual([
         [
           nameCell(placementRequest),
-          htmlCell(tierBadge(placementRequest.personTier)),
+          versionedTierCell(placementRequest.person, { level: placementRequest.personTier }),
           textCell('Parole'),
           textCell(DateFormats.isoDateToUIDate(placementRequest.firstBookingArrivalDate, { format: 'short' })),
           textCell(placementRequest.firstBookingPremisesName),

--- a/server/utils/placementRequests/table.ts
+++ b/server/utils/placementRequests/table.ts
@@ -8,9 +8,9 @@ import { TableCell, TableRow } from '@approved-premises/ui'
 import adminPaths from '../../paths/admin'
 import { DateFormats } from '../dateUtils'
 import { linkTo } from '../utils'
-import { dateCell, htmlCell, textCell } from '../tableUtils'
+import { dateCell, htmlCell, textCell, versionedTierCell } from '../tableUtils'
 import { sortHeader } from '../sortHeader'
-import { displayName, isFullPerson, personTier, tierBadge, versionedTierBadge } from '../personUtils'
+import { displayName, isFullPerson } from '../personUtils'
 import { placementRequestStatus } from '../formUtils'
 import config from '../../config'
 
@@ -21,11 +21,7 @@ export const dashboardTableRows = (
   placementRequests.map(placementRequest =>
     [
       nameCell(placementRequest),
-      htmlCell(
-        config.flags.useLiveTiers
-          ? versionedTierBadge(personTier(placementRequest.person))
-          : tierBadge(placementRequest.personTier),
-      ),
+      versionedTierCell(placementRequest.person, { level: placementRequest.personTier }),
       textCell(placementRequest.isParole ? 'Parole' : 'Standard release'),
       status === 'matched' && dateCell(placementRequest.firstBookingArrivalDate),
       status === 'matched' && textCell(placementRequest.firstBookingPremisesName),

--- a/server/utils/placementRequests/table.ts
+++ b/server/utils/placementRequests/table.ts
@@ -10,8 +10,9 @@ import { DateFormats } from '../dateUtils'
 import { linkTo } from '../utils'
 import { dateCell, htmlCell, textCell } from '../tableUtils'
 import { sortHeader } from '../sortHeader'
-import { displayName, isFullPerson, tierBadge } from '../personUtils'
+import { displayName, isFullPerson, personTier, tierBadge, versionedTierBadge } from '../personUtils'
 import { placementRequestStatus } from '../formUtils'
+import config from '../../config'
 
 export const dashboardTableRows = (
   placementRequests: Array<Cas1PlacementRequestSummary>,
@@ -20,7 +21,11 @@ export const dashboardTableRows = (
   placementRequests.map(placementRequest =>
     [
       nameCell(placementRequest),
-      htmlCell(tierBadge(placementRequest.personTier)),
+      htmlCell(
+        config.flags.useLiveTiers
+          ? versionedTierBadge(personTier(placementRequest.person))
+          : tierBadge(placementRequest.personTier),
+      ),
       textCell(placementRequest.isParole ? 'Parole' : 'Standard release'),
       status === 'matched' && dateCell(placementRequest.firstBookingArrivalDate),
       status === 'matched' && textCell(placementRequest.firstBookingPremisesName),
@@ -62,7 +67,7 @@ export const dashboardTableHeader = (
 
   return [
     sortColumn('Name and CRN', 'person_name'),
-    sortColumn('Tier', 'person_risks_tier'),
+    sortColumn('Tier', config.flags.useLiveTiers ? 'person_tier' : 'person_risks_tier'),
     sortColumn('Request type', 'request_type'),
     status === 'matched' && sortColumn('Booked arrival date', 'canonical_arrival_date'),
     status === 'matched' && sortColumn('Approved Premises', 'name'),

--- a/server/utils/tableUtils.ts
+++ b/server/utils/tableUtils.ts
@@ -35,7 +35,7 @@ export const tierCell = (value: string) => ({
   attributes: { 'data-sort-value': tierSortKey(value) },
 })
 
-export const versionedTierCell = (person: Person | PersonSummary, tierOnApplicationCreation?: RiskTier) => {
+export const versionedTierCell = (person: Person | PersonSummary, tierOnApplicationCreation?: Partial<RiskTier>) => {
   const tierScore = config.flags.useLiveTiers ? personTier(person)?.tierScore : tierOnApplicationCreation?.level
 
   return {


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/FM-974
<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- Uses live tier badge in tier column on all CRU dashboard tabs.
- Switch sort column from `person_risks_tier` to `person_tier`
- Enabled with `Use_Live_Tiers` feature flag

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes
<details>
  <summary>Before</summary>
<h3>Ready to book tab</h3>
<img width="1050" height="345" alt="image" src="https://github.com/user-attachments/assets/2dcf5d87-aa0d-49a5-810e-e7175a4cd427" />
<h3>Search tab</h3>
<img width="1187" height="507" alt="image" src="https://github.com/user-attachments/assets/a90575d1-cc7f-422e-bfc8-f66005d94dfa" />
</details>

<details>
  <summary>After</summary>
<h3>Ready to book tab</h3>
<img width="1039" height="359" alt="image" src="https://github.com/user-attachments/assets/fcac5d3b-1e06-4058-bef2-f4a96d293df0" />
<h3>Search tab</h3>
<img width="1097" height="457" alt="image" src="https://github.com/user-attachments/assets/e038b564-4109-4782-9dad-8ac2a1741366" />
</details>
