### PR TITLE
Feature/fm 1011 manage show live tier in placement listing

### DIFF
--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -135,6 +135,12 @@ export type Table = {
   rows: Array<TableRow>
 }
 
+export type ColumnDefinition<T extends string = string> = {
+  title: string
+  fieldName: T
+  sortable: boolean
+}
+
 export type RadioItemButton = (
   | {
       text: string

--- a/server/utils/premises/index.test.ts
+++ b/server/utils/premises/index.test.ts
@@ -299,9 +299,7 @@ describe('premisesUtils', () => {
 
       const tableHeadings = placementTableHeader('upcoming', 'personTier', 'asc', 'Test_Href_Prefix')
 
-      expect(tableHeadings).toContainEqual(
-        sortHeader('Tier', 'personTier', 'personTier', 'asc', 'Test_Href_Prefix'),
-      )
+      expect(tableHeadings).toContainEqual(sortHeader('Tier', 'personTier', 'personTier', 'asc', 'Test_Href_Prefix'))
     })
   })
 

--- a/server/utils/premises/index.test.ts
+++ b/server/utils/premises/index.test.ts
@@ -1,4 +1,4 @@
-import { Cas1SpaceBookingResidency, Cas1SpaceBookingSummary, RiskTier } from '@approved-premises/api'
+import { Cas1SpaceBookingResidency, Cas1SpaceBookingSummary } from '@approved-premises/api'
 import { TextItem } from '@approved-premises/ui'
 import { addDays } from 'date-fns'
 import { createMock } from '@golevelup/ts-jest'
@@ -324,7 +324,7 @@ describe('premisesUtils', () => {
             {
               html: legacyLink(placement),
             },
-            versionedTierCell(placement.person, { level: placement.tier } as RiskTier),
+            versionedTierCell(placement.person, { level: placement.tier }),
             { text: DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' }) },
             { text: DateFormats.isoDateToUIDate(departureDate, { format: 'short' }) },
           ]

--- a/server/utils/premises/index.test.ts
+++ b/server/utils/premises/index.test.ts
@@ -1,4 +1,4 @@
-import { Cas1SpaceBookingResidency, Cas1SpaceBookingSummary } from '@approved-premises/api'
+import { Cas1SpaceBookingResidency, Cas1SpaceBookingSummary, RiskTier } from '@approved-premises/api'
 import { TextItem } from '@approved-premises/ui'
 import { addDays } from 'date-fns'
 import { createMock } from '@golevelup/ts-jest'
@@ -28,8 +28,9 @@ import { linkTo } from '../utils'
 import { displayName } from '../personUtils'
 import { DateFormats } from '../dateUtils'
 import { sortHeader } from '../sortHeader'
-import { textCell } from '../tableUtils'
+import { textCell, versionedTierCell } from '../tableUtils'
 import { restrictedPersonSummaryFactory } from '../../testutils/factories/person'
+import config from '../../config'
 
 describe('premisesUtils', () => {
   describe('premisesActions', () => {
@@ -266,6 +267,10 @@ describe('premisesUtils', () => {
   })
 
   describe('placementTableHeader', () => {
+    afterEach(() => {
+      config.flags.useLiveTiers = false
+    })
+
     it.each(['upcoming', 'current', 'historic'])(
       'should return the sortable table headings for tab "%s" of the placement list',
       (activeTab: Cas1SpaceBookingResidency) => {
@@ -288,6 +293,16 @@ describe('premisesUtils', () => {
         expect(tableHeadings).toEqual(expectedTableHeadings)
       },
     )
+
+    it('should return the Tier column sorted on "personTier" when the useLiveTiers flag is enabled', () => {
+      config.flags.useLiveTiers = true
+
+      const tableHeadings = placementTableHeader('upcoming', 'personTier', 'asc', 'Test_Href_Prefix')
+
+      expect(tableHeadings).toContainEqual(
+        sortHeader('Tier', 'personTier', 'personTier', 'asc', 'Test_Href_Prefix'),
+      )
+    })
   })
 
   describe('placementTableRows', () => {
@@ -311,7 +326,7 @@ describe('premisesUtils', () => {
             {
               html: legacyLink(placement),
             },
-            { html: `<span class="moj-badge moj-badge--red">${placement.tier}</span>` },
+            versionedTierCell(placement.person, { level: placement.tier } as RiskTier),
             { text: DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' }) },
             { text: DateFormats.isoDateToUIDate(departureDate, { format: 'short' }) },
           ]

--- a/server/utils/premises/index.ts
+++ b/server/utils/premises/index.ts
@@ -6,7 +6,6 @@ import type {
   Cas1SpaceBookingSummary,
   Cas1SpaceBookingSummarySortField,
   NamedId,
-  RiskTier,
   SortDirection,
 } from '@approved-premises/api'
 import {
@@ -212,7 +211,7 @@ export const mapPlacementTableRows = (
     const link = getPlacementLink({ request, premisesId, person, placementId: placement.id })
     const fieldValues: Record<ColumnField, TableCell> = {
       personName: htmlCell(`<a href="${link}" data-cy-id="${id}">${displayName(person)}, ${person.crn}</a>`),
-      tier: versionedTierCell(person, tier ? ({ level: tier } as RiskTier) : undefined),
+      tier: versionedTierCell(person, tier ? { level: tier } : undefined),
       canonicalArrivalDate: dateCell(arrivalDate),
       canonicalDepartureDate: dateCell(departureDate),
       keyWorkerName: textCell(keyWorkerAllocation?.name || 'Not assigned'),

--- a/server/utils/premises/index.ts
+++ b/server/utils/premises/index.ts
@@ -4,7 +4,9 @@ import type {
   Cas1PremisesBasicSummary,
   Cas1SpaceBookingResidency,
   Cas1SpaceBookingSummary,
+  Cas1SpaceBookingSummarySortField,
   NamedId,
+  RiskTier,
   SortDirection,
 } from '@approved-premises/api'
 import {
@@ -18,12 +20,13 @@ import {
   v2SortField,
 } from '@approved-premises/ui'
 import { Request } from 'express'
+import config from '../../config'
 import managePaths from '../../paths/manage'
 import { createQueryString, linkTo } from '../utils'
 import { sortHeader } from '../sortHeader'
-import { displayName, getTierOrBlank } from '../personUtils'
+import { displayName } from '../personUtils'
 import { canonicalDates, placementStatusCell } from '../placements'
-import { dateCell, htmlCell, textCell } from '../tableUtils'
+import { dateCell, htmlCell, textCell, versionedTierCell } from '../tableUtils'
 import { getRoomCharacteristicLabel } from '../characteristicsUtils'
 import { getPlacementLink } from '../resident'
 
@@ -178,13 +181,16 @@ const columnMap: Record<PremisesTab, Array<ColumnDefinition>> = {
 
 export const placementTableHeader = (
   activeTab: PremisesTab,
-  sortBy: v2SortField,
+  sortBy: Cas1SpaceBookingSummarySortField,
   sortDirection: SortDirection,
   hrefPrefix: string,
 ): Array<TableCell> => {
-  return columnMap[activeTab].map(({ title, fieldName, sortable }: ColumnDefinition) =>
-    sortable ? sortHeader<ColumnField>(title, fieldName, sortBy, sortDirection, hrefPrefix) : textCell(title),
-  )
+  return columnMap[activeTab].map(({ title, fieldName, sortable }: ColumnDefinition) => {
+    if (!sortable) return textCell(title)
+    const targetField: Cas1SpaceBookingSummarySortField =
+      fieldName === 'tier' && config.flags.useLiveTiers ? 'personTier' : fieldName
+    return sortHeader<Cas1SpaceBookingSummarySortField>(title, targetField, sortBy, sortDirection, hrefPrefix)
+  })
 }
 
 export const placementTableRows = (
@@ -208,7 +214,7 @@ export const mapPlacementTableRows = (
     const link = getPlacementLink({ request, premisesId, person, placementId: placement.id })
     const fieldValues: Record<ColumnField, TableCell> = {
       personName: htmlCell(`<a href="${link}" data-cy-id="${id}">${displayName(person)}, ${person.crn}</a>`),
-      tier: htmlCell(getTierOrBlank(tier)),
+      tier: versionedTierCell(person, tier ? ({ level: tier } as RiskTier) : undefined),
       canonicalArrivalDate: dateCell(arrivalDate),
       canonicalDepartureDate: dateCell(departureDate),
       keyWorkerName: textCell(keyWorkerAllocation?.name || 'Not assigned'),

--- a/server/utils/premises/index.ts
+++ b/server/utils/premises/index.ts
@@ -200,8 +200,8 @@ export const placementTableRows = (
   return mapPlacementTableRows(columnMap[activeTab], premisesId, placements, request)
 }
 
-export const mapPlacementTableRows = <T extends string>(
-  fields: Array<ColumnDefinition<T>>,
+export const mapPlacementTableRows = (
+  fields: Array<ColumnDefinition<ColumnField>>,
   premisesId: string,
   placements: Array<Cas1SpaceBookingSummary>,
   request: RequestWithSession,
@@ -226,7 +226,7 @@ export const mapPlacementTableRows = <T extends string>(
       ),
     }
 
-    return fields.map(({ fieldName }) => fieldValues[fieldName as ColumnField])
+    return fields.map(({ fieldName }) => fieldValues[fieldName])
   })
 
 export const localRestrictionsTableRows = (premises: Cas1Premises): Array<TableRow> =>

--- a/server/utils/premises/index.ts
+++ b/server/utils/premises/index.ts
@@ -17,7 +17,7 @@ import {
   TabItem,
   TableCell,
   TableRow,
-  v2SortField,
+  ColumnDefinition,
 } from '@approved-premises/ui'
 import { Request } from 'express'
 import config from '../../config'
@@ -156,23 +156,22 @@ export const keyworkersToSelectOptions = (
     })),
 ]
 
-type ColumnField = v2SortField | 'status' | 'spaceType'
+type ColumnField = Exclude<Cas1SpaceBookingSummarySortField, 'personTier'> | 'status' | 'spaceType'
 
-type ColumnDefinition = {
-  title: string
-  fieldName: ColumnField
-  sortable: boolean
-}
-const baseColumns: Array<ColumnDefinition> = [
+const baseColumns: Array<ColumnDefinition<ColumnField>> = [
   { title: 'Name and CRN', fieldName: 'personName', sortable: true },
   { title: 'Tier', fieldName: 'tier', sortable: true },
   { title: 'Arrival date', fieldName: 'canonicalArrivalDate', sortable: true },
   { title: 'Departure date', fieldName: 'canonicalDepartureDate', sortable: true },
 ]
-const statusColumn: ColumnDefinition = { title: 'Status', fieldName: 'status', sortable: false }
-const keyWorkerColumn: ColumnDefinition = { title: 'Key worker', fieldName: 'keyWorkerName', sortable: true }
+const statusColumn: ColumnDefinition<ColumnField> = { title: 'Status', fieldName: 'status', sortable: false }
+const keyWorkerColumn: ColumnDefinition<ColumnField> = {
+  title: 'Key worker',
+  fieldName: 'keyWorkerName',
+  sortable: true,
+}
 
-const columnMap: Record<PremisesTab, Array<ColumnDefinition>> = {
+const columnMap: Record<PremisesTab, Array<ColumnDefinition<ColumnField>>> = {
   upcoming: [...baseColumns, keyWorkerColumn, statusColumn],
   current: [...baseColumns, keyWorkerColumn, statusColumn],
   historic: [...baseColumns, statusColumn],
@@ -185,11 +184,10 @@ export const placementTableHeader = (
   sortDirection: SortDirection,
   hrefPrefix: string,
 ): Array<TableCell> => {
-  return columnMap[activeTab].map(({ title, fieldName, sortable }: ColumnDefinition) => {
+  return columnMap[activeTab].map(({ title, fieldName, sortable }: ColumnDefinition<ColumnField>) => {
     if (!sortable) return textCell(title)
-    const targetField: Cas1SpaceBookingSummarySortField =
-      fieldName === 'tier' && config.flags.useLiveTiers ? 'personTier' : fieldName
-    return sortHeader<Cas1SpaceBookingSummarySortField>(title, targetField, sortBy, sortDirection, hrefPrefix)
+    const targetField = fieldName === 'tier' && config.flags.useLiveTiers ? 'personTier' : fieldName
+    return sortHeader(title, targetField, sortBy, sortDirection, hrefPrefix)
   })
 }
 
@@ -202,8 +200,8 @@ export const placementTableRows = (
   return mapPlacementTableRows(columnMap[activeTab], premisesId, placements, request)
 }
 
-export const mapPlacementTableRows = (
-  fields: Array<ColumnDefinition>,
+export const mapPlacementTableRows = <T extends string>(
+  fields: Array<ColumnDefinition<T>>,
   premisesId: string,
   placements: Array<Cas1SpaceBookingSummary>,
   request: RequestWithSession,
@@ -228,7 +226,7 @@ export const mapPlacementTableRows = (
       ),
     }
 
-    return fields.map(({ fieldName }: ColumnDefinition) => fieldValues[fieldName])
+    return fields.map(({ fieldName }) => fieldValues[fieldName as ColumnField])
   })
 
 export const localRestrictionsTableRows = (premises: Cas1Premises): Array<TableRow> =>

--- a/server/utils/premises/occupancy.test.ts
+++ b/server/utils/premises/occupancy.test.ts
@@ -1,4 +1,4 @@
-import type { SelectOption } from '@approved-premises/ui'
+import type { ColumnDefinition, SelectOption } from '@approved-premises/ui'
 import {
   Cas1OutOfServiceBedSummary,
   Cas1PremiseCapacityForDay,
@@ -15,7 +15,6 @@ import {
   cas1SpaceBookingSummaryFactory,
 } from '../../testutils/factories'
 import {
-  ColumnDefinition,
   dayStatusFromDayCapacity,
   daySummaryRows,
   durationSelectOptions,

--- a/server/utils/premises/occupancy.test.ts
+++ b/server/utils/premises/occupancy.test.ts
@@ -35,6 +35,7 @@ import { roomCharacteristicMap } from '../characteristicsUtils'
 import { sortHeader } from '../sortHeader'
 import { canonicalDates } from '../placements'
 import * as premisesUtils from './index'
+import config from '../../config'
 
 describe('apOccupancy utils', () => {
   describe('dayStatusFromDayCapacity', () => {
@@ -265,6 +266,27 @@ describe('apOccupancy utils', () => {
       expect(tableHeader(tableDefinition, 'fn1', 'asc', prefix)).toEqual([
         sortHeader('Col 1', 'fn1', 'fn1', 'asc', prefix),
         { text: 'Col 2' },
+      ])
+    })
+
+    it('should render the Tier column sorted on "personTier" when the useLiveTiers flag is enabled', () => {
+      config.flags.useLiveTiers = true
+      const tierColumn: Array<ColumnDefinition<'tier' | 'personTier'>> = [
+        { title: 'Tier', fieldName: 'tier', sortable: true },
+      ]
+      expect(tableHeader(tierColumn, 'personTier', 'asc', prefix)).toEqual([
+        sortHeader('Tier', 'personTier', 'personTier', 'asc', prefix),
+      ])
+      config.flags.useLiveTiers = false
+    })
+
+    it('should render the Tier column sorted on "tier" when the useLiveTiers flag is disabled', () => {
+      config.flags.useLiveTiers = false
+      const tierColumn: Array<ColumnDefinition<'tier' | 'personTier'>> = [
+        { title: 'Tier', fieldName: 'tier', sortable: true },
+      ]
+      expect(tableHeader(tierColumn, 'tier', 'asc', prefix)).toEqual([
+        sortHeader('Tier', 'tier', 'tier', 'asc', prefix),
       ])
     })
   })

--- a/server/utils/premises/occupancy.test.ts
+++ b/server/utils/premises/occupancy.test.ts
@@ -247,6 +247,10 @@ describe('apOccupancy utils', () => {
   describe('tableHeader', () => {
     const prefix: string = 'prefix'
     type FieldName = 'fn1' | 'fn2'
+    afterEach(() => {
+      config.flags.useLiveTiers = false
+    })
+
     it('should render a data table header', () => {
       const tableDefinition: Array<ColumnDefinition<FieldName>> = [
         { title: 'Col 1', fieldName: 'fn1', sortable: true },
@@ -276,7 +280,6 @@ describe('apOccupancy utils', () => {
       expect(tableHeader(tierColumn, 'personTier', 'asc', prefix)).toEqual([
         sortHeader('Tier', 'personTier', 'personTier', 'asc', prefix),
       ])
-      config.flags.useLiveTiers = false
     })
 
     it('should render the Tier column sorted on "tier" when the useLiveTiers flag is disabled', () => {

--- a/server/utils/premises/occupancy.ts
+++ b/server/utils/premises/occupancy.ts
@@ -7,7 +7,7 @@ import {
   Cas1SpaceBookingSummary,
   SortDirection,
 } from '@approved-premises/api'
-import { SelectOption, SummaryListItem, TableCell, TableRow } from '@approved-premises/ui'
+import { ColumnDefinition, SelectOption, SummaryListItem, TableCell, TableRow } from '@approved-premises/ui'
 import { Request } from 'express'
 import { DateFormats } from '../dateUtils'
 import managePaths from '../../paths/manage'
@@ -169,12 +169,6 @@ const itemListHtml = (items: Array<string>): TableCell =>
 export type SortablePlacementColumnField = Exclude<Cas1SpaceBookingDaySummarySortField, 'releaseType'>
 export type PlacementColumnField = SortablePlacementColumnField | 'spaceType'
 export type OutOfServiceBedColumnField = keyof Cas1OutOfServiceBedSummary
-
-export type ColumnDefinition<T> = {
-  title: string
-  fieldName: T
-  sortable: boolean
-}
 
 export const placementColumnMap: Array<ColumnDefinition<PlacementColumnField>> = [
   { title: 'Name and CRN', fieldName: 'personName', sortable: true },

--- a/server/utils/premises/occupancy.ts
+++ b/server/utils/premises/occupancy.ts
@@ -170,7 +170,7 @@ export type SortablePlacementColumnField = Exclude<Cas1SpaceBookingDaySummarySor
 export type PlacementColumnField = SortablePlacementColumnField | 'spaceType'
 export type OutOfServiceBedColumnField = keyof Cas1OutOfServiceBedSummary
 
-export const placementColumnMap: Array<ColumnDefinition<PlacementColumnField>> = [
+export const placementColumnMap: Array<ColumnDefinition<Exclude<PlacementColumnField, 'personTier'>>> = [
   { title: 'Name and CRN', fieldName: 'personName', sortable: true },
   { title: 'Tier', fieldName: 'tier', sortable: true },
   { title: 'Arrival date', fieldName: 'canonicalArrivalDate', sortable: true },

--- a/server/utils/premises/occupancy.ts
+++ b/server/utils/premises/occupancy.ts
@@ -18,6 +18,7 @@ import { placementCriteriaLabels } from '../placementCriteriaUtils'
 import { getRoomCharacteristicLabel, roomCharacteristicMap } from '../characteristicsUtils'
 import { mapPlacementTableRows } from './index'
 import { htmlCell, textCell } from '../tableUtils'
+import config from '../../config'
 
 type CalendarDayStatus = 'available' | 'full' | 'overbooked'
 
@@ -197,9 +198,11 @@ export const tableHeader = <T extends string>(
   sortDirection?: SortDirection,
   hrefPrefix?: string,
 ): Array<TableCell> => {
-  return columnMap.map(({ title, fieldName, sortable }: ColumnDefinition<T>) =>
-    sortable ? sortHeader<T>(title, fieldName, sortBy, sortDirection, hrefPrefix) : textCell(title),
-  )
+  return columnMap.map(({ title, fieldName, sortable }: ColumnDefinition<T>) => {
+    if (!sortable) return textCell(title)
+    const targetField = fieldName === 'tier' && config.flags.useLiveTiers ? ('personTier' as T) : fieldName
+    return sortHeader<T>(title, targetField, sortBy, sortDirection, hrefPrefix)
+  })
 }
 
 export const placementTableRows = (


### PR DESCRIPTION
# Context

[This](https://dsdmoj.atlassian.net/browse/FM-1011) updates the premises placement tables with live tier along with allowing them to be sorted on tier.

# Changes in this PR

<!-- [] I have run the E2E tests locally and they passed -->

## Screenshots of UI changes

<details>
<summary>Before</summary>
### Before
<img width="1011" height="567" alt="image" src="https://github.com/user-attachments/assets/944af94a-57ff-41f7-a9c3-ce31608dae09" />

Sorted on tier
<img width="1015" height="575" alt="image" src="https://github.com/user-attachments/assets/216626b4-b339-4073-a3ab-8c548761c192" />

View spaces
<img width="994" height="528" alt="image" src="https://github.com/user-attachments/assets/8c869e85-365f-439f-a4d5-a06f68b2352b" />

Sorted on tier
<img width="985" height="520" alt="image" src="https://github.com/user-attachments/assets/04126a6e-52f7-4974-aabb-44292b22a603" />
</details>

<details>
<summary>After</summary>
### After
<img width="1000" height="576" alt="image" src="https://github.com/user-attachments/assets/d55b26fa-24fa-4c12-9d2e-4b587fd58dae" />

Sorted on tier
<img width="1002" height="567" alt="image" src="https://github.com/user-attachments/assets/2c38ddd6-a3f0-4a8f-90ce-d9534cc7f9aa" />

View spaces
<img width="987" height="521" alt="image" src="https://github.com/user-attachments/assets/85735244-2e02-4ee2-a797-cc66bac5a51e" />

Sorted on tier
<img width="983" height="524" alt="image" src="https://github.com/user-attachments/assets/f18a0888-5c0b-46cd-b646-6e6388c072a6" />
</details>
