### PR TITLE
Remove tier from e2e tests

### DIFF
--- a/e2e/steps/match.ts
+++ b/e2e/steps/match.ts
@@ -122,7 +122,6 @@ export const matchAndBookApplication = async ({
   // And the placement should be listed
   await cruDashboard.findRowWithValues([
     `${person.name}, ${person.crn}`,
-    person.tier,
     DateFormats.isoDateToUIDate(newDatesOfPlacement.startDate, { format: 'short' }),
     premisesName,
   ])


### PR DESCRIPTION
# Context

<!-- Is there a Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
The tier on our main e2e test CRN (X371199) has been changed from 'B3S' to 'A3S', resulting in a failure of the e2e tests.
Given that tiers are subject to change in the coming weeks, it seems prudent to remove the e2e test reliance on a hard-coded tier matching that returned for the specific CRN.

[x] I have run the E2E tests locally and they passed

## Screenshots of UI changes

None
